### PR TITLE
Consolidate handleChange and normalize lastDelivery format

### DIFF
--- a/src/components/makeCardDescription.js
+++ b/src/components/makeCardDescription.js
@@ -1,7 +1,8 @@
 import { normalizeLocation } from './normalizeLocation';
+import { formatDateToDisplay } from 'components/inputValidations';
 
 export const makeCardDescription = user => {
-  const birthsInfo = [user.ownKids, user.lastDelivery]
+  const birthsInfo = [user.ownKids, formatDateToDisplay(user.lastDelivery)]
     .filter(Boolean)
     .join('-');
 

--- a/src/components/smallCard/fieldDeliveryInfo.js
+++ b/src/components/smallCard/fieldDeliveryInfo.js
@@ -1,9 +1,11 @@
 import { handleChange } from './actions';
 import { utilCalculateMonthsAgo } from './utilCalculateMonthsAgo';
 import { AttentionButton } from 'components/styles';
+import { formatDateToDisplay } from 'components/inputValidations';
 
 export const fieldDeliveryInfo = (setUsers, setState, userData) => {
   const { ownKids, lastDelivery, csection } = userData;
+  const formattedLastDelivery = formatDateToDisplay(lastDelivery);
 
   // Функція для парсингу дати з формату дд.мм.рррр
   const parseCsectionDate = dateString => {
@@ -27,7 +29,7 @@ export const fieldDeliveryInfo = (setUsers, setState, userData) => {
   };
 
   // Використовуємо `csection` як дату останніх пологів, якщо `lastDelivery` не задано
-  const effectiveLastDelivery = lastDelivery || (csection && parseCsectionDate(csection));
+  const effectiveLastDelivery = formattedLastDelivery || (csection && parseCsectionDate(csection));
 
   // Додаємо перевірку перед викликом `split`
   let deliveryDate = null;

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -62,6 +62,7 @@ const formatDate = date => {
 
 export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
   const [isPregnant, setIsPregnant] = React.useState(false);
+  const submittedRef = React.useRef(false);
 
   const nextCycle = React.useMemo(() => calculateNextDate(userData.lastCycle), [userData.lastCycle]);
 
@@ -87,49 +88,29 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
         ? Number(userData.ownKids || 0)
         : Number(userData.ownKids || 0) + 1;
 
-      handleChange(
-        setUsers,
-        setState,
-        userData.userId,
-        'lastCycle',
-        formatDateToServer(formatDate(lastCycleDate)),
-        true,
-        {},
-        isToastOn,
-      );
+      const lastCycleFormatted = formatDateToServer(formatDate(lastCycleDate));
+      const lastDeliveryFormatted = formatDateToServer(formatDate(lastDelivery));
+      const getInTouchFormatted = formatDateToServer(formatDate(getInTouch));
 
-      handleChange(
-        setUsers,
-        setState,
-        userData.userId,
-        'lastDelivery',
-        formatDate(lastDelivery),
-        true,
-        {},
-        isToastOn,
-      );
-
-      handleChange(
-        setUsers,
-        setState,
-        userData.userId,
-        'getInTouch',
-        formatDateToServer(formatDate(getInTouch)),
-        true,
-        {},
-        isToastOn,
-      );
-
-      handleChange(
-        setUsers,
-        setState,
-        userData.userId,
-        'ownKids',
+      handleChange(setUsers, setState, userData.userId, {
+        lastCycle: lastCycleFormatted,
+        lastDelivery: lastDeliveryFormatted,
+        getInTouch: getInTouchFormatted,
         ownKids,
-        true,
-        {},
+      });
+
+      handleSubmit(
+        {
+          ...userData,
+          lastCycle: lastCycleFormatted,
+          lastDelivery: lastDeliveryFormatted,
+          getInTouch: getInTouchFormatted,
+          ownKids,
+        },
+        'overwrite',
         isToastOn,
       );
+      submittedRef.current = true;
     } else {
       const serverFormattedDate = formatDateToServer(value);
       handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
@@ -150,38 +131,26 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
 
           const ownKids = Number(userData.ownKids || 0) + 1;
 
-          handleChange(
-            setUsers,
-            setState,
-            userData.userId,
-            'lastDelivery',
-            formatDate(lastDelivery),
-            true,
-            {},
-            isToastOn,
-          );
+          const lastDeliveryFormatted = formatDateToServer(formatDate(lastDelivery));
+          const getInTouchFormatted = formatDateToServer(formatDate(getInTouch));
 
-          handleChange(
-            setUsers,
-            setState,
-            userData.userId,
-            'getInTouch',
-            formatDateToServer(formatDate(getInTouch)),
-            true,
-            {},
-            isToastOn,
-          );
-
-          handleChange(
-            setUsers,
-            setState,
-            userData.userId,
-            'ownKids',
+          handleChange(setUsers, setState, userData.userId, {
+            lastDelivery: lastDeliveryFormatted,
+            getInTouch: getInTouchFormatted,
             ownKids,
-            true,
-            {},
+          });
+
+          handleSubmit(
+            {
+              ...userData,
+              lastDelivery: lastDeliveryFormatted,
+              getInTouch: getInTouchFormatted,
+              ownKids,
+            },
+            'overwrite',
             isToastOn,
           );
+          submittedRef.current = true;
         }
       }
       return newState;
@@ -204,7 +173,12 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           value={formatDateToDisplay(userData.lastCycle) || ''}
           placeholder="міс"
           onChange={handleLastCycleChange}
-          onBlur={() => handleSubmit(userData, 'overwrite', isToastOn)}
+          onBlur={() => {
+            if (!submittedRef.current) {
+              handleSubmit(userData, 'overwrite', isToastOn);
+            }
+            submittedRef.current = false;
+          }}
           style={{
             marginLeft: 0,
             textAlign: 'left',


### PR DESCRIPTION
## Summary
- Allow handleChange to accept object updates and auto-format lastDelivery
- Save lastDelivery in YYYY-MM-DD regardless of pregnancy toggle
- Batch pregnancy date updates via a single handleChange call

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bd68e21e108326acd7a8a0b8f04f60