### PR TITLE
Fix medication schedule day indicator toggling logic

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1562,14 +1562,12 @@ const MedicationSchedule = ({
               schedule.rows.forEach((row, index) => {
                 const dayNumber = index + 1;
                 const hasDayNumber = Number.isFinite(dayNumber) && dayNumber > 0;
-                const diff = hasDayNumber ? dayNumber - 1 : 0;
-                const weeks = Math.floor(diff / 7);
-                const days = diff % 7;
-                const blockIndex = Math.floor(diff / 7);
-                const showWeeksDaysToken = hasDayNumber && blockIndex % 2 === 1;
+                const dayOffset = hasDayNumber ? dayNumber - 1 : 0;
+                const showWeeksDaysToken =
+                  hasDayNumber && dayNumber > 7 && dayOffset % 7 === 0;
                 const showDayNumber = hasDayNumber && !showWeeksDaysToken;
                 const weeksDaysToken = showWeeksDaysToken
-                  ? formatWeeksDaysToken(weeks, days)
+                  ? formatWeeksDaysToken(Math.floor(dayOffset / 7), 0)
                   : null;
                 const parsedDate = parseDateString(row.date, baseDate);
                 const formattedDate = formatDateForDisplay(parsedDate);


### PR DESCRIPTION
## Summary
- ensure the medication schedule only replaces day numbers with week/day badges at the start of each new week
- compute the badge token using the consistent `formatWeeksDaysToken` signature

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee5b64d38832685aa77ef3365562e