### PR TITLE
feat: cache dislike cards and sync statuses

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -6,9 +6,13 @@ import {
   auth,
 } from '../config';
 import { color } from '../styles';
+import { setDislike, cacheDislikedUsers } from 'utils/dislikesStorage';
+import { setFavorite } from 'utils/favoritesStorage';
+import { removeCardFromList } from 'utils/cardsStorage';
 
 export const BtnDislike = ({
   userId,
+  userData = {},
   dislikeUsers = {},
   setDislikeUsers,
   onRemove,
@@ -28,6 +32,8 @@ export const BtnDislike = ({
         const updated = { ...dislikeUsers };
         delete updated[userId];
         setDislikeUsers(updated);
+        setDislike(userId, false);
+        removeCardFromList(userId, 'dislike');
         if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to remove dislike:', error);
@@ -35,7 +41,10 @@ export const BtnDislike = ({
     } else {
       try {
         await addDislikeUser(userId);
-        setDislikeUsers({ ...dislikeUsers, [userId]: true });
+        const updated = { ...dislikeUsers, [userId]: true };
+        setDislikeUsers(updated);
+        setDislike(userId, true);
+        cacheDislikedUsers({ [userId]: userData });
         if (favoriteUsers[userId]) {
           try {
             await removeFavoriteUser(userId);
@@ -45,6 +54,7 @@ export const BtnDislike = ({
           const upd = { ...favoriteUsers };
           delete upd[userId];
           if (setFavoriteUsers) setFavoriteUsers(upd);
+          setFavorite(userId, false);
           if (onRemove) onRemove(userId);
         } else if (onRemove) {
           onRemove(userId);

--- a/src/utils/dislikesStorage.js
+++ b/src/utils/dislikesStorage.js
@@ -1,0 +1,49 @@
+import { addCardToList, updateCard, getCardsByList, removeCardFromList } from './cardsStorage';
+
+export const DISLIKES_KEY = 'dislikes';
+const DISLIKE_LIST_KEY = 'dislike';
+
+export const getDislikes = () => {
+  try {
+    const raw = JSON.parse(localStorage.getItem(DISLIKES_KEY)) || {};
+    return Object.fromEntries(Object.entries(raw).map(([k, v]) => [k, !!v]));
+  } catch {
+    return {};
+  }
+};
+
+export const setDislike = (id, isDisliked) => {
+  try {
+    const dislikes = getDislikes();
+    if (isDisliked) {
+      dislikes[id] = true;
+    } else {
+      delete dislikes[id];
+    }
+    localStorage.setItem(DISLIKES_KEY, JSON.stringify(dislikes));
+    if (!isDisliked) {
+      removeCardFromList(id, DISLIKE_LIST_KEY);
+    }
+  } catch {
+    // ignore write errors
+  }
+};
+
+export const syncDislikes = remoteDislikes => {
+  try {
+    localStorage.setItem(DISLIKES_KEY, JSON.stringify(remoteDislikes || {}));
+  } catch {
+    // ignore write errors
+  }
+};
+
+export const cacheDislikedUsers = usersObj => {
+  Object.entries(usersObj).forEach(([id, data]) => {
+    updateCard(id, data);
+    addCardToList(id, DISLIKE_LIST_KEY);
+  });
+};
+
+export const getDislikedCards = remoteFetch =>
+  getCardsByList(DISLIKE_LIST_KEY, remoteFetch);
+


### PR DESCRIPTION
## Summary
- store disliked card IDs and data in local storage
- sync like/dislike states with backend and filter matched cards
- persist favorite/dislike cards for offline access

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22f644530832681d59c8514bb4d57