### PR TITLE
fix: preserve matching list scroll on back navigation

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1169,15 +1169,24 @@ const Matching = () => {
 
   useEffect(() => {
     if (!scrollRestoredRef.current && users.length) {
-      const saved = parseInt(
-        sessionStorage.getItem('matching-scroll') || '0',
-        10
-      );
-      if (saved) {
-        window.scrollTo(0, saved);
+      const anchor = sessionStorage.getItem('matching-anchor');
+      if (anchor) {
+        const el = document.getElementById(`card-${anchor}`);
+        if (el) {
+          el.scrollIntoView({ block: 'center' });
+        }
+        sessionStorage.removeItem('matching-anchor');
+      } else {
+        const saved = parseInt(
+          sessionStorage.getItem('matching-scroll') || '0',
+          10
+        );
+        if (saved) {
+          window.scrollTo(0, saved);
+        }
+        sessionStorage.removeItem('matching-scroll');
       }
       scrollRestoredRef.current = true;
-      sessionStorage.removeItem('matching-scroll');
     }
   }, [users.length]);
 
@@ -1286,7 +1295,7 @@ const Matching = () => {
                       </NextInfoCard>
                     )}
                     {nextPhoto && <NextPhoto src={nextPhoto} alt="next" />}
-                    <CardWrapper>
+                    <CardWrapper id={`card-${user.userId}`}>
                       <SwipeableCard
                         user={user}
                         photo={photo}
@@ -1321,6 +1330,10 @@ const Matching = () => {
                             sessionStorage.setItem(
                               'matching-scroll',
                               String(window.scrollY)
+                            );
+                            sessionStorage.setItem(
+                              'matching-anchor',
+                              user.userId
                             );
                             scrollSavedRef.current = true;
                             navigate(`/edit/${user.userId}`);


### PR DESCRIPTION
## Summary
- restore scroll position by tracking clicked card id
- return users to previous card when navigating back from profile editing

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688ef1d54d2c83268ddcb2ada224a13e