### PR TITLE
Add pregnancy week field and automate due date

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -249,9 +249,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
-    const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
+    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction', 'lastLogin2'];
+    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'dueDate', 'ownKids'];
 
     const formatDate = date => {
       const dd = String(date.getDate()).padStart(2, '0');
@@ -290,7 +290,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       }
 
       const cleanedStateForNewUsers = Object.fromEntries(
-        Object.entries(syncedState).filter(([key]) => [...fieldsForNewUsersOnly, ...contacts].includes(key))
+        Object.entries(syncedState).filter(([key]) =>
+          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'dueDate', 'ownKids'].includes(key)
+        )
       );
 
       await updateDataInNewUsersRTDB(syncedState.userId, cleanedStateForNewUsers, 'update');

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -39,9 +39,9 @@ const EditProfile = () => {
   const [isToastOn, setIsToastOn] = useState(false);
 
   async function remoteUpdate({ updatedState, overwrite, delCondition }) {
-    const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
+    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction', 'lastLogin2'];
+    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'dueDate', 'ownKids'];
 
     if (updatedState?.userId?.length > 20) {
       const { existingData } = await fetchUserById(updatedState.userId);
@@ -63,7 +63,9 @@ const EditProfile = () => {
       await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
 
       const cleanedStateForNewUsers = Object.fromEntries(
-        Object.entries(updatedState).filter(([key]) => [...fieldsForNewUsersOnly, ...contacts].includes(key))
+        Object.entries(updatedState).filter(([key]) =>
+          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'dueDate', 'ownKids'].includes(key)
+        )
       );
 
       await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update');

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -185,7 +185,7 @@ export const ProfileForm = ({
         </div>
       )}
       {sortedFieldsToRender
-        .filter(field => !['myComment', 'getInTouch', 'writer'].includes(field.name))
+        .filter(field => !['myComment', 'getInTouch', 'writer', 'pregnancyWeek'].includes(field.name))
         .map((field, index) => {
           const displayValue =
             field.name === 'updatedAt'
@@ -446,6 +446,56 @@ export const ProfileForm = ({
         />
         <Button onClick={handleAddCustomField}>+</Button>
       </KeyValueRow>
+      <InputDiv>
+        <InputFieldContainer fieldName="pregnancyWeek" value={state.pregnancyWeek}>
+          <InputField
+            fieldName="pregnancyWeek"
+            inputMode="numeric"
+            name="pregnancyWeek"
+            value={state.pregnancyWeek || ''}
+            placeholder="25"
+            onChange={e =>
+              setState(prev => ({ ...prev, pregnancyWeek: e.target.value }))
+            }
+            onBlur={e => {
+              const week = parseInt(e.target.value, 10);
+              if (!isNaN(week)) {
+                const today = new Date();
+                const dueDate = new Date(today);
+                dueDate.setDate(today.getDate() + (40 - week) * 7);
+                const getInTouch = new Date(dueDate);
+                getInTouch.setMonth(getInTouch.getMonth() + 9);
+                const format = d =>
+                  `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.${d.getFullYear()}`;
+                const updatedState = {
+                  ...state,
+                  pregnancyWeek: e.target.value,
+                  dueDate: format(dueDate),
+                  getInTouch: format(getInTouch),
+                };
+                if (state.ownKids !== undefined && state.ownKids !== '') {
+                  updatedState.ownKids = Number(state.ownKids) + 1;
+                }
+                setState(updatedState);
+                handleSubmit(updatedState, 'overwrite');
+              }
+            }}
+          />
+          {state.pregnancyWeek && (
+            <ClearButton
+              type="button"
+              onMouseDown={e => e.preventDefault()}
+              onClick={() =>
+                setState(prev => ({ ...prev, pregnancyWeek: '' }))
+              }
+            >
+              &times;
+            </ClearButton>
+          )}
+        </InputFieldContainer>
+        <Hint fieldName="pregnancyWeek" isActive={state.pregnancyWeek}>25</Hint>
+        <Placeholder isActive={state.pregnancyWeek}>Тиждень вагітності</Placeholder>
+      </InputDiv>
       <Photos state={state} setState={setState} />
     </>
   );

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -282,6 +282,7 @@ export const pickerFieldsExtended = [
   { name: 'userId', placeholder: 'userId', svg: 'user', ukrainianHint: 'Id' },
   { name: 'role', placeholder: 'см/до/смдо/агент', svg: 'user', ukrainianHint: 'СМДО?' },
   { name: 'myComment', placeholder: 'коментар', svg: 'user', ukrainianHint: 'Коментра' },
+  { name: 'pregnancyWeek', placeholder: '25', hint: 'pregnancy week', svg: 'no', ukrainianHint: 'Тиждень вагітності' },
   { name: 'getInTouch', placeholder: '30.01.2025', svg: 'user', ukrainianHint: 'Коли звернутись' },
   { name: 'lastAction', placeholder: '-', svg: 'user', ukrainianHint: 'Останні зміни' },
   { name: 'lastLogin2', placeholder: '-', svg: 'user', ukrainianHint: 'Останній логін' },


### PR DESCRIPTION
## Summary
- add pregnancyWeek field to extended picker fields
- render pregnancyWeek input with due date and get-in-touch calculations
- include pregnancy data in profile state and backend submissions
- remove unintended pregnancyWeek initialization in MyProfile

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bc1768fb888326b15faf9759c5548f