### PR TITLE
Remove agency extra info heading

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -788,9 +788,15 @@ const SwipeableCard = ({
           )}
           {moreInfo && (
             <MoreInfo>
-              <strong>More information</strong>
-              <br />
-              {moreInfo}
+              {role === 'ag' ? (
+                moreInfo
+              ) : (
+                <>
+                  <strong>More information</strong>
+                  <br />
+                  {moreInfo}
+                </>
+              )}
             </MoreInfo>
           )}
         </InfoSlide>
@@ -1010,9 +1016,15 @@ const InfoCardContent = ({ user, variant }) => {
         )}
         {moreInfo && (
           <MoreInfo>
-            <strong>More information</strong>
-            <br />
-            {moreInfo}
+            {role === 'ag' ? (
+              moreInfo
+            ) : (
+              <>
+                <strong>More information</strong>
+                <br />
+                {moreInfo}
+              </>
+            )}
           </MoreInfo>
         )}
       </InfoSlide>


### PR DESCRIPTION
## Summary
- hide "More information" heading on agency cards in matching view

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bbee093148832683855aa46720339a