### PR TITLE
Improve load3 performance

### DIFF
--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -8,7 +8,7 @@ export async function defaultFetchByDate(dateStr, limit) {
   return snap.exists() ? Object.entries(snap.val()) : [];
 }
 
-export async function fetchByDateFromIndex(dateStr, limit) {
+export async function fetchByDateFromIndex(dateStr, limit, allowedIds) {
   const { fetchUserById } = await import('./config');
   const db = getDatabase();
   const snap = await get(ref2(db, `usersIndex/getInTouch/${dateStr}`));
@@ -16,12 +16,16 @@ export async function fetchByDateFromIndex(dateStr, limit) {
   const idsRaw = snap.val();
   let ids;
   if (Array.isArray(idsRaw)) {
-    ids = idsRaw.slice(0, limit);
+    ids = idsRaw;
   } else if (idsRaw && typeof idsRaw === 'object') {
-    ids = Object.keys(idsRaw).slice(0, limit);
+    ids = Object.keys(idsRaw);
   } else {
     ids = [idsRaw];
   }
+  if (allowedIds) {
+    ids = ids.filter(id => allowedIds.has(id));
+  }
+  ids = ids.slice(0, limit);
   const results = await Promise.all(ids.map(id => fetchUserById(id)));
   const entries = [];
   results.forEach((data, i) => {


### PR DESCRIPTION
## Summary
- filter allowed IDs in `fetchByDateFromIndex`
- pass ID filter to `fetchUsersByIndexAndDate`
- parallelize fetching index categories in `getIdsByIndexFilters`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614c9ef2b083269c558bc1c99c07a2