### PR TITLE
Implement Load2 with server-side paging

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -24,6 +24,7 @@ import {
   removeCardAndSearchId,
   fetchAllUsersFromRTDB,
   fetchTotalNewUsersCount,
+  fetchFilteredUsersByPage,
   // removeSpecificSearchId,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -708,6 +709,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [currentFilter, setCurrentFilter] = useState(null);
   const [dateOffset, setDateOffset] = useState(0);
+  const [dateOffset2, setDateOffset2] = useState(0);
   const [favoriteUsersData, setFavoriteUsersData] = useState({});
 
   const ownerId = auth.currentUser?.uid;
@@ -1129,13 +1131,29 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
+  const loadMoreUsers2 = async () => {
+    const res = await fetchFilteredUsersByPage(dateOffset2);
+    if (res && Object.keys(res.users).length > 0) {
+      setUsers(prev => ({ ...prev, ...res.users }));
+      setDateOffset2(res.lastKey);
+      setHasMore(res.hasMore);
+      const count = Object.keys(res.users).length;
+      return { count, hasMore: res.hasMore };
+    }
+    setHasMore(false);
+    return { count: 0, hasMore: false };
+  };
+
   const handlePageChange = async page => {
     const needed = page * PAGE_SIZE;
     let loaded = Object.keys(users).length;
     let more = hasMore;
 
     while (more && loaded < needed) {
-      const { count, hasMore: nextMore } = await loadMoreUsers(currentFilter);
+      const { count, hasMore: nextMore } =
+        currentFilter === 'DATE2'
+          ? await loadMoreUsers2()
+          : await loadMoreUsers(currentFilter);
       loaded += count;
       more = nextMore;
     }
@@ -1590,6 +1608,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 }}
               >
                 Load
+              </Button>
+              <Button
+                onClick={() => {
+                  setUsers({});
+                  setHasMore(true);
+                  setCurrentPage(1);
+                  setCurrentFilter('DATE2');
+                  setDateOffset2(0);
+                  loadMoreUsers2();
+                }}
+              >
+                Load2
               </Button>
               <Button onClick={loadFavoriteUsers}>❤</Button>
               <Button onClick={makeIndex}>Index</Button>

--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -1,0 +1,20 @@
+import { TextDecoder, TextEncoder } from 'util';
+global.TextDecoder = TextDecoder;
+global.TextEncoder = TextEncoder;
+const { fetchFilteredUsersByPage } = require('../dateLoad');
+const { PAGE_SIZE } = require('../constants');
+
+test('fetchFilteredUsersByPage limits results to PAGE_SIZE', async () => {
+  const sampleData = {
+    '2024-01-05': Array.from({ length: 15 }, (_, i) => [`id${i}`, { getInTouch: '2024-01-05' }]),
+    '2024-01-04': Array.from({ length: 15 }, (_, i) => [`idB${i}`, { getInTouch: '2024-01-04' }]),
+  };
+
+  const fetchStub = async (dateStr, limit) => {
+    return (sampleData[dateStr] || []).slice(0, limit);
+  };
+  const fetchUserStub = async id => ({ userId: id });
+
+  const res = await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
+  expect(Object.keys(res.users).length).toBeLessThanOrEqual(PAGE_SIZE);
+});

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -19,6 +19,7 @@ import {
   endAt,
   equalTo,
 } from 'firebase/database';
+import { PAGE_SIZE } from './constants';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_API_KEY,
@@ -39,7 +40,7 @@ export const db = getFirestore(app);
 export const storage = getStorage(app);
 export const database = getDatabase(app);
 
-export const PAGE_SIZE = 20;
+export { PAGE_SIZE } from './constants';
 
 const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'other', 'vk', 'name', 'surname', 'lastAction', 'getInTouch'];
 
@@ -2090,3 +2091,5 @@ export async function fetchSortedUsersByDate(limit = PAGE_SIZE, offset = 0) {
   const sliced = result.slice(offset, offset + limit);
   return { data: Object.fromEntries(sliced), totalCount: result.length };
 }
+
+export { fetchFilteredUsersByPage } from './dateLoad';

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 20;

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -1,0 +1,48 @@
+import { getDatabase, ref as ref2, query, orderByChild, equalTo, limitToFirst, get } from 'firebase/database';
+import { PAGE_SIZE } from './constants';
+
+export async function defaultFetchByDate(dateStr, limit) {
+  const db = getDatabase();
+  const q = query(ref2(db, 'newUsers'), orderByChild('getInTouch'), equalTo(dateStr), limitToFirst(limit));
+  const snap = await get(q);
+  return snap.exists() ? Object.entries(snap.val()) : [];
+}
+
+export async function fetchFilteredUsersByPage(
+  startOffset = 0,
+  fetchDateFn = defaultFetchByDate,
+  fetchUserByIdFn
+) {
+  const result = [];
+  let offset = startOffset;
+  let currentDate = new Date();
+  currentDate.setDate(currentDate.getDate() - offset);
+
+  while (result.length < PAGE_SIZE) {
+    const dateStr = currentDate.toISOString().split('T')[0];
+    // eslint-disable-next-line no-await-in-loop
+    const entries = await fetchDateFn(dateStr, PAGE_SIZE - result.length);
+    if (entries.length) {
+      result.push(...entries);
+    }
+    offset += 1;
+    currentDate.setDate(currentDate.getDate() - 1);
+    if (offset > 365) break;
+  }
+
+  if (!fetchUserByIdFn) {
+    const { fetchUserById } = await import('./config');
+    fetchUserByIdFn = fetchUserById;
+  }
+
+  const userIds = result.map(([id]) => id);
+  const userResults = await Promise.all(userIds.map(id => fetchUserByIdFn(id)));
+
+  const users = {};
+  userResults.forEach((data, idx) => {
+    const id = userIds[idx];
+    if (data) users[id] = { ...result[idx][1], ...data };
+  });
+
+  return { users, lastKey: offset, hasMore: result.length === PAGE_SIZE };
+}


### PR DESCRIPTION
## Summary
- add `dateOffset2` state for new loading mode
- implement `loadMoreUsers2` and integrate with pagination
- add new *Load2* button in the UI
- create `dateLoad.js` providing `fetchFilteredUsersByPage`
- expose a `PAGE_SIZE` constant and reexport it
- test that `fetchFilteredUsersByPage` respects `PAGE_SIZE`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6857157f34dc83268b2d4186e26dac09