### PR TITLE
Adjust search and profile form styles

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -38,6 +38,11 @@ const Grid = styled.div`
 
 const CardWrapper = styled.div`
   width: 100%;
+  padding: 3px;
+  border: 3px solid;
+  border-image: linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1;
+  border-radius: 8px;
+  box-sizing: border-box;
 `;
 
 const Card = styled.div`

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -72,7 +72,7 @@ export const ProfileForm = ({
   ];
 
   return (
-    <>
+    <FormContainer>
       {sortedFieldsToRender
         .filter(field => !['myComment', 'getInTouch', 'writer'].includes(field.name))
         .map((field, index) => (
@@ -294,7 +294,7 @@ export const ProfileForm = ({
           </PickerContainer>
         ))}
       <Photos state={state} setState={setState} />
-    </>
+    </FormContainer>
   );
 };
 
@@ -308,6 +308,13 @@ const PickerContainer = styled.div`
   @media (max-width: 768px) {
     background-color: #f5f5f5;
   }
+`;
+
+const FormContainer = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  background-color: #f0f0f0;
+  padding: 20px;
 `;
 
 const InputDiv = styled.div`
@@ -329,6 +336,7 @@ const InputField = styled.input`
   border: none;
   outline: none;
   flex: 1;
+  width: 100%;
   align-items: center;
   padding-left: ${({ fieldName, value }) => {
     if (fieldName === 'phone') return '20px';

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -25,8 +25,7 @@ const InputDiv = styled.div`
   margin: 10px 0;
   padding: 4px 10px;
   background-color: #fff;
-  border: 3px solid;
-  border-image: linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1;
+  border: 1px solid #ccc;
   border-radius: 5px;
   box-sizing: border-box;
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- remove rainbow border from SearchBar input
- apply rainbow border around photo and comment blocks in Matching
- wrap ProfileForm fields with a new container using the same color as on AddNewProfile
- make ProfileForm inputs full width

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bd860797c8326990e3bd9c4697c34