### PR TITLE
Fix spinner and search handling

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -162,6 +162,9 @@ const Button = styled.button`
   cursor: pointer;
   font-size: 12px;
   flex: 0 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition:
     background-color 0.3s ease,
     box-shadow 0.3s ease;
@@ -485,8 +488,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           return updatedUsers; // Повертаємо оновлений об'єкт користувачів
         });
         setShowInfoModal(null); // Close modal after deletion
+        setSearch('');
         console.log(`User ${state.userId} deleted.`);
-        navigate(-1); // Return to previous screen after deletion
+        navigate('/add'); // Return to list screen after deletion
       } catch (error) {
         console.error('Error deleting user:', error);
       }

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -80,6 +80,7 @@ const EditProfile = () => {
         await updateDataInNewUsersRTDB(state.userId, state, 'update');
       }
     }
+    setState(updatedState);
   };
 
   const handleBlur = () => handleSubmit();

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -139,7 +139,7 @@ const DonorCard = styled.div`
   border: 1px solid ${color.gray};
   border-radius: 8px;
   padding: 16px;
-  background: ${color.oppositeAccent};
+  background: #f0f0f0;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   color: ${color.black};
   max-height: 80vh;

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -23,7 +23,7 @@ const InputDiv = styled.div`
   align-items: center;
   position: relative;
   margin: 10px 0;
-  padding: 10px;
+  padding: 4px 10px;
   background-color: #fff;
   border: 1px solid #ccc;
   border-radius: 5px;
@@ -53,7 +53,7 @@ const InputField = styled.textarea`
   resize: none;
   overflow: hidden;
   line-height: 1.2;
-  min-height: 35px;
+  min-height: 24px;
 `;
 
 const ClearButton = styled.button`

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -41,8 +41,10 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: `${isDisliked ? 2 : 1}px solid ${isDisliked ? 'red' : '#ccc'}`,
-        color: isDisliked ? 'red' : 'lightcoral',
+        border: `${isDisliked ? 2 : 1}px solid ${
+          isDisliked ? color.accent3 : color.paleAccent
+        }`,
+        color: isDisliked ? color.accent3 : color.paleAccent,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -59,8 +61,8 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         viewBox="0 0 24 24"
         width="18"
         height="18"
-        fill={isDisliked ? 'red' : 'none'}
-        stroke={isDisliked ? 'red' : 'lightcoral'}
+        fill={isDisliked ? color.accent3 : 'none'}
+        stroke={isDisliked ? color.accent3 : color.paleAccent}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -40,8 +40,10 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: `${isFavorite ? 2 : 1}px solid ${isFavorite ? 'green' : '#ccc'}`,
-        color: isFavorite ? 'green' : 'lightgreen',
+        border: `${isFavorite ? 2 : 1}px solid ${
+          isFavorite ? color.accent : color.paleAccent
+        }`,
+        color: isFavorite ? color.accent : color.paleAccent,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -58,8 +60,8 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         viewBox="0 0 24 24"
         width="18"
         height="18"
-        fill={isFavorite ? 'green' : 'none'}
-        stroke={isFavorite ? 'green' : 'lightgreen'}
+        fill={isFavorite ? color.accent : 'none'}
+        stroke={isFavorite ? color.accent : color.paleAccent}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
## Summary
- center button spinner in AddNewProfile
- clear search input after deleting a card
- adjust search bar padding and line-height
- keep edited data visible after saving
- tweak favorite and dislike button colors
- match profile modal background color

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687b2aee7a1483269a78832b687d7474