### PR TITLE
fix addNewProfile default load

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -220,6 +220,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     profileSync.init();
     if (!search) {
+      const storedSearch = localStorage.getItem(SEARCH_KEY);
+      if (storedSearch) {
+        setSearch(storedSearch);
+        return;
+      }
       const cached = profileSync.getData();
       if (cached) {
         setState(cached);
@@ -228,6 +233,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         profileSync.pollServer();
       }, 5000);
       return () => clearInterval(intervalId);
+    } else {
+      setState({});
     }
   }, [search]);
 


### PR DESCRIPTION
## Summary
- fix addNewProfile default load not to ignore saved search and avoid stale ProfileForm data

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977b73b0cc8326be4aed6fc5406ced