### PR TITLE
Fix stimulation shortcut refresh callback loop in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1539,7 +1539,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const refreshStimulationShortcuts = useCallback(async (providedIds = null) => {
     try {
-      const rawIds = Array.isArray(providedIds) ? providedIds : stimulationShortcutIds;
+      const rawIds = Array.isArray(providedIds) ? providedIds : getStoredStimulationShortcutIds();
       const ids = Array.from(new Set((rawIds || []).filter(Boolean).map(String)));
       if (!isMountedRef.current) return;
       setStimulationShortcutIdsState(ids);
@@ -1582,7 +1582,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       if (!isMountedRef.current) return;
       setStimulationScheduleProfiles([]);
     }
-  }, [compareUsersByGetInTouch, isMountedRef, stimulationShortcutIds]);
+  }, [compareUsersByGetInTouch, isMountedRef]);
 
   const updateStimulationShortcutMembership = useCallback(
     (userId, hasSchedule) => {


### PR DESCRIPTION
### Motivation
- Виявлено нескінченний цикл ререндерів через `useEffect(() => refreshStimulationShortcuts(), [refreshStimulationShortcuts])`, де `refreshStimulationShortcuts` залежав від `stimulationShortcutIds` і сам викликав `setStimulationShortcutIdsState`, що створювало цикл оновлень стану та повторних викликів ефекту.

### Description
- Змінено реалізацію `refreshStimulationShortcuts` у `src/components/AddNewProfile.jsx` щоб за замовчуванням читати ID з `getStoredStimulationShortcutIds()` коли `providedIds` не передані, замість прямої залежності від `stimulationShortcutIds`.
- Видалено `stimulationShortcutIds` з масиву залежностей `useCallback` для `refreshStimulationShortcuts`, залишивши лише `[compareUsersByGetInTouch, isMountedRef]`, щоб запобігти повторному пересозданню callback при кожному `setStimulationShortcutIdsState`.
- Підтримана логіка фільтрації та підвантаження карт користувачів лишилася без змін, результати встановлюються в `setStimulationScheduleProfiles` як і раніше.

### Testing
- Запущено лінтер командою `npm run -s lint:js -- src/components/AddNewProfile.jsx` і перевірка пройшла успішно з типовим попередженням про застарілий `caniuse-lite`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e221ea152c832696881ea1efaf77cb)