### PR TITLE
Reduce stimulation schedule date column width

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -2057,15 +2057,16 @@ const StimulationSchedule = ({
     return createAlternateShade(baseRowBackgroundColor, 0.02);
   })();
   const scheduleHorizontalPadding = 7;
+  const dateColumnWidth = '55px';
   const dateColumnStyle = {
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'flex-start',
     gap: '2px',
-    flex: '0 0 calc(110px - 1em)',
-    minWidth: 'calc(110px - 1em)',
-    maxWidth: 'calc(110px - 1em)',
+    flex: `0 0 ${dateColumnWidth}`,
+    minWidth: dateColumnWidth,
+    maxWidth: dateColumnWidth,
     lineHeight: 1.2,
   };
   const datePrimaryRowStyle = {


### PR DESCRIPTION
## Summary
- halve the width of the stimulation schedule date column so the date and day stack in a narrower space

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10cc04f288326b106bbf6423bcedf