### PR TITLE
Fix donor info layout

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -315,14 +315,16 @@ const DonorCard = styled.div`
   position: relative;
 `;
 
-const Title = styled.div`
+const Title = styled.span`
   color: ${color.accent};
   font-weight: bold;
   margin-bottom: 4px;
+  margin-right: 4px;
+  display: inline-block;
 `;
 
 const DonorName = styled.strong`
-  display: block;
+  display: inline;
   margin-bottom: 2px;
   line-height: 1.2;
 `;


### PR DESCRIPTION
## Summary
- show donor name inline with title on matching cards

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a67dad26c832695272fa7bc028df6