### PR TITLE
Fix photos field rendering

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1302,7 +1302,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     'role',
   ];
   const additionalFields = Object.keys(state).filter(
-    key => !pickerFields.some(field => field.name === key) && key !== 'attitude' && key !== 'whiteList' && key !== 'blackList'
+    key =>
+      !pickerFields.some(field => field.name === key) &&
+      key !== 'attitude' &&
+      key !== 'whiteList' &&
+      key !== 'blackList' &&
+      key !== 'photos'
   );
 
   // console.log('additionalFields :>> ', additionalFields);


### PR DESCRIPTION
## Summary
- exclude `photos` key from dynamic fields when rendering form inputs in AddNewProfile

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686704d2e5048326987b3e3e4b50f841