### PR TITLE
Revise pregnancy timeline token formatting

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -170,17 +170,17 @@ export const FieldLastCycle = ({ userData, setUsers, setState, isToastOn }) => {
   const pregnancyDuration = React.useMemo(() => {
     const lastCycleDate = parseDate(userData.lastCycle);
     if (!lastCycleDate) {
-      return { weeks: 0, days: 0 };
+      return { weeks: 0, days: 1 };
     }
 
     const diffMs = Date.now() - lastCycleDate.getTime();
     if (diffMs <= 0) {
-      return { weeks: 0, days: 0 };
+      return { weeks: 0, days: 1 };
     }
 
     const totalDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
     const weeks = Math.floor(totalDays / 7);
-    const days = totalDays % 7;
+    const days = (totalDays % 7) + 1;
 
     return { weeks, days };
   }, [userData.lastCycle]);

--- a/src/index.css
+++ b/src/index.css
@@ -95,3 +95,13 @@ code {
     transform: rotate(360deg);
   }
 }
+
+.stimulation-custom-event-input::placeholder {
+  color: rgba(0, 0, 0, 0.55);
+  opacity: 1;
+}
+
+.stimulation-custom-event-input::-webkit-input-placeholder {
+  color: rgba(0, 0, 0, 0.55);
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- show pregnancy tokens using days 1–7 and centralize custom event label formatting so every custom entry starts with date, weekday, and pregnancy token
- update schedule adjustments, today-placeholder filtering, clipboard output, and label rendering to support the new format without duplicating placeholders or overflowing text
- surface pregnancy duration with 1–7 day counts and add a visible placeholder color for the custom event input

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68cd4ca8767083269d3ba63dbe02b90a