### PR TITLE
feat: add data source toast

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1154,6 +1154,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               handleSubmit={handleSubmit}
               handleClear={handleClear}
               handleDelKeyValue={handleDelKeyValue}
+              dataSource={dataSource}
             />
           </>
         ) : (

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,5 +1,6 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
+import toast from 'react-hot-toast';
 import Photos from './Photos';
 import { inputUpdateValue } from './inputUpdatedValue';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -126,10 +127,16 @@ export const ProfileForm = ({
   handleSubmit,
   handleClear,
   handleDelKeyValue,
+  dataSource,
 }) => {
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
   const [customField, setCustomField] = useState({ key: '', value: '' });
+
+  useEffect(() => {
+    if (dataSource === undefined || dataSource === null) return;
+    toast.success(dataSource ? 'Дані з локального сховища' : 'Дані з бекенду');
+  }, [dataSource]);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;


### PR DESCRIPTION
## Summary
- add dataSource prop to ProfileForm and show toast depending on source
- wire dataSource into AddNewProfile profile form usage

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c14f9a96608326814197838a5ef0d3