### PR TITLE
Fix matching order by lastLogin2

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -4,6 +4,11 @@
       ".read": true,
       ".write": true,
       ".indexOn": ["lastLogin2"]
+    },
+    "users": {
+      ".read": true,
+      ".write": true,
+      ".indexOn": ["lastLogin2"]
     }
   }
 }

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -23,6 +23,7 @@ import {
   runTransaction,
 } from 'firebase/database';
 import { PAGE_SIZE, BATCH_SIZE } from './constants';
+import { getCurrentDate } from './foramtDate';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -193,10 +194,11 @@ export const fetchLatestUsers = async (limit = 9, lastKey) => {
 export const fetchUsersByLastLogin2 = async (limit = 9, lastDate) => {
   const usersRef = ref2(database, 'users');
   const realLimit = limit + 1;
+  const { todayDash } = getCurrentDate();
   const q =
     lastDate !== undefined
       ? query(usersRef, orderByChild('lastLogin2'), endBefore(lastDate), limitToLast(realLimit))
-      : query(usersRef, orderByChild('lastLogin2'), limitToLast(realLimit));
+      : query(usersRef, orderByChild('lastLogin2'), endAt(todayDash), limitToLast(realLimit));
 
   const snapshot = await get(q);
   if (!snapshot.exists()) {


### PR DESCRIPTION
## Summary
- index lastLogin2 on both `newUsers` and `users` paths
- fetch users by `lastLogin2` ending at today so that matching cards show most recent logins first
- import date helper in config

## Testing
- `npm run lint:js`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687ff20455a08326988e104f92aaac91