### PR TITLE
Fix NewLoad result count

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1381,7 +1381,7 @@ export const fetchPaginatedNewUsers = async (lastKey, filterForload, filterSetti
 
     // 5. Фільтруємо користувачів, якщо передані активні фільтри
     const noExplicitFilters =
-      !filterForload &&
+      (!filterForload || filterForload === 'NewLoad') &&
       (!filterSettings ||
         Object.values(filterSettings).every(value => value === 'off'));
 


### PR DESCRIPTION
## Summary
- ensure `NewLoad` doesn't apply extra filters when fetching users

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684f052c1fc08326a273f3018b3657f3