### PR TITLE
fix: prevent stale state after profile save

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -83,7 +83,8 @@ const EditProfile = () => {
         await updateDataInNewUsersRTDB(state.userId, state, 'update');
       }
     }
-    setState(updatedState);
+    // Avoid overwriting local state with potentially stale data
+    // Callers like handleClear manage state updates themselves
   };
 
   const handleBlur = () => handleSubmit();


### PR DESCRIPTION
## Summary
- prevent EditProfile handleSubmit from overwriting state with stale data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f348c58648326b82c0dfbbc5b392e