### PR TITLE
Load profile editor from cached cards and persist refreshes

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -13,6 +13,7 @@ import { ProfileForm } from './ProfileForm';
 import { renderTopBlock } from "./smallCard/renderTopBlock";
 import { coloredCard } from "./styles";
 import { updateCachedUser } from '../utils/cache';
+import { getCard } from '../utils/cardIndex';
 
 const Container = styled.div`
   display: flex;
@@ -34,7 +35,7 @@ const EditProfile = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const [state, setState] = useState(location.state || null);
+  const [state, setState] = useState(() => getCard(userId) || location.state || null);
   const [isSyncing, setIsSyncing] = useState(false);
   const [isToastOn, setIsToastOn] = useState(false);
 

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -16,6 +16,7 @@ import { fieldIMT } from './fieldIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
+import { updateCard } from 'utils/cardsStorage';
 
 const getParentBackground = element => {
   let el = element;
@@ -152,6 +153,7 @@ export const renderTopBlock = (
           try {
             const fresh = await fetchUserById(userData.userId);
             if (fresh) {
+              updateCard(userData.userId, { ...fresh, updatedAt: Date.now() });
               if (setUsers) {
                 setUsers(prev => {
                   if (Array.isArray(prev)) {


### PR DESCRIPTION
## Summary
- Seed EditProfile form state from cached `cards` and avoid initial network fetches
- Persist refreshed card data to localStorage when the three-dot menu is used

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bdaf6db61883268afe70266e892da2