### PR TITLE
Avoid saving empty lastDelivery fields

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -271,11 +271,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     cacheFetchedUsers({ [updatedState.userId]: updatedState }, cacheLoad2Users, filters);
     setUsers(prev => ({ ...prev, [updatedState.userId]: updatedState }));
 
+    const formattedLastDelivery = formatDateToServer(
+      formatDateAndFormula(updatedState.lastDelivery)
+    );
+
     const syncedState = {
       ...updatedState,
-      lastDelivery: formatDateToServer(
-        formatDateAndFormula(updatedState.lastDelivery)
-      ),
+      ...(formattedLastDelivery ? { lastDelivery: formattedLastDelivery } : {}),
     };
 
     if (syncedState?.userId?.length > 20) {
@@ -300,13 +302,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         )
       );
 
-      await updateDataInNewUsersRTDB(syncedState.userId, cleanedStateForNewUsers, 'update');
+      await updateDataInNewUsersRTDB(
+        syncedState.userId,
+        cleanedStateForNewUsers,
+        'update'
+      );
     } else {
       if (newState) {
+        const newStateWithDelivery = formattedLastDelivery
+          ? { ...newState, lastDelivery: formattedLastDelivery }
+          : { ...newState };
         await updateDataInNewUsersRTDB(
           syncedState.userId,
-          { ...newState, lastDelivery: syncedState.lastDelivery },
-          'update',
+          newStateWithDelivery,
+          'update'
         );
       } else {
         await updateDataInNewUsersRTDB(syncedState.userId, syncedState, 'update');

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -117,15 +117,20 @@ const EditProfile = () => {
     const removeKeys = delCondition ? Object.keys(delCondition) : [];
     updateCachedUser(updatedState, { removeKeys });
 
+    const formattedLastDelivery = formatDateToServer(
+      formatDateAndFormula(updatedState.lastDelivery),
+    );
     const syncedState = {
       ...updatedState,
-      lastDelivery: formatDateToServer(
-        formatDateAndFormula(updatedState.lastDelivery),
-      ),
+      ...(formattedLastDelivery ? { lastDelivery: formattedLastDelivery } : {}),
     };
     setIsSyncing(true);
     try {
-      const serverData = await remoteUpdate({ updatedState: syncedState, overwrite, delCondition });
+      const serverData = await remoteUpdate({
+        updatedState: syncedState,
+        overwrite,
+        delCondition,
+      });
       const serverLast = normalizeLastAction(serverData?.lastAction);
       if (serverLast && serverLast > updatedState.lastAction) {
         const formattedServerData = {


### PR DESCRIPTION
## Summary
- skip adding `lastDelivery` when it has no value in profile creation/editing
- drop empty `lastDelivery` during card updates and submissions
- remove `lastDelivery` key from state when cleared in small card

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c691b77b888326bfc3e772c7828a1c