### PR TITLE
Fix useMemo dependency for additional rules in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -522,13 +522,14 @@ export const ProfileForm = ({
     () => buildAdditionalRulesTextFromBuilder(additionalRuleBuilder),
     [additionalRuleBuilder]
   );
+  const additionalAccessFieldValue = state?.[ADDITIONAL_ACCESS_FIELD];
   const additionalRulesInputs = useMemo(() => {
-    const rawValue = state?.[ADDITIONAL_ACCESS_FIELD];
+    const rawValue = additionalAccessFieldValue;
     if (Array.isArray(rawValue)) {
       return rawValue.map(item => String(item || ''));
     }
     return additionalRulesTextToInputs(rawValue);
-  }, [state?.[ADDITIONAL_ACCESS_FIELD]]);
+  }, [additionalAccessFieldValue]);
   const combinedAdditionalRulesDraftText = useMemo(() => {
     const nextInputs = [...additionalRulesInputs];
     nextInputs[activeAdditionalRuleInputIndex] = additionalRulesDraftText;


### PR DESCRIPTION
### Motivation
- Silence the `react-hooks/exhaustive-deps` warning by stabilizing the value used inside a `useMemo` for additional access rules so the memo dependency array is explicit and accurate.

### Description
- Extract `state?.[ADDITIONAL_ACCESS_FIELD]` into a local `additionalAccessFieldValue` and use that variable inside the `useMemo` and its dependency array to avoid referencing `state` indirectly.

### Testing
- Ran `npm run -s lint:js -- src/components/ProfileForm.jsx` which completed successfully (exit 0) and confirmed the lint warning is addressed, with only a non-failing Browserslist notice reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4852d119c8326bb9e38f5f91ce56d)