### PR TITLE
Move egg donor contacts below region on Matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -723,32 +723,34 @@ const SwipeableCard = ({
           <ProfileSection>
             <Info>
               <Title>{getRoleTitle(user)}</Title>
-              <DonorName>
-                {displayName}
-                {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
-              </DonorName>
-              <br />
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                  flexWrap: 'nowrap',
-                  justifyContent: 'flex-start',
-                }}
-              >
-                {locationInfo}
-              </div>
-            </Info>
-          </ProfileSection>
-          {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
-          {contacts && (
-            <Contact $withBorder={selectedFields.length > 0}>
-              <Icons>{contacts}</Icons>
-            </Contact>
-          )}
-        </InfoSlide>
+          <DonorName>
+            {displayName}
+            {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+          </DonorName>
+          <br />
+          <div
+            style={{
+              display: 'flex',
+              alignItems: isEggDonor ? 'flex-start' : 'center',
+              gap: '4px',
+              flexWrap: 'nowrap',
+              justifyContent: 'flex-start',
+              flexDirection: isEggDonor ? 'column' : 'row',
+            }}
+          >
+            <span>{locationInfo}</span>
+            {isEggDonor && contacts && <Icons>{contacts}</Icons>}
+          </div>
+        </Info>
+      </ProfileSection>
+      {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
+      {!isEggDonor && contacts && (
+        <Contact $withBorder={selectedFields.length > 0}>
+          <Icons>{contacts}</Icons>
+        </Contact>
       )}
+    </InfoSlide>
+  )}
       {current === 'main' && role !== 'ag' && (
         <BasicInfo>
           {displayName}
@@ -926,18 +928,20 @@ const InfoCardContent = ({ user, variant }) => {
           <div
             style={{
               display: 'flex',
-              alignItems: 'center',
+              alignItems: isEggDonor ? 'flex-start' : 'center',
               gap: '4px',
               flexWrap: 'nowrap',
               justifyContent: 'flex-start',
+              flexDirection: isEggDonor ? 'column' : 'row',
             }}
           >
-            {locationInfo}
+            <span>{locationInfo}</span>
+            {isEggDonor && contacts && <Icons>{contacts}</Icons>}
           </div>
         </Info>
       </ProfileSection>
       {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
-      {contacts && (
+      {!isEggDonor && contacts && (
         <Contact $withBorder={selectedFields.length > 0}>
           <Icons>{contacts}</Icons>
         </Contact>


### PR DESCRIPTION
## Summary
- For egg donor profiles on the Matching page, place contact icons on the line following the region
- Hide the bottom contact section and separator when the role is `ed`

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b834f761ec8326bb5b0dfc5ecec0f7