### PR TITLE
Replace 99 action with dislike and like buttons

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -445,6 +445,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [dateOffset, setDateOffset] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
   const [favoriteUsersData, setFavoriteUsersData] = useState({});
+  const [dislikeUsersData, setDislikeUsersData] = useState({});
 
   useEffect(() => {
     const cacheKey = JSON.stringify({ currentFilter, filters });
@@ -471,6 +472,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const favRef = ref(database, `multiData/favorites/${ownerId}`);
     const unsubscribe = onValue(favRef, snap => {
       setFavoriteUsersData(snap.exists() ? snap.val() : {});
+    });
+
+    return () => unsubscribe();
+  }, [ownerId]);
+
+  useEffect(() => {
+    if (!ownerId) return;
+
+    const disRef = ref(database, `multiData/dislikes/${ownerId}`);
+    const unsubscribe = onValue(disRef, snap => {
+      setDislikeUsersData(snap.exists() ? snap.val() : {});
     });
 
     return () => unsubscribe();
@@ -850,6 +862,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 false,
                 favoriteUsersData,
                 setFavoriteUsersData,
+                dislikeUsersData,
+                setDislikeUsersData,
                 currentFilter,
                 isDateInRange,
                 false,
@@ -945,6 +959,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   users={paginatedUsers}
                   favoriteUsers={favoriteUsersData}
                   setFavoriteUsers={setFavoriteUsersData}
+                  dislikeUsers={dislikeUsersData}
+                  setDislikeUsers={setDislikeUsersData}
                   setUsers={setUsers}
                   setSearch={setSearch}
                   setState={setState}

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -82,6 +82,8 @@ const UserCard = ({
   setState,
   favoriteUsers,
   setFavoriteUsers,
+  dislikeUsers,
+  setDislikeUsers,
   currentFilter,
   isDateInRange,
 }) => {
@@ -95,6 +97,8 @@ const UserCard = ({
         'isFromListOfUsers',
         favoriteUsers,
         setFavoriteUsers,
+        dislikeUsers,
+        setDislikeUsers,
         currentFilter,
         isDateInRange,
         false,
@@ -116,6 +120,8 @@ const UsersList = ({
   setCompare,
   favoriteUsers = {},
   setFavoriteUsers,
+  dislikeUsers = {},
+  setDislikeUsers,
   currentFilter,
   isDateInRange,
 }) => {
@@ -181,6 +187,8 @@ const UsersList = ({
                 setState={setState}
                 favoriteUsers={favoriteUsers}
                 setFavoriteUsers={setFavoriteUsers}
+                dislikeUsers={dislikeUsers}
+                setDislikeUsers={setDislikeUsers}
                 currentFilter={currentFilter}
                 isDateInRange={isDateInRange}
               />

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -27,6 +27,8 @@ export const renderTopBlock = (
   isFromListOfUsers,
   favoriteUsers = {},
   setFavoriteUsers,
+  dislikeUsers = {},
+  setDislikeUsers = () => {},
   currentFilter,
   isDateInRange,
   showUserId = true,
@@ -40,6 +42,8 @@ export const renderTopBlock = (
         userId={userData.userId}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
       />
       {btnExport(userData)}
       <div>
@@ -47,7 +51,17 @@ export const renderTopBlock = (
         {userData.lastAction && ', '}
         {showUserId && userData.userId}
         {(userData.userRole !== 'ag' && userData.userRole !== 'ip' && userData.role !== 'ag' && userData.role !== 'ip') &&
-          fieldGetInTouch(userData, setUsers, setState, currentFilter, isDateInRange)}
+          fieldGetInTouch(
+            userData,
+            setUsers,
+            setState,
+            currentFilter,
+            isDateInRange,
+            favoriteUsers,
+            setFavoriteUsers,
+            dislikeUsers,
+            setDislikeUsers,
+          )}
         {fieldRole(userData, setUsers, setState)}
         {(userData.userRole !== 'ag' && userData.userRole !== 'ip' && userData.role !== 'ag' && userData.role !== 'ip') && fieldLastCycle(userData, setUsers, setState)}
         {fieldDeliveryInfo(setUsers, setState, userData)}


### PR DESCRIPTION
## Summary
- Replace 99 action in get-in-touch field with dislike and like buttons
- Connect buttons to favorite and dislike logic across top block and lists

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6897c0bbe800832693040340f8155778