### PR TITLE
fix: avoid stale state in EditProfile handleSubmit

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -44,17 +44,18 @@ const EditProfile = () => {
     load();
   }, [userId]);
 
+  const formatDate = date => {
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    return `${dd}.${mm}.${yyyy}`;
+  };
+
   const handleSubmit = async (newState, overwrite, delCondition) => {
     const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
     const commonFields = ['lastAction', 'lastLogin2'];
 
-    const formatDate = date => {
-      const dd = String(date.getDate()).padStart(2, '0');
-      const mm = String(date.getMonth() + 1).padStart(2, '0');
-      const yyyy = date.getFullYear();
-      return `${dd}.${mm}.${yyyy}`;
-    };
     const currentDate = formatDate(new Date());
 
     const updatedState = newState ? { ...newState, lastAction: currentDate } : { ...state, lastAction: currentDate };
@@ -83,7 +84,6 @@ const EditProfile = () => {
         await updateDataInNewUsersRTDB(state.userId, state, 'update');
       }
     }
-    setState(updatedState);
   };
 
   const handleBlur = () => handleSubmit();
@@ -103,7 +103,8 @@ const EditProfile = () => {
         newValue = '';
       }
 
-      const newState = { ...prev, [fieldName]: newValue };
+      const currentDate = formatDate(new Date());
+      const newState = { ...prev, [fieldName]: newValue, lastAction: currentDate };
       handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
       return newState;
     });


### PR DESCRIPTION
## Summary
- remove stale setState from handleSubmit and extract formatDate helper
- ensure handleClear updates state once with lastAction before submitting

## Testing
- `CI=true npm test`
- `npm run lint:js`
- simulated rapid handleClear calls to verify deleted fields stay removed

------
https://chatgpt.com/codex/tasks/task_e_688e76643c6483269974ea8f1bd2fc95