### PR TITLE
refactor: migrate matching cache to card storage

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -12,7 +12,6 @@ import { makeUploadedInfo } from './makeUploadedInfo';
 import { ProfileForm } from './ProfileForm';
 import { renderTopBlock } from "./smallCard/renderTopBlock";
 import { coloredCard } from "./styles";
-import { mergeCache, getCacheKey } from '../hooks/cardsCache';
 import { updateCachedUser } from '../utils/cache';
 
 const Container = styled.div`
@@ -106,17 +105,11 @@ const EditProfile = () => {
 
     const removeKeys = delCondition ? Object.keys(delCondition) : [];
     updateCachedUser(updatedState, { removeKeys });
-    mergeCache(getCacheKey('default'), {
-      users: { [updatedState.userId]: updatedState },
-    });
     setIsSyncing(true);
     try {
       const serverData = await remoteUpdate({ updatedState, overwrite, delCondition });
       if (serverData?.updatedAt && serverData.updatedAt > updatedState.updatedAt) {
         updateCachedUser(serverData);
-        mergeCache(getCacheKey('default'), {
-          users: { [serverData.userId]: serverData },
-        });
         setState(serverData);
       }
     } finally {

--- a/src/hooks/cardsCache.js
+++ b/src/hooks/cardsCache.js
@@ -65,6 +65,3 @@ export const createCache = (prefix, ttl = TTL_MS) => {
 
   return { loadCache, saveCache, clearCache, mergeCache };
 };
-
-// default cache for matching to keep backward compatibility
-export const { loadCache, saveCache, clearCache, mergeCache } = createCache('matchingCache');

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -35,8 +35,7 @@ describe('clearAllCardsCache', () => {
     localStorage.clear();
   });
 
-  it('clears all cache except login state', () => {
-    localStorage.setItem('matchingCache:cards:default', 'cached');
+  it('removes only cards and queries entries', () => {
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
     localStorage.setItem('isLoggedIn', 'true');
@@ -44,10 +43,9 @@ describe('clearAllCardsCache', () => {
 
     clearAllCardsCache();
 
-    expect(localStorage.getItem('matchingCache:cards:default')).toBeNull();
     expect(localStorage.getItem('cards')).toBeNull();
     expect(localStorage.getItem('queries')).toBeNull();
-    expect(localStorage.getItem('other')).toBeNull();
+    expect(localStorage.getItem('other')).toBe('value');
     expect(localStorage.getItem('isLoggedIn')).toBe('true');
   });
 });

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,16 +1,12 @@
 import { getCacheKey } from 'hooks/cardsCache';
 import { updateCard, addCardToList, removeCardFromList } from './cardsStorage';
-import { setIdsForQuery } from './cardIndex';
+import { setIdsForQuery, CARDS_KEY, QUERIES_KEY } from './cardIndex';
 
 export { getCacheKey };
 
-// Clears localStorage but preserves the login flag
+// Clears cached cards and queries from localStorage
 export const clearAllCardsCache = () => {
-  const KEEP_KEYS = ['isLoggedIn'];
-
-  Object.keys(localStorage)
-    .filter(key => !KEEP_KEYS.includes(key))
-    .forEach(key => localStorage.removeItem(key));
+  [CARDS_KEY, QUERIES_KEY].forEach(key => localStorage.removeItem(key));
 };
 
 let favoriteIds = {};


### PR DESCRIPTION
## Summary
- remove matchingCache-specific exports
- persist matching results using cardIndex/cardsStorage instead of load/save cache
- limit cache clearing to cards and queries only

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bbec6af8c88326a331888e5e22ad03