### PR TITLE
fix: allow back nav to duplicates

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -892,6 +892,26 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [duplicates, setDuplicates] = useState('');
   const [isDuplicateView, setIsDuplicateView] = useState(false);
 
+  useEffect(() => {
+    if (isDuplicateView && state.userId) {
+      const currentId = state.userId;
+      const handlePopState = () => {
+        setState({});
+        const el = document.getElementById(currentId);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      };
+
+      window.history.pushState({ duplicateEdit: true }, '');
+      window.addEventListener('popstate', handlePopState);
+
+      return () => {
+        window.removeEventListener('popstate', handlePopState);
+      };
+    }
+  }, [isDuplicateView, state.userId]);
+
   const searchDuplicates = async () => {
     const { mergedUsers, totalDuplicates } = await loadDuplicateUsers();
     // console.log('res :>> ', res);


### PR DESCRIPTION
## Summary
- return to duplicates list when pressing device back while editing

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68b3485e4fb48326888f59928d93e7a7