### PR TITLE
Use inline-flex to keep last cycle fields on one line

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -405,7 +405,14 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
       }
     `}
       </style>
-      <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '8px',
+          flexWrap: 'nowrap',
+        }}
+      >
         <UnderlinedInput
           type="text"
           value={localValue}


### PR DESCRIPTION
## Summary
- keep last cycle input, button and info on one horizontal line with inline-flex and centered alignment

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c5db158a4883269b3640429196b77a