### PR TITLE
Use lastDelivery for pregnancy week calculations

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -251,7 +251,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'dueDate', 'ownKids'];
+    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids'];
 
     const formatDate = date => {
       const dd = String(date.getDate()).padStart(2, '0');
@@ -291,7 +291,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
       const cleanedStateForNewUsers = Object.fromEntries(
         Object.entries(syncedState).filter(([key]) =>
-          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'dueDate', 'ownKids'].includes(key)
+          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
 

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -41,7 +41,7 @@ const EditProfile = () => {
   async function remoteUpdate({ updatedState, overwrite, delCondition }) {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'dueDate', 'ownKids'];
+    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids'];
 
     if (updatedState?.userId?.length > 20) {
       const { existingData } = await fetchUserById(updatedState.userId);
@@ -64,7 +64,7 @@ const EditProfile = () => {
 
       const cleanedStateForNewUsers = Object.fromEntries(
         Object.entries(updatedState).filter(([key]) =>
-          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'dueDate', 'ownKids'].includes(key)
+          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
 

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -476,16 +476,16 @@ export const ProfileForm = ({
               const week = parseInt(e.target.value, 10);
               if (!isNaN(week)) {
                 const today = new Date();
-                const dueDate = new Date(today);
-                dueDate.setDate(today.getDate() + (40 - week) * 7);
-                const getInTouch = new Date(dueDate);
+                const lastDelivery = new Date(today);
+                lastDelivery.setDate(today.getDate() + (40 - week) * 7);
+                const getInTouch = new Date(lastDelivery);
                 getInTouch.setMonth(getInTouch.getMonth() + 9);
                 const format = d =>
                   `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.${d.getFullYear()}`;
                 const updatedState = {
                   ...state,
                   pregnancyWeek: e.target.value,
-                  dueDate: format(dueDate),
+                  lastDelivery: format(lastDelivery),
                   getInTouch: format(getInTouch),
                 };
                 if (state.ownKids !== undefined && state.ownKids !== '') {


### PR DESCRIPTION
## Summary
- Replace `dueDate` field with `lastDelivery` across profile creation and editing
- Compute `lastDelivery` and `getInTouch` from pregnancy week input
## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc91c6e6208326aa3de01e1e630319