### PR TITLE
Ensure medication schedule renders default stimulation events

### DIFF
--- a/src/components/MedicationSchedule.test.jsx
+++ b/src/components/MedicationSchedule.test.jsx
@@ -16,6 +16,8 @@ jest.mock('components/smallCard/actions', () => ({
 const {
   applyDefaultDistribution,
   mergeScheduleWithClipboardData,
+  buildStimulationEventLookup,
+  cleanMedicationEventComment,
 } = require('components/MedicationSchedule');
 
 const buildRows = (count, medicationKey) =>
@@ -148,5 +150,22 @@ describe('mergeScheduleWithClipboardData', () => {
       label: 'Custom med',
       issued: 6,
     });
+  });
+});
+
+describe('buildStimulationEventLookup', () => {
+  it('uses generated defaults when stimulation schedule is missing', () => {
+    const baseDate = '2024-02-05';
+
+    const lookup = buildStimulationEventLookup(undefined, baseDate, {
+      fallbackBaseDate: baseDate,
+    });
+
+    expect(lookup.events.length).toBeGreaterThan(0);
+
+    const [firstEvent] = lookup.events;
+
+    const comment = cleanMedicationEventComment(firstEvent);
+    expect(comment).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- generate stimulation events from the default template when a profile has no custom schedule stored
- expose the lookup helper and cover the fallback behaviour with a dedicated test

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e404bff8588326a221ff5e250d564c