### PR TITLE
Fix dateLoad filtering loop

### DIFF
--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -8,6 +8,12 @@ jest.mock('../config', () => ({
   filterMain: jest.fn((users) => users),
 }));
 
+jest.mock('../constants', () => ({
+  PAGE_SIZE: 20,
+  INVALID_DATE_TOKENS: ['', '2099-99-99', '9999-99-99'],
+  MAX_LOOKBACK_DAYS: 2,
+}));
+
 const { fetchFilteredUsersByPage } = require('../dateLoad');
 const { PAGE_SIZE, INVALID_DATE_TOKENS } = require('../constants');
 
@@ -109,4 +115,50 @@ test('fetchFilteredUsersByPage paginates with startOffset', async () => {
   expect(Object.keys(second.users).length).toBe(sampleData.length - PAGE_SIZE);
   expect(second.hasMore).toBe(false);
   expect(second.lastKey).toBe(sampleData.length);
+});
+
+test('fetchFilteredUsersByPage continues fetching when filters remove records', async () => {
+  const calls = [];
+  const today = new Date();
+  const todayStr = today.toISOString().split('T')[0];
+  const yesterdayStr = new Date(today.getTime() - 86400000)
+    .toISOString()
+    .split('T')[0];
+
+  const dataMap = {
+    [todayStr]: Array.from({ length: PAGE_SIZE }, (_, i) => [
+      `skip${i}`,
+      { getInTouch: todayStr },
+    ]),
+    [yesterdayStr]: Array.from({ length: PAGE_SIZE }, (_, i) => [
+      `id${i}`,
+      { getInTouch: yesterdayStr },
+    ]),
+  };
+
+  const fetchStub = jest.fn(async (dateStr, limit) => {
+    calls.push(dateStr);
+    const arr = dataMap[dateStr] || [];
+    return arr.slice(0, limit);
+  });
+  const fetchUserStub = async id => ({ userId: id });
+
+  const { filterMain } = require('../config');
+  filterMain.mockImplementation(users =>
+    users.filter(([id]) => !id.startsWith('skip')),
+  );
+
+  const res = await fetchFilteredUsersByPage(
+    0,
+    fetchStub,
+    fetchUserStub,
+    {},
+    {},
+    filterMain,
+  );
+
+  expect(fetchStub.mock.calls[0][0]).toBe(todayStr);
+  expect(fetchStub.mock.calls.some(call => call[0] === yesterdayStr)).toBe(true);
+  expect(Object.keys(res.users).length).toBe(PAGE_SIZE);
+  expect(res.hasMore).toBe(false);
 });

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -18,35 +18,6 @@ export async function fetchFilteredUsersByPage(
 ) {
   const today = new Date();
   const limit = startOffset + PAGE_SIZE + 1;
-  const entries = [];
-
-  let dayOffset = 0;
-  let invalidIndex = 0;
-
-  while (entries.length < limit && dayOffset < MAX_LOOKBACK_DAYS) {
-    const date = new Date(today);
-    date.setDate(today.getDate() - dayOffset);
-    const dateStr = date.toISOString().split('T')[0];
-    // eslint-disable-next-line no-await-in-loop
-    const chunk = await fetchDateFn(dateStr, limit - entries.length);
-    if (chunk.length === 0) {
-      while (
-        entries.length < limit &&
-        invalidIndex < INVALID_DATE_TOKENS.length
-      ) {
-        // eslint-disable-next-line no-await-in-loop
-        const extra = await fetchDateFn(
-          INVALID_DATE_TOKENS[invalidIndex],
-          limit - entries.length
-        );
-        invalidIndex += 1;
-        entries.push(...extra);
-      }
-    } else {
-      entries.push(...chunk);
-    }
-    dayOffset += 1;
-  }
 
   let filterMainFn = filterMainFnParam;
   if (!fetchUserByIdFn || !filterMainFn) {
@@ -56,14 +27,54 @@ export async function fetchFilteredUsersByPage(
   }
 
   const combined = [];
-  for (let i = 0; i < entries.length; i += 1) {
-    const [id, data] = entries[i];
+  let filtered = [];
+
+  let dayOffset = 0;
+  let invalidIndex = 0;
+
+  while (filtered.length < limit && dayOffset < MAX_LOOKBACK_DAYS) {
+    const fetchLimit = limit - filtered.length;
+    const date = new Date(today);
+    date.setDate(today.getDate() - dayOffset);
+    const dateStr = date.toISOString().split('T')[0];
     // eslint-disable-next-line no-await-in-loop
-    const extra = await fetchUserByIdFn(id);
-    combined.push([id, extra ? { ...data, ...extra } : data]);
+    const chunk = await fetchDateFn(dateStr, fetchLimit);
+    if (chunk.length === 0) {
+      while (
+        filtered.length < limit &&
+        invalidIndex < INVALID_DATE_TOKENS.length
+      ) {
+        // eslint-disable-next-line no-await-in-loop
+        const extra = await fetchDateFn(
+          INVALID_DATE_TOKENS[invalidIndex],
+          limit - filtered.length
+        );
+        invalidIndex += 1;
+        for (let i = 0; i < extra.length; i += 1) {
+          const [eid, edata] = extra[i];
+          // eslint-disable-next-line no-await-in-loop
+          const extraUser = await fetchUserByIdFn(eid);
+          combined.push([eid, extraUser ? { ...edata, ...extraUser } : edata]);
+        }
+        filtered = filterMainFn(
+          combined,
+          'DATE2',
+          filterSettings,
+          favoriteUsers
+        );
+      }
+    } else {
+      for (let i = 0; i < chunk.length; i += 1) {
+        const [id, data] = chunk[i];
+        // eslint-disable-next-line no-await-in-loop
+        const extra = await fetchUserByIdFn(id);
+        combined.push([id, extra ? { ...data, ...extra } : data]);
+      }
+      filtered = filterMainFn(combined, 'DATE2', filterSettings, favoriteUsers);
+    }
+    dayOffset += 1;
   }
 
-  const filtered = filterMainFn(combined, 'DATE2', filterSettings, favoriteUsers);
   const slice = filtered.slice(startOffset, startOffset + PAGE_SIZE);
 
   const users = {};


### PR DESCRIPTION
## Summary
- accumulate and filter results while loading in `fetchFilteredUsersByPage`
- stop fetching based on filtered result count
- update `hasMore` calculation
- add regression test covering filtered pagination logic

## Testing
- `npm test src/components/__tests__/fetchFilteredUsersByPage.test.js --runInBand`
- `npm test --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6857f16e5228832693bdf9cc000d6133