### PR TITLE
Fix profile form background layout

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -316,11 +316,12 @@ const InputDiv = styled.div`
   position: relative;
   margin: 10px 0;
   padding: 10px;
-  background-color: #fff;
+  background-color: inherit;
   border: 1px solid #ccc;
   border-radius: 5px;
   box-sizing: border-box;
   flex: 1 1 auto;
+  width: 100%;
   min-width: 0;
   height: auto;
 `;
@@ -400,6 +401,7 @@ const InputFieldContainer = styled.div`
   height: 100%;
   box-sizing: border-box;
   flex: 1 1 auto;
+  width: 100%;
   min-width: 0;
   height: auto;
   &::before {

--- a/src/index.css
+++ b/src/index.css
@@ -71,7 +71,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: var(--primary-text-color);
-  /* background-color: #333333; */
+  background-color: #f5f5f5;
 }
 
 code {


### PR DESCRIPTION
## Summary
- ensure body background uses same light grey as forms
- make ProfileForm inputs stretch to full width and inherit background

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_687be83489e48326a80d3b3dee722111