### PR TITLE
Fix card width on Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -53,8 +53,8 @@ const Container = styled.div`
 `;
 
 const InnerContainer = styled.div`
-  max-width: 450px;
-  width: 90%;
+  max-width: 480px;
+  width: 100%;
   background-color: #f0f0f0;
   padding: 20px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- expand Matching cards to use full width up to typical mobile size

## Testing
- `CI=true npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_68868d5fc9148326a12f353f5cf93544