### PR TITLE
Update predicted delivery when adjusting stimulation cycle

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1406,14 +1406,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   setUsers={setUsers}
                   setState={setState}
                   isToastOn={isToastOn}
-                  onLastCyclePersisted={({ lastCycle, needsSync }) => {
-                    if (!needsSync || !lastCycle) return;
+                  onLastCyclePersisted={({ lastCycle, lastDelivery, needsSync }) => {
+                    if (!needsSync) return;
                     const targetUserId = scheduleUserData?.userId;
                     if (!targetUserId) return;
+                    const updates = {};
+                    if (lastCycle) updates.lastCycle = lastCycle;
+                    if (lastDelivery) updates.lastDelivery = lastDelivery;
+                    if (!Object.keys(updates).length) return;
                     if (typeof setState === 'function') {
                       setState(prev => {
                         if (!prev || prev.userId !== targetUserId) return prev;
-                        return { ...prev, lastCycle };
+                        return { ...prev, ...updates };
                       });
                     }
                     if (typeof setUsers === 'function') {
@@ -1421,7 +1425,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                         if (!prev) return prev;
                         if (Array.isArray(prev)) {
                           return prev.map(item =>
-                            item?.userId === targetUserId ? { ...item, lastCycle } : item,
+                            item?.userId === targetUserId ? { ...item, ...updates } : item,
                           );
                         }
                         if (typeof prev === 'object') {
@@ -1431,7 +1435,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                             ...prev,
                             [targetUserId]: {
                               ...current,
-                              lastCycle,
+                              ...updates,
                             },
                           };
                         }

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -243,9 +243,13 @@ const EditProfile = () => {
             userData={scheduleUserData}
             setState={setState}
             isToastOn={isToastOn}
-            onLastCyclePersisted={({ lastCycle, needsSync }) => {
-              if (!needsSync || !lastCycle) return;
-              setState(prev => ({ ...prev, lastCycle }));
+            onLastCyclePersisted={({ lastCycle, lastDelivery, needsSync }) => {
+              if (!needsSync) return;
+              const updates = {};
+              if (lastCycle) updates.lastCycle = lastCycle;
+              if (lastDelivery) updates.lastDelivery = lastDelivery;
+              if (!Object.keys(updates).length) return;
+              setState(prev => ({ ...prev, ...updates }));
             }}
           />
         </div>

--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1374,13 +1374,24 @@ const StimulationSchedule = ({
       const normalizedDate = normalizeDate(newBaseDate);
       const formattedNextCycle = formatDateToServer(formatFullDate(normalizedDate));
       if (!formattedNextCycle) return;
+
+      const predictedDeliveryBase = new Date(normalizedDate);
+      predictedDeliveryBase.setDate(predictedDeliveryBase.getDate() + 7 * 40);
+      const predictedDelivery = normalizeDate(predictedDeliveryBase);
+      const formattedLastDelivery = formatDateToServer(
+        formatFullDate(predictedDelivery),
+      );
+
       const updates = { lastCycle: formattedNextCycle };
+      if (formattedLastDelivery) {
+        updates.lastDelivery = formattedLastDelivery;
+      }
       let stateSynced = false;
       if (context.setUsers && context.setState) {
         handleChange(context.setUsers, context.setState, context.userId, updates);
         stateSynced = true;
       } else if (context.setState) {
-        context.setState(prev => ({ ...prev, lastCycle: formattedNextCycle }));
+        context.setState(prev => ({ ...prev, ...updates }));
         stateSynced = true;
       } else if (context.setUsers) {
         handleChange(context.setUsers, null, context.userId, updates);
@@ -1390,6 +1401,7 @@ const StimulationSchedule = ({
       if (typeof onLastCyclePersisted === 'function') {
         onLastCyclePersisted({
           lastCycle: formattedNextCycle,
+          lastDelivery: formattedLastDelivery,
           date: normalizedDate,
           needsSync: !stateSynced,
         });

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -57,12 +57,17 @@ const UserCard = ({
             setUsers={setUsers}
             setState={setState}
             isToastOn={isToastOn}
-            onLastCyclePersisted={({ lastCycle, needsSync }) => {
-              if (!needsSync || !lastCycle) return;
+            onLastCyclePersisted={({ lastCycle, lastDelivery, needsSync }) => {
+              if (!needsSync) return;
+              const updates = {};
+              if (lastCycle) updates.lastCycle = lastCycle;
+              if (lastDelivery) updates.lastDelivery = lastDelivery;
+              if (!Object.keys(updates).length) return;
+
               if (typeof setState === 'function') {
                 setState(prev => {
                   if (!prev || prev.userId !== userData.userId) return prev;
-                  return { ...prev, lastCycle };
+                  return { ...prev, ...updates };
                 });
               }
               if (typeof setUsers === 'function') {
@@ -70,7 +75,7 @@ const UserCard = ({
                   if (!prev) return prev;
                   if (Array.isArray(prev)) {
                     return prev.map(item =>
-                      item?.userId === userData.userId ? { ...item, lastCycle } : item,
+                      item?.userId === userData.userId ? { ...item, ...updates } : item,
                     );
                   }
                   if (typeof prev === 'object') {
@@ -80,7 +85,7 @@ const UserCard = ({
                       ...prev,
                       [userData.userId]: {
                         ...current,
-                        lastCycle,
+                        ...updates,
                       },
                     };
                   }


### PR DESCRIPTION
## Summary
- update stimulation schedule persistence to calculate and store the predicted delivery date alongside the next cycle date
- propagate lastDelivery updates to local state when the schedule changes in add/edit views and the users list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae2d8a9f88326b0d7a2daf6df185b