### PR TITLE
Separate filter persistence per page

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -446,7 +446,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [ownerId]);
 
   useEffect(() => {
-    localStorage.setItem('userFilters', JSON.stringify(filters));
+    localStorage.setItem('addFilters', JSON.stringify(filters));
   }, [filters]);
 
   useEffect(() => {
@@ -829,7 +829,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 {duplicates ? ` з (${duplicates})` : ''}
               </p>
             ) : null}
-            <FilterPanel onChange={setFilters} />
+            <FilterPanel onChange={setFilters} storageKey="addFilters" />
             <ButtonsContainer>
               {userNotFound && (
                 <Button onClick={handleAddUser} disabled={adding}>

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -54,9 +54,19 @@ const normalizeFilterGroup = (value, defaults) => {
   return typeof value === 'object' && value !== null ? { ...defaults, ...value } : { ...defaults };
 };
 
-const FilterPanel = ({ onChange, hideUserId = false, hideCommentLength = false, mode = 'default' }) => {
-  const defaultFilters = useMemo(() => (mode === 'matching' ? defaultsMatching : defaultsAdd), [mode]);
-  const storageKey = mode === 'matching' ? 'matchingFilters' : 'userFilters';
+const FilterPanel = ({
+  onChange,
+  hideUserId = false,
+  hideCommentLength = false,
+  mode = 'default',
+  storageKey: customKey,
+}) => {
+  const defaultFilters = useMemo(
+    () => (mode === 'matching' ? defaultsMatching : defaultsAdd),
+    [mode],
+  );
+  const storageKey =
+    customKey || (mode === 'matching' ? 'matchingFilters' : 'userFilters');
 
   const getInitialFilters = () => {
     const stored = localStorage.getItem(storageKey);


### PR DESCRIPTION
## Summary
- add optional `storageKey` prop to `FilterPanel` to control where filters are saved
- store AddNewProfile filters under new `addFilters` key
- pass the `addFilters` key to `FilterPanel` on the AddNewProfile page

## Testing
- `npm install`
- `npm test --silent` *(fails: "No tests found related to files changed since last commit.")*

------
https://chatgpt.com/codex/tasks/task_e_68849c44a0a4832680e0f7aaa5bcd8ff