### PR TITLE
Fix modal overlay centering

### DIFF
--- a/src/components/InfoModal.jsx
+++ b/src/components/InfoModal.jsx
@@ -5,12 +5,13 @@ const ModalOverlay = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 1000;
 `;
 
 const OptionsList = styled.ul`


### PR DESCRIPTION
## Summary
- ensure the info modal overlay covers the viewport

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68728f76d13c8326a04edfc06fc803a3