### PR TITLE
Add favorites feature with filter

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -400,6 +400,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       w200_plus: true,
       other: true,
     },
+    favorite: { favOnly: false },
   };
 
   const normalizeFilterGroup = (value, defaults) => {
@@ -420,6 +421,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         userId: normalizeFilterGroup(parsed.userId, defaultFilters.userId),
         fields: normalizeFilterGroup(parsed.fields, defaultFilters.fields),
         commentLength: normalizeFilterGroup(parsed.commentLength, defaultFilters.commentLength),
+        favorite: normalizeFilterGroup(parsed.favorite, defaultFilters.favorite),
       };
     } catch {
       return { ...defaultFilters };

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -89,6 +89,13 @@ export const SearchFilters = ({ filters, onChange }) => {
         { val: 'other', label: 'Все інше' },
       ],
     },
+    {
+      filterName: 'favorite',
+      label: 'Favorite',
+      options: [
+        { val: 'favOnly', label: 'fav only' },
+      ],
+    },
   ];
 
   return (

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -996,6 +996,11 @@ const getCommentLengthCategory = comment => {
   return 'w200_plus';
 };
 
+const isFavoriteUser = userId => {
+  const stored = JSON.parse(localStorage.getItem('favoriteUsers') || '{}');
+  return !!stored[userId];
+};
+
 // Фільтр за віком
 const filterByAge = (value, ageLimit = 30) => {
   // Якщо дата народження відсутня або не є рядком, пропускаємо користувача
@@ -1068,6 +1073,10 @@ const filterMain = (usersData, filterForload, filterSettings = {}) => {
     if (filterSettings.commentLength && Object.values(filterSettings.commentLength).some(v => !v)) {
       const cat = getCommentLengthCategory(value.myComment);
       filters.commentLength = !!filterSettings.commentLength[cat];
+    }
+
+    if (filterSettings.favorite && filterSettings.favorite.favOnly) {
+      filters.favorite = isFavoriteUser(userId);
     }
 
     const failedFilters = Object.entries(filters).filter(([, result]) => !result);

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+
+export const BtnFavorite = ({ userId }) => {
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem('favoriteUsers') || '{}');
+    setIsFavorite(!!stored[userId]);
+  }, [userId]);
+
+  const toggleFavorite = () => {
+    const stored = JSON.parse(localStorage.getItem('favoriteUsers') || '{}');
+    if (stored[userId]) {
+      delete stored[userId];
+      setIsFavorite(false);
+    } else {
+      stored[userId] = true;
+      setIsFavorite(true);
+    }
+    localStorage.setItem('favoriteUsers', JSON.stringify(stored));
+  };
+
+  return (
+    <button
+      style={{
+        position: 'absolute',
+        top: '10px',
+        right: '50px',
+        width: '35px',
+        height: '35px',
+        borderRadius: '50%',
+        background: 'white',
+        border: `2px solid ${isFavorite ? 'red' : 'gray'}`,
+        color: isFavorite ? 'red' : 'gray',
+        cursor: 'pointer',
+      }}
+      onClick={e => {
+        e.stopPropagation();
+        toggleFavorite();
+      }}
+    >
+      {isFavorite ? '❤' : '♡'}
+    </button>
+  );
+};

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
+import { BtnFavorite } from './btnFavorite';
 import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
@@ -20,6 +21,7 @@ export const renderTopBlock = (userData, setUsers, setShowInfoModal, setState, i
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
       {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
+      <BtnFavorite userId={userData.userId} />
       {btnExport(userData)}
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}


### PR DESCRIPTION
## Summary
- add `BtnFavorite` for marking favorites
- integrate favorite button into top block
- extend search filters with "favorite" checkbox
- persist favorite filter state in AddNewProfile
- update filtering logic to handle favorites

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855c27d783483268eabdb2d1c8aa086