### PR TITLE
Handle clearing search after editing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1062,6 +1062,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           setState={setState}
           setUserNotFound={setUserNotFound}
           onSearchKey={setSearchKeyValuePair}
+          onClear={() => {
+            setState({});
+            setSearchKeyValuePair(null);
+          }}
         />
         {state.userId ? (
           <>

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -63,6 +63,7 @@ const SearchBar = ({
   onSearchKey,
   search: externalSearch,
   setSearch: externalSetSearch,
+  onClear,
 }) => {
   const [internalSearch, setInternalSearch] = useState(
     () => localStorage.getItem('searchQuery') || '',
@@ -277,6 +278,7 @@ const SearchBar = ({
             onClick={() => {
               setSearch('');
               setUserNotFound && setUserNotFound(false);
+              onClear && onClear();
             }}
           >
             &times;


### PR DESCRIPTION
## Summary
- pass new `onClear` prop to `SearchBar` for custom clear behavior
- reset profile state when clearing search in AddNewProfile

## Testing
- `npm test -- -w=0`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6879544200f48326a207bb29fb14f570