### PR TITLE
Fix dislike realtime update

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -252,14 +252,35 @@ const Matching = () => {
   }, []);
 
   const fetchChunk = async (limit, key) => {
-    const res = await fetchLatestUsers(limit, key);
-    const withPhotos = await Promise.all(
-      res.users.map(async user => {
-        const photos = await getAllUserPhotos(user.userId);
-        return { ...user, photos };
-      }),
-    );
-    return { users: withPhotos, lastKey: res.lastKey, hasMore: res.hasMore };
+    const ignored = new Set([
+      ...Object.keys(favoriteUsers || {}),
+      ...Object.keys(dislikeUsers || {}),
+    ]);
+    let hasMoreRes = true;
+    let last = key;
+    const collected = [];
+
+    while (hasMoreRes && collected.length < limit) {
+      const res = await fetchLatestUsers(limit, last);
+      last = res.lastKey;
+      hasMoreRes = res.hasMore;
+
+      const filtered = res.users.filter(u => !ignored.has(u.userId));
+      const withPhotos = await Promise.all(
+        filtered.map(async user => {
+          const photos = await getAllUserPhotos(user.userId);
+          return { ...user, photos };
+        }),
+      );
+      collected.push(...withPhotos);
+
+      if (!hasMoreRes) break;
+      if (collected.length < limit) {
+        continue;
+      }
+    }
+
+    return { users: collected.slice(0, limit), lastKey: last, hasMore: hasMoreRes };
   };
 
   const loadInitial = React.useCallback(async () => {
@@ -357,15 +378,22 @@ const Matching = () => {
                   : {}
               }
             >
-              <BtnFavorite
-                userId={user.userId}
-                favoriteUsers={favoriteUsers}
-                setFavoriteUsers={setFavoriteUsers}
-              />
               <BtnDislike
                 userId={user.userId}
                 dislikeUsers={dislikeUsers}
                 setDislikeUsers={setDislikeUsers}
+                style={{ bottom: '10px', left: '10px', top: 'auto', right: 'auto' }}
+                onToggle={disliked => {
+                  if (disliked) {
+                    setUsers(prev => prev.filter(u => u.userId !== user.userId));
+                  }
+                }}
+              />
+              <BtnFavorite
+                userId={user.userId}
+                favoriteUsers={favoriteUsers}
+                setFavoriteUsers={setFavoriteUsers}
+                style={{ bottom: '10px', right: '10px', top: 'auto', left: 'auto' }}
               />
             </Card>
           );

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { addDislikeUser, removeDislikeUser, auth } from '../config';
 
-export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
+export const BtnDislike = ({
+  userId,
+  dislikeUsers = {},
+  setDislikeUsers,
+  style = {},
+  onToggle,
+}) => {
   const isDisliked = !!dislikeUsers[userId];
 
   const toggleDislike = async () => {
@@ -26,6 +32,7 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
         console.error('Failed to add dislike:', error);
       }
     }
+    if (onToggle) onToggle(!isDisliked);
   };
 
   return (
@@ -41,6 +48,7 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
         border: `2px solid ${isDisliked ? 'blue' : 'gray'}`,
         color: isDisliked ? 'blue' : 'gray',
         cursor: 'pointer',
+        ...style,
       }}
       disabled={!auth.currentUser}
       onClick={e => {

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { addFavoriteUser, removeFavoriteUser, auth } from '../config';
 
-export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) => {
+export const BtnFavorite = ({
+  userId,
+  favoriteUsers = {},
+  setFavoriteUsers,
+  style = {},
+  onToggle,
+}) => {
   const isFavorite = !!favoriteUsers[userId];
 
   const toggleFavorite = async () => {
@@ -26,6 +32,7 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) =>
         console.error('Failed to add favorite:', error);
       }
     }
+    if (onToggle) onToggle(!isFavorite);
   };
 
   return (
@@ -41,6 +48,7 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) =>
         border: `2px solid ${isFavorite ? 'red' : 'gray'}`,
         color: isFavorite ? 'red' : 'gray',
         cursor: 'pointer',
+        ...style,
       }}
       disabled={!auth.currentUser}
       onClick={e => {


### PR DESCRIPTION
## Summary
- allow custom style and toggle callback for like/dislike buttons
- filter disliked and liked users when loading Matching cards
- move dislike/like controls to bottom positions on Matching cards

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6877b84306dc83269c2356e15358d174