### PR TITLE
Fix phone display in Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -308,11 +308,6 @@ const Matching = () => {
               </MoreInfo>
             )}
             <Contact>
-              <div className="phone">
-                {Array.isArray(selected.phone)
-                  ? selected.phone[0]
-                  : selected.phone}
-              </div>
               <Icons>{fieldContactsIcons(selected)}</Icons>
             </Contact>
             <Id>ID: {selected.userId}</Id>

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -186,44 +186,52 @@ export const fieldContactsIcons = data => {
     if (!value || (Array.isArray(value) && value.length === 0)) return null;
 
     if (key === 'phone') {
-      const val = Array.isArray(value) ? value[0] : value;
-      const processed = val.replace(/\s/g, '');
-      return (
-        <div key="phone" style={{ marginBottom: '2px' }}>
-          <a
-            href={links.phone(processed)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
-          >
-            {`+${processed}`}
-          </a>
-          <a
-            href={links.telegramFromPhone(`+${val}`)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-          >
-            <FaTelegramPlane />
-          </a>
-          <a
-            href={links.viberFromPhone(processed)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-          >
-            <FaViber />
-          </a>
-          <a
-            href={links.whatsappFromPhone(processed)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-          >
-            <FaWhatsapp />
-          </a>
-        </div>
-      );
+      const numbers = Array.isArray(value) ? value : [value];
+      return numbers
+        .filter(val => typeof val === 'string' && val.trim() !== '')
+        .map((val, idx) => {
+          const processed = val.replace(/\s/g, '');
+          return (
+            <div key={`phone-${idx}`} style={{ marginBottom: '2px' }}>
+              <a
+                href={links.phone(processed)}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: 'inherit',
+                  textDecoration: 'none',
+                  marginRight: '8px',
+                }}
+              >
+                {`+${processed}`}
+              </a>
+              <a
+                href={links.telegramFromPhone(`+${val}`)}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
+              >
+                <FaTelegramPlane />
+              </a>
+              <a
+                href={links.viberFromPhone(processed)}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
+              >
+                <FaViber />
+              </a>
+              <a
+                href={links.whatsappFromPhone(processed)}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
+              >
+                <FaWhatsapp />
+              </a>
+            </div>
+          );
+        });
     }
 
     if (iconMap[key]) {


### PR DESCRIPTION
## Summary
- only show phone numbers once in matching modal
- render all phone numbers with Tg/Viber/WA icons

## Testing
- `npm run lint:js`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687632688320832698cb293139b7fece