### PR TITLE
Add role field component

### DIFF
--- a/src/components/smallCard/fieldRole.js
+++ b/src/components/smallCard/fieldRole.js
@@ -1,0 +1,29 @@
+import { handleChange, handleSubmit } from './actions';
+const { OrangeBtn, UnderlinedInput } = require('components/styles');
+
+export const fieldRole = (userData, setUsers, setState) => {
+  const handleSetRole = role => {
+    handleChange(setUsers, setState, userData.userId, 'role', role, true);
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <UnderlinedInput
+        type="text"
+        value={userData.role || ''}
+        onChange={e => handleChange(setUsers, setState, userData.userId, 'role', e.target.value)}
+        onBlur={() => handleSubmit(userData, 'overwrite')}
+        style={{ marginLeft: 0, textAlign: 'left', width: '6ch' }}
+      />
+      {['ed', 'ip', 'ag'].map(role => (
+        <OrangeBtn
+          key={role}
+          onClick={() => handleSetRole(role)}
+          style={{ width: '25px', height: '25px', marginLeft: '5px', marginRight: 0 }}
+        >
+          {role}
+        </OrangeBtn>
+      ))}
+    </div>
+  );
+};

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -5,6 +5,7 @@ import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
 import { fieldGetInTouch } from './fieldGetInTouch';
+import { fieldRole } from './fieldRole';
 import { fieldLastCycle } from './fieldLastCycle';
 import { FieldComment } from './FieldComment';
 import { fieldBirth } from './fieldBirth';
@@ -25,6 +26,7 @@ export const renderTopBlock = (userData, setUsers, setShowInfoModal, setState, i
         {userData.lastAction && ', '}
         {userData.userId}
         {fieldGetInTouch(userData, setUsers, setState)}
+        {fieldRole(userData, setUsers, setState)}
         {(userData.userRole !== 'ag' || userData.userRole !== 'ip' || userData.role !== 'ag') && fieldLastCycle(userData, setUsers, setState)}
         {fieldDeliveryInfo(setUsers, setState, userData)}
         {userData.birth && `${userData.birth} - `}


### PR DESCRIPTION
## Summary
- add `fieldRole` helper component with quick `ed`, `ip`, and `ag` buttons
- show `fieldRole` next to `fieldGetInTouch` in small card top block

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684c1056a5708326a48e27c47e5a5ec7