### PR TITLE
Add remaining card progress to SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -282,6 +282,17 @@ const SearchBar = ({
     () => loadHistoryCache('queries') || [],
   );
   const [showHistory, setShowHistory] = useState(false);
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    if (remaining > 0) {
+      toast.loading(`Filtering... ${remaining} left`, {
+        id: 'remaining-counter',
+      });
+    } else {
+      toast.dismiss('remaining-counter');
+    }
+  }, [remaining]);
 
   useEffect(() => {
     if (dataSource === undefined || dataSource === null) return;
@@ -483,9 +494,12 @@ const SearchBar = ({
       }
       const allResults = searchCachedCards(term);
       const results = {};
-      ids.forEach(id => {
+      setRemaining(ids.length);
+      for (const id of ids) {
         if (allResults[id]) results[id] = allResults[id];
-      });
+        setRemaining(r => r - 1);
+        await new Promise(requestAnimationFrame);
+      }
       if (Object.keys(results).length === 0) {
         setState && setState({});
         setUsers && setUsers({});


### PR DESCRIPTION
## Summary
- track remaining card count while filtering
- show a toast with the remaining cards count
- search filtering loop yields to the event loop for smoother UI

## Testing
- `CI=1 npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c1370f8b808326a2e37bfb714b87f7