### PR TITLE
Add contact card description generator

### DIFF
--- a/src/components/ExportContact.jsx
+++ b/src/components/ExportContact.jsx
@@ -1,3 +1,5 @@
+import { makeCardDescription } from './makeCardDescription'
+
 // Функція для експорту контактів у форматі vCard
 export const makeVCard = user => {
   // Формуємо vCard
@@ -148,23 +150,7 @@ export const makeVCard = user => {
     });
   });
 
-  // Додаткові поля для NOTE
-  const additionalInfo = {
-    Birth: user.birth || '',
-    Marriage: user.maritalStatus || '',
-    Height: user.height || '',
-    Weight: user.weight || '',
-    Blood: user.blood || '',
-    Deliveries: user.ownKids || '',
-    Last_Delivery: user.lastDelivery || '',
-    Csection: user.csection || '',
-  };
-
-  const description = Object.entries(additionalInfo)
-    .filter(([, value]) => value) // Виключаємо порожні значення
-    .map(([key, value]) => `${key}: ${value}`)
-    .join(', ');
-
+  const description = makeCardDescription(user)
   if (description) {
     contactVCard += `NOTE;CHARSET=UTF-8:${description}\r\n`;
   }

--- a/src/components/makeCardDescription.js
+++ b/src/components/makeCardDescription.js
@@ -1,0 +1,44 @@
+export const makeCardDescription = user => {
+  const birthsInfo = [user.ownKids, user.lastDelivery]
+    .filter(Boolean)
+    .join('-');
+
+  const location = [user.region, user.city]
+    .filter(Boolean)
+    .join(', ');
+
+  const birthDate = user.birth || '';
+
+  const maritalStatus = user.maritalStatus || '';
+
+  const csectionInfo = user.csection || 'не було';
+
+  const heightWeight = user.height || user.weight
+    ? `${user.height || ''}/${user.weight || ''}`
+    : '';
+
+  const lastCycle = user.lastCycle || '';
+
+  const phones = (Array.isArray(user.phone) ? user.phone : [user.phone])
+    .filter(Boolean)
+    .map(p => String(p).replace(/^\+?38/, ''))
+    .join(', ');
+
+  const fullName = [user.surname, user.name, user.fathersname]
+    .filter(Boolean)
+    .join(' ');
+
+  const parts = [
+    birthsInfo,
+    location,
+    birthDate,
+    maritalStatus,
+    csectionInfo,
+    heightWeight,
+    lastCycle,
+    phones,
+    fullName,
+  ].filter(Boolean);
+
+  return parts.join('\n');
+};


### PR DESCRIPTION
## Summary
- create helper to generate contact card description text
- use new generator when exporting vCards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68625310f08083268c6d44b3a2d792cc