### PR TITLE
Add `no` (empty) checkbox for Marital status in SearchKey mode

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -5,7 +5,7 @@ import { REACTION_FILTER_DEFAULTS } from 'utils/reactionCategory';
 const defaultsAdd = {
   csection: { cs2plus: true, cs1: true, cs0: true, no: true, other: true },
   role: { ed: true, sm: true, ag: true, ip: true, cl: true, other: true },
-  maritalStatus: { married: true, unmarried: true, other: true },
+  maritalStatus: { married: true, unmarried: true, other: true, empty: true },
   bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },
   rh: { '+': true, '-': true, other: true, empty: true },
   age: {
@@ -41,7 +41,7 @@ const defaultsAdd = {
 
 const defaultsMatching = {
   userRole: { ed: true, ag: false, ip: false, other: false },
-  maritalStatus: { married: true, unmarried: true, other: true },
+  maritalStatus: { married: true, unmarried: true, other: true, empty: true },
   bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },
   rh: { '+': true, '-': true, other: true, empty: true },
   age: {

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -134,6 +134,11 @@ export const SearchFilters = ({
           { val: 'married', label: 'Married' },
           { val: 'unmarried', label: 'Single' },
           { val: 'other', label: '?' },
+          ...(bloodSearchKeyMode
+            ? [
+                { val: 'empty', label: 'no' },
+              ]
+            : []),
         ],
       },
       {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2745,6 +2745,7 @@ const getMaritalStatusFilterKey = bucket => {
   const normalizedBucket = String(bucket || '').trim().toLowerCase();
   if (normalizedBucket === '+') return 'married';
   if (normalizedBucket === '-') return 'unmarried';
+  if (normalizedBucket === 'no') return 'empty';
   return 'other';
 };
 


### PR DESCRIPTION
### Motivation
- Allow SearchKey-based filters to include/exclude records with missing marital status (`no`) by exposing an explicit checkbox for that case.

### Description
- Add an `empty` (`no`) option to the **Marital status** filter in `SearchFilters.jsx` when `bloodSearchKeyMode` is enabled by conditionally appending `{ val: 'empty', label: 'no' }`.
- Add `empty: true` to the default filter states for `maritalStatus` in `FilterPanel.jsx` so the new checkbox is initialized and persisted correctly.
- Map the search-key bucket value `no` to the `empty` filter key in `config.js` via `getMaritalStatusFilterKey` so backend index buckets align with the UI option.

### Testing
- Ran lint on the touched files with `npm run lint:js -- src/components/SearchFilters.jsx src/components/FilterPanel.jsx src/components/config.js` and it completed successfully (only non-blocking `browserslist`/npm warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d939f6473c83268828b71e8008046a)