### PR TITLE
Add spacing for toggled profile details

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -131,6 +131,7 @@ export const renderTopBlock = (
           if (details) {
             const isHidden = details.style.display === 'none';
             details.style.display = isHidden ? 'block' : 'none';
+            details.style.marginTop = isHidden ? '8px' : '0';
             if (isHidden) {
               const bg = getParentBackground(details);
               details.style.color = getContrastColor(bg);


### PR DESCRIPTION
## Summary
- add top margin when expanding profile details via ellipsis so blocks don't merge

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689854d8c2e88326bfc3f2f20440bdbe