### PR TITLE
Fix empty results for favorites in searchKey mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2105,12 +2105,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const loadMoreUsersSearchKey = async (currentFilters = filters) => {
-    let favRaw = getFavorites();
+    let favRaw = {
+      ...getFavorites(),
+      ...favoriteUsersData,
+    };
     let fav = Object.fromEntries(Object.entries(favRaw).filter(([, v]) => v));
-    if (currentFilters.favorite?.favOnly && Object.keys(favRaw).length === 0) {
-      fav = await fetchFavoriteUsers(auth.currentUser.uid);
-      setFavoriteUsersData(fav);
-      syncFavorites(fav);
+
+    if (currentFilters.favorite?.favOnly) {
+      const ownerId = auth.currentUser?.uid;
+      if (ownerId) {
+        const remoteFavRaw = await fetchFavoriteUsers(ownerId);
+        const remoteFav = Object.fromEntries(Object.entries(remoteFavRaw || {}).filter(([, v]) => v));
+        fav = remoteFav;
+        setFavoriteUsersData(remoteFav);
+        setFavoriteIds(remoteFav);
+        syncFavorites(remoteFav);
+      }
     }
 
     if (isEditingRef.current) {


### PR DESCRIPTION
### Motivation
- `searchKey` pagination could return empty results when `favOnly` was enabled because the favorites map was taken from local cache only and could be stale or belong to a different owner. 
- The intent is to ensure favorites-based filtering uses the up-to-date set of liked users for the current owner. 
- Make the `searchKey` branch consistent with other loading paths by reconciling in-memory, local and remote favorites before filtering.

### Description
- Update `loadMoreUsersSearchKey` to build `favRaw` from both `getFavorites()` and in-memory `favoriteUsersData` so local and in-memory sources are merged. 
- When `filters.favorite?.favOnly` is active, fetch remote favorites for the current owner via `fetchFavoriteUsers(ownerId)` and replace `fav` with the remote, validated set. 
- After refreshing remote favorites, sync them back into component state and local queries using `setFavoriteUsersData`, `setFavoriteIds`, and `syncFavorites` so subsequent filtering and caching use the correct map. 
- Leave the rest of `searchKey` pagination logic intact while using the refreshed `fav` for `favoritesMap` and reaction filtering.

### Testing
- Ran `npm run lint:js -- src/components/AddNewProfile.jsx`, which completed successfully. 
- Ran unit tests `CI=true npm test -- --watch=false --runInBand src/utils/__tests__/favoritesStorage.test.js`, and the suite passed (4 tests, 1 file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa4e6930c8326af9774f2fe416b28)