### PR TITLE
Add phone icon and tighten contact spacing

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -23,7 +23,7 @@ const iconStyle = {
 const phoneBtnStyle = {
   color: 'inherit',
   textDecoration: 'none',
-  marginLeft: '8px',
+  marginLeft: '4px',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -64,6 +64,7 @@ const icons = {
   tiktok: <SiTiktok style={iconStyle} />,
   vk: <FaVk style={iconStyle} />,
   otherLink: <FaGlobe style={iconStyle} />,
+  phone: <FaPhoneVolume style={iconStyle} />,
 };
 
   return Object.keys(data).map(key => {
@@ -84,11 +85,11 @@ const icons = {
             display: 'flex',
             alignItems: 'center',
             flexWrap: 'wrap',
-            gap: '4px',
+            gap: '2px',
           }}
         >
-          {!['email', 'phone'].includes(key) && (
-            <strong style={{ marginRight: '4px', display: 'flex', alignItems: 'center' }}>
+          {key !== 'email' && (
+            <strong style={{ marginRight: '2px', display: 'flex', alignItems: 'center' }}>
               {label}
             </strong>
           )}


### PR DESCRIPTION
## Summary
- show phone SVG before number in top block contacts
- reduce spacing between contact icons and their text for a tighter layout

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bee6d810608326a8a55773a1093c2a