### PR TITLE
Remove pregnancyWeek field in favor of lastCycle

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -185,7 +185,7 @@ export const ProfileForm = ({
         </div>
       )}
       {sortedFieldsToRender
-        .filter(field => !['myComment', 'getInTouch', 'writer', 'pregnancyWeek'].includes(field.name))
+        .filter(field => !['myComment', 'getInTouch', 'writer'].includes(field.name))
         .map((field, index) => {
           const displayValue =
             field.name === 'updatedAt'
@@ -461,57 +461,7 @@ export const ProfileForm = ({
         />
         <Button onClick={handleAddCustomField}>+</Button>
       </KeyValueRow>
-      <InputDiv>
-        <InputFieldContainer fieldName="pregnancyWeek" value={state.pregnancyWeek}>
-          <InputField
-            fieldName="pregnancyWeek"
-            inputMode="numeric"
-            name="pregnancyWeek"
-            value={state.pregnancyWeek || ''}
-            placeholder="25"
-            onChange={e =>
-              setState(prev => ({ ...prev, pregnancyWeek: e.target.value }))
-            }
-            onBlur={e => {
-              const week = parseInt(e.target.value, 10);
-              if (!isNaN(week)) {
-                const today = new Date();
-                const lastDelivery = new Date(today);
-                lastDelivery.setDate(today.getDate() + (40 - week) * 7);
-                const getInTouch = new Date(lastDelivery);
-                getInTouch.setMonth(getInTouch.getMonth() + 9);
-                const format = d =>
-                  `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.${d.getFullYear()}`;
-                const updatedState = {
-                  ...state,
-                  pregnancyWeek: e.target.value,
-                  lastDelivery: format(lastDelivery),
-                  getInTouch: format(getInTouch),
-                };
-                if (state.ownKids !== undefined && state.ownKids !== '') {
-                  updatedState.ownKids = Number(state.ownKids) + 1;
-                }
-                setState(updatedState);
-                handleSubmit(updatedState, 'overwrite');
-              }
-            }}
-          />
-          {state.pregnancyWeek && (
-            <ClearButton
-              type="button"
-              onMouseDown={e => e.preventDefault()}
-              onClick={() =>
-                setState(prev => ({ ...prev, pregnancyWeek: '' }))
-              }
-            >
-              &times;
-            </ClearButton>
-          )}
-        </InputFieldContainer>
-        <Hint fieldName="pregnancyWeek" isActive={state.pregnancyWeek}>25</Hint>
-        <Placeholder isActive={state.pregnancyWeek}>Тиждень вагітності</Placeholder>
-      </InputDiv>
-      <Photos state={state} setState={setState} />
+        <Photos state={state} setState={setState} />
     </>
   );
 };

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -282,7 +282,6 @@ export const pickerFieldsExtended = [
   { name: 'userId', placeholder: 'userId', svg: 'user', ukrainianHint: 'Id' },
   { name: 'role', placeholder: 'см/до/смдо/агент', svg: 'user', ukrainianHint: 'СМДО?' },
   { name: 'myComment', placeholder: 'коментар', svg: 'user', ukrainianHint: 'Коментра' },
-  { name: 'pregnancyWeek', placeholder: '25', hint: 'pregnancy week', svg: 'no', ukrainianHint: 'Тиждень вагітності' },
   { name: 'getInTouch', placeholder: '30.01.2025', svg: 'user', ukrainianHint: 'Коли звернутись' },
   { name: 'lastAction', placeholder: '-', svg: 'user', ukrainianHint: 'Останні зміни' },
   { name: 'lastLogin2', placeholder: '-', svg: 'user', ukrainianHint: 'Останній логін' },


### PR DESCRIPTION
## Summary
- remove pregnancyWeek from extended picker fields
- drop pregnancyWeek input from profile form and filter list
- rely on lastCycle for term calculations instead

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bd5bed696c83269edd2c83d79119ff