### PR TITLE
Add 'csection' to allowedFilterNames in NoGIT+IdKey mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3326,7 +3326,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus'] : undefined}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'csection'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (


### PR DESCRIPTION
### Motivation
- Allow filtering by cesarean-section (`csection`) when operating in the NoGIT+IdKey search mode so profiles can be narrowed by that attribute in the constrained search configuration.

### Description
- Update `src/components/AddNewProfile.jsx` to include `'csection'` in the `allowedFilterNames` passed to `FilterPanel` when `searchIdAndSearchKeyOnlyMode` is true.

### Testing
- Ran the project's test suite with `yarn test` and linting with `yarn lint`, and all tests and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f3115d48832694e81c931bf942d7)