### PR TITLE
Fix card loading update conflicts

### DIFF
--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -58,7 +58,13 @@ export const handleChange = (
     options.isDateInRange &&
     !options.isDateInRange(newValue)
   ) {
-    // Do not remove the card from the DATE2 list when getInTouch is changed.
+    setUsers(prev => {
+      const copy = { ...prev };
+      if (copy[userId]) {
+        copy[userId]._pendingRemove = true;
+      }
+      return copy;
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- avoid overwriting already loaded cards while fetching more
- pause incremental loading when editing a card
- remove cards if edited `getInTouch` date no longer fits filter

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685e863d05308326bdb039620b848feb