### PR TITLE
fix: preserve edit state in profile form

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -234,10 +234,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         profileSync.pollServer();
       }, 5000);
       return () => clearInterval(intervalId);
-    } else {
+    } else if (search !== state.userId) {
       setState({});
     }
-  }, [search]);
+  }, [search, state.userId]);
 
   const handleBlur = () => {
     handleSubmit();


### PR DESCRIPTION
## Summary
- avoid clearing profile state when search matches current userId so edit opens in one click

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6898f86a75808326b015708053c38ab2