### PR TITLE
fix: keep profile form open after phone search

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -243,8 +243,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         profileSync.pollServer();
       }, 5000);
       return () => clearInterval(intervalId);
-    } else if (search !== state.userId) {
-      setState({});
     }
   }, [search, state.userId]);
 


### PR DESCRIPTION
## Summary
- remove state reset when search term doesn't match userId so phone-based search opens profile

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b296c30708326814b88d83507900f