### PR TITLE
Fix comment length filter

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -391,7 +391,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     age: { le25: true, '26_29': true, '31_36': true, '37_42': true, other: true },
     userId: { vk: true, aa: true, ab: true, long: true, mid: true, other: true },
     fields: { lt4: true, lt8: true, lt12: true, other: true },
-    commentLength: { w0_9: true, w10_29: true, w30_49: true, w50_99: true, w100_199: true, other: true },
+    commentLength: {
+      w0_9: true,
+      w10_29: true,
+      w30_49: true,
+      w50_99: true,
+      w100_199: true,
+      w200_plus: true,
+      other: true,
+    },
   };
 
   const normalizeFilterGroup = (value, defaults) => {

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -85,7 +85,8 @@ export const SearchFilters = ({ filters, onChange }) => {
         { val: 'w30_49', label: '30-49' },
         { val: 'w50_99', label: '50-99' },
         { val: 'w100_199', label: '100-199' },
-        { val: 'other', label: '200+' },
+        { val: 'w200_plus', label: '200+' },
+        { val: 'other', label: 'Все інше' },
       ],
     },
   ];

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -993,7 +993,7 @@ const getCommentLengthCategory = comment => {
   if (wordCount < 50) return 'w30_49';
   if (wordCount < 100) return 'w50_99';
   if (wordCount < 200) return 'w100_199';
-  return 'other';
+  return 'w200_plus';
 };
 
 // Фільтр за віком


### PR DESCRIPTION
## Summary
- update comment filters with separate `200+` and `Все інше` options
- adjust defaults for new comment filter
- change `getCommentLengthCategory` to map >200 words to `w200_plus`

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68547292df788326bc6cc77c4acb5e32