### PR TITLE
Fix terms button placement in profile page

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -31,8 +31,8 @@ const InnerContainer = styled.div`
 `;
 
 const InputDiv = styled.div`
-  display: flex;
-  align-items: center;
+  display: inline-block;
+  vertical-align: middle;
   position: relative;
   margin: 10px 0;
   padding: 10px;
@@ -65,7 +65,7 @@ const Label = styled.label`
       left: 10px;
       top: 0;
       transform: translateY(-100%);
-      font-size: 14px;
+      font-size: 12px;
       color: orange;
     `}
 `;
@@ -114,8 +114,8 @@ const CheckboxLabel = styled.label`
   /* font-weight: bold; */
   color: #333;
   cursor: pointer;
-  display: flex;
-  align-items: center;
+  display: inline-block;
+  vertical-align: middle;
   max-width: 300px;
   transition: color 0.3s ease, box-shadow 0.3s ease;
   &:hover {

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -229,7 +229,7 @@ const AuthLabel = styled.label`
       left: 10px;
       top: 0;
       transform: translateY(-100%);
-      font-size: 14px;
+      font-size: 12px;
       color: orange;
     `}
 `;
@@ -281,6 +281,26 @@ const PublishButton = styled.button`
 `;
 
 const AgreeButton = styled(PublishButton)`
+  margin-bottom: 10px;
+`;
+const TermsButton = styled.button`
+  background-color: ${color.oppositeAccent};
+  border: 1px solid ${color.gray};
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-left: 8px;
+  font-size: 12px;
+  cursor: pointer;
+  color: ${color.accent5};
+  &:hover {
+    background-color: ${color.paleAccent5};
+  }
+`;
+
+const AgreeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-bottom: 10px;
 `;
 
@@ -702,7 +722,10 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               />
               <AuthLabel isActive={focused === 'passwordReg' || state.password}>Придумайте / введіть пароль</AuthLabel>
             </AuthInputDiv>
-            <AgreeButton onClick={handleAgree}>Я погоджуюся з умовами програми</AgreeButton>
+            <AgreeContainer>
+              <AgreeButton onClick={handleAgree}>Я погоджуюся з умовами програми</AgreeButton>
+              <TermsButton onClick={() => navigate('/policy')}>Умови</TermsButton>
+            </AgreeContainer>
           </>
         )}
         {state.userId && <Photos state={state} setState={setState} />}


### PR DESCRIPTION
## Summary
- add Terms button to new combined profile page
- keep login label small when active

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm start` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4130ee9c8326b31da98e9deac6b8