### PR TITLE
Avoid duplicate info slide for photo profiles

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -805,6 +805,14 @@ const renderSelectedFields = user => {
   });
 };
 
+const getInfoSlidesCount = user => {
+  const moreInfo = getCurrentValue(user.moreInfo_main);
+  const profession = getCurrentValue(user.profession);
+  const education = getCurrentValue(user.education);
+  const showDescriptionSlide = Boolean(moreInfo || profession || education);
+  return 1 + (showDescriptionSlide ? 1 : 0);
+};
+
 const InfoCardContent = ({ user, variant }) => {
   const moreInfo = getCurrentValue(user.moreInfo_main);
   const profession = getCurrentValue(user.profession);
@@ -1413,37 +1421,46 @@ const Matching = () => {
               const photo = photos[0];
               const nextPhoto = photos[1];
               const thirdPhoto = photos[2];
-              const moreInfo = getCurrentValue(user.moreInfo_main);
-              const profession = getCurrentValue(user.profession);
-              const education = getCurrentValue(user.education);
-              const showDescriptionSlide = Boolean(moreInfo || profession || education);
+              const role = (user.role || user.userRole || '')
+                .toString()
+                .trim()
+                .toLowerCase();
+              const isAgency = role === 'ag' || role === 'ip';
 
               const infoVariants = [];
-              if (!photo) infoVariants.push('info');
-              if (showDescriptionSlide) infoVariants.push('description');
+              if (role === 'ag') {
+                const moreInfo = getCurrentValue(user.moreInfo_main);
+                const profession = getCurrentValue(user.profession);
+                const education = getCurrentValue(user.education);
+                const showDescriptionSlide = Boolean(
+                  moreInfo || profession || education
+                );
+                if (!photo) infoVariants.push('info');
+                if (showDescriptionSlide) infoVariants.push('description');
+              } else {
+                const infoSlides = getInfoSlidesCount(user);
+                if (infoSlides >= 1) infoVariants.push('info');
+                if (infoSlides >= 2) infoVariants.push('description');
+                if (!photo) infoVariants.shift();
+              }
 
               const nextVariant = nextPhoto ? null : infoVariants.shift();
               const thirdVariant = thirdPhoto ? null : infoVariants.shift();
 
-                const role = (user.role || user.userRole || '')
-                  .toString()
-                  .trim()
-                  .toLowerCase();
-                const isAgency = role === 'ag' || role === 'ip';
-                const nameParts = [
-                  getCurrentValue(user.name),
-                  getCurrentValue(user.surname),
-                ]
-                  .filter(Boolean)
-                  .map(v => String(v).trim())
-                  .join(' ');
-                return (
-                  <CardContainer key={user.userId}>
-                    {thirdVariant && (
-                      <ThirdInfoCard>
-                        <InfoCardContent user={user} variant={thirdVariant} />
-                      </ThirdInfoCard>
-                    )}
+              const nameParts = [
+                getCurrentValue(user.name),
+                getCurrentValue(user.surname),
+              ]
+                .filter(Boolean)
+                .map(v => String(v).trim())
+                .join(' ');
+              return (
+                <CardContainer key={user.userId}>
+                  {thirdVariant && (
+                    <ThirdInfoCard>
+                      <InfoCardContent user={user} variant={thirdVariant} />
+                    </ThirdInfoCard>
+                  )}
                     {thirdPhoto && <ThirdPhoto src={thirdPhoto} alt="third" />}
                     {nextVariant && (
                       <NextInfoCard>

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -571,7 +571,7 @@ const SwipeableCard = ({
       : [getCurrentValue(user.photos)]
           .filter(Boolean)
           .map(convertDriveLinkToImage);
-    const base = photo ? ['main', 'info'] : ['info'];
+    const base = photo ? ['main'] : ['info'];
     if (showDescriptionSlide) base.push('description');
     base.push(...photosArr.slice(1));
     return base;
@@ -803,14 +803,6 @@ const renderSelectedFields = user => {
       </div>
     );
   });
-};
-
-const getInfoSlidesCount = user => {
-  const moreInfo = getCurrentValue(user.moreInfo_main);
-  const profession = getCurrentValue(user.profession);
-  const education = getCurrentValue(user.education);
-  const showDescriptionSlide = Boolean(moreInfo || profession || education);
-  return 1 + (showDescriptionSlide ? 1 : 0);
 };
 
 const InfoCardContent = ({ user, variant }) => {
@@ -1421,12 +1413,14 @@ const Matching = () => {
               const photo = photos[0];
               const nextPhoto = photos[1];
               const thirdPhoto = photos[2];
-              const infoSlides = getInfoSlidesCount(user);
+              const moreInfo = getCurrentValue(user.moreInfo_main);
+              const profession = getCurrentValue(user.profession);
+              const education = getCurrentValue(user.education);
+              const showDescriptionSlide = Boolean(moreInfo || profession || education);
 
               const infoVariants = [];
-              if (infoSlides >= 1) infoVariants.push('info');
-              if (infoSlides >= 2) infoVariants.push('description');
-              if (!photo) infoVariants.shift();
+              if (!photo) infoVariants.push('info');
+              if (showDescriptionSlide) infoVariants.push('description');
 
               const nextVariant = nextPhoto ? null : infoVariants.shift();
               const thirdVariant = thirdPhoto ? null : infoVariants.shift();


### PR DESCRIPTION
## Summary
- ensure matching cards skip extra info slide when photo is present
- adjust info variant logic to show description only as needed

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b4a81d4fc08326aac20aed16653854