### PR TITLE
Add cachedAt metadata for cached cards

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -347,7 +347,15 @@ const SearchBar = ({
     if (!cacheKey) return false;
     const queries = loadQueries();
     const entry = queries[cacheKey];
-    return !!(entry && Date.now() - entry.lastAction < TTL_MS);
+    if (!entry) return false;
+    const timestampSource =
+      typeof entry.cachedAt === 'number' && Number.isFinite(entry.cachedAt)
+        ? entry.cachedAt
+        : Number(entry.cachedAt ?? entry.lastAction ?? 0);
+    if (!Number.isFinite(timestampSource) || timestampSource <= 0) {
+      return false;
+    }
+    return Date.now() - timestampSource < TTL_MS;
   };
 
   const addToHistory = value => {
@@ -463,7 +471,11 @@ const SearchBar = ({
       const queries = loadQueries();
       const entry = queries[cacheKey];
       let ids = [];
-      if (entry && Date.now() - entry.lastAction < TTL_MS) {
+      const timestampSource =
+        typeof entry?.cachedAt === 'number' && Number.isFinite(entry.cachedAt)
+          ? entry.cachedAt
+          : Number(entry?.cachedAt ?? entry?.lastAction ?? 0);
+      if (entry && Number.isFinite(timestampSource) && timestampSource > 0 && Date.now() - timestampSource < TTL_MS) {
         ids = getIdsByQuery(cacheKey);
       } else {
         if (entry) {

--- a/src/utils/__tests__/cardIndex.test.js
+++ b/src/utils/__tests__/cardIndex.test.js
@@ -38,4 +38,26 @@ describe('cardIndex queries', () => {
     expect(getCard('userId01')).toBeNull();
     expect(getIdsByQuery('test')).toEqual([]);
   });
+
+  it('migrates legacy timestamps to cachedAt fields', () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'cards',
+      JSON.stringify({
+        userId01: { userId: 'userId01', name: 'Legacy', lastAction: now },
+      }),
+    );
+    localStorage.setItem(
+      'queries',
+      JSON.stringify({ test: { ids: ['userId01'], lastAction: now } }),
+    );
+
+    expect(getIdsByQuery('test')).toEqual(['userId01']);
+    const storedQueries = JSON.parse(localStorage.getItem('queries'));
+    expect(storedQueries.test.cachedAt).toBe(now);
+
+    const card = getCard('userId01');
+    expect(card).not.toBeNull();
+    expect(card.cachedAt).toBe(now);
+  });
 });

--- a/src/utils/__tests__/cardsStorage.test.js
+++ b/src/utils/__tests__/cardsStorage.test.js
@@ -20,7 +20,10 @@ describe('cardsStorage', () => {
     const stored = JSON.parse(localStorage.getItem('cards'));
     expect(stored['1'].title).toBe('Card 1');
     expect(remoteSave).toHaveBeenCalledWith({ title: 'Card 1', userId: '1' });
-    expect(card).toHaveProperty('lastAction');
+    expect(card).toHaveProperty('cachedAt');
+    expect(typeof card.cachedAt).toBe('number');
+    expect(stored['1'].cachedAt).toBe(card.cachedAt);
+    expect(card.lastAction).toBeUndefined();
   });
 
   it('removes specified keys from card', () => {
@@ -62,7 +65,7 @@ describe('cardsStorage', () => {
     setIdsForQuery('favorite', ['1']);
     // expire list entry
     const queries = JSON.parse(localStorage.getItem('queries'));
-    queries['favorite'].lastAction = expired;
+    queries['favorite'].cachedAt = expired;
     localStorage.setItem('queries', JSON.stringify(queries));
 
     const remoteFetch = jest

--- a/src/utils/dislikesStorage.js
+++ b/src/utils/dislikesStorage.js
@@ -24,15 +24,22 @@ export const setDislike = (id, isDisliked) => {
     ids.delete(id);
     removeCardFromList(id, DISLIKE_LIST_KEY);
   }
-  queries[DISLIKE_LIST_KEY] = { ids: Array.from(ids), lastAction: Date.now() };
+  const now = Date.now();
+  queries[DISLIKE_LIST_KEY] = {
+    ids: Array.from(ids),
+    cachedAt: now,
+    lastAction: now,
+  };
   saveQueries(queries);
 };
 
 export const syncDislikes = remoteDislikes => {
   const queries = loadQueries();
+  const now = Date.now();
   queries[DISLIKE_LIST_KEY] = {
     ids: Object.keys(remoteDislikes || {}),
-    lastAction: Date.now(),
+    cachedAt: now,
+    lastAction: now,
   };
   saveQueries(queries);
 };

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -18,15 +18,22 @@ export const setFavorite = (id, isFav) => {
   } else {
     ids.delete(id);
   }
-  queries[FAVORITE_LIST_KEY] = { ids: Array.from(ids), lastAction: Date.now() };
+  const now = Date.now();
+  queries[FAVORITE_LIST_KEY] = {
+    ids: Array.from(ids),
+    cachedAt: now,
+    lastAction: now,
+  };
   saveQueries(queries);
 };
 
 export const syncFavorites = remoteFavs => {
   const queries = loadQueries();
+  const now = Date.now();
   queries[FAVORITE_LIST_KEY] = {
     ids: Object.keys(remoteFavs || {}).filter(id => remoteFavs[id]),
-    lastAction: Date.now(),
+    cachedAt: now,
+    lastAction: now,
   };
   saveQueries(queries);
 };


### PR DESCRIPTION
## Summary
- add a dedicated cachedAt timestamp when storing cards so cache freshness no longer relies on lastAction
- adjust card and query indexing logic plus UI cache checks to honour cachedAt and migrate older entries
- update favorites/dislikes cache writers and extend unit tests to cover the new metadata

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca8656719483268be3caa5c34c3be4