### PR TITLE
Fix date loader to alternate around today

### DIFF
--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -18,3 +18,27 @@ test('fetchFilteredUsersByPage limits results to PAGE_SIZE', async () => {
   const res = await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
   expect(Object.keys(res.users).length).toBeLessThanOrEqual(PAGE_SIZE);
 });
+
+test('fetchFilteredUsersByPage queries dates around today', async () => {
+  const calls = [];
+  const fetchStub = async (dateStr, limit) => {
+    calls.push(dateStr);
+    return [];
+  };
+  const fetchUserStub = async () => null;
+
+  await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
+
+  const today = new Date();
+  const todayStr = today.toISOString().split('T')[0];
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = yesterday.toISOString().split('T')[0];
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = tomorrow.toISOString().split('T')[0];
+
+  expect(calls[0]).toBe(todayStr);
+  expect(calls[1]).toBe(yesterdayStr);
+  expect(calls[2]).toBe(tomorrowStr);
+});

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -8,6 +8,12 @@ export async function defaultFetchByDate(dateStr, limit) {
   return snap.exists() ? Object.entries(snap.val()) : [];
 }
 
+function offsetToDiff(offset) {
+  if (offset === 0) return 0;
+  const step = Math.ceil(offset / 2);
+  return offset % 2 ? -step : step;
+}
+
 export async function fetchFilteredUsersByPage(
   startOffset = 0,
   fetchDateFn = defaultFetchByDate,
@@ -15,10 +21,11 @@ export async function fetchFilteredUsersByPage(
 ) {
   const result = [];
   let offset = startOffset;
-  let currentDate = new Date();
-  currentDate.setDate(currentDate.getDate() - offset);
 
   while (result.length < PAGE_SIZE) {
+    const diff = offsetToDiff(offset);
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() + diff);
     const dateStr = currentDate.toISOString().split('T')[0];
     // eslint-disable-next-line no-await-in-loop
     const entries = await fetchDateFn(dateStr, PAGE_SIZE - result.length);
@@ -26,8 +33,7 @@ export async function fetchFilteredUsersByPage(
       result.push(...entries);
     }
     offset += 1;
-    currentDate.setDate(currentDate.getDate() - 1);
-    if (offset > 365) break;
+    if (offset > 730) break;
   }
 
   if (!fetchUserByIdFn) {


### PR DESCRIPTION
## Summary
- update `fetchFilteredUsersByPage` to search today, previous and next dates using `equalTo`
- extend unit tests for new search order

## Testing
- `npm run lint:js` *(fails: ESLint configuration missing)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a72abd308326b3a4457c497d30e2