### PR TITLE
Allow fractional issued amounts for custom medications

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1658,7 +1658,8 @@ const MedicationSchedule = ({
     const fallbackShort = deriveShortLabel(label);
     const normalizedShort = (shortInput || fallbackShort || label.slice(0, 2)).toUpperCase();
     const issuedRaw = Number(newMedicationDraft.issued);
-    const issued = Number.isFinite(issuedRaw) && issuedRaw > 0 ? Math.floor(issuedRaw) : 0;
+    const issued =
+      Number.isFinite(issuedRaw) && issuedRaw > 0 ? Number(issuedRaw.toFixed(2)) : 0;
 
     updateSchedule(prev => {
       if (!prev) return prev;
@@ -1862,7 +1863,7 @@ const MedicationSchedule = ({
           <AddMedicationInput
             type="number"
             min="0"
-            step="1"
+            step="0.01"
             placeholder="Видано"
             value={newMedicationDraft.issued}
             onChange={event => handleNewMedicationDraftChange('issued', event.target.value)}


### PR DESCRIPTION
## Summary
- preserve decimal precision when creating custom medication schedules so fractional issued amounts are retained
- allow entering fractional issued values in the custom medication form by relaxing the input step constraint

## Testing
- npm test -- MedicationSchedule.test.jsx --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e38ebbc7588326b17d72573331372e