### PR TITLE
Improve icon contrast

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -42,9 +42,9 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         borderRadius: '50%',
         background: color.accent5,
         border: `${isDisliked ? 2 : 1}px solid ${
-          isDisliked ? color.accent3 : color.paleAccent
+          isDisliked ? color.iconActive : color.iconInactive
         }`,
-        color: isDisliked ? color.accent3 : color.paleAccent,
+        color: isDisliked ? color.iconActive : color.iconInactive,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -61,8 +61,8 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
         viewBox="0 0 24 24"
         width="18"
         height="18"
-        fill={isDisliked ? color.accent3 : 'none'}
-        stroke={isDisliked ? color.accent3 : color.paleAccent}
+        fill={isDisliked ? color.iconActive : 'none'}
+        stroke={isDisliked ? color.iconActive : color.iconInactive}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -41,9 +41,9 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         borderRadius: '50%',
         background: color.accent5,
         border: `${isFavorite ? 2 : 1}px solid ${
-          isFavorite ? color.accent : color.paleAccent
+          isFavorite ? color.iconActive : color.iconInactive
         }`,
-        color: isFavorite ? color.accent : color.paleAccent,
+        color: isFavorite ? color.iconActive : color.iconInactive,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -60,8 +60,8 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
         viewBox="0 0 24 24"
         width="18"
         height="18"
-        fill={isFavorite ? color.accent : 'none'}
-        stroke={isFavorite ? color.accent : color.paleAccent}
+        fill={isFavorite ? color.iconActive : 'none'}
+        stroke={isFavorite ? color.iconActive : color.iconInactive}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -75,6 +75,9 @@ export const color = {
   orange: '#EC9804',
   //
 
+  iconActive: '#212121',
+  iconInactive: '#353535',
+
   paleAccent: `#FF6C0055`,
   paleAccent2: '#FFA50030',
   paleAccent5: '#FF8C0055',


### PR DESCRIPTION
## Summary
- use new icon color tokens with higher contrast
- update favorite/dislike icons to use new tokens
- add color constants for active and inactive icons

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687c06c8c3e88326bb3d349cd3f32585