### PR TITLE
Show toast when loading profile data

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -185,13 +185,11 @@ export const renderTopBlock = (
             }
 
             if (updated) {
-              if (isToastOn) {
-                toast.success(
-                  source === 'backend'
-                    ? 'Data loaded from backend'
-                    : 'Data loaded from cache'
-                );
-              }
+              toast.success(
+                source === 'backend'
+                  ? 'Data loaded from backend'
+                  : 'Data loaded from cache'
+              );
 
               updated = updateCard(userData.userId, updated);
 
@@ -213,9 +211,7 @@ export const renderTopBlock = (
             }
           } catch (error) {
             console.error(error);
-            if (isToastOn) {
-              toast.error(error.message);
-            }
+            toast.error(error.message);
           }
           toggleDetails();
         }}


### PR DESCRIPTION
## Summary
- default toast notifications on for edit profile
- show toast if profile data loaded from cache or backend
- always show toast when refreshing small card details

## Testing
- `npm run lint:js`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6cfbd8a288326b3d98a7c94516dbc