### PR TITLE
Add location normalization helper

### DIFF
--- a/src/components/__tests__/normalizeLocation.test.js
+++ b/src/components/__tests__/normalizeLocation.test.js
@@ -1,0 +1,12 @@
+const { normalizeLocation, normalizeRegion } = require('../normalizeLocation');
+
+test('normalizeLocation trims parts and adds oblast if needed', () => {
+  const input = 'Харьковская , Слобожанське ';
+  const output = normalizeLocation(input);
+  expect(output).toBe('Харьковская область, Слобожанське');
+});
+
+test('normalizeRegion adds oblast to known region names', () => {
+  expect(normalizeRegion('  Київська')).toBe('Київська область');
+  expect(normalizeRegion('Львівська область')).toBe('Львівська область');
+});

--- a/src/components/normalizeLocation.js
+++ b/src/components/normalizeLocation.js
@@ -1,0 +1,40 @@
+export const OBLASTS_UA = [
+  'Вінницька', 'Волинська', 'Дніпропетровська', 'Донецька',
+  'Житомирська', 'Закарпатська', 'Запорізька', 'Івано-Франківська',
+  'Київська', 'Кіровоградська', 'Луганська', 'Львівська',
+  'Миколаївська', 'Одеська', 'Полтавська', 'Рівненська',
+  'Сумська', 'Тернопільська', 'Харківська', 'Херсонська',
+  'Хмельницька', 'Черкаська', 'Чернівецька', 'Чернігівська'
+];
+
+export const OBLASTS_RU = [
+  'Винницкая', 'Волынская', 'Днепропетровская', 'Донецкая',
+  'Житомирская', 'Закарпатская', 'Запорожская', 'Ивано-Франковская',
+  'Киевская', 'Кировоградская', 'Луганская', 'Львовская',
+  'Николаевская', 'Одесская', 'Полтавская', 'Ровненская',
+  'Сумская', 'Тернопольская', 'Харьковская', 'Херсонская',
+  'Хмельницкая', 'Черкасская', 'Черновицкая', 'Черниговская'
+];
+
+const TRIM_RE = /\s+область$/i;
+
+export const normalizeRegion = region => {
+  if (!region || typeof region !== 'string') return region;
+  let trimmed = region.trim().replace(/,$/, '');
+  const base = trimmed.replace(TRIM_RE, '');
+  const lower = base.toLowerCase();
+  const uaMatch = OBLASTS_UA.some(o => o.toLowerCase() === lower);
+  const ruMatch = OBLASTS_RU.some(o => o.toLowerCase() === lower);
+  if ((uaMatch || ruMatch) && !TRIM_RE.test(trimmed)) {
+    trimmed = `${base} область`;
+  }
+  return trimmed;
+};
+
+export const normalizeLocation = str => {
+  if (!str || typeof str !== 'string') return str;
+  const parts = str.split(',');
+  const region = parts[0] ? normalizeRegion(parts[0]) : '';
+  const city = parts.slice(1).join(',').trim();
+  return city ? `${region}, ${city}`.trim() : region;
+};


### PR DESCRIPTION
## Summary
- add `normalizeLocation` helper to trim whitespace
- append `область` for known Ukrainian regions
- test `normalizeLocation` and `normalizeRegion`

## Testing
- `npm test --silent -- src/components/__tests__/normalizeLocation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687e56ad418883269e96ecbb38e00004