### PR TITLE
Relax ID validation and always apply matching filters to visible users

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -64,8 +64,8 @@ import {
 } from '../utils/commentsStorage';
 import { isUserAllowedByAdditionalAccess, parseAdditionalAccessRules } from 'utils/additionalAccessRules';
 
-// Filter out users with invalid identifiers; IDs must be longer than 20 characters
-const isValidId = id => typeof id === 'string' && id.length > 20;
+// Filter out users with invalid identifiers; Firebase push IDs are usually 20 chars.
+const isValidId = id => typeof id === 'string' && id.length >= 20;
 const filterLongUsers = list => list.filter(u => isValidId(u?.userId));
 
 const compareUsersByLastLogin2 = (a = {}, b = {}) =>
@@ -1929,17 +1929,15 @@ const Matching = () => {
     return Array.from(byId.values());
   }, [additionalNewUsers, isAdmin, parsedAdditionalAccessRules, users]);
 
-  const filteredUsers = isAdmin
-    ? applyMatchingSearchKeyFilters(
-        filterMain(
-          visibleUsers.map(u => [u.userId, u]),
-          null,
-          getMatchingFiltersWithoutSearchKeyGroups(filters),
-          favoriteUsers
-        ).map(([, u]) => u),
-        filters
-      ).filter(u => isValidId(u.userId))
-    : visibleUsers.filter(u => isValidId(u.userId));
+  const filteredUsers = applyMatchingSearchKeyFilters(
+    filterMain(
+      visibleUsers.map(u => [u.userId, u]),
+      null,
+      getMatchingFiltersWithoutSearchKeyGroups(filters),
+      favoriteUsers
+    ).map(([, u]) => u),
+    filters
+  ).filter(u => isValidId(u.userId));
 
   useEffect(() => {
     if (viewMode !== 'default') return;


### PR DESCRIPTION
### Motivation
- Accept Firebase push IDs of 20 characters and make filtering behavior consistent for admin and non-admin users by unifying the matching pipeline.

### Description
- Update `isValidId` to accept IDs with `length >= 20` and adjust the comment to note Firebase push IDs are usually 20 chars, and remove the admin-only branch so `filteredUsers` always goes through `filterMain` and `applyMatchingSearchKeyFilters` before applying `isValidId`.

### Testing
- Ran the automated test suite and linter (`yarn test` and `yarn lint`); all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e32373178483268e4508fc2d0be934)