### PR TITLE
Fix infinite scroll observer

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -176,8 +176,11 @@ const Matching = () => {
     );
 
     observer.observe(node);
-    return () => observer.disconnect();
-  }, [loadMore]);
+    return () => {
+      observer.unobserve(node);
+      observer.disconnect();
+    };
+  }, [loadMore, users.length]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- reattach intersection observer after users update in Matching

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68753cd01c6883269cbe258ad4c5ca86