### PR TITLE
Adjust alternating row colors in stimulation schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1644,7 +1644,7 @@ const StimulationSchedule = ({
   });
 
   const baseRowBackgroundColor = 'rgba(16, 16, 16, 0.6)';
-  const alternateRowBackgroundColor = 'rgba(16, 16, 16, 0.45)';
+  const alternateRowBackgroundColor = 'rgba(16, 16, 16, 0.52)';
   const scheduleHorizontalPadding = 7;
 
   displayItems.forEach((item, index) => {


### PR DESCRIPTION
## Summary
- adjust alternating row background colors in the stimulation schedule event list to use a subtle tint difference

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4598d13a4832683425be38298f418