### PR TITLE
Add Search-ID/Key-only load mode with blood-group search-key index and paged fetch

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -36,6 +36,7 @@ import {
   syncUserSearchIdIndex,
   syncUserSearchKeyIndex,
   createSearchKeyIndexInCollection,
+  fetchUsersBySearchKeyBloodPaged,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
@@ -548,6 +549,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     GIT: 'GIT',
     LAST_ACTION: 'LA',
     NO_GIT: 'NoGIT',
+    SEARCH_ID_KEY_ONLY: 'SearchIdKeyOnly',
   };
 
   const location = useLocation();
@@ -1310,6 +1312,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       case LOAD_SORT_MODES.LAST_ACTION:
         return 'LAST_ACTION';
       case LOAD_SORT_MODES.NO_GIT:
+      case LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY:
         return 'DATE2.1';
       case LOAD_SORT_MODES.GIT:
       default:
@@ -1319,6 +1322,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const filterStorageKey =
     loadSortMode === LOAD_SORT_MODES.LAST_ACTION ? 'addFiltersLA' : 'addFilters';
+
+  const searchIdAndSearchKeyOnlyMode = loadSortMode === LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY;
+
+  const effectiveEnabledSearchKeys = searchIdAndSearchKeyOnlyMode
+    ? {
+        ...enabledSearchKeys,
+        searchId: true,
+        equalToAllCards: true,
+        partialUserId: false,
+      }
+    : enabledSearchKeys;
 
   const handleLoadSortModeChange = useCallback(mode => {
     setLoadSortMode(mode);
@@ -1548,7 +1562,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
 
     if (currentFilter === 'DATE2.1') {
-      loadMoreUsers21()
+      const loadPromise = searchIdAndSearchKeyOnlyMode
+        ? loadMoreUsersSearchKey()
+        : loadMoreUsers21();
+      loadPromise
         .then(({ cacheCount, backendCount }) => {
           setCacheCount(cacheCount);
           setBackendCount(backendCount);
@@ -1598,7 +1615,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         .finally(() => setSearchLoading(false));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, currentFilter, search, loadRequestId]);
+  }, [filters, currentFilter, search, loadRequestId, searchIdAndSearchKeyOnlyMode]);
 
 
   const [adding, setAdding] = useState(false);
@@ -1971,6 +1988,51 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
   };
 
+  const loadMoreUsersSearchKey = async (currentFilters = filters) => {
+    let favRaw = getFavorites();
+    let fav = Object.fromEntries(Object.entries(favRaw).filter(([, v]) => v));
+    if (currentFilters.favorite?.favOnly && Object.keys(favRaw).length === 0) {
+      fav = await fetchFavoriteUsers(auth.currentUser.uid);
+      setFavoriteUsersData(fav);
+      syncFavorites(fav);
+    }
+
+    if (isEditingRef.current) {
+      return { cacheCount: 0, backendCount: 0, hasMore };
+    }
+
+    const res = await fetchUsersBySearchKeyBloodPaged({
+      filterSettings: currentFilters,
+      offset: dateOffset21,
+      limit: PAGE_SIZE,
+    });
+
+    const normalizedUsers = Object.entries(res?.users || {}).reduce((acc, [id, user]) => {
+      const targetId = user?.userId || id;
+      if (!targetId || !user) return acc;
+      if (currentFilters.favorite?.favOnly && !fav[targetId]) return acc;
+      if (!passesReactionFilter(user, currentFilters?.reaction, fav, dislikeUsersData)) return acc;
+      acc[targetId] = { ...user, userId: targetId };
+      return acc;
+    }, {});
+
+    cacheFetchedUsers(normalizedUsers, cacheLoad2Users, currentFilters);
+    if (!isEditingRef.current) {
+      setUsers(prev => mergeWithoutOverwrite(prev, normalizedUsers));
+    }
+
+    const queryKey = buildQueryKey('DATE2.1', currentFilters, search);
+    const existingIds = getIdsByQuery(queryKey);
+    setIdsForQuery(queryKey, [...new Set([...existingIds, ...Object.keys(normalizedUsers)])]);
+
+    setDateOffset21(res?.lastKey ?? dateOffset21);
+    setHasMore(Boolean(res?.hasMore));
+    setTotalCount(res?.totalCount || 0);
+
+    const backendCount = Object.keys(normalizedUsers).length;
+    return { cacheCount: 0, backendCount, hasMore: Boolean(res?.hasMore) };
+  };
+
   const loadMoreUsers2Base = async (
     currentFilters = filters,
     {
@@ -2219,7 +2281,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         currentFilter === 'DATE2'
           ? await loadMoreUsers2()
           : currentFilter === 'DATE2.1'
-          ? await loadMoreUsers21()
+          ? searchIdAndSearchKeyOnlyMode
+            ? await loadMoreUsersSearchKey()
+            : await loadMoreUsers21()
           : currentFilter === 'LAST_ACTION'
           ? await loadMoreUsersLastAction()
           : await loadMoreUsers(currentFilter);
@@ -2866,12 +2930,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             filterForload={currentFilter}
             favoriteUsers={favoriteUsersData}
             dislikeUsers={dislikeUsersData}
-            enabledSearchKeys={enabledSearchKeys}
+            enabledSearchKeys={effectiveEnabledSearchKeys}
             searchOptions={{
               searchIdPrefixes: selectedSearchIdPrefixes,
               equalToKeys: selectedEqualToKeys,
               autoOtherFallback: shouldAutoRunOtherFallback,
-              enabledSearchKeys,
+              enabledSearchKeys: effectiveEnabledSearchKeys,
             }}
           />
           <SearchSettingsButton
@@ -3088,11 +3152,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 />
                 NoGIT
               </SortModeLabel>
+              <SortModeLabel>
+                <input
+                  type="radio"
+                  name="load-sort-mode"
+                  value={LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY}
+                  checked={loadSortMode === LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY}
+                  onChange={event => handleLoadSortModeChange(event.target.value)}
+                />
+                NoGIT+IdKey
+              </SortModeLabel>
             </SortModeContainer>
             <FilterPanel
               key={filterStorageKey}
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -74,6 +74,7 @@ const FilterPanel = ({
   storageKey: customKey,
   resetToken,
   nonAdminAllActive = false,
+  allowedFilterNames,
 }) => {
   const defaultFilters = useMemo(() => {
     if (mode !== 'matching') return defaultsAdd;
@@ -124,7 +125,16 @@ const FilterPanel = ({
     setFilters({ ...defaultFilters });
   }, [defaultFilters, resetToken]);
 
-  return <SearchFilters filters={filters} onChange={setFilters} hideUserId={hideUserId} hideCommentLength={hideCommentLength} mode={mode} />;
+  return (
+    <SearchFilters
+      filters={filters}
+      onChange={setFilters}
+      hideUserId={hideUserId}
+      hideCommentLength={hideCommentLength}
+      mode={mode}
+      allowedFilterNames={allowedFilterNames}
+    />
+  );
 };
 
 export default FilterPanel;

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -5,7 +5,14 @@ import { SiTiktok } from 'react-icons/si';
 import { CheckboxGroup } from './CheckboxGroup';
 import { REACTION_FILTER_OPTIONS } from 'utils/reactionCategory';
 
-export const SearchFilters = ({ filters, onChange, hideUserId = false, hideCommentLength = false, mode = 'default' }) => {
+export const SearchFilters = ({
+  filters,
+  onChange,
+  hideUserId = false,
+  hideCommentLength = false,
+  mode = 'default',
+  allowedFilterNames,
+}) => {
   let groups = [];
   const contactIconStyle = { display: 'inline-flex', alignItems: 'center' };
 
@@ -238,6 +245,10 @@ export const SearchFilters = ({ filters, onChange, hideUserId = false, hideComme
   }
   if (hideCommentLength) {
     groups = groups.filter(g => g.filterName !== 'commentLength');
+  }
+  if (Array.isArray(allowedFilterNames) && allowedFilterNames.length > 0) {
+    const allowedSet = new Set(allowedFilterNames);
+    groups = groups.filter(group => allowedSet.has(group.filterName));
   }
 
   return (

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2657,6 +2657,46 @@ const getBloodIndexSet = data => {
   return new Set([normalizeBloodIndexValue(data.blood)]);
 };
 
+const BLOOD_SEARCH_KEY_BUCKETS = ['1+', '1-', '2+', '2-', '3+', '3-', '4+', '4-', '+', '-', '?', 'no'];
+
+const getBloodBucketMeta = bucket => {
+  const normalizedBucket = String(bucket || '').trim().toLowerCase();
+
+  if (/^[1-4][+-]$/.test(normalizedBucket)) {
+    return {
+      bloodGroup: normalizedBucket[0],
+      rh: normalizedBucket[1],
+    };
+  }
+
+  if (normalizedBucket === '+') {
+    return { bloodGroup: 'other', rh: '+' };
+  }
+
+  if (normalizedBucket === '-') {
+    return { bloodGroup: 'other', rh: '-' };
+  }
+
+  return { bloodGroup: 'other', rh: 'other' };
+};
+
+const hasExplicitFilterSelection = filterMap =>
+  Boolean(filterMap && typeof filterMap === 'object' && Object.values(filterMap).some(value => value === false));
+
+const isBucketAllowedByFilters = (bucket, filterSettings = {}) => {
+  const { bloodGroup, rh } = getBloodBucketMeta(bucket);
+  const bloodGroupFilters = filterSettings?.bloodGroup;
+  const rhFilters = filterSettings?.rh;
+
+  const shouldApplyBloodGroup = hasExplicitFilterSelection(bloodGroupFilters);
+  const shouldApplyRh = hasExplicitFilterSelection(rhFilters);
+
+  const bloodGroupAllowed = shouldApplyBloodGroup ? Boolean(bloodGroupFilters?.[bloodGroup]) : true;
+  const rhAllowed = shouldApplyRh ? Boolean(rhFilters?.[rh]) : true;
+
+  return bloodGroupAllowed && rhAllowed;
+};
+
 const updateSearchKeyLeaf = async (indexName, value, userId, action) => {
   if (!indexName || !value || !userId) return;
   const indexRef = ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${indexName}/${value}/${userId}`);
@@ -2715,6 +2755,44 @@ export const createSearchKeyIndexInCollection = async (collection, onProgress) =
     const progress = Math.floor(((i + batchIds.length) / totalUsers) * 100);
     if (onProgress && progress % 10 === 0) onProgress(progress);
   }
+};
+
+export const fetchUsersBySearchKeyBloodPaged = async ({
+  filterSettings = {},
+  offset = 0,
+  limit = PAGE_SIZE,
+} = {}) => {
+  const filteredBuckets = BLOOD_SEARCH_KEY_BUCKETS.filter(bucket => isBucketAllowedByFilters(bucket, filterSettings));
+
+  const bucketSnapshots = await Promise.all(
+    filteredBuckets.map(bucket => get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${BLOOD_SEARCH_KEY_INDEX}/${bucket}`)))
+  );
+
+  const orderedIds = [];
+  const seenIds = new Set();
+
+  bucketSnapshots.forEach(snapshot => {
+    if (!snapshot.exists()) return;
+    Object.keys(snapshot.val() || {}).forEach(id => {
+      if (!id || seenIds.has(id)) return;
+      seenIds.add(id);
+      orderedIds.push(id);
+    });
+  });
+
+  const sortedIds = [...orderedIds].sort((a, b) => a.localeCompare(b));
+  const pageIds = sortedIds.slice(offset, offset + limit);
+  const users = await fetchUsersByIds(pageIds);
+  const nextOffset = offset + pageIds.length;
+  const hasMore = nextOffset < sortedIds.length;
+
+  return {
+    users,
+    lastKey: nextOffset,
+    hasMore,
+    totalCount: sortedIds.length,
+    loadedIds: pageIds,
+  };
 };
 
 // export const updateSearchId = async (searchKey, searchValue, userId, action) => {


### PR DESCRIPTION
### Motivation

- Provide a fast, search-key-focused load mode that queries the search-key index (blood group / RH buckets) and limits filter options to relevant keys for efficient paged lookups.

### Description

- Added a new load-sort mode `SEARCH_ID_KEY_ONLY` in `AddNewProfile`, exposed in the UI as the radio option `NoGIT+IdKey`, and wired into load and pagination flows.
- Implemented `loadMoreUsersSearchKey` in `AddNewProfile` which uses the new `fetchUsersBySearchKeyBloodPaged` function, merges and caches fetched users, updates query ids and paging state, and honors favorite/reaction filters.
- Added blood search-key utilities and a paged index fetcher `fetchUsersBySearchKeyBloodPaged` in `config.js`, including `BLOOD_SEARCH_KEY_BUCKETS`, `getBloodBucketMeta`, `isBucketAllowedByFilters`, and logic to collect, sort and page user ids from the search-key index before fetching user objects.
- Restricted filter UI when the new mode is active by adding an `allowedFilterNames` prop to `FilterPanel` and `SearchFilters`, and applying it so only `bloodGroup` and `rh` filters are shown for the search-key-only mode; also applied `effectiveEnabledSearchKeys` to `SearchBar` props when the mode is enabled.

### Testing

- Ran the project test suite with `npm test` and a build with `npm run build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d892cf86b48326bb28124d71e03afd)