### PR TITLE
Switch name order in matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -611,7 +611,7 @@ const SwipeableCard = ({
             <Info>
               <Title>Egg donor</Title>
               <DonorName>
-                {(getCurrentValue(user.surname) || '').trim()} {(getCurrentValue(user.name) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+                {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
               </DonorName>
               <br />
               {[

--- a/src/components/__tests__/makeCardDescription.test.js
+++ b/src/components/__tests__/makeCardDescription.test.js
@@ -23,7 +23,7 @@ test('makeCardDescription returns enumerated description with literal \\n', () =
   expect(parts.length).toBe(8);
   expect(parts[0]).toBe('1. 2-2023');
   expect(parts[1]).toBe('2. Kyivska, Kyiv');
-  expect(parts[7]).toBe('8. Doe Jane Petrovna');
+  expect(parts[7]).toBe('8. Jane Doe Petrovna');
 });
 
 test('makeCardDescription skips empty fields and enumerates correctly', () => {
@@ -42,7 +42,7 @@ test('makeCardDescription skips empty fields and enumerates correctly', () => {
     '3. ?',
     '4. ?',
     '5. 0555555555',
-    '6. Smith John',
+    '6. John Smith',
   ]);
 });
 

--- a/src/components/makeCardDescription.js
+++ b/src/components/makeCardDescription.js
@@ -49,7 +49,7 @@ export const makeCardDescription = user => {
     .map(p => String(p).replace(/^\+?38/, ''))
     .join(', ');
 
-  const fullName = [user.surname, user.name, user.fathersname]
+  const fullName = [user.name, user.surname, user.fathersname]
     .filter(Boolean)
     .join(' ');
 


### PR DESCRIPTION
## Summary
- display first name before surname on matching cards
- adjust makeCardDescription and tests accordingly
- revert accidental change in renderTopBlock

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688b53c5801c83268e258b1c3d0d1df3