### PR TITLE
Ignore filters when viewing favorites and dislikes

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1602,16 +1602,16 @@ const Matching = () => {
 
 
   const filteredUsers =
-    filters && Object.keys(filters).length > 0
-      ? filterMain(
+    viewMode === 'favorites' || viewMode === 'dislikes' || !filters || Object.keys(filters).length === 0
+      ? users
+      : filterMain(
           users.map(u => [u.userId, u]),
           null,
           filters,
           favoriteUsers
         )
           .map(([id, u]) => u)
-          .filter(u => isValidId(u.userId))
-      : users;
+          .filter(u => isValidId(u.userId));
 
   // automatic loading disabled
 


### PR DESCRIPTION
## Summary
- Skip filter-based user filtering in favorites and dislikes views so lists show all entries

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bbfea012548326a811f218887badda