### PR TITLE
Fix infinite load when no more users

### DIFF
--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -1,5 +1,5 @@
 import { getDatabase, ref as ref2, query, orderByChild, equalTo, limitToFirst, get } from 'firebase/database';
-import { PAGE_SIZE, INVALID_DATE_TOKENS } from './constants';
+import { PAGE_SIZE, INVALID_DATE_TOKENS, MAX_LOOKBACK_DAYS } from './constants';
 
 export async function defaultFetchByDate(dateStr, limit) {
   const db = getDatabase();
@@ -32,7 +32,7 @@ export async function fetchFilteredUsersByPage(
   const combined = [];
   let filtered = [];
 
-  const MAX_LOAD_DAYS = 3650; // safety cap ~10 years
+  const MAX_LOAD_DAYS = MAX_LOOKBACK_DAYS; // safety cap
   let dayOffset = 0;
   let invalidIndex = 0;
 

--- a/src/components/lastLoginLoad.js
+++ b/src/components/lastLoginLoad.js
@@ -8,7 +8,7 @@ import {
   limitToFirst,
   get,
 } from 'firebase/database';
-import { PAGE_SIZE } from './constants';
+import { PAGE_SIZE, MAX_LOOKBACK_DAYS } from './constants';
 
 export async function defaultFetchByLastLogin(dateStr, limit) {
   const db = getDatabase();
@@ -39,7 +39,7 @@ export async function fetchUsersByLastLoginPaged(
   console.log('[fetchUsersByLastLoginPaged] startOffset', startOffset, 'limit', limit);
 
   const combined = [];
-  const MAX_LOAD_DAYS = 3650; // safety cap ~10 years
+  const MAX_LOAD_DAYS = MAX_LOOKBACK_DAYS; // safety cap
   let dayOffset = 0;
 
   while (combined.length < target && dayOffset < MAX_LOAD_DAYS) {


### PR DESCRIPTION
## Summary
- prevent endless loops when searching for additional user data by limiting lookback days

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688234f9a90c83268827731a6f14e734