### PR TITLE
Use separate caches for load2 and favorite cards

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import toast from 'react-hot-toast';
 import styled from 'styled-components';
 // import { FaUser, FaTelegramPlane, FaFacebookF, FaInstagram, FaVk, FaMailBulk, FaPhone } from 'react-icons/fa';
@@ -38,7 +38,7 @@ import { VerifyEmail } from './VerifyEmail';
 import { color, coloredCard } from './styles';
 //import { formatPhoneNumber } from './inputValidations';
 import { UsersList } from './UsersList';
-import { getFavorites, syncFavorites } from 'utils/favoritesStorage';
+import { getFavorites, syncFavorites, cacheFavoriteUsers } from 'utils/favoritesStorage';
 import { getLoad2Cards, cacheLoad2Users } from 'utils/load2Storage';
 // import ExcelToJson from './ExcelToJson';
 import { saveToContact } from './ExportContact';
@@ -229,10 +229,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const navigate = useNavigate();
   const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
-
-  const cacheFetchedUsers = (usersObj, currentFilters = filters) => {
-    cacheLoad2Users(usersObj, currentFilters);
-  };
 
   useEffect(() => {
     profileSync.init();
@@ -468,6 +464,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [dislikeUsersData, setDislikeUsersData] = useState({});
   const [isToastOn, setIsToastOn] = useState(false);
   const prevCacheKey = useRef(buildAddCacheKey(currentFilter, filters, search));
+
+  const cacheFetchedUsers = useCallback(
+    (usersObj, currentFilters = filters, mode = currentFilter) => {
+      if (mode === 'FAVORITE') {
+        cacheFavoriteUsers(usersObj);
+      } else {
+        cacheLoad2Users(usersObj, currentFilters);
+      }
+    },
+    [filters, currentFilter]
+  );
 
   useEffect(() => {
     mergeAddCache(prevCacheKey.current, { users, lastKey, hasMore, totalCount });

--- a/src/utils/__tests__/favoritesStorage.test.js
+++ b/src/utils/__tests__/favoritesStorage.test.js
@@ -1,4 +1,4 @@
-import { getFavorites, setFavorite } from '../favoritesStorage';
+import { getFavorites, setFavorite, cacheFavoriteUsers, getFavoriteCards } from '../favoritesStorage';
 
 describe('favoritesStorage', () => {
   beforeEach(() => {
@@ -16,5 +16,13 @@ describe('favoritesStorage', () => {
     const favs = getFavorites();
     expect(favs['42']).toBe(false);
     expect(Object.keys(favs)).toEqual(['42']);
+  });
+
+  it('caches favorite users separately from load2', async () => {
+    cacheFavoriteUsers({ '1': { title: 'Fav Card' } });
+    const cards = await getFavoriteCards();
+    expect(cards[0].title).toBe('Fav Card');
+    const queries = JSON.parse(localStorage.getItem('queries'));
+    expect(queries['favorite'].ids).toEqual(['1']);
   });
 });

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -1,4 +1,7 @@
+import { addCardToList, updateCard, getCardsByList } from './cardsStorage';
+
 export const FAVORITES_KEY = 'favorites';
+const FAVORITE_LIST_KEY = 'favorite';
 
 export const getFavorites = () => {
   try {
@@ -28,4 +31,14 @@ export const syncFavorites = remoteFavs => {
     // ignore write errors
   }
 };
+
+export const cacheFavoriteUsers = usersObj => {
+  Object.entries(usersObj).forEach(([id, data]) => {
+    updateCard(id, data);
+    addCardToList(id, FAVORITE_LIST_KEY);
+  });
+};
+
+export const getFavoriteCards = (remoteFetch) =>
+  getCardsByList(FAVORITE_LIST_KEY, remoteFetch);
 


### PR DESCRIPTION
## Summary
- Cache favorite card details separately from load2 lists
- Split AddNewProfile cache helper to route data into load2 or favorite lists
- Cover favorite card caching with unit tests

## Testing
- `npm test -- src/utils/__tests__/favoritesStorage.test.js --watchAll=false`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a194f540908326a0628cacd3c214fd