### PR TITLE
Add quick-set today button for last cycle

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -7,6 +7,7 @@ import {
   UnderlinedInput,
   AttentionButton,
   AttentionDiv,
+  OrangeBtn,
 } from 'components/styles';
 
 const calculateNextDate = dateString => {
@@ -357,6 +358,22 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
     );
   }, [setUsers, setState, userData, isToastOn]);
 
+  const handleSetToday = () => {
+    const today = new Date();
+    const day = String(today.getDate()).padStart(2, '0');
+    const month = String(today.getMonth() + 1).padStart(2, '0');
+    const year = today.getFullYear();
+    const formatted = `${day}.${month}.${year}`;
+    processLastCycle(formatted);
+    if (status === 'stimulation') {
+      recalcSchedule(formatted);
+    }
+    if (!submittedRef.current) {
+      handleSubmit(userData, 'overwrite', isToastOn);
+    }
+    submittedRef.current = false;
+  };
+
   return (
     <React.Fragment>
       <style>
@@ -379,6 +396,12 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
             color: 'white',
           }}
         />
+        <OrangeBtn
+          onClick={handleSetToday}
+          style={{ width: '25px', height: '25px', marginLeft: '5px' }}
+        >
+          T
+        </OrangeBtn>
         {status === 'pregnant' ? (
           <React.Fragment>
             <AttentionDiv


### PR DESCRIPTION
## Summary
- import OrangeBtn to fieldLastCycle and add a quick-set today action
- adjust schedule recalculation when setting today's date
- add Today button next to last cycle input

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c5caf781bc8326b6528d7c1c29db8d