### PR TITLE
Sync cached user on profile submit

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -62,6 +62,7 @@ import {
   setFavoriteIds,
   clearAllCardsCache,
   clearAddCache,
+  updateCachedUser,
 } from 'utils/cache';
 
 const Container = styled.div`
@@ -270,6 +271,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const updatedState = newState ? { ...newState, lastAction: currentDate } : { ...state, lastAction: currentDate };
 
     const syncedState = await profileSync.update(updatedState);
+    updateCachedUser(syncedState);
     cacheFetchedUsers({ [syncedState.userId]: syncedState });
     setUsers(prev => ({ ...prev, [syncedState.userId]: syncedState }));
 


### PR DESCRIPTION
## Summary
- ensure local cache reflects updates by importing and calling `updateCachedUser` in AddNewProfile submit handler

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a2346b0d548326b12b8daf60e0c02a