### PR TITLE
Update lastLogin2 indexing with registrationDate fallback

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2729,11 +2729,18 @@ export const indexLastLogin = async onProgress => {
       date = parseDate(user.lastLogin);
     }
 
+    if (!date && typeof user.registrationDate === 'string') {
+      date = parseDate(user.registrationDate);
+    }
+
     if (!date) {
       const other = usersData[id];
       if (other) {
         if (typeof other.lastLogin === 'string') {
           date = parseDate(other.lastLogin);
+        }
+        if (!date && typeof other.registrationDate === 'string') {
+          date = parseDate(other.registrationDate);
         }
         if (!date && typeof other.createdAt === 'string') {
           date = parseDate(other.createdAt);


### PR DESCRIPTION
## Summary
- add fallback to use `registrationDate` when deriving `lastLogin2`
- support checking both `newUsers` and `users` collections for this field

## Testing
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687e548aade4832681fa4955a6700cd6