### PR TITLE
Fix matching route actions

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addDislikeUser, removeDislikeUser, auth } from '../config';
 
-export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
+export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemove }) => {
   const isDisliked = !!dislikeUsers[userId];
 
   const toggleDislike = async () => {
@@ -15,6 +15,7 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
         const updated = { ...dislikeUsers };
         delete updated[userId];
         setDislikeUsers(updated);
+        if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to remove dislike:', error);
       }
@@ -22,6 +23,7 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
       try {
         await addDislikeUser(userId);
         setDislikeUsers({ ...dislikeUsers, [userId]: true });
+        if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to add dislike:', error);
       }
@@ -32,8 +34,8 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
     <button
       style={{
         position: 'absolute',
-        top: '10px',
-        right: '10px',
+        bottom: '10px',
+        left: '10px',
         width: '35px',
         height: '35px',
         borderRadius: '50%',
@@ -48,7 +50,7 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers }) => {
         toggleDislike();
       }}
     >
-      {isDisliked ? '👎' : '👍'}
+      {'👎'}
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addFavoriteUser, removeFavoriteUser, auth } from '../config';
 
-export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) => {
+export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRemove }) => {
   const isFavorite = !!favoriteUsers[userId];
 
   const toggleFavorite = async () => {
@@ -15,6 +15,7 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) =>
         const updated = { ...favoriteUsers };
         delete updated[userId];
         setFavoriteUsers(updated);
+        if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to remove favorite:', error);
       }
@@ -32,8 +33,8 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers }) =>
     <button
       style={{
         position: 'absolute',
-        top: '10px',
-        right: '50px',
+        bottom: '10px',
+        right: '10px',
         width: '35px',
         height: '35px',
         borderRadius: '50%',


### PR DESCRIPTION
## Summary
- exclude liked or disliked cards when loading matching page
- track view state to manage favorites/dislikes lists
- reposition like/dislike buttons on cards
- keep real-time updates and allow removing cards from favorites/dislikes

## Testing
- `CI=1 npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877e2d772dc8326b7a5d79071122d9a