### PR TITLE
Store DPL results in queries

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -44,6 +44,7 @@ import {
   getFavoriteCards,
 } from 'utils/favoritesStorage';
 import { getLoad2Cards, cacheLoad2Users } from 'utils/load2Storage';
+import { cacheDplUsers } from 'utils/dplStorage';
 import { getDislikes, syncDislikes } from 'utils/dislikesStorage';
 import {
   setIdsForQuery,
@@ -894,7 +895,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const searchDuplicates = async () => {
     const { mergedUsers, totalDuplicates } = await loadDuplicateUsers();
     // console.log('res :>> ', res);
-    cacheFetchedUsers(mergedUsers, cacheLoad2Users);
+    cacheFetchedUsers(mergedUsers, cacheDplUsers);
     setUsers(prevUsers => ({ ...prevUsers, ...mergedUsers }));
     setDuplicates(totalDuplicates);
     setIsDuplicateView(true);

--- a/src/utils/__tests__/dplStorage.test.js
+++ b/src/utils/__tests__/dplStorage.test.js
@@ -1,0 +1,15 @@
+import { cacheDplUsers, getDplCards } from '../dplStorage';
+
+describe('dplStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores ids in queries and retrieves cards', async () => {
+    cacheDplUsers({ '1': { title: 'Card 1' } });
+    const cards = await getDplCards();
+    expect(cards[0].title).toBe('Card 1');
+    const queries = JSON.parse(localStorage.getItem('queries'));
+    expect(queries['dpl'].ids).toEqual(['1']);
+  });
+});

--- a/src/utils/dplStorage.js
+++ b/src/utils/dplStorage.js
@@ -1,0 +1,16 @@
+import { addCardToList, updateCard, getCardsByList } from './cardsStorage';
+import { loadCards } from './cardIndex';
+
+const DPL_LIST_KEY = 'dpl';
+
+export const cacheDplUsers = usersObj => {
+  const existing = loadCards();
+  Object.entries(usersObj).forEach(([id, data]) => {
+    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    updateCard(id, merged);
+    addCardToList(id, DPL_LIST_KEY);
+  });
+};
+
+export const getDplCards = remoteFetch =>
+  getCardsByList(DPL_LIST_KEY, remoteFetch);


### PR DESCRIPTION
## Summary
- Add local storage utilities for DPL results
- Persist duplicate search results to queries and update search workflow
- Cover DPL storage with tests

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b33bd6d54483268ef44c5fc401dda0