### PR TITLE
Add additional-access rule builder, multi-group parsing, and matching integration

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -63,8 +63,8 @@ import {
   pruneComments,
 } from '../utils/commentsStorage';
 import {
-  isUserAllowedByAdditionalAccess,
-  parseAdditionalAccessRules,
+  isUserAllowedByAnyAdditionalAccessRule,
+  parseAdditionalAccessRuleGroups,
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
 
@@ -140,33 +140,48 @@ const fetchUsersAndNewUsersByIds = async ids => {
   return snapshots.filter(Boolean);
 };
 
-const fetchAdditionalNewUsersBySearchIndex = async parsedRules => {
-  const buckets = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
-  const activeSources = [
-    { indexName: SEARCH_KEY_INDEX_NAMES.blood, values: buckets.blood },
-    { indexName: SEARCH_KEY_INDEX_NAMES.maritalStatus, values: buckets.maritalStatus },
-    { indexName: SEARCH_KEY_INDEX_NAMES.csection, values: buckets.csection },
-    { indexName: SEARCH_KEY_INDEX_NAMES.age, values: buckets.age },
-  ].filter(source => source.values.length > 0);
+const fetchAdditionalNewUsersBySearchIndex = async parsedRuleGroups => {
+  if (!Array.isArray(parsedRuleGroups) || parsedRuleGroups.length === 0) return [];
 
-  if (activeSources.length === 0) return [];
+  const matchedIdsSet = new Set();
 
-  const indexedSets = await Promise.all(
-    activeSources.map(source => readIndexedIds(source.indexName, source.values))
-  );
+  for (const parsedRules of parsedRuleGroups) {
+    const buckets = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
+    const activeSources = Object.entries(buckets || {})
+      .map(([indexName, values]) => ({
+        indexName: SEARCH_KEY_INDEX_NAMES[indexName] || indexName,
+        values: Array.isArray(values) ? values : [...(values || [])],
+      }))
+      .filter(source => source.values.length > 0);
 
-  const normalizedSets = indexedSets.filter(set => set instanceof Set);
-  const nonEmptySets = normalizedSets.filter(set => set.size > 0);
-  if (nonEmptySets.length === 0) return [];
+    if (activeSources.length === 0) continue;
 
-  const matchedIds = [...new Set(nonEmptySets.flatMap(set => [...set]))];
+    const indexedSets = await Promise.all(
+      activeSources.map(source => readIndexedIds(source.indexName, source.values))
+    );
+
+    const normalizedSets = indexedSets.filter(set => set instanceof Set);
+    const nonEmptySets = normalizedSets.filter(set => set.size > 0);
+    if (nonEmptySets.length === 0) continue;
+
+    nonEmptySets.forEach(set => {
+      [...set].forEach(userId => matchedIdsSet.add(userId));
+    });
+  }
+
+  const matchedIds = [...matchedIdsSet];
   if (matchedIds.length === 0) return [];
 
   const combinedRows = await fetchUsersAndNewUsersByIds(matchedIds);
   return combinedRows
     .filter(row => row.hasNewUser)
     .filter(row => isValidId(row.merged?.userId))
-    .filter(row => isUserAllowedByAdditionalAccess({ userId: row.merged.userId, ...(row.newUserData || {}) }, parsedRules))
+    .filter(row =>
+      isUserAllowedByAnyAdditionalAccessRule(
+        { userId: row.merged.userId, ...(row.newUserData || {}) },
+        parsedRuleGroups
+      )
+    )
     .map(row => ({ ...row.merged, __sourceCollection: 'newUsers' }));
 };
 
@@ -1457,7 +1472,7 @@ const Matching = () => {
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
   const parsedAdditionalAccessRules = useMemo(
-    () => parseAdditionalAccessRules(currentAdditionalAccessRules),
+    () => parseAdditionalAccessRuleGroups(currentAdditionalAccessRules),
     [currentAdditionalAccessRules]
   );
   const loadingRef = useRef(false);
@@ -1673,7 +1688,7 @@ const Matching = () => {
     let cancelled = false;
 
     const loadAdditionalNewUsers = async () => {
-      if (!parsedAdditionalAccessRules) {
+      if (!parsedAdditionalAccessRules || parsedAdditionalAccessRules.length === 0) {
         setAdditionalNewUsers([]);
         additionalRulesToastRef.current = '';
         return;
@@ -2097,7 +2112,7 @@ const Matching = () => {
       : users.filter(user => user.__sourceCollection === 'newUsers' || user.publish === true);
 
     const shouldInjectAdditionalCards =
-      parsedAdditionalAccessRules &&
+      parsedAdditionalAccessRules.length > 0 &&
       additionalNewUsers.length > 0;
 
     if (!shouldInjectAdditionalCards) {

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import { get, ref as refDb } from 'firebase/database';
 import Photos from './Photos';
@@ -15,10 +15,16 @@ import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { patchOverlayField } from 'utils/multiAccountEdits';
 import toast from 'react-hot-toast';
 import { removeField } from './smallCard/actions';
-import { FaInfoCircle, FaTimes } from 'react-icons/fa';
+import { FaPlus, FaTimes } from 'react-icons/fa';
 import { InfoModal } from './InfoModal';
 import { auth, database } from './config';
-import { ADDITIONAL_ACCESS_TEMPLATE } from 'utils/additionalAccessRules';
+import {
+  ADDITIONAL_ACCESS_FILTER_OPTIONS,
+  ADDITIONAL_ACCESS_TEMPLATE,
+  isUserAllowedByAnyAdditionalAccessRule,
+  parseAdditionalAccessRuleGroups,
+  resolveAdditionalAccessSearchKeyBuckets,
+} from 'utils/additionalAccessRules';
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -79,6 +85,65 @@ const nestedIndentStyle = {
 };
 
 const ADDITIONAL_ACCESS_FIELD = 'additionalAccessRules';
+const SEARCH_KEY_ROOT = 'searchKey';
+const ADDITIONAL_RULE_LABELS = {
+  age: 'Вік',
+  csection: 'КС',
+  bloodGroup: 'Кров',
+  rh: 'Резус',
+  maritalStatus: 'Сімейний стан',
+  imt: 'ІМТ',
+  role: 'Роль',
+  contact: 'Контакти',
+  userId: 'UserId',
+  reaction: 'Reaction',
+  height: 'Height',
+  weight: 'Weight',
+  ageBirthDate: 'Birth date',
+};
+const ADDITIONAL_RULE_ORDER = Object.keys(ADDITIONAL_RULE_LABELS);
+const ADDITIONAL_RULE_OPTION_LABELS = {
+  le21: '<=21',
+  '22_42': '22...42',
+  cs2plus: '>=2',
+  cs1: '1',
+  cs0: '0',
+};
+
+const parseAdditionalRulesTextToBuilder = raw => {
+  const lines = String(raw || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  return lines
+    .map(line => {
+      const [keyRaw, ...rest] = line.split(':');
+      if (!keyRaw || rest.length === 0) return null;
+      const key = keyRaw.trim();
+      const allowedValues = new Set(
+        rest
+          .join(':')
+          .split(',')
+          .map(token => token.trim())
+          .filter(Boolean)
+      );
+      return { key, allowedValues };
+    })
+    .filter(Boolean);
+};
+
+const buildAdditionalRulesTextFromBuilder = rules =>
+  rules
+    .filter(rule => rule?.key && rule.allowedValues instanceof Set && rule.allowedValues.size > 0)
+    .map(rule => `${rule.key}: ${[...rule.allowedValues].join(',')}`)
+    .join('\n');
+
+const additionalRulesTextToInputs = raw => {
+  const text = String(raw || '');
+  if (!text.trim()) return [''];
+  return text.split(/\r?\n/);
+};
 
 
 const sanitizeOverlayValue = value => {
@@ -395,12 +460,127 @@ export const ProfileForm = ({
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [autoOverlayFieldAdditions, setAutoOverlayFieldAdditions] = useState({});
   const [dismissedOverlayEntries, setDismissedOverlayEntries] = useState({});
+  const [showAdditionalRulesModal, setShowAdditionalRulesModal] = useState(false);
+  const [additionalRuleBuilder, setAdditionalRuleBuilder] = useState([]);
+  const [additionalRulesInputs, setAdditionalRulesInputs] = useState(() =>
+    additionalRulesTextToInputs(state?.[ADDITIONAL_ACCESS_FIELD])
+  );
+  const [availableCards, setAvailableCards] = useState([]);
+  const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const autoAppliedOverlayForUserRef = useRef('');
+
+  const addEmptyAdditionalFilter = useCallback(() => {
+    const used = new Set(additionalRuleBuilder.map(rule => rule.key));
+    const firstAvailable = ADDITIONAL_RULE_ORDER.find(key => !used.has(key)) || ADDITIONAL_RULE_ORDER[0];
+    if (!firstAvailable) return;
+    setAdditionalRuleBuilder(prev => [...prev, { key: firstAvailable, allowedValues: new Set() }]);
+  }, [additionalRuleBuilder]);
+
+  const additionalRulesDraftText = useMemo(
+    () => buildAdditionalRulesTextFromBuilder(additionalRuleBuilder),
+    [additionalRuleBuilder]
+  );
+  const additionalRulesRawValue = state?.[ADDITIONAL_ACCESS_FIELD] || '';
 
   useEffect(() => {
     if (state?.userId) return;
     autoAppliedOverlayForUserRef.current = '';
   }, [state?.userId]);
+
+  useEffect(() => {
+    setAdditionalRulesInputs(additionalRulesTextToInputs(additionalRulesRawValue));
+  }, [additionalRulesRawValue]);
+
+  useEffect(() => {
+    if (!showAdditionalRulesModal) return;
+    const parsed = parseAdditionalRulesTextToBuilder(additionalRulesRawValue);
+    if (parsed.length > 0) {
+      setAdditionalRuleBuilder(parsed);
+      return;
+    }
+    setAdditionalRuleBuilder(ADDITIONAL_RULE_ORDER.map(key => ({ key, allowedValues: new Set() })));
+  }, [additionalRulesRawValue, showAdditionalRulesModal]);
+
+  useEffect(() => {
+    if (!showAdditionalRulesModal) return;
+
+    let cancelled = false;
+    const loadAvailableCards = async () => {
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(additionalRulesDraftText);
+      if (!parsedRuleGroups.length) {
+        setAvailableCards([]);
+        return;
+      }
+
+      setIsLoadingAvailableCards(true);
+      try {
+        const matchedIds = new Set();
+
+        for (const parsedRules of parsedRuleGroups) {
+          const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
+          const activeGroups = Object.entries(bucketMap || {}).filter(([, values]) => {
+            const asArray = Array.isArray(values) ? values : [...(values || [])];
+            return asArray.length > 0;
+          });
+
+          if (!activeGroups.length) continue;
+
+          const snapshots = await Promise.all(
+            activeGroups.map(([indexName, values]) =>
+              Promise.all(
+                (Array.isArray(values) ? values : [...values]).map(value =>
+                  get(refDb(database, `${SEARCH_KEY_ROOT}/${indexName}/${value}`))
+                )
+              )
+            )
+          );
+
+          snapshots.forEach(groupSnapshots => {
+            groupSnapshots.forEach(snap => {
+              if (!snap.exists()) return;
+              Object.keys(snap.val() || {}).forEach(userId => matchedIds.add(userId));
+            });
+          });
+        }
+
+        const previewIds = [...matchedIds].slice(0, 120);
+        const rows = await Promise.all(
+          previewIds.map(async userId => {
+            const [newUserSnap, userSnap] = await Promise.all([
+              get(refDb(database, `newUsers/${userId}`)),
+              get(refDb(database, `users/${userId}`)),
+            ]);
+            if (!newUserSnap.exists() && !userSnap.exists()) return null;
+            const merged = {
+              userId,
+              ...(userSnap.exists() ? userSnap.val() : {}),
+              ...(newUserSnap.exists() ? newUserSnap.val() : {}),
+            };
+            if (!isUserAllowedByAnyAdditionalAccessRule(merged, parsedRuleGroups)) return null;
+            return merged;
+          })
+          );
+
+        if (!cancelled) {
+          setAvailableCards(rows.filter(Boolean));
+        }
+      } catch (error) {
+        console.error('Failed to build additional access preview', error);
+        if (!cancelled) {
+          setAvailableCards([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingAvailableCards(false);
+        }
+      }
+    };
+
+    loadAvailableCards();
+    return () => {
+      cancelled = true;
+    };
+  }, [additionalRulesDraftText, showAdditionalRulesModal]);
 
   useEffect(() => {
     setDismissedOverlayEntries({});
@@ -445,6 +625,60 @@ export const ProfileForm = ({
       return newState;
     });
     setCustomField({ key: '', value: '' });
+  };
+
+  const handleAdditionalRuleKeyChange = (index, nextKey) => {
+    setAdditionalRuleBuilder(prev =>
+      prev.map((rule, ruleIndex) =>
+        ruleIndex === index ? { key: nextKey, allowedValues: new Set() } : rule
+      )
+    );
+  };
+
+  const toggleAdditionalRuleValue = (index, token) => {
+    setAdditionalRuleBuilder(prev =>
+      prev.map((rule, ruleIndex) => {
+        if (ruleIndex !== index) return rule;
+        const next = new Set(rule.allowedValues);
+        if (next.has(token)) {
+          next.delete(token);
+        } else {
+          next.add(token);
+        }
+        return { ...rule, allowedValues: next };
+      })
+    );
+  };
+
+  const removeAdditionalRule = index => {
+    setAdditionalRuleBuilder(prev => prev.filter((_, ruleIndex) => ruleIndex !== index));
+  };
+
+  const syncAdditionalRulesInputs = nextInputs => {
+    setAdditionalRulesInputs(nextInputs);
+    const nextRulesText = nextInputs.map(item => String(item || '').trim()).filter(Boolean).join('\n');
+    setState(prevState => ({
+      ...prevState,
+      [ADDITIONAL_ACCESS_FIELD]: nextRulesText,
+    }));
+  };
+
+  const addAdditionalRulesInput = () => {
+    syncAdditionalRulesInputs([...additionalRulesInputs, '']);
+  };
+
+  const applyAdditionalRulesFromBuilder = () => {
+    const rulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+    setAdditionalRulesInputs(additionalRulesTextToInputs(rulesText));
+    setState(prevState => {
+      const updated = {
+        ...prevState,
+        [ADDITIONAL_ACCESS_FIELD]: rulesText,
+      };
+      submitWithNormalization(updated, 'overwrite');
+      return updated;
+    });
+    setShowAdditionalRulesModal(false);
   };
 
   const autoResizeMyComment = useAutoResize(textareaRef, state.myComment);
@@ -1055,40 +1289,27 @@ ${entries.join('\n')}`;
                     </AccessLevelSelect>
                   ) : field.name === ADDITIONAL_ACCESS_FIELD ? (
                     <>
-                      <InputField
-                        fieldName={field.name}
-                        as="textarea"
-                        name={field.name}
-                        value={state[field.name] || ''}
-                        placeholder={ADDITIONAL_ACCESS_TEMPLATE}
-                        onFocus={() => handleFieldFocus && handleFieldFocus(field.name)}
-                        onChange={e => {
-                          const value = e?.target?.value;
-                          setState(prevState => ({
-                            ...prevState,
-                            [field.name]: value,
-                          }));
-                        }}
-                        onBlur={() => submitWithNormalization(state, 'overwrite')}
-                      />
+                      <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                        {additionalRulesInputs.map((value, idx) => (
+                          <InputField
+                            key={`additional-rules-input-${idx}`}
+                            fieldName={field.name}
+                            name={`${field.name}-${idx}`}
+                            value={value}
+                            placeholder={ADDITIONAL_ACCESS_TEMPLATE}
+                            readOnly
+                            onFocus={() => handleFieldFocus && handleFieldFocus(field.name)}
+                            onClick={() => setShowAdditionalRulesModal(true)}
+                          />
+                        ))}
+                      </div>
                       <AccessInfoButton
                         type="button"
                         onMouseDown={e => e.preventDefault()}
-                        onClick={async () => {
-                          try {
-                            if (navigator?.clipboard?.writeText) {
-                              await navigator.clipboard.writeText(ADDITIONAL_ACCESS_TEMPLATE);
-                              toast.success('Шаблон доступу скопійовано');
-                            } else {
-                              window.alert(ADDITIONAL_ACCESS_TEMPLATE);
-                            }
-                          } catch {
-                            window.alert(ADDITIONAL_ACCESS_TEMPLATE);
-                          }
-                        }}
-                        title="Приклад максимального доступу. Натисніть, щоб скопіювати."
+                        onClick={addAdditionalRulesInput}
+                        title="Додати ще інпут правил"
                       >
-                        <FaInfoCircle />
+                        <FaPlus />
                       </AccessInfoButton>
                     </>
                   ) : (
@@ -1403,6 +1624,70 @@ ${entries.join('\n')}`;
         </OverlayDebugButton>
       )}
 
+      {showAdditionalRulesModal && (
+        <AdditionalRulesOverlay onClick={() => setShowAdditionalRulesModal(false)}>
+          <AdditionalRulesModal onClick={e => e.stopPropagation()}>
+            <AdditionalRulesClose type="button" onClick={() => setShowAdditionalRulesModal(false)}>
+              <FaTimes />
+            </AdditionalRulesClose>
+            <h3>Додаткові правила доступу</h3>
+            <small>Оберіть фільтри по групах. Порожня група не застосовується.</small>
+
+            {additionalRuleBuilder.map((rule, index) => {
+              const options = ADDITIONAL_ACCESS_FILTER_OPTIONS[rule.key] || [];
+              return (
+                <AdditionalRuleBlock key={`${rule.key}-${index}`}>
+                  <AdditionalRuleHeader>
+                    <select
+                      value={rule.key}
+                      onChange={event => handleAdditionalRuleKeyChange(index, event.target.value)}
+                    >
+                      {ADDITIONAL_RULE_ORDER.map(key => (
+                        <option key={key} value={key}>
+                          {ADDITIONAL_RULE_LABELS[key]}
+                        </option>
+                      ))}
+                    </select>
+                    <button type="button" onClick={() => removeAdditionalRule(index)}>
+                      <FaTimes />
+                    </button>
+                  </AdditionalRuleHeader>
+                  <AdditionalRuleOptions>
+                    {options.map(option => (
+                      <label key={`${rule.key}-${option}`}>
+                        <input
+                          type="checkbox"
+                          checked={rule.allowedValues.has(option)}
+                          onChange={() => toggleAdditionalRuleValue(index, option)}
+                        />
+                        <span>{ADDITIONAL_RULE_OPTION_LABELS[option] || option}</span>
+                      </label>
+                    ))}
+                  </AdditionalRuleOptions>
+                </AdditionalRuleBlock>
+              );
+            })}
+
+            <AdditionalRuleActions>
+              <button type="button" onClick={addEmptyAdditionalFilter}>+ Фільтр</button>
+              <button type="button" onClick={applyAdditionalRulesFromBuilder}>Застосувати</button>
+            </AdditionalRuleActions>
+
+            <AdditionalRulePreview>{additionalRulesDraftText || ADDITIONAL_ACCESS_TEMPLATE}</AdditionalRulePreview>
+            <AdditionalCardsTitle>
+              Доступні карточки ({availableCards.length}) {isLoadingAvailableCards ? '...завантаження' : ''}
+            </AdditionalCardsTitle>
+            <AdditionalCardsList>
+              {availableCards.map(card => (
+                <li key={card.userId}>
+                  {card.userId} {card.name ? `• ${card.name}` : ''}
+                </li>
+              ))}
+            </AdditionalCardsList>
+          </AdditionalRulesModal>
+        </AdditionalRulesOverlay>
+      )}
+
       {showInfoModal && (
         <InfoModal
           onClose={handleCloseModal}
@@ -1638,6 +1923,87 @@ const AccessInfoButton = styled.button`
   align-items: center;
   justify-content: center;
   cursor: pointer;
+`;
+
+const AdditionalRulesOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1200;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+`;
+
+const AdditionalRulesModal = styled.div`
+  background: #fff;
+  width: min(980px, 100vw);
+  height: 100vh;
+  padding: 20px;
+  overflow: auto;
+  position: relative;
+`;
+
+const AdditionalRulesClose = styled.button`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+`;
+
+const AdditionalRuleBlock = styled.div`
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 12px;
+  margin-top: 12px;
+`;
+
+const AdditionalRuleHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+
+  select,
+  button {
+    padding: 6px 10px;
+  }
+`;
+
+const AdditionalRuleOptions = styled.div`
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+`;
+
+const AdditionalRuleActions = styled.div`
+  margin-top: 14px;
+  display: flex;
+  gap: 8px;
+`;
+
+const AdditionalRulePreview = styled.pre`
+  margin-top: 14px;
+  background: #fafafa;
+  border: 1px solid #ddd;
+  padding: 10px;
+  white-space: pre-wrap;
+`;
+
+const AdditionalCardsTitle = styled.h4`
+  margin-top: 14px;
+  margin-bottom: 8px;
+`;
+
+const AdditionalCardsList = styled.ul`
+  margin: 0;
+  padding-left: 18px;
+  max-height: 220px;
+  overflow: auto;
 `;
 
 const DelKeyValueBTN = styled.button`

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -1,4 +1,5 @@
 import { utilCalculateAge } from 'components/smallCard/utilCalculateAge';
+import { utilCalculateIMT } from 'components/smallCard/utilCalculateIMT';
 
 const GROUP_KEYS = ['1', '2', '3', '4'];
 
@@ -109,6 +110,45 @@ const AGE_BUCKET_KEYS = new Set(['le25', '26_30', '31_33', '34_36', '37_42', '43
 const BLOOD_BUCKET_KEYS = new Set(['1+', '1-', '1', '2+', '2-', '2', '3+', '3-', '3', '4+', '4-', '4', '?', 'no']);
 const CSECTION_BUCKET_KEYS = new Set(['cs2plus', 'cs1', 'cs0', 'other', 'no']);
 
+const ADDITIONAL_ACCESS_KEY_ALIASES = {
+  'вік': 'age',
+  age: 'age',
+  blood: 'blood',
+  кров: 'bloodGroup',
+  bloodgroup: 'bloodGroup',
+  rh: 'rh',
+  'резус': 'rh',
+  maritalstatus: 'maritalStatus',
+  'сімейнийстан': 'maritalStatus',
+  csection: 'csection',
+  'кс': 'csection',
+  imt: 'imt',
+  'імт': 'imt',
+  role: 'role',
+  contact: 'contact',
+  userid: 'userId',
+  reaction: 'reaction',
+  height: 'height',
+  weight: 'weight',
+  agebirthdate: 'ageBirthDate',
+};
+
+export const ADDITIONAL_ACCESS_FILTER_OPTIONS = {
+  age: ['le21', '22_42', '43_plus', '?', 'no'],
+  csection: ['cs2plus', 'cs1', 'cs0', '?', 'no'],
+  bloodGroup: ['1', '2', '3', '4', '?', 'no'],
+  rh: ['+', '-', '?', 'no'],
+  maritalStatus: ['+', '-', '?', 'no'],
+  imt: ['le28', '29_31', '32_35', '36_plus', '?', 'no'],
+  role: ['ed', 'sm', 'ag', 'ip', 'cl', '?', 'no'],
+  contact: ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'],
+  userId: ['vk', 'aa', 'ab', 'long', 'mid', 'other'],
+  reaction: ['past', 'future', '99', '?', 'no'],
+  height: ['lt163', '163_176', '177_180', '181_plus', '?', 'no'],
+  weight: ['lt55', '55_69', '70_84', '85_plus', '?', 'no'],
+  ageBirthDate: ['d_2001-01-30', '?', 'no'],
+};
+
 const parseCsectionCount = value => {
   if (Array.isArray(value)) {
     const numericValues = value
@@ -136,6 +176,149 @@ ageBirthDate: d_2001-01-30,?,no
 reaction: d_2026-04-18,99,?,no
 height: 170,165.5,?,no
 weight: 55,60.5,?,no`;
+
+const normalizeRuleKey = key => ADDITIONAL_ACCESS_KEY_ALIASES[key] || key;
+
+const toRoleBucket = user => {
+  const normalize = value => String(value || '').trim().toLowerCase();
+  const rawRole = normalize(user?.role);
+  const rawUserRole = normalize(user?.userRole);
+  const value = rawRole || rawUserRole;
+  if (['ed', 'sm', 'ag', 'ip', 'cl'].includes(value)) return value;
+  if (!value) return 'no';
+  return '?';
+};
+
+const toUserIdBuckets = userId => {
+  const normalized = String(userId || '').trim().toLowerCase();
+  if (!normalized) return ['other'];
+  const buckets = [];
+  if (normalized.startsWith('vk')) buckets.push('vk');
+  if (normalized.startsWith('aa')) buckets.push('aa');
+  if (normalized.startsWith('ab')) buckets.push('ab');
+  if (normalized.length > 20) buckets.push('long');
+  if (normalized.length > 8 && normalized.length <= 20) buckets.push('mid');
+  if (!buckets.length) buckets.push('other');
+  return buckets;
+};
+
+const toImtBucket = user => {
+  const explicitImt = Number.parseFloat(String(user?.imt ?? '').trim().replace(',', '.'));
+  let imtValue = Number.isFinite(explicitImt) && explicitImt > 0 ? explicitImt : null;
+  if (!Number.isFinite(imtValue)) {
+    const calculated = utilCalculateIMT(
+      Number.parseFloat(String(user?.weight ?? '').trim().replace(',', '.')),
+      Number.parseFloat(String(user?.height ?? '').trim().replace(',', '.'))
+    );
+    if (Number.isFinite(calculated) && calculated > 0) {
+      imtValue = calculated;
+    }
+  }
+  if (!Number.isFinite(imtValue) || imtValue <= 0) {
+    const hasAny = String(user?.imt ?? '').trim() || String(user?.weight ?? '').trim() || String(user?.height ?? '').trim();
+    return hasAny ? '?' : 'no';
+  }
+  const rounded = Math.round(imtValue);
+  if (rounded <= 28) return 'le28';
+  if (rounded <= 31) return '29_31';
+  if (rounded <= 35) return '32_35';
+  return '36_plus';
+};
+
+const toMetricBucket = (value, ranges) => {
+  const normalized = String(value ?? '').trim().replace(',', '.');
+  if (!normalized) return 'no';
+  const parsed = Number.parseFloat(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) return '?';
+  return ranges(parsed);
+};
+
+const toContactBuckets = user => {
+  const keys = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'];
+  return keys.filter(key => String(user?.[key] || '').trim() !== '');
+};
+
+const normalizeBirthToIsoBucket = birth => {
+  const raw = String(birth || '').trim();
+  if (!raw) return 'no';
+  const match = raw.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+  if (!match) return '?';
+  const day = Number(match[1]);
+  const month = Number(match[2]);
+  const year = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return '?';
+  }
+  return `d_${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+};
+
+const getUserBucketsByRuleKey = (user, key) => {
+  if (key === 'bloodGroup') {
+    const blood = parseBloodFromUser(user?.blood);
+    if (['1', '2', '3', '4'].includes(blood.group)) return [blood.group];
+    if (blood.group === 'empty') return ['no'];
+    return ['?'];
+  }
+  if (key === 'rh') {
+    const blood = parseBloodFromUser(user?.blood);
+    if (blood.rh === '+' || blood.rh === '-') return [blood.rh];
+    if (blood.rh === 'empty') return ['no'];
+    return ['?'];
+  }
+  if (key === 'maritalStatus') {
+    const marital = normalizeMarital(user?.maritalStatus);
+    if (marital === 'married') return ['+'];
+    if (marital === 'unmarried') return ['-'];
+    if (marital === 'empty') return ['no'];
+    return ['?'];
+  }
+  if (key === 'role') {
+    return [toRoleBucket(user)];
+  }
+  if (key === 'contact') {
+    return toContactBuckets(user);
+  }
+  if (key === 'userId') {
+    return toUserIdBuckets(user?.userId);
+  }
+  if (key === 'imt') {
+    return [toImtBucket(user)];
+  }
+  if (key === 'height') {
+    return [
+      toMetricBucket(user?.height, metric => {
+        if (metric < 163) return 'lt163';
+        if (metric <= 176) return '163_176';
+        if (metric <= 180) return '177_180';
+        return '181_plus';
+      }),
+    ];
+  }
+  if (key === 'weight') {
+    return [
+      toMetricBucket(user?.weight, metric => {
+        if (metric < 55) return 'lt55';
+        if (metric <= 69) return '55_69';
+        if (metric <= 84) return '70_84';
+        return '85_plus';
+      }),
+    ];
+  }
+  if (key === 'ageBirthDate') {
+    return [normalizeBirthToIsoBucket(user?.birth)];
+  }
+  if (key === 'reaction') {
+    const reaction = String(user?.reaction || '').trim().toLowerCase();
+    if (!reaction) return ['no'];
+    if (reaction === '99') return ['99'];
+    if (reaction === '?') return ['?'];
+    if (reaction.includes('past')) return ['past'];
+    if (reaction.includes('future')) return ['future'];
+    return [reaction];
+  }
+  return [];
+};
 
 
 const normalizeCsectionRuleBucket = value => {
@@ -168,12 +351,34 @@ export const parseAdditionalAccessRules = raw => {
     const tokens = parseTokens(value);
     if (!tokens.length) return;
 
-    if (key === 'age') {
+    const normalizedKey = normalizeRuleKey(key);
+
+    if (normalizedKey === 'age') {
       const allowedAges = new Set();
       const allowedAgeBuckets = new Set();
 
       tokens.forEach(token => {
         const normalizedToken = String(token || '').trim().toLowerCase();
+        if (normalizedToken === 'le21') {
+          allowedAges.add(21);
+          allowedAgeBuckets.add('le25');
+          return;
+        }
+        if (normalizedToken === '22_42') {
+          allowedAgeBuckets.add('26_30');
+          allowedAgeBuckets.add('31_33');
+          allowedAgeBuckets.add('34_36');
+          allowedAgeBuckets.add('37_42');
+          return;
+        }
+        if (normalizedToken === 'no') {
+          allowedAgeBuckets.add('other');
+          return;
+        }
+        if (normalizedToken === '?') {
+          allowedAgeBuckets.add('other');
+          return;
+        }
         if (AGE_BUCKET_KEYS.has(normalizedToken)) {
           allowedAgeBuckets.add(normalizedToken);
           return;
@@ -195,7 +400,7 @@ export const parseAdditionalAccessRules = raw => {
       return;
     }
 
-    if (key === 'blood') {
+    if (normalizedKey === 'blood') {
       const groups = new Set();
       const rhs = new Set();
       const buckets = new Set();
@@ -221,7 +426,7 @@ export const parseAdditionalAccessRules = raw => {
       return;
     }
 
-    if (key === 'maritalstatus') {
+    if (normalizedKey === 'maritalStatus') {
       const allowed = new Set(tokens.map(token => parseMaritalRuleToken(token)).filter(Boolean));
       if (allowed.size) {
         result.maritalStatus = allowed;
@@ -229,7 +434,7 @@ export const parseAdditionalAccessRules = raw => {
       return;
     }
 
-    if (key === 'csection') {
+    if (normalizedKey === 'csection') {
       const csectionBuckets = new Set(
         tokens
           .map(token => String(token || '').trim().toLowerCase())
@@ -253,10 +458,37 @@ export const parseAdditionalAccessRules = raw => {
         result.csection = { mode: 'exact', value: exact };
       }
     }
+
+    if ([
+      'bloodGroup',
+      'rh',
+      'role',
+      'contact',
+      'userId',
+      'imt',
+      'reaction',
+      'height',
+      'weight',
+      'ageBirthDate',
+    ].includes(normalizedKey)) {
+      const normalizedTokens = new Set(tokens.map(token => String(token || '').trim().toLowerCase()).filter(Boolean));
+      if (normalizedTokens.size > 0) {
+        if (!result.generic) result.generic = {};
+        result.generic[normalizedKey] = normalizedTokens;
+      }
+    }
   });
 
   return Object.keys(result).length ? result : null;
 };
+
+export const parseAdditionalAccessRuleGroups = raw =>
+  String(raw || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => parseAdditionalAccessRules(line))
+    .filter(Boolean);
 
 export const isUserAllowedByAdditionalAccess = (user, parsedRules) => {
   if (!parsedRules) return true;
@@ -317,7 +549,26 @@ export const isUserAllowedByAdditionalAccess = (user, parsedRules) => {
     }
   }
 
+  if (parsedRules.generic && typeof parsedRules.generic === 'object') {
+    const genericKeys = Object.keys(parsedRules.generic);
+    for (const key of genericKeys) {
+      const allowed = parsedRules.generic[key];
+      if (!(allowed instanceof Set) || allowed.size === 0) continue;
+      const userBuckets = getUserBucketsByRuleKey(user, key);
+      if (!Array.isArray(userBuckets) || userBuckets.length === 0) continue;
+      const isMatched = userBuckets.some(bucket => allowed.has(String(bucket || '').trim().toLowerCase()));
+      if (!isMatched) {
+        return false;
+      }
+    }
+  }
+
   return true;
+};
+
+export const isUserAllowedByAnyAdditionalAccessRule = (user, parsedRuleGroups) => {
+  if (!Array.isArray(parsedRuleGroups) || parsedRuleGroups.length === 0) return true;
+  return parsedRuleGroups.some(rule => isUserAllowedByAdditionalAccess(user, rule));
 };
 
 export const filterUsersByAdditionalAccess = (usersMap, parsedRules) => {
@@ -416,6 +667,7 @@ export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({
   maritalStatus: resolveMaritalStatusSearchKeyBuckets(parsedRules),
   csection: resolveCsectionSearchKeyBuckets(parsedRules),
   age: resolveAgeSearchKeyBuckets(parsedRules),
+  ...(parsedRules?.generic || {}),
 });
 
 export const createAllFalseFilterGroup = keys =>


### PR DESCRIPTION
### Motivation
- Provide a flexible UI to author multiple additional-access rule groups and preview which user cards they would surface. 
- Extend rule parsing and matching to support many more attributes (IMT, role, contact, userId, height, weight, birth date, reaction, etc.) and allow OR-composition of rule groups. 
- Integrate the new rule-groups logic into the matching flow so `newUsers` can be injected from any matching rule group.

### Description
- Matching: replaced single-rule parsing with group-aware parsing by importing `parseAdditionalAccessRuleGroups` and `isUserAllowedByAnyAdditionalAccessRule`, updated `fetchAdditionalNewUsersBySearchIndex` to accept multiple parsed rule groups, aggregate matched ids across groups, and filter users by any matching rule group; updated places that check parsed rules to handle arrays. 
- ProfileForm: added an interactive modal and inputs to build additional-access rule groups visually, with a builder UI, checkbox options, preview of generated rule text, and a preview list of available cards resolved from search-key indexes; added state for builder inputs and helpers to sync builder <-> text and apply rules. 
- additionalAccessRules: significantly extended parsing and normalization logic, added key aliases and `ADDITIONAL_ACCESS_FILTER_OPTIONS`, support for many generic rule keys, functions to map users to buckets for new keys (IMT, role, contact, userId, height, weight, ageBirthDate, reaction), exported `parseAdditionalAccessRuleGroups`, `isUserAllowedByAnyAdditionalAccessRule`, and adapted `resolveAdditionalAccessSearchKeyBuckets` to include generic buckets; added `utilCalculateIMT` import and helper bucketizers. 
- Small UI updates and styled components added for the Additional Rules modal and related controls, plus minor adjustments in existing components to use the new APIs and checks.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e855212c8326a425b0a47e660291)