### PR TITLE
Prioritize userId search in SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -574,10 +574,10 @@ const SearchBar = ({
       }
     }
 
+    if (await processUserSearch('userId', parseUserId, query)) return;
     if (await processUserSearch('facebook', parseFacebookId, query)) return;
     if (await processUserSearch('instagram', parseInstagramId, query)) return;
     if (await processUserSearch('telegram', parseTelegramId, query)) return;
-    if (await processUserSearch('userId', parseUserId, query)) return;
     if (await processUserSearch('email', parseEmail, query)) return;
     if (await processUserSearch('tiktok', parseTikTokLink, query)) return;
     if (await processUserSearch('phone', parsePhoneNumber, query)) return;


### PR DESCRIPTION
## Summary
- run the userId search first in the SearchBar lookup sequence to prioritize direct identifier matches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb9ad4b1508326b77e93c5fabe50c5