### PR TITLE
Reset AddNewProfile spinner when filter cleared

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -639,7 +639,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setCacheCount(0);
     setBackendCount(0);
 
-    if (!currentFilter) return;
+    if (!currentFilter) {
+      setSearchLoading(false);
+      setHasSearched(false);
+      return;
+    }
 
     setSearchLoading(true);
     setHasSearched(true);


### PR DESCRIPTION
## Summary
- ensure AddNewProfile clears the search loading state when no filter is selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d04f9f8fa88326bfbe0b540dc432ac