### PR TITLE
Fix Matching unused toast import

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -23,7 +23,6 @@ import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
 import { fieldContactsIcons } from './smallCard/fieldContacts';
 import PhotoViewer from './PhotoViewer';
-import toast from 'react-hot-toast';
 import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 


### PR DESCRIPTION
## Summary
- remove unused toast import

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68791e6761c48326b3f5a132f1752e35