### PR TITLE
Add progress toast for getting names

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1336,6 +1336,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     // });
   };
 
+  // Builds search indexes for names in both 'newUsers' and 'users'
+  // collections. Progress is shown with toast notifications.
   const indexNames = async () => {
     toast.loading('Indexing names newUsers 0%', { id: 'name-index-progress' });
     await createSearchIdsInCollection('newUsers', progress => {
@@ -1359,12 +1361,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
+  // Retrieves all names, surnames and Telegram handles from both
+  // 'newUsers' and 'users' collections. Shows progress via toasts and
+  // stores the result in the `nameDump` state.
   const collectNames = async () => {
-    const data = await fetchAllNamesAndTelegrams();
+    toast.loading('Collecting names 0%', { id: 'name-collect-progress' });
+    const data = await fetchAllNamesAndTelegrams(progress => {
+      toast.loading(`Collecting names ${progress}%`, {
+        id: 'name-collect-progress',
+      });
+    });
     setNameDump(data);
+    toast.success('Names collected', { id: 'name-collect-progress' });
     console.log('Collected names:', data);
   };
 
+  // Downloads the `nameDump` state as a names.json file on the client.
   const downloadNames = () => {
     if (!nameDump) return;
     const blob = new Blob([JSON.stringify(nameDump, null, 2)], {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2474,7 +2474,7 @@ export const fetchAllUsersFromRTDB = async () => {
   }
 };
 
-export const fetchAllNamesAndTelegrams = async () => {
+export const fetchAllNamesAndTelegrams = async onProgress => {
   try {
     const [newUsersSnapshot, usersSnapshot] = await Promise.all([
       get(ref2(database, 'newUsers')),
@@ -2493,7 +2493,11 @@ export const fetchAllNamesAndTelegrams = async () => {
     const surnames = new Set();
     const telegrams = new Set();
 
-    for (const userId of allUserIds) {
+    const userIds = Array.from(allUserIds);
+    const total = userIds.length;
+    let processed = 0;
+
+    for (const userId of userIds) {
       const user = {
         ...(newUsersData[userId] || {}),
         ...(usersData[userId] || {}),
@@ -2508,6 +2512,10 @@ export const fetchAllNamesAndTelegrams = async () => {
       if (user.telegram && typeof user.telegram === 'string') {
         telegrams.add(user.telegram.trim());
       }
+
+      processed += 1;
+      const progress = Math.floor((processed / total) * 100);
+      if (onProgress && progress % 10 === 0) onProgress(progress);
     }
 
     return {


### PR DESCRIPTION
## Summary
- document name-related utilities
- add progress updates when collecting names
- expose progress parameter in `fetchAllNamesAndTelegrams`

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686e510c5d8483268bf5e7dba5eb1057