### PR TITLE
Standardize accent block spacing

### DIFF
--- a/src/components/App.styled.jsx
+++ b/src/components/App.styled.jsx
@@ -22,10 +22,7 @@ export const TitleH2 = styled.h2`
   margin-bottom: 10px;
 `;
 
-export const Button = styled.button`
-  margin-left: 10px;
-  /* margin-bottom: 10px; */
-  padding: 5px 5px;
+export const Button = styled.button.attrs({ className: 'accent-block' })`
   width: 40px;
   height: 40px;
   background-color: var(--accent-color);
@@ -37,6 +34,6 @@ export const Button = styled.button`
   &:hover,
   &:focus {
     background-color: var(--accent-color-hover);
-  };
+  }
   align-self: flex-end;
 `;

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -77,18 +77,16 @@ const Label = styled.label`
     `}
 `;
 
-const SubmitButton = styled.button`
+const SubmitButton = styled.button.attrs({ className: 'accent-block' })`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 5px auto 0 auto;
+  margin: var(--accent-block-margin) auto;
   color: ${({ disabled }) => (disabled ? '#b0b0b0' : 'white')};
   border: none;
   border-radius: 5px;
-  cursor: pointer;
   font-size: 16px;
-  padding: 10px 20px;
   background-color: ${({ disabled }) => (disabled ? '#d0d0d0' : color.accent5)}; /* Сірий для вимкненої кнопки, синій для активної */
   text-align: center;
   font-weight: bold;

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -328,10 +328,9 @@ const TopActions = styled.div`
   z-index: 10;
 `;
 
-const ActionButton = styled.button`
+const ActionButton = styled.button.attrs({ className: 'accent-block' })`
   width: 35px;
   height: 35px;
-  padding: 3px;
   border: none;
   background-color: ${color.accent5};
   color: white;

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -265,17 +265,15 @@ export const SubmitButton = styled.button`
   }
 `;
 
-const PublishButton = styled.button`
+const PublishButton = styled.button.attrs({ className: 'accent-block' })`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 5px auto 0 auto;
+  margin: var(--accent-block-margin) auto;
   color: white;
   border: none;
   border-radius: 5px;
-  cursor: pointer;
   font-size: 16px;
-  padding: 10px 20px;
   background-color: ${color.accent5};
   text-align: center;
   font-weight: bold;

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -76,9 +76,8 @@ const UploadButtonWrapper = styled.div`
   margin-top: 20px;
 `;
 
-const UploadButtonLabel = styled.label`
+const UploadButtonLabel = styled.label.attrs({ className: 'accent-block' })`
   display: inline-block;
-  padding: 10px 20px;
   background-color: ${color.accent5};
   color: white;
   border-radius: 5px;
@@ -90,12 +89,12 @@ const UploadButtonLabel = styled.label`
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
 
   &:hover {
-    background-color: ${color.accent}; 
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); 
+    background-color: ${color.accent};
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   }
 
   &:active {
-    transform: scale(0.98); 
+    transform: scale(0.98);
   }
 `;
 

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,8 @@
   --box-shadow: 0px 0px 10px 5px rgba(0, 0, 0, 0.2);
   --border: 1px solid #122236;
   --animation-timing-function: 300ms cubic-bezier(0.4, 0, 0.2, 1) 0s;
+  --accent-block-padding: 4px;
+  --accent-block-margin: 8px;
 }
 
 body,
@@ -77,6 +79,11 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+.accent-block {
+  padding: var(--accent-block-padding);
+  margin: var(--accent-block-margin);
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- add global variables and `.accent-block` class for uniform padding and margin
- apply `.accent-block` to accent color buttons and labels

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bef13e0a448326a3cec7060f05c04d