### PR TITLE
Remove redundant load triggers

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1620,7 +1620,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setCurrentPage(1);
                   setCurrentFilter('DATE');
                   setDateOffset(0);
-                  loadMoreUsers('DATE');
                 }}
               >
                 Load
@@ -1632,7 +1631,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setCurrentPage(1);
                   setCurrentFilter('DATE2');
                   setDateOffset2(0);
-                  loadMoreUsers2();
                 }}
               >
                 Load2


### PR DESCRIPTION
## Summary
- call `loadMoreUsers2` from effect only, not directly in **Load2** button
- do the same for **Load** button for consistent behavior

## Testing
- `npm ci`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857fbd3c2b88326bfdd77bbf7fcebf8