### PR TITLE
Index `searchKey/reaction` by date keys and query ranges for rolling past/future filters

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3133,10 +3133,7 @@ const normalizeReactionSearchKeyIndexValue = rawGetInTouch => {
 
   const parsedDate = parseIsoDate(normalized);
   if (!parsedDate) return '?';
-
-  const today = new Date();
-  const todayAtMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  return parsedDate < todayAtMidnight ? 'past' : 'future';
+  return `${AGE_DATE_PREFIX}${toIsoDate(parsedDate)}`;
 };
 
 const getReactionIndexSet = data => {
@@ -3155,19 +3152,62 @@ const collectReactionIdsByFilters = async (
   const reactionIds = new Set();
   const requests = [];
 
+  const today = new Date();
+  const todayAtMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const todayKey = `${AGE_DATE_PREFIX}${toIsoDate(todayAtMidnight)}`;
+
+  const addRangeRequest = ({ startKey, endKey }) => {
+    requests.push(
+      get(
+        query(
+          ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${REACTION_SEARCH_KEY_INDEX}`),
+          orderByKey(),
+          startAt(startKey),
+          endAt(endKey)
+        )
+      )
+    );
+  };
+
   const addBucketRequest = bucket => {
     requests.push(get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${REACTION_SEARCH_KEY_INDEX}/${bucket}`)));
   };
 
   if (selected('special99')) addBucketRequest('99');
-  if (selected('pastGetInTouch')) addBucketRequest('past');
-  if (selected('futureGetInTouch')) addBucketRequest('future');
+  if (selected('pastGetInTouch')) {
+    addRangeRequest({ startKey: `${AGE_DATE_PREFIX}1900-01-01`, endKey: todayKey });
+  }
+  if (selected('futureGetInTouch')) {
+    addRangeRequest({ startKey: todayKey, endKey: `${AGE_DATE_PREFIX}9999-12-31` });
+  }
   if (selected('question')) addBucketRequest('?');
   if (selected('none')) addBucketRequest('no');
 
   const snapshots = await Promise.all(requests);
   snapshots.forEach(snapshot => {
     if (!snapshot.exists()) return;
+    const isRangeResult = snapshot.key === REACTION_SEARCH_KEY_INDEX;
+
+    if (isRangeResult) {
+      snapshot.forEach(bucketSnapshot => {
+        const bucketKey = String(bucketSnapshot.key || '');
+        if (!bucketKey.startsWith(AGE_DATE_PREFIX)) return;
+
+        if (selected('pastGetInTouch') && bucketKey < todayKey) {
+          Object.keys(bucketSnapshot.val() || {}).forEach(userId => {
+            if (userId) reactionIds.add(userId);
+          });
+        }
+
+        if (selected('futureGetInTouch') && bucketKey >= todayKey) {
+          Object.keys(bucketSnapshot.val() || {}).forEach(userId => {
+            if (userId) reactionIds.add(userId);
+          });
+        }
+      });
+      return;
+    }
+
     Object.keys(snapshot.val() || {}).forEach(userId => {
       if (userId) reactionIds.add(userId);
     });


### PR DESCRIPTION
### Motivation
- Prevent reaction buckets (`past`/`future`) from becoming stale after the day changes by making date classification relative to query time. 
- Align `reaction` indexing with the existing `age` approach using date-prefixed keys so range queries can be performed efficiently. 
- Keep existing handling for special/invalid/empty values and preserve like/dislike overlays.

### Description
- Changed `normalizeReactionSearchKeyIndexValue` to return a date key in the form ``d_YYYY-MM-DD`` for valid ISO dates instead of returning static `past`/`future` buckets. 
- Updated `collectReactionIdsByFilters` to: compute `todayKey`, add an `addRangeRequest` helper to query date-key ranges under the `reaction` index, and fetch/classify range results into `pastGetInTouch` and `futureGetInTouch` sets at query time. 
- Adjusted the past range end to use `todayKey` so past entries stop at the current day, and preserved bucket requests for `99`, `?`, and `no` as well as merging `like`/`dislike` overlays.

### Testing
- Ran linter: `npx eslint src/components/config.js`, which completed without lint errors (only an npm/browserslist warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a8528e3483269297cac5e771861c)