### PR TITLE
Hide toast toggle on user lists

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
@@ -86,8 +86,6 @@ const UserCard = ({
   setDislikeUsers,
   currentFilter,
   isDateInRange,
-  isToastOn,
-  setIsToastOn,
 }) => {
   return (
     <div>
@@ -103,8 +101,6 @@ const UserCard = ({
         setDislikeUsers,
         currentFilter,
         isDateInRange,
-        isToastOn,
-        setIsToastOn,
       )}
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}
@@ -128,7 +124,6 @@ const UsersList = ({
   currentFilter,
   isDateInRange,
 }) => {
-  const [isToastOn, setIsToastOn] = useState(false);
   const entries = Object.entries(users);
 
   const handleCreate = async value => {
@@ -195,8 +190,6 @@ const UsersList = ({
                 setDislikeUsers={setDislikeUsers}
                 currentFilter={currentFilter}
                 isDateInRange={isDateInRange}
-                isToastOn={isToastOn}
-                setIsToastOn={setIsToastOn}
               />
             </>
           )}

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -50,15 +50,17 @@ export const renderTopBlock = (
   setDislikeUsers = () => {},
   currentFilter,
   isDateInRange,
-  isToastOn,
-  setIsToastOn,
+  isToastOn = false,
+  setIsToastOn = () => {},
 ) => {
   if (!userData) return null;
 
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
       {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
-      <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />
+      {!isFromListOfUsers && (
+        <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />
+      )}
       {btnExport(userData)}
       <div>
         {userData.lastAction && formatDateToDisplay(userData.lastAction)}


### PR DESCRIPTION
## Summary
- Render toast toggle only for single profile cards
- Remove list view's toast state and button

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689dc3fd456c8326bafce64a32b118e1