### PR TITLE
Refactor GetInTouchInput usage

### DIFF
--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -1,24 +1,44 @@
 import { handleChange, handleSubmit } from './actions';
+import { useState, useEffect } from 'react';
 const { formatDateToDisplay, formatDateAndFormula, formatDateToServer } = require('components/inputValidations');
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
-export const fieldGetInTouch = (
-  userData,
-  setUsers,
-  setState,
-  currentFilter,
-  isDateInRange,
-) => {
+export const GetInTouchInput = ({ initialValue, userData, setUsers, setState, currentFilter, isDateInRange, handleChange }) => {
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    setValue(formatDateToDisplay(formatDateAndFormula(initialValue)) || '');
+  }, [initialValue]);
+
+  const handleBlur = () => {
+    const serverFormattedDate = formatDateToServer(formatDateAndFormula(value));
+    handleChange(setUsers, setState, userData.userId, 'getInTouch', serverFormattedDate, false, {
+      currentFilter,
+      isDateInRange,
+    });
+    handleSubmit(userData, 'overwrite');
+  };
+
+  return (
+    <UnderlinedInput
+      type="text"
+      value={value}
+      onChange={e => setValue(e.target.value)}
+      onBlur={handleBlur}
+      style={{
+        marginLeft: 0,
+        textAlign: 'left',
+      }}
+    />
+  );
+};
+
+export const fieldGetInTouch = (userData, setUsers, setState, currentFilter, isDateInRange) => {
   const handleSendToEnd = () => {
-    handleChange(
-      setUsers,
-      setState,
-      userData.userId,
-      'getInTouch',
-      '2099-99-99',
-      true,
-      { currentFilter, isDateInRange }
-    );
+    handleChange(setUsers, setState, userData.userId, 'getInTouch', '2099-99-99', true, {
+      currentFilter,
+      isDateInRange,
+    });
   };
 
   const handleAddDays = days => {
@@ -30,15 +50,10 @@ export const fieldGetInTouch = (
     const month = String(currentDate.getMonth() + 1).padStart(2, '0'); // Додаємо 1, оскільки місяці в Date починаються з 0
     const day = String(currentDate.getDate()).padStart(2, '0');
     const formattedDate = `${year}-${month}-${day}`; // Формат YYYY-MM-DD
-    handleChange(
-      setUsers,
-      setState,
-      userData.userId,
-      'getInTouch',
-      formattedDate,
-      true,
-      { currentFilter, isDateInRange }
-    );
+    handleChange(setUsers, setState, userData.userId, 'getInTouch', formattedDate, true, {
+      currentFilter,
+      isDateInRange,
+    });
   };
 
   const ActionButton = ({ label, days, onClick }) => (
@@ -57,27 +72,14 @@ export const fieldGetInTouch = (
 
   return (
     <div style={{ display: 'flex', alignItems: 'center' }}>
-      <UnderlinedInput
-        type="text"
-        value={formatDateToDisplay(formatDateAndFormula(userData.getInTouch)) || ''}
-        onChange={e => {
-          // Повертаємо формат YYYY-MM-DD для збереження
-          const serverFormattedDate = formatDateToServer(formatDateAndFormula(e.target.value));
-          handleChange(
-            setUsers,
-            setState,
-            userData.userId,
-            'getInTouch',
-            serverFormattedDate,
-            false,
-            { currentFilter, isDateInRange }
-          );
-        }}
-        onBlur={() => handleSubmit(userData, 'overwrite')}
-        style={{
-          marginLeft: 0,
-          textAlign: 'left',
-        }}
+      <GetInTouchInput
+        initialValue={userData.getInTouch}
+        userData={userData}
+        setUsers={setUsers}
+        setState={setState}
+        currentFilter={currentFilter}
+        isDateInRange={isDateInRange}
+        handleChange={handleChange}
       />
       <ActionButton label="3д" days={3} onClick={handleAddDays} />
       {/* <ActionButton label="7д" days={7} onClick={handleAddDays} /> */}


### PR DESCRIPTION
## Summary
- use imported `handleSubmit` directly inside `GetInTouchInput`
- drop `handleSubmit` prop from `fieldGetInTouch`

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4c03f8fc83269bf76e0ac528830f