### PR TITLE
Fix stale searchKey entries when deleting profile field values

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -16,7 +16,6 @@ import {
   fetchDislikeUsers,
   fetchDislikeUsersData,
   fetchCycleUsersData,
-  removeKeyFromFirebase,
   // fetchListOfUsers,
   makeNewUser,
   // removeSearchId,
@@ -1047,11 +1046,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         removedValue = prevState[fieldName][idx];
 
         if (filteredArray.length === 0 || (filteredArray.length === 1 && filteredArray[0] === '')) {
-          const deletedValue = prevState[fieldName];
           delete newState[fieldName];
-          if (isAdmin) {
-            removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
-          }
         } else if (filteredArray.length === 1) {
           newState[fieldName] = filteredArray[0];
         } else {
@@ -1059,11 +1054,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       } else {
         removedValue = prevState[fieldName];
-        const deletedValue = prevState[fieldName];
         delete newState[fieldName];
-        if (isAdmin) {
-          removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
-        }
       }
 
       handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
@@ -1088,11 +1079,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       //  newState[fieldName] = 'del_key';
 
       console.log(`Поле "${fieldName}" позначено для видалення`);
-
-      // Видалення ключа з Firebase
-      if (isAdmin) {
-        removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
-      }
 
       handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState; // Повертаємо оновлений стан


### PR DESCRIPTION
### Motivation
- Deleting a field via the inline `del` / input clear path called Firebase removal directly before the main save flow, causing `syncUserSearchKeyIndex` to miss removals because `existingData` could arrive already missing the old value.

### Description
- Removed direct `removeKeyFromFirebase` calls from `handleClear` and `handleDelKeyValue` in `src/components/AddNewProfile.jsx` so deletions flow through the existing `handleSubmit` path.
- Rely on the `handleSubmit` flow that calls `syncUserSearchKeyIndex` (which diffs `prevData` and `nextData`) to add/remove searchKey index buckets correctly.
- Removed the now-unused `removeKeyFromFirebase` import from `AddNewProfile.jsx`.

### Testing
- Ran linter on the modified file with `npm run lint:js -- src/components/AddNewProfile.jsx`, which completed successfully (only a browserslist npm warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cf5918b88326858e83518f85f3ad)