### PR TITLE
Adjust card layers and move info to extra tab

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -91,8 +91,8 @@ const CardContainer = styled.div`
 
 const NextPhoto = styled.img`
   position: absolute;
-  top: -3px;
-  right: -3px;
+  top: -4px;
+  right: -4px;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -103,8 +103,8 @@ const NextPhoto = styled.img`
 
 const ThirdPhoto = styled.img`
   position: absolute;
-  top: -6px;
-  right: -6px;
+  top: -8px;
+  right: -8px;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -377,7 +377,6 @@ const FIELDS = [
   { key: 'breastSize', label: 'Breast size' },
   { key: 'bodyType', label: 'Body type' },
   { key: 'maritalStatus', label: 'Marital status' },
-  { key: 'education', label: 'Education' },
   { key: 'ownKids', label: 'Own kids' },
   { key: 'reward', label: 'Expected reward $' },
   { key: 'experience', label: 'Donation exp' },
@@ -543,15 +542,11 @@ const SwipeableCard = ({
   togglePublish,
   onSelect,
 }) => {
-  const wordCount = text =>
-    text ? text.trim().split(/\s+/).filter(Boolean).length : 0;
-
   const moreInfo = getCurrentValue(user.moreInfo_main);
   const profession = getCurrentValue(user.profession);
+  const education = getCurrentValue(user.education);
 
-  const moreInfoWords = wordCount(moreInfo);
-  const professionWords = wordCount(profession);
-  const showDescriptionSlide = moreInfoWords > 10 || professionWords > 10;
+  const showDescriptionSlide = Boolean(moreInfo || profession || education);
 
   const slides = React.useMemo(() => {
     const photos = Array.isArray(user.photos)
@@ -632,10 +627,29 @@ const SwipeableCard = ({
       style={style}
     >
       {current === 'description' && (
-        <DescriptionPage style={{ whiteSpace: 'pre-wrap', padding: '10px' }}>
-          {moreInfoWords > 10 && <div>{moreInfo}</div>}
-          {professionWords > 10 && <div>{profession}</div>}
-        </DescriptionPage>
+        <InfoSlide>
+          {education && (
+            <MoreInfo>
+              <strong>Education</strong>
+              <br />
+              {education}
+            </MoreInfo>
+          )}
+          {profession && (
+            <MoreInfo>
+              <strong>Profession</strong>
+              <br />
+              {profession}
+            </MoreInfo>
+          )}
+          {moreInfo && (
+            <MoreInfo>
+              <strong>More information</strong>
+              <br />
+              {moreInfo}
+            </MoreInfo>
+          )}
+        </InfoSlide>
       )}
       {current === 'info' && (
         <InfoSlide>
@@ -655,20 +669,6 @@ const SwipeableCard = ({
             </Info>
           </ProfileSection>
           <Table>{renderSelectedFields(user)}</Table>
-          {getCurrentValue(user.profession) && (
-            <MoreInfo>
-              <strong>Profession</strong>
-              <br />
-              {getCurrentValue(user.profession)}
-            </MoreInfo>
-          )}
-          {getCurrentValue(user.moreInfo_main) && (
-            <MoreInfo>
-              <strong>More information</strong>
-              <br />
-              {getCurrentValue(user.moreInfo_main)}
-            </MoreInfo>
-          )}
           <Contact>
             <Icons>{fieldContactsIcons(user)}</Icons>
           </Contact>
@@ -800,8 +800,7 @@ const Matching = () => {
 
   const selectedProfession = selected ? getCurrentValue(selected.profession) : '';
   const selectedMoreInfoMain = selected ? getCurrentValue(selected.moreInfo_main) : '';
-  const selectedProfessionWords = countWords(selectedProfession);
-  const selectedMoreInfoWords = countWords(selectedMoreInfoMain);
+  const selectedEducation = selected ? getCurrentValue(selected.education) : '';
   const handleRemove = id => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
@@ -1281,20 +1280,6 @@ const Matching = () => {
                 {getCurrentValue(selected.myComment)}
               </MoreInfo>
             )}
-            {selectedProfession && selectedProfessionWords <= 10 && (
-              <MoreInfo>
-                <strong>Profession</strong>
-                <br />
-                {selectedProfession}
-              </MoreInfo>
-            )}
-            {selectedMoreInfoMain && selectedMoreInfoWords <= 10 && (
-              <MoreInfo>
-                <strong>More information</strong>
-                <br />
-                {selectedMoreInfoMain}
-              </MoreInfo>
-            )}
             <Contact>
               <Icons>{fieldContactsIcons(selected)}</Icons>
             </Contact>
@@ -1318,16 +1303,23 @@ const Matching = () => {
               ID: {selected.userId ? selected.userId.slice(0, 5) : ''}
             </Id>
           </DonorCard>
-          {(selectedProfessionWords > 10 || selectedMoreInfoWords > 10) && (
+          {(selectedEducation || selectedProfession || selectedMoreInfoMain) && (
             <DonorCard onClick={e => e.stopPropagation()}>
-              {selectedProfessionWords > 10 && (
+              {selectedEducation && (
+                <MoreInfo>
+                  <strong>Education</strong>
+                  <br />
+                  {selectedEducation}
+                </MoreInfo>
+              )}
+              {selectedProfession && (
                 <MoreInfo>
                   <strong>Profession</strong>
                   <br />
                   {selectedProfession}
                 </MoreInfo>
               )}
-              {selectedMoreInfoWords > 10 && (
+              {selectedMoreInfoMain && (
                 <MoreInfo>
                   <strong>More information</strong>
                   <br />


### PR DESCRIPTION
## Summary
- tweak card layer offsets for additional photos
- always provide dedicated slide for education, profession and more info
- show extra info slide even when no photos are present
- show education/profession details in modal on a separate card

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a60aa5dec8326a32f343c8a620ea3