### PR TITLE
Add border around photo and comment input

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -39,7 +39,9 @@ const Grid = styled.div`
 const CardWrapper = styled.div`
   width: 100%;
   border: 2px solid ${color.gray3};
+  border-radius: 8px;
   box-sizing: border-box;
+  padding: 5px;
 `;
 
 const CommentInput = styled.textarea`
@@ -47,6 +49,8 @@ const CommentInput = styled.textarea`
   margin-top: ${props => props.mt || '5px'};
   display: block;
   box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
 `;
 
 const Card = styled.div`


### PR DESCRIPTION
## Summary
- adjust the Matching card wrapper with padding and rounded corners
- center the comment input within the card wrapper

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_687c0f1e482c8326be261374c123defc