### PR TITLE
Align schedule prefixes for distant base-relative events

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -215,8 +215,9 @@ const getSchedulePrefixForDate = (date, baseDate, transferDate) => {
   }
 
   let useDayPrefix = true;
-  if (normalizedTransfer) {
-    const cutoff = new Date(normalizedTransfer);
+  const cutoffReference = referenceForDay;
+  if (cutoffReference) {
+    const cutoff = new Date(cutoffReference);
     cutoff.setDate(cutoff.getDate() + DAY_PREFIX_TRANSFER_WINDOW_DAYS);
     if (normalizedDate.getTime() > cutoff.getTime()) {
       useDayPrefix = false;
@@ -231,7 +232,7 @@ const getSchedulePrefixForDate = (date, baseDate, transferDate) => {
     }
   }
 
-  const referenceForWeeks = normalizedBase || normalizedTransfer || referenceForDay;
+  const referenceForWeeks = referenceForDay || normalizedBase || normalizedTransfer;
   if (referenceForWeeks) {
     const tokenInfo = getWeeksDaysTokenForDate(normalizedDate, referenceForWeeks);
     if (tokenInfo?.token) {
@@ -422,8 +423,6 @@ const buildPostTransferLabel = (key, labelSource, date, transferReference) => {
   return buildTransferDayLabel(key, dayNumber, suffix, sign);
 };
 
-const STIMULATION_RANGE_EXTENSION_DAYS = DAY_PREFIX_TRANSFER_WINDOW_DAYS;
-
 const isWithinStimulationRange = (date, baseDate, transferDate) => {
   if (!date) return false;
   if (!baseDate && !transferDate) return false;
@@ -432,25 +431,12 @@ const isWithinStimulationRange = (date, baseDate, transferDate) => {
   const normalizedBase = baseDate ? normalizeDate(baseDate) : null;
   const normalizedTransfer = transferDate ? normalizeDate(transferDate) : null;
 
-  const rangeStart = normalizedBase || normalizedTransfer;
+  const rangeStart = normalizedTransfer || normalizedBase;
   if (!rangeStart) {
     return false;
   }
 
   if (normalizedDate.getTime() < rangeStart.getTime()) {
-    return false;
-  }
-
-  let rangeEnd = null;
-  if (normalizedTransfer) {
-    rangeEnd = new Date(normalizedTransfer);
-    rangeEnd.setDate(rangeEnd.getDate() + STIMULATION_RANGE_EXTENSION_DAYS);
-  } else if (normalizedBase) {
-    rangeEnd = new Date(normalizedBase);
-    rangeEnd.setDate(rangeEnd.getDate() + STIMULATION_RANGE_EXTENSION_DAYS);
-  }
-
-  if (rangeEnd && normalizedDate.getTime() > rangeEnd.getTime()) {
     return false;
   }
 

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -23,6 +23,25 @@ describe('adjustItemForDate', () => {
 
     expect(adjusted.label).toBe('20й день (перенос)');
   });
+
+  it('keeps week-day prefix for distant base-relative custom events without transfer', () => {
+    const baseDate = new Date(2024, 0, 1);
+    const distant = new Date(baseDate);
+    distant.setDate(distant.getDate() + 21 * 7 + 5);
+
+    const customItem = {
+      key: 'ap-custom-note',
+      date: new Date(distant),
+      label: '21т6д контроль',
+    };
+
+    const adjusted = adjustItemForDate(customItem, distant, {
+      baseDate,
+      transferDate: null,
+    });
+
+    expect(adjusted.label).toBe('21т6д контроль');
+  });
 });
 
 describe('splitCustomEventEntries', () => {


### PR DESCRIPTION
## Summary
- share the same reference date when building day and week prefixes so distant base-relative events fall back to week/day tokens
- allow stimulation schedule labels to emit week-day prefixes for base-only timelines beyond the previous 30 day limit
- add a regression test covering a custom event about 21 weeks after the base date

## Testing
- CI=true npm test -- StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d791d5b2988326a919385e7c5d5f19