### PR TITLE
Persist cycle status for user cards

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -256,9 +256,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
-    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer'];
+    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids'];
+    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     const now = Date.now();
     const baseState = newState ? { ...newState } : { ...state };
@@ -321,6 +321,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           ...serverData,
           lastAction: serverLast,
           lastDelivery: formatDateToDisplay(serverData.lastDelivery),
+          cycleStatus: serverData.cycleStatus || 'menstruation',
         };
         updateCachedUser(formattedServer);
         cacheFetchedUsers(
@@ -1175,12 +1176,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 isToastOn,
                 setIsToastOn,
               )}
-              <StimulationSchedule
-                userData={state}
-                setUsers={setUsers}
-                setState={setState}
-                isToastOn={isToastOn}
-              />
+              {state.cycleStatus === 'stimulation' && (
+                <StimulationSchedule
+                  userData={state}
+                  setUsers={setUsers}
+                  setState={setState}
+                  isToastOn={isToastOn}
+                />
+              )}
             </div>
 
             <ProfileForm

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -47,9 +47,9 @@ const EditProfile = () => {
   const [isToastOn, setIsToastOn] = useState(false);
 
   async function remoteUpdate({ updatedState, overwrite, delCondition }) {
-    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer'];
+    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids'];
+    const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (updatedState?.userId?.length > 20) {
       const { existingData } = await fetchUserById(updatedState.userId);
@@ -132,6 +132,7 @@ const EditProfile = () => {
           ...serverData,
           lastAction: serverLast,
           lastDelivery: formatDateToDisplay(serverData.lastDelivery),
+          cycleStatus: serverData.cycleStatus || 'menstruation',
         };
         updateCachedUser(formattedServerData);
         setState(formattedServerData);
@@ -207,7 +208,9 @@ const EditProfile = () => {
           isToastOn,
           setIsToastOn,
         )}
-        <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
+        {state.cycleStatus === 'stimulation' && (
+          <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
+        )}
       </div>
       <ProfileForm
         state={state}

--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -229,7 +229,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
   );
 
   React.useEffect(() => {
-    if (!userData?.stimulation || !base) return;
+    if (userData?.cycleStatus !== 'stimulation' || !base) return;
 
     const gen = generateSchedule(base);
     const expectedFirst = gen[0]?.date;
@@ -278,7 +278,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
     } else {
       setSchedule(gen);
     }
-  }, [userData.stimulationSchedule, userData.stimulation, base, userData.lastCycle]);
+  }, [userData.stimulationSchedule, userData.cycleStatus, base, userData.lastCycle]);
 
   const postTransferKeys = React.useMemo(() => ['hcg', 'us'], []);
 
@@ -354,7 +354,8 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
     });
   };
 
-  if (!userData?.stimulation || !base || schedule.length === 0) return null;
+  if (userData?.cycleStatus !== 'stimulation' || !base || schedule.length === 0)
+    return null;
 
   const rendered = [];
   let currentYear = null;

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -105,7 +105,9 @@ const UserCard = ({
         currentFilter,
         isDateInRange,
       )}
-      <StimulationSchedule userData={userData} setUsers={setUsers} setState={setState} />
+      {userData.cycleStatus === 'stimulation' && (
+        <StimulationSchedule userData={userData} setUsers={setUsers} setState={setState} />
+      )}
       <div id={userData.userId} style={{ display: 'none' }}>
         {renderFields(userData)}
       </div>

--- a/src/components/__tests__/makeNewUser.test.js
+++ b/src/components/__tests__/makeNewUser.test.js
@@ -66,6 +66,7 @@ describe('makeNewUser', () => {
     const newUser = db.set.mock.calls[0][1];
     expect(newUser.userId).toBe('generatedId');
     expect(newUser.searchedUserId).toBe('searchedId');
+    expect(newUser.cycleStatus).toBe('menstruation');
   });
 
   it('adds field for non-userId searches', async () => {
@@ -74,6 +75,7 @@ describe('makeNewUser', () => {
     expect(newUser.userId).toBe('generatedId');
     expect(newUser.email).toBe('test@example.com');
     expect(newUser.searchedUserId).toBeUndefined();
+    expect(newUser.cycleStatus).toBe('menstruation');
   });
 });
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -623,6 +623,7 @@ export const makeNewUser = async searchedValue => {
     userId: newUserId,
     createdAt,
     createdAt2,
+    cycleStatus: 'menstruation',
   };
 
   if (searchKey !== 'userId') {

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -152,9 +152,25 @@ export const handleChange = (
 };
 
 export const handleSubmit = (userData, condition, isToastOn) => {
-  const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
+  const fieldsForNewUsersOnly = [
+    'role',
+    'getInTouch',
+    'lastCycle',
+    'myComment',
+    'writer',
+    'cycleStatus',
+    'stimulationSchedule',
+  ];
   const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-  const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids'];
+  const commonFields = [
+    'lastAction',
+    'lastLogin2',
+    'getInTouch',
+    'lastDelivery',
+    'ownKids',
+    'cycleStatus',
+    'stimulationSchedule',
+  ];
   const dublicateFields = ['weight', 'height'];
 
   const uploadedInfo = { ...userData };
@@ -184,9 +200,25 @@ export const handleSubmit = (userData, condition, isToastOn) => {
 };
 
 export const handleSubmitAll = async (userData, overwrite) => {
-  const fieldsForNewUsersOnly = ['role', 'getInTouch', 'lastCycle', 'myComment', 'writer'];
+  const fieldsForNewUsersOnly = [
+    'role',
+    'getInTouch',
+    'lastCycle',
+    'myComment',
+    'writer',
+    'cycleStatus',
+    'stimulationSchedule',
+  ];
   const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
-  const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids'];
+  const commonFields = [
+    'lastAction',
+    'lastLogin2',
+    'getInTouch',
+    'lastDelivery',
+    'ownKids',
+    'cycleStatus',
+    'stimulationSchedule',
+  ];
 
   const { existingData } = await fetchUserById(userData.userId);
   const uploadedInfo =

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -76,7 +76,9 @@ const formatDate = date => {
 };
 
 export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
-  const [status, setStatus] = React.useState('menstruation');
+  const [status, setStatus] = React.useState(
+    userData.cycleStatus || 'menstruation',
+  );
   const submittedRef = React.useRef(false);
   const prevDataRef = React.useRef(null);
   const [localValue, setLocalValue] = React.useState(
@@ -96,15 +98,8 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
   }, [userData.lastCycle]);
 
   React.useEffect(() => {
-    const date = parseDate(userData.lastDelivery);
-    if (date && date > new Date()) {
-      setStatus('pregnant');
-    } else if (userData.stimulation) {
-      setStatus('stimulation');
-    } else {
-      setStatus('menstruation');
-    }
-  }, [userData.lastDelivery, userData.stimulation]);
+    setStatus(userData.cycleStatus || 'menstruation');
+  }, [userData.cycleStatus]);
 
   React.useEffect(() => {
     setLocalValue(formatDateToDisplay(userData.lastCycle) || '');
@@ -139,6 +134,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           lastDelivery: lastDeliveryFormatted,
           getInTouch: getInTouchFormatted,
           ownKids,
+          cycleStatus: status,
         });
 
         handleSubmit(
@@ -148,20 +144,35 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
             lastDelivery: lastDeliveryFormatted,
             getInTouch: getInTouchFormatted,
             ownKids,
+            cycleStatus: status,
           },
           'overwrite',
           isToastOn,
         );
         submittedRef.current = true;
       } else {
-        handleChange(setUsers, setState, userData.userId, 'lastCycle', lastCycleFormatted);
-        handleSubmit({ ...userData, lastCycle: lastCycleFormatted }, 'overwrite', isToastOn);
+        handleChange(setUsers, setState, userData.userId, {
+          lastCycle: lastCycleFormatted,
+          cycleStatus: status,
+        });
+        handleSubmit(
+          { ...userData, lastCycle: lastCycleFormatted, cycleStatus: status },
+          'overwrite',
+          isToastOn,
+        );
         submittedRef.current = true;
       }
     } else {
       const serverFormattedDate = formatDateToServer(val);
-      handleChange(setUsers, setState, userData.userId, 'lastCycle', serverFormattedDate);
-      handleSubmit({ ...userData, lastCycle: serverFormattedDate }, 'overwrite', isToastOn);
+      handleChange(setUsers, setState, userData.userId, {
+        lastCycle: serverFormattedDate,
+        cycleStatus: status,
+      });
+      handleSubmit(
+        { ...userData, lastCycle: serverFormattedDate, cycleStatus: status },
+        'overwrite',
+        isToastOn,
+      );
       submittedRef.current = true;
     }
   };
@@ -172,26 +183,31 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
 
   const handleStatusClick = () => {
     setStatus(prev => {
-      const newState = prev === 'menstruation' ? 'stimulation' : prev === 'stimulation' ? 'pregnant' : 'menstruation';
+      const newState =
+        prev === 'menstruation'
+          ? 'stimulation'
+          : prev === 'stimulation'
+          ? 'pregnant'
+          : 'menstruation';
       if (newState === 'stimulation') {
         handleChange(
           setUsers,
           setState,
           userData.userId,
-          { stimulation: true },
+          { stimulation: true, cycleStatus: 'stimulation' },
           true,
           {},
           isToastOn,
         );
         handleSubmit(
-          { ...userData, stimulation: true },
+          { ...userData, stimulation: true, cycleStatus: 'stimulation' },
           'overwrite',
           isToastOn,
         );
         submittedRef.current = true;
       } else if (prev === 'stimulation') {
-        const updates = { stimulation: false };
-        const submitObj = { ...userData, stimulation: false };
+        const updates = { stimulation: false, cycleStatus: newState };
+        const submitObj = { ...userData, stimulation: false, cycleStatus: newState };
         if (userData.stimulationSchedule !== undefined) {
           updates.stimulationSchedule = undefined;
           submitObj.stimulationSchedule = undefined;
@@ -241,6 +257,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
             lastDelivery: lastDeliveryFormatted,
             getInTouch: getInTouchFormatted,
             ownKids,
+            cycleStatus: 'pregnant',
           });
 
           handleSubmit(
@@ -250,6 +267,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
               lastDelivery: lastDeliveryFormatted,
               getInTouch: getInTouchFormatted,
               ownKids,
+              cycleStatus: 'pregnant',
             },
             'overwrite',
             isToastOn,
@@ -257,9 +275,12 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           submittedRef.current = true;
         }
       } else if (prev === 'pregnant' && prevDataRef.current) {
-        handleChange(setUsers, setState, userData.userId, prevDataRef.current);
+        handleChange(setUsers, setState, userData.userId, {
+          ...prevDataRef.current,
+          cycleStatus: newState,
+        });
         handleSubmit(
-          { ...userData, ...prevDataRef.current },
+          { ...userData, ...prevDataRef.current, cycleStatus: newState },
           'overwrite',
           isToastOn,
         );


### PR DESCRIPTION
## Summary
- add cycleStatus to user data persistence and new user creation
- store cycle status changes from LastCycle field and render based on cycleStatus
- show stimulation schedule only when cycleStatus is `stimulation`
- persist `stimulationSchedule` alongside other user fields

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c5cc7522f48326b1b31220a5a13484