### PR TITLE
Add like/dislike buttons to photo-less matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -712,7 +712,15 @@ const renderSelectedFields = user => {
   });
 };
 
-const NoPhotoCard = ({ user }) => {
+const NoPhotoCard = ({
+  user,
+  favoriteUsers,
+  setFavoriteUsers,
+  dislikeUsers,
+  setDislikeUsers,
+  viewMode,
+  handleRemove,
+}) => {
   return (
     <DonorCard style={{ boxShadow: 'none', border: 'none', maxHeight: '40vh' }}>
       <ProfileSection>
@@ -749,6 +757,22 @@ const NoPhotoCard = ({ user }) => {
       <Contact>
         <Icons>{fieldContactsIcons(user)}</Icons>
       </Contact>
+      <BtnFavorite
+        userId={user.userId}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+      />
+      <BtnDislike
+        userId={user.userId}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+      />
     </DonorCard>
   );
 };
@@ -1195,7 +1219,15 @@ const Matching = () => {
                           onSelect={setSelected}
                         />
                       ) : (
-                        <NoPhotoCard user={user} />
+                        <NoPhotoCard
+                          user={user}
+                          favoriteUsers={favoriteUsers}
+                          setFavoriteUsers={setFavoriteUsers}
+                          dislikeUsers={dislikeUsers}
+                          setDislikeUsers={setDislikeUsers}
+                          viewMode={viewMode}
+                          handleRemove={handleRemove}
+                        />
                       )}
                       <ResizableCommentInput
                         plain


### PR DESCRIPTION
## Summary
- show BtnFavorite and BtnDislike on `NoPhotoCard`
- pass favorite/dislike props when rendering `NoPhotoCard`

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688924b971f8832687b9ebb57b02c045