### PR TITLE
Sort searchKey cards by past/future getInTouch

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1537,6 +1537,35 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     return 0;
   }, [getInTouchSortValue]);
 
+  const getSearchKeyReactionSortDirection = useCallback(reactionFilters => {
+    if (!searchIdAndSearchKeyOnlyMode || !reactionFilters || typeof reactionFilters !== 'object') {
+      return null;
+    }
+
+    const hasExplicitReactionSelection = Object.values(reactionFilters).some(value => value === false);
+    if (!hasExplicitReactionSelection) {
+      return null;
+    }
+
+    const selectedKeys = Object.entries(reactionFilters)
+      .filter(([, enabled]) => Boolean(enabled))
+      .map(([key]) => key);
+
+    if (selectedKeys.length !== 1) {
+      return null;
+    }
+
+    if (selectedKeys[0] === 'pastGetInTouch') {
+      return 'desc';
+    }
+
+    if (selectedKeys[0] === 'futureGetInTouch') {
+      return 'asc';
+    }
+
+    return null;
+  }, [searchIdAndSearchKeyOnlyMode]);
+
   const refreshStimulationShortcuts = useCallback(async (providedIds = null) => {
     try {
       const rawIds = Array.isArray(providedIds) ? providedIds : getStoredStimulationShortcutIds();
@@ -3186,9 +3215,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     if (isDuplicateView || currentFilter === 'CYCLE_FAVORITE') {
       return ids;
     }
-    return ids.sort((a, b) =>
-      compareUsersByGetInTouch(users[a] || {}, users[b] || {}),
-    );
+
+    const reactionSortDirection = getSearchKeyReactionSortDirection(filters?.reaction);
+    if (reactionSortDirection) {
+      return ids.sort((a, b) => {
+        const left = users[a]?.getInTouch || '';
+        const right = users[b]?.getInTouch || '';
+        return reactionSortDirection === 'desc'
+          ? right.localeCompare(left)
+          : left.localeCompare(right);
+      });
+    }
+
+    return ids.sort((a, b) => compareUsersByGetInTouch(users[a] || {}, users[b] || {}));
   };
 
   const sortedIds = getSortedIds();


### PR DESCRIPTION
### Motivation
- When using the `searchKey` (SEARCH_ID_KEY_ONLY) mode and toggling the reaction checkboxes `pastGetInTouch` / `futureGetInTouch`, the card ordering should follow descending / ascending `getInTouch` respectively.
- The change provides a deterministic override for that specific search mode and single-reaction-selection case to improve user expectation when filtering by past/future dates.

### Description
- Added `getSearchKeyReactionSortDirection` in `src/components/AddNewProfile.jsx` to detect a single active reaction filter in `searchKey` mode and return `'desc'` for `pastGetInTouch` or `'asc'` for `futureGetInTouch`.
- Updated `getSortedIds` in `src/components/AddNewProfile.jsx` to apply an explicit `getInTouch`-based sort (descending or ascending) when the searchKey reaction sort direction is present, and to fall back to the existing `compareUsersByGetInTouch` for all other cases.
- Kept changes localized to `AddNewProfile.jsx` and preserved previous behavior for non-searchKey modes and multi-selection reaction filters.

### Testing
- Ran the project linter via `npm run lint:js -- src/components/AddNewProfile.jsx` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e271be8b588326acd9bf4651d82653)