### PR TITLE
Align ProfileForm styles with MyProfile

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -316,7 +316,7 @@ const InputDiv = styled.div`
   position: relative;
   margin: 10px 0;
   padding: 10px;
-  background-color: inherit;
+  background-color: #fff;
   border: 1px solid #ccc;
   border-radius: 5px;
   box-sizing: border-box;
@@ -327,14 +327,10 @@ const InputDiv = styled.div`
 `;
 
 const InputField = styled.input`
-  background-color: inherit;
   border: none;
   outline: none;
   flex: 1;
   align-items: center;
-  &:focus {
-    background-color: inherit;
-  }
   padding-left: ${({ fieldName, value }) => {
     if (fieldName === 'phone') return '20px';
     if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok') return '25px';


### PR DESCRIPTION
## Summary
- tweak input and background colors in `ProfileForm` to match styling from MyProfile

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687bfa3d52dc83268f86fe762ecd8271