### PR TITLE
Fix unused import in Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5,7 +5,6 @@ import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import styled, { keyframes } from 'styled-components';
 import { color } from './styles';
 import {
-  fetchLatestUsers,
   fetchUsersByLastLogin2,
   getAllUserPhotos,
   fetchFavoriteUsersData,


### PR DESCRIPTION
## Summary
- remove the unused `fetchLatestUsers` import

## Testing
- `npm run lint:js`
- `CI=true npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687d33c104608326bbef8bd3a6f276f3