### PR TITLE
Fix AddNewProfile stale cache behavior with search

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -220,14 +220,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     profileSync.init();
     const cached = profileSync.getData();
-    if (cached) {
+    if (!search && cached) {
       setState(cached);
     }
     const intervalId = setInterval(() => {
       profileSync.pollServer();
     }, 5000);
     return () => clearInterval(intervalId);
-  }, []);
+  }, [search]);
 
   const handleBlur = () => {
     handleSubmit();


### PR DESCRIPTION
## Summary
- Guard loading cached profile when a search query is active
- Re-run profile sync when search changes to avoid stale profile data

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6895cebd8a9c832688deb9d1f94fc075