### PR TITLE
Handle blood-only group values in searchKey blood index

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2641,6 +2641,10 @@ const normalizeBloodIndexValue = rawValue => {
     return normalized;
   }
 
+  if (/^[1-4]$/.test(normalized)) {
+    return normalized;
+  }
+
   if (normalized === '+') {
     return '+';
   }
@@ -2657,7 +2661,7 @@ const getBloodIndexSet = data => {
   return new Set([normalizeBloodIndexValue(data.blood)]);
 };
 
-const BLOOD_SEARCH_KEY_BUCKETS = ['1+', '1-', '2+', '2-', '3+', '3-', '4+', '4-', '+', '-', '?', 'no'];
+const BLOOD_SEARCH_KEY_BUCKETS = ['1+', '1-', '1', '2+', '2-', '2', '3+', '3-', '3', '4+', '4-', '4', '+', '-', '?', 'no'];
 
 const getBloodBucketMeta = bucket => {
   const normalizedBucket = String(bucket || '').trim().toLowerCase();
@@ -2666,6 +2670,13 @@ const getBloodBucketMeta = bucket => {
     return {
       bloodGroup: normalizedBucket[0],
       rh: normalizedBucket[1],
+    };
+  }
+
+  if (/^[1-4]$/.test(normalizedBucket)) {
+    return {
+      bloodGroup: normalizedBucket,
+      rh: 'unclear',
     };
   }
 


### PR DESCRIPTION
### Motivation
- Ensure blood group values without Rh (plain `1`, `2`, `3`, `4`) are recognized and indexed so those profiles can be found and filtered via `searchKey`.

### Description
- In `src/components/config.js` updated `normalizeBloodIndexValue` to accept `/^[1-4]$/`, extended `BLOOD_SEARCH_KEY_BUCKETS` to include standalone `1,2,3,4`, and added mapping in `getBloodBucketMeta` to return `rh: 'unclear'` for these buckets.

### Testing
- Ran `npm run lint:js` and it completed successfully; `npm run lint` is not available in this project (missing `lint` script).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a128ec1c8326b68713535492c5d2)