### PR TITLE
Remove tests for derive schedule display info

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -80,3 +80,4 @@ describe('splitCustomEventEntries', () => {
     ]);
   });
 });
+


### PR DESCRIPTION
## Summary
- remove the newly added deriveScheduleDisplayInfo import from the stimulation schedule tests
- drop the extra describe block so no new tests run for the display helper

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d99561d7cc8326829b1b895caff462