### PR TITLE
Fix birth scheduling on weekends

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -570,6 +570,16 @@ const adjustToNextWorkingDay = (date, base) => {
   return { ...adjusted, date: normalizeDate(adjusted.date) };
 };
 
+const buildUnadjustedDayInfo = (date, base) => {
+  const normalizedDate = normalizeDate(date);
+  if (!base) {
+    return { date: normalizedDate, day: null, sign: '' };
+  }
+  const normalizedBase = normalizeDate(base);
+  const day = diffDays(normalizedDate, normalizedBase);
+  return { date: normalizedDate, day, sign: '' };
+};
+
 export const generateSchedule = base => {
   const visits = [];
 
@@ -672,7 +682,7 @@ export const generateSchedule = base => {
   weeks.forEach(week => {
     let wd = new Date(base);
     wd.setDate(wd.getDate() + week * 7);
-    const adj = adjustForward(wd, base);
+    const adj = week === 40 ? buildUnadjustedDayInfo(wd, base) : adjustForward(wd, base);
     const prefix = getSchedulePrefixForDate(adj.date, base, transferBase);
     let labelText = prefix;
     if (week === 40) {


### PR DESCRIPTION
## Summary
- add helper to keep 40-week milestone on its calculated date even if it falls on a weekend
- update pregnancy visit generation to avoid shifting the delivery entry forward to Monday

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d43ac166308326b0b77ca01b3ba290