### PR TITLE
Handle telegram trigger parsing when creating new users

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -688,13 +688,30 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleAddUser = async () => {
     setAdding(true);
-    const newProfile = await makeNewUser(searchKeyValuePair);
-    updateCachedUser(newProfile);
-    cacheFetchedUsers({ [newProfile.userId]: newProfile }, cacheLoad2Users, filters);
-    setUsers(prev => ({ ...prev, [newProfile.userId]: newProfile }));
-    setState(newProfile);
-    setUserNotFound(false);
-    setAdding(false);
+    try {
+      const rawSearch = search || '';
+      const hasSearchText = rawSearch.trim().length > 0;
+
+      if (!hasSearchText && searchKeyValuePair) {
+        setSearchKeyValuePair(null);
+      }
+
+      const newProfile = await makeNewUser(
+        hasSearchText ? searchKeyValuePair : null,
+        rawSearch,
+      );
+      updateCachedUser(newProfile);
+      cacheFetchedUsers(
+        { [newProfile.userId]: newProfile },
+        cacheLoad2Users,
+        filters,
+      );
+      setUsers(prev => ({ ...prev, [newProfile.userId]: newProfile }));
+      setState(newProfile);
+      setUserNotFound(false);
+    } finally {
+      setAdding(false);
+    }
   };
   const dotsMenu = () => {
     return (

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -92,7 +92,7 @@ const UsersList = ({
   const entries = Object.entries(users);
 
   const handleCreate = async value => {
-    const res = await makeNewUser({ name: value });
+    const res = await makeNewUser({ name: value }, value);
     setUsers(prev => {
       const copy = { ...prev };
       delete copy[`new_${value}`];

--- a/src/utils/__tests__/parseUkTrigger.test.js
+++ b/src/utils/__tests__/parseUkTrigger.test.js
@@ -1,0 +1,51 @@
+import { parseUkTriggerQuery } from '../../utils/parseUkTrigger';
+
+describe('parseUkTriggerQuery', () => {
+  it('returns null when trigger is missing', () => {
+    expect(parseUkTriggerQuery('Просто текст')).toBeNull();
+    expect(parseUkTriggerQuery('')).toBeNull();
+    expect(parseUkTriggerQuery(null)).toBeNull();
+  });
+
+  it('parses trigger without handle', () => {
+    const result = parseUkTriggerQuery('УК СМ Анна Марія');
+    expect(result).toEqual({
+      contactType: 'telegram',
+      contactValues: ['УК СМ Анна Марія'],
+      name: 'Анна',
+      surname: 'Марія',
+      handle: null,
+      searchPair: { telegram: 'УК СМ Анна Марія' },
+    });
+  });
+
+  it('parses trigger with handle and names', () => {
+    const result = parseUkTriggerQuery('   УК СМ   Анна  Марія   @anna_user ');
+    expect(result).toEqual({
+      contactType: 'telegram',
+      contactValues: ['УК СМ Анна Марія @anna_user', 'anna_user'],
+      name: 'Анна',
+      surname: 'Марія',
+      handle: 'anna_user',
+      searchPair: { telegram: 'УК СМ Анна Марія @anna_user' },
+    });
+  });
+
+  it('parses trigger with handle but without names', () => {
+    const result = parseUkTriggerQuery('УК СМ @just_nickname');
+    expect(result).toEqual({
+      contactType: 'telegram',
+      contactValues: ['УК СМ @just_nickname', 'just_nickname'],
+      name: '',
+      surname: '',
+      handle: 'just_nickname',
+      searchPair: { telegram: 'УК СМ @just_nickname' },
+    });
+  });
+
+  it('supports other triggers (УК ІР, УК IP, УК ДО)', () => {
+    expect(parseUkTriggerQuery('УК ІР Іван @ivan').searchPair.telegram).toBe('УК ІР Іван @ivan');
+    expect(parseUkTriggerQuery('УК IP Петро').searchPair.telegram).toBe('УК IP Петро');
+    expect(parseUkTriggerQuery('УК ДО Марія').searchPair.telegram).toBe('УК ДО Марія');
+  });
+});

--- a/src/utils/parseUkTrigger.js
+++ b/src/utils/parseUkTrigger.js
@@ -1,0 +1,51 @@
+const TRIGGER_PATTERN = /^(ук)\s*(см|ір|ip|до)\s*(.*)$/i;
+
+export const parseUkTriggerQuery = rawQuery => {
+  if (typeof rawQuery !== 'string') return null;
+
+  const trimmed = rawQuery.trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(TRIGGER_PATTERN);
+  if (!match) return null;
+
+  const afterTrigger = match[3] || '';
+
+  const normalizedAfterTrigger = afterTrigger
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .join(' ');
+
+  const normalizedTriggerPrefix = `${match[1].toUpperCase()} ${match[2].toUpperCase()}`;
+  const normalizedQuery = normalizedAfterTrigger
+    ? `${normalizedTriggerPrefix} ${normalizedAfterTrigger}`
+    : normalizedTriggerPrefix;
+
+  const handleMatch = afterTrigger.match(/@([A-Za-z0-9_.]+)/);
+  const handle = handleMatch ? handleMatch[1] : null;
+
+  const beforeHandle = handleMatch
+    ? afterTrigger.slice(0, handleMatch.index).trim()
+    : afterTrigger.trim();
+
+  const nameParts = beforeHandle.split(/\s+/).filter(Boolean);
+  const name = nameParts[0] || '';
+  const surname = nameParts.slice(1).join(' ') || '';
+
+  const contactValues = [normalizedQuery];
+  if (handle) {
+    contactValues.push(handle);
+  }
+
+  return {
+    contactType: 'telegram',
+    contactValues,
+    name,
+    surname,
+    handle,
+    searchPair: { telegram: normalizedQuery },
+  };
+};
+
+export default parseUkTriggerQuery;


### PR DESCRIPTION
## Summary
- add a helper to parse UK trigger search strings into telegram contact details and coverage tests
- update makeNewUser to accept the raw query, populate telegram/name fields, and index both the trigger string and handle
- adjust the add user flows to pass the raw search string and clear stale key/value pairs when necessary
- keep telegram trigger keys spaced (for example, "УК СМ …") so downstream filters continue to drop the service value

## Testing
- CI=true npm test -- parseUkTrigger

------
https://chatgpt.com/codex/tasks/task_e_68cae74197e4832688c5a108a7492fb8