### PR TITLE
Fix day prefix calculation after embryo transfer

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -156,7 +156,15 @@ const getSchedulePrefixForDate = (date, baseDate, transferDate) => {
   const normalizedDate = normalizeDate(date);
   const normalizedBase = baseDate ? normalizeDate(baseDate) : null;
   const normalizedTransfer = transferDate ? normalizeDate(transferDate) : null;
-  const referenceForDay = normalizedBase || normalizedTransfer;
+
+  let referenceForDay = null;
+  if (normalizedTransfer && normalizedDate.getTime() >= normalizedTransfer.getTime()) {
+    referenceForDay = normalizedTransfer;
+  } else if (normalizedBase) {
+    referenceForDay = normalizedBase;
+  } else if (normalizedTransfer) {
+    referenceForDay = normalizedTransfer;
+  }
 
   if (!referenceForDay) {
     return '';


### PR DESCRIPTION
## Summary
- update the day-prefix calculation to use the transfer date for post-transfer events
- keep week/day notation anchored to the base cycle date after the post-transfer window

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ddd229748326a3973e74ac0d9eb2