### PR TITLE
Update transfer label wording

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1042,7 +1042,7 @@ export const generateSchedule = base => {
   visits.push({
     key: 'transfer',
     date: transfer.date,
-    label: `${transfer.day}й день (перенос)${transfer.sign ? ` ${transfer.sign}` : ''}`,
+    label: `${transfer.day}й день Перенос${transfer.sign ? ` ${transfer.sign}` : ''}`,
   });
 
   // HCG 12 days after transfer

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -18,7 +18,7 @@ describe('adjustItemForDate', () => {
     const transferItem = {
       key: 'transfer',
       date: new Date(transferDate),
-      label: '20й день (перенос)',
+      label: '20й день Перенос',
     };
 
     const adjusted = adjustItemForDate(transferItem, transferDate, {
@@ -26,7 +26,7 @@ describe('adjustItemForDate', () => {
       transferDate,
     });
 
-    expect(adjusted.label).toBe('20й день (перенос)');
+    expect(adjusted.label).toBe('20й день Перенос');
   });
 
   it('keeps week-day prefix for distant base-relative custom events without transfer', () => {


### PR DESCRIPTION
## Summary
- replace the transfer visit label to use "Перенос" without parentheses in the stimulation schedule
- update the associated test expectation to match the new wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da30ceb85c83268984e4b754e88ac9