### PR TITLE
Adjust schedule gap between Dipherelin and new cycle

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1557,6 +1557,95 @@ const StimulationSchedule = ({
     [adjustItemForDateFn, persistLastCycleDate, resolvedBaseDate, saveSchedule],
   );
 
+  const adjustNextCycleGap = React.useCallback(
+    newVisitDate => {
+      if (!newVisitDate) return;
+      const normalizedNewBase = normalizeDate(newVisitDate);
+
+      setSchedule(prev => {
+        if (!Array.isArray(prev) || prev.length === 0) return prev;
+        const currentFirst = prev.find(entry => entry.key === 'visit1' && entry.date);
+        if (!currentFirst?.date) return prev;
+        const currentBase = normalizeDate(currentFirst.date);
+        if (!currentBase) return prev;
+        if (normalizedNewBase.getTime() === currentBase.getTime()) {
+          return prev;
+        }
+
+        const MS_PER_DAY = 1000 * 60 * 60 * 24;
+        const deltaDays = Math.round(
+          (normalizedNewBase.getTime() - currentBase.getTime()) / MS_PER_DAY,
+        );
+
+        const preVisitItem = prev.find(entry => entry.key === 'pre-visit1');
+        const preservedPreBase = preVisitItem?.date ? normalizeDate(preVisitItem.date) : null;
+
+        const preservedPreCycle = prev.filter(item => isPreCycleKey(item?.key));
+        const itemsToShift = prev.filter(item => !isPreCycleKey(item?.key));
+
+        const regenerated = generateSchedule(normalizedNewBase).map(item => ({
+          ...item,
+          date: normalizeDate(item.date),
+        }));
+        const regeneratedMap = new Map(regenerated.map(item => [item.key, item]));
+        const regeneratedTransfer = regeneratedMap.get('transfer')?.date || null;
+        const normalizedTransfer = regeneratedTransfer ? normalizeDate(regeneratedTransfer) : null;
+
+        const shiftCustomItem = scheduleItem => {
+          if (!scheduleItem?.date) return scheduleItem;
+          const next = new Date(scheduleItem.date);
+          next.setDate(next.getDate() + deltaDays);
+          return adjustItemForDateFn(scheduleItem, next, {
+            baseDate: normalizedNewBase,
+            transferDate: normalizedTransfer,
+            preCycleBase: preservedPreBase,
+          });
+        };
+
+        const shiftedItems = itemsToShift.map(scheduleItem => {
+          if (!scheduleItem) return scheduleItem;
+
+          if (scheduleItem.key === 'visit1') {
+            const generatedVisit1 = regeneratedMap.get('visit1');
+            const overrideLabel = generatedVisit1?.label || scheduleItem.label;
+            return adjustItemForDateFn(scheduleItem, normalizedNewBase, {
+              baseDate: normalizedNewBase,
+              transferDate: normalizedTransfer,
+              overrideLabel,
+              preCycleBase: preservedPreBase,
+            });
+          }
+
+          const generatedMatch = regeneratedMap.get(scheduleItem.key);
+          if (generatedMatch) {
+            return adjustItemForDateFn(scheduleItem, generatedMatch.date, {
+              baseDate: normalizedNewBase,
+              transferDate: normalizedTransfer,
+              overrideLabel: scheduleItem.label,
+              preCycleBase: preservedPreBase,
+            });
+          }
+
+          return shiftCustomItem(scheduleItem);
+        });
+
+        const combined = [...preservedPreCycle, ...shiftedItems].filter(Boolean);
+        combined.sort((a, b) => {
+          if (!a?.date || !b?.date) return 0;
+          return a.date - b.date;
+        });
+
+        transferRef.current = normalizedTransfer || null;
+
+        hasChanges.current = true;
+        saveSchedule(combined);
+        return combined;
+      });
+
+    },
+    [adjustItemForDateFn, saveSchedule],
+  );
+
   const requestDeleteItem = React.useCallback(item => {
     if (!item) return;
     setPendingDelete(item);
@@ -1757,7 +1846,11 @@ const StimulationSchedule = ({
           if (item.key === 'visit1') {
             const target = new Date(item.date);
             target.setDate(target.getDate() + delta);
-            rebaseScheduleFromDayOne(target);
+            if (preCycleActive) {
+              adjustNextCycleGap(target);
+            } else {
+              rebaseScheduleFromDayOne(target);
+            }
           } else if (firstDayIndex !== -1) {
             shiftDate(firstDayIndex, delta);
           }


### PR DESCRIPTION
## Summary
- add a helper that shifts only the post-cycle events when the first day is nudged during the pre-cycle phase
- update the +/- handler to use the new helper so the previous cycle day stays intact while the gap to the next cycle changes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d5ad19db20832698987b7f768a0152