### PR TITLE
Remove 'unclear' blood filter option and standardize empty label to 'no'

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -6,8 +6,8 @@ const defaultsAdd = {
   csection: { cs2plus: true, cs1: true, cs0: true, other: true },
   role: { ed: true, sm: true, ag: true, ip: true, cl: true, other: true },
   maritalStatus: { married: true, unmarried: true, other: true },
-  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true, unclear: true },
-  rh: { '+': true, '-': true, other: true, empty: true, unclear: true },
+  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },
+  rh: { '+': true, '-': true, other: true, empty: true },
   age: {
     le25: true,
     '26_30': true,
@@ -42,8 +42,8 @@ const defaultsAdd = {
 const defaultsMatching = {
   userRole: { ed: true, ag: false, ip: false, other: false },
   maritalStatus: { married: true, unmarried: true, other: true },
-  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true, unclear: true },
-  rh: { '+': true, '-': true, other: true, empty: true, unclear: true },
+  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },
+  rh: { '+': true, '-': true, other: true, empty: true },
   age: {
     le25: true,
     '26_30': true,

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -146,8 +146,7 @@ export const SearchFilters = ({
           { val: 'other', label: '?' },
           ...(bloodSearchKeyMode
             ? [
-                { val: 'empty', label: '∅' },
-                { val: 'unclear', label: '??' },
+                { val: 'empty', label: 'no' },
               ]
             : []),
         ],
@@ -161,8 +160,7 @@ export const SearchFilters = ({
           { val: 'other', label: '?' },
           ...(bloodSearchKeyMode
             ? [
-                { val: 'empty', label: '∅' },
-                { val: 'unclear', label: '??' },
+                { val: 'empty', label: 'no' },
               ]
             : []),
         ],

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2682,7 +2682,7 @@ const getBloodBucketMeta = bucket => {
   }
 
   if (normalizedBucket === '?') {
-    return { bloodGroup: 'unclear', rh: 'unclear' };
+    return { bloodGroup: 'other', rh: 'other' };
   }
 
   return { bloodGroup: 'other', rh: 'other' };


### PR DESCRIPTION
### Motivation
- Remove the special `unclear` blood category and standardize how empty/unknown blood values are represented in the UI and bucket mapping.
- Make blood filter options clearer by replacing the symbolic empty label with a textual `no` label for consistency.

### Description
- Updated default filter maps in `src/components/FilterPanel.jsx` to drop the `unclear` keys from `bloodGroup` and `rh` and keep `empty` as the representation for missing values.
- Updated `src/components/SearchFilters.jsx` to remove the `unclear` option from the `bloodGroup` and `rh` filter option lists and change the `empty` option label from `∅` to `no` when `bloodSearchKeyMode` is enabled.
- Updated `getBloodBucketMeta` in `src/components/config.js` to map the `?` bucket to `{ bloodGroup: 'other', rh: 'other' }` instead of the previous `unclear` mapping.
- Left other bucket handling and matching logic unchanged so existing bucket lists and filter application continue to work with the new mappings.

### Testing
- Ran the frontend unit test suite via `npm test`, and all tests passed.
- Ran the linter via `npm run lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a068fb388326b832678d4145f4a4)