### PR TITLE
feat: refine stimulation schedule and last cycle input

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1175,7 +1175,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 isToastOn,
                 setIsToastOn,
               )}
-              <StimulationSchedule userData={state} />
+              <StimulationSchedule
+                userData={state}
+                setUsers={setUsers}
+                setState={setState}
+                isToastOn={isToastOn}
+              />
             </div>
 
             <ProfileForm

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -207,7 +207,7 @@ const EditProfile = () => {
           isToastOn,
           setIsToastOn,
         )}
-        <StimulationSchedule userData={state} />
+        <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
       </div>
       <ProfileForm
         state={state}

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -105,7 +105,7 @@ const UserCard = ({
         currentFilter,
         isDateInRange,
       )}
-      <StimulationSchedule userData={userData} />
+      <StimulationSchedule userData={userData} setUsers={setUsers} setState={setState} />
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}
       </div>

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -76,6 +76,9 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
   const [status, setStatus] = React.useState('menstruation');
   const submittedRef = React.useRef(false);
   const prevDataRef = React.useRef(null);
+  const [localValue, setLocalValue] = React.useState(
+    formatDateToDisplay(userData.lastCycle) || ''
+  );
 
   const nextCycle = React.useMemo(() => calculateNextDate(userData.lastCycle), [userData.lastCycle]);
 
@@ -90,9 +93,13 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
     }
   }, [userData.lastDelivery, userData.stimulation]);
 
-  const handleLastCycleChange = e => {
-    const value = e.target.value.trim();
-    const date = parseDate(value);
+  React.useEffect(() => {
+    setLocalValue(formatDateToDisplay(userData.lastCycle) || '');
+  }, [userData.lastCycle]);
+
+  const processLastCycle = value => {
+    const val = value.trim();
+    const date = parseDate(val);
 
     if (date) {
       const lastCycleFormatted = formatDateToServer(formatDate(date));
@@ -134,12 +141,20 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
         );
         submittedRef.current = true;
       } else {
-      handleChange(setUsers, setState, userData.userId, 'lastCycle', lastCycleFormatted);
+        handleChange(setUsers, setState, userData.userId, 'lastCycle', lastCycleFormatted);
+        handleSubmit({ ...userData, lastCycle: lastCycleFormatted }, 'overwrite', isToastOn);
+        submittedRef.current = true;
       }
     } else {
-      const serverFormattedDate = formatDateToServer(value);
+      const serverFormattedDate = formatDateToServer(val);
       handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
+      handleSubmit({ ...userData, lastCycle: serverFormattedDate }, 'overwrite', isToastOn);
+      submittedRef.current = true;
     }
+  };
+
+  const handleLastCycleChange = e => {
+    setLocalValue(e.target.value);
   };
 
   const handleStatusClick = () => {
@@ -245,10 +260,11 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
       <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
         <UnderlinedInput
           type="text"
-          value={formatDateToDisplay(userData.lastCycle) || ''}
+          value={localValue}
           placeholder="міс"
           onChange={handleLastCycleChange}
           onBlur={() => {
+            processLastCycle(localValue);
             if (!submittedRef.current) {
               handleSubmit(userData, 'overwrite', isToastOn);
             }


### PR DESCRIPTION
## Summary
- delay last cycle date formatting until blur to preserve user edits
- expand stimulation schedule with weekday note, per-date adjustment, and '+'/'-' shift indicators saved to profile

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c53106079c8326813a65cd11f8781d