### PR TITLE
Open profile from matching

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -32,7 +32,7 @@ import {
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { pickerFieldsExtended as pickerFields } from './formFields';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import InfoModal from './InfoModal';
 import { VerifyEmail } from './VerifyEmail';
 
@@ -392,9 +392,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   //   publish: false,
   // };
 
+  const location = useLocation();
+
   const [userNotFound, setUserNotFound] = useState(false); // Стан для зберігання останнього ключа
 
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('search') || '';
+  });
 
   const [state, setState] = useState({});
   const isEditingRef = useRef(false);

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { UserCard } from './UsersList';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import styled, { keyframes } from 'styled-components';
@@ -286,6 +287,7 @@ const roleMatchesFilter = (user, filter) => {
 };
 
 const Matching = () => {
+  const navigate = useNavigate();
   const [users, setUsers] = useState([]);
   const [lastKey, setLastKey] = useState();
   const [hasMore, setHasMore] = useState(true);
@@ -633,7 +635,9 @@ const Matching = () => {
             />
             <Id
               onClick={() => {
-                if (isAdmin) setShowUserCard(true);
+                if (isAdmin) {
+                  navigate(`/add?search=${selected.userId}`);
+                }
               }}
               style={{ cursor: isAdmin ? 'pointer' : 'default' }}
             >


### PR DESCRIPTION
## Summary
- read `search` query param in `AddNewProfile`
- navigate to `/add?search=<userId>` when clicking a profile id in Matching

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879e5e18b5083268215e1b7e3509cef