### PR TITLE
Implement logout modal closing and hide Exit

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -566,6 +566,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
+      setShowInfoModal(false);
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -1107,7 +1108,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
-        <ExitButton onClick={handleExit}>Exit</ExitButton>
+        {isLoggedIn && <ExitButton onClick={handleExit}>Exit</ExitButton>}
       </>
     );
   };

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -521,6 +521,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('myProfileDraft');
       setState(initialProfileState);
       setIsLoggedIn(false);
+      setShowInfoModal(false);
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -758,7 +759,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
-        <ExitButton onClick={handleExit}>Exit</ExitButton>
+        {isLoggedIn && <ExitButton onClick={handleExit}>Exit</ExitButton>}
       </>
     );
   };

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -406,6 +406,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
+      setShowInfoModal(false);
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -553,7 +554,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
-        <ExitButton onClick={handleExit}>Exit</ExitButton>
+        {isLoggedIn && <ExitButton onClick={handleExit}>Exit</ExitButton>}
       </>
     );
   };


### PR DESCRIPTION
## Summary
- close dots menu after logout by setting `setShowInfoModal(false)`
- only show `ExitButton` when the user is logged in

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687231b2c7bc8326a5e67699c409e0f5