### PR TITLE
Move Exit option to dots menu

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1036,7 +1036,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             >
               ⋮
             </DotsButton>
-            <ExitButton onClick={handleExit}>Exit</ExitButton>
           </TopButtons>
         )}
 


### PR DESCRIPTION
## Summary
- Remove extraneous Exit button from AddNewProfile top buttons, keeping Exit only in dots menu.

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b433fd0bd88326abc0c63003292605