### PR TITLE
UI fixes and filtering improvements

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -486,6 +486,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         });
         setShowInfoModal(null); // Close modal after deletion
         console.log(`User ${state.userId} deleted.`);
+        navigate(-1); // Return to previous screen after deletion
       } catch (error) {
         console.error('Error deleting user:', error);
       }

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -29,7 +29,7 @@ const defaultsAdd = {
 };
 
 const defaultsMatching = {
-  role: { ed: true, ag: true, ip: true, other: true },
+  role: { ed: true, ag: false, ip: false, other: false },
   maritalStatus: { married: true, unmarried: true, other: true },
   bloodGroup: { '1': true, '2': true, '3': true, '4': true, other: true },
   rh: { '+': true, '-': true, other: true },

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -105,7 +105,7 @@ const FilterContainer = styled.div`
   top: 0;
   right: 0;
   height: 100%;
-  width: 300px;
+  width: 320px;
   max-width: 80%;
   background: #fff;
   z-index: 20;
@@ -384,6 +384,21 @@ const Matching = () => {
     };
   }, [roleFilter]);
 
+  useEffect(() => {
+    if (filters.role) {
+      const { ed, ag, ip } = filters.role;
+      if (ed && !ag && !ip) {
+        setRoleFilter('donor');
+      } else if (!ed && ag && !ip) {
+        setRoleFilter('agency');
+      } else if (!ed && !ag && ip) {
+        setRoleFilter('parent');
+      } else {
+        setRoleFilter('donor');
+      }
+    }
+  }, [filters.role]);
+
   const fetchChunk = async (limit, key, exclude = new Set(), role) => {
     const res = await fetchLatestUsers(limit + exclude.size + 1, key);
     const filtered = res.users.filter(
@@ -492,10 +507,16 @@ const Matching = () => {
       : users;
 
   useEffect(() => {
+    if (filteredUsers.length <= 1 && hasMore) {
+      loadMore();
+    }
+  }, [filteredUsers.length, hasMore, loadMore]);
+
+  useEffect(() => {
     if (!gridRef.current || !hasMore) return;
 
     const cards = gridRef.current.querySelectorAll('[data-card]');
-    const index = users.length > 3 ? users.length - 3 : users.length - 1;
+    const index = filteredUsers.length > 3 ? filteredUsers.length - 3 : filteredUsers.length - 1;
     const target = cards[index];
     if (!target) return;
 
@@ -513,7 +534,7 @@ const Matching = () => {
     return () => {
       if (observerRef.current) observerRef.current.disconnect();
     };
-  }, [loadMore, users.length, hasMore]);
+  }, [loadMore, filteredUsers.length, hasMore]);
 
   return (
     <>
@@ -536,35 +557,12 @@ const Matching = () => {
           <ActionButton onClick={loadDislikeCards}>👎</ActionButton>
           <ActionButton onClick={() => setShowFilters(s => !s)}>⚙</ActionButton>
         </TopActions>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            gap: '10px',
-            marginBottom: '10px',
-            marginTop: '20px',
-          }}
-        >
-          <button
-            onClick={() => setRoleFilter('donor')}
-            disabled={roleFilter === 'donor'}
-          >
-            Донори
-          </button>
-          <button
-            onClick={() => setRoleFilter('agency')}
-            disabled={roleFilter === 'agency'}
-          >
-            Агентсва та Клініки
-          </button>
-          <button
-            onClick={() => setRoleFilter('parent')}
-            disabled={roleFilter === 'parent'}
-          >
-            Біо батьки
-          </button>
-        </div>
-        
+        {isAdmin && (
+          <p style={{ textAlign: 'center', color: 'black' }}>
+            {filteredUsers.length} карточок
+          </p>
+        )}
+
         <Grid ref={gridRef} style={{ overflowY: 'auto', height: '80vh' }}>
           {filteredUsers.map(user => {
             const photo = getCurrentValue(user.photos);

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -304,6 +304,7 @@ const PickerContainer = styled.div`
   align-items: center;
   background-color: #f0f0f0;
   box-sizing: border-box;
+  width: 100%;
   @media (max-width: 768px) {
     background-color: #f5f5f5;
   }

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import { useAutoResize } from '../hooks/useAutoResize';
 import styled from 'styled-components';
 
 const SearchIcon = (
@@ -34,14 +35,14 @@ const InputDiv = styled.div`
 
 const InputFieldContainer = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   position: relative;
   height: auto;
   flex: 1 1 auto;
   min-width: 0;
 `;
 
-const InputField = styled.input`
+const InputField = styled.textarea`
   border: none;
   outline: none;
   flex: 1;
@@ -49,7 +50,10 @@ const InputField = styled.input`
   max-width: 100%;
   min-width: 0;
   pointer-events: auto;
-  height: 35px;
+  resize: none;
+  overflow: hidden;
+  line-height: 1.2;
+  min-height: 35px;
 `;
 
 const ClearButton = styled.button`
@@ -86,6 +90,9 @@ const SearchBar = ({
   const [internalSearch, setInternalSearch] = useState(
     () => localStorage.getItem('searchQuery') || '',
   );
+
+  const textareaRef = useRef(null);
+  useAutoResize(textareaRef, search);
 
   const search = externalSearch !== undefined ? externalSearch : internalSearch;
   const setSearch = externalSetSearch !== undefined ? externalSetSearch : setInternalSearch;
@@ -288,6 +295,8 @@ const SearchBar = ({
       {leftIcon && <span style={{ marginRight: '5px' }}>{leftIcon}</span>}
       <InputFieldContainer value={search}>
         <InputField
+          ref={textareaRef}
+          rows={1}
           value={search || ''}
           onChange={e => setSearch(e.target.value)}
           onBlur={() => writeData()}

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -11,8 +11,8 @@ export const SearchFilters = ({ filters, onChange, hideUserId = false, hideComme
         label: 'Role',
         options: [
           { val: 'ed', label: 'ДО' },
-          { val: 'ag', label: 'Агентсва/Клініки' },
-          { val: 'ip', label: 'біобатьки' },
+          { val: 'ag', label: 'Агентства' },
+          { val: 'ip', label: 'Батьки' },
           { val: 'other', label: '?' },
         ],
       },
@@ -20,8 +20,8 @@ export const SearchFilters = ({ filters, onChange, hideUserId = false, hideComme
         filterName: 'maritalStatus',
         label: 'Marital status',
         options: [
-          { val: 'married', label: 'заміжня' },
-          { val: 'unmarried', label: 'незаміжня' },
+          { val: 'married', label: 'Так/+' },
+          { val: 'unmarried', label: 'Ні/-' },
           { val: 'other', label: '?' },
         ],
       },
@@ -95,8 +95,8 @@ export const SearchFilters = ({ filters, onChange, hideUserId = false, hideComme
       filterName: 'maritalStatus',
       label: 'Marital status',
       options: [
-        { val: 'married', label: 'заміжня' },
-        { val: 'unmarried', label: 'незаміжня' },
+        { val: 'married', label: 'Так/+' },
+        { val: 'unmarried', label: 'Ні/-' },
         { val: 'other', label: '?' },
       ],
     },

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1332,8 +1332,10 @@ const getRoleCategory = value => {
 const getMaritalStatusCategory = value => {
   if (!value.maritalStatus || typeof value.maritalStatus !== 'string') return 'other';
   const m = value.maritalStatus.trim().toLowerCase();
-  if (['yes', '+', 'married', 'одружена', 'заміжня'].includes(m)) return 'married';
-  if (['no', '-', 'unmarried', 'single', 'ні', 'незаміжня'].includes(m)) return 'unmarried';
+  if (['yes', 'так', '+', 'married', 'одружена', 'заміжня'].includes(m))
+    return 'married';
+  if (['no', 'ні', '-', 'unmarried', 'single', 'незаміжня'].includes(m))
+    return 'unmarried';
   return 'other';
 };
 

--- a/src/components/makeCardDescription.js
+++ b/src/components/makeCardDescription.js
@@ -14,10 +14,10 @@ export const makeCardDescription = user => {
   const getMaritalStatus = val => {
     if (!val) return '?';
     const normalized = normalizeStr(val);
-    if (['yes', '+', 'married', 'одружена', 'заміжня'].includes(normalized))
+    if (['yes', 'так', '+', 'married', 'одружена', 'заміжня'].includes(normalized))
       return 'заміжня';
     if (
-      ['no', '-', 'unmarried', 'single', 'ні', 'незаміжня'].includes(normalized)
+      ['no', 'ні', '-', 'unmarried', 'single', 'незаміжня'].includes(normalized)
     )
       return 'не заміжня';
     return '?';

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -41,9 +41,12 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: 'none',
-        color: 'white',
+        border: `${isDisliked ? 2 : 1}px solid ${isDisliked ? 'red' : '#ccc'}`,
+        color: isDisliked ? 'red' : 'lightcoral',
         cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
       }}
       disabled={!auth.currentUser}
       onClick={e => {
@@ -51,7 +54,20 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         toggleDislike();
       }}
     >
-      {'👎'}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        fill={isDisliked ? 'red' : 'none'}
+        stroke={isDisliked ? 'red' : 'lightcoral'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -40,9 +40,12 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: 'none',
-        color: 'white',
+        border: `${isFavorite ? 2 : 1}px solid ${isFavorite ? 'green' : '#ccc'}`,
+        color: isFavorite ? 'green' : 'lightgreen',
         cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
       }}
       disabled={!auth.currentUser}
       onClick={e => {
@@ -50,7 +53,19 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         toggleFavorite();
       }}
     >
-      {isFavorite ? '❤' : '♡'}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        fill={isFavorite ? 'green' : 'none'}
+        stroke={isFavorite ? 'green' : 'lightgreen'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6.5 3.5 5 5.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5 18.5 5 20 6.5 20 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+      </svg>
     </button>
   );
 };

--- a/src/components/smallCard/fieldMaritalStatus.js
+++ b/src/components/smallCard/fieldMaritalStatus.js
@@ -4,10 +4,12 @@ export const fieldMaritalStatus = maritalStatus => {
   let text;
   switch (maritalStatus) {
     case 'Yes':
+    case 'Так':
     case '+':
       text = 'Заміжня';
       break;
     case 'No':
+    case 'Ні':
     case '-':
       text = 'Незаміжня';
       break;

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,8 @@ code {
 }
 
 .spinner {
+  display: inline-block;
+  box-sizing: border-box;
   border: 2px solid #ccc;
   border-top-color: #555;
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- navigate back after profile deletion
- fix spinner display
- auto-resize search field using textarea
- stretch profile form inputs
- load more matching cards when filtered to one
- widen matching filter drawer and update labels
- replace like/dislike icons
- default matching role filter shows only donors
- handle Так/Ні in marital status logic
- show card count for admin

## Testing
- `npm install`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9169640c8326a955a3a6cedc0ee4