### PR TITLE
Fix Rh '?' filter to exclude missing rhesus values

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3161,6 +3161,8 @@ const getRhCategory = value => {
   const b = (value.blood || '').toString().trim().toLowerCase().replace(/\s+/g, '');
   if (b.endsWith('+') || b === '+') return '+';
   if (b.endsWith('-') || b === '-') return '-';
+  if (/^[1-4]$/.test(b)) return 'empty';
+  if (!b) return 'empty';
   return 'other';
 };
 


### PR DESCRIPTION
### Motivation
- The Rh `?` filter was including records that only had a blood group (e.g. "2") or an empty blood value, but it should only match truly invalid/garbage Rh values.

### Description
- Updated `getRhCategory` in `src/components/config.js` to return `empty` for values that are only a blood group (`/^[1-4]$/`) and for completely empty `blood` strings, while keeping `other` for non-empty invalid values.

### Testing
- Ran lint on the modified file with `npm run -s lint:js -- src/components/config.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8cfbbc50883268621da1cb1d45f9a)