### PR TITLE
Add auto resize for moreInfo_main

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -48,6 +48,7 @@ import { btnExportUsers } from './topBtns/btnExportUsers';
 import { btnMerge } from './smallCard/btnMerge';
 import { SearchFilters } from './SearchFilters';
 import { Pagination } from './Pagination';
+import { useAutoResize } from '../hooks/useAutoResize';
 import { PAGE_SIZE, database } from './config';
 import { onValue, ref } from 'firebase/database';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
@@ -1394,17 +1395,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   //////////// висота text area
   const textareaRef = useRef(null);
+  const moreInfoRef = useRef(null);
 
-  const autoResize = textarea => {
-    textarea.style.height = 'auto'; // Скидаємо висоту
-    textarea.style.height = `${textarea.scrollHeight}px`; // Встановлюємо нову висоту
-  };
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      autoResize(textareaRef.current); // Встановлюємо висоту після завантаження
-    }
-  }, [state.myComment]); // Виконується при завантаженні та зміні коментаря
+  const autoResizeMyComment = useAutoResize(textareaRef, state.myComment);
+  const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE) || 1;
   const getSortedIds = () => {
@@ -1498,7 +1492,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                                 <InputField
                                   fieldName={`${field.name}-${idx}`}
                                   as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
-                                  ref={field.name === 'myComment' ? textareaRef : null}
+                                  ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
                                   inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                                   name={`${field.name}-${idx}`}
                                   value={value || ''}
@@ -1506,7 +1500,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                                   ///глючить якщо телефон не в правильному форматі
                                   onChange={e => {
                                     // const updatedValue = inputUpdateValue(e?.target?.value, field);
-                                    field.name === 'myComment' && autoResize(e.target);
+                                    if (field.name === 'myComment') {
+                                      autoResizeMyComment(e.target);
+                                    }
+                                    if (field.name === 'moreInfo_main') {
+                                      autoResizeMoreInfo(e.target);
+                                    }
                                     const updatedValue =
                                       field.name === 'telegram'
                                         ? e?.target?.value // Без inputUpdateValue для 'telegram'
@@ -1543,13 +1542,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                           <InputField
                             fieldName={field.name}
                             as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
-                            ref={field.name === 'myComment' ? textareaRef : null}
+                            ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
                             inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                             name={field.name}
                             value={state[field.name] || ''}
                             // value={field.name === 'phone' ? formatPhoneNumber(state[field.name] || '') : state[field.name] || ''}
                             onChange={e => {
-                              field.name === 'myComment' && autoResize(e.target);
+                              if (field.name === 'myComment') {
+                                autoResizeMyComment(e.target);
+                              }
+                              if (field.name === 'moreInfo_main') {
+                                autoResizeMoreInfo(e.target);
+                              }
                               let value = e?.target?.value;
                               // Якщо ім'я поля - 'publish', перетворюємо значення в булеве
                               if (field.name === 'publish') {

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import styled, { css } from 'styled-components';
 // import { FaUser, FaTelegramPlane, FaFacebookF, FaInstagram, FaVk, FaMailBulk, FaPhone } from 'react-icons/fa';
 import { auth, fetchUserData } from './config';
@@ -13,6 +13,7 @@ import { VerifyEmail } from './VerifyEmail';
 
 import { color } from './styles';
 import { inputUpdateValue } from './inputUpdatedValue';
+import { useAutoResize } from '../hooks/useAutoResize';
 
 const Container = styled.div`
   display: flex;
@@ -341,6 +342,8 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   const [focused, setFocused] = useState(null);
   console.log('focused :>> ', focused);
   const navigate = useNavigate();
+  const moreInfoRef = useRef(null);
+  const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
   ////////////////////GPS
 
@@ -573,13 +576,15 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
               <InputDiv key={field.name}>
                 <InputFieldContainer fieldName={field.name} value={state[field.name]}>
                   <InputField
-                    fieldName={field.name} 
+                    fieldName={field.name}
                     as={field.name === 'moreInfo_main' && 'textarea'}
+                    ref={field.name === 'moreInfo_main' ? moreInfoRef : null}
                     inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                     name={field.name}
                     value={state[field.name]}
                     onChange={e => {
                       const value = e?.target?.value;
+                      field.name === 'moreInfo_main' && autoResizeMoreInfo(e.target);
                       const updatedValue = inputUpdateValue(value, field)
                       // if (state[field.name]!=='No' && state[field.name]!=='Yes') {
                       setState(prevState => ({ ...prevState, [field.name]: updatedValue }));

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -1,24 +1,17 @@
 import { handleChange, handleSubmit } from './actions';
-import { useEffect, useRef } from "react";
+import { useRef } from 'react';
+import { useAutoResize } from '../../hooks/useAutoResize';
 
 export const FieldComment = ({ userData, setUsers, setState }) => {
   // console.log('userData in RenderCommentInput :>> ', userData);
   const textareaRef = useRef(null);
+  const autoResize = useAutoResize(textareaRef, userData.myComment);
 
   const handleInputChange = e => {
     handleChange(setUsers, setState, userData.userId, 'myComment', e.target.value);
   };
 
-  const autoResize = textarea => {
-    textarea.style.height = 'auto'; // Скидаємо висоту
-    textarea.style.height = `${textarea.scrollHeight}px`; // Встановлюємо нову висоту
-  };
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      autoResize(textareaRef.current); // Встановлюємо висоту після завантаження
-    }
-  }, [userData.myComment]); // Виконується при завантаженні та зміні коментаря
+  // autoResize will adjust height on mount and when value changes
 
   return (
     <div

--- a/src/hooks/useAutoResize.js
+++ b/src/hooks/useAutoResize.js
@@ -1,0 +1,15 @@
+import { useEffect, useCallback } from 'react';
+
+export const useAutoResize = (ref, value) => {
+  const autoResize = useCallback(textarea => {
+    if (!textarea) return;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, []);
+
+  useEffect(() => {
+    autoResize(ref.current);
+  }, [ref, value, autoResize]);
+
+  return autoResize;
+};


### PR DESCRIPTION
## Summary
- add reusable `useAutoResize` hook
- enlarge `moreInfo_main` field with auto-resizing like `myComment`
- refactor existing comment textarea to use the new hook

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d83c8fe208326ab21e6a8e20ba99d