### PR TITLE
Fix donor card spacing

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -304,9 +304,9 @@ const DonorCard = styled.div`
   max-width: 400px;
   width: 90%;
   margin: 10px;
-  border: 1px solid ${color.gray};
+  border: none;
   border-radius: 8px;
-  padding: 16px;
+  padding: 0;
   background: #f0f0f0;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   color: ${color.black};


### PR DESCRIPTION
## Summary
- remove border and padding from donor card to eliminate inner white frames

## Testing
- `npx react-scripts test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688a6855c408832681e2d39b387c6bc9