### PR TITLE
Fix medication schedule event descriptions

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1368,7 +1368,13 @@ const parseStimulationEvents = (stimulationSchedule, startDate, options = {}) =>
       return;
     }
 
-    const descriptionParts = [info.secondaryLabel, info.displayLabel].filter(Boolean);
+    const descriptionParts = [];
+    if (trimmedDisplayLabel) {
+      descriptionParts.push(trimmedDisplayLabel);
+    } else if (meaningfulRemainder) {
+      descriptionParts.push(meaningfulRemainder);
+    }
+
     const description = descriptionParts.join(' • ') || info.labelValue || '';
     const iso = formatISODate(date);
 

--- a/src/components/MedicationSchedule.test.jsx
+++ b/src/components/MedicationSchedule.test.jsx
@@ -168,4 +168,21 @@ describe('buildStimulationEventLookup', () => {
     const comment = cleanMedicationEventComment(firstEvent);
     expect(comment).toBeTruthy();
   });
+
+  it('omits cycle day prefixes from stimulation event descriptions', () => {
+    const stimulationSchedule = [
+      { date: '2024-03-01', label: '01.03 пт 12й день УЗД' },
+      { date: '2024-03-05', label: '05.03 вт 24й день Контроль' },
+    ];
+
+    const lookup = buildStimulationEventLookup(stimulationSchedule, '2024-02-20');
+
+    expect(lookup.events).toHaveLength(2);
+
+    const descriptions = lookup.events.map(event => event.description);
+    expect(descriptions).toEqual(['УЗД', 'Контроль']);
+
+    const secondaryLabels = lookup.events.map(event => event.secondaryLabel);
+    expect(secondaryLabels).toEqual(['12', '24']);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent cycle day prefixes from being included in medication schedule event descriptions
- cover the behaviour with a targeted test for stimulation event parsing

## Testing
- CI=true npm test -- MedicationSchedule

------
https://chatgpt.com/codex/tasks/task_e_68e4047ef288832690bd26fd28a4b2c6