### PR TITLE
Show fetch info in toasts

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -19,6 +19,7 @@ import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
 import { fieldContactsIcons } from './smallCard/fieldContacts';
 import PhotoViewer from './PhotoViewer';
+import toast from 'react-hot-toast';
 
 const Grid = styled.div`
   display: flex;
@@ -308,6 +309,9 @@ const Matching = () => {
       setLastKey(res.lastKey);
       setHasMore(res.hasMore);
       setViewMode('default');
+      toast(
+        `Initial load: ${res.users.length} users. hasMore: ${res.hasMore}. lastKey: ${res.lastKey}`,
+      );
     } finally {
       loadingRef.current = false;
       setLoading(false);
@@ -348,6 +352,9 @@ const Matching = () => {
       setUsers(prev => [...prev, ...res.users]);
       setLastKey(res.lastKey);
       setHasMore(res.hasMore);
+      toast(
+        `Loaded ${res.users.length} more. hasMore: ${res.hasMore}. lastKey: ${res.lastKey}`,
+      );
     } finally {
       loadingRef.current = false;
       setLoading(false);


### PR DESCRIPTION
## Summary
- notify how many cards load by showing toast message on fetch

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878b9048040832693b21f8277a6d600