### PR TITLE
Simplify cached card search

### DIFF
--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -12,22 +12,6 @@ import { normalizeLastAction } from './normalizeLastAction';
 
 export { TTL_MS };
 
-const buildSearchText = card =>
-  Object.values(card || {})
-    .map(value => {
-      if (value === undefined || value === null) return '';
-      if (typeof value === 'object') {
-        try {
-          return JSON.stringify(value);
-        } catch {
-          return '';
-        }
-      }
-      return String(value);
-    })
-    .join(' ')
-    .toLowerCase();
-
 export const addCardToList = (cardId, listKey) => {
   const ids = getIdsByQuery(listKey);
   if (!ids.includes(cardId)) {
@@ -184,7 +168,7 @@ export const searchCachedCards = (term, ids) => {
   list.forEach(id => {
     const card = cards[id];
     if (!card) return;
-    const text = buildSearchText(card);
+    const text = (card.myComment || '').toLowerCase();
     if (text.includes(search)) {
       results[id] = card;
     }


### PR DESCRIPTION
## Summary
- remove unused `buildSearchText` helper
- simplify `searchCachedCards` to check only `myComment`

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c437f9111083269c14399bef1bdeda