### PR TITLE
Improve pagination lookback

### DIFF
--- a/src/components/__tests__/fetchFilteredUsersByPage.test.js
+++ b/src/components/__tests__/fetchFilteredUsersByPage.test.js
@@ -110,3 +110,49 @@ test('fetchFilteredUsersByPage paginates with startOffset', async () => {
   expect(second.hasMore).toBe(false);
   expect(second.lastKey).toBe(sampleData.length);
 });
+
+test('fetchFilteredUsersByPage continues fetching when filters remove records', async () => {
+  const calls = [];
+  const today = new Date();
+  const todayStr = today.toISOString().split('T')[0];
+  const yesterdayStr = new Date(today.getTime() - 86400000)
+    .toISOString()
+    .split('T')[0];
+
+  const dataMap = {
+    [todayStr]: Array.from({ length: PAGE_SIZE }, (_, i) => [
+      `skip${i}`,
+      { getInTouch: todayStr },
+    ]),
+    [yesterdayStr]: Array.from({ length: PAGE_SIZE }, (_, i) => [
+      `id${i}`,
+      { getInTouch: yesterdayStr },
+    ]),
+  };
+
+  const fetchStub = jest.fn(async (dateStr, limit) => {
+    calls.push(dateStr);
+    const arr = dataMap[dateStr] || [];
+    return arr.slice(0, limit);
+  });
+  const fetchUserStub = async id => ({ userId: id });
+
+  const { filterMain } = require('../config');
+  filterMain.mockImplementation(users =>
+    users.filter(([id]) => !id.startsWith('skip')),
+  );
+
+  const res = await fetchFilteredUsersByPage(
+    0,
+    fetchStub,
+    fetchUserStub,
+    {},
+    {},
+    filterMain,
+  );
+
+  expect(fetchStub.mock.calls[0][0]).toBe(todayStr);
+  expect(fetchStub.mock.calls.some(call => call[0] === yesterdayStr)).toBe(true);
+  expect(Object.keys(res.users).length).toBe(PAGE_SIZE);
+  expect(res.hasMore).toBe(false);
+});

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -17,36 +17,8 @@ export async function fetchFilteredUsersByPage(
   filterMainFnParam
 ) {
   const today = new Date();
-  const limit = startOffset + PAGE_SIZE + 1;
-  const entries = [];
-
-  let dayOffset = 0;
-  let invalidIndex = 0;
-
-  while (entries.length < limit && dayOffset < MAX_LOOKBACK_DAYS) {
-    const date = new Date(today);
-    date.setDate(today.getDate() - dayOffset);
-    const dateStr = date.toISOString().split('T')[0];
-    // eslint-disable-next-line no-await-in-loop
-    const chunk = await fetchDateFn(dateStr, limit - entries.length);
-    if (chunk.length === 0) {
-      while (
-        entries.length < limit &&
-        invalidIndex < INVALID_DATE_TOKENS.length
-      ) {
-        // eslint-disable-next-line no-await-in-loop
-        const extra = await fetchDateFn(
-          INVALID_DATE_TOKENS[invalidIndex],
-          limit - entries.length
-        );
-        invalidIndex += 1;
-        entries.push(...extra);
-      }
-    } else {
-      entries.push(...chunk);
-    }
-    dayOffset += 1;
-  }
+  const target = startOffset + PAGE_SIZE;
+  const limit = target + 1;
 
   let filterMainFn = filterMainFnParam;
   if (!fetchUserByIdFn || !filterMainFn) {
@@ -56,14 +28,54 @@ export async function fetchFilteredUsersByPage(
   }
 
   const combined = [];
-  for (let i = 0; i < entries.length; i += 1) {
-    const [id, data] = entries[i];
+  let filtered = [];
+
+  let dayOffset = 0;
+  let invalidIndex = 0;
+
+  while (filtered.length < target && dayOffset < MAX_LOOKBACK_DAYS) {
+    const fetchLimit = limit - filtered.length;
+    const date = new Date(today);
+    date.setDate(today.getDate() - dayOffset);
+    const dateStr = date.toISOString().split('T')[0];
     // eslint-disable-next-line no-await-in-loop
-    const extra = await fetchUserByIdFn(id);
-    combined.push([id, extra ? { ...data, ...extra } : data]);
+    const chunk = await fetchDateFn(dateStr, fetchLimit);
+    if (chunk.length === 0) {
+      while (
+        filtered.length < target &&
+        invalidIndex < INVALID_DATE_TOKENS.length
+      ) {
+        // eslint-disable-next-line no-await-in-loop
+        const extra = await fetchDateFn(
+          INVALID_DATE_TOKENS[invalidIndex],
+          limit - filtered.length
+        );
+        invalidIndex += 1;
+        for (let i = 0; i < extra.length; i += 1) {
+          const [eid, edata] = extra[i];
+          // eslint-disable-next-line no-await-in-loop
+          const extraUser = await fetchUserByIdFn(eid);
+          combined.push([eid, extraUser ? { ...edata, ...extraUser } : edata]);
+        }
+        filtered = filterMainFn(
+          combined,
+          'DATE2',
+          filterSettings,
+          favoriteUsers
+        );
+      }
+    } else {
+      for (let i = 0; i < chunk.length; i += 1) {
+        const [id, data] = chunk[i];
+        // eslint-disable-next-line no-await-in-loop
+        const extra = await fetchUserByIdFn(id);
+        combined.push([id, extra ? { ...data, ...extra } : data]);
+      }
+      filtered = filterMainFn(combined, 'DATE2', filterSettings, favoriteUsers);
+    }
+    dayOffset += 1;
   }
 
-  const filtered = filterMainFn(combined, 'DATE2', filterSettings, favoriteUsers);
   const slice = filtered.slice(startOffset, startOffset + PAGE_SIZE);
 
   const users = {};


### PR DESCRIPTION
## Summary
- paginate by fetching additional dates while filtered results are below the desired page size
- tweak next offset calculation to skip by returned items
- add regression test covering filters that drop first batch

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685806675a888326889b1fe66c89ae1e