### PR TITLE
Fix clipboard medication import without line breaks

### DIFF
--- a/src/utils/__tests__/medicationClipboard.test.js
+++ b/src/utils/__tests__/medicationClipboard.test.js
@@ -1,0 +1,23 @@
+const { parseMedicationClipboardData } = require('utils/medicationClipboard');
+
+describe('parseMedicationClipboardData', () => {
+  const scheduleText = [
+    'Аспірин кардіо, 31.10.2025 1+1 30.10.2025 14',
+    'Фолієва кислота, 30.10.2025 1 30.10.2025 25',
+    'Метипред, 02.11.2025 1+1+1+1 30.10.2025 30',
+    'Прогінова, 31.10.2025 1+1 30.10.2025 21',
+  ].join('\n');
+
+  it('restores all medications from multiline clipboard text', () => {
+    const parsed = parseMedicationClipboardData(scheduleText);
+    expect(parsed).not.toBeNull();
+    expect(parsed.medicationOrder).toEqual(['aspirin', 'folicAcid', 'metypred', 'progynova']);
+  });
+
+  it('restores all medications when line breaks are lost during paste', () => {
+    const singleLine = scheduleText.replace(/\n/g, ' ');
+    const parsed = parseMedicationClipboardData(singleLine);
+    expect(parsed).not.toBeNull();
+    expect(parsed.medicationOrder).toEqual(['aspirin', 'folicAcid', 'metypred', 'progynova']);
+  });
+});

--- a/src/utils/medicationClipboard.js
+++ b/src/utils/medicationClipboard.js
@@ -8,9 +8,10 @@ import {
 const DATE_PATTERN = /(\d{1,2}[./-]\d{1,2}[./-]\d{2,4})/g;
 const DATE_SOURCE_PATTERN = '\\d{1,2}[./-]\\d{1,2}[./-]\\d{2,4}';
 const SINGLE_LINE_ENTRY_BOUNDARY = new RegExp(
-  `(${DATE_SOURCE_PATTERN})\\s+(\\d+(?:[.,]\\d+)?)[ \\t]+(?=[^,]+,\\s*${DATE_SOURCE_PATTERN})`,
+  `(${DATE_SOURCE_PATTERN})\\s+(\\d+(?:[.,]\\d+)?)[ \\t]+(?=\\s*[^\\d,][^,]*,\\s*${DATE_SOURCE_PATTERN})`,
   'g',
 );
+const TRAILING_DATE_PATTERN = new RegExp(DATE_SOURCE_PATTERN);
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const parseISODate = isoString => {
@@ -261,6 +262,13 @@ const parseClipboardLine = line => {
   const issued = Number(issuedMatch[0].replace(',', '.'));
   if (!Number.isFinite(issued)) {
     return null;
+  }
+
+  const trailing = afterStart.slice(issuedMatch[0].length).trim();
+  if (trailing) {
+    if (TRAILING_DATE_PATTERN.test(trailing) || trailing.includes(',')) {
+      return null;
+    }
   }
 
   const doseTokens = dosesPart.split('+').map(token => token.trim()).filter(Boolean);


### PR DESCRIPTION
## Summary
- ensure the medication clipboard parser detects trailing data and reprocesses single-line input
- add regression tests for restoring medication schedules when pasted with or without preserved line breaks

## Testing
- CI=true npm test -- --runTestsByPath src/utils/__tests__/medicationClipboard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e63c3729288326a65deb9eb6088ae6