### PR TITLE
Keep favorites/dislikes buttons and add main list shortcut on matching page

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -282,6 +282,11 @@ const ActionButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
+  &:disabled {
+    background-color: ${color.gray3};
+    color: ${color.gray4};
+    cursor: default;
+  }
 `;
 
 const HeaderContainer = styled.div`
@@ -1428,17 +1433,22 @@ const Matching = () => {
           <HeaderContainer>
             <CardCount>{filteredUsers.length} карточок</CardCount>
             <TopActions>
+              {viewMode !== 'default' && (
+                <ActionButton onClick={loadInitial}><FaDownload /></ActionButton>
+              )}
               <ActionButton onClick={() => setShowFilters(s => !s)}><FaFilter /></ActionButton>
-              {viewMode === 'dislikes' ? (
-                <ActionButton onClick={loadInitial}><FaDownload /></ActionButton>
-              ) : (
-                <ActionButton onClick={loadDislikeCards}><FaTimes /></ActionButton>
-              )}
-              {viewMode === 'favorites' ? (
-                <ActionButton onClick={loadInitial}><FaDownload /></ActionButton>
-              ) : (
-                <ActionButton onClick={loadFavoriteCards}><FaHeart /></ActionButton>
-              )}
+              <ActionButton
+                onClick={loadDislikeCards}
+                disabled={viewMode === 'dislikes'}
+              >
+                <FaTimes />
+              </ActionButton>
+              <ActionButton
+                onClick={loadFavoriteCards}
+                disabled={viewMode === 'favorites'}
+              >
+                <FaHeart />
+              </ActionButton>
               <ActionButton onClick={() => setShowInfoModal('dotsMenu')}><FaEllipsisV /></ActionButton>
             </TopActions>
           </HeaderContainer>


### PR DESCRIPTION
## Summary
- Keep favorite and dislike buttons visible in matching view and disable them when their list is active
- Add a main list button next to the filter to return from favorites or dislikes view
- Style action buttons to turn gray when disabled

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68af2f601fb88326bae9e62bce8a84cc