### PR TITLE
Fix stimulation schedule container overflow

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1214,7 +1214,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               )}
             </div>
             {state.cycleStatus === 'stimulation' && (
-              <div style={{ ...coloredCard(), padding: '7px', marginBottom: '8px' }}>
+              <div style={{ ...coloredCard(), marginBottom: '8px' }}>
                 <StimulationSchedule
                   userData={state}
                   setUsers={setUsers}

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -231,7 +231,7 @@ const EditProfile = () => {
         )}
       </div>
       {state.cycleStatus === 'stimulation' && (
-        <div style={{ ...coloredCard(), padding: '7px', marginBottom: '8px' }}>
+        <div style={{ ...coloredCard(), marginBottom: '8px' }}>
           <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
         </div>
       )}

--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -517,7 +517,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
   }
 
   return (
-    <div style={{ marginTop: '8px' }}>
+    <div style={{ padding: '7px', position: 'relative' }}>
       <div style={{ display: 'flex', gap: '2px', margin: '4px 0' }}>
         <input
           type="text"

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -108,7 +108,7 @@ const UserCard = ({
         )}
       </div>
       {userData.cycleStatus === 'stimulation' && (
-        <div style={{ ...coloredCard(), padding: '7px', marginBottom: '8px' }}>
+        <div style={{ ...coloredCard(), marginBottom: '8px' }}>
           <StimulationSchedule userData={userData} setUsers={setUsers} setState={setState} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Prevent stimulation schedule cards from overflowing by moving padding inside the component
- Adjust schedule wrappers to match `renderTopBlock` styling

## Testing
- `npm run lint:js`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c7cf94177483269a8dfcd24b79d9b4