### PR TITLE
Fix cycle rebasing and last cycle persistence

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1301,6 +1301,39 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setUsers={setUsers}
                   setState={setState}
                   isToastOn={isToastOn}
+                  onLastCyclePersisted={({ lastCycle, needsSync }) => {
+                    if (!needsSync || !lastCycle) return;
+                    const targetUserId = scheduleUserData?.userId;
+                    if (!targetUserId) return;
+                    if (typeof setState === 'function') {
+                      setState(prev => {
+                        if (!prev || prev.userId !== targetUserId) return prev;
+                        return { ...prev, lastCycle };
+                      });
+                    }
+                    if (typeof setUsers === 'function') {
+                      setUsers(prev => {
+                        if (!prev) return prev;
+                        if (Array.isArray(prev)) {
+                          return prev.map(item =>
+                            item?.userId === targetUserId ? { ...item, lastCycle } : item,
+                          );
+                        }
+                        if (typeof prev === 'object') {
+                          const current = prev[targetUserId];
+                          if (!current) return prev;
+                          return {
+                            ...prev,
+                            [targetUserId]: {
+                              ...current,
+                              lastCycle,
+                            },
+                          };
+                        }
+                        return prev;
+                      });
+                    }
+                  }}
                 />
               </div>
             )}

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -243,6 +243,10 @@ const EditProfile = () => {
             userData={scheduleUserData}
             setState={setState}
             isToastOn={isToastOn}
+            onLastCyclePersisted={({ lastCycle, needsSync }) => {
+              if (!needsSync || !lastCycle) return;
+              setState(prev => ({ ...prev, lastCycle }));
+            }}
           />
         </div>
       )}

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -57,6 +57,37 @@ const UserCard = ({
             setUsers={setUsers}
             setState={setState}
             isToastOn={isToastOn}
+            onLastCyclePersisted={({ lastCycle, needsSync }) => {
+              if (!needsSync || !lastCycle) return;
+              if (typeof setState === 'function') {
+                setState(prev => {
+                  if (!prev || prev.userId !== userData.userId) return prev;
+                  return { ...prev, lastCycle };
+                });
+              }
+              if (typeof setUsers === 'function') {
+                setUsers(prev => {
+                  if (!prev) return prev;
+                  if (Array.isArray(prev)) {
+                    return prev.map(item =>
+                      item?.userId === userData.userId ? { ...item, lastCycle } : item,
+                    );
+                  }
+                  if (typeof prev === 'object') {
+                    const current = prev[userData.userId];
+                    if (!current) return prev;
+                    return {
+                      ...prev,
+                      [userData.userId]: {
+                        ...current,
+                        lastCycle,
+                      },
+                    };
+                  }
+                  return prev;
+                });
+              }
+            }}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- keep pre-cycle entries intact when rebasing schedules and stop appending an unnecessary plus sign to HCG/US labels
- add a fallback last-cycle persistence callback and wire schedule consumers to sync renderTopBlock when setters are unavailable

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68d1635cbcd483268931ac1719fceb55