### PR TITLE
Show phone numbers with messenger icons

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -13,150 +13,107 @@ import { getCurrentValue } from '../getCurrentValue';
 
 const ICON_SIZE = 16;
 
-export const fieldContacts = (data, parentKey = '') => {
+// Render phone numbers with Telegram, Viber and Facebook icons
+export const fieldContacts = data => {
   if (!data || typeof data !== 'object') {
     console.error('Invalid data passed to renderContacts:', data);
     return null;
   }
 
   const links = {
-    telegram: value => `https://t.me/${value}`,
-    instagram: value => `https://instagram.com/${value}`,
-    tiktok: value => `https://www.tiktok.com/@${value}`,
     phone: value => `tel:+${value}`,
-    facebook: value => `https://facebook.com/${value}`,
-    vk: value => `https://vk.com/${value}`,
-    otherLink: value => `${value}`,
-    email: value => `mailto:${value}`,
     telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
     viberFromPhone: value => `viber://chat?number=%2B${value.replace(/\s+/g, '')}`,
-    whatsappFromPhone: value => `https://wa.me/${value.replace(/\s+/g, '')}`,
+    facebook: value => `https://facebook.com/${value}`,
   };
 
-  return Object.keys(data).map(key => {
-    const nestedKey = parentKey ? `${parentKey}.${key}` : key;
-    const value = data[key];
+  const iconStyle = { width: ICON_SIZE, height: ICON_SIZE };
+  const iconLinkStyle = {
+    color: 'inherit',
+    textDecoration: 'none',
+    lineHeight: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    margin: 0,
+    padding: 0,
+  };
 
-    // Пропускаємо ключ, якщо його значення — порожній рядок або порожній масив
-    if (!value || (Array.isArray(value) && value.length === 0)) {
-      return null;
-    }
+  const numberLinkStyle = {
+    color: 'inherit',
+    textDecoration: 'none',
+    margin: 0,
+    padding: 0,
+  };
 
-    if (links[key]) {
-      return (
-        <div key={nestedKey}>
-          {!['email', 'phone'].includes(key) && <strong>{key}:</strong>}{' '}
-          {Array.isArray(value) ? (
-            value
-              .filter(val => typeof val === 'string' && val.trim() !== '') // Фільтруємо лише непусті рядки
-              .map((val, idx) => {
-                try {
-                  const processedVal = key === 'phone' ? val.replace(/\s/g, '') : val; // Видаляємо пробіли тільки для phone
-                  return (
-                    <div key={`${nestedKey}-${idx}`} style={{ marginBottom: '2px' }}>
-                      <a
-                        href={links[key](processedVal)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
-                      >
-                        {key === 'phone' ? `+${processedVal}` : processedVal}
-                      </a>
-                      {key === 'phone' && (
-                        <>
-                          <a
-                            href={links.telegramFromPhone(`+${val}`)} // Telegram отримує значення з пробілами
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-                          >
-                            Tg
-                          </a>
-                          <a
-                            href={links.viberFromPhone(processedVal)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-                          >
-                            V
-                          </a>
-                          <a
-                            href={links.whatsappFromPhone(processedVal)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-                          >
-                            W
-                          </a>
-                        </>
-                      )}
-                    </div>
-                  );
-                } catch (error) {
-                  return (
-                    <div key={`${nestedKey}-${idx}`} style={{ marginBottom: '2px' }}>
-                      {val}
-                    </div>
-                  );
-                }
-              })
-          ) : (
-            <>
-              {(() => {
-                try {
-                  const processedValue = key === 'phone' ? value.replace(/\s/g, '') : value; // Видаляємо пробіли тільки для phone
-                  return (
-                    <>
-                      <a
-                        href={links[key](processedValue)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{ color: 'inherit', textDecoration: 'none', marginRight: '8px' }}
-                      >
-                        {key === 'phone' ? `+${processedValue}` : processedValue}
-                      </a>
-                      {key === 'phone' && (
-                        <>
-                          <a
-                            href={links.telegramFromPhone(`+${value}`)} // Telegram отримує значення з пробілами
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-                          >
-                            Tg
-                          </a>
-                          <a
-                            href={links.viberFromPhone(processedValue)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-                          >
-                            V
-                          </a>
-                          <a
-                            href={links.whatsappFromPhone(processedValue)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ color: 'inherit', textDecoration: 'none', marginLeft: '8px' }}
-                          >
-                            W
-                          </a>
-                        </>
-                      )}
-                    </>
-                  );
-                } catch (error) {
-                  return <div>{value}</div>;
-                }
-              })()}
-            </>
-          )}
-        </div>
-      );
-    }
+  const processed = Object.fromEntries(
+    Object.entries(data).map(([k, v]) => [k, getCurrentValue(v)])
+  );
 
-    return null; // Якщо ключ не обробляється
-  });
+  const phoneValues = processed.phone
+    ? Array.isArray(processed.phone)
+      ? processed.phone.filter(v => v)
+      : [processed.phone]
+    : [];
+
+  const hasFacebook = !!processed.facebook;
+
+  if (phoneValues.length === 0 && !hasFacebook) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}
+      onClick={e => e.stopPropagation()}
+      onTouchStart={e => e.stopPropagation()}
+      onTouchEnd={e => e.stopPropagation()}
+    >
+      {phoneValues.map((val, idx) => {
+        const processedVal = String(val).replace(/\s/g, '');
+        return (
+          <span
+            key={`phone-${idx}`}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}
+          >
+            <a
+              href={links.phone(processedVal)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={numberLinkStyle}
+            >
+              {`+${processedVal}`}
+            </a>
+            <a
+              href={links.telegramFromPhone(`+${val}`)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={iconLinkStyle}
+            >
+              <FaTelegramPlane style={iconStyle} />
+            </a>
+            <a
+              href={links.viberFromPhone(processedVal)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={iconLinkStyle}
+            >
+              <FaViber style={iconStyle} />
+            </a>
+          </span>
+        );
+      })}
+      {hasFacebook && (
+        <a
+          href={links.facebook(processed.facebook)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={iconLinkStyle}
+        >
+          <FaFacebookF style={iconStyle} />
+        </a>
+      )}
+    </div>
+  );
 };
 
 export const fieldContactsIcons = data => {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -3,7 +3,7 @@ import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
 import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
-import { fieldContactsIcons } from './fieldContacts';
+import { fieldContacts } from './fieldContacts';
 import { fieldGetInTouch } from './fieldGetInTouch';
 import { fieldRole } from './fieldRole';
 import { fieldLastCycle } from './fieldLastCycle';
@@ -115,7 +115,7 @@ export const renderTopBlock = (
           {[normalizeCountry(userData.country), normalizeRegion(userData.region)]
             .filter(Boolean)
             .join(', ')}
-          {fieldContactsIcons(userData)}
+          {fieldContacts(userData)}
         </div>
       </div>
       {fieldWriter(userData, setUsers, setState, isToastOn)}


### PR DESCRIPTION
## Summary
- Render phone numbers with Telegram, Viber and Facebook icons
- Use phone-number rendering in top block; keep icon-only view for matching cards

## Testing
- `npm run lint:js`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6a21193788326b61a5fae40ead7e3