### PR TITLE
Add 43+ filter

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -392,7 +392,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     role: { ed: true, sm: true, ag: true, ip: true, cl: true, other: true },
     maritalStatus: { married: true, unmarried: true, other: true },
     blood: { pos: true, neg: true, other: true },
-    age: { le25: true, '26_29': true, '31_36': true, '37_42': true, other: true },
+    age: {
+      le25: true,
+      '26_29': true,
+      '31_36': true,
+      '37_42': true,
+      '43_plus': true,
+      other: true,
+    },
     userId: { vk: true, aa: true, ab: true, long: true, mid: true, other: true },
     fields: { lt4: true, lt8: true, lt12: true, other: true },
     commentLength: {

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -51,6 +51,7 @@ export const SearchFilters = ({ filters, onChange }) => {
         { val: '26_29', label: '26-29' },
         { val: '31_36', label: '31-36' },
         { val: '37_42', label: '37-42' },
+        { val: '43_plus', label: '43+' },
         { val: 'other', label: '?' },
       ],
     },

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1017,6 +1017,7 @@ const getAgeCategory = value => {
   if (age >= 26 && age <= 29) return '26_29';
   if (age >= 31 && age <= 36) return '31_36';
   if (age >= 37 && age <= 42) return '37_42';
+  if (age >= 43) return '43_plus';
   return 'other';
 };
 


### PR DESCRIPTION
## Summary
- add new age filter checkbox `43+`
- support `43_plus` age category in filter config
- initialize `43_plus` option in default filters

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68592b5340148326944efe1c3fe5ba85