### PR TITLE
Add clear (×) button to top card comment input

### DIFF
--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -1,4 +1,4 @@
-import { handleChange } from './actions';
+import { handleChange, removeField } from './actions';
 import { useRef } from 'react';
 import { useAutoResize } from '../../hooks/useAutoResize';
 
@@ -20,6 +20,8 @@ export const FieldComment = ({ userData, setUsers, setState }) => {
         justifyContent: 'center', // Центрування по горизонталі
         alignItems: 'center', // Центрування по вертикалі
         height: '100%', // Висота контейнера
+        width: '100%',
+        position: 'relative',
       }}
     >
       <textarea
@@ -50,8 +52,34 @@ export const FieldComment = ({ userData, setUsers, setState }) => {
           resize: 'none',
           overflow: 'hidden',
           padding: '5px',
+          paddingRight: userData.myComment ? '22px' : '5px',
         }}
       />
+      {userData.myComment && (
+        <button
+          type="button"
+          aria-label="Очистити коментар"
+          onClick={event => {
+            event.stopPropagation();
+            removeField(userData.userId, 'myComment', setUsers, setState);
+          }}
+          style={{
+            position: 'absolute',
+            top: '50%',
+            right: '6px',
+            transform: 'translateY(-50%)',
+            cursor: 'pointer',
+            border: 'none',
+            background: 'transparent',
+            color: 'inherit',
+            fontSize: '18px',
+            lineHeight: 1,
+            padding: 0,
+          }}
+        >
+          &times;
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Provide a clear control for the comment textarea in the top card block so comments can be removed from local state and deleted in the backend.

### Description
- Imported `removeField` and added an inline clear button (`×`) to `FieldComment` that is shown only when `myComment` exists and calls `removeField(userData.userId, 'myComment', setUsers, setState)` to remove the key and trigger backend deletion, and applied minor UI tweaks (`width: '100%'`, `position: 'relative'`, `paddingRight`) to avoid overlap (file: `src/components/smallCard/FieldComment.js`).

### Testing
- Ran `npx eslint src/components/smallCard/FieldComment.js`, which completed successfully with only non-blocking npm/browserslist warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e082831d448326a957348f7d492de8)