### PR TITLE
Add pregnancy toggle and adjust follow-up date logic

### DIFF
--- a/src/assets/icons/pregnant.svg
+++ b/src/assets/icons/pregnant.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="4" r="2"/>
+  <path d="M9 7c0-1.1.9-2 2-2h2a2 2 0 012 2v1c1.66 0 3 1.34 3 3s-1.34 3-3 3h-1v4h1v2h-4v-2h1v-4h-1a3 3 0 01-3-3c0-1.3.84-2.4 2-2.82V7z"/>
+</svg>

--- a/src/components/smallCard/fieldDeliveryInfo.js
+++ b/src/components/smallCard/fieldDeliveryInfo.js
@@ -38,7 +38,14 @@ export const fieldDeliveryInfo = (setUsers, setState, userData) => {
 
   const monthsAgo = effectiveLastDelivery ? utilCalculateMonthsAgo(effectiveLastDelivery) : null;
 
-  const whenGetInTouch = deliveryDate ? new Date(deliveryDate.getFullYear(), deliveryDate.getMonth() + 18, deliveryDate.getDate()) : null;
+  const monthsToAdd = (() => {
+    const val = (csection || '').toLowerCase().replace(/\s/g, '');
+    return ['кс-', '-', 'no', 'ні', '0'].includes(val) ? 9 : 18;
+  })();
+
+  const whenGetInTouch = deliveryDate
+    ? new Date(deliveryDate.getFullYear(), deliveryDate.getMonth() + monthsToAdd, deliveryDate.getDate())
+    : null;
 
   // Форматування дати у формат "дд.мм.рррр"
   const formatDate = date =>

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -1,81 +1,138 @@
+import React from 'react';
 import { handleChange, handleSubmit } from './actions';
 import { formatDateToDisplay, formatDateToServer } from 'components/inputValidations';
-import { UnderlinedInput, AttentionButton } from 'components/styles';
-import React from 'react';
+import { UnderlinedInput, AttentionButton, color } from 'components/styles';
+import { ReactComponent as PregnantIcon } from 'assets/icons/pregnant.svg';
 
 const calculateNextDate = dateString => {
   if (!dateString) return '';
 
-  // Перевіряємо, чи введена дата у форматі DD.MM.YYYY
   const inputPattern = /^\d{2}\.\d{2}\.\d{4}$/;
   if (inputPattern.test(dateString)) {
-    // Перетворюємо DD.MM.YYYY у формат YYYY-MM-DD
     const [day, month, year] = dateString.split('.');
     dateString = `${year}-${month}-${day}`;
   }
 
-  // Перевіряємо, чи дата тепер у форматі YYYY-MM-DD
   const storagePattern = /^\d{4}-\d{2}-\d{2}$/;
   if (!storagePattern.test(dateString)) {
     console.error('Invalid date format after conversion:', dateString);
     return '';
   }
 
-  // Створюємо об'єкт дати
   const [year, month, day] = dateString.split('-').map(Number);
   const currentDate = new Date(year, month - 1, day);
 
-  // Перевіряємо, чи дата валідна
   if (isNaN(currentDate.getTime())) {
     console.error('Invalid date object:', currentDate);
     return '';
   }
 
-  // Додаємо 28 днів
   currentDate.setDate(currentDate.getDate() + 28);
 
-  // Форматуємо результат у форматі DD.MM.YYYY
   const dayFormatted = String(currentDate.getDate()).padStart(2, '0');
   const monthFormatted = String(currentDate.getMonth() + 1).padStart(2, '0');
   const yearFormatted = currentDate.getFullYear();
 
   return `${dayFormatted}.${monthFormatted}.${yearFormatted}`;
-  // return `${dayFormatted}.${monthFormatted}`;
 };
 
-export const fieldLastCycle = (userData, setUsers, setState, isToastOn) => {
-  const nextCycle = calculateNextDate(userData.lastCycle);
+const parseDate = dateString => {
+  if (!dateString) return null;
+
+  const inputPattern = /^\d{2}\.\d{2}\.\d{4}$/;
+  if (inputPattern.test(dateString)) {
+    const [day, month, year] = dateString.split('.');
+    return new Date(Number(year), Number(month) - 1, Number(day));
+  }
+
+  const storagePattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (storagePattern.test(dateString)) {
+    const [year, month, day] = dateString.split('-').map(Number);
+    return new Date(year, month - 1, day);
+  }
+
+  return null;
+};
+
+const formatDateForServer = date => {
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return formatDateToServer(`${day}.${month}.${year}`);
+};
+
+export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
+  const [isPregnant, setIsPregnant] = React.useState(false);
+
+  const nextCycle = React.useMemo(() => calculateNextDate(userData.lastCycle), [userData.lastCycle]);
+
+  const handlePregnantClick = () => {
+    setIsPregnant(prev => {
+      const newState = !prev;
+      if (!prev) {
+        const lastCycleDate = parseDate(userData.lastCycle);
+        if (lastCycleDate) {
+          const lastDelivery = new Date(lastCycleDate);
+          lastDelivery.setDate(lastDelivery.getDate() + 7 * 40);
+
+          const getInTouch = new Date(lastDelivery);
+          getInTouch.setMonth(getInTouch.getMonth() + 9);
+
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            'lastDelivery',
+            formatDateForServer(lastDelivery),
+          );
+
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            'getInTouch',
+            formatDateForServer(getInTouch),
+            true,
+            {},
+            isToastOn,
+          );
+        }
+      }
+      return newState;
+    });
+  };
 
   return (
     <React.Fragment>
       <style>
         {`
       input::placeholder {
-        color: white; /* Робимо плейсхолдер білим */
-        opacity: 1;   /* Для чіткої видимості */
+        color: white;
+        opacity: 1;
       }
     `}
       </style>
-      <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
         <UnderlinedInput
           type="text"
           value={formatDateToDisplay(userData.lastCycle) || ''}
           placeholder="міс"
           onChange={e => {
-            // Повертаємо формат YYYY-MM-DD для збереження
             const serverFormattedDate = formatDateToServer(e.target.value);
             handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
           }}
           onBlur={() => handleSubmit(userData, 'overwrite', isToastOn)}
-          // placeholder="01.01.2021"
           style={{
             marginLeft: 0,
             textAlign: 'left',
-            color: 'white', // Колір текст
+            color: 'white',
           }}
         />
-        {/* {nextCycle && <span> місячні - {nextCycle}</span>} */}
-        {nextCycle && (
+        <PregnantIcon
+          onClick={handlePregnantClick}
+          style={{ cursor: 'pointer', width: 20, height: 20, fill: isPregnant ? color.accent : 'white' }}
+        />
+        {!isPregnant && nextCycle && (
           <React.Fragment>
             <span style={{ marginLeft: '10px', marginRight: '5px', color: 'white' }}>місячні -</span>
             <AttentionButton
@@ -101,3 +158,4 @@ export const fieldLastCycle = (userData, setUsers, setState, isToastOn) => {
     </React.Fragment>
   );
 };
+

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -6,7 +6,7 @@ import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
 import { fieldGetInTouch } from './fieldGetInTouch';
 import { fieldRole } from './fieldRole';
-import { fieldLastCycle } from './fieldLastCycle';
+import { FieldLastCycle } from './fieldLastCycle';
 import { FieldComment } from './FieldComment';
 import { BtnToast } from './btnToast';
 import { fieldBirth } from './fieldBirth';
@@ -85,8 +85,14 @@ export const renderTopBlock = (
         {userData.userRole !== 'ag' &&
           userData.userRole !== 'ip' &&
           userData.role !== 'ag' &&
-          userData.role !== 'ip' &&
-          fieldLastCycle(userData, setUsers, setState, isToastOn)}
+          userData.role !== 'ip' && (
+            <FieldLastCycle
+              userData={userData}
+              setUsers={setUsers}
+              setState={setState}
+              isToastOn={isToastOn}
+            />
+          )}
         {fieldDeliveryInfo(setUsers, setState, userData)}
         {userData.birth && `${userData.birth} - `}
         {userData.birth && fieldBirth(userData.birth)}


### PR DESCRIPTION
## Summary
- add pregnant SVG toggle to last-cycle field that schedules delivery and contact dates
- hide next menstruation date when pregnancy is active
- fix getInTouch calculation for "кс-" C-section button

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc999734448326a893f625ab8b95a8