### PR TITLE
Add like/dislike buttons to Matching modal

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1270,12 +1270,26 @@ const Matching = () => {
                 {getCurrentValue(selected.myComment)}
               </MoreInfo>
             )}
-            <Contact>
-              <Icons>{fieldContactsIcons(selected)}</Icons>
-            </Contact>
-            <ResizableCommentInput
-              mt="10px"
-              value={comments[selected.userId] || ''}
+          <Contact>
+            <Icons>{fieldContactsIcons(selected)}</Icons>
+          </Contact>
+          <BtnFavorite
+            userId={selected.userId}
+            favoriteUsers={favoriteUsers}
+            setFavoriteUsers={setFavoriteUsers}
+            dislikeUsers={dislikeUsers}
+            setDislikeUsers={setDislikeUsers}
+          />
+          <BtnDislike
+            userId={selected.userId}
+            dislikeUsers={dislikeUsers}
+            setDislikeUsers={setDislikeUsers}
+            favoriteUsers={favoriteUsers}
+            setFavoriteUsers={setFavoriteUsers}
+          />
+          <ResizableCommentInput
+            mt="10px"
+            value={comments[selected.userId] || ''}
               onChange={e => setComments(prev => ({ ...prev, [selected.userId]: e.target.value }))}
               onBlur={() => {
                 const owner = auth.currentUser?.uid;


### PR DESCRIPTION
## Summary
- show favorite and dislike buttons on the selected card modal in Matching

## Testing
- `npm test --silent` *(fails: No tests found related to files changed since last commit)*

------
https://chatgpt.com/codex/tasks/task_e_688aef5a0418832685efaeb6a8aa2db4