### PR TITLE
Fix unused ExitButton in Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -617,7 +617,7 @@ const Matching = () => {
           <SubmitButton onClick={() => navigate('/matching')}>matching</SubmitButton>
         </>
       )}
-      <SubmitButton onClick={handleExit}>Exit</SubmitButton>
+      <ExitButton onClick={handleExit}>Exit</ExitButton>
     </>
   );
 


### PR DESCRIPTION
## Summary
- use `ExitButton` rather than `SubmitButton` for exiting from Matching page

## Testing
- `npm run lint:js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d1f7a0c448326b6113d8fceb34d70