### PR TITLE
Export all filtered users with single fetch

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -10,6 +10,7 @@ import {
   updateDataInRealtimeDB,
   updateDataInFiresoreDB,
   fetchPaginatedNewUsers,
+  fetchAllFilteredUsers,
   removeKeyFromFirebase,
   // fetchListOfUsers,
   makeNewUser,
@@ -671,6 +672,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     localStorage.setItem('userFilters', JSON.stringify(filters));
   }, [filters]);
 
+  useEffect(() => {
+    setUsers({});
+    setLastKey(null);
+    setHasMore(true);
+  }, [filters]);
+
   // Use saved query on initial load
   useEffect(() => {
     if (search) {
@@ -1042,6 +1049,11 @@ console.log('parseTelegramId!!!!!!!!!!!!!! :>> ', );
     } else {
       setHasMore(false); // Якщо немає більше користувачів, оновлюємо hasMore
     }
+  };
+
+  const exportFilteredUsers = async () => {
+    const allUsers = await fetchAllFilteredUsers(undefined, filters);
+    saveToContact(allUsers);
   };
 
   const saveAllContacts = async () => {
@@ -1417,7 +1429,7 @@ console.log('parseTelegramId!!!!!!!!!!!!!! :>> ', );
               {hasMore && <Button onClick={makeIndex}>Index</Button>}
               {<Button onClick={searchDuplicates}>DPL</Button>}
               {<Button onClick={()=>{btnMerge(users, setUsers, setDuplicates)}}>Merg</Button>}
-              {btnExportUsers(users)}
+              {btnExportUsers(exportFilteredUsers)}
               <Button onClick={saveAllContacts}> S_All</Button>
               
               {/* <ExcelToJson/> */}

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2066,6 +2066,44 @@ export const removeCardAndSearchId = async userId => {
   }
 };
 
+export const fetchAllFilteredUsers = async (filterForload, filterSettings = {}) => {
+  try {
+    const [newUsersSnapshot, usersSnapshot] = await Promise.all([
+      get(ref2(database, 'newUsers')),
+      get(ref2(database, 'users')),
+    ]);
+
+    const newUsersData = newUsersSnapshot.exists() ? newUsersSnapshot.val() : {};
+    const usersData = usersSnapshot.exists() ? usersSnapshot.val() : {};
+
+    const allUserIds = new Set([
+      ...Object.keys(newUsersData),
+      ...Object.keys(usersData),
+    ]);
+
+    const allUsersArray = Array.from(allUserIds).map(userId => {
+      const newUserRaw = newUsersData[userId] || {};
+      const { searchId, ...newUserDataWithoutSearchId } = newUserRaw;
+
+      return [
+        userId,
+        {
+          userId,
+          ...newUserDataWithoutSearchId,
+          ...(usersData[userId] || {}),
+        },
+      ];
+    });
+
+    const filteredUsers = filterMain(allUsersArray, filterForload, filterSettings);
+    const sortedUsers = sortUsers(filteredUsers);
+    return Object.fromEntries(sortedUsers);
+  } catch (error) {
+    console.error('Error fetching filtered users:', error);
+    return {};
+  }
+};
+
 export const fetchAllUsersFromRTDB = async () => {
   try {
     // Отримуємо дані з двох колекцій

--- a/src/components/topBtns/btnExportUsers.js
+++ b/src/components/topBtns/btnExportUsers.js
@@ -1,14 +1,9 @@
 import React from 'react';
-import { saveToContact } from 'components/ExportContact';
 import { OrangeBtn } from 'components/styles';
 
-export const btnExportUsers = users => {
+export const btnExportUsers = onExport => {
   return (
-    <OrangeBtn
-      onClick={() => {
-        saveToContact(users);
-      }}
-    >
+    <OrangeBtn onClick={onExport}>
       Save
     </OrangeBtn>
   );


### PR DESCRIPTION
## Summary
- add `fetchAllFilteredUsers` to retrieve all filtered users in one request
- update Save button logic to use the new function
- keep filter resets when settings change

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db79389ac8326b024ea0c6599f06f