### PR TITLE
Fix Save export when filters are off

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1052,7 +1052,14 @@ console.log('parseTelegramId!!!!!!!!!!!!!! :>> ', );
   };
 
   const exportFilteredUsers = async () => {
-    const allUsers = await fetchAllFilteredUsers(undefined, filters);
+    const noFilters =
+      !filters ||
+      Object.values(filters).every(value => value === 'off');
+
+    const allUsers = noFilters
+      ? await fetchAllUsersFromRTDB()
+      : await fetchAllFilteredUsers(undefined, filters);
+
     saveToContact(allUsers);
   };
 

--- a/src/components/ExportContact.jsx
+++ b/src/components/ExportContact.jsx
@@ -174,31 +174,38 @@ export const makeVCard = user => {
 };
 
 export const saveToContact = data => {
-  let contactVCard = '';
-  var fileName = '';
+  const CHUNK_SIZE = 22000;
+  let usersList = [];
+  let baseName = 'contacts';
 
   if (data.name) {
     // Один користувач (у нього є поле 'name')
-    contactVCard += makeVCard(data);
-    fileName = 'contact.vcf';
+    usersList = [data];
+    baseName = 'contact';
   } else {
-    // Об’єкт з користувачами {id: user, ...}
-    const firstFiveUsers = Object.entries(data)
-    // .slice(0, 5);
-    firstFiveUsers.forEach(([userId, user]) => {
-      contactVCard += makeVCard(user);
-    });
-    fileName = 'contacts.vcf';
+    usersList = Object.values(data);
   }
 
-  const vCardBlob = new Blob([contactVCard], { type: 'text/vcard;charset=utf-8' });
-  const url = window.URL.createObjectURL(vCardBlob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = fileName;
-  link.click();
+  for (let i = 0; i < usersList.length; i += CHUNK_SIZE) {
+    const chunk = usersList.slice(i, i + CHUNK_SIZE);
+    let contactVCard = '';
 
-  console.log('Generated vCard:', contactVCard);
+    chunk.forEach(user => {
+      contactVCard += makeVCard(user);
+    });
 
-  window.URL.revokeObjectURL(url);
+    const fileSuffix = usersList.length > CHUNK_SIZE ? `_${Math.floor(i / CHUNK_SIZE) + 1}` : '';
+    const fileName = `${baseName}${fileSuffix}.vcf`;
+
+    const vCardBlob = new Blob([contactVCard], { type: 'text/vcard;charset=utf-8' });
+    const url = window.URL.createObjectURL(vCardBlob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+
+    console.log('Generated vCard:', contactVCard);
+
+    window.URL.revokeObjectURL(url);
+  }
 };


### PR DESCRIPTION
## Summary
- ensure `Save` button exports all contacts when filters are not applied
- split large contact exports into 22k-sized files

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684dd85297ac8326b744b909f231b77d