### PR TITLE
Add helper to fetch second matching page for ED users with photo

### DIFF
--- a/src/utils/matchingPage.js
+++ b/src/utils/matchingPage.js
@@ -1,0 +1,25 @@
+import { fetchUsersByLastLogin2 } from '../components/config';
+
+const DEFAULT_PAGE_SIZE = 9;
+
+const hasPhoto = user => {
+  if (Array.isArray(user.photos)) {
+    return user.photos.some(Boolean);
+  }
+  return Boolean(user.photos);
+};
+
+const isEdRole = user => {
+  const role = (user.userRole || user.role || '').toString().trim().toLowerCase();
+  return role === 'ed';
+};
+
+export const fetchEdUsersWithPhotoPage = async (page = 2, pageSize = DEFAULT_PAGE_SIZE) => {
+  const limit = page * pageSize;
+  const res = await fetchUsersByLastLogin2(limit);
+  const filtered = res.users.filter(u => isEdRole(u) && hasPhoto(u));
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  return filtered.slice(start, end);
+};
+


### PR DESCRIPTION
## Summary
- add `fetchEdUsersWithPhotoPage` to return second page of matching data for ED-role users who have a photo

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a5c413e88326bf3e2118793a7ea4