### PR TITLE
refactor: move test imports to top

### DIFF
--- a/src/components/__tests__/makeNewUser.test.js
+++ b/src/components/__tests__/makeNewUser.test.js
@@ -1,3 +1,6 @@
+import { makeNewUser } from '../config';
+import * as db from 'firebase/database';
+
 jest.mock('firebase/app', () => ({
   initializeApp: jest.fn(() => ({})),
 }));
@@ -47,9 +50,6 @@ jest.mock('firebase/database', () => ({
   equalTo: jest.fn(),
   runTransaction: jest.fn(),
 }));
-
-import { makeNewUser } from '../config';
-import * as db from 'firebase/database';
 
 describe('makeNewUser', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- reorder imports to top in makeNewUser test

## Testing
- `CI=true npm test src/components/__tests__/makeNewUser.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a06c68a3948326ab4100b1714a887b