### PR TITLE
Add c-section checkbox categories and searchKey indexing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -37,6 +37,7 @@ import {
   syncUserSearchKeyIndex,
   createSearchKeyIndexInCollection,
   createMaritalStatusSearchKeyIndexInCollection,
+  createCsectionSearchKeyIndexInCollection,
   fetchUsersBySearchKeyBloodPaged,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -2732,6 +2733,26 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     toast.success('searchKey/maritalStatus indexed', { id: 'index-searchkey-marital-progress' });
   };
 
+  const indexSearchKeyCsectionHandler = async () => {
+    toast.loading('Indexing searchKey/csection in newUsers 0%', {
+      id: 'index-searchkey-csection-progress',
+    });
+    await createCsectionSearchKeyIndexInCollection('newUsers', progress => {
+      toast.loading(`Indexing searchKey/csection in newUsers ${progress}%`, {
+        id: 'index-searchkey-csection-progress',
+      });
+    });
+    toast.loading('Indexing searchKey/csection in users 0%', {
+      id: 'index-searchkey-csection-progress',
+    });
+    await createCsectionSearchKeyIndexInCollection('users', progress => {
+      toast.loading(`Indexing searchKey/csection in users ${progress}%`, {
+        id: 'index-searchkey-csection-progress',
+      });
+    });
+    toast.success('searchKey/csection indexed', { id: 'index-searchkey-csection-progress' });
+  };
+
   const fieldsToRender = getFieldsToRender(state);
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
@@ -3250,6 +3271,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 title="Індексація searchKey/maritalStatus"
               >
                 IdxMarital
+              </Button>
+              <Button
+                onClick={indexSearchKeyCsectionHandler}
+                title="Індексація searchKey/csection"
+              >
+                IdxCsection
               </Button>
               <Button onClick={makeIndex}>Index</Button>
               {<Button onClick={searchDuplicates}>DPL</Button>}

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -3,7 +3,7 @@ import { SearchFilters } from './SearchFilters';
 import { REACTION_FILTER_DEFAULTS } from 'utils/reactionCategory';
 
 const defaultsAdd = {
-  csection: { cs2plus: true, cs1: true, cs0: true, other: true },
+  csection: { cs2plus: true, cs1: true, cs0: true, no: true, other: true },
   role: { ed: true, sm: true, ag: true, ip: true, cl: true, other: true },
   maritalStatus: { married: true, unmarried: true, other: true },
   bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -111,6 +111,7 @@ export const SearchFilters = ({
           { val: 'cs2plus', label: 'cs2+' },
           { val: 'cs1', label: 'cs1' },
           { val: 'cs0', label: 'cs0' },
+          { val: 'no', label: 'no' },
           { val: 'other', label: '?' },
         ],
       },

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -60,6 +60,7 @@ const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tik
 const SEARCH_KEY_INDEX_ROOT = 'searchKey';
 const BLOOD_SEARCH_KEY_INDEX = 'blood';
 const MARITAL_STATUS_SEARCH_KEY_INDEX = 'maritalStatus';
+const CSECTION_SEARCH_KEY_INDEX = 'csection';
 const SEARCH_KEY_BATCH_UPLOAD_SIZE = 100;
 const SEARCH_INDEX_COLLECTION_CACHE_PREFIX = 'search-index:collection:v1:';
 const SEARCH_INDEX_COLLECTION_CACHE_TTL_MS = 15 * 60 * 1000;
@@ -2785,6 +2786,31 @@ const getMaritalStatusIndexSet = data => {
   return new Set([normalizeMaritalStatusIndexValue(data.maritalStatus)]);
 };
 
+export const normalizeCsectionIndexValue = value => {
+  if (value === null || value === undefined) return 'other';
+
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return 'other';
+
+  const parsedInt = Number.parseInt(normalized, 10);
+  if (!Number.isNaN(parsedInt)) {
+    if (parsedInt >= 2) return 'cs2plus';
+    if (parsedInt === 1) return 'cs1';
+    if (parsedInt === 0) return 'cs0';
+  }
+
+  if (['+', 'plus', 'yes', 'так', 'був', 'була'].includes(normalized)) return 'cs1';
+  if (['-', 'no', 'ні', 'none', 'нема', 'немає'].includes(normalized)) return 'no';
+  if (['?', 'unknown', 'невідомо'].includes(normalized)) return 'other';
+
+  return 'other';
+};
+
+const getCsectionIndexSet = data => {
+  if (!data || typeof data !== 'object') return new Set();
+  return new Set([normalizeCsectionIndexValue(data.csection)]);
+};
+
 const BLOOD_SEARCH_KEY_BUCKETS = ['1+', '1-', '1', '2+', '2-', '2', '3+', '3-', '3', '4+', '4-', '4', '+', '-', '?', 'no'];
 
 const getBloodBucketMeta = bucket => {
@@ -2861,6 +2887,8 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   const nextValues = getBloodIndexSet(nextData);
   const prevMaritalStatusValues = getMaritalStatusIndexSet(prevData);
   const nextMaritalStatusValues = getMaritalStatusIndexSet(nextData);
+  const prevCsectionValues = getCsectionIndexSet(prevData);
+  const nextCsectionValues = getCsectionIndexSet(nextData);
 
   for (const value of prevValues) {
     if (!nextValues.has(value)) {
@@ -2887,6 +2915,20 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
     if (!prevMaritalStatusValues.has(value)) {
       // eslint-disable-next-line no-await-in-loop
       await updateSearchKeyLeaf(MARITAL_STATUS_SEARCH_KEY_INDEX, value, userId, 'add');
+    }
+  }
+
+  for (const value of prevCsectionValues) {
+    if (!nextCsectionValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(CSECTION_SEARCH_KEY_INDEX, value, userId, 'remove');
+    }
+  }
+
+  for (const value of nextCsectionValues) {
+    if (!prevCsectionValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(CSECTION_SEARCH_KEY_INDEX, value, userId, 'add');
     }
   }
 };
@@ -2927,6 +2969,34 @@ export const createMaritalStatusSearchKeyIndexInCollection = async (collection, 
     const user = usersData[userId] || {};
     const maritalStatusValue = normalizeMaritalStatusIndexValue(user.maritalStatus);
     acc[`${SEARCH_KEY_INDEX_ROOT}/${MARITAL_STATUS_SEARCH_KEY_INDEX}/${maritalStatusValue}/${userId}`] = true;
+    return acc;
+  }, {});
+
+  const updateEntries = Object.entries(updates);
+
+  for (let i = 0; i < updateEntries.length; i += SEARCH_KEY_BATCH_UPLOAD_SIZE) {
+    const chunkEntries = updateEntries.slice(i, i + SEARCH_KEY_BATCH_UPLOAD_SIZE);
+    const chunkPayload = Object.fromEntries(chunkEntries);
+    // eslint-disable-next-line no-await-in-loop
+    await update(ref2(database), chunkPayload);
+
+    const progress = Math.floor((Math.min(i + chunkEntries.length, totalUsers) / totalUsers) * 100);
+    if (onProgress && progress % 10 === 0) onProgress(progress);
+  }
+};
+
+export const createCsectionSearchKeyIndexInCollection = async (collection, onProgress) => {
+  const usersData = await loadCollectionWithIndexCache(collection);
+  if (!usersData) return;
+
+  const userIds = Object.keys(usersData);
+  const totalUsers = userIds.length;
+  if (totalUsers === 0) return;
+
+  const updates = userIds.reduce((acc, userId) => {
+    const user = usersData[userId] || {};
+    const csectionValue = normalizeCsectionIndexValue(user.csection);
+    acc[`${SEARCH_KEY_INDEX_ROOT}/${CSECTION_SEARCH_KEY_INDEX}/${csectionValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3170,18 +3240,7 @@ const filterByUserIdLength = userId => {
   return typeof userId === 'string' && userId.length <= 25;
 };
 
-const categorizeCsection = val => {
-  if (!val) return 'other';
-  const c = val.toString().trim().toLowerCase();
-  if (!isNaN(parseInt(c, 10))) {
-    const num = parseInt(c, 10);
-    if (num >= 2) return 'cs2plus';
-    if (num === 1) return 'cs1';
-    if (num === 0) return 'cs0';
-  }
-  if (['-', 'no', 'ні'].includes(c)) return 'cs0';
-  return 'other';
-};
+const categorizeCsection = val => normalizeCsectionIndexValue(val);
 
 const getRoleCategory = value => {
   const role = (value.role || value.userRole || '').toString().trim().toLowerCase();


### PR DESCRIPTION
### Motivation
- Add c-section filtering and server-side search-key indexing analogous to the existing marital status indexing to support card data stored as `1, 2, 3, +, -` and provide checkboxes `cs2+`, `cs1`, `cs0`, `no`, `?` for UI filtering.

### Description
- Added `no` option to the `csection` checkbox group in `SearchFilters.jsx` and added `csection.no` to the default `filters` in `FilterPanel.jsx` so the UI exposes `cs2+`, `cs1`, `cs0`, `no`, `other`.
- Implemented c-section indexing support in `config.js` by adding `CSECTION_SEARCH_KEY_INDEX`, `normalizeCsectionIndexValue`, `getCsectionIndexSet`, and `createCsectionSearchKeyIndexInCollection`, and wired these into `syncUserSearchKeyIndex` so index leaves are kept in sync.
- Reused the normalization via `categorizeCsection = normalizeCsectionIndexValue` so runtime filtering and the searchKey index use the same logic for values like numeric counts and `+ / - / ?`.
- Added admin tooling in `AddNewProfile.jsx`: import of the new indexer, `indexSearchKeyCsectionHandler` with progress toasts, and an `IdxCsection` button in the admin buttons area.
- Modified files: `src/components/SearchFilters.jsx`, `src/components/FilterPanel.jsx`, `src/components/config.js`, `src/components/AddNewProfile.jsx`.

### Testing
- Ran lint on modified files with `npx eslint src/components/SearchFilters.jsx src/components/FilterPanel.jsx src/components/config.js src/components/AddNewProfile.jsx` and it completed with no lint errors; only informational `npm/browserslist` warnings were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d8da7af483269c0f4b53eba53362)