### PR TITLE
Adjust medication update event to track transfer date

### DIFF
--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1791,9 +1791,18 @@ const StimulationSchedule = ({
 
       const hcgIndex = next.findIndex(entry => entry.key === 'hcg');
       if (hcgIndex !== -1) {
-        const hcgTarget = new Date(normalizedTransfer);
-        hcgTarget.setDate(hcgTarget.getDate() + 11);
-        updateWithTarget(hcgIndex, hcgTarget);
+        const hcgTarget = computeDateFromTransferDay(12, normalizedTransfer, baseForState);
+        if (hcgTarget) {
+          updateWithTarget(hcgIndex, hcgTarget);
+        }
+      }
+
+      const medsIndex = next.findIndex(entry => entry.key === 'meds');
+      if (medsIndex !== -1) {
+        const medsTarget = computeDateFromTransferDay(15, normalizedTransfer, baseForState);
+        if (medsTarget) {
+          updateWithTarget(medsIndex, medsTarget);
+        }
       }
 
       const usIndex = next.findIndex(entry => entry.key === 'us');


### PR DESCRIPTION
## Summary
- update transfer-dependent schedule recalculation to reuse the shared transfer-day helper for HCG
- ensure the medication update event shifts with the transfer date by scheduling it three days after HCG

## Testing
- CI=1 npm test -- StimulationSchedule

------
https://chatgpt.com/codex/tasks/task_e_68e6623620ac8326ad84ff45905d5d52