### PR TITLE
Add spacing after top block details in profile form

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -165,7 +165,10 @@ export const ProfileForm = ({
   return (
     <>
       {state.userId && (
-        <div id={state.userId} style={{ display: 'none', textAlign: 'left' }}>
+        <div
+          id={state.userId}
+          style={{ display: 'none', textAlign: 'left', marginBottom: '8px' }}
+        >
           {renderAllFields(state)}
         </div>
       )}


### PR DESCRIPTION
## Summary
- add bottom margin to details shown via renderTopBlock to prevent merged blocks

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6898d15e578083269101f71200a8b6e6