### PR TITLE
Fix grid scrolling on matching page

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -80,6 +80,8 @@ const Grid = styled.div`
   gap: 10px;
   padding: 10px 10px 0;
   justify-content: center;
+  max-height: 80vh;
+  overflow-y: auto;
 `;
 
 const CardWrapper = styled.div`


### PR DESCRIPTION
## Summary
- make matching grid scrollable so infinite scroll triggers correctly

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6887b29a905c8326aa38277ad3404b5e