### PR TITLE
Align country text with contact icons

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -442,6 +442,7 @@ const Icons = styled.div`
   gap: 10px;
   font-size: 16px;
   color: ${color.accent};
+  align-items: center;
 `;
 
 const BasicInfo = styled.div`
@@ -765,7 +766,7 @@ const SwipeableCard = ({
               display: 'flex',
               alignItems: 'center',
               gap: '4px',
-              flexWrap: 'wrap',
+              flexWrap: 'nowrap',
               justifyContent: 'flex-start',
             }}
           >


### PR DESCRIPTION
## Summary
- Keep agent country and contact icons on a single line
- Center contact icons vertically for better alignment

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b4a85792f883268acb0461bc96d16c