### PR TITLE
Treat plain blood group (e.g. `2`) as empty Rh in search buckets

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2675,7 +2675,7 @@ const getBloodBucketMeta = bucket => {
   if (/^[1-4]$/.test(normalizedBucket)) {
     return {
       bloodGroup: normalizedBucket,
-      rh: 'unclear',
+      rh: 'empty',
     };
   }
 


### PR DESCRIPTION
### Motivation
- Indexed blood bucket metadata treated plain group values like `1`, `2`, `3`, `4` as `rh: 'unclear'`, which caused `?`/`other` filters to incorrectly include records that actually have missing Rh rather than garbage data. 
- The intent is to keep `?` for truly unknown/garbage values and have a separate `empty` category for missing Rh so filtering behaves consistently with direct-field categorization.

### Description
- Changed `getBloodBucketMeta` in `src/components/config.js` so that buckets matching `/^[1-4]$/` return `rh: 'empty'` instead of `rh: 'unclear'` by setting `rh: 'empty'` for plain numeric blood group buckets. 
- This aligns the indexed bucket behavior with `getRhCategory` which already treats plain `1-4` as `empty` and prevents `?` filters from pulling those records.

### Testing
- Ran `npm run lint:js` and the lint job completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8df3b3ed48326acba6feca31beb12)