### PR TITLE
Fix reaction filter options for `bloodSearchKeyMode` in SearchFilters

### DIFF
--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -18,11 +18,10 @@ export const SearchFilters = ({
   const contactIconStyle = { display: 'inline-flex', alignItems: 'center' };
   const reactionOptions = bloodSearchKeyMode
     ? [
-        { key: 'special99', label: '99' },
         { key: 'pastGetInTouch', label: 'past' },
         { key: 'futureGetInTouch', label: 'future' },
-        { key: 'dislike', label: '✖' },
         { key: 'like', label: '❤️' },
+        { key: 'special99', label: '✖' },
         { key: 'question', label: '?' },
         { key: 'none', label: 'no' },
       ]


### PR DESCRIPTION
### Motivation
- Correct the reaction filter set used when `bloodSearchKeyMode` is enabled to remove an unintended `dislike` entry and present the intended symbols/order. 

### Description
- Updated `src/components/SearchFilters.jsx` to modify the `reactionOptions` array when `bloodSearchKeyMode` is true by removing the `dislike` option. 
- Changed the `special99` entry so it now displays the cross symbol `✖` instead of `99` and moved it into the options list after `like`. 
- Adjusted the ordering of reaction options to better reflect the intended UX when `bloodSearchKeyMode` is active.

### Testing
- Ran the test suite with `npm test` and the linter with `npm run lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff4f68f048326a28331ac7fc5e635)