### PR TITLE
feat: add generic key search

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -838,7 +838,23 @@ const searchByPrefixes = async (searchValue, uniqueUserIds, users) => {
 
 export const fetchNewUsersCollectionInRTDB = async searchedValue => {
   if (isDev) console.log('fetchNewUsersCollectionInRTDB → searchedValue:', searchedValue);
-  const { searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
+  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
+  if (
+    searchValue === '__exists__' ||
+    !keysToCheck.includes(searchKey)
+  ) {
+    const allCards = await getUserCards();
+    const filtered = allCards.filter(card => {
+      const val = card[searchKey];
+      if (searchValue === '__exists__') return val !== undefined;
+      return val !== undefined && String(val) === String(searchValue);
+    });
+    if (filtered.length === 1) return filtered[0];
+    return filtered.reduce((acc, card) => {
+      acc[card.userId] = card;
+      return acc;
+    }, {});
+  }
   if (isDev)
     console.log('fetchNewUsersCollectionInRTDB → params:', {
       searchValue,


### PR DESCRIPTION
## Summary
- support colon-based key queries in detectSearchParams
- handle generic key searches and caching in writeData
- allow backend search by arbitrary field or field existence

## Testing
- `CI=true npm test --silent`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68bf3f8a82348326a6bb0e2e60fd440c