### PR TITLE
Add like/dislike features to matching

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -212,6 +212,26 @@ export const removeFavoriteUser = async userId => {
   }
 };
 
+export const addDislikeUser = async userId => {
+  try {
+    const owner = auth.currentUser;
+    if (!owner) return;
+    await set(ref2(database, `multiData/dislikes/${owner.uid}/${userId}`), true);
+  } catch (error) {
+    console.error('Error adding dislike user:', error);
+  }
+};
+
+export const removeDislikeUser = async userId => {
+  try {
+    const owner = auth.currentUser;
+    if (!owner) return;
+    await remove(ref2(database, `multiData/dislikes/${owner.uid}/${userId}`));
+  } catch (error) {
+    console.error('Error removing dislike user:', error);
+  }
+};
+
 // Retrieve favorites for a specific owner
 export const fetchFavoriteUsers = async ownerId => {
   try {
@@ -237,6 +257,33 @@ export const fetchFavoriteUsersData = async ownerId => {
     return data;
   } catch (error) {
     console.error('Error fetching favorite users data:', error);
+    return {};
+  }
+};
+
+export const fetchDislikeUsers = async ownerId => {
+  try {
+    const refPath = ref2(database, `multiData/dislikes/${ownerId}`);
+    const snap = await get(refPath);
+    return snap.exists() ? snap.val() : {};
+  } catch (error) {
+    console.error('Error fetching dislike users:', error);
+    return {};
+  }
+};
+
+export const fetchDislikeUsersData = async ownerId => {
+  try {
+    const dislikeIds = await fetchDislikeUsers(ownerId);
+    const ids = Object.keys(dislikeIds || {});
+    const results = await Promise.all(ids.map(id => fetchUserById(id)));
+    const data = {};
+    results.forEach((user, idx) => {
+      if (user) data[ids[idx]] = user;
+    });
+    return data;
+  } catch (error) {
+    console.error('Error fetching dislike users data:', error);
     return {};
   }
 };

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { addDislikeUser, removeDislikeUser, auth } from '../config';
+
+export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
+  const isDisliked = !!dislikeUsers[userId];
+
+  const toggleDislike = async () => {
+    if (!auth.currentUser) {
+      alert('Please sign in to manage dislikes');
+      return;
+    }
+    if (isDisliked) {
+      try {
+        await removeDislikeUser(userId);
+        const updated = { ...dislikeUsers };
+        delete updated[userId];
+        setDislikeUsers(updated);
+      } catch (error) {
+        console.error('Failed to remove dislike:', error);
+      }
+    } else {
+      try {
+        await addDislikeUser(userId);
+        setDislikeUsers({ ...dislikeUsers, [userId]: true });
+      } catch (error) {
+        console.error('Failed to add dislike:', error);
+      }
+    }
+  };
+
+  return (
+    <button
+      style={{
+        position: 'absolute',
+        top: '10px',
+        right: '10px',
+        width: '35px',
+        height: '35px',
+        borderRadius: '50%',
+        background: 'white',
+        border: `2px solid ${isDisliked ? 'blue' : 'gray'}`,
+        color: isDisliked ? 'blue' : 'gray',
+        cursor: 'pointer',
+      }}
+      disabled={!auth.currentUser}
+      onClick={e => {
+        e.stopPropagation();
+        toggleDislike();
+      }}
+    >
+      {isDisliked ? '👎' : '👍'}
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- add dislike button component
- support dislikes in Firebase config
- implement loading favorites/dislikes and update name formatting in Matching
- preload more cards on scroll with 6+2 strategy

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68779f5cd6508326b666455f4391d1ef