### PR TITLE
Rewrite fullscreen photo view logic

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { deletePhotos, getUrlofUploadedAvatar } from './config';
 import { updateDataInFiresoreDB, updateDataInRealtimeDB } from './config';
@@ -54,6 +54,57 @@ const DeleteButton = styled.button`
   justify-content: center;
 `;
 
+const FullScreenOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const FullScreenImage = styled.img`
+  max-width: 90%;
+  max-height: 90%;
+  object-fit: contain;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 32px;
+  cursor: pointer;
+`;
+
+const FullDeleteButton = styled.button`
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TrashIcon = () => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+    <path d="M3 6h18M8 6v12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6m-9 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+  </svg>
+);
+
 const NoPhotosText = styled.p`
   text-align: center;
   color: ${color.gray3};
@@ -92,7 +143,39 @@ const HiddenFileInput = styled.input`
   display: none; /* Ховаємо справжній input */
 `;
 
+const FullScreenPhotoViewer = ({ url, onClose, onDelete }) => {
+  const handleDelete = useCallback(
+    e => {
+      e.stopPropagation();
+      onDelete();
+    },
+    [onDelete]
+  );
+
+  useEffect(() => {
+    const keyHandler = e => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', keyHandler);
+    return () => document.removeEventListener('keydown', keyHandler);
+  }, [onClose]);
+
+  return (
+    <FullScreenOverlay onClick={onClose}>
+      <FullScreenImage src={url} alt="full screen" />
+      <CloseButton onClick={onClose}>×</CloseButton>
+      <FullDeleteButton onClick={handleDelete}>
+        <TrashIcon />
+      </FullDeleteButton>
+    </FullScreenOverlay>
+  );
+};
+
 export const Photos = ({ state, setState }) => {
+  const [selectedPhoto, setSelectedPhoto] = useState(null);
 
   const handleDeletePhoto = async photoUrl => {
     const newPhotos = state.photos.filter(url => url !== photoUrl);
@@ -127,30 +210,41 @@ export const Photos = ({ state, setState }) => {
     <Container>
       <PhotosWrapper>
         {state.photos && state.photos.length > 0 ? (
-          <PhotosWrapper>
-            {state.photos.map((url, index) => (
-              <PhotoItem key={index}>
-                <PhotoImage src={url} alt={`user avatar ${index}`} />
-                <DeleteButton onClick={() => handleDeletePhoto(url)}>×</DeleteButton>
-              </PhotoItem>
-            ))}
-          </PhotosWrapper>
+          state.photos.map((url, index) => (
+            <PhotoItem key={index}>
+              <PhotoImage
+                src={url}
+                alt={`user avatar ${index}`}
+                onClick={() => setSelectedPhoto(url)}
+              />
+              <DeleteButton onClick={() => handleDeletePhoto(url)}>×</DeleteButton>
+            </PhotoItem>
+          ))
         ) : (
           <NoPhotosText>Додайте свої фото, максимум 9 шт</NoPhotosText>
         )}
       </PhotosWrapper>
-     {((state.photos && state.photos.length < 9) || (!state.photos)) && <UploadButtonWrapper>
-        <UploadButtonLabel htmlFor="file-upload">
-          Додати фото
-          <HiddenFileInput
-            id="file-upload"
-            type="file"
-            multiple
-            accept="image/*"
-            onChange={addPhoto}
-          />
-        </UploadButtonLabel>
-      </UploadButtonWrapper>}
+      {((state.photos && state.photos.length < 9) || !state.photos) && (
+        <UploadButtonWrapper>
+          <UploadButtonLabel htmlFor="file-upload">
+            Додати фото
+            <HiddenFileInput
+              id="file-upload"
+              type="file"
+              multiple
+              accept="image/*"
+              onChange={addPhoto}
+            />
+          </UploadButtonLabel>
+        </UploadButtonWrapper>
+      )}
+      {selectedPhoto && (
+        <FullScreenPhotoViewer
+          url={selectedPhoto}
+          onClose={() => setSelectedPhoto(null)}
+          onDelete={() => handleDeletePhoto(selectedPhoto)}
+        />
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
- refactor fullscreen viewer into `FullScreenPhotoViewer` component
- handle Escape key press to close viewer
- simplify photo list rendering logic

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864421be70883268f8dbc2e886e554d