### PR TITLE
Fix exit button logic

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -566,6 +566,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
+      handleCloseModal();
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -1414,13 +1415,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   return (
     <Container>
       <InnerContainer>
-        <DotsButton
-          onClick={() => {
-            setShowInfoModal('dotsMenu');
-          }}
-        >
-          ⋮
-        </DotsButton>
+        {isLoggedIn && (
+          <DotsButton
+            onClick={() => {
+              setShowInfoModal('dotsMenu');
+            }}
+          >
+            ⋮
+          </DotsButton>
+        )}
 
 
         <InputDiv>

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -521,6 +521,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('myProfileDraft');
       setState(initialProfileState);
       setIsLoggedIn(false);
+      handleCloseModal();
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -766,13 +767,15 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   return (
     <Container>
       <InnerContainer>
-        <DotsButton
-          onClick={() => {
-            setShowInfoModal('dotsMenu');
-          }}
-        >
-          ⋮
-        </DotsButton>
+        {isLoggedIn && (
+          <DotsButton
+            onClick={() => {
+              setShowInfoModal('dotsMenu');
+            }}
+          >
+            ⋮
+          </DotsButton>
+        )}
         <StatusMessage published={state.publish}>
           {state.publish ? 'Анкета опублікована' : 'Анкета прихована'}
         </StatusMessage>

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -406,6 +406,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
+      handleCloseModal();
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -561,13 +562,15 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   return (
     <Container>
       <InnerContainer>
-        <DotsButton
-          onClick={() => {
-            setShowInfoModal('dotsMenu');
-          }}
-        >
-          ⋮
-        </DotsButton>
+        {isLoggedIn && (
+          <DotsButton
+            onClick={() => {
+              setShowInfoModal('dotsMenu');
+            }}
+          >
+            ⋮
+          </DotsButton>
+        )}
         <Photos state={state} setState={setState} />
 
         {pickerFields.map(field => {


### PR DESCRIPTION
## Summary
- call `handleCloseModal` when exiting so the dialog closes
- hide the "Exit" button when logged out

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68717b2aa2c083269f28a770b90e5ac3