### PR TITLE
Isolate search states and avoid matching load race

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -200,11 +200,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [userNotFound, setUserNotFound] = useState(false);
 
+  const SEARCH_KEY = 'addSearchQuery';
   const [search, setSearch] = useState(() => {
     const params = new URLSearchParams(location.search);
     const urlSearch = params.get('search');
     if (urlSearch) return urlSearch;
-    return localStorage.getItem('searchQuery') || '';
+    return localStorage.getItem(SEARCH_KEY) || '';
   });
 
   const [state, setState] = useState({});
@@ -821,6 +822,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             setState({});
             setSearchKeyValuePair(null);
           }}
+          storageKey={SEARCH_KEY}
         />
         {state.userId ? (
           <>

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -859,6 +859,7 @@ const InfoCardContent = ({ user, variant }) => {
 const INITIAL_LOAD = 6;
 const LOAD_MORE = 6;
 const SCROLL_Y_KEY = 'matchingScrollY';
+const SEARCH_KEY = 'matchingSearchQuery';
 
 const Matching = () => {
   const navigate = useNavigate();
@@ -1184,6 +1185,10 @@ const Matching = () => {
   }, [hasMore, lastKey, viewMode, fetchChunk, filters]);
 
   useEffect(() => {
+    const savedSearch = localStorage.getItem(SEARCH_KEY);
+    if (savedSearch) {
+      return;
+    }
     console.log('[useEffect] calling loadInitial');
     loadInitial();
   }, [loadInitial]);
@@ -1226,6 +1231,8 @@ const Matching = () => {
           setUserNotFound={() => {}}
           wrapperStyle={{ width: '100%', marginBottom: '10px' }}
           leftIcon="🔍"
+          storageKey={SEARCH_KEY}
+          onClear={loadInitial}
         />
         <FilterPanel mode="matching" hideUserId hideCommentLength onChange={setFilters} />
       </FilterContainer>

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -90,9 +90,10 @@ const SearchBar = ({
   onClear,
   wrapperStyle = {},
   leftIcon = SearchIcon,
+  storageKey = 'searchQuery',
 }) => {
   const [internalSearch, setInternalSearch] = useState(
-    () => localStorage.getItem('searchQuery') || '',
+    () => localStorage.getItem(storageKey) || '',
   );
 
   const search = externalSearch !== undefined ? externalSearch : internalSearch;
@@ -104,11 +105,11 @@ const SearchBar = ({
 
   useEffect(() => {
     if (search) {
-      localStorage.setItem('searchQuery', search);
+      localStorage.setItem(storageKey, search);
     } else {
-      localStorage.removeItem('searchQuery');
+      localStorage.removeItem(storageKey);
     }
-  }, [search]);
+  }, [search, storageKey]);
 
   useEffect(() => {
     if (search) {


### PR DESCRIPTION
## Summary
- avoid overriding search results on Matching by skipping initial load when a saved query exists
- give SearchBar a configurable storage key to separate queries for different pages
- store AddNewProfile and Matching searches independently

## Testing
- `CI=true npm test --silent`
- `npm run lint:js --silent`


------
https://chatgpt.com/codex/tasks/task_e_689444ae7a7083268c95a683e75d3433