### PR TITLE
feat: preserve auth when clearing cache

### DIFF
--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -26,10 +26,11 @@ describe('clearAllCardsCache', () => {
     localStorage.clear();
   });
 
-  it('removes matching cache and related keys', () => {
+  it('clears all cache except auth data', () => {
     localStorage.setItem('matchingCache:cards:default', 'cached');
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
+    localStorage.setItem('persist:auth', '{"token":"123"}');
     localStorage.setItem('other', 'value');
 
     clearAllCardsCache();
@@ -37,6 +38,7 @@ describe('clearAllCardsCache', () => {
     expect(localStorage.getItem('matchingCache:cards:default')).toBeNull();
     expect(localStorage.getItem('cards')).toBeNull();
     expect(localStorage.getItem('queries')).toBeNull();
-    expect(localStorage.getItem('other')).toBe('value');
+    expect(localStorage.getItem('other')).toBeNull();
+    expect(localStorage.getItem('persist:auth')).toBe('{"token":"123"}');
   });
 });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -4,16 +4,13 @@ import { setIdsForQuery } from './cardIndex';
 
 export { getCacheKey };
 
-// Removes all cached card lists regardless of mode or search term
+// Clears localStorage while preserving authentication state
 export const clearAllCardsCache = () => {
-  const CARDS_PREFIX = 'matchingCache:cards:';
-  const EXTRA_KEYS = ['cards', 'queries'];
+  const AUTH_KEYS = ['persist:auth', 'auth'];
 
   Object.keys(localStorage)
-    .filter(key => key.startsWith(CARDS_PREFIX))
+    .filter(key => !AUTH_KEYS.includes(key))
     .forEach(key => localStorage.removeItem(key));
-
-  EXTRA_KEYS.forEach(key => localStorage.removeItem(key));
 };
 
 let favoriteIds = {};


### PR DESCRIPTION
## Summary
- clear all localStorage except authentication data
- update cache tests for new behavior

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b32d7fb3508326b7b45187a95c7fdf