### PR TITLE
Remove medication fill button and simplify delete label

### DIFF
--- a/src/components/MedicationsPage.jsx
+++ b/src/components/MedicationsPage.jsx
@@ -77,27 +77,6 @@ const CopyButton = styled.button`
   }
 `;
 
-const FillScheduleButton = styled.button`
-  padding: 6px 12px;
-  border-radius: 6px;
-  border: none;
-  background-color: #ffb347;
-  color: white;
-  cursor: pointer;
-  font-size: 14px;
-  margin-left: auto;
-  transition: background-color 0.2s ease;
-
-  &:hover:not(:disabled) {
-    background-color: #ff9a1a;
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-`;
-
 const TitleBlock = styled.div`
   display: flex;
   flex-direction: column;
@@ -123,6 +102,7 @@ const DeleteButton = styled.button`
   color: white;
   cursor: pointer;
   font-size: 14px;
+  margin-left: auto;
   transition: background-color 0.2s ease;
 
   &:hover:not(:disabled) {
@@ -163,8 +143,6 @@ const MedicationsPage = () => {
   const [isScheduleLoading, setIsScheduleLoading] = useState(true);
   const ownerId = useMemo(() => localStorage.getItem('ownerId'), []);
   const saveTimeoutRef = useRef(null);
-  const resetDistributionHandlerRef = useRef(null);
-  const [hasResetDistribution, setHasResetDistribution] = useState(false);
 
   const hasScheduleData = useMemo(
     () =>
@@ -331,17 +309,6 @@ const MedicationsPage = () => {
     }
   }, [hasScheduleData, schedule]);
 
-  const handleResetDistributionHandlerChange = useCallback(handler => {
-    resetDistributionHandlerRef.current = handler;
-    setHasResetDistribution(typeof handler === 'function');
-  }, []);
-
-  const handleResetDistributionClick = useCallback(() => {
-    if (typeof resetDistributionHandlerRef.current === 'function') {
-      resetDistributionHandlerRef.current();
-    }
-  }, []);
-
   const handleDelete = useCallback(async () => {
     if (!ownerId || !userId) {
       toast.error('Не вдалося визначити користувача для видалення ліків');
@@ -412,19 +379,12 @@ const MedicationsPage = () => {
           >
             <FiCopy size={18} />
           </CopyButton>
-          <FillScheduleButton
-            type="button"
-            onClick={handleResetDistributionClick}
-            disabled={!hasResetDistribution || isScheduleLoading}
-          >
-            Заповнити за графіком
-          </FillScheduleButton>
           <DeleteButton
             type="button"
             onClick={handleDelete}
             disabled={!ownerId || !userId || isScheduleLoading}
           >
-            Видалити весь графік прийому ліків
+            Видалити
           </DeleteButton>
         </ButtonRow>
         <TitleBlock>
@@ -449,7 +409,6 @@ const MedicationsPage = () => {
           onChange={handleScheduleChange}
           cycleStart={user?.lastCycle}
           stimulationSchedule={user?.stimulationSchedule}
-          onResetDistributionChange={handleResetDistributionHandlerChange}
         />
       )}
     </PageContainer>


### PR DESCRIPTION
## Summary
- remove the "Заповнити за графіком" control from the medications page header
- rename the delete schedule action to the shorter "Видалити" label and keep it right-aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19249927c8326bc8c65cd4d76e5a5