### PR TITLE
fix: remove unused duplicates state variable

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -990,7 +990,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setBackendCount(backendCount);
   };
 
-  const [duplicates, setDuplicates] = useState('');
+  const [, setDuplicates] = useState('');
   const [isDuplicateView, setIsDuplicateView] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid unused `duplicates` variable in `AddNewProfile`

## Testing
- `npm test -- --watchAll=false`
- `npm run lint:js --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c717f7a4a48326a465b828571edb27