### PR TITLE
fix cache key handling when search criteria changes

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -458,11 +458,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [favoriteUsersData, setFavoriteUsersData] = useState({});
   const [dislikeUsersData, setDislikeUsersData] = useState({});
   const [isToastOn, setIsToastOn] = useState(false);
+  const prevCacheKey = useRef(buildAddCacheKey(currentFilter, filters, search));
 
   useEffect(() => {
-    const cacheKey = buildAddCacheKey(currentFilter, filters, search);
-    mergeAddCache(cacheKey, { users, lastKey, hasMore, totalCount });
-  }, [users, lastKey, hasMore, totalCount, currentFilter, filters, search]);
+    mergeAddCache(prevCacheKey.current, { users, lastKey, hasMore, totalCount });
+  }, [users, lastKey, hasMore, totalCount]);
 
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
   const isDateInRange = dateStr => {
@@ -509,6 +509,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     const cacheKey = buildAddCacheKey(currentFilter, filters, search);
+    // зберігаємо попередні дані перед зміною ключа
+    mergeAddCache(prevCacheKey.current, { users, lastKey, hasMore, totalCount });
+    prevCacheKey.current = cacheKey;
+
     setAddCacheKeys(cacheKey, buildAddCacheKey('FAVORITE', filters, search));
     const cached = loadAddCache(cacheKey);
     if (cached) {


### PR DESCRIPTION
## Summary
- prevent merging old results into new cache key by tracking previous key with a ref
- update cache only when data changes and persist previous key state before reloading

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689fa78a53808326b1d537b7bf2ffa8a