### PR TITLE
fix: prevent blur when deleting profile key

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -170,7 +170,13 @@ export const ProfileForm = ({
                     </ClearButton>
                   )}
                   {state[field.name] && (
-                    <DelKeyValueBTN onClick={() => handleDelKeyValue(field.name)} disabled={isSubmitting}>del</DelKeyValueBTN>
+                    <DelKeyValueBTN
+                      onMouseDown={e => e.preventDefault()}
+                      onClick={() => handleDelKeyValue(field.name)}
+                      disabled={isSubmitting}
+                    >
+                      del
+                    </DelKeyValueBTN>
                   )}
                 </InputFieldContainer>
 


### PR DESCRIPTION
## Summary
- prevent input blur when clicking profile key delete button

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6890ff5647808326a90f77a65a8f336f