### PR TITLE
Fix duplicate sanitizeDescription export

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -2839,7 +2839,6 @@ const StimulationSchedule = ({
 };
 
 export {
-  sanitizeDescription,
   buildCustomEventLabel,
   computeCustomDateAndLabel,
   splitCustomEventEntries,


### PR DESCRIPTION
## Summary
- remove the redundant sanitizeDescription re-export that conflicted with its original export

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68e11091206c83269f16b9a57d34e5a0