### PR TITLE
Fix day indicator after first week

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -174,13 +174,6 @@ const extractDayPrefix = value => {
 
 const deriveDayIndicatorFromNumber = day => {
   const safeDayNumber = Math.max(Math.trunc(day), 1);
-  if (safeDayNumber <= 7) {
-    return String(safeDayNumber);
-  }
-  if ((safeDayNumber - 1) % 7 === 0) {
-    const completedWeeks = Math.floor((safeDayNumber - 1) / 7);
-    return `${completedWeeks}т1д`;
-  }
   return String(safeDayNumber);
 };
 

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -108,5 +108,13 @@ describe('deriveScheduleDisplayInfo', () => {
     expect(result.secondaryLabel).toBe('2');
     expect(result.displayLabel).toBe('');
   });
+
+  it('keeps ordinal day indicator after the first week without converting to week tokens', () => {
+    const date = new Date(2024, 9, 29);
+    const result = deriveScheduleDisplayInfo({ date, label: '29.10 вт 8й день' });
+
+    expect(result.secondaryLabel).toBe('8');
+    expect(result.displayLabel).not.toContain('1т1д');
+  });
 });
 


### PR DESCRIPTION
## Summary
- ensure deriveDayIndicatorFromNumber keeps day indicators numeric after the first week
- add a regression test to confirm the 8th day is not converted into a week/day token

## Testing
- npm test -- --runTestsByPath src/components/StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e109a91d18832697a89d02738a44b0