### PR TITLE
chore: drop legacy users indexes

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -19,7 +19,6 @@ import {
   // removeSearchId,
   // createSearchIdsForAllUsers,
   createSearchIdsInCollection,
-  createIndexesSequentiallyInCollection,
   fetchUserById,
   loadDuplicateUsers,
   removeCardAndSearchId,
@@ -951,13 +950,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     // });
   };
 
-  const indexData = async () => {
-    const collections = ['newUsers', 'users'];
-    for (const col of collections) {
-      await createIndexesSequentiallyInCollection(col);
-    }
-  };
-
   const indexLastLoginHandler = async () => {
     toast.loading('Indexing lastLogin2 0%', { id: 'index-lastlogin-progress' });
     await indexLastLogin(progress => {
@@ -1099,7 +1091,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 Load2
               </Button>
               <Button onClick={() => setCurrentFilter('FAVORITE')}>❤</Button>
-              <Button onClick={indexData}>IndData</Button>
               <Button onClick={indexLastLoginHandler}>indexLastLogin</Button>
               <Button onClick={makeIndex}>Index</Button>
               {<Button onClick={searchDuplicates}>DPL</Button>}

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -564,8 +564,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         await updateDataInNewUsersRTDB(
           userCredential.user.uid,
           { lastLogin2: todayDash },
-          'update',
-          true
+          'update'
         );
       } else {
         userCredential = await createUserWithEmailAndPassword(auth, state.email, state.password);
@@ -584,8 +583,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         await updateDataInNewUsersRTDB(
           userCredential.user.uid,
           { lastLogin2: todayDash },
-          'update',
-          true
+          'update'
         );
       }
 
@@ -686,16 +684,14 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         await updateDataInNewUsersRTDB(
           user.uid,
           { lastLogin2: todayDash },
-          'update',
-          true
+          'update'
         );
         Object.assign(processedData, defaults);
       } else {
         await updateDataInNewUsersRTDB(
           user.uid,
           { lastLogin2: todayDash },
-          'update',
-          true
+          'update'
         );
       }
 


### PR DESCRIPTION
## Summary
- remove usersIndex helpers and searchId-skip flag usage
- keep searchId updates in RTDB writes
- drop unused indexing imports and UI elements

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af2b2af3388326affabadc10f51b2b