### PR TITLE
Add gradient placeholder for matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -79,7 +79,7 @@ const ResizableCommentInput = ({ value, onChange, onBlur, onClick, ...rest }) =>
 const Card = styled.div`
   width: 100%;
   height: 40vh;
-  background-color: orange;
+  background: linear-gradient(135deg, orange, yellow);
   background-size: cover;
   background-position: center;
   border-radius: 0;


### PR DESCRIPTION
## Summary
- style Matching cards so placeholders use an orange-to-yellow gradient

## Testing
- `CI=true npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_687d07eae6f48326aeee60348751b4d5