### PR TITLE
Style dislike button to match like button

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -77,9 +77,9 @@ export const BtnDislike = ({
         borderRadius: '50%',
         background: color.accent5,
         border: `${isDisliked ? 2 : 2}px solid ${
-          isDisliked ? color.iconInactive : color.white
+          isDisliked ? color.iconActive : color.white
         }`,
-        color: isDisliked ? color.iconInactive : color.white,
+        color: isDisliked ? color.iconActive : color.white,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
@@ -92,7 +92,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={18} color={isDisliked ? color.iconInactive : color.white} />
+      <FaTimes size={18} color={isDisliked ? color.iconActive : color.white} />
     </button>
   );
 };

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -15,12 +15,7 @@ import {
 import { updateCachedUser, setFavoriteIds } from 'utils/cache';
 import { setFavorite } from 'utils/favoritesStorage';
 import { setDislike } from 'utils/dislikesStorage';
-import {
-  FaTimesCircle,
-  FaRegTimesCircle,
-  FaHeart,
-  FaRegHeart,
-} from 'react-icons/fa';
+import { FaTimes, FaHeart, FaRegHeart } from 'react-icons/fa';
 
 export const fieldGetInTouch = (
   userData,
@@ -243,14 +238,10 @@ export const fieldGetInTouch = (
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          border: `${isDisliked ? 2 : 0}px solid ${color.iconInactive}`,
+          border: `${isDisliked ? 2 : 0}px solid ${color.iconActive}`,
         }}
       >
-        {isDisliked ? (
-          <FaTimesCircle size={18} color={color.iconInactive} />
-        ) : (
-          <FaRegTimesCircle size={18} color={color.white} />
-        )}
+        <FaTimes size={18} color={isDisliked ? color.iconActive : color.white} />
       </OrangeBtn>
       <OrangeBtn
         onClick={handleLike}


### PR DESCRIPTION
## Summary
- Use black border and icon for active dislike button to mirror like styling
- Replace dislike icon with simple cross and update top block to match like button states

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b612ef22e08326ae4c08579cf07e38