### PR TITLE
Add comment length filter

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -391,6 +391,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     age: { le25: true, '26_29': true, '31_36': true, '37_42': true, other: true },
     userId: { vk: true, aa: true, ab: true, long: true, mid: true, other: true },
     fields: { lt4: true, lt8: true, lt12: true, other: true },
+    commentLength: { lt10: true, lt30: true, lt50: true, lt100: true, lt200: true, other: true },
   };
 
   const normalizeFilterGroup = (value, defaults) => {
@@ -410,6 +411,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         age: normalizeFilterGroup(parsed.age, defaultFilters.age),
         userId: normalizeFilterGroup(parsed.userId, defaultFilters.userId),
         fields: normalizeFilterGroup(parsed.fields, defaultFilters.fields),
+        commentLength: normalizeFilterGroup(parsed.commentLength, defaultFilters.commentLength),
       };
     } catch {
       return { ...defaultFilters };

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -76,6 +76,18 @@ export const SearchFilters = ({ filters, onChange }) => {
         { val: 'other', label: '?' },
       ],
     },
+    {
+      filterName: 'commentLength',
+      label: 'Comment words',
+      options: [
+        { val: 'lt10', label: '<10' },
+        { val: 'lt30', label: '<30' },
+        { val: 'lt50', label: '<50' },
+        { val: 'lt100', label: '<100' },
+        { val: 'lt200', label: '<200' },
+        { val: 'other', label: '?' },
+      ],
+    },
   ];
 
   return (

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -992,6 +992,17 @@ const getFieldCountCategory = value => {
   return 'other';
 };
 
+const getCommentLengthCategory = comment => {
+  if (!comment || typeof comment !== 'string') return 'other';
+  const wordCount = comment.trim().split(/\s+/).length;
+  if (wordCount < 10) return 'lt10';
+  if (wordCount < 30) return 'lt30';
+  if (wordCount < 50) return 'lt50';
+  if (wordCount < 100) return 'lt100';
+  if (wordCount < 200) return 'lt200';
+  return 'other';
+};
+
 
 // Фільтр за віком
 const filterByAge = (value, ageLimit = 30) => {
@@ -1061,6 +1072,11 @@ const filterMain = (usersData, filterForload, filterSettings = {}) => {
     if (filterSettings.fields && Object.values(filterSettings.fields).some(v => !v)) {
       const cat = getFieldCountCategory(value);
       filters.fields = !!filterSettings.fields[cat];
+    }
+
+    if (filterSettings.commentLength && Object.values(filterSettings.commentLength).some(v => !v)) {
+      const cat = getCommentLengthCategory(value.myComment);
+      filters.commentLength = !!filterSettings.commentLength[cat];
     }
 
     const failedFilters = Object.entries(filters).filter(([, result]) => !result);


### PR DESCRIPTION
## Summary
- add category for comment length to filter logic
- include commentLength filter when computing filtered data
- add comment length filter option to UI
- persist comment length filter in local storage

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6854102599648326b46a34e465870978