### PR TITLE
Add cache clearing button to AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -738,6 +738,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     alert(`Total cards in newUsers: ${count}`);
   };
 
+  const handleClearCache = () => {
+    localStorage.clear();
+    toast.success('Cache cleared');
+  };
+
   const makeIndex = async () => {
     toast.loading('Indexing newUsers 0%', { id: 'index-progress' });
     await createSearchIdsInCollection('newUsers', progress => {
@@ -873,6 +878,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 </Button>
               )}
               <Button onClick={handleInfo}>Info</Button>
+              <Button onClick={handleClearCache}>ClearCache</Button>
               <Button
                 onClick={() => {
                   setUsers({});


### PR DESCRIPTION
## Summary
- allow clearing browser cache from AddNewProfile

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68960f0b67c08326ac17f71d451b937c