### PR TITLE
Add matching page for admin

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -4,6 +4,7 @@ import { PrivacyPolicy } from './PrivacyPolicy';
 import { MyProfile } from './MyProfile';
 import { SubmitForm } from './SubmitForm';
 import {AddNewProfile} from './AddNewProfile';
+import Matching from './Matching';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from './config';
 
@@ -47,6 +48,7 @@ export const App = () => {
       <Route path="/submit" element={<SubmitForm />} />
       <Route path="/my-profile"  element={<MyProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
       {isAdmin && <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
+      {isAdmin && <Route path="/matching" element={<Matching />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { fetchUsersCollectionInRTDB, getAllUserPhotos } from './config';
+import { getCurrentValue } from './getCurrentValue';
+
+const Grid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px;
+`;
+
+const Card = styled.div`
+  width: 120px;
+  height: 160px;
+  background-color: orange;
+  background-size: cover;
+  background-position: center;
+  border-radius: 8px;
+`;
+
+const Matching = () => {
+  const [users, setUsers] = useState([]);
+
+  const loadUsers = async () => {
+    try {
+      const data = await fetchUsersCollectionInRTDB();
+      const withPhotos = await Promise.all(
+        data.map(async user => {
+          const photos = await getAllUserPhotos(user.userId);
+          return { ...user, photos };
+        })
+      );
+      setUsers(withPhotos);
+    } catch (e) {
+      console.error('Error loading users:', e);
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  return (
+    <Grid>
+      {users.map(user => {
+        const photo = getCurrentValue(user.photos);
+
+        return (
+          <Card
+            key={user.userId}
+            style={
+              photo
+                ? { backgroundImage: `url(${photo})`, backgroundColor: 'transparent' }
+                : {}
+            }
+          />
+        );
+      })}
+    </Grid>
+  );
+};
+
+export default Matching;

--- a/src/components/getCurrentValue.js
+++ b/src/components/getCurrentValue.js
@@ -1,0 +1,11 @@
+export const getCurrentValue = value => {
+  if (Array.isArray(value)) {
+    const filtered = value.filter(v => v !== undefined && v !== null && v !== '');
+    return filtered[filtered.length - 1];
+  }
+  if (value && typeof value === 'object') {
+    const vals = Object.values(value).filter(v => v !== undefined && v !== null && v !== '');
+    return vals[vals.length - 1];
+  }
+  return value;
+};


### PR DESCRIPTION
## Summary
- add simple Matching component that lists user cards from the `users` collection
- expose new admin-only route `/matching`
- allow Matching to read photo either from an array or single value

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6874db7558048326be3b8dc56e5c04e2