### PR TITLE
Cache card search results in localStorage

### DIFF
--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -1,5 +1,8 @@
 import { CardMenuBtn } from 'components/styles';
 import React from 'react';
+import { createCache } from '../../hooks/cardsCache';
+
+const { saveCache: saveSearchCache } = createCache('searchResults');
 
 // Use already loaded card data instead of re-fetching from the server
 export const btnEdit = (userData, setSearch, setState) => {
@@ -7,6 +10,7 @@ export const btnEdit = (userData, setSearch, setState) => {
     if (userData) {
       setSearch(`${userData.userId}`);
       setState(userData);
+      saveSearchCache(JSON.stringify({ userId: userData.userId }), userData);
     } else {
       console.log('Користувача не знайдено.');
     }


### PR DESCRIPTION
## Summary
- cache search responses in localStorage for future lookups
- store opened card data in the search cache to reuse existing info

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689855c9383883269f2e57905e2ffee5