### PR TITLE
refactor: store favorite flags under queries key

### DIFF
--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -52,7 +52,7 @@ describe('clearAllCardsCache', () => {
     localStorage.setItem('matchingCache:cards:default', 'cached');
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
-    localStorage.setItem('favorites', '{}');
+    localStorage.setItem('queries/favorite', '{}');
     localStorage.setItem('favorite', '[]');
     localStorage.setItem('other', 'value');
 
@@ -61,7 +61,7 @@ describe('clearAllCardsCache', () => {
     expect(localStorage.getItem('matchingCache:cards:default')).toBeNull();
     expect(localStorage.getItem('cards')).toBeNull();
     expect(localStorage.getItem('queries')).toBeNull();
-    expect(localStorage.getItem('favorites')).toBeNull();
+    expect(localStorage.getItem('queries/favorite')).toBeNull();
     expect(localStorage.getItem('favorite')).toBeNull();
     expect(localStorage.getItem('other')).toBe('value');
   });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -12,7 +12,7 @@ export { getCacheKey, loadCache, saveCache };
 // Removes all cached card lists regardless of mode or search term
 export const clearAllCardsCache = () => {
   const CARDS_PREFIX = 'matchingCache:cards:';
-  const EXTRA_KEYS = ['cards', 'queries', 'favorites', 'favorite'];
+  const EXTRA_KEYS = ['cards', 'queries', 'queries/favorite', 'favorite'];
 
   Object.keys(localStorage)
     .filter(key => key.startsWith(CARDS_PREFIX))

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -1,7 +1,7 @@
 import { addCardToList, updateCard, getCardsByList } from './cardsStorage';
 import { loadCards } from './cardIndex';
 
-export const FAVORITES_KEY = 'favorites';
+export const FAVORITES_KEY = 'queries/favorite';
 const FAVORITE_LIST_KEY = 'favorite';
 
 export const getFavorites = () => {


### PR DESCRIPTION
## Summary
- store favorite true/false map under `queries/favorite` key
- clear cache now removes `queries/favorite`
- align tests with updated storage key

## Testing
- `npm test -- src/utils/__tests__/favoritesStorage.test.js src/utils/__tests__/cache.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d6febb4832690adfdb826194111