### PR TITLE
Implement 6h cache for matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -30,6 +30,7 @@ import PhotoViewer from './PhotoViewer';
 import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
+import { loadCache, saveCache, clearCache } from "../hooks/useMatchingCache";
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
 import { FaFilter, FaTimes, FaHeart, FaEllipsisV } from 'react-icons/fa';
@@ -542,6 +543,18 @@ const Matching = () => {
         setDislikeUsers(disIds);
         exclude = new Set([...Object.keys(favIds), ...Object.keys(disIds)]);
       }
+
+      const cacheKey = JSON.stringify(filters.role || {});
+      const cached = loadCache(cacheKey);
+      if (cached) {
+        loadedIdsRef.current = new Set(cached.users.map(u => u.userId));
+        setUsers(cached.users);
+        await loadCommentsFor(cached.users);
+        setLastKey(cached.lastKey);
+        setHasMore(cached.hasMore);
+        setViewMode('default');
+        return;
+      }
       const res = await fetchChunk(
         INITIAL_LOAD,
         0,
@@ -560,7 +573,9 @@ const Matching = () => {
       setUsers(prev => {
         const map = new Map(prev.map(u => [u.userId, u]));
         res.users.forEach(u => map.set(u.userId, u));
-        return Array.from(map.values());
+        const result = Array.from(map.values());
+        saveCache(cacheKey, { users: result, lastKey: res.lastKey, hasMore: res.hasMore });
+        return result;
       });
       await loadCommentsFor(res.users);
       setLastKey(res.lastKey);
@@ -644,7 +659,14 @@ const Matching = () => {
       );
       const unique = res.users.filter(u => !loadedIdsRef.current.has(u.userId));
       unique.forEach(u => loadedIdsRef.current.add(u.userId));
-      setUsers(prev => [...prev, ...unique]);
+      setUsers(prev => {
+        const map = new Map(prev.map(u => [u.userId, u]));
+        unique.forEach(u => map.set(u.userId, u));
+        const result = Array.from(map.values());
+        const cacheKey = JSON.stringify(filters.role || {});
+        saveCache(cacheKey, { users: result, lastKey: res.lastKey, hasMore: res.hasMore });
+        return result;
+      });
       await loadCommentsFor(unique);
       setLastKey(res.lastKey);
       setHasMore(res.hasMore);

--- a/src/hooks/useMatchingCache.js
+++ b/src/hooks/useMatchingCache.js
@@ -1,0 +1,33 @@
+const CACHE_PREFIX = 'matchingCache:';
+const TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+export const loadCache = key => {
+  if (!key) return null;
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed.timestamp || Date.now() - parsed.timestamp > TTL_MS) {
+      localStorage.removeItem(CACHE_PREFIX + key);
+      return null;
+    }
+    return parsed.data;
+  } catch {
+    return null;
+  }
+};
+
+export const saveCache = (key, data) => {
+  if (!key) return;
+  try {
+    const record = { data, timestamp: Date.now() };
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(record));
+  } catch {
+    // ignore write errors
+  }
+};
+
+export const clearCache = key => {
+  if (!key) return;
+  localStorage.removeItem(CACHE_PREFIX + key);
+};


### PR DESCRIPTION
## Summary
- create `useMatchingCache` hook to store matching data in `localStorage`
- read cached users before fetching and save on each fetch
- refresh cache every 6 hours

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688132353b5c8326935bce984f230d34