### PR TITLE
feat: support week input for last cycle

### DIFF
--- a/src/components/__tests__/formatDateAndFormula.test.js
+++ b/src/components/__tests__/formatDateAndFormula.test.js
@@ -1,0 +1,19 @@
+import { formatDateAndFormula } from '../inputValidations';
+
+describe('formatDateAndFormula weeks', () => {
+  it('converts "22т" to date 22 weeks ago', () => {
+    const today = new Date();
+    const expected = new Date(today);
+    expected.setDate(expected.getDate() - 22 * 7);
+    const expectedStr = expected.toISOString().split('T')[0];
+    expect(formatDateAndFormula('22т')).toBe(expectedStr);
+  });
+
+  it('converts "22w" to date 22 weeks ago', () => {
+    const today = new Date();
+    const expected = new Date(today);
+    expected.setDate(expected.getDate() - 22 * 7);
+    const expectedStr = expected.toISOString().split('T')[0];
+    expect(formatDateAndFormula('22w')).toBe(expectedStr);
+  });
+});

--- a/src/components/inputValidations.js
+++ b/src/components/inputValidations.js
@@ -325,6 +325,15 @@ export const removeSpaceAndNewLine = value => {
       }
       return today.toISOString().split('T')[0]; // Повертаємо у форматі YYYY-MM-DD
     }
+
+    // Якщо формат типу "22т", "22t" або "22w" (тижнів тому)
+    const weeksPattern = /^(\d+)(т|t|w)$/i;
+    const matchWeeks = input.match(weeksPattern);
+    if (matchWeeks) {
+      const weeks = parseInt(matchWeeks[1], 10);
+      today.setDate(today.getDate() - weeks * 7);
+      return today.toISOString().split('T')[0]; // Повертаємо у форматі YYYY-MM-DD
+    }
   
     // Якщо формат типу "360-90"
     const offsetPattern = /^(\d+)-(\d+)$/;

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -65,6 +65,77 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
 
   const nextCycle = React.useMemo(() => calculateNextDate(userData.lastCycle), [userData.lastCycle]);
 
+  const handleLastCycleChange = e => {
+    const value = e.target.value.trim();
+    const weekPattern = /^(\d+)([тtw])$/i;
+
+    if (isPregnant && weekPattern.test(value)) {
+      const weeks = parseInt(value, 10);
+      const today = new Date();
+      const lastCycleDate = new Date(today);
+      lastCycleDate.setDate(today.getDate() - weeks * 7);
+
+      const lastDelivery = new Date(lastCycleDate);
+      lastDelivery.setDate(lastDelivery.getDate() + 7 * 40);
+
+      const getInTouch = new Date(lastDelivery);
+      getInTouch.setMonth(getInTouch.getMonth() + 9);
+
+      const existingLastDelivery = parseDate(userData.lastDelivery);
+      const hasUpcomingDelivery = existingLastDelivery && existingLastDelivery > today;
+      const ownKids = hasUpcomingDelivery
+        ? Number(userData.ownKids || 0)
+        : Number(userData.ownKids || 0) + 1;
+
+      handleChange(
+        setUsers,
+        setState,
+        userData.userId,
+        'lastCycle',
+        formatDateToServer(formatDate(lastCycleDate)),
+        true,
+        {},
+        isToastOn,
+      );
+
+      handleChange(
+        setUsers,
+        setState,
+        userData.userId,
+        'lastDelivery',
+        formatDate(lastDelivery),
+        true,
+        {},
+        isToastOn,
+      );
+
+      handleChange(
+        setUsers,
+        setState,
+        userData.userId,
+        'getInTouch',
+        formatDateToServer(formatDate(getInTouch)),
+        true,
+        {},
+        isToastOn,
+      );
+
+      handleChange(
+        setUsers,
+        setState,
+        userData.userId,
+        'ownKids',
+        ownKids,
+        true,
+        {},
+        isToastOn,
+      );
+    } else {
+      const serverFormattedDate = formatDateToServer(value);
+      handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
+    }
+  };
+
   const handlePregnantClick = () => {
     setIsPregnant(prev => {
       const newState = !prev;
@@ -132,10 +203,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           type="text"
           value={formatDateToDisplay(userData.lastCycle) || ''}
           placeholder="міс"
-          onChange={e => {
-            const serverFormattedDate = formatDateToServer(e.target.value);
-            handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
-          }}
+          onChange={handleLastCycleChange}
           onBlur={() => handleSubmit(userData, 'overwrite', isToastOn)}
           style={{
             marginLeft: 0,


### PR DESCRIPTION
## Summary
- allow `22т`, `22t`, or `22w` inputs to auto-calc last cycle, delivery, get in touch, and guard ownKids during pregnancy
- convert week abbreviations to dates in `formatDateAndFormula`
- test week parsing for `formatDateAndFormula`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd4e4ba8a48326bbf506ac40f316e9