### PR TITLE
Show MoreInfo only for admin

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -245,7 +245,8 @@ const Table = styled.div`
 const MoreInfo = styled.div`
   background-color: ${color.paleAccent2};
   padding: 10px;
-  border-left: 4px solid ${color.accent};
+  border-left: 4px solid
+    ${props => (props.$isAdmin ? color.red : color.accent)};
   margin-bottom: 10px;
   font-size: 14px;
 `;
@@ -628,8 +629,8 @@ const Matching = () => {
               </Info>
             </ProfileSection>
             <Table>{renderSelectedFields(selected)}</Table>
-            {getCurrentValue(selected.myComment) && (
-              <MoreInfo>
+            {isAdmin && getCurrentValue(selected.myComment) && (
+              <MoreInfo $isAdmin={isAdmin}>
                 <strong>More information</strong>
                 <br />
                 {getCurrentValue(selected.myComment)}


### PR DESCRIPTION
## Summary
- Show donor 'More information' for admins only
- Highlight admin-only info with a red border

## Testing
- `npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_687cc550803c8326b908d674bf39a603