### PR TITLE
Optimize cached card search

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useRef } from 'react';
-import toast from 'react-hot-toast';
 import { useAutoResize } from '../hooks/useAutoResize';
 import styled from 'styled-components';
 import { createCache } from '../hooks/cardsCache';
@@ -281,17 +280,6 @@ const SearchBar = ({
     () => loadHistoryCache('queries') || [],
   );
   const [showHistory, setShowHistory] = useState(false);
-  const [remaining, setRemaining] = useState(0);
-
-  useEffect(() => {
-    if (remaining > 0) {
-      toast.loading(`Filtering... ${remaining} left`, {
-        id: 'remaining-counter',
-      });
-    } else {
-      toast.dismiss('remaining-counter');
-    }
-  }, [remaining]);
 
   const loadCachedResult = (key, value) => {
     if (typeof value === 'string' && value.startsWith('[') && value.endsWith(']')) {
@@ -486,14 +474,7 @@ const SearchBar = ({
         await cacheFilteredUsers(filterForload, filters, favoriteUsers, cacheKey);
         ids = getIdsByQuery(cacheKey);
       }
-      const allResults = searchCachedCards(term);
-      const results = {};
-      setRemaining(ids.length);
-      for (const id of ids) {
-        if (allResults[id]) results[id] = allResults[id];
-        setRemaining(r => r - 1);
-        await new Promise(resolve => requestAnimationFrame(resolve));
-      }
+      const results = searchCachedCards(term, ids);
       if (Object.keys(results).length === 0) {
         setState && setState({});
         setUsers && setUsers({});

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -12,6 +12,22 @@ import { normalizeLastAction } from './normalizeLastAction';
 
 export { TTL_MS };
 
+const buildSearchText = card =>
+  Object.values(card || {})
+    .map(value => {
+      if (value === undefined || value === null) return '';
+      if (typeof value === 'object') {
+        try {
+          return JSON.stringify(value);
+        } catch {
+          return '';
+        }
+      }
+      return String(value);
+    })
+    .join(' ')
+    .toLowerCase();
+
 export const addCardToList = (cardId, listKey) => {
   const ids = getIdsByQuery(listKey);
   if (!ids.includes(cardId)) {
@@ -140,11 +156,12 @@ export const getFilteredCardsByList = async (
       const extra = await fetchMore(needed);
       extra.forEach(([id, data]) => {
         const { id: _, ...rest } = data;
-        cards[id] = {
+        const card = {
           ...rest,
           userId: id,
           lastAction: normalizeLastAction(rest.lastAction) || Date.now(),
         };
+        cards[id] = card;
         if (!ids.includes(id)) ids.push(id);
       });
       saveCards(cards);
@@ -158,25 +175,17 @@ export const getFilteredCardsByList = async (
   return filtered.slice(0, target).map(([id]) => cards[id]);
 };
 
-export const searchCachedCards = term => {
+export const searchCachedCards = (term, ids) => {
   const search = String(term || '').toLowerCase();
   if (!search) return {};
   const cards = loadCards();
   const results = {};
-  Object.entries(cards).forEach(([id, card]) => {
-    const matched = Object.entries(card || {}).some(([key, value]) => {
-      if (String(key).toLowerCase().includes(search)) return true;
-      if (value === undefined || value === null) return false;
-      if (typeof value === 'object') {
-        try {
-          return JSON.stringify(value).toLowerCase().includes(search);
-        } catch {
-          return false;
-        }
-      }
-      return String(value).toLowerCase().includes(search);
-    });
-    if (matched) {
+  const list = Array.isArray(ids) && ids.length ? ids : Object.keys(cards);
+  list.forEach(id => {
+    const card = cards[id];
+    if (!card) return;
+    const text = buildSearchText(card);
+    if (text.includes(search)) {
       results[id] = card;
     }
   });


### PR DESCRIPTION
## Summary
- remove toast-based remaining counter and requestAnimationFrame loop from SearchBar
- search cached cards by ID list and build search text on demand instead of persisting `_searchText`
- drop leftover `_searchText` cleanup from card updates

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8c68bd883269e2776d371ffad66