### PR TITLE
Implement search fallback with 'UK SM' prefix

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1049,21 +1049,27 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     let res = await fetchNewUsersCollectionInRTDB({ name: query.trim() });
     setSearchKeyValuePair({ name: query.trim() });
 
+    // Additional search variant with prefix "УК СМ"
+    if (!res || Object.keys(res).length === 0) {
+      const prefixedQuery = /^ук\s*см/i.test(query)
+        ? query.trim()
+        : `УК СМ ${query.trim()}`;
+      if (prefixedQuery !== query.trim()) {
+        res = await fetchNewUsersCollectionInRTDB({ name: prefixedQuery });
+        if (res && Object.keys(res).length > 0) {
+          setSearchKeyValuePair({ name: prefixedQuery });
+        }
+      }
+    }
+
+    // Search without the "УК СМ" prefix if the user entered it
     if (!res || Object.keys(res).length === 0) {
       const cleanedQuery = query.replace(/^ук\s*см\s*/i, '').trim();
       if (cleanedQuery && cleanedQuery !== query.trim()) {
         res = await fetchNewUsersCollectionInRTDB({ name: cleanedQuery });
-        setSearchKeyValuePair({ name: cleanedQuery });
-      }
-    }
-
-    if (!res || Object.keys(res).length === 0) {
-      const withPrefix = /^ук\s*см/i.test(query)
-        ? null
-        : `УК СМ ${query.trim()}`;
-      if (withPrefix) {
-        res = await fetchNewUsersCollectionInRTDB({ name: withPrefix });
-        setSearchKeyValuePair({ name: withPrefix });
+        if (res && Object.keys(res).length > 0) {
+          setSearchKeyValuePair({ name: cleanedQuery });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- improve `AddNewProfile` search logic
  - after a regular search fails, retry using the `УК СМ` prefix
  - remove the prefix and retry if the user entered it

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a7be8c834832698c1665f7ed4a68d