### PR TITLE
Start spinner immediately on search and filter updates

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1131,7 +1131,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         <SearchBar
           searchFunc={fetchNewUsersCollectionInRTDB}
           search={search}
-          setSearch={setSearch}
+          setSearch={value => {
+            setSearchLoading(true);
+            setTotalCount(0);
+            setSearch(value);
+          }}
           setUsers={setUsers}
           setState={setState}
           setUserNotFound={setUserNotFound}
@@ -1196,7 +1200,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               </p>
             ) : null}
             <FilterPanel
-              onChange={setFilters}
+              onChange={f => {
+                setSearchLoading(true);
+                setTotalCount(0);
+                setFilters(f);
+              }}
               storageKey="addFilters"
             />
             <ButtonsContainer>


### PR DESCRIPTION
## Summary
- trigger spinner and reset count when search input changes
- show spinner when filters adjust to reflect reloading results

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c526697f408326a6ed5660f08df5f7