### PR TITLE
Derive pregnancy status from future deliveries

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -56,6 +56,7 @@ import {
 import { saveToContact } from './ExportContact';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
+import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 // import { UploadJson } from './topBtns/uploadNewJSON';
 import { btnExportUsers } from './topBtns/btnExportUsers';
 import { btnMerge } from './smallCard/btnMerge';
@@ -1125,6 +1126,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const fieldsToRender = getFieldsToRender(state);
 
+  const effectiveCycleStatus = getEffectiveCycleStatus(state);
+  const scheduleUserData = state
+    ? { ...state, cycleStatus: effectiveCycleStatus ?? state.cycleStatus }
+    : state;
+  const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveCycleStatus);
+
 
   // const fieldsToRender = [
   //   ...pickerFields,
@@ -1213,10 +1220,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 setIsToastOn,
               )}
             </div>
-            {state.cycleStatus === 'stimulation' && (
+            {shouldShowSchedule && state && (
               <div style={{ ...coloredCard(), marginBottom: '8px' }}>
                 <StimulationSchedule
-                  userData={state}
+                  userData={scheduleUserData}
                   setUsers={setUsers}
                   setState={setState}
                   isToastOn={isToastOn}

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -22,6 +22,7 @@ import {
 } from 'components/inputValidations';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import toast from 'react-hot-toast';
+import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 
 const Container = styled.div`
   display: flex;
@@ -207,6 +208,12 @@ const EditProfile = () => {
     });
   };
 
+  const effectiveCycleStatus = getEffectiveCycleStatus(state);
+  const scheduleUserData = state
+    ? { ...state, cycleStatus: effectiveCycleStatus ?? state.cycleStatus }
+    : state;
+  const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveCycleStatus);
+
   if (!state) return null;
 
   return (
@@ -230,9 +237,13 @@ const EditProfile = () => {
           setIsToastOn,
         )}
       </div>
-      {state.cycleStatus === 'stimulation' && (
+      {shouldShowSchedule && state && (
         <div style={{ ...coloredCard(), marginBottom: '8px' }}>
-          <StimulationSchedule userData={state} setState={setState} isToastOn={isToastOn} />
+          <StimulationSchedule
+            userData={scheduleUserData}
+            setState={setState}
+            isToastOn={isToastOn}
+          />
         </div>
       )}
       <ProfileForm

--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { handleChange, handleSubmit } from './smallCard/actions';
 import { OrangeBtn } from 'components/styles';
 import { ReactComponent as ClipboardIcon } from 'assets/icons/clipboard.svg';
+import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 
 const parseDate = str => {
   if (!str) return null;
@@ -184,6 +185,7 @@ export const serializeSchedule = sched =>
 
 const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }) => {
   const base = React.useMemo(() => parseDate(userData?.lastCycle), [userData?.lastCycle]);
+  const effectiveStatus = getEffectiveCycleStatus(userData);
   const [schedule, setSchedule] = React.useState([]);
   const [apDescription, setApDescription] = React.useState('');
   const [editingIndex, setEditingIndex] = React.useState(null);
@@ -219,7 +221,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
   );
 
   React.useEffect(() => {
-    if (userData?.cycleStatus !== 'stimulation' || !base) return;
+    if (!['stimulation', 'pregnant'].includes(effectiveStatus) || !base) return;
 
     const gen = generateSchedule(base);
     const expectedFirst = gen[0]?.date;
@@ -268,7 +270,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
     } else {
       setSchedule(gen);
     }
-  }, [userData.stimulationSchedule, userData.cycleStatus, base, userData.lastCycle]);
+  }, [userData.stimulationSchedule, effectiveStatus, base, userData.lastCycle]);
 
   const postTransferKeys = React.useMemo(() => ['hcg', 'us'], []);
 
@@ -345,7 +347,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
     });
   };
 
-  if (userData?.cycleStatus !== 'stimulation' || !base || schedule.length === 0)
+  if (!['stimulation', 'pregnant'].includes(effectiveStatus) || !base || schedule.length === 0)
     return null;
 
   const today = new Date().setHours(0, 0, 0, 0);

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
-import StimulationSchedule from './StimulationSchedule';
 import { btnCompare } from './smallCard/btnCompare';
 import { btnEdit } from './smallCard/btnEdit';
 import { renderAllFields } from './ProfileForm';
 // import { btnExportUsers } from './topBtns/btnExportUsers';
+import StimulationSchedule from './StimulationSchedule';
+import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 
 // Компонент для рендерингу картки користувача
 const UserCard = ({
@@ -23,6 +24,13 @@ const UserCard = ({
   isDateInRange,
   isToastOn = false,
 }) => {
+  const effectiveStatus = getEffectiveCycleStatus(userData);
+  const scheduleUserData = {
+    ...userData,
+    cycleStatus: effectiveStatus ?? userData?.cycleStatus,
+  };
+  const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveStatus);
+
   return (
     <div>
       <div style={{ ...coloredCard(), marginBottom: '8px' }}>
@@ -42,10 +50,10 @@ const UserCard = ({
           isToastOn,
         )}
       </div>
-      {userData.cycleStatus === 'stimulation' && (
+      {shouldShowSchedule && (
         <div style={{ ...coloredCard(), marginBottom: '8px' }}>
           <StimulationSchedule
-            userData={userData}
+            userData={scheduleUserData}
             setUsers={setUsers}
             setState={setState}
             isToastOn={isToastOn}

--- a/src/components/__tests__/StimulationSchedule.test.jsx
+++ b/src/components/__tests__/StimulationSchedule.test.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import StimulationSchedule from '../StimulationSchedule';
+
+jest.mock('../smallCard/actions', () => ({
+  handleChange: jest.fn(),
+  handleSubmit: jest.fn(),
+}));
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const formatServerDate = date => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+describe('StimulationSchedule', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root.unmount();
+      });
+    }
+    if (container?.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+    root = null;
+  });
+
+  const renderComponent = async userData => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(<StimulationSchedule userData={userData} setState={jest.fn()} />);
+    });
+  };
+
+  it('renders schedule for pregnant users', async () => {
+    const base = new Date();
+    base.setHours(12, 0, 0, 0);
+    const userData = {
+      userId: 'test-user',
+      lastCycle: formatServerDate(base),
+      cycleStatus: 'pregnant',
+    };
+
+    await renderComponent(userData);
+
+    expect(container.textContent).toContain('1й день');
+  });
+
+  it('renders schedule when lastDelivery implies pregnancy', async () => {
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const lastCycle = new Date(today);
+    lastCycle.setDate(today.getDate() - 28);
+    const futureDelivery = new Date(today);
+    futureDelivery.setDate(today.getDate() + 14);
+
+    const userData = {
+      userId: 'future-delivery',
+      lastCycle: formatServerDate(lastCycle),
+      lastDelivery: formatServerDate(futureDelivery),
+    };
+
+    await renderComponent(userData);
+
+    expect(container.textContent).toContain('1й день');
+  });
+});

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -18,6 +18,7 @@ import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
 import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
+import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import toast from 'react-hot-toast';
 
 const getParentBackground = element => {
@@ -57,24 +58,25 @@ export const renderTopBlock = (
 ) => {
   if (!userData) return null;
 
-  const region = normalizeRegion(userData.region);
+  const cardData = { ...userData, cycleStatus: getEffectiveCycleStatus(userData) };
+  const region = normalizeRegion(cardData.region);
 
   return (
     <div style={{ padding: '7px', position: 'relative' }}>
-      {btnDel(userData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
+      {btnDel(cardData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
       {!isFromListOfUsers && <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />}
-      {btnExport(userData)}
+      {btnExport(cardData)}
       <div>
-        {userData.lastAction &&
-          formatDateToDisplay(normalizeLastAction(userData.lastAction))}
-        {userData.lastAction && ', '}
-        {userData.userId}
-        {userData.userRole !== 'ag' &&
-          userData.userRole !== 'ip' &&
-          userData.role !== 'ag' &&
-          userData.role !== 'ip' &&
+        {cardData.lastAction &&
+          formatDateToDisplay(normalizeLastAction(cardData.lastAction))}
+        {cardData.lastAction && ', '}
+        {cardData.userId}
+        {cardData.userRole !== 'ag' &&
+          cardData.userRole !== 'ip' &&
+          cardData.role !== 'ag' &&
+          cardData.role !== 'ip' &&
           fieldGetInTouch(
-            userData,
+            cardData,
             setUsers,
             setState,
             currentFilter,
@@ -85,22 +87,22 @@ export const renderTopBlock = (
             setDislikeUsers,
             isToastOn
           )}
-        {fieldRole(userData, setUsers, setState, isToastOn)}
-        {userData.userRole !== 'ag' &&
-          userData.userRole !== 'ip' &&
-          userData.role !== 'ag' &&
-          userData.role !== 'ip' && (
+        {fieldRole(cardData, setUsers, setState, isToastOn)}
+        {cardData.userRole !== 'ag' &&
+          cardData.userRole !== 'ip' &&
+          cardData.role !== 'ag' &&
+          cardData.role !== 'ip' && (
             <FieldLastCycle
-              userData={userData}
+              userData={cardData}
               setUsers={setUsers}
               setState={setState}
               isToastOn={isToastOn}
             />
           )}
-        <div>{fieldDeliveryInfo(setUsers, setState, userData)}</div>
+        <div>{fieldDeliveryInfo(setUsers, setState, cardData)}</div>
         <div>
-          {userData.birth && `${userData.birth} - `}
-          {userData.birth && fieldBirth(userData.birth)}
+          {cardData.birth && `${cardData.birth} - `}
+          {cardData.birth && fieldBirth(cardData.birth)}
         </div>
       </div>
       {/* <div style={{ color: '#856404', fontWeight: 'bold' }}>{nextContactDate}</div> */}
@@ -109,32 +111,32 @@ export const renderTopBlock = (
           {(() => {
             const nameParts = [];
 
-            if (Array.isArray(userData.surname)) {
-              if (userData.surname.length === 2) {
-                nameParts.push(`${userData.surname[1]} (${userData.surname[0]})`);
-              } else if (userData.surname.length > 0) {
-                nameParts.push(userData.surname.join(' '));
+            if (Array.isArray(cardData.surname)) {
+              if (cardData.surname.length === 2) {
+                nameParts.push(`${cardData.surname[1]} (${cardData.surname[0]})`);
+              } else if (cardData.surname.length > 0) {
+                nameParts.push(cardData.surname.join(' '));
               }
-            } else if (userData.surname) {
-              nameParts.push(userData.surname);
+            } else if (cardData.surname) {
+              nameParts.push(cardData.surname);
             }
 
-            if (userData.name) nameParts.push(userData.name);
-            if (userData.fathersname) nameParts.push(userData.fathersname);
+            if (cardData.name) nameParts.push(cardData.name);
+            if (cardData.fathersname) nameParts.push(cardData.fathersname);
 
             return nameParts.length > 0 ? `${nameParts.join(' ')}` : '';
           })()}
         </strong>
-        {/* {renderCsection(userData.csection)}  */}
+        {/* {renderCsection(cardData.csection)}  */}
         <div style={{ whiteSpace: 'pre-wrap', display: 'flex', alignItems: 'center', gap: '2px', flexWrap: 'wrap' }}>
           {(() => {
             const parts = [];
-            if (userData.maritalStatus) parts.push(fieldMaritalStatus(userData.maritalStatus));
-            if (userData.blood) parts.push(fieldBlood(userData.blood));
-            if (userData.height) parts.push(userData.height);
-            if (userData.height && userData.weight) parts.push('/');
-            if (userData.weight) parts.push(`${userData.weight}-`);
-            if (userData.weight && userData.height) parts.push(fieldIMT(userData.weight, userData.height));
+            if (cardData.maritalStatus) parts.push(fieldMaritalStatus(cardData.maritalStatus));
+            if (cardData.blood) parts.push(fieldBlood(cardData.blood));
+            if (cardData.height) parts.push(cardData.height);
+            if (cardData.height && cardData.weight) parts.push('/');
+            if (cardData.weight) parts.push(`${cardData.weight}-`);
+            if (cardData.weight && cardData.height) parts.push(fieldIMT(cardData.weight, cardData.height));
             return parts.map((part, index) => <React.Fragment key={index}>{part}</React.Fragment>);
           })()}
         </div>
@@ -147,16 +149,16 @@ export const renderTopBlock = (
             gap: '4px',
           }}
         >
-          {fieldContacts(userData)}
+          {fieldContacts(cardData)}
         </div>
       </div>
-      {fieldWriter(userData, setUsers, setState, isToastOn)}
-      <FieldComment userData={userData} setUsers={setUsers} setState={setState} isToastOn={isToastOn} />
+      {fieldWriter(cardData, setUsers, setState, isToastOn)}
+      <FieldComment userData={cardData} setUsers={setUsers} setState={setState} isToastOn={isToastOn} />
 
       <div
         onClick={async e => {
           e.stopPropagation();
-          const details = document.getElementById(userData.userId);
+          const details = document.getElementById(cardData.userId);
           const toggleDetails = () => {
             if (details) {
               const isHidden = details.style.display === 'none';
@@ -175,18 +177,18 @@ export const renderTopBlock = (
           let toastFn = toast.error;
           let toastMsg = 'Failed to load data';
           try {
-            fresh = await fetchUserById(userData.userId);
+            fresh = await fetchUserById(cardData.userId);
             if (fresh) {
-              clearCardCache(userData.userId);
-              const updated = updateCard(userData.userId, fresh);
+              clearCardCache(cardData.userId);
+              const updated = updateCard(cardData.userId, fresh);
 
               if (setUsers) {
                 setUsers(prev => {
                   if (Array.isArray(prev)) {
-                    return prev.map(u => (u.userId === userData.userId ? updated : u));
+                    return prev.map(u => (u.userId === cardData.userId ? updated : u));
                   }
                   if (typeof prev === 'object' && prev !== null) {
-                    return { ...prev, [userData.userId]: updated };
+                    return { ...prev, [cardData.userId]: updated };
                   }
                   return prev;
                 });

--- a/src/utils/__tests__/cycleStatus.test.js
+++ b/src/utils/__tests__/cycleStatus.test.js
@@ -1,0 +1,44 @@
+import { getEffectiveCycleStatus } from '../cycleStatus';
+
+const formatServerDate = date => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+describe('getEffectiveCycleStatus', () => {
+  it('returns pregnant when lastDelivery is in the future', () => {
+    const base = new Date();
+    base.setHours(12, 0, 0, 0);
+    const future = new Date(base);
+    future.setDate(base.getDate() + 7);
+    const user = {
+      cycleStatus: 'stimulation',
+      lastDelivery: formatServerDate(future),
+    };
+
+    expect(getEffectiveCycleStatus(user)).toBe('pregnant');
+  });
+
+  it('falls back to cycleStatus when lastDelivery is not in the future', () => {
+    const base = new Date();
+    base.setHours(12, 0, 0, 0);
+    const past = new Date(base);
+    past.setDate(base.getDate() - 7);
+    const user = {
+      cycleStatus: 'menstruation',
+      lastDelivery: formatServerDate(past),
+    };
+
+    expect(getEffectiveCycleStatus(user)).toBe('menstruation');
+  });
+
+  it('returns undefined when user has no cycleStatus or future delivery', () => {
+    const user = {
+      lastDelivery: 'invalid-date',
+    };
+
+    expect(getEffectiveCycleStatus(user)).toBeUndefined();
+  });
+});

--- a/src/utils/cycleStatus.js
+++ b/src/utils/cycleStatus.js
@@ -1,0 +1,28 @@
+const SERVER_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const parseServerDate = value => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  const match = SERVER_DATE_PATTERN.exec(trimmed);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const getEffectiveCycleStatus = user => {
+  if (!user) return undefined;
+
+  const parsedDelivery = parseServerDate(user.lastDelivery);
+  if (parsedDelivery) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (parsedDelivery.getTime() > today.getTime()) {
+      return 'pregnant';
+    }
+  }
+
+  return user.cycleStatus;
+};
+
+export { parseServerDate };


### PR DESCRIPTION
## Summary
- derive an effective cycle status helper that flags future deliveries as pregnancy and feed the result into the small card render pipeline
- surface stimulation schedules for both stimulation and pregnant users across list/add/edit views and let the schedule component accept the derived status
- cover the new helper and pregnant schedule scenarios with dedicated unit tests

## Testing
- CI=true npm test -- --watch=false
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68c97037c89c83269cb38314ecfca5a0