### PR TITLE
Prevent unintended form submit, adjust focus for maritalStatus/csection, and remove csection from extended picker

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1045,6 +1045,11 @@ ${entries.join('\n')}`;
                         return;
                       }
 
+                      if (['maritalStatus', 'csection'].includes(field.name)) {
+                        handleFieldFocus && handleFieldFocus(field.name);
+                        return;
+                      }
+
                       if (state[field.name] !== '' && state[field.name] !== undefined) {
                         handleFieldFocus && handleFieldFocus(field.name);
                         return;
@@ -1163,6 +1168,7 @@ ${entries.join('\n')}`;
               field.options.length === 2 ? (
                 <ButtonGroup>
                   <Button
+                    type="button"
                     onClick={() => {
                       if (!state.myComment?.trim()) {
                         handleDelKeyValue('myComment');
@@ -1180,6 +1186,7 @@ ${entries.join('\n')}`;
                     Так
                   </Button>
                   <Button
+                    type="button"
                     onClick={() => {
                       if (!state.myComment?.trim()) {
                         handleDelKeyValue('myComment');
@@ -1197,6 +1204,7 @@ ${entries.join('\n')}`;
                     Ні
                   </Button>
                   <Button
+                    type="button"
                     onClick={() => {
                       if (!state.myComment?.trim()) {
                         handleDelKeyValue('myComment');
@@ -1218,6 +1226,7 @@ ${entries.join('\n')}`;
               ) : field.options.length === 3 ? (
                 <ButtonGroup>
                   <Button
+                    type="button"
                     onClick={() => {
                       if (!state.myComment?.trim()) {
                         handleDelKeyValue('myComment');
@@ -1235,6 +1244,7 @@ ${entries.join('\n')}`;
                     Ні
                   </Button>
                   <Button
+                    type="button"
                     onClick={() => {
                       if (!state.myComment?.trim()) {
                         handleDelKeyValue('myComment');
@@ -1252,6 +1262,7 @@ ${entries.join('\n')}`;
                     1
                   </Button>
                   <Button
+                    type="button"
                     onClick={() => {
                       if (!state.myComment?.trim()) {
                         handleDelKeyValue('myComment');

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -288,7 +288,6 @@ export const pickerFieldsExtended = [
   { name: 'publish', placeholder: 'false', svg: 'user', ukrainianHint: 'Анкета опублікована' },
   { name: 'fathersname', placeholder: 'По-батькові', svg: 'user', ukrainianHint: 'По-батькові' },
   { name: 'otherLink', placeholder: 'www', svg: 'user', ukrainianHint: 'Лінк' },
-  { name: 'csection', placeholder: '30.01.2020', hint: 'c-section', svg: 'no', width: '33%', ukrainianHint: 'кесарів розтин', options: csectionOptions,},
 
   // { name: 'name', placeholder: 'Ваше ім’я', svg: 'user', ukrainianHint: 'Ім’я' },
   // { name: 'surname', placeholder: 'Ваше призіище', svg: 'user', ukrainianHint: 'Прізвище'},


### PR DESCRIPTION
### Motivation
- Prevent option buttons from submitting the surrounding form accidentally by making them non-submit buttons.
- Ensure `maritalStatus` and `csection` fields trigger the same focus handling as non-picker fields instead of opening the modal picker.
- Stop including `csection` in the `pickerFieldsExtended` list to avoid it being treated as an extended picker field.

### Description
- Added an early `handleFieldFocus` return for fields named `maritalStatus` and `csection` inside the `InputField` `onFocus` handler in `ProfileForm.jsx`.
- Added `type="button"` to multiple option `Button` elements in `ProfileForm.jsx` to prevent default form submission behavior.
- Removed the `csection` entry from `pickerFieldsExtended` in `src/components/formFields.js` while leaving the `csectionOptions` definition in place.

### Testing
- Ran unit tests with `yarn test` and the test suite passed.
- Ran the linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9431c62a883269f1e7fc3a867fc5c)