### PR TITLE
fix: avoid parsing phone numbers as userId

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -193,6 +193,8 @@ const parseUserId = input => {
   const pattern = /(?:\bId\s*[:\s]+)(\w+)/i;
   const match = trimmed.match(pattern);
   const candidate = (match ? match[1] : trimmed).trim();
+  const normalized = candidate.replace(/[+\s()-]/g, '');
+  if (/^(?:0|380)\d{9}$/.test(normalized)) return null;
   if (/^-?[a-zA-Z0-9]{4,}$/.test(candidate)) return candidate;
   return null;
 };
@@ -212,7 +214,7 @@ const parseTelegramId = input => {
 
 const parseOtherContact = input => input;
 
-const detectSearchParams = query => {
+export const detectSearchParams = query => {
   const trimmed = query.trim();
   const parsers = [
     ['facebook', parseFacebookId],

--- a/src/components/__tests__/SearchBar.test.js
+++ b/src/components/__tests__/SearchBar.test.js
@@ -1,0 +1,13 @@
+import { detectSearchParams } from '../SearchBar';
+
+describe('detectSearchParams', () => {
+  it('detects phone numbers starting with 0 as phone', () => {
+    const result = detectSearchParams('0957209136');
+    expect(result).toEqual({ key: 'phone', value: '380957209136' });
+  });
+
+  it('detects numeric userId when not phone-like', () => {
+    const result = detectSearchParams('123456');
+    expect(result).toEqual({ key: 'userId', value: '123456' });
+  });
+});


### PR DESCRIPTION
## Summary
- avoid misclassifying phone numbers as userId in SearchBar
- test phone vs userId detection

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06f9b724c83268893eb376237c7bd