### PR TITLE
Follow-up: persist profile field deletions in AddNewProfile flow

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -45,6 +45,7 @@ import {
   createImtHeightWeightSearchKeyIndexInCollection,
   createReactionSearchKeyIndexInCollection,
   fetchUsersBySearchKeyBloodPaged,
+  removeKeyFromFirebase,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
@@ -1046,7 +1047,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         removedValue = prevState[fieldName][idx];
 
         if (filteredArray.length === 0 || (filteredArray.length === 1 && filteredArray[0] === '')) {
+          const deletedValue = prevState[fieldName];
           delete newState[fieldName];
+          if (isAdmin) {
+            removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
+          }
         } else if (filteredArray.length === 1) {
           newState[fieldName] = filteredArray[0];
         } else {
@@ -1054,7 +1059,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       } else {
         removedValue = prevState[fieldName];
+        const deletedValue = prevState[fieldName];
         delete newState[fieldName];
+        if (isAdmin) {
+          removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
+        }
       }
 
       handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
@@ -1071,6 +1080,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
       // Видаляємо ключ з нового стану
       delete newState[fieldName];
+      if (isAdmin) {
+        removeKeyFromFirebase(fieldName, deletedValue, prevState.userId);
+      }
 
       // console.log('Видалили ключ з локального стану:', fieldName);
       // console.log('newState:', newState);


### PR DESCRIPTION
### Motivation
- A previous change stopped performing real backend deletions when a user cleared or deleted profile fields, causing keys to remain in RealtimeDB/Firestore and reappear after reload because `makeUploadedInfo(existingData, cleanedState, overwrite)` starts from `existingData` and preserves omitted keys.
- Field removals must perform explicit backend deletes so `syncUserSearchKeyIndex` and related index logic can correctly remove searchKey entries.

### Description
- Reintroduced `removeKeyFromFirebase` import in `src/components/AddNewProfile.jsx` and restored backend deletion calls. 
- Updated `handleClear` to call `removeKeyFromFirebase(fieldName, deletedValue, prevState.userId)` when clearing a scalar field or when an array field becomes empty, while still calling `handleSubmit` to run the regular submit/indexing flow. 
- Updated `handleDelKeyValue` to call `removeKeyFromFirebase` before calling `handleSubmit` so deletions persist in backend storage.

### Testing
- Ran linting with `npm run lint:js -- src/components/AddNewProfile.jsx`, which completed successfully (only a non-blocking Browserslist warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d4ff20ac8326a90870e0ed098bdc)