### PR TITLE
Fix persistence when clearing array fields

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -62,11 +62,18 @@ const EditProfile = () => {
     if (updatedState?.userId?.length > 20) {
       const { existingData } = await fetchUserById(updatedState.userId);
 
+      const sanitizedExistingData = { ...existingData };
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          delete sanitizedExistingData[key];
+        });
+      }
+
       const cleanedState = Object.fromEntries(
         Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
       );
 
-      const uploadedInfo = makeUploadedInfo(existingData, cleanedState, overwrite);
+      const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
 
       await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
       await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);


### PR DESCRIPTION
## Summary
- ensure deleted fields don't reappear when removing array entries in edit profile

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f529aba8883269e77406b51c76e20