### PR TITLE
Switch to my-profile on start

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -566,7 +566,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
-      navigate('/login');
+      navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
       console.error('Error signing out:', error);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Route, Routes, useNavigate  } from 'react-router-dom';
 import { PrivacyPolicy } from './PrivacyPolicy';
 import { MyProfile } from './MyProfile';
-import { LoginScreen } from './LoginScreen';
 import { SubmitForm } from './SubmitForm';
 import {AddNewProfile} from './AddNewProfile';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -38,7 +37,6 @@ export const App = () => {
       <Route path="/" element={user ? <AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} /> : <PrivacyPolicy />} />
       <Route path="/submit" element={<SubmitForm />} />
       <Route path="/my-profile"  element={<MyProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
-      <Route path="/login" element={<LoginScreen isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />
       {user&& <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       {user&&<Route path="/policy" element={<PrivacyPolicy/>} />}
     </Routes>

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -275,7 +275,7 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const loggedIn = localStorage.getItem('isLoggedIn');
     if (!isLoggedIn && !loggedIn) {
-      navigate('/login');
+      navigate('/my-profile');
     } else {
       setIsLoggedIn(true);
       navigate('/my-profile');

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -513,7 +513,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
-      navigate('/login');
+      navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
       console.error('Error signing out:', error);

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -406,7 +406,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
-      navigate('/login');
+      navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
       console.error('Error signing out:', error);
@@ -475,7 +475,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const loggedIn = localStorage.getItem('isLoggedIn');
     if (!isLoggedIn && !loggedIn) {
-      navigate('/login');
+      navigate('/my-profile');
     } else {
       setIsLoggedIn(true);
       navigate('/my-profile');


### PR DESCRIPTION
## Summary
- default to `/my-profile` instead of `/login`
- remove the unused `LoginScreen` route
- update sign out and login redirects

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_686ec2ada0248326b5c0464df5ad42c5