### PR TITLE
Fix photos from storage overriding on fetchUserById

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1773,15 +1773,15 @@ export const fetchUserById = async userId => {
       if (userSnapshotInUsers.exists()) {
         return {
           userId,
-          photos,
           ...newUserSnapshot.val(),
           ...userSnapshotInUsers.val(),
+          photos,
         };
       }
       return {
         userId,
-        photos,
         ...newUserSnapshot.val(),
+        photos,
       };
     }
 
@@ -1792,8 +1792,8 @@ export const fetchUserById = async userId => {
       console.log('Знайдено користувача у users: ', userSnapshot.val());
       return {
         userId,
-        photos,
         ...userSnapshot.val(),
+        photos,
       };
     }
 


### PR DESCRIPTION
## Summary
- ensure photos from Firebase Storage are not overwritten when merging user data

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f3e5b2a08326b2e5b583623afec3