### PR TITLE
Improve pagination arrows

### DIFF
--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,26 +1,46 @@
 import React from 'react';
+import { FaArrowLeft, FaArrowRight } from 'react-icons/fa';
 
 export const Pagination = ({ currentPage, totalPages, onPageChange }) => {
   if (totalPages <= 1) return null;
 
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  const handlePrev = () => {
+    if (currentPage > 1) onPageChange(currentPage - 1);
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPages) onPageChange(currentPage + 1);
+  };
+
+  const buttonStyle = {
+    margin: '0 5px',
+    padding: '5px 10px',
+  };
 
   return (
-    <div style={{ margin: '20px 0', display: 'flex', justifyContent: 'center' }}>
-      {pages.map(page => (
-        <button
-          key={page}
-          style={{
-            margin: '0 5px',
-            padding: '5px 10px',
-            backgroundColor: page === currentPage ? '#ddd' : '#fff',
-          }}
-          onClick={() => onPageChange(page)}
-          disabled={page === currentPage}
-        >
-          {page}
-        </button>
-      ))}
+    <div
+      style={{
+        margin: '20px 0',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <button
+        onClick={handlePrev}
+        disabled={currentPage === 1}
+        style={buttonStyle}
+      >
+        <FaArrowLeft />
+      </button>
+      <span style={{ margin: '0 10px' }}>{`${currentPage} / ${totalPages}`}</span>
+      <button
+        onClick={handleNext}
+        disabled={currentPage === totalPages}
+        style={buttonStyle}
+      >
+        <FaArrowRight />
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- simplify pagination controls to left/right arrows with current page display

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684e99d37eec8326ba49b01d5cb62f49