### PR TITLE
Fix admin login redirect

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,7 +10,7 @@ import { auth } from './config';
 export const App = () => {
 
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [user, setUser] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(null);
   // console.log('isLoggedIn :>> ', isLoggedIn);
 
   const navigate = useNavigate();
@@ -23,17 +23,19 @@ export const App = () => {
   }, []);
 
   useEffect(() => {
-    if (isLoggedIn) {
+    if (isLoggedIn && isAdmin === false) {
       navigate('/my-profile');
     }
-  }, [isLoggedIn, navigate]);
+  }, [isLoggedIn, navigate, isAdmin]);
 
   // Special page for admin
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, user => {
       if (user && user.uid === process.env.REACT_APP_USER1) {
-       setUser(true)
-      } 
+        setIsAdmin(true);
+      } else {
+        setIsAdmin(false);
+      }
     });
     // Clean up the subscription on component unmount
     return () => unsubscribe();
@@ -41,10 +43,10 @@ export const App = () => {
 
   return (
     <Routes>
-      <Route path="/" element={user ? <AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} /> : <PrivacyPolicy />} />
+      <Route path="/" element={isAdmin ? <AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} /> : <PrivacyPolicy />} />
       <Route path="/submit" element={<SubmitForm />} />
       <Route path="/my-profile"  element={<MyProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
-      {user&& <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
+      {isAdmin && <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -245,7 +245,9 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.setItem('userEmail', state.email);
 
       setIsLoggedIn(true);
-      navigate('/my-profile');
+      if (userCredential.user.uid !== process.env.REACT_APP_USER1) {
+        navigate('/my-profile');
+      }
       console.log('User signed in:', userCredential.user);
     } catch (error) {
       if (error.code === 'auth/wrong-password') {
@@ -280,7 +282,9 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.setItem('userEmail', state.email);
 
       setIsLoggedIn(true);
-      navigate('/my-profile');
+      if (userCredential.user.uid !== process.env.REACT_APP_USER1) {
+        navigate('/my-profile');
+      }
     } catch (error) {
       console.error('Error signing in:', error);
     }

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -575,7 +575,9 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
       setIsLoggedIn(true);
       setState(prev => ({ ...prev, userId: userCredential.user.uid }));
-      navigate('/my-profile');
+      if (userCredential.user.uid !== process.env.REACT_APP_USER1) {
+        navigate('/my-profile');
+      }
     } catch (error) {
       if (error.code === 'auth/wrong-password') {
         toast.error('Невірний пароль');


### PR DESCRIPTION
## Summary
- prevent sending admin to `/my-profile` during login

## Testing
- `npm run lint:js`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68729abaffdc83268c6d336966f21cd0