### PR TITLE
Add '?' and 'no' options to height searchKey filters

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -31,6 +31,8 @@ const defaultsAdd = {
     '163_176': true,
     '177_180': true,
     '181_plus': true,
+    other: true,
+    no: true,
   },
   contact: { vk: true, instagram: true, facebook: true, phone: true, telegram: true, telegram2: true, tiktok: true, email: true },
   userId: { vk: true, aa: true, ab: true, long: true, mid: true, other: true },

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -226,6 +226,8 @@ export const SearchFilters = ({
           { val: '163_176', label: '163-176' },
           { val: '177_180', label: '177-180' },
           { val: '181_plus', label: '181+' },
+          { val: 'other', label: '?' },
+          { val: 'no', label: 'no' },
         ],
       },
       {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3085,7 +3085,9 @@ const collectHeightIdsByFilters = async heightFilters => {
 
   Object.entries(snapshot.val() || {}).forEach(([storedHeight, usersMap]) => {
     const parsedHeight = Number.parseFloat(String(storedHeight || '').replace(',', '.'));
-    const bucket = getHeightFilterBucket(parsedHeight);
+    let bucket = getHeightFilterBucket(parsedHeight);
+    if (!bucket && storedHeight === '?') bucket = 'other';
+    if (!bucket && storedHeight === 'no') bucket = 'no';
     if (!bucket || !selectedSet.has(bucket)) return;
     Object.keys(usersMap || {}).forEach(userId => {
       if (userId) heightIds.add(userId);


### PR DESCRIPTION
### Motivation
- Make `height` filter follow the same checkbox semantics as other searchKey filters by exposing unknown (`?`) and empty (`no`) states in the UI and search logic.

### Description
- Added two new options to the `height` filter group in the UI: `{ val: 'other', label: '?' }` and `{ val: 'no', label: 'no' }` in `src/components/SearchFilters.jsx`.
- Enabled these new `height` options by default in `src/components/FilterPanel.jsx` so they participate in default filter state.
- Updated height search-key collection logic in `src/components/config.js` (`collectHeightIdsByFilters`) to map stored index values `?` -> `other` and `no` -> `no`, so the new checkboxes actually return matching users.

### Testing
- Ran linter: `npm run lint:js -- src/components/SearchFilters.jsx src/components/FilterPanel.jsx src/components/config.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a2152f008326be9ab98633dde934)