### PR TITLE
Use local-first saves before backend

### DIFF
--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -103,8 +103,8 @@ export const handleSubmit = async userData => {
 
   console.log('cleanedStateForNewUsers!!!!!!!!!!!!!!', cleanedStateForNewUsers);
 
-  await updateDataInNewUsersRTDB(userData.userId, cleanedStateForNewUsers, 'update');
   updateCachedUser({ ...cleanedStateForNewUsers, userId: userData.userId });
+  await updateDataInNewUsersRTDB(userData.userId, cleanedStateForNewUsers, 'update');
 };
 
 export const handleSubmitAll = async userData => {
@@ -119,6 +119,6 @@ export const handleSubmitAll = async userData => {
   const day = String(currentDate.getDate()).padStart(2, '0');
   const formattedDate = `${year}-${month}-${day}`; // Формат YYYY-MM-DD
   uploadedInfo.lastAction = formattedDate;
-  await updateDataInNewUsersRTDB(userData.userId, uploadedInfo, 'update');
   updateCachedUser({ ...uploadedInfo, userId: userData.userId });
+  await updateDataInNewUsersRTDB(userData.userId, uploadedInfo, 'update');
 };

--- a/src/hooks/localServerSync.js
+++ b/src/hooks/localServerSync.js
@@ -38,10 +38,26 @@ export const createLocalFirstSync = (storageKey, initialData = null, remotePush)
       load();
     },
     getData: () => data,
-    update: newData => {
+    update: async newData => {
       data = newData;
-      save();
-      push();
+      const id = newData?.userId ?? newData?.updatedState?.userId;
+
+      if (!id && typeof remotePush === 'function') {
+        try {
+          const res = await remotePush({ data });
+          if (res) {
+            data = res;
+          }
+        } catch {
+          // ignore network errors
+        }
+        save();
+      } else {
+        save();
+        push();
+      }
+
+      return data;
     },
     pollServer: () => {
       push();


### PR DESCRIPTION
## Summary
- Save profile updates to local storage before backend writes and wait for backend userId when creating a contact.
- Update card actions to cache changes locally before updating the server.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6fc390988326aae01241761c643f