### PR TITLE
Виправити контраст тексту в модалці додаткових правил доступу

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2049,6 +2049,7 @@ const AdditionalRulesOverlay = styled.div`
 
 const AdditionalRulesModal = styled.div`
   background: #fff;
+  color: #1f1f1f;
   width: min(760px, 100vw);
   height: 100vh;
   padding: 16px 14px;
@@ -2122,6 +2123,7 @@ const AdditionalRuleActions = styled.div`
 const AdditionalRulePreview = styled.pre`
   margin-top: 14px;
   background: #fafafa;
+  color: #1f1f1f;
   border: 1px solid #ddd;
   padding: 10px;
   white-space: pre-wrap;


### PR DESCRIPTION
### Motivation
- Текст у модалці додаткових правил доступу був білим через успадкування глобальних стилів і став невидимим на світлому фоні, тому потрібно встановити явний темний колір для покращення читабельності.

### Description
- В `src/components/ProfileForm.jsx` додано `color: #1f1f1f` у стилі `AdditionalRulesModal` і в `AdditionalRulePreview`, щоб забезпечити читабельний темний текст на світлому фоні.

### Testing
- Запущено `npm run -s lint:js`, лінт пройшов успішно (є тільки попередження про застарілий `caniuse-lite`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4eddf3ed883268a964925897aa4fe)