### PR TITLE
Add default userRole and fallback fields

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -642,6 +642,21 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         return acc;
       }, {});
 
+      const { todayDays } = getCurrentDate();
+      const defaults = {};
+      if (!existingData?.userRole) defaults.userRole = 'ed';
+      if (!existingData?.userId) defaults.userId = user.uid;
+      if (!existingData?.email && user.email) defaults.email = user.email;
+      if (!existingData?.registrationDate) defaults.registrationDate = todayDays;
+      if (!existingData?.areTermsConfirmed) defaults.areTermsConfirmed = todayDays;
+      if (!existingData?.lastLogin) defaults.lastLogin = todayDays;
+
+      if (Object.keys(defaults).length) {
+        await updateDataInRealtimeDB(user.uid, defaults, 'update');
+        await updateDataInFiresoreDB(user.uid, defaults, 'check');
+        Object.assign(processedData, defaults);
+      }
+
       console.log('processedData :>> ', processedData);
       setState(prevState => ({
         ...prevState, // Зберегти попередні значення


### PR DESCRIPTION
## Summary
- ensure a default `userRole: 'ed'` exists
- add missing registration info if absent when loading a profile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68716c047b0c83268b275f2c0e65bdec