### PR TITLE
Add Info button to show newUsers count

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -21,6 +21,7 @@ import {
   loadDuplicateUsers,
   removeCardAndSearchId,
   fetchAllUsersFromRTDB,
+  fetchTotalNewUsersCount,
   // removeSpecificSearchId,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -1098,6 +1099,11 @@ console.log('parseTelegramId!!!!!!!!!!!!!! :>> ', );
 
   };
 
+  const handleInfo = async () => {
+    const count = await fetchTotalNewUsersCount();
+    alert(`Total cards in newUsers: ${count}`);
+  };
+
   const makeIndex = async () => {
 
     // await new Promise(resolve => setTimeout(resolve, 15000)); // Чекаємо 15 секунд
@@ -1472,6 +1478,9 @@ console.log('parseTelegramId!!!!!!!!!!!!!! :>> ', );
                 >
                   ED
                 </Button>
+              )}
+              {hasMore && (
+                <Button onClick={handleInfo}>Info</Button>
               )}
               {hasMore && (
                 <Button

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2129,6 +2129,21 @@ export const fetchTotalFilteredUsersCount = async (filterForload, filterSettings
   return Object.keys(allUsers).length;
 };
 
+export const fetchTotalNewUsersCount = async () => {
+  try {
+    const snapshot = await get(ref2(database, 'newUsers'));
+    if (snapshot.exists()) {
+      const data = snapshot.val();
+      const userKeys = Object.keys(data).filter(key => key !== 'searchId');
+      return userKeys.length;
+    }
+    return 0;
+  } catch (error) {
+    console.error('Error fetching total newUsers count:', error);
+    return 0;
+  }
+};
+
 export const fetchAllUsersFromRTDB = async () => {
   try {
     // Отримуємо дані з двох колекцій


### PR DESCRIPTION
## Summary
- add fetchTotalNewUsersCount helper
- show count of `newUsers` via new Info button in AddNewProfile

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecdcbf0dc832689242647cb0e660b