### PR TITLE
Fix today placeholder label to respect transfer calculations

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1230,7 +1230,20 @@ const StimulationSchedule = ({ userData, setUsers, setState, isToastOn = false }
       const totalDays = Math.max(diff, 0);
       const weeks = Math.floor(totalDays / 7);
       const days = totalDays % 7;
-      const comment = formatWeeksDaysToken(weeks, days);
+      const normalizedBaseForPlaceholder = normalizeDate(baseForDiff);
+      const transferSource =
+        transferRef.current ||
+        schedule.find(entry => entry.key === 'transfer' && entry.date)?.date ||
+        null;
+      const normalizedTransferForPlaceholder = transferSource
+        ? normalizeDate(transferSource)
+        : null;
+      const computedPrefix = getSchedulePrefixForDate(
+        todayDate,
+        normalizedBaseForPlaceholder,
+        normalizedTransferForPlaceholder,
+      );
+      const comment = computedPrefix || formatWeeksDaysToken(weeks, days);
       const placeholder = {
         key: 'today-placeholder',
         date: new Date(todayDate),


### PR DESCRIPTION
## Summary
- align the auto-inserted "today" placeholder with getSchedulePrefixForDate so early pregnancy shows day-based labels
- fall back to the previous weeks/days token when no prefix is available

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d0fd7ce3488326ac248275adb63c01