### PR TITLE
Fix sorting when lastLogin fields missing

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -205,7 +205,11 @@ export const fetchUsersByLastLogin2 = async (limit = 9, lastDate) => {
     return { users: [], lastKey: null, hasMore: false };
   }
 
-  let entries = Object.entries(snapshot.val()).sort((a, b) => b[1].lastLogin2.localeCompare(a[1].lastLogin2));
+  let entries = Object.entries(snapshot.val()).sort((a, b) => {
+    const bDate = b[1].lastLogin2 || '';
+    const aDate = a[1].lastLogin2 || '';
+    return bDate.localeCompare(aDate);
+  });
 
   const hasMore = entries.length > limit;
   if (hasMore) entries = entries.slice(0, limit);

--- a/src/components/lastLoginLoad.js
+++ b/src/components/lastLoginLoad.js
@@ -58,7 +58,11 @@ export async function fetchUsersByLastLoginPaged(
         const [d, m, y] = str.split('.');
         return `${y}-${m}-${d}`;
       };
-      chunk.sort((a, b) => parse(b[1].lastLogin).localeCompare(parse(a[1].lastLogin)));
+      chunk.sort((a, b) => {
+        const bDate = b[1].lastLogin ? parse(b[1].lastLogin) : '';
+        const aDate = a[1].lastLogin ? parse(a[1].lastLogin) : '';
+        return bDate.localeCompare(aDate);
+      });
       combined.push(...chunk);
     }
 


### PR DESCRIPTION
## Summary
- avoid calling `localeCompare` on undefined when sorting by dates
- sort user date fields more safely by falling back to an empty string

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688682000118832689d277bfd22876fa