### PR TITLE
Remove special date tokens from results

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2071,7 +2071,7 @@ export async function fetchSortedUsersByDate(limit = PAGE_SIZE, offset = 0) {
 
   entries = await fetchData(query(usersRef, orderByChild('getInTouch'), startAt(twoWeeksAheadDate)));
   entries = entries.filter(
-    ([, u]) => isValidDate(u.getInTouch) && u.getInTouch > twoWeeksAheadDate && u.getInTouch !== '2099-99-99' && u.getInTouch !== '9999-99-99'
+    ([, u]) => isValidDate(u.getInTouch) && u.getInTouch > twoWeeksAheadDate
   );
   pushUnique(entries);
 
@@ -2083,15 +2083,11 @@ export async function fetchSortedUsersByDate(limit = PAGE_SIZE, offset = 0) {
   entries = await fetchData(query(usersRef, orderByChild('getInTouch')));
   entries = entries.filter(([id, u]) => {
     const d = u.getInTouch;
-    return d && !isValidDate(d) && d !== '2099-99-99' && d !== '9999-99-99' && !fetchedIds.has(id);
+    return d && !isValidDate(d) && !fetchedIds.has(id);
   });
   pushUnique(entries);
 
-  // Records with special future dates
-  entries = await fetchData(query(usersRef, orderByChild('getInTouch'), equalTo('2099-99-99')));
-  pushUnique(entries);
-  entries = await fetchData(query(usersRef, orderByChild('getInTouch'), equalTo('9999-99-99')));
-  pushUnique(entries);
+  // Records with special future dates are no longer included
 
   const sliced = result.slice(offset, offset + limit);
   return { data: Object.fromEntries(sliced), totalCount: result.length };

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -3,7 +3,7 @@ export const PAGE_SIZE = 20;
 // List of invalid date tokens used when no records exist for a real date.
 // These values help fetch orphaned records that might have malformed
 // `getInTouch` fields.
-export const INVALID_DATE_TOKENS = ['', '2099-99-99', '9999-99-99'];
+export const INVALID_DATE_TOKENS = [''];
 
 // Maximum amount of days to look back when loading users by date.
 // Prevents infinite loops if the database contains sparse or malformed dates.


### PR DESCRIPTION
## Summary
- exclude special invalid date tokens from `INVALID_DATE_TOKENS`
- stop fetching entries with `2099-99-99` or `9999-99-99`

## Testing
- `CI=true npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68586785f1b08326b9bd18411047723e