### PR TITLE
Avoid empty contact separators on matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -432,9 +432,9 @@ const Contact = styled.div`
   justify-content: flex-start;
   align-items: center;
   font-size: 14px;
-  border-top: 1px solid ${color.gray4};
-  padding-top: 10px;
-  margin-top: 10px;
+  border-top: ${props => (props.$withBorder ? `1px solid ${color.gray4}` : 'none')};
+  padding-top: ${props => (props.$withBorder ? '10px' : '0')};
+  margin-top: ${props => (props.$withBorder ? '10px' : '0')};
 `;
 
 const Icons = styled.div`
@@ -653,6 +653,8 @@ const SwipeableCard = ({
     .filter(Boolean)
     .map(v => String(v).trim())
     .join(' ');
+  const contacts = fieldContactsIcons(user);
+  const selectedFields = renderSelectedFields(user).filter(Boolean);
 
   return (
     <AnimatedCard
@@ -708,10 +710,12 @@ const SwipeableCard = ({
                 .join(', ')}
             </Info>
           </ProfileSection>
-          <Table>{renderSelectedFields(user)}</Table>
-          <Contact>
-            <Icons>{fieldContactsIcons(user)}</Icons>
-          </Contact>
+          {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
+          {contacts && (
+            <Contact $withBorder={selectedFields.length > 0}>
+              <Icons>{contacts}</Icons>
+            </Contact>
+          )}
         </InfoSlide>
       )}
       {current === 'main' && (
@@ -772,7 +776,7 @@ const SwipeableCard = ({
             {getCurrentValue(user.country) && (
               <span>{normalizeCountry(getCurrentValue(user.country))}</span>
             )}
-            <Icons>{fieldContactsIcons(user)}</Icons>
+            {contacts && <Icons>{contacts}</Icons>}
           </div>
         </CardInfo>
       )}
@@ -825,6 +829,8 @@ const InfoCardContent = ({ user, variant }) => {
     .filter(Boolean)
     .map(v => String(v).trim())
     .join(' ');
+  const contacts = fieldContactsIcons(user);
+  const selectedFields = renderSelectedFields(user).filter(Boolean);
 
   if (variant === 'description') {
     return (
@@ -872,10 +878,12 @@ const InfoCardContent = ({ user, variant }) => {
             .join(', ')}
         </Info>
       </ProfileSection>
-      <Table>{renderSelectedFields(user)}</Table>
-      <Contact>
-        <Icons>{fieldContactsIcons(user)}</Icons>
-      </Contact>
+      {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
+      {contacts && (
+        <Contact $withBorder={selectedFields.length > 0}>
+          <Icons>{contacts}</Icons>
+        </Contact>
+      )}
     </InfoSlide>
   );
 };

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -196,6 +196,17 @@ export const fieldContactsIcons = data => {
       ? processed.phone.filter(v => v)
       : [processed.phone]
     : [];
+  const hasContacts =
+    phoneValues.length > 0 ||
+    telegramValues.length > 0 ||
+    processed.email ||
+    processed.facebook ||
+    processed.instagram ||
+    processed.tiktok;
+
+  if (!hasContacts) {
+    return null;
+  }
 
   return (
     <div


### PR DESCRIPTION
## Summary
- return null from fieldContactsIcons when user has no contact info
- show contact section on matching cards only when contact info exists
- hide profile table and contact separator when no extra details follow location

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7dfc7a08326a570af2284d00d83