### PR TITLE
Fix handling of cleared default medication doses

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -604,10 +604,15 @@ const doesMedicationMatchDefaultDistribution = (schedule, key) => {
 
   for (let index = 0; index < rows.length; index += 1) {
     const actual = sanitizeCellValue(rows[index]?.values?.[key]);
+    const expected = sanitizeCellValue(expectedRows[index]?.values?.[key]);
+
     if (actual === '') {
+      if (expected !== '') {
+        return false;
+      }
       continue;
     }
-    const expected = sanitizeCellValue(expectedRows[index]?.values?.[key]);
+
     if (actual !== expected) {
       return false;
     }


### PR DESCRIPTION
## Summary
- update the default distribution comparison to treat cleared cells with non-empty defaults as changes
- ensure sanitized schedules preserve user-cleared medication doses within default ranges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1003b90108326ae67e67598eb8333