### PR TITLE
Count transfer day as day one for follow-up visits

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -357,17 +357,16 @@ export const generateSchedule = base => {
 
   // HCG 12 days after transfer
   d = new Date(transfer.date);
-  d.setDate(d.getDate() + 12);
-  let hcg = adjustForward(d, transfer.date);
+  d.setDate(d.getDate() + 11);
   visits.push({
     key: 'hcg',
-    date: hcg.date,
-    label: `ХГЧ на 12й день${hcg.sign ? ` ${hcg.sign}` : ''}`,
+    date: d,
+    label: 'ХГЧ на 12й день',
   });
 
   // Ultrasound 28 days after transfer
   d = new Date(transfer.date);
-  d.setDate(d.getDate() + 28);
+  d.setDate(d.getDate() + 27);
   let us = adjustForward(d, transfer.date);
   visits.push({
     key: 'us',


### PR DESCRIPTION
## Summary
- schedule the HCG check without weekend adjustments and count the transfer day as day one for both HCG and the 28-day ultrasound

## Testing
- npm run lint:js
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cef4c234088326bab052af7254f959