### PR TITLE
Fix duplicate export in stimulation schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -2563,7 +2563,6 @@ const StimulationSchedule = ({
 
 export {
   sanitizeDescription,
-  deriveScheduleDisplayInfo,
   buildCustomEventLabel,
   computeCustomDateAndLabel,
   splitCustomEventEntries,


### PR DESCRIPTION
## Summary
- remove the duplicate re-export of `deriveScheduleDisplayInfo` in `StimulationSchedule.jsx` to resolve linting errors

## Testing
- npm run lint:js -- src/components/StimulationSchedule.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9a17e8e048326841a76909c90b0cb