### PR TITLE
Remove duplicate userId button in AddNewProfile list

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { auth } from './config';
 import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
@@ -87,9 +85,6 @@ const UserCard = ({
   currentFilter,
   isDateInRange,
 }) => {
-  const navigate = useNavigate();
-  const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
-
   return (
     <div>
       {renderTopBlock(
@@ -102,25 +97,10 @@ const UserCard = ({
         setFavoriteUsers,
         currentFilter,
         isDateInRange,
+        false,
       )}
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}
-      </div>
-      <div
-        onClick={() => {
-          if (isAdmin) {
-            navigate(`/edit/${userData.userId}`, { state: userData });
-          }
-        }}
-        style={{
-          fontSize: '12px',
-          color: 'gray',
-          textAlign: 'right',
-          marginTop: '5px',
-          cursor: isAdmin ? 'pointer' : 'default',
-        }}
-      >
-        ID: {userData.userId ? userData.userId.slice(0, 5) : ''}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Hide user IDs in user list top blocks to avoid redundant edit entry points
- Clean up UserCard markup by dropping admin-only userId navigation element

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6897bc3bf524832686ade64ad13a4c70