### PR TITLE
Refactor comment handling and caching

### DIFF
--- a/src/utils/commentsStorage.js
+++ b/src/utils/commentsStorage.js
@@ -26,9 +26,9 @@ export const saveComments = comments => {
   }
 };
 
-export const setLocalComment = (id, text) => {
+export const setLocalComment = (id, text, updatedAt = Date.now()) => {
   const comments = loadComments();
-  comments[id] = { text, updatedAt: Date.now() };
+  comments[id] = { text, updatedAt };
   saveComments(comments);
 };
 


### PR DESCRIPTION
## Summary
- store comments with unique `commentId` including `cardId` and `updatedAt`
- support server-side comment lookups by `cardId`
- refresh and prune local comment cache for visible users only
- fetch only requested user profiles when enriching cards

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e8e9ccc832688a862a5828217f2