### PR TITLE
Fix placeholder position in auth fields

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -213,12 +213,12 @@ const AuthInputDiv = styled(InputDiv)`
   `;
 
 const AuthInputField = styled(InputField)`
-  padding-left: 10px;
+  padding-left: 20px;
 `;
 
 const AuthLabel = styled.label`
   position: absolute;
-  left: 10px;
+  left: 20px;
   top: 50%;
   transform: translateY(-50%);
   transition: all 0.3s ease;
@@ -228,7 +228,7 @@ const AuthLabel = styled.label`
   ${({ isActive }) =>
     isActive &&
     css`
-      left: 10px;
+      left: 20px;
       top: 0;
       transform: translateY(-100%);
       font-size: 12px;


### PR DESCRIPTION
## Summary
- adjust padding for `AuthInputField` and `AuthLabel` in `MyProfile` so floating placeholders line up with other inputs

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6870054b502c8326bcf8ce6396a6df61