### PR TITLE
Fix donor name order on matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -653,7 +653,7 @@ const SwipeableCard = ({
             <Info>
               <Title>Egg donor</Title>
               <DonorName>
-                {(getCurrentValue(user.surname) || '').trim()} {(getCurrentValue(user.name) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+                {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
               </DonorName>
               <br />
               {[
@@ -1260,7 +1260,7 @@ const Matching = () => {
               <Info>
                 <Title>Egg donor</Title>
                 <DonorName>
-                  {(getCurrentValue(selected.surname) || '').trim()} {(getCurrentValue(selected.name) || '').trim()}{selected.birth ? `, ${utilCalculateAge(selected.birth)}р` : ''}
+                  {(getCurrentValue(selected.name) || '').trim()} {(getCurrentValue(selected.surname) || '').trim()}{selected.birth ? `, ${utilCalculateAge(selected.birth)}р` : ''}
                 </DonorName>
                 <br />
                 {[


### PR DESCRIPTION
## Summary
- display first name before surname on matching info cards
- update selected donor modal to show first name before surname

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688b38efd9088326a1b72626ce2ffe8b