### PR TITLE
Require intersection for additional-access indexed searches and support blank-line grouped rule inputs

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -161,12 +161,16 @@ const fetchAdditionalNewUsersBySearchIndex = async parsedRuleGroups => {
     );
 
     const normalizedSets = indexedSets.filter(set => set instanceof Set);
-    const nonEmptySets = normalizedSets.filter(set => set.size > 0);
-    if (nonEmptySets.length === 0) continue;
+    if (normalizedSets.length === 0) continue;
+    if (normalizedSets.some(set => set.size === 0)) {
+      continue;
+    }
 
-    nonEmptySets.forEach(set => {
-      [...set].forEach(userId => matchedIdsSet.add(userId));
-    });
+    const [firstSet, ...restSets] = normalizedSets;
+    const matchedByCurrentRule = [...firstSet].filter(userId =>
+      restSets.every(set => set.has(userId))
+    );
+    matchedByCurrentRule.forEach(userId => matchedIdsSet.add(userId));
   }
 
   const matchedIds = [...matchedIdsSet];

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -230,9 +230,14 @@ const buildAdditionalRulesTextFromBuilder = rules =>
     .join('\n');
 
 const additionalRulesTextToInputs = raw => {
+  if (Array.isArray(raw)) {
+    const items = raw.map(item => String(item || ''));
+    return items.length ? items : [''];
+  }
+
   const text = String(raw || '');
   if (!text.trim()) return [''];
-  return text.split(/\r?\n/);
+  return text.split(/\r?\n\s*\r?\n+/);
 };
 
 
@@ -599,7 +604,7 @@ export const ProfileForm = ({
     const loadAvailableCards = async () => {
       const nextInputs = [...additionalRulesInputs];
       nextInputs[activeAdditionalRuleInputIndex] = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
-      const combinedDraftText = nextInputs.map(item => String(item || '').trim()).filter(Boolean).join('\n');
+      const combinedDraftText = nextInputs.map(item => String(item || '').trim()).filter(Boolean).join('\n\n');
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(combinedDraftText);
       if (!parsedRuleGroups.length) {
         setAvailableCardsCount(0);

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -538,13 +538,22 @@ export const parseAdditionalAccessRules = raw => {
   return Object.keys(result).length ? result : null;
 };
 
-export const parseAdditionalAccessRuleGroups = raw =>
-  String(raw || '')
-    .split(/\r?\n/)
-    .map(line => line.trim())
-    .filter(Boolean)
-    .map(line => parseAdditionalAccessRules(line))
+export const parseAdditionalAccessRuleGroups = raw => {
+  const groupsFromArray = Array.isArray(raw)
+    ? raw
+      .map(item => String(item || '').trim())
+      .filter(Boolean)
+    : String(raw || '')
+      .split(/\r?\n\s*\r?\n+/)
+      .map(group => group.trim())
+      .filter(Boolean);
+
+  if (!groupsFromArray.length) return [];
+
+  return groupsFromArray
+    .map(group => parseAdditionalAccessRules(group))
     .filter(Boolean);
+};
 
 export const isUserAllowedByAdditionalAccess = (user, parsedRules) => {
   if (!parsedRules) return true;


### PR DESCRIPTION
### Motivation
- Ensure additional-access search criteria are combined with AND semantics across indexed sources rather than unioning partial matches so results better reflect conjunctive rules.
- Improve handling of rule input formats by supporting arrays and using blank-line separation for grouped rule definitions in the UI and parser.

### Description
- Change matching logic in `fetchAdditionalNewUsersBySearchIndex` to skip when any indexed set is empty and compute intersection across all `indexedSets` instead of unioning non-empty sets. 
- Update `additionalRulesTextToInputs` in `ProfileForm.jsx` to accept array inputs, and split text into inputs using blank-line (`\n\n`) grouping; update how draft text is combined to preserve group boundaries. 
- Modify `parseAdditionalAccessRuleGroups` in `src/utils/additionalAccessRules.js` to accept either an array or raw string, split groups by blank lines, trim entries, and return an array of parsed rule objects (or an empty array when none).

### Testing
- Ran unit tests covering `parseAdditionalAccessRules` and `parseAdditionalAccessRuleGroups`, which passed. 
- Executed component tests for `ProfileForm` that exercise additional rules input handling, which passed. 
- Ran the full test suite and linting, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50e0b20d08326bfb74ff2cd60d269)