### PR TITLE
Fix today placeholder prefix reference

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -2198,17 +2198,51 @@ const StimulationSchedule = ({
                       let dateChanged = false;
 
                       if (isPlaceholder) {
-                        const tokenInfo = scheduleBaseDate
-                          ? getWeeksDaysTokenForDate(updated.date, scheduleBaseDate)
+                        const normalizedToday = normalizeDate(new Date());
+                        const normalizedScheduleBase = scheduleBaseDate
+                          ? normalizeDate(scheduleBaseDate)
                           : null;
-                        const prefix = extractWeeksDaysPrefix(trimmedLabel);
-                        const rest = prefix
-                          ? trimmedLabel.slice(prefix.length).trim()
-                          : trimmedLabel.trim();
-                        if (tokenInfo) {
+                        const normalizedPreBase = preBaseForState
+                          ? normalizeDate(preBaseForState)
+                          : null;
+                        const normalizedTransfer = transferDate
+                          ? normalizeDate(transferDate)
+                          : null;
+                        let placeholderBase = normalizedScheduleBase;
+                        if (
+                          normalizedScheduleBase &&
+                          normalizedPreBase &&
+                          normalizedToday.getTime() < normalizedScheduleBase.getTime()
+                        ) {
+                          placeholderBase = normalizedPreBase;
+                        } else if (!placeholderBase && normalizedPreBase) {
+                          placeholderBase = normalizedPreBase;
+                        }
+
+                        const weeksPrefix = extractWeeksDaysPrefix(trimmedLabel);
+                        const dayPrefix = weeksPrefix ? null : extractDayPrefix(trimmedLabel);
+                        const rest = weeksPrefix
+                          ? trimmedLabel.slice(weeksPrefix.length).trim()
+                          : dayPrefix
+                            ? dayPrefix.rest || ''
+                            : trimmedLabel.trim();
+
+                        let nextPrefix = placeholderBase
+                          ? getSchedulePrefixForDate(
+                              updated.date,
+                              placeholderBase,
+                              normalizedTransfer,
+                            )
+                          : '';
+                        if (!nextPrefix && placeholderBase) {
+                          const tokenInfo = getWeeksDaysTokenForDate(updated.date, placeholderBase);
+                          nextPrefix = tokenInfo?.token || '';
+                        }
+
+                        if (nextPrefix) {
                           updated = {
                             ...updated,
-                            label: rest ? `${tokenInfo.token} ${rest}` : tokenInfo.token,
+                            label: rest ? `${nextPrefix} ${rest}` : nextPrefix,
                           };
                         }
                       } else {


### PR DESCRIPTION
## Summary
- ensure the today placeholder reuses the same base reference as during render when rebuilding its prefix
- preserve any custom description while restoring the correct day or week token when editing the placeholder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbaa1b6a44832681aa6b3b179baa26