### PR TITLE
Preserve medication doses when issued quantity changes

### DIFF
--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -1683,22 +1683,24 @@ const MedicationSchedule = ({
         const medicationOrder = Array.isArray(prev.medicationOrder) ? prev.medicationOrder : [];
         const minRows = calculateRequiredRows(medicationOrder, medications, prev.rows.length);
         const baseRows = ensureRowsLength(prev.rows, minRows, prev.startDate, medicationOrder);
-        const clearedRows = baseRows.map(row => ({
-          ...row,
-          values: {
-            ...row.values,
-            [key]: '',
-          },
-        }));
         const scheduleWithMedication = {
           ...prev,
           medications,
           medicationOrder,
         };
-        const rows =
-          issued > 0
-            ? applyDefaultDistribution(clearedRows, scheduleWithMedication, { onlyKeys: [key] })
-            : clearedRows;
+        let rows;
+
+        if (issued > 0) {
+          rows = applyDefaultDistribution(baseRows, scheduleWithMedication, { onlyKeys: [key] });
+        } else {
+          rows = baseRows.map(row => ({
+            ...row,
+            values: {
+              ...row.values,
+              [key]: '',
+            },
+          }));
+        }
 
         return {
           ...scheduleWithMedication,


### PR DESCRIPTION
## Summary
- stop clearing existing medication dose values when editing the issued amount
- reuse the existing grid rows when reapplying default distribution so manual doses stay intact
- clear column values only when the issued amount is reduced to zero

## Testing
- CI=1 npm test -- MedicationSchedule

------
https://chatgpt.com/codex/tasks/task_e_68e4dd8d01e8832680329ffc6c79b544