### PR TITLE
Add 36-week relocation and card signing events to stimulation schedule

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1071,11 +1071,19 @@ export const generateSchedule = base => {
   weeks.forEach(week => {
     let wd = new Date(base);
     wd.setDate(wd.getDate() + week * 7);
-    const adj = week === 40 ? buildUnadjustedDayInfo(wd, base) : adjustForward(wd, base);
+    const adj =
+      week === 40 || week === 36
+        ? buildUnadjustedDayInfo(wd, base)
+        : adjustForward(wd, base);
     const prefix = getSchedulePrefixForDate(adj.date, base, transferBase);
     let labelText = prefix;
     if (week === 40) {
       labelText = labelText ? `${labelText} пологи` : 'пологи';
+    }
+    if (week === 36) {
+      labelText = labelText
+        ? `${labelText} Переїзд в Київ`
+        : 'Переїзд в Київ';
     }
     if (adj.sign) {
       labelText = labelText ? `${labelText} ${adj.sign}` : adj.sign;
@@ -1085,6 +1093,24 @@ export const generateSchedule = base => {
       date: adj.date,
       label: labelText.trim(),
     });
+
+    if (week === 36) {
+      const nextDay = new Date(base);
+      nextDay.setDate(nextDay.getDate() + week * 7 + 1);
+      const nextAdj = buildUnadjustedDayInfo(nextDay, base);
+      let nextPrefix = getSchedulePrefixForDate(nextAdj.date, base, transferBase);
+      let nextLabel = nextPrefix
+        ? `${nextPrefix} Підписати обмінну карту`
+        : 'Підписати обмінну карту';
+      if (nextAdj.sign) {
+        nextLabel = nextLabel ? `${nextLabel} ${nextAdj.sign}` : nextAdj.sign;
+      }
+      visits.push({
+        key: 'week36-day2',
+        date: nextAdj.date,
+        label: nextLabel.trim(),
+      });
+    }
   });
 
   return visits;


### PR DESCRIPTION
## Summary
- ensure the 36т1д pregnancy visit keeps its planned timing and is labeled for relocating to Kyiv
- add a follow-up 36т2д visit to sign the exchange card in the default stimulation schedule

## Testing
- npm test -- StimulationSchedule

------
https://chatgpt.com/codex/tasks/task_e_68da361d0e508326ab268e36da8c4ded