### PR TITLE
Adjust UsersList primitive field layout

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -86,10 +86,9 @@ const renderFields = (
           display: 'inline-flex',
           alignItems: 'center',
           gap: '4px',
-          width: '100%',
         }}
       >
-        <span style={{ wordBreak: 'break-word', flex: '0 1 auto' }}>
+        <span style={{ wordBreak: 'break-word' }}>
           <strong>{key}</strong>
           {': '}
           {value != null ? value.toString() : '—'}


### PR DESCRIPTION
## Summary
- wrap primitive field text in a span so the delete control follows the value directly
- align the field container and delete button styling with the inline-flex + 25×25 OrangeBtn pattern

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68c86243e0f88326b42a8636404c5629