### PR TITLE
Add my-profile route combining profile and registration

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Route, Routes, useNavigate  } from 'react-router-dom';
 import { PrivacyPolicy } from './PrivacyPolicy';
-import {ProfileScreen} from './ProfileScreen';
+import { MyProfile } from './MyProfile';
 import { LoginScreen } from './LoginScreen';
 import { SubmitForm } from './SubmitForm';
 import {AddNewProfile} from './AddNewProfile';
@@ -18,7 +18,7 @@ export const App = () => {
 
   useEffect(() => {
     if (isLoggedIn) {
-      navigate('/profile');
+      navigate('/my-profile');
     }
   }, [isLoggedIn, navigate]);
 
@@ -37,7 +37,7 @@ export const App = () => {
     <Routes>
       <Route path="/" element={user ? <AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} /> : <PrivacyPolicy />} />
       <Route path="/submit" element={<SubmitForm />} />
-      <Route path="/profile"  element={<ProfileScreen isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
+      <Route path="/my-profile"  element={<MyProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
       <Route path="/login" element={<LoginScreen isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />
       {user&& <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       {user&&<Route path="/policy" element={<PrivacyPolicy/>} />}

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -222,7 +222,7 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.setItem('userEmail', state.email);
 
       setIsLoggedIn(true);
-      navigate('/profile');
+      navigate('/my-profile');
       console.log('User signed in:', userCredential.user);
     } catch (error) {
       console.error('Error signing in:', error);
@@ -253,7 +253,7 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.setItem('userEmail', state.email);
 
       setIsLoggedIn(true);
-      navigate('/profile');
+      navigate('/my-profile');
     } catch (error) {
       console.error('Error signing in:', error);
     }
@@ -278,7 +278,7 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       navigate('/login');
     } else {
       setIsLoggedIn(true);
-      navigate('/profile');
+      navigate('/my-profile');
     }
     // eslint-disable-next-line
   }, []);


### PR DESCRIPTION
## Summary
- create `MyProfile` component by duplicating `ProfileScreen` and merging registration fields
- add status indicator of publication state
- support email/password registration when publishing
- route to `/my-profile` instead of `/profile`
- update navigation in login and other components

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb89a99ec83269ab82edc8e9f2760