### PR TITLE
Ensure custom pre-cycle events display day prefixes

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -1,6 +1,7 @@
 import {
   adjustItemForDate,
   buildCustomEventLabel,
+  computeCustomDateAndLabel,
   splitCustomEventEntries,
 } from 'components/StimulationSchedule';
 
@@ -57,6 +58,23 @@ describe('buildCustomEventLabel', () => {
     const label = buildCustomEventLabel(customDate, baseDate, transferDate, 'контроль');
 
     expect(label).toBe('6й день контроль');
+  });
+});
+
+describe('computeCustomDateAndLabel', () => {
+  it('prefers pre-cycle base for custom events before the main stimulation visit 1', () => {
+    const visitOne = new Date(2025, 0, 16);
+    const preCycleBase = new Date(2024, 11, 24);
+
+    const result = computeCustomDateAndLabel(
+      '28.12.2024 міс',
+      visitOne,
+      visitOne,
+      null,
+      preCycleBase,
+    );
+
+    expect(result.label).toBe('5й день міс');
   });
 });
 


### PR DESCRIPTION
## Summary
- add a helper to resolve the correct base date for custom event labels, covering pre-cycle difherelin days
- update custom-event handling to use the new base resolver and verify with targeted tests

## Testing
- npm test -- --runTestsByPath src/components/StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9a565f4088326b6a1f6a664a40292