### PR TITLE
Improve top block styling

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -61,7 +61,7 @@ export const renderTopBlock = (
           })()}
         </strong>
         {/* {renderCsection(userData.csection)}  */}
-        <div style={{ whiteSpace: 'pre-wrap' }}>
+        <div style={{ whiteSpace: 'pre-wrap', display: 'flex', alignItems: 'center', gap: '5px', flexWrap: 'wrap' }}>
           {(() => {
             const parts = [];
             if (userData.maritalStatus) parts.push(fieldMaritalStatus(userData.maritalStatus));

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -278,8 +278,8 @@ export const AttentionDiv = styled.div`
   color: white;
   border: none;
   border-radius: 4px;
-  font-size: 12px;
-  line-height: 14px;
+  font-size: 14px;
+  line-height: 16px;
   padding: 0 5px;
   display: inline-flex;
   text-align: center;
@@ -293,8 +293,8 @@ export const AttentionButton = styled.button`
   color: white;
   border: none;
   border-radius: 4px;
-  font-size: 12px;
-  line-height: 14px;
+  font-size: 14px;
+  line-height: 16px;
   padding: 0 10px;
   display: inline-flex;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- center colored items in `renderTopBlock`
- enlarge fonts for key status tags

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6863bbd4f3048326b16f03b624aaaea1