### PR TITLE
Fix Agree button height

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -284,7 +284,8 @@ const PublishButton = styled.button`
 
 const AgreeButton = styled(PublishButton)`
   margin-bottom: 10px;
-  font-size: 14px;
+  font-size: 12px;
+  white-space: nowrap;
   flex-grow: 1;
 `;
 const TermsButton = styled.button`


### PR DESCRIPTION
## Summary
- reduce font size on AgreeButton to avoid wrapping
- prevent wrapping to keep button height consistent

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687005951b8083268403cef645c73408