### PR TITLE
Clear stale profile cache when search is empty

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -225,10 +225,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setSearch(storedSearch);
         return;
       }
-      const cached = profileSync.getData();
-      if (cached) {
-        setState(cached);
-      }
+
+      // Clear any leftover cached profile data so a blank form is shown
+      profileSync.update(null);
+      setState({});
+
       const intervalId = setInterval(() => {
         profileSync.pollServer();
       }, 5000);


### PR DESCRIPTION
## Summary
- Clear leftover pending profile data when opening AddNewProfile with no search query

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689782fec57883268bb1135a5cb264bd