### PR TITLE
Refine user ID filtering in matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -61,7 +61,8 @@ import {
   pruneComments,
 } from '../utils/commentsStorage';
 
-const isValidId = id => typeof id === 'string' && id.length >= 20;
+// Filter out users with invalid identifiers; IDs must be longer than 20 characters
+const isValidId = id => typeof id === 'string' && id.length > 20;
 const filterLongUsers = list => list.filter(u => isValidId(u?.userId));
 
 const compareUsersByLastLogin2 = (a = {}, b = {}) =>


### PR DESCRIPTION
## Summary
- ensure Matching component only allows user IDs longer than 20 characters
- document user ID filter logic within Matching

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68c2873fa4688326832f787a30977b65