### PR TITLE
Polish stimulation schedule controls and AP date parsing

### DIFF
--- a/src/assets/icons/clipboard.svg
+++ b/src/assets/icons/clipboard.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M16 2h-1.5a2.5 2.5 0 0 0-5 0H8a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm-4-1a1.5 1.5 0 0 1 1.5 1.5V3h-3v-.5A1.5 1.5 0 0 1 12 1zm4 20H8V4h1v2h6V4h1v17z"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace text export button with clipboard icon button placed at the top-right
- add year separators and parse dates from AP descriptions
- allow dd.mm format date parsing and remove parsed date from AP labels

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c5ad27c5fc8326bf943134778df0d7