### PR TITLE
Add admin ID navigation on matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -534,6 +534,7 @@ const SwipeableCard = ({
   togglePublish,
   onSelect,
 }) => {
+  const navigate = useNavigate();
   const moreInfo = getCurrentValue(user.moreInfo_main);
   const profession = getCurrentValue(user.profession);
   const education = getCurrentValue(user.education);
@@ -732,6 +733,19 @@ const SwipeableCard = ({
             <Icons>{fieldContactsIcons(user)}</Icons>
           </div>
         </CardInfo>
+      )}
+      {(current === 'info' || current === 'main') && (
+        <Id
+          onClick={e => {
+            e.stopPropagation();
+            if (isAdmin) {
+              navigate(`/edit/${user.userId}`);
+            }
+          }}
+          style={{ cursor: isAdmin ? 'pointer' : 'default' }}
+        >
+          ID: {user.userId ? user.userId.slice(0, 5) : ''}
+        </Id>
       )}
     </AnimatedCard>
   );


### PR DESCRIPTION
## Summary
- show user ID on swipeable cards
- make ID clickable for admins to open edit page

## Testing
- `npm test` *(fails: react-scripts not found / interactive)*
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_688a7223280c83269cc5107224b6a77e