### PR TITLE
Avoid unnecessary scroll restoration

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -882,8 +882,11 @@ const Matching = () => {
     if (!loading && users.length > 0) {
       const savedScroll = sessionStorage.getItem('matchingScroll');
       if (savedScroll !== null) {
-        window.scrollTo(0, parseInt(savedScroll, 10));
+        const scrollPosition = parseInt(savedScroll, 10);
         sessionStorage.removeItem('matchingScroll');
+        if (!Number.isNaN(scrollPosition) && scrollPosition !== window.scrollY) {
+          window.scrollTo(0, scrollPosition);
+        }
       }
     }
   }, [loading, users.length]);


### PR DESCRIPTION
## Summary
- call `window.scrollTo` only when stored scroll differs from current position in Matching

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_6890e51a2dd483268d5e3411c6a2d0ab