### PR TITLE
refactor: safeguard EditProfile state updates

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -90,50 +90,56 @@ const EditProfile = () => {
         await updateDataInNewUsersRTDB(state.userId, state, 'update');
       }
     }
-    setState(updatedState);
+    setState(prev => {
+      if (newState) {
+        const merged = { ...prev, ...updatedState };
+        Object.keys(prev).forEach(key => {
+          if (!(key in updatedState)) {
+            delete merged[key];
+          }
+        });
+        return merged;
+      }
+      return { ...prev, lastAction: currentDate };
+    });
   };
 
   const handleBlur = () => handleSubmit();
 
   const handleClear = (fieldName, idx) => {
-    setState(prev => {
-      const isArray = Array.isArray(prev[fieldName]);
-      const newState = { ...prev };
-      let removedValue;
+    const isArray = Array.isArray(state[fieldName]);
+    const newState = { ...state };
+    let removedValue;
 
-      if (isArray) {
-        const filtered = prev[fieldName].filter((_, i) => i !== idx);
-        removedValue = prev[fieldName][idx];
+    if (isArray) {
+      const filtered = state[fieldName].filter((_, i) => i !== idx);
+      removedValue = state[fieldName][idx];
 
-        if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
-          const deletedValue = prev[fieldName];
-          delete newState[fieldName];
-          removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-        } else if (filtered.length === 1) {
-          newState[fieldName] = filtered[0];
-        } else {
-          newState[fieldName] = filtered;
-        }
-      } else {
-        removedValue = prev[fieldName];
-        const deletedValue = prev[fieldName];
+      if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
+        const deletedValue = state[fieldName];
         delete newState[fieldName];
-        removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
+        removeKeyFromFirebase(fieldName, deletedValue, state.userId);
+      } else if (filtered.length === 1) {
+        newState[fieldName] = filtered[0];
+      } else {
+        newState[fieldName] = filtered;
       }
+    } else {
+      removedValue = state[fieldName];
+      const deletedValue = state[fieldName];
+      delete newState[fieldName];
+      removeKeyFromFirebase(fieldName, deletedValue, state.userId);
+    }
 
-      handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
-      return newState;
-    });
+    handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
   };
 
   const handleDelKeyValue = fieldName => {
-    setState(prev => {
-      const newState = { ...prev };
-      const deletedValue = newState[fieldName];
-      delete newState[fieldName];
-      removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-      return newState;
-    });
+    const newState = { ...state };
+    const deletedValue = newState[fieldName];
+    delete newState[fieldName];
+    removeKeyFromFirebase(fieldName, deletedValue, state.userId);
+    handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
   };
 
   if (!state) return null;


### PR DESCRIPTION
## Summary
- prevent stale overwrites in `handleSubmit` by merging against latest state
- centralize state changes so `handleClear` and `handleDelKeyValue` delegate to `handleSubmit`

## Testing
- `CI=1 npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_688f9ed7473c8326bcb0b922181618b3