### PR TITLE
Optimistically update profile cache on edit

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -271,9 +271,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     };
     const currentDate = formatDate(new Date());
 
-    const updatedState = newState ? { ...newState, lastAction: currentDate } : { ...state, lastAction: currentDate };
+    const updatedState = newState
+      ? { ...newState, lastAction: currentDate }
+      : { ...state, lastAction: currentDate };
+
+    // Optimistically update local cache and UI state before syncing with server
+    updateCachedUser(updatedState);
+    cacheFetchedUsers({ [updatedState.userId]: updatedState }, cacheLoad2Users, filters);
+    setUsers(prev => ({ ...prev, [updatedState.userId]: updatedState }));
 
     const syncedState = await profileSync.update(updatedState);
+    // Ensure caches stay in sync with server response
     updateCachedUser(syncedState);
     cacheFetchedUsers({ [syncedState.userId]: syncedState }, cacheLoad2Users, filters);
     setUsers(prev => ({ ...prev, [syncedState.userId]: syncedState }));


### PR DESCRIPTION
## Summary
- update local card cache and users state before server sync when editing profiles
- ensure cache stays consistent after sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf37fc7d88326b23b77acd317cea8