### PR TITLE
Use phone icon instead of number in matching cards

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -3,13 +3,13 @@ import {
   FaFacebookF,
   FaInstagram,
   FaTelegramPlane,
+  FaPhone,
   FaViber,
   FaWhatsapp,
 } from 'react-icons/fa';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getCurrentValue } from '../getCurrentValue';
-import { color } from '../styles';
 
 export const fieldContacts = (data, parentKey = '') => {
   if (!data || typeof data !== 'object') {
@@ -223,9 +223,9 @@ export const fieldContactsIcons = data => {
               href={links.phone(processedVal)}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: color.black, textDecoration: 'none' }}
+              style={{ color: 'inherit', textDecoration: 'none' }}
             >
-              {`+${processedVal}`}
+              <FaPhone />
             </a>
             <a
               href={links.telegramFromPhone(`+${val}`)}


### PR DESCRIPTION
## Summary
- Replace phone number text with phone icon in contact icons to save space

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd982d748326a19ed301ec357d75