### PR TITLE
Hide toast control when rendering user list

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -58,7 +58,9 @@ export const renderTopBlock = (
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
       {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
-      <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />
+      {!isFromListOfUsers && (
+        <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />
+      )}
       {btnExport(userData)}
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}


### PR DESCRIPTION
## Summary
- Hide toast toggle button on top block when rendering multiple user cards

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689da305d3908326977fd73e8e98b432