### PR TITLE
Use cached duplicates before hitting server

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -946,13 +946,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [isDuplicateView, state.userId]);
 
   const searchDuplicates = async () => {
+    const cached = await getDplCards();
+    if (cached.length > 0) {
+      const merged = cached.reduce((acc, user) => {
+        acc[user.id] = user;
+        return acc;
+      }, {});
+      setUsers(prev => ({ ...prev, ...merged }));
+      setDuplicates(Math.floor(cached.length / 2));
+      setIsDuplicateView(true);
+      return;
+    }
     const { mergedUsers, totalDuplicates } = await loadDuplicateUsers();
-    // console.log('res :>> ', res);
     cacheFetchedUsers(mergedUsers, cacheDplUsers);
     setUsers(prevUsers => ({ ...prevUsers, ...mergedUsers }));
     setDuplicates(totalDuplicates);
     setIsDuplicateView(true);
-    // console.log('res!!!!!!!! :>> ', res.length);
   };
 
   const handleInfo = async () => {


### PR DESCRIPTION
## Summary
- prefer local cached duplicate cards before fetching from backend

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b4335330288326baadfbe6893524f8