### PR TITLE
Fix Load2 filtering

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1135,8 +1135,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
-  const loadMoreUsers2 = async () => {
-    const res = await fetchFilteredUsersByPage(dateOffset2);
+  const loadMoreUsers2 = async (currentFilters = filters) => {
+    let fav = favoriteUsersData;
+    if (currentFilters.favorite?.favOnly && Object.keys(fav).length === 0) {
+      fav = await fetchFavoriteUsers(auth.currentUser.uid);
+      setFavoriteUsersData(fav);
+    }
+
+    const res = await fetchFilteredUsersByPage(
+      dateOffset2,
+      undefined,
+      undefined,
+      currentFilters,
+      fav
+    );
     if (res && Object.keys(res.users).length > 0) {
       setUsers(prev => ({ ...prev, ...res.users }));
       setDateOffset2(res.lastKey);

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1069,7 +1069,12 @@ const filterByAge = (value, ageLimit = 30) => {
 };
 
 // Основна функція фільтрації
-const filterMain = (usersData, filterForload, filterSettings = {}, favoriteUsers = {}) => {
+export const filterMain = (
+  usersData,
+  filterForload,
+  filterSettings = {},
+  favoriteUsers = {}
+) => {
   console.log('filterMain called with', {
     filterForload,
     filterSettings,


### PR DESCRIPTION
## Summary
- export `filterMain` utility
- filter data in `fetchFilteredUsersByPage`
- use checkbox filters in `loadMoreUsers2`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1f833648326882fbdf7ad0d704f