### PR TITLE
Replace phone handset icon with FaPhoneVolume

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -8,7 +8,7 @@ import {
   FaVk,
   FaGlobe,
 } from 'react-icons/fa';
-import { BsTelephone } from 'react-icons/bs';
+import { FaPhoneVolume } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getCurrentValue } from '../getCurrentValue';
@@ -310,7 +310,7 @@ export const fieldContactsIcons = (
           rel="noopener noreferrer"
           style={{ color: phoneAsIcon ? 'inherit' : color.black, textDecoration: 'none' }}
         >
-          {phoneAsIcon ? <BsTelephone style={iconStyle} /> : `+${processedVal}`}
+          {phoneAsIcon ? <FaPhoneVolume style={iconStyle} /> : `+${processedVal}`}
         </a>
         <a
           href={links.telegramFromPhone(`+${val}`)}


### PR DESCRIPTION
## Summary
- use FaPhoneVolume from Font Awesome 6 for phone links

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbefadc5ec8326bc3258114f82f073