### PR TITLE
fix: preserve scroll after excluded toast

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -881,7 +881,7 @@ const Matching = () => {
   const showExcludedToast = count => {
     const currentScroll = window.scrollY;
     toast.success(`${count} excluded`, { id: 'matching-excluded' });
-    window.scrollTo(0, currentScroll);
+    requestAnimationFrame(() => window.scrollTo(0, currentScroll));
   };
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- keep scroll position after excluded toast by deferring window scroll

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688f5d2f941083269ae6d4254a429de7