### PR TITLE
Fix export chunk size

### DIFF
--- a/src/components/ExportContact.jsx
+++ b/src/components/ExportContact.jsx
@@ -174,7 +174,8 @@ export const makeVCard = user => {
 };
 
 export const saveToContact = data => {
-  const CHUNK_SIZE = 22000;
+  // Limit each exported file to no more than 8000 contacts
+  const CHUNK_SIZE = 8000;
   let usersList = [];
   let baseName = 'contacts';
 


### PR DESCRIPTION
## Summary
- cap exported contacts at 8000 per vCard file

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686218cd98dc8326ac36e3dd47934d30