### PR TITLE
Fix delete action on user cards

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -233,6 +233,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [searchKeyValuePair, setSearchKeyValuePair] = useState(null);
   const [filters, setFilters] = useState({});
   const [isDeleting, setIsDeleting] = useState(false);
+  const [userIdToDelete, setUserIdToDelete] = useState(null);
   const navigate = useNavigate();
   const isAdmin = auth.currentUser?.uid === process.env.REACT_APP_USER1;
 
@@ -349,6 +350,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     // setIsModalOpen(false);
     setSelectedField(null);
     setShowInfoModal(false);
+    setUserIdToDelete(null);
   };
 
   const handleSelectOption = option => {
@@ -606,10 +608,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const handleRemoveUser = async () => {
       try {
         setIsDeleting(true);
-        await removeCardAndSearchId(state.userId);
+        const id = userIdToDelete || state.userId;
+        if (!id) return;
+        await removeCardAndSearchId(id);
         setUsers(prevUsers => {
           const updatedUsers = { ...prevUsers };
-          delete updatedUsers[state.userId];
+          delete updatedUsers[id];
           return updatedUsers;
         });
         const res = await fetchNewUsersCollectionInRTDB({ name: '' });
@@ -620,7 +624,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setSearch('');
         setState({});
         setShowInfoModal(null);
-        console.log(`User ${state.userId} deleted.`);
+        setUserIdToDelete(null);
+        console.log(`User ${id} deleted.`);
         navigate('/add');
       } catch (error) {
         console.error('Error deleting user:', error);
@@ -637,7 +642,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           <>
             <p>Видалити профіль?</p>
             <SubmitButton onClick={handleRemoveUser}>Видалити</SubmitButton>
-            <SubmitButton onClick={() => setShowInfoModal(null)}>Відмінити</SubmitButton>
+            <SubmitButton onClick={handleCloseModal}>Відмінити</SubmitButton>
           </>
         )}
       </>
@@ -1076,6 +1081,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 setUsers,
                 setShowInfoModal,
                 setState,
+                setUserIdToDelete,
                 false,
                 favoriteUsersData,
                 setFavoriteUsersData,
@@ -1193,6 +1199,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setUsers={setUsers}
                   setSearch={setSearch}
                   setState={setState}
+                  setUserIdToDelete={setUserIdToDelete}
                   currentFilter={currentFilter}
                   isDateInRange={isDateInRange}
                   isDuplicateView={isDuplicateView}

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -167,6 +167,7 @@ const EditProfile = () => {
           () => {},
           () => {},
           setState,
+          () => {},
           undefined,
           undefined,
           undefined,

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -80,6 +80,7 @@ const UserCard = ({
   setUsers,
   setShowInfoModal,
   setState,
+  setUserIdToDelete,
   favoriteUsers,
   setFavoriteUsers,
   dislikeUsers,
@@ -94,6 +95,7 @@ const UserCard = ({
         setUsers,
         setShowInfoModal,
         setState,
+        setUserIdToDelete,
         'isFromListOfUsers',
         favoriteUsers,
         setFavoriteUsers,
@@ -117,6 +119,7 @@ const UsersList = ({
   setState,
   setShowInfoModal,
   setCompare,
+  setUserIdToDelete,
   favoriteUsers = {},
   setFavoriteUsers,
   dislikeUsers = {},
@@ -185,6 +188,7 @@ const UsersList = ({
                 userData={userData}
                 setUsers={setUsers}
                 setState={setState}
+                setUserIdToDelete={setUserIdToDelete}
                 favoriteUsers={favoriteUsers}
                 setFavoriteUsers={setFavoriteUsers}
                 dislikeUsers={dislikeUsers}

--- a/src/components/smallCard/btnDel.js
+++ b/src/components/smallCard/btnDel.js
@@ -1,7 +1,12 @@
 import { CardMenuBtn } from 'components/styles';
 import React from 'react';
 
-export const btnDel = (userData, setState, setShowInfoModal, isFromListOfUsers) => (
+export const btnDel = (
+  userData,
+  setShowInfoModal,
+  setUserIdToDelete,
+  isFromListOfUsers,
+) => (
   <CardMenuBtn
     style={{
       backgroundColor: 'red',
@@ -10,7 +15,7 @@ export const btnDel = (userData, setState, setShowInfoModal, isFromListOfUsers) 
     onClick={e => {
       e.stopPropagation(); // Запобігаємо активації кліку картки
       if (isFromListOfUsers === 'isFromListOfUsers') {
-        setState({ userId: userData.userId });
+        setUserIdToDelete(userData.userId);
       }
       setShowInfoModal('delConfirm');
     }}

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -43,6 +43,7 @@ export const renderTopBlock = (
   setUsers,
   setShowInfoModal,
   setState,
+  setUserIdToDelete,
   isFromListOfUsers,
   favoriteUsers = {},
   setFavoriteUsers,
@@ -57,7 +58,7 @@ export const renderTopBlock = (
 
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
-      {btnDel(userData, setState, setShowInfoModal, isFromListOfUsers)}
+      {btnDel(userData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
       {!isFromListOfUsers && (
         <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />
       )}


### PR DESCRIPTION
## Summary
- Add dedicated `userIdToDelete` state and reset it when closing modals
- Update delete button and supporting components to use separate deletion state

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b481e7b6948326af9724f15f1542da