### PR TITLE
Non-blocking removeCard updates

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -488,7 +488,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const handleRemoveUser = async () => {
       try {
         setIsDeleting(true);
-        await removeCardAndSearchId(state.userId);
+        removeCardAndSearchId(state.userId).catch(console.error);
         setUsers(prevUsers => {
           const updatedUsers = { ...prevUsers };
           delete updatedUsers[state.userId];

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2526,6 +2526,10 @@ export const removeCardAndSearchId = async userId => {
     const userData = userSnapshot.val();
     console.log(`Дані користувача:`, userData);
 
+    // Видаляємо картку користувача з newUsers перед оновленням індексів
+    await remove(ref2(db, `newUsers/${userId}`));
+    console.log(`Картка користувача видалена з newUsers: ${userId}`);
+
     if (userData.blood) {
       await updateBloodIndex(getBloodIndexCategory(userData.blood), userId, 'remove');
     }
@@ -2566,10 +2570,6 @@ export const removeCardAndSearchId = async userId => {
         }
       }
     }
-    // console.warn(`Видаляємо картку користувача з newUsers: ${userId}`);
-    // Видаляємо картку користувача з newUsers
-    await remove(ref2(db, `newUsers/${userId}`));
-    console.log(`Картка користувача видалена з newUsers: ${userId}`);
   } catch (error) {
     console.error(`Помилка під час видалення searchId для userId: ${userId}`, error);
   }


### PR DESCRIPTION
## Summary
- make handleRemoveUser call removeCardAndSearchId without waiting
- delete newUsers card first in removeCardAndSearchId

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d19a009ec8326b0625f4f6c04cfd1