### PR TITLE
Adjust MyProfile csection field UX to allow custom input and quick buttons

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -1026,6 +1026,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         {visiblePickerFields.map(field => {
           // console.log('field.options:', field.options);
           const isPickerField = Array.isArray(field.options);
+          const isCsectionField = field.name === 'csection';
 
           return (
             <PickerContainer>
@@ -1038,7 +1039,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                     name={field.name}
                     value={state[field.name]}
-                    readOnly={isPickerField}
+                    readOnly={isPickerField && !isCsectionField}
                     onChange={e => {
                       const value = e?.target?.value;
                       field.name === 'moreInfo_main' && autoResizeMoreInfo(e.target);
@@ -1050,17 +1051,17 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                       // }
                     }}
                     onMouseDown={event => {
-                      if (isPickerField) {
+                      if (isPickerField && !isCsectionField) {
                         event.preventDefault();
                       }
                     }}
                     onFocus={() => {
-                      if (!isPickerField) {
+                      if (!isPickerField || isCsectionField) {
                         handleFocus(field.name);
                       }
                     }}
                     onClick={() => {
-                      if (!isPickerField) return;
+                      if (!isPickerField || isCsectionField) return;
                       handleOpenModal(field.name);
                       setShowInfoModal('pickerOptions');
                     }}
@@ -1099,6 +1100,22 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   >
                     Інше
                   </Button>
+                </ButtonGroup>
+              )}
+              {field.name === 'csection' && (
+                <ButtonGroup>
+                  {field.options.map(option => (
+                    <Button
+                      key={`${field.name}-${option.placeholder}`}
+                      type="button"
+                      onClick={() => {
+                        setState(prevState => ({ ...prevState, [field.name]: option.placeholder }));
+                        handleBlur(field.name);
+                      }}
+                    >
+                      {option.ukrainian || option.placeholder}
+                    </Button>
+                  ))}
                 </ButtonGroup>
               )}
             </PickerContainer>


### PR DESCRIPTION
### Motivation
- Make the `csection` (кесарів розтин) field in `MyProfile` behave the same way as in `ProfileForm`: allow typing custom text directly and provide quick buttons for the common options instead of forcing a modal picker.

### Description
- Added a per-field check `isCsectionField` and made the input `readOnly` only for picker fields except `csection` so `csection` can be edited inline.
- Prevented the picker modal from opening for `csection` by adjusting `onMouseDown`, `onFocus`, and `onClick` conditions for picker fields.
- Rendered an inline `ButtonGroup` for the `csection` field that maps its `options` to quick action buttons (`Ні`, `1`, `2`) which set the field value and call the existing `handleBlur`/submit flow.
- Kept existing submit/normalization behavior (`handleBlur` / `handleSubmit`) so selecting a quick button persists immediately and custom text is saved on blur.

### Testing
- Ran lint on the changed file with `npm run lint:js -- src/components/MyProfile.jsx` and it completed (only non-blocking `browserslist`/npm warnings were shown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0a49852883268bf2a4d393ac35dc)