### PR TITLE
Оновлення перерахунку додаткових правил доступу та поведінки модалки

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -576,12 +576,6 @@ export const ProfileForm = ({
     }
     return additionalRulesTextToInputs(rawValue);
   }, [additionalAccessFieldValue]);
-  const combinedAdditionalRulesDraftText = useMemo(() => {
-    const nextInputs = [...additionalRulesInputs];
-    nextInputs[activeAdditionalRuleInputIndex] = additionalRulesDraftText;
-    return nextInputs.map(item => String(item || '').trim()).filter(Boolean).join('\n');
-  }, [activeAdditionalRuleInputIndex, additionalRulesDraftText, additionalRulesInputs]);
-
   useEffect(() => {
     if (state?.userId) return;
     autoAppliedOverlayForUserRef.current = '';
@@ -603,7 +597,10 @@ export const ProfileForm = ({
 
     let cancelled = false;
     const loadAvailableCards = async () => {
-      const parsedRuleGroups = parseAdditionalAccessRuleGroups(combinedAdditionalRulesDraftText);
+      const nextInputs = [...additionalRulesInputs];
+      nextInputs[activeAdditionalRuleInputIndex] = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+      const combinedDraftText = nextInputs.map(item => String(item || '').trim()).filter(Boolean).join('\n');
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(combinedDraftText);
       if (!parsedRuleGroups.length) {
         setAvailableCardsCount(0);
         return;
@@ -718,7 +715,12 @@ export const ProfileForm = ({
     return () => {
       cancelled = true;
     };
-  }, [combinedAdditionalRulesDraftText, showAdditionalRulesModal]);
+  }, [
+    activeAdditionalRuleInputIndex,
+    additionalRuleBuilder,
+    additionalRulesInputs,
+    showAdditionalRulesModal,
+  ]);
 
   useEffect(() => {
     setDismissedOverlayEntries({});
@@ -806,7 +808,6 @@ export const ProfileForm = ({
       submitWithNormalization(updated, 'overwrite');
       return updated;
     });
-    setShowAdditionalRulesModal(false);
   };
 
   const autoResizeMyComment = useAutoResize(textareaRef, state.myComment);
@@ -1750,7 +1751,7 @@ ${entries.join('\n')}`;
       )}
 
       {showAdditionalRulesModal && (
-        <AdditionalRulesOverlay onClick={() => setShowAdditionalRulesModal(false)}>
+        <AdditionalRulesOverlay>
           <AdditionalRulesModal onClick={e => e.stopPropagation()}>
             <AdditionalRulesClose type="button" onClick={() => setShowAdditionalRulesModal(false)}>
               <FaTimes />


### PR DESCRIPTION
### Motivation
- Потрібно щоб лічильник "Доступні карточки" у модалці додаткових правил доступу оновлювався одразу після зміни чекбоксів, а модалка закривалася тільки по хрестику, щоб уникнути випадкових закриттів.

### Description
- Замінив джерело для перерахунку доступних карточок: ефект тепер будує комбінований текст правил із поточного стану чекбоксів (`additionalRuleBuilder`) і існуючих інпутів перед парсингом (`parseAdditionalAccessRuleGroups`).
- Оновив залежності ефекту, щоб він перезапускався при зміні `additionalRuleBuilder`, `activeAdditionalRuleInputIndex` та `additionalRulesInputs` під час відкритої модалки.
- Прибрав закриття модалки по кліку на overlay, тепер overlay не викликає `setShowAdditionalRulesModal(false)` і модалка закривається лише через кнопку хрестика (`FaTimes`).
- Скасовано автоматичне закриття модалки після натискання кнопки "Застосувати" — кнопка все ще зберігає правила через `submitWithNormalization`, але не закриває модалку.

### Testing
- Запущено `npx eslint src/components/ProfileForm.jsx`, лінтер завершився успішно.
- Компонентні/більш широкі автоматизовані тести не запускалися в цій зміні.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a4b10f4c8326a58cf0d0ef845d0f)