### PR TITLE
Fix add-profile creation for UK-trigger queries without surname

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1564,8 +1564,12 @@ export const makeNewUser = async (searchedValue, rawQuery = '') => {
   if (parsedQuery) {
     const { contactType, contactValues, name, surname } = parsedQuery;
     newUser[contactType] = contactValues;
-    newUser.name = name;
-    newUser.surname = surname;
+    if (name !== undefined) {
+      newUser.name = name;
+    }
+    if (surname !== undefined) {
+      newUser.surname = surname;
+    }
   }
 
   if (searchMeta) {


### PR DESCRIPTION
### Motivation
- Creating a new profile from UK-trigger input (e.g. `УК СМ Лиля @liliyalozitskaya`) could fail silently because `undefined` `name`/`surname` values were being written into the RTDB payload.

### Description
- Update `makeNewUser` in `src/components/config.js` to assign `newUser.name` and `newUser.surname` only when those values are defined, avoiding `undefined` fields in the object sent to `set(newUserRef, newUser)`.
- This change prevents runtime rejection when the parser returns only a handle or only one of `name`/`surname`.

### Testing
- Ran linter: `npx eslint src/components/config.js` — succeeded. 
- Ran unit tests for the UK trigger parser: `npm test -- --watchAll=false --runInBand src/utils/__tests__/parseUkTrigger.test.js` — test suite failed (2 failing expectations) due to existing test expectations that require empty-string `name`/`surname` rather than omitted keys; failures are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94f3525d883268982a40330729aa7)