### PR TITLE
Update search to include УК СМ prefix

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -322,9 +322,11 @@ const addUserToResults = async (userId, users, userIdOrArray = null) => {
 };
 
 const searchBySearchId = async (modifiedSearchValue, uniqueUserIds, users) => {
+  const ukSmPrefix = encodeKey('УК СМ ');
   const searchPromises = keysToCheck.flatMap(prefix => {
     const searchKeys = [
       `${prefix}_${modifiedSearchValue.toLowerCase()}`,
+      `${prefix}_${ukSmPrefix.toLowerCase()}${modifiedSearchValue.toLowerCase()}`,
       ...(modifiedSearchValue.startsWith('0') ? [`${prefix}_38${modifiedSearchValue.toLowerCase()}`] : []),
       ...(modifiedSearchValue.startsWith('+') ? [`${prefix}_${modifiedSearchValue.slice(1).toLowerCase()}`] : []),
     ];


### PR DESCRIPTION
## Summary
- allow searching by "УК СМ" prefix when using the searchId index

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686aafe83558832682812a46cd67c9e1