### PR TITLE
Refactor profile loading and data source toasts

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -72,6 +72,7 @@ import {
   clearAllCardsCache,
   updateCachedUser,
 } from 'utils/cache';
+import { updateCard } from 'utils/cardsStorage';
 import {
   formatDateAndFormula,
   formatDateToDisplay,
@@ -515,19 +516,42 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const initialDis = getDislikes();
   const [dislikeUsersData, setDislikeUsersData] = useState(initialDis);
   const [isToastOn, setIsToastOn] = useState(false);
-  const [cacheCount, setCacheCount] = useState(0);
-  const [backendCount, setBackendCount] = useState(0);
+  const [, setCacheCount] = useState(0);
+  const [, setBackendCount] = useState(0);
+  const [profileSource, setProfileSource] = useState('');
 
   useEffect(() => {
-    if (cacheCount === 0 && backendCount === 0) return;
-    const message =
-      cacheCount > 0 && backendCount > 0
-        ? `${cacheCount} cards from local storage and ${backendCount} from backend`
-        : cacheCount > 0
-        ? `${cacheCount} cards from local storage`
-        : `${backendCount} cards from backend`;
-    toast.success(message);
-  }, [cacheCount, backendCount]);
+    if (!state.userId || profileSource) return;
+
+    if (Object.keys(state).length > 1) {
+      setProfileSource('cache');
+      return;
+    }
+
+    const cached = getCard(state.userId);
+    if (cached) {
+      setState(cached);
+      setProfileSource('cache');
+    } else {
+      (async () => {
+        try {
+          const data = await fetchUserById(state.userId);
+          if (data) {
+            updateCard(state.userId, data);
+            setState(data);
+          }
+        } catch (error) {
+          toast.error(error.message);
+        } finally {
+          setProfileSource('backend');
+        }
+      })();
+    }
+  }, [state, profileSource, setState]);
+
+  useEffect(() => {
+    if (!state.userId) setProfileSource('');
+  }, [state.userId]);
 
   const cacheFetchedUsers = useCallback(
     (usersObj, cacheFn, currentFilters = filters) => {
@@ -990,7 +1014,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setBackendCount(backendCount);
   };
 
-  const [duplicates, setDuplicates] = useState('');
+  const [, setDuplicates] = useState('');
   const [isDuplicateView, setIsDuplicateView] = useState(false);
 
   useEffect(() => {
@@ -1207,6 +1231,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               handleSubmit={handleSubmit}
               handleClear={handleClear}
               handleDelKeyValue={handleDelKeyValue}
+              dataSource={profileSource}
             />
           </>
         ) : (

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import Photos from './Photos';
 import { inputUpdateValue } from './inputUpdatedValue';
@@ -8,6 +8,7 @@ import { pickerFieldsExtended as pickerFields } from './formFields';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
+import toast from 'react-hot-toast';
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -126,11 +127,22 @@ export const ProfileForm = ({
   handleSubmit,
   handleClear,
   handleDelKeyValue,
+  dataSource,
 }) => {
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
   const [customField, setCustomField] = useState({ key: '', value: '' });
   const [collection, setCollection] = useState('newUsers');
+
+  useEffect(() => {
+    if (dataSource) {
+      toast.success(
+        dataSource === 'backend'
+          ? 'Data loaded from backend'
+          : 'Data loaded from local storage'
+      );
+    }
+  }, [dataSource]);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -17,7 +17,6 @@ import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
 import { updateCard } from 'utils/cardsStorage';
-import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import toast from 'react-hot-toast';
 
@@ -168,30 +167,11 @@ export const renderTopBlock = (
           };
 
           try {
-            const cached = getCard(userData.userId);
-            let updated = cached;
-            let source = 'cache';
-
             const fresh = await fetchUserById(userData.userId);
             if (fresh) {
-              const cachedTs = normalizeLastAction(cached?.lastAction);
-              const freshTs = normalizeLastAction(fresh.lastAction);
-              const isNewer = !cached || !cachedTs || !freshTs || freshTs > cachedTs;
+              toast.success('Data loaded from backend');
 
-              if (isNewer) {
-                updated = fresh;
-                source = 'backend';
-              }
-            }
-
-            if (updated) {
-              toast.success(
-                source === 'backend'
-                  ? 'Data loaded from backend'
-                  : 'Data loaded from cache'
-              );
-
-              updated = updateCard(userData.userId, updated);
+              const updated = updateCard(userData.userId, fresh);
 
               if (setUsers) {
                 setUsers(prev => {


### PR DESCRIPTION
## Summary
- Fetch card details directly from backend when expanding "..." and update local cache
- Remove global card count toast and determine data source when opening ProfileForm
- Display toast in ProfileForm indicating whether data came from backend or local cache

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c70d30005c83268aff6fec89947a79