### PR TITLE
fix: prevent search restore in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -230,13 +230,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
 
   useEffect(() => {
-    if (!search) {
-      const storedSearch = localStorage.getItem(SEARCH_KEY);
-      if (storedSearch) {
-        setSearch(storedSearch);
-      }
+    const storedSearch = localStorage.getItem(SEARCH_KEY);
+    if (storedSearch) {
+      setSearch(storedSearch);
     }
-  }, [search]);
+  }, []); // run once
 
   const handleBlur = () => {
     handleSubmit();
@@ -989,6 +987,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           setUserNotFound={setUserNotFound}
           onSearchKey={setSearchKeyValuePair}
           onClear={() => {
+            localStorage.removeItem(SEARCH_KEY);
             setState({});
             setSearchKeyValuePair(null);
             setUsers({});


### PR DESCRIPTION
## Summary
- load stored search only once when AddNewProfile mounts
- clear stored search value when search input is cleared

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b2167f12508326adac68757ded29dd