### PR TITLE
Add toast progress for lastLogin2 indexing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -734,8 +734,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const indexLastLoginHandler = async () => {
-    await indexLastLogin();
-    toast.success('lastLogin2 indexed');
+    toast.loading('Indexing lastLogin2 0%', { id: 'index-lastlogin-progress' });
+    await indexLastLogin(progress => {
+      toast.loading(`Indexing lastLogin2 ${progress}%`, {
+        id: 'index-lastlogin-progress',
+      });
+    });
+    toast.success('lastLogin2 indexed', { id: 'index-lastlogin-progress' });
   };
 
   const fieldsToRender = getFieldsToRender(state);


### PR DESCRIPTION
## Summary
- show progress toast while indexing lastLogin2
- support progress callback in `indexLastLogin`

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687d37ac338483269f4ad28b9d5dc704