### PR TITLE
Sync profile updates with local state

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -285,6 +285,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         await updateDataInNewUsersRTDB(state.userId, state, 'update');
       }
     }
+
+    profileSync.update(updatedState);
+    setUsers(prev => ({ ...prev, [updatedState.userId]: updatedState }));
   };
 
   const handleExit = async () => {


### PR DESCRIPTION
## Summary
- Ensure profile updates sync to localStorage and backend via profileSync.update in handleSubmit
- Refresh local users collection and cache after submitting profile changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a53f635d4832685924f405d42dccc