### PR TITLE
Fix getInTouch persistence and add edit loading

### DIFF
--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -65,6 +65,8 @@ export const handleChange = (
         [userId]: { ...prev[userId], _pendingRemove: true },
       };
     });
+    // Зберігаємо зміну дати одразу, навіть якщо карточка буде прихована
+    handleSubmit({ userId, getInTouch: newValue }, 'overwrite');
   }
 };
 

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -1,10 +1,15 @@
 import { fetchUserById } from 'components/config';
 import { CardMenuBtn } from 'components/styles';
-import React from 'react';
+import React, { useState } from 'react';
+import { RotatingLines } from 'react-loader-spinner';
 
 export const btnEdit = (userId, setSearch, setState) => {
+  const [loading, setLoading] = useState(false);
+
   const handleCardClick = async () => {
+    setLoading(true);
     const userData = await fetchUserById(userId);
+    setLoading(false);
     if (userData) {
       console.log('Дані знайденого користувача: ', userData);
       setSearch(`id: ${userData.userId}`);
@@ -20,8 +25,13 @@ export const btnEdit = (userId, setSearch, setState) => {
         e.stopPropagation(); // Запобігаємо активації кліку картки
         handleCardClick();
       }}
+      disabled={loading}
     >
-      edit
+      {loading ? (
+        <RotatingLines width="18" strokeColor="white" />
+      ) : (
+        'edit'
+      )}
     </CardMenuBtn>
   );
 };


### PR DESCRIPTION
## Summary
- immediately persist getInTouch changes if card is removed due to date filter
- show loading indicator while fetching data for Edit button

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find a config)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858355b37d08326b05f6930e3132025