### PR TITLE
Remove redundant weekday from stimulation schedule display

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -687,18 +687,18 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
       }
       const sanitizedRemainder = sanitizeDescription(remainderWithoutToken);
       const displayParts = [];
-      if (hadPrefix) {
-        displayParts.push(weekday);
-      }
       if (normalizedToken) {
         displayParts.push(normalizedToken);
       }
       if (sanitizedRemainder) {
         displayParts.push(sanitizedRemainder);
       }
+      if (displayParts.length === 0 && hadPrefix) {
+        displayParts.push(weekday);
+      }
       let displayLabel = displayParts.join(' ').trim();
       if (!displayLabel) {
-        displayLabel = normalizedToken || sanitizedRemainder || remainder;
+        displayLabel = normalizedToken || sanitizedRemainder || remainder || trimmedLabel;
       }
       const year = item.date.getFullYear();
       const isToday = item.date.getTime() === today;


### PR DESCRIPTION
## Summary
- avoid re-attaching the weekday prefix when displaying schedule labels after cleaning
- ensure labels still have a fallback when no normalized token or description remains

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68cdb0bdba0483269ba7757516fda028