### PR TITLE
Add like/dislike buttons to matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -689,26 +689,22 @@ const SwipeableCard = ({
           }}
         />
       )}
-      {current === 'main' && (
-        <>
-          <BtnFavorite
-            userId={user.userId}
-            favoriteUsers={favoriteUsers}
-            setFavoriteUsers={setFavoriteUsers}
-            dislikeUsers={dislikeUsers}
-            setDislikeUsers={setDislikeUsers}
-            onRemove={viewMode !== 'default' ? handleRemove : undefined}
-          />
-          <BtnDislike
-            userId={user.userId}
-            dislikeUsers={dislikeUsers}
-            setDislikeUsers={setDislikeUsers}
-            favoriteUsers={favoriteUsers}
-            setFavoriteUsers={setFavoriteUsers}
-            onRemove={viewMode !== 'default' ? handleRemove : undefined}
-          />
-        </>
-      )}
+      <BtnFavorite
+        userId={user.userId}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+      />
+      <BtnDislike
+        userId={user.userId}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+      />
       {current === 'main' && isAgency && (
         <CardInfo>
           <RoleHeader>{role === 'ag' ? 'Agency' : 'Couple'}</RoleHeader>


### PR DESCRIPTION
## Summary
- show `BtnFavorite` and `BtnDislike` for all slides in `Matching` cards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a7a6ab15c83269c194247ff7e9b12