### PR TITLE
Adjust matching display order and reward handling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -169,6 +169,15 @@ const renderSelectedFields = user => {
       }
     }
 
+    if (field.key === 'reward') {
+      if (Array.isArray(value)) {
+        value = value[value.length - 1];
+      } else if (typeof value === 'string' && value.includes(',')) {
+        const parts = value.split(',');
+        value = parts[parts.length - 1].trim();
+      }
+    }
+
     if (value === undefined || value === '' || value === null) return null;
 
     return (
@@ -310,7 +319,7 @@ const Matching = () => {
             <Contact>
               <Icons>{fieldContactsIcons(selected)}</Icons>
             </Contact>
-            <Id>ID: {selected.userId}</Id>
+            <Id>ID: {selected.userId ? selected.userId.slice(0, 5) : ''}</Id>
           </DonorCard>
         </ModalOverlay>
       )}

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   FaFacebookF,
   FaInstagram,
@@ -180,46 +181,20 @@ export const fieldContactsIcons = data => {
     instagram: <FaInstagram />,
     tiktok: <SiTiktok />,
     email: <MdEmail />,
+    telegram: <FaTelegramPlane />,
   };
 
   const processed = Object.fromEntries(
     Object.entries(data).map(([k, v]) => [k, getCurrentValue(v)])
   );
 
-  const socialKeys = ['instagram', 'facebook', 'vk', 'tiktok', 'telegram', 'otherLink', 'email'];
-
-  const socialRow = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
-      {socialKeys.map(key => {
-        const val = processed[key];
-        if (!val) return null;
-        if (iconMap[key]) {
-          return (
-            <a
-              key={key}
-              href={links[key](val)}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: 'inherit', textDecoration: 'none' }}
-            >
-              {iconMap[key]}
-            </a>
-          );
-        }
-        return (
-          <a
-            key={key}
-            href={links[key](val)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none' }}
-          >
-            {val}
-          </a>
-        );
-      })}
-    </div>
-  );
+  const telegramValues = processed.telegram
+    ? Array.isArray(processed.telegram)
+      ? processed.telegram.filter(v => v && !String(v).trim().startsWith('УК СМ'))
+      : String(processed.telegram).trim().startsWith('УК СМ')
+        ? []
+        : [processed.telegram]
+    : [];
 
   const phoneValues = processed.phone
     ? Array.isArray(processed.phone)
@@ -227,50 +202,103 @@ export const fieldContactsIcons = data => {
       : [processed.phone]
     : [];
 
-  const phoneRows = phoneValues.map((val, idx) => {
-    const processedVal = String(val).replace(/\s/g, '');
-    return (
-      <div key={`phone-${idx}`} style={{ marginTop: idx ? '2px' : '0px' }}>
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+      {phoneValues.map((val, idx) => {
+        const processedVal = String(val).replace(/\s/g, '');
+        return (
+          <React.Fragment key={`phone-${idx}`}>
+            <a
+              href={links.phone(processedVal)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'none' }}
+            >
+              {`+${processedVal}`}
+            </a>
+            <a
+              href={links.telegramFromPhone(`+${val}`)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'none' }}
+            >
+              <FaTelegramPlane />
+            </a>
+            <a
+              href={links.viberFromPhone(processedVal)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'none' }}
+            >
+              <FaViber />
+            </a>
+            <a
+              href={links.whatsappFromPhone(processedVal)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'none' }}
+            >
+              <FaWhatsapp />
+            </a>
+          </React.Fragment>
+        );
+      })}
+
+      {processed.email && (
         <a
-          href={links.phone(processedVal)}
+          href={links.email(processed.email)}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
+          style={{ color: 'inherit', textDecoration: 'none' }}
         >
-          {`+${processedVal}`}
+          <MdEmail />
         </a>
+      )}
+
+      {processed.facebook && (
         <a
-          href={links.telegramFromPhone(`+${val}`)}
+          href={links.facebook(processed.facebook)}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          <FaFacebookF />
+        </a>
+      )}
+
+      {processed.instagram && (
+        <a
+          href={links.instagram(processed.instagram)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          <FaInstagram />
+        </a>
+      )}
+
+      {telegramValues.map((val, idx) => (
+        <a
+          key={`telegram-${idx}`}
+          href={links.telegram(val)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none' }}
         >
           <FaTelegramPlane />
         </a>
-        <a
-          href={links.viberFromPhone(processedVal)}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
-        >
-          <FaViber />
-        </a>
-        <a
-          href={links.whatsappFromPhone(processedVal)}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
-        >
-          <FaWhatsapp />
-        </a>
-      </div>
-    );
-  });
+      ))}
 
-  return (
-    <div>
-      {socialRow}
-      {phoneRows}
+      {processed.tiktok && (
+        <a
+          href={links.tiktok(processed.tiktok)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          <SiTiktok />
+        </a>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- filter telegram links and reorder icons in `fieldContactsIcons`
- clean up expected reward display for archived values
- truncate user IDs in Matching modal

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687654abdb08832682efb01dcaa26394