### PR TITLE
Fix input color

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -327,10 +327,14 @@ const InputDiv = styled.div`
 `;
 
 const InputField = styled.input`
+  background-color: inherit;
   border: none;
   outline: none;
   flex: 1;
   align-items: center;
+  &:focus {
+    background-color: inherit;
+  }
   padding-left: ${({ fieldName, value }) => {
     if (fieldName === 'phone') return '20px';
     if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok') return '25px';


### PR DESCRIPTION
## Summary
- ensure ProfileForm input inherits background color

## Testing
- `npm test --silent` *(fails: No tests found related to files changed)*

------
https://chatgpt.com/codex/tasks/task_e_687bec7bc68c8326990fca42ae0e151f