### PR TITLE
Handle getInTouch blur confirmation

### DIFF
--- a/src/components/__tests__/handleChange.test.js
+++ b/src/components/__tests__/handleChange.test.js
@@ -1,0 +1,57 @@
+const { TextDecoder, TextEncoder } = require('util');
+
+global.TextDecoder = TextDecoder;
+global.TextEncoder = TextEncoder;
+
+jest.mock('../config', () => ({
+  updateDataInNewUsersRTDB: jest.fn(),
+  fetchUserById: jest.fn(),
+}));
+
+const { handleChange } = require('../smallCard/actions');
+
+describe('handleChange', () => {
+  test('does not set _pendingRemove on onChange', () => {
+    let state = { id1: { userId: 'id1', getInTouch: '2024-01-01' } };
+    const setUsers = fn => {
+      state = fn(state);
+    };
+
+    handleChange(
+      setUsers,
+      null,
+      'id1',
+      'getInTouch',
+      '2025-01-01',
+      false,
+      {
+        currentFilter: 'DATE2',
+        isDateInRange: () => false,
+      },
+    );
+
+    expect(state.id1._pendingRemove).toBeUndefined();
+  });
+
+  test('sets _pendingRemove after confirm', () => {
+    let state = { id1: { userId: 'id1', getInTouch: '2024-01-01' } };
+    const setUsers = fn => {
+      state = fn(state);
+    };
+
+    handleChange(
+      setUsers,
+      null,
+      'id1',
+      'getInTouch',
+      '2025-01-01',
+      true,
+      {
+        currentFilter: 'DATE2',
+        isDateInRange: () => false,
+      },
+    );
+
+    expect(state.id1._pendingRemove).toBe(true);
+  });
+});

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -53,6 +53,7 @@ export const handleChange = (
   }
 
   if (
+    click &&
     key === 'getInTouch' &&
     options.currentFilter === 'DATE2' &&
     options.isDateInRange &&

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -1,4 +1,4 @@
-import { handleChange, handleSubmit } from './actions';
+import { handleChange } from './actions';
 const { formatDateToDisplay, formatDateAndFormula, formatDateToServer } = require('components/inputValidations');
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
@@ -73,7 +73,20 @@ export const fieldGetInTouch = (
             { currentFilter, isDateInRange }
           );
         }}
-        onBlur={() => handleSubmit(userData, 'overwrite')}
+        onBlur={e => {
+          const serverFormattedDate = formatDateToServer(
+            formatDateAndFormula(e.target.value)
+          );
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            'getInTouch',
+            serverFormattedDate,
+            true,
+            { currentFilter, isDateInRange }
+          );
+        }}
         style={{
           marginLeft: 0,
           textAlign: 'left',


### PR DESCRIPTION
## Summary
- modify `handleChange` so `_pendingRemove` is set only when confirming edits
- update `getInTouch` field to call `handleChange` on blur
- add tests for `handleChange` pending-remove behaviour

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685857a06ac08326ba041c360d10ad8c