### PR TITLE
Add multi-date indexing for contact and birth fields

### DIFF
--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -8,6 +8,21 @@ export async function defaultFetchByDate(dateStr, limit) {
   return snap.exists() ? Object.entries(snap.val()) : [];
 }
 
+export async function fetchByDateFromIndex(dateStr, limit) {
+  const { fetchUserById } = await import('./config');
+  const db = getDatabase();
+  const snap = await get(ref2(db, `usersIndex/getInTouch/${dateStr}`));
+  if (!snap.exists()) return [];
+  const idsRaw = snap.val();
+  const ids = Array.isArray(idsRaw) ? idsRaw.slice(0, limit) : [idsRaw];
+  const results = await Promise.all(ids.map(id => fetchUserById(id)));
+  const entries = [];
+  results.forEach((data, i) => {
+    if (data) entries.push([ids[i], data]);
+  });
+  return entries;
+}
+
 export async function fetchFilteredUsersByPage(
   startOffset = 0,
   fetchDateFn = defaultFetchByDate,


### PR DESCRIPTION
## Summary
- support multiple date keys for `getInTouch` and `birth`
- create helpers to update index entries for several categories
- keep indexes in sync when user data changes or cards are removed
- remove debug logging from Firestore update helper

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860387192688326b3c1dac1110aa77f