### PR TITLE
Alternate medication schedule day numbering display

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1565,7 +1565,10 @@ const MedicationSchedule = ({
                 const diff = hasDayNumber ? dayNumber - 1 : 0;
                 const weeks = Math.floor(diff / 7);
                 const days = diff % 7;
-                const weeksDaysToken = hasDayNumber
+                const blockIndex = Math.floor(diff / 7);
+                const showWeeksDaysToken = hasDayNumber && blockIndex % 2 === 1;
+                const showDayNumber = hasDayNumber && !showWeeksDaysToken;
+                const weeksDaysToken = showWeeksDaysToken
                   ? formatWeeksDaysToken(weeks, days)
                   : null;
                 const parsedDate = parseDateString(row.date, baseDate);
@@ -1606,7 +1609,7 @@ const MedicationSchedule = ({
                   <RowComponent key={rowKey}>
                     <Td style={{ textAlign: 'center' }}>
                       <DayCell>
-                        {hasDayNumber && <DayNumber>{dayNumber}</DayNumber>}
+                        {showDayNumber && <DayNumber>{dayNumber}</DayNumber>}
                         {weeksDaysToken && <DayBadge>{weeksDaysToken}</DayBadge>}
                       </DayCell>
                     </Td>


### PR DESCRIPTION
## Summary
- alternate the day numbering and week/day token displays every seven schedule rows
- ensure only one of the number or token renders per row to avoid duplicate labels

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd95b7ab7083268e5062fc7b5c1db1