### PR TITLE
Implement pagination for user list

### DIFF
--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export const Pagination = ({ currentPage, totalPages, onPageChange }) => {
+  if (totalPages <= 1) return null;
+
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  return (
+    <div style={{ margin: '20px 0', display: 'flex', justifyContent: 'center' }}>
+      {pages.map(page => (
+        <button
+          key={page}
+          style={{
+            margin: '0 5px',
+            padding: '5px 10px',
+            backgroundColor: page === currentPage ? '#ddd' : '#fff',
+          }}
+          onClick={() => onPageChange(page)}
+          disabled={page === currentPage}
+        >
+          {page}
+        </button>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a `Pagination` component
- integrate pagination state in `AddNewProfile` and load next pages on demand

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684df15e64d48326b9bd2ef84627a3af