### PR TITLE
Add dedicated medications page and refine medication schedule display

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,6 +6,7 @@ import { SubmitForm } from './SubmitForm';
 import { AddNewProfile } from './AddNewProfile';
 import Matching from './Matching';
 import EditProfile from './EditProfile';
+import MedicationsPage from './MedicationsPage';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from './config';
 
@@ -57,6 +58,7 @@ export const App = () => {
       {isAdmin && <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       {isAdmin && <Route path="/matching" element={<Matching />} />}
       {isAdmin && <Route path="/edit/:userId" element={<EditProfile />} />}
+      {isAdmin && <Route path="/medications/:userId" element={<MedicationsPage />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import {
@@ -49,6 +49,21 @@ const EditProfile = () => {
   const [isToastOn, setIsToastOn] = useState(true);
   const [isDataLoaded, setIsDataLoaded] = useState(false);
   const [dataSource, setDataSource] = useState('');
+
+  const handleOpenMedications = useCallback(
+    user => {
+      if (!user?.userId) return;
+      const labelParts = [user.name, user.surname].filter(Boolean);
+      navigate(`/medications/${user.userId}`, {
+        state: {
+          from: location.pathname,
+          label: labelParts.join(' '),
+          user,
+        },
+      });
+    },
+    [navigate, location.pathname],
+  );
 
   async function remoteUpdate({ updatedState, overwrite, delCondition }) {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
@@ -235,6 +250,7 @@ const EditProfile = () => {
           undefined,
           isToastOn,
           setIsToastOn,
+          handleOpenMedications,
         )}
       </div>
       {shouldShowSchedule && state && (

--- a/src/components/InfoModal.jsx
+++ b/src/components/InfoModal.jsx
@@ -76,14 +76,7 @@ const OrangeStrong = styled.strong`
   color: orange;
 `;
 
-const LargeModalContent = styled(ModalContent)`
-  width: min(920px, 95vw);
-  max-height: 90vh;
-  overflow-y: auto;
-  text-align: left;
-`;
-
-export const InfoModal = ({ onClose, onSelect, options, text, Context, DelConfirm, CompareCards, Medications }) => {
+export const InfoModal = ({ onClose, onSelect, options, text, Context, DelConfirm, CompareCards }) => {
 
   const delProfile = (
     <>
@@ -166,8 +159,6 @@ export const InfoModal = ({ onClose, onSelect, options, text, Context, DelConfir
     </>
   );
 
-  const medicationContent = Medications ? <Medications /> : null;
-
   let ContentComponent = ModalContent;
   let body = null;
 
@@ -189,10 +180,6 @@ export const InfoModal = ({ onClose, onSelect, options, text, Context, DelConfir
       break;
     case 'compareCards':
       body = compareCards;
-      break;
-    case 'medications':
-      ContentComponent = LargeModalContent;
-      body = medicationContent;
       break;
     default:
       body = null;

--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -121,17 +121,35 @@ const Td = styled.td`
 `;
 
 const CellInput = styled.input`
-  width: 100%;
-  padding: 6px 8px;
+  width: 2.5ch;
+  min-width: 32px;
+  padding: 4px 6px;
   border-radius: 6px;
   border: 1px solid #d0d0d0;
   font-size: 13px;
   text-align: center;
   color: black;
+  box-sizing: border-box;
+  display: inline-block;
 `;
 
 const DateInput = styled(CellInput)`
   text-align: left;
+`;
+
+const DayCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-weight: 500;
+`;
+
+const DayBadge = styled.span`
+  font-size: 11px;
+  color: #555;
+  font-weight: 600;
+  white-space: nowrap;
 `;
 
 const ActionsRow = styled.div`
@@ -631,9 +649,18 @@ const MedicationSchedule = ({ data, onChange, onClose, userLabel, userId }) => {
             </tr>
           </thead>
           <tbody>
-            {schedule.rows.map((row, index) => (
-              <tr key={`${row.date || 'row'}-${index}`}>
-                <Td>{index + 1}</Td>
+            {schedule.rows.map((row, index) => {
+              const dayNumber = index + 1;
+              const showOneTabletLabel = dayNumber >= 8 && (dayNumber - 1) % 7 === 0;
+
+              return (
+                <tr key={`${row.date || 'row'}-${index}`}>
+                  <Td style={{ textAlign: 'center' }}>
+                    <DayCell>
+                      <span>{dayNumber}</span>
+                      {showOneTabletLabel && <DayBadge>1т1д</DayBadge>}
+                    </DayCell>
+                  </Td>
                 <Td>
                   <DateInput
                     value={formatDateForDisplay(row.date)}
@@ -649,8 +676,9 @@ const MedicationSchedule = ({ data, onChange, onClose, userLabel, userId }) => {
                     />
                   </Td>
                 ))}
-              </tr>
-            ))}
+                </tr>
+              );
+            })}
           </tbody>
         </StyledTable>
       </TableWrapper>

--- a/src/components/MedicationsPage.jsx
+++ b/src/components/MedicationsPage.jsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import toast from 'react-hot-toast';
+import { onValue } from 'firebase/database';
+import MedicationSchedule from './MedicationSchedule';
+import { fetchUserById, getMedicationScheduleRef, saveMedicationSchedule } from './config';
+
+const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  max-width: 960px;
+  margin: 0 auto;
+  box-sizing: border-box;
+  color: black;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const BackButton = styled.button`
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  background-color: #ffb347;
+  color: white;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #ff9a1a;
+  }
+`;
+
+const TitleBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+`;
+
+const Subtitle = styled.span`
+  font-size: 14px;
+  color: #555;
+`;
+
+const Card = styled.div`
+  background-color: #f9f9f9;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  padding: 20px;
+`;
+
+const Message = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: #444;
+`;
+
+const LoadingState = styled.div`
+  font-size: 14px;
+  color: #666;
+`;
+
+const MedicationsPage = () => {
+  const { userId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [user, setUser] = useState(() => location.state?.user ?? null);
+  const [isUserLoading, setIsUserLoading] = useState(!user);
+  const [schedule, setSchedule] = useState(null);
+  const [isScheduleLoading, setIsScheduleLoading] = useState(true);
+  const ownerId = useMemo(() => localStorage.getItem('ownerId'), []);
+  const saveTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!userId) {
+      setIsUserLoading(false);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setIsUserLoading(true);
+    fetchUserById(userId)
+      .then(result => {
+        if (!isMounted) return;
+        setUser(result || null);
+        setIsUserLoading(false);
+      })
+      .catch(error => {
+        console.error('Failed to fetch user for medications page', error);
+        if (isMounted) {
+          setIsUserLoading(false);
+          toast.error('Не вдалося завантажити профіль користувача');
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId]);
+
+  useEffect(() => {
+    setIsScheduleLoading(true);
+
+    if (!ownerId || !userId) {
+      setSchedule(null);
+      setIsScheduleLoading(false);
+      return undefined;
+    }
+
+    const scheduleRef = getMedicationScheduleRef(ownerId, userId);
+    if (!scheduleRef) {
+      setIsScheduleLoading(false);
+      return undefined;
+    }
+
+    const unsubscribe = onValue(
+      scheduleRef,
+      snapshot => {
+        setSchedule(snapshot.exists() ? snapshot.val() : null);
+        setIsScheduleLoading(false);
+      },
+      error => {
+        console.error('Failed to subscribe to medication schedule', error);
+        toast.error('Не вдалося завантажити розклад ліків');
+        setIsScheduleLoading(false);
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [ownerId, userId]);
+
+  useEffect(
+    () => () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const handleClose = useCallback(() => {
+    const from = location.state?.from;
+    if (from) {
+      navigate(from);
+      return;
+    }
+    navigate(-1);
+  }, [navigate, location.state]);
+
+  const handleScheduleChange = useCallback(
+    updatedSchedule => {
+      setSchedule(updatedSchedule);
+
+      if (!ownerId || !userId) {
+        toast.error('Увійдіть, щоб зберігати зміни по ліках');
+        return;
+      }
+
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+
+      saveTimeoutRef.current = setTimeout(() => {
+        saveMedicationSchedule(ownerId, userId, updatedSchedule).catch(error => {
+          console.error('Failed to save medication schedule', error);
+          toast.error('Не вдалося зберегти зміни по ліках');
+        });
+      }, 400);
+    },
+    [ownerId, userId],
+  );
+
+  const userLabel = useMemo(() => {
+    if (location.state?.label) return location.state.label;
+    if (!user) return '';
+    const parts = [user.surname, user.name, user.fathersname].filter(Boolean);
+    return parts.join(' ');
+  }, [location.state, user]);
+
+  const isReady = !isScheduleLoading && !!ownerId;
+
+  return (
+    <PageContainer>
+      <Header>
+        <BackButton type="button" onClick={handleClose}>
+          Назад
+        </BackButton>
+        <TitleBlock>
+          <Title>Ліки</Title>
+          {userLabel && <Subtitle>{userLabel}</Subtitle>}
+        </TitleBlock>
+      </Header>
+
+      {!ownerId && (
+        <Card>
+          <Message>Щоб працювати з розкладом ліків, увійдіть до системи.</Message>
+        </Card>
+      )}
+
+      {isUserLoading && <LoadingState>Завантаження профілю…</LoadingState>}
+
+      {isScheduleLoading && ownerId && <LoadingState>Завантаження розкладу…</LoadingState>}
+
+      {isReady && (
+        <Card>
+          <MedicationSchedule
+            data={schedule || {}}
+            onChange={handleScheduleChange}
+            onClose={handleClose}
+            userLabel={userLabel}
+            userId={userId}
+          />
+        </Card>
+      )}
+    </PageContainer>
+  );
+};
+
+export default MedicationsPage;

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -3,7 +3,6 @@ import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import { btnCompare } from './smallCard/btnCompare';
-import { btnMedications } from './smallCard/btnMedications';
 import { btnEdit } from './smallCard/btnEdit';
 import { renderAllFields } from './ProfileForm';
 // import { btnExportUsers } from './topBtns/btnExportUsers';
@@ -17,6 +16,7 @@ const UserCard = ({
   setShowInfoModal,
   setState,
   setUserIdToDelete,
+  onOpenMedications,
   favoriteUsers,
   setFavoriteUsers,
   dislikeUsers,
@@ -49,6 +49,8 @@ const UserCard = ({
           currentFilter,
           isDateInRange,
           isToastOn,
+          undefined,
+          onOpenMedications,
         )}
       </div>
       {shouldShowSchedule && (
@@ -182,13 +184,13 @@ const UsersList = ({
             <>
               {btnEdit(userData, setSearch, setState)}
               {btnCompare(index, users, setUsers, setShowInfoModal, setCompare, )}
-              {btnMedications(userData, onOpenMedications)}
               <UserCard
                 setShowInfoModal={setShowInfoModal}
                 userData={userData}
                 setUsers={setUsers}
                 setState={setState}
                 setUserIdToDelete={setUserIdToDelete}
+                onOpenMedications={onOpenMedications}
                 favoriteUsers={favoriteUsers}
                 setFavoriteUsers={setFavoriteUsers}
                 dislikeUsers={dislikeUsers}

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -13,6 +13,7 @@ import { fieldBirth } from './fieldBirth';
 import { fieldBlood } from './fieldBlood';
 import { fieldMaritalStatus } from './fieldMaritalStatus';
 import { fieldIMT } from './fieldIMT';
+import { btnMedications } from './btnMedications';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
 import { fetchUserById } from '../config';
@@ -54,7 +55,8 @@ export const renderTopBlock = (
   currentFilter,
   isDateInRange,
   isToastOn = false,
-  setIsToastOn = () => {}
+  setIsToastOn = () => {},
+  onOpenMedications,
 ) => {
   if (!userData) return null;
 
@@ -66,6 +68,7 @@ export const renderTopBlock = (
       {btnDel(cardData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
       {!isFromListOfUsers && <BtnToast isToastOn={isToastOn} setIsToastOn={setIsToastOn} />}
       {btnExport(cardData)}
+      {btnMedications(cardData, onOpenMedications)}
       <div>
         {cardData.lastAction &&
           formatDateToDisplay(normalizeLastAction(cardData.lastAction))}


### PR DESCRIPTION
## Summary
- add a dedicated medications page with realtime schedule loading/saving and navigation from user cards and profile views
- remove the modal-based medications UI in favour of routing and expose the medications button via the shared top block
- tweak the medication schedule layout to flag 1т1д days and shrink daily dosage inputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbfdf564608326912c85bffcd136e8