### PR TITLE
Fix agency card duplication above dislike

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -719,7 +719,7 @@ const SwipeableCard = ({
           )}
         </InfoSlide>
       )}
-      {current === 'main' && (
+      {current === 'main' && role !== 'ag' && (
         <BasicInfo>
           {displayName}
           {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}


### PR DESCRIPTION
## Summary
- hide bottom info overlay for agency users to prevent duplicate name/location near dislike icon

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b4b10f22948326bc1b60d973e9b114