### PR TITLE
Fix array clearing for profile forms

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -326,18 +326,23 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       let newValue;
       let removedValue;
 
-      if (isArray) {
-        // Якщо значення є масивом, фільтруємо масив, щоб видалити елемент за індексом
-        const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
-        removedValue = prevState[fieldName][idx];
+        if (isArray) {
+          // Якщо значення є масивом, фільтруємо масив, щоб видалити елемент за індексом
+          const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
+          removedValue = prevState[fieldName][idx];
 
-        // Якщо після фільтрації залишається лише одне значення, зберігаємо його як ключ-значення
-        newValue = filteredArray.length === 1 ? filteredArray[0] : filteredArray;
-      } else {
-        // Якщо значення не є масивом, видаляємо його
-        removedValue = prevState[fieldName];
-        newValue = '';
-      }
+          // Повертаємо порожній рядок, якщо масив спорожнів, один елемент — як значення, інакше — масив
+          newValue =
+            filteredArray.length === 0
+              ? ''
+              : filteredArray.length === 1
+              ? filteredArray[0]
+              : filteredArray;
+        } else {
+          // Якщо значення не є масивом, видаляємо його
+          removedValue = prevState[fieldName];
+          newValue = '';
+        }
 
       // Створюємо новий стан
       const newState = {

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -97,7 +97,12 @@ const EditProfile = () => {
       if (isArray) {
         const filtered = prev[fieldName].filter((_, i) => i !== idx);
         removedValue = prev[fieldName][idx];
-        newValue = filtered.length === 1 ? filtered[0] : filtered;
+        newValue =
+          filtered.length === 0
+            ? ''
+            : filtered.length === 1
+            ? filtered[0]
+            : filtered;
       } else {
         removedValue = prev[fieldName];
         newValue = '';


### PR DESCRIPTION
## Summary
- ensure clearing array fields sets empty string when last value removed in edit profile
- apply same array clearing logic to new profile flow

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688f2e8d6f688326a0775bdd93601bac