### PR TITLE
Open Drive photos in new tab

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -237,6 +237,19 @@ export const Photos = ({ state, setState }) => {
     }
   };
 
+  const handlePhotoClick = (url, index) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname.includes('drive.google.com')) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+        return;
+      }
+    } catch {
+      // ignore malformed URLs and fallback to viewer
+    }
+    setViewerIndex(index);
+  };
+
   return (
     <Container>
       <PhotosWrapper>
@@ -247,7 +260,7 @@ export const Photos = ({ state, setState }) => {
                 <PhotoImage
                   src={url}
                   alt={`user avatar ${index}`}
-                  onClick={() => setViewerIndex(index)}
+                  onClick={() => handlePhotoClick(url, index)}
                   onLoad={() => console.log('Image loaded', url)}
                   onError={e => {
                     console.error('Image failed to load', url, e);


### PR DESCRIPTION
## Summary
- Open Google Drive hosted photos in a new browser tab instead of the internal photo viewer

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7421d2bc8326b26b5c0e67e55dba