### PR TITLE
Add local storage filtering with backend logic

### DIFF
--- a/src/utils/__tests__/getFilteredCardsByList.test.js
+++ b/src/utils/__tests__/getFilteredCardsByList.test.js
@@ -1,0 +1,40 @@
+import { getFilteredCardsByList } from '../cardsStorage';
+
+jest.mock('../../components/config', () => ({
+  filterMain: jest.fn(users => users.filter(([, u]) => u.ok)),
+}));
+
+describe('getFilteredCardsByList', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('filters stored cards and fetches more when needed', async () => {
+    const now = Date.now();
+    localStorage.setItem('cards', JSON.stringify({
+      a: { id: 'a', ok: true, updatedAt: now },
+      b: { id: 'b', ok: false, updatedAt: now },
+    }));
+    localStorage.setItem('testList', JSON.stringify(['a', 'b']));
+
+    const fetchMore = jest.fn(async count => {
+      expect(count).toBe(1);
+      return [['c', { ok: true }]];
+    });
+
+    const res = await getFilteredCardsByList(
+      'testList',
+      fetchMore,
+      'DATE2',
+      {},
+      {},
+      2,
+    );
+
+    expect(res.map(c => c.id)).toEqual(['a', 'c']);
+    const storedCards = JSON.parse(localStorage.getItem('cards'));
+    expect(storedCards.c.ok).toBe(true);
+    const ids = JSON.parse(localStorage.getItem('testList'));
+    expect(ids).toContain('c');
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `getFilteredCardsByList` to filter cards from local storage using existing backend filter logic and fetch additional cards when needed
- Add tests for local storage filtering behavior

## Testing
- `CI=true npm test -- src/utils/__tests__/cardsStorage.test.js src/utils/__tests__/getFilteredCardsByList.test.js src/components/__tests__/fetchFilteredUsersByPage.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689f87e277a8832696a81def14e87533