### PR TITLE
Preserve existing medication schedule when importing clipboard data

### DIFF
--- a/src/components/MedicationSchedule.test.jsx
+++ b/src/components/MedicationSchedule.test.jsx
@@ -1,0 +1,90 @@
+const { TextDecoder, TextEncoder } = require('util');
+
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+
+jest.mock('components/smallCard/actions', () => ({
+  handleChange: jest.fn(),
+  handleSubmit: jest.fn(),
+}));
+
+const { mergeScheduleWithClipboardData } = require('components/MedicationSchedule');
+
+describe('mergeScheduleWithClipboardData', () => {
+  it('preserves existing base medication doses when clipboard starts later', () => {
+    const baseSchedule = {
+      startDate: '2024-01-01',
+      medicationOrder: ['progynova'],
+      medications: {
+        progynova: {
+          issued: 21,
+          displayValue: '',
+          label: 'Прогінова',
+          short: 'PG',
+          plan: 'progynova',
+          startDate: '2024-01-01',
+        },
+      },
+      rows: [
+        { date: '2024-01-01', values: { progynova: 1 } },
+        { date: '2024-01-02', values: { progynova: 1 } },
+        { date: '2024-01-03', values: { progynova: 2 } },
+      ],
+    };
+
+    const clipboardSchedule = {
+      startDate: '2024-01-03',
+      medicationOrder: ['custom-med'],
+      medications: {
+        'custom-med': {
+          issued: 6,
+          displayValue: '',
+          label: 'Custom med',
+          short: 'CM',
+          plan: 'custom',
+          startDate: '2024-01-03',
+        },
+      },
+      rows: [
+        { date: '2024-01-03', values: { 'custom-med': 2 } },
+        { date: '2024-01-04', values: { 'custom-med': 2 } },
+      ],
+    };
+
+    const merged = mergeScheduleWithClipboardData(baseSchedule, clipboardSchedule);
+
+    expect(merged.startDate).toBe('2024-01-01');
+    expect(merged.medicationOrder).toEqual(['progynova', 'custom-med']);
+
+    expect(merged.rows[0]).toMatchObject({
+      date: '2024-01-01',
+      values: { progynova: 1, 'custom-med': '' },
+    });
+
+    expect(merged.rows[1]).toMatchObject({
+      date: '2024-01-02',
+      values: { progynova: 1, 'custom-med': '' },
+    });
+
+    expect(merged.rows[2]).toMatchObject({
+      date: '2024-01-03',
+      values: { progynova: 2, 'custom-med': 2 },
+    });
+
+    expect(merged.rows[3]).toMatchObject({
+      date: '2024-01-04',
+      values: { progynova: '', 'custom-med': 2 },
+    });
+
+    expect(merged.medications.progynova.plan).toBe('progynova');
+    expect(merged.medications['custom-med']).toMatchObject({
+      label: 'Custom med',
+      issued: 6,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add calendar-day utilities and merge logic to align clipboard imports with existing medication schedules
- update clipboard import handling to merge parsed data without shifting pre-existing medication dosages
- add a regression test covering imports that start after the existing schedule to ensure default medications stay in place

## Testing
- npm test -- --watchAll=false --runTestsByPath src/components/MedicationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68df66032f0483269f579d08e5555dd6