### PR TITLE
Adjust slide base formation in Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -583,7 +583,7 @@ const SwipeableCard = ({
     if (role === 'ag') {
       base = ['main'];
     } else {
-      base = photo ? ['main'] : ['info'];
+      base = photo ? ['main', 'info'] : ['info'];
     }
     if (showDescriptionSlide) base.push('description');
     base.push(...photosArr.slice(1));


### PR DESCRIPTION
## Summary
- Ensure Matching component includes info slide when non-agent users have photos

## Testing
- `CI=true npm test --silent`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68b6b41997c8832699c4f1fb14688112