### PR TITLE
parseUkTrigger: support Unicode handles and omit empty name/surname fields

### DIFF
--- a/src/utils/parseUkTrigger.js
+++ b/src/utils/parseUkTrigger.js
@@ -23,7 +23,7 @@ export const parseUkTriggerQuery = rawQuery => {
     : normalizedTriggerPrefix;
 
 
-  const handleMatch = afterTrigger.match(/@([A-Za-z0-9_.]+)/);
+  const handleMatch = afterTrigger.match(/@([\p{L}\p{N}_.-]+)/u);
   const handle = handleMatch ? handleMatch[1] : null;
 
   const beforeHandle = handleMatch
@@ -36,14 +36,17 @@ export const parseUkTriggerQuery = rawQuery => {
 
   const contactValues = handle ? [normalizedQuery, handle] : normalizedQuery;
 
-  return {
+  const result = {
     contactType: 'telegram',
     contactValues,
-    name,
-    surname,
     handle,
     searchPair: { telegram: normalizedQuery },
   };
+
+  if (name) result.name = name;
+  if (surname) result.surname = surname;
+
+  return result;
 };
 
 export default parseUkTriggerQuery;


### PR DESCRIPTION
### Motivation
- Accept international Telegram handles and prevent returning empty `name`/`surname` keys when they're not present in the query.

### Description
- Update handle extraction to use a Unicode-aware pattern `@([\p{L}\p{N}_.-]+)` with the `u` flag to allow letters, numbers, underscores, dots and hyphens from international alphabets.
- Build the response into a `result` object and only attach `name` and `surname` keys when they are non-empty to avoid empty-string fields in the output.
- Keep existing normalization logic for the trigger prefix and `contactValues` construction unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d917e283f883269315459aea27f075)