### PR TITLE
fix: preserve local edits when caching user cards

### DIFF
--- a/src/utils/dislikesStorage.js
+++ b/src/utils/dislikesStorage.js
@@ -1,4 +1,10 @@
-import { addCardToList, updateCard, getCardsByList, removeCardFromList } from './cardsStorage';
+import {
+  addCardToList,
+  updateCard,
+  getCardsByList,
+  removeCardFromList,
+} from './cardsStorage';
+import { loadCards } from './cardIndex';
 
 export const DISLIKES_KEY = 'dislikes';
 const DISLIKE_LIST_KEY = 'dislike';
@@ -38,8 +44,10 @@ export const syncDislikes = remoteDislikes => {
 };
 
 export const cacheDislikedUsers = usersObj => {
+  const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    updateCard(id, data);
+    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    updateCard(id, merged);
     addCardToList(id, DISLIKE_LIST_KEY);
   });
 };

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -1,4 +1,5 @@
 import { addCardToList, updateCard, getCardsByList } from './cardsStorage';
+import { loadCards } from './cardIndex';
 
 export const FAVORITES_KEY = 'favorites';
 const FAVORITE_LIST_KEY = 'favorite';
@@ -33,8 +34,10 @@ export const syncFavorites = remoteFavs => {
 };
 
 export const cacheFavoriteUsers = usersObj => {
+  const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    updateCard(id, data);
+    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    updateCard(id, merged);
     addCardToList(id, FAVORITE_LIST_KEY);
   });
 };

--- a/src/utils/load2Storage.js
+++ b/src/utils/load2Storage.js
@@ -1,13 +1,15 @@
 import { addCardToList, updateCard, getCardsByList } from './cardsStorage';
-import { normalizeQueryKey } from './cardIndex';
+import { normalizeQueryKey, loadCards } from './cardIndex';
 
 export const buildLoad2Key = (filters = {}) =>
   normalizeQueryKey(`load2:${JSON.stringify(filters || {})}`);
 
 export const cacheLoad2Users = (usersObj, filters = {}) => {
   const listKey = buildLoad2Key(filters);
+  const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    updateCard(id, data);
+    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    updateCard(id, merged);
     addCardToList(id, listKey);
   });
 };


### PR DESCRIPTION
## Summary
- ensure favorite cache merges server data with existing local cards
- keep load2 cache consistent with latest local edits
- maintain local overrides for disliked user cache

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a5d99ae1ec8326af45d5f825806430