### PR TITLE
Improve indexer concurrency

### DIFF
--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,4 +1,6 @@
 export const PAGE_SIZE = 20;
+// Number of users to index concurrently when creating indexes
+export const BATCH_SIZE = 10;
 
 // List of invalid date tokens used when no records exist for a real date.
 // These values help fetch orphaned records that might have malformed


### PR DESCRIPTION
## Summary
- expose `BATCH_SIZE` constant
- index users concurrently within `indexUserData`
- batch concurrent indexing in `createIndexesSequentiallyInCollection`

## Testing
- `npm test -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_686146b66ad083269896388902301d01