### PR TITLE
Optimize handleSubmit to accept previous data snapshot and avoid redundant fetches

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -794,7 +794,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
   };
 
-  const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
+  const handleSubmit = async (newState, overwrite, delCondition, makeIndex, previousDataSnapshot = null) => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
@@ -867,7 +867,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     cacheFetchedUsers({ [syncedState.userId]: syncedState }, cacheLoad2Users, filters);
     setUsers(prev => ({ ...prev, [syncedState.userId]: syncedState }));
 
-    const existingData = syncedState?.userId ? await fetchUserById(syncedState.userId) : null;
+    const existingData =
+      previousDataSnapshot || (syncedState?.userId ? await fetchUserById(syncedState.userId) : null);
     if (syncedState?.userId) {
       await Promise.all([
         syncUserSearchIdIndex(syncedState.userId, existingData || {}, syncedState),
@@ -1066,7 +1067,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       }
 
-      handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
+      handleSubmit(newState, 'overwrite', { [fieldName]: removedValue }, undefined, prevState);
       return newState;
     });
   };
@@ -1094,7 +1095,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
       }
 
-      handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
+      handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue }, undefined, prevState);
       return newState; // Повертаємо оновлений стан
     });
   };


### PR DESCRIPTION
### Motivation

- Reduce redundant remote reads when submitting state updates by allowing callers to supply an existing data snapshot.
- Ensure optimistic UI updates can provide the server-side snapshot to index sync and update logic to prevent an extra `fetchUserById` call.

### Description

- Updated `handleSubmit` signature to `handleSubmit(newState, overwrite, delCondition, makeIndex, previousDataSnapshot = null)` to accept an optional previous data snapshot.
- Short-circuited the `existingData` retrieval to use `previousDataSnapshot` when provided, otherwise fall back to `fetchUserById` as before.
- Propagated the new `previousDataSnapshot` argument to callers in removal flows by passing `prevState` when invoking `handleSubmit` after deleting keys or values.
- Kept existing behavior for admins and indexing logic while using the provided snapshot for `syncUserSearchIdIndex` and `syncUserSearchKeyIndex` calls to avoid unnecessary fetches.

### Testing

- Ran unit tests with `npm test` and the test suite completed successfully. 
- Ran linting with `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c3c857588326a75437f94f863985)