### PR TITLE
Avoid day prefix for pre-cycle custom events

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -170,6 +170,10 @@ const getSchedulePrefixForDate = (date, baseDate, transferDate) => {
     return '';
   }
 
+  if (normalizedDate.getTime() < referenceForDay.getTime()) {
+    return '';
+  }
+
   let useDayPrefix = true;
   if (normalizedTransfer) {
     const cutoff = new Date(normalizedTransfer);


### PR DESCRIPTION
## Summary
- stop attaching a day-based prefix to schedule labels when a custom event occurs before the base cycle date

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68d43fdb1c5883268ce08325adbfbad1