### PR TITLE
feat: allow removing fields from cached cards

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -258,7 +258,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       : { ...state, lastAction: currentDate };
 
     // Optimistically update local cache and UI state before syncing with server
-    updateCachedUser(updatedState);
+    const removeKeys = delCondition ? Object.keys(delCondition) : [];
+    updateCachedUser(updatedState, { removeKeys });
     cacheFetchedUsers({ [updatedState.userId]: updatedState }, cacheLoad2Users, filters);
     setUsers(prev => ({ ...prev, [updatedState.userId]: updatedState }));
 

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -99,7 +99,8 @@ const EditProfile = () => {
       ? { ...newState, lastAction: currentDate }
       : { ...state, lastAction: currentDate };
 
-    updateCachedUser(updatedState);
+    const removeKeys = delCondition ? Object.keys(delCondition) : [];
+    updateCachedUser(updatedState, { removeKeys });
     mergeCache(getCacheKey('default'), {
       users: { [updatedState.userId]: updatedState },
     });

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -19,6 +19,15 @@ describe('updateCachedUser', () => {
     updateCachedUser(user, { removeFavorite: true });
     expect(getIdsByQuery('favorite')).not.toContain('1');
   });
+
+  it('removes specified keys from cached user', () => {
+    const user = { userId: '1', name: 'John', email: 'john@example.com' };
+    updateCachedUser(user);
+    updateCachedUser({ userId: '1' }, { removeKeys: ['email'] });
+    const stored = getCard('1');
+    expect(stored.email).toBeUndefined();
+    expect(stored.name).toBe('John');
+  });
 });
 
 describe('clearAllCardsCache', () => {

--- a/src/utils/__tests__/cardsStorage.test.js
+++ b/src/utils/__tests__/cardsStorage.test.js
@@ -14,6 +14,14 @@ describe('cardsStorage', () => {
     expect(remoteSave).toHaveBeenCalledWith(card);
   });
 
+  it('removes specified keys from card', () => {
+    updateCard('1', { title: 'Old', email: 'a' });
+    updateCard('1', { title: 'New' }, undefined, ['email']);
+    const stored = JSON.parse(localStorage.getItem('cards'));
+    expect(stored['1'].email).toBeUndefined();
+    expect(stored['1'].title).toBe('New');
+  });
+
   it('shares updated data across lists without extra fetch', async () => {
     addCardToList('1', 'load2');
     addCardToList('1', 'favorite');

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -23,8 +23,11 @@ export const setFavoriteIds = fav => {
 
 const isFavorite = id => !!favoriteIds[id];
 
-export const updateCachedUser = (user, { removeFavorite = false } = {}) => {
-  updateCard(user.userId, user);
+export const updateCachedUser = (
+  user,
+  { removeFavorite = false, removeKeys = [] } = {},
+) => {
+  updateCard(user.userId, user, undefined, removeKeys);
   addCardToList(user.userId, 'load2');
   const shouldFav = isFavorite(user.userId);
 

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -22,7 +22,7 @@ export const removeCardFromList = (cardId, listKey) => {
   setIdsForQuery(listKey, ids);
 };
 
-export const updateCard = (cardId, data, remoteSave) => {
+export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
   const cards = loadCards();
   const updatedCard = {
     ...cards[cardId],
@@ -30,6 +30,9 @@ export const updateCard = (cardId, data, remoteSave) => {
     id: cardId,
     updatedAt: Date.now(),
   };
+  removeKeys.forEach(key => {
+    delete updatedCard[key];
+  });
   cards[cardId] = updatedCard;
   saveCards(cards);
   touchCardInQueries(cardId);


### PR DESCRIPTION
## Summary
- support removing keys when caching user cards
- propagate deleted field names from profile forms
- cover cache removal with tests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b349025dac83268eecf920a795c04a