### PR TITLE
Refine transfer-relative day labels

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -98,6 +98,22 @@ const extractWeeksDaysPrefix = value => {
   };
 };
 
+const extractDayPrefix = value => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(\d+)\s*й(?:\s+день)?/i);
+  if (!match) return null;
+  const rawDay = Number(match[1]);
+  if (!Number.isFinite(rawDay)) return null;
+  const length = match[0].length;
+  const rest = trimmed.slice(length).trim();
+  return {
+    day: Math.max(Math.trunc(rawDay), 0),
+    length,
+    rest,
+  };
+};
+
 const parseWeeksDaysToken = (token, baseDate) => {
   if (!token || !baseDate) return null;
   const normalized = normalizeWeeksDaysToken(token);
@@ -147,6 +163,76 @@ const sanitizeDescription = text => {
     break;
   }
   return result.trim();
+};
+
+const normalizeDayNumber = day => {
+  const raw = Number(day);
+  if (!Number.isFinite(raw)) return 0;
+  return Math.max(Math.trunc(raw), 0);
+};
+
+const transferRelativeConfig = {
+  hcg: {
+    baseLabel: 'ХГЧ',
+    defaultSuffix: 'ХГЧ',
+    prefix: /^хгч/i,
+  },
+  us: {
+    baseLabel: 'УЗД',
+    defaultSuffix: 'УЗД, підтвердження вагітності',
+    prefix: /^узд/i,
+  },
+};
+
+const normalizeTransferSuffix = (key, suffix) => {
+  const config = transferRelativeConfig[key];
+  const sanitized = sanitizeDescription(suffix);
+  const trimmed = sanitized.replace(/\s+/g, ' ').trim();
+  if (!config) return trimmed;
+  if (!trimmed) return config.defaultSuffix;
+  const withoutPrefix = trimmed.replace(config.prefix, '').trim();
+  if (!withoutPrefix) {
+    return config.baseLabel;
+  }
+  if (/^[,.;:]/.test(withoutPrefix)) {
+    return `${config.baseLabel}${withoutPrefix}`;
+  }
+  return `${config.baseLabel} ${withoutPrefix}`;
+};
+
+const buildTransferDayLabel = (key, day, suffix, sign = '') => {
+  const normalizedDay = normalizeDayNumber(day);
+  const normalizedSuffix = normalizeTransferSuffix(key, suffix);
+  const label = `${normalizedDay}й день ${normalizedSuffix}`.trim();
+  return sign ? `${label} ${sign}`.trim() : label;
+};
+
+const buildHcgLabel = (day, suffix) => buildTransferDayLabel('hcg', day, suffix);
+
+const buildUsLabel = (day, suffix, sign = '') =>
+  buildTransferDayLabel('us', day, suffix, sign);
+
+const getTransferRelativeReference = (transferDate, base) => {
+  const normalizedTransfer = transferDate ? normalizeDate(transferDate) : null;
+  if (normalizedTransfer) return normalizedTransfer;
+  return base ? normalizeDate(base) : null;
+};
+
+const computeDateFromTransferDay = (day, transferDate, base) => {
+  const reference = getTransferRelativeReference(transferDate, base);
+  if (!reference) return null;
+  const normalizedDay = normalizeDayNumber(day);
+  const computed = new Date(reference);
+  computed.setDate(reference.getDate() + normalizedDay - 1);
+  return computed;
+};
+
+const getTransferSuffixFromLabel = (key, label) => {
+  const trimmed = (label || '').trim();
+  const dayInfo = extractDayPrefix(trimmed);
+  const suffix = dayInfo ? dayInfo.rest : trimmed;
+  if (suffix) return suffix;
+  return transferRelativeConfig[key]?.defaultSuffix || '';
 };
 
 const buildCustomEventLabel = (date, referenceDate, description) => {
@@ -356,22 +442,24 @@ export const generateSchedule = base => {
   });
 
   // HCG 12 days after transfer
-  d = new Date(transfer.date);
+  const transferBase = normalizeDate(transfer.date);
+  d = new Date(transferBase);
   d.setDate(d.getDate() + 11);
+  const hcgDay = diffDays(d, transferBase);
   visits.push({
     key: 'hcg',
     date: d,
-    label: 'ХГЧ на 12й день',
+    label: buildHcgLabel(hcgDay),
   });
 
   // Ultrasound 28 days after transfer
-  d = new Date(transfer.date);
+  d = new Date(transferBase);
   d.setDate(d.getDate() + 27);
-  let us = adjustForward(d, transfer.date);
+  let us = adjustForward(d, transferBase);
   visits.push({
     key: 'us',
     date: us.date,
-    label: `УЗД${us.sign ? ` ${us.sign}` : ''}`,
+    label: buildUsLabel(us.day, 'УЗД, підтвердження вагітності', us.sign),
   });
 
   // Pregnancy visits at specific weeks
@@ -525,7 +613,10 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
     }
   }, [userData.stimulationSchedule, effectiveStatus, base, userData.lastCycle]);
 
-  const postTransferKeys = React.useMemo(() => ['hcg', 'us'], []);
+  const postTransferKeys = React.useMemo(
+    () => Object.keys(transferRelativeConfig),
+    [],
+  );
 
   React.useEffect(() => {
     const transferItem = schedule.find(v => v.key === 'transfer');
@@ -545,8 +636,10 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
         copy.find(v => v.key === 'transfer')?.date || transferRef.current || base;
 
       const applyAdjust = (it, d) => {
-        const refBase = postTransferKeys.includes(it.key) ? transferDate : base;
-        let adj = { date: d, day: diffDays(d, refBase), sign: '' };
+        const isPostTransferKey = postTransferKeys.includes(it.key);
+        const preferredBase = isPostTransferKey && transferDate ? transferDate : base;
+        const effectiveBase = preferredBase || base || transferDate || d;
+        let adj = { date: d, day: diffDays(d, effectiveBase), sign: '' };
         if (it.key.startsWith('week')) {
           const diff = Math.round((adj.date - base) / (1000 * 60 * 60 * 24));
           const weeks = Math.floor(diff / 7);
@@ -561,6 +654,18 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
           return {
             ...it,
             date: adj.date,
+            label: labelText,
+          };
+        }
+        if (transferRelativeConfig[it.key]) {
+          const normalizedDate = normalizeDate(adj.date);
+          const reference = getTransferRelativeReference(transferDate, base);
+          const dayNumber = reference ? diffDays(normalizedDate, reference) : adj.day;
+          const suffix = getTransferSuffixFromLabel(it.key, it.label);
+          const labelText = buildTransferDayLabel(it.key, dayNumber, suffix, adj.sign);
+          return {
+            ...it,
+            date: normalizedDate,
             label: labelText,
           };
         }
@@ -835,6 +940,31 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
                             ...updated,
                             label: rest ? `${prefix.normalized} ${rest}` : prefix.normalized,
                           };
+                        } else if (transferRelativeConfig[updated.key]) {
+                          const dayInfo = extractDayPrefix(trimmedLabel);
+                          if (dayInfo) {
+                            const computedDate = computeDateFromTransferDay(
+                              dayInfo.day,
+                              transferDate,
+                              base,
+                            );
+                            if (computedDate && !isSameDay(computedDate, updated.date)) {
+                              updated = {
+                                ...updated,
+                                date: computedDate,
+                              };
+                              dateChanged = true;
+                            }
+                            const suffix = dayInfo.rest || transferRelativeConfig[updated.key].defaultSuffix;
+                            updated = {
+                              ...updated,
+                              label: buildTransferDayLabel(
+                                updated.key,
+                                dayInfo.day,
+                                suffix,
+                              ),
+                            };
+                          }
                         } else if (updated.key.startsWith('ap-')) {
                           const computed = computeCustomDateAndLabel(
                             trimmedLabel,


### PR DESCRIPTION
## Summary
- consolidate transfer-relative helpers to parse day prefixes, reuse suffix defaults, and rebuild `${day}й день …` labels for HCG and ultrasound
- update default schedule generation plus +/- adjustments to rely on the shared helpers so date shifts keep labels synchronized with the transfer day
- normalize manual edits through the same utilities so entering `12й день ХГЧ` or `28й день УЗД…` recalculates dates and labels consistently

## Testing
- npm run lint:js
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cf146a7e088326a298e99afd64e16e