### PR TITLE
Fix contact click not to flip card

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -198,7 +198,12 @@ export const fieldContactsIcons = data => {
     : [];
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+    <div
+      style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}
+      onClick={e => e.stopPropagation()}
+      onTouchStart={e => e.stopPropagation()}
+      onTouchEnd={e => e.stopPropagation()}
+    >
       {phoneValues.map((val, idx) => {
         const processedVal = String(val).replace(/\s/g, '');
         return (


### PR DESCRIPTION
## Summary
- prevent propagation on contact icons in Matching

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688ce3fa49b88326b222be1180bf4262