### PR TITLE
Center comment input text

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -175,6 +175,10 @@ const CommentInput = styled.textarea`
   overflow: hidden;
   min-height: 16px;
   line-height: 16px;
+  text-align: center;
+  &::placeholder {
+    text-align: center;
+  }
   border: ${props => (props.plain ? 'none' : `1px solid ${color.gray3}`)};
   border-radius: ${props => (props.plain ? '0' : '8px')};
   outline: ${props => (props.plain ? 'none' : 'auto')};


### PR DESCRIPTION
## Summary
- center comment input and its placeholder in Matching screen

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b89a94f46083268b8b21cdadab593e