### PR TITLE
Fix stimulation schedule display order

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -2063,7 +2063,12 @@ const StimulationSchedule = ({
     null;
   const pregnancyTransferDate = transferSource ? normalizeDate(transferSource) : null;
 
-  const filtered = schedule.filter(item => item.date);
+  const filtered = schedule
+    .filter(item => item.date)
+    .sort((a, b) => {
+      if (!a?.date || !b?.date) return 0;
+      return a.date - b.date;
+    });
   if (!filtered.some(item => item.date.getTime() === today)) {
     const baseForDiff = (() => {
       if (!resolvedBaseDate) return null;


### PR DESCRIPTION
## Summary
- ensure the rendered stimulation schedule is sorted by event date to keep chronological order

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e619d7d458832688c4e04b27181281