### PR TITLE
Add searchKey/age filters with dynamic birth-date indexing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -39,6 +39,7 @@ import {
   createMaritalStatusSearchKeyIndexInCollection,
   createCsectionSearchKeyIndexInCollection,
   createRoleSearchKeyIndexInCollection,
+  createAgeSearchKeyIndexInCollection,
   fetchUsersBySearchKeyBloodPaged,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -2890,6 +2891,26 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     toast.success('searchKey/role indexed', { id: 'index-searchkey-role-progress' });
   };
 
+  const indexSearchKeyAgeHandler = async () => {
+    toast.loading('Indexing searchKey/age in newUsers 0%', {
+      id: 'index-searchkey-age-progress',
+    });
+    await createAgeSearchKeyIndexInCollection('newUsers', progress => {
+      toast.loading(`Indexing searchKey/age in newUsers ${progress}%`, {
+        id: 'index-searchkey-age-progress',
+      });
+    });
+    toast.loading('Indexing searchKey/age in users 0%', {
+      id: 'index-searchkey-age-progress',
+    });
+    await createAgeSearchKeyIndexInCollection('users', progress => {
+      toast.loading(`Indexing searchKey/age in users ${progress}%`, {
+        id: 'index-searchkey-age-progress',
+      });
+    });
+    toast.success('searchKey/age indexed', { id: 'index-searchkey-age-progress' });
+  };
+
   const fieldsToRender = getFieldsToRender(state);
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
@@ -3347,7 +3368,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'role', 'csection'] : undefined}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'age', 'role', 'csection'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (
@@ -3420,6 +3441,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 title="Індексація searchKey/role"
               >
                 IdxRole
+              </Button>
+              <Button
+                onClick={indexSearchKeyAgeHandler}
+                title="Індексація searchKey/age"
+              >
+                IdxAge
               </Button>
               <Button onClick={makeIndex}>Index</Button>
               {<Button onClick={searchDuplicates}>DPL</Button>}

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -16,6 +16,7 @@ const defaultsAdd = {
     '37_42': true,
     '43_plus': true,
     other: true,
+    empty: true,
   },
   imt: {
     lt31: true,

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -187,6 +187,11 @@ export const SearchFilters = ({
           { val: '37_42', label: '37-42' },
           { val: '43_plus', label: '43+' },
           { val: 'other', label: '?' },
+          ...(bloodSearchKeyMode
+            ? [
+                { val: 'empty', label: 'no' },
+              ]
+            : []),
         ],
       },
       {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -66,6 +66,7 @@ const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tik
 const SEARCH_KEY_INDEX_ROOT = 'searchKey';
 const BLOOD_SEARCH_KEY_INDEX = 'blood';
 const MARITAL_STATUS_SEARCH_KEY_INDEX = 'maritalStatus';
+const AGE_SEARCH_KEY_INDEX = 'age';
 const CSECTION_SEARCH_KEY_INDEX = 'csection';
 const ROLE_SEARCH_KEY_INDEX = 'role';
 const SEARCH_KEY_BATCH_UPLOAD_SIZE = 100;
@@ -2651,6 +2652,39 @@ const getMaritalStatusIndexSet = data => {
   return new Set([normalizeMaritalStatusIndexValue(data.maritalStatus)]);
 };
 
+const normalizeAgeBirthDateIndexValue = rawValue => {
+  const normalized = String(rawValue || '').trim();
+  if (!normalized) return 'no';
+
+  const match = normalized.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+  if (!match) return '?';
+
+  const day = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const year = Number.parseInt(match[3], 10);
+
+  if (!Number.isInteger(day) || !Number.isInteger(month) || !Number.isInteger(year)) {
+    return '?';
+  }
+
+  const parsedDate = new Date(year, month - 1, day);
+  if (
+    parsedDate.getFullYear() !== year ||
+    parsedDate.getMonth() !== month - 1 ||
+    parsedDate.getDate() !== day
+  ) {
+    return '?';
+  }
+
+  const isoDate = `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  return `d_${isoDate}`;
+};
+
+const getAgeIndexSet = data => {
+  if (!data || typeof data !== 'object') return new Set();
+  return new Set([normalizeAgeBirthDateIndexValue(data.birth)]);
+};
+
 export const normalizeRoleSearchKeyIndexValue = (roleValue, userRoleValue) => {
   const normalizeSingleRole = value => {
     const normalized = String(value || '')
@@ -2821,6 +2855,103 @@ const isRoleBucketAllowedByFilters = (bucket, filterSettings = {}) => {
   return Boolean(roleFilters?.[filterKey]);
 };
 
+const AGE_DATE_PREFIX = 'd_';
+
+const toIsoDate = date => {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+};
+
+const subtractYears = (date, years) => {
+  const shifted = new Date(date);
+  shifted.setFullYear(shifted.getFullYear() - years);
+  return shifted;
+};
+
+const shiftDays = (date, days) => {
+  const shifted = new Date(date);
+  shifted.setDate(shifted.getDate() + days);
+  return shifted;
+};
+
+const getBirthDateRangeByAge = ({ minAge, maxAge, today = new Date() }) => {
+  let startDate = null;
+  let endDate = null;
+
+  if (Number.isFinite(maxAge)) {
+    startDate = shiftDays(subtractYears(today, maxAge + 1), 1);
+  }
+
+  if (Number.isFinite(minAge)) {
+    endDate = subtractYears(today, minAge);
+  }
+
+  if (!startDate) startDate = new Date(1900, 0, 1);
+  if (!endDate) endDate = today;
+  if (startDate > endDate) return null;
+
+  return {
+    startKey: `${AGE_DATE_PREFIX}${toIsoDate(startDate)}`,
+    endKey: `${AGE_DATE_PREFIX}${toIsoDate(endDate)}`,
+  };
+};
+
+const collectIdsFromAgeSnapshot = (snapshot, idSet) => {
+  if (!snapshot.exists()) return;
+  snapshot.forEach(bucketSnapshot => {
+    const usersMap = bucketSnapshot.val() || {};
+    Object.keys(usersMap).forEach(userId => {
+      if (userId) idSet.add(userId);
+    });
+  });
+};
+
+const collectAgeIdsByFilters = async ageFilters => {
+  const shouldApplyAge = hasExplicitFilterSelection(ageFilters);
+  if (!shouldApplyAge) return null;
+
+  const selected = key => Boolean(ageFilters?.[key]);
+  const ageIds = new Set();
+  const requests = [];
+
+  const addRangeRequest = range => {
+    if (!range) return;
+    requests.push(
+      get(
+        query(
+          ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${AGE_SEARCH_KEY_INDEX}`),
+          orderByKey(),
+          startAt(range.startKey),
+          endAt(range.endKey)
+        )
+      )
+    );
+  };
+
+  if (selected('le25')) addRangeRequest(getBirthDateRangeByAge({ maxAge: 25 }));
+  if (selected('26_30')) addRangeRequest(getBirthDateRangeByAge({ minAge: 26, maxAge: 30 }));
+  if (selected('31_33')) addRangeRequest(getBirthDateRangeByAge({ minAge: 31, maxAge: 33 }));
+  if (selected('34_36')) addRangeRequest(getBirthDateRangeByAge({ minAge: 34, maxAge: 36 }));
+  if (selected('37_42')) addRangeRequest(getBirthDateRangeByAge({ minAge: 37, maxAge: 42 }));
+  if (selected('43_plus')) addRangeRequest(getBirthDateRangeByAge({ minAge: 43 }));
+  if (selected('other')) requests.push(get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${AGE_SEARCH_KEY_INDEX}/?`)));
+  if (selected('empty')) requests.push(get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${AGE_SEARCH_KEY_INDEX}/no`)));
+
+  const snapshots = await Promise.all(requests);
+  snapshots.forEach(snapshot => {
+    if (!snapshot.exists()) return;
+    const isRangeResult = snapshot.key === AGE_SEARCH_KEY_INDEX;
+    if (isRangeResult) {
+      collectIdsFromAgeSnapshot(snapshot, ageIds);
+      return;
+    }
+    Object.keys(snapshot.val() || {}).forEach(userId => {
+      if (userId) ageIds.add(userId);
+    });
+  });
+
+  return ageIds;
+};
+
 const updateSearchKeyLeaf = async (indexName, value, userId, action) => {
   if (!indexName || !value || !userId) return;
   const indexRef = ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${indexName}/${value}/${userId}`);
@@ -2846,6 +2977,8 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   const nextCsectionValues = getCsectionIndexSet(nextData);
   const prevRoleValues = getRoleIndexSet(prevData);
   const nextRoleValues = getRoleIndexSet(nextData);
+  const prevAgeValues = getAgeIndexSet(prevData);
+  const nextAgeValues = getAgeIndexSet(nextData);
 
   for (const value of prevValues) {
     if (!nextValues.has(value)) {
@@ -2900,6 +3033,20 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
     if (!prevRoleValues.has(value)) {
       // eslint-disable-next-line no-await-in-loop
       await updateSearchKeyLeaf(ROLE_SEARCH_KEY_INDEX, value, userId, 'add');
+    }
+  }
+
+  for (const value of prevAgeValues) {
+    if (!nextAgeValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(AGE_SEARCH_KEY_INDEX, value, userId, 'remove');
+    }
+  }
+
+  for (const value of nextAgeValues) {
+    if (!prevAgeValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(AGE_SEARCH_KEY_INDEX, value, userId, 'add');
     }
   }
 };
@@ -3014,6 +3161,34 @@ export const createRoleSearchKeyIndexInCollection = async (collection, onProgres
   }
 };
 
+export const createAgeSearchKeyIndexInCollection = async (collection, onProgress) => {
+  const usersData = await loadCollectionWithIndexCache(collection);
+  if (!usersData) return;
+
+  const userIds = Object.keys(usersData);
+  const totalUsers = userIds.length;
+  if (totalUsers === 0) return;
+
+  const updates = userIds.reduce((acc, userId) => {
+    const user = usersData[userId] || {};
+    const ageValue = normalizeAgeBirthDateIndexValue(user.birth);
+    acc[`${SEARCH_KEY_INDEX_ROOT}/${AGE_SEARCH_KEY_INDEX}/${ageValue}/${userId}`] = true;
+    return acc;
+  }, {});
+
+  const updateEntries = Object.entries(updates);
+
+  for (let i = 0; i < updateEntries.length; i += SEARCH_KEY_BATCH_UPLOAD_SIZE) {
+    const chunkEntries = updateEntries.slice(i, i + SEARCH_KEY_BATCH_UPLOAD_SIZE);
+    const chunkPayload = Object.fromEntries(chunkEntries);
+    // eslint-disable-next-line no-await-in-loop
+    await update(ref2(database), chunkPayload);
+
+    const progress = Math.floor((Math.min(i + chunkEntries.length, totalUsers) / totalUsers) * 100);
+    if (onProgress && progress % 10 === 0) onProgress(progress);
+  }
+};
+
 export const fetchUsersBySearchKeyBloodPaged = async ({
   filterSettings = {},
   offset = 0,
@@ -3024,6 +3199,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
     isMaritalStatusBucketAllowedByFilters(bucket, filterSettings)
   );
   const filteredRoleBuckets = ROLE_SEARCH_KEY_BUCKETS.filter(bucket => isRoleBucketAllowedByFilters(bucket, filterSettings));
+  const ageUserIds = await collectAgeIdsByFilters(filterSettings?.age);
 
   const [bucketSnapshots, maritalStatusSnapshots, roleSnapshots] = await Promise.all([
     Promise.all(
@@ -3058,6 +3234,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   const roleUserIds = collectIdsFromSnapshots(roleSnapshots);
   const shouldApplyMaritalStatusFilter = hasExplicitFilterSelection(filterSettings?.maritalStatus);
   const shouldApplyRoleFilter = hasExplicitFilterSelection(filterSettings?.role);
+  const shouldApplyAgeFilter = ageUserIds instanceof Set;
 
   let finalIds = [...bloodUserIds];
   if (shouldApplyMaritalStatusFilter) {
@@ -3065,6 +3242,9 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   }
   if (shouldApplyRoleFilter) {
     finalIds = finalIds.filter(id => roleUserIds.has(id));
+  }
+  if (shouldApplyAgeFilter) {
+    finalIds = finalIds.filter(id => ageUserIds.has(id));
   }
 
   const sortedIds = [...finalIds].sort((a, b) => a.localeCompare(b));


### PR DESCRIPTION
### Motivation
- Add age checkbox filters (≤25, 26-30, 31-33, 34-36, 37-42, 43+, ?, no) similar to `maritalStatus` and compute age from `birth` (format `dd.mm.yyyy`) at query time. 
- Ensure age is resolved dynamically during queries rather than stored as static buckets, by indexing birth dates to allow efficient range queries.

### Description
- Introduced `AGE_SEARCH_KEY_INDEX` and added normalization that converts `birth` (`dd.mm.yyyy`) into an ISO-prefixed index key `d_YYYY-MM-DD`, returning `?` for invalid format and `no` for empty; implemented in `src/components/config.js` (`normalizeAgeBirthDateIndexValue`, `getAgeIndexSet`).
- Extended search-key sync in `src/components/config.js` (`syncUserSearchKeyIndex`) to update `searchKey/age` (remove/add) when a profile's `birth` changes.
- Added batch reindexing helper `createAgeSearchKeyIndexInCollection` to build `searchKey/age` for a collection in chunks (in `src/components/config.js`).
- Implemented dynamic age filter resolution by converting selected age checkboxes into birth-date key ranges (`getBirthDateRangeByAge`, helpers) and collecting matching IDs (`collectAgeIdsByFilters`), then intersecting these IDs in `fetchUsersBySearchKeyBloodPaged` so age is evaluated at query time (in `src/components/config.js`).
- UI adjustments: exposed `age` in SearchKey-only mode (`allowedFilterNames`) and added `empty`/`no` checkbox to Age options in `src/components/SearchFilters.jsx`, added `age.empty` default in `src/components/FilterPanel.jsx` so "no" state is persisted, and added an admin `IdxAge` button + handler to rebuild the age index in `src/components/AddNewProfile.jsx`.

### Testing
- Ran the focused unit test: `npm run -s test -- --watch=false --runInBand src/utils/__tests__/cardIndex.test.js`, which passed (`1` test suite, `5` tests passed). 
- Performed a production build: `npm run -s build`, which completed successfully and produced the optimized build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f55a0a88326b3732c140ad85fad)