### PR TITLE
Remove manual scroll restoration from Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useLayoutEffect } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import styled, { keyframes } from 'styled-components';
@@ -876,23 +876,6 @@ const Matching = () => {
   const handleRemove = id => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
-
-
-  useLayoutEffect(() => {
-    if (!loading && users.length > 0) {
-      const savedScroll = sessionStorage.getItem('matchingScroll');
-      if (savedScroll !== null) {
-        window.scrollTo(0, parseInt(savedScroll, 10));
-        sessionStorage.removeItem('matchingScroll');
-      }
-    }
-  }, [loading, users.length]);
-
-  useEffect(() => {
-    return () => {
-      sessionStorage.setItem('matchingScroll', String(window.scrollY));
-    };
-  }, []);
 
   const togglePublish = async user => {
     if (!isAdmin) return;


### PR DESCRIPTION
## Summary
- drop `useLayoutEffect` and `useEffect` that wrote/read scroll position from `sessionStorage` in `Matching`

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689071d661088326b129ecbf1cf95820