### PR TITLE
Open profile form directly from matching

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,8 +3,9 @@ import { Route, Routes, useNavigate  } from 'react-router-dom';
 import { PrivacyPolicy } from './PrivacyPolicy';
 import { MyProfile } from './MyProfile';
 import { SubmitForm } from './SubmitForm';
-import {AddNewProfile} from './AddNewProfile';
+import { AddNewProfile } from './AddNewProfile';
 import Matching from './Matching';
+import EditProfile from './EditProfile';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from './config';
 
@@ -49,6 +50,7 @@ export const App = () => {
       <Route path="/my-profile"  element={<MyProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>} />
       {isAdmin && <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       {isAdmin && <Route path="/matching" element={<Matching />} />}
+      {isAdmin && <Route path="/edit/:userId" element={<EditProfile />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import {
+  fetchUserById,
+  updateDataInNewUsersRTDB,
+  updateDataInRealtimeDB,
+  updateDataInFiresoreDB,
+  removeKeyFromFirebase,
+} from './config';
+import { makeUploadedInfo } from './makeUploadedInfo';
+import { ProfileForm } from './ProfileForm';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5px;
+`;
+
+const BackButton = styled.button`
+  align-self: flex-start;
+  margin-bottom: 10px;
+`;
+
+const EditProfile = () => {
+  const { userId } = useParams();
+  const navigate = useNavigate();
+  const [state, setState] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (userId) {
+        const data = await fetchUserById(userId);
+        setState(data || { userId });
+      }
+    };
+    load();
+  }, [userId]);
+
+  const handleSubmit = async (newState, overwrite, delCondition) => {
+    const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
+    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
+    const commonFields = ['lastAction'];
+
+    const formatDate = date => {
+      const dd = String(date.getDate()).padStart(2, '0');
+      const mm = String(date.getMonth() + 1).padStart(2, '0');
+      const yyyy = date.getFullYear();
+      return `${dd}.${mm}.${yyyy}`;
+    };
+    const currentDate = formatDate(new Date());
+
+    const updatedState = newState ? { ...newState, lastAction: currentDate } : { ...state, lastAction: currentDate };
+
+    if (updatedState?.userId?.length > 20) {
+      const { existingData } = await fetchUserById(updatedState.userId);
+
+      const cleanedState = Object.fromEntries(
+        Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
+      );
+
+      const uploadedInfo = makeUploadedInfo(existingData, cleanedState, overwrite);
+
+      await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
+      await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
+
+      const cleanedStateForNewUsers = Object.fromEntries(
+        Object.entries(updatedState).filter(([key]) => [...fieldsForNewUsersOnly, ...contacts].includes(key))
+      );
+
+      await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update');
+    } else if (state?.userId) {
+      if (newState) {
+        await updateDataInNewUsersRTDB(state.userId, newState, 'update');
+      } else {
+        await updateDataInNewUsersRTDB(state.userId, state, 'update');
+      }
+    }
+  };
+
+  const handleBlur = () => handleSubmit();
+
+  const handleClear = (fieldName, idx) => {
+    setState(prev => {
+      const isArray = Array.isArray(prev[fieldName]);
+      let newValue;
+      let removedValue;
+
+      if (isArray) {
+        const filtered = prev[fieldName].filter((_, i) => i !== idx);
+        removedValue = prev[fieldName][idx];
+        newValue = filtered.length === 1 ? filtered[0] : filtered;
+      } else {
+        removedValue = prev[fieldName];
+        newValue = '';
+      }
+
+      const newState = { ...prev, [fieldName]: newValue };
+      handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
+      return newState;
+    });
+  };
+
+  const handleDelKeyValue = fieldName => {
+    setState(prev => {
+      const newState = { ...prev };
+      const deletedValue = newState[fieldName];
+      delete newState[fieldName];
+      removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
+      return newState;
+    });
+  };
+
+  if (!state) return null;
+
+  return (
+    <Container>
+      <BackButton onClick={() => navigate(-1)}>Back</BackButton>
+      <ProfileForm
+        state={state}
+        setState={setState}
+        handleBlur={handleBlur}
+        handleSubmit={handleSubmit}
+        handleClear={handleClear}
+        handleDelKeyValue={handleDelKeyValue}
+      />
+    </Container>
+  );
+};
+
+export default EditProfile;
+

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -636,7 +636,7 @@ const Matching = () => {
             <Id
               onClick={() => {
                 if (isAdmin) {
-                  navigate(`/add?search=${selected.userId}`);
+                  navigate(`/edit/${selected.userId}`);
                 }
               }}
               style={{ cursor: isAdmin ? 'pointer' : 'default' }}


### PR DESCRIPTION
## Summary
- add EditProfile page with ProfileForm for editing
- open EditProfile when clicking userId in Matching
- link new page from router and keep navigation history

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a47d1189c8326aa3156cb8c271833