### PR TITLE
Center cursor in search bar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -46,7 +46,7 @@ const InputField = styled.textarea`
   border: none;
   outline: none;
   flex: 1;
-  padding-left: 10px;
+  padding: 4px 0 4px 10px;
   max-width: 100%;
   min-width: 0;
   pointer-events: auto;


### PR DESCRIPTION
## Summary
- adjust padding for the textarea so the cursor is vertically centered

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687be204f76483268cf59b4cfc3ea4a4