### PR TITLE
Add lastLogin2 field in ProfileForm

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -214,7 +214,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
     const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction'];
+    const commonFields = ['lastAction', 'lastLogin2'];
 
     const formatDate = date => {
       const dd = String(date.getDate()).padStart(2, '0');

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -44,7 +44,7 @@ const EditProfile = () => {
   const handleSubmit = async (newState, overwrite, delCondition) => {
     const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction'];
+    const commonFields = ['lastAction', 'lastLogin2'];
 
     const formatDate = date => {
       const dd = String(date.getDate()).padStart(2, '0');

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -284,6 +284,7 @@ export const pickerFieldsExtended = [
   { name: 'myComment', placeholder: 'коментар', svg: 'user', ukrainianHint: 'Коментра' },
   { name: 'getInTouch', placeholder: '30.01.2025', svg: 'user', ukrainianHint: 'Коли звернутись' },
   { name: 'lastAction', placeholder: '-', svg: 'user', ukrainianHint: 'Останні зміни' },
+  { name: 'lastLogin2', placeholder: '-', svg: 'user', ukrainianHint: 'Останній логін' },
   { name: 'publish', placeholder: 'false', svg: 'user', ukrainianHint: 'Анкета опублікована' },
   { name: 'fathersname', placeholder: 'По-батькові', svg: 'user', ukrainianHint: 'По-батькові' },
   { name: 'otherLink', placeholder: 'www', svg: 'user', ukrainianHint: 'Лінк' },

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -71,7 +71,7 @@ export const handleChange = (
 export const handleSubmit = async userData => {
   const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
   const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-  const commonFields = ['lastAction'];
+  const commonFields = ['lastAction', 'lastLogin2'];
   const dublicateFields = ['weight', 'height'];
 
   // console.log('userData В handleSubmit', userData);


### PR DESCRIPTION
## Summary
- add `lastLogin2` to extended form fields
- include `lastLogin2` when mapping required fields in add/edit flows

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e5583a7c88326a9089d2d89a53b61