### PR TITLE
Sync favorites/dislikes and load initial data unconditionally

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1059,10 +1059,12 @@ const Matching = () => {
         const unsubFav = onValue(favRef, snap => {
           const data = snap.exists() ? filterLongIds(snap.val()) : {};
           setFavoriteUsers(data);
+          syncFavorites(snap.val());
         });
         const unsubDis = onValue(disRef, snap => {
           const data = snap.exists() ? filterLongIds(snap.val()) : {};
           setDislikeUsers(data);
+          syncDislikes(snap.val());
         });
 
       return () => {
@@ -1382,10 +1384,6 @@ const Matching = () => {
   }, [hasMore, lastKey, viewMode, fetchChunk]);
 
   useEffect(() => {
-    const savedSearch = localStorage.getItem(SEARCH_KEY);
-    if (savedSearch) {
-      return;
-    }
     console.log('[useEffect] calling loadInitial');
     loadInitial();
   }, [loadInitial]);


### PR DESCRIPTION
## Summary
- sync local favorite and dislike caches when realtime updates arrive
- always run initial data load regardless of saved search

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b6749cea7883268543b3b5ec20fd78