### PR TITLE
Reorder csection search checkbox options (move 'no' to end)

### DIFF
--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -111,8 +111,8 @@ export const SearchFilters = ({
           { val: 'cs2plus', label: 'cs2+' },
           { val: 'cs1', label: 'cs1' },
           { val: 'cs0', label: 'cs0' },
-          { val: 'no', label: 'no' },
           { val: 'other', label: '?' },
+          { val: 'no', label: 'no' },
         ],
       },
       {


### PR DESCRIPTION
### Motivation
- Make the `csection` checkbox ordering in search filters clearer by placing the explicit `no` option at the end of the list.

### Description
- Reordered the `csection` options in `src/components/SearchFilters.jsx` so the list is now `cs2+`, `cs1`, `cs0`, `?`, `no` (moved `{ val: 'no', label: 'no' }` to the end).

### Testing
- Ran `npm run -s test -- --watch=false --runInBand` and `npm run -s test -- --watch=false --runInBand --passWithNoTests`, both reported `No tests found related to files changed since last commit` and no test failures were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9402a594c8326a794a9523737e393)