### PR TITLE
Add smooth removal animation for matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -94,6 +94,11 @@ const Grid = styled.div`
 const CardContainer = styled.div`
   position: relative;
   width: 100%;
+  &.removing {
+    transform: translateY(-100%);
+    opacity: 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
 `;
 
 const NextPhoto = styled.img`
@@ -901,6 +906,7 @@ const Matching = () => {
   const [comments, setComments] = useState({});
   const [showFilters, setShowFilters] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
+  const [removingId, setRemovingId] = useState(null);
   const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
@@ -909,9 +915,7 @@ const Matching = () => {
   const saveScrollPosition = () => {
     sessionStorage.setItem(SCROLL_Y_KEY, String(scrollPositionRef.current));
   };
-  const handleRemove = id => {
-    setUsers(prev => prev.filter(u => u.userId !== id));
-  };
+  const handleRemove = id => setRemovingId(id);
   useEffect(() => {
     window.history.scrollRestoration = 'manual';
     const handleScroll = () => {
@@ -1433,8 +1437,19 @@ const Matching = () => {
                   .filter(Boolean)
                   .map(v => String(v).trim())
                   .join(' ');
+                const isRemoving = user.userId === removingId;
                 return (
-                  <CardContainer key={user.userId}>
+                  <CardContainer
+                    key={user.userId}
+                    isRemoving={isRemoving}
+                    className={isRemoving ? 'removing' : ''}
+                    onTransitionEnd={() =>
+                      isRemoving &&
+                      setUsers(prev =>
+                        prev.filter(u => u.userId !== removingId)
+                      )
+                    }
+                  >
                     {thirdVariant && (
                       <ThirdInfoCard>
                         <InfoCardContent user={user} variant={thirdVariant} />

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -56,8 +56,8 @@ export const BtnFavorite = ({
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
           setDislike(userId, false);
-          if (onRemove) onRemove(userId);
         }
+        if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to add favorite:', error);
       }


### PR DESCRIPTION
## Summary
- animate matching cards out of view before deleting
- track card being removed via `removingId`
- remove liked cards through common handler

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b095fef4fc83268f160ff400974cbe