### PR TITLE
Refactor search caching to persist only card IDs

### DIFF
--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -1,8 +1,8 @@
 import { CardMenuBtn } from 'components/styles';
 import React from 'react';
-import { saveCache } from '../../hooks/cardsCache';
 import { getCacheKey } from '../../utils/cache';
-import { normalizeQueryKey } from '../../utils/cardIndex';
+import { normalizeQueryKey, setIdsForQuery } from '../../utils/cardIndex';
+import { saveCard } from '../../utils/cardsStorage';
 
 // Use already loaded card data instead of re-fetching from the server
 export const btnEdit = (userData, setSearch, setState) => {
@@ -11,7 +11,8 @@ export const btnEdit = (userData, setSearch, setState) => {
       setSearch(`${userData.userId}`);
       setState(userData);
       const cacheKey = getCacheKey('search', normalizeQueryKey(`userId=${userData.userId}`));
-      saveCache(cacheKey, { raw: userData });
+      saveCard({ ...userData, id: userData.userId });
+      setIdsForQuery(cacheKey, [userData.userId]);
     } else {
       console.log('Користувача не знайдено.');
     }

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -1,44 +1,21 @@
 import { updateCachedUser, clearAllCardsCache, setFavoriteIds } from '../cache';
-import { getCacheKey, loadCache, saveCache } from '../../hooks/cardsCache';
-import { normalizeQueryKey, getIdsByQuery } from '../cardIndex';
+import { getCard, getIdsByQuery } from '../cardIndex';
 
-describe('updateCachedUser search cache', () => {
+describe('updateCachedUser', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it('updates search cache entries with new data', () => {
-    const oldUser = { userId: '1', name: 'John', favorite: false };
-    saveCache(getCacheKey('search', normalizeQueryKey('userId=1')), { raw: oldUser });
-    saveCache(getCacheKey('search', normalizeQueryKey('name=John')), { raw: { '1': oldUser } });
-
-    const updatedUser = { userId: '1', name: 'John', favorite: true };
-    updateCachedUser(updatedUser);
-
-    const byId = loadCache(getCacheKey('search', normalizeQueryKey('userId=1')));
-    const byName = loadCache(getCacheKey('search', normalizeQueryKey('name=John')));
-
-    expect(byId.raw.favorite).toBe(true);
-    expect(byName.raw['1'].favorite).toBe(true);
-  });
-
-  it('removes search cache entries on removeFavorite', () => {
-    const user = { userId: '1', name: 'John', favorite: true };
-    saveCache(getCacheKey('search', normalizeQueryKey('userId=1')), { raw: user });
-    saveCache(getCacheKey('search', normalizeQueryKey('name=John')), { raw: { '1': user } });
-
-    updateCachedUser(user, { removeFavorite: true });
-
-    expect(loadCache(getCacheKey('search', normalizeQueryKey('userId=1')))).toBeNull();
-    expect(loadCache(getCacheKey('search', normalizeQueryKey('name=John')))).toBeNull();
-  });
-
-  it('updates favorite and load2 lists', () => {
+  it('updates card data and favorite/load2 lists', () => {
     const user = { userId: '1', name: 'John' };
     setFavoriteIds({ '1': true });
     updateCachedUser(user);
+
+    const stored = getCard('1');
+    expect(stored.name).toBe('John');
     expect(getIdsByQuery('favorite')).toContain('1');
     expect(getIdsByQuery('load2')).toContain('1');
+
     updateCachedUser(user, { removeFavorite: true });
     expect(getIdsByQuery('favorite')).not.toContain('1');
   });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,8 +1,8 @@
-import { getCacheKey, loadCache, saveCache } from 'hooks/cardsCache';
+import { getCacheKey } from 'hooks/cardsCache';
 import { updateCard, addCardToList, removeCardFromList } from './cardsStorage';
-import { normalizeQueryKey, setIdsForQuery } from './cardIndex';
+import { setIdsForQuery } from './cardIndex';
 
-export { getCacheKey, loadCache, saveCache };
+export { getCacheKey };
 
 // Removes all cached card lists regardless of mode or search term
 export const clearAllCardsCache = () => {
@@ -30,27 +30,6 @@ export const updateCachedUser = (user, { removeFavorite = false } = {}) => {
   updateCard(user.userId, user);
   addCardToList(user.userId, 'load2');
   const shouldFav = isFavorite(user.userId);
-
-  const searchKeys = [getCacheKey('search', normalizeQueryKey(`userId=${user.userId}`))];
-  if (typeof user.name === 'string') {
-    searchKeys.push(getCacheKey('search', normalizeQueryKey(`name=${user.name}`)));
-  }
-  searchKeys.forEach(key => {
-    const cached = loadCache(key);
-    if (!cached) return;
-    if (removeFavorite) {
-      localStorage.removeItem(`matchingCache:${key}`);
-      return;
-    }
-    const raw = cached.raw;
-    if (!raw) return;
-    if (raw.userId === user.userId) {
-      saveCache(key, { raw: { ...raw, ...user } });
-    } else if (raw[user.userId]) {
-      raw[user.userId] = { ...raw[user.userId], ...user };
-      saveCache(key, { raw });
-    }
-  });
 
   if (removeFavorite) {
     removeCardFromList(user.userId, 'favorite');


### PR DESCRIPTION
## Summary
- Drop raw search caches and rely on card ID lists backed by `cardsStorage`
- Update search and edit components to store IDs and snapshot cards
- Simplify `updateCachedUser` to use `cardsStorage.updateCard` and list helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31972f0f883269086ef422869ca78