### PR TITLE
Fix blur submit for comment and other fields

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1551,7 +1551,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                               }));
                             }}
                             // onBlur={() => handleBlur(field.name)}
-                            onBlur={() => handleSubmit(state, 'overwrite')}
+                            onBlur={e =>
+                              handleSubmit(
+                                { ...state, [field.name]: e.target.value },
+                                'overwrite'
+                              )
+                            }
                           />
                           {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times;</ClearButton>}
                           {state[field.name] && <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)}>del</DelKeyValueBTN>}

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -37,7 +37,12 @@ export const FieldComment = ({ userData, setUsers, setState }) => {
           handleInputChange(e);
           autoResize(e.target);
         }}
-        onBlur={() => handleSubmit(userData, 'overwrite')}
+        onBlur={e =>
+          handleSubmit(
+            { ...userData, myComment: e.target.value },
+            'overwrite'
+          )
+        }
         style={{
           // marginLeft: '10px',
           width: '100%',

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -66,7 +66,10 @@ export const fieldLastCycle = (userData, setUsers, setState) => {
             const serverFormattedDate = formatDateToServer(e.target.value);
             handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
           }}
-          onBlur={() => handleSubmit(userData, 'overwrite')}
+          onBlur={e => {
+            const serverFormattedDate = formatDateToServer(e.target.value);
+            handleSubmit({ ...userData, lastCycle: serverFormattedDate }, 'overwrite');
+          }}
           // placeholder="01.01.2021"
           style={{
             marginLeft: 0,

--- a/src/components/smallCard/fieldRole.js
+++ b/src/components/smallCard/fieldRole.js
@@ -12,7 +12,9 @@ export const fieldRole = (userData, setUsers, setState) => {
         type="text"
         value={userData.role || ''}
         onChange={e => handleChange(setUsers, setState, userData.userId, 'role', e.target.value)}
-        onBlur={() => handleSubmit(userData, 'overwrite')}
+        onBlur={e =>
+          handleSubmit({ ...userData, role: e.target.value }, 'overwrite')
+        }
         style={{ marginLeft: 0, textAlign: 'left', width: '6ch' }}
       />
       {['ed', 'ip', 'ag'].map(role => (

--- a/src/components/smallCard/fieldWritter.js
+++ b/src/components/smallCard/fieldWritter.js
@@ -16,7 +16,9 @@ export const fieldWriter = (userData, setUsers, setState) => {
           // placeholder="Введіть ім'я"
           value={userData.writer || ''}
           onChange={e => handleChange(setUsers, setState, userData.userId, 'writer', e.target.value)}
-          onBlur={() => handleSubmit(userData, 'overwrite')}
+          onBlur={e =>
+            handleSubmit({ ...userData, writer: e.target.value }, 'overwrite')
+          }
           style={{
             flexGrow: 1, // Займає залишковий простір
             maxWidth: '100%', // Обмежує ширину контейнером


### PR DESCRIPTION
## Summary
- ensure latest textarea comment is sent onBlur
- keep freshest input value when blurring date, role and writer fields
- update AddNewProfile onBlur to pass current field value

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae665234883268d9d284529c4031e