### PR TITLE
Add TikTok and VK contact icons

### DIFF
--- a/src/components/smallCard/__tests__/renderTopBlock.icons.test.js
+++ b/src/components/smallCard/__tests__/renderTopBlock.icons.test.js
@@ -1,0 +1,63 @@
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+require('@testing-library/jest-dom');
+
+// Mock unrelated components to isolate fieldContacts rendering
+jest.mock('../btnDel', () => ({ btnDel: () => null }));
+jest.mock('../btnExport', () => ({ btnExport: () => null }));
+jest.mock('../fieldDeliveryInfo', () => ({ fieldDeliveryInfo: () => null }));
+jest.mock('../fieldWritter', () => ({ fieldWriter: () => null }));
+jest.mock('../fieldGetInTouch', () => ({ fieldGetInTouch: () => null }));
+jest.mock('../fieldRole', () => ({ fieldRole: () => null }));
+jest.mock('../fieldLastCycle', () => ({ fieldLastCycle: () => null }));
+jest.mock('../FieldComment', () => ({ FieldComment: () => null }));
+jest.mock('../btnToast', () => ({ BtnToast: () => null }));
+jest.mock('../fieldBirth', () => ({ fieldBirth: () => null }));
+jest.mock('../fieldBlood', () => ({ fieldBlood: () => null }));
+jest.mock('../fieldMaritalStatus', () => ({ fieldMaritalStatus: () => null }));
+jest.mock('../fieldIMT', () => ({ fieldIMT: () => null }));
+jest.mock('components/inputValidations', () => ({ formatDateToDisplay: () => null }));
+jest.mock('../../normalizeLocation', () => ({ normalizeRegion: () => null }));
+
+const { renderTopBlock } = require('../renderTopBlock');
+
+describe('renderTopBlock contact icons', () => {
+  it('renders TikTok and VK icons when corresponding links are provided', () => {
+    const userData = {
+      userId: '1',
+      userRole: 'ag',
+      tiktok: 'toktok',
+      vk: 'vkuser',
+    };
+
+    const html = ReactDOMServer.renderToString(
+      renderTopBlock(
+        userData,
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+        false,
+        {},
+        jest.fn(),
+        {},
+        jest.fn(),
+        null,
+        jest.fn(),
+        false,
+        jest.fn()
+      )
+    );
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+
+    const tiktokLink = container.querySelector('a[href="https://www.tiktok.com/@toktok"]');
+    const vkLink = container.querySelector('a[href="https://vk.com/vkuser"]');
+
+    expect(tiktokLink).not.toBeNull();
+    expect(vkLink).not.toBeNull();
+    expect(tiktokLink?.closest('div')?.querySelector('strong svg')).not.toBeNull();
+    expect(vkLink?.closest('div')?.querySelector('strong svg')).not.toBeNull();
+  });
+});

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -5,6 +5,7 @@ import {
   FaTelegramPlane,
   FaViber,
   FaWhatsapp,
+  FaVk,
 } from 'react-icons/fa';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
@@ -51,14 +52,16 @@ export const fieldContacts = (data, parentKey = '') => {
     whatsappFromPhone: value => `https://wa.me/${value.replace(/\s+/g, '')}`,
   };
 
-  const icons = {
-    facebook: <FaFacebookF style={iconStyle} />,
-    instagram: <FaInstagram style={iconStyle} />,
-    telegram: <FaTelegramPlane style={iconStyle} />,
-    telegramFromPhone: <FaTelegramPlane style={iconStyle} />,
-    viberFromPhone: <FaViber style={iconStyle} />,
-    whatsappFromPhone: <FaWhatsapp style={iconStyle} />,
-  };
+const icons = {
+  facebook: <FaFacebookF style={iconStyle} />,
+  instagram: <FaInstagram style={iconStyle} />,
+  telegram: <FaTelegramPlane style={iconStyle} />,
+  telegramFromPhone: <FaTelegramPlane style={iconStyle} />,
+  viberFromPhone: <FaViber style={iconStyle} />,
+  whatsappFromPhone: <FaWhatsapp style={iconStyle} />,
+  tiktok: <SiTiktok style={iconStyle} />,
+  vk: <FaVk style={iconStyle} />,
+};
 
   return Object.keys(data).map(key => {
     const nestedKey = parentKey ? `${parentKey}.${key}` : key;
@@ -359,6 +362,17 @@ export const fieldContactsIcons = data => {
           style={{ color: 'inherit', textDecoration: 'none' }}
         >
           <SiTiktok style={iconStyle} />
+        </a>
+      )}
+
+      {processed.vk && (
+        <a
+          href={links.vk(processed.vk)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          <FaVk style={iconStyle} />
         </a>
       )}
     </div>


### PR DESCRIPTION
## Summary
- show TikTok and VK icons for contacts
- cover renderTopBlock with tests for TikTok and VK links

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b74c086f5083268a77a93b997221db