### PR TITLE
Narrow medication schedule day number column

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1811,7 +1811,7 @@ const MedicationSchedule = ({
         <StyledTable>
           <thead>
             <tr>
-              <Th style={{ width: '60px' }}>#</Th>
+              <Th style={{ width: '30px' }}>#</Th>
               <Th style={DATE_COLUMN_STYLE}>Дата</Th>
               {medicationList.map(({ key, short }) => (
                 <MedicationTh key={key}>


### PR DESCRIPTION
## Summary
- reduce the day number column width in the medication schedule table to make it narrower

## Testing
- npm start *(fails: Parsing error: `sanitizeDescription` has already been exported)*

------
https://chatgpt.com/codex/tasks/task_e_68e11041853883268ade88e5d11c7b54