### PR TITLE
Ensure custom event labels keep weeks/days token

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -266,8 +266,9 @@ const sanitizeDescription = text => {
     }
     const tokenMatch = extractWeeksDaysPrefix(result);
     if (tokenMatch) {
-      result = stripLeadingDelimiters(result.slice(tokenMatch.length));
-      continue;
+      // Залишаємо токен тижнів/днів у підписі, тож припиняємо подальше очищення
+      result = result.trimStart();
+      break;
     }
     break;
   }


### PR DESCRIPTION
## Summary
- stop stripping week/day prefixes when sanitizing custom event descriptions
- ensure custom event labels keep tokens like `15т6д`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d791b4ab908326a608b269c4aa3c00