### PR TITLE
Adjust matching card order and filter photos

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -554,12 +554,12 @@ const SwipeableCard = ({
   const showDescriptionSlide = moreInfoWords > 10 || professionWords > 10;
 
   const slides = React.useMemo(() => {
-    const photos = Array.isArray(user.photos)
-      ? user.photos
+    const photosArr = Array.isArray(user.photos)
+      ? user.photos.filter(Boolean)
       : [getCurrentValue(user.photos)].filter(Boolean);
-    const base = ['main', ...photos];
+    const base = ['main', 'info'];
     if (showDescriptionSlide) base.push('description');
-    base.push('info');
+    base.push(...photosArr.slice(1));
     return base;
   }, [user.photos, showDescriptionSlide]);
 
@@ -1183,7 +1183,7 @@ const Matching = () => {
             <Grid ref={gridRef}>
               {filteredUsers.map(user => {
                 const photos = Array.isArray(user.photos)
-                  ? user.photos
+                  ? user.photos.filter(Boolean)
                   : [getCurrentValue(user.photos)].filter(Boolean);
                 const photo = photos[0];
                 const nextPhoto = photos[1];


### PR DESCRIPTION
## Summary
- filter empty values from user photos
- show info slide after main slide
- put description slide third
- display only remaining photos afterward

## Testing
- `npx react-scripts test --watchAll=false --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_688a69a3e9a48326a155f8d047f2cce3