### PR TITLE
Fix URL-driven card selection

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -225,6 +225,7 @@ const ButtonsContainer = styled.div`
 export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const location = useLocation();
+  const lastUrlUserIdRef = useRef(new URLSearchParams(location.search).get('userId'));
 
   const [userNotFound, setUserNotFound] = useState(false);
 
@@ -557,11 +558,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setSearch(prev => (prev ? prev : urlUserId));
     }
 
-    if (urlUserId && urlUserId !== state.userId) {
-      setProfileSource('');
-      setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
+    if (urlUserId) {
+      if (lastUrlUserIdRef.current !== urlUserId) {
+        lastUrlUserIdRef.current = urlUserId;
+        setProfileSource('');
+        setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
+      }
+    } else {
+      lastUrlUserIdRef.current = null;
     }
-  }, [location.search, state.userId]);
+  }, [location.search, setSearch, setState]);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);


### PR DESCRIPTION
## Summary
- prevent AddNewProfile from overwriting the selected card when the URL query hasn't changed
- track the last processed userId from the address bar before resetting profileSource

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d40b5aa4a88326af4f98167d933a9c