### PR TITLE
Add console logs for matching debug

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -497,6 +497,7 @@ const Matching = () => {
         }
       }
     );
+    console.log('[fetchChunk] loaded', res.users.length, 'offset', offset, 'limit', limit);
     const filtered = res.users.filter(u => !exclude.has(u.userId) && roleMatchesFilter(u, role));
     const hasMore = filtered.length > limit || res.hasMore;
     const slice = filtered.slice(0, limit);
@@ -525,6 +526,7 @@ const Matching = () => {
         exclude = new Set([...Object.keys(favIds), ...Object.keys(disIds)]);
       }
       const res = await fetchChunk(INITIAL_LOAD, 0, exclude, roleFilter);
+      console.log('[loadInitial] initial loaded', res.users.length, 'hasMore', res.hasMore);
       loadedIdsRef.current = new Set(res.users.map(u => u.userId));
       setUsers(res.users);
       await loadCommentsFor(res.users);
@@ -584,6 +586,7 @@ const Matching = () => {
     try {
       const exclude = new Set([...Object.keys(favoriteUsers), ...Object.keys(dislikeUsers)]);
       const res = await fetchChunk(LOAD_MORE, lastKey, exclude, roleFilter);
+      console.log('[loadMore] loaded', res.users.length, 'lastKey', lastKey, 'hasMore', res.hasMore);
       const unique = res.users.filter(u => !loadedIdsRef.current.has(u.userId));
       unique.forEach(u => loadedIdsRef.current.add(u.userId));
       setUsers(prev => [...prev, ...unique]);

--- a/src/components/lastLoginLoad.js
+++ b/src/components/lastLoginLoad.js
@@ -21,6 +21,8 @@ export async function fetchUsersByLastLoginPaged(
   const target = startOffset + limit;
   const totalLimit = target + 1;
 
+  console.log('[fetchUsersByLastLoginPaged] startOffset', startOffset, 'limit', limit);
+
   const combined = [];
   let dayOffset = 0;
 
@@ -30,6 +32,7 @@ export async function fetchUsersByLastLoginPaged(
     const dateStr = date.toISOString().split('T')[0];
     // eslint-disable-next-line no-await-in-loop
     const chunk = await fetchDateFn(dateStr, totalLimit - combined.length);
+    console.log('[fetchUsersByLastLoginPaged] fetched', dateStr, 'count', chunk.length);
 
     if (chunk.length > 0) {
       chunk.sort((a, b) => b[1].lastLogin2.localeCompare(a[1].lastLogin2));


### PR DESCRIPTION
## Summary
- show startOffset and limit in `fetchUsersByLastLoginPaged`
- log chunk sizes and offsets when loading Matching users

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688006628cb083269ebd5553d0ba180e