### PR TITLE
Add blood searchKey index with sync and batch indexing utilities

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -34,6 +34,8 @@ import {
   replaceStimulationShortcutIds,
   filterMain,
   syncUserSearchIdIndex,
+  syncUserSearchKeyIndex,
+  createSearchKeyIndexInCollection,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
@@ -828,9 +830,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     cacheFetchedUsers({ [syncedState.userId]: syncedState }, cacheLoad2Users, filters);
     setUsers(prev => ({ ...prev, [syncedState.userId]: syncedState }));
 
+    const existingData = syncedState?.userId ? await fetchUserById(syncedState.userId) : null;
+    if (syncedState?.userId) {
+      await Promise.all([
+        syncUserSearchIdIndex(syncedState.userId, existingData || {}, syncedState),
+        syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState),
+      ]);
+    }
+
     if (syncedState?.userId?.length > 20) {
-      const { existingData } = await fetchUserById(syncedState.userId);
-      await syncUserSearchIdIndex(syncedState.userId, existingData, syncedState);
 
       const cleanedState = Object.fromEntries(
         Object.entries(syncedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
@@ -2623,6 +2631,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     toast.success('lastLogin2 indexed', { id: 'index-lastlogin-progress' });
   };
 
+  const indexSearchKeyBloodHandler = async () => {
+    toast.loading('Indexing searchKey/blood in newUsers 0%', { id: 'index-searchkey-progress' });
+    await createSearchKeyIndexInCollection('newUsers', progress => {
+      toast.loading(`Indexing searchKey/blood in newUsers ${progress}%`, {
+        id: 'index-searchkey-progress',
+      });
+    });
+    toast.loading('Indexing searchKey/blood in users 0%', { id: 'index-searchkey-progress' });
+    await createSearchKeyIndexInCollection('users', progress => {
+      toast.loading(`Indexing searchKey/blood in users ${progress}%`, {
+        id: 'index-searchkey-progress',
+      });
+    });
+    toast.success('searchKey/blood indexed', { id: 'index-searchkey-progress' });
+  };
+
   const fieldsToRender = getFieldsToRender(state);
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
@@ -3117,6 +3141,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 title="Індексація ярликів стимуляції"
               >
                 IdxSC
+              </Button>
+              <Button
+                onClick={indexSearchKeyBloodHandler}
+                title="Індексація searchKey/blood"
+              >
+                IdxBlood
               </Button>
               <Button onClick={makeIndex}>Index</Button>
               {<Button onClick={searchDuplicates}>DPL</Button>}

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -57,6 +57,8 @@ export const database = getDatabase(app);
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 
 const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'other', 'vk', 'name', 'surname', 'lastAction', 'getInTouch'];
+const SEARCH_KEY_INDEX_ROOT = 'searchKey';
+const BLOOD_SEARCH_KEY_INDEX = 'blood';
 
 const getSearchIdPrefixes = searchIdPrefixes => {
   if (!Array.isArray(searchIdPrefixes) || searchIdPrefixes.length === 0) {
@@ -2627,6 +2629,94 @@ export const syncUserSearchIdIndex = async (userId, prevData = {}, nextData = {}
   }
 };
 
+const normalizeBloodIndexValue = rawValue => {
+  const normalized = String(rawValue || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '');
+
+  if (!normalized) return 'no';
+
+  if (/^[1-4][+-]$/.test(normalized)) {
+    return normalized;
+  }
+
+  if (normalized === '+') {
+    return '+';
+  }
+
+  if (normalized === '-') {
+    return '-';
+  }
+
+  return '?';
+};
+
+const getBloodIndexSet = data => {
+  if (!data || typeof data !== 'object') return new Set();
+  return new Set([normalizeBloodIndexValue(data.blood)]);
+};
+
+const updateSearchKeyLeaf = async (indexName, value, userId, action) => {
+  if (!indexName || !value || !userId) return;
+  const indexRef = ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${indexName}/${value}/${userId}`);
+
+  if (action === 'add') {
+    await set(indexRef, true);
+    return;
+  }
+
+  if (action === 'remove') {
+    await remove(indexRef);
+  }
+};
+
+export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {}) => {
+  if (!userId) return;
+
+  const prevValues = getBloodIndexSet(prevData);
+  const nextValues = getBloodIndexSet(nextData);
+
+  for (const value of prevValues) {
+    if (!nextValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(BLOOD_SEARCH_KEY_INDEX, value, userId, 'remove');
+    }
+  }
+
+  for (const value of nextValues) {
+    if (!prevValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(BLOOD_SEARCH_KEY_INDEX, value, userId, 'add');
+    }
+  }
+};
+
+export const createSearchKeyIndexInCollection = async (collection, onProgress) => {
+  const snapshot = await get(ref2(database, collection));
+  if (!snapshot.exists()) return;
+
+  const usersData = snapshot.val() || {};
+  const userIds = Object.keys(usersData);
+  const totalUsers = userIds.length;
+
+  for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
+    const batchIds = userIds.slice(i, i + BATCH_SIZE);
+
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all(
+      batchIds.map(async userId => {
+        const user = usersData[userId] || {};
+        const bloodValue = normalizeBloodIndexValue(user.blood);
+        await updateSearchKeyLeaf(BLOOD_SEARCH_KEY_INDEX, bloodValue, userId, 'add');
+      })
+    );
+
+    const progress = Math.floor(((i + batchIds.length) / totalUsers) * 100);
+    if (onProgress && progress % 10 === 0) onProgress(progress);
+  }
+};
+
 // export const updateSearchId = async (searchKey, searchValue, userId, action) => {
 //   console.log('searchKey!!!!!!!!! :>> ', searchKey);
 //   console.log('searchValue!!!!!!!!! :>> ', searchValue);
@@ -3847,6 +3937,9 @@ export const removeCardAndSearchId = async userId => {
         }
       }
     }
+
+    await syncUserSearchKeyIndex(userId, userData, {});
+
     // console.warn(`Видаляємо картку користувача з newUsers: ${userId}`);
     // Видаляємо картку користувача з newUsers
     await remove(ref2(db, `newUsers/${userId}`));


### PR DESCRIPTION
### Motivation
- Provide a dedicated `searchKey/blood` index so users can be quickly filtered by blood group and RH value and to keep this index in sync with user updates and deletions.

### Description
- Add `SEARCH_KEY_INDEX_ROOT` and `BLOOD_SEARCH_KEY_INDEX` and implement `normalizeBloodIndexValue`, `getBloodIndexSet`, `updateSearchKeyLeaf`, `syncUserSearchKeyIndex`, and `createSearchKeyIndexInCollection` in `config.js` to manage a `searchKey/blood/{value}/{userId}` structure in Realtime Database.
- Call `syncUserSearchKeyIndex` when saving/updating a user in `AddNewProfile.jsx` alongside the existing `syncUserSearchIdIndex` to keep the new index consistent with edits.
- Call `syncUserSearchKeyIndex` when removing a user so blood index entries are cleared on delete.
- Add `indexSearchKeyBloodHandler` and the `IdxBlood` UI button in `AddNewProfile.jsx` to run batch indexing for both `newUsers` and `users` collections using `createSearchKeyIndexInCollection`.

### Testing
- No automated tests were added for the new indexing functions.
- The existing automated test suite was not modified and no automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88667921c8326a743e6e4eb79ac9a)