### PR TITLE
Show info cards as fallback stacked items

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1220,6 +1220,15 @@ const Matching = () => {
               const nextPhoto = photos[1];
               const thirdPhoto = photos[2];
               const infoSlides = getInfoSlidesCount(user);
+
+              const infoVariants = [];
+              if (infoSlides >= 1) infoVariants.push('info');
+              if (infoSlides >= 2) infoVariants.push('description');
+              if (!photo) infoVariants.shift();
+
+              const nextVariant = nextPhoto ? null : infoVariants.shift();
+              const thirdVariant = thirdPhoto ? null : infoVariants.shift();
+
                 const role = (user.role || user.userRole || '')
                   .toString()
                   .trim()
@@ -1234,15 +1243,15 @@ const Matching = () => {
                   .join(' ');
                 return (
                   <CardContainer key={user.userId}>
-                    {photos.length === 1 && infoSlides >= 2 && !thirdPhoto && (
+                    {thirdVariant && (
                       <ThirdInfoCard>
-                        <InfoCardContent user={user} variant="description" />
+                        <InfoCardContent user={user} variant={thirdVariant} />
                       </ThirdInfoCard>
                     )}
                     {thirdPhoto && <ThirdPhoto src={thirdPhoto} alt="third" />}
-                    {photos.length === 1 && infoSlides >= 1 && !nextPhoto && (
+                    {nextVariant && (
                       <NextInfoCard>
-                        <InfoCardContent user={user} variant="info" />
+                        <InfoCardContent user={user} variant={nextVariant} />
                       </NextInfoCard>
                     )}
                     {nextPhoto && <NextPhoto src={nextPhoto} alt="next" />}


### PR DESCRIPTION
## Summary
- Fill missing stacked card slots with info card previews regardless of photo count
- Avoid rendering extra stacks when no photos and only one info card exists

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688dc11a9ab483269933c62852908a52