### PR TITLE
Extract Telegram candidate builder for UK-trigger and use it in SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -15,6 +15,7 @@ import {
 } from '../utils/cardIndex';
 import { updateCard, searchCachedCards } from '../utils/cardsStorage';
 import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
+import { buildUkTriggerTelegramCandidates } from '../utils/ukTriggerSearchCandidates';
 
 const SearchIcon = (
   <svg
@@ -976,11 +977,7 @@ const SearchBar = ({
     if (!id && platform === 'telegram' && allowUkTrigger) {
       const ukTrigger = parseUkTriggerQuery(trimmedInput);
       if (ukTrigger?.searchPair?.telegram) {
-        const normalizedTelegram = ukTrigger.searchPair.telegram;
-        const searchCandidates = [normalizedTelegram];
-        if (ukTrigger.handle) {
-          searchCandidates.push(ukTrigger.handle);
-        }
+        const searchCandidates = buildUkTriggerTelegramCandidates(ukTrigger);
 
         for (const [index, candidate] of searchCandidates.entries()) {
           const telegramValue = candidate?.trim();

--- a/src/utils/ukTriggerSearchCandidates.js
+++ b/src/utils/ukTriggerSearchCandidates.js
@@ -1,0 +1,18 @@
+export const buildUkTriggerTelegramCandidates = ukTrigger => {
+  const normalizedTelegram = ukTrigger?.searchPair?.telegram?.trim();
+  if (!normalizedTelegram) return [];
+
+  const candidates = [normalizedTelegram];
+  const handle = String(ukTrigger?.handle || '').trim();
+
+  // Єдине правило: завжди шукаємо і повний UK-тригер, і fallback по handle.
+  // Це зберігає partial-поведінку для запитів типу "УК СМ @yuliia420",
+  // де очікуються також збіги на кшталт "УК СМ @yuliia4201".
+  if (handle) {
+    candidates.push(handle);
+  }
+
+  return candidates;
+};
+
+export default buildUkTriggerTelegramCandidates;


### PR DESCRIPTION
### Motivation
- Isolate and reuse the logic that builds Telegram search candidates from a parsed UK-trigger to simplify `SearchBar` and make the candidate logic testable and clearer.

### Description
- Add `buildUkTriggerTelegramCandidates` in `src/utils/ukTriggerSearchCandidates.js` to return an ordered list of telegram candidates from a parsed UK-trigger including a fallback to the `handle` when present. 
- Replace inline candidate assembly in `src/components/SearchBar.jsx` with an import and call to `buildUkTriggerTelegramCandidates` and add the import statement.

### Testing
- Ran the existing automated test suite and linting (`npm test` and `npm run lint`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db850697408326914a1688c423b5dd)