### PR TITLE
Fix data source toast for profile cards

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -619,10 +619,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [setFilters, setHasSearched, setSearchLoading, setTotalCount]);
 
   useEffect(() => {
-    if (!state.userId || profileSource) return;
+    if (!state.userId) return;
 
     if (Object.keys(state).length > 1) {
-      setProfileSource('cache');
+      if (!profileSource) {
+        setProfileSource('cache');
+      }
       return;
     }
 
@@ -631,6 +633,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setState(cached);
       setProfileSource('cache');
     } else {
+      setProfileSource('loading');
       (async () => {
         try {
           const data = await fetchUserById(state.userId);

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -278,13 +278,13 @@ export const ProfileForm = ({
   const [collection, setCollection] = useState('newUsers');
 
   useEffect(() => {
-    if (dataSource) {
-      toast.success(
-        dataSource === 'backend'
-          ? 'Data loaded from backend'
-          : 'Data loaded from local storage'
-      );
-    }
+    if (!dataSource || dataSource === 'loading') return;
+
+    toast.success(
+      dataSource === 'backend'
+        ? 'Data loaded from backend'
+        : 'Data loaded from local storage'
+    );
   }, [dataSource]);
 
   const handleAddCustomField = () => {


### PR DESCRIPTION
## Summary
- prevent the profile source tracker from defaulting to cache while a backend fetch is in progress
- ensure the profile form toast ignores the temporary loading state so only true data sources are announced

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68d44ec66c388326bc6660673e16f53d