### PR TITLE
Sync search cache with user updates

### DIFF
--- a/src/hooks/cardsCache.js
+++ b/src/hooks/cardsCache.js
@@ -1,5 +1,9 @@
 const TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
+// Builds a cache key for cards list depending on mode and optional search term
+export const getCacheKey = (mode, term) =>
+  `cards:${mode}${term ? `:${term}` : ''}`;
+
 export const createCache = (prefix, ttl = TTL_MS) => {
   const CACHE_PREFIX = `${prefix}:`;
 

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -1,0 +1,34 @@
+import { updateCachedUser } from '../cache';
+import { getCacheKey, loadCache, saveCache } from '../../hooks/cardsCache';
+
+describe('updateCachedUser search cache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('updates search cache entries with new data', () => {
+    const oldUser = { userId: '1', name: 'John', favorite: false };
+    saveCache(getCacheKey('search', 'userId=1'), { raw: oldUser });
+    saveCache(getCacheKey('search', 'name=John'), { raw: { '1': oldUser } });
+
+    const updatedUser = { userId: '1', name: 'John', favorite: true };
+    updateCachedUser(updatedUser);
+
+    const byId = loadCache(getCacheKey('search', 'userId=1'));
+    const byName = loadCache(getCacheKey('search', 'name=John'));
+
+    expect(byId.raw.favorite).toBe(true);
+    expect(byName.raw['1'].favorite).toBe(true);
+  });
+
+  it('removes search cache entries on removeFavorite', () => {
+    const user = { userId: '1', name: 'John', favorite: true };
+    saveCache(getCacheKey('search', 'userId=1'), { raw: user });
+    saveCache(getCacheKey('search', 'name=John'), { raw: { '1': user } });
+
+    updateCachedUser(user, { removeFavorite: true });
+
+    expect(loadCache(getCacheKey('search', 'userId=1'))).toBeNull();
+    expect(loadCache(getCacheKey('search', 'name=John'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- expose `getCacheKey` in cards cache utilities
- update user cache to refresh or clear search results entries
- test search cache is updated and removed appropriately

## Testing
- `npm test -- src/utils/__tests__/cache.test.js`
- `npx eslint src/hooks/cardsCache.js src/utils/cache.js src/utils/__tests__/cache.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689fa94905d083268cdb1e232abc4cd1