### PR TITLE
Allow decimal comma input for metypred doses

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -589,7 +589,15 @@ const getPlanMaxDay = plan => {
 
 const sanitizeCellValue = value => {
   if (value === null || value === undefined) return '';
-  if (value === '') return '';
+  if (typeof value === 'string') {
+    const normalized = value.trim().replace(/,/g, '.');
+    if (normalized === '') return '';
+    const numberValue = Number(normalized);
+    return Number.isNaN(numberValue) ? '' : numberValue;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : '';
+  }
   const numberValue = Number(value);
   return Number.isNaN(numberValue) ? '' : numberValue;
 };


### PR DESCRIPTION
## Summary
- normalize cell sanitization to treat comma decimals as valid numbers
- retain validation for invalid inputs while accepting both 0.5 and 0,5 entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10d2d221083269629649292e01cc7