### PR TITLE
Handle custom field add on enter or blur

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -437,12 +437,27 @@ export const ProfileForm = ({
           placeholder="ключ"
           value={customField.key}
           onChange={e => setCustomField(prev => ({ ...prev, key: e.target.value }))}
+          onBlur={() => {
+            if (customField.key && customField.value) {
+              handleAddCustomField();
+            }
+          }}
         />
         <Colon>:</Colon>
         <CustomInput
           placeholder="значення"
           value={customField.value}
           onChange={e => setCustomField(prev => ({ ...prev, value: e.target.value }))}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              handleAddCustomField();
+            }
+          }}
+          onBlur={() => {
+            if (customField.key && customField.value) {
+              handleAddCustomField();
+            }
+          }}
         />
         <Button onClick={handleAddCustomField}>+</Button>
       </KeyValueRow>


### PR DESCRIPTION
## Summary
- allow adding custom fields by pressing Enter
- automatically add custom fields on blur when both inputs filled

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bc8d49bf4c83268442ea908f47df1b