### PR TITLE
Fix donor name spacing

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -619,6 +619,14 @@ const SwipeableCard = ({
       ? { backgroundImage: `url(${current})`, backgroundColor: 'transparent' }
       : { backgroundColor: '#fff' };
 
+  const displayName = [
+    getCurrentValue(user.name),
+    getCurrentValue(user.surname),
+  ]
+    .filter(Boolean)
+    .map(v => String(v).trim())
+    .join(' ');
+
   return (
     <AnimatedCard
       $dir={dir}
@@ -661,7 +669,8 @@ const SwipeableCard = ({
             <Info>
               <Title>Egg donor</Title>
               <DonorName>
-                {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+                {displayName}
+                {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
               </DonorName>
               <br />
               {[
@@ -680,7 +689,8 @@ const SwipeableCard = ({
       )}
       {current === 'main' && (
         <BasicInfo>
-          {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}{user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+          {displayName}
+          {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
           <br />
           {[
             normalizeCountry(getCurrentValue(user.country)),
@@ -781,6 +791,14 @@ const InfoCardContent = ({ user, variant }) => {
   const profession = getCurrentValue(user.profession);
   const education = getCurrentValue(user.education);
 
+  const displayName = [
+    getCurrentValue(user.name),
+    getCurrentValue(user.surname),
+  ]
+    .filter(Boolean)
+    .map(v => String(v).trim())
+    .join(' ');
+
   if (variant === 'description') {
     return (
       <InfoSlide>
@@ -815,7 +833,7 @@ const InfoCardContent = ({ user, variant }) => {
         <Info>
           <Title>Egg donor</Title>
           <DonorName>
-            {(getCurrentValue(user.name) || '').trim()} {(getCurrentValue(user.surname) || '').trim()}
+            {displayName}
             {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
           </DonorName>
           <br />
@@ -1209,8 +1227,12 @@ const Matching = () => {
                   .trim()
                   .toLowerCase();
                 const isAgency = role === 'ag' || role === 'ip';
-                const nameParts = [getCurrentValue(user.name), getCurrentValue(user.surname)]
+                const nameParts = [
+                  getCurrentValue(user.name),
+                  getCurrentValue(user.surname),
+                ]
                   .filter(Boolean)
+                  .map(v => String(v).trim())
                   .join(' ');
                 return (
                   <CardContainer key={user.userId}>


### PR DESCRIPTION
## Summary
- handle trailing spaces in user name and surname when rendering donor cards
- trim `nameParts` used for agencies

## Testing
- `npm run lint:js`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc190e428832683a92a4f40212a3a