### PR TITLE
Add Photos support in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
-// import Photos from './Photos';
+import Photos from './Photos';
 // import { FaUser, FaTelegramPlane, FaFacebookF, FaInstagram, FaVk, FaMailBulk, FaPhone } from 'react-icons/fa';
 import {
   auth,
@@ -1376,7 +1376,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         >
           ⋮
         </DotsButton>
-        {/* {search && !userNotFound && <Photos state={state} setState={setState} />} */}
+
 
         <InputDiv>
           <InputFieldContainer value={search}>
@@ -1652,6 +1652,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   </PickerContainer>
                 );
               })}
+              <Photos state={state} setState={setState} />
           </>
         ) : (
           <div>


### PR DESCRIPTION
## Summary
- enable photo management in AddNewProfile
- render Photos component at the end of the input list

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_6864348bbc1483269759868fc5725edb