### PR TITLE
Clear my-profile draft at login

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -250,6 +250,7 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
 
       localStorage.setItem('isLoggedIn', 'true');
       localStorage.setItem('userEmail', state.email);
+      localStorage.removeItem('myProfileDraft');
 
       setIsLoggedIn(true);
       if (userCredential.user.uid !== process.env.REACT_APP_USER1) {
@@ -289,6 +290,7 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
 
       localStorage.setItem('isLoggedIn', 'true');
       localStorage.setItem('userEmail', state.email);
+      localStorage.removeItem('myProfileDraft');
 
       setIsLoggedIn(true);
       if (userCredential.user.uid !== process.env.REACT_APP_USER1) {

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -591,6 +591,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
       localStorage.setItem('isLoggedIn', 'true');
       localStorage.setItem('userEmail', state.email);
+      localStorage.removeItem('myProfileDraft');
 
       setIsLoggedIn(true);
       setState(prev => ({ ...prev, userId: userCredential.user.uid }));
@@ -629,6 +630,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         await updateDataInRealtimeDB(userCredential.user.uid, uploadedInfo, 'update');
         await updateDataInFiresoreDB(userCredential.user.uid, uploadedInfo, 'update');
         setIsLoggedIn(true);
+        localStorage.removeItem('myProfileDraft');
         setState(prev => ({ ...prev, userId: userCredential.user.uid }));
       } catch (error) {
         if (error.code === 'auth/wrong-password') {


### PR DESCRIPTION
## Summary
- ensure logging in removes `myProfileDraft`
- clear draft when signing in/up from login screen and profile page

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68820da671148326a0b680ea57eceaae