### PR TITLE
Persist duplicate view between sessions

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -893,6 +893,42 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [duplicates, setDuplicates] = useState('');
   const [isDuplicateView, setIsDuplicateView] = useState(false);
 
+  const clearDuplicateCache = useCallback(() => {
+    sessionStorage.removeItem('duplicateUsers');
+    sessionStorage.removeItem('isDuplicateView');
+    sessionStorage.removeItem('duplicatesTotal');
+  }, []);
+
+  useEffect(() => {
+    const flag = sessionStorage.getItem('isDuplicateView');
+    if (flag === 'true') {
+      const cachedUsers = sessionStorage.getItem('duplicateUsers');
+      if (cachedUsers) {
+        const parsed = JSON.parse(cachedUsers);
+        setUsers(prevUsers => ({ ...prevUsers, ...parsed }));
+        const dupCount = sessionStorage.getItem('duplicatesTotal');
+        if (dupCount) {
+          setDuplicates(Number(dupCount));
+        }
+      }
+      setIsDuplicateView(true);
+    }
+    return () => {
+      clearDuplicateCache();
+    };
+  }, [clearDuplicateCache]);
+
+  const firstRun = useRef(true);
+  useEffect(() => {
+    if (firstRun.current) {
+      firstRun.current = false;
+      return;
+    }
+    if (!isDuplicateView) {
+      clearDuplicateCache();
+    }
+  }, [isDuplicateView, clearDuplicateCache]);
+
   useEffect(() => {
     if (isDuplicateView && state.userId) {
       const currentId = state.userId;
@@ -919,6 +955,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     cacheFetchedUsers(mergedUsers, cacheLoad2Users);
     setUsers(prevUsers => ({ ...prevUsers, ...mergedUsers }));
     setDuplicates(totalDuplicates);
+    sessionStorage.setItem('duplicateUsers', JSON.stringify(mergedUsers));
+    sessionStorage.setItem('duplicatesTotal', String(totalDuplicates));
+    sessionStorage.setItem('isDuplicateView', 'true');
     setIsDuplicateView(true);
     // console.log('res!!!!!!!! :>> ', res.length);
   };


### PR DESCRIPTION
## Summary
- cache duplicate user results and duplicate-view flag in sessionStorage
- restore duplicate view from sessionStorage on mount
- clear duplicate cache when leaving the page or closing duplicate view

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b404cf1efc8326a692d29e82f77491