### PR TITLE
fix: show google drive photos in profile

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -15,7 +15,9 @@ const convertDriveLinkToImage = link => {
       const fileMatch = url.pathname.match(/\/file\/d\/([^/]+)/);
       const fileId = fileMatch ? fileMatch[1] : url.searchParams.get('id');
 
-      return fileId ? `https://drive.google.com/uc?id=${fileId}` : link;
+      return fileId
+        ? `https://drive.google.com/uc?export=view&id=${fileId}`
+        : link;
     }
 
     return link;


### PR DESCRIPTION
## Summary
- ensure Google Drive links are converted to viewable image URLs

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a3b46242483269092572a2e6882b5