### PR TITLE
Persist profile field deletions to backend (fix stale searchKey entries)

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -881,6 +881,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       );
 
       const uploadedInfo = makeUploadedInfo(existingData, cleanedState, overwrite);
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          uploadedInfo[key] = null;
+        });
+      }
 
       if (!makeIndex) {
         await Promise.all([
@@ -908,6 +913,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           newStateWithDelivery.lastDelivery = formattedLastDelivery;
         } else {
           delete newStateWithDelivery.lastDelivery;
+        }
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            newStateWithDelivery[key] = null;
+          });
         }
         await updateDataInNewUsersRTDB(
           syncedState.userId,

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2197,20 +2197,29 @@ export const getUserCards = async () => {
   return allUserCards;
 };
 
-export const updateDataInFiresoreDB = async (userId, uploadedInfo, condition) => {
+export const updateDataInFiresoreDB = async (userId, uploadedInfo, condition, delCondition) => {
   const cleanedUploadedInfo = removeUndefined(uploadedInfo);
+  const keysToDelete = delCondition ? Object.keys(delCondition) : [];
+  const basePayload = { ...cleanedUploadedInfo };
+  keysToDelete.forEach(key => {
+    delete basePayload[key];
+  });
+  const updatePayload = { ...basePayload };
+  keysToDelete.forEach(key => {
+    updatePayload[key] = deleteField();
+  });
   try {
     const userRef = doc(db, `users/${userId}`);
     if (condition === 'update') {
-      await updateDoc(userRef, cleanedUploadedInfo);
+      await updateDoc(userRef, updatePayload);
     } else if (condition === 'set') {
-      await setDoc(userRef, cleanedUploadedInfo);
+      await setDoc(userRef, basePayload);
     } else if (condition === 'check') {
       const userDoc = await getDoc(userRef);
       if (userDoc.exists()) {
-        await updateDoc(userRef, cleanedUploadedInfo);
+        await updateDoc(userRef, updatePayload);
       } else {
-        await setDoc(userRef, cleanedUploadedInfo);
+        await setDoc(userRef, basePayload);
       }
     }
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Deleting a profile field via `handleClear` / `handleDelKeyValue` only removed the key from local state and never persisted the deletion to the backend, causing omitted keys to survive merges and reappear on reload.
- The submit flow used `makeUploadedInfo(existingData, cleanedState, overwrite)` which merged from `existingData` and therefore did not remove keys that were only deleted locally.

### Description
- Apply deletion markers to outgoing RTDB payloads in `AddNewProfile.jsx` by injecting `null` for keys present in `delCondition` before calling `updateDataInRealtimeDB` and `updateDataInNewUsersRTDB` so Realtime Database `update()` removes those fields. (modified: `src/components/AddNewProfile.jsx`)
- Pass `delCondition` through to Firestore updates and translate deleted keys into Firestore `deleteField()` operations for `update`/`check` flows while keeping `set` payloads free of delete sentinels. (modified: `src/components/config.js`)
- Keep optimistic local updates and caching behavior but ensure remote deletions are explicitly sent so indexes and persisted data do not retain stale values.

### Testing
- Ran linting on modified files with `npx eslint src/components/AddNewProfile.jsx src/components/config.js`, which completed successfully (only non-blocking npm/browserslist warnings were printed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d6efbb6c83268cee441b76f023e1)