### PR TITLE
Move Save/Delete controls into More actions and style like reactions

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -147,15 +147,37 @@ const MoreActionsCommandButton = styled.button`
   width: 100%;
   padding: 8px 10px;
   margin-bottom: 8px;
-  border: 1px solid #d0d0d0;
-  border-radius: 6px;
-  background: #f8f8f8;
+  border: 2px solid
+    ${({ $tone }) =>
+      $tone === 'like'
+        ? color.reactionLike
+        : $tone === 'dislike'
+          ? color.reactionDislike
+          : color.reactionIdleBorder};
+  border-radius: 999px;
+  background: ${({ $tone }) =>
+    $tone === 'like'
+      ? color.reactionLikeBg
+      : $tone === 'dislike'
+        ? color.reactionDislikeBg
+        : color.accent5};
   cursor: pointer;
   font-size: 14px;
-  color: #222;
+  color: ${({ $tone }) =>
+    $tone === 'like'
+      ? color.reactionLike
+      : $tone === 'dislike'
+        ? color.reactionDislike
+        : color.reactionIdleIcon};
+  font-weight: 600;
+  transition: transform 0.15s ease, filter 0.15s ease;
 
   &:hover {
-    background: #efefef;
+    filter: brightness(0.97);
+  }
+
+  &:active {
+    transform: scale(0.98);
   }
 `;
 
@@ -1938,12 +1960,29 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const moreActions = () => {
     const user = moreActionsState.user;
     if (!user) return null;
+    const openDeleteConfirm = () => {
+      setUserIdToDelete(user.userId);
+      setShowInfoModal('delConfirm');
+    };
 
     return (
       <>
         <MoreActionsInfo>
           Останній логін: <strong>{formatDateToDisplay(user.lastLogin2) || user.lastLogin2 || 'немає даних'}</strong>
         </MoreActionsInfo>
+
+        <MoreActionsCommandButton
+          $tone="like"
+          onClick={() => {
+            saveToContact(user);
+          }}
+        >
+          save
+        </MoreActionsCommandButton>
+
+        <MoreActionsCommandButton $tone="dislike" onClick={openDeleteConfirm}>
+          del
+        </MoreActionsCommandButton>
 
         <MoreActionsCommandButton onClick={toggleLikeDislikeCards}>Like/Dislike</MoreActionsCommandButton>
 

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -61,6 +61,7 @@ export const renderTopBlock = (
 
   const cardData = { ...userData, cycleStatus: getEffectiveCycleStatus(userData) };
   const region = normalizeRegion(cardData.region);
+  const showSaveDeleteButtons = !additionalActions;
 
   const renderOverlayEntries = fieldNames => {
     const normalizedFieldNames = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
@@ -98,8 +99,8 @@ export const renderTopBlock = (
           zIndex: 999,
         }}
       >
-        {btnExport(cardData)}
-        {btnDel(cardData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
+        {showSaveDeleteButtons && btnExport(cardData)}
+        {showSaveDeleteButtons && btnDel(cardData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
         {btnMedications(cardData, onOpenMedications)}
         {additionalActions}
       </div>


### PR DESCRIPTION
### Motivation
- Consolidate `save`/`del` actions into the More menu for list cards that render custom `additionalActions`, and make those action buttons visually consistent with existing Like/Dislike reaction styling.

### Description
- Hide inline `save` and `del` in the top block by checking for `additionalActions` in `src/components/smallCard/renderTopBlock.js` and only render `btnExport`/`btnDel` when `additionalActions` is absent.
- Add `save` and `del` entries to the More Actions modal in `src/components/AddNewProfile.jsx`, where `save` calls `saveToContact(user)` and `del` opens the delete confirmation using `setUserIdToDelete` + `setShowInfoModal('delConfirm')`.
- Restyle `MoreActionsCommandButton` in `src/components/AddNewProfile.jsx` to accept a `$tone` prop and provide `like`/`dislike` visual variants using `color.reactionLike`, `color.reactionDislike` and their background/border variants.
- Preserve previous behavior for contexts without `additionalActions` so inline save/del remain available where needed.

### Testing
- Ran lint on changed files with `npx eslint src/components/smallCard/renderTopBlock.js src/components/AddNewProfile.jsx` and it completed successfully.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0824f63008326b7bb9668e2e521b7)