### PR TITLE
feat: set data source when loading cached profiles

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -613,6 +613,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       }, {});
       setUsers(cachedUsers);
       setTotalCount(ids.length);
+      setDataSource('cache');
     } else {
       loadMoreUsers(currentFilter);
     }


### PR DESCRIPTION
## Summary
- call `setDataSource('cache')` when cached profiles are used so toast messages show

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2876f38b48326bdaf15631db3bda6