### PR TITLE
Refine data source notifications

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -502,7 +502,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const initialDis = getDislikes();
   const [dislikeUsersData, setDislikeUsersData] = useState(initialDis);
   const [isToastOn, setIsToastOn] = useState(false);
-  const [dataSource, setDataSource] = useState(null);
+  const [isLocalData, setIsLocalData] = useState(null);
+
+  useEffect(() => {
+    if (isLocalData === null) return;
+    toast.success(isLocalData ? 'Дані з локального сховища' : 'Дані з бекенду');
+  }, [isLocalData]);
 
   const cacheFetchedUsers = useCallback(
     (usersObj, cacheFn, currentFilters = filters) => {
@@ -721,8 +726,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       syncFavorites(fav);
     }
     const res = await fetchPaginatedNewUsers(param, filterForload, currentFilters, fav);
-    setDataSource(false);
-    toast.success('Дані з бекенду');
+    setIsLocalData(false);
     // console.log('res :>> ', res);
     // Перевіряємо, чи є користувачі у відповіді
     if (res && typeof res.users === 'object' && Object.keys(res.users).length > 0) {
@@ -786,8 +790,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       currentFilters,
       id => fetchUserById(id),
     );
-    toast.success(fromCache ? 'Дані з локального сховища' : 'Дані з бекенду');
-    setDataSource(fromCache);
+    setIsLocalData(fromCache);
     const today = new Date().toISOString().split('T')[0];
     const isValid = d => {
       if (!d) return true;
@@ -905,8 +908,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const { cards: loadedArr, fromCache } = await getFavoriteCards(
         id => fetchUserById(id),
       );
-      toast.success(fromCache ? 'Дані з локального сховища' : 'Дані з бекенду');
-      setDataSource(fromCache);
+      setIsLocalData(fromCache);
       const sorted = loadedArr
         .sort((a, b) => compareUsersByGetInTouch(a, b))
         .reduce((acc, user) => {
@@ -936,8 +938,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const { cards: loadedArr, fromCache } = await getFavoriteCards(
       id => fetchUserById(id),
     );
-    toast.success(fromCache ? 'Дані з локального сховища' : 'Дані з бекенду');
-    setDataSource(fromCache);
+    setIsLocalData(fromCache);
     const sorted = loadedArr
       .sort((a, b) => compareUsersByGetInTouch(a, b))
       .reduce((acc, user) => {
@@ -1126,7 +1127,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           filters={filters}
           filterForload={currentFilter}
           favoriteUsers={favoriteUsersData}
-          dataSource={dataSource}
         />
         {state.userId ? (
           <>
@@ -1156,7 +1156,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               handleSubmit={handleSubmit}
               handleClear={handleClear}
               handleDelKeyValue={handleDelKeyValue}
-              dataSource={dataSource}
             />
           </>
         ) : (
@@ -1174,7 +1173,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             <FilterPanel
               onChange={setFilters}
               storageKey="addFilters"
-              dataSource={dataSource}
             />
             <ButtonsContainer>
               {userNotFound && (
@@ -1262,7 +1260,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setUserIdToDelete={setUserIdToDelete}
                   currentFilter={currentFilter}
                   isDateInRange={isDateInRange}
-                  dataSource={dataSource}
                 />
                 <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
               </>

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import toast from 'react-hot-toast';
 import { SearchFilters } from './SearchFilters';
 
 const defaultsAdd = {
@@ -55,7 +54,7 @@ const normalizeFilterGroup = (value, defaults) => {
   return typeof value === 'object' && value !== null ? { ...defaults, ...value } : { ...defaults };
 };
 
-const FilterPanel = ({ onChange, hideUserId = false, hideCommentLength = false, mode = 'default', storageKey: customKey, dataSource }) => {
+const FilterPanel = ({ onChange, hideUserId = false, hideCommentLength = false, mode = 'default', storageKey: customKey }) => {
   const defaultFilters = useMemo(() => (mode === 'matching' ? defaultsMatching : defaultsAdd), [mode]);
   const storageKey = customKey || (mode === 'matching' ? 'matchingFilters' : 'userFilters');
 
@@ -81,11 +80,6 @@ const FilterPanel = ({ onChange, hideUserId = false, hideCommentLength = false, 
     localStorage.setItem(storageKey, JSON.stringify(filters));
     if (onChange) onChange(filters);
   }, [filters, onChange, storageKey]);
-
-  useEffect(() => {
-    if (dataSource === undefined || dataSource === null) return;
-    toast.success(dataSource ? 'Дані з локального сховища' : 'Дані з бекенду');
-  }, [dataSource]);
 
   return <SearchFilters filters={filters} onChange={setFilters} hideUserId={hideUserId} hideCommentLength={hideCommentLength} mode={mode} />;
 };

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,6 +1,5 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
-import toast from 'react-hot-toast';
 import Photos from './Photos';
 import { inputUpdateValue } from './inputUpdatedValue';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -127,16 +126,10 @@ export const ProfileForm = ({
   handleSubmit,
   handleClear,
   handleDelKeyValue,
-  dataSource,
 }) => {
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
   const [customField, setCustomField] = useState({ key: '', value: '' });
-
-  useEffect(() => {
-    if (dataSource === undefined || dataSource === null) return;
-    toast.success(dataSource ? 'Дані з локального сховища' : 'Дані з бекенду');
-  }, [dataSource]);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -265,7 +265,6 @@ const SearchBar = ({
   filters = {},
   filterForload,
   favoriteUsers = {},
-  dataSource,
 }) => {
   const [internalSearch, setInternalSearch] = useState(
     () => localStorage.getItem(storageKey) || '',
@@ -293,11 +292,6 @@ const SearchBar = ({
       toast.dismiss('remaining-counter');
     }
   }, [remaining]);
-
-  useEffect(() => {
-    if (dataSource === undefined || dataSource === null) return;
-    toast.success(dataSource ? 'Дані з локального сховища' : 'Дані з бекенду');
-  }, [dataSource]);
 
   const loadCachedResult = (key, value) => {
     if (typeof value === 'string' && value.startsWith('[') && value.endsWith(']')) {

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react';
-import toast from 'react-hot-toast';
+import React from 'react';
 import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
@@ -127,14 +126,8 @@ const UsersList = ({
   setDislikeUsers,
   currentFilter,
   isDateInRange,
-  dataSource,
 }) => {
   const entries = Object.entries(users);
-
-  useEffect(() => {
-    if (dataSource === undefined || dataSource === null) return;
-    toast.success(dataSource ? 'Дані з локального сховища' : 'Дані з бекенду');
-  }, [dataSource]);
 
   const handleCreate = async value => {
     const res = await makeNewUser({ name: value });


### PR DESCRIPTION
## Summary
- centralize data source tracking with a boolean `isLocalData` flag
- drop redundant toasts from list, filter, search, and form components

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1bfefbdbc832694af9adbfaed50ae