### PR TITLE
Skip phone search key generation for non-phone inputs and short numeric fragments

### DIFF
--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -29,6 +29,7 @@ export const buildSearchIdCandidateKeys = (
   options = {},
 ) => {
   const normalizedValue = String(modifiedSearchValue || '').toLowerCase();
+  const rawValue = String(rawSearchValue || '').trim();
   if (!normalizedValue) return [];
 
   const {
@@ -40,6 +41,17 @@ export const buildSearchIdCandidateKeys = (
   const prefixesToCheck = getSearchIdPrefixes(searchIdPrefixes);
 
   return prefixesToCheck.flatMap(prefix => {
+    if (prefix === 'phone') {
+      const hasPhoneLabel = /(?:^|\b)(?:phone|телефон|тел|номер|моб)\b/i.test(rawValue);
+      const hasLetters = /[A-Za-zА-Яа-яІіЇїЄєҐґ]/.test(rawValue);
+      const digitsOnly = rawValue.replace(/\D/g, '');
+      const isShortNumericFragment = digitsOnly.length > 0 && digitsOnly.length < 4;
+
+      if ((hasLetters && !hasPhoneLabel) || isShortNumericFragment) {
+        return [];
+      }
+    }
+
     if (prefix === 'phone' && includeAdaptedPhoneVariant) {
       const adaptedPhoneValue = normalizePhoneSearchIdValue(rawSearchValue);
       const adaptedPhoneKey = encodeKey(adaptedPhoneValue).toLowerCase();


### PR DESCRIPTION
### Motivation

- Reduce false-positive phone search keys and unnecessary index entries for inputs that are unlikely to be phone numbers, such as names or very short numeric fragments.

### Description

- Trimmed the incoming raw search value into `rawValue` and added heuristics to skip generating `phone` prefixed keys when the input contains letters but no explicit phone label or when the numeric portion is a short fragment (1–3 digits).
- The label detection uses a regex for common phone label words and letter detection uses a regex covering Latin and Cyrillic letters, while numeric fragments are detected by stripping non-digits and checking length. 
- Kept existing handling for `includeAdaptedPhoneVariant` which still generates phone keys using `normalizePhoneSearchIdValue` when requested.

### Testing

- Ran the unit test suite with `yarn test` and all tests related to search key generation passed. 
- Ran linting with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf9e51ba083268648433647e71610)