### PR TITLE
Fix DATE2 loader to apply correct query

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -736,7 +736,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setTotalCount(0);
     setCurrentPage(1);
     if (currentFilter) {
-      loadMoreUsers(currentFilter);
+      if (currentFilter === 'DATE2') {
+        loadMoreUsers2();
+      } else {
+        loadMoreUsers(currentFilter);
+      }
     }
     // loadMoreUsers depends on many state values, so we skip it from the deps
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- ensure DATE2 filter triggers `loadMoreUsers2` instead of generic loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ca5055e883268720b21215bcf1ce