### PR TITLE
Ensure back button returns to duplicates list after editing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1152,6 +1152,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setState={setState}
                   currentFilter={currentFilter}
                   isDateInRange={isDateInRange}
+                  isDuplicateView={isDuplicateView}
                 />
                 <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
               </>

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -123,6 +123,7 @@ const UsersList = ({
   setDislikeUsers,
   currentFilter,
   isDateInRange,
+  isDuplicateView,
 }) => {
   const entries = Object.entries(users);
 
@@ -177,7 +178,7 @@ const UsersList = ({
             </div>
           ) : (
             <>
-              {btnEdit(userData, setSearch, setState)}
+              {btnEdit(userData, setSearch, setState, isDuplicateView)}
               {btnCompare(index, users, setUsers, setShowInfoModal, setCompare, )}
               <UserCard
                 setShowInfoModal={setShowInfoModal}

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -5,10 +5,12 @@ import { normalizeQueryKey, setIdsForQuery } from '../../utils/cardIndex';
 import { saveCard } from '../../utils/cardsStorage';
 
 // Use already loaded card data instead of re-fetching from the server
-export const btnEdit = (userData, setSearch, setState) => {
+export const btnEdit = (userData, setSearch, setState, isDuplicateView = false) => {
   const handleCardClick = () => {
     if (userData) {
-      setSearch(`${userData.userId}`);
+      if (!isDuplicateView) {
+        setSearch(`${userData.userId}`);
+      }
       setState(userData);
       const cacheKey = getCacheKey('search', normalizeQueryKey(`userId=${userData.userId}`));
       saveCard({ ...userData, id: userData.userId });


### PR DESCRIPTION
## Summary
- Propagate duplicate view flag through UsersList and into edit button
- Skip search updates when editing duplicates so list persists

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68b353cf6b1483268efb4ea7743ed295