### PR TITLE
Reduce spacing between checkboxes and labels

### DIFF
--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -12,14 +12,14 @@ export const CheckboxGroup = ({ label, filterName, options, filters, onChange, c
   };
 
   return (
-    <div style={{ marginBottom: compact ? '4px' : '8px' }}>
-      {label && <span style={{ marginRight: '8px' }}>{label}:</span>}
-      {options.map(({ val, label: optionLabel }) => (
-        <label key={val} style={{ marginLeft: '10px', color: 'black' }}>
-          <input type="checkbox" checked={filters[filterName][val]} onChange={() => handleToggle(val)} />
-          {optionLabel}
-        </label>
-      ))}
+      <div style={{ marginBottom: compact ? '4px' : '8px' }}>
+        {label && <span style={{ marginRight: compact ? '4px' : '8px' }}>{label}:</span>}
+        {options.map(({ val, label: optionLabel }) => (
+          <label key={val} style={{ marginLeft: compact ? '4px' : '10px', color: 'black' }}>
+            <input type="checkbox" checked={filters[filterName][val]} onChange={() => handleToggle(val)} />
+            {optionLabel}
+          </label>
+        ))}
       <hr style={{ borderColor: '#ccc', borderWidth: '1px', borderStyle: 'solid', margin: '4px 0' }} />
     </div>
   );


### PR DESCRIPTION
## Summary
- tweak `CheckboxGroup` layout so compact groups use smaller margins

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bfd148f4c83269dbef2b8b18b9230