### PR TITLE
Send empty value when adding profile field

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -192,13 +192,15 @@ export const ProfileForm = ({
                     marginLeft: '10px',
                   }}
                   onClick={() => {
-                    setState(prevState => ({
-                      ...prevState,
-                      [field.name]:
+                    setState(prevState => {
+                      const updatedField =
                         Array.isArray(prevState[field.name]) && prevState[field.name].length > 0
                           ? [...prevState[field.name], '']
-                          : [prevState[field.name], ''],
-                    }));
+                          : [prevState[field.name], ''];
+                      const newState = { ...prevState, [field.name]: updatedField };
+                      handleSubmit(newState, 'overwrite');
+                      return newState;
+                    });
                   }}
                 >
                   +


### PR DESCRIPTION
## Summary
- send an empty value when adding a profile form field to ensure updates are saved immediately

## Testing
- `npm run lint:js`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688f969cd688832688933120aa0c308b