### PR TITLE
feat: avoid storing default stimulation schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -192,38 +192,73 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
   const saveSchedule = React.useCallback(
     sched => {
       const scheduleString = serializeSchedule(sched);
+      const defaultString = base
+        ? serializeSchedule(generateSchedule(base))
+        : '';
+      const isDefault = base && scheduleString === defaultString;
       if (setUsers && setState) {
-        handleChange(
-          setUsers,
-          setState,
-          userData.userId,
-          'stimulationSchedule',
-          scheduleString,
-          true,
-          {},
-          isToastOn,
-        );
+        if (isDefault) {
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            { stimulationSchedule: undefined },
+            true,
+            {},
+            isToastOn,
+          );
+        } else {
+          handleChange(
+            setUsers,
+            setState,
+            userData.userId,
+            'stimulationSchedule',
+            scheduleString,
+            true,
+            {},
+            isToastOn,
+          );
+        }
       } else if (setState) {
-        setState(prev => ({ ...prev, stimulationSchedule: scheduleString }));
-        handleSubmit(
-          { ...userData, stimulationSchedule: scheduleString },
-          'overwrite',
-          isToastOn,
-        );
+        if (isDefault) {
+          setState(prev => {
+            const copy = { ...prev };
+            delete copy.stimulationSchedule;
+            return copy;
+          });
+        } else {
+          setState(prev => ({ ...prev, stimulationSchedule: scheduleString }));
+        }
+        const submitObj = { ...userData };
+        if (!isDefault) submitObj.stimulationSchedule = scheduleString;
+        else delete submitObj.stimulationSchedule;
+        handleSubmit(submitObj, 'overwrite', isToastOn);
       } else if (setUsers) {
-        handleChange(
-          setUsers,
-          null,
-          userData.userId,
-          'stimulationSchedule',
-          scheduleString,
-          true,
-          {},
-          isToastOn,
-        );
+        if (isDefault) {
+          handleChange(
+            setUsers,
+            null,
+            userData.userId,
+            { stimulationSchedule: undefined },
+            true,
+            {},
+            isToastOn,
+          );
+        } else {
+          handleChange(
+            setUsers,
+            null,
+            userData.userId,
+            'stimulationSchedule',
+            scheduleString,
+            true,
+            {},
+            isToastOn,
+          );
+        }
       }
     },
-    [setUsers, setState, userData, isToastOn],
+    [setUsers, setState, userData, isToastOn, base],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- add helper to detect default stimulation schedules
- skip confirmation/reset and persistence when the schedule matches default
- drop default schedules from local and server state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7cf1104e08326a340f7acb5200ae8