### PR TITLE
Fix filtering logic

### DIFF
--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -148,8 +148,8 @@ export const SearchFilters = ({ filters, onChange }) => {
           { val: 'ab', label: 'ab' },
           { val: 'aa', label: 'aa' },
           { val: 'dash', label: '-' },
-          { val: 'long', label: '>16' },
-          { val: 'notlong', label: '<=16' },
+          { val: 'long', label: '>20' },
+          { val: 'notlong', label: '\u2264 20' },
         ].map(({ val, label }) => (
           <label key={val} style={{ marginLeft: '10px', color: 'black' }}>
             <input

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1030,15 +1030,15 @@ const filterByUserIdLength = value => {
 
 const filterByUserIdPrefix = (value, prefix) => {
   if (!value.userId) return false;
-  return value.userId.startsWith(prefix);
+  return value.userId.toLowerCase().startsWith(prefix.toLowerCase());
 };
 
 const filterByUserIdLong = value => {
-  return value.userId && value.userId.length > 16;
+  return value.userId && value.userId.length > 20;
 };
 
 const filterByUserIdNotLong = value => {
-  return !(value.userId && value.userId.length > 16);
+  return !(value.userId && value.userId.length > 20);
 };
 
 // Фільтр за групою крові додано умову для донорів, вік до 36, імт до 28
@@ -1137,14 +1137,14 @@ const filterByCSectionNone = value => {
 
 const filterMarriedOnly = value => {
   if (!value.maritalStatus) return true;
-  const unmarried = ['no', 'ні', '-'];
-  return !unmarried.includes(value.maritalStatus.toLowerCase());
+  const married = ['yes', '+', 'married', 'одружена', 'заміжня'];
+  return married.includes(value.maritalStatus.trim().toLowerCase());
 };
 
 const filterUnmarriedOnly = value => {
   if (!value.maritalStatus) return true;
-  const unmarried = ['no', 'ні', '-'];
-  return unmarried.includes(value.maritalStatus.toLowerCase());
+  const unmarried = ['no', '-', 'unmarried', 'single', 'ні', 'незаміжня'];
+  return unmarried.includes(value.maritalStatus.trim().toLowerCase());
 };
 
 


### PR DESCRIPTION
## Summary
- update UserId filtering to be case-insensitive
- consider IDs longer than 20 characters as "long"
- broaden marital status checks
- update filter labels

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find a config)*
- `npm test --silent` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_684d55644a908326acea4a4eb1a8c515