### PR TITLE
Move searchId reference to root

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -774,7 +774,7 @@ export const updateSearchId = async (searchKey, searchValue, userId, action) => 
 //   }
 
 //   const searchIdKey = `${searchKey}_${encodeKey(searchValue)}`;
-//   const searchIdRef = ref2(database, `newUsers/searchId/${searchIdKey}`);
+//   const searchIdRef = ref2(database, `searchId/${searchIdKey}`);
 //   console.log('searchIdKey in updateSearchId :>> ', searchIdKey);
 
 //   try {
@@ -1479,7 +1479,7 @@ export const removeKeyFromFirebase = async (field, value, userId) => {
 
 //   try {
 //     // Запит для отримання всіх записів з searchId
-//     const searchIdSnapshot = await get(ref2(database, 'newUsers/searchId'));
+//     const searchIdSnapshot = await get(ref2(database, 'searchId'));
 
 //     if (searchIdSnapshot.exists()) {
 //       const searchIdData = searchIdSnapshot.val();


### PR DESCRIPTION
## Summary
- reference `searchId` at root rather than under `newUsers`
- update logic that filtered out the old `searchId` key

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6856e47c09248326ab5be88eb72b9d44