### PR TITLE
Sequential indexing in Firebase

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -19,14 +19,7 @@ import {
   // removeSearchId,
   // createSearchIdsForAllUsers,
   createSearchIdsInCollection,
-  createBloodIndexInCollection,
-  createMaritalIndexInCollection,
-  createCsectionIndexInCollection,
-  createRoleIndexInCollection,
-  createUserIdIndexInCollection,
-  createFieldsIndexInCollection,
-  createCommentWordsIndexInCollection,
-  createAgeIndexInCollection,
+  createIndexesSequentiallyInCollection,
   fetchUsersByBloodIndex,
   fetchUserById,
   loadDuplicateUsers,
@@ -1321,16 +1314,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const indexData = async () => {
     const collections = ['newUsers', 'users'];
     for (const col of collections) {
-      await Promise.all([
-        createBloodIndexInCollection(col),
-        createMaritalIndexInCollection(col),
-        createCsectionIndexInCollection(col),
-        createRoleIndexInCollection(col),
-        createUserIdIndexInCollection(col),
-        createFieldsIndexInCollection(col),
-        createCommentWordsIndexInCollection(col),
-        createAgeIndexInCollection(col),
-      ]);
+      await createIndexesSequentiallyInCollection(col);
     }
   };
 


### PR DESCRIPTION
## Summary
- avoid concurrent updates when building indexes
- add helpers to index a user across all categories
- run sequential index creation in AddNewProfile

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fb063bbb083268fc062c9cc3552d1