### PR TITLE
Restrict UK-trigger Telegram search to full query and disable prefix matches

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1003,7 +1003,7 @@ const SearchBar = ({
 
           const res = await cachedSearch(
             { telegram: telegramValue },
-            { allowTelegramPrefixMatches: true },
+            { allowTelegramPrefixMatches: false },
           );
           if (res && Object.keys(res).length > 0) {
             notifySearchResult(

--- a/src/utils/parseUkTrigger.js
+++ b/src/utils/parseUkTrigger.js
@@ -34,7 +34,7 @@ export const parseUkTriggerQuery = rawQuery => {
   const name = nameParts[0] || '';
   const surname = nameParts.slice(1).join(' ') || '';
 
-  const contactValues = handle ? [normalizedQuery, handle] : normalizedQuery;
+  const contactValues = normalizedQuery;
 
   const result = {
     contactType: 'telegram',

--- a/src/utils/ukTriggerSearchCandidates.js
+++ b/src/utils/ukTriggerSearchCandidates.js
@@ -2,17 +2,10 @@ export const buildUkTriggerTelegramCandidates = ukTrigger => {
   const normalizedTelegram = ukTrigger?.searchPair?.telegram?.trim();
   if (!normalizedTelegram) return [];
 
-  const candidates = [normalizedTelegram];
-  const handle = String(ukTrigger?.handle || '').trim();
-
-  // Єдине правило: завжди шукаємо і повний UK-тригер, і fallback по handle.
-  // Це зберігає partial-поведінку для запитів типу "УК СМ @yuliia420",
-  // де очікуються також збіги на кшталт "УК СМ @yuliia4201".
-  if (handle) {
-    candidates.push(handle);
-  }
-
-  return candidates;
+  // Для UK-тригера використовуємо лише повний telegram-запит:
+  // "УК СМ ... @nickname". Не робимо fallback за частиною handle,
+  // щоб уникати хибних збігів (наприклад, коли "420" збігається з phone).
+  return [normalizedTelegram];
 };
 
 export default buildUkTriggerTelegramCandidates;


### PR DESCRIPTION
### Motivation
- Prevent false-positive matches from partial handles when processing UK-trigger searches by avoiding fallback to handle substrings. 
- Ensure UK-trigger queries search the full normalized telegram query only, so results reflect the explicit trigger text. 
- Disable prefix-based telegram matching in the cached search path for UK-trigger flows to avoid unintended partial matches.

### Description
- In `SearchBar.jsx`, set `allowTelegramPrefixMatches` to `false` for cached searches initiated by UK-trigger logic to prevent prefix matches.  
- In `parseUkTrigger.js`, return `contactValues` as the full normalized query string instead of an array containing the handle, and keep `searchPair.telegram` as the normalized query.  
- In `ukTriggerSearchCandidates.js`, simplify candidate generation to return only the full normalized telegram query and remove the previous fallback to the raw handle to avoid ambiguous partial matches.

### Testing
- Ran the unit test suite with `yarn test`, and all tests related to search parsing and UK-trigger behavior passed.  
- Ran linters with `yarn lint` to ensure formatting and static checks passed.  
- Manually exercised UK-trigger search scenarios in the dev build to confirm that only full-query telegram matches are returned and no unexpected prefix matches occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8df16f7c8326967c6cc4df4f619e)