### PR TITLE
fix: preserve matching cache offline

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -886,13 +886,6 @@ const Matching = () => {
   const handleRemove = id => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
-
-  useEffect(() => {
-    if (viewMode !== 'default') return;
-    const cacheKey = JSON.stringify(filters || {});
-    saveCache(cacheKey, { users, lastKey, hasMore });
-  }, [users, lastKey, hasMore, filters, viewMode]);
-
   useEffect(() => {
     window.history.scrollRestoration = 'manual';
     return saveScrollPosition;


### PR DESCRIPTION
## Summary
- prevent matching list from overwriting cached cards on mount
- cache is now updated only after new cards are fetched

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689375de535883269fd3eaa7df85be12