### PR TITLE
Persist owner ID across auth state

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -307,6 +307,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     try {
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('userEmail');
+      localStorage.removeItem('ownerId');
       setState({});
       setIsLoggedIn(false);
       setShowInfoModal(false);
@@ -428,8 +429,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async user => {
       if (user && user.emailVerified) {
+        localStorage.setItem('ownerId', user.uid);
         setIsEmailVerified(true);
       } else {
+        localStorage.removeItem('ownerId');
         setIsEmailVerified(false);
       }
     });

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -33,9 +33,15 @@ export const App = () => {
   // Special page for admin
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, user => {
-      if (user && user.uid === process.env.REACT_APP_USER1) {
-        setIsAdmin(true);
+      if (user) {
+        localStorage.setItem('ownerId', user.uid);
+        if (user.uid === process.env.REACT_APP_USER1) {
+          setIsAdmin(true);
+        } else {
+          setIsAdmin(false);
+        }
       } else {
+        localStorage.removeItem('ownerId');
         setIsAdmin(false);
       }
     });

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1044,7 +1044,10 @@ const Matching = () => {
 
   useEffect(() => {
     const unsubscribeAuth = onAuthStateChanged(auth, user => {
-      if (!user) {
+      if (user) {
+        localStorage.setItem('ownerId', user.uid);
+      } else {
+        localStorage.removeItem('ownerId');
         setFavoriteUsers({});
         setDislikeUsers({});
         return;
@@ -1209,7 +1212,7 @@ const Matching = () => {
   }, [fetchChunk]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
 
   const loadFavoriteCards = async () => {
-    const owner = auth.currentUser?.uid;
+    const owner = auth.currentUser?.uid || localStorage.getItem('ownerId');
     if (!owner) return;
     setLoading(true);
     setUsers([]);
@@ -1252,7 +1255,7 @@ const Matching = () => {
   };
 
   const loadDislikeCards = async () => {
-    const owner = auth.currentUser?.uid;
+    const owner = auth.currentUser?.uid || localStorage.getItem('ownerId');
     if (!owner) return;
     setLoading(true);
 
@@ -1323,6 +1326,7 @@ const Matching = () => {
     try {
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('userEmail');
+      localStorage.removeItem('ownerId');
       setShowInfoModal(false);
       saveScrollPosition();
       navigate('/my-profile');

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -528,6 +528,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('userEmail');
       localStorage.removeItem('myProfileDraft');
+      localStorage.removeItem('ownerId');
       setState(initialProfileState);
       setIsLoggedIn(false);
       setShowInfoModal(false);
@@ -708,9 +709,11 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, user => {
       if (user) {
+        localStorage.setItem('ownerId', user.uid);
         console.log('User is logged in: ', user.uid);
         fetchData(user);
       } else {
+        localStorage.removeItem('ownerId');
         console.log('No user is logged in.');
       }
     });
@@ -793,8 +796,10 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async user => {
       if (user && user.emailVerified) {
+        localStorage.setItem('ownerId', user.uid);
         setIsEmailVerified(true);
       } else {
+        localStorage.removeItem('ownerId');
         setIsEmailVerified(false);
       }
     });

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -409,6 +409,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
     try {
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('userEmail');
+      localStorage.removeItem('ownerId');
       setState({});
       setIsLoggedIn(false);
       setShowInfoModal(false);
@@ -462,9 +463,11 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, user => {
       if (user) {
+        localStorage.setItem('ownerId', user.uid);
         console.log('User is logged in: ', user.uid);
         fetchData(user);
       } else {
+        localStorage.removeItem('ownerId');
         console.log('No user is logged in.');
       }
     });
@@ -549,8 +552,10 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async user => {
       if (user && user.emailVerified) {
+        localStorage.setItem('ownerId', user.uid);
         setIsEmailVerified(true);
       } else {
+        localStorage.removeItem('ownerId');
         setIsEmailVerified(false);
       }
     });

--- a/src/components/VerifyEmail.jsx
+++ b/src/components/VerifyEmail.jsx
@@ -26,6 +26,7 @@ margin-bottom: 20px;
           try {
             const unsubscribe = onAuthStateChanged(auth, async user => {
               if (user) {
+                localStorage.setItem('ownerId', user.uid);
                 try {
                   await sendEmailVerification(user);
                   console.log('sendEmailVerification(user) :>> ',);
@@ -37,6 +38,8 @@ margin-bottom: 20px;
                       console.log('Помилка надсилання підтвердження');
                   }
                 }
+              } else {
+                localStorage.removeItem('ownerId');
               }
             });
             return () => {


### PR DESCRIPTION
## Summary
- Save ownerId to localStorage on auth state changes and clear it when logged out
- Use stored ownerId as fallback when loading favorites or dislikes before auth initializes
- Remove ownerId on sign-out to avoid stale identifiers

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b68cafcad4832686b5784f89d31d1c