### PR TITLE
Use Local Storage for load2 card list

### DIFF
--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -66,6 +66,7 @@ export const updateCachedUser = (
     mergeAddCache(currentAddCacheKey, { users: { [user.userId]: user } });
   }
   updateCard(user.userId, user);
+  addCardToList(user.userId, 'load2');
   const shouldFav = forceFavorite || isFavorite(user.userId);
 
   const searchKeys = [getCacheKey('search', normalizeQueryKey(`userId=${user.userId}`))];


### PR DESCRIPTION
## Summary
- Save cards to `load2` list whenever a cached user is updated
- Cache fetched users in AddNewProfile and load existing `load2` cards from Local Storage

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a0c517f2888326aa5f4a8ef9f3a6b7