### PR TITLE
Fix stimulation schedule recalculation

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -262,6 +262,28 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
     });
   };
 
+  const recalcSchedule = React.useCallback(() => {
+    const baseDate = parseDate(userData.lastCycle);
+    if (!baseDate) return;
+    const sched = generateSchedule(baseDate);
+    const scheduleString = serializeSchedule(sched);
+    handleChange(
+      setUsers,
+      setState,
+      userData.userId,
+      'stimulationSchedule',
+      scheduleString,
+      true,
+      {},
+      isToastOn,
+    );
+    handleSubmit(
+      { ...userData, stimulationSchedule: scheduleString },
+      'overwrite',
+      isToastOn,
+    );
+  }, [setUsers, setState, userData, isToastOn]);
+
   return (
     <React.Fragment>
       <style>
@@ -301,15 +323,23 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
             вагітна
           </AttentionDiv>
         ) : status === 'stimulation' ? (
-          <AttentionDiv
-            onClick={handleStatusClick}
-            style={{
-              cursor: 'pointer',
-              backgroundColor: 'orange',
-            }}
-          >
-            стимуляція
-          </AttentionDiv>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            <AttentionDiv
+              onClick={handleStatusClick}
+              style={{
+                cursor: 'pointer',
+                backgroundColor: 'orange',
+              }}
+            >
+              стимуляція
+            </AttentionDiv>
+            <AttentionButton
+              onClick={recalcSchedule}
+              style={{ backgroundColor: 'orange' }}
+            >
+              ↻
+            </AttentionButton>
+          </div>
         ) : (
           <span
             onClick={handleStatusClick}


### PR DESCRIPTION
## Summary
- label stimulation visits with the actual cycle day, shifting the first visit to Monday when needed
- regenerate and save stimulation schedule when lastCycle changes
- add manual schedule recalculation button next to "стимуляція"

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c59f2b99b08326a7705f0b55f221dc