### PR TITLE
Extract search key helpers into utils and clean up config imports

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -26,12 +26,18 @@ import { filterOutMedicationPhotos } from '../utils/photoFilters';
 import { getCurrentDate } from './foramtDate';
 import toast from 'react-hot-toast';
 import { removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
-import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
 import { updateCard } from '../utils/cardsStorage';
-import { normalizePhoneValue } from './inputValidations';
+import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
 import { getCacheKey } from '../utils/cache';
 import { getReactionCategory } from 'utils/reactionCategory';
 import { buildSearchIndexCandidates, encodeKey } from '../utils/searchIndexCandidates';
+import {
+  buildSearchIdCandidateKeys,
+  getEqualToCandidates,
+  makeSearchKeyValue,
+  shouldSkipBroadFallbackForExactSearchId,
+} from '../utils/searchKeyUtils';
+import { resolveEqualToSearchKeys } from '../utils/searchKeyCheckboxFilters';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -126,102 +132,6 @@ const loadCollectionWithIndexCache = async (collection, options = {}) => {
   const data = snapshot.val() || {};
   writeCachedIndexCollection(collection, data);
   return data;
-};
-
-const getSearchIdPrefixes = searchIdPrefixes => {
-  if (!Array.isArray(searchIdPrefixes) || searchIdPrefixes.length === 0) {
-    return keysToCheck;
-  }
-
-  const normalizedPrefixes = searchIdPrefixes
-    .map(prefix => (typeof prefix === 'string' ? prefix.trim() : ''))
-    .filter(Boolean);
-
-  const allowedPrefixes = keysToCheck.filter(prefix =>
-    normalizedPrefixes.includes(prefix)
-  );
-
-  return allowedPrefixes.length > 0 ? allowedPrefixes : keysToCheck;
-};
-
-const normalizeSearchIdInput = (searchKey, rawValue) => {
-  const baseValue = String(rawValue || '').trim();
-  if (!baseValue) return '';
-
-  if (searchKey === 'phone') {
-    return normalizePhoneValue(baseValue);
-  }
-
-  if (searchKey === 'telegram') {
-    const parsedTrigger = parseUkTriggerQuery(baseValue);
-    if (parsedTrigger?.searchPair?.telegram) {
-      return parsedTrigger.searchPair.telegram;
-    }
-  }
-
-  return baseValue.replace(/\s+/g, ' ');
-};
-
-const normalizePhoneSearchIdValue = rawValue => normalizePhoneValue(rawValue);
-
-const buildSearchIdCandidateKeys = (
-  modifiedSearchValue,
-  rawSearchValue,
-  searchIdPrefixes,
-  options = {},
-) => {
-  const normalizedValue = String(modifiedSearchValue || '').toLowerCase();
-  if (!normalizedValue) return [];
-
-  const {
-    includeVariants = true,
-    includeAdaptedPhoneVariant = false,
-  } = options;
-  const ukSmPrefix = encodeKey('УК СМ ').toLowerCase();
-  const hasUkSm = normalizedValue.startsWith(ukSmPrefix);
-  const prefixesToCheck = getSearchIdPrefixes(searchIdPrefixes);
-
-  return prefixesToCheck.flatMap(prefix => {
-    if (prefix === 'phone' && includeAdaptedPhoneVariant) {
-      const adaptedPhoneValue = normalizePhoneSearchIdValue(rawSearchValue);
-      const adaptedPhoneKey = encodeKey(adaptedPhoneValue).toLowerCase();
-      const rawPhoneKey = encodeKey(String(rawSearchValue || '').trim()).toLowerCase();
-      const valuesToCheck = [...new Set([adaptedPhoneKey, rawPhoneKey].filter(Boolean))];
-      return valuesToCheck.map(value => `${prefix}_${value}`);
-    }
-
-    const searchKeys = [`${prefix}_${normalizedValue}`];
-
-    if (!includeVariants) {
-      return searchKeys;
-    }
-
-    if (hasUkSm) {
-      searchKeys.push(`${prefix}_${normalizedValue.slice(ukSmPrefix.length)}`);
-    } else {
-      searchKeys.push(`${prefix}_${ukSmPrefix}${normalizedValue}`);
-    }
-
-    if (normalizedValue.startsWith('0')) {
-      searchKeys.push(`${prefix}_38${normalizedValue}`);
-    }
-    if (normalizedValue.startsWith('+')) {
-      searchKeys.push(`${prefix}_${normalizedValue.slice(1)}`);
-    }
-
-    return searchKeys;
-  });
-};
-
-
-const shouldSkipBroadFallbackForExactSearchId = searchKey => {
-  if (searchKey !== 'searchId') return false;
-
-  // `searchId` в UI — окремий режим пошуку.
-  // Тому додаткові broad-fallback запити (по users/newUsers, partial userId тощо)
-  // не мають виконуватись, інакше можна отримати результати з інших полів
-  // (наприклад, telegram), навіть якщо вибрано тільки instagram-префікс.
-  return true;
 };
 
 const collectUserIdsBySearchIdKeys = async (searchKeys, options = {}) => {
@@ -1688,13 +1598,7 @@ export const makeNewUser = async (searchedValue, rawQuery = '') => {
   };
 };
 
-const makeSearchKeyValue = searchedValue => {
-  const [searchKey, searchValue] = Object.entries(searchedValue)[0];
-  const normalizedSearchValue = normalizeSearchIdInput(searchKey, searchValue);
-  const modifiedSearchValue = encodeKey(normalizedSearchValue);
-  const searchIdKey = `${searchKey}_${modifiedSearchValue.toLowerCase()}`; // Формуємо ключ для пошуку у searchId
-  return { searchKey, searchValue: normalizedSearchValue, modifiedSearchValue, searchIdKey };
-};
+
 
 
 export const searchUserByPartialUserId = async (userId, users) => {
@@ -1887,62 +1791,6 @@ const executeSearchBySearchIdIndex = async (
 };
 
 const SEARCH_COLLECTIONS = ['newUsers', 'users'];
-const EQUAL_TO_INDEX_KEYS = [
-  'instagram',
-  'facebook',
-  'email',
-  'phone',
-  'telegram',
-  'tiktok',
-  'vk',
-  'other',
-  'userId',
-  'getInTouch',
-  'myComment',
-  'lastAction',
-  'name',
-  'surname',
-  'lastLogin2',
-  'createdAt',
-  'cycleStatus',
-  'lastCycle',
-  'lastLogin',
-];
-
-const resolveEqualToSearchKeys = equalToKeys => {
-  const normalizedSelected = Array.isArray(equalToKeys)
-    ? equalToKeys
-      .map(key => (typeof key === 'string' ? key.trim() : ''))
-      .filter(Boolean)
-    : [];
-
-  const allowedSelected = EQUAL_TO_INDEX_KEYS.filter(key =>
-    normalizedSelected.includes(key)
-  );
-
-  if (
-    allowedSelected.length === 0 ||
-    allowedSelected.length === EQUAL_TO_INDEX_KEYS.length
-  ) {
-    return [...EQUAL_TO_INDEX_KEYS];
-  }
-
-  return allowedSelected;
-};
-
-const getEqualToCandidates = (searchKey, rawSearchValue) => {
-  const trimmed = String(rawSearchValue || '').trim();
-  if (!trimmed) return [];
-
-  if (searchKey === 'phone') {
-    const normalizedPhone = normalizeSearchIdInput('phone', trimmed);
-    return [...new Set([normalizedPhone, trimmed].filter(Boolean))];
-  }
-
-  return [trimmed];
-};
-
-
 const executeSearchByEqualToFields = async (searchKeys, rawSearchValue, uniqueUserIds, users) => {
   if (!Array.isArray(searchKeys) || searchKeys.length === 0) return;
 

--- a/src/utils/searchKeyCheckboxFilters.js
+++ b/src/utils/searchKeyCheckboxFilters.js
@@ -1,0 +1,73 @@
+const SEARCH_ID_CHECKBOX_KEYS = [
+  'instagram',
+  'facebook',
+  'email',
+  'phone',
+  'telegram',
+  'tiktok',
+  'other',
+  'vk',
+  'name',
+  'surname',
+  'lastAction',
+  'getInTouch',
+];
+
+const EQUAL_TO_INDEX_KEYS = [
+  'instagram',
+  'facebook',
+  'email',
+  'phone',
+  'telegram',
+  'tiktok',
+  'vk',
+  'other',
+  'userId',
+  'getInTouch',
+  'myComment',
+  'lastAction',
+  'name',
+  'surname',
+  'lastLogin2',
+  'createdAt',
+  'cycleStatus',
+  'lastCycle',
+  'lastLogin',
+];
+
+export const getSearchIdPrefixes = searchIdPrefixes => {
+  if (!Array.isArray(searchIdPrefixes) || searchIdPrefixes.length === 0) {
+    return SEARCH_ID_CHECKBOX_KEYS;
+  }
+
+  const normalizedPrefixes = searchIdPrefixes
+    .map(prefix => (typeof prefix === 'string' ? prefix.trim() : ''))
+    .filter(Boolean);
+
+  const allowedPrefixes = SEARCH_ID_CHECKBOX_KEYS.filter(prefix =>
+    normalizedPrefixes.includes(prefix)
+  );
+
+  return allowedPrefixes.length > 0 ? allowedPrefixes : SEARCH_ID_CHECKBOX_KEYS;
+};
+
+export const resolveEqualToSearchKeys = equalToKeys => {
+  const normalizedSelected = Array.isArray(equalToKeys)
+    ? equalToKeys
+      .map(key => (typeof key === 'string' ? key.trim() : ''))
+      .filter(Boolean)
+    : [];
+
+  const allowedSelected = EQUAL_TO_INDEX_KEYS.filter(key =>
+    normalizedSelected.includes(key)
+  );
+
+  if (
+    allowedSelected.length === 0 ||
+    allowedSelected.length === EQUAL_TO_INDEX_KEYS.length
+  ) {
+    return [...EQUAL_TO_INDEX_KEYS];
+  }
+
+  return allowedSelected;
+};

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -1,0 +1,108 @@
+import { normalizePhoneValue } from '../components/inputValidations';
+import { parseUkTriggerQuery } from './parseUkTrigger';
+import { encodeKey } from './searchIndexCandidates';
+import { getSearchIdPrefixes } from './searchKeyCheckboxFilters';
+export const normalizeSearchIdInput = (searchKey, rawValue) => {
+  const baseValue = String(rawValue || '').trim();
+  if (!baseValue) return '';
+
+  if (searchKey === 'phone') {
+    return normalizePhoneValue(baseValue);
+  }
+
+  if (searchKey === 'telegram') {
+    const parsedTrigger = parseUkTriggerQuery(baseValue);
+    if (parsedTrigger?.searchPair?.telegram) {
+      return parsedTrigger.searchPair.telegram;
+    }
+  }
+
+  return baseValue.replace(/\s+/g, ' ');
+};
+
+const normalizePhoneSearchIdValue = rawValue => normalizePhoneValue(rawValue);
+
+export const buildSearchIdCandidateKeys = (
+  modifiedSearchValue,
+  rawSearchValue,
+  searchIdPrefixes,
+  options = {},
+) => {
+  const normalizedValue = String(modifiedSearchValue || '').toLowerCase();
+  if (!normalizedValue) return [];
+
+  const {
+    includeVariants = true,
+    includeAdaptedPhoneVariant = false,
+  } = options;
+  const ukSmPrefix = encodeKey('УК СМ ').toLowerCase();
+  const hasUkSm = normalizedValue.startsWith(ukSmPrefix);
+  const prefixesToCheck = getSearchIdPrefixes(searchIdPrefixes);
+
+  return prefixesToCheck.flatMap(prefix => {
+    if (prefix === 'phone' && includeAdaptedPhoneVariant) {
+      const adaptedPhoneValue = normalizePhoneSearchIdValue(rawSearchValue);
+      const adaptedPhoneKey = encodeKey(adaptedPhoneValue).toLowerCase();
+      const rawPhoneKey = encodeKey(String(rawSearchValue || '').trim()).toLowerCase();
+      const valuesToCheck = [...new Set([adaptedPhoneKey, rawPhoneKey].filter(Boolean))];
+      return valuesToCheck.map(value => `${prefix}_${value}`);
+    }
+
+    const searchKeys = [`${prefix}_${normalizedValue}`];
+
+    if (!includeVariants) {
+      return searchKeys;
+    }
+
+    if (hasUkSm) {
+      searchKeys.push(`${prefix}_${normalizedValue.slice(ukSmPrefix.length)}`);
+    } else {
+      searchKeys.push(`${prefix}_${ukSmPrefix}${normalizedValue}`);
+    }
+
+    if (normalizedValue.startsWith('0')) {
+      searchKeys.push(`${prefix}_38${normalizedValue}`);
+    }
+    if (normalizedValue.startsWith('+')) {
+      searchKeys.push(`${prefix}_${normalizedValue.slice(1)}`);
+    }
+
+    return searchKeys;
+  });
+};
+
+export const shouldSkipBroadFallbackForExactSearchId = searchKey => {
+  if (searchKey !== 'searchId') return false;
+
+  // `searchId` в UI — окремий режим пошуку.
+  // Тому додаткові broad-fallback запити (по users/newUsers, partial userId тощо)
+  // не мають виконуватись, інакше можна отримати результати з інших полів
+  // (наприклад, telegram), навіть якщо вибрано тільки instagram-префікс.
+  return true;
+};
+
+export const makeSearchKeyValue = searchedValue => {
+  const [searchKey, searchValue] = Object.entries(searchedValue)[0];
+  const normalizedSearchValue = normalizeSearchIdInput(searchKey, searchValue);
+  const modifiedSearchValue = encodeKey(normalizedSearchValue);
+  const searchIdKey = `${searchKey}_${modifiedSearchValue.toLowerCase()}`;
+
+  return {
+    searchKey,
+    searchValue: normalizedSearchValue,
+    modifiedSearchValue,
+    searchIdKey,
+  };
+};
+
+export const getEqualToCandidates = (searchKey, rawSearchValue) => {
+  const trimmed = String(rawSearchValue || '').trim();
+  if (!trimmed) return [];
+
+  if (searchKey === 'phone') {
+    const normalizedPhone = normalizeSearchIdInput('phone', trimmed);
+    return [...new Set([normalizedPhone, trimmed].filter(Boolean))];
+  }
+
+  return [trimmed];
+};


### PR DESCRIPTION
### Motivation

- Consolidate and reuse search key / searchId related logic by moving helper functions out of `src/components/config.js` into dedicated utility modules. 

### Description

- Extracted search-id and equal-to helper implementations into `src/utils/searchKeyUtils.js` and checkbox/filter keys into `src/utils/searchKeyCheckboxFilters.js` and updated imports in `src/components/config.js` to use these utilities. 
- Removed duplicated implementations from `config.js` for `getSearchIdPrefixes`, `normalizeSearchIdInput`, `buildSearchIdCandidateKeys`, `makeSearchKeyValue`, `getEqualToCandidates`, `resolveEqualToSearchKeys`, and `shouldSkipBroadFallbackForExactSearchId`. 
- Preserved original behavior for search key normalization, phone adaptations, UK trigger parsing, and candidate key generation while centralizing encoding via `encodeKey`. 
- Adjusted import paths for `normalizePhoneValue` and `parseUkTriggerQuery` usages to reference the new utility modules. 

### Testing

- Ran unit tests with `yarn test`, which completed successfully. 
- Ran linter checks with `yarn lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d90975a48326b5989b8adeb71574)