### PR TITLE
Add searchKey/contact index and contact filter checkboxes

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -39,6 +39,7 @@ import {
   createSearchKeyIndexInCollection,
   createMaritalStatusSearchKeyIndexInCollection,
   createCsectionSearchKeyIndexInCollection,
+  createContactSearchKeyIndexInCollection,
   createRoleSearchKeyIndexInCollection,
   createAgeSearchKeyIndexInCollection,
   createReactionSearchKeyIndexInCollection,
@@ -3085,6 +3086,26 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     toast.success('searchKey/csection indexed', { id: 'index-searchkey-csection-progress' });
   };
 
+  const indexSearchKeyContactHandler = async () => {
+    toast.loading('Indexing searchKey/contact in newUsers 0%', {
+      id: 'index-searchkey-contact-progress',
+    });
+    await createContactSearchKeyIndexInCollection('newUsers', progress => {
+      toast.loading(`Indexing searchKey/contact in newUsers ${progress}%`, {
+        id: 'index-searchkey-contact-progress',
+      });
+    });
+    toast.loading('Indexing searchKey/contact in users 0%', {
+      id: 'index-searchkey-contact-progress',
+    });
+    await createContactSearchKeyIndexInCollection('users', progress => {
+      toast.loading(`Indexing searchKey/contact in users ${progress}%`, {
+        id: 'index-searchkey-contact-progress',
+      });
+    });
+    toast.success('searchKey/contact indexed', { id: 'index-searchkey-contact-progress' });
+  };
+
   const indexSearchKeyRoleHandler = async () => {
     toast.loading('Indexing searchKey/role in newUsers 0%', {
       id: 'index-searchkey-role-progress',
@@ -3602,7 +3623,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'age', 'imt', 'height', 'role', 'csection', 'reaction'] : undefined}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'csection', 'reaction'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (
@@ -3669,6 +3690,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 title="Індексація searchKey/csection"
               >
                 IdxCsection
+              </Button>
+              <Button
+                onClick={indexSearchKeyContactHandler}
+                title="Індексація searchKey/contact"
+              >
+                IdxContact
               </Button>
               <Button
                 onClick={indexSearchKeyRoleHandler}

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -66,6 +66,7 @@ const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tik
 const SEARCH_KEY_INDEX_ROOT = 'searchKey';
 const BLOOD_SEARCH_KEY_INDEX = 'blood';
 const MARITAL_STATUS_SEARCH_KEY_INDEX = 'maritalStatus';
+const CONTACT_SEARCH_KEY_INDEX = 'contact';
 const AGE_SEARCH_KEY_INDEX = 'age';
 const IMT_SEARCH_KEY_INDEX = 'imt';
 const HEIGHT_SEARCH_KEY_INDEX = 'height';
@@ -2894,6 +2895,7 @@ const isBucketAllowedByFilters = (bucket, filterSettings = {}) => {
 };
 
 const MARITAL_STATUS_SEARCH_KEY_BUCKETS = ['+', '-', '?', 'no'];
+const CONTACT_SEARCH_KEY_BUCKETS = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'];
 const ROLE_SEARCH_KEY_BUCKETS = ['ed', 'sm', 'ag', 'ip', 'cl', '?', 'no'];
 const IMT_SEARCH_KEY_BUCKETS = ['le28', '29_31', '32_35', '36_plus', '?', 'no'];
 
@@ -2912,6 +2914,13 @@ const isMaritalStatusBucketAllowedByFilters = (bucket, filterSettings = {}) => {
 
   const filterKey = getMaritalStatusFilterKey(bucket);
   return Boolean(maritalStatusFilters?.[filterKey]);
+};
+
+const isContactBucketAllowedByFilters = (bucket, filterSettings = {}) => {
+  const contactFilters = filterSettings?.contact;
+  const shouldApplyContact = hasExplicitFilterSelection(contactFilters);
+  if (!shouldApplyContact) return true;
+  return Boolean(contactFilters?.[bucket]);
 };
 
 const getRoleFilterKey = bucket => {
@@ -3202,6 +3211,8 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   const nextMaritalStatusValues = getMaritalStatusIndexSet(nextData);
   const prevCsectionValues = getCsectionIndexSet(prevData);
   const nextCsectionValues = getCsectionIndexSet(nextData);
+  const prevContactValues = getContactIndexSet(prevData);
+  const nextContactValues = getContactIndexSet(nextData);
   const prevRoleValues = getRoleIndexSet(prevData);
   const nextRoleValues = getRoleIndexSet(nextData);
   const prevAgeValues = getAgeIndexSet(prevData);
@@ -3252,6 +3263,20 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
     if (!prevCsectionValues.has(value)) {
       // eslint-disable-next-line no-await-in-loop
       await updateSearchKeyLeaf(CSECTION_SEARCH_KEY_INDEX, value, userId, 'add');
+    }
+  }
+
+  for (const value of prevContactValues) {
+    if (!nextContactValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(CONTACT_SEARCH_KEY_INDEX, value, userId, 'remove');
+    }
+  }
+
+  for (const value of nextContactValues) {
+    if (!prevContactValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateSearchKeyLeaf(CONTACT_SEARCH_KEY_INDEX, value, userId, 'add');
     }
   }
 
@@ -3425,6 +3450,36 @@ export const createCsectionSearchKeyIndexInCollection = async (collection, onPro
   }
 };
 
+export const createContactSearchKeyIndexInCollection = async (collection, onProgress) => {
+  const usersData = await loadCollectionWithIndexCache(collection);
+  if (!usersData) return;
+
+  const userIds = Object.keys(usersData);
+  const totalUsers = userIds.length;
+  if (totalUsers === 0) return;
+
+  const updates = userIds.reduce((acc, userId) => {
+    const user = usersData[userId] || {};
+    const contactValues = getContactIndexSet(user);
+    contactValues.forEach(contactValue => {
+      acc[`${SEARCH_KEY_INDEX_ROOT}/${CONTACT_SEARCH_KEY_INDEX}/${contactValue}/${userId}`] = true;
+    });
+    return acc;
+  }, {});
+
+  const updateEntries = Object.entries(updates);
+
+  for (let i = 0; i < updateEntries.length; i += SEARCH_KEY_BATCH_UPLOAD_SIZE) {
+    const chunkEntries = updateEntries.slice(i, i + SEARCH_KEY_BATCH_UPLOAD_SIZE);
+    const chunkPayload = Object.fromEntries(chunkEntries);
+    // eslint-disable-next-line no-await-in-loop
+    await update(ref2(database), chunkPayload);
+
+    const progress = Math.floor((Math.min(i + chunkEntries.length, totalUsers) / totalUsers) * 100);
+    if (onProgress && progress % 10 === 0) onProgress(progress);
+  }
+};
+
 export const createRoleSearchKeyIndexInCollection = async (collection, onProgress) => {
   const usersData = await loadCollectionWithIndexCache(collection);
   if (!usersData) return;
@@ -3526,6 +3581,9 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   const filteredMaritalStatusBuckets = MARITAL_STATUS_SEARCH_KEY_BUCKETS.filter(bucket =>
     isMaritalStatusBucketAllowedByFilters(bucket, filterSettings)
   );
+  const filteredContactBuckets = CONTACT_SEARCH_KEY_BUCKETS.filter(bucket =>
+    isContactBucketAllowedByFilters(bucket, filterSettings)
+  );
   const filteredRoleBuckets = ROLE_SEARCH_KEY_BUCKETS.filter(bucket => isRoleBucketAllowedByFilters(bucket, filterSettings));
   const filteredImtBuckets = IMT_SEARCH_KEY_BUCKETS.filter(bucket => {
     const imtFilters = filterSettings?.imt;
@@ -3542,13 +3600,18 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
     dislikedMap,
   });
 
-  const [bucketSnapshots, maritalStatusSnapshots, roleSnapshots, imtSnapshots] = await Promise.all([
+  const [bucketSnapshots, maritalStatusSnapshots, contactSnapshots, roleSnapshots, imtSnapshots] = await Promise.all([
     Promise.all(
     filteredBuckets.map(bucket => get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${BLOOD_SEARCH_KEY_INDEX}/${bucket}`)))
     ),
     Promise.all(
       filteredMaritalStatusBuckets.map(bucket =>
         get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${MARITAL_STATUS_SEARCH_KEY_INDEX}/${bucket}`))
+      )
+    ),
+    Promise.all(
+      filteredContactBuckets.map(bucket =>
+        get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${CONTACT_SEARCH_KEY_INDEX}/${bucket}`))
       )
     ),
     Promise.all(
@@ -3577,9 +3640,11 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
 
   const bloodUserIds = collectIdsFromSnapshots(bucketSnapshots);
   const maritalStatusUserIds = collectIdsFromSnapshots(maritalStatusSnapshots);
+  const contactUserIds = collectIdsFromSnapshots(contactSnapshots);
   const roleUserIds = collectIdsFromSnapshots(roleSnapshots);
   const indexedImtUserIds = collectIdsFromSnapshots(imtSnapshots);
   const shouldApplyMaritalStatusFilter = hasExplicitFilterSelection(filterSettings?.maritalStatus);
+  const shouldApplyContactFilter = hasExplicitFilterSelection(filterSettings?.contact);
   const shouldApplyRoleFilter = hasExplicitFilterSelection(filterSettings?.role);
   const shouldApplyAgeFilter = ageUserIds instanceof Set;
   const shouldApplyImtFilter = imtUserIds instanceof Set;
@@ -3589,6 +3654,9 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   let finalIds = [...bloodUserIds];
   if (shouldApplyMaritalStatusFilter) {
     finalIds = finalIds.filter(id => maritalStatusUserIds.has(id));
+  }
+  if (shouldApplyContactFilter) {
+    finalIds = finalIds.filter(id => contactUserIds.has(id));
   }
   if (shouldApplyRoleFilter) {
     finalIds = finalIds.filter(id => roleUserIds.has(id));
@@ -3885,12 +3953,30 @@ const getTelegramValues = value => {
 };
 const hasTelegramNonUk = value => {
   const values = getTelegramValues(value);
-  return values.some(item => !item.startsWith('УК'));
+  return values.some(item => !item.toLowerCase().startsWith('ук'));
 };
 
 const isTelegramUkOnly = value => {
   const values = getTelegramValues(value);
-  return values.length > 0 && values.every(item => item.startsWith('УК'));
+  return values.length > 0 && values.every(item => item.toLowerCase().startsWith('ук'));
+};
+
+const getContactIndexSet = data => {
+  if (!data || typeof data !== 'object') return new Set();
+
+  const contactSet = new Set();
+  if (hasContactValue(data.vk)) contactSet.add('vk');
+  if (hasContactValue(data.instagram)) contactSet.add('instagram');
+  if (hasContactValue(data.facebook)) contactSet.add('facebook');
+  if (hasContactValue(data.phone)) contactSet.add('phone');
+  if (hasTelegramNonUk(data.telegram)) contactSet.add('telegram');
+  if (getTelegramValues(data.telegram).some(item => item.toLowerCase().startsWith('ук'))) {
+    contactSet.add('telegram2');
+  }
+  if (hasContactValue(data.tiktok)) contactSet.add('tiktok');
+  if (hasContactValue(data.email)) contactSet.add('email');
+
+  return contactSet;
 };
 
 const getBmiCategory = value => {


### PR DESCRIPTION
### Motivation
- Expose contact-type checkboxes in the `searchKey` (NoGIT+IdKey) search UI so contacts can be filtered the same way as `maritalStatus`.
- Index contact presence per user (including separate buckets for Telegram variants) so `searchKey` queries can efficiently restrict by available contact types.

### Description
- Added a new search-key index `contact` via `CONTACT_SEARCH_KEY_INDEX` and defined buckets `['vk','instagram','facebook','phone','telegram','telegram2','tiktok','email']`.
- Implemented `getContactIndexSet` to derive contact buckets for a user (detects `telegram` when any telegram value does not start with `УК` and `telegram2` when value(s) start with `УК`, using case-insensitive checks with `toLowerCase`).
- Added `createContactSearchKeyIndexInCollection` for bulk indexing and an `IdxContact` admin button + handler in `src/components/AddNewProfile.jsx` to rebuild `searchKey/contact` for `newUsers` and `users`.
- Integrated contact index into runtime flows: `syncUserSearchKeyIndex` now updates `searchKey/contact` on profile change, and `fetchUsersBySearchKeyBloodPaged` fetches/filters by contact buckets when `contact` filters are applied.
- Enabled the `contact` filter group in `NoGIT+IdKey` mode by adding `contact` to `allowedFilterNames` in the search UI.

### Testing
- Ran lint: `npm run lint:js -- src/components/config.js src/components/AddNewProfile.jsx` and the linter completed successfully (exit code 0) with standard environment warnings; no lint errors reported for the modified files.
- No additional automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a56b71a48326b65263f05d20603a)