### PR TITLE
Fix modal text color and implement lazy loading

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -39,6 +39,7 @@ const ModalContent = styled.div`
   border-radius: 8px;
   max-height: 90vh;
   overflow-y: auto;
+  color: black;
 `;
 
 const renderFields = (data, parentKey = '') => {
@@ -157,16 +158,24 @@ const Matching = () => {
     loadInitial();
   }, [loadInitial]);
 
-  const handleScroll = e => {
-    const { scrollTop, clientHeight, scrollHeight } = e.currentTarget;
-    if (scrollTop + clientHeight >= scrollHeight - 10) {
-      loadMore();
-    }
-  };
+  const loaderRef = useRef(null);
+
+  useEffect(() => {
+    const node = loaderRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        loadMore();
+      }
+    });
+
+    observer.observe(node);
+    return () => observer.unobserve(node);
+  }, [loadMore]);
 
   return (
     <>
-      <Grid onScroll={handleScroll} style={{ overflowY: 'auto', height: '80vh' }}>
+      <Grid style={{ overflowY: 'auto', height: '80vh' }}>
         {users.map(user => {
           const photo = getCurrentValue(user.photos);
           return (
@@ -181,6 +190,7 @@ const Matching = () => {
             />
           );
         })}
+        <div ref={loaderRef} style={{ width: '100%', height: '1px' }} />
       </Grid>
       {selected && (
         <ModalOverlay onClick={() => setSelected(null)}>


### PR DESCRIPTION
## Summary
- ensure modal text is readable by setting text color to black
- replace scroll-based loading with an IntersectionObserver loader

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687523b89a9883268d40d358b52d2722