### PR TITLE
Fix placeholder alignment and button height

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -218,7 +218,7 @@ const AuthInputField = styled(InputField)`
 
 const AuthLabel = styled.label`
   position: absolute;
-  left: 30px;
+  left: 10px;
   top: 50%;
   transform: translateY(-50%);
   transition: all 0.3s ease;
@@ -291,10 +291,13 @@ const TermsButton = styled.button`
   background-color: ${color.oppositeAccent};
   border: 1px solid ${color.gray};
   border-radius: 4px;
-  padding: 10px 6px;
+  padding: 10px 20px;
   width: 110px;
   margin-left: 8px;
-  font-size: 16px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   color: ${color.accent5};
   &:hover {


### PR DESCRIPTION
## Summary
- align email and password placeholders with the cursor
- standardize Terms button height

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f9c5649488326aa5c5963f00ffe82