### PR TITLE
Limit addNewProfile cache clearing to cards and filters

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -59,6 +59,8 @@ import {
   buildAddCacheKey,
   setAddCacheKeys,
   setFavoriteIds,
+  clearAllCardsCache,
+  clearAddCache,
 } from 'utils/cache';
 
 const Container = styled.div`
@@ -916,7 +918,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const handleClearCache = () => {
-    localStorage.clear();
+    clearAllCardsCache();
+    clearAddCache();
+    localStorage.removeItem('addFilters');
     toast.success('Cache cleared');
   };
 

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -17,6 +17,15 @@ export const clearAllCardsCache = () => {
     .forEach(key => localStorage.removeItem(key));
 };
 
+// Removes all cached AddNewProfile data
+export const clearAddCache = () => {
+  const ADD_PREFIX = 'addCache:';
+
+  Object.keys(localStorage)
+    .filter(key => key.startsWith(ADD_PREFIX))
+    .forEach(key => localStorage.removeItem(key));
+};
+
 // ----- AddNewProfile cache helpers -----
 
 export const buildAddCacheKey = (mode, filters = {}, term = '') =>


### PR DESCRIPTION
## Summary
- Narrow cache clearing to only cards and filter data on AddNewProfile
- Add utility to purge AddNewProfile caches without touching other storage

## Testing
- `npm run lint:js`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a03a791628832684eba022f785a2a1