### PR TITLE
Support УК Агент trigger and refine VK detection

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -199,13 +199,20 @@ const parseTikTokLink = url => {
 
 const normalizeVkValue = rawValue => {
   if (typeof rawValue !== 'string') return null;
-  let value = rawValue.trim();
-  if (!value) return null;
+  const trimmed = rawValue.trim();
+  if (!trimmed) return null;
 
-  const labelMatch = value.match(/^(?:vk|вк)\s*[:=]?\s*(.+)$/i);
-  if (labelMatch && labelMatch[1]) {
-    value = labelMatch[1].trim();
+  const labelMatch = trimmed.match(/^(?:vk|вк)\s*[:=]?\s*(.+)$/i);
+  const hasVkLabel = Boolean(labelMatch);
+  const hasVkDomain = /(?:^|[\s:=\/])vk\.com(?:\/|\b)/i.test(trimmed);
+  const hasExplicitId = /\b(?:id|club|public)\d+\b/i.test(trimmed);
+  const isExplicitIdOnly = /^(?:id|club|public)\d+$/i.test(trimmed);
+
+  if (!hasVkLabel && !hasVkDomain && !hasExplicitId && !isExplicitIdOnly) {
+    return null;
   }
+
+  let value = hasVkLabel ? labelMatch[1].trim() : trimmed;
 
   value = value
     .replace(/^https?:\/\/(?:www\.)?(?:m\.)?vk\.com\//i, '')

--- a/src/components/__tests__/detectSearchParams.test.js
+++ b/src/components/__tests__/detectSearchParams.test.js
@@ -1,0 +1,33 @@
+jest.mock('../../utils/parseUkTrigger', () => ({
+  parseUkTriggerQuery: jest.fn(() => null),
+}));
+
+import { detectSearchParams } from '../../components/SearchBar';
+import { parseUkTriggerQuery } from '../../utils/parseUkTrigger';
+
+describe('detectSearchParams', () => {
+  beforeEach(() => {
+    parseUkTriggerQuery.mockReturnValue(null);
+  });
+
+  it('falls back to other when no platform is detected', () => {
+    expect(detectSearchParams('УК Агент Надія')).toEqual({
+      key: 'other',
+      value: 'УК Агент Надія',
+    });
+  });
+
+  it('detects VK urls with identifiers', () => {
+    expect(detectSearchParams('https://vk.com/id123456')).toEqual({
+      key: 'vk',
+      value: 'id123456',
+    });
+  });
+
+  it('detects VK identifiers without domain', () => {
+    expect(detectSearchParams('club987654')).toEqual({
+      key: 'vk',
+      value: 'club987654',
+    });
+  });
+});

--- a/src/utils/__tests__/parseUkTrigger.test.js
+++ b/src/utils/__tests__/parseUkTrigger.test.js
@@ -11,7 +11,7 @@ describe('parseUkTriggerQuery', () => {
     const result = parseUkTriggerQuery('УК СМ Анна Марія');
     expect(result).toEqual({
       contactType: 'telegram',
- contactValues: ['УК СМ Анна Марія'],
+      contactValues: ['УК СМ Анна Марія'],
       name: 'Анна',
       surname: 'Марія',
       handle: null,
@@ -23,12 +23,11 @@ describe('parseUkTriggerQuery', () => {
     const result = parseUkTriggerQuery('   УК СМ   Анна  Марія   @anna_user ');
     expect(result).toEqual({
       contactType: 'telegram',
-  contactValues: ['УК СМ Анна Марія @anna_user', 'anna_user'],
+      contactValues: ['УК СМ Анна Марія @anna_user', 'anna_user'],
       name: 'Анна',
       surname: 'Марія',
       handle: 'anna_user',
       searchPair: { telegram: 'УК СМ Анна Марія @anna_user' },
-
     });
   });
 
@@ -41,13 +40,42 @@ describe('parseUkTriggerQuery', () => {
       surname: '',
       handle: 'just_nickname',
       searchPair: { telegram: 'УК СМ @just_nickname' },
-
     });
   });
 
   it('supports other triggers (УК ІР, УК IP, УК ДО)', () => {
-    expect(parseUkTriggerQuery('УК ІР Іван @ivan').searchPair.telegram).toBe('УК ІР Іван @ivan');
-    expect(parseUkTriggerQuery('УК IP Петро').searchPair.telegram).toBe('УК IP Петро');
-    expect(parseUkTriggerQuery('УК ДО Марія').searchPair.telegram).toBe('УК ДО Марія');
+    expect(parseUkTriggerQuery('УК ІР Іван @ivan').searchPair.telegram).toBe(
+      'УК ІР Іван @ivan',
+    );
+    expect(parseUkTriggerQuery('УК IP Петро').searchPair.telegram).toBe(
+      'УК IP Петро',
+    );
+    expect(parseUkTriggerQuery('УК ДО Марія').searchPair.telegram).toBe(
+      'УК ДО Марія',
+    );
+  });
+
+  it('parses УК Агент trigger without handle', () => {
+    const result = parseUkTriggerQuery('УК Агент Надія Сидоренко');
+    expect(result).toEqual({
+      contactType: 'telegram',
+      contactValues: ['УК АГЕНТ Надія Сидоренко'],
+      name: 'Надія',
+      surname: 'Сидоренко',
+      handle: null,
+      searchPair: { telegram: 'УК АГЕНТ Надія Сидоренко' },
+    });
+  });
+
+  it('parses УК Агент trigger with handle', () => {
+    const result = parseUkTriggerQuery('УК агент  Надія  @nadia_agent');
+    expect(result).toEqual({
+      contactType: 'telegram',
+      contactValues: ['УК АГЕНТ Надія @nadia_agent', 'nadia_agent'],
+      name: 'Надія',
+      surname: '',
+      handle: 'nadia_agent',
+      searchPair: { telegram: 'УК АГЕНТ Надія @nadia_agent' },
+    });
   });
 });

--- a/src/utils/parseUkTrigger.js
+++ b/src/utils/parseUkTrigger.js
@@ -1,4 +1,4 @@
-const TRIGGER_PATTERN = /^(ук)\s*(см|ір|ip|до)\s*(.*)$/i;
+const TRIGGER_PATTERN = /^(ук)\s*(см|ір|ip|до|агент)\s*(.*)$/i;
 
 export const parseUkTriggerQuery = rawQuery => {
   if (typeof rawQuery !== 'string') return null;


### PR DESCRIPTION
## Summary
- add УК Агент to the UK trigger parser and expand its test coverage
- ensure VK normalization only accepts valid identifiers and add detectSearchParams tests for the new logic

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d6e9bc6d30832687801f0d8c47574b