### PR TITLE
Fix base medication defaults restoration

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -889,6 +889,36 @@ const normalizeRows = (rowsInput, startDate, schedule) => {
     });
   }
 
+  const medicationKeys = Array.isArray(schedule?.medicationOrder)
+    ? schedule.medicationOrder
+    : [];
+
+  const rowsWithValues = Array.isArray(rowsInput) ? rowsInput : [];
+
+  const keysNeedingDefaults = medicationKeys.filter(key => {
+    const medication = schedule?.medications?.[key];
+    const issued = Number(medication?.issued) || 0;
+
+    if (issued <= 0) {
+      return false;
+    }
+
+    return !rowsWithValues.some(row => {
+      if (!row || typeof row !== 'object') {
+        return false;
+      }
+
+      const sourceValues =
+        row.values && typeof row.values === 'object' ? row.values : row;
+
+      return sanitizeCellValue(sourceValues?.[key]) !== '';
+    });
+  });
+
+  if (keysNeedingDefaults.length > 0) {
+    return applyDefaultDistribution(baseRows, schedule, { onlyKeys: keysNeedingDefaults });
+  }
+
   return baseRows;
 };
 
@@ -1636,5 +1666,5 @@ const MedicationSchedule = ({
   );
 };
 
-export { applyDefaultDistribution };
+export { applyDefaultDistribution, normalizeRows };
 export default MedicationSchedule;

--- a/src/components/MedicationSchedule.test.jsx
+++ b/src/components/MedicationSchedule.test.jsx
@@ -1,0 +1,35 @@
+jest.mock('./StimulationSchedule', () => ({
+  deriveScheduleDisplayInfo: jest.fn(),
+  formatWeeksDaysToken: jest.fn(),
+}));
+
+import { normalizeRows } from 'components/MedicationSchedule';
+
+describe('normalizeRows', () => {
+  it('restores default distribution for base medications when only Injesta values remain', () => {
+    const schedule = {
+      startDate: '2024-01-01',
+      medicationOrder: ['progynova', 'aspirin', 'injesta'],
+      medications: {
+        progynova: { issued: 21, plan: 'progynova' },
+        aspirin: { issued: 14, plan: 'aspirin' },
+        injesta: { issued: 40, plan: 'injesta' },
+      },
+    };
+
+    const defaultRows = normalizeRows([], schedule.startDate, schedule);
+
+    const sanitizedRows = defaultRows.map(row => ({
+      date: row.date,
+      values: { injesta: row.values?.injesta },
+    }));
+
+    const normalizedRows = normalizeRows(sanitizedRows, schedule.startDate, schedule);
+
+    for (let index = 0; index < 60; index += 1) {
+      expect(normalizedRows[index].values.progynova).toBe(defaultRows[index].values.progynova);
+      expect(normalizedRows[index].values.aspirin).toBe(defaultRows[index].values.aspirin);
+      expect(normalizedRows[index].values.injesta).toBe(sanitizedRows[index].values.injesta);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- reapply default dosing distribution for base medications when schedules retain only Injesta-issued data
- add regression coverage ensuring Progynova and Aspirin defaults persist after normalization

## Testing
- CI=1 npm test -- --runTestsByPath src/components/MedicationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68dd6e6d748c8326a7da11966b0d29d1