### PR TITLE
Respect reduced motion in card removal animations

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -97,6 +97,11 @@ const CardContainer = styled.div`
   overflow: hidden;
   max-height: 1000px;
   transition: transform 0.3s ease, max-height 0.3s ease, margin 0.3s ease, opacity 0.3s ease;
+  will-change: transform, max-height, margin, opacity;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 
   &.removing.up {
     transform: translateY(-100%);


### PR DESCRIPTION
## Summary
- honor `prefers-reduced-motion` to disable card removal transitions
- hint browser about upcoming animations with `will-change` for smoother updates

## Testing
- `CI=true npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae27e546a083268b92ce59f833092b