### PR TITLE
Add additionalAccessRules feature: parsing, profile field, and injection into Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useLayoutEffect } from 'react';
+import React, { useEffect, useState, useRef, useLayoutEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { resolveAccess } from 'utils/accessLevel';
@@ -23,7 +23,7 @@ import {
   updateDataInRealtimeDB,
   updateDataInFiresoreDB,
 } from './config';
-import { onValue, ref as refDb } from 'firebase/database';
+import { get, onValue, ref as refDb } from 'firebase/database';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
@@ -62,6 +62,7 @@ import {
   setLocalComment,
   pruneComments,
 } from '../utils/commentsStorage';
+import { isUserAllowedByAdditionalAccess, parseAdditionalAccessRules } from 'utils/additionalAccessRules';
 
 // Filter out users with invalid identifiers; IDs must be longer than 20 characters
 const isValidId = id => typeof id === 'string' && id.length > 20;
@@ -1142,8 +1143,17 @@ const Matching = () => {
   const [showFilters, setShowFilters] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [ownerId, setOwnerId] = useState(null);
-  const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: localStorage.getItem('accessLevel') });
+  const [currentAccessLevel, setCurrentAccessLevel] = useState(() => localStorage.getItem('accessLevel') || '');
+  const [currentAdditionalAccessRules, setCurrentAdditionalAccessRules] = useState(
+    () => localStorage.getItem('additionalAccessRules') || ''
+  );
+  const [additionalNewUsers, setAdditionalNewUsers] = useState([]);
+  const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
+  const parsedAdditionalAccessRules = useMemo(
+    () => parseAdditionalAccessRules(currentAdditionalAccessRules),
+    [currentAdditionalAccessRules]
+  );
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
   const restoreRef = useRef(false);
@@ -1287,11 +1297,37 @@ const Matching = () => {
       if (user) {
         localStorage.setItem('ownerId', user.uid);
         setOwnerId(user.uid);
+
+        const syncAccessProfile = async () => {
+          try {
+            const profile = await fetchUserById(user.uid);
+            const accessLevel = profile?.accessLevel || '';
+            const additionalAccessRules = profile?.additionalAccessRules || '';
+
+            setCurrentAccessLevel(accessLevel);
+            setCurrentAdditionalAccessRules(additionalAccessRules);
+            localStorage.setItem('accessLevel', accessLevel);
+            localStorage.setItem('additionalAccessRules', additionalAccessRules);
+          } catch (error) {
+            console.error('Failed to refresh access profile on Matching', error);
+            const cachedAccessLevel = localStorage.getItem('accessLevel') || '';
+            const cachedAdditionalAccessRules = localStorage.getItem('additionalAccessRules') || '';
+            setCurrentAccessLevel(cachedAccessLevel);
+            setCurrentAdditionalAccessRules(cachedAdditionalAccessRules);
+          }
+        };
+
+        syncAccessProfile();
       } else {
         localStorage.removeItem('ownerId');
+        localStorage.removeItem('accessLevel');
+        localStorage.removeItem('additionalAccessRules');
         setOwnerId('');
         setFavoriteUsers({});
         setDislikeUsers({});
+        setCurrentAccessLevel('');
+        setCurrentAdditionalAccessRules('');
+        setAdditionalNewUsers([]);
         return;
       }
 
@@ -1322,6 +1358,45 @@ const Matching = () => {
       unsubscribeAuth();
     };
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadAdditionalNewUsers = async () => {
+      if (!parsedAdditionalAccessRules) {
+        setAdditionalNewUsers([]);
+        return;
+      }
+
+      try {
+        const snapshot = await get(refDb(database, 'newUsers'));
+        if (!snapshot.exists()) {
+          if (!cancelled) setAdditionalNewUsers([]);
+          return;
+        }
+
+        const loaded = Object.entries(snapshot.val() || {})
+          .map(([userId, data]) => ({ userId, ...(data || {}) }))
+          .filter(user => isValidId(user.userId))
+          .filter(user => isUserAllowedByAdditionalAccess(user, parsedAdditionalAccessRules));
+
+        if (!cancelled) {
+          setAdditionalNewUsers(loaded);
+        }
+      } catch (error) {
+        console.error('Failed to load additional newUsers for matching', error);
+        if (!cancelled) {
+          setAdditionalNewUsers([]);
+        }
+      }
+    };
+
+    loadAdditionalNewUsers();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [parsedAdditionalAccessRules]);
 
   const fetchChunk = React.useCallback(
     async (
@@ -1699,9 +1774,31 @@ const Matching = () => {
   const [preLastCardNode, setPreLastCardNode] = useState(null);
 
 
-  const visibleUsers = isAdmin
-    ? users
-    : users.filter(user => user.publish === true);
+  const visibleUsers = useMemo(() => {
+    const baseUsers = isAdmin
+      ? users
+      : users.filter(user => user.publish === true);
+
+    const shouldInjectAdditionalCards =
+      parsedAdditionalAccessRules &&
+      additionalNewUsers.length > 0;
+
+    if (!shouldInjectAdditionalCards) {
+      return baseUsers;
+    }
+
+    const byId = new Map(baseUsers.map(user => [user.userId, user]));
+    additionalNewUsers.forEach(user => {
+      const existing = byId.get(user.userId);
+      if (existing) {
+        byId.set(user.userId, { ...existing, ...user });
+      } else {
+        byId.set(user.userId, user);
+      }
+    });
+
+    return Array.from(byId.values());
+  }, [additionalNewUsers, isAdmin, parsedAdditionalAccessRules, users]);
 
   const filteredUsers = isAdmin
     ? filterMain(

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -15,9 +15,10 @@ import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { patchOverlayField } from 'utils/multiAccountEdits';
 import toast from 'react-hot-toast';
 import { removeField } from './smallCard/actions';
-import { FaTimes } from 'react-icons/fa';
+import { FaInfoCircle, FaTimes } from 'react-icons/fa';
 import { InfoModal } from './InfoModal';
 import { auth, database } from './config';
+import { ADDITIONAL_ACCESS_TEMPLATE } from 'utils/additionalAccessRules';
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -76,6 +77,8 @@ const nestedValueContainerStyle = {
 const nestedIndentStyle = {
   marginLeft: '20px',
 };
+
+const ADDITIONAL_ACCESS_FIELD = 'additionalAccessRules';
 
 
 const sanitizeOverlayValue = value => {
@@ -467,6 +470,8 @@ export const ProfileForm = ({
     'ownKids',
     'lastDelivery',
     'role',
+    'accessLevel',
+    ADDITIONAL_ACCESS_FIELD,
   ];
 
   const accessLevelOptions = [
@@ -481,9 +486,26 @@ export const ProfileForm = ({
 
   const fieldsToRender = getFieldsToRender(state);
 
-  const normalizedFieldsToRender = canManageAccessLevel && !fieldsToRender.some(field => field.name === 'accessLevel')
-    ? [...fieldsToRender, { name: 'accessLevel', placeholder: 'access level', ukrainianHint: 'рівень доступу' }]
-    : fieldsToRender;
+  const normalizedFieldsToRender = (() => {
+    let next = fieldsToRender;
+
+    if (canManageAccessLevel && !next.some(field => field.name === 'accessLevel')) {
+      next = [...next, { name: 'accessLevel', placeholder: 'access level', ukrainianHint: 'рівень доступу' }];
+    }
+
+    if (canManageAccessLevel && !next.some(field => field.name === ADDITIONAL_ACCESS_FIELD)) {
+      next = [
+        ...next,
+        {
+          name: ADDITIONAL_ACCESS_FIELD,
+          placeholder: 'age: 21,22,23',
+          ukrainianHint: 'додаткові правила доступу до newUsers',
+        },
+      ];
+    }
+
+    return next;
+  })();
 
 
   const getOverlayEntrySignature = entry => {
@@ -939,6 +961,7 @@ ${entries.join('\n')}`;
       )}
       {sortedFieldsToRender
         .filter(field => !['myComment', 'writer'].includes(field.name))
+        .filter(field => (isAdmin ? true : field.name !== ADDITIONAL_ACCESS_FIELD))
         .map((field, index) => {
           const overlayEntries = getOverlayEntriesForField(field.name);
           const hasOverlaySuggestions = overlayEntries.length > 0;
@@ -1030,6 +1053,44 @@ ${entries.join('\n')}`;
                         </option>
                       ))}
                     </AccessLevelSelect>
+                  ) : field.name === ADDITIONAL_ACCESS_FIELD ? (
+                    <>
+                      <InputField
+                        fieldName={field.name}
+                        as="textarea"
+                        name={field.name}
+                        value={state[field.name] || ''}
+                        placeholder={ADDITIONAL_ACCESS_TEMPLATE}
+                        onFocus={() => handleFieldFocus && handleFieldFocus(field.name)}
+                        onChange={e => {
+                          const value = e?.target?.value;
+                          setState(prevState => ({
+                            ...prevState,
+                            [field.name]: value,
+                          }));
+                        }}
+                        onBlur={() => submitWithNormalization(state, 'overwrite')}
+                      />
+                      <AccessInfoButton
+                        type="button"
+                        onMouseDown={e => e.preventDefault()}
+                        onClick={async () => {
+                          try {
+                            if (navigator?.clipboard?.writeText) {
+                              await navigator.clipboard.writeText(ADDITIONAL_ACCESS_TEMPLATE);
+                              toast.success('Шаблон доступу скопійовано');
+                            } else {
+                              window.alert(ADDITIONAL_ACCESS_TEMPLATE);
+                            }
+                          } catch {
+                            window.alert(ADDITIONAL_ACCESS_TEMPLATE);
+                          }
+                        }}
+                        title="Приклад максимального доступу. Натисніть, щоб скопіювати."
+                      >
+                        <FaInfoCircle />
+                      </AccessInfoButton>
+                    </>
                   ) : (
                   <InputField
                     fieldName={field.name}
@@ -1564,6 +1625,19 @@ const ClearButton = styled.button`
   &:hover {
     color: black;
   }
+`;
+
+const AccessInfoButton = styled.button`
+  margin-left: 6px;
+  border: 1px solid #c7c7c7;
+  background: #fff;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 `;
 
 const DelKeyValueBTN = styled.button`

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -1,0 +1,241 @@
+import { utilCalculateAge } from 'components/smallCard/utilCalculateAge';
+
+const GROUP_KEYS = ['1', '2', '3', '4'];
+
+const defaultAllowed = keys =>
+  keys.reduce((acc, key) => {
+    acc[key] = true;
+    return acc;
+  }, {});
+
+const normalizeLineKey = key =>
+  String(key || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '');
+
+const parseRulesLines = raw =>
+  String(raw || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [left, ...rest] = line.split(':');
+      if (!left || rest.length === 0) return null;
+      return {
+        key: normalizeLineKey(left),
+        value: rest.join(':').trim(),
+      };
+    })
+    .filter(Boolean);
+
+const parseTokens = value =>
+  String(value || '')
+    .split(',')
+    .map(token => token.trim())
+    .filter(Boolean);
+
+const ageToBucket = age => {
+  if (!Number.isFinite(age) || age < 0) return 'other';
+  if (age <= 25) return 'le25';
+  if (age <= 30) return '26_30';
+  if (age <= 33) return '31_33';
+  if (age <= 36) return '34_36';
+  if (age <= 42) return '37_42';
+  return '43_plus';
+};
+
+const normalizeBlood = value =>
+  String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '');
+
+const parseBloodFromRuleToken = token => {
+  const normalized = normalizeBlood(token);
+  if (!normalized) return null;
+
+  if (normalized === '+' || normalized === '-') {
+    return { groups: [...GROUP_KEYS], rhs: [normalized] };
+  }
+
+  const match = normalized.match(/^([1-4])([+-])?$/);
+  if (!match) return null;
+
+  const [, group, rh] = match;
+  return {
+    groups: [group],
+    rhs: rh ? [rh] : ['+', '-'],
+  };
+};
+
+const parseBloodFromUser = value => {
+  const normalized = normalizeBlood(value);
+  if (!normalized) return { group: 'other', rh: 'other' };
+
+  const match = normalized.match(/^([1-4])([+-])$/);
+  if (!match) return { group: 'other', rh: 'other' };
+
+  return { group: match[1], rh: match[2] };
+};
+
+const normalizeMarital = value => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (['+', 'yes', 'так', 'заміжня', 'married'].includes(normalized)) return 'married';
+  if (['-', 'no', 'ні', 'незаміжня', 'unmarried', 'single'].includes(normalized)) return 'unmarried';
+  return 'other';
+};
+
+const parseCsectionCount = value => {
+  if (Array.isArray(value)) {
+    const numericValues = value
+      .map(item => Number.parseInt(String(item), 10))
+      .filter(num => Number.isFinite(num));
+    if (numericValues.length) {
+      return Math.max(...numericValues);
+    }
+  }
+
+  const match = String(value || '').match(/\d+/);
+  if (match) return Number.parseInt(match[0], 10);
+  return null;
+};
+
+export const ADDITIONAL_ACCESS_TEMPLATE = `age: 21,22,23\nblood: 1+,2,-\nmaritalStatus: +,-\ncsection: 2+`;
+
+export const parseAdditionalAccessRules = raw => {
+  const lines = parseRulesLines(raw);
+  if (!lines.length) return null;
+
+  const result = {};
+
+  lines.forEach(({ key, value }) => {
+    const tokens = parseTokens(value);
+    if (!tokens.length) return;
+
+    if (key === 'age') {
+      const allowedAges = new Set(
+        tokens
+          .map(token => Number.parseInt(token, 10))
+          .filter(num => Number.isFinite(num) && num >= 0)
+      );
+      if (allowedAges.size) {
+        result.age = allowedAges;
+      }
+      return;
+    }
+
+    if (key === 'blood') {
+      const groups = new Set();
+      const rhs = new Set();
+      tokens.forEach(token => {
+        const parsed = parseBloodFromRuleToken(token);
+        if (!parsed) return;
+        parsed.groups.forEach(group => groups.add(group));
+        parsed.rhs.forEach(rh => rhs.add(rh));
+      });
+
+      if (groups.size || rhs.size) {
+        result.blood = {
+          groups,
+          rhs,
+        };
+      }
+      return;
+    }
+
+    if (key === 'maritalstatus') {
+      const allowed = new Set(tokens.map(token => normalizeMarital(token)).filter(Boolean));
+      if (allowed.size) {
+        result.maritalStatus = allowed;
+      }
+      return;
+    }
+
+    if (key === 'csection') {
+      const rule = tokens[0];
+      if (!rule) return;
+      const atLeastMatch = rule.match(/^(\d+)\+$/);
+      if (atLeastMatch) {
+        result.csection = { mode: 'atLeast', value: Number.parseInt(atLeastMatch[1], 10) };
+        return;
+      }
+
+      const exact = Number.parseInt(rule, 10);
+      if (Number.isFinite(exact)) {
+        result.csection = { mode: 'exact', value: exact };
+      }
+    }
+  });
+
+  return Object.keys(result).length ? result : null;
+};
+
+export const isUserAllowedByAdditionalAccess = (user, parsedRules) => {
+  if (!parsedRules) return true;
+
+  if (parsedRules.age) {
+    const age = utilCalculateAge(user?.birth);
+    if (!Number.isFinite(age) || !parsedRules.age.has(age)) {
+      return false;
+    }
+  }
+
+  if (parsedRules.blood) {
+    const blood = parseBloodFromUser(user?.blood);
+    const groupOk = parsedRules.blood.groups.size === 0 || parsedRules.blood.groups.has(blood.group);
+    const rhOk = parsedRules.blood.rhs.size === 0 || parsedRules.blood.rhs.has(blood.rh);
+
+    if (!groupOk || !rhOk) {
+      return false;
+    }
+  }
+
+  if (parsedRules.maritalStatus) {
+    const marital = normalizeMarital(user?.maritalStatus);
+    if (!parsedRules.maritalStatus.has(marital)) {
+      return false;
+    }
+  }
+
+  if (parsedRules.csection) {
+    const csectionCount = parseCsectionCount(user?.csection);
+    if (!Number.isFinite(csectionCount)) {
+      return false;
+    }
+
+    if (parsedRules.csection.mode === 'atLeast' && csectionCount < parsedRules.csection.value) {
+      return false;
+    }
+
+    if (parsedRules.csection.mode === 'exact' && csectionCount !== parsedRules.csection.value) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const filterUsersByAdditionalAccess = (usersMap, parsedRules) => {
+  if (!parsedRules || !usersMap || typeof usersMap !== 'object') return usersMap || {};
+
+  return Object.fromEntries(
+    Object.entries(usersMap).filter(([, user]) => isUserAllowedByAdditionalAccess(user, parsedRules))
+  );
+};
+
+export const createAllFalseFilterGroup = keys =>
+  keys.reduce((acc, key) => {
+    acc[key] = false;
+    return acc;
+  }, {});
+
+export const defaultAdditionalAccessFilterState = {
+  age: defaultAllowed(['le25', '26_30', '31_33', '34_36', '37_42', '43_plus', 'other', 'empty']),
+  bloodGroup: defaultAllowed(['1', '2', '3', '4', 'other', 'empty']),
+  rh: defaultAllowed(['+', '-', 'other', 'empty']),
+  maritalStatus: defaultAllowed(['married', 'unmarried', 'other', 'empty']),
+  csection: defaultAllowed(['cs2plus', 'cs1', 'cs0', 'other', 'no']),
+};
+
+export const ageBucketFromAge = ageToBucket;


### PR DESCRIPTION
### Motivation
- Allow admins to define additional access rules (age, blood, marital status, csection) on user profiles and use those rules to surface eligible `newUsers` inside the Matching feed. 
- Provide a convenient editable field and template in the profile editor for configuring these rules. 
- Keep existing matching behavior intact for non-admins and when no additional rules are present.

### Description
- Introduced a new utility `src/utils/additionalAccessRules.js` that implements parsing of a simple rules format, validation helpers, `ADDITIONAL_ACCESS_TEMPLATE`, and functions `parseAdditionalAccessRules`, `isUserAllowedByAdditionalAccess`, `filterUsersByAdditionalAccess`, and related helpers. 
- Updated `Matching.jsx` to load and keep `additionalAccessRules` from the current user's profile in local storage and state, to fetch `newUsers` from RTDB and filter them using parsed additional access rules, and to inject or merge these additional `newUsers` into the visible users list via a `useMemo` computed `visibleUsers`. 
- Ensured access profile is refreshed on auth state change by fetching the current user's profile (`fetchUserById`) and storing `accessLevel` and `additionalAccessRules` in state and `localStorage`, and cleaned up state on sign-out. 
- Added `get` import from `firebase/database` and usage to read `newUsers` snapshot in `Matching`. 
- Updated `ProfileForm.jsx` to surface a new `additionalAccessRules` field when the editor can manage access levels, to include the `accessLevel` and `additionalAccessRules` in the prioritized field order, to add an info/copy button using `ADDITIONAL_ACCESS_TEMPLATE`, and to hide this field from non-admins. 
- Added a small `AccessInfoButton` styled component and imported `FaInfoCircle` for the UI affordance. 
- Preserved existing filtering and publishing logic for non-admins and ensured existing favorites/dislikes handling remains unchanged.

### Testing
- Ran unit tests with `yarn test` and the suite completed successfully. 
- Ran linter with `yarn lint` and no new linting errors were reported. 
- Performed a production build with `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e277c739848326be69783630a1f351)