### PR TITLE
Fix sorting and variable usage

### DIFF
--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -118,16 +118,16 @@ export const SearchFilters = ({ filters, onChange }) => {
           />
           no filter
         </label>
-        {['43', '38', '36', '32', '30', '25'].map(limit => (
-          <label key={limit} style={{ marginLeft: '10px', color: 'black' }}>
+        {['43', '38', '36', '32', '30', '25'].map(ageLimit => (
+          <label key={ageLimit} style={{ marginLeft: '10px', color: 'black' }}>
             <input
               type="radio"
               name="age"
-              value={limit}
-              checked={filters.age === limit}
-              onChange={() => handleChange('age', limit)}
+              value={ageLimit}
+              checked={filters.age === ageLimit}
+              onChange={() => handleChange('age', ageLimit)}
             />
-            {!isNaN(limit) ? `≤${limit}` : limit}
+            {!isNaN(ageLimit) ? `≤${ageLimit}` : ageLimit}
           </label>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- normalize date strings and refine group ordering
- keep special dates 2099-99-99 and 9999-99-99 last
- rename `limit` variable in SearchFilters to `ageLimit`

## Testing
- `npm ci --silent`
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcee756a083269b073a9b36760c22