### PR TITLE
fix: clean label dash after date shift

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -344,7 +344,10 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
             label: it.label,
           };
         }
-        const lbl = `${adj.day}й день${it.key === 'transfer' ? ' (перенос)' : ''}`;
+        let lbl = `${adj.day}й день${it.key === 'transfer' ? ' (перенос)' : ''}${adj.sign ? ` ${adj.sign}` : ''}`;
+        if (!adj.sign) {
+          lbl = lbl.replace(/-$/, '').trim();
+        }
         return { ...it, date: adj.date, label: lbl };
       };
 


### PR DESCRIPTION
## Summary
- remove trailing dash from schedule labels if no adjustment sign
- keep dash indicator when date shift crosses weekends

## Testing
- `CI=true npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb64fd0c8326a733c02694c339d6