### PR TITLE
Simplify today's date fetching

### DIFF
--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -1,27 +1,27 @@
 import { TextDecoder, TextEncoder } from 'util';
+
 global.TextDecoder = TextDecoder;
 global.TextEncoder = TextEncoder;
+
 const { fetchFilteredUsersByPage } = require('../dateLoad');
 const { PAGE_SIZE } = require('../constants');
 
 test('fetchFilteredUsersByPage limits results to PAGE_SIZE', async () => {
-  const sampleData = {
-    '2024-01-05': Array.from({ length: 15 }, (_, i) => [`id${i}`, { getInTouch: '2024-01-05' }]),
-    '2024-01-04': Array.from({ length: 15 }, (_, i) => [`idB${i}`, { getInTouch: '2024-01-04' }]),
-  };
+  const today = new Date().toISOString().split('T')[0];
+  const sampleData = Array.from({ length: 25 }, (_, i) => [`id${i}`, { getInTouch: today }]);
 
-  const fetchStub = async (dateStr, limit) => {
-    return (sampleData[dateStr] || []).slice(0, limit);
-  };
+  const fetchStub = async (dateStr, limit) => sampleData.slice(0, limit);
   const fetchUserStub = async id => ({ userId: id });
 
   const res = await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
-  expect(Object.keys(res.users).length).toBeLessThanOrEqual(PAGE_SIZE);
+  expect(Object.keys(res.users).length).toBe(PAGE_SIZE);
+  expect(res.hasMore).toBe(true);
+  expect(res.lastKey).toBe(PAGE_SIZE);
 });
 
-test('fetchFilteredUsersByPage queries dates around today', async () => {
+test('fetchFilteredUsersByPage queries current date only once', async () => {
   const calls = [];
-  const fetchStub = async (dateStr, limit) => {
+  const fetchStub = async dateStr => {
     calls.push(dateStr);
     return [];
   };
@@ -29,29 +29,21 @@ test('fetchFilteredUsersByPage queries dates around today', async () => {
 
   await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
 
-  const today = new Date();
-  const todayStr = today.toISOString().split('T')[0];
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = yesterday.toISOString().split('T')[0];
-  const twoDaysAgo = new Date(today);
-  twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-  const twoDaysAgoStr = twoDaysAgo.toISOString().split('T')[0];
-
-  expect(calls[0]).toBe(todayStr);
-  expect(calls[1]).toBe(yesterdayStr);
-  expect(calls[2]).toBe(twoDaysAgoStr);
+  const todayStr = new Date().toISOString().split('T')[0];
+  expect(calls).toEqual([todayStr]);
 });
 
-test('fetchFilteredUsersByPage stops after checking three days', async () => {
-  const calls = [];
-  const fetchStub = async (dateStr, limit) => {
-    calls.push(dateStr);
-    return [];
-  };
-  const fetchUserStub = async () => null;
+test('fetchFilteredUsersByPage paginates with startOffset', async () => {
+  const today = new Date().toISOString().split('T')[0];
+  const sampleData = Array.from({ length: 25 }, (_, i) => [`id${i}`, { getInTouch: today }]);
 
-  await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
+  const fetchStub = async (dateStr, limit) => sampleData.slice(0, limit);
+  const fetchUserStub = async id => ({ userId: id });
 
-  expect(calls.length).toBe(3);
+  const first = await fetchFilteredUsersByPage(0, fetchStub, fetchUserStub);
+  const second = await fetchFilteredUsersByPage(first.lastKey, fetchStub, fetchUserStub);
+
+  expect(Object.keys(second.users).length).toBe(sampleData.length - PAGE_SIZE);
+  expect(second.hasMore).toBe(false);
+  expect(second.lastKey).toBe(sampleData.length);
 });


### PR DESCRIPTION
## Summary
- simplify `fetchFilteredUsersByPage` to only pull users with today's `getInTouch`
- update tests for new logic

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6857c3ec0ce483268bc244136968875a