### PR TITLE
Ensure edited profiles update local cache

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -13,8 +13,8 @@ import { ProfileForm } from './ProfileForm';
 import { renderTopBlock } from "./smallCard/renderTopBlock";
 import { coloredCard } from "./styles";
 import { createLocalFirstSync } from '../hooks/localServerSync';
-import { updateCard } from '../utils/cardsStorage';
 import { mergeCache, getCacheKey } from '../hooks/cardsCache';
+import { updateCachedUser } from '../utils/cache';
 
 const Container = styled.div`
   display: flex;
@@ -114,7 +114,7 @@ const EditProfile = () => {
       ? { ...newState, lastAction: currentDate }
       : { ...state, lastAction: currentDate };
 
-    updateCard(updatedState.userId, updatedState);
+    updateCachedUser(updatedState);
     mergeCache(getCacheKey('default'), {
       users: { [updatedState.userId]: updatedState },
     });


### PR DESCRIPTION
## Summary
- Update EditProfile to propagate changes to local storage caches via `updateCachedUser`
- Keep card lists in sync after edits by merging updated data into caches

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4181f2eb8832697691d4fa8ce30ff