### PR TITLE
Support multi-event custom schedule input

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -1,4 +1,4 @@
-import { adjustItemForDate } from 'components/StimulationSchedule';
+import { adjustItemForDate, splitCustomEventEntries } from 'components/StimulationSchedule';
 
 jest.mock('components/smallCard/actions', () => ({
   handleChange: jest.fn(),
@@ -22,5 +22,26 @@ describe('adjustItemForDate', () => {
     });
 
     expect(adjusted.label).toBe('20й день (перенос)');
+  });
+});
+
+describe('splitCustomEventEntries', () => {
+  it('splits multi-line input into separate entries', () => {
+    const input = '13.01 прийом\n16.01 міс\n\n22.01 прийом';
+    expect(splitCustomEventEntries(input)).toEqual([
+      '13.01 прийом',
+      '16.01 міс',
+      '22.01 прийом',
+    ]);
+  });
+
+  it('splits single-line input with multiple dates', () => {
+    const input =
+      '13.01 прийом на 21й день. Вкололи диф 16.01 міс 22.01 прийом. Анна теж ок.';
+    expect(splitCustomEventEntries(input)).toEqual([
+      '13.01 прийом на 21й день. Вкололи диф',
+      '16.01 міс',
+      '22.01 прийом. Анна теж ок.',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- allow the custom event input to detect and split multiple dated entries
- reuse the splitter during blur handling so grouped entries stay readable and scheduled correctly
- add targeted unit tests covering newline and single-line multi-event parsing

## Testing
- npm test -- StimulationSchedule

------
https://chatgpt.com/codex/tasks/task_e_68d451096ecc8326969894d9cf80f303