### PR TITLE
Preserve paragraphs in More information on matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -425,6 +425,7 @@ const MoreInfo = styled.div`
     ${props => (props.$isAdmin ? color.red : color.accent)};
   margin-bottom: 10px;
   font-size: 14px;
+  white-space: pre-line;
 `;
 
 const Contact = styled.div`


### PR DESCRIPTION
## Summary
- render line breaks in matching's More information section so user-entered paragraphs are preserved

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b5f34a29f4832681fef2b94d35ea6e