### PR TITLE
Track and restore Matching scroll via ref

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -880,15 +880,24 @@ const Matching = () => {
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
   const restoreRef = useRef(false);
+  const scrollPositionRef = useRef(0);
   const saveScrollPosition = () => {
-    sessionStorage.setItem(SCROLL_Y_KEY, String(window.scrollY));
+    sessionStorage.setItem(SCROLL_Y_KEY, String(scrollPositionRef.current));
   };
   const handleRemove = id => {
     setUsers(prev => prev.filter(u => u.userId !== id));
   };
   useEffect(() => {
     window.history.scrollRestoration = 'manual';
-    return saveScrollPosition;
+    const handleScroll = () => {
+      scrollPositionRef.current = window.scrollY;
+    };
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      saveScrollPosition();
+    };
   }, []);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- Track scroll position via `scrollPositionRef`
- Persist scroll in session storage on unmount and before navigation
- Restore previous scroll offset after returning to Matching

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68910e9900408326babc3946f8bc0851