### PR TITLE
Fix missing imports for Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -21,7 +21,7 @@ import {
   updateDataInNewUsersRTDB,
 } from './config';
 import { onValue, ref as refDb } from 'firebase/database';
-import { onAuthStateChanged } from 'firebase/auth';
+import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
@@ -31,6 +31,8 @@ import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { getCurrentDate } from './foramtDate';
+import InfoModal from './InfoModal';
+import { FaFilter, FaTimes, FaHeart, FaEllipsisV } from 'react-icons/fa';
 
 
 const Grid = styled.div`


### PR DESCRIPTION
## Summary
- add required icon imports and InfoModal
- import signOut function

## Testing
- `npm test -- --watchAll=false`
- `npx eslint src/**/*.{js,jsx}`

------
https://chatgpt.com/codex/tasks/task_e_687d2cda92d48326a941cfc069615343