### PR TITLE
Fix custom event day prefix before transfer

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -473,16 +473,21 @@ const isWithinStimulationRange = (date, baseDate, transferDate) => {
   const normalizedBase = baseDate ? normalizeDate(baseDate) : null;
   const normalizedTransfer = transferDate ? normalizeDate(transferDate) : null;
 
-  const rangeStart = normalizedTransfer || normalizedBase;
-  if (!rangeStart) {
-    return false;
+  if (normalizedTransfer) {
+    if (normalizedDate.getTime() < normalizedTransfer.getTime()) {
+      if (!normalizedBase) {
+        return false;
+      }
+      return normalizedDate.getTime() >= normalizedBase.getTime();
+    }
+    return true;
   }
 
-  if (normalizedDate.getTime() < rangeStart.getTime()) {
-    return false;
+  if (normalizedBase) {
+    return normalizedDate.getTime() >= normalizedBase.getTime();
   }
 
-  return true;
+  return false;
 };
 
 const buildCustomEventLabel = (date, baseDate, transferDate, description) => {
@@ -1040,7 +1045,11 @@ export const adjustItemForDate = (
   }
 
   if (baseDateValue && adj.day !== null) {
-    const prefix = getSchedulePrefixForDate(adjustedDate, baseDateValue, normalizedTransfer);
+    let prefix = getSchedulePrefixForDate(adjustedDate, baseDateValue, normalizedTransfer);
+    if (item.key === 'transfer') {
+      const transferDayNumber = diffDays(adjustedDate, baseDateValue);
+      prefix = `${Math.max(transferDayNumber, 1)}й день`;
+    }
     let suffix = stripSchedulePrefixTokens(sanitizeDescription(labelSource));
     if (suffix) {
       suffix = suffix.replace(/\s*[+-]$/, '').trim();

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -1,4 +1,8 @@
-import { adjustItemForDate, splitCustomEventEntries } from 'components/StimulationSchedule';
+import {
+  adjustItemForDate,
+  buildCustomEventLabel,
+  splitCustomEventEntries,
+} from 'components/StimulationSchedule';
 
 jest.mock('components/smallCard/actions', () => ({
   handleChange: jest.fn(),
@@ -41,6 +45,18 @@ describe('adjustItemForDate', () => {
     });
 
     expect(adjusted.label).toBe('21т6д контроль');
+  });
+});
+
+describe('buildCustomEventLabel', () => {
+  it('adds day prefix for custom events between stimulation start and transfer', () => {
+    const baseDate = new Date(2024, 0, 10);
+    const transferDate = new Date(2024, 0, 18);
+    const customDate = new Date(2024, 0, 15);
+
+    const label = buildCustomEventLabel(customDate, baseDate, transferDate, 'контроль');
+
+    expect(label).toBe('6й день контроль');
   });
 });
 


### PR DESCRIPTION
## Summary
- allow `isWithinStimulationRange` to accept dates that fall between stimulation start and transfer so pre-transfer custom entries keep their day numbers
- preserve transfer day numbering when recalculating schedule items and cover the scenario with a regression test for custom events before transfer

## Testing
- CI=1 npm test -- --runTestsByPath src/components/StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d97dbebf008326abbff5d9c64f3006