### PR TITLE
Adjust phone contact icon styles

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -11,7 +11,12 @@ import { SiTiktok } from 'react-icons/si';
 import { getCurrentValue } from '../getCurrentValue';
 import { color } from '../styles';
 
-const iconStyle = { verticalAlign: 'middle' };
+const iconStyle = {
+  verticalAlign: 'middle',
+  width: '12px',
+  height: '12px',
+  fontSize: '12px',
+};
 const phoneBtnStyle = {
   color: 'inherit',
   textDecoration: 'none',
@@ -21,6 +26,7 @@ const phoneBtnStyle = {
   justifyContent: 'center',
   width: '20px',
   height: '20px',
+  lineHeight: '0',
   border: `1px solid ${color.white}`,
   borderRadius: '50%',
 };
@@ -276,7 +282,7 @@ export const fieldContactsIcons = data => {
               href={links.telegramFromPhone(`+${val}`)}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ ...phoneBtnStyle, marginLeft: 0 }}
+              style={{ ...phoneBtnStyle, marginLeft: 0, border: 'none' }}
             >
               <FaTelegramPlane style={iconStyle} />
             </a>
@@ -284,7 +290,7 @@ export const fieldContactsIcons = data => {
               href={links.viberFromPhone(processedVal)}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ ...phoneBtnStyle, marginLeft: 0 }}
+              style={{ ...phoneBtnStyle, marginLeft: 0, border: 'none' }}
             >
               <FaViber style={iconStyle} />
             </a>
@@ -292,7 +298,7 @@ export const fieldContactsIcons = data => {
               href={links.whatsappFromPhone(processedVal)}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ ...phoneBtnStyle, marginLeft: 0 }}
+              style={{ ...phoneBtnStyle, marginLeft: 0, border: 'none' }}
             >
               <FaWhatsapp style={iconStyle} />
             </a>


### PR DESCRIPTION
## Summary
- shrink phone contact icons and center them inside bordered circles
- drop borders from phone contact icons on matching screen

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b715da64e48326a0941ab2a3a142af