### PR TITLE
UI tweaks and add new profile improvements

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -453,9 +453,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [filters, currentFilter]);
 
 
+  const [adding, setAdding] = useState(false);
+
   const handleAddUser = async () => {
-    await makeNewUser(searchKeyValuePair);
+    setAdding(true);
+    const newUser = await makeNewUser(searchKeyValuePair);
+    setState(newUser);
     setUserNotFound(false);
+    setAdding(false);
   };
   const dotsMenu = () => {
     return (
@@ -782,7 +787,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             ) : null}
             <FilterPanel onChange={setFilters} />
             <div>
-              {userNotFound && <Button onClick={handleAddUser}>+</Button>}
+              {userNotFound && (
+                <Button onClick={handleAddUser} disabled={adding}>
+                  {adding ? (
+                    <span className="spinner" />
+                  ) : (
+                    '+'
+                  )}
+                </Button>
+              )}
               <Button onClick={handleInfo}>Info</Button>
               <Button
                 onClick={() => {

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -15,7 +15,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 5px;
+  padding: 20px;
+  box-sizing: border-box;
+  max-width: 450px;
+  width: 100%;
 `;
 
 const BackButton = styled.button`

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -105,7 +105,7 @@ const FilterContainer = styled.div`
   top: 0;
   right: 0;
   height: 100%;
-  width: 250px;
+  width: 300px;
   max-width: 80%;
   background: #fff;
   z-index: 20;
@@ -495,7 +495,7 @@ const Matching = () => {
     if (!gridRef.current || !hasMore) return;
 
     const cards = gridRef.current.querySelectorAll('[data-card]');
-    const index = users.length - 3;
+    const index = users.length > 3 ? users.length - 3 : users.length - 1;
     const target = cards[index];
     if (!target) return;
 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,6 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+const SearchIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="gray"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
 const InputDiv = styled.div`
   display: flex;
   align-items: center;
@@ -25,7 +41,7 @@ const InputFieldContainer = styled.div`
   min-width: 0;
 `;
 
-const InputField = styled.textarea`
+const InputField = styled.input`
   border: none;
   outline: none;
   flex: 1;
@@ -33,7 +49,7 @@ const InputField = styled.textarea`
   max-width: 100%;
   min-width: 0;
   pointer-events: auto;
-  resize: vertical;
+  height: 35px;
 `;
 
 const ClearButton = styled.button`
@@ -65,7 +81,7 @@ const SearchBar = ({
   setSearch: externalSetSearch,
   onClear,
   wrapperStyle = {},
-  leftIcon = null,
+  leftIcon = SearchIcon,
 }) => {
   const [internalSearch, setInternalSearch] = useState(
     () => localStorage.getItem('searchQuery') || '',

--- a/src/index.css
+++ b/src/index.css
@@ -78,3 +78,18 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.spinner {
+  border: 2px solid #ccc;
+  border-top-color: #555;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- show grey search icon in SearchBar and restrict to single line
- create new users with spinner feedback
- widen Matching filter sidebar and fix infinite scroll when few cards
- make EditProfile inputs stretch full width
- add spinner styles

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_687a6be099988326965a06c11222b1be