### PR TITLE
Restore scroll position after data load

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useLayoutEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import styled, { keyframes } from 'styled-components';
@@ -878,12 +878,17 @@ const Matching = () => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
 
-  useEffect(() => {
-    const savedScroll = sessionStorage.getItem('matchingScroll');
-    if (savedScroll !== null) {
-      window.scrollTo(0, parseInt(savedScroll, 10));
-      sessionStorage.removeItem('matchingScroll');
+  useLayoutEffect(() => {
+    if (!loading && users.length > 0) {
+      const savedScroll = sessionStorage.getItem('matchingScroll');
+      if (savedScroll !== null) {
+        window.scrollTo(0, parseInt(savedScroll, 10));
+        sessionStorage.removeItem('matchingScroll');
+      }
     }
+  }, [loading, users.length]);
+
+  useEffect(() => {
     return () => {
       sessionStorage.setItem('matchingScroll', String(window.scrollY));
     };


### PR DESCRIPTION
## Summary
- ensure matching page restores scroll after user data loads
- keep unmount cleanup for scroll position persistence

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688f4bfc10d08326999744d4157ce5b4