### PR TITLE
fix: remove unnecessary escape in date regex

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -569,8 +569,8 @@ const addUserToResults = async (userId, users, userIdOrArray = null) => {
 
 const getDateFormats = input => {
   const trimmed = (input || '').trim();
-  const isoMatch = /^(\d{4})[-.\/](\d{2})[-.\/](\d{2})$/;
-  const dmyMatch = /^(\d{2})[-.\/](\d{2})[-.\/](\d{4})$/;
+  const isoMatch = /^(\d{4})[-./\\](\d{2})[-./\\](\d{2})$/;
+  const dmyMatch = /^(\d{2})[-./\\](\d{2})[-./\\](\d{4})$/;
   let yyyy, mm, dd;
 
   if (isoMatch.test(trimmed)) {


### PR DESCRIPTION
## Summary
- avoid escaping forward slash in date regex

## Testing
- `npm run lint:js`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6890c6df790483268b50183d606adac7