### PR TITLE
fix: remove dash indicator from stimulation schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -49,13 +49,11 @@ const adjustForward = (date, base) => {
 
 const adjustBackward = (date, base) => {
   let day = diffDays(date, base);
-  let moved = false;
   while (isWeekend(date)) {
     date.setDate(date.getDate() - 1);
     day = diffDays(date, base);
-    moved = true;
   }
-  return { date, day, sign: moved ? '-' : '' };
+  return { date, day, sign: '' };
 };
 
 const weekdayNames = ['нд', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'];


### PR DESCRIPTION
## Summary
- remove "-" marker from dates shifted before weekends in Stimulation Schedule
- clean up backward adjustment logic

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c65b40245c8326aca8209c004aa519