### PR TITLE
Show search date progress

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4,6 +4,7 @@ import { UserCard } from './UsersList';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import styled, { keyframes } from 'styled-components';
 import { color } from './styles';
+import toast from 'react-hot-toast';
 import {
   fetchUsersByLastLoginPaged,
   getAllUserPhotos,
@@ -486,7 +487,16 @@ const Matching = () => {
   }, [filters.role]);
 
   const fetchChunk = async (limit, offset, exclude = new Set(), role) => {
-    const res = await fetchUsersByLastLoginPaged(offset, limit + exclude.size + 1);
+    const res = await fetchUsersByLastLoginPaged(
+      offset,
+      limit + exclude.size + 1,
+      undefined,
+      (_part, date) => {
+        if (date) {
+          toast.loading(`Searching ${date}`, { id: 'matching-progress' });
+        }
+      }
+    );
     const filtered = res.users.filter(u => !exclude.has(u.userId) && roleMatchesFilter(u, role));
     const hasMore = filtered.length > limit || res.hasMore;
     const slice = filtered.slice(0, limit);
@@ -497,6 +507,7 @@ const Matching = () => {
       })
     );
     const lastKeyResult = res.lastKey;
+    toast.dismiss('matching-progress');
     return { users: withPhotos, lastKey: lastKeyResult, hasMore };
   };
 

--- a/src/components/lastLoginLoad.js
+++ b/src/components/lastLoginLoad.js
@@ -9,6 +9,8 @@ export async function defaultFetchByLastLogin(dateStr, limit) {
   return snap.exists() ? Object.entries(snap.val()) : [];
 }
 
+// onProgress(partialUsers, dateStr) is called after each date is processed.
+// partialUsers contains users found so far starting from startOffset.
 export async function fetchUsersByLastLoginPaged(
   startOffset = 0,
   limit = PAGE_SIZE,
@@ -28,18 +30,21 @@ export async function fetchUsersByLastLoginPaged(
     const dateStr = date.toISOString().split('T')[0];
     // eslint-disable-next-line no-await-in-loop
     const chunk = await fetchDateFn(dateStr, totalLimit - combined.length);
+
     if (chunk.length > 0) {
       chunk.sort((a, b) => b[1].lastLogin2.localeCompare(a[1].lastLogin2));
       combined.push(...chunk);
-      if (onProgress) {
-        const partial = combined.slice(startOffset, Math.min(combined.length, startOffset + limit));
-        const partUsers = {};
-        partial.forEach(([pid, pdata]) => {
-          partUsers[pid] = pdata;
-        });
-        onProgress(partUsers);
-      }
     }
+
+    if (onProgress) {
+      const partial = combined.slice(startOffset, Math.min(combined.length, startOffset + limit));
+      const partUsers = {};
+      partial.forEach(([pid, pdata]) => {
+        partUsers[pid] = pdata;
+      });
+      onProgress(partUsers, dateStr);
+    }
+
     dayOffset += 1;
   }
 


### PR DESCRIPTION
## Summary
- enhance `fetchUsersByLastLoginPaged` to pass current date to progress callback
- display checked date in toast on Matching screen

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687fffde751083269c8d809afea8f3b4