### PR TITLE
Update vCard description fields

### DIFF
--- a/src/components/__tests__/makeCardDescription.test.js
+++ b/src/components/__tests__/makeCardDescription.test.js
@@ -20,10 +20,10 @@ test('makeCardDescription returns enumerated description with literal \\n', () =
 
   const description = makeCardDescription(user);
   const parts = description.split('\\n');
-  expect(parts.length).toBe(9);
+  expect(parts.length).toBe(8);
   expect(parts[0]).toBe('1. 2-2023');
   expect(parts[1]).toBe('2. Kyivska, Kyiv');
-  expect(parts[8]).toBe('9. Doe Jane Petrovna');
+  expect(parts[7]).toBe('8. Doe Jane Petrovna');
 });
 
 test('makeCardDescription skips empty fields and enumerates correctly', () => {
@@ -38,8 +38,10 @@ test('makeCardDescription skips empty fields and enumerates correctly', () => {
   const parts = description.split('\\n');
   expect(parts).toEqual([
     '1. Lvivska',
-    '2. не було',
-    '3. 0555555555',
-    '4. Smith John',
+    '2. ?',
+    '3. ?',
+    '4. ?',
+    '5. 0555555555',
+    '6. Smith John',
   ]);
 });

--- a/src/components/makeCardDescription.js
+++ b/src/components/makeCardDescription.js
@@ -9,15 +9,38 @@ export const makeCardDescription = user => {
 
   const birthDate = user.birth || '';
 
-  const maritalStatus = user.maritalStatus || '';
+  const normalizeStr = str => str.toString().trim().toLowerCase();
 
-  const csectionInfo = user.csection || 'не було';
+  const getMaritalStatus = val => {
+    if (!val) return '?';
+    const normalized = normalizeStr(val);
+    if (['yes', '+', 'married', 'одружена', 'заміжня'].includes(normalized))
+      return 'заміжня';
+    if (
+      ['no', '-', 'unmarried', 'single', 'ні', 'незаміжня'].includes(normalized)
+    )
+      return 'не заміжня';
+    return '?';
+  };
 
-  const heightWeight = user.height || user.weight
-    ? `${user.height || ''}/${user.weight || ''}`
-    : '';
+  const maritalStatus = getMaritalStatus(user.maritalStatus);
 
-  const lastCycle = user.lastCycle || '';
+  const getCsectionInfo = val => {
+    if (val === undefined || val === null || val === '') return '?';
+    const normalized = normalizeStr(val);
+    if (['не було', 'no', 'ні', '-', '0', 'false'].includes(normalized)) return '-';
+    return val;
+  };
+
+  const csectionInfo = getCsectionInfo(user.csection);
+
+  const heightWeightBloodParts = [user.height, user.weight, user.blood].filter(
+    Boolean,
+  );
+  const heightWeightBlood =
+    heightWeightBloodParts.length > 0
+      ? heightWeightBloodParts.join('/')
+      : '?';
 
   const phones = (Array.isArray(user.phone) ? user.phone : [user.phone])
     .filter(Boolean)
@@ -34,8 +57,7 @@ export const makeCardDescription = user => {
     birthDate,
     maritalStatus,
     csectionInfo,
-    heightWeight,
-    lastCycle,
+    heightWeightBlood,
     phones,
     fullName,
   ].filter(Boolean);


### PR DESCRIPTION
## Summary
- modify makeCardDescription to handle marital status, c-section and blood information
- adjust enumeration to skip lastCycle and include placeholders when data missing
- update tests for new description logic

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862eed7835483268ae5bf17b311a4b6