### PR TITLE
Align agency cards without photo to photo style

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -572,11 +572,17 @@ const SwipeableCard = ({
       : [getCurrentValue(user.photos)]
           .filter(Boolean)
           .map(convertDriveLinkToImage);
-    const base = photo ? ['main'] : ['info'];
+    let base;
+    if (role === 'ag') {
+      base = ['main'];
+      if (!photo) base.push('info');
+    } else {
+      base = photo ? ['main'] : ['info'];
+    }
     if (showDescriptionSlide) base.push('description');
     base.push(...photosArr.slice(1));
     return base;
-  }, [user.photos, showDescriptionSlide, photo]);
+  }, [user.photos, showDescriptionSlide, photo, role]);
 
   const [index, setIndex] = useState(0);
   const [dir, setDir] = useState(null);


### PR DESCRIPTION
## Summary
- Always render main slide for agency matching cards even if photo is missing

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b5f264df948326a89d4f245c79bfbb