### PR TITLE
Fix medication schedule cell updates

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1865,17 +1865,17 @@ const MedicationSchedule = ({
 
   const handleCellChange = useCallback((rowIndex, key, rawValue) => {
     updateSchedule(prev => {
+      const sanitized = sanitizeCellValue(rawValue);
       const rows = prev.rows.map((row, index) => {
-        if (index < rowIndex) {
+        if (index !== rowIndex) {
           return row;
         }
-        const nextValues = { ...row.values };
-        const sanitized = sanitizeCellValue(rawValue);
-        if (index === rowIndex) {
-          nextValues[key] = sanitized;
-        } else {
-          nextValues[key] = sanitized;
-        }
+
+        const nextValues = {
+          ...(row.values || {}),
+          [key]: sanitized,
+        };
+
         return {
           ...row,
           values: nextValues,


### PR DESCRIPTION
## Summary
- stop propagating medication cell edits to all following days
- ensure manual edits only affect the selected day when updating a dose

## Testing
- npm test -- MedicationSchedule.test.jsx --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e41d4c94b083268fe3411f709f0da9