### PR TITLE
Fix AddNewProfile and sync photos

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -696,19 +696,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     isEditingRef.current = !!state.userId;
   }, [state.userId]);
 
-  // useEffect для скидання значень при зміні search
-  useEffect(() => {
-    // setState({});
-    // Скинути значення стану для pickerFields
-    // setState(prevState => {
-    //   const updatedState = {};
-    //   // Проходимося по всіх ключах в попередньому стані
-    //   Object.keys(prevState).forEach(key => {
-    //     updatedState[key] = ''; // Скидаємо значення до ''
-    //   });
-    //   return updatedState; // Повертаємо новий стан
-    // });
-  }, [search]); // Виконується при зміні search
 
   // Save search query to localStorage
   useEffect(() => {

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -113,11 +113,16 @@ export const Photos = ({ state, setState }) => {
   const addPhoto = async event => {
     const photoArray = Array.from(event.target.files);
     try {
-      const newUrls = await Promise.all(photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId)));
+      const newUrls = await Promise.all(
+        photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId))
+      );
+      const updatedPhotos = [...(state.photos || []), ...newUrls];
       setState(prevState => ({
         ...prevState,
-        photos: [...(prevState.photos || []), ...newUrls],
+        photos: updatedPhotos,
       }));
+      await updateDataInRealtimeDB(state.userId, { photos: updatedPhotos });
+      await updateDataInFiresoreDB(state.userId, { photos: updatedPhotos }, 'check');
     } catch (error) {
       console.error('Error uploading photos:', error);
     }


### PR DESCRIPTION
## Summary
- remove an unused search reset effect in `AddNewProfile`
- keep uploaded and deleted photos in sync across Firestore and Realtime DB

## Testing
- `npm run lint:js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68656aaf8bec83269d0a1bb294563fe3