### PR TITLE
Refine like/dislike logic in top block

### DIFF
--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -61,7 +61,6 @@ export const fieldGetInTouch = (
 
   const handleDislike = async e => {
     e.stopPropagation();
-    handleSendToEnd();
     if (!auth.currentUser) {
       alert('Please sign in to manage dislikes');
       return;
@@ -72,10 +71,20 @@ export const fieldGetInTouch = (
         const updated = { ...dislikeUsers };
         delete updated[userData.userId];
         setDislikeUsers(updated);
+        handleChange(
+          setUsers,
+          setState,
+          userData.userId,
+          'getInTouch',
+          '',
+          true,
+          { currentFilter, isDateInRange }
+        );
       } catch (error) {
         console.error('Failed to remove dislike:', error);
       }
     } else {
+      handleSendToEnd();
       try {
         await addDislikeUser(userData.userId);
         const updated = { ...dislikeUsers, [userData.userId]: true };
@@ -125,6 +134,15 @@ export const fieldGetInTouch = (
           const upd = { ...dislikeUsers };
           delete upd[userData.userId];
           setDislikeUsers(upd);
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            'getInTouch',
+            '',
+            true,
+            { currentFilter, isDateInRange }
+          );
         }
       } catch (error) {
         console.error('Failed to add favorite:', error);
@@ -198,6 +216,7 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          border: isDisliked ? '2px solid black' : 'none',
         }}
       >
         <svg
@@ -225,6 +244,7 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          border: isFavorite ? '2px solid black' : 'none',
         }}
       >
         <svg

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
-import { BtnFavorite } from './btnFavorite';
 import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
@@ -57,13 +56,6 @@ export const renderTopBlock = (
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
       {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
-      <BtnFavorite
-        userId={userData.userId}
-        favoriteUsers={favoriteUsers}
-        setFavoriteUsers={setFavoriteUsers}
-        dislikeUsers={dislikeUsers}
-        setDislikeUsers={setDislikeUsers}
-      />
       {btnExport(userData)}
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}


### PR DESCRIPTION
## Summary
- remove redundant like button from top block
- clear getInTouch when dislike is removed and ensure like/dislike exclusivity
- highlight active like/dislike with a 2px black border

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68985480cba083269babbd1070eec9f5