### PR TITLE
Fix invisible search dropdown text

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -98,6 +98,7 @@ const HistoryItem = styled.li`
   justify-content: space-between;
   padding: 5px 10px;
   cursor: pointer;
+  color: black;
 
   &:hover {
     background-color: #f0f0f0;


### PR DESCRIPTION
## Summary
- ensure search history dropdown options use black text for visibility

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js --silent`


------
https://chatgpt.com/codex/tasks/task_e_6898d84536fc83269f0ceac1ffd19f60