### PR TITLE
Remove unused saveAddCache from add profile cache

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -199,7 +199,6 @@ const profileSync = createLocalFirstSync('pendingProfile', null, ({ data }) =>
 );
 const {
   loadCache: loadAddCache,
-  saveCache: saveAddCache,
   mergeCache: mergeAddCache,
 } = createCache('addCache');
 


### PR DESCRIPTION
## Summary
- remove `saveAddCache` destructuring from add profile cache setup

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689b35ebd0648326abbe5c7ae12972f9