### PR TITLE
feat: cache filtered users for bang search

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1107,6 +1107,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             setUserNotFound(false);
           }}
           storageKey={SEARCH_KEY}
+          filters={filters}
+          filterForload={currentFilter}
+          favoriteUsers={favoriteUsersData}
         />
         {state.userId ? (
           <>

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -196,6 +196,34 @@ export const fetchAllUsers = async () => {
   setIdsForQuery('allUsers', allIds);
 };
 
+export const cacheFilteredUsers = async (
+  filterForload,
+  filterSettings = {},
+  favoriteUsers = {},
+  cacheKey,
+) => {
+  const usersObj = await fetchAllFilteredUsers(
+    filterForload,
+    filterSettings,
+    favoriteUsers,
+  );
+  const ids = [];
+  Object.entries(usersObj).forEach(([id, data]) => {
+    updateCard(id, data);
+    ids.push(id);
+    Object.entries(data).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      const keyCache = getCacheKey(
+        'search',
+        normalizeQueryKey(`${key}=${value}`),
+      );
+      setIdsForQuery(keyCache, [id]);
+    });
+  });
+  if (cacheKey) setIdsForQuery(cacheKey, ids);
+  return ids;
+};
+
 export const fetchLatestUsers = async (limit = 9, lastKey) => {
   const usersRef = ref2(database, 'users');
   const realLimit = limit + 1;


### PR DESCRIPTION
## Summary
- cache filtered users for ! searches
- wire filters into SearchBar and AddNewProfile
- leave Matching component unchanged

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c07db51c588326ab7c1c45eb945919