### PR TITLE
Use 1-hour collection cache freshness for blood search-key indexing

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -70,6 +70,7 @@ const CSECTION_SEARCH_KEY_INDEX = 'csection';
 const SEARCH_KEY_BATCH_UPLOAD_SIZE = 100;
 const SEARCH_INDEX_COLLECTION_CACHE_PREFIX = 'search-index:collection:v1:';
 const SEARCH_INDEX_COLLECTION_CACHE_TTL_MS = 15 * 60 * 1000;
+const BLOOD_SEARCH_INDEX_COLLECTION_CACHE_TTL_MS = 60 * 60 * 1000;
 
 const getSearchIndexCacheStorage = () => {
   if (typeof window === 'undefined') return null;
@@ -2800,7 +2801,9 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
 };
 
 export const createSearchKeyIndexInCollection = async (collection, onProgress) => {
-  const usersData = await loadCollectionWithIndexCache(collection);
+  const usersData = await loadCollectionWithIndexCache(collection, {
+    maxAgeMs: BLOOD_SEARCH_INDEX_COLLECTION_CACHE_TTL_MS,
+  });
   if (!usersData) return;
 
   const userIds = Object.keys(usersData);


### PR DESCRIPTION
### Motivation
- Indexing for the `maritalStatus` search key already reuses cached collection data to avoid repeated full downloads, and `blood` should behave the same to reduce unnecessary reads and load.

### Description
- Added a dedicated TTL constant `BLOOD_SEARCH_INDEX_COLLECTION_CACHE_TTL_MS = 60 * 60 * 1000` in `src/components/config.js`.
- Updated `createSearchKeyIndexInCollection` to call `loadCollectionWithIndexCache(collection, { maxAgeMs: BLOOD_SEARCH_INDEX_COLLECTION_CACHE_TTL_MS })` so the blood index builder uses the cached collection when fresh within 1 hour.
- The only modified file is `src/components/config.js` and behavior for reading/writing other search index caches is unchanged.

### Testing
- Ran `npm run lint:js -- src/components/config.js` and the linter completed successfully.
- No unit tests were changed or required for this small cache/TTL adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8dc3135cc832699fcdac7a3607a35)