### PR TITLE
Update Progynova default dosing sequence

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -476,9 +476,7 @@ const formatDateForDisplay = value => {
   return `${day}.${month}`;
 };
 
-const PROGYNOVA_DOUBLE_DOSE_START_DAY = 3;
-const PROGYNOVA_TEN_WEEKS_DAY = 10 * 7;
-const PROGYNOVA_TAPER_DAYS = 5;
+const PROGYNOVA_MAX_DAY = 10 * 7 + 5;
 const DAYS_IN_WEEK = 7;
 const INJESTA_START_DAY = 14;
 const INJESTA_END_DAY = 12 * DAYS_IN_WEEK;
@@ -487,18 +485,11 @@ const INJESTA_DEFAULT_DAILY_DOSE = 2;
 const PLAN_HANDLERS = {
   progynova: {
     defaultIssued: 21,
-    maxDay: PROGYNOVA_TEN_WEEKS_DAY + PROGYNOVA_TAPER_DAYS,
+    maxDay: PROGYNOVA_MAX_DAY,
     getDailyValue: ({ dayNumber }) => {
       if (!Number.isFinite(dayNumber) || dayNumber <= 0) return '';
-      if (dayNumber === 1 || dayNumber === 2) return 1;
-      if (dayNumber >= PROGYNOVA_DOUBLE_DOSE_START_DAY && dayNumber <= PROGYNOVA_TEN_WEEKS_DAY) return 2;
-      if (
-        dayNumber > PROGYNOVA_TEN_WEEKS_DAY &&
-        dayNumber <= PROGYNOVA_TEN_WEEKS_DAY + PROGYNOVA_TAPER_DAYS
-      ) {
-        return 1;
-      }
-      return '';
+      if (dayNumber > PROGYNOVA_MAX_DAY) return '';
+      return Math.floor(dayNumber / 2);
     },
   },
   metypred: {
@@ -805,17 +796,11 @@ const applyDefaultDistribution = (rows, schedule, options = {}) => {
     const rowDate = parseDateString(row.date, baseDate) || addDays(baseDate, rowIndex);
     const nextValues = { ...row.values };
     const shouldSkipRow = skipExisting && rowIndex < existingLength;
-    const isFirstRow = rowIndex === 0;
 
     medicationKeys.forEach(key => {
       const shouldProcessKey = filteredKeys.includes(key);
 
       if (!shouldProcessKey) {
-        return;
-      }
-
-      if (isFirstRow) {
-        nextValues[key] = '';
         return;
       }
 
@@ -850,8 +835,13 @@ const applyDefaultDistribution = (rows, schedule, options = {}) => {
         used: usageCounters[key],
       });
 
+      if (proposed === '' || proposed === null || proposed === undefined) {
+        nextValues[key] = '';
+        return;
+      }
+
       const numericValue = Number(proposed);
-      if (!Number.isFinite(numericValue) || numericValue <= 0) {
+      if (!Number.isFinite(numericValue) || numericValue < 0) {
         nextValues[key] = '';
         return;
       }

--- a/src/components/MedicationSchedule.test.jsx
+++ b/src/components/MedicationSchedule.test.jsx
@@ -13,7 +13,7 @@ jest.mock('components/smallCard/actions', () => ({
   handleSubmit: jest.fn(),
 }));
 
-const { mergeScheduleWithClipboardData } = require('components/MedicationSchedule');
+const { applyDefaultDistribution, mergeScheduleWithClipboardData } = require('components/MedicationSchedule');
 
 describe('mergeScheduleWithClipboardData', () => {
   it('preserves existing base medication doses when clipboard starts later', () => {
@@ -31,9 +31,9 @@ describe('mergeScheduleWithClipboardData', () => {
         },
       },
       rows: [
-        { date: '2024-01-01', values: { progynova: 1 } },
+        { date: '2024-01-01', values: { progynova: 0 } },
         { date: '2024-01-02', values: { progynova: 1 } },
-        { date: '2024-01-03', values: { progynova: 2 } },
+        { date: '2024-01-03', values: { progynova: 1 } },
       ],
     };
 
@@ -63,7 +63,7 @@ describe('mergeScheduleWithClipboardData', () => {
 
     expect(merged.rows[0]).toMatchObject({
       date: '2024-01-01',
-      values: { progynova: 1, 'custom-med': '' },
+      values: { progynova: 0, 'custom-med': '' },
     });
 
     expect(merged.rows[1]).toMatchObject({
@@ -73,7 +73,7 @@ describe('mergeScheduleWithClipboardData', () => {
 
     expect(merged.rows[2]).toMatchObject({
       date: '2024-01-03',
-      values: { progynova: 2, 'custom-med': 2 },
+      values: { progynova: 1, 'custom-med': 2 },
     });
 
     expect(merged.rows[3]).toMatchObject({
@@ -86,5 +86,27 @@ describe('mergeScheduleWithClipboardData', () => {
       label: 'Custom med',
       issued: 6,
     });
+  });
+});
+
+describe('applyDefaultDistribution', () => {
+  it('generates Progynova defaults starting from zero and escalating every two days', () => {
+    const schedule = {
+      startDate: '2024-01-01',
+      medicationOrder: ['progynova'],
+      medications: {
+        progynova: {
+          issued: 21,
+          plan: 'progynova',
+        },
+      },
+    };
+
+    const rows = Array.from({ length: 6 }, () => ({ values: {} }));
+
+    const distributed = applyDefaultDistribution(rows, schedule);
+    const doses = distributed.slice(0, 6).map(row => row.values.progynova);
+
+    expect(doses).toEqual([0, 1, 1, 2, 2, 3]);
   });
 });


### PR DESCRIPTION
## Summary
- adjust the Progynova plan handler to start at 0 mg and escalate every two days while allowing zero-dose defaults
- let the default distribution keep plan-provided zero values instead of clearing the first day
- refresh MedicationSchedule tests to cover the new progression and ensure existing values persist when merging schedules

## Testing
- `npm test -- MedicationSchedule`


------
https://chatgpt.com/codex/tasks/task_e_68e101ba43d08326b7910de5ce764e66