### PR TITLE
Add user ID to search when editing duplicates

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1195,7 +1195,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setState={setState}
                   currentFilter={currentFilter}
                   isDateInRange={isDateInRange}
-                  isDuplicateView={isDuplicateView}
                 />
                 <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
               </>

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -123,7 +123,6 @@ const UsersList = ({
   setDislikeUsers,
   currentFilter,
   isDateInRange,
-  isDuplicateView,
 }) => {
   const entries = Object.entries(users);
 
@@ -178,7 +177,7 @@ const UsersList = ({
             </div>
           ) : (
             <>
-              {btnEdit(userData, setSearch, setState, isDuplicateView)}
+              {btnEdit(userData, setSearch, setState)}
               {btnCompare(index, users, setUsers, setShowInfoModal, setCompare, )}
               <UserCard
                 setShowInfoModal={setShowInfoModal}

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -5,12 +5,10 @@ import { normalizeQueryKey, setIdsForQuery } from '../../utils/cardIndex';
 import { saveCard } from '../../utils/cardsStorage';
 
 // Use already loaded card data instead of re-fetching from the server
-export const btnEdit = (userData, setSearch, setState, isDuplicateView = false) => {
+export const btnEdit = (userData, setSearch, setState) => {
   const handleCardClick = () => {
     if (userData) {
-      if (!isDuplicateView) {
-        setSearch(`${userData.userId}`);
-      }
+      setSearch(`${userData.userId}`);
       setState(userData);
       const cacheKey = getCacheKey('search', normalizeQueryKey(`userId=${userData.userId}`));
       saveCard({ ...userData, id: userData.userId });


### PR DESCRIPTION
## Summary
- Always set search field to the user's ID when editing, enabling duplicate-list edits to behave like favorites
- Simplify UsersList and AddNewProfile components by removing the unused duplicate-view prop

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48213413883269eff02e2ac6e5579