### PR TITLE
Replace DATE2 addCache with cardsStorage list

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -123,7 +123,7 @@ Add New Profile page.
 
 The Add New Profile page now caches favorites and date-based results using
 `cardsStorage` query lists (`favorite`, `load2`) instead of dedicated
-`addCache` keys.
+`addCache` keys. Other filters still rely on `addCache` for offline support.
 
 ## Features
 - Added 43+ age filter for profile search

--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ const favoriteCards = await getCardsByList('favorite', fetchCard);
 
 Страница `AddNewProfile` использует эти списки `favorite` и `load2` через
 `cardsStorage`, избавившись от отдельного кеша `addCache` для избранного и
-загрузки по датам (`DATE2`).
+загрузки по датам (`DATE2`). `addCache` остаётся для офлайн‑режима при других фильтрах.

--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -792,8 +792,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       offset = slice.length;
       setDateOffset2(offset);
       setHasMore(filteredArr.length > slice.length);
-      const cacheKey = buildAddCacheKey('DATE2', currentFilters, search);
-      if (slice.length >= PAGE_SIZE && loadAddCache(cacheKey) !== undefined) {
+      if (slice.length >= PAGE_SIZE) {
         return { count: slice.length, hasMore: filteredArr.length > slice.length };
       }
     }


### PR DESCRIPTION
## Summary
- avoid addCache lookup for DATE2 and rely on cardsStorage query list
- clarify documentation that addCache is only used for offline mode on other filters

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68a5b02bd2c8832685a32dd282b1bd17