### PR TITLE
Adjust phone icon layout on matching page

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -736,7 +736,9 @@ const SwipeableCard = ({
                 }}
               >
                 {locationInfo}
-                {showContactsAfterCity && contacts && <Icons>{contacts}</Icons>}
+                {showContactsAfterCity && contacts && (
+                  <Icons style={{ marginLeft: '8px' }}>{contacts}</Icons>
+                )}
               </div>
             </Info>
           </ProfileSection>
@@ -930,7 +932,9 @@ const InfoCardContent = ({ user, variant }) => {
             }}
           >
             {locationInfo}
-            {showContactsAfterCity && contacts && <Icons>{contacts}</Icons>}
+            {showContactsAfterCity && contacts && (
+              <Icons style={{ marginLeft: '8px' }}>{contacts}</Icons>
+            )}
           </div>
         </Info>
       </ProfileSection>

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -6,8 +6,8 @@ import {
   FaViber,
   FaWhatsapp,
   FaVk,
-  FaPhone,
 } from 'react-icons/fa';
+import { FaPhoneFlip } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getCurrentValue } from '../getCurrentValue';
@@ -300,7 +300,7 @@ export const fieldContactsIcons = (
           rel="noopener noreferrer"
           style={{ color: phoneAsIcon ? 'inherit' : color.black, textDecoration: 'none' }}
         >
-          {phoneAsIcon ? <FaPhone style={iconStyle} /> : `+${processedVal}`}
+          {phoneAsIcon ? <FaPhoneFlip style={iconStyle} /> : `+${processedVal}`}
         </a>
         <a
           href={links.telegramFromPhone(`+${val}`)}


### PR DESCRIPTION
## Summary
- use vertical phone icon for contacts
- add spacing between city and contact icons on matching page

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b82ccbafd083269a48bf9ae5aa7c38