### PR TITLE
feat: track and display updated timestamp

### DIFF
--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -28,7 +28,7 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
     ...cards[cardId],
     ...data,
     id: cardId,
-    updatedAt: Date.now(),
+    updatedAt: data.updatedAt ?? Date.now(),
   };
   removeKeys.forEach(key => {
     delete updatedCard[key];

--- a/src/utils/parseDDMMYYYY.js
+++ b/src/utils/parseDDMMYYYY.js
@@ -1,0 +1,8 @@
+export const parseDDMMYYYY = str => {
+  if (!str) return undefined;
+  const [day, month, year] = str.split('.').map(Number);
+  if (!day || !month || !year) return undefined;
+  return new Date(year, month - 1, day).getTime();
+};
+
+export default parseDDMMYYYY;


### PR DESCRIPTION
## Summary
- store `updatedAt` timestamps in milliseconds and sync cache when server returns newer data
- show formatted, read-only `updatedAt` in profile form
- keep server-provided timestamps when caching cards

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bb5c40707083269c8f95b06ada0ae9