### PR TITLE
Improve admin controls on matching cards

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -788,11 +788,15 @@ export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) =>
     const userRefRTDB = ref2(database, `users/${userId}`);
     const cleanedUploadedInfo = removeUndefined(uploadedInfo);
     if (condition === 'update') {
-      await update(userRefRTDB, { ...cleanedUploadedInfo });
+      await update(userRefRTDB, cleanedUploadedInfo);
+    } else {
+      await set(userRefRTDB, cleanedUploadedInfo);
     }
-    await set(userRefRTDB, { ...cleanedUploadedInfo });
   } catch (error) {
-    console.error('Сталася помилка під час збереження даних в Realtime Database2:', error);
+    console.error(
+      'Сталася помилка під час збереження даних в Realtime Database2:',
+      error
+    );
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- show card role info at the top of agency and couple cards
- add small admin toggle button to change `publish` status
- only update the `publish` field when toggling

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `npm test -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68867870a9148326b423ea6dd518c8a5