### PR TITLE
Preserve empty string arrays when clearing profile fields

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -331,8 +331,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
         removedValue = prevState[fieldName][idx];
 
-        // Якщо після фільтрації залишається лише одне значення, зберігаємо його як ключ-значення
-        newValue = filteredArray.length === 1 ? filteredArray[0] : filteredArray;
+        // Якщо після фільтрації залишився лише порожній рядок, зберігаємо масив
+        if (filteredArray.length === 0) {
+          newValue = '';
+        } else if (filteredArray.length === 1 && filteredArray[0] !== '') {
+          newValue = filteredArray[0];
+        } else {
+          newValue = filteredArray;
+        }
       } else {
         // Якщо значення не є масивом, видаляємо його
         removedValue = prevState[fieldName];

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -97,7 +97,13 @@ const EditProfile = () => {
       if (isArray) {
         const filtered = prev[fieldName].filter((_, i) => i !== idx);
         removedValue = prev[fieldName][idx];
-        newValue = filtered.length === 1 ? filtered[0] : filtered;
+        if (filtered.length === 0) {
+          newValue = '';
+        } else if (filtered.length === 1 && filtered[0] !== '') {
+          newValue = filtered[0];
+        } else {
+          newValue = filtered;
+        }
       } else {
         removedValue = prev[fieldName];
         newValue = '';

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -40,16 +40,16 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
             updatedField.push(state[field]);
             uploadedInfo[field] = updatedField;
           }
-        }else if (overwrite && state[field]===''&& !Array.isArray(existingData[field])){
+        } else if (overwrite && typeof state[field] === 'string' && state[field] === '' && !Array.isArray(existingData[field])) {
         console.log('Якщо це не масиви', state[field], existingData[field]);
         uploadedInfo[field] = '';
-      } else if (overwrite && !Array.isArray(state[field]==='') && !Array.isArray(existingData[field])){
+      } else if (overwrite && !Array.isArray(state[field]) && !Array.isArray(existingData[field])) {
         console.log('Якщо ЕxistingData не масив та state не масив і його треба перезаписати', state[field], existingData[field]);
         uploadedInfo[field] = state[field];
-      } else if (existingData[field]===''){
+      } else if (existingData[field] === '') {
         console.log('Якщо це не масиви', state[field], existingData[field]);
         uploadedInfo[field] = state[field];
-      } else if (!Array.isArray(state[field])){
+      } else if (!Array.isArray(state[field])) {
         console.log('Якщо ЕxistingData не масив та state не масив, то створюємо масив', state[field], existingData[field]);
         uploadedInfo[field] = [existingData[field], state[field]];
       } else {


### PR DESCRIPTION
## Summary
- keep array values intact in EditProfile and AddNewProfile when clearing leaves an empty string
- avoid converting `['']` to `''` during upload by tightening type checks in `makeUploadedInfo`

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1f8b0ec883268573bb7b0674cdc6