### PR TITLE
Display cached Load2 cards in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -450,7 +450,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [lastKey, setLastKey] = useState(null); // Стан для зберігання останнього ключа
   const [totalCount, setTotalCount] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
-  const [currentFilter, setCurrentFilter] = useState(null);
+  const [currentFilter, setCurrentFilter] = useState('DATE2');
   const [dateOffset, setDateOffset] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
   const [favoriteUsersData, setFavoriteUsersData] = useState({});
@@ -757,6 +757,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         });
         return { count: Object.keys(validUsers).length, hasMore: false };
       }
+      setHasMore(false);
+      mergeAddCache(cacheKey, { users: {}, lastKey: null, hasMore: false });
+      return { count: 0, hasMore: false };
     }
 
     const res = await fetchFilteredUsersByPage(


### PR DESCRIPTION
## Summary
- Default AddNewProfile to Load2 mode to pull cards from local storage
- Skip remote fetch when no valid Load2 cache is found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c8a8735dc8326851b842d92b6bd4b