### PR TITLE
Treat `education` as two-step field and surface `modalOptions` in pickers

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1050,12 +1050,21 @@ ${entries.join('\n')}`;
                         return;
                       }
 
-                      if (state[field.name] !== '' && state[field.name] !== undefined) {
+                      if (
+                        field.name !== 'education' &&
+                        state[field.name] !== '' &&
+                        state[field.name] !== undefined
+                      ) {
                         handleFieldFocus && handleFieldFocus(field.name);
                         return;
                       }
 
                       handleOpenModal(field.name);
+                    }}
+                    onClick={() => {
+                      if (field.name === 'education') {
+                        handleOpenModal(field.name);
+                      }
                     }}
                     {...(field.name === 'lastAction'
                       ? { readOnly: true }
@@ -1164,7 +1173,7 @@ ${entries.join('\n')}`;
                 </Button>
               )}
 
-            {Array.isArray(field.options) ? (
+            {Array.isArray(field.options) && field.name !== 'education' ? (
               field.options.length === 2 ? (
                 <ButtonGroup>
                   <Button
@@ -1336,7 +1345,10 @@ ${entries.join('\n')}`;
       {showInfoModal && (
         <InfoModal
           onClose={handleCloseModal}
-          options={sortedFieldsToRender.find(field => field.name === selectedField)?.options}
+          options={
+            sortedFieldsToRender.find(field => field.name === selectedField)?.modalOptions ||
+            sortedFieldsToRender.find(field => field.name === selectedField)?.options
+          }
           onSelect={handleSelectOption}
           text={showInfoModal}
         />

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -665,7 +665,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
                 <Hint fieldName={field.name} isActive={state[field.name]}>{field.ukrainian || field.placeholder}</Hint>
                 <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
               </InputDiv>
-              {Array.isArray(field.options) && field.options.length === 2 && (
+              {Array.isArray(field.options) && field.name !== 'education' && field.options.length === 2 && (
                 <ButtonGroup>
                   <Button
                     onClick={() => {
@@ -702,7 +702,10 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       {showInfoModal && (
         <InfoModal
           onClose={handleOverlayClick}
-          options={pickerFields.find(field => field.name === selectedField)?.options}
+          options={
+            pickerFields.find(field => field.name === selectedField)?.modalOptions ||
+            pickerFields.find(field => field.name === selectedField)?.options
+          }
           onSelect={handleSelectOption}
           text={showInfoModal}
           Context={dotsMenu}

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -125,9 +125,17 @@ export const bodyTypeOptions = [
 ];
 
 export const educationOptions = [
+  { placeholder: 'No', ukrainian: 'Ні' },
+  { placeholder: 'Yes', ukrainian: 'Так' },
+];
+
+export const educationModalOptions = [
   { placeholder: 'Higher', ukrainian: 'Вища освіта' },
   { placeholder: 'Technical', ukrainian: 'Професійно-технічна освіта' },
   { placeholder: 'Secondary', ukrainian: 'Загальна середня освіта' },
+  { placeholder: 'Bachelor', ukrainian: 'Бакалавр' },
+  { placeholder: 'Master', ukrainian: 'Магістр' },
+  { placeholder: 'PhD', ukrainian: 'Доктор філософії (PhD)' },
 ];
 
 export const csectionOptions = [
@@ -251,6 +259,7 @@ export const pickerFields = [
     svg: 'no',
     width: '33%',
     options: educationOptions,
+    modalOptions: educationModalOptions,
     ukrainian: 'Вища освіта',
     ukrainianHint: 'освіта',
   },


### PR DESCRIPTION
### Motivation
- Allow the `education` field to act as a quick two-option selector (Yes/No) while also providing a richer, separate modal list of detailed education values.
- Ensure the InfoModal uses a dedicated `modalOptions` list when available so detailed selections are shown where appropriate.

### Description
- Added `educationOptions` (No/Yes) and `educationModalOptions` (Higher, Technical, Secondary, Bachelor, Master, PhD) to `formFields.js` and attached `modalOptions` to the `education` picker field.
- Updated `ProfileForm.jsx` to special-case `education` so it does not trigger the standard focus-to-open-modal flow when a value exists, and added an `onClick` that explicitly opens the modal for `education`.
- Updated both `ProfileForm.jsx` and `ProfileScreen.jsx` to pass `modalOptions` to `InfoModal` when present, falling back to `options` otherwise.
- Adjusted rendering logic in both form components to exclude `education` from the inline two-option button groups so it uses the new two-step/modal UX.

### Testing
- Ran the project test suite via `yarn test` and the tests completed successfully.
- Ran the linter via `yarn lint` and a production build via `yarn build`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0785b9c4832692c646b43cdd5b73)