### PR TITLE
feat: add submission state to profile editing

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -33,6 +33,7 @@ const EditProfile = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
   const [state, setState] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -49,48 +50,52 @@ const EditProfile = () => {
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
     const commonFields = ['lastAction', 'lastLogin2'];
 
-    const formatDate = date => {
-      const dd = String(date.getDate()).padStart(2, '0');
-      const mm = String(date.getMonth() + 1).padStart(2, '0');
-      const yyyy = date.getFullYear();
-      return `${dd}.${mm}.${yyyy}`;
-    };
-    const currentDate = formatDate(new Date());
+    setIsSubmitting(true);
+    try {
+      const formatDate = date => {
+        const dd = String(date.getDate()).padStart(2, '0');
+        const mm = String(date.getMonth() + 1).padStart(2, '0');
+        const yyyy = date.getFullYear();
+        return `${dd}.${mm}.${yyyy}`;
+      };
+      const currentDate = formatDate(new Date());
 
-    const updatedState = newState ? { ...newState, lastAction: currentDate } : { ...state, lastAction: currentDate };
+      const updatedState = newState ? { ...newState, lastAction: currentDate } : { ...state, lastAction: currentDate };
 
-    if (updatedState?.userId?.length > 20) {
-      const { existingData } = await fetchUserById(updatedState.userId);
+      if (updatedState?.userId?.length > 20) {
+        const { existingData } = await fetchUserById(updatedState.userId);
 
-      const sanitizedExistingData = { ...existingData };
-      if (delCondition) {
-        Object.keys(delCondition).forEach(key => {
-          delete sanitizedExistingData[key];
-        });
+        const sanitizedExistingData = { ...existingData };
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            delete sanitizedExistingData[key];
+          });
+        }
+
+        const cleanedState = Object.fromEntries(
+          Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
+        );
+
+        const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
+
+        await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
+        await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
+
+        const cleanedStateForNewUsers = Object.fromEntries(
+          Object.entries(updatedState).filter(([key]) => [...fieldsForNewUsersOnly, ...contacts].includes(key))
+        );
+
+        await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update');
+      } else if (state?.userId) {
+        if (newState) {
+          await updateDataInNewUsersRTDB(state.userId, newState, 'update');
+        } else {
+          await updateDataInNewUsersRTDB(state.userId, state, 'update');
+        }
       }
-
-      const cleanedState = Object.fromEntries(
-        Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
-      );
-
-      const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
-
-      await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
-      await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
-
-      const cleanedStateForNewUsers = Object.fromEntries(
-        Object.entries(updatedState).filter(([key]) => [...fieldsForNewUsersOnly, ...contacts].includes(key))
-      );
-
-      await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update');
-    } else if (state?.userId) {
-      if (newState) {
-        await updateDataInNewUsersRTDB(state.userId, newState, 'update');
-      } else {
-        await updateDataInNewUsersRTDB(state.userId, state, 'update');
-      }
+    } finally {
+      setIsSubmitting(false);
     }
-    setState(updatedState);
   };
 
   const handleBlur = () => handleSubmit();
@@ -152,7 +157,7 @@ const EditProfile = () => {
 
   return (
     <Container>
-      <BackButton onClick={() => navigate(-1)}>Back</BackButton>
+      <BackButton onClick={() => navigate(-1)} disabled={isSubmitting}>Back</BackButton>
       <div style={{ ...coloredCard() }}>
         {renderTopBlock(state, () => {}, () => {}, setState)}
       </div>
@@ -163,6 +168,7 @@ const EditProfile = () => {
         handleSubmit={handleSubmit}
         handleClear={handleClear}
         handleDelKeyValue={handleDelKeyValue}
+        isSubmitting={isSubmitting}
       />
     </Container>
   );

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -33,6 +33,7 @@ export const ProfileForm = ({
   handleSubmit,
   handleClear,
   handleDelKeyValue,
+  isSubmitting,
 }) => {
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
@@ -112,6 +113,7 @@ export const ProfileForm = ({
                           type="button"
                           onMouseDown={e => e.preventDefault()}
                           onClick={() => handleClear(field.name, idx)}
+                          disabled={isSubmitting}
                         >
                           &times;
                         </ClearButton>
@@ -162,12 +164,13 @@ export const ProfileForm = ({
                       type="button"
                       onMouseDown={e => e.preventDefault()}
                       onClick={() => handleClear(field.name)}
+                      disabled={isSubmitting}
                     >
                       &times;
                     </ClearButton>
                   )}
                   {state[field.name] && (
-                    <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)}>del</DelKeyValueBTN>
+                    <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)} disabled={isSubmitting}>del</DelKeyValueBTN>
                   )}
                 </InputFieldContainer>
 
@@ -202,6 +205,7 @@ export const ProfileForm = ({
                       return newState;
                     });
                   }}
+                  disabled={isSubmitting}
                 >
                   +
                 </Button>
@@ -221,6 +225,7 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
+                    disabled={isSubmitting}
                   >
                     Так
                   </Button>
@@ -235,6 +240,7 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
+                    disabled={isSubmitting}
                   >
                     Ні
                   </Button>
@@ -250,6 +256,7 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
+                    disabled={isSubmitting}
                   >
                     Інше
                   </Button>
@@ -267,6 +274,7 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
+                    disabled={isSubmitting}
                   >
                     Ні
                   </Button>
@@ -281,6 +289,7 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
+                    disabled={isSubmitting}
                   >
                     1
                   </Button>
@@ -295,6 +304,7 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
+                    disabled={isSubmitting}
                   >
                     2
                   </Button>


### PR DESCRIPTION
## Summary
- track submission state in EditProfile and guard async requests
- disable form buttons while a save is in progress

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6890c64f05308326ac9681fea023f34f