### PR TITLE
Fix missing useEffect dependency in Matching additional rules loader

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1706,7 +1706,7 @@ const Matching = () => {
     return () => {
       cancelled = true;
     };
-  }, [parsedAdditionalAccessRules]);
+  }, [parsedAdditionalAccessRules, currentAdditionalAccessRules]);
 
   const fetchChunk = React.useCallback(
     async (


### PR DESCRIPTION
### Motivation
- Resolve a `react-hooks/exhaustive-deps` warning by ensuring the effect that loads additional new-users reacts to all referenced values (`currentAdditionalAccessRules`).

### Description
- Add `currentAdditionalAccessRules` to the dependency array of the `useEffect` that loads additional new-users in `src/components/Matching.jsx`, so the effect tracks the value used in the toast signature and state updates.

### Testing
- Ran `npm run lint:js -- src/components/Matching.jsx`, and the lint check completed successfully (only non-blocking environment/browserslist warnings were printed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e360b8df6c8326ab5e52dbe946772e)