### PR TITLE
Use cleaned value when editing custom stimulation events

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -722,6 +722,9 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
         rendered.push(<div key={`year-${year}`}>{year}</div>);
         currentYear = year;
       }
+      const isCustomEvent = (item.key || '').startsWith('ap-');
+      const inputValue = isCustomEvent ? String(displayLabel || '') : labelValue;
+
       if (item.key === 'visit1') {
         rendered.push(
           <div key={item.key} style={rowStyle}>
@@ -752,7 +755,7 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
               </div>
               {editingIndex === i ? (
                 <input
-                  value={item.label}
+                  value={inputValue}
                   autoFocus
                   onChange={e =>
                     setSchedule(prev => {


### PR DESCRIPTION
## Summary
- show the sanitized display label when editing custom stimulation events instead of the raw stored label
- keep the change handlers intact so saving still restores the full date-enriched label after edits

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68ce6692376883268f57b3786ad1dff1