### PR TITLE
Align medication schedule with cycle data

### DIFF
--- a/src/components/MedicationsPage.jsx
+++ b/src/components/MedicationsPage.jsx
@@ -229,6 +229,8 @@ const MedicationsPage = () => {
             onClose={handleClose}
             userLabel={userLabel}
             userId={userId}
+            cycleStart={user?.lastCycle}
+            stimulationSchedule={user?.stimulationSchedule}
           />
         </Card>
       )}


### PR DESCRIPTION
## Summary
- derive the medication table from the user's cycle start and render read-only date/weekday info with yearly separators
- keep manual cell edits intact, simplify the 1т1д badge display, and surface stimulation schedule highlights with descriptions
- pass cycle and stimulation schedule data through the medications page for synchronization

## Testing
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68dc19ed4564832698ca866faf79e30b