### PR TITLE
Improve caching for AddNewProfile and favorites

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -54,6 +54,11 @@ import { onValue, ref } from 'firebase/database';
 // import { aiHandler } from './aiHandler';
 import { createLocalFirstSync } from '../hooks/localServerSync';
 import { createCache } from '../hooks/cardsCache';
+import {
+  buildAddCacheKey,
+  setAddCacheKeys,
+  setFavoriteIds,
+} from 'utils/cache';
 
 const Container = styled.div`
   display: flex;
@@ -192,7 +197,10 @@ const ButtonsContainer = styled.div`
 const profileSync = createLocalFirstSync('pendingProfile', null, ({ data }) =>
   data?.userId ? data : makeNewUser(data),
 );
-const { loadCache: loadAddCache, saveCache: saveAddCache } = createCache('addCache');
+const {
+  loadCache: loadAddCache,
+  mergeCache: mergeAddCache,
+} = createCache('addCache');
 
 export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
@@ -451,9 +459,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [dislikeUsersData, setDislikeUsersData] = useState({});
 
   useEffect(() => {
-    const cacheKey = JSON.stringify({ currentFilter, filters });
-    saveAddCache(cacheKey, { users, lastKey, hasMore, totalCount });
-  }, [users, lastKey, hasMore, totalCount, currentFilter, filters]);
+    const cacheKey = buildAddCacheKey(currentFilter, filters, search);
+    mergeAddCache(cacheKey, { users, lastKey, hasMore, totalCount });
+  }, [users, lastKey, hasMore, totalCount, currentFilter, filters, search]);
 
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
   const isDateInRange = dateStr => {
@@ -474,7 +482,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     const favRef = ref(database, `multiData/favorites/${ownerId}`);
     const unsubscribe = onValue(favRef, snap => {
-      setFavoriteUsersData(snap.exists() ? snap.val() : {});
+      const fav = snap.exists() ? snap.val() : {};
+      setFavoriteUsersData(fav);
+      setFavoriteIds(fav);
     });
 
     return () => unsubscribe();
@@ -496,7 +506,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [filters]);
 
   useEffect(() => {
-    const cacheKey = JSON.stringify({ currentFilter, filters });
+    const cacheKey = buildAddCacheKey(currentFilter, filters, search);
+    setAddCacheKeys(cacheKey, buildAddCacheKey('FAVORITE', filters, search));
     const cached = loadAddCache(cacheKey);
     if (cached) {
       setUsers(cached.users || {});
@@ -519,7 +530,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
     // loadMoreUsers depends on many state values, so we skip it from the deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, currentFilter]);
+  }, [filters, currentFilter, search]);
 
 
   const [adding, setAdding] = useState(false);
@@ -647,6 +658,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       // Оновлюємо стан користувачів
       // Оновлюємо стан користувачів
       setUsers(prevUsers => mergeWithoutOverwrite(prevUsers, newUsers)); // Додаємо нових користувачів до попередніх без перезапису
+      const cacheKey = buildAddCacheKey(filterForload, currentFilters, search);
+      mergeAddCache(cacheKey, {
+        users: newUsers,
+        lastKey: res.lastKey,
+        hasMore: res.hasMore,
+        totalCount: res.totalCount,
+      });
       if (filterForload === 'DATE') {
         setDateOffset(prev => prev + PAGE_SIZE);
         setHasMore(res.hasMore);
@@ -673,7 +691,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (isEditingRef.current) return { count: 0, hasMore };
 
-    const cacheKey = JSON.stringify({ currentFilter: 'DATE2', filters: currentFilters });
+    const cacheKey = buildAddCacheKey('DATE2', currentFilters, search);
     if (dateOffset2 === 0) {
       const cached = loadAddCache(cacheKey);
       if (cached && cached.users) {
@@ -693,6 +711,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           }
           setDateOffset2(cached.lastKey);
           setHasMore(cached.hasMore);
+          mergeAddCache(cacheKey, {
+            users: validUsers,
+            lastKey: cached.lastKey,
+            hasMore: cached.hasMore,
+          });
           return { count: Object.keys(validUsers).length, hasMore: cached.hasMore };
         }
         if (!isEditingRef.current && validEntries.length > 0) {
@@ -718,12 +741,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           const combined = { ...validUsers, ...resFromCache.users };
           setDateOffset2(resFromCache.lastKey);
           setHasMore(resFromCache.hasMore);
+          mergeAddCache(cacheKey, {
+            users: combined,
+            lastKey: resFromCache.lastKey,
+            hasMore: resFromCache.hasMore,
+          });
           return {
             count: Object.keys(combined).length,
             hasMore: resFromCache.hasMore,
           };
         }
         setHasMore(false);
+        mergeAddCache(cacheKey, {
+          users: validUsers,
+          lastKey: null,
+          hasMore: false,
+        });
         return { count: Object.keys(validUsers).length, hasMore: false };
       }
     }
@@ -747,10 +780,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       }
       setDateOffset2(res.lastKey);
       setHasMore(res.hasMore);
+      mergeAddCache(cacheKey, {
+        users: res.users,
+        lastKey: res.lastKey,
+        hasMore: res.hasMore,
+      });
       const count = Object.keys(res.users).length;
       return { count, hasMore: res.hasMore };
     }
     setHasMore(false);
+    mergeAddCache(cacheKey, { users: {}, lastKey: null, hasMore: false });
     return { count: 0, hasMore: false };
   };
 

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -716,6 +716,7 @@ const SwipeableCard = ({
       )}
       <BtnFavorite
         userId={user.userId}
+        userData={user}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
         dislikeUsers={dislikeUsers}

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -1,4 +1,5 @@
 import { fetchUserById, updateDataInNewUsersRTDB } from "components/config";
+import { updateCachedUser } from "utils/cache";
 import { formatDateAndFormula } from "components/inputValidations";
 import { makeUploadedInfo } from "components/makeUploadedInfo";
 
@@ -103,6 +104,7 @@ export const handleSubmit = async userData => {
   console.log('cleanedStateForNewUsers!!!!!!!!!!!!!!', cleanedStateForNewUsers);
 
   await updateDataInNewUsersRTDB(userData.userId, cleanedStateForNewUsers, 'update');
+  updateCachedUser({ ...cleanedStateForNewUsers, userId: userData.userId });
 };
 
 export const handleSubmitAll = async userData => {
@@ -118,4 +120,5 @@ export const handleSubmitAll = async userData => {
   const formattedDate = `${year}-${month}-${day}`; // Формат YYYY-MM-DD
   uploadedInfo.lastAction = formattedDate;
   await updateDataInNewUsersRTDB(userData.userId, uploadedInfo, 'update');
+  updateCachedUser({ ...uploadedInfo, userId: userData.userId });
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -6,9 +6,11 @@ import {
   auth,
 } from '../config';
 import { color } from '../styles';
+import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 
 export const BtnFavorite = ({
   userId,
+  userData = {},
   favoriteUsers = {},
   setFavoriteUsers,
   onRemove,
@@ -28,6 +30,8 @@ export const BtnFavorite = ({
         const updated = { ...favoriteUsers };
         delete updated[userId];
         setFavoriteUsers(updated);
+        setFavoriteIds(updated);
+        updateCachedUser(userData || { userId }, { forceFavorite: true, removeFavorite: true });
         if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to remove favorite:', error);
@@ -35,7 +39,10 @@ export const BtnFavorite = ({
     } else {
       try {
         await addFavoriteUser(userId);
-        setFavoriteUsers({ ...favoriteUsers, [userId]: true });
+        const updatedFav = { ...favoriteUsers, [userId]: true };
+        setFavoriteUsers(updatedFav);
+        setFavoriteIds(updatedFav);
+        updateCachedUser(userData || { userId }, { forceFavorite: true });
         if (dislikeUsers[userId]) {
           try {
             await removeDislikeUser(userId);

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -12,6 +12,7 @@ import {
   removeFavoriteUser,
   auth,
 } from '../config';
+import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 
 export const fieldGetInTouch = (
   userData,
@@ -98,6 +99,8 @@ export const fieldGetInTouch = (
           const upd = { ...favoriteUsers };
           delete upd[userData.userId];
           setFavoriteUsers(upd);
+          setFavoriteIds(upd);
+          updateCachedUser(userData, { forceFavorite: true, removeFavorite: true });
         }
       } catch (error) {
         console.error('Failed to add dislike:', error);
@@ -117,6 +120,8 @@ export const fieldGetInTouch = (
         const updated = { ...favoriteUsers };
         delete updated[userData.userId];
         setFavoriteUsers(updated);
+        setFavoriteIds(updated);
+        updateCachedUser(userData, { forceFavorite: true, removeFavorite: true });
       } catch (error) {
         console.error('Failed to remove favorite:', error);
       }
@@ -125,6 +130,8 @@ export const fieldGetInTouch = (
         await addFavoriteUser(userData.userId);
         const updated = { ...favoriteUsers, [userData.userId]: true };
         setFavoriteUsers(updated);
+        setFavoriteIds(updated);
+        updateCachedUser(userData, { forceFavorite: true });
         if (dislikeUsers[userData.userId]) {
           try {
             await removeDislikeUser(userData.userId);

--- a/src/hooks/cardsCache.js
+++ b/src/hooks/cardsCache.js
@@ -35,13 +35,30 @@ export const createCache = (prefix, ttl = TTL_MS) => {
     }
   };
 
+  const mergeCache = (key, partial) => {
+    if (!key || !partial) return;
+    try {
+      const existing = loadCache(key) || {};
+      const merged = {
+        ...existing,
+        ...partial,
+        ...(existing.users || partial.users
+          ? { users: { ...(existing.users || {}), ...(partial.users || {}) } }
+          : {}),
+      };
+      saveCache(key, merged);
+    } catch {
+      saveCache(key, partial);
+    }
+  };
+
   const clearCache = key => {
     if (!key) return;
     localStorage.removeItem(CACHE_PREFIX + key);
   };
 
-  return { loadCache, saveCache, clearCache };
+  return { loadCache, saveCache, clearCache, mergeCache };
 };
 
 // default cache for matching to keep backward compatibility
-export const { loadCache, saveCache, clearCache } = createCache('matchingCache');
+export const { loadCache, saveCache, clearCache, mergeCache } = createCache('matchingCache');

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,3 +1,5 @@
+import { createCache } from 'hooks/cardsCache';
+
 // Builds a cache key for cards list depending on mode and optional search term
 export const getCacheKey = (mode, term) =>
   `cards:${mode}${term ? `:${term}` : ''}`;
@@ -9,4 +11,51 @@ export const clearAllCardsCache = () => {
   Object.keys(localStorage)
     .filter(key => key.startsWith(CARDS_PREFIX))
     .forEach(key => localStorage.removeItem(key));
+};
+
+// ----- AddNewProfile cache helpers -----
+
+export const buildAddCacheKey = (mode, filters = {}, term = '') =>
+  `${mode || 'all'}:${term || ''}:${JSON.stringify(filters)}`;
+
+let currentAddCacheKey = '';
+let favoriteAddCacheKey = '';
+let favoriteIds = {};
+
+export const setAddCacheKeys = (activeKey, favoriteKey) => {
+  currentAddCacheKey = activeKey;
+  favoriteAddCacheKey = favoriteKey;
+};
+
+export const setFavoriteIds = fav => {
+  favoriteIds = fav || {};
+};
+
+const isFavorite = id => !!favoriteIds[id];
+
+const {
+  loadCache: loadAddCacheUtil,
+  saveCache: saveAddCacheUtil,
+  mergeCache: mergeAddCache,
+} = createCache('addCache');
+
+export const updateCachedUser = (
+  user,
+  { forceFavorite = false, removeFavorite = false } = {},
+) => {
+  if (currentAddCacheKey) {
+    mergeAddCache(currentAddCacheKey, { users: { [user.userId]: user } });
+  }
+  const shouldFav = forceFavorite || isFavorite(user.userId);
+  if (shouldFav && favoriteAddCacheKey) {
+    if (removeFavorite) {
+      const cached = loadAddCacheUtil(favoriteAddCacheKey) || {};
+      if (cached.users) {
+        delete cached.users[user.userId];
+        saveAddCacheUtil(favoriteAddCacheKey, cached);
+      }
+    } else {
+      mergeAddCache(favoriteAddCacheKey, { users: { [user.userId]: user } });
+    }
+  }
 };


### PR DESCRIPTION
## Summary
- Add mergeable cache utilities and key builder for AddNewProfile
- Update card caches after edits and favorite/dislike actions
- Prevent cache overwrites by merging incremental data during loads
- Remove unused saveAddCache reference from AddNewProfile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1fd0f4808326890c9d24e7471c42