### PR TITLE
Fix stimulation schedule date serialization and validation

### DIFF
--- a/src/components/__tests__/StimulationSchedule.test.js
+++ b/src/components/__tests__/StimulationSchedule.test.js
@@ -1,0 +1,20 @@
+jest.mock('../smallCard/actions', () => ({
+  handleChange: jest.fn(),
+  handleSubmit: jest.fn(),
+}));
+
+import { generateSchedule, serializeSchedule } from '../StimulationSchedule';
+
+describe('StimulationSchedule serialization', () => {
+  it('stores dates in yyyy-mm-dd format', () => {
+    const base = new Date('2024-01-01');
+    const sched = generateSchedule(base);
+    const serialized = serializeSchedule(sched);
+    const lines = serialized.split('\n').filter(Boolean);
+    lines.forEach(line => {
+      const [dateStr] = line.split(' - ');
+      expect(dateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(new Date(dateStr).toISOString().slice(0, 10)).toBe(dateStr);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- store stimulation schedule dates in `yyyy-mm-dd` format and skip entries without valid dates
- filter out invalid schedule entries when loading or rendering to prevent crashes
- test schedule serialization ensures ISO date format

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5787fa378832690089f85b14338e5