### PR TITLE
Update Matching UI

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -19,7 +19,6 @@ import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
 import { fieldContactsIcons } from './smallCard/fieldContacts';
 import PhotoViewer from './PhotoViewer';
-import toast from 'react-hot-toast';
 
 const Grid = styled.div`
   display: flex;
@@ -30,7 +29,7 @@ const Grid = styled.div`
 `;
 
 const Card = styled.div`
-  width: calc(50% - 20px);
+  width: 100%;
   height: 40vh;
   background-color: orange;
   background-size: cover;
@@ -248,8 +247,8 @@ const renderSelectedFields = user => {
   });
 };
 
-const INITIAL_LOAD = 6;
-const LOAD_MORE = 2;
+const INITIAL_LOAD = 3;
+const LOAD_MORE = 1;
 
 const roleMatchesFilter = (user, filter) => {
   const userRoles = Array.isArray(user.userRole)
@@ -357,9 +356,6 @@ const Matching = () => {
       setLastKey(res.lastKey);
       setHasMore(res.hasMore);
       setViewMode('default');
-      toast(
-        `Initial load: ${res.users.length} users. hasMore: ${res.hasMore}. lastKey: ${res.lastKey}`,
-      );
     } finally {
       loadingRef.current = false;
       setLoading(false);
@@ -404,9 +400,6 @@ const Matching = () => {
       setUsers(prev => [...prev, ...unique]);
       setLastKey(res.lastKey);
       setHasMore(res.hasMore);
-      toast(
-        `Loaded ${res.users.length} more. hasMore: ${res.hasMore}. lastKey: ${res.lastKey}`,
-      );
     } finally {
       loadingRef.current = false;
       setLoading(false);

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { addDislikeUser, removeDislikeUser, auth } from '../config';
+import { color } from '../styles';
 
 export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemove }) => {
   const isDisliked = !!dislikeUsers[userId];
@@ -39,9 +40,9 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         width: '35px',
         height: '35px',
         borderRadius: '50%',
-        background: 'white',
-        border: `2px solid ${isDisliked ? 'blue' : 'gray'}`,
-        color: isDisliked ? 'blue' : 'gray',
+        background: color.accent5,
+        border: 'none',
+        color: 'white',
         cursor: 'pointer',
       }}
       disabled={!auth.currentUser}

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { addFavoriteUser, removeFavoriteUser, auth } from '../config';
+import { color } from '../styles';
 
 export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRemove }) => {
   const isFavorite = !!favoriteUsers[userId];
@@ -38,9 +39,9 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         width: '35px',
         height: '35px',
         borderRadius: '50%',
-        background: 'white',
-        border: `2px solid ${isFavorite ? 'red' : 'gray'}`,
-        color: isFavorite ? 'red' : 'gray',
+        background: color.accent5,
+        border: 'none',
+        color: 'white',
         cursor: 'pointer',
       }}
       disabled={!auth.currentUser}


### PR DESCRIPTION
## Summary
- remove debug toasts from matching screen
- adjust card layout to single column and tweak chunk sizes
- unify like/dislike button styling across matching

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6878f889b8bc8326a75757b5b880d18d