### PR TITLE
Align search card caching with SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useAutoResize } from '../hooks/useAutoResize';
 import styled from 'styled-components';
-import { createCache, loadCache } from '../hooks/cardsCache';
+import { createCache, loadCache, saveCache } from '../hooks/cardsCache';
 import { getCacheKey } from '../utils/cache';
 
 const SearchIcon = (
@@ -314,7 +314,15 @@ const SearchBar = ({
   }, []);
 
   const cachedSearch = async params => {
-    return await searchFunc(params);
+    const res = await searchFunc(params);
+    if (res && Object.keys(res).length > 0) {
+      const [key, value] = Object.entries(params)[0] || [];
+      if (key && value) {
+        const cacheKey = getCacheKey('search', `${key}=${value}`);
+        saveCache(cacheKey, { raw: res });
+      }
+    }
+    return res;
   };
 
   const processUserSearch = async (platform, parseFunction, inputData) => {

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -1,8 +1,7 @@
 import { CardMenuBtn } from 'components/styles';
 import React from 'react';
-import { createCache } from '../../hooks/cardsCache';
-
-const { saveCache: saveSearchCache } = createCache('searchResults');
+import { saveCache } from '../../hooks/cardsCache';
+import { getCacheKey } from '../../utils/cache';
 
 // Use already loaded card data instead of re-fetching from the server
 export const btnEdit = (userData, setSearch, setState) => {
@@ -10,7 +9,8 @@ export const btnEdit = (userData, setSearch, setState) => {
     if (userData) {
       setSearch(`${userData.userId}`);
       setState(userData);
-      saveSearchCache(JSON.stringify({ userId: userData.userId }), userData);
+      const cacheKey = getCacheKey('search', `userId=${userData.userId}`);
+      saveCache(cacheKey, { raw: userData });
     } else {
       console.log('Користувача не знайдено.');
     }


### PR DESCRIPTION
## Summary
- switch smallCard edit button to use matching cache for search results
- persist SearchBar fetch results to the shared cache for reuse

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689ed2bc399083268fea7da7561c79d6