### PR TITLE
Remove deleted users from cache

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -24,6 +24,7 @@ import {
 import { PAGE_SIZE, BATCH_SIZE } from './constants';
 import { getCurrentDate } from './foramtDate';
 import toast from 'react-hot-toast';
+import { removeCard } from '../utils/cardIndex';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -2307,6 +2308,8 @@ export const removeCardAndSearchId = async userId => {
     // Видаляємо картку користувача з newUsers
     await remove(ref2(db, `newUsers/${userId}`));
     console.log(`Картка користувача видалена з newUsers: ${userId}`);
+
+    removeCard(userId);
 
     if (deletedFields.length) {
       toast.success(`Видалені дані:\n${deletedFields.join('\n')}`, {

--- a/src/utils/__tests__/cardIndex.test.js
+++ b/src/utils/__tests__/cardIndex.test.js
@@ -1,5 +1,11 @@
 describe('cardIndex queries', () => {
-  const { setIdsForQuery, getIdsByQuery, normalizeQueryKey, getCard } = require('../cardIndex');
+  const {
+    setIdsForQuery,
+    getIdsByQuery,
+    normalizeQueryKey,
+    getCard,
+    removeCard,
+  } = require('../cardIndex');
   const { updateCard } = require('../cardsStorage');
 
   beforeEach(() => {
@@ -23,5 +29,13 @@ describe('cardIndex queries', () => {
     expect(ids).toEqual(['1']);
     const card = getCard('1');
     expect(card.title).toBe('New');
+  });
+
+  it('removes card from cards and queries', () => {
+    updateCard('userId01', { name: 'A' });
+    setIdsForQuery('test', ['userId01']);
+    removeCard('userId01');
+    expect(getCard('userId01')).toBeNull();
+    expect(getIdsByQuery('test')).toEqual([]);
   });
 });

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -84,3 +84,27 @@ export const touchCardInQueries = cardId => {
   });
   if (changed) saveQueries(queries);
 };
+
+export const removeCard = id => {
+  if (!id) return;
+
+  const cards = loadCards();
+  if (cards[id]) {
+    delete cards[id];
+    saveCards(cards);
+  }
+
+  const queries = loadQueries();
+  let changed = false;
+  Object.keys(queries).forEach(key => {
+    const entry = queries[key];
+    if (entry.ids && entry.ids.includes(id)) {
+      entry.ids = entry.ids.filter(existingId => existingId !== id);
+      if (entry.ids.length === 0) {
+        delete queries[key];
+      }
+      changed = true;
+    }
+  });
+  if (changed) saveQueries(queries);
+};


### PR DESCRIPTION
## Summary
- remove user cards and query indexes from local storage when deleting a user
- call cache cleanup during `removeCardAndSearchId`
- cover cache removal with a new unit test

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b463036da08326bdd6289a08f8fe3d