### PR TITLE
Center agency card contact info

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -791,7 +791,7 @@ const SwipeableCard = ({
           <div
             style={{
               display: 'flex',
-              alignItems: 'flex-end',
+              alignItems: 'center',
               gap: '4px',
               flexWrap: 'nowrap',
               justifyContent: 'flex-start',


### PR DESCRIPTION
## Summary
- Align agency card location text and contact icons using `alignItems: 'center'`

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68b6fa7c43288326b41015aebc6efb83