### PR TITLE
Implement logout modal closing and hide Exit

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -239,6 +239,10 @@ export const SubmitButton = styled.button`
   width: 100%;
   transition: background-color 0.3s ease;
 
+  &:last-child {
+    border-bottom: none;
+  }
+
   &:hover {
     background-color: #f5f5f5; /* Легкий фон при наведенні */
   }
@@ -566,6 +570,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
+      setShowInfoModal(false);
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -1107,7 +1112,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
-        <ExitButton onClick={handleExit}>Exit</ExitButton>
+        {isLoggedIn && <ExitButton onClick={handleExit}>Exit</ExitButton>}
       </>
     );
   };

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -252,6 +252,10 @@ export const SubmitButton = styled.button`
   width: 100%;
   transition: background-color 0.3s ease;
 
+  &:last-child {
+    border-bottom: none;
+  }
+
   &:hover {
     background-color: #f5f5f5; /* Легкий фон при наведенні */
   }
@@ -521,6 +525,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('myProfileDraft');
       setState(initialProfileState);
       setIsLoggedIn(false);
+      setShowInfoModal(false);
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -758,7 +763,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
-        <ExitButton onClick={handleExit}>Exit</ExitButton>
+        {isLoggedIn && <ExitButton onClick={handleExit}>Exit</ExitButton>}
       </>
     );
   };

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -196,6 +196,10 @@ export const SubmitButton = styled.button`
   width: 100%;
   transition: background-color 0.3s ease;
 
+  &:last-child {
+    border-bottom: none;
+  }
+
   &:hover {
     background-color: #f5f5f5; /* Легкий фон при наведенні */
   }
@@ -406,6 +410,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('userEmail');
       setState({});
       setIsLoggedIn(false);
+      setShowInfoModal(false);
       navigate('/my-profile');
       await signOut(auth);
     } catch (error) {
@@ -553,7 +558,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
-        <ExitButton onClick={handleExit}>Exit</ExitButton>
+        {isLoggedIn && <ExitButton onClick={handleExit}>Exit</ExitButton>}
       </>
     );
   };


### PR DESCRIPTION
## Summary
- close dots menu after logout by setting `setShowInfoModal(false)`
- only show `ExitButton` when the user is logged in
- remove menu line above Exit when Exit isn't rendered

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687231b2c7bc8326a5e67699c409e0f5