### PR TITLE
refactor: remove unused filter deps

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1103,7 +1103,7 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [fetchChunk, filters]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
+  }, [fetchChunk]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
 
   const loadFavoriteCards = async () => {
     const owner = auth.currentUser?.uid;
@@ -1224,7 +1224,7 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [hasMore, lastKey, viewMode, fetchChunk, filters]);
+  }, [hasMore, lastKey, viewMode, fetchChunk]);
 
   useEffect(() => {
     const savedSearch = localStorage.getItem(SEARCH_KEY);


### PR DESCRIPTION
## Summary
- remove unused `filters` dependency from Matching callbacks

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689908a158d08326a23e9f715e602da2