### PR TITLE
Refactor profile card wrappers for distinct sections

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1168,7 +1168,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         />
         {state.userId ? (
           <>
-            <div style={{ ...coloredCard() }}>
+            <div style={{ ...coloredCard(), marginBottom: '8px' }}>
               {renderTopBlock(
                 state,
                 setUsers,
@@ -1185,17 +1185,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 isToastOn,
                 setIsToastOn,
               )}
-              {state.cycleStatus === 'stimulation' && (
-                <div style={{ padding: '7px', position: 'relative', marginTop: '8px' }}>
-                  <StimulationSchedule
-                    userData={state}
-                    setUsers={setUsers}
-                    setState={setState}
-                    isToastOn={isToastOn}
-                  />
-                </div>
-              )}
             </div>
+            {state.cycleStatus === 'stimulation' && (
+              <div style={{ ...coloredCard(), padding: '7px', marginBottom: '8px' }}>
+                <StimulationSchedule
+                  userData={state}
+                  setUsers={setUsers}
+                  setState={setState}
+                  isToastOn={isToastOn}
+                />
+              </div>
+            )}
 
             <ProfileForm
               state={state}

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -209,7 +209,7 @@ const EditProfile = () => {
   return (
     <Container>
       <BackButton onClick={() => navigate(-1)}>Back</BackButton>
-      <div style={{ ...coloredCard() }}>
+      <div style={{ ...coloredCard(), marginBottom: '8px' }}>
         {renderTopBlock(
           state,
           () => {},
@@ -226,12 +226,12 @@ const EditProfile = () => {
           isToastOn,
           setIsToastOn,
         )}
-        {state.cycleStatus === 'stimulation' && (
-          <div style={{ padding: '7px', position: 'relative', marginTop: '8px' }}>
-            <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
-          </div>
-        )}
       </div>
+      {state.cycleStatus === 'stimulation' && (
+        <div style={{ ...coloredCard(), padding: '7px', marginBottom: '8px' }}>
+          <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
+        </div>
+      )}
       <ProfileForm
         state={state}
         setState={setState}

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -91,22 +91,24 @@ const UserCard = ({
 }) => {
   return (
     <div>
-      {renderTopBlock(
-        userData,
-        setUsers,
-        setShowInfoModal,
-        setState,
-        setUserIdToDelete,
-        'isFromListOfUsers',
-        favoriteUsers,
-        setFavoriteUsers,
-        dislikeUsers,
-        setDislikeUsers,
-        currentFilter,
-        isDateInRange,
-      )}
+      <div style={{ ...coloredCard(), marginBottom: '8px' }}>
+        {renderTopBlock(
+          userData,
+          setUsers,
+          setShowInfoModal,
+          setState,
+          setUserIdToDelete,
+          'isFromListOfUsers',
+          favoriteUsers,
+          setFavoriteUsers,
+          dislikeUsers,
+          setDislikeUsers,
+          currentFilter,
+          isDateInRange,
+        )}
+      </div>
       {userData.cycleStatus === 'stimulation' && (
-        <div style={{ padding: '7px', position: 'relative', marginTop: '8px' }}>
+        <div style={{ ...coloredCard(), padding: '7px', marginBottom: '8px' }}>
           <StimulationSchedule userData={userData} setUsers={setUsers} setState={setState} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Separate profile header and schedule into individual colored cards for clearer spacing
- Apply the same block separation across Add, Edit and list views for consistent styling

## Testing
- `npm run lint:js`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70db819a083268b622d3f596079f6