### PR TITLE
feat: update lists after liking or disliking cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -965,6 +965,20 @@ const Matching = () => {
     dislikeUsersRef.current = dislikeUsers;
   }, [dislikeUsers]);
 
+  useEffect(() => {
+    setUsers(prev => {
+      if (viewMode === 'favorites') {
+        return prev.filter(u => favoriteUsers[u.userId]);
+      }
+      if (viewMode === 'dislikes') {
+        return prev.filter(u => dislikeUsers[u.userId]);
+      }
+      return prev.filter(
+        u => !favoriteUsers[u.userId] && !dislikeUsers[u.userId]
+      );
+    });
+  }, [favoriteUsers, dislikeUsers, viewMode]);
+
   const loadCommentsFor = async list => {
     const owner = auth.currentUser?.uid;
     if (!owner) return;


### PR DESCRIPTION
## Summary
- remove liked or disliked cards from current list
- keep lists synced when switching between favorites and dislikes

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68acc5a399d48326bff3b557ae737502