### PR TITLE
Add gradient overlay to matching card

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -87,6 +87,22 @@ const Card = styled.div`
   background-position: center;
   border-radius: 0;
   position: relative;
+  overflow: hidden;
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 20%;
+    background: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.5) 100%
+    );
+    pointer-events: none;
+    z-index: 0;
+  }
 `;
 
 const loadingWave = keyframes`

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -69,6 +69,7 @@ export const BtnDislike = ({
           isDisliked ? color.iconActive : color.iconInactive
         }`,
         color: isDisliked ? color.iconActive : color.iconInactive,
+        zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -67,6 +67,7 @@ export const BtnFavorite = ({
           isFavorite ? color.iconActive : color.iconInactive
         }`,
         color: isFavorite ? color.iconActive : color.iconInactive,
+        zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
## Summary
- improve contrast of like/dislike buttons with a bottom gradient overlay
- ensure buttons appear above overlay

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_687d240ea4d88326aca76fb845d2b065