### PR TITLE
Animate card removal after like/dislike

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -759,7 +759,7 @@ const SwipeableCard = ({
         setFavoriteUsers={setFavoriteUsers}
         dislikeUsers={dislikeUsers}
         setDislikeUsers={setDislikeUsers}
-        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+        onRemove={handleRemove}
       />
       <BtnDislike
         userId={user.userId}
@@ -768,7 +768,7 @@ const SwipeableCard = ({
         setDislikeUsers={setDislikeUsers}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
-        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+        onRemove={handleRemove}
       />
       {current === 'main' && isAgency && (
         <CardInfo>

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -56,8 +56,8 @@ export const BtnFavorite = ({
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
           setDislike(userId, false);
-          if (onRemove) onRemove(userId, 'up');
         }
+        if (onRemove) onRemove(userId, 'up');
       } catch (error) {
         console.error('Failed to add favorite:', error);
       }


### PR DESCRIPTION
## Summary
- Animate card removal when liking or disliking so next cards slide up smoothly
- Ensure favoriting a card triggers the same removal animation

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af2e4e97e883268479e2ae9318d795