### PR TITLE
Fix extra padding at bottom of matching list

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -61,7 +61,7 @@ const Grid = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  padding: 10px;
+  padding: 10px 10px 0;
   justify-content: center;
 `;
 


### PR DESCRIPTION
## Summary
- remove padding at the bottom of the Matching grid

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688649f62f948326a7cdb6d540f03b4f