### PR TITLE
Adjust profile field row layout

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -47,13 +47,15 @@ const removeButtonStyle = {
 
 const fieldRowStyle = {
   display: 'flex',
-  alignItems: 'flex-start',
+  alignItems: 'center',
+  justifyContent: 'space-between',
   gap: '8px',
-  flexWrap: 'wrap',
+  flexWrap: 'nowrap',
   marginBottom: '4px',
 };
 
 const fieldValueStyle = {
+  flex: 1,
   wordBreak: 'break-word',
   whiteSpace: 'pre-wrap',
 };


### PR DESCRIPTION
## Summary
- update `fieldRowStyle` to center content, keep items on one line, and space the value from the delete button
- allow the field value span to flex so long content does not wrap the delete button

## Testing
- `npm start` (manually verified layout in the running app)`

------
https://chatgpt.com/codex/tasks/task_e_68c91ac2491883268ae8c0e13624093f