### PR TITLE
Refactor: extract indexOn search logic to src/components/searchByIndexOn.js

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -38,6 +38,7 @@ import {
   shouldSkipBroadFallbackForExactSearchId,
 } from '../utils/searchKeyUtils';
 import { resolveEqualToSearchKeys } from '../utils/searchKeyCheckboxFilters';
+import { searchByIndexOn } from './searchByIndexOn';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -1970,147 +1971,6 @@ const searchByPrefixes = async (searchValue, uniqueUserIds, users) => {
   }
 };
 
-const normalizeIndexOnList = rawIndexes => {
-  if (!rawIndexes) return [];
-
-  const fields = new Set();
-
-  if (Array.isArray(rawIndexes)) {
-    rawIndexes.forEach(field => {
-      if (typeof field === 'string') {
-        const trimmed = field.trim();
-        if (trimmed) fields.add(trimmed);
-      }
-    });
-  } else if (typeof rawIndexes === 'string') {
-    rawIndexes
-      .split(',')
-      .map(item => item.trim())
-      .filter(Boolean)
-      .forEach(item => fields.add(item));
-  } else if (typeof rawIndexes === 'object') {
-    Object.entries(rawIndexes).forEach(([key, value]) => {
-      if (typeof value === 'string') {
-        const trimmed = value.trim();
-        if (trimmed) fields.add(trimmed);
-      } else if (value) {
-        fields.add(key);
-      }
-    });
-  }
-
-  return [...fields];
-};
-
-const getValueForPath = (data, path) => {
-  if (!path) return undefined;
-  return path.split('/').reduce((acc, segment) => {
-    if (acc === null || acc === undefined) return undefined;
-    return acc[segment];
-  }, data);
-};
-
-const valueMatchesSearchTerm = (value, normalizedTerm) => {
-  if (value === null || value === undefined) return false;
-
-  if (typeof value === 'string') {
-    return value.trim().toLowerCase().includes(normalizedTerm);
-  }
-
-  if (typeof value === 'number') {
-    return String(value).toLowerCase().includes(normalizedTerm);
-  }
-
-  if (Array.isArray(value)) {
-    return value.some(item => valueMatchesSearchTerm(item, normalizedTerm));
-  }
-
-  if (typeof value === 'object') {
-    return Object.values(value).some(item => valueMatchesSearchTerm(item, normalizedTerm));
-  }
-
-  return false;
-};
-
-const formatSearchForIndexedField = (fieldPath, searchValue) => {
-  if (typeof searchValue !== 'string') return null;
-  const trimmedSearch = searchValue.trim();
-  if (!trimmedSearch) return null;
-
-  const fieldName = fieldPath.includes('/')
-    ? fieldPath.split('/').pop()
-    : fieldPath;
-
-  if (fieldName === 'name' || fieldName === 'surname') {
-    return (
-      trimmedSearch.charAt(0).toUpperCase() +
-      trimmedSearch.slice(1).toLowerCase()
-    );
-  }
-
-  return trimmedSearch.toLowerCase();
-};
-
-const searchByIndexOn = async (searchValue, uniqueUserIds, users) => {
-  if (typeof searchValue !== 'string') return;
-  const trimmedSearch = searchValue.trim();
-  if (!trimmedSearch) return;
-
-  const normalizedTerm = trimmedSearch.toLowerCase();
-
-  for (const collection of SEARCH_COLLECTIONS) {
-    let indexedFields = [];
-
-    try {
-      const indexRef = ref2(database, `indexOn/${collection}`);
-      const indexSnapshot = await get(indexRef);
-      if (!indexSnapshot.exists()) continue;
-      indexedFields = normalizeIndexOnList(indexSnapshot.val());
-    } catch (error) {
-      if (isDev) console.error(`searchByIndexOn → failed to load index metadata for ${collection}:`, error);
-      continue;
-    }
-
-    if (indexedFields.length === 0) continue;
-
-    const searchPromises = indexedFields.map(async fieldPath => {
-      const formattedSearchValue = formatSearchForIndexedField(fieldPath, trimmedSearch);
-      if (!formattedSearchValue) return;
-
-      try {
-        const snapshot = await get(
-          query(
-            ref2(database, collection),
-            orderByChild(fieldPath),
-            startAt(formattedSearchValue),
-            endAt(`${formattedSearchValue}\uf8ff`)
-          )
-        );
-
-        if (!snapshot.exists()) return;
-
-        const promises = [];
-
-        snapshot.forEach(userSnapshot => {
-          const userId = userSnapshot.key;
-          if (uniqueUserIds.has(userId)) return;
-
-          const candidateValue = getValueForPath(userSnapshot.val(), fieldPath);
-          if (!valueMatchesSearchTerm(candidateValue, normalizedTerm)) return;
-
-          uniqueUserIds.add(userId);
-          promises.push(addUserToResults(userId, users));
-        });
-
-        await Promise.all(promises);
-      } catch (error) {
-        if (isDev) console.error(`searchByIndexOn → error querying ${collection}.${fieldPath}:`, error);
-      }
-    });
-
-    await Promise.all(searchPromises);
-  }
-};
 
 export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {}) => {
   const {
@@ -2170,7 +2030,21 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
 
         if (!shouldSkipBroadFallback) {
           await searchByPrefixes(searchValue, uniqueUserIds, users);
-          await searchByIndexOn(searchValue, uniqueUserIds, users);
+          await searchByIndexOn({
+            searchValue,
+            uniqueUserIds,
+            users,
+            searchCollections: SEARCH_COLLECTIONS,
+            database,
+            addUserToResults,
+            isDev,
+            ref2,
+            get,
+            query,
+            orderByChild,
+            startAt,
+            endAt,
+          });
         }
       }
     }

--- a/src/components/searchByIndexOn.js
+++ b/src/components/searchByIndexOn.js
@@ -1,0 +1,150 @@
+const normalizeIndexOnList = rawIndexes => {
+  if (!rawIndexes) return [];
+
+  const fields = new Set();
+
+  if (Array.isArray(rawIndexes)) {
+    rawIndexes.forEach(field => {
+      if (typeof field === 'string') {
+        const trimmed = field.trim();
+        if (trimmed) fields.add(trimmed);
+      }
+    });
+  } else if (typeof rawIndexes === 'string') {
+    rawIndexes
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean)
+      .forEach(item => fields.add(item));
+  } else if (typeof rawIndexes === 'object') {
+    Object.entries(rawIndexes).forEach(([key, value]) => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) fields.add(trimmed);
+      } else if (value) {
+        fields.add(key);
+      }
+    });
+  }
+
+  return [...fields];
+};
+
+const getValueForPath = (data, path) => {
+  if (!path) return undefined;
+  return path.split('/').reduce((acc, segment) => {
+    if (acc === null || acc === undefined) return undefined;
+    return acc[segment];
+  }, data);
+};
+
+const valueMatchesSearchTerm = (value, normalizedTerm) => {
+  if (value === null || value === undefined) return false;
+
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase().includes(normalizedTerm);
+  }
+
+  if (typeof value === 'number') {
+    return String(value).toLowerCase().includes(normalizedTerm);
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(item => valueMatchesSearchTerm(item, normalizedTerm));
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value).some(item => valueMatchesSearchTerm(item, normalizedTerm));
+  }
+
+  return false;
+};
+
+const formatSearchForIndexedField = (fieldPath, searchValue) => {
+  if (typeof searchValue !== 'string') return null;
+  const trimmedSearch = searchValue.trim();
+  if (!trimmedSearch) return null;
+
+  const fieldName = fieldPath.includes('/') ? fieldPath.split('/').pop() : fieldPath;
+
+  if (fieldName === 'name' || fieldName === 'surname') {
+    return trimmedSearch.charAt(0).toUpperCase() + trimmedSearch.slice(1).toLowerCase();
+  }
+
+  return trimmedSearch.toLowerCase();
+};
+
+export const searchByIndexOn = async ({
+  searchValue,
+  uniqueUserIds,
+  users,
+  searchCollections,
+  database,
+  addUserToResults,
+  isDev = false,
+  ref2,
+  get,
+  query,
+  orderByChild,
+  startAt,
+  endAt,
+}) => {
+  if (typeof searchValue !== 'string') return;
+  const trimmedSearch = searchValue.trim();
+  if (!trimmedSearch) return;
+
+  const normalizedTerm = trimmedSearch.toLowerCase();
+
+  for (const collection of searchCollections) {
+    let indexedFields = [];
+
+    try {
+      const indexRef = ref2(database, `indexOn/${collection}`);
+      const indexSnapshot = await get(indexRef);
+      if (!indexSnapshot.exists()) continue;
+      indexedFields = normalizeIndexOnList(indexSnapshot.val());
+    } catch (error) {
+      if (isDev) console.error(`searchByIndexOn → failed to load index metadata for ${collection}:`, error);
+      continue;
+    }
+
+    if (indexedFields.length === 0) continue;
+
+    const searchPromises = indexedFields.map(async fieldPath => {
+      const formattedSearchValue = formatSearchForIndexedField(fieldPath, trimmedSearch);
+      if (!formattedSearchValue) return;
+
+      try {
+        const snapshot = await get(
+          query(
+            ref2(database, collection),
+            orderByChild(fieldPath),
+            startAt(formattedSearchValue),
+            endAt(`${formattedSearchValue}\uf8ff`)
+          )
+        );
+
+        if (!snapshot.exists()) return;
+
+        const promises = [];
+
+        snapshot.forEach(userSnapshot => {
+          const userId = userSnapshot.key;
+          if (uniqueUserIds.has(userId)) return;
+
+          const candidateValue = getValueForPath(userSnapshot.val(), fieldPath);
+          if (!valueMatchesSearchTerm(candidateValue, normalizedTerm)) return;
+
+          uniqueUserIds.add(userId);
+          promises.push(addUserToResults(userId, users));
+        });
+
+        await Promise.all(promises);
+      } catch (error) {
+        if (isDev) console.error(`searchByIndexOn → error querying ${collection}.${fieldPath}:`, error);
+      }
+    });
+
+    await Promise.all(searchPromises);
+  }
+};


### PR DESCRIPTION
### Motivation
- Reduce size and coupling of `src/components/config.js` by moving the indexed-field search logic into a dedicated module to improve readability and maintainability.
- Make the `indexOn` search implementation easier to test and reuse by isolating helper functions and the main search routine.

### Description
- Added `src/components/searchByIndexOn.js` which contains `normalizeIndexOnList`, `getValueForPath`, `valueMatchesSearchTerm`, `formatSearchForIndexedField`, and the exported `searchByIndexOn` function.
- Updated `src/components/config.js` to import `searchByIndexOn` and removed the in-file `indexOn` search implementation, replacing its call with a dependency-injected invocation of `searchByIndexOn`.
- The new `searchByIndexOn` is called with explicit dependencies (`searchCollections`, Firebase helpers, `addUserToResults`, etc.) to avoid hidden globals and make the function portable.

### Testing
- Ran `npm run test -- --watch=false --runInBand src/utils/__tests__/cardIndex.test.js` and the test suite passed (1 suite, 5 tests all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e3d8dd448326b229dc58daf02036)