### PR TITLE
Enable closing photo viewer by clicking outside image

### DIFF
--- a/src/components/PhotoViewer.jsx
+++ b/src/components/PhotoViewer.jsx
@@ -85,8 +85,14 @@ export const PhotoViewer = ({ photos = [], index = 0, onClose, onDelete }) => {
 
   if (!photos.length) return null;
 
+  const handleOverlayClick = e => {
+    if (e.target === e.currentTarget && onClose) {
+      onClose();
+    }
+  };
+
   return (
-    <Overlay onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+    <Overlay onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onClick={handleOverlayClick}>
       <FullImage src={photos[current]} alt="full" />
       <CloseButton onClick={onClose} aria-label="Close">
         <FiX size={30} />


### PR DESCRIPTION
## Summary
- add click handler on overlay in `PhotoViewer`
- run existing tests

## Testing
- `CI=true npm test --silent --runTestsByPath src/components/__tests__/fetchFilteredUsersByPage.test.js src/components/__tests__/makeCardDescription.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68692e6815448326825e0bc2a3e6d4be