### PR TITLE
Fix card load interfering with focused inputs

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -385,6 +385,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState({});
   const isEditingRef = useRef(false);
+  const focusCounter = useRef(0);
+
+  const handleFocusCapture = () => {
+    focusCounter.current += 1;
+    isEditingRef.current = true;
+  };
+
+  const handleBlurCapture = () => {
+    focusCounter.current = Math.max(focusCounter.current - 1, 0);
+    if (focusCounter.current === 0 && !state.userId) {
+      isEditingRef.current = false;
+    }
+  };
 
   const [search, setSearch] = useState(() => localStorage.getItem('searchQuery') || '');
   const [searchKeyValuePair, setSearchKeyValuePair] = useState(null);
@@ -1348,7 +1361,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, {});
 
   return (
-    <Container>
+    <Container onFocusCapture={handleFocusCapture} onBlurCapture={handleBlurCapture}>
       <InnerContainer>
         <DotsButton
           onClick={() => {


### PR DESCRIPTION
## Summary
- track focus events in `AddNewProfile` to pause auto-loading
- attach focus/blur handlers on container

## Testing
- `npm test --silent --unsafe-perm` *(fails: react-scripts not found)*
- `npm run lint:js --silent` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685ebd18b3908326a999ac87b65cc1c0