### PR TITLE
Align first-day action buttons layout

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -5,8 +5,12 @@ import { OrangeBtn } from 'components/styles';
 import { ReactComponent as ClipboardIcon } from 'assets/icons/clipboard.svg';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 
+const FIRST_DAY_BUTTON_WIDTH = 88;
+const FIRST_DAY_BUTTON_GAP = 2;
+const FIRST_DAY_GROUP_WIDTH = FIRST_DAY_BUTTON_WIDTH * 3 + FIRST_DAY_BUTTON_GAP * 2;
+
 const firstDayActionButtonStyle = {
-  minWidth: '88px',
+  minWidth: `${FIRST_DAY_BUTTON_WIDTH}px`,
   height: '24px',
   borderRadius: '4px',
   boxShadow: '0 2px 4px rgba(0,0,0,0.3)',
@@ -15,6 +19,14 @@ const firstDayActionButtonStyle = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  flex: 1,
+};
+
+const firstDayActionContainerStyle = {
+  display: 'flex',
+  gap: `${FIRST_DAY_BUTTON_GAP}px`,
+  marginLeft: 'auto',
+  width: `${FIRST_DAY_GROUP_WIDTH}px`,
 };
 
 const parseDate = str => {
@@ -1866,7 +1878,7 @@ const StimulationSchedule = ({
                 {displayLabel}
               </div>
             </div>
-            <div style={{ display: 'flex', gap: '2px', marginLeft: 'auto' }}>
+            <div style={firstDayActionContainerStyle}>
               {showAdjustmentButtons ? (
                 <React.Fragment>
                   <OrangeBtn


### PR DESCRIPTION
## Summary
- introduce shared sizing constants for the first-day action group container
- allow first-day action buttons to flex evenly within the fixed-width container for consistent alignment

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d8da64b0548326994ebb10079c970a