### PR TITLE
Fix date load ordering

### DIFF
--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -34,11 +34,11 @@ test('fetchFilteredUsersByPage queries dates around today', async () => {
   const yesterday = new Date(today);
   yesterday.setDate(yesterday.getDate() - 1);
   const yesterdayStr = yesterday.toISOString().split('T')[0];
-  const tomorrow = new Date(today);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const tomorrowStr = tomorrow.toISOString().split('T')[0];
+  const twoDaysAgo = new Date(today);
+  twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+  const twoDaysAgoStr = twoDaysAgo.toISOString().split('T')[0];
 
   expect(calls[0]).toBe(todayStr);
   expect(calls[1]).toBe(yesterdayStr);
-  expect(calls[2]).toBe(tomorrowStr);
+  expect(calls[2]).toBe(twoDaysAgoStr);
 });

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -9,9 +9,7 @@ export async function defaultFetchByDate(dateStr, limit) {
 }
 
 function offsetToDiff(offset) {
-  if (offset === 0) return 0;
-  const step = Math.ceil(offset / 2);
-  return offset % 2 ? -step : step;
+  return -offset;
 }
 
 export async function fetchFilteredUsersByPage(


### PR DESCRIPTION
## Summary
- adjust `offsetToDiff` to only fetch from past dates
- update test to expect sequential past dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857b4ac4c608326976f8fc79038f000