### PR TITLE
Hide user ID button in AddNewProfile top block

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -852,6 +852,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 setFavoriteUsersData,
                 currentFilter,
                 isDateInRange,
+                false,
               )}
             </div>
 

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -29,6 +29,7 @@ export const renderTopBlock = (
   setFavoriteUsers,
   currentFilter,
   isDateInRange,
+  showUserId = true,
 ) => {
   if (!userData) return null;
 
@@ -44,7 +45,7 @@ export const renderTopBlock = (
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}
         {userData.lastAction && ', '}
-        {userData.userId}
+        {showUserId && userData.userId}
         {(userData.userRole !== 'ag' && userData.userRole !== 'ip' && userData.role !== 'ag' && userData.role !== 'ip') &&
           fieldGetInTouch(userData, setUsers, setState, currentFilter, isDateInRange)}
         {fieldRole(userData, setUsers, setState)}


### PR DESCRIPTION
## Summary
- add `showUserId` flag to `renderTopBlock`
- hide user ID in AddNewProfile's top block to avoid duplicate edit link

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6897a3bf2ac08326bd6001a7713f6e22