### PR TITLE
Fix transfer day label when shifting forward

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1190,8 +1190,10 @@ const StimulationSchedule = ({
       newDate.setDate(newDate.getDate() + delta);
 
       const stateBase = copy.find(entry => entry.key === 'visit1')?.date || resolvedBaseDate;
-      const stateTransfer =
+      const currentTransfer =
         copy.find(entry => entry.key === 'transfer')?.date || transferRef.current || null;
+      const stateTransfer =
+        item.key === 'transfer' ? newDate : currentTransfer;
       const statePreBase = copy.find(entry => entry.key === 'pre-visit1')?.date || preCycleBaseDate;
 
       const adjustedItem = adjustItemForDateFn(item, newDate, {


### PR DESCRIPTION
## Summary
- ensure transfer adjustments use the updated transfer date as the reference when calculating labels

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d445af2bd88326b543e47fe621d38f