### PR TITLE
fix: remove duplicate info slide for ag users without photo

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -576,7 +576,6 @@ const SwipeableCard = ({
     let base;
     if (role === 'ag') {
       base = ['main'];
-      if (!photo) base.push('info');
     } else {
       base = photo ? ['main'] : ['info'];
     }
@@ -1473,7 +1472,6 @@ const Matching = () => {
                 const showDescriptionSlide = Boolean(
                   moreInfo || profession || education
                 );
-                if (!photo) infoVariants.push('info');
                 if (showDescriptionSlide) infoVariants.push('description');
               } else {
                 const infoSlides = getInfoSlidesCount(user);


### PR DESCRIPTION
## Summary
- avoid rendering the info slide for agency users without photos in Matching
- stop adding info placeholders for such agency cards

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd333ce88326a51d7140a1102d68