### PR TITLE
Fix regex hyphen escaping

### DIFF
--- a/src/utils/stimulationScheduleSort.js
+++ b/src/utils/stimulationScheduleSort.js
@@ -45,7 +45,7 @@ const formatFullDate = date => {
   return `${day}.${month}.${year}`;
 };
 
-const stripLeadingToken = text => text.replace(/^[,.;:\-]+/, '').trim();
+const stripLeadingToken = text => text.replace(/^[-,.;:]+/, '').trim();
 
 const stripDayOfWeekToken = text => {
   if (!text) return '';


### PR DESCRIPTION
## Summary
- simplify the leading token stripping regex to use a literal hyphen without unnecessary escaping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da74dba49883268b3b69b85aca469f