### PR TITLE
Fix name formatting on matching card

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -649,8 +649,7 @@ const SwipeableCard = ({
             <Info>
               <Title>Egg donor</Title>
               <DonorName>
-                {(getCurrentValue(user.surname) || '').trim()} {(getCurrentValue(user.name) || '').trim()}
-                {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+                {(getCurrentValue(user.surname) || '').trim()} {(getCurrentValue(user.name) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
               </DonorName>
               <br />
               {normalizeLocation([
@@ -669,8 +668,7 @@ const SwipeableCard = ({
       )}
       {current === 'main' && (
         <BasicInfo>
-          {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}
-          {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+          {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
           <br />
           {[
             normalizeCountry(getCurrentValue(user.country)),
@@ -1251,8 +1249,7 @@ const Matching = () => {
               <Info>
                 <Title>Egg donor</Title>
                 <DonorName>
-                  {(getCurrentValue(selected.surname) || '').trim()} {(getCurrentValue(selected.name) || '').trim()}
-                  {selected.birth ? `, ${utilCalculateAge(selected.birth)}р` : ''}
+                  {(getCurrentValue(selected.surname) || '').trim()} {(getCurrentValue(selected.name) || '').trim()}{selected.birth ? `, ${utilCalculateAge(selected.birth)}р` : ''}
                 </DonorName>
                 <br />
                 {normalizeLocation([


### PR DESCRIPTION
## Summary
- clean up newlines that caused a space before comma in matching cards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a70df0060832688c60b2ca1617de7