### PR TITLE
Preserve duplicate list after editing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -996,7 +996,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             localStorage.removeItem(SEARCH_KEY);
             setState({});
             setSearchKeyValuePair(null);
-            setUsers({});
+            // У режимі перегляду дублікатів зберігаємо поточний список
+            if (!isDuplicateView) {
+              setUsers({});
+            }
             setUserNotFound(false);
           }}
           storageKey={SEARCH_KEY}


### PR DESCRIPTION
## Summary
- keep duplicate results when clearing search after editing a card

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b34572dda483269696c12d80df61d9