### PR TITLE
Clear cached card before refreshing data

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -16,7 +16,7 @@ import { fieldIMT } from './fieldIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
-import { updateCard } from 'utils/cardsStorage';
+import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import toast from 'react-hot-toast';
 
@@ -176,6 +176,7 @@ export const renderTopBlock = (
           try {
             fresh = await fetchUserById(userData.userId);
             if (fresh) {
+              clearCardCache(userData.userId);
               const updated = updateCard(userData.userId, fresh);
 
               if (setUsers) {

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -24,6 +24,19 @@ export const removeCardFromList = (cardId, listKey) => {
   setIdsForQuery(listKey, ids);
 };
 
+export const clearCardCache = cardId => {
+  if (!cardId) {
+    return;
+  }
+
+  const cards = loadCards();
+
+  if (cards[cardId]) {
+    delete cards[cardId];
+    saveCards(cards);
+  }
+};
+
 const removeNestedValue = (current, segments, depth = 0) => {
   if (current === undefined || current === null) {
     return { changed: false, value: current };


### PR DESCRIPTION
## Summary
- add a clearCardCache helper in cardsStorage to drop stale local entries
- clear cached data before refreshing a card in renderTopBlock so removed photos stay removed

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68c8627696dc8326b1df5b2e313ce347