### PR TITLE
Include weekday when copying schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -531,12 +531,13 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
               .forEach(it => {
                 const y = it.date.getFullYear();
                 const dateStr = formatDisplay(it.date);
+                const weekday = weekdayNames[it.date.getDay()];
                 if (y !== yr) {
                   if (text) text += '\n';
                   text += `${y}\n`;
                   yr = y;
                 }
-                text += `${dateStr} ${it.label}\n`;
+                text += `${dateStr} ${weekday} ${it.label}\n`;
               });
             navigator.clipboard.writeText(text.trim());
           }}


### PR DESCRIPTION
## Summary
- Add weekday extraction when copying stimulation schedule to clipboard
- Include weekday name in copied schedule lines

## Testing
- `node - <<'NODE' ... NODE`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5c1fe759c8326808fe50abfe30c51