### PR TITLE
Adjust profile field row layout for inline delete buttons

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -48,14 +48,15 @@ const removeButtonStyle = {
 const fieldRowStyle = {
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'space-between',
+  justifyContent: 'flex-start',
   gap: '8px',
   flexWrap: 'nowrap',
   marginBottom: '4px',
 };
 
 const fieldValueStyle = {
-  flex: 1,
+  flexShrink: 1,
+  minWidth: 0,
   wordBreak: 'break-word',
   whiteSpace: 'pre-wrap',
 };


### PR DESCRIPTION
## Summary
- align the profile field rows so delete buttons render directly after their values
- stop the value span from stretching across the row by removing flex growth and allowing it to shrink with wrapping

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68ca7edecd14832681066790d425a8a3