### PR TITLE
Add main list button for liked/disliked matching views

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -34,7 +34,7 @@ import { getCacheKey, clearAllCardsCache, setFavoriteIds } from "../utils/cache"
 import { normalizeQueryKey, getIdsByQuery, setIdsForQuery } from '../utils/cardIndex';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
-import { FaFilter, FaTimes, FaHeart, FaEllipsisV, FaArrowDown } from 'react-icons/fa';
+import { FaFilter, FaTimes, FaHeart, FaEllipsisV, FaArrowDown, FaDownload } from 'react-icons/fa';
 import { handleEmptyFetch } from './loadMoreUtils';
 import {
   normalizeCountry,
@@ -1377,8 +1377,16 @@ const Matching = () => {
             <CardCount>{filteredUsers.length} карточок</CardCount>
             <TopActions>
               <ActionButton onClick={() => setShowFilters(s => !s)}><FaFilter /></ActionButton>
-              <ActionButton onClick={loadDislikeCards}><FaTimes /></ActionButton>
-              <ActionButton onClick={loadFavoriteCards}><FaHeart /></ActionButton>
+              {viewMode === 'dislikes' ? (
+                <ActionButton onClick={loadInitial}><FaDownload /></ActionButton>
+              ) : (
+                <ActionButton onClick={loadDislikeCards}><FaTimes /></ActionButton>
+              )}
+              {viewMode === 'favorites' ? (
+                <ActionButton onClick={loadInitial}><FaDownload /></ActionButton>
+              ) : (
+                <ActionButton onClick={loadFavoriteCards}><FaHeart /></ActionButton>
+              )}
               <ActionButton onClick={() => setShowInfoModal('dotsMenu')}><FaEllipsisV /></ActionButton>
             </TopActions>
           </HeaderContainer>


### PR DESCRIPTION
## Summary
- replace like/dislike action button with a main list button when viewing liked or disliked cards
- add download icon for returning to the main list

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68accff0f3748326baf82ac6eb785d2d