### PR TITLE
Make first stimulation schedule day read-only

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -377,6 +377,22 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
         rendered.push(<div key={`year-${year}`}>{year}</div>);
         currentYear = year;
       }
+      if (item.key === 'visit1') {
+        rendered.push(
+          <div
+            key={item.key}
+            style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '2px' }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px', flex: 1 }}>
+              <div>
+                {dateStr} {weekday}
+              </div>
+              <div style={{ flex: 1 }}>{item.label}</div>
+            </div>
+          </div>,
+        );
+        return;
+      }
       rendered.push(
         <div
           key={item.key}


### PR DESCRIPTION
## Summary
- make the first stimulation day display-only without edit or shift controls

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c5c13bf8e48326bbbb88fbcf760272