### PR TITLE
Fix date range check timing

### DIFF
--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -62,18 +62,30 @@ export const fieldGetInTouch = (
         value={formatDateToDisplay(formatDateAndFormula(userData.getInTouch)) || ''}
         onChange={e => {
           // Повертаємо формат YYYY-MM-DD для збереження
-          const serverFormattedDate = formatDateToServer(formatDateAndFormula(e.target.value));
+          const serverFormattedDate = formatDateToServer(
+            formatDateAndFormula(e.target.value)
+          );
           handleChange(
             setUsers,
             setState,
             userData.userId,
             'getInTouch',
             serverFormattedDate,
+            false
+          );
+        }}
+        onBlur={() => {
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            'getInTouch',
+            userData.getInTouch,
             false,
             { currentFilter, isDateInRange }
           );
+          handleSubmit(userData, 'overwrite');
         }}
-        onBlur={() => handleSubmit(userData, 'overwrite')}
         style={{
           marginLeft: 0,
           textAlign: 'left',


### PR DESCRIPTION
## Summary
- update `fieldGetInTouch` so date range validation triggers on blur instead of every keypress

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619d3816b8832693400683be5daae9