### PR TITLE
Remove duplicate field injection from search cache

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -726,7 +726,7 @@ export const searchUserByPartialUserId = async (userId, users) => {
   }
 };
 
-const addUserToResults = async (userId, users, userIdOrArray = null) => {
+const addUserToResults = async (userId, users) => {
   const userSnapshotInNewUsers = await get(ref2(database, `newUsers/${userId}`));
   const userFromNewUsers = userSnapshotInNewUsers.exists() ? userSnapshotInNewUsers.val() : {};
 
@@ -743,7 +743,6 @@ const addUserToResults = async (userId, users, userIdOrArray = null) => {
     userId,
     ...userFromNewUsers,
     ...userFromUsers,
-    ...(userIdOrArray ? { duplicate: userIdOrArray } : {}), // Додаємо ключ duplicate, якщо userIdOrArray не null
   };
 };
 
@@ -840,7 +839,7 @@ const searchBySearchId = async (modifiedSearchValue, uniqueUserIds, users) => {
               // console.log('userId33333333333333 :>> ', userId);
               if (!uniqueUserIds.has(userId)) {
                 uniqueUserIds.add(userId);
-                await addUserToResults(userId, users, userIdOrArray);
+                await addUserToResults(userId, users);
               }
             }
           } else {

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -116,6 +116,9 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
     cachedAt: Date.now(),
   };
   delete updatedCard.id;
+  if (Object.prototype.hasOwnProperty.call(updatedCard, 'duplicate')) {
+    delete updatedCard.duplicate;
+  }
 
   if (data.lastAction !== undefined) {
     const normalized = normalizeLastAction(data.lastAction);


### PR DESCRIPTION
## Summary
- stop attaching the duplicate field when loading search results
- sanitize cached cards by stripping any duplicate property before persisting them

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68cf0aba3b1c83268955dc90d279bd05