### PR TITLE
Update custom event labels when rebasing stimulation schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1504,7 +1504,43 @@ const StimulationSchedule = ({
         const shiftCustomItem = scheduleItem => {
           if (!scheduleItem) return scheduleItem;
           if (isCustomKey(scheduleItem.key)) {
-            return scheduleItem;
+            const normalizedItemDate = scheduleItem.date
+              ? normalizeDate(scheduleItem.date)
+              : null;
+            if (!normalizedItemDate) {
+              return scheduleItem;
+            }
+
+            const parsed = computeCustomDateAndLabel(
+              scheduleItem.label,
+              normalizedNewBase,
+              normalizedItemDate,
+              normalizedTransfer,
+            );
+            const description = parsed.description || parsed.raw || scheduleItem.label;
+            const baseForLabel = normalizedNewBase || normalizedTransfer || normalizedItemDate;
+            const updatedLabel = buildCustomEventLabel(
+              normalizedItemDate,
+              baseForLabel,
+              normalizedTransfer,
+              description,
+            );
+
+            if (!updatedLabel || updatedLabel === scheduleItem.label) {
+              if (normalizedItemDate.getTime() === scheduleItem.date.getTime()) {
+                return scheduleItem;
+              }
+              return {
+                ...scheduleItem,
+                date: normalizedItemDate,
+              };
+            }
+
+            return {
+              ...scheduleItem,
+              date: normalizedItemDate,
+              label: updatedLabel,
+            };
           }
           if (!scheduleItem.date) return scheduleItem;
           const normalizedItemDate = normalizeDate(scheduleItem.date);


### PR DESCRIPTION
## Summary
- recompute custom event labels when the cycle base date changes so day prefixes stay aligned with the new day one

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6623c647c8326813faf7fe5a03ef7