### PR TITLE
feat: show globe icon for other links

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -7,6 +7,7 @@ import {
   FaWhatsapp,
   FaVk,
   FaPhone,
+  FaGlobe,
 } from 'react-icons/fa';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
@@ -62,6 +63,7 @@ const icons = {
   whatsappFromPhone: <FaWhatsapp style={iconStyle} />,
   tiktok: <SiTiktok style={iconStyle} />,
   vk: <FaVk style={iconStyle} />,
+  otherLink: <FaGlobe style={iconStyle} />,
 };
 
   return Object.keys(data).map(key => {
@@ -412,6 +414,25 @@ export const fieldContactsIcons = (
         <FaVk style={iconStyle} />
       </a>
     );
+  }
+
+  if (processed.otherLink) {
+    const others = Array.isArray(processed.otherLink)
+      ? processed.otherLink.filter(v => v)
+      : [processed.otherLink];
+    others.forEach((val, idx) => {
+      elements.push(
+        <a
+          key={`otherLink-${idx}`}
+          href={links.otherLink(val)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          <FaGlobe style={iconStyle} />
+        </a>
+      );
+    });
   }
 
   if (elements.length === 0) return null;


### PR DESCRIPTION
## Summary
- display globe icon for otherLink entries in contact blocks
- handle otherLink icons in contact icon-only view

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7fc52e2ac8326aa9c4fe447eb5545