### PR TITLE
Add search-scope hints, projected counts, and option disabling; propagate hints to filter UI

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import toast from 'react-hot-toast';
 import styled from 'styled-components';
 // import { FaUser, FaTelegramPlane, FaFacebookF, FaInstagram, FaVk, FaMailBulk, FaPhone } from 'react-icons/fa';
@@ -508,7 +508,7 @@ const SearchScopeLabel = styled.label`
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: #1f1f1f;
+  color: ${({ $muted }) => ($muted ? '#b8b8b8' : '#1f1f1f')};
 `;
 
 const SearchScopeRow = styled.div`
@@ -539,6 +539,79 @@ const SearchScopeLabelTextGroup = styled.span`
   flex-direction: column;
   line-height: 1.2;
 `;
+
+const SearchScopeOptionCount = styled.span`
+  font-size: 0.45em;
+  line-height: 1;
+  color: ${({ $muted }) => ($muted ? '#c8c8c8' : '#7e7e7e')};
+  margin-bottom: 1px;
+  min-height: 1em;
+`;
+
+const DATE_SEARCH_KEYS = new Set(['getInTouch', 'lastAction', 'lastLogin2', 'createdAt', 'lastCycle', 'lastLogin']);
+const CONTACT_OR_TEXT_SEARCH_KEYS = new Set([
+  'phone',
+  'telegram',
+  'instagram',
+  'facebook',
+  'email',
+  'vk',
+  'tiktok',
+  'other',
+  'name',
+  'surname',
+  'userId',
+]);
+
+const looksLikeDateQuery = value => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return false;
+
+  return [
+    /^\d{1,2}[./-]\d{1,2}[./-]\d{2,4}$/,
+    /^\d{4}[./-]\d{1,2}[./-]\d{1,2}$/,
+    /^\d{1,2}\s+[а-яіїєґa-z]+\s+\d{2,4}$/i,
+  ].some(pattern => pattern.test(trimmed));
+};
+
+const SEARCH_SCOPE_BLOCKS = [
+  {
+    id: 'id-search',
+    title: 'Пошук по ID',
+    options: [
+      { key: 'searchId', label: 'searchId (точний)' },
+      { key: 'equalToAllCards', label: 'equalTo по всіх карточках (за поточним ключем)' },
+      { key: 'partialUserId', label: 'userId (частковий збіг)' },
+    ],
+  },
+  {
+    id: 'search-keys',
+    title: 'Пошук в searchId / equalTo',
+    options: [
+      { key: 'phone', label: 'phone', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'telegram', label: 'telegram', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'instagram', label: 'instagram', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'facebook', label: 'facebook', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'email', label: 'email', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'vk', label: 'vk', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'tiktok', label: 'tiktok', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'other', label: 'other', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'myComment', label: 'myComment', supportsSearchId: false, supportsEqualTo: true },
+      { key: 'name', label: 'name', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'surname', label: 'surname', supportsSearchId: true, supportsEqualTo: true },
+      { key: 'cycleStatus', label: 'cycleStatus', supportsSearchId: false, supportsEqualTo: true },
+      { key: 'getInTouch', label: 'getInTouch', supportsSearchId: true, supportsEqualTo: true, isDate: true },
+      { key: 'lastAction', label: 'lastAction', supportsSearchId: true, supportsEqualTo: true, isDate: true },
+      { key: 'lastLogin2', label: 'lastLogin2', supportsSearchId: false, supportsEqualTo: true, isDate: true },
+      { key: 'createdAt', label: 'createdAt', supportsSearchId: false, supportsEqualTo: true, isDate: true },
+      { key: 'lastCycle', label: 'lastCycle', supportsSearchId: false, supportsEqualTo: true, isDate: true },
+      { key: 'lastLogin', label: 'lastLogin', supportsSearchId: false, supportsEqualTo: true, isDate: true },
+    ],
+  },
+];
+
+const SEARCH_KEY_OPTIONS =
+  SEARCH_SCOPE_BLOCKS.find(block => block.id === 'search-keys')?.options || [];
 
 const SearchBarRow = styled.div`
   display: flex;
@@ -604,44 +677,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [searchBarQueryActive, setSearchBarQueryActive] = useState(false);
   const [lastSearchBarQuery, setLastSearchBarQuery] = useState('');
 
-
-  const SEARCH_SCOPE_BLOCKS = [
-    {
-      id: 'id-search',
-      title: 'Пошук по ID',
-      options: [
-        { key: 'searchId', label: 'searchId (точний)' },
-        { key: 'equalToAllCards', label: 'equalTo по всіх карточках (за поточним ключем)' },
-        { key: 'partialUserId', label: 'userId (частковий збіг)' },
-      ],
-    },
-    {
-      id: 'search-keys',
-      title: 'Пошук в searchId / equalTo',
-      options: [
-        { key: 'phone', label: 'phone', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'telegram', label: 'telegram', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'instagram', label: 'instagram', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'facebook', label: 'facebook', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'email', label: 'email', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'vk', label: 'vk', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'tiktok', label: 'tiktok', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'other', label: 'other', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'myComment', label: 'myComment', supportsSearchId: false, supportsEqualTo: true },
-        { key: 'name', label: 'name', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'surname', label: 'surname', supportsSearchId: true, supportsEqualTo: true },
-        { key: 'cycleStatus', label: 'cycleStatus', supportsSearchId: false, supportsEqualTo: true },
-        { key: 'getInTouch', label: 'getInTouch', supportsSearchId: true, supportsEqualTo: true, isDate: true },
-        { key: 'lastAction', label: 'lastAction', supportsSearchId: true, supportsEqualTo: true, isDate: true },
-        { key: 'lastLogin2', label: 'lastLogin2', supportsSearchId: false, supportsEqualTo: true, isDate: true },
-        { key: 'createdAt', label: 'createdAt', supportsSearchId: false, supportsEqualTo: true, isDate: true },
-        { key: 'lastCycle', label: 'lastCycle', supportsSearchId: false, supportsEqualTo: true, isDate: true },
-        { key: 'lastLogin', label: 'lastLogin', supportsSearchId: false, supportsEqualTo: true, isDate: true },
-      ],
-    },
-  ];
-
-  const SEARCH_KEY_OPTIONS = SEARCH_SCOPE_BLOCKS.find(block => block.id === 'search-keys')?.options || [];
   const TOGGLEABLE_SEARCH_KEYS = [
     'searchId',
     'equalToAllCards',
@@ -1133,6 +1168,49 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [lastKey, setLastKey] = useState(null); // Стан для зберігання останнього ключа
   const [lastKey21, setLastKey21] = useState(null);
   const [totalCount, setTotalCount] = useState(0);
+  const searchScopeHints = useMemo(() => {
+    const trimmedSearch = String(search || '').trim();
+    if (!trimmedSearch) return {};
+
+    const detected = detectSearchParams(trimmedSearch);
+    const detectedKey = detected?.key || null;
+    const isDateQuery = looksLikeDateQuery(trimmedSearch);
+    const hints = {};
+
+    SEARCH_KEY_OPTIONS.forEach(option => {
+      const { key } = option;
+      const isDateKey = DATE_SEARCH_KEYS.has(key);
+      const isDetectedScopedKey = detectedKey && CONTACT_OR_TEXT_SEARCH_KEYS.has(detectedKey);
+      const isTargetScopedKey = CONTACT_OR_TEXT_SEARCH_KEYS.has(key);
+
+      const disabledByDateMismatch =
+        (isDateQuery && !isDateKey) || (!isDateQuery && isDateKey);
+
+      const disabledByDetectedKey =
+        isDetectedScopedKey &&
+        isTargetScopedKey &&
+        key !== detectedKey;
+
+      const isImpossible = disabledByDateMismatch || disabledByDetectedKey;
+      const normalizedValue = String(detected?.value || trimmedSearch);
+      const cacheKey = getCacheKey('search', normalizeQueryKey(`${key}=${normalizedValue}`));
+      const cachedIds = getIdsByQuery(cacheKey);
+      const cachedCount = Array.isArray(cachedIds) ? cachedIds.length : 0;
+
+      const projectedCount = isImpossible
+        ? 0
+        : (enabledSearchKeys[key] && totalCount > 0)
+          ? totalCount
+          : cachedCount;
+
+      hints[key] = {
+        isImpossible,
+        projectedCount,
+      };
+    });
+
+    return hints;
+  }, [enabledSearchKeys, search, totalCount]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -1422,6 +1500,51 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         partialUserId: false,
       }
     : enabledSearchKeys;
+
+  const searchKeyOptionHints = useMemo(() => {
+    if (!searchIdAndSearchKeyOnlyMode) return {};
+
+    const usersEntries = Object.entries(users || {}).filter(([, value]) => Boolean(value));
+    if (usersEntries.length === 0 || !filters || typeof filters !== 'object') return {};
+
+    return Object.entries(filters).reduce((acc, [groupName, groupValue]) => {
+      if (!groupValue || typeof groupValue !== 'object' || Array.isArray(groupValue)) return acc;
+
+      const groupHints = Object.keys(groupValue).reduce((groupAcc, optionKey) => {
+        const projectedFilters = {
+          ...filters,
+          [groupName]: {
+            ...groupValue,
+            [optionKey]: true,
+          },
+        };
+
+        const projectedCount = filterMain(
+          usersEntries,
+          currentFilter,
+          projectedFilters,
+          favoriteUsersData,
+          dislikeUsersData,
+        ).length;
+
+        groupAcc[optionKey] = {
+          count: projectedCount,
+          disabled: projectedCount === 0,
+        };
+        return groupAcc;
+      }, {});
+
+      acc[groupName] = groupHints;
+      return acc;
+    }, {});
+  }, [
+    currentFilter,
+    dislikeUsersData,
+    favoriteUsersData,
+    filters,
+    searchIdAndSearchKeyOnlyMode,
+    users,
+  ]);
 
   const handleLoadSortModeChange = useCallback(mode => {
     setLoadSortMode(mode);
@@ -3471,10 +3594,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                       const isSearchModeOption = block.id === 'search-keys';
                       const searchIdModeOnly = enabledSearchKeys.searchId && !enabledSearchKeys.equalToAllCards;
                       const equalToModeOnly = enabledSearchKeys.equalToAllCards && !enabledSearchKeys.searchId;
-                      const disabled = isSearchModeOption && (
+                      const isImpossibleByCurrentSearch = isSearchModeOption && searchScopeHints[option.key]?.isImpossible;
+                      const disabled = isImpossibleByCurrentSearch || (isSearchModeOption && (
                         (searchIdModeOnly && !option.supportsSearchId) ||
                         (equalToModeOnly && !option.supportsEqualTo)
-                      );
+                      ));
+                      const projectedCount = isSearchModeOption ? searchScopeHints[option.key]?.projectedCount : null;
+                      const showProjectedCount = isSearchModeOption && Number.isFinite(projectedCount);
 
                       const isFirstDateOption = option.isDate && options[index - 1] && !options[index - 1].isDate;
 
@@ -3483,7 +3609,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                         {hasDateOptions && isFirstDateOption && <SearchScopeDivider />}
                         {option.key === 'searchId' ? (
                           <SearchScopeRow>
-                            <SearchScopeLabel>
+                            <SearchScopeLabel $muted={disabled}>
                               <input
                                 type="checkbox"
                                 checked={Boolean(enabledSearchKeys[option.key])}
@@ -3491,6 +3617,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                                 onChange={() => handleSearchScopeChange(option.key, disabled)}
                               />
                               <SearchScopeLabelTextGroup>
+                                {showProjectedCount && (
+                                  <SearchScopeOptionCount $muted={disabled}>
+                                    {projectedCount}
+                                  </SearchScopeOptionCount>
+                                )}
                                 <span>{option.label}</span>
                               </SearchScopeLabelTextGroup>
                             </SearchScopeLabel>
@@ -3499,7 +3630,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                             </ToggleSearchScopeButton>
                           </SearchScopeRow>
                         ) : (
-                          <SearchScopeLabel>
+                          <SearchScopeLabel $muted={disabled}>
                             <input
                               type="checkbox"
                               checked={Boolean(enabledSearchKeys[option.key])}
@@ -3507,6 +3638,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                               onChange={() => handleSearchScopeChange(option.key, disabled)}
                             />
                             <SearchScopeLabelTextGroup>
+                              {showProjectedCount && (
+                                <SearchScopeOptionCount $muted={disabled}>
+                                  {projectedCount}
+                                </SearchScopeOptionCount>
+                              )}
                               <span>{option.label}</span>
                             </SearchScopeLabelTextGroup>
                           </SearchScopeLabel>
@@ -3661,6 +3797,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
+              optionHints={searchIdAndSearchKeyOnlyMode ? searchKeyOptionHints : undefined}
               allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'csection', 'reaction'] : undefined}
             />
             <ButtonsContainer>

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-export const CheckboxGroup = ({ label, filterName, options, filters, onChange, compact = false }) => {
+export const CheckboxGroup = ({
+  label,
+  filterName,
+  options,
+  filters,
+  onChange,
+  compact = false,
+  optionHints = {},
+}) => {
   const handleToggle = option => {
     onChange({
       ...filters,
@@ -14,12 +22,40 @@ export const CheckboxGroup = ({ label, filterName, options, filters, onChange, c
   return (
       <div style={{ marginBottom: compact ? '4px' : '8px' }}>
         {label && <span style={{ marginRight: compact ? '4px' : '8px' }}>{label}:</span>}
-        {options.map(({ val, label: optionLabel }) => (
-          <label key={val} style={{ marginLeft: compact ? '4px' : '10px', color: 'black' }}>
-            <input type="checkbox" checked={filters[filterName][val]} onChange={() => handleToggle(val)} />
-            {optionLabel}
-          </label>
-        ))}
+        {options.map(({ val, label: optionLabel }) => {
+          const hint = optionHints?.[val];
+          const isChecked = Boolean(filters?.[filterName]?.[val]);
+          const isDisabled = Boolean(hint?.disabled) && !isChecked;
+          const showCount = Number.isFinite(hint?.count);
+
+          return (
+            <label
+              key={val}
+              style={{
+                marginLeft: compact ? '4px' : '10px',
+                color: isDisabled ? '#bfbfbf' : 'black',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={isChecked}
+                disabled={isDisabled}
+                onChange={() => handleToggle(val)}
+              />
+              <span style={{ display: 'inline-flex', flexDirection: 'column', lineHeight: 1.1 }}>
+                {showCount && (
+                  <span style={{ fontSize: '0.45em', color: isDisabled ? '#cccccc' : '#7a7a7a' }}>
+                    {hint.count}
+                  </span>
+                )}
+                <span>{optionLabel}</span>
+              </span>
+            </label>
+          );
+        })}
       <hr style={{ borderColor: '#ccc', borderWidth: '1px', borderStyle: 'solid', margin: '4px 0' }} />
     </div>
   );

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -86,6 +86,7 @@ const FilterPanel = ({
   nonAdminAllActive = false,
   allowedFilterNames,
   bloodSearchKeyMode = false,
+  optionHints,
 }) => {
   const defaultFilters = useMemo(() => {
     if (mode !== 'matching') return defaultsAdd;
@@ -145,6 +146,7 @@ const FilterPanel = ({
       mode={mode}
       bloodSearchKeyMode={bloodSearchKeyMode}
       allowedFilterNames={allowedFilterNames}
+      optionHints={optionHints}
     />
   );
 };

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -13,6 +13,7 @@ export const SearchFilters = ({
   mode = 'default',
   allowedFilterNames,
   bloodSearchKeyMode = false,
+  optionHints,
 }) => {
   let groups = [];
   const contactIconStyle = { display: 'inline-flex', alignItems: 'center' };
@@ -313,6 +314,7 @@ export const SearchFilters = ({
           filters={filters}
           onChange={onChange}
           compact={group.compact}
+          optionHints={optionHints?.[group.filterName]}
         />
       ))}
     </div>


### PR DESCRIPTION
### Motivation
- Improve search UX by showing which search keys are applicable for the current query and projecting result counts for search/filter options. 
- Disable options that are impossible based on the typed query (e.g. date vs non-date keys or detected scoped contacts) to prevent confusing/fruitless searches.

### Description
- Added top-level constants and helper utilities to `AddNewProfile.jsx`: `SEARCH_SCOPE_BLOCKS`, `SEARCH_KEY_OPTIONS`, `DATE_SEARCH_KEYS`, `CONTACT_OR_TEXT_SEARCH_KEYS`, and `looksLikeDateQuery` to centralize search-key metadata and basic query detection.
- Implemented memoized hint computation (`searchScopeHints` via `useMemo`) that analyzes the current `search` value and `enabledSearchKeys` to mark options as `isImpossible` and provide a `projectedCount` by consulting cached query results; added a similar memo `searchKeyOptionHints` for filter-projection when `SEARCH_ID_KEY_ONLY` mode is active.
- Updated search options UI in `AddNewProfile.jsx` to show projected counts (`SearchScopeOptionCount`), apply muted styling when options are disabled, and prevent enabling options impossible for the current query.
- Propagated option hints through `FilterPanel` -> `SearchFilters` -> `CheckboxGroup` via a new `optionHints` prop and updated `CheckboxGroup.jsx` to render counts, apply disabled state and muted color for options with zero projections.
- Small style and behavior tweaks: added `$muted` prop support for `SearchScopeLabel`, `SearchScopeOptionCount`, and arrangement for date-options ordering.

### Testing
- Ran the project's automated test suite with `npm test` and static checks with `npm run lint`, both completed without errors.
- No new automated tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ec81d0408326b6dc7d37a33c66ca)