### PR TITLE
Add marital status filters to SearchKey mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3189,7 +3189,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh'] : undefined}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2840,6 +2840,24 @@ const isBucketAllowedByFilters = (bucket, filterSettings = {}) => {
   return bloodGroupAllowed && rhAllowed;
 };
 
+const MARITAL_STATUS_SEARCH_KEY_BUCKETS = ['+', '-', '?', 'no'];
+
+const getMaritalStatusFilterKey = bucket => {
+  const normalizedBucket = String(bucket || '').trim().toLowerCase();
+  if (normalizedBucket === '+') return 'married';
+  if (normalizedBucket === '-') return 'unmarried';
+  return 'other';
+};
+
+const isMaritalStatusBucketAllowedByFilters = (bucket, filterSettings = {}) => {
+  const maritalStatusFilters = filterSettings?.maritalStatus;
+  const shouldApplyMaritalStatus = hasExplicitFilterSelection(maritalStatusFilters);
+  if (!shouldApplyMaritalStatus) return true;
+
+  const filterKey = getMaritalStatusFilterKey(bucket);
+  return Boolean(maritalStatusFilters?.[filterKey]);
+};
+
 const updateSearchKeyLeaf = async (indexName, value, userId, action) => {
   if (!indexName || !value || !userId) return;
   const indexRef = ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${indexName}/${value}/${userId}`);
@@ -2949,24 +2967,42 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   limit = PAGE_SIZE,
 } = {}) => {
   const filteredBuckets = BLOOD_SEARCH_KEY_BUCKETS.filter(bucket => isBucketAllowedByFilters(bucket, filterSettings));
-
-  const bucketSnapshots = await Promise.all(
-    filteredBuckets.map(bucket => get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${BLOOD_SEARCH_KEY_INDEX}/${bucket}`)))
+  const filteredMaritalStatusBuckets = MARITAL_STATUS_SEARCH_KEY_BUCKETS.filter(bucket =>
+    isMaritalStatusBucketAllowedByFilters(bucket, filterSettings)
   );
 
-  const orderedIds = [];
-  const seenIds = new Set();
+  const [bucketSnapshots, maritalStatusSnapshots] = await Promise.all([
+    Promise.all(
+    filteredBuckets.map(bucket => get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${BLOOD_SEARCH_KEY_INDEX}/${bucket}`)))
+    ),
+    Promise.all(
+      filteredMaritalStatusBuckets.map(bucket =>
+        get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${MARITAL_STATUS_SEARCH_KEY_INDEX}/${bucket}`))
+      )
+    ),
+  ]);
 
-  bucketSnapshots.forEach(snapshot => {
-    if (!snapshot.exists()) return;
-    Object.keys(snapshot.val() || {}).forEach(id => {
-      if (!id || seenIds.has(id)) return;
-      seenIds.add(id);
-      orderedIds.push(id);
+  const collectIdsFromSnapshots = snapshots => {
+    const ids = new Set();
+    snapshots.forEach(snapshot => {
+      if (!snapshot.exists()) return;
+      Object.keys(snapshot.val() || {}).forEach(id => {
+        if (!id) return;
+        ids.add(id);
+      });
     });
-  });
+    return ids;
+  };
 
-  const sortedIds = [...orderedIds].sort((a, b) => a.localeCompare(b));
+  const bloodUserIds = collectIdsFromSnapshots(bucketSnapshots);
+  const maritalStatusUserIds = collectIdsFromSnapshots(maritalStatusSnapshots);
+  const shouldApplyMaritalStatusFilter = hasExplicitFilterSelection(filterSettings?.maritalStatus);
+
+  const finalIds = shouldApplyMaritalStatusFilter
+    ? [...bloodUserIds].filter(id => maritalStatusUserIds.has(id))
+    : [...bloodUserIds];
+
+  const sortedIds = [...finalIds].sort((a, b) => a.localeCompare(b));
   const pageIds = sortedIds.slice(offset, offset + limit);
   const users = await fetchUsersByIds(pageIds);
   const nextOffset = offset + pageIds.length;


### PR DESCRIPTION
### Motivation
- Enable filtering by family/marital status when using SearchKey-only mode so users can narrow results by marital status in addition to blood group and Rh.

### Description
- Show `maritalStatus` checkbox group in SearchKey-only filter panel by adding it to `allowedFilterNames` in `src/components/AddNewProfile.jsx`.
- Add `MARITAL_STATUS_SEARCH_KEY_BUCKETS`, `getMaritalStatusFilterKey`, and `isMaritalStatusBucketAllowedByFilters` helpers in `src/components/config.js` to map index buckets to filter keys and determine allowed buckets.
- Extend `fetchUsersBySearchKeyBloodPaged` in `src/components/config.js` to read `searchKey/maritalStatus` index, collect IDs from both blood and marital-status snapshots, and intersect them when a marital status filter is explicitly applied; otherwise retain previous blood-only behavior.
- Mapping of marital-status buckets is `+ -> married`, `- -> unmarried`, and `?`/`no -> other` (used when building/reading the index).

### Testing
- Ran linter: `npx eslint src/components/config.js src/components/AddNewProfile.jsx` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d81077ec8326b69af849ad665181)