### PR TITLE
Sync photos to dbs

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -696,6 +696,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     isEditingRef.current = !!state.userId;
   }, [state.userId]);
 
+  // Photo changes should trigger saving the profile.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    handleSubmit(state, 'overwrite');
+  }, [state.photos]);
+
   // useEffect для скидання значень при зміні search
   useEffect(() => {
     // setState({});

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -113,11 +113,24 @@ export const Photos = ({ state, setState }) => {
   const addPhoto = async event => {
     const photoArray = Array.from(event.target.files);
     try {
-      const newUrls = await Promise.all(photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId)));
+      const newUrls = await Promise.all(
+        photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId))
+      );
+      const updatedPhotos = [...(state.photos || []), ...newUrls];
       setState(prevState => ({
         ...prevState,
-        photos: [...(prevState.photos || []), ...newUrls],
+        photos: updatedPhotos,
       }));
+      await updateDataInRealtimeDB(
+        state.userId,
+        { photos: updatedPhotos },
+        'update'
+      );
+      await updateDataInFiresoreDB(
+        state.userId,
+        { photos: updatedPhotos },
+        'check'
+      );
     } catch (error) {
       console.error('Error uploading photos:', error);
     }


### PR DESCRIPTION
## Summary
- sync uploaded photos to Firestore and Realtime DB
- trigger profile save when photos update
- silence useEffect lint warning for photo sync

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654b5d2ed08326b4edc86415881ff3