### PR TITLE
Improve Matching loadMore

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -34,6 +34,7 @@ import { loadCache, saveCache } from "../hooks/useMatchingCache";
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
 import { FaFilter, FaTimes, FaHeart, FaEllipsisV } from 'react-icons/fa';
+import { handleEmptyFetch } from './loadMoreUtils';
 
 const Container = styled.div`
   display: flex;
@@ -687,8 +688,13 @@ const Matching = () => {
       if (res.excludedCount) {
         toast.success(`${res.excludedCount} excluded`, { id: 'matching-excluded' });
       }
+      if (handleEmptyFetch(res, lastKey, setHasMore)) {
+        toast.dismiss('matching-progress');
+        toast.error('No more cards found', { id: 'matching-no-more' });
+      } else {
+        setHasMore(res.hasMore);
+      }
       setLastKey(res.lastKey);
-      setHasMore(res.hasMore);
     } finally {
       loadingRef.current = false;
       setLoading(false);

--- a/src/components/__tests__/loadMoreUtils.test.js
+++ b/src/components/__tests__/loadMoreUtils.test.js
@@ -1,0 +1,16 @@
+const { handleEmptyFetch } = require('../loadMoreUtils');
+
+test('handleEmptyFetch sets hasMore false when results empty and key unchanged', () => {
+  const setHasMore = jest.fn();
+  const prevKey = 5;
+  const res = { users: [], lastKey: 5 };
+  const stop = handleEmptyFetch(res, prevKey, setHasMore);
+  expect(stop).toBe(true);
+  expect(setHasMore).toHaveBeenCalledWith(false);
+});
+
+test('handleEmptyFetch returns false when users found or key changed', () => {
+  const setHasMore = jest.fn();
+  expect(handleEmptyFetch({ users: [{ id: 1 }], lastKey: 6 }, 5, setHasMore)).toBe(false);
+  expect(handleEmptyFetch({ users: [], lastKey: 6 }, 5, setHasMore)).toBe(false);
+});

--- a/src/components/loadMoreUtils.js
+++ b/src/components/loadMoreUtils.js
@@ -1,0 +1,7 @@
+export const handleEmptyFetch = (res, prevLastKey, setHasMore) => {
+  const shouldStop = res.users.length === 0 && res.lastKey === prevLastKey;
+  if (shouldStop) {
+    setHasMore(false);
+  }
+  return shouldStop;
+};


### PR DESCRIPTION
## Summary
- handle repeated empty fetches in Matching loadMore
- dismiss loading toast and show a "No more cards" error toast
- expose helper for detecting empty fetches
- test loadMoreUtils

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68823ba9f23483268fa6b7aef2f7847e