### PR TITLE
Fix duplicate textareaRef

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -91,11 +91,9 @@ const SearchBar = ({
     () => localStorage.getItem('searchQuery') || '',
   );
 
-  const textareaRef = useRef(null);
-  useAutoResize(textareaRef, search);
-
   const search = externalSearch !== undefined ? externalSearch : internalSearch;
-  const setSearch = externalSetSearch !== undefined ? externalSetSearch : setInternalSearch;
+  const setSearch =
+    externalSetSearch !== undefined ? externalSetSearch : setInternalSearch;
 
   const textareaRef = useRef(null);
   useAutoResize(textareaRef, search);


### PR DESCRIPTION
## Summary
- remove duplicate `textareaRef` declaration and use `search` after it's defined

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint:js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ac30436c883268b9023b55681cb58