### PR TITLE
Keep HCG check on calendar day 12

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -358,11 +358,10 @@ export const generateSchedule = base => {
   // HCG 12 days after transfer
   d = new Date(transfer.date);
   d.setDate(d.getDate() + 12);
-  let hcg = adjustForward(d, transfer.date);
   visits.push({
     key: 'hcg',
-    date: hcg.date,
-    label: `ХГЧ на 12й день${hcg.sign ? ` ${hcg.sign}` : ''}`,
+    date: d,
+    label: 'ХГЧ на 12й день',
   });
 
   // Ultrasound 28 days after transfer


### PR DESCRIPTION
## Summary
- keep the post-transfer HCG visit on the exact calendar day 12 without weekend adjustments

## Testing
- CI=true npm test -- --watch=false
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68cee7d9cddc832691e4a5ffff4c427e