### PR TITLE
Group duplicate cards without date sorting

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -889,6 +889,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const [duplicates, setDuplicates] = useState('');
+  const [isDuplicateView, setIsDuplicateView] = useState(false);
 
   const searchDuplicates = async () => {
     const { mergedUsers, totalDuplicates } = await loadDuplicateUsers();
@@ -896,6 +897,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     cacheFetchedUsers(mergedUsers, cacheLoad2Users);
     setUsers(prevUsers => ({ ...prevUsers, ...mergedUsers }));
     setDuplicates(totalDuplicates);
+    setIsDuplicateView(true);
     // console.log('res!!!!!!!! :>> ', res.length);
   };
 
@@ -953,6 +955,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const totalPages = Math.ceil(totalCount / PAGE_SIZE) || 1;
   const getSortedIds = () => {
     const ids = Object.keys(users);
+    if (isDuplicateView) {
+      return ids;
+    }
     return ids.sort((a, b) =>
       compareUsersByGetInTouch(users[a] || {}, users[b] || {}),
     );
@@ -1057,6 +1062,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setCurrentPage(1);
                   setCurrentFilter('DATE');
                   setDateOffset(0);
+                  setDuplicates('');
+                  setIsDuplicateView(false);
                   loadMoreUsers('DATE');
                 }}
               >
@@ -1069,12 +1076,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setCurrentPage(1);
                   setCurrentFilter('DATE2');
                   setDateOffset2(0);
+                  setDuplicates('');
+                  setIsDuplicateView(false);
                   loadMoreUsers2();
                 }}
               >
                 Load2
               </Button>
-              <Button onClick={() => setCurrentFilter('FAVORITE')}>❤</Button>
+              <Button
+                onClick={() => {
+                  setCurrentFilter('FAVORITE');
+                  setDuplicates('');
+                  setIsDuplicateView(false);
+                }}
+              >
+                ❤
+              </Button>
               <Button onClick={indexLastLoginHandler}>indexLastLogin</Button>
               <Button onClick={makeIndex}>Index</Button>
               {<Button onClick={searchDuplicates}>DPL</Button>}


### PR DESCRIPTION
## Summary
- Avoid sorting by date when duplicate cards are loaded via DPL to keep duplicate pairs adjacent
- Reset duplicate view when reloading or filtering users

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b338f161288326a6d081d3546cbad6