### PR TITLE
Refresh stimulation shortcuts by IDs with cache-aware fetching

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -72,7 +72,6 @@ import {
   serializeQueryFilters,
 } from 'utils/cardIndex';
 import {
-  getStimulationShortcutCards,
   getStoredStimulationShortcutIds,
   setStoredStimulationShortcutIds,
   addStoredStimulationShortcutId,
@@ -1538,16 +1537,37 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     return 0;
   }, [getInTouchSortValue]);
 
-  const refreshStimulationShortcuts = useCallback(async () => {
+  const refreshStimulationShortcuts = useCallback(async (providedIds = null) => {
     try {
-      const { cards } = await getStimulationShortcutCards(id => fetchUserById(id));
-      const ids = getStoredStimulationShortcutIds();
+      const rawIds = Array.isArray(providedIds) ? providedIds : stimulationShortcutIds;
+      const ids = Array.from(new Set((rawIds || []).filter(Boolean).map(String)));
       if (!isMountedRef.current) return;
       setStimulationShortcutIdsState(ids);
-      if (!Array.isArray(cards) || cards.length === 0) {
+      if (ids.length === 0) {
         setStimulationScheduleProfiles([]);
         return;
       }
+
+      const cards = (
+        await Promise.all(
+          ids.map(async id => {
+            const cached = getCard(id);
+            if (cached) return cached;
+
+            const fresh = await fetchUserById(id);
+            if (!fresh) return null;
+
+            updateCard(id, fresh);
+            return { ...fresh, userId: id };
+          }),
+        )
+      ).filter(Boolean);
+
+      if (cards.length === 0) {
+        setStimulationScheduleProfiles([]);
+        return;
+      }
+
       const annotated = sortUsersByStimulationSchedule(cards, {
         fallbackComparator: compareUsersByGetInTouch,
       });
@@ -1562,7 +1582,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       if (!isMountedRef.current) return;
       setStimulationScheduleProfiles([]);
     }
-  }, [compareUsersByGetInTouch, isMountedRef]);
+  }, [compareUsersByGetInTouch, isMountedRef, stimulationShortcutIds]);
 
   const updateStimulationShortcutMembership = useCallback(
     (userId, hasSchedule) => {
@@ -1597,7 +1617,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           Promise.resolve(removeStimulationShortcutId(ownerId, id)).catch(() => {});
         }
       }
-      refreshStimulationShortcuts();
+      refreshStimulationShortcuts(Array.from(currentIds));
     },
     [ownerId, refreshStimulationShortcuts, isMountedRef, stimulationShortcutIds],
   );
@@ -1677,7 +1697,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const ids = Object.keys(data).filter(Boolean);
       setStoredStimulationShortcutIds(ids);
       setStimulationShortcutIdsState(ids);
-      refreshStimulationShortcuts();
+      refreshStimulationShortcuts(ids);
     });
 
     return () => unsubscribe();


### PR DESCRIPTION
### Motivation

- Avoid relying on a single helper that fetched full shortcut cards and instead drive stimulation shortcut refreshes directly from the stored IDs to make updates immediate and more cache-friendly.
- Reduce unnecessary network requests by preferring cached cards and only fetching missing users, and ensure state updates are correct when shortcut membership changes.

### Description

- Reworked `refreshStimulationShortcuts` to accept an optional `providedIds` parameter, derive a unique set of IDs, and early-return when the list is empty, while updating `stimulationShortcutIdsState` accordingly.
- Replaced the previous bulk `getStimulationShortcutCards` approach with an ID-based loader that uses `getCard` to read cached entries, `fetchUserById` to fetch missing users, and `updateCard` to update the index, then filters and sorts the resulting cards before setting `stimulationScheduleProfiles`.
- Updated the hook dependencies to include `stimulationShortcutIds` and changed callers to pass explicit ID arrays where appropriate, including the DB `onValue` listener and `updateStimulationShortcutMembership` to trigger targeted refreshes.
- Removed reliance on the removed `getStimulationShortcutCards` import and adjusted logic to use the existing card index/cache helpers (`getCard`, `updateCard`) instead.

### Testing

- Ran the existing automated unit test suite with `yarn test`, and all tests passed.
- Executed the project smoke tests in the dev environment (automated) and the stimulation shortcuts flow loaded and updated without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e5a10e3083269ae9eb534e3e1b64)