### PR TITLE
Reorder base medications to match desired layout

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -5,10 +5,10 @@ import { FaTrash } from 'react-icons/fa';
 import { deriveScheduleDisplayInfo } from './StimulationSchedule';
 
 const BASE_MEDICATIONS = [
-  { key: 'progynova', label: 'Прогінова', short: 'Пр', plan: 'progynova' },
-  { key: 'metypred', label: 'Метипред', short: 'Мт', plan: 'metypred' },
-  { key: 'folicAcid', label: 'Фолієва кислота', short: 'ФК', plan: 'folicAcid' },
   { key: 'aspirin', label: 'Аспірин кардіо', short: 'АК', plan: 'aspirin' },
+  { key: 'folicAcid', label: 'Фолієва кислота', short: 'ФК', plan: 'folicAcid' },
+  { key: 'metypred', label: 'Метипред', short: 'Мт', plan: 'metypred' },
+  { key: 'progynova', label: 'Прогінова', short: 'Пр', plan: 'progynova' },
   { key: 'injesta', label: 'Інжеста', short: 'Ін', plan: 'injesta' },
   { key: 'luteina', label: 'Лютеіна', short: 'Лт', plan: 'luteina' },
 ];


### PR DESCRIPTION
## Summary
- reorder the base medication list so the UI shows aspirin, folic acid, metypred, progynova, injesta, and luteina in the requested sequence

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcf3ac7f9883268cd46ebe52d1b4c7