### PR TITLE
Remove keys when handleClear empties field

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -321,35 +321,31 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleClear = (fieldName, idx) => {
     setState(prevState => {
-      // Перевірка, чи є значення масивом
       const isArray = Array.isArray(prevState[fieldName]);
-      let newValue;
+      const newState = { ...prevState };
       let removedValue;
 
       if (isArray) {
-        // Якщо значення є масивом, фільтруємо масив, щоб видалити елемент за індексом
         const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
         removedValue = prevState[fieldName][idx];
 
-        // Якщо після фільтрації залишається лише одне значення, зберігаємо його як ключ-значення
-        newValue = filteredArray.length === 1 ? filteredArray[0] : filteredArray;
+        if (filteredArray.length === 0 || (filteredArray.length === 1 && filteredArray[0] === '')) {
+          const deletedValue = prevState[fieldName];
+          delete newState[fieldName];
+          removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
+        } else if (filteredArray.length === 1) {
+          newState[fieldName] = filteredArray[0];
+        } else {
+          newState[fieldName] = filteredArray;
+        }
       } else {
-        // Якщо значення не є масивом, видаляємо його
         removedValue = prevState[fieldName];
-        newValue = '';
+        const deletedValue = prevState[fieldName];
+        delete newState[fieldName];
+        removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
       }
 
-      // Створюємо новий стан
-      const newState = {
-        ...prevState,
-        [fieldName]: newValue,
-      };
-
-      console.log('newState', newState);
-
-      // Викликаємо сабміт після оновлення стейту
       handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
-
       return newState;
     });
   };

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -91,19 +91,29 @@ const EditProfile = () => {
   const handleClear = (fieldName, idx) => {
     setState(prev => {
       const isArray = Array.isArray(prev[fieldName]);
-      let newValue;
+      const newState = { ...prev };
       let removedValue;
 
       if (isArray) {
         const filtered = prev[fieldName].filter((_, i) => i !== idx);
         removedValue = prev[fieldName][idx];
-        newValue = filtered.length === 1 ? filtered[0] : filtered;
+
+        if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
+          const deletedValue = prev[fieldName];
+          delete newState[fieldName];
+          removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
+        } else if (filtered.length === 1) {
+          newState[fieldName] = filtered[0];
+        } else {
+          newState[fieldName] = filtered;
+        }
       } else {
         removedValue = prev[fieldName];
-        newValue = '';
+        const deletedValue = prev[fieldName];
+        delete newState[fieldName];
+        removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
       }
 
-      const newState = { ...prev, [fieldName]: newValue };
       handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
       return newState;
     });


### PR DESCRIPTION
## Summary
- delete profile fields when the last value is cleared instead of leaving empty strings
- mirror full field deletion in both AddNewProfile and EditProfile

## Testing
- `node - <<'NODE' ... NODE`
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688f34d1922c83269acf40b9c7c40bdc