### PR TITLE
Adjust pregnancy token display to keep day prefix before day 30

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -204,6 +204,22 @@ const getWeeksDaysTokenForDate = (date, reference) => {
 
 const DAY_PREFIX_TRANSFER_WINDOW_DAYS = 30;
 
+export const shouldUsePregnancyToken = (itemDate, transferDate) => {
+  if (!itemDate || !transferDate) return false;
+
+  const normalizedItem = normalizeDate(itemDate);
+  const normalizedTransfer = normalizeDate(transferDate);
+
+  if (normalizedItem.getTime() < normalizedTransfer.getTime()) {
+    return false;
+  }
+
+  const diffMs = normalizedItem.getTime() - normalizedTransfer.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  return diffDays > DAY_PREFIX_TRANSFER_WINDOW_DAYS;
+};
+
 const getSchedulePrefixForDate = (date, baseDate, transferDate) => {
   if (!date) return '';
 
@@ -2198,12 +2214,15 @@ const StimulationSchedule = ({
           label: item.label,
         });
       const pregnancyToken = (() => {
-        if (!pregnancyBaseDate || !pregnancyTransferDate) return '';
-        if (!item.date) return '';
-        const normalizedItemDate = normalizeDate(item.date);
-        if (normalizedItemDate.getTime() < pregnancyTransferDate.getTime()) {
+        if (
+          !pregnancyBaseDate ||
+          !pregnancyTransferDate ||
+          !item.date ||
+          !shouldUsePregnancyToken(item.date, pregnancyTransferDate)
+        ) {
           return '';
         }
+        const normalizedItemDate = normalizeDate(item.date);
         const tokenInfo = getWeeksDaysTokenForDate(normalizedItemDate, pregnancyBaseDate);
         return tokenInfo?.token || '';
       })();

--- a/src/components/StimulationSchedule.test.jsx
+++ b/src/components/StimulationSchedule.test.jsx
@@ -4,6 +4,7 @@ import {
   computeCustomDateAndLabel,
   deriveScheduleDisplayInfo,
   generateSchedule,
+  shouldUsePregnancyToken,
   splitCustomEventEntries,
 } from 'components/StimulationSchedule';
 
@@ -150,6 +151,24 @@ describe('deriveScheduleDisplayInfo', () => {
 
     expect(result.secondaryLabel).toBe('8');
     expect(result.displayLabel).not.toContain('1т1д');
+  });
+});
+
+describe('shouldUsePregnancyToken', () => {
+  it('returns false for events within thirty days after transfer', () => {
+    const transfer = new Date(2024, 0, 10);
+    const hcg = new Date(transfer);
+    hcg.setDate(hcg.getDate() + 12);
+
+    expect(shouldUsePregnancyToken(hcg, transfer)).toBe(false);
+  });
+
+  it('returns true once more than thirty days have passed after transfer', () => {
+    const transfer = new Date(2024, 0, 10);
+    const followUp = new Date(transfer);
+    followUp.setDate(followUp.getDate() + 31);
+
+    expect(shouldUsePregnancyToken(followUp, transfer)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a helper to detect when pregnancy week tokens should be shown after transfer
- ensure schedule rows keep the numeric day prefix for the first 30 days post-transfer
- cover the new behaviour with unit tests for the helper

## Testing
- npm test -- StimulationSchedule

------
https://chatgpt.com/codex/tasks/task_e_68e6560142f08326b797466e7e0df3b0