### PR TITLE
Fix unused variable warning

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -534,7 +534,6 @@ const SwipeableCard = ({
   togglePublish,
   onSelect,
 }) => {
-  const navigate = useNavigate();
   const moreInfo = getCurrentValue(user.moreInfo_main);
   const profession = getCurrentValue(user.profession);
   const education = getCurrentValue(user.education);


### PR DESCRIPTION
## Summary
- remove unused `navigate` variable in `SwipeableCard`

## Testing
- `npm test --silent`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_688aefb3b0d4832686da1cf4a9ef9c48