### PR TITLE
Add default 'Прийом' suffix to stimulation schedule visits

### DIFF
--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -3,6 +3,7 @@ import {
   buildCustomEventLabel,
   computeCustomDateAndLabel,
   deriveScheduleDisplayInfo,
+  generateSchedule,
   splitCustomEventEntries,
 } from 'components/StimulationSchedule';
 
@@ -47,6 +48,40 @@ describe('adjustItemForDate', () => {
     });
 
     expect(adjusted.label).toBe('21т6д контроль');
+  });
+
+  it('restores default visit description for visits after the first before transfer', () => {
+    const baseDate = new Date(2024, 3, 1);
+    const transferDate = new Date(2024, 3, 20);
+    const visitThree = {
+      key: 'visit3',
+      date: new Date(baseDate),
+      label: '7й день',
+    };
+
+    const targetDate = new Date(baseDate);
+    targetDate.setDate(baseDate.getDate() + 6);
+
+    const adjusted = adjustItemForDate(visitThree, targetDate, {
+      baseDate,
+      transferDate,
+    });
+
+    expect(adjusted.label).toBe('7й день Прийом');
+  });
+});
+
+describe('generateSchedule', () => {
+  it('adds default description to visits after the first', () => {
+    const baseDate = new Date(2024, 4, 10);
+    const schedule = generateSchedule(baseDate);
+    const visit2 = schedule.find(item => item.key === 'visit2');
+    const visit3 = schedule.find(item => item.key === 'visit3');
+    const visit4 = schedule.find(item => item.key === 'visit4');
+
+    expect(visit2.label).toContain('Прийом');
+    expect(visit3.label.endsWith('Прийом')).toBe(true);
+    expect(visit4.label.endsWith('Прийом')).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/stimulationScheduleSort.test.js
+++ b/src/utils/__tests__/stimulationScheduleSort.test.js
@@ -9,7 +9,7 @@ describe('stimulationScheduleSort utilities', () => {
   it('parses string schedules and marks descriptive events', () => {
     const schedule = [
       '2024-07-01\tvisit1\t01.07 пн',
-      '2024-07-10\tvisit2\t10.07 ср 6т2д',
+      '2024-07-10\tvisit2\t10.07 ср 6т2д Прийом',
       '2024-07-15\ttransfer\t15.07 пн перенос',
     ].join('\n');
 
@@ -26,7 +26,7 @@ describe('stimulationScheduleSort utilities', () => {
   it('computes sort info with beacon and next events', () => {
     const schedule = [
       '2024-07-01\tvisit1\t01.07 пн',
-      '2024-07-10\tvisit2\t10.07 ср 6т2д',
+      '2024-07-10\tvisit2\t10.07 ср 6т2д Прийом',
     ].join('\n');
 
     const info = getStimulationScheduleSortInfo(schedule, {
@@ -47,20 +47,20 @@ describe('stimulationScheduleSort utilities', () => {
         userId: 'b',
         stimulationSchedule: [
           '2024-07-06\tvisit1\t06.07 сб',
-          '2024-07-08\tvisit2\t08.07 пн',
+          '2024-07-08\tvisit2\t08.07 пн Прийом',
         ].join('\n'),
       },
       {
         userId: 'a',
         stimulationSchedule: [
           '2024-07-06\tvisit1\t06.07 сб 2й день',
-          '2024-07-12\tvisit2\t12.07 пт',
+          '2024-07-12\tvisit2\t12.07 пт Прийом',
         ].join('\n'),
       },
       {
         userId: 'c',
         stimulationSchedule: [
-          { date: '2024-07-09', label: '09.07 вт 3й день' },
+          { date: '2024-07-09', label: '09.07 вт 3й день Прийом' },
           { date: '2024-07-15', label: '15.07 пн' },
         ],
       },
@@ -73,12 +73,12 @@ describe('stimulationScheduleSort utilities', () => {
     });
 
     const order = annotated.map(item => item.user.userId);
-    expect(order).toEqual(['a', 'c', 'b']);
+    expect(order).toEqual(['a', 'b', 'c']);
 
     const infoA = annotated[0].sortInfo;
-    const infoB = annotated[2].sortInfo;
+    const infoC = annotated[2].sortInfo;
     expect(
-      compareStimulationScheduleSortInfo(infoA, infoB) < 0,
+      compareStimulationScheduleSortInfo(infoA, infoC) < 0,
     ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- introduce a shared default suffix for pre-transfer visits and use it in generated schedules
- ensure visit adjustments restore the default description when cleared and cover the behavior with tests
- update sorting utilities tests to expect the default visit description

## Testing
- npm test -- --runTestsByPath src/components/StimulationSchedule.test.jsx src/utils/__tests__/stimulationScheduleSort.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e25112f9b0832692c0ebeae706c67c