### PR TITLE
Adjust stimulation schedule numbering display and layout

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -351,15 +351,23 @@ export const deriveScheduleDisplayInfo = ({ date, label }) => {
   }
 
   const dayInfo = extractDayPrefix(remainderWithoutToken);
-  let normalizedDayPrefix = '';
   let remainderWithoutDay = remainderWithoutToken;
+  let formattedDayIndicator = '';
   if (dayInfo) {
-    normalizedDayPrefix = dayInfo.raw || `${Math.max(dayInfo.day, 1)}й день`;
     remainderWithoutDay = dayInfo.rest;
+    const safeDayNumber = Math.max(Math.trunc(dayInfo.day), 1);
+    if (safeDayNumber <= 7) {
+      formattedDayIndicator = String(safeDayNumber);
+    } else if ((safeDayNumber - 1) % 7 === 0) {
+      const completedWeeks = Math.floor((safeDayNumber - 1) / 7);
+      formattedDayIndicator = `${completedWeeks}т1д`;
+    } else {
+      formattedDayIndicator = String(safeDayNumber);
+    }
   }
 
   const sanitizedRemainder = sanitizeDescription(remainderWithoutDay);
-  const secondaryLabel = normalizedToken || normalizedDayPrefix || '';
+  const secondaryLabel = normalizedToken || formattedDayIndicator || '';
   const normalizedSecondary = secondaryLabel.trim().toLowerCase();
   const matchesSecondary = candidate =>
     !!candidate && !!normalizedSecondary && candidate.trim().toLowerCase() === normalizedSecondary;
@@ -2030,6 +2038,37 @@ const StimulationSchedule = ({
     return createAlternateShade(baseRowBackgroundColor, 0.02);
   })();
   const scheduleHorizontalPadding = 7;
+  const numberingColumnStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: '0 0 40px',
+    minWidth: '40px',
+    maxWidth: '40px',
+    fontWeight: 600,
+    lineHeight: 1.2,
+    whiteSpace: 'nowrap',
+    fontVariantNumeric: 'tabular-nums',
+  };
+  const dateColumnStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    flex: '0 0 110px',
+    minWidth: '110px',
+    maxWidth: '110px',
+    lineHeight: 1.2,
+  };
+  const contentColumnStyle = {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    minHeight: '2.4em',
+    whiteSpace: 'pre-wrap',
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
+  };
 
   displayItems.forEach((item, index) => {
       const { dateStr, weekday, secondaryLabel, displayLabel, labelValue } =
@@ -2090,32 +2129,14 @@ const StimulationSchedule = ({
         rendered.push(
           <div key={item.key} style={rowStyle}>
             <div style={{ display: 'flex', alignItems: 'stretch', gap: '8px', flex: 1 }}>
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  lineHeight: 1.2,
-                  minHeight: '2.4em',
-                }}
-              >
-                <span>{`${dateStr} ${weekday}`}</span>
-                <span>{secondaryLabel}</span>
+              <div style={numberingColumnStyle}>
+                <span>{secondaryLabel || ' '}</span>
               </div>
-              <div
-                style={{
-                  flex: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  minHeight: '2.4em',
-                  whiteSpace: 'pre-wrap',
-                  overflowWrap: 'anywhere',
-                  wordBreak: 'break-word',
-                }}
-              >
-                {displayLabel}
+              <div style={dateColumnStyle}>
+                <span>{dateStr}</span>
+                <span style={{ opacity: 0.7, fontSize: '0.85em' }}>{weekday}</span>
               </div>
+              <div style={contentColumnStyle}>{displayLabel}</div>
             </div>
             <div
               style={{ display: 'flex', gap: '2px', marginLeft: 'auto', alignItems: 'center' }}
@@ -2153,17 +2174,12 @@ const StimulationSchedule = ({
         rendered.push(
           <div key={item.key} style={rowStyle}>
             <div style={{ display: 'flex', alignItems: 'stretch', gap: '8px', flex: 1 }}>
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  lineHeight: 1.2,
-                  minHeight: '2.4em',
-                }}
-              >
-                <span>{`${dateStr} ${weekday}`}</span>
-                <span>{secondaryLabel}</span>
+              <div style={numberingColumnStyle}>
+                <span>{secondaryLabel || ' '}</span>
+              </div>
+              <div style={dateColumnStyle}>
+                <span>{dateStr}</span>
+                <span style={{ opacity: 0.7, fontSize: '0.85em' }}>{weekday}</span>
               </div>
               {isEditing ? (
                 <input
@@ -2413,24 +2429,16 @@ const StimulationSchedule = ({
                     }
                   }}
                   style={{
-                    flex: 1,
+                    ...contentColumnStyle,
                     alignSelf: 'stretch',
-                    minHeight: '2.4em',
                   }}
                 />
               ) : (
                 <div
                   onClick={() => setEditingKey(item.key)}
                   style={{
+                    ...contentColumnStyle,
                     cursor: 'pointer',
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    minHeight: '2.4em',
-                    whiteSpace: 'pre-wrap',
-                    overflowWrap: 'anywhere',
-                    wordBreak: 'break-word',
                   }}
                 >
                   {displayLabel}


### PR DESCRIPTION
## Summary
- convert derived day prefixes to display days 1-7 plainly and new weeks as Nт1д before continuing with straight numbering
- refactor schedule rows to give numbering, date, and description their own columns with reduced numbering width and a tighter date column

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de3f56c87c83269d9f8cb876c65223