### PR TITLE
Reuse fetched profile data in editor

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import {
   fetchUserById,
@@ -33,7 +33,8 @@ const BackButton = styled.button`
 const EditProfile = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
-  const [state, setState] = useState(null);
+  const location = useLocation();
+  const [state, setState] = useState(location.state || null);
   const [isSyncing, setIsSyncing] = useState(false);
 
   async function remoteUpdate({ updatedState, overwrite, delCondition }) {
@@ -88,14 +89,14 @@ const EditProfile = () => {
   }, []);
 
   useEffect(() => {
-    const load = async () => {
-      if (userId) {
+    if (!state && userId) {
+      const load = async () => {
         const data = await fetchUserById(userId);
         setState(data || { userId });
-      }
-    };
-    load();
-  }, [userId]);
+      };
+      load();
+    }
+  }, [state, userId]);
 
   const handleSubmit = (newState, overwrite, delCondition) => {
     const formatDate = date => {

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1318,7 +1318,7 @@ const Matching = () => {
                         <Id
                           onClick={() => {
                             saveScrollPosition();
-                            navigate(`/edit/${user.userId}`);
+                            navigate(`/edit/${user.userId}`, { state: user });
                           }}
                           style={{ cursor: 'pointer' }}
                         >

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -90,7 +90,7 @@ const UserCard = ({
       <div
         onClick={() => {
           if (isAdmin) {
-            navigate(`/edit/${userData.userId}`);
+            navigate(`/edit/${userData.userId}`, { state: userData });
           }
         }}
         style={{


### PR DESCRIPTION
## Summary
- Pass user info as route state when navigating to profile editing
- Use route state in EditProfile to skip redundant fetches

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68938cc8e8dc8326b53f44baea6e6263