### PR TITLE
Fix container overflow when adding side buttons

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -130,7 +130,8 @@ const InputDiv = styled.div`
   border-radius: 5px;
 
   box-sizing: border-box;
-  flex-grow: 1;
+  flex: 1 1 auto; /* Дозволяє займати доступне місце і стискатись */
+  min-width: 0; /* Запобігає переповненню при додаванні кнопок */
   height: auto;
 `;
 
@@ -266,7 +267,8 @@ const InputFieldContainer = styled.div`
   /* width: 100%; */
   height: 100%; /* Дозволяє розтягувати висоту по висоті контейнера */
   box-sizing: border-box;
-  flex-grow: 1;
+  flex: 1 1 auto;
+  min-width: 0; /* Дозволяє контейнеру звужуватись разом з інпутом */
   height: auto; /* Дозволяє висоті адаптуватися до вмісту */
 
   &::before {


### PR DESCRIPTION
## Summary
- ensure input containers shrink properly in `AddNewProfile`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c62636548326a63811d31398b615