### PR TITLE
Avoid stale profile when search present

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -219,14 +219,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     profileSync.init();
-    const cached = profileSync.getData();
-    if (!search && cached) {
-      setState(cached);
+    if (!search) {
+      const cached = profileSync.getData();
+      if (cached) {
+        setState(cached);
+      }
+      const intervalId = setInterval(() => {
+        profileSync.pollServer();
+      }, 5000);
+      return () => clearInterval(intervalId);
     }
-    const intervalId = setInterval(() => {
-      profileSync.pollServer();
-    }, 5000);
-    return () => clearInterval(intervalId);
   }, [search]);
 
   const handleBlur = () => {


### PR DESCRIPTION
## Summary
- prevent cached profile from overwriting state when a search query is active
- stop polling server when search query is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896f9f391e083269eef24bd28d3031e