### PR TITLE
Fix scroll restoration jump on Matching list

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -905,11 +905,12 @@ const Matching = () => {
     if (restoreRef.current || loading || users.length === 0) return;
     const savedY = sessionStorage.getItem(SCROLL_Y_KEY);
     if (savedY !== null) {
-      requestAnimationFrame(() => {
-        window.scrollTo(0, Number(savedY));
-        restoreRef.current = true;
-        sessionStorage.removeItem(SCROLL_Y_KEY);
-      });
+      const y = Number(savedY);
+      if (Math.abs(window.scrollY - y) > 1) {
+        window.scrollTo(0, y);
+      }
+      restoreRef.current = true;
+      sessionStorage.removeItem(SCROLL_Y_KEY);
     }
   }, [loading, users]);
 


### PR DESCRIPTION
## Summary
- avoid unnecessary scroll restoration when returning from edit
- keep previous scroll position without visible jump

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6890cc347640832680a8bb0dff7fe422