### PR TITLE
Adjust Matching route info display

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import styled from 'styled-components';
 import { color } from './styles';
 import { fetchLatestUsers, getAllUserPhotos } from './config';
@@ -135,7 +136,7 @@ const MoreInfo = styled.div`
 
 const Contact = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   font-size: 14px;
   border-top: 1px solid ${color.gray4};
@@ -295,6 +296,7 @@ const Matching = () => {
                 <strong>
                   {selected.surname || ''} {selected.name || ''}
                   {selected.fathersname ? `, ${selected.fathersname}` : ''}
+                  {selected.birth ? `, ${utilCalculateAge(selected.birth)}р` : ''}
                 </strong>
                 <br />
                 {selected.region || ''}
@@ -309,8 +311,16 @@ const Matching = () => {
                 {selected.myComment}
               </MoreInfo>
             )}
+            {selected.moreInfo_main && (
+              <MoreInfo>
+                {selected.moreInfo_main}
+              </MoreInfo>
+            )}
             <Contact>
               <Icons>{fieldContactsIcons(selected)}</Icons>
+              {selected.writer && (
+                <div style={{ marginLeft: '10px' }}>{selected.writer}</div>
+              )}
             </Contact>
             <Id>ID: {selected.userId ? selected.userId.slice(0, 5) : ''}</Id>
           </DonorCard>

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -206,7 +206,7 @@ export const fieldContactsIcons = data => {
               href={links.phone(processedVal)}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: 'inherit', textDecoration: 'none' }}
+              style={{ color: 'black', textDecoration: 'none' }}
             >
               {`+${processedVal}`}
             </a>


### PR DESCRIPTION
## Summary
- enhance Matching modal: add age next to name and display moreInfo_main before contacts
- style contacts row with writer text and show phone numbers in black

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68768b4facdc8326bf9021d413c6fdcb