### PR TITLE
Reset search results when clearing SearchBar

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -991,6 +991,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           onClear={() => {
             setState({});
             setSearchKeyValuePair(null);
+            setUsers({});
+            setUserNotFound(false);
           }}
           storageKey={SEARCH_KEY}
         />


### PR DESCRIPTION
## Summary
- Reset users list and "not found" state when the search bar is cleared to remove previous cards and allow immediate new queries.

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b20d621cb8832683d8ff193b3137fa