### PR TITLE
Update matching container padding

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -56,7 +56,7 @@ const InnerContainer = styled.div`
   max-width: 480px;
   width: 100%;
   background-color: #f0f0f0;
-  padding: 20px;
+  padding: 20px 0;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- remove horizontal padding from the Matching container

## Testing
- `npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68873f2b18bc8326a4f55253c790bd74