### PR TITLE
Persist unfavorited IDs and skip them in user loading

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -632,8 +632,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
     if (isEditingRef.current) return { count: 0, hasMore };
     const param = filterForload === 'DATE' ? dateOffset : lastKey;
-    let fav = getFavorites();
-    if (currentFilters.favorite?.favOnly && Object.keys(fav).length === 0) {
+    let favRaw = getFavorites();
+    let fav = Object.fromEntries(Object.entries(favRaw).filter(([, v]) => v));
+    if (currentFilters.favorite?.favOnly && Object.keys(favRaw).length === 0) {
       fav = await fetchFavoriteUsers(auth.currentUser.uid);
       setFavoriteUsersData(fav);
       syncFavorites(fav);
@@ -690,8 +691,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const loadMoreUsers2 = async (currentFilters = filters) => {
-    let fav = getFavorites();
-    if (currentFilters.favorite?.favOnly && Object.keys(fav).length === 0) {
+    let favRaw = getFavorites();
+    let fav = Object.fromEntries(Object.entries(favRaw).filter(([, v]) => v));
+    if (currentFilters.favorite?.favOnly && Object.keys(favRaw).length === 0) {
       fav = await fetchFavoriteUsers(auth.currentUser.uid);
       setFavoriteUsersData(fav);
       syncFavorites(fav);

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -28,10 +28,9 @@ export const BtnFavorite = ({
     if (isFavorite) {
       try {
         await removeFavoriteUser(userId);
-        const updated = { ...favoriteUsers };
-        delete updated[userId];
+        const updated = { ...favoriteUsers, [userId]: false };
         setFavoriteUsers(updated);
-        setFavoriteIds(updated);
+        setFavoriteIds(Object.fromEntries(Object.entries(updated).filter(([, v]) => v)));
         updateCachedUser(userData || { userId }, { forceFavorite: true, removeFavorite: true });
         setFavorite(userId, false);
         if (onRemove) onRemove(userId);

--- a/src/utils/__tests__/favoritesStorage.test.js
+++ b/src/utils/__tests__/favoritesStorage.test.js
@@ -1,0 +1,20 @@
+import { getFavorites, setFavorite } from '../favoritesStorage';
+
+describe('favoritesStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores false for unfavorited ids instead of deleting', () => {
+    setFavorite('1', true);
+    setFavorite('2', false);
+    expect(getFavorites()).toEqual({ '1': true, '2': false });
+  });
+
+  it('retains unfavorited ids to avoid refetching', () => {
+    setFavorite('42', false);
+    const favs = getFavorites();
+    expect(favs['42']).toBe(false);
+    expect(Object.keys(favs)).toEqual(['42']);
+  });
+});

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -2,7 +2,10 @@ export const FAVORITES_KEY = 'favorites';
 
 export const getFavorites = () => {
   try {
-    return JSON.parse(localStorage.getItem(FAVORITES_KEY)) || {};
+    const raw = JSON.parse(localStorage.getItem(FAVORITES_KEY)) || {};
+    return Object.fromEntries(
+      Object.entries(raw).map(([k, v]) => [k, !!v]),
+    );
   } catch {
     return {};
   }
@@ -11,11 +14,7 @@ export const getFavorites = () => {
 export const setFavorite = (id, isFav) => {
   try {
     const favs = getFavorites();
-    if (isFav) {
-      favs[id] = true;
-    } else {
-      delete favs[id];
-    }
+    favs[id] = !!isFav;
     localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
   } catch {
     // ignore write errors


### PR DESCRIPTION
## Summary
- Preserve unfavorited IDs in local storage with boolean states and expose them via `getFavorites`
- Ignore explicitly unfavorited IDs when loading more users and when removing favorites
- Add tests for favorite storage to ensure unfavorited IDs are retained

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689ed543dc18832699c5d83979c72b8e