### PR TITLE
Fix import order in StimulationSchedule test

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -1,9 +1,9 @@
+import { adjustItemForDate } from 'components/StimulationSchedule';
+
 jest.mock('components/smallCard/actions', () => ({
   handleChange: jest.fn(),
   handleSubmit: jest.fn(),
 }));
-
-import { adjustItemForDate } from 'components/StimulationSchedule';
 
 describe('adjustItemForDate', () => {
   it('preserves transfer day numbering when recalculating on the transfer date', () => {


### PR DESCRIPTION
## Summary
- move the `adjustItemForDate` import to the top of the StimulationSchedule test module to satisfy linting rules

## Testing
- npx eslint src/components/StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d29ae781a88326ba53bfcf8fcfd037