### PR TITLE
Remove forceFavorite handling from cache updates

### DIFF
--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -31,7 +31,7 @@ export const BtnFavorite = ({
         const updated = { ...favoriteUsers, [userId]: false };
         setFavoriteUsers(updated);
         setFavoriteIds(Object.fromEntries(Object.entries(updated).filter(([, v]) => v)));
-        updateCachedUser(userData || { userId }, { forceFavorite: true, removeFavorite: true });
+        updateCachedUser(userData || { userId }, { removeFavorite: true });
         setFavorite(userId, false);
         if (onRemove) onRemove(userId);
       } catch (error) {
@@ -43,7 +43,7 @@ export const BtnFavorite = ({
         const updatedFav = { ...favoriteUsers, [userId]: true };
         setFavoriteUsers(updatedFav);
         setFavoriteIds(updatedFav);
-        updateCachedUser(userData || { userId }, { forceFavorite: true });
+        updateCachedUser(userData || { userId });
         setFavorite(userId, true);
         if (dislikeUsers[userId]) {
           try {

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -106,7 +106,7 @@ export const fieldGetInTouch = (
           setFavoriteUsers(upd);
           setFavoriteIds(upd);
           setFavorite(userData.userId, false);
-          updateCachedUser(userData, { forceFavorite: true, removeFavorite: true });
+          updateCachedUser(userData, { removeFavorite: true });
         }
       } catch (error) {
         console.error('Failed to add dislike:', error);
@@ -128,7 +128,7 @@ export const fieldGetInTouch = (
         setFavoriteUsers(updated);
         setFavoriteIds(updated);
         setFavorite(userData.userId, false);
-        updateCachedUser(userData, { forceFavorite: true, removeFavorite: true });
+        updateCachedUser(userData, { removeFavorite: true });
       } catch (error) {
         console.error('Failed to remove favorite:', error);
       }
@@ -139,7 +139,7 @@ export const fieldGetInTouch = (
         setFavoriteUsers(updated);
         setFavoriteIds(updated);
         setFavorite(userData.userId, true);
-        updateCachedUser(userData, { forceFavorite: true });
+        updateCachedUser(userData);
         if (dislikeUsers[userData.userId]) {
           try {
             await removeDislikeUser(userData.userId);

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -1,4 +1,4 @@
-import { updateCachedUser, clearAllCardsCache } from '../cache';
+import { updateCachedUser, clearAllCardsCache, setFavoriteIds } from '../cache';
 import { getCacheKey, loadCache, saveCache } from '../../hooks/cardsCache';
 import { normalizeQueryKey, getIdsByQuery } from '../cardIndex';
 
@@ -35,7 +35,8 @@ describe('updateCachedUser search cache', () => {
 
   it('updates favorite and load2 lists', () => {
     const user = { userId: '1', name: 'John' };
-    updateCachedUser(user, { forceFavorite: true });
+    setFavoriteIds({ '1': true });
+    updateCachedUser(user);
     expect(getIdsByQuery('favorite')).toContain('1');
     expect(getIdsByQuery('load2')).toContain('1');
     updateCachedUser(user, { removeFavorite: true });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -29,13 +29,10 @@ export const setFavoriteIds = fav => {
 
 const isFavorite = id => !!favoriteIds[id];
 
-export const updateCachedUser = (
-  user,
-  { forceFavorite = false, removeFavorite = false } = {},
-) => {
+export const updateCachedUser = (user, { removeFavorite = false } = {}) => {
   updateCard(user.userId, user);
   addCardToList(user.userId, 'load2');
-  const shouldFav = forceFavorite || isFavorite(user.userId);
+  const shouldFav = isFavorite(user.userId);
 
   const searchKeys = [getCacheKey('search', normalizeQueryKey(`userId=${user.userId}`))];
   if (typeof user.name === 'string') {


### PR DESCRIPTION
## Summary
- remove forceFavorite option from updateCachedUser and its callers
- update tests to manage favorite IDs directly

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68ab492851e08326a98b45590738f645