### PR TITLE
Prevent removal from DATE2 list when updating getInTouch

### DIFF
--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -58,13 +58,7 @@ export const handleChange = (
     options.isDateInRange &&
     !options.isDateInRange(newValue)
   ) {
-    setUsers(prev => {
-      if (!prev[userId]) return prev;
-      return {
-        ...prev,
-        [userId]: { ...prev[userId], _pendingRemove: true },
-      };
-    });
+    // Do not remove the card from the DATE2 list when getInTouch is changed.
   }
 };
 


### PR DESCRIPTION
## Summary
- tweak `handleChange` logic so cards stay visible in DATE2 filter after changing `getInTouch`

## Testing
- `npm test --silent` *(fails: No tests found related to files changed since last commit)*

------
https://chatgpt.com/codex/tasks/task_e_685bd67cbbc08326ad569bc5cff72c32