### PR TITLE
Skip date-based matching for exact `searchId` queries to avoid false positives

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2127,7 +2127,12 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
       }
     }
 
-    const isDateSearch = await searchByDate(searchValue, uniqueUserIds, users);
+    // Для exact-пошуку по searchId не запускаємо date-пошук по полях картки
+    // (getInTouch/lastAction/...): інакше запити на кшталт
+    // "УК СМ Лилит 12.04.2026" можуть некоректно підтягувати date-збіги.
+    const isDateSearch = searchKey === 'searchId'
+      ? false
+      : await searchByDate(searchValue, uniqueUserIds, users);
     if (isDev) console.log('fetchNewUsersCollectionInRTDB → isDateSearch:', isDateSearch);
     if (!isDateSearch) {
       if (forcePartialUserIdSearch) {


### PR DESCRIPTION
### Motivation
- Prevent date-based field matching from producing false positives when the query is an exact `searchId` (e.g. queries containing dates like "УК СМ Лилит 12.04.2026").

### Description
- Add a conditional to skip calling `searchByDate` when `searchKey === 'searchId'` (`const isDateSearch = searchKey === 'searchId' ? false : await searchByDate(...)`) and include a clarifying comment about the rationale.

### Testing
- Ran the automated unit test suite with `yarn test` after the change and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db566f17f08326b1c384ec819f8bd8)