### PR TITLE
Remove id prefix from search

### DIFF
--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -7,7 +7,7 @@ export const btnEdit = (userId, setSearch, setState) => {
     const userData = await fetchUserById(userId);
     if (userData) {
       console.log('Дані знайденого користувача: ', userData);
-      setSearch(`id: ${userData.userId}`);
+      setSearch(`${userData.userId}`);
       setState(userData);
     } else {
       console.log('Користувача не знайдено.');


### PR DESCRIPTION
## Summary
- open card without adding `id:` prefix to the search input

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d20707d548326a5fd1a56325df4e8