### PR TITLE
Replace 99 action with dislike/like buttons

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -445,6 +445,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [dateOffset, setDateOffset] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
   const [favoriteUsersData, setFavoriteUsersData] = useState({});
+  const [dislikeUsersData, setDislikeUsersData] = useState({});
 
   useEffect(() => {
     const cacheKey = JSON.stringify({ currentFilter, filters });
@@ -850,6 +851,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 false,
                 favoriteUsersData,
                 setFavoriteUsersData,
+                dislikeUsersData,
+                setDislikeUsersData,
                 currentFilter,
                 isDateInRange,
                 false,
@@ -945,6 +948,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   users={paginatedUsers}
                   favoriteUsers={favoriteUsersData}
                   setFavoriteUsers={setFavoriteUsersData}
+                  dislikeUsers={dislikeUsersData}
+                  setDislikeUsers={setDislikeUsersData}
                   setUsers={setUsers}
                   setSearch={setSearch}
                   setState={setState}

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -84,6 +84,8 @@ const UserCard = ({
   setState,
   favoriteUsers,
   setFavoriteUsers,
+  dislikeUsers,
+  setDislikeUsers,
   currentFilter,
   isDateInRange,
 }) => {
@@ -100,6 +102,8 @@ const UserCard = ({
         'isFromListOfUsers',
         favoriteUsers,
         setFavoriteUsers,
+        dislikeUsers,
+        setDislikeUsers,
         currentFilter,
         isDateInRange,
       )}
@@ -136,6 +140,8 @@ const UsersList = ({
   setCompare,
   favoriteUsers = {},
   setFavoriteUsers,
+  dislikeUsers = {},
+  setDislikeUsers,
   currentFilter,
   isDateInRange,
 }) => {
@@ -201,6 +207,8 @@ const UsersList = ({
                 setState={setState}
                 favoriteUsers={favoriteUsers}
                 setFavoriteUsers={setFavoriteUsers}
+                dislikeUsers={dislikeUsers}
+                setDislikeUsers={setDislikeUsers}
                 currentFilter={currentFilter}
                 isDateInRange={isDateInRange}
               />

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -10,10 +10,11 @@ import { color } from '../styles';
 export const BtnDislike = ({
   userId,
   dislikeUsers = {},
-  setDislikeUsers,
+  setDislikeUsers = () => {},
   onRemove,
+  onAdd,
   favoriteUsers = {},
-  setFavoriteUsers,
+  setFavoriteUsers = () => {},
   style = {},
 }) => {
   const isDisliked = !!dislikeUsers[userId];
@@ -37,6 +38,7 @@ export const BtnDislike = ({
       try {
         await addDislikeUser(userId);
         setDislikeUsers({ ...dislikeUsers, [userId]: true });
+        if (onAdd) onAdd(userId);
         if (favoriteUsers[userId]) {
           try {
             await removeFavoriteUser(userId);

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -1,6 +1,8 @@
 import { handleChange, handleSubmit } from './actions';
 const { formatDateToDisplay, formatDateAndFormula, formatDateToServer } = require('components/inputValidations');
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
+import { BtnDislike } from './btnDislike';
+import { BtnFavorite } from './btnFavorite';
 
 export const fieldGetInTouch = (
   userData,
@@ -8,6 +10,10 @@ export const fieldGetInTouch = (
   setState,
   currentFilter,
   isDateInRange,
+  favoriteUsers = {},
+  setFavoriteUsers = () => {},
+  dislikeUsers = {},
+  setDislikeUsers = () => {},
 ) => {
   const handleSendToEnd = () => {
     handleChange(
@@ -97,7 +103,35 @@ export const fieldGetInTouch = (
       <ActionButton label="3м" days={90} onClick={handleAddDays} />
       <ActionButton label="6м" days={180} onClick={handleAddDays} />
       <ActionButton label="1р" days={365} onClick={handleAddDays} />
-      <ActionButton label="99" onClick={handleSendToEnd} />
+      <BtnDislike
+        userId={userData.userId}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        onAdd={handleSendToEnd}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        style={{
+          position: 'static',
+          width: '25px',
+          height: '25px',
+          marginLeft: '5px',
+          marginRight: 0,
+        }}
+      />
+      <BtnFavorite
+        userId={userData.userId}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        style={{
+          position: 'static',
+          width: '25px',
+          height: '25px',
+          marginLeft: '5px',
+          marginRight: 0,
+        }}
+      />
     </div>
   );
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
-import { BtnFavorite } from './btnFavorite';
 import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
@@ -26,7 +25,9 @@ export const renderTopBlock = (
   setState,
   isFromListOfUsers,
   favoriteUsers = {},
-  setFavoriteUsers,
+  setFavoriteUsers = () => {},
+  dislikeUsers = {},
+  setDislikeUsers = () => {},
   currentFilter,
   isDateInRange,
   showUserId = true,
@@ -36,19 +37,23 @@ export const renderTopBlock = (
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
       {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
-      <BtnFavorite
-        userId={userData.userId}
-        favoriteUsers={favoriteUsers}
-        setFavoriteUsers={setFavoriteUsers}
-        style={{ bottom: '45px' }}
-      />
       {btnExport(userData)}
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}
         {userData.lastAction && ', '}
         {showUserId && userData.userId}
         {(userData.userRole !== 'ag' && userData.userRole !== 'ip' && userData.role !== 'ag' && userData.role !== 'ip') &&
-          fieldGetInTouch(userData, setUsers, setState, currentFilter, isDateInRange)}
+          fieldGetInTouch(
+            userData,
+            setUsers,
+            setState,
+            currentFilter,
+            isDateInRange,
+            favoriteUsers,
+            setFavoriteUsers,
+            dislikeUsers,
+            setDislikeUsers,
+          )}
         {fieldRole(userData, setUsers, setState)}
         {(userData.userRole !== 'ag' && userData.userRole !== 'ip' && userData.role !== 'ag' && userData.role !== 'ip') && fieldLastCycle(userData, setUsers, setState)}
         {fieldDeliveryInfo(setUsers, setState, userData)}


### PR DESCRIPTION
## Summary
- add onAdd hook to BtnDislike to allow extra actions when disliking
- replace "99" with inline dislike and like buttons inside fieldGetInTouch
- plumb dislike state through renderTopBlock, UsersList and AddNewProfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ba9294ac8326a14b1fc822bfc98c