### PR TITLE
Implement Firebase favorites

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -55,10 +55,25 @@ const renderFields = (data, parentKey = '') => {
 };
 
 // Компонент для рендерингу картки користувача
-const UserCard = ({ userData, setUsers, setShowInfoModal, setState }) => {
+const UserCard = ({
+  userData,
+  setUsers,
+  setShowInfoModal,
+  setState,
+  favoriteUsers,
+  setFavoriteUsers,
+}) => {
   return (
     <div>
-      {renderTopBlock(userData, setUsers, setShowInfoModal, setState, 'isFromListOfUsers')}
+      {renderTopBlock(
+        userData,
+        setUsers,
+        setShowInfoModal,
+        setState,
+        'isFromListOfUsers',
+        favoriteUsers,
+        setFavoriteUsers,
+      )}
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}
       </div>
@@ -67,10 +82,19 @@ const UserCard = ({ userData, setUsers, setShowInfoModal, setState }) => {
 };
 
 // Компонент для рендерингу списку користувачів
-const UsersList = ({ users, setUsers, setSearch, setState, setShowInfoModal, setCompare, sortFavorites }) => {
+const UsersList = ({
+  users,
+  setUsers,
+  setSearch,
+  setState,
+  setShowInfoModal,
+  setCompare,
+  sortFavorites,
+  favoriteUsers = {},
+  setFavoriteUsers,
+}) => {
   const isFavoriteUser = userId => {
-    const stored = JSON.parse(localStorage.getItem('favoriteUsers') || '{}');
-    return !!stored[userId];
+    return !!favoriteUsers[userId];
   };
 
   const entries = Object.entries(users);
@@ -95,6 +119,8 @@ const UsersList = ({ users, setUsers, setSearch, setState, setShowInfoModal, set
             userData={userData}
             setUsers={setUsers}
             setState={setState}
+            favoriteUsers={favoriteUsers}
+            setFavoriteUsers={setFavoriteUsers}
           />
         </div>
       ))}

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -1,23 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import { addFavoriteUser, removeFavoriteUser } from '../config';
 
-export const BtnFavorite = ({ userId }) => {
-  const [isFavorite, setIsFavorite] = useState(false);
+export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) => {
+  const isFavorite = !!favoriteUsers[userId];
 
-  useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem('favoriteUsers') || '{}');
-    setIsFavorite(!!stored[userId]);
-  }, [userId]);
-
-  const toggleFavorite = () => {
-    const stored = JSON.parse(localStorage.getItem('favoriteUsers') || '{}');
-    if (stored[userId]) {
-      delete stored[userId];
-      setIsFavorite(false);
+  const toggleFavorite = async () => {
+    if (isFavorite) {
+      await removeFavoriteUser(userId);
+      const updated = { ...favoriteUsers };
+      delete updated[userId];
+      setFavoriteUsers(updated);
     } else {
-      stored[userId] = true;
-      setIsFavorite(true);
+      await addFavoriteUser(userId);
+      setFavoriteUsers({ ...favoriteUsers, [userId]: true });
     }
-    localStorage.setItem('favoriteUsers', JSON.stringify(stored));
   };
 
   return (

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -15,13 +15,25 @@ import { fieldMaritalStatus } from './fieldMaritalStatus';
 import { utilCalculateIMT } from './utilCalculateIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 
-export const renderTopBlock = (userData, setUsers, setShowInfoModal, setState, isFromListOfUsers) => {
+export const renderTopBlock = (
+  userData,
+  setUsers,
+  setShowInfoModal,
+  setState,
+  isFromListOfUsers,
+  favoriteUsers = {},
+  setFavoriteUsers,
+) => {
   if (!userData) return null;
 
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
       {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
-      <BtnFavorite userId={userData.userId} />
+      <BtnFavorite
+        userId={userData.userId}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+      />
       {btnExport(userData)}
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}


### PR DESCRIPTION
## Summary
- add Firestore helpers for saving favorite users
- update favorite button to sync with backend
- fetch favorites when loading/sorting users
- filter and sort users using backend favorites
- allow loading favorites via new button
- add helper to fetch full favorite user data
- document multi-user favorite helpers
- **store only the userId in favorites**
- move favorites path under `multiData` directory

## Testing
- `npm test --silent --yes` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6856744996208326a6881d4251a5e8d1