### PR TITLE
Skip default medication distribution for day one

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -779,8 +779,14 @@ const applyDefaultDistribution = (rows, schedule, options = {}) => {
     const rowDate = parseDateString(row.date, baseDate) || addDays(baseDate, rowIndex);
     const nextValues = { ...row.values };
     const shouldSkipRow = skipExisting && rowIndex < existingLength;
+    const isFirstRow = rowIndex === 0;
 
     medicationKeys.forEach(key => {
+      if (isFirstRow) {
+        nextValues[key] = '';
+        return;
+      }
+
       const medication = schedule?.medications?.[key] || {};
       const plan = medication.plan || key;
       const handler = getPlanHandler(plan);


### PR DESCRIPTION
## Summary
- ensure default distribution leaves the first day of the medication schedule empty
- prevent usage counters from incrementing for the first row so dosing begins on day two

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcef2b7f8c83269cb588f7d6c9fc4c