### PR TITLE
Use realtime user ID and timestamps

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -54,7 +54,6 @@ import { onValue, ref } from 'firebase/database';
 // import { aiHandler } from './aiHandler';
 import { createLocalFirstSync } from '../hooks/localServerSync';
 import { createCache } from '../hooks/cardsCache';
-import { generateUserId } from './generateUserId';
 
 const Container = styled.div`
   display: flex;
@@ -191,7 +190,7 @@ const ButtonsContainer = styled.div`
 `;
 
 const profileSync = createLocalFirstSync('pendingProfile', null, ({ data }) =>
-  makeNewUser(data),
+  data?.userId ? data : makeNewUser(data),
 );
 const { loadCache: loadAddCache, saveCache: saveAddCache } = createCache('addCache');
 
@@ -499,11 +498,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [adding, setAdding] = useState(false);
 
-  const handleAddUser = () => {
+  const handleAddUser = async () => {
     setAdding(true);
-    const newProfile = { userId: generateUserId(), ...searchKeyValuePair };
+    const newProfile = await makeNewUser(searchKeyValuePair);
     profileSync.update(newProfile);
-    setState(profileSync.getData());
+    setState(newProfile);
     setUserNotFound(false);
     setAdding(false);
   };

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -468,13 +468,15 @@ export const makeNewUser = async searchedValue => {
   const newUserRef = push(newUsersRef); // Генеруємо унікальний ключ
   const newUserId = newUserRef.key;
 
-  // Форматування дати у форматі дд.мм.рррр
-  const createdAt = new Date().toLocaleDateString('uk-UA');
+  const now = new Date();
+  const createdAt = now.toLocaleDateString('uk-UA');
+  const createdAt2 = now.toISOString().split('T')[0];
 
   const newUser = {
     userId: newUserId,
     [searchKey]: searchValue,
     createdAt,
+    createdAt2,
   };
 
   // Записуємо нового користувача в базу даних


### PR DESCRIPTION
## Summary
- rely on realtime database to generate user IDs instead of local ACxxxx sequence
- store both readable and ISO dates when creating new users

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689342b6cfec832680254cf5bf2e893a