### PR TITLE
Fix favorites subscription

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -714,17 +714,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [favoriteSort, setFavoriteSort] = useState(false);
   const [favoriteUsersData, setFavoriteUsersData] = useState({});
 
-  useEffect(() => {
-    const owner = auth.currentUser?.uid;
-    if (!owner) return;
+  const ownerId = auth.currentUser?.uid;
 
-    const favRef = ref(database, `multiData/favorites/${owner}`);
+  useEffect(() => {
+    if (!ownerId) return;
+
+    const favRef = ref(database, `multiData/favorites/${ownerId}`);
     const unsubscribe = onValue(favRef, snap => {
       setFavoriteUsersData(snap.exists() ? snap.val() : {});
     });
 
     return () => unsubscribe();
-  }, [isEmailVerified]);
+  }, [ownerId]);
 
   useEffect(() => {
     localStorage.setItem('userFilters', JSON.stringify(filters));


### PR DESCRIPTION
## Summary
- fix subscription to favorites list in AddNewProfile so it updates whenever the authenticated user changes

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae6400448326bbf9acbbcb777c86