### PR TITLE
Fix early transfer event prefixes to use day labels

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -204,6 +204,14 @@ const getWeeksDaysTokenForDate = (date, reference) => {
 
 const DAY_PREFIX_TRANSFER_WINDOW_DAYS = 30;
 
+const TRANSFER_DAY_KEYWORDS = [
+  'перенос',
+  'хгч',
+  'оновити ліки',
+  'узд',
+  'підтвердження вагітності',
+];
+
 const getSchedulePrefixForDate = (date, baseDate, transferDate) => {
   if (!date) return '';
 
@@ -350,14 +358,26 @@ export const deriveScheduleDisplayInfo = ({ date, label }) => {
   const tokenInfo = extractWeeksDaysPrefix(remainder);
   let normalizedToken = '';
   let remainderWithoutToken = remainder;
+  let tokenDerivedDayIndicator = '';
   if (tokenInfo) {
     normalizedToken = tokenInfo.normalized;
     remainderWithoutToken = remainder.slice(tokenInfo.length).trim();
+
+    const tokenDayNumber = tokenInfo.weeks * 7 + tokenInfo.days + 1;
+    const remainderLower = remainderWithoutToken.toLowerCase();
+    const matchesTransferKeyword = TRANSFER_DAY_KEYWORDS.some(keyword =>
+      remainderLower.includes(keyword),
+    );
+
+    if (matchesTransferKeyword && tokenDayNumber <= DAY_PREFIX_TRANSFER_WINDOW_DAYS) {
+      tokenDerivedDayIndicator = deriveDayIndicatorFromNumber(tokenDayNumber);
+      normalizedToken = '';
+    }
   }
 
   const dayInfo = extractDayPrefix(remainderWithoutToken);
   let remainderWithoutDay = remainderWithoutToken;
-  let formattedDayIndicator = '';
+  let formattedDayIndicator = tokenDerivedDayIndicator;
   if (dayInfo) {
     remainderWithoutDay = dayInfo.rest;
     formattedDayIndicator = deriveDayIndicatorFromNumber(dayInfo.day);

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -151,5 +151,21 @@ describe('deriveScheduleDisplayInfo', () => {
     expect(result.secondaryLabel).toBe('8');
     expect(result.displayLabel).not.toContain('1т1д');
   });
+
+  it('converts early transfer-related week tokens into day indicators for display', () => {
+    const date = new Date(2024, 0, 20);
+    const result = deriveScheduleDisplayInfo({ date, label: '2т3д Перенос' });
+
+    expect(result.secondaryLabel).toBe('17');
+    expect(result.displayLabel).toBe('Перенос');
+  });
+
+  it('preserves transfer-related week tokens once they exceed the day-prefix window', () => {
+    const date = new Date(2024, 1, 25);
+    const result = deriveScheduleDisplayInfo({ date, label: '5т6д Перенос' });
+
+    expect(result.secondaryLabel).toBe('5т6д');
+    expect(result.displayLabel).toBe('Перенос');
+  });
 });
 


### PR DESCRIPTION
## Summary
- normalize week tokens for transfer-related events to day indicators within the first 30 days
- cover the new formatting behaviour with unit tests for deriveScheduleDisplayInfo

## Testing
- npm test -- StimulationSchedule --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e63e08c064832683995a57270b486d