### PR TITLE
fix: prevent blur when clearing inputs

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -109,9 +109,9 @@ export const ProfileForm = ({
                       />
                       {(value || value === '') && (
                         <ClearButton
-                          onClick={() => {
-                            handleClear(field.name, idx);
-                          }}
+                          type="button"
+                          onMouseDown={e => e.preventDefault()}
+                          onClick={() => handleClear(field.name, idx)}
                         >
                           &times;
                         </ClearButton>
@@ -157,7 +157,15 @@ export const ProfileForm = ({
                     }}
                     onBlur={() => handleSubmit(state, 'overwrite')}
                   />
-                  {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times;</ClearButton>}
+                  {state[field.name] && (
+                    <ClearButton
+                      type="button"
+                      onMouseDown={e => e.preventDefault()}
+                      onClick={() => handleClear(field.name)}
+                    >
+                      &times;
+                    </ClearButton>
+                  )}
                   {state[field.name] && (
                     <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)}>del</DelKeyValueBTN>
                   )}


### PR DESCRIPTION
## Summary
- avoid blur when clearing array field values in `ProfileForm`
- revert prior blur-prevention changes outside `ProfileForm`

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688f5a5ef0b08326836cd9410582a8b8