### PR TITLE
Use cache flag in loadMoreUsers2

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -796,8 +796,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       currentFilters,
       id => fetchUserById(id),
     );
-    const hasCacheData = cachedArr.length > 0;
-    let hasBackendData = false;
+    const hasCacheData = fromCache && cachedArr.length > 0;
+    let hasBackendData = !fromCache && cachedArr.length > 0;
     const today = new Date().toISOString().split('T')[0];
     const isValid = d => {
       if (!d) return true;


### PR DESCRIPTION
## Summary
- track if load2 users came from cache or backend
- fix unused `fromCache` variable

## Testing
- `CI=true npm test --silent`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c1de053c0c83268826553f98cf6dba