### PR TITLE
Fix medication issued input clearing behavior

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -663,10 +663,17 @@ const sanitizeScheduleForStorage = schedule => {
 };
 
 const evaluateIssuedInput = (displayValue, fallbackIssued) => {
-  if (displayValue === null || displayValue === undefined || displayValue === '') {
+  if (displayValue === null || displayValue === undefined) {
     const fallback = Number(fallbackIssued);
     return {
       issued: Number.isFinite(fallback) ? fallback : 0,
+      displayValue: '',
+    };
+  }
+
+  if (displayValue === '') {
+    return {
+      issued: 0,
       displayValue: '',
     };
   }


### PR DESCRIPTION
## Summary
- allow issued medication inputs to be cleared without restoring the previous value
- keep fallback behaviour for null/undefined values while treating empty strings as zero issued amount

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0a75befe083268e2fc4a9eeaaac4c