### PR TITLE
Preserve Matching scroll position on return

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -878,6 +878,17 @@ const Matching = () => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
 
+  useEffect(() => {
+    const savedScroll = sessionStorage.getItem('matchingScroll');
+    if (savedScroll !== null) {
+      window.scrollTo(0, parseInt(savedScroll, 10));
+      sessionStorage.removeItem('matchingScroll');
+    }
+    return () => {
+      sessionStorage.setItem('matchingScroll', String(window.scrollY));
+    };
+  }, []);
+
   const togglePublish = async user => {
     if (!isAdmin) return;
     const newValue = !user.publish;


### PR DESCRIPTION
## Summary
- remember scroll position in matching view and restore it on return

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f350950b883268879504eca198b9e