### PR TITLE
feat: add toast notifications for user fetch

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -19,6 +19,7 @@ import { fetchUserById } from '../config';
 import { updateCard } from 'utils/cardsStorage';
 import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
+import toast from 'react-hot-toast';
 
 const getParentBackground = element => {
   let el = element;
@@ -169,6 +170,7 @@ export const renderTopBlock = (
           try {
             const cached = getCard(userData.userId);
             let updated = cached;
+            let source = 'cache';
 
             const fresh = await fetchUserById(userData.userId);
             if (fresh) {
@@ -178,10 +180,19 @@ export const renderTopBlock = (
 
               if (isNewer) {
                 updated = fresh;
+                source = 'backend';
               }
             }
 
             if (updated) {
+              if (isToastOn) {
+                toast.success(
+                  source === 'backend'
+                    ? 'Data loaded from backend'
+                    : 'Data loaded from cache'
+                );
+              }
+
               updated = updateCard(userData.userId, updated);
 
               if (setUsers) {
@@ -202,6 +213,9 @@ export const renderTopBlock = (
             }
           } catch (error) {
             console.error(error);
+            if (isToastOn) {
+              toast.error(error.message);
+            }
           }
           toggleDetails();
         }}


### PR DESCRIPTION
## Summary
- show toast notifications on cache or backend fetch
- notify on fetch errors

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17a81a6e483268bdf6801f80bc5ce