### PR TITLE
Add empty and unclear blood filter checkboxes for searchKey mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3167,6 +3167,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               key={filterStorageKey}
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
+              bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
               allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh'] : undefined}
             />
             <ButtonsContainer>

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -6,8 +6,8 @@ const defaultsAdd = {
   csection: { cs2plus: true, cs1: true, cs0: true, other: true },
   role: { ed: true, sm: true, ag: true, ip: true, cl: true, other: true },
   maritalStatus: { married: true, unmarried: true, other: true },
-  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true },
-  rh: { '+': true, '-': true, other: true },
+  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true, unclear: true },
+  rh: { '+': true, '-': true, other: true, empty: true, unclear: true },
   age: {
     le25: true,
     '26_30': true,
@@ -42,8 +42,8 @@ const defaultsAdd = {
 const defaultsMatching = {
   userRole: { ed: true, ag: false, ip: false, other: false },
   maritalStatus: { married: true, unmarried: true, other: true },
-  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true },
-  rh: { '+': true, '-': true, other: true },
+  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true, unclear: true },
+  rh: { '+': true, '-': true, other: true, empty: true, unclear: true },
   age: {
     le25: true,
     '26_30': true,
@@ -75,6 +75,7 @@ const FilterPanel = ({
   resetToken,
   nonAdminAllActive = false,
   allowedFilterNames,
+  bloodSearchKeyMode = false,
 }) => {
   const defaultFilters = useMemo(() => {
     if (mode !== 'matching') return defaultsAdd;
@@ -132,6 +133,7 @@ const FilterPanel = ({
       hideUserId={hideUserId}
       hideCommentLength={hideCommentLength}
       mode={mode}
+      bloodSearchKeyMode={bloodSearchKeyMode}
       allowedFilterNames={allowedFilterNames}
     />
   );

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -12,6 +12,7 @@ export const SearchFilters = ({
   hideCommentLength = false,
   mode = 'default',
   allowedFilterNames,
+  bloodSearchKeyMode = false,
 }) => {
   let groups = [];
   const contactIconStyle = { display: 'inline-flex', alignItems: 'center' };
@@ -143,6 +144,12 @@ export const SearchFilters = ({
           { val: '3', label: '3' },
           { val: '4', label: '4' },
           { val: 'other', label: '?' },
+          ...(bloodSearchKeyMode
+            ? [
+                { val: 'empty', label: '∅' },
+                { val: 'unclear', label: '??' },
+              ]
+            : []),
         ],
       },
       {
@@ -152,6 +159,12 @@ export const SearchFilters = ({
           { val: '+', label: '+' },
           { val: '-', label: '-' },
           { val: 'other', label: '?' },
+          ...(bloodSearchKeyMode
+            ? [
+                { val: 'empty', label: '∅' },
+                { val: 'unclear', label: '??' },
+              ]
+            : []),
         ],
       },
       {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2677,6 +2677,14 @@ const getBloodBucketMeta = bucket => {
     return { bloodGroup: 'other', rh: '-' };
   }
 
+  if (normalizedBucket === 'no') {
+    return { bloodGroup: 'empty', rh: 'empty' };
+  }
+
+  if (normalizedBucket === '?') {
+    return { bloodGroup: 'unclear', rh: 'unclear' };
+  }
+
   return { bloodGroup: 'other', rh: 'other' };
 };
 


### PR DESCRIPTION
### Motivation
- Improve filtering for `searchKey/blood` mode by exposing options for empty/missing and unclear blood values so users can explicitly include/exclude those cases.
- Ensure persisted filter state and index mapping align with the new UI options.

### Description
- Added a `bloodSearchKeyMode` flag propagated from `AddNewProfile` into `FilterPanel` and `SearchFilters` to enable blood-specific UI only for `searchKey/blood` mode.
- Extended default filter state in `FilterPanel` (`defaultsAdd` and `defaultsMatching`) to include `empty` and `unclear` keys for `bloodGroup` and `rh`. 
- Added two new checkbox options for both `bloodGroup` and `rh` in `SearchFilters` when `bloodSearchKeyMode` is enabled: `∅` (`empty`) and `??` (`unclear`).
- Updated blood index mapping in `config.js` so indexed buckets `no` -> `empty` and `?` -> `unclear` via `getBloodBucketMeta` to align index values with the new filter keys.

### Testing
- Ran linter: `npm run lint:js -- src/components/SearchFilters.jsx src/components/FilterPanel.jsx src/components/config.js src/components/AddNewProfile.jsx`, which completed successfully (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89a896d0083269d73cee6bd2aaaf2)