### PR TITLE
Fix numeric day prefix stripping for medication event comments

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1499,13 +1499,26 @@ const stripPrefixOnce = (text, prefix) => {
     return null;
   }
 
-  const nextChar = normalizedText.slice(normalizedPrefix.length).charAt(0);
-  if (nextChar && !/[\s•.,;:!?()\-–—]/.test(nextChar)) {
+  const remainderSlice = normalizedText.slice(normalizedPrefix.length);
+  const nextChar = remainderSlice.charAt(0);
+  const prefixIsNumeric = /^\d+$/.test(normalizedPrefix);
+
+  if (!prefixIsNumeric && nextChar && !/[\s•.,;:!?()\-–—]/.test(nextChar)) {
     return null;
   }
 
-  const remainder = stripLeadingDelimiters(normalizedText.slice(normalizedPrefix.length));
-  return remainder;
+  let remainder = remainderSlice;
+
+  if (prefixIsNumeric) {
+    const dayPrefixMatch = remainder.match(/^(?:\s*[-–—]?\s*)(?:й|ий)(?:\s*день)?/i);
+    if (dayPrefixMatch) {
+      remainder = remainder.slice(dayPrefixMatch[0].length);
+    } else if (nextChar && !/[\s•.,;:!?()\-–—]/.test(nextChar)) {
+      return null;
+    }
+  }
+
+  return stripLeadingDelimiters(remainder);
 };
 
 const cleanMedicationEventComment = event => {

--- a/src/components/MedicationSchedule.test.jsx
+++ b/src/components/MedicationSchedule.test.jsx
@@ -169,3 +169,32 @@ describe('buildStimulationEventLookup', () => {
     expect(comment).toBeTruthy();
   });
 });
+
+describe('cleanMedicationEventComment', () => {
+  it('removes numeric day prefixes with "й день" wording', () => {
+    const event = {
+      labelValue: '24й день Прийом',
+      secondaryLabel: '24',
+    };
+
+    expect(cleanMedicationEventComment(event)).toBe('Прийом');
+  });
+
+  it('removes numeric day prefixes with hyphenated wording', () => {
+    const event = {
+      labelValue: '12-й день контроль',
+      secondaryLabel: '12',
+    };
+
+    expect(cleanMedicationEventComment(event)).toBe('контроль');
+  });
+
+  it('keeps existing behaviour for week/day tokens', () => {
+    const event = {
+      labelValue: '8т6д УЗД',
+      secondaryLabel: '8т6д',
+    };
+
+    expect(cleanMedicationEventComment(event)).toBe('УЗД');
+  });
+});


### PR DESCRIPTION
## Summary
- handle numeric day prefixes such as "24й день" when deriving medication schedule event comments
- extend unit tests to cover hyphenated prefixes and ensure week/day tokens continue to be stripped correctly

## Testing
- npm test -- --runTestsByPath src/components/MedicationSchedule.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e40c35343883269c2c36e75e41ef61