### PR TITLE
Handle duplicate day-only schedule labels

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -2,6 +2,7 @@ import {
   adjustItemForDate,
   buildCustomEventLabel,
   computeCustomDateAndLabel,
+  deriveScheduleDisplayInfo,
   splitCustomEventEntries,
 } from 'components/StimulationSchedule';
 
@@ -96,6 +97,16 @@ describe('splitCustomEventEntries', () => {
       '16.01 міс',
       '22.01 прийом. Анна теж ок.',
     ]);
+  });
+});
+
+describe('deriveScheduleDisplayInfo', () => {
+  it('hides duplicate day-only description when it matches numeric secondary label', () => {
+    const date = new Date(2024, 6, 6);
+    const result = deriveScheduleDisplayInfo({ date, label: '06.07 сб 2й день' });
+
+    expect(result.secondaryLabel).toBe('2');
+    expect(result.displayLabel).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary
- add a reusable helper to normalize numeric day indicators for stimulation schedule entries
- treat day-only descriptions such as "2й день" as duplicates of the numeric secondary label when deriving display text
- cover the new behaviour with a unit test for deriveScheduleDisplayInfo

## Testing
- npm test -- StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e10501c230832682934fbe861a116d