### PR TITLE
Fix no-photo card padding

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -714,7 +714,9 @@ const renderSelectedFields = user => {
 
 const NoPhotoCard = ({ user }) => {
   return (
-    <DonorCard style={{ boxShadow: 'none', border: 'none', maxHeight: '40vh' }}>
+    <DonorCard
+      style={{ boxShadow: 'none', border: 'none', maxHeight: '40vh', margin: 0 }}
+    >
       <ProfileSection>
         <Info>
           <Title>Egg donor profile</Title>


### PR DESCRIPTION
## Summary
- remove margin so the no-photo card sits flush without white borders

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6889247e45008326b61cf53083d9ab05