### PR TITLE
Align stimulation schedule action column widths

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -17,6 +17,15 @@ const firstDayActionButtonStyle = {
   justifyContent: 'center',
 };
 
+const actionsColumnStyle = {
+  display: 'flex',
+  gap: '2px',
+  marginLeft: 'auto',
+  minWidth: firstDayActionButtonStyle.minWidth,
+  justifyContent: 'flex-end',
+  flexShrink: 0,
+};
+
 const parseDate = str => {
   if (!str) return null;
   const fullPattern = /^\d{2}\.\d{2}\.\d{4}$/;
@@ -1834,7 +1843,7 @@ const StimulationSchedule = ({
                 {displayLabel}
               </div>
             </div>
-            <div style={{ display: 'flex', gap: '2px', marginLeft: 'auto' }}>
+            <div style={actionsColumnStyle}>
               {showAdjustmentButtons ? (
                 <React.Fragment>
                   <OrangeBtn
@@ -2087,7 +2096,7 @@ const StimulationSchedule = ({
                 </div>
               )}
             </div>
-            <div style={{ display: 'flex', gap: '2px', marginLeft: 'auto' }}>
+            <div style={actionsColumnStyle}>
               {isEditing
                 ? null
                 : isPlaceholder


### PR DESCRIPTION
## Summary
- add a shared style for the actions column so button groups share the same width
- reuse the shared column style for both first-day and regular rows to align the buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a106a63c8326962e8390995ee315