### PR TITLE
Support bucket-based age/blood/marital/csection rules and enhance parsing for additional access

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -71,20 +71,43 @@ const parseBloodFromRuleToken = token => {
 
 const parseBloodFromUser = value => {
   const normalized = normalizeBlood(value);
-  if (!normalized) return { group: 'other', rh: 'other' };
+  if (!normalized) return { group: 'empty', rh: 'empty', bucket: 'no' };
 
-  const match = normalized.match(/^([1-4])([+-])$/);
-  if (!match) return { group: 'other', rh: 'other' };
+  const fullMatch = normalized.match(/^([1-4])([+-])$/);
+  if (fullMatch) {
+    return { group: fullMatch[1], rh: fullMatch[2], bucket: `${fullMatch[1]}${fullMatch[2]}` };
+  }
 
-  return { group: match[1], rh: match[2] };
+  const groupOnlyMatch = normalized.match(/^([1-4])$/);
+  if (groupOnlyMatch) {
+    return { group: groupOnlyMatch[1], rh: 'empty', bucket: groupOnlyMatch[1] };
+  }
+
+  if (normalized === '+') return { group: 'other', rh: '+', bucket: '+' };
+  if (normalized === '-') return { group: 'other', rh: '-', bucket: '-' };
+
+  return { group: 'other', rh: 'other', bucket: '?' };
 };
 
 const normalizeMarital = value => {
   const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return 'empty';
   if (['+', 'yes', 'так', 'заміжня', 'married'].includes(normalized)) return 'married';
   if (['-', 'no', 'ні', 'незаміжня', 'unmarried', 'single'].includes(normalized)) return 'unmarried';
   return 'other';
 };
+
+const parseMaritalRuleToken = token => {
+  const normalized = String(token || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === '?') return 'other';
+  if (['no', 'empty'].includes(normalized)) return 'empty';
+  return normalizeMarital(normalized);
+};
+
+const AGE_BUCKET_KEYS = new Set(['le25', '26_30', '31_33', '34_36', '37_42', '43_plus', 'other']);
+const BLOOD_BUCKET_KEYS = new Set(['1+', '1-', '1', '2+', '2-', '2', '3+', '3-', '3', '4+', '4-', '4', '?', 'no']);
+const CSECTION_BUCKET_KEYS = new Set(['cs2plus', 'cs1', 'cs0', 'other', 'no']);
 
 const parseCsectionCount = value => {
   if (Array.isArray(value)) {
@@ -101,7 +124,39 @@ const parseCsectionCount = value => {
   return null;
 };
 
-export const ADDITIONAL_ACCESS_TEMPLATE = `age: 21,22,23\nblood: 1+,2,-\nmaritalStatus: +,-\ncsection: 2+`;
+export const ADDITIONAL_ACCESS_TEMPLATE = `age: le25,26_30,31_33,34_36,37_42,43_plus,other
+blood: 1+,1-,1,2+,2-,2,3+,3-,3,4+,4-,4,?,no
+maritalStatus: +,-,?,no
+csection: cs2plus,cs1,cs0,other,no
+contact: vk,instagram,facebook,phone,telegram,telegram2,tiktok,email
+role: ed,sm,ag,ip,cl,?,no
+userId: vk,aa,ab,long,mid,other
+imt: le28,29_31,32_35,36_plus,?,no
+ageBirthDate: d_2001-01-30,?,no
+reaction: d_2026-04-18,99,?,no
+height: 170,165.5,?,no
+weight: 55,60.5,?,no`;
+
+
+const normalizeCsectionRuleBucket = value => {
+  if (value === null || value === undefined) return 'no';
+
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return 'no';
+  const token = normalized.replace(/[.,;:!?]+$/g, '');
+
+  if (/\b\d{1,2}[./-]\d{1,2}[./-]\d{2,4}\b/.test(token)) return 'cs1';
+  if (token === '+' || token === 'plus') return 'cs1';
+  if (token === '++' || token === '+++') return 'cs2plus';
+  if (/^[+-]?\d+$/.test(token)) {
+    const parsedInt = Number.parseInt(token, 10);
+    if (parsedInt === 1) return 'cs1';
+    if (parsedInt === 2 || parsedInt === 3) return 'cs2plus';
+  }
+
+  if (['-', 'no', 'ні', 'minus'].includes(token)) return 'cs0';
+  return 'other';
+};
 
 export const parseAdditionalAccessRules = raw => {
   const lines = parseRulesLines(raw);
@@ -114,13 +169,28 @@ export const parseAdditionalAccessRules = raw => {
     if (!tokens.length) return;
 
     if (key === 'age') {
-      const allowedAges = new Set(
-        tokens
-          .map(token => Number.parseInt(token, 10))
-          .filter(num => Number.isFinite(num) && num >= 0)
-      );
+      const allowedAges = new Set();
+      const allowedAgeBuckets = new Set();
+
+      tokens.forEach(token => {
+        const normalizedToken = String(token || '').trim().toLowerCase();
+        if (AGE_BUCKET_KEYS.has(normalizedToken)) {
+          allowedAgeBuckets.add(normalizedToken);
+          return;
+        }
+
+        const parsedAge = Number.parseInt(normalizedToken, 10);
+        if (Number.isFinite(parsedAge) && parsedAge >= 0) {
+          allowedAges.add(parsedAge);
+        }
+      });
+
       if (allowedAges.size) {
         result.age = allowedAges;
+      }
+
+      if (allowedAgeBuckets.size) {
+        result.ageBuckets = allowedAgeBuckets;
       }
       return;
     }
@@ -128,24 +198,31 @@ export const parseAdditionalAccessRules = raw => {
     if (key === 'blood') {
       const groups = new Set();
       const rhs = new Set();
+      const buckets = new Set();
       tokens.forEach(token => {
+        const normalizedToken = String(token || '').trim().toLowerCase();
+        if (BLOOD_BUCKET_KEYS.has(normalizedToken)) {
+          buckets.add(normalizedToken);
+        }
+
         const parsed = parseBloodFromRuleToken(token);
         if (!parsed) return;
         parsed.groups.forEach(group => groups.add(group));
         parsed.rhs.forEach(rh => rhs.add(rh));
       });
 
-      if (groups.size || rhs.size) {
+      if (groups.size || rhs.size || buckets.size) {
         result.blood = {
           groups,
           rhs,
+          buckets,
         };
       }
       return;
     }
 
     if (key === 'maritalstatus') {
-      const allowed = new Set(tokens.map(token => normalizeMarital(token)).filter(Boolean));
+      const allowed = new Set(tokens.map(token => parseMaritalRuleToken(token)).filter(Boolean));
       if (allowed.size) {
         result.maritalStatus = allowed;
       }
@@ -153,6 +230,16 @@ export const parseAdditionalAccessRules = raw => {
     }
 
     if (key === 'csection') {
+      const csectionBuckets = new Set(
+        tokens
+          .map(token => String(token || '').trim().toLowerCase())
+          .filter(token => CSECTION_BUCKET_KEYS.has(token))
+      );
+
+      if (csectionBuckets.size > 0) {
+        result.csectionBuckets = csectionBuckets;
+      }
+
       const rule = tokens[0];
       if (!rule) return;
       const atLeastMatch = rule.match(/^(\d+)\+$/);
@@ -174,19 +261,29 @@ export const parseAdditionalAccessRules = raw => {
 export const isUserAllowedByAdditionalAccess = (user, parsedRules) => {
   if (!parsedRules) return true;
 
-  if (parsedRules.age) {
+  if (parsedRules.age || parsedRules.ageBuckets) {
     const age = utilCalculateAge(user?.birth);
-    if (!Number.isFinite(age) || !parsedRules.age.has(age)) {
-      return false;
+    if (!Number.isFinite(age)) {
+      if (parsedRules.age || (parsedRules.ageBuckets && !parsedRules.ageBuckets.has('other'))) {
+        return false;
+      }
+    } else {
+      const byAge = !parsedRules.age || parsedRules.age.has(age);
+      const ageBucket = ageToBucket(age);
+      const byBucket = !parsedRules.ageBuckets || parsedRules.ageBuckets.has(ageBucket);
+      if (!byAge && !byBucket) {
+        return false;
+      }
     }
   }
 
   if (parsedRules.blood) {
     const blood = parseBloodFromUser(user?.blood);
+    const bucketOk = !parsedRules.blood.buckets || parsedRules.blood.buckets.size === 0 || parsedRules.blood.buckets.has(blood.bucket);
     const groupOk = parsedRules.blood.groups.size === 0 || parsedRules.blood.groups.has(blood.group);
     const rhOk = parsedRules.blood.rhs.size === 0 || parsedRules.blood.rhs.has(blood.rh);
 
-    if (!groupOk || !rhOk) {
+    if (!bucketOk && (!groupOk || !rhOk)) {
       return false;
     }
   }
@@ -194,6 +291,13 @@ export const isUserAllowedByAdditionalAccess = (user, parsedRules) => {
   if (parsedRules.maritalStatus) {
     const marital = normalizeMarital(user?.maritalStatus);
     if (!parsedRules.maritalStatus.has(marital)) {
+      return false;
+    }
+  }
+
+  if (parsedRules.csectionBuckets && parsedRules.csectionBuckets.size > 0) {
+    const csectionBucket = normalizeCsectionRuleBucket(user?.csection);
+    if (!parsedRules.csectionBuckets.has(csectionBucket)) {
       return false;
     }
   }
@@ -231,6 +335,10 @@ const uniq = values => [...new Set((values || []).filter(Boolean))];
 const resolveBloodSearchKeyBuckets = parsedRules => {
   if (!parsedRules?.blood) return [];
 
+  if (parsedRules.blood.buckets?.size) {
+    return uniq([...parsedRules.blood.buckets]);
+  }
+
   const groups = parsedRules.blood.groups?.size
     ? [...parsedRules.blood.groups]
     : [...ALL_BLOOD_GROUPS];
@@ -257,13 +365,20 @@ const resolveMaritalStatusSearchKeyBuckets = parsedRules => {
   if (parsedRules.maritalStatus.has('married')) buckets.push('+');
   if (parsedRules.maritalStatus.has('unmarried')) buckets.push('-');
   if (parsedRules.maritalStatus.has('other')) {
-    buckets.push('?', 'no');
+    buckets.push('?');
+  }
+  if (parsedRules.maritalStatus.has('empty')) {
+    buckets.push('no');
   }
 
   return uniq(buckets);
 };
 
 const resolveCsectionSearchKeyBuckets = parsedRules => {
+  if (parsedRules?.csectionBuckets?.size) {
+    return uniq([...parsedRules.csectionBuckets]);
+  }
+
   if (!parsedRules?.csection) return [];
 
   const { mode, value } = parsedRules.csection;
@@ -286,12 +401,14 @@ const resolveCsectionSearchKeyBuckets = parsedRules => {
 };
 
 const resolveAgeSearchKeyBuckets = parsedRules => {
-  if (!parsedRules?.age || parsedRules.age.size === 0) return [];
-  return uniq(
-    [...parsedRules.age]
+  const directBuckets = parsedRules?.ageBuckets ? [...parsedRules.ageBuckets] : [];
+  const numericBuckets = parsedRules?.age
+    ? [...parsedRules.age]
       .filter(age => Number.isFinite(age) && age >= 0)
       .map(age => ageToBucket(age))
-  );
+    : [];
+
+  return uniq([...directBuckets, ...numericBuckets]);
 };
 
 export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({


### PR DESCRIPTION
### Motivation
- Extend the additional access rule syntax to support bucketed tokens (age buckets, blood buckets, c-section buckets) in addition to numeric values for more flexible matching.
- Make parsing and matching more robust for empty/unknown values and varied token formats (e.g. partial blood group, plus/minus, date or shorthand c-section values).
- Provide a richer `ADDITIONAL_ACCESS_TEMPLATE` to document available buckets and contact/role/user fields.

### Description
- Added bucket key sets `AGE_BUCKET_KEYS`, `BLOOD_BUCKET_KEYS`, and `CSECTION_BUCKET_KEYS`, expanded `ADDITIONAL_ACCESS_TEMPLATE`, and introduced `parseMaritalRuleToken` and `normalizeCsectionRuleBucket` helper functions. 
- Enhanced `parseBloodFromUser` to return a `bucket` and extended parsing to accept full, group-only, and sign-only blood tokens; adjusted `parseAdditionalAccessRules` to collect `ageBuckets`, `blood.buckets`, and `csectionBuckets` alongside existing numeric values. 
- Updated `isUserAllowedByAdditionalAccess` to consider bucket matches for `age`, `blood`, and `csection` in addition to numeric/group/rh checks, and to treat empty/unknown values according to parsed rule buckets. 
- Updated search-key resolvers (`resolveBloodSearchKeyBuckets`, `resolveMaritalStatusSearchKeyBuckets`, `resolveCsectionSearchKeyBuckets`, `resolveAgeSearchKeyBuckets`) to include bucketed results and adjusted default filter state keys accordingly.

### Testing
- Ran the existing automated test suite with `npm test`, and the suite completed successfully. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3709940d883268522fa08a2ef83e2)