### PR TITLE
Fix small card blur handlers and add tests

### DIFF
--- a/src/components/__tests__/FieldComment.test.jsx
+++ b/src/components/__tests__/FieldComment.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act, Simulate } from 'react-dom/test-utils';
+
+jest.mock('../smallCard/actions', () => ({
+  handleChange: jest.fn(),
+  handleSubmit: jest.fn(),
+}));
+
+jest.mock('../../hooks/useAutoResize', () => ({
+  useAutoResize: () => jest.fn(),
+}));
+
+import { FieldComment } from '../smallCard/FieldComment';
+import { handleSubmit } from '../smallCard/actions';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('FieldComment', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    jest.clearAllMocks();
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    container = null;
+    root = null;
+  });
+
+  it('submits the current textarea value on blur', () => {
+    const userData = { userId: 'user-1', myComment: 'Initial comment' };
+
+    act(() => {
+      root.render(
+        <FieldComment
+          userData={userData}
+          setUsers={() => {}}
+          setState={() => {}}
+          isToastOn={true}
+        />
+      );
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      Simulate.focus(textarea);
+      Simulate.change(textarea, { target: { value: 'Updated comment' } });
+      textarea.value = 'Updated comment';
+      Simulate.blur(textarea);
+    });
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', myComment: 'Updated comment' }),
+      'overwrite',
+      true,
+    );
+  });
+});

--- a/src/components/__tests__/fieldGetInTouch.test.js
+++ b/src/components/__tests__/fieldGetInTouch.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+
+jest.mock('components/config', () => ({
+  fetchUserById: jest.fn(),
+  updateDataInNewUsersRTDB: jest.fn(),
+  updateDataInRealtimeDB: jest.fn(),
+  updateDataInFiresoreDB: jest.fn(),
+  addDislikeUser: jest.fn(),
+  removeDislikeUser: jest.fn(),
+  addFavoriteUser: jest.fn(),
+  removeFavoriteUser: jest.fn(),
+  auth: { currentUser: null },
+}));
+
+jest.mock('utils/cache', () => ({
+  updateCachedUser: jest.fn(),
+  setFavoriteIds: jest.fn(),
+}));
+
+jest.mock('utils/favoritesStorage', () => ({
+  setFavorite: jest.fn(),
+}));
+
+jest.mock('utils/dislikesStorage', () => ({
+  setDislike: jest.fn(),
+}));
+
+jest.mock('../smallCard/actions', () => ({
+  handleChange: jest.fn(),
+  handleSubmit: jest.fn(),
+}));
+
+import { fieldGetInTouch } from '../smallCard/fieldGetInTouch';
+import { handleChange, handleSubmit } from '../smallCard/actions';
+
+describe('fieldGetInTouch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the current input value when submitting on blur', () => {
+    const userData = { userId: 'user-123', getInTouch: '2024-01-10' };
+    const setUsers = jest.fn();
+    const setState = jest.fn();
+    const currentFilter = 'DATE2';
+    const isDateInRange = jest.fn().mockReturnValue(true);
+
+    const element = fieldGetInTouch(
+      userData,
+      setUsers,
+      setState,
+      currentFilter,
+      isDateInRange,
+      {},
+      jest.fn(),
+      {},
+      jest.fn(),
+      true,
+    );
+
+    const inputElement = React.Children.toArray(element.props.children).find(
+      child => child?.props?.onBlur,
+    );
+
+    expect(inputElement).toBeDefined();
+
+    inputElement.props.onBlur({ target: { value: '15.07.2024' } });
+
+    const expectedDate = '2024-07-15';
+
+    expect(handleChange).toHaveBeenCalledWith(
+      setUsers,
+      setState,
+      userData.userId,
+      'getInTouch',
+      expectedDate,
+      false,
+      { currentFilter, isDateInRange },
+      true,
+    );
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      { ...userData, getInTouch: expectedDate },
+      'overwrite',
+      true,
+    );
+  });
+});

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -30,7 +30,15 @@ export const FieldComment = ({ userData, setUsers, setState, isToastOn }) => {
           handleInputChange(e);
           autoResize(e.target);
         }}
-        onBlur={() => handleSubmit(userData, 'overwrite', isToastOn)}
+        onBlur={() => {
+          const currentComment =
+            textareaRef.current?.value ?? userData.myComment ?? '';
+          const payload = {
+            ...userData,
+            myComment: currentComment,
+          };
+          handleSubmit(payload, 'overwrite', isToastOn);
+        }}
         style={{
           // marginLeft: '10px',
           width: '100%',

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -204,18 +204,29 @@ export const fieldGetInTouch = (
             false
           );
         }}
-        onBlur={() => {
+        onBlur={e => {
+          const rawValue = e?.target?.value ?? '';
+          const serverFormattedDate = formatDateToServer(
+            formatDateAndFormula(rawValue)
+          );
+
           handleChange(
             setUsers,
             setState,
             userData.userId,
             'getInTouch',
-            userData.getInTouch,
+            serverFormattedDate,
             false,
             { currentFilter, isDateInRange },
             isToastOn,
           );
-          handleSubmit(userData, 'overwrite', isToastOn);
+
+          const updatedUser = {
+            ...userData,
+            getInTouch: serverFormattedDate,
+          };
+
+          handleSubmit(updatedUser, 'overwrite', isToastOn);
         }}
         style={{
           marginLeft: 0,


### PR DESCRIPTION
## Summary
- submit the current textarea value from FieldComment when the field loses focus
- convert the manual getInTouch input to server format on blur and send the updated payload
- add tests to cover blur handling for FieldComment and fieldGetInTouch

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9b751d3408326b39b64e9f6106d12