### PR TITLE
Refactor fieldsToRender into ProfileForm

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import styled, { css } from 'styled-components';
-import Photos from './Photos';
 // import { FaUser, FaTelegramPlane, FaFacebookF, FaInstagram, FaVk, FaMailBulk, FaPhone } from 'react-icons/fa';
 import {
   auth,
@@ -30,14 +29,12 @@ import {
   // removeSpecificSearchId,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
-import { pickerFieldsExtended as pickerFields } from './formFields';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { useNavigate } from 'react-router-dom';
 import InfoModal from './InfoModal';
 import { VerifyEmail } from './VerifyEmail';
 
 import { color, coloredCard } from './styles';
-import { inputUpdateValue } from './inputUpdatedValue';
 //import { formatPhoneNumber } from './inputValidations';
 import { UsersList } from './UsersList';
 // import ExcelToJson from './ExcelToJson';
@@ -49,7 +46,7 @@ import { btnMerge } from './smallCard/btnMerge';
 import FilterPanel from './FilterPanel';
 import SearchBar from './SearchBar';
 import { Pagination } from './Pagination';
-import { useAutoResize } from '../hooks/useAutoResize';
+import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { PAGE_SIZE, database } from './config';
 import { onValue, ref } from 'firebase/database';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
@@ -969,65 +966,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
-  const priorityOrder = [
-    'birth',
-    'name',
-    'surname',
-    'fathersname',
-    'phone',
-    'facebook',
-    'instagram',
-    'telegram',
-    'tiktok',
-    'region',
-    'city',
-    'height',
-    'weight',
-    'blood',
-    'maritalStatus',
-    'csection',
-    'ownKids',
-    'lastDelivery',
-    'role',
-  ];
-  const additionalFields = Object.keys(state).filter(
-    key =>
-      !pickerFields.some(field => field.name === key) &&
-      key !== 'attitude' &&
-      key !== 'whiteList' &&
-      key !== 'blackList' &&
-      key !== 'photos'
-  );
+  const fieldsToRender = getFieldsToRender(state);
 
-  // console.log('additionalFields :>> ', additionalFields);
-
-  // Об'єднуємо `pickerFields` та додаткові ключі
-  // Об'єднуємо `pickerFields` та додаткові ключі
-  const fieldsToRender = [
-    ...pickerFields,
-    ...additionalFields.map(key => ({
-      name: key,
-      placeholder: key,
-      ukrainianHint: key,
-    })),
-  ];
-
-  const sortedFieldsToRender = [
-    ...priorityOrder.map(key => fieldsToRender.find(field => field.name === key)).filter(Boolean),
-    ...fieldsToRender.filter(field => !priorityOrder.includes(field.name)),
-  ];
 
   // const fieldsToRender = [
   //   ...pickerFields,
 
   // ];
 
-  //////////// висота text area
-  const textareaRef = useRef(null);
-  const moreInfoRef = useRef(null);
-
-  const autoResizeMyComment = useAutoResize(textareaRef, state.myComment);
-  const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE) || 1;
   const getSortedIds = () => {
@@ -1083,241 +1029,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               )}
             </div>
 
-            {sortedFieldsToRender
-              .filter(field => !['myComment', 'getInTouch', 'writer'].includes(field.name)) // Фільтруємо поле myComment
-              .map((field, index) => {
-                // console.log('field:', field);
-                // console.log('state[field.name] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!:>> ', state[field.name]);
-
-                return (
-                  <PickerContainer key={index}>
-                    {Array.isArray(state[field.name]) ? (
-                      <div style={{ width: '100%', display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
-                        {state[field.name].map((value, idx) => {
-                          // console.log('state[field.name] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!:>> ', state[field.name]);
-
-                          return (
-                            <InputDiv key={`${field.name}-${idx}`}>
-                              <InputFieldContainer fieldName={`${field.name}-${idx}`} value={value}>
-                                <InputField
-                                  fieldName={`${field.name}-${idx}`}
-                                  as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
-                                  ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
-                                  inputMode={field.name === 'phone' ? 'numeric' : 'text'}
-                                  name={`${field.name}-${idx}`}
-                                  value={value || ''}
-                                  // value={field.name === 'phone'  ? formatPhoneNumber(value || '') : value || ''}
-                                  ///глючить якщо телефон не в правильному форматі
-                                  onChange={e => {
-                                    // const updatedValue = inputUpdateValue(e?.target?.value, field);
-                                    if (field.name === 'myComment') {
-                                      autoResizeMyComment(e.target);
-                                    }
-                                    if (field.name === 'moreInfo_main') {
-                                      autoResizeMoreInfo(e.target);
-                                    }
-                                    const updatedValue =
-                                      field.name === 'telegram'
-                                        ? e?.target?.value // Без inputUpdateValue для 'telegram'
-                                        : inputUpdateValue(e?.target?.value, field);
-                                    setState(prevState => ({
-                                      ...prevState,
-                                      [field.name]: prevState[field.name].map((item, i) => (i === idx ? updatedValue : item)),
-                                    }));
-                                  }}
-                                  onBlur={() => handleBlur(`${field.name}-${idx}`)}
-                                />
-                                {(value || value === '') && (
-                                  <ClearButton
-                                    onClick={() => {
-                                      handleClear(field.name, idx);
-                                    }}
-                                  >
-                                    &times;
-                                  </ClearButton>
-                                )}
-                              </InputFieldContainer>
-
-                              <Hint fieldName={field.name} isActive={value}>
-                                {field.ukrainian || field.placeholder}
-                              </Hint>
-                              <Placeholder isActive={value}>{field.ukrainianHint}</Placeholder>
-                            </InputDiv>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <InputDiv>
-                        <InputFieldContainer fieldName={field.name} value={state[field.name]}>
-                          <InputField
-                            fieldName={field.name}
-                            as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
-                            ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
-                            inputMode={field.name === 'phone' ? 'numeric' : 'text'}
-                            name={field.name}
-                            value={state[field.name] || ''}
-                            // value={field.name === 'phone' ? formatPhoneNumber(state[field.name] || '') : state[field.name] || ''}
-                            onChange={e => {
-                              if (field.name === 'myComment') {
-                                autoResizeMyComment(e.target);
-                              }
-                              if (field.name === 'moreInfo_main') {
-                                autoResizeMoreInfo(e.target);
-                              }
-                              let value = e?.target?.value;
-                              // Якщо ім'я поля - 'publish', перетворюємо значення в булеве
-                              if (field.name === 'publish') {
-                                value = value.toLowerCase() === 'true'; // true, якщо значення 'true', інакше false
-                              } else if (field.name === 'telgram') {
-                                value = e?.target?.value;
-                              } else {
-                                // value = inputUpdateValue(value, field); // Оновлення значення для інших полів
-                              }
-
-                              setState(prevState => ({
-                                ...prevState,
-                                [field.name]: Array.isArray(prevState[field.name]) ? [value, ...(prevState[field.name].slice(1) || [])] : value,
-                              }));
-                            }}
-                            // onBlur={() => handleBlur(field.name)}
-                            onBlur={() => handleSubmit(state, 'overwrite')}
-                          />
-                          {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times;</ClearButton>}
-                          {state[field.name] && <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)}>del</DelKeyValueBTN>}
-                        </InputFieldContainer>
-
-                        <Hint fieldName={field.name} isActive={state[field.name]}>
-                          {field.ukrainian || field.placeholder}
-                        </Hint>
-                        <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
-                      </InputDiv>
-                    )}
-
-                    {/* Додати новий інпут до масиву */}
-
-                    {state[field.name] &&
-                      (Array.isArray(state[field.name]) ? state[field.name].length === 0 || state[field.name][state[field.name].length - 1] !== '' : true) &&
-                      ((Array.isArray(field.options) && field.options.length !== 2 && field.options.length !== 3) || !Array.isArray(field.options)) && (
-                        <Button
-                          style={{
-                            display: Array.isArray(state[field.name]) ? 'block' : 'inline-block',
-                            alignSelf: Array.isArray(state[field.name]) ? 'flex-end' : 'auto',
-                            marginBottom: Array.isArray(state[field.name]) ? '14px' : '0',
-                            marginLeft: '10px',
-                          }}
-                          onClick={() => {
-                            setState(prevState => ({
-                              ...prevState,
-                              [field.name]:
-                                Array.isArray(prevState[field.name]) && prevState[field.name].length > 0
-                                  ? [...prevState[field.name], ''] // Додати новий пустий елемент до масиву
-                                  : [prevState[field.name], ''],
-                            }));
-                          }}
-                        >
-                          +
-                        </Button>
-                      )}
-
-                    {Array.isArray(field.options) ? (
-                      field.options.length === 2 ? (
-                        <ButtonGroup>
-                          <Button
-                            onClick={() => {
-                              setState(prevState => {
-                                const newState = {
-                                  ...prevState,
-                                  [field.name]: 'Yes',
-                                };
-                                handleSubmit(newState, 'overwrite');
-                                return newState;
-                              });
-                            }}
-                          >
-                            Так
-                          </Button>
-                          <Button
-                            onClick={() => {
-                              setState(prevState => {
-                                const newState = {
-                                  ...prevState,
-                                  [field.name]: 'No',
-                                };
-                                handleSubmit(newState, 'overwrite');
-                                return newState;
-                              });
-                            }}
-                          >
-                            Ні
-                          </Button>
-                          <Button
-                            onClick={() => {
-                              setState(prevState => {
-                                const newState = {
-                                  ...prevState,
-                                  [field.name]: 'Other',
-                                };
-                                handleSubmit(newState, 'overwrite');
-                                handleBlur(field.name);
-                                return newState;
-                              });
-                            }}
-                          >
-                            Інше
-                          </Button>
-                        </ButtonGroup>
-                      ) : field.options.length === 3 ? (
-                        <ButtonGroup>
-                          <Button
-                            onClick={() => {
-                              setState(prevState => {
-                                const newState = {
-                                  ...prevState,
-                                  [field.name]: '-',
-                                };
-                                handleSubmit(newState, 'overwrite');
-                                return newState;
-                              });
-                            }}
-                          >
-                            Ні
-                          </Button>
-                          <Button
-                            onClick={() => {
-                              setState(prevState => {
-                                const newState = {
-                                  ...prevState,
-                                  [field.name]: '1',
-                                };
-                                handleSubmit(newState, 'overwrite');
-                                return newState;
-                              });
-                            }}
-                          >
-                            1
-                          </Button>
-                          <Button
-                            onClick={() => {
-                              setState(prevState => {
-                                const newState = {
-                                  ...prevState,
-                                  [field.name]: '2',
-                                };
-                                handleSubmit(newState, 'overwrite');
-                                // handleBlur(field.name); - csection не працювало по натисканню, лише з другої спроби
-                                return newState;
-                              });
-                            }}
-                          >
-                            2
-                          </Button>
-                        </ButtonGroup>
-                      ) : null
-                    ) : null}
-                  </PickerContainer>
-                );
-              })}
-              <Photos state={state} setState={setState} />
+            <ProfileForm
+              state={state}
+              setState={setState}
+              handleBlur={handleBlur}
+              handleSubmit={handleSubmit}
+              handleClear={handleClear}
+              handleDelKeyValue={handleDelKeyValue}
+            />
           </>
         ) : (
           <div>

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,0 +1,486 @@
+import React, { useRef } from 'react';
+import styled, { css } from 'styled-components';
+import Photos from './Photos';
+import { inputUpdateValue } from './inputUpdatedValue';
+import { useAutoResize } from '../hooks/useAutoResize';
+import { color } from './styles';
+import { pickerFieldsExtended as pickerFields } from './formFields';
+
+export const getFieldsToRender = state => {
+  const additionalFields = Object.keys(state).filter(
+    key =>
+      !pickerFields.some(field => field.name === key) &&
+      key !== 'attitude' &&
+      key !== 'whiteList' &&
+      key !== 'blackList' &&
+      key !== 'photos'
+  );
+
+  return [
+    ...pickerFields,
+    ...additionalFields.map(key => ({
+      name: key,
+      placeholder: key,
+      ukrainianHint: key,
+    })),
+  ];
+};
+
+export const ProfileForm = ({
+  state,
+  setState,
+  handleBlur,
+  handleSubmit,
+  handleClear,
+  handleDelKeyValue,
+}) => {
+  const textareaRef = useRef(null);
+  const moreInfoRef = useRef(null);
+
+  const autoResizeMyComment = useAutoResize(textareaRef, state.myComment);
+  const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
+
+  const priorityOrder = [
+    'birth',
+    'name',
+    'surname',
+    'fathersname',
+    'phone',
+    'facebook',
+    'instagram',
+    'telegram',
+    'tiktok',
+    'region',
+    'city',
+    'height',
+    'weight',
+    'blood',
+    'maritalStatus',
+    'csection',
+    'ownKids',
+    'lastDelivery',
+    'role',
+  ];
+
+  const fieldsToRender = getFieldsToRender(state);
+
+  const sortedFieldsToRender = [
+    ...priorityOrder
+      .map(key => fieldsToRender.find(field => field.name === key))
+      .filter(Boolean),
+    ...fieldsToRender.filter(field => !priorityOrder.includes(field.name)),
+  ];
+
+  return (
+    <>
+      {sortedFieldsToRender
+        .filter(field => !['myComment', 'getInTouch', 'writer'].includes(field.name))
+        .map((field, index) => (
+          <PickerContainer key={index}>
+            {Array.isArray(state[field.name]) ? (
+              <div style={{ width: '100%', display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
+                {state[field.name].map((value, idx) => (
+                  <InputDiv key={`${field.name}-${idx}`}>
+                    <InputFieldContainer fieldName={`${field.name}-${idx}`} value={value}>
+                      <InputField
+                        fieldName={`${field.name}-${idx}`}
+                        as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
+                        ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
+                        inputMode={field.name === 'phone' ? 'numeric' : 'text'}
+                        name={`${field.name}-${idx}`}
+                        value={value || ''}
+                        onChange={e => {
+                          if (field.name === 'myComment') {
+                            autoResizeMyComment(e.target);
+                          }
+                          if (field.name === 'moreInfo_main') {
+                            autoResizeMoreInfo(e.target);
+                          }
+                          const updatedValue =
+                            field.name === 'telegram'
+                              ? e?.target?.value
+                              : inputUpdateValue(e?.target?.value, field);
+                          setState(prevState => ({
+                            ...prevState,
+                            [field.name]: prevState[field.name].map((item, i) => (i === idx ? updatedValue : item)),
+                          }));
+                        }}
+                        onBlur={() => handleBlur(`${field.name}-${idx}`)}
+                      />
+                      {(value || value === '') && (
+                        <ClearButton
+                          onClick={() => {
+                            handleClear(field.name, idx);
+                          }}
+                        >
+                          &times;
+                        </ClearButton>
+                      )}
+                    </InputFieldContainer>
+
+                    <Hint fieldName={field.name} isActive={value}>
+                      {field.ukrainian || field.placeholder}
+                    </Hint>
+                    <Placeholder isActive={value}>{field.ukrainianHint}</Placeholder>
+                  </InputDiv>
+                ))}
+              </div>
+            ) : (
+              <InputDiv>
+                <InputFieldContainer fieldName={field.name} value={state[field.name]}>
+                  <InputField
+                    fieldName={field.name}
+                    as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
+                    ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
+                    inputMode={field.name === 'phone' ? 'numeric' : 'text'}
+                    name={field.name}
+                    value={state[field.name] || ''}
+                    onChange={e => {
+                      if (field.name === 'myComment') {
+                        autoResizeMyComment(e.target);
+                      }
+                      if (field.name === 'moreInfo_main') {
+                        autoResizeMoreInfo(e.target);
+                      }
+                      let value = e?.target?.value;
+                      if (field.name === 'publish') {
+                        value = value.toLowerCase() === 'true';
+                      } else if (field.name === 'telgram') {
+                        value = e?.target?.value;
+                      }
+                      setState(prevState => ({
+                        ...prevState,
+                        [field.name]: Array.isArray(prevState[field.name])
+                          ? [value, ...(prevState[field.name].slice(1) || [])]
+                          : value,
+                      }));
+                    }}
+                    onBlur={() => handleSubmit(state, 'overwrite')}
+                  />
+                  {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times;</ClearButton>}
+                  {state[field.name] && (
+                    <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)}>del</DelKeyValueBTN>
+                  )}
+                </InputFieldContainer>
+
+                <Hint fieldName={field.name} isActive={state[field.name]}>
+                  {field.ukrainian || field.placeholder}
+                </Hint>
+                <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
+              </InputDiv>
+            )}
+
+            {state[field.name] &&
+              (Array.isArray(state[field.name])
+                ? state[field.name].length === 0 || state[field.name][state[field.name].length - 1] !== ''
+                : true) &&
+              ((Array.isArray(field.options) && field.options.length !== 2 && field.options.length !== 3) ||
+                !Array.isArray(field.options)) && (
+                <Button
+                  style={{
+                    display: Array.isArray(state[field.name]) ? 'block' : 'inline-block',
+                    alignSelf: Array.isArray(state[field.name]) ? 'flex-end' : 'auto',
+                    marginBottom: Array.isArray(state[field.name]) ? '14px' : '0',
+                    marginLeft: '10px',
+                  }}
+                  onClick={() => {
+                    setState(prevState => ({
+                      ...prevState,
+                      [field.name]:
+                        Array.isArray(prevState[field.name]) && prevState[field.name].length > 0
+                          ? [...prevState[field.name], '']
+                          : [prevState[field.name], ''],
+                    }));
+                  }}
+                >
+                  +
+                </Button>
+              )}
+
+            {Array.isArray(field.options) ? (
+              field.options.length === 2 ? (
+                <ButtonGroup>
+                  <Button
+                    onClick={() => {
+                      setState(prevState => {
+                        const newState = {
+                          ...prevState,
+                          [field.name]: 'Yes',
+                        };
+                        handleSubmit(newState, 'overwrite');
+                        return newState;
+                      });
+                    }}
+                  >
+                    Так
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setState(prevState => {
+                        const newState = {
+                          ...prevState,
+                          [field.name]: 'No',
+                        };
+                        handleSubmit(newState, 'overwrite');
+                        return newState;
+                      });
+                    }}
+                  >
+                    Ні
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setState(prevState => {
+                        const newState = {
+                          ...prevState,
+                          [field.name]: 'Other',
+                        };
+                        handleSubmit(newState, 'overwrite');
+                        handleBlur(field.name);
+                        return newState;
+                      });
+                    }}
+                  >
+                    Інше
+                  </Button>
+                </ButtonGroup>
+              ) : field.options.length === 3 ? (
+                <ButtonGroup>
+                  <Button
+                    onClick={() => {
+                      setState(prevState => {
+                        const newState = {
+                          ...prevState,
+                          [field.name]: '-',
+                        };
+                        handleSubmit(newState, 'overwrite');
+                        return newState;
+                      });
+                    }}
+                  >
+                    Ні
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setState(prevState => {
+                        const newState = {
+                          ...prevState,
+                          [field.name]: '1',
+                        };
+                        handleSubmit(newState, 'overwrite');
+                        return newState;
+                      });
+                    }}
+                  >
+                    1
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setState(prevState => {
+                        const newState = {
+                          ...prevState,
+                          [field.name]: '2',
+                        };
+                        handleSubmit(newState, 'overwrite');
+                        return newState;
+                      });
+                    }}
+                  >
+                    2
+                  </Button>
+                </ButtonGroup>
+              ) : null
+            ) : null}
+          </PickerContainer>
+        ))}
+      <Photos state={state} setState={setState} />
+    </>
+  );
+};
+
+const PickerContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f0f0f0;
+  box-sizing: border-box;
+  @media (max-width: 768px) {
+    background-color: #f5f5f5;
+  }
+`;
+
+const InputDiv = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin: 10px 0;
+  padding: 10px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-sizing: border-box;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: auto;
+`;
+
+const InputField = styled.input`
+  border: none;
+  outline: none;
+  flex: 1;
+  align-items: center;
+  padding-left: ${({ fieldName, value }) => {
+    if (fieldName === 'phone') return '20px';
+    if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok') return '25px';
+    if (fieldName === 'facebook') return /^\d+$/.test(value) ? '20px' : '25px';
+    if (fieldName === 'vk') return /^\d+$/.test(value) || value === '' ? '23px' : '10px';
+    return '10px';
+  }};
+  max-width: 100%;
+  min-width: 0;
+  pointer-events: auto;
+  height: 100%;
+  resize: vertical;
+  &::placeholder {
+    color: transparent;
+  }
+`;
+
+const Hint = styled.label`
+  position: absolute;
+  padding-left: ${({ fieldName }) => {
+    if (fieldName === 'phone') return '20px';
+    if (fieldName === 'telegram' || fieldName === 'facebook' || fieldName === 'instagram' || fieldName === 'tiktok') return '25px';
+    if (fieldName === 'vk') return '23px';
+    return '10px';
+  }};
+  display: flex;
+  align-items: center;
+  transition: all 0.3s ease;
+  color: gray;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  ${({ isActive }) =>
+    isActive &&
+    css`
+      display: none;
+    `}
+`;
+
+const Placeholder = styled.label`
+  position: absolute;
+  padding-left: 10px;
+  top: 0;
+  transform: translateY(-100%);
+  transition: all 0.3s ease;
+  color: gray;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  ${({ isActive }) =>
+    isActive &&
+    css`
+      left: 10px;
+      top: 0;
+      transform: translateY(-100%);
+      font-size: 12px;
+      color: orange;
+    `}
+`;
+
+const InputFieldContainer = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  height: 100%;
+  box-sizing: border-box;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: auto;
+  &::before {
+    content: ${({ fieldName, value }) => {
+      if (fieldName === 'phone') return "'+'";
+      if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok') return "'@'";
+      if (fieldName === 'facebook') return /^\d+$/.test(value) ? "'='" : "'@'";
+      if (fieldName === 'vk') return /^\d+$/.test(value) || value === '' || value === undefined ? "'id'" : "''";
+      return "''";
+    }};
+    position: absolute;
+    left: 10px;
+    display: flex;
+    align-items: center;
+    color: ${({ value }) => (value ? '#000' : 'gray')};
+    font-size: 16px;
+    text-align: center;
+  }
+`;
+
+const ClearButton = styled.button`
+  position: absolute;
+  right: 0px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: gray;
+  font-size: 18px;
+  width: 35px;
+  height: 35px;
+  &:hover {
+    color: black;
+  }
+`;
+
+const DelKeyValueBTN = styled.button`
+  position: absolute;
+  right: 45px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: red;
+  font-size: 18px;
+  width: 35px;
+  height: 35px;
+  &:hover {
+    color: black;
+  }
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-left: 8px;
+  box-sizing: border-box;
+`;
+
+const Button = styled.button`
+  width: 35px;
+  height: 35px;
+  padding: 3px;
+  border: none;
+  background-color: ${color.accent5};
+  color: white;
+  border-radius: 50px;
+  cursor: pointer;
+  font-size: 12px;
+  flex: 0 1 auto;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  margin-right: 10px;
+  &:hover {
+    background-color: ${color.accent};
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+  &:active {
+    transform: scale(0.98);
+  }
+`;
+


### PR DESCRIPTION
## Summary
- expose `getFieldsToRender` in `ProfileForm`
- remove redundant field calculations in `AddNewProfile`
- use `getFieldsToRender` for `InfoModal` options

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6879e524fdc88326b41fcd02a02b75d9