### PR TITLE
Adjust marital status labels for 'ed' users

### DIFF
--- a/src/components/smallCard/fieldMaritalStatus.js
+++ b/src/components/smallCard/fieldMaritalStatus.js
@@ -1,17 +1,17 @@
 import { AttentionDiv } from 'components/styles';
 
-export const fieldMaritalStatus = maritalStatus => {
+export const fieldMaritalStatus = (maritalStatus, userRole) => {
   let text;
   switch (maritalStatus) {
     case 'Yes':
     case 'Так':
     case '+':
-      text = 'Заміжня';
+      text = userRole === 'ed' ? 'Married' : 'Заміжня';
       break;
     case 'No':
     case 'Ні':
     case '-':
-      text = 'Незаміжня';
+      text = userRole === 'ed' ? 'Single' : 'Незаміжня';
       break;
     default:
       text = maritalStatus || '';

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -101,7 +101,8 @@ export const renderTopBlock = (
         <div style={{ whiteSpace: 'pre-wrap', display: 'flex', alignItems: 'center', gap: '5px', flexWrap: 'wrap' }}>
           {(() => {
             const parts = [];
-            if (userData.maritalStatus) parts.push(fieldMaritalStatus(userData.maritalStatus));
+            if (userData.maritalStatus)
+              parts.push(fieldMaritalStatus(userData.maritalStatus, userData.userRole));
             if (userData.blood) parts.push(fieldBlood(userData.blood));
             if (userData.height) parts.push(userData.height);
             if (userData.height && userData.weight) parts.push('/');


### PR DESCRIPTION
## Summary
- Show "Married" for marital status `Yes` and "Single" for `No` on user cards with role `ed`
- Pass user role into marital status renderer

## Testing
- `npm run lint:js`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b82e691dc88326a7c39fde917bbee5