### PR TITLE
refactor: unify last action timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ GitHub.
 ```json
 {
   "cards": {
-    "1": { "id": "1", "title": "Card 1", "updatedAt": 1690000000000 }
+    "1": { "id": "1", "title": "Card 1", "lastAction": 1690000000000 }
   },
   "load2": ["1"],
   "favorite": ["1"]
@@ -170,7 +170,7 @@ const load2Cards = await getCardsByList('load2', fetchCard);
 const favoriteCards = await getCardsByList('favorite', fetchCard);
 ```
 
-Каждая карточка содержит поле `updatedAt`. При невозможности получить карточку с
+Каждая карточка содержит поле `lastAction`. При невозможности получить карточку с
 бекенда её идентификатор удаляется из соответствующего списка.
 
 Страница `AddNewProfile` использует эти списки `favorite` и `load2` через

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1210,7 +1210,7 @@ const Matching = () => {
       const arr = fetched[id] || [];
       const server = arr[0];
       const local = cache[id];
-      if (server && (!local || server.updatedAt > local.updatedAt)) {
+      if (server && (!local || server.lastAction > local.lastAction)) {
         newStore[id] = server;
         commentsMap[id] = server.text;
       } else if (local) {
@@ -1752,7 +1752,7 @@ const Matching = () => {
                             if (auth.currentUser) {
                               const text = comments[user.userId] || '';
                               const res = await setUserComment(user.userId, text);
-                              setLocalComment(user.userId, text, res?.updatedAt);
+                              setLocalComment(user.userId, text, res?.lastAction);
                             }
                           }}
                         />

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -6,8 +6,8 @@ import { useAutoResize } from '../hooks/useAutoResize';
 import { color } from './styles';
 import { pickerFieldsExtended as pickerFields } from './formFields';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
-import { parseDDMMYYYY } from '../utils/parseDDMMYYYY';
 import { formatDateToDisplay } from 'components/inputValidations';
+import { normalizeLastAction } from 'utils/normalizeLastAction';
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -189,10 +189,8 @@ export const ProfileForm = ({
         .filter(field => !['myComment', 'getInTouch', 'writer'].includes(field.name))
         .map((field, index) => {
           const displayValue =
-            field.name === 'updatedAt'
-              ? new Date(
-                  state.updatedAt ?? parseDDMMYYYY(state.lastAction)
-                ).toLocaleDateString('uk-UA')
+            field.name === 'lastAction'
+              ? formatDateToDisplay(normalizeLastAction(state.lastAction))
               : field.name === 'lastDelivery'
               ? formatDateToDisplay(state.lastDelivery)
               : state[field.name] || '';
@@ -256,7 +254,7 @@ export const ProfileForm = ({
                     inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                     name={field.name}
                     value={displayValue}
-                    {...(field.name === 'updatedAt'
+                    {...(field.name === 'lastAction'
                       ? { readOnly: true }
                       : {
                           onChange: e => {
@@ -282,7 +280,7 @@ export const ProfileForm = ({
                           onBlur: () => handleSubmit(state, 'overwrite'),
                         })}
                   />
-                  {field.name !== 'updatedAt' && state[field.name] && (
+                  {field.name !== 'lastAction' && state[field.name] && (
                     <ClearButton
                       type="button"
                       onMouseDown={e => e.preventDefault()}
@@ -291,7 +289,7 @@ export const ProfileForm = ({
                       &times;
                     </ClearButton>
                   )}
-                  {field.name !== 'updatedAt' && state[field.name] && (
+                  {field.name !== 'lastAction' && state[field.name] && (
                     <DelKeyValueBTN
                       onMouseDown={e => e.preventDefault()}
                       onClick={() => handleDelKeyValue(field.name)}
@@ -308,7 +306,7 @@ export const ProfileForm = ({
               </InputDiv>
             )}
 
-            {field.name !== 'updatedAt' &&
+            {field.name !== 'lastAction' &&
               state[field.name] &&
               (Array.isArray(state[field.name])
                 ? state[field.name].length === 0 || state[field.name][state[field.name].length - 1] !== ''

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -343,7 +343,7 @@ const SearchBar = ({
     if (!cacheKey) return false;
     const queries = loadQueries();
     const entry = queries[cacheKey];
-    return !!(entry && Date.now() - entry.updatedAt < TTL_MS);
+    return !!(entry && Date.now() - entry.lastAction < TTL_MS);
   };
 
   const addToHistory = value => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -363,20 +363,20 @@ export const setUserComment = async (cardId, text) => {
     const commentsRef = ref2(database, `multiData/comments/${user.uid}`);
     const q = query(commentsRef, orderByChild('cardId'), equalTo(cardId));
     const snap = await get(q);
-    const updatedAt = Date.now();
+    const lastAction = Date.now();
     if (snap.exists()) {
       const key = Object.keys(snap.val())[0];
       await set(ref2(database, `multiData/comments/${user.uid}/${key}`), {
         cardId,
         text,
         authorId: user.uid,
-        updatedAt,
+        lastAction,
       });
-      return { commentId: key, updatedAt };
+      return { commentId: key, lastAction };
     }
     const newRef = push(commentsRef);
-    await set(newRef, { cardId, text, authorId: user.uid, updatedAt });
-    return { commentId: newRef.key, updatedAt };
+    await set(newRef, { cardId, text, authorId: user.uid, lastAction });
+    return { commentId: newRef.key, lastAction };
   } catch (error) {
     console.error('Error setting comment:', error);
     return null;
@@ -396,7 +396,7 @@ export const fetchUserComment = async (ownerId, cardId) => {
       commentId,
       cardId: value.cardId,
       text: value.text,
-      updatedAt: value.updatedAt || 0,
+      lastAction: value.lastAction || 0,
     }));
   } catch (error) {
     console.error('Error fetching comment:', error);
@@ -418,7 +418,7 @@ export const fetchUserComments = async (ownerId, cardIds = []) => {
         const arr = Object.entries(snap.val()).map(([commentId, val]) => ({
           commentId,
           text: val.text || '',
-          updatedAt: val.updatedAt || 0,
+          lastAction: val.lastAction || 0,
         }));
         result[cardIds[idx]] = arr;
       }

--- a/src/components/inputValidations.js
+++ b/src/components/inputValidations.js
@@ -402,14 +402,37 @@ export const removeSpaceAndNewLine = value => {
   };
   
      // Перетворення дати з формату YYYY-MM-DD в DD.MM.YYYY
-  export const formatDateToDisplay = (dateString) => {
-    if (!dateString) return '';
-    const dashPattern = /^\d{4}-\d{2}-\d{2}$/;
-    if (dashPattern.test(dateString)) {
-      const [year, month, day] = dateString.split('-');
-      return `${day}.${month}.${year}`;
+  export const formatDateToDisplay = date => {
+    if (date === undefined || date === null || date === '') return '';
+
+    let timestamp;
+
+    if (typeof date === 'number') {
+      if (date > 1e9) timestamp = date;
+    } else if (typeof date === 'string') {
+      const trimmed = date.trim();
+      if (/^\d{10,}$/.test(trimmed)) {
+        const num = Number(trimmed);
+        if (!Number.isNaN(num)) timestamp = num;
+      } else if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        const [year, month, day] = trimmed.split('-');
+        return `${day}.${month}.${year}`;
+      } else if (/^\d{2}\.\d{2}\.\d{4}$/.test(trimmed)) {
+        return trimmed;
+      } else {
+        return trimmed;
+      }
     }
-    return dateString; // якщо вже у форматі дд.мм.рррр або невірний
+
+    if (timestamp !== undefined) {
+      const d = new Date(timestamp);
+      const dd = String(d.getDate()).padStart(2, '0');
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const yyyy = d.getFullYear();
+      return `${dd}.${mm}.${yyyy}`;
+    }
+
+    return String(date);
   };
 
 // Перетворення дати з формату DD.MM.YYYY в YYYY-MM-DD

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -169,17 +169,8 @@ export const handleSubmit = async (userData, condition, isToastOn) => {
     uploadedInfo.lastDelivery = formatDateToServer(uploadedInfo.lastDelivery);
   }
 
-  // Оновлюємо поле lastAction поточною датою у форматі рррр-мм-дд
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate());
-
-  // Форматуємо дату в локальному часі замість використання UTC
-  const year = currentDate.getFullYear();
-  const month = String(currentDate.getMonth() + 1).padStart(2, '0'); // Додаємо 1, оскільки місяці в Date починаються з 0
-  const day = String(currentDate.getDate()).padStart(2, '0');
-  const formattedDate = `${year}-${month}-${day}`; // Формат YYYY-MM-DD
-
-  uploadedInfo.lastAction = formattedDate;
+  // Оновлюємо поле lastAction поточною датою в мілісекундах
+  uploadedInfo.lastAction = Date.now();
 
   // Фільтруємо ключі, щоб видалити зайві поля
   const cleanedStateForNewUsers = Object.fromEntries(
@@ -209,15 +200,7 @@ export const handleSubmitAll = async (userData, overwrite) => {
     uploadedInfo.lastDelivery = formatDateToServer(uploadedInfo.lastDelivery);
   }
 
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate());
-
-  // Форматуємо дату в локальному часі замість використання UTC
-  const year = currentDate.getFullYear();
-  const month = String(currentDate.getMonth() + 1).padStart(2, '0'); // Додаємо 1, оскільки місяці в Date починаються з 0
-  const day = String(currentDate.getDate()).padStart(2, '0');
-  const formattedDate = `${year}-${month}-${day}`; // Формат YYYY-MM-DD
-  uploadedInfo.lastAction = formattedDate;
+  uploadedInfo.lastAction = Date.now();
 
   updateCachedUser({ ...uploadedInfo, userId: userData.userId });
 

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -18,6 +18,7 @@ import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
 import { updateCard } from 'utils/cardsStorage';
 import { getCard } from 'utils/cardIndex';
+import { normalizeLastAction } from 'utils/normalizeLastAction';
 
 const getParentBackground = element => {
   let el = element;
@@ -64,7 +65,8 @@ export const renderTopBlock = (
       {!isFromListOfUsers && <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />}
       {btnExport(userData)}
       <div>
-        {userData.lastAction && formatDateToDisplay(userData.lastAction)}
+        {userData.lastAction &&
+          formatDateToDisplay(normalizeLastAction(userData.lastAction))}
         {userData.lastAction && ', '}
         {userData.userId}
         {userData.userRole !== 'ag' &&
@@ -170,11 +172,9 @@ export const renderTopBlock = (
 
             const fresh = await fetchUserById(userData.userId);
             if (fresh) {
-              const isNewer =
-                !cached ||
-                !cached.serverUpdatedAt ||
-                !fresh.serverUpdatedAt ||
-                new Date(fresh.serverUpdatedAt) > new Date(cached.serverUpdatedAt);
+              const cachedTs = normalizeLastAction(cached?.lastAction);
+              const freshTs = normalizeLastAction(fresh.lastAction);
+              const isNewer = !cached || !cachedTs || !freshTs || freshTs > cachedTs;
 
               if (isNewer) {
                 updated = fresh;

--- a/src/utils/__tests__/cardsStorage.test.js
+++ b/src/utils/__tests__/cardsStorage.test.js
@@ -11,7 +11,8 @@ describe('cardsStorage', () => {
     const card = updateCard('1', { title: 'Card 1' }, remoteSave);
     const stored = JSON.parse(localStorage.getItem('cards'));
     expect(stored['1'].title).toBe('Card 1');
-    expect(remoteSave).toHaveBeenCalledWith(card);
+    expect(remoteSave).toHaveBeenCalledWith({ title: 'Card 1', userId: '1' });
+    expect(card).toHaveProperty('lastAction');
   });
 
   it('removes specified keys from card', () => {
@@ -40,7 +41,7 @@ describe('cardsStorage', () => {
   it('refreshes expired card from backend', async () => {
     const SIX_HOURS = 6 * 60 * 60 * 1000;
     const expired = Date.now() - SIX_HOURS - 1000;
-    const oldCard = { userId: '1', title: 'Old', updatedAt: expired };
+    const oldCard = { userId: '1', title: 'Old', lastAction: expired };
     localStorage.setItem('cards', JSON.stringify({ '1': oldCard }));
     setIdsForQuery('favorite', ['1']);
 

--- a/src/utils/__tests__/getFilteredCardsByList.test.js
+++ b/src/utils/__tests__/getFilteredCardsByList.test.js
@@ -13,8 +13,8 @@ describe('getFilteredCardsByList', () => {
   it('filters stored cards and fetches more when needed', async () => {
     const now = Date.now();
     localStorage.setItem('cards', JSON.stringify({
-      a: { userId: 'a', ok: true, updatedAt: now },
-      b: { userId: 'b', ok: false, updatedAt: now },
+      a: { userId: 'a', ok: true, lastAction: now },
+      b: { userId: 'b', ok: false, lastAction: now },
     }));
     setIdsForQuery('testList', ['a', 'b']);
 

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -37,14 +37,14 @@ export const getCard = id => {
   const cards = loadCards();
   const card = cards[id];
   if (!card) return null;
-  if (Date.now() - card.updatedAt > TTL_MS) return null;
+  if (Date.now() - card.lastAction > TTL_MS) return null;
   return card;
 };
 
 export const saveCard = card => {
   if (!card || !card.userId) return;
   const cards = loadCards();
-  cards[card.userId] = { ...card, userId: card.userId, updatedAt: Date.now() };
+  cards[card.userId] = { ...card, userId: card.userId, lastAction: Date.now() };
   saveCards(cards);
 };
 
@@ -53,7 +53,7 @@ export const getIdsByQuery = queryKey => {
   const queries = loadQueries();
   const entry = queries[key];
   if (!entry) return [];
-  if (Date.now() - entry.updatedAt > TTL_MS) {
+  if (Date.now() - entry.lastAction > TTL_MS) {
     delete queries[key];
     saveQueries(queries);
     return [];
@@ -70,7 +70,7 @@ export const getIdsByQuery = queryKey => {
 export const setIdsForQuery = (queryKey, ids) => {
   const key = normalizeQueryKey(queryKey);
   const queries = loadQueries();
-  queries[key] = { ids: ids.slice(), updatedAt: Date.now() };
+  queries[key] = { ids: ids.slice(), lastAction: Date.now() };
   saveQueries(queries);
 };
 
@@ -80,7 +80,7 @@ export const touchCardInQueries = cardId => {
   Object.keys(queries).forEach(key => {
     const entry = queries[key];
     if (entry.ids && entry.ids.includes(cardId)) {
-      entry.updatedAt = Date.now();
+      entry.lastAction = Date.now();
       changed = true;
     }
   });

--- a/src/utils/commentsStorage.js
+++ b/src/utils/commentsStorage.js
@@ -10,7 +10,7 @@ export const loadComments = () => {
     const parsed = JSON.parse(raw);
     const result = {};
     Object.entries(parsed).forEach(([id, entry]) => {
-      if (entry && (!entry.updatedAt || Date.now() - entry.updatedAt <= TTL_MS)) {
+      if (entry && (!entry.lastAction || Date.now() - entry.lastAction <= TTL_MS)) {
         result[id] = entry;
       }
     });
@@ -28,9 +28,9 @@ export const saveComments = comments => {
   }
 };
 
-export const setLocalComment = (id, text, updatedAt = Date.now()) => {
+export const setLocalComment = (id, text, lastAction = Date.now()) => {
   const comments = loadComments();
-  comments[id] = { text, updatedAt };
+  comments[id] = { text, lastAction };
   saveComments(comments);
 };
 

--- a/src/utils/dislikesStorage.js
+++ b/src/utils/dislikesStorage.js
@@ -24,7 +24,7 @@ export const setDislike = (id, isDisliked) => {
     ids.delete(id);
     removeCardFromList(id, DISLIKE_LIST_KEY);
   }
-  queries[DISLIKE_LIST_KEY] = { ids: Array.from(ids), updatedAt: Date.now() };
+  queries[DISLIKE_LIST_KEY] = { ids: Array.from(ids), lastAction: Date.now() };
   saveQueries(queries);
 };
 
@@ -32,7 +32,7 @@ export const syncDislikes = remoteDislikes => {
   const queries = loadQueries();
   queries[DISLIKE_LIST_KEY] = {
     ids: Object.keys(remoteDislikes || {}),
-    updatedAt: Date.now(),
+    lastAction: Date.now(),
   };
   saveQueries(queries);
 };

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -18,7 +18,7 @@ export const setFavorite = (id, isFav) => {
   } else {
     ids.delete(id);
   }
-  queries[FAVORITE_LIST_KEY] = { ids: Array.from(ids), updatedAt: Date.now() };
+  queries[FAVORITE_LIST_KEY] = { ids: Array.from(ids), lastAction: Date.now() };
   saveQueries(queries);
 };
 
@@ -26,7 +26,7 @@ export const syncFavorites = remoteFavs => {
   const queries = loadQueries();
   queries[FAVORITE_LIST_KEY] = {
     ids: Object.keys(remoteFavs || {}).filter(id => remoteFavs[id]),
-    updatedAt: Date.now(),
+    lastAction: Date.now(),
   };
   saveQueries(queries);
 };

--- a/src/utils/normalizeLastAction.js
+++ b/src/utils/normalizeLastAction.js
@@ -1,0 +1,22 @@
+export const normalizeLastAction = value => {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (/^\d+$/.test(trimmed)) {
+      const num = Number(trimmed);
+      if (!Number.isNaN(num)) return num;
+    }
+    if (/^\d{2}\.\d{2}\.\d{4}$/.test(trimmed)) {
+      const [day, month, year] = trimmed.split('.').map(Number);
+      return new Date(year, month - 1, day).getTime();
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const [year, month, day] = trimmed.split('-').map(Number);
+      return new Date(year, month - 1, day).getTime();
+    }
+  }
+  return undefined;
+};
+
+export default normalizeLastAction;


### PR DESCRIPTION
## Summary
- standardize timestamp handling with new `normalizeLastAction` utility
- store and display last action dates consistently across profiles and cards
- refactor local caches to rely on `lastAction` and omit timestamps from server payloads

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05c0fd05883268b3c38da5045b1b3