### PR TITLE
Add full-screen photo viewer

### DIFF
--- a/src/components/PhotoViewer.jsx
+++ b/src/components/PhotoViewer.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { FiTrash2, FiX } from 'react-icons/fi';
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const FullImage = styled.img`
+  max-width: 90%;
+  max-height: 90%;
+  object-fit: contain;
+`;
+
+const IconButton = styled.button`
+  position: absolute;
+  top: 20px;
+  background: transparent;
+  border: none;
+  color: white;
+  cursor: pointer;
+`;
+
+const CloseButton = styled(IconButton)`
+  right: 20px;
+`;
+
+const DeleteButton = styled(IconButton)`
+  right: 70px;
+`;
+
+export const PhotoViewer = ({ photos = [], index = 0, onClose, onDelete }) => {
+  const [current, setCurrent] = useState(index);
+  const [startX, setStartX] = useState(null);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  const next = () => {
+    if (photos.length === 0) return;
+    setCurrent(prev => (prev + 1) % photos.length);
+  };
+
+  const prev = () => {
+    if (photos.length === 0) return;
+    setCurrent(prev => (prev - 1 + photos.length) % photos.length);
+  };
+
+  const handleTouchStart = e => {
+    if (e.touches && e.touches.length > 0) {
+      setStartX(e.touches[0].clientX);
+    }
+  };
+
+  const handleTouchEnd = e => {
+    if (startX === null) return;
+    const endX = e.changedTouches[0].clientX;
+    const deltaX = endX - startX;
+    if (deltaX > 50) {
+      prev();
+    } else if (deltaX < -50) {
+      next();
+    }
+    setStartX(null);
+  };
+
+  const handleDelete = () => {
+    if (onDelete) {
+      onDelete(current);
+    }
+  };
+
+  if (!photos.length) return null;
+
+  return (
+    <Overlay onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <FullImage src={photos[current]} alt="full" />
+      <CloseButton onClick={onClose} aria-label="Close">
+        <FiX size={30} />
+      </CloseButton>
+      <DeleteButton onClick={handleDelete} aria-label="Delete">
+        <FiTrash2 size={30} />
+      </DeleteButton>
+    </Overlay>
+  );
+};
+
+export default PhotoViewer;

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { deletePhotos, getUrlofUploadedAvatar, getAllUserPhotos } from './config';
 import { updateDataInNewUsersRTDB } from './config';
 import { color } from './styles';
+import PhotoViewer from './PhotoViewer';
 
 const Container = styled.div`
   padding-bottom: 10px;
@@ -93,6 +94,7 @@ const HiddenFileInput = styled.input`
 `;
 
 export const Photos = ({ state, setState }) => {
+  const [viewerIndex, setViewerIndex] = useState(null);
   useEffect(() => {
     const load = async () => {
       try {
@@ -131,6 +133,18 @@ export const Photos = ({ state, setState }) => {
     }
   };
 
+  const handleDeleteFromViewer = async index => {
+    const newLength = state.photos.length - 1;
+    await handleDeletePhoto(index);
+    if (newLength <= 0) {
+      setViewerIndex(null);
+    } else if (index >= newLength) {
+      setViewerIndex(newLength - 1);
+    } else {
+      setViewerIndex(index);
+    }
+  };
+
   const addPhoto = async event => {
     const photoArray = Array.from(event.target.files);
     try {
@@ -159,6 +173,7 @@ export const Photos = ({ state, setState }) => {
                 <PhotoImage
                   src={url}
                   alt={`user avatar ${index}`}
+                  onClick={() => setViewerIndex(index)}
                   onError={e => {
                     e.target.onerror = null;
                     e.target.src = '/logo192.png';
@@ -184,6 +199,14 @@ export const Photos = ({ state, setState }) => {
           />
         </UploadButtonLabel>
       </UploadButtonWrapper>}
+      {viewerIndex !== null && (
+        <PhotoViewer
+          photos={state.photos}
+          index={viewerIndex}
+          onClose={() => setViewerIndex(null)}
+          onDelete={handleDeleteFromViewer}
+        />
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
- add `PhotoViewer` component for full screen mode
- integrate viewer with `Photos` component
- allow swipe navigation, closing and deleting from viewer

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68681ff51874832699f6d0cf55153652