### PR TITLE
Move ID click to user info card

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -732,19 +732,7 @@ const SwipeableCard = ({
           </div>
         </CardInfo>
       )}
-      {(current === 'info' || current === 'main') && (
-        <Id
-          onClick={e => {
-            e.stopPropagation();
-            if (isAdmin) {
-              navigate(`/edit/${user.userId}`);
-            }
-          }}
-          style={{ cursor: isAdmin ? 'pointer' : 'default' }}
-        >
-          ID: {user.userId ? user.userId.slice(0, 5) : ''}
-        </Id>
-      )}
+      {(current === 'info' || current === 'main') && null}
     </AnimatedCard>
   );
 };

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { auth } from './config';
 import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
@@ -66,6 +68,9 @@ const UserCard = ({
   currentFilter,
   isDateInRange,
 }) => {
+  const navigate = useNavigate();
+  const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
+
   return (
     <div>
       {renderTopBlock(
@@ -81,6 +86,22 @@ const UserCard = ({
       )}
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}
+      </div>
+      <div
+        onClick={() => {
+          if (isAdmin) {
+            navigate(`/edit/${userData.userId}`);
+          }
+        }}
+        style={{
+          fontSize: '12px',
+          color: 'gray',
+          textAlign: 'right',
+          marginTop: '5px',
+          cursor: isAdmin ? 'pointer' : 'default',
+        }}
+      >
+        ID: {userData.userId ? userData.userId.slice(0, 5) : ''}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove clickable ID from the swipeable card in `Matching`
- make the ID clickable inside `UserCard` so admins can navigate to edit user

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a81b9ac788326b561d786ef0e5075