### PR TITLE
feat: sync profile form with local cache

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -235,23 +235,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     profileSync.init();
+    const cachedProfile = profileSync.getData();
+    if (cachedProfile) {
+      setState(cachedProfile);
+    }
+
     if (!search) {
       const storedSearch = localStorage.getItem(SEARCH_KEY);
       if (storedSearch) {
         setSearch(storedSearch);
-        return;
       }
-
-      // Clear any leftover cached profile data so a blank form is shown
-      profileSync.update(null);
-      setState({});
-
-      const intervalId = setInterval(() => {
-        profileSync.pollServer();
-      }, 5000);
-      return () => clearInterval(intervalId);
     }
-  }, [search, state.userId]);
+  }, [search]);
 
   const handleBlur = () => {
     handleSubmit();
@@ -588,6 +583,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleAddUser = async () => {
     setAdding(true);
     const newProfile = await makeNewUser(searchKeyValuePair);
+    updateCachedUser(newProfile);
+    cacheFetchedUsers({ [newProfile.userId]: newProfile }, cacheLoad2Users, filters);
+    setUsers(prev => ({ ...prev, [newProfile.userId]: newProfile }));
     await profileSync.update(newProfile);
     setState(newProfile);
     setUserNotFound(false);


### PR DESCRIPTION
## Summary
- load cached profile data on mount for immediate display
- update cache and user lists when creating a new profile
- drop interval-based polling from AddNewProfile

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68b02a98d8348326a36146a110a46c8d