### PR TITLE
Animate match list on card removal

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -34,7 +34,7 @@ export const BtnDislike = ({
         setDislikeUsers(updated);
         setDislike(userId, false);
         removeCardFromList(userId, 'dislike');
-        if (onRemove) onRemove(userId);
+        if (onRemove) onRemove(userId, 'down');
       } catch (error) {
         console.error('Failed to remove dislike:', error);
       }
@@ -55,9 +55,9 @@ export const BtnDislike = ({
           delete upd[userId];
           if (setFavoriteUsers) setFavoriteUsers(upd);
           setFavorite(userId, false);
-          if (onRemove) onRemove(userId);
+          if (onRemove) onRemove(userId, 'down');
         } else if (onRemove) {
-          onRemove(userId);
+          onRemove(userId, 'down');
         }
       } catch (error) {
         console.error('Failed to add dislike:', error);

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -34,7 +34,7 @@ export const BtnFavorite = ({
         setFavoriteIds(Object.fromEntries(Object.entries(updated).filter(([, v]) => v)));
         updateCachedUser(userData || { userId }, { removeFavorite: true });
         setFavorite(userId, false);
-        if (onRemove) onRemove(userId);
+        if (onRemove) onRemove(userId, 'down');
       } catch (error) {
         console.error('Failed to remove favorite:', error);
       }
@@ -56,7 +56,7 @@ export const BtnFavorite = ({
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
           setDislike(userId, false);
-          if (onRemove) onRemove(userId);
+          if (onRemove) onRemove(userId, 'up');
         }
       } catch (error) {
         console.error('Failed to add favorite:', error);


### PR DESCRIPTION
## Summary
- animate match list items collapsing with directional slide when removing cards
- wire favorite/dislike buttons to pass slide direction for animations

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68ade75824ac8326a40fec4ee7cc7866