### PR TITLE
fix: include initialFav in AddNewProfile effect

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -527,7 +527,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     setFavoriteIds(initialFav);
-  }, []);
+  }, [initialFav]);
 
   useEffect(() => {
     if (!ownerId) return;


### PR DESCRIPTION
## Summary
- include `initialFav` in AddNewProfile's `useEffect` dependency list to satisfy React Hooks lint rules

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa23aef48c83269a497450ace8493d