### PR TITLE
Fix edit button search state

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -394,6 +394,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [userNotFound, setUserNotFound] = useState(false); // Стан для зберігання останнього ключа
 
+  const [search, setSearch] = useState('');
+
   const [state, setState] = useState({});
   const isEditingRef = useRef(false);
 
@@ -1054,6 +1056,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
         <SearchBar
           searchFunc={fetchNewUsersCollectionInRTDB}
+          search={search}
+          setSearch={setSearch}
           setUsers={setUsers}
           setState={setState}
           setUserNotFound={setUserNotFound}
@@ -1382,6 +1386,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   favoriteUsers={favoriteUsersData}
                   setFavoriteUsers={setFavoriteUsersData}
                   setUsers={setUsers}
+                  setSearch={setSearch}
                   setState={setState}
                   currentFilter={currentFilter}
                   isDateInRange={isDateInRange}

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -55,8 +55,21 @@ const ClearButton = styled.button`
   }
 `;
 
-const SearchBar = ({ searchFunc, setUsers, setState, setUserNotFound, onSearchKey }) => {
-  const [search, setSearch] = useState(() => localStorage.getItem('searchQuery') || '');
+const SearchBar = ({
+  searchFunc,
+  setUsers,
+  setState,
+  setUserNotFound,
+  onSearchKey,
+  search: externalSearch,
+  setSearch: externalSetSearch,
+}) => {
+  const [internalSearch, setInternalSearch] = useState(
+    () => localStorage.getItem('searchQuery') || '',
+  );
+
+  const search = externalSearch !== undefined ? externalSearch : internalSearch;
+  const setSearch = externalSetSearch !== undefined ? externalSetSearch : setInternalSearch;
 
   useEffect(() => {
     if (search) {


### PR DESCRIPTION
## Summary
- allow SearchBar to accept external search state
- store `search` in AddNewProfile and pass it down to SearchBar and UsersList

## Testing
- `npm run lint:js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68793a50b9d083268b8f7afce7552be8