### PR TITLE
feat: sync merged profiles to db

### DIFF
--- a/src/components/smallCard/__tests__/handleSubmitAll.test.js
+++ b/src/components/smallCard/__tests__/handleSubmitAll.test.js
@@ -1,0 +1,50 @@
+jest.mock('components/config', () => ({
+  fetchUserById: jest.fn(),
+  updateDataInNewUsersRTDB: jest.fn(),
+  updateDataInRealtimeDB: jest.fn(),
+  updateDataInFiresoreDB: jest.fn(),
+}));
+
+jest.mock('components/makeUploadedInfo', () => ({
+  makeUploadedInfo: jest.fn((existingData, state) => ({ ...existingData, ...state })),
+}));
+
+jest.mock('utils/cache', () => ({
+  updateCachedUser: jest.fn(),
+}));
+
+const { handleSubmitAll } = require('../actions');
+const {
+  fetchUserById,
+  updateDataInNewUsersRTDB,
+  updateDataInRealtimeDB,
+  updateDataInFiresoreDB,
+} = require('components/config');
+
+describe('handleSubmitAll', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates Realtime DB and Firestore for userId longer than 20 chars', async () => {
+    fetchUserById.mockResolvedValue({ existingData: { a: 1 } });
+    const userData = { userId: 'x'.repeat(21), field: 'value' };
+
+    await handleSubmitAll(userData);
+
+    expect(updateDataInRealtimeDB).toHaveBeenCalledWith(userData.userId, expect.any(Object), 'update');
+    expect(updateDataInFiresoreDB).toHaveBeenCalledWith(userData.userId, expect.any(Object), 'check');
+    expect(updateDataInNewUsersRTDB).toHaveBeenCalled();
+  });
+
+  it('updates only new users DB for short userId', async () => {
+    fetchUserById.mockResolvedValue({ existingData: { a: 1 } });
+    const userData = { userId: 'shortId', field: 'value' };
+
+    await handleSubmitAll(userData);
+
+    expect(updateDataInRealtimeDB).not.toHaveBeenCalled();
+    expect(updateDataInFiresoreDB).not.toHaveBeenCalled();
+    expect(updateDataInNewUsersRTDB).toHaveBeenCalledWith(userData.userId, expect.any(Object), 'update');
+  });
+});


### PR DESCRIPTION
## Summary
- sync handleSubmitAll with realtime and firestore DBs when merging profiles
- add tests for userId length branching logic

## Testing
- `CI=true npm test -- src/components/smallCard/__tests__/handleSubmitAll.test.js`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b45aa6fa6c8326aa1c87d1f65959f9