### PR TITLE
Recalculate stimulation schedule on blur and make save manual

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -260,21 +260,13 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
       const firstDate = parsed[0]?.date;
       if (!firstDate || firstDate.toDateString() !== expectedFirst?.toDateString()) {
         setSchedule(gen);
-        saveSchedule(gen);
       } else {
         setSchedule(parsed);
       }
     } else {
       setSchedule(gen);
-      saveSchedule(gen);
     }
-  }, [
-    userData.stimulationSchedule,
-    userData.stimulation,
-    base,
-    userData.lastCycle,
-    saveSchedule,
-  ]);
+  }, [userData.stimulationSchedule, userData.stimulation, base, userData.lastCycle]);
 
   const postTransferKeys = React.useMemo(
     () => [

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -262,18 +262,32 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
     });
   };
 
-  const recalcSchedule = React.useCallback(() => {
-    const baseDate = parseDate(userData.lastCycle);
-    if (!baseDate) return;
-    const sched = generateSchedule(baseDate);
-    const scheduleString = serializeSchedule(sched);
+  const recalcSchedule = React.useCallback(
+    dateString => {
+      const baseDate = parseDate(dateString);
+      if (!baseDate) return;
+      const sched = generateSchedule(baseDate);
+      const scheduleString = serializeSchedule(sched);
+      handleChange(
+        setUsers,
+        setState,
+        userData.userId,
+        'stimulationSchedule',
+        scheduleString,
+      );
+    },
+    [setUsers, setState, userData.userId],
+  );
+
+  const saveSchedule = React.useCallback(() => {
+    const scheduleString = userData.stimulationSchedule || '';
     handleChange(
       setUsers,
       setState,
       userData.userId,
       'stimulationSchedule',
       scheduleString,
-      true,
+      false,
       {},
       isToastOn,
     );
@@ -302,6 +316,9 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           onChange={handleLastCycleChange}
           onBlur={() => {
             processLastCycle(localValue);
+            if (status === 'stimulation') {
+              recalcSchedule(localValue);
+            }
             if (!submittedRef.current) {
               handleSubmit(userData, 'overwrite', isToastOn);
             }
@@ -334,7 +351,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
               стимуляція
             </AttentionDiv>
             <AttentionButton
-              onClick={recalcSchedule}
+              onClick={saveSchedule}
               style={{ backgroundColor: 'orange' }}
             >
               ↻


### PR DESCRIPTION
## Summary
- Recompute stimulation schedule whenever the last cycle date loses focus
- Turn stimulation refresh button into save action
- Stop StimulationSchedule from auto-saving new schedules

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_68c5ae884c448326a3ac856f91a7c97e