### PR TITLE
Cache comments locally and fetch in bulk

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -339,6 +339,43 @@ export const fetchUserComment = async (ownerId, userId) => {
   }
 };
 
+export const fetchUserComments = async (ownerId, userIds = []) => {
+  try {
+    const snap = await get(ref2(database, `multiData/comments/${ownerId}`));
+    const all = snap.exists() ? snap.val() : {};
+    const result = {};
+    userIds.forEach(id => {
+      result[id] = all[id] || '';
+    });
+    return result;
+  } catch (error) {
+    console.error('Error fetching comments:', error);
+    return {};
+  }
+};
+
+export const fetchUsersByIds = async ids => {
+  try {
+    const [newUsersSnap, usersSnap] = await Promise.all([
+      get(ref2(database, 'newUsers')),
+      get(ref2(database, 'users')),
+    ]);
+    const newUsers = newUsersSnap.exists() ? newUsersSnap.val() : {};
+    const users = usersSnap.exists() ? usersSnap.val() : {};
+    const result = {};
+    ids.forEach(id => {
+      const data = { userId: id, ...(newUsers[id] || {}), ...(users[id] || {}) };
+      if (Object.keys(data).length > 1) {
+        result[id] = data;
+      }
+    });
+    return result;
+  } catch (error) {
+    console.error('Error fetching users by ids:', error);
+    return {};
+  }
+};
+
 const addUserFromUsers = async (userId, users) => {
   const userSnap = await get(ref2(database, `users/${userId}`));
   const newUserSnap = await get(ref2(database, `newUsers/${userId}`));

--- a/src/utils/commentsStorage.js
+++ b/src/utils/commentsStorage.js
@@ -1,0 +1,48 @@
+const COMMENTS_KEY = 'commentsCache';
+const TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+export const loadComments = () => {
+  try {
+    const raw = localStorage.getItem(COMMENTS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    const result = {};
+    Object.entries(parsed).forEach(([id, entry]) => {
+      if (entry && (!entry.updatedAt || Date.now() - entry.updatedAt <= TTL_MS)) {
+        result[id] = entry;
+      }
+    });
+    return result;
+  } catch {
+    return {};
+  }
+};
+
+export const saveComments = comments => {
+  try {
+    localStorage.setItem(COMMENTS_KEY, JSON.stringify(comments));
+  } catch {
+    // ignore write errors
+  }
+};
+
+export const setLocalComment = (id, text) => {
+  const comments = loadComments();
+  comments[id] = { text, updatedAt: Date.now() };
+  saveComments(comments);
+};
+
+export const pruneComments = ids => {
+  const existing = loadComments();
+  const pruned = {};
+  ids.forEach(id => {
+    if (existing[id]) pruned[id] = existing[id];
+  });
+  saveComments(pruned);
+};
+
+export const getLocalComment = id => {
+  const comments = loadComments();
+  return comments[id]?.text || '';
+};
+


### PR DESCRIPTION
## Summary
- cache card comments in localStorage with 6h TTL
- batch fetch comments and user data for loaded cards
- persist edits to comments locally

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9ec08da4c8326914ba377575c247d