### PR TITLE
style: unify like/dislike icon styles

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -75,10 +75,10 @@ export const BtnDislike = ({
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: `${isDisliked ? 2 : 1}px solid ${
-          isDisliked ? color.iconActive : color.iconInactive
+        border: `${isDisliked ? 3 : 2}px solid ${
+          isDisliked ? color.iconInactive : color.white
         }`,
-        color: isDisliked ? color.iconActive : color.iconInactive,
+        color: isDisliked ? color.iconInactive : color.white,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
@@ -96,9 +96,9 @@ export const BtnDislike = ({
         viewBox="0 0 24 24"
         width="18"
         height="18"
-        fill={isDisliked ? color.iconActive : 'none'}
-        stroke={isDisliked ? color.iconActive : color.iconInactive}
-        strokeWidth="2"
+        fill="none"
+        stroke={isDisliked ? color.iconInactive : color.white}
+        strokeWidth={isDisliked ? 3 : 2}
         strokeLinecap="round"
         strokeLinejoin="round"
       >

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -74,10 +74,10 @@ export const BtnFavorite = ({
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: `${isFavorite ? 2 : 1}px solid ${
-          isFavorite ? color.iconActive : color.iconInactive
+        border: `${isFavorite ? 3 : 2}px solid ${
+          isFavorite ? color.iconInactive : color.white
         }`,
-        color: isFavorite ? color.iconActive : color.iconInactive,
+        color: isFavorite ? color.iconInactive : color.white,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
@@ -95,9 +95,9 @@ export const BtnFavorite = ({
         viewBox="0 0 24 24"
         width="18"
         height="18"
-        fill={isFavorite ? color.iconActive : 'none'}
-        stroke={isFavorite ? color.iconActive : color.iconInactive}
-        strokeWidth="2"
+        fill={isFavorite ? color.iconInactive : 'none'}
+        stroke={isFavorite ? color.iconInactive : color.white}
+        strokeWidth={isFavorite ? 3 : 2}
         strokeLinecap="round"
         strokeLinejoin="round"
       >

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -237,7 +237,9 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          border: isDisliked ? '2px solid black' : 'none',
+          border: `${isDisliked ? 3 : 2}px solid ${
+            isDisliked ? color.iconInactive : color.white
+          }`,
         }}
       >
         <svg
@@ -245,9 +247,9 @@ export const fieldGetInTouch = (
           viewBox="0 0 24 24"
           width="18"
           height="18"
-          fill={isDisliked ? color.iconActive : 'none'}
-          stroke={isDisliked ? color.iconActive : color.iconInactive}
-          strokeWidth="2"
+          fill="none"
+          stroke={isDisliked ? color.iconInactive : color.white}
+          strokeWidth={isDisliked ? 3 : 2}
           strokeLinecap="round"
           strokeLinejoin="round"
         >
@@ -265,7 +267,9 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          border: isFavorite ? '2px solid black' : 'none',
+          border: `${isFavorite ? 3 : 2}px solid ${
+            isFavorite ? color.iconInactive : color.white
+          }`,
         }}
       >
         <svg
@@ -273,9 +277,9 @@ export const fieldGetInTouch = (
           viewBox="0 0 24 24"
           width="18"
           height="18"
-          fill={isFavorite ? color.iconActive : 'none'}
-          stroke={isFavorite ? color.iconActive : color.iconInactive}
-          strokeWidth="2"
+          fill={isFavorite ? color.iconInactive : 'none'}
+          stroke={isFavorite ? color.iconInactive : color.white}
+          strokeWidth={isFavorite ? 3 : 2}
           strokeLinecap="round"
           strokeLinejoin="round"
         >


### PR DESCRIPTION
## Summary
- Harmonize dislike button with white inactive and dark gray active states
- Apply matching styles to favorite buttons across components

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f53e400083268d9fc242b2daa31e