### PR TITLE
Implement draft persistence and auth UI improvements

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -6,6 +6,7 @@ import { createUserWithEmailAndPassword, sendEmailVerification, signInWithEmailA
 import { getCurrentDate } from './foramtDate';
 import { useNavigate } from 'react-router-dom';
 import { color } from './styles';
+import toast from 'react-hot-toast';
 
 const Container = styled.div`
   display: flex;
@@ -31,15 +32,16 @@ const InnerContainer = styled.div`
 `;
 
 const InputDiv = styled.div`
-  display: inline-block;
-  vertical-align: middle;
+  display: flex;
+  align-items: center;
   position: relative;
   margin: 10px 0;
   padding: 10px;
   background-color: #fff;
   border: 1px solid #ccc;
   border-radius: 5px;
-  width: 300px;
+  width: 100%;
+  box-sizing: border-box;
 `;
 
 const InputField = styled.input`
@@ -197,6 +199,8 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
     };
 
     checkAutofill();
+    const timer = setTimeout(checkAutofill, 500);
+    return () => clearTimeout(timer);
   }, []);
 
   const handleChange = e => {
@@ -244,7 +248,11 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       navigate('/my-profile');
       console.log('User signed in:', userCredential.user);
     } catch (error) {
-      console.error('Error signing in:', error);
+      if (error.code === 'auth/wrong-password') {
+        toast.error('Невірний пароль');
+      } else {
+        console.error('Error signing in:', error);
+      }
     }
   };
 

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -16,6 +16,7 @@ import {
 } from 'firebase/auth';
 import { useNavigate } from 'react-router-dom';
 import { getCurrentDate } from './foramtDate';
+import toast from 'react-hot-toast';
 import InfoModal from './InfoModal';
 import Photos from './Photos';
 import { VerifyEmail } from './VerifyEmail';
@@ -427,6 +428,21 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const moreInfoRef = useRef(null);
   const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
+  useEffect(() => {
+    const savedDraft = localStorage.getItem('myProfileDraft');
+    if (savedDraft && !state.userId) {
+      setState(prev => ({ ...prev, ...JSON.parse(savedDraft) }));
+    }
+  }, [state.userId]);
+
+  useEffect(() => {
+    if (!state.publish) {
+      localStorage.setItem('myProfileDraft', JSON.stringify(state));
+    } else {
+      localStorage.removeItem('myProfileDraft');
+    }
+  }, [state, state.publish]);
+
   ////////////////////GPS
 
   useEffect(() => {
@@ -484,6 +500,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     try {
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('userEmail');
+      localStorage.removeItem('myProfileDraft');
       setState({});
       setIsLoggedIn(false);
       navigate('/my-profile');
@@ -537,7 +554,11 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setState(prev => ({ ...prev, userId: userCredential.user.uid }));
       navigate('/my-profile');
     } catch (error) {
-      console.error('auth error', error);
+      if (error.code === 'auth/wrong-password') {
+        toast.error('Невірний пароль');
+      } else {
+        console.error('auth error', error);
+      }
     }
   };
 
@@ -566,7 +587,11 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setIsLoggedIn(true);
         setState(prev => ({ ...prev, userId: userCredential.user.uid }));
       } catch (error) {
-        console.error('auth error', error);
+        if (error.code === 'auth/wrong-password') {
+          toast.error('Невірний пароль');
+        } else {
+          console.error('auth error', error);
+        }
         return;
       }
     }
@@ -744,7 +769,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               <AuthLabel isActive={focused === 'passwordReg' || state.password}>Придумайте / введіть пароль</AuthLabel>
             </AuthInputDiv>
             <AgreeContainer>
-              <AgreeButton onClick={handleAgree}>Я погоджуюся з умовами програми</AgreeButton>
+              <AgreeButton onClick={handleAgree}>Я погоджуюсь</AgreeButton>
               <TermsButton onClick={() => navigate('/policy')}>Умови</TermsButton>
             </AgreeContainer>
           </>


### PR DESCRIPTION
## Summary
- persist MyProfile form values in local storage
- remove saved draft on publish or logout
- normalize login inputs styling
- retry autofill check to avoid placeholder overlap
- show toast on wrong password
- shorten "Agree" button text
- fix useEffect missing dependency warning in MyProfile

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686f721f16708326aa6d3b29f1f662e1