### PR TITLE
feat: cache key helper for cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1185,6 +1185,7 @@ const Matching = () => {
     loadingRef.current = true;
     setLoading(true);
     try {
+      const cacheKey = getCacheKey('default');
       const exclude = new Set([
         ...Object.keys(favoriteUsersRef.current),
         ...Object.keys(dislikeUsersRef.current),
@@ -1209,7 +1210,6 @@ const Matching = () => {
         const map = new Map(prev.map(u => [u.userId, u]));
         unique.forEach(u => map.set(u.userId, u));
         const result = Array.from(map.values());
-        const cacheKey = getCacheKey('default');
         saveCache(cacheKey, { users: result, lastKey: res.lastKey, hasMore: res.hasMore });
         return result;
       });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,9 +1,12 @@
-export const getCacheKey = (mode, term) => {
-  return `cards:${mode}${term ? `:${term}` : ''}`;
-};
+// Builds a cache key for cards list depending on mode and optional search term
+export const getCacheKey = (mode, term) =>
+  `cards:${mode}${term ? `:${term}` : ''}`;
 
+// Removes all cached card lists regardless of mode or search term
 export const clearAllCardsCache = () => {
+  const CARDS_PREFIX = 'matchingCache:cards:';
+
   Object.keys(localStorage)
-    .filter(key => key.startsWith('matchingCache:cards:'))
+    .filter(key => key.startsWith(CARDS_PREFIX))
     .forEach(key => localStorage.removeItem(key));
 };


### PR DESCRIPTION
## Summary
- add utility to build cache key and remove card caches
- refactor loadMore to reuse cache key helper

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689a25bee26c8326b499726974e6c897