### PR TITLE
Fix unused NameText styled component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -321,10 +321,6 @@ const Title = styled.div`
   margin-bottom: 4px;
 `;
 
-const NameText = styled.span`
-  color: ${color.black};
-`;
-
 const ProfileSection = styled.div`
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove unused `NameText` styled component
- tidy spacing after removal

## Testing
- `npm run lint:js`
- `CI=true npm test -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_6889f1c1d018832696f54af54806620d