### PR TITLE
Skip saving command queries to history

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -469,7 +469,7 @@ const SearchBar = ({
   const writeData = async (query = search) => {
     setUserNotFound && setUserNotFound(false);
     const trimmed = query?.trim();
-    if (trimmed) {
+    if (trimmed && !trimmed.startsWith('!')) {
       addToHistory(trimmed);
     }
     if (trimmed && trimmed.startsWith('!')) {
@@ -628,7 +628,7 @@ const SearchBar = ({
               key={item}
               onMouseDown={e => e.preventDefault()}
               onClick={() => {
-                setSearch(item);
+                if (!item.startsWith('!')) setSearch(item);
                 setShowHistory(false);
                 writeData(item);
               }}


### PR DESCRIPTION
## Summary
- avoid adding !-prefixed searches to the history
- prevent autofill from history entries beginning with !

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c13cd55c848326b782ffa2daaea7ce