### PR TITLE
fix: stabilize stimulation schedule base

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -183,7 +183,7 @@ export const serializeSchedule = sched =>
     .join('\n');
 
 const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }) => {
-  const base = parseDate(userData?.lastCycle);
+  const base = React.useMemo(() => parseDate(userData?.lastCycle), [userData?.lastCycle]);
   const [schedule, setSchedule] = React.useState([]);
   const [apDescription, setApDescription] = React.useState('');
   const [editingIndex, setEditingIndex] = React.useState(null);


### PR DESCRIPTION
## Summary
- stabilize base date value in StimulationSchedule using `useMemo`

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68c717b6e63883269bf458fa9a9de0e5