### PR TITLE
Fix search initialization

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -195,7 +195,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [search, setSearch] = useState(() => {
     const params = new URLSearchParams(location.search);
-    return params.get('search') || '';
+    const urlSearch = params.get('search');
+    if (urlSearch) return urlSearch;
+    return localStorage.getItem('searchQuery') || '';
   });
 
   const [state, setState] = useState({});


### PR DESCRIPTION
## Summary
- ensure AddNewProfile loads the search query from localStorage if no search parameter is provided

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883eec0d4948326a9fd06c54fd8da0d