### PR TITLE
Refine like/dislike button styles and icons

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -9,6 +9,7 @@ import { color } from '../styles';
 import { setDislike, cacheDislikedUsers } from 'utils/dislikesStorage';
 import { setFavorite } from 'utils/favoritesStorage';
 import { removeCardFromList } from 'utils/cardsStorage';
+import { FaTimes } from 'react-icons/fa';
 
 export const BtnDislike = ({
   userId,
@@ -75,7 +76,7 @@ export const BtnDislike = ({
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: `${isDisliked ? 3 : 2}px solid ${
+        border: `${isDisliked ? 2 : 2}px solid ${
           isDisliked ? color.iconInactive : color.white
         }`,
         color: isDisliked ? color.iconInactive : color.white,
@@ -91,20 +92,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        width="18"
-        height="18"
-        fill="none"
-        stroke={isDisliked ? color.iconInactive : color.white}
-        strokeWidth={isDisliked ? 3 : 2}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <line x1="18" y1="6" x2="6" y2="18" />
-        <line x1="6" y1="6" x2="18" y2="18" />
-      </svg>
+      <FaTimes size={18} color={isDisliked ? color.iconInactive : color.white} />
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -9,6 +9,7 @@ import { color } from '../styles';
 import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 import { setFavorite } from 'utils/favoritesStorage';
 import { setDislike } from 'utils/dislikesStorage';
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
 export const BtnFavorite = ({
   userId,
@@ -74,7 +75,7 @@ export const BtnFavorite = ({
         height: '35px',
         borderRadius: '50%',
         background: color.accent5,
-        border: `${isFavorite ? 3 : 2}px solid ${
+        border: `${isFavorite ? 2 : 2}px solid ${
           isFavorite ? color.iconInactive : color.white
         }`,
         color: isFavorite ? color.iconInactive : color.white,
@@ -90,19 +91,11 @@ export const BtnFavorite = ({
         toggleFavorite();
       }}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        width="18"
-        height="18"
-        fill={isFavorite ? color.iconInactive : 'none'}
-        stroke={isFavorite ? color.iconInactive : color.white}
-        strokeWidth={isFavorite ? 3 : 2}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6.5 3.5 5 5.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5 18.5 5 20 6.5 20 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-      </svg>
+      {isFavorite ? (
+        <FaHeart size={18} color={color.iconInactive} />
+      ) : (
+        <FaRegHeart size={18} color={color.white} />
+      )}
     </button>
   );
 };

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -15,6 +15,7 @@ import {
 import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 import { setFavorite } from 'utils/favoritesStorage';
 import { setDislike } from 'utils/dislikesStorage';
+import { FaTimes, FaHeart, FaRegHeart } from 'react-icons/fa';
 
 export const fieldGetInTouch = (
   userData,
@@ -237,25 +238,10 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          border: `${isDisliked ? 3 : 2}px solid ${
-            isDisliked ? color.iconInactive : color.white
-          }`,
+          border: `${isDisliked ? 2 : 0}px solid ${color.iconInactive}`,
         }}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          width="18"
-          height="18"
-          fill="none"
-          stroke={isDisliked ? color.iconInactive : color.white}
-          strokeWidth={isDisliked ? 3 : 2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <line x1="18" y1="6" x2="6" y2="18" />
-          <line x1="6" y1="6" x2="18" y2="18" />
-        </svg>
+        <FaTimes size={18} color={isDisliked ? color.iconInactive : color.white} />
       </OrangeBtn>
       <OrangeBtn
         onClick={handleLike}
@@ -267,24 +253,14 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          border: `${isFavorite ? 3 : 2}px solid ${
-            isFavorite ? color.iconInactive : color.white
-          }`,
+          border: `${isFavorite ? 2 : 0}px solid ${color.iconInactive}`,
         }}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          width="18"
-          height="18"
-          fill={isFavorite ? color.iconInactive : 'none'}
-          stroke={isFavorite ? color.iconInactive : color.white}
-          strokeWidth={isFavorite ? 3 : 2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6.5 3.5 5 5.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5 18.5 5 20 6.5 20 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-        </svg>
+        {isFavorite ? (
+          <FaHeart size={18} color={color.iconInactive} />
+        ) : (
+          <FaRegHeart size={18} color={color.white} />
+        )}
       </OrangeBtn>
     </div>
   );


### PR DESCRIPTION
## Summary
- Use FontAwesome heart and times icons for like and dislike buttons
- Slim down active borders and remove passive borders in top block
- Update contact actions to match new icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b608e9c9ec83268582debb953aa014