### PR TITLE
Handle UK triggers in search while preserving legacy payload

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -13,6 +13,7 @@ import {
   TTL_MS,
 } from '../utils/cardIndex';
 import { updateCard, searchCachedCards } from '../utils/cardsStorage';
+import { parseUkTrigger } from '../utils/ukTriggers';
 
 const SearchIcon = (
   <svg
@@ -553,9 +554,15 @@ const SearchBar = ({
       if (values.length > 0) {
         const results = {};
         for (const val of values) {
-          const res = await cachedSearch({ name: val });
+          const ukTriggerInfo = parseUkTrigger(val);
+          const searchName = ukTriggerInfo?.normalizedName || val;
+          const res = await cachedSearch({ name: searchName });
           if (!res || Object.keys(res).length === 0) {
-            results[`new_${val}`] = { _notFound: true, searchVal: val };
+            results[`new_${val}`] = {
+              _notFound: true,
+              searchVal: val,
+              ...(ukTriggerInfo?.prefill ? { prefill: ukTriggerInfo.prefill } : {}),
+            };
           } else if ('userId' in res) {
             results[res.userId] = res;
           } else {
@@ -583,30 +590,67 @@ const SearchBar = ({
     if (await processUserSearch('vk', parseVk, query)) return;
     if (await processUserSearch('other', parseOtherContact, query)) return;
 
-    const nameTrim = query.trim();
-    const hasCache = loadCachedResult('name', nameTrim);
-    const freshCache = hasCache && isCacheFresh('name', nameTrim);
-    onSearchKey && onSearchKey({ name: nameTrim });
+    const trimmedOriginal = (query || '').trim();
+    const ukTriggerInfo = trimmedOriginal ? parseUkTrigger(query) : null;
+
+    const variants = [];
+    const variantSet = new Set();
+    const addVariant = value => {
+      const normalized = (value || '').trim();
+      if (!normalized) return;
+      const key = normalized.toLowerCase();
+      if (variantSet.has(key)) return;
+      variantSet.add(key);
+      variants.push(normalized);
+    };
+
+    const normalizedName = ukTriggerInfo?.normalizedName?.trim();
+    if (normalizedName) addVariant(normalizedName);
+    addVariant(trimmedOriginal);
+
+    const cleanedWithoutPrefix =
+      (ukTriggerInfo?.withoutPrefix || '').trim() ||
+      (trimmedOriginal ? trimmedOriginal.replace(/^ук\s*см\s*/i, '').trim() : '');
+    addVariant(cleanedWithoutPrefix);
+
+    const prefixBase = normalizedName || cleanedWithoutPrefix || trimmedOriginal;
+    if (prefixBase) {
+      const withPrefixVariant = /^ук\s*см/i.test(prefixBase)
+        ? prefixBase
+        : `УК СМ ${prefixBase}`.trim();
+      addVariant(withPrefixVariant);
+    }
+
+    if (variants.length === 0) return;
+
+    const emittedKeys = new Set();
+    const emitSearchKey = value => {
+      const payload = (value || '').trim();
+      if (!payload) return;
+      const key = payload.toLowerCase();
+      if (emittedKeys.has(key)) return;
+      emittedKeys.add(key);
+      onSearchKey && onSearchKey({ name: payload });
+    };
+
+    emitSearchKey(trimmedOriginal);
+
+    const [primaryVariant, ...fallbackVariants] = variants;
+    emitSearchKey(primaryVariant);
+    const hasCache = loadCachedResult('name', primaryVariant);
+    const freshCache = hasCache && isCacheFresh('name', primaryVariant);
     if (freshCache) return;
     if (!hasCache) {
       setState && setState({});
       setUsers && setUsers({});
     }
-    let res = await cachedSearch({ name: nameTrim });
-    if (!res || Object.keys(res).length === 0) {
-      const cleanedQuery = query.replace(/^ук\s*см\s*/i, '').trim();
-      if (cleanedQuery && cleanedQuery !== nameTrim) {
-          res = await cachedSearch({ name: cleanedQuery });
-        onSearchKey && onSearchKey({ name: cleanedQuery });
-      }
+    let res = await cachedSearch({ name: primaryVariant });
+    for (const variant of fallbackVariants) {
+      if (res && Object.keys(res).length > 0) break;
+      emitSearchKey(variant);
+      res = await cachedSearch({ name: variant });
     }
-    if (!res || Object.keys(res).length === 0) {
-      const withPrefix = /^ук\s*см/i.test(query) ? null : `УК СМ ${query.trim()}`;
-      if (withPrefix) {
-          res = await cachedSearch({ name: withPrefix });
-        onSearchKey && onSearchKey({ name: withPrefix });
-      }
-    }
+
     if (!res || Object.keys(res).length === 0) {
       setUserNotFound && setUserNotFound(true);
     } else {

--- a/src/utils/__tests__/ukTriggers.test.js
+++ b/src/utils/__tests__/ukTriggers.test.js
@@ -1,0 +1,49 @@
+import { parseUkTrigger } from '../ukTriggers';
+
+describe('parseUkTrigger', () => {
+  it('returns null when no УК trigger is present', () => {
+    expect(parseUkTrigger('Марія Сидоренко')).toBeNull();
+    expect(parseUkTrigger('')).toBeNull();
+  });
+
+  it('parses contact information and normalized name from a trigger', () => {
+    const raw =
+      'УК СМ Марія Сидоренко телеграм @maria_test +380 50 123 45 67 insta: maria.story email TEST@MAIL.COM';
+    const parsed = parseUkTrigger(raw);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.normalizedName).toBe('Марія Сидоренко');
+    expect(parsed?.prefill).toMatchObject({
+      name: 'Марія Сидоренко',
+      telegram: 'maria_test',
+      phone: '380501234567',
+      instagram: 'maria.story',
+      email: 'test@mail.com',
+    });
+    expect(parsed?.prefill?._ukTrigger).toMatchObject({
+      raw,
+      normalizedName: 'Марія Сидоренко',
+      payload: parsed?.withoutPrefix,
+    });
+  });
+
+  it('handles compact prefix formatting and missing name data', () => {
+    const parsed = parseUkTrigger('УкСм тг @anon_user');
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.prefill?.telegram).toBe('anon_user');
+    expect(parsed?.normalizedName).toBe('тг @anon_user');
+  });
+
+  it('supports latin prefix variations and multiple contact types', () => {
+    const parsed = parseUkTrigger('uk sm Oksana tg oksana123 tt: oksana.tt phone 050-123-45-67');
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.prefill).toMatchObject({
+      name: 'Oksana',
+      telegram: 'oksana123',
+      tiktok: 'oksana.tt',
+      phone: '380501234567',
+    });
+  });
+});

--- a/src/utils/ukTriggers.js
+++ b/src/utils/ukTriggers.js
@@ -1,0 +1,211 @@
+const PREFIX_PATTERN = /^(?:ук|uk)(?:\s*см)?(?:[\s:/-]+|$)(.+)$/i;
+
+const sanitizeHandle = value => value?.replace(/^@+/, '').trim();
+const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const normalizePhone = raw => {
+  if (!raw) return null;
+  const digits = raw.replace(/\D+/g, '');
+  if (!digits) return null;
+  if (digits.length === 12 && digits.startsWith('380')) return digits;
+  if (digits.length === 11 && digits.startsWith('80')) return `3${digits}`;
+  if (digits.length === 10 && digits.startsWith('0')) return `38${digits}`;
+  if (digits.length > 12) {
+    const tail10 = digits.slice(-10);
+    if (/^\d{10}$/.test(tail10)) return `38${tail10}`;
+  }
+  return null;
+};
+
+const FILLER_WORDS = new RegExp(
+  [
+    "ім['’]я",
+    'імя',
+    'name',
+    'прізвище',
+    'surname',
+    'телефон',
+    'phone',
+    'mobile',
+    'номер',
+    'тг',
+    'tg',
+    'telegram',
+    'телеграм',
+    'телега',
+    'інста',
+    'insta',
+    'instagram',
+    'інстаграм',
+    'tik',
+    'tiktok',
+    'тікток',
+    'tt',
+    'sm',
+    'см',
+    'фб',
+    'facebook',
+    'vk',
+    'вк',
+    'email',
+    'mail',
+    'пошта',
+    'city',
+    'місто',
+    'country',
+    'країна',
+    'age',
+    'вік',
+    'років',
+  ]
+    .map(word => `(?:${word})`)
+    .join('|'),
+  'gi',
+);
+
+const collapseSpaces = value => value.replace(/\s+/g, ' ').trim();
+
+export const parseUkTrigger = input => {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(PREFIX_PATTERN);
+  if (!match || !match[1]) return null;
+
+  const withoutPrefix = match[1].trim();
+  if (!withoutPrefix) return null;
+
+  let remainder = withoutPrefix;
+  const prefill = {};
+
+  const extract = (field, pattern, normalizer = value => value?.trim()) => {
+    remainder = remainder.replace(pattern, (fullMatch, captured) => {
+      const candidate = normalizer(captured ?? fullMatch, { fullMatch });
+      if (candidate && !prefill[field]) {
+        prefill[field] = candidate;
+      }
+      return ' ';
+    });
+  };
+
+  extract(
+    'email',
+    /(?:^|\s)([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})(?=$|\s)/gi,
+    value => value?.toLowerCase(),
+  );
+
+  extract(
+    'phone',
+    /((?:\+?38)?0(?:[\s().-]*\d){9})/g,
+    value => normalizePhone(value),
+  );
+
+  extract(
+    'instagram',
+    /instagram\.com\/(?:p\/|stories\/|explore\/)?@?([A-Za-z0-9._]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'instagram',
+    /(?:^|\s)(?:інстаграм|інста|insta(?:gram)?|ig)\s*[:\-]?\s*@?([A-Za-z0-9._]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'tiktok',
+    /tiktok\.com\/@?([A-Za-z0-9._-]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'tiktok',
+    /(?:^|\s)(?:тікток|tiktok|tik\s*tok|tt)\s*[:\-]?\s*@?([A-Za-z0-9._-]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'facebook',
+    /facebook\.com\/(?:profile\.php\?id=)?([A-Za-z0-9.]+)/gi,
+    value => value?.trim(),
+  );
+
+  extract(
+    'facebook',
+    /(?:^|\s)(?:facebook|фб|fb)\s*[:\-]?\s*@?([A-Za-z0-9.]+)/gi,
+    value => sanitizeHandle(value) ?? value,
+  );
+
+  extract(
+    'vk',
+    /vk\.com\/(?:id)?([A-Za-z0-9._]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'vk',
+    /(?:^|\s)(?:vk|вк)\s*[:\-]?\s*@?([A-Za-z0-9._]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'telegram',
+    /t\.me\/@?([A-Za-z0-9._]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  extract(
+    'telegram',
+    /(?:^|\s)(?:telegram|телеграм|телега|tg|тг)\s*[:\-]?\s*@?([A-Za-z0-9._]+)/gi,
+    value => sanitizeHandle(value),
+  );
+
+  if (!prefill.telegram) {
+    extract(
+      'telegram',
+      /(?:^|\s)@([A-Za-z0-9_]{4,})(?=$|\s|[.,;])/gi,
+      value => sanitizeHandle(value),
+    );
+  }
+
+  remainder = remainder.replace(FILLER_WORDS, ' ');
+  remainder = remainder.replace(/[,:;|/\\]+/g, ' ');
+  remainder = remainder.replace(/\s+/g, ' ');
+
+  let normalizedName = collapseSpaces(remainder) || withoutPrefix;
+
+  const contactFields = ['telegram', 'instagram', 'tiktok', 'facebook', 'vk', 'email', 'phone'];
+  contactFields.forEach(field => {
+    const val = prefill[field];
+    if (!val) return;
+    const pattern = new RegExp(`\\b${escapeRegExp(String(val))}\\b`, 'gi');
+    normalizedName = normalizedName.replace(pattern, ' ');
+  });
+  normalizedName = collapseSpaces(normalizedName);
+  const fallbackBaseline = normalizedName.replace(/[@\s]+/g, '');
+  if (!fallbackBaseline || fallbackBaseline.length <= 2) {
+    normalizedName = withoutPrefix;
+  }
+
+  if (normalizedName && !prefill.name) {
+    prefill.name = normalizedName;
+  } else if (prefill.name) {
+    prefill.name = collapseSpaces(String(prefill.name));
+  }
+
+  const triggerMeta = {
+    raw: trimmed,
+    payload: withoutPrefix,
+  };
+  if (normalizedName) triggerMeta.normalizedName = normalizedName;
+  prefill._ukTrigger = triggerMeta;
+
+  return {
+    normalizedName,
+    withoutPrefix,
+    prefill,
+  };
+};
+
+export default parseUkTrigger;


### PR DESCRIPTION
## Summary
- add a dedicated УК trigger parser that extracts name and contact prefill information
- wire search fallbacks to use the parsed name while still emitting legacy onSearchKey payloads
- keep generated _notFound cards enriched with trigger prefill metadata and cover the parser with unit tests

## Testing
- CI=true npm test -- ukTriggers

------
https://chatgpt.com/codex/tasks/task_e_68cabcba44dc8326a65429ad2a782be2