### PR TITLE
Map 3-option ButtonGroup to dynamic `field.options` and handle 'Other' blur

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1225,60 +1225,30 @@ ${entries.join('\n')}`;
                 </ButtonGroup>
               ) : field.options.length === 3 ? (
                 <ButtonGroup>
-                  <Button
-                    type="button"
-                    onClick={() => {
-                      if (!state.myComment?.trim()) {
-                        handleDelKeyValue('myComment');
-                      }
-                      setState(prevState => {
-                        const newState = {
-                          ...prevState,
-                          [field.name]: '-',
-                        };
-                        submitWithNormalization(newState, 'overwrite');
-                        return newState;
-                      });
-                    }}
-                  >
-                    Ні
-                  </Button>
-                  <Button
-                    type="button"
-                    onClick={() => {
-                      if (!state.myComment?.trim()) {
-                        handleDelKeyValue('myComment');
-                      }
-                      setState(prevState => {
-                        const newState = {
-                          ...prevState,
-                          [field.name]: '1',
-                        };
-                        submitWithNormalization(newState, 'overwrite');
-                        return newState;
-                      });
-                    }}
-                  >
-                    1
-                  </Button>
-                  <Button
-                    type="button"
-                    onClick={() => {
-                      if (!state.myComment?.trim()) {
-                        handleDelKeyValue('myComment');
-                      }
-                      setState(prevState => {
-                        const newState = {
-                          ...prevState,
-                          [field.name]: '2',
-                        };
-                        submitWithNormalization(newState, 'overwrite');
-                        return newState;
-                      });
-                    }}
-                  >
-                    2
-                  </Button>
+                  {field.options.map(option => (
+                    <Button
+                      key={`${field.name}-${option.placeholder}`}
+                      type="button"
+                      onClick={() => {
+                        if (!state.myComment?.trim()) {
+                          handleDelKeyValue('myComment');
+                        }
+                        setState(prevState => {
+                          const newState = {
+                            ...prevState,
+                            [field.name]: option.placeholder,
+                          };
+                          submitWithNormalization(newState, 'overwrite');
+                          if (option.placeholder === 'Other') {
+                            handleBlur(field.name);
+                          }
+                          return newState;
+                        });
+                      }}
+                    >
+                      {option.ukrainian || option.placeholder}
+                    </Button>
+                  ))}
                 </ButtonGroup>
               ) : null
             ) : null}


### PR DESCRIPTION
### Motivation

- Remove duplicated hardcoded buttons for the 3-option case and make the UI driven by `field.options` so options can vary without code changes.  
- Ensure the special-case behavior for an "Other" option (triggering `handleBlur`) is applied when that option is selected.  

### Description

- Replaced the three hardcoded `<Button>` elements with a dynamic `field.options.map(...)` that renders one `<Button>` per option.  
- Buttons now use `option.placeholder` as the stored value and display `option.ukrainian` when available, falling back to the placeholder.  
- Retained existing behavior to remove empty `myComment` via `handleDelKeyValue` and to call `submitWithNormalization` with `'overwrite'` on selection.  
- Added a `handleBlur` call when the selected option's placeholder equals `'Other'` and added a stable `key` for each mapped button.  

### Testing

- Ran the project's unit tests (`npm test` / Jest) and all tests passed.  
- Ran linters (`npm run lint`) and formatting checks and they passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfa471d80832683d070c0414ebcaf)