### PR TITLE
Fix stale card cache and skip redundant fetches

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -17,6 +17,7 @@ import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
 import { updateCard } from 'utils/cardsStorage';
+import { getCard } from 'utils/cardIndex';
 
 const getParentBackground = element => {
   let el = element;
@@ -164,9 +165,14 @@ export const renderTopBlock = (
           };
 
           try {
-            const fresh = await fetchUserById(userData.userId);
-            if (fresh) {
-              const updated = updateCard(userData.userId, fresh);
+            let updated = getCard(userData.userId);
+            if (!updated) {
+              const fresh = await fetchUserById(userData.userId);
+              if (fresh) {
+                updated = updateCard(userData.userId, fresh);
+              }
+            }
+            if (updated) {
               if (setUsers) {
                 setUsers(prev => {
                   if (Array.isArray(prev)) {

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -28,7 +28,8 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
     ...cards[cardId],
     ...data,
     id: cardId,
-    updatedAt: data.updatedAt ?? Date.now(),
+    updatedAt: Date.now(),
+    ...(data.updatedAt ? { serverUpdatedAt: data.updatedAt } : {}),
   };
   removeKeys.forEach(key => {
     delete updatedCard[key];


### PR DESCRIPTION
## Summary
- Store local `updatedAt` time in cards and keep server's timestamp separately
- Reuse cached cards in `renderTopBlock` to avoid unnecessary backend requests

## Testing
- `CI=true npm test -- --watch=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bf33d2b12c832696fa55f9d2474cbb