### PR TITLE
Persist favorites only via queries

### DIFF
--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -53,8 +53,6 @@ describe('clearAllCardsCache', () => {
     localStorage.setItem('matchingCache:cards:default', 'cached');
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
-    localStorage.setItem('favorites', '{}');
-    localStorage.setItem('favorite', '[]');
     localStorage.setItem('other', 'value');
 
     clearAllCardsCache();
@@ -62,8 +60,6 @@ describe('clearAllCardsCache', () => {
     expect(localStorage.getItem('matchingCache:cards:default')).toBeNull();
     expect(localStorage.getItem('cards')).toBeNull();
     expect(localStorage.getItem('queries')).toBeNull();
-    expect(localStorage.getItem('favorites')).toBeNull();
-    expect(localStorage.getItem('favorite')).toBeNull();
     expect(localStorage.getItem('other')).toBe('value');
   });
 });

--- a/src/utils/__tests__/favoritesStorage.test.js
+++ b/src/utils/__tests__/favoritesStorage.test.js
@@ -10,17 +10,17 @@ describe('favoritesStorage', () => {
     localStorage.clear();
   });
 
-  it('stores false for unfavorited ids instead of deleting', () => {
+  it('stores favorite ids only in queries', () => {
     setFavorite('1', true);
-    setFavorite('2', false);
-    expect(getFavorites()).toEqual({ '1': true, '2': false });
+    setFavorite('2', true);
+    setFavorite('1', false);
+    const queries = JSON.parse(localStorage.getItem('queries'));
+    expect(queries['favorite'].ids).toEqual(['2']);
   });
 
-  it('retains unfavorited ids to avoid refetching', () => {
-    setFavorite('42', false);
-    const favs = getFavorites();
-    expect(favs['42']).toBe(false);
-    expect(Object.keys(favs)).toEqual(['42']);
+  it('retrieves favorites from queries', () => {
+    setFavorite('1', true);
+    expect(getFavorites()).toEqual({ '1': true });
   });
 
   it('caches favorite users separately from load2', async () => {

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,13 +1,13 @@
 import { getCacheKey, loadCache, saveCache } from 'hooks/cardsCache';
 import { updateCard, addCardToList, removeCardFromList } from './cardsStorage';
-import { normalizeQueryKey } from './cardIndex';
+import { normalizeQueryKey, setIdsForQuery } from './cardIndex';
 
 export { getCacheKey, loadCache, saveCache };
 
 // Removes all cached card lists regardless of mode or search term
 export const clearAllCardsCache = () => {
   const CARDS_PREFIX = 'matchingCache:cards:';
-  const EXTRA_KEYS = ['cards', 'queries', 'favorites', 'favorite'];
+  const EXTRA_KEYS = ['cards', 'queries'];
 
   Object.keys(localStorage)
     .filter(key => key.startsWith(CARDS_PREFIX))
@@ -20,11 +20,8 @@ let favoriteIds = {};
 
 export const setFavoriteIds = fav => {
   favoriteIds = fav || {};
-  try {
-    localStorage.setItem('favorite', JSON.stringify(Object.keys(favoriteIds)));
-  } catch {
-    // ignore write errors
-  }
+  const ids = Object.keys(favoriteIds).filter(id => favoriteIds[id]);
+  setIdsForQuery('favorite', ids);
 };
 
 const isFavorite = id => !!favoriteIds[id];


### PR DESCRIPTION
## Summary
- store favorite card ids solely under `queries.favorite`
- update caching utilities to sync favorites with query list
- revise tests for new favorites persistence

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68ab6bb98b408326b4d953fcd5482784