### PR TITLE
Support chunked searchKey index rebuild with result reporting and UI feedback

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2594,10 +2594,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const makeIndex = async () => {
     toast.loading('Rebuilding searchKey index 0%', { id: 'index-progress' });
-    await rebuildSearchKeyIndexForCollections(['newUsers', 'users'], progress => {
-      toast.loading(`Rebuilding searchKey index ${progress}%`, { id: 'index-progress' });
-    });
-    toast.success('searchKey index rebuilt', { id: 'index-progress' });
+    const chunkSize = 20;
+    const result = await rebuildSearchKeyIndexForCollections(
+      ['newUsers', 'users'],
+      progress => {
+        toast.loading(`Rebuilding searchKey index ${progress}%`, { id: 'index-progress' });
+      },
+      { chunkSize },
+    );
+    const processedUsers = result?.processedUsers || 0;
+    const indexedPaths = result?.indexedPaths || 0;
+    toast.success(
+      `searchKey index rebuilt: users ${processedUsers}, records ${indexedPaths}, chunk ${chunkSize}`,
+      { id: 'index-progress' },
+    );
+    console.log('[AddNewProfile] searchKey index rebuild result', result);
 
     // const res = await fetchListOfUsers();
     // res.forEach(async userId => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2796,16 +2796,28 @@ export const createSearchIdsInCollection = async (collection, onProgress) => {
   }
 };
 
-export const rebuildSearchKeyIndexForCollections = async (collections = ['newUsers', 'users'], onProgress) => {
+export const rebuildSearchKeyIndexForCollections = async (
+  collections = ['newUsers', 'users'],
+  onProgress,
+  options = {},
+) => {
+  const chunkSizeRaw = Number(options?.chunkSize);
+  const chunkSize = Number.isFinite(chunkSizeRaw) && chunkSizeRaw > 0 ? Math.floor(chunkSizeRaw) : 20;
   const validCollections = (collections || []).filter(Boolean);
   if (validCollections.length === 0) {
-    return;
+    return {
+      processedUsers: 0,
+      indexedPaths: 0,
+      collections: [],
+      chunkSize,
+    };
   }
 
   await update(ref2(database), { searchKey: null });
 
   let processed = 0;
   let total = 0;
+  let indexedPaths = 0;
   const snapshots = {};
 
   for (const collection of validCollections) {
@@ -2822,13 +2834,14 @@ export const rebuildSearchKeyIndexForCollections = async (collections = ['newUse
     const usersData = snapshots[collection];
     const userIds = Object.keys(usersData);
 
-    for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
-      const batchIds = userIds.slice(i, i + BATCH_SIZE);
+    for (let i = 0; i < userIds.length; i += chunkSize) {
+      const batchIds = userIds.slice(i, i + chunkSize);
       const updates = {};
 
       batchIds.forEach(userId => {
         Object.assign(updates, buildUpdateMap(userId, usersData[userId], {}));
       });
+      indexedPaths += Object.values(updates).filter(Boolean).length;
 
       // eslint-disable-next-line no-await-in-loop
       await update(ref2(database), updates);
@@ -2839,6 +2852,13 @@ export const rebuildSearchKeyIndexForCollections = async (collections = ['newUse
       }
     }
   }
+
+  return {
+    processedUsers: processed,
+    indexedPaths,
+    collections: validCollections,
+    chunkSize,
+  };
 };
 
 // Функція для видалення пар у searchId


### PR DESCRIPTION
### Motivation

- Provide configurable chunking for rebuilding the `searchKey` index to avoid large batch operations and reduce timeouts.  
- Return structured results from the rebuild function so callers can report metrics such as processed user count and indexed paths.  
- Surface rebuild progress and final metrics in the UI so operators can verify the operation outcome.

### Description

- Extend `rebuildSearchKeyIndexForCollections` to accept an `options` param with `chunkSize`, use a default chunk size of `20`, and return an object containing `processedUsers`, `indexedPaths`, `collections`, and `chunkSize` instead of returning nothing for empty input.  
- Replace fixed batch stepping with the configurable `chunkSize` and accumulate `indexedPaths` by counting non-empty update entries for each batch.  
- Update callers in `AddNewProfile.jsx` to pass `chunkSize`, display progress toasts, and present a summary toast showing `processedUsers`, `indexedPaths`, and `chunkSize`, and log the full result to the console.  
- Preserve progress callbacks semantics and keep backward-compatible defaults for callers that do not pass `options`.

### Testing

- Ran the project's automated unit test suite and linting checks locally and they passed.  
- No new automated tests were added for the new return object or option, and existing tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8799e80b483268068fce678cb51c6)