### PR TITLE
Refine stimulation schedule handling and backend serialization

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { handleChange, handleSubmit } from './actions';
 import { formatDateToDisplay, formatDateToServer } from 'components/inputValidations';
+import { generateSchedule, serializeSchedule } from '../StimulationSchedule';
 import {
   UnderlinedInput,
   AttentionButton,
@@ -161,14 +162,24 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
     setStatus(prev => {
       const newState = prev === 'menstruation' ? 'stimulation' : prev === 'stimulation' ? 'pregnant' : 'menstruation';
       if (newState === 'stimulation') {
+        const baseDate = parseDate(userData.lastCycle);
+        let scheduleString = '';
+        if (baseDate) {
+          const sched = generateSchedule(baseDate);
+          scheduleString = serializeSchedule(sched);
+        }
         handleChange(
           setUsers,
           setState,
           userData.userId,
-          'stimulation',
-          true,
+          { stimulation: true, stimulationSchedule: scheduleString },
           true,
           {},
+          isToastOn,
+        );
+        handleSubmit(
+          { ...userData, stimulation: true, stimulationSchedule: scheduleString },
+          'overwrite',
           isToastOn,
         );
         submittedRef.current = true;
@@ -177,10 +188,14 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           setUsers,
           setState,
           userData.userId,
-          'stimulation',
-          false,
+          { stimulation: false, stimulationSchedule: '' },
           true,
           {},
+          isToastOn,
+        );
+        handleSubmit(
+          { ...userData, stimulation: false, stimulationSchedule: '' },
+          'overwrite',
           isToastOn,
         );
         submittedRef.current = true;


### PR DESCRIPTION
## Summary
- Ensure second stimulation visit never precedes day 6 and block manual shifts before day 6
- Serialize schedule as newline-separated string, update backend on every change, and generate/sync schedule when stimulation starts
- Remove '+' indicators, freeze dates after ultrasound, shrink control buttons, allow deleting entries, and keep AP events sorted
- Avoid auto-saving generated schedules so backend persistence only occurs on activation or user edits

## Testing
- `npm test` (no tests found related to files changed since last commit)
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c565c049c48326be49d913151595b5