### PR TITLE
Fix overlap of like buttons with ellipsis

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -14,6 +14,7 @@ export const BtnDislike = ({
   onRemove,
   favoriteUsers = {},
   setFavoriteUsers,
+  style = {},
 }) => {
   const isDisliked = !!dislikeUsers[userId];
 
@@ -74,6 +75,7 @@ export const BtnDislike = ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        ...style,
       }}
       disabled={!auth.currentUser}
       onClick={e => {

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -14,6 +14,7 @@ export const BtnFavorite = ({
   onRemove,
   dislikeUsers = {},
   setDislikeUsers,
+  style = {},
 }) => {
   const isFavorite = !!favoriteUsers[userId];
 
@@ -72,6 +73,7 @@ export const BtnFavorite = ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        ...style,
       }}
       disabled={!auth.currentUser}
       onClick={e => {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -39,6 +39,7 @@ export const renderTopBlock = (
         userId={userData.userId}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
+        style={{ bottom: '45px' }}
       />
       {btnExport(userData)}
       <div>


### PR DESCRIPTION
## Summary
- allow BtnFavorite and BtnDislike to accept custom styles
- lift like button in top block so ellipsis menu remains accessible

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6897a3f3da9483268145f832be611b7f