### PR TITLE
feat: cache dislike ids locally

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -45,6 +45,7 @@ import {
   getFavoriteCards,
 } from 'utils/favoritesStorage';
 import { getLoad2Cards, cacheLoad2Users } from 'utils/load2Storage';
+import { getDislikes, syncDislikes } from 'utils/dislikesStorage';
 import {
   setIdsForQuery,
   getIdsByQuery,
@@ -466,7 +467,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [dateOffset2, setDateOffset2] = useState(0);
   const initialFav = getFavorites();
   const [favoriteUsersData, setFavoriteUsersData] = useState(initialFav);
-  const [dislikeUsersData, setDislikeUsersData] = useState({});
+  const initialDis = getDislikes();
+  const [dislikeUsersData, setDislikeUsersData] = useState(initialDis);
   const [isToastOn, setIsToastOn] = useState(false);
 
   const cacheFetchedUsers = useCallback(
@@ -526,7 +528,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     const disRef = ref(database, `multiData/dislikes/${ownerId}`);
     const unsubscribe = onValue(disRef, snap => {
-      setDislikeUsersData(snap.exists() ? snap.val() : {});
+      const data = snap.exists() ? snap.val() : {};
+      setDislikeUsersData(data);
+      syncDislikes(data);
     });
 
     return () => unsubscribe();

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -8,6 +8,7 @@ import {
 import { color } from '../styles';
 import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 import { setFavorite } from 'utils/favoritesStorage';
+import { setDislike } from 'utils/dislikesStorage';
 
 export const BtnFavorite = ({
   userId,
@@ -54,6 +55,7 @@ export const BtnFavorite = ({
           const upd = { ...dislikeUsers };
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
+          setDislike(userId, false);
           if (onRemove) onRemove(userId);
         }
       } catch (error) {

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -14,6 +14,7 @@ import {
 } from '../config';
 import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 import { setFavorite } from 'utils/favoritesStorage';
+import { setDislike } from 'utils/dislikesStorage';
 
 export const fieldGetInTouch = (
   userData,
@@ -76,6 +77,7 @@ export const fieldGetInTouch = (
         const updated = { ...dislikeUsers };
         delete updated[userData.userId];
         setDislikeUsers(updated);
+        setDislike(userData.userId, false);
         handleChange(
           setUsers,
           setState,
@@ -95,6 +97,7 @@ export const fieldGetInTouch = (
         await addDislikeUser(userData.userId);
         const updated = { ...dislikeUsers, [userData.userId]: true };
         setDislikeUsers(updated);
+        setDislike(userData.userId, true);
         if (favoriteUsers[userData.userId]) {
           try {
             await removeFavoriteUser(userData.userId);
@@ -149,6 +152,7 @@ export const fieldGetInTouch = (
           const upd = { ...dislikeUsers };
           delete upd[userData.userId];
           setDislikeUsers(upd);
+          setDislike(userData.userId, false);
           handleChange(
             setUsers,
             setState,


### PR DESCRIPTION
## Summary
- persist disliked user IDs in local queries for offline access
- sync dislike lists on AddNewProfile and small card actions
- ensure liking clears corresponding dislike entries

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac381a2cac83268f4a872ad58e46e8