### PR TITLE
Update admin menu and matching controls

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -204,6 +204,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [filters, setFilters] = useState({});
   const [isDeleting, setIsDeleting] = useState(false);
   const navigate = useNavigate();
+  const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
 
   const handleBlur = () => {
     handleSubmit();
@@ -475,6 +476,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const dotsMenu = () => {
     return (
       <>
+        {isAdmin && (
+          <>
+            <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+            <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+            <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+          </>
+        )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -28,6 +28,9 @@ import PhotoViewer from './PhotoViewer';
 import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
+import InfoModal from './InfoModal';
+import { signOut } from 'firebase/auth';
+import { FaHeart, FaTimes, FaFilter, FaEllipsisV } from 'react-icons/fa';
 
 const Grid = styled.div`
   display: flex;
@@ -123,6 +126,36 @@ const ActionButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+const SubmitButton = styled.button`
+  padding: 10px 20px;
+  color: black;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 16px;
+  align-self: flex-start;
+  border-bottom: 1px solid #ddd;
+  width: 100%;
+  transition: background-color 0.3s ease;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+`;
+
+const ExitButton = styled(SubmitButton)`
+  background: none;
+  border-bottom: none;
+  transition: background-color 0.3s ease;
+  &:hover {
+    background-color: #f5f5f5;
+  }
 `;
 
 const FilterOverlay = styled.div`
@@ -356,6 +389,7 @@ const Matching = () => {
   const [comments, setComments] = useState({});
   const [showUserCard, setShowUserCard] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
+  const [showInfoModal, setShowInfoModal] = useState(false);
   const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
@@ -496,6 +530,18 @@ const Matching = () => {
     setLoading(false);
   };
 
+  const handleExit = async () => {
+    try {
+      localStorage.removeItem('isLoggedIn');
+      localStorage.removeItem('userEmail');
+      setShowInfoModal(false);
+      navigate('/my-profile');
+      await signOut(auth);
+    } catch (error) {
+      console.error('Error signing out:', error);
+    }
+  };
+
   const loadMore = React.useCallback(async () => {
     if (!hasMore || loadingRef.current || viewMode !== 'default') return;
     loadingRef.current = true;
@@ -562,6 +608,19 @@ const Matching = () => {
     };
   }, [loadMore, filteredUsers.length, hasMore]);
 
+  const dotsMenu = () => (
+    <>
+      {isAdmin && (
+        <>
+          <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+          <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+          <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+        </>
+      )}
+      <SubmitButton onClick={handleExit}>Exit</SubmitButton>
+    </>
+  );
+
   return (
     <>
       {showFilters && <FilterOverlay show={showFilters} onClick={() => setShowFilters(false)} />}
@@ -577,9 +636,10 @@ const Matching = () => {
       </FilterContainer>
       <div style={{ position: 'relative' }}>
         <TopActions>
-          <ActionButton onClick={loadFavoriteCards}>❤</ActionButton>
-          <ActionButton onClick={loadDislikeCards}>👎</ActionButton>
-          <ActionButton onClick={() => setShowFilters(s => !s)}>⚙</ActionButton>
+          <ActionButton onClick={() => setShowFilters(s => !s)}><FaFilter /></ActionButton>
+          <ActionButton onClick={loadDislikeCards}><FaTimes /></ActionButton>
+          <ActionButton onClick={loadFavoriteCards}><FaHeart /></ActionButton>
+          <ActionButton onClick={() => setShowInfoModal('dotsMenu')}><FaEllipsisV /></ActionButton>
         </TopActions>
         {isAdmin && <p style={{ textAlign: 'center', color: 'black' }}>{filteredUsers.length} карточок</p>}
 
@@ -717,6 +777,9 @@ const Matching = () => {
             />
           </div>
         </ModalOverlay>
+      )}
+      {showInfoModal && (
+        <InfoModal onClose={() => setShowInfoModal(false)} text="dotsMenu" Context={dotsMenu} />
       )}
     </>
   );

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -447,6 +447,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [showPassword, setShowPassword] = useState(false);
   console.log('focused :>> ', focused);
   const navigate = useNavigate();
+  const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
   const moreInfoRef = useRef(null);
   const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
@@ -775,6 +776,13 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const dotsMenu = () => {
     return (
       <>
+        {isAdmin && (
+          <>
+            <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+            <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+            <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+          </>
+        )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -348,6 +348,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   const [focused, setFocused] = useState(null);
   console.log('focused :>> ', focused);
   const navigate = useNavigate();
+  const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
   const moreInfoRef = useRef(null);
   const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
 
@@ -561,6 +562,13 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   const dotsMenu = () => {
     return (
       <>
+        {isAdmin && (
+          <>
+            <SubmitButton onClick={() => navigate('/my-profile')}>my-profile</SubmitButton>
+            <SubmitButton onClick={() => navigate('/add')}>add</SubmitButton>
+            <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
+          </>
+        )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
         {!isEmailVerified && <VerifyEmail />}


### PR DESCRIPTION
## Summary
- show admin shortcut links in menu
- add admin shortcuts to AddNewProfile, ProfileScreen, and MyProfile
- add menu button and standard icons to Matching page

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d12098574832686db2c2a01b20cd4