### PR TITLE
Unify marital status styling in matching view

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -26,7 +26,6 @@ import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
 import { fieldContactsIcons } from './smallCard/fieldContacts';
-import { fieldMaritalStatus } from './smallCard/fieldMaritalStatus';
 import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -924,7 +923,7 @@ const renderSelectedFields = user => {
     return (
       <div key={field.key}>
         <strong>{field.label}</strong>{' '}
-        {field.key === 'maritalStatus' ? fieldMaritalStatus(value) : String(value)}
+        {String(value)}
       </div>
     );
   });


### PR DESCRIPTION
## Summary
- Render marital status in matching table as plain text like other profile fields

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68b8aea549148326b52da04b636d563e