### PR TITLE
Use explicit callback with requestAnimationFrame

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -498,7 +498,7 @@ const SearchBar = ({
       for (const id of ids) {
         if (allResults[id]) results[id] = allResults[id];
         setRemaining(r => r - 1);
-        await new Promise(requestAnimationFrame);
+        await new Promise(resolve => requestAnimationFrame(resolve));
       }
       if (Object.keys(results).length === 0) {
         setState && setState({});


### PR DESCRIPTION
## Summary
- wrap requestAnimationFrame in a promise with an explicit resolve callback in writeData
- ensure requestAnimationFrame usage is consistent across the project

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c14f6cc41483268aa78f992de2cfff