### PR TITLE
Fix clearAllCardsCache not removing base storage keys

### DIFF
--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -1,4 +1,4 @@
-import { updateCachedUser } from '../cache';
+import { updateCachedUser, clearAllCardsCache } from '../cache';
 import { getCacheKey, loadCache, saveCache } from '../../hooks/cardsCache';
 import { normalizeQueryKey } from '../cardIndex';
 
@@ -31,5 +31,29 @@ describe('updateCachedUser search cache', () => {
 
     expect(loadCache(getCacheKey('search', normalizeQueryKey('userId=1')))).toBeNull();
     expect(loadCache(getCacheKey('search', normalizeQueryKey('name=John')))).toBeNull();
+  });
+});
+
+describe('clearAllCardsCache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('removes matching cache and related keys', () => {
+    localStorage.setItem('matchingCache:cards:default', 'cached');
+    localStorage.setItem('cards', '{}');
+    localStorage.setItem('queries', '{}');
+    localStorage.setItem('favorites', '{}');
+    localStorage.setItem('favorite', '[]');
+    localStorage.setItem('other', 'value');
+
+    clearAllCardsCache();
+
+    expect(localStorage.getItem('matchingCache:cards:default')).toBeNull();
+    expect(localStorage.getItem('cards')).toBeNull();
+    expect(localStorage.getItem('queries')).toBeNull();
+    expect(localStorage.getItem('favorites')).toBeNull();
+    expect(localStorage.getItem('favorite')).toBeNull();
+    expect(localStorage.getItem('other')).toBe('value');
   });
 });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -12,10 +12,13 @@ export { getCacheKey, loadCache, saveCache };
 // Removes all cached card lists regardless of mode or search term
 export const clearAllCardsCache = () => {
   const CARDS_PREFIX = 'matchingCache:cards:';
+  const EXTRA_KEYS = ['cards', 'queries', 'favorites', 'favorite'];
 
   Object.keys(localStorage)
     .filter(key => key.startsWith(CARDS_PREFIX))
     .forEach(key => localStorage.removeItem(key));
+
+  EXTRA_KEYS.forEach(key => localStorage.removeItem(key));
 };
 
 // Removes all cached AddNewProfile data


### PR DESCRIPTION
## Summary
- extend `clearAllCardsCache` to also wipe `cards`, `queries`, `favorites`, and `favorite`
- test cache clearing behavior for all related keys

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4bb6265ac832691bf1c9329eebf26