### PR TITLE
Guard against outdated profile state updates

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import {
@@ -33,6 +33,7 @@ const EditProfile = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
   const [state, setState] = useState(null);
+  const submitCounter = useRef(0);
 
   useEffect(() => {
     const load = async () => {
@@ -45,6 +46,9 @@ const EditProfile = () => {
   }, [userId]);
 
   const handleSubmit = async (newState, overwrite, delCondition) => {
+    submitCounter.current += 1;
+    const callId = submitCounter.current;
+
     const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
     const commonFields = ['lastAction', 'lastLogin2'];
@@ -90,7 +94,10 @@ const EditProfile = () => {
         await updateDataInNewUsersRTDB(state.userId, state, 'update');
       }
     }
-    setState(updatedState);
+
+    if (callId === submitCounter.current) {
+      setState(prev => ({ ...prev, ...updatedState }));
+    }
   };
 
   const handleBlur = () => handleSubmit();


### PR DESCRIPTION
## Summary
- ensure EditProfile uses a call counter and functional state update so only the newest submit updates local state

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689089041448832685e3f98b92b7b31e