### PR TITLE
Enable local-first profile edits with async syncing

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -33,7 +33,6 @@ export const ProfileForm = ({
   handleSubmit,
   handleClear,
   handleDelKeyValue,
-  isSubmitting,
 }) => {
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
@@ -109,11 +108,10 @@ export const ProfileForm = ({
                         onBlur={() => handleBlur(`${field.name}-${idx}`)}
                       />
                       {(value || value === '') && (
-                        <ClearButton
+                          <ClearButton
                           type="button"
                           onMouseDown={e => e.preventDefault()}
                           onClick={() => handleClear(field.name, idx)}
-                          disabled={isSubmitting}
                         >
                           &times;
                         </ClearButton>
@@ -164,7 +162,6 @@ export const ProfileForm = ({
                       type="button"
                       onMouseDown={e => e.preventDefault()}
                       onClick={() => handleClear(field.name)}
-                      disabled={isSubmitting}
                     >
                       &times;
                     </ClearButton>
@@ -173,7 +170,6 @@ export const ProfileForm = ({
                     <DelKeyValueBTN
                       onMouseDown={e => e.preventDefault()}
                       onClick={() => handleDelKeyValue(field.name)}
-                      disabled={isSubmitting}
                     >
                       del
                     </DelKeyValueBTN>
@@ -211,7 +207,6 @@ export const ProfileForm = ({
                       return newState;
                     });
                   }}
-                  disabled={isSubmitting}
                 >
                   +
                 </Button>
@@ -231,7 +226,6 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
-                    disabled={isSubmitting}
                   >
                     Так
                   </Button>
@@ -246,7 +240,6 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
-                    disabled={isSubmitting}
                   >
                     Ні
                   </Button>
@@ -262,7 +255,6 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
-                    disabled={isSubmitting}
                   >
                     Інше
                   </Button>
@@ -280,7 +272,6 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
-                    disabled={isSubmitting}
                   >
                     Ні
                   </Button>
@@ -295,7 +286,6 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
-                    disabled={isSubmitting}
                   >
                     1
                   </Button>
@@ -310,7 +300,6 @@ export const ProfileForm = ({
                         return newState;
                       });
                     }}
-                    disabled={isSubmitting}
                   >
                     2
                   </Button>


### PR DESCRIPTION
## Summary
- save profile edits locally first with createLocalFirstSync and sync to server in background
- remove submit-blocking disables on profile form and back button
- show simple syncing indicator while background updates run

## Testing
- `npm run lint:js`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68922a3f689c8326ad6e7f1ffe48f280