### PR TITLE
Remove default load2 on AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -455,7 +455,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [lastKey, setLastKey] = useState(null); // Стан для зберігання останнього ключа
   const [totalCount, setTotalCount] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
-  const [currentFilter, setCurrentFilter] = useState('DATE2');
+  const [currentFilter, setCurrentFilter] = useState('');
   const [dateOffset, setDateOffset] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
   const [favoriteUsersData, setFavoriteUsersData] = useState({});


### PR DESCRIPTION
## Summary
- Stop loading 'load2' list by default on AddNewProfile by starting with no active filter

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a05ee0471c8326bd7f33e65a07b8be