### PR TITLE
Export names for synonyms

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -27,6 +27,7 @@ import {
   fetchAllUsersFromRTDB,
   fetchTotalNewUsersCount,
   fetchFilteredUsersByPage,
+  fetchAllNamesAndTelegrams,
   // removeSpecificSearchId,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -1299,6 +1300,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [duplicates, setDuplicates] = useState('');
 
+  const [nameDump, setNameDump] = useState(null);
+
   const searchDuplicates = async () => {
     const { mergedUsers, totalDuplicates } = await loadDuplicateUsers();
     // console.log('res :>> ', res);
@@ -1338,6 +1341,27 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     for (const col of collections) {
       await createIndexesSequentiallyInCollection(col);
     }
+  };
+
+  const collectNames = async () => {
+    const data = await fetchAllNamesAndTelegrams();
+    setNameDump(data);
+    console.log('Collected names:', data);
+  };
+
+  const downloadNames = () => {
+    if (!nameDump) return;
+    const blob = new Blob([JSON.stringify(nameDump, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'names.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   };
 
   const priorityOrder = [
@@ -1750,6 +1774,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               >
                 Load2
               </Button>
+              <Button onClick={collectNames}>GetNames</Button>
+              <Button onClick={downloadNames}>SaveNames</Button>
               <Button onClick={loadFavoriteUsers}>❤</Button>
               <Button onClick={indexData}>IndData</Button>
               <Button onClick={makeIndex}>Index</Button>

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2429,6 +2429,53 @@ export const fetchAllUsersFromRTDB = async () => {
   }
 };
 
+export const fetchAllNamesAndTelegrams = async () => {
+  try {
+    const [newUsersSnapshot, usersSnapshot] = await Promise.all([
+      get(ref2(database, 'newUsers')),
+      get(ref2(database, 'users')),
+    ]);
+
+    const newUsersData = newUsersSnapshot.exists() ? newUsersSnapshot.val() : {};
+    const usersData = usersSnapshot.exists() ? usersSnapshot.val() : {};
+
+    const allUserIds = new Set([
+      ...Object.keys(newUsersData),
+      ...Object.keys(usersData),
+    ]);
+
+    const names = new Set();
+    const surnames = new Set();
+    const telegrams = new Set();
+
+    for (const userId of allUserIds) {
+      const user = {
+        ...(newUsersData[userId] || {}),
+        ...(usersData[userId] || {}),
+      };
+
+      if (user.name && typeof user.name === 'string') {
+        names.add(user.name.trim());
+      }
+      if (user.surname && typeof user.surname === 'string') {
+        surnames.add(user.surname.trim());
+      }
+      if (user.telegram && typeof user.telegram === 'string') {
+        telegrams.add(user.telegram.trim());
+      }
+    }
+
+    return {
+      names: Array.from(names),
+      surnames: Array.from(surnames),
+      telegrams: Array.from(telegrams),
+    };
+  } catch (error) {
+    console.error('Error fetching names and telegrams:', error);
+    return { names: [], surnames: [], telegrams: [] };
+  }
+};
+
 export async function fetchSortedUsersByDate(limit = PAGE_SIZE, offset = 0) {
   const dbInstance = getDatabase();
   const usersRef = ref2(dbInstance, 'newUsers');


### PR DESCRIPTION
## Summary
- add `fetchAllNamesAndTelegrams` helper to gather names, surnames and telegram handles
- collect names from UI and allow saving them as JSON
- expose temporary buttons `GetNames` and `SaveNames` next to `Load2`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686dfe86b760832699cd1399c9924b0a