### PR TITLE
Restrict userId regex patterns and extend tests

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -203,7 +203,14 @@ const parseUserId = input => {
   const candidate = (match ? match[1] : trimmed).trim();
   const normalized = candidate.replace(/[+\s()-]/g, '');
   if (/^(?:0|380)\d{9}$/.test(normalized)) return null;
-  if (/^-?[a-zA-Z0-9]{4,}$/.test(candidate)) return candidate;
+  const patterns = [
+    /^AA\d{4}$/,
+    /^AB\d{4}$/,
+    /^VK\d{5}$/,
+    /^-[A-Za-z0-9-]{4,}$/,
+    /^[A-Za-z0-9]{28}$/,
+  ];
+  if (patterns.some(p => p.test(candidate))) return candidate;
   return null;
 };
 

--- a/src/components/__tests__/SearchBar.test.js
+++ b/src/components/__tests__/SearchBar.test.js
@@ -6,8 +6,19 @@ describe('detectSearchParams', () => {
     expect(result).toEqual({ key: 'phone', value: '380957209136' });
   });
 
-  it('detects numeric userId when not phone-like', () => {
-    const result = detectSearchParams('123456');
-    expect(result).toEqual({ key: 'userId', value: '123456' });
+  it.each([
+    'AA1234',
+    'AB1234',
+    'VK12345',
+    '-abcd',
+    '1234567890123456789012345678',
+  ])('detects %s as userId', val => {
+    const result = detectSearchParams(val);
+    expect(result).toEqual({ key: 'userId', value: val });
+  });
+
+  it('places random string into other', () => {
+    const result = detectSearchParams('randomstring');
+    expect(result).toEqual({ key: 'other', value: 'randomstring' });
   });
 });


### PR DESCRIPTION
## Summary
- limit userId detection to specific patterns (AA####, AB####, VK##### , leading-hyphen codes, 28-char alphanumerics)
- return null when no userId pattern matches
- test allowed userId formats and random string falls to `other`

## Testing
- `npm test src/components/__tests__/SearchBar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c049bb2c5883269371382c3591ffd3