### PR TITLE
Fix logout menu behavior

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -590,6 +590,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [showInfoModal, setShowInfoModal] = useState(false);
 
+  useEffect(() => {
+    const logged = localStorage.getItem('isLoggedIn');
+    if (!isLoggedIn && logged) {
+      setIsLoggedIn(true);
+    }
+  }, [isLoggedIn, setIsLoggedIn]);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setShowInfoModal(false);
+    }
+  }, [isLoggedIn]);
+
   const handleCloseModal = () => {
     // setIsModalOpen(false);
     setSelectedField(null);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -13,6 +13,13 @@ export const App = () => {
   const [user, setUser] = useState(false);
   // console.log('isLoggedIn :>> ', isLoggedIn);
 
+  useEffect(() => {
+    const stored = localStorage.getItem('isLoggedIn');
+    if (stored === 'true') {
+      setIsLoggedIn(true);
+    }
+  }, []);
+
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -447,6 +447,13 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
   useEffect(() => {
+    const logged = localStorage.getItem('isLoggedIn');
+    if (!isLoggedIn && logged) {
+      setIsLoggedIn(true);
+    }
+  }, [isLoggedIn, setIsLoggedIn]);
+
+  useEffect(() => {
     const savedDraft = localStorage.getItem('myProfileDraft');
     if (savedDraft && !state.userId) {
       setState(prev => ({ ...prev, ...JSON.parse(savedDraft) }));
@@ -704,6 +711,12 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const [showInfoModal, setShowInfoModal] = useState(false);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setShowInfoModal(false);
+    }
+  }, [isLoggedIn]);
 
   const handleCloseModal = () => {
     // setIsModalOpen(false);

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -500,6 +500,12 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [showInfoModal, setShowInfoModal] = useState(false);
 
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setShowInfoModal(false);
+    }
+  }, [isLoggedIn]);
+
   const handleCloseModal = () => {
     // setIsModalOpen(false);
     setSelectedField(null);


### PR DESCRIPTION
## Summary
- restore login state from localStorage when the app mounts
- sync login state on MyProfile and admin pages
- close open menus after logout

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6872088402308326943082e548115b25