### PR TITLE
Color medication remaining totals by sign

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -69,6 +69,21 @@ const IssuedStats = styled.span`
   color: #666;
 `;
 
+const RemainingValue = styled.span`
+  color: ${props => {
+    if (props.$negative) {
+      return '#d1433f';
+    }
+
+    if (props.$positive) {
+      return '#1a7f37';
+    }
+
+    return 'inherit';
+  }};
+  font-weight: 500;
+`;
+
 const FormulaHint = styled.span`
   font-size: 12px;
   color: #888;
@@ -1850,7 +1865,13 @@ const MedicationSchedule = ({
                   placeholder={placeholderText}
                 />
                 <IssuedStats>
-                  Видано: {formatNumber(issued)} • Використано: {formatNumber(stats.used)} • Залишок: {formatNumber(stats.remaining)}
+                  Видано: {formatNumber(issued)} • Використано: {formatNumber(stats.used)} • Залишок:{' '}
+                  <RemainingValue
+                    $negative={stats.remaining < 0}
+                    $positive={stats.remaining > 0}
+                  >
+                    {formatNumber(stats.remaining)}
+                  </RemainingValue>
                 </IssuedStats>
               </IssuedRowHeader>
               {showFormula && displayValue && (


### PR DESCRIPTION
## Summary
- add a styled RemainingValue component to highlight remaining stock counts
- show negative balances in red and positive balances in green while keeping zero neutral

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18e96e1808326a172532c3e73ae03