### PR TITLE
Improve utility helpers for profile data

### DIFF
--- a/src/components/__tests__/areObjectsEqual.test.js
+++ b/src/components/__tests__/areObjectsEqual.test.js
@@ -1,0 +1,30 @@
+import { areObjectsEqual } from '../areObjectsEqual';
+
+describe('areObjectsEqual', () => {
+  it('returns true for equal objects', () => {
+    expect(areObjectsEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+  });
+
+  it('ignores statusDate differences', () => {
+    expect(
+      areObjectsEqual({ a: 1, statusDate: '2024-01-01' }, { a: 1 })
+    ).toBe(true);
+    expect(
+      areObjectsEqual({ a: 1 }, { a: 1, statusDate: '2024-01-02' })
+    ).toBe(true);
+  });
+
+  it('returns false for different values', () => {
+    expect(areObjectsEqual({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false);
+  });
+
+  it('compares nested objects', () => {
+    expect(
+      areObjectsEqual({ a: { b: 2 }, c: 3 }, { a: { b: 2 }, c: 3 })
+    ).toBe(true);
+    expect(
+      areObjectsEqual({ a: { b: 2 }, c: 3 }, { a: { b: 4 }, c: 3 })
+    ).toBe(false);
+  });
+});
+

--- a/src/components/__tests__/getCurrentValue.test.js
+++ b/src/components/__tests__/getCurrentValue.test.js
@@ -1,0 +1,19 @@
+import { getCurrentValue } from '../getCurrentValue';
+
+describe('getCurrentValue', () => {
+  it('returns last non-empty value from array', () => {
+    const arr = [undefined, null, '', 'first', 'second'];
+    expect(getCurrentValue(arr)).toBe('second');
+  });
+
+  it('returns last non-empty value from object', () => {
+    const obj = { a: '', b: null, c: 'value' };
+    expect(getCurrentValue(obj)).toBe('value');
+  });
+
+  it('handles nested structures', () => {
+    const nested = [null, { a: '', b: ['', 'deep'] }];
+    expect(getCurrentValue(nested)).toBe('deep');
+  });
+});
+

--- a/src/components/areObjectsEqual.js
+++ b/src/components/areObjectsEqual.js
@@ -1,32 +1,44 @@
 export const areObjectsEqual = (obj1, obj2) => {
-  // Перевірка на наявність об'єктів і їх типу
-  if (typeof obj1 !== 'object' || typeof obj2 !== 'object') {
-    // console.log('Об"єкти різні. Не об"єкт :>> ');
+  if (obj1 === obj2) {
+    return true;
+  }
+
+  if (
+    obj1 === null ||
+    obj2 === null ||
+    typeof obj1 !== 'object' ||
+    typeof obj2 !== 'object'
+  ) {
     return false;
   }
 
-  // Отримання масивів ключів об'єктів
-  const keys1 = Object.keys(obj1);
-  const keys2 = Object.keys(obj2);
+  const filterKeys = obj => Object.keys(obj).filter(key => key !== 'statusDate');
 
-  // Перевірка на рівну кількість ключів
+  const keys1 = filterKeys(obj1);
+  const keys2 = filterKeys(obj2);
+
   if (keys1.length !== keys2.length) {
-    // console.log('Об"єкти різні. Різна кіькість ключів :>> ');
     return false;
   }
 
-  // Перевірка значень кожного ключа
   for (const key of keys1) {
-    if (key !== 'statusDate') {
-      if (obj1[key] !== obj2[key]) {
-        // console.log('key :>> ', key);
-        // console.log('obj1[key] !== obj2[key] :>> ', obj1[key], obj2[key]);
-        // console.log('Об"єкти різні. Значення ключів різні :>> ');
+    if (!keys2.includes(key)) {
+      return false;
+    }
+
+    const val1 = obj1[key];
+    const val2 = obj2[key];
+    const bothObjects =
+      typeof val1 === 'object' && val1 !== null && typeof val2 === 'object' && val2 !== null;
+
+    if (bothObjects) {
+      if (!areObjectsEqual(val1, val2)) {
         return false;
       }
+    } else if (val1 !== val2) {
+      return false;
     }
   }
 
-  // Якщо всі перевірки пройшли, повертаємо true
   return true;
-}
+};

--- a/src/components/getCurrentValue.js
+++ b/src/components/getCurrentValue.js
@@ -1,11 +1,24 @@
+const isMeaningful = v => v !== undefined && v !== null && v !== '';
+
 export const getCurrentValue = value => {
   if (Array.isArray(value)) {
-    const filtered = value.filter(v => v !== undefined && v !== null && v !== '');
-    return filtered[filtered.length - 1];
+    for (let i = value.length - 1; i >= 0; i--) {
+      const current = getCurrentValue(value[i]);
+      if (isMeaningful(current)) {
+        return current;
+      }
+    }
+    return undefined;
   }
   if (value && typeof value === 'object') {
-    const vals = Object.values(value).filter(v => v !== undefined && v !== null && v !== '');
-    return vals[vals.length - 1];
+    const keys = Object.keys(value);
+    for (let i = keys.length - 1; i >= 0; i--) {
+      const current = getCurrentValue(value[keys[i]]);
+      if (isMeaningful(current)) {
+        return current;
+      }
+    }
+    return undefined;
   }
   return value;
 };


### PR DESCRIPTION
## Summary
- allow `getCurrentValue` to walk nested arrays/objects and return last meaningful value
- enhance `areObjectsEqual` to deep-compare objects while ignoring `statusDate`
- add unit tests for new helper behaviour

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689265a918088326ac0a0c17f6aa79bc