### PR TITLE
Handle photo links without storage

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -145,6 +145,20 @@ export const Photos = ({ state, setState }) => {
         if (changed) {
           setState(prev => ({ ...prev, photos: converted }));
         }
+      } else {
+        const links = Object.entries(state)
+          .filter(([key, value]) =>
+            key.toLowerCase().startsWith('photo') &&
+            key !== 'photos' &&
+            typeof value === 'string' &&
+            value.trim() !== '',
+          )
+          .map(([, value]) => convertDriveLinkToImage(value))
+          .filter(Boolean);
+
+        if (links.length) {
+          setState(prev => ({ ...prev, photos: links }));
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- Convert photo fields to display when Firebase storage lacks images

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68978371c1288326b26209b1f0847641