### PR TITLE
Fix favorites pagination counts

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -561,6 +561,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     if (!state.userId) setProfileSource('');
   }, [state.userId]);
 
+  useEffect(() => {
+    if (currentFilter !== 'FAVORITE') return;
+
+    const favoriteCount = Object.values(favoriteUsersData || {}).filter(Boolean)
+      .length;
+
+    if (favoriteCount !== totalCount) {
+      setTotalCount(favoriteCount);
+    }
+
+    const maxPage = Math.max(1, Math.ceil(favoriteCount / PAGE_SIZE) || 1);
+    if (currentPage > maxPage) {
+      setCurrentPage(maxPage);
+    }
+  }, [currentFilter, favoriteUsersData, totalCount, currentPage]);
+
   const cacheFetchedUsers = useCallback(
     (usersObj, cacheFn, currentFilters = filters) => {
       cacheFn(usersObj, currentFilters);
@@ -1029,7 +1045,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         acc[user.userId] = user;
         return acc;
       }, {});
-    const total = Object.keys(sorted).length;
+    const total = Object.values(favIds).filter(Boolean).length ||
+      Object.keys(sorted).length;
     setUsers(sorted);
     setHasMore(false);
     setLastKey(null);
@@ -1174,7 +1191,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     );
   };
 
-  const displayedUserIds = getSortedIds().slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+  const sortedIds = getSortedIds();
+  const isFavoriteMode =
+    currentFilter === 'FAVORITE' || filters?.favorite?.favOnly;
+  const limit = isFavoriteMode && totalCount
+    ? Math.min(totalCount, sortedIds.length)
+    : sortedIds.length;
+  const idsForDisplay = isFavoriteMode
+    ? sortedIds.slice(0, limit)
+    : sortedIds;
+  const startIndex = (currentPage - 1) * PAGE_SIZE;
+  const displayedUserIds = idsForDisplay.slice(
+    startIndex,
+    startIndex + PAGE_SIZE,
+  );
   const paginatedUsers = displayedUserIds.reduce((acc, id) => {
     acc[id] = users[id];
     return acc;


### PR DESCRIPTION
## Summary
- synchronize favorite pagination with the latest favorite id list and clamp the current page when entries shrink
- cap rendered ids by the reported favorite total so pagination shows every saved favorite

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cf1440de1c8326881c07618669543c