### PR TITLE
Fix photo upload after deletions

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -163,13 +163,21 @@ export const Photos = ({ state, setState }) => {
   };
 
   const addPhoto = async event => {
-    const photoArray = Array.from(event.target.files);
+    const input = event.target;
+    const photoArray = Array.from(input.files);
+
     try {
-      const newUrls = await Promise.all(photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId)));
+      const newUrls = await Promise.all(
+        photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId))
+      );
+
       setState(prevState => ({
         ...prevState,
         photos: [...(prevState.photos || []), ...newUrls],
       }));
+
+      // Clear the input to ensure change event fires when re-adding same file
+      input.value = '';
     } catch (error) {
       console.error('Error uploading photos:', error);
     }


### PR DESCRIPTION
## Summary
- reset file input after adding photos to prevent event pooling issues

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_686449a7a6988326aca18a24705d2993