### PR TITLE
Add icon-based contact display in Matching modal

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { color } from './styles';
 import { fetchLatestUsers, getAllUserPhotos } from './config';
 import { getCurrentValue } from './getCurrentValue';
-import { fieldContacts } from './smallCard/fieldContacts';
+import { fieldContactsIcons } from './smallCard/fieldContacts';
 
 const Grid = styled.div`
   display: flex;
@@ -313,7 +313,7 @@ const Matching = () => {
                   ? selected.phone[0]
                   : selected.phone}
               </div>
-              <Icons>{fieldContacts(selected)}</Icons>
+              <Icons>{fieldContactsIcons(selected)}</Icons>
             </Contact>
             <Id>ID: {selected.userId}</Id>
           </DonorCard>

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -1,3 +1,13 @@
+import {
+  FaFacebookF,
+  FaInstagram,
+  FaTelegramPlane,
+  FaViber,
+  FaWhatsapp,
+} from 'react-icons/fa';
+import { MdEmail } from 'react-icons/md';
+import { SiTiktok } from 'react-icons/si';
+
 export const fieldContacts = (data, parentKey = '') => {
   if (!data || typeof data !== 'object') {
     console.error('Invalid data passed to renderContacts:', data);
@@ -141,5 +151,111 @@ export const fieldContacts = (data, parentKey = '') => {
     }
 
     return null; // Якщо ключ не обробляється
+  });
+};
+
+export const fieldContactsIcons = data => {
+  if (!data || typeof data !== 'object') {
+    console.error('Invalid data passed to renderContacts:', data);
+    return null;
+  }
+
+  const links = {
+    telegram: value => `https://t.me/${value}`,
+    instagram: value => `https://instagram.com/${value}`,
+    tiktok: value => `https://www.tiktok.com/@${value}`,
+    phone: value => `tel:${value}`,
+    facebook: value => `https://facebook.com/${value}`,
+    vk: value => `https://vk.com/${value}`,
+    otherLink: value => `${value}`,
+    email: value => `mailto:${value}`,
+    telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
+    viberFromPhone: value => `viber://chat?number=%2B${value.replace(/\s+/g, '')}`,
+    whatsappFromPhone: value => `https://wa.me/${value.replace(/\s+/g, '')}`,
+  };
+
+  const iconMap = {
+    facebook: <FaFacebookF />,
+    instagram: <FaInstagram />,
+    tiktok: <SiTiktok />,
+    email: <MdEmail />,
+  };
+
+  return Object.keys(data).map(key => {
+    const value = data[key];
+    if (!value || (Array.isArray(value) && value.length === 0)) return null;
+
+    if (key === 'phone') {
+      const val = Array.isArray(value) ? value[0] : value;
+      const processed = val.replace(/\s/g, '');
+      return (
+        <div key="phone" style={{ marginBottom: '2px' }}>
+          <a
+            href={links.phone(processed)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
+          >
+            {`+${processed}`}
+          </a>
+          <a
+            href={links.telegramFromPhone(`+${val}`)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
+          >
+            <FaTelegramPlane />
+          </a>
+          <a
+            href={links.viberFromPhone(processed)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
+          >
+            <FaViber />
+          </a>
+          <a
+            href={links.whatsappFromPhone(processed)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
+          >
+            <FaWhatsapp />
+          </a>
+        </div>
+      );
+    }
+
+    if (iconMap[key]) {
+      const val = Array.isArray(value) ? value[0] : value;
+      return (
+        <a
+          key={key}
+          href={links[key](val)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
+        >
+          {iconMap[key]}
+        </a>
+      );
+    }
+
+    if (links[key]) {
+      const val = Array.isArray(value) ? value[0] : value;
+      return (
+        <a
+          key={key}
+          href={links[key](val)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
+        >
+          {val}
+        </a>
+      );
+    }
+
+    return null;
   });
 };


### PR DESCRIPTION
## Summary
- render contact icons inside the Matching modal
- support icon-only rendering in `fieldContacts`

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find a config)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761992238c83268906dba9ba913973