### PR TITLE
Fix Load2 to fetch recent cards only

### DIFF
--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -42,3 +42,16 @@ test('fetchFilteredUsersByPage queries dates around today', async () => {
   expect(calls[1]).toBe(yesterdayStr);
   expect(calls[2]).toBe(twoDaysAgoStr);
 });
+
+test('fetchFilteredUsersByPage stops after checking three days', async () => {
+  const calls = [];
+  const fetchStub = async (dateStr, limit) => {
+    calls.push(dateStr);
+    return [];
+  };
+  const fetchUserStub = async () => null;
+
+  await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
+
+  expect(calls.length).toBe(3);
+});

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -19,8 +19,10 @@ export async function fetchFilteredUsersByPage(
 ) {
   const result = [];
   let offset = startOffset;
+  let daysChecked = 0;
+  const MAX_DAYS = 3;
 
-  while (result.length < PAGE_SIZE) {
+  while (result.length < PAGE_SIZE && daysChecked < MAX_DAYS) {
     const diff = offsetToDiff(offset);
     const currentDate = new Date();
     currentDate.setDate(currentDate.getDate() + diff);
@@ -31,7 +33,7 @@ export async function fetchFilteredUsersByPage(
       result.push(...entries);
     }
     offset += 1;
-    if (offset > 730) break;
+    daysChecked += 1;
   }
 
   if (!fetchUserByIdFn) {


### PR DESCRIPTION
## Summary
- limit `fetchFilteredUsersByPage` to check only three days
- add unit test verifying the limit

## Testing
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6857be1268e08326bf283855768d0b68