### PR TITLE
Update Matching card stacking & long text handling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -91,8 +91,8 @@ const CardContainer = styled.div`
 
 const NextPhoto = styled.img`
   position: absolute;
-  top: -3px;
-  right: -3px;
+  top: -4px;
+  right: -4px;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -103,8 +103,8 @@ const NextPhoto = styled.img`
 
 const ThirdPhoto = styled.img`
   position: absolute;
-  top: -6px;
-  right: -6px;
+  top: -8px;
+  right: -8px;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -371,11 +371,13 @@ const FIELDS = [
   { key: 'breastSize', label: 'Breast size' },
   { key: 'bodyType', label: 'Body type' },
   { key: 'maritalStatus', label: 'Marital status' },
-  { key: 'education', label: 'Education' },
   { key: 'ownKids', label: 'Own kids' },
   { key: 'reward', label: 'Expected reward $' },
   { key: 'experience', label: 'Donation exp' },
 ];
+
+const countWords = text =>
+  text ? text.trim().split(/\s+/).filter(Boolean).length : 0;
 
 const Table = styled.div`
   display: grid;
@@ -532,7 +534,6 @@ const SwipeableCard = ({
 
   const moreInfo = getCurrentValue(user.moreInfo_main);
   const profession = getCurrentValue(user.profession);
-
   const moreInfoWords = wordCount(moreInfo);
   const professionWords = wordCount(profession);
   const showDescriptionSlide = moreInfoWords > 10 || professionWords > 10;
@@ -669,9 +670,9 @@ const SwipeableCard = ({
               justifyContent: 'flex-start',
             }}
           >
-            {getCurrentValue(user.country) && (
-              <span>{normalizeCountry(getCurrentValue(user.country))}</span>
-            )}
+          {getCurrentValue(user.country) && (
+            <span>{normalizeCountry(getCurrentValue(user.country))}</span>
+          )}
             <Icons>{fieldContactsIcons(user)}</Icons>
           </div>
           {moreInfo && moreInfoWords <= 10 && (
@@ -711,11 +712,18 @@ const renderSelectedFields = user => {
 };
 
 const NoPhotoCard = ({ user }) => {
+  const profession = getCurrentValue(user.profession);
+  const moreInfoMain = getCurrentValue(user.moreInfo_main);
+  const professionWords = countWords(profession);
+  const moreInfoMainWords = countWords(moreInfoMain);
+  const showExtraCard = professionWords > 10 || moreInfoMainWords > 10;
+
   return (
-    <DonorCard style={{ boxShadow: 'none', border: 'none', maxHeight: '40vh' }}>
-      <ProfileSection>
-        <Info>
-          <Title>Egg donor profile</Title>
+    <>
+      <DonorCard style={{ boxShadow: 'none', border: 'none', maxHeight: '40vh' }}>
+        <ProfileSection>
+          <Info>
+            <Title>Egg donor profile</Title>
           <strong>
             {(getCurrentValue(user.surname) || '').trim()} {(getCurrentValue(user.name) || '').trim()}
             {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
@@ -730,24 +738,43 @@ const NoPhotoCard = ({ user }) => {
         </Info>
       </ProfileSection>
       <Table>{renderSelectedFields(user)}</Table>
-      {getCurrentValue(user.profession) && (
+      {profession && professionWords <= 10 && (
         <MoreInfo>
           <strong>Profession</strong>
           <br />
-          {getCurrentValue(user.profession)}
+          {profession}
         </MoreInfo>
       )}
-      {getCurrentValue(user.moreInfo_main) && (
+      {moreInfoMain && moreInfoMainWords <= 10 && (
         <MoreInfo>
           <strong>More information</strong>
           <br />
-          {getCurrentValue(user.moreInfo_main)}
+          {moreInfoMain}
         </MoreInfo>
       )}
       <Contact>
         <Icons>{fieldContactsIcons(user)}</Icons>
       </Contact>
-    </DonorCard>
+      </DonorCard>
+      {showExtraCard && (
+        <DonorCard style={{ boxShadow: 'none', border: 'none', maxHeight: '40vh' }}>
+          {professionWords > 10 && (
+            <MoreInfo>
+              <strong>Profession</strong>
+              <br />
+              {profession}
+            </MoreInfo>
+          )}
+          {moreInfoMainWords > 10 && (
+            <MoreInfo>
+              <strong>More information</strong>
+              <br />
+              {moreInfoMain}
+            </MoreInfo>
+          )}
+        </DonorCard>
+      )}
+    </>
   );
 };
 
@@ -777,13 +804,12 @@ const Matching = () => {
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
 
-  const countWords = text =>
-    text ? text.trim().split(/\s+/).filter(Boolean).length : 0;
-
   const selectedProfession = selected ? getCurrentValue(selected.profession) : '';
   const selectedMoreInfoMain = selected ? getCurrentValue(selected.moreInfo_main) : '';
   const selectedProfessionWords = countWords(selectedProfession);
   const selectedMoreInfoWords = countWords(selectedMoreInfoMain);
+  const showExtraSelectedCard =
+    selectedProfessionWords > 10 || selectedMoreInfoWords > 10;
   const handleRemove = id => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
@@ -1305,7 +1331,7 @@ const Matching = () => {
               ID: {selected.userId ? selected.userId.slice(0, 5) : ''}
             </Id>
           </DonorCard>
-          {(selectedProfessionWords > 10 || selectedMoreInfoWords > 10) && (
+          {showExtraSelectedCard && (
             <DonorCard onClick={e => e.stopPropagation()}>
               {selectedProfessionWords > 10 && (
                 <MoreInfo>


### PR DESCRIPTION
## Summary
- keep second and third photo layers offset by 4px
- only add description slide in cards when profession or moreInfo exceed ten words
- show short profession/moreInfo directly on cards and move long text to an extra card
- apply same logic for profiles without photos and in the modal view

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889295475888326ada85af22ed46828