### PR TITLE
Add toast notifications for user loading errors

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -50,6 +50,7 @@ import { SearchFilters } from './SearchFilters';
 import { Pagination } from './Pagination';
 import { PAGE_SIZE, database } from './config';
 import { onValue, ref } from 'firebase/database';
+import { toast } from 'react-hot-toast';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
 // import { aiHandler } from './aiHandler';
 
@@ -1210,6 +1211,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const loadMoreUsers3 = async (currentFilters = filters) => {
+    console.log('loadMoreUsers3 called', currentFilters, indexOffset);
     let fav = favoriteUsersData;
     if (currentFilters.favorite?.favOnly && Object.keys(fav).length === 0) {
       fav = await fetchFavoriteUsers(auth.currentUser.uid);
@@ -1232,6 +1234,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const count = Object.keys(res.users).length;
       return { count, hasMore: res.hasMore };
     }
+    console.log('loadMoreUsers3: no users returned', res);
+    toast.error('No users found for current filters or indexes');
     setHasMore(false);
     return { count: 0, hasMore: false };
   };

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -22,6 +22,7 @@ import {
 } from 'firebase/database';
 import { PAGE_SIZE } from './constants';
 import { fetchFilteredUsersByPage } from './dateLoad';
+import { toast } from 'react-hot-toast';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_API_KEY,
@@ -1409,7 +1410,11 @@ export const fetchUsersByIndexAndDate = async (
   onProgress
 ) => {
   const ids = await getIdsByIndexFilters(filterSettings);
-  if (ids.size === 0) return { users: {}, lastKey: null, hasMore: false };
+  console.log('fetchUsersByIndexAndDate ids size', ids.size);
+  if (ids.size === 0) {
+    toast.error('Index is empty or filters removed all users');
+    return { users: {}, lastKey: null, hasMore: false };
+  }
 
   const customFilterMain = (entries, filterForload, fs, fav) => {
     const subset = entries.filter(([id]) => ids.has(id));

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import { store, persistor } from 'redux/store';
+import { Toaster } from 'react-hot-toast';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
@@ -13,6 +14,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <PersistGate loading={null} persistor={persistor}>
         <BrowserRouter basename="/main">
           <App />
+          <Toaster />
         </BrowserRouter>
       </PersistGate>
     </Provider>


### PR DESCRIPTION
## Summary
- show `Toaster` for the whole app
- trigger toast errors when indexed user search returns nothing
- log filter activity in `loadMoreUsers3`

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68612e172b488326b0748da857f3401b