### PR TITLE
Implement local-first profile creation sync

### DIFF
--- a/src/hooks/localServerSync.js
+++ b/src/hooks/localServerSync.js
@@ -1,0 +1,51 @@
+export const createLocalFirstSync = (storageKey, initialData = null, remotePush) => {
+  let data = initialData;
+
+  const load = () => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (raw) {
+        data = JSON.parse(raw);
+      }
+    } catch {
+      // ignore parse errors
+    }
+  };
+
+  const save = () => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(data));
+    } catch {
+      // ignore write errors
+    }
+  };
+
+  const push = async () => {
+    if (typeof remotePush !== 'function' || !data) return;
+    try {
+      const res = await remotePush({ data });
+      if (res) {
+        data = res;
+        save();
+      }
+    } catch {
+      // ignore network errors, keep data for retry
+    }
+  };
+
+  return {
+    init: () => {
+      load();
+    },
+    getData: () => data,
+    update: newData => {
+      data = newData;
+      save();
+      push();
+    },
+    pollServer: () => {
+      push();
+    },
+  };
+};
+


### PR DESCRIPTION
## Summary
- Add `createLocalFirstSync` utility to cache pending profile data and push updates to the server
- Initialize and poll the profile sync helper in `AddNewProfile` to hydrate cached data
- Replace user creation flow to persist locally with a generated ID and sync remotely asynchronously

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6891bdde6640832696e6714228aec74d