### PR TITLE
feat: cache load2 cards by filters

### DIFF
--- a/src/utils/__tests__/load2Storage.test.js
+++ b/src/utils/__tests__/load2Storage.test.js
@@ -1,0 +1,17 @@
+import { cacheLoad2Users, getLoad2Cards, buildLoad2Key } from '../load2Storage';
+
+describe('load2Storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores ids by filters and retrieves cards', async () => {
+    const filters = { city: 'Kyiv' };
+    cacheLoad2Users({ '1': { title: 'Card 1' } }, filters);
+    const cards = await getLoad2Cards(filters);
+    expect(cards[0].title).toBe('Card 1');
+    const queries = JSON.parse(localStorage.getItem('queries'));
+    const key = buildLoad2Key(filters);
+    expect(queries[key].ids).toEqual(['1']);
+  });
+});

--- a/src/utils/load2Storage.js
+++ b/src/utils/load2Storage.js
@@ -1,0 +1,16 @@
+import { addCardToList, updateCard, getCardsByList } from './cardsStorage';
+import { normalizeQueryKey } from './cardIndex';
+
+export const buildLoad2Key = (filters = {}) =>
+  normalizeQueryKey(`load2:${JSON.stringify(filters || {})}`);
+
+export const cacheLoad2Users = (usersObj, filters = {}) => {
+  const listKey = buildLoad2Key(filters);
+  Object.entries(usersObj).forEach(([id, data]) => {
+    updateCard(id, data);
+    addCardToList(id, listKey);
+  });
+};
+
+export const getLoad2Cards = (filters = {}, remoteFetch) =>
+  getCardsByList(buildLoad2Key(filters), remoteFetch);


### PR DESCRIPTION
## Summary
- store load2 cards in local storage keyed by active filters
- reuse cached IDs to rebuild cards without server requests
- add tests for filter-based load2 caching

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a0d9e23cc4832692cceaaf86673d4d