### PR TITLE
Sanitize phone submissions and skip short phone searches

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -176,7 +176,7 @@ const parsePhoneNumber = phone => {
 
   const digitsOnly = trimmed.replace(/\D/g, '');
   if (!digitsOnly) return;
-  if (digitsOnly.length < 3) return;
+  if (digitsOnly.length < 4) return;
 
   // Для коротких фрагментів зберігаємо введене значення,
   // щоб підтримати пошук за частиною номера.

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2224,6 +2224,30 @@ const removeUndefined = obj => {
   return obj;
 };
 
+const normalizePhoneForStorage = value => {
+  if (value === undefined || value === null) return value;
+
+  if (Array.isArray(value)) {
+    return value
+      .map(item => normalizePhoneForStorage(item))
+      .filter(item => item !== '' && item !== undefined && item !== null);
+  }
+
+  const digitsOnly = String(value).replace(/\D/g, '');
+  return digitsOnly;
+};
+
+const sanitizeUploadedInfoPhones = uploadedInfo => {
+  if (!uploadedInfo || typeof uploadedInfo !== 'object') return uploadedInfo;
+  if (!Object.prototype.hasOwnProperty.call(uploadedInfo, 'phone')) return uploadedInfo;
+
+  const normalizedPhone = normalizePhoneForStorage(uploadedInfo.phone);
+  return {
+    ...uploadedInfo,
+    phone: normalizedPhone,
+  };
+};
+
 export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) => {
   try {
     const userRefRTDB = ref2(database, `users/${userId}`);
@@ -2244,9 +2268,11 @@ export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) =>
 
 export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, skipIndexing = false) => {
   try {
+    uploadedInfo = sanitizeUploadedInfoPhones(uploadedInfo);
     const userRefRTDB = ref2(database, `newUsers/${userId}`);
     const snapshot = await get(userRefRTDB);
-    const currentUserData = snapshot.exists() ? snapshot.val() : {};
+    const currentUserDataRaw = snapshot.exists() ? snapshot.val() : {};
+    const currentUserData = sanitizeUploadedInfoPhones(currentUserDataRaw) || {};
 
     if (!skipIndexing) {
       // Перебір ключів та їх обробка
@@ -2292,17 +2318,7 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
 
             // Якщо ключ — це 'phone', прибираємо пробіли у значенні
             if (key === 'phone') {
-              if (typeof value === 'number') {
-                cleanedValue = String(value).replace(/\s+/g, '');
-              } else if (typeof value === 'string') {
-                cleanedValue = value.replace(/\s+/g, '');
-              } else if (Array.isArray(value)) {
-                // Якщо value є масивом телефонів
-                cleanedValue = value.map(v => (typeof v === 'number' ? String(v) : v)).map(v => v.replace(/\s+/g, ''));
-              } else {
-                console.warn(`Неправильний тип даних для ключа 'phone':`, value);
-                cleanedValue = ''; // Запобігаємо помилці та уникаємо некоректного значення
-              }
+              cleanedValue = normalizePhoneForStorage(value);
             }
 
             if (!newValues.includes(cleanedValue)) {
@@ -2316,17 +2332,7 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
 
             // Якщо ключ — це 'phone', прибираємо пробіли у значенні
             if (key === 'phone') {
-              if (typeof value === 'number') {
-                cleanedValue = String(value).replace(/\s+/g, '');
-              } else if (typeof value === 'string') {
-                cleanedValue = value.replace(/\s+/g, '');
-              } else if (Array.isArray(value)) {
-                // Якщо value є масивом телефонів
-                cleanedValue = value.map(v => (typeof v === 'number' ? String(v) : v)).map(v => v.replace(/\s+/g, ''));
-              } else {
-                console.warn(`Неправильний тип даних для ключа 'phone':`, value);
-                cleanedValue = ''; // Запобігаємо помилці та уникаємо некоректного значення
-              }
+              cleanedValue = normalizePhoneForStorage(value);
             }
 
             // console.log('cleanedValue :>> ', cleanedValue);


### PR DESCRIPTION
### Motivation
- Prevent non-digit characters (like leading `+`) from being stored or indexed for `phone`, because backend received plus signs and that breaks search/indexing.
- Avoid triggering phone-based searches for very short numeric fragments that should not be treated as full phone lookups.

### Description
- Add `normalizePhoneForStorage` and `sanitizeUploadedInfoPhones` helpers and sanitize incoming `uploadedInfo.phone` and existing `currentUserData` in `updateDataInNewUsersRTDB` so stored/indexed phone values contain only digits (strips `+` and other non-digits). (modified `src/components/config.js`)
- Replace duplicated phone-cleanup branches inside the indexing loop with the shared normalizer so add/remove `searchId` operations compare normalized digit-only values. (modified `src/components/config.js`)
- Increase minimal digit threshold in phone parsing from 3 to 4 so phone search detection will skip queries with fewer than 4 digits. (modified `src/components/SearchBar.jsx`)

### Testing
- Ran linter: `npm run lint:js -- src/components/SearchBar.jsx src/components/config.js` (succeeded).
- Ran unit tests for an unrelated suite: `CI=true npm test -- --watchAll=false src/utils/__tests__/parseUkTrigger.test.js` (2 existing tests failed; failures are unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddecee631083269a58a9f6f165a063)