### PR TITLE
Fix transfer day prefix and cover adjustItemForDate

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -1,0 +1,26 @@
+jest.mock('components/smallCard/actions', () => ({
+  handleChange: jest.fn(),
+  handleSubmit: jest.fn(),
+}));
+
+import { adjustItemForDate } from 'components/StimulationSchedule';
+
+describe('adjustItemForDate', () => {
+  it('preserves transfer day numbering when recalculating on the transfer date', () => {
+    const baseDate = new Date(2023, 5, 1);
+    const transferDate = new Date(2023, 5, 20, 14, 30);
+
+    const transferItem = {
+      key: 'transfer',
+      date: new Date(transferDate),
+      label: '20й день (перенос)',
+    };
+
+    const adjusted = adjustItemForDate(transferItem, transferDate, {
+      baseDate,
+      transferDate,
+    });
+
+    expect(adjusted.label).toBe('20й день (перенос)');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure transfer-day prefixes keep counting from the cycle start when the date matches the transfer
- extract the adjustItemForDate helper so component logic reuses it consistently
- add a unit test that verifies the transfer label stays on day 19–22 instead of resetting to day 1

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d27604c7688326ac6bd5f521b5a367