### PR TITLE
Fix user data missing in matching modal

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -184,7 +184,7 @@ export const fetchLatestUsers = async (limit = 9, lastKey) => {
   const lastEntry = entries[entries.length - 1];
 
   return {
-    users: entries.map(([id, data]) => data),
+    users: entries.map(([id, data]) => ({ userId: id, ...data })),
     lastKey: lastEntry ? lastEntry[0] : null,
     hasMore,
   };


### PR DESCRIPTION
## Summary
- ensure `fetchLatestUsers` includes user id when returning users

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68751c58e3e48326a4cd4c79618c5ab2