### PR TITLE
Restore favorites after local storage reset

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -44,6 +44,7 @@ import {
   getFavoriteCards,
 } from 'utils/favoritesStorage';
 import { getLoad2Cards, cacheLoad2Users } from 'utils/load2Storage';
+import { setIdsForQuery } from 'utils/cardIndex';
 // import ExcelToJson from './ExcelToJson';
 import { saveToContact } from './ExportContact';
 import { renderTopBlock } from './smallCard/renderTopBlock';
@@ -870,8 +871,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const loadFavoriteUsers = async () => {
     const owner = auth.currentUser?.uid;
     if (!owner) return;
-    const favIds = await fetchFavoriteUsers(owner);
+
+    let favIds = getFavorites();
+    if (!Object.keys(favIds).length) {
+      favIds = await fetchFavoriteUsers(owner);
+      syncFavorites(favIds);
+    }
+
     setFavoriteUsersData(favIds);
+    setFavoriteIds(favIds);
+    setIdsForQuery('favorite', Object.keys(favIds));
     const loadedArr = await getFavoriteCards(id => fetchUserById(id));
     const sorted = loadedArr
       .sort((a, b) => compareUsersByGetInTouch(a, b))


### PR DESCRIPTION
## Summary
- Ensure favorite IDs repopulate query cache when loading favorites
- Keep favorite ID cache in sync so favorites display after clearing storage
- Prefer locally cached favorite IDs and only hit backend when missing

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a4e1cb623c8326abecfb5b84e60042