### PR TITLE
Fix pre-cycle stimulation schedule persistence

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -490,6 +490,9 @@ const transferRelativeConfig = {
 
 const PRE_CYCLE_KEYS = new Set(['pre-visit1', 'pre-uzd', 'pre-dipherelin']);
 
+export const hasPreCycleEntries = entries =>
+  Array.isArray(entries) && entries.some(entry => entry && PRE_CYCLE_KEYS.has(entry.key));
+
 const isPreCycleKey = key => PRE_CYCLE_KEYS.has(key);
 
 const isCustomKey = key => typeof key === 'string' && key.startsWith('ap-');
@@ -1376,7 +1379,9 @@ const StimulationSchedule = ({
       const defaultString = baseForDefaults
         ? serializeSchedule(generateSchedule(baseForDefaults))
         : '';
-      const isDefault = Boolean(baseForDefaults) && scheduleString === defaultString;
+      const containsPreCycleEntries = hasPreCycleEntries(Array.isArray(sched) ? sched : []);
+      const isDefault =
+        !containsPreCycleEntries && Boolean(baseForDefaults) && scheduleString === defaultString;
       const update = isDefault
         ? { stimulationSchedule: undefined }
         : { stimulationSchedule: scheduleString };

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -4,7 +4,11 @@ import {
   computeCustomDateAndLabel,
   deriveScheduleDisplayInfo,
   splitCustomEventEntries,
+  generateSchedule,
+  serializeSchedule,
+  hasPreCycleEntries,
 } from 'components/StimulationSchedule';
+import { normalizeScheduleEntries } from 'components/smallCard/fieldLastCycle';
 
 jest.mock('components/smallCard/actions', () => ({
   handleChange: jest.fn(),
@@ -115,6 +119,31 @@ describe('deriveScheduleDisplayInfo', () => {
 
     expect(result.secondaryLabel).toBe('8');
     expect(result.displayLabel).not.toContain('1т1д');
+  });
+});
+
+describe('pre-cycle serialization', () => {
+  it('preserves edited pre-dipherelin labels after normalization and prevents default detection', () => {
+    const baseDate = new Date(2024, 0, 10);
+    const defaultSchedule = generateSchedule(baseDate);
+    const customSchedule = [
+      {
+        key: 'pre-dipherelin',
+        date: new Date(2024, 0, 5),
+        label: '5й день Диферелін Тест',
+      },
+      ...defaultSchedule,
+    ];
+
+    const serialized = serializeSchedule(customSchedule);
+    const normalizedEntries = normalizeScheduleEntries(serialized);
+    expect(hasPreCycleEntries(normalizedEntries)).toBe(true);
+
+    const reserialized = serializeSchedule(normalizedEntries);
+    expect(reserialized).toContain('Диферелін Тест');
+
+    const defaultString = serializeSchedule(defaultSchedule);
+    expect(reserialized).not.toBe(defaultString);
   });
 });
 

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { handleChange, handleSubmit } from './actions';
 import { formatDateToDisplay, formatDateToServer } from 'components/inputValidations';
-import { generateSchedule, serializeSchedule } from '../StimulationSchedule';
+import { generateSchedule, serializeSchedule, hasPreCycleEntries } from '../StimulationSchedule';
 import InfoModal from 'components/InfoModal';
 import { UnderlinedInput, AttentionButton, AttentionDiv, OrangeBtn, color } from 'components/styles';
 
@@ -75,7 +75,7 @@ const isSameDay = (a, b) => {
   return normalizeDate(a).getTime() === normalizeDate(b).getTime();
 };
 
-const normalizeScheduleEntries = schedule => {
+export const normalizeScheduleEntries = schedule => {
   if (!schedule) return [];
   if (Array.isArray(schedule)) {
     const today = normalizeDate(new Date());
@@ -147,7 +147,11 @@ const isDefaultSchedule = (lastCycle, scheduleString) => {
   const baseDate = parseDate(lastCycle);
   if (!baseDate) return false;
   const defaultString = serializeSchedule(generateSchedule(baseDate));
-  const normalized = serializeSchedule(normalizeScheduleEntries(scheduleString));
+  const normalizedEntries = normalizeScheduleEntries(scheduleString);
+  if (hasPreCycleEntries(normalizedEntries)) {
+    return false;
+  }
+  const normalized = serializeSchedule(normalizedEntries);
   return defaultString === normalized;
 };
 


### PR DESCRIPTION
## Summary
- ensure schedules containing pre-cycle entries are always persisted instead of treated as defaults
- mirror the pre-cycle detection logic in the last cycle field helper and expose its normalizer for reuse
- add regression coverage proving pre-dipherelin edits survive serialization/normalization round-trips

## Testing
- npm test -- StimulationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e18a0ce6bc8326bec6b22ef06170b2