### PR TITLE
feat: add collection toggle for photo management

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -103,7 +103,7 @@ const HiddenFileInput = styled.input`
   display: none; /* Ховаємо справжній input */
 `;
 
-export const Photos = ({ state, setState }) => {
+export const Photos = ({ state, setState, collection }) => {
   const [viewerIndex, setViewerIndex] = useState(null);
   const photoKeys = Object.keys(state).filter(
     k => k.toLowerCase().startsWith('photo') && k !== 'photos'
@@ -119,10 +119,10 @@ export const Photos = ({ state, setState }) => {
       photoValues,
     });
     const load = async () => {
-      if (state.userId && state.userId.length <= 20) {
+      if (state.userId) {
         try {
           console.log('Fetching photos for user', state.userId);
-          const urls = await getAllUserPhotos(state.userId);
+          const urls = await getAllUserPhotos(state.userId, collection);
           console.log('Fetched URLs', urls);
           if (urls.length > 0) {
             if (!arraysEqual(urls, state.photos)) {
@@ -171,22 +171,22 @@ export const Photos = ({ state, setState }) => {
 
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.userId, photoValues, setState]);
+  }, [state.userId, photoValues, setState, collection]);
 
   const savePhotoList = async updatedPhotos => {
-    await updateDataInRealtimeDB(
-      state.userId,
-      { photos: updatedPhotos },
-      'update'
-    );
-    await updateDataInFiresoreDB(
-      state.userId,
-      { photos: updatedPhotos },
-      'update'
-    );
-
-    if (state.userId.length > 20) {
+    if (collection === 'newUsers') {
       await updateDataInNewUsersRTDB(
+        state.userId,
+        { photos: updatedPhotos },
+        'update'
+      );
+    } else {
+      await updateDataInRealtimeDB(
+        state.userId,
+        { photos: updatedPhotos },
+        'update'
+      );
+      await updateDataInFiresoreDB(
         state.userId,
         { photos: updatedPhotos },
         'update'

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -130,6 +130,7 @@ export const ProfileForm = ({
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
   const [customField, setCustomField] = useState({ key: '', value: '' });
+  const [collection, setCollection] = useState('newUsers');
 
   const handleAddCustomField = () => {
     if (!customField.key) return;
@@ -492,10 +493,31 @@ export const ProfileForm = ({
         />
         <Button onClick={handleAddCustomField}>+</Button>
       </KeyValueRow>
-        <Photos state={state} setState={setState} />
+      <PhotosBlock>
+        <CollectionToggle
+          value={collection}
+          onChange={e => setCollection(e.target.value)}
+        >
+          <option value="users">users</option>
+          <option value="newUsers">newUsers</option>
+        </CollectionToggle>
+        <Photos state={state} setState={setState} collection={collection} />
+      </PhotosBlock>
     </>
   );
 };
+
+const PhotosBlock = styled.div`
+  position: relative;
+  max-width: 400px;
+  margin: 0 auto;
+`;
+
+const CollectionToggle = styled.select`
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
 
 const PickerContainer = styled.div`
   display: flex;


### PR DESCRIPTION
## Summary
- allow choosing between `users` and `newUsers` when managing profile photos
- send selected collection to Photos component and persist changes in the corresponding database

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c476a20154832695ac66160702579d