### PR TITLE
Fix photo field restoration after refresh

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -39,6 +39,80 @@ const getContrastColor = background => {
   return luminance > 0.5 ? '#000' : '#fff';
 };
 
+const removeNestedValue = (current, segments, depth = 0) => {
+  if (current === undefined || current === null) {
+    return { changed: false, value: current };
+  }
+
+  const key = segments[depth];
+  const isLast = depth === segments.length - 1;
+
+  if (Array.isArray(current)) {
+    if (!/^\d+$/.test(key)) {
+      return { changed: false, value: current };
+    }
+
+    const index = Number(key);
+    if (index < 0 || index >= current.length) {
+      return { changed: false, value: current };
+    }
+
+    if (isLast) {
+      const next = current.slice();
+      next.splice(index, 1);
+      return { changed: true, value: next };
+    }
+
+    const { changed, value } = removeNestedValue(current[index], segments, depth + 1);
+    if (!changed) {
+      return { changed: false, value: current };
+    }
+
+    const next = current.slice();
+    next[index] = value;
+    return { changed: true, value: next };
+  }
+
+  if (typeof current === 'object') {
+    if (!Object.prototype.hasOwnProperty.call(current, key)) {
+      return { changed: false, value: current };
+    }
+
+    if (isLast) {
+      const { [key]: _, ...rest } = current;
+      return { changed: true, value: rest };
+    }
+
+    const { changed, value } = removeNestedValue(current[key], segments, depth + 1);
+    if (!changed) {
+      return { changed: false, value: current };
+    }
+
+    return { changed: true, value: { ...current, [key]: value } };
+  }
+
+  return { changed: false, value: current };
+};
+
+const removePathsFromObject = (source, paths = []) => {
+  if (!source || typeof source !== 'object') {
+    return source;
+  }
+
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return source;
+  }
+
+  return paths
+    .map(path => String(path).trim())
+    .filter(path => path && path !== 'userId')
+    .reduce((acc, path) => {
+      const segments = path.split('.');
+      const { changed, value } = removeNestedValue(acc, segments);
+      return changed ? value : acc;
+    }, source);
+};
+
 export const renderTopBlock = (
   userData,
   setUsers,
@@ -176,7 +250,21 @@ export const renderTopBlock = (
           try {
             fresh = await fetchUserById(userData.userId);
             if (fresh) {
-              const updated = updateCard(userData.userId, fresh);
+              const removalTargets = [];
+              const hadLocalPhotos = Object.prototype.hasOwnProperty.call(userData, 'photos');
+              const photosMissingInFresh =
+                !Object.prototype.hasOwnProperty.call(fresh, 'photos') || fresh.photos == null;
+
+              if (hadLocalPhotos && photosMissingInFresh) {
+                removalTargets.push('photos');
+              }
+
+              const updated = updateCard(
+                userData.userId,
+                fresh,
+                undefined,
+                removalTargets,
+              );
 
               if (setUsers) {
                 setUsers(prev => {
@@ -191,7 +279,22 @@ export const renderTopBlock = (
               }
 
               if (setState) {
-                setState(prev => ({ ...prev, ...updated }));
+                setState(prev => {
+                  if (!prev || typeof prev !== 'object') {
+                    return { ...updated };
+                  }
+
+                  if (!removalTargets.length) {
+                    return { ...prev, ...updated };
+                  }
+
+                  const cleanedPrev = removePathsFromObject(prev, removalTargets);
+                  if (!cleanedPrev || typeof cleanedPrev !== 'object') {
+                    return { ...updated };
+                  }
+
+                  return { ...cleanedPrev, ...updated };
+                });
               }
 
               toastFn = toast.success;


### PR DESCRIPTION
## Summary
- add utilities to drop nested keys from local state when rehydrating cards
- ensure the photo field is removed from local caches/state when the backend no longer returns it

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c84c57d784832691663177f2cdc0ee