### PR TITLE
Sanitize stimulation comments before rendering

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1362,7 +1362,7 @@ const parseStimulationEvents = (stimulationSchedule, startDate) => {
     }
 
     const descriptionParts = [info.secondaryLabel, info.displayLabel].filter(Boolean);
-    const description = descriptionParts.join(' • ') || info.labelValue || '';
+    const description = descriptionParts.join(' • ') || sanitizedRawLabel || '';
     const iso = formatISODate(date);
 
     events.push({
@@ -1372,7 +1372,7 @@ const parseStimulationEvents = (stimulationSchedule, startDate) => {
       dayMonth: formatDateForDisplay(date),
       secondaryLabel: info.secondaryLabel || '',
       displayLabel: info.displayLabel || '',
-      labelValue: info.labelValue || '',
+      labelValue: sanitizedRawLabel,
       description,
       hasExplicitYear: containsYearInfo(rawDate),
     });


### PR DESCRIPTION
## Summary
- ensure medication schedule descriptions fall back to a date-free version of stimulation comments
- reuse the sanitized text when no derived description is present

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e2e7d072108326a4d9c272e585c8b9