### PR TITLE
feat: add comment placeholder on matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1475,6 +1475,7 @@ const Matching = () => {
                       />
                       <ResizableCommentInput
                         plain
+                        placeholder="Мій коментар / My comment"
                         value={comments[user.userId] || ''}
                         onClick={e => e.stopPropagation()}
                         onChange={e => {


### PR DESCRIPTION
## Summary
- show "Мій коментар / My comment" placeholder below matching cards

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a552092c832684883df54c6cf849