### PR TITLE
Fix AddNewProfile parsing error

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -725,8 +725,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
 
   const handleAddUser = async () => {
-    const res = await makeNewUser(searchKeyValuePair);
+    await makeNewUser(searchKeyValuePair);
     setUserNotFound(false);
+  };
   const dotsMenu = () => {
     return (
       <>
@@ -1381,7 +1382,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   favoriteUsers={favoriteUsersData}
                   setFavoriteUsers={setFavoriteUsersData}
                   setUsers={setUsers}
-                  setSearch={setSearch}
                   setState={setState}
                   currentFilter={currentFilter}
                   isDateInRange={isDateInRange}


### PR DESCRIPTION
## Summary
- fix missing brace causing parse errors in `AddNewProfile.jsx`
- remove unused `setSearch` prop and lint warning

## Testing
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_687924cdcf848326824a263e7294b658