### PR TITLE
Fix mutually exclusive like/dislike behavior

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -570,12 +570,16 @@ const Matching = () => {
                     userId={user.userId}
                     favoriteUsers={favoriteUsers}
                     setFavoriteUsers={setFavoriteUsers}
-                    onRemove={viewMode === 'favorites' ? handleRemove : undefined}
+                    dislikeUsers={dislikeUsers}
+                    setDislikeUsers={setDislikeUsers}
+                    onRemove={viewMode !== 'default' ? handleRemove : undefined}
                   />
                   <BtnDislike
                     userId={user.userId}
                     dislikeUsers={dislikeUsers}
                     setDislikeUsers={setDislikeUsers}
+                    favoriteUsers={favoriteUsers}
+                    setFavoriteUsers={setFavoriteUsers}
                     onRemove={viewMode !== 'default' ? handleRemove : undefined}
                   />
                 </Card>

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -1,8 +1,20 @@
 import React from 'react';
-import { addDislikeUser, removeDislikeUser, auth } from '../config';
+import {
+  addDislikeUser,
+  removeDislikeUser,
+  removeFavoriteUser,
+  auth,
+} from '../config';
 import { color } from '../styles';
 
-export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemove }) => {
+export const BtnDislike = ({
+  userId,
+  dislikeUsers = {},
+  setDislikeUsers,
+  onRemove,
+  favoriteUsers = {},
+  setFavoriteUsers,
+}) => {
   const isDisliked = !!dislikeUsers[userId];
 
   const toggleDislike = async () => {
@@ -24,7 +36,19 @@ export const BtnDislike = ({ userId, dislikeUsers = {}, setDislikeUsers, onRemov
       try {
         await addDislikeUser(userId);
         setDislikeUsers({ ...dislikeUsers, [userId]: true });
-        if (onRemove) onRemove(userId);
+        if (favoriteUsers[userId]) {
+          try {
+            await removeFavoriteUser(userId);
+          } catch (err) {
+            console.error('Failed to remove favorite when adding dislike:', err);
+          }
+          const upd = { ...favoriteUsers };
+          delete upd[userId];
+          if (setFavoriteUsers) setFavoriteUsers(upd);
+          if (onRemove) onRemove(userId);
+        } else if (onRemove) {
+          onRemove(userId);
+        }
       } catch (error) {
         console.error('Failed to add dislike:', error);
       }

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -1,8 +1,20 @@
 import React from 'react';
-import { addFavoriteUser, removeFavoriteUser, auth } from '../config';
+import {
+  addFavoriteUser,
+  removeFavoriteUser,
+  removeDislikeUser,
+  auth,
+} from '../config';
 import { color } from '../styles';
 
-export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRemove }) => {
+export const BtnFavorite = ({
+  userId,
+  favoriteUsers = {},
+  setFavoriteUsers,
+  onRemove,
+  dislikeUsers = {},
+  setDislikeUsers,
+}) => {
   const isFavorite = !!favoriteUsers[userId];
 
   const toggleFavorite = async () => {
@@ -24,6 +36,17 @@ export const BtnFavorite = ({ userId, favoriteUsers = {}, setFavoriteUsers, onRe
       try {
         await addFavoriteUser(userId);
         setFavoriteUsers({ ...favoriteUsers, [userId]: true });
+        if (dislikeUsers[userId]) {
+          try {
+            await removeDislikeUser(userId);
+          } catch (err) {
+            console.error('Failed to remove dislike when adding favorite:', err);
+          }
+          const upd = { ...dislikeUsers };
+          delete upd[userId];
+          if (setDislikeUsers) setDislikeUsers(upd);
+          if (onRemove) onRemove(userId);
+        }
       } catch (error) {
         console.error('Failed to add favorite:', error);
       }


### PR DESCRIPTION
## Summary
- prevent cards from being liked and disliked at the same time
- when liking a disliked card, remove it from dislikes and vice versa
- remove card from list in non-default views after toggling

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_687c9eb34fb083269b7ebd50a3ed0e65