### PR TITLE
Fix removal flow and cycle status defaults

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -90,7 +90,7 @@ const renderAllFields = (data, parentKey = '', state, setState) => {
           <strong>{key}</strong>
           <button
             style={removeButtonStyle}
-            onClick={() => removeField(state?.userId, nestedKey, setState)}
+            onClick={() => removeField(state?.userId, nestedKey, setState, undefined, false, nestedKey)}
           >
             X
           </button>
@@ -104,7 +104,7 @@ const renderAllFields = (data, parentKey = '', state, setState) => {
                     <strong>[{idx}]</strong>
                     <button
                       style={removeButtonStyle}
-                      onClick={() => removeField(state?.userId, arrayKey, setState)}
+                      onClick={() => removeField(state?.userId, arrayKey, setState, undefined, false, arrayKey)}
                     >
                       X
                     </button>
@@ -121,7 +121,7 @@ const renderAllFields = (data, parentKey = '', state, setState) => {
                   <strong>[{idx}]</strong>
                   <button
                     style={removeButtonStyle}
-                    onClick={() => removeField(state?.userId, arrayKey, setState)}
+                    onClick={() => removeField(state?.userId, arrayKey, setState, undefined, false, arrayKey)}
                   >
                     X
                   </button>
@@ -141,7 +141,7 @@ const renderAllFields = (data, parentKey = '', state, setState) => {
           <strong>{key}</strong>
           <button
             style={removeButtonStyle}
-            onClick={() => removeField(state?.userId, nestedKey, setState)}
+            onClick={() => removeField(state?.userId, nestedKey, setState, undefined, false, nestedKey)}
           >
             X
           </button>
@@ -156,7 +156,7 @@ const renderAllFields = (data, parentKey = '', state, setState) => {
         <strong>{key}</strong>
         <button
           style={removeButtonStyle}
-          onClick={() => removeField(state?.userId, nestedKey, setState)}
+          onClick={() => removeField(state?.userId, nestedKey, setState, undefined, false, nestedKey)}
         >
           X
         </button>

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -78,16 +78,27 @@ const renderFields = (
     }
 
     return (
-      <div key={nestedKey}>
-        <strong>{key}</strong>
+      <div
+        key={nestedKey}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '8px',
+          width: '100%',
+        }}
+      >
+        <span style={{ wordBreak: 'break-word', flex: '1 1 auto' }}>
+          <strong>{key}</strong>
+          {': '}
+          {value != null ? value.toString() : '—'}
+        </span>
         <button
-          style={{ marginLeft: '5px', cursor: 'pointer' }}
-          onClick={() => removeField(userId, nestedKey, setUsers, setState, isToastOn)}
+          style={{ cursor: 'pointer' }}
+          onClick={() => removeField(userId, nestedKey, setUsers, setState, isToastOn, nestedKey)}
         >
           X
         </button>
-        {': '}
-        {value != null ? value.toString() : '—'}
       </div>
     );
   });

--- a/src/components/__tests__/makeNewUser.test.js
+++ b/src/components/__tests__/makeNewUser.test.js
@@ -66,7 +66,7 @@ describe('makeNewUser', () => {
     const newUser = db.set.mock.calls[0][1];
     expect(newUser.userId).toBe('generatedId');
     expect(newUser.searchedUserId).toBe('searchedId');
-    expect(newUser.cycleStatus).toBe('menstruation');
+    expect(newUser.cycleStatus).toBeUndefined();
   });
 
   it('adds field for non-userId searches', async () => {
@@ -75,7 +75,7 @@ describe('makeNewUser', () => {
     expect(newUser.userId).toBe('generatedId');
     expect(newUser.email).toBe('test@example.com');
     expect(newUser.searchedUserId).toBeUndefined();
-    expect(newUser.cycleStatus).toBe('menstruation');
+    expect(newUser.cycleStatus).toBeUndefined();
   });
 });
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -623,7 +623,6 @@ export const makeNewUser = async searchedValue => {
     userId: newUserId,
     createdAt,
     createdAt2,
-    cycleStatus: 'menstruation',
   };
 
   if (searchKey !== 'userId') {
@@ -1009,13 +1008,15 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
     if (!skipIndexing) {
       // Перебір ключів та їх обробка
       for (const key of keysToCheck) {
-        const isEmptyString = uploadedInfo[key] === '';
+        const shouldRemoveKey = uploadedInfo[key] === '' || uploadedInfo[key] === null;
 
-        if (isEmptyString) {
-          console.log(`${key} має пусте значення. Видаляємо.`);
-          await updateSearchId(key, currentUserData[key], userId, 'remove'); // Видаляємо з searchId
-          uploadedInfo[key] = null; // Видаляємо ключ з newUsers/${userId}
-          continue; // Переходимо до наступного ключа
+        if (shouldRemoveKey) {
+          console.log(`${key} має пусте або null значення. Видаляємо.`);
+          if (currentUserData[key] !== undefined && currentUserData[key] !== null) {
+            await updateSearchId(key, currentUserData[key], userId, 'remove');
+          }
+          uploadedInfo[key] = null;
+          continue;
         }
 
         if (uploadedInfo[key] !== undefined) {

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -79,7 +79,7 @@ const formatDate = date => {
 };
 
 export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
-  const [status, setStatus] = React.useState(userData.cycleStatus || 'menstruation');
+  const [status, setStatus] = React.useState(userData.cycleStatus ?? '');
   const submittedRef = React.useRef(false);
   const [localValue, setLocalValue] = React.useState(formatDateToDisplay(userData.lastCycle) || '');
   const [showConfirm, setShowConfirm] = React.useState(false);
@@ -99,7 +99,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
   );
 
   React.useEffect(() => {
-    setStatus(userData.cycleStatus || 'menstruation');
+    setStatus(userData.cycleStatus ?? '');
   }, [userData.cycleStatus]);
 
   React.useEffect(() => {
@@ -109,11 +109,16 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
   const processLastCycle = value => {
     const val = value.trim();
     const date = parseDate(val);
+    const normalizedStatus = status || (val ? 'menstruation' : '');
+
+    if (!status && normalizedStatus) {
+      setStatus(normalizedStatus);
+    }
 
     if (date) {
       const lastCycleFormatted = formatDateToServer(formatDate(date));
 
-      if (status === 'pregnant') {
+      if (normalizedStatus === 'pregnant') {
         const lastDelivery = new Date(date);
         lastDelivery.setDate(lastDelivery.getDate() + 7 * 40);
 
@@ -133,20 +138,24 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
           lastDelivery: lastDeliveryFormatted,
           getInTouch: getInTouchFormatted,
           ownKids,
-          cycleStatus: status,
+          cycleStatus: normalizedStatus,
         };
         handleChange(setUsers, setState, userData.userId, updates);
         handleSubmit({ userId: userData.userId, ...updates }, 'overwrite', isToastOn);
         submittedRef.current = true;
       } else {
-        const updates = { lastCycle: lastCycleFormatted, cycleStatus: status };
+        const updates = normalizedStatus
+          ? { lastCycle: lastCycleFormatted, cycleStatus: normalizedStatus }
+          : { lastCycle: lastCycleFormatted };
         handleChange(setUsers, setState, userData.userId, updates);
         handleSubmit({ userId: userData.userId, ...updates }, 'overwrite', isToastOn);
         submittedRef.current = true;
       }
     } else {
       const serverFormattedDate = formatDateToServer(val);
-      const updates = { lastCycle: serverFormattedDate, cycleStatus: status };
+      const updates = normalizedStatus
+        ? { lastCycle: serverFormattedDate, cycleStatus: normalizedStatus }
+        : { lastCycle: serverFormattedDate };
       handleChange(setUsers, setState, userData.userId, updates);
       handleSubmit({ userId: userData.userId, ...updates }, 'overwrite', isToastOn);
       submittedRef.current = true;


### PR DESCRIPTION
## Summary
- move the inline delete button next to displayed values and pipe the removed field key through forms
- teach small card removal logic to propagate deletions to cache and backend, and update cached card handling
- stop seeding new users with a cycle status and only send it after user interaction

## Testing
- CI=true npm test -- --runTestsByPath src/components/__tests__/removeField.test.js src/components/__tests__/makeNewUser.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c842c4a5b08326a4e0b15e989e0616