### PR TITLE
Display user ID alongside last action date

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -921,7 +921,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 setDislikeUsersData,
                 currentFilter,
                 isDateInRange,
-                false,
               )}
             </div>
 

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -101,7 +101,6 @@ const UserCard = ({
         setDislikeUsers,
         currentFilter,
         isDateInRange,
-        false,
       )}
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -49,7 +49,6 @@ export const renderTopBlock = (
   setDislikeUsers = () => {},
   currentFilter,
   isDateInRange,
-  showUserId = true,
 ) => {
   if (!userData) return null;
 
@@ -60,7 +59,7 @@ export const renderTopBlock = (
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}
         {userData.lastAction && ', '}
-        {showUserId && userData.userId}
+        {userData.userId}
         {(userData.userRole !== 'ag' && userData.userRole !== 'ip' && userData.role !== 'ag' && userData.role !== 'ip') &&
           fieldGetInTouch(
             userData,


### PR DESCRIPTION
## Summary
- Always display the user ID next to the last action date in `renderTopBlock`
- Adjust user card rendering in `UsersList` and `AddNewProfile` to use updated `renderTopBlock`

## Testing
- `CI=true npm test`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_689a25f7be3c832698e97c568da399e0