### PR TITLE
Implement directional click for Matching carousel

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -570,14 +570,21 @@ const SwipeableCard = ({
     }
   }, [dir]);
 
-  const handleClick = () => {
+  const handleClick = e => {
     if (wasSwiped.current) {
       wasSwiped.current = false;
       return;
     }
     if (slides.length > 1) {
-      setDir('left');
-      setIndex(i => (i + 1) % slides.length);
+      const rect = e.currentTarget.getBoundingClientRect();
+      const clickX = e.clientX - rect.left;
+      if (clickX > rect.width / 2) {
+        setDir('left');
+        setIndex(i => (i + 1) % slides.length);
+      } else {
+        setDir('right');
+        setIndex(i => (i - 1 + slides.length) % slides.length);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- make swipeable card carousel advance based on where you click

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ce86d24d88326b21792e4a8f1bcdd