### PR TITLE
Fix card stack overflow with border-box

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -93,6 +93,7 @@ const NextPhoto = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  box-sizing: border-box;
   border: 2px solid ${color.gray3};
   border-radius: 8px;
   transform: translate(4px, -4px);
@@ -106,6 +107,7 @@ const ThirdPhoto = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  box-sizing: border-box;
   border: 2px solid ${color.gray4};
   border-radius: 8px;
   transform: translate(8px, -8px);


### PR DESCRIPTION
## Summary
- keep card stack dimensions consistent by applying `box-sizing: border-box` to stacked card photos

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c7d5ed558832687b5ea0ba31b7f26