### PR TITLE
Add admin links and actions

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -473,8 +473,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setAdding(false);
   };
   const dotsMenu = () => {
+    const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
     return (
       <>
+        {isAdmin && (
+          <>
+            <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+            <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+            <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+          </>
+        )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -78,6 +78,30 @@ const DotsButton = styled.button`
   display: flex;
 `;
 
+const TopActions = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  gap: 10px;
+  z-index: 10;
+`;
+
+const ActionButton = styled.button`
+  width: 35px;
+  height: 35px;
+  padding: 3px;
+  border: none;
+  background-color: ${color.accent5};
+  color: white;
+  border-radius: 50px;
+  cursor: pointer;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const PickerContainer = styled.div`
   display: flex;
   /* flex-direction: column; */
@@ -773,8 +797,16 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, []);
 
   const dotsMenu = () => {
+    const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
     return (
       <>
+        {isAdmin && (
+          <>
+            <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+            <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+            <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+          </>
+        )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}
@@ -787,13 +819,18 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     <Container>
       <InnerContainer>
         {isLoggedIn && (
-          <DotsButton
-            onClick={() => {
-              setShowInfoModal('dotsMenu');
-            }}
-          >
-            ⋮
-          </DotsButton>
+          <TopActions>
+            <ActionButton>❤</ActionButton>
+            <ActionButton>❌</ActionButton>
+            <ActionButton>⚙</ActionButton>
+            <DotsButton
+              onClick={() => {
+                setShowInfoModal('dotsMenu');
+              }}
+            >
+              ⋮
+            </DotsButton>
+          </TopActions>
         )}
         <StatusMessage published={state.publish}>
           {state.publish ? 'Анкета опублікована' : 'Анкета прихована'}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -559,8 +559,16 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   }, []);
 
   const dotsMenu = () => {
+    const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
     return (
       <>
+        {isAdmin && (
+          <>
+            <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+            <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+            <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+          </>
+        )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}


### PR DESCRIPTION
## Summary
- add links to admin menu for quick navigation
- show top action buttons in MyProfile

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_687cc44c9e8c83268036d0e667c492d6