### PR TITLE
Separate transform and collapse phases for card removal

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -96,14 +96,7 @@ const CardContainer = styled.div`
   width: 100%;
   overflow: hidden;
   max-height: 1000px;
-  transition: max-height 0.3s ease, margin 0.3s ease, opacity 0.3s ease,
-    transform 0.3s ease;
-
-  &.removing {
-    max-height: 0;
-    margin: 0;
-    opacity: 0;
-  }
+  transition: transform 0.3s ease;
 
   &.removing.up {
     transform: translateY(-100%);
@@ -111,6 +104,13 @@ const CardContainer = styled.div`
 
   &.removing.down {
     transform: translateY(100%);
+  }
+
+  &.collapsing {
+    transition: max-height 0.3s ease, margin 0.3s ease, opacity 0.3s ease;
+    max-height: 0;
+    margin: 0;
+    opacity: 0;
   }
 `;
 
@@ -924,7 +924,27 @@ const Matching = () => {
     sessionStorage.setItem(SCROLL_Y_KEY, String(scrollPositionRef.current));
   };
   const handleRemove = (id, dir = 'up') => {
-    setRemoving(prev => ({ ...prev, [id]: dir }));
+    setRemoving(prev => ({ ...prev, [id]: { dir, collapsing: false } }));
+
+    const el = document.getElementById(`card-${id}`);
+    if (!el) return;
+
+    const startCollapse = e => {
+      if (e.propertyName !== 'transform') return;
+      setRemoving(prev => ({
+        ...prev,
+        [id]: { ...prev[id], collapsing: true },
+      }));
+      el.removeEventListener('transitionend', startCollapse);
+      el.addEventListener('transitionend', finishRemoval, { once: true });
+    };
+
+    const finishRemoval = e => {
+      if (e.propertyName !== 'max-height') return;
+      handleTransitionEnd(id);
+    };
+
+    el.addEventListener('transitionend', startCollapse, { once: true });
   };
 
   const handleTransitionEnd = id => {
@@ -1453,18 +1473,14 @@ const Matching = () => {
                 return (
                   <CardContainer
                     key={user.userId}
+                    id={`card-${user.userId}`}
                     className={
-                      removing[user.userId] ? `removing ${removing[user.userId]}` : ''
+                      removing[user.userId]
+                        ? `removing ${removing[user.userId].dir} ${
+                            removing[user.userId].collapsing ? 'collapsing' : ''
+                          }`
+                        : ''
                     }
-                    onTransitionEnd={e => {
-                      if (
-                        e.propertyName === 'max-height' &&
-                        e.target === e.currentTarget &&
-                        removing[user.userId]
-                      ) {
-                        handleTransitionEnd(user.userId);
-                      }
-                    }}
                   >
                     {thirdVariant && (
                       <ThirdInfoCard>


### PR DESCRIPTION
## Summary
- animate card transform first, then collapse height/margin/opacity after transition
- trigger collapse and removal in `handleRemove` using transition events

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68ae0366c1148326be1b5eb5fef810c3