### PR TITLE
Add exit button to profile creation and refine cache clearing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -160,6 +160,12 @@ export const ExitButton = styled(SubmitButton)`
   }
 `;
 
+const TopButtons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
 // const iconMap = {
 //   user: <FaUser style={{ color: 'orange' }} />,
 //   mail: <FaMailBulk style={{ color: 'orange' }} />,
@@ -1035,15 +1041,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     <Container>
       <InnerContainer>
         {isLoggedIn && (
-          <DotsButton
-            onClick={() => {
-              setShowInfoModal('dotsMenu');
-            }}
-          >
-            ⋮
-          </DotsButton>
+          <TopButtons>
+            <DotsButton
+              style={{ marginLeft: 0 }}
+              onClick={() => {
+                setShowInfoModal('dotsMenu');
+              }}
+            >
+              ⋮
+            </DotsButton>
+            <ExitButton onClick={handleExit}>Exit</ExitButton>
+          </TopButtons>
         )}
-
 
         <SearchBar
           searchFunc={fetchNewUsersCollectionInRTDB}

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -35,11 +35,11 @@ describe('clearAllCardsCache', () => {
     localStorage.clear();
   });
 
-  it('clears all cache except auth data', () => {
+  it('clears all cache except login state', () => {
     localStorage.setItem('matchingCache:cards:default', 'cached');
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
-    localStorage.setItem('persist:auth', '{"token":"123"}');
+    localStorage.setItem('isLoggedIn', 'true');
     localStorage.setItem('other', 'value');
 
     clearAllCardsCache();
@@ -48,6 +48,6 @@ describe('clearAllCardsCache', () => {
     expect(localStorage.getItem('cards')).toBeNull();
     expect(localStorage.getItem('queries')).toBeNull();
     expect(localStorage.getItem('other')).toBeNull();
-    expect(localStorage.getItem('persist:auth')).toBe('{"token":"123"}');
+    expect(localStorage.getItem('isLoggedIn')).toBe('true');
   });
 });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -4,12 +4,12 @@ import { setIdsForQuery } from './cardIndex';
 
 export { getCacheKey };
 
-// Clears localStorage while preserving authentication state
+// Clears localStorage but preserves the login flag
 export const clearAllCardsCache = () => {
-  const AUTH_KEYS = ['persist:auth', 'auth'];
+  const KEEP_KEYS = ['isLoggedIn'];
 
   Object.keys(localStorage)
-    .filter(key => !AUTH_KEYS.includes(key))
+    .filter(key => !KEEP_KEYS.includes(key))
     .forEach(key => localStorage.removeItem(key));
 };
 


### PR DESCRIPTION
## Summary
- show an Exit button on the AddNewProfile page alongside the menu
- adjust cache clearing to keep only the `isLoggedIn` flag
- update tests for new cache-clearing behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42464f2d48326badba2cb55ffada8