### PR TITLE
Ensure cache updates after profile field deletion

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -408,6 +408,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       // Видалення ключа з Firebase
       removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
 
+      handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState; // Повертаємо оновлений стан
     });
   };

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -150,6 +150,7 @@ const EditProfile = () => {
       const deletedValue = newState[fieldName];
       delete newState[fieldName];
       removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
+      handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState;
     });
   };


### PR DESCRIPTION
## Summary
- update `handleDelKeyValue` in AddNewProfile and EditProfile to trigger `handleSubmit` and keep local cache in sync after Firebase deletions

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b33daebfe88326953d5f55bdef1fb0