### PR TITLE
Fix dot menu behavior in user list cards

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -146,7 +146,7 @@ const UserCard = ({
           setShowInfoModal,
           setState,
           setUserIdToDelete,
-          'isFromListOfUsers',
+          true,
           favoriteUsers,
           setFavoriteUsers,
           dislikeUsers,

--- a/src/components/smallCard/btnDel.js
+++ b/src/components/smallCard/btnDel.js
@@ -5,7 +5,7 @@ export const btnDel = (
   userData,
   setShowInfoModal,
   setUserIdToDelete,
-  isFromListOfUsers,
+  isFromListOfUsers = false,
 ) => (
   <CardMenuBtn
     style={{
@@ -14,7 +14,7 @@ export const btnDel = (
     }}
     onClick={e => {
       e.stopPropagation(); // Запобігаємо активації кліку картки
-      if (isFromListOfUsers === 'isFromListOfUsers') {
+      if (isFromListOfUsers) {
         setUserIdToDelete(userData.userId);
       }
       setShowInfoModal('delConfirm');

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -154,7 +154,8 @@ export const renderTopBlock = (
       <FieldComment userData={userData} setUsers={setUsers} setState={setState} isToastOn={isToastOn} />
 
       <div
-        onClick={async () => {
+        onClick={async e => {
+          e.stopPropagation();
           const details = document.getElementById(userData.userId);
           const toggleDetails = () => {
             if (details) {
@@ -191,7 +192,7 @@ export const renderTopBlock = (
                 });
               }
 
-              if (setState) {
+              if (setState && !isFromListOfUsers) {
                 setState(prev => ({ ...prev, ...updated }));
               }
 


### PR DESCRIPTION
## Summary
- stop the dots menu click from propagating so it only toggles details
- avoid setState updates when the card is rendered from the users list and use a boolean flag
- update the delete button logic to use the boolean list flag when determining whether to set the user ID

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68c871dfde808326b4e461bf2d10a30a