### PR TITLE
Add stacked photo style to matching card

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -83,7 +83,8 @@ const CardWrapper = styled.div`
   border: 2px solid ${color.gray3};
   border-radius: 8px;
   box-sizing: border-box;
-  overflow: hidden;
+  position: relative;
+  overflow: visible;
 `;
 
 const CommentInput = styled.textarea`
@@ -129,9 +130,11 @@ const Card = styled.div`
   background: linear-gradient(135deg, orange, yellow);
   background-size: cover;
   background-position: center;
-  border-radius: 0;
+  border-radius: 8px;
   position: relative;
   overflow: hidden;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1;
   &::after {
     content: '';
     position: absolute;
@@ -156,6 +159,16 @@ const loadingWave = keyframes`
   100% {
     background-position: calc(200px + 100%) 0;
   }
+`;
+
+const StackedCard = styled(Card)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: rotate(3deg);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+  z-index: 0;
 `;
 
 const SkeletonCard = styled(Card)`
@@ -538,22 +551,35 @@ const SwipeableCard = ({
   };
 
   const current = slides[index];
+  const nextIndex = (index + 1) % slides.length;
+  const nextSlide = slides[nextIndex];
   const style =
     current !== 'description' && current
       ? { backgroundImage: `url(${current})`, backgroundColor: 'transparent' }
       : { backgroundColor: '#fff' };
 
   return (
-    <AnimatedCard
-      $dir={dir}
-      $small={isAgency}
-      $hasPhoto={!!photo}
-      data-card
-      onClick={handleClick}
+    <>
+      {slides.length > 1 && nextSlide !== 'description' && (
+        <StackedCard
+          $small={isAgency}
+          $hasPhoto={!!photo}
+          style={{
+            backgroundImage: `url(${nextSlide})`,
+            backgroundColor: 'transparent',
+          }}
+        />
+      )}
+      <AnimatedCard
+        $dir={dir}
+        $small={isAgency}
+        $hasPhoto={!!photo}
+        data-card
+        onClick={handleClick}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
-      style={style}
-    >
+        style={style}
+      >
       {current === 'description' && (
         <DescriptionPage style={{ whiteSpace: 'pre-wrap', padding: '10px' }}>
           {getCurrentValue(user.moreInfo_main) || 'No description'}
@@ -622,6 +648,7 @@ const SwipeableCard = ({
         </CardInfo>
       )}
     </AnimatedCard>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- style `CardWrapper` for stacking effect
- give `Card` a shadow and rounded corners
- show the next photo rotated slightly as a `StackedCard`

## Testing
- `npm install`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887065e22c883268f2a0b7e32a8fdd6