### PR TITLE
Improve card removal transitions in Matching view

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -96,7 +96,7 @@ const CardContainer = styled.div`
   width: 100%;
   overflow: hidden;
   max-height: 1000px;
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, max-height 0.3s ease, margin 0.3s ease, opacity 0.3s ease;
 
   &.removing.up {
     transform: translateY(-100%);
@@ -107,7 +107,6 @@ const CardContainer = styled.div`
   }
 
   &.collapsing {
-    transition: max-height 0.3s ease, margin 0.3s ease, opacity 0.3s ease;
     max-height: 0;
     margin: 0;
     opacity: 0;
@@ -936,15 +935,16 @@ const Matching = () => {
         [id]: { ...prev[id], collapsing: true },
       }));
       el.removeEventListener('transitionend', startCollapse);
-      el.addEventListener('transitionend', finishRemoval, { once: true });
     };
 
     const finishRemoval = e => {
       if (e.propertyName !== 'max-height') return;
+      el.removeEventListener('transitionend', finishRemoval);
       handleTransitionEnd(id);
     };
 
-    el.addEventListener('transitionend', startCollapse, { once: true });
+    el.addEventListener('transitionend', startCollapse);
+    el.addEventListener('transitionend', finishRemoval);
   };
 
   const handleTransitionEnd = id => {


### PR DESCRIPTION
## Summary
- smooth card animations by transitioning transform, max-height, margin and opacity
- simplify collapse styles and handle transitionend for transform and max-height separately

## Testing
- `npx eslint src/components/Matching.jsx`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae228b48848326acd2faf864712b55