### PR TITLE
Use userId consistently instead of id

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -600,7 +600,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const cards = ids.map(id => getCard(id)).filter(Boolean);
     if (cards.length > 0) {
       const cachedUsers = cards.reduce((acc, u) => {
-        acc[u.id] = u;
+        acc[u.userId] = u;
         return acc;
       }, {});
       setUsers(cachedUsers);
@@ -791,7 +791,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return !/^\d{4}-\d{2}-\d{2}$/.test(d) || d <= today;
     };
     const filteredArr = cachedArr.filter(
-      u => isValid(u.getInTouch) && (!currentFilters.favorite?.favOnly || fav[u.id]),
+      u => isValid(u.getInTouch) && (!currentFilters.favorite?.favOnly || fav[u.userId]),
     );
 
     let offset = dateOffset2;
@@ -800,7 +800,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const slice = filteredArr.slice(offset, offset + PAGE_SIZE);
     if (slice.length > 0) {
       const cachedUsers = slice.reduce((acc, u) => {
-        acc[u.id] = u;
+        acc[u.userId] = u;
         return acc;
       }, {});
       cacheFetchedUsers(cachedUsers, cacheLoad2Users, currentFilters);
@@ -902,7 +902,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const sorted = loadedArr
         .sort((a, b) => compareUsersByGetInTouch(a, b))
         .reduce((acc, user) => {
-          acc[user.id] = user;
+          acc[user.userId] = user;
           return acc;
         }, {});
       const total = Object.keys(sorted).length;
@@ -929,7 +929,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const sorted = loadedArr
       .sort((a, b) => compareUsersByGetInTouch(a, b))
       .reduce((acc, user) => {
-        acc[user.id] = user;
+        acc[user.userId] = user;
         return acc;
       }, {});
     const total = Object.keys(sorted).length;
@@ -957,7 +957,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const cached = await getDplCards(verifyDuplicate);
       if (cached.length > 0) {
         const merged = cached.reduce((acc, user) => {
-          acc[user.id] = user;
+          acc[user.userId] = user;
           return acc;
         }, {});
         setUsers(prev => ({ ...prev, ...merged }));
@@ -993,7 +993,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const cached = await getDplCards();
     if (cached.length > 0) {
       const merged = cached.reduce((acc, user) => {
-        acc[user.id] = user;
+        acc[user.userId] = user;
         return acc;
       }, {});
       setUsers(prev => ({ ...prev, ...merged }));

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -62,8 +62,7 @@ import {
 } from '../utils/commentsStorage';
 
 const isValidId = id => typeof id === 'string' && id.length >= 20;
-const filterLongUsers = list =>
-  list.filter(u => isValidId(u?.id || u?.userId));
+const filterLongUsers = list => list.filter(u => isValidId(u?.userId));
 
 const compareUsersByLastLogin2 = (a = {}, b = {}) =>
   (b.lastLogin2 || '').localeCompare(a.lastLogin2 || '');
@@ -1423,7 +1422,7 @@ const Matching = () => {
       const list = filterLongUsers(
         await getFavoriteCards(id => fetchUserById(id))
       ).sort(compareUsersByLastLogin2);
-      loadedIdsRef.current = new Set(list.map(u => u.id));
+      loadedIdsRef.current = new Set(list.map(u => u.userId));
       setUsers(list);
       await loadCommentsFor(list);
       setHasMore(false);
@@ -1442,7 +1441,7 @@ const Matching = () => {
     const list = filterLongUsers(
       await getFavoriteCards(id => fetchUserById(id))
     ).sort(compareUsersByLastLogin2);
-    loadedIdsRef.current = new Set(list.map(u => u.id));
+    loadedIdsRef.current = new Set(list.map(u => u.userId));
     setUsers(list);
     await loadCommentsFor(list);
     setHasMore(false);
@@ -1469,7 +1468,7 @@ const Matching = () => {
       const list = filterLongUsers(
         await getDislikedCards(id => fetchUserById(id))
       ).sort(compareUsersByLastLogin2);
-      loadedIdsRef.current = new Set(list.map(u => u.id));
+      loadedIdsRef.current = new Set(list.map(u => u.userId));
       setUsers(list);
       await loadCommentsFor(list);
       setHasMore(false);
@@ -1487,7 +1486,7 @@ const Matching = () => {
     const list = filterLongUsers(
       await getDislikedCards(id => fetchUserById(id))
     ).sort(compareUsersByLastLogin2);
-    loadedIdsRef.current = new Set(list.map(u => u.id));
+    loadedIdsRef.current = new Set(list.map(u => u.userId));
     setUsers(list);
     await loadCommentsFor(list);
     setHasMore(false);

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -11,7 +11,7 @@ export const btnEdit = (userData, setSearch, setState) => {
       setSearch(`${userData.userId}`);
       setState(userData);
       const cacheKey = getCacheKey('search', normalizeQueryKey(`userId=${userData.userId}`));
-      saveCard({ ...userData, id: userData.userId });
+      saveCard(userData);
       setIdsForQuery(cacheKey, [userData.userId]);
     } else {
       console.log('Користувача не знайдено.');

--- a/src/utils/__tests__/cardsStorage.test.js
+++ b/src/utils/__tests__/cardsStorage.test.js
@@ -40,11 +40,11 @@ describe('cardsStorage', () => {
   it('refreshes expired card from backend', async () => {
     const SIX_HOURS = 6 * 60 * 60 * 1000;
     const expired = Date.now() - SIX_HOURS - 1000;
-    const oldCard = { id: '1', title: 'Old', updatedAt: expired };
+    const oldCard = { userId: '1', title: 'Old', updatedAt: expired };
     localStorage.setItem('cards', JSON.stringify({ '1': oldCard }));
     setIdsForQuery('favorite', ['1']);
 
-    const remoteFetch = jest.fn().mockResolvedValue({ id: '1', title: 'Fresh' });
+    const remoteFetch = jest.fn().mockResolvedValue({ userId: '1', title: 'Fresh' });
     const cards = await getCardsByList('favorite', remoteFetch);
 
     expect(remoteFetch).toHaveBeenCalledWith('1');

--- a/src/utils/__tests__/getFilteredCardsByList.test.js
+++ b/src/utils/__tests__/getFilteredCardsByList.test.js
@@ -13,14 +13,14 @@ describe('getFilteredCardsByList', () => {
   it('filters stored cards and fetches more when needed', async () => {
     const now = Date.now();
     localStorage.setItem('cards', JSON.stringify({
-      a: { id: 'a', ok: true, updatedAt: now },
-      b: { id: 'b', ok: false, updatedAt: now },
+      a: { userId: 'a', ok: true, updatedAt: now },
+      b: { userId: 'b', ok: false, updatedAt: now },
     }));
     setIdsForQuery('testList', ['a', 'b']);
 
     const fetchMore = jest.fn(async count => {
       expect(count).toBe(1);
-      return [['c', { ok: true }]];
+      return [['c', { userId: 'c', ok: true }]];
     });
 
     const res = await getFilteredCardsByList(
@@ -32,7 +32,7 @@ describe('getFilteredCardsByList', () => {
       2,
     );
 
-    expect(res.map(c => c.id)).toEqual(['a', 'c']);
+    expect(res.map(c => c.userId)).toEqual(['a', 'c']);
     const storedCards = JSON.parse(localStorage.getItem('cards'));
     expect(storedCards.c.ok).toBe(true);
     const ids = getIdsByQuery('testList');

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -42,9 +42,9 @@ export const getCard = id => {
 };
 
 export const saveCard = card => {
-  if (!card || !card.id) return;
+  if (!card || !card.userId) return;
   const cards = loadCards();
-  cards[card.id] = { ...card, id: card.id, updatedAt: Date.now() };
+  cards[card.userId] = { ...card, userId: card.userId, updatedAt: Date.now() };
   saveCards(cards);
 };
 

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -27,10 +27,11 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
   const updatedCard = {
     ...cards[cardId],
     ...data,
-    id: cardId,
+    userId: cardId,
     updatedAt: Date.now(),
     ...(data.updatedAt ? { serverUpdatedAt: data.updatedAt } : {}),
   };
+  delete updatedCard.id;
   removeKeys.forEach(key => {
     delete updatedCard[key];
   });
@@ -71,7 +72,8 @@ export const getCardsByList = async (listKey, remoteFetch) => {
 
     fetched.forEach(([id, fresh]) => {
       if (fresh) {
-        const card = { ...fresh, id, updatedAt: Date.now() };
+        const { id: _, ...rest } = fresh;
+        const card = { ...rest, userId: id, updatedAt: Date.now() };
         cards[id] = card;
         result.push(card);
         freshIds.push(id);
@@ -118,7 +120,8 @@ export const getFilteredCardsByList = async (
     try {
       const extra = await fetchMore(needed);
       extra.forEach(([id, data]) => {
-        cards[id] = { ...data, id, updatedAt: Date.now() };
+        const { id: _, ...rest } = data;
+        cards[id] = { ...rest, userId: id, updatedAt: Date.now() };
         if (!ids.includes(id)) ids.push(id);
       });
       saveCards(cards);


### PR DESCRIPTION
## Summary
- Store and cache cards keyed by `userId` and remove redundant `id` field
- Update profile management and matching views to reference `userId` only
- Adjust tests to use `userId` for identifying users

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04ac3c2548326a99312066f40af60