### PR TITLE
Fix marital status filtering

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1137,14 +1137,14 @@ const filterByCSectionNone = value => {
 
 const filterMarriedOnly = value => {
   if (!value.maritalStatus) return true;
-  const married = ['yes', '+', 'married', 'одружена', 'заміжня'];
-  return married.includes(value.maritalStatus.trim().toLowerCase());
+  const unmarried = ['no', '-', 'unmarried', 'single', 'ні', 'незаміжня'];
+  return !unmarried.includes(value.maritalStatus.trim().toLowerCase());
 };
 
 const filterUnmarriedOnly = value => {
   if (!value.maritalStatus) return true;
-  const unmarried = ['no', '-', 'unmarried', 'single', 'ні', 'незаміжня'];
-  return unmarried.includes(value.maritalStatus.trim().toLowerCase());
+  const married = ['yes', '+', 'married', 'одружена', 'заміжня'];
+  return !married.includes(value.maritalStatus.trim().toLowerCase());
 };
 
 


### PR DESCRIPTION
## Summary
- update marital status filters to keep entries unless they explicitly match the opposite list

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58e52bb88326809c07f6c8ced0df