### PR TITLE
Handle marital status normalization within Matching only

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -26,6 +26,7 @@ import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
 import { fieldContactsIcons } from './smallCard/fieldContacts';
+import { fieldMaritalStatus } from './smallCard/fieldMaritalStatus';
 import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -831,11 +832,38 @@ const renderSelectedFields = user => {
 
     value = getCurrentValue(value);
 
+    if (field.key === 'maritalStatus') {
+      const role = (user.userRole || '').toString().trim().toLowerCase();
+      if (role === 'ed' && value) {
+        const normalized = value.toString().trim().toLowerCase();
+        if (
+          ['yes', 'так', '+', 'married', 'заміжня', 'одружена'].includes(
+            normalized
+          )
+        ) {
+          value = 'Married';
+        } else if (
+          [
+            'no',
+            'ні',
+            '-',
+            'single',
+            'unmarried',
+            'незаміжня',
+            'не заміжня',
+          ].includes(normalized)
+        ) {
+          value = 'Single';
+        }
+      }
+    }
+
     if (value === undefined || value === '' || value === null) return null;
 
     return (
       <div key={field.key}>
-        <strong>{field.label}</strong> {String(value)}
+        <strong>{field.label}</strong>{' '}
+        {field.key === 'maritalStatus' ? fieldMaritalStatus(value) : String(value)}
       </div>
     );
   });


### PR DESCRIPTION
## Summary
- Revert small card marital status helper to original switch logic without "Married/Single" translations
- In Matching view, normalize marital status to Married/Single only for `ed` role and render via `fieldMaritalStatus`

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8a3f371d88326a0ac4033ec45285c