### PR TITLE
Handle navigation after deleting card

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -497,6 +497,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         const res = await fetchNewUsersCollectionInRTDB({ name: '' });
         if (res) setUsers(res);
         setSearch('');
+        setState({});
         setShowInfoModal(null);
         console.log(`User ${state.userId} deleted.`);
         navigate('/add');


### PR DESCRIPTION
## Summary
- when deleting a profile reset selected user state so the list view is shown again after empty search submit

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c05e1323c8326b7e44eef553a4afc