### PR TITLE
Update cache after filter change

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -567,7 +567,7 @@ const Matching = () => {
         setLastKey(cached.lastKey);
         setHasMore(cached.hasMore);
         setViewMode('default');
-        return;
+        // continue to fetch latest data to refresh cache
       }
       const res = await fetchChunk(
         INITIAL_LOAD,


### PR DESCRIPTION
## Summary
- keep fetching new data when cached match results exist

## Testing
- `npm run lint:js`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688643c3b0c48326a7438170c300069a