### PR TITLE
Show top block in profile editing

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -10,6 +10,8 @@ import {
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { ProfileForm } from './ProfileForm';
+import { renderTopBlock } from "./smallCard/renderTopBlock";
+import { coloredCard } from "./styles";
 
 const Container = styled.div`
   display: flex;
@@ -121,6 +123,9 @@ const EditProfile = () => {
   return (
     <Container>
       <BackButton onClick={() => navigate(-1)}>Back</BackButton>
+      <div style={{ ...coloredCard() }}>
+        {renderTopBlock(state, () => {}, () => {}, setState)}
+      </div>
       <ProfileForm
         state={state}
         setState={setState}


### PR DESCRIPTION
## Summary
- add `renderTopBlock` import in `EditProfile`
- render profile top block over the form when editing a profile

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find a config)*
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cc71ec0288326a9672d3c33870432