### PR TITLE
fix: tighten BMI spacing

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -128,7 +128,7 @@ export const renderTopBlock = (
             if (userData.blood) parts.push(fieldBlood(userData.blood));
             if (userData.height) parts.push(userData.height);
             if (userData.height && userData.weight) parts.push('/');
-            if (userData.weight) parts.push(`${userData.weight} - `);
+            if (userData.weight) parts.push(`${userData.weight} -`);
             if (userData.weight && userData.height) parts.push(fieldIMT(userData.weight, userData.height));
             return parts.map((part, index) => <React.Fragment key={index}>{part} </React.Fragment>);
           })()}


### PR DESCRIPTION
## Summary
- adjust BMI line in renderTopBlock to remove extra gap after weight

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bee5e19ef8832699f9d76b7e82b303