### PR TITLE
Fix getInTouch input handling

### DIFF
--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -1,5 +1,5 @@
 import { handleChange, handleSubmit } from './actions';
-const { formatDateToDisplay, formatDateAndFormula, formatDateToServer } = require('components/inputValidations');
+const { formatDateToDisplay, formatDateToServer } = require('components/inputValidations');
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
 export const fieldGetInTouch = (
@@ -59,10 +59,10 @@ export const fieldGetInTouch = (
     <div style={{ display: 'flex', alignItems: 'center' }}>
       <UnderlinedInput
         type="text"
-        value={formatDateToDisplay(formatDateAndFormula(userData.getInTouch)) || ''}
+        value={formatDateToDisplay(userData.getInTouch) || ''}
         onChange={e => {
-          // Повертаємо формат YYYY-MM-DD для збереження
-          const serverFormattedDate = formatDateToServer(formatDateAndFormula(e.target.value));
+          // Перетворюємо введення на формат YYYY-MM-DD для збереження
+          const serverFormattedDate = formatDateToServer(e.target.value);
           handleChange(
             setUsers,
             setState,


### PR DESCRIPTION
## Summary
- remove extra formatting in `getInTouch` input
- match the update logic of `lastCycle`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbc92cc7c8326908f5ca295b97b58