### PR TITLE
Add BMI filter and adjust Rh labels

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -40,6 +40,13 @@ const defaultsMatching = {
     '37_plus': true,
     other: true,
   },
+  bmi: {
+    lt18_5: true,
+    '18_5_24_9': true,
+    '25_29_9': true,
+    '30_plus': true,
+    other: true,
+  },
   country: { ua: true, other: true, unknown: true },
 };
 

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -39,11 +39,11 @@ export const SearchFilters = ({ filters, onChange, hideUserId = false, hideComme
       },
       {
         filterName: 'rh',
-        label: 'Rh',
+        label: '',
         compact: true,
         options: [
-          { val: '+', label: '+' },
-          { val: '-', label: '-' },
+          { val: '+', label: 'Rh+' },
+          { val: '-', label: 'Rh-' },
           { val: 'other', label: '?' },
         ],
       },
@@ -56,6 +56,18 @@ export const SearchFilters = ({ filters, onChange, hideUserId = false, hideComme
           { val: '26_30', label: '26-30' },
           { val: '31_36', label: '31-36' },
           { val: '37_plus', label: '37+' },
+          { val: 'other', label: '?' },
+        ],
+      },
+      {
+        filterName: 'bmi',
+        label: 'BMI',
+        compact: true,
+        options: [
+          { val: 'lt18_5', label: '<18.5' },
+          { val: '18_5_24_9', label: '18.5-24.9' },
+          { val: '25_29_9', label: '25-29.9' },
+          { val: '30_plus', label: '30+' },
           { val: 'other', label: '?' },
         ],
       },


### PR DESCRIPTION
## Summary
- update matching filters: rename Rh options to `Rh+` and `Rh-`
- add BMI filter with 4 ranges and unknown option
- support BMI indexes and categories in config
- adjust defaults for matching filter sets

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c03df882c8326ae663879b542fb25