### PR TITLE
Fix Terms button height

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -38,7 +38,7 @@ export const App = () => {
       <Route path="/submit" element={<SubmitForm />} />
       <Route path="/my-profile"  element={<MyProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
       {user&& <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
-      {user&&<Route path="/policy" element={<PrivacyPolicy/>} />}
+      <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );
 };

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -127,9 +127,9 @@ const TermsButton = styled.button`
   background-color: ${color.oppositeAccent};
   border: 1px solid ${color.gray};
   border-radius: 4px;
-  padding: 2px 6px;
+  padding: 10px 6px;
   margin-left: 8px;
-  font-size: 12px;
+  font-size: 16px;
   cursor: pointer;
   color: ${color.accent5};
 

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -287,9 +287,9 @@ const TermsButton = styled.button`
   background-color: ${color.oppositeAccent};
   border: 1px solid ${color.gray};
   border-radius: 4px;
-  padding: 2px 6px;
+  padding: 10px 6px;
   margin-left: 8px;
-  font-size: 12px;
+  font-size: 16px;
   cursor: pointer;
   color: ${color.accent5};
   &:hover {


### PR DESCRIPTION
## Summary
- keep `/policy` route always available
- match the height of the `Умови` button to the agree button

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f4c05abe08326a603b05da1126f9d