### PR TITLE
Always refresh small card from backend

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -165,14 +165,25 @@ export const renderTopBlock = (
           };
 
           try {
-            let updated = getCard(userData.userId);
-            if (!updated) {
-              const fresh = await fetchUserById(userData.userId);
-              if (fresh) {
-                updated = updateCard(userData.userId, fresh);
+            const cached = getCard(userData.userId);
+            let updated = cached;
+
+            const fresh = await fetchUserById(userData.userId);
+            if (fresh) {
+              const isNewer =
+                !cached ||
+                !cached.serverUpdatedAt ||
+                !fresh.serverUpdatedAt ||
+                new Date(fresh.serverUpdatedAt) > new Date(cached.serverUpdatedAt);
+
+              if (isNewer) {
+                updated = fresh;
               }
             }
+
             if (updated) {
+              updated = updateCard(userData.userId, updated);
+
               if (setUsers) {
                 setUsers(prev => {
                   if (Array.isArray(prev)) {
@@ -184,6 +195,7 @@ export const renderTopBlock = (
                   return prev;
                 });
               }
+
               if (setState) {
                 setState(prev => ({ ...prev, ...updated }));
               }


### PR DESCRIPTION
## Summary
- Always fetch latest user data on small card toggle
- Refresh local cache only when server data is newer based on `serverUpdatedAt`

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68bf3c51b8548326a273ea6fa8719cb1