### PR TITLE
Use vertical phone icon in contact list

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -6,9 +6,9 @@ import {
   FaViber,
   FaWhatsapp,
   FaVk,
-  FaPhone,
   FaGlobe,
 } from 'react-icons/fa';
+import { BsTelephone } from 'react-icons/bs';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getCurrentValue } from '../getCurrentValue';
@@ -302,7 +302,7 @@ export const fieldContactsIcons = (
           rel="noopener noreferrer"
           style={{ color: phoneAsIcon ? 'inherit' : color.black, textDecoration: 'none' }}
         >
-          {phoneAsIcon ? <FaPhone style={iconStyle} /> : `+${processedVal}`}
+          {phoneAsIcon ? <BsTelephone style={iconStyle} /> : `+${processedVal}`}
         </a>
         <a
           href={links.telegramFromPhone(`+${val}`)}


### PR DESCRIPTION
## Summary
- replace FontAwesome phone with vertical Bootstrap telephone icon for contacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83101e2c48326a25f3819ba5bce4d