### PR TITLE
Optimize deletion flow

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -494,8 +494,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           delete updatedUsers[state.userId];
           return updatedUsers;
         });
-        const res = await fetchNewUsersCollectionInRTDB({ name: '' });
-        if (res) setUsers(res);
+        fetchNewUsersCollectionInRTDB({ name: '' })
+          .then(res => {
+            if (res) setUsers(res);
+          })
+          .catch(err => console.error('Error reloading users:', err));
         setSearch('');
         setState({});
         setShowInfoModal(null);


### PR DESCRIPTION
## Summary
- async refresh user list after deleting a card so UI doesn't freeze

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687c0d06501c83268e04e65607434f4f