### PR TITLE
Cache searchKey Firebase reads with getCachedSearchKeyPayload

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -67,6 +67,7 @@ import {
   parseAdditionalAccessRuleGroups,
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
+import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
 
 // Filter out users with invalid identifiers; Firebase push IDs are usually 20 chars.
 const isValidId = id => typeof id === 'string' && id.length >= 20;
@@ -87,14 +88,22 @@ const readIndexedIds = async (indexName, values = []) => {
   const uniqueValues = [...new Set(values.filter(Boolean))];
   if (!indexName || uniqueValues.length === 0) return null;
 
-  const snapshots = await Promise.all(
-    uniqueValues.map(value => get(refDb(database, `${SEARCH_KEY_ROOT}/${indexName}/${value}`)))
+  const payloads = await Promise.all(
+    uniqueValues.map(value =>
+      getCachedSearchKeyPayload(`${SEARCH_KEY_ROOT}/${indexName}/${value}`, async () => {
+        const snapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/${indexName}/${value}`));
+        return {
+          exists: snapshot.exists(),
+          value: snapshot.exists() ? snapshot.val() || {} : null,
+        };
+      })
+    )
   );
 
   const ids = new Set();
-  snapshots.forEach(snapshot => {
-    if (!snapshot.exists()) return;
-    Object.keys(snapshot.val() || {}).forEach(userId => {
+  payloads.forEach(payload => {
+    if (!payload?.exists) return;
+    Object.keys(payload.value || {}).forEach(userId => {
       if (userId) ids.add(userId);
     });
   });

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -25,6 +25,7 @@ import {
   parseAdditionalAccessRuleGroups,
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
+import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -619,11 +620,17 @@ export const ProfileForm = ({
             return new Set();
           }
 
-          const ageSnapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/age`));
-          if (!ageSnapshot.exists()) return new Set();
+          const agePayload = await getCachedSearchKeyPayload(`${SEARCH_KEY_ROOT}/age`, async () => {
+            const ageSnapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/age`));
+            return {
+              exists: ageSnapshot.exists(),
+              value: ageSnapshot.exists() ? ageSnapshot.val() || {} : null,
+            };
+          });
+          if (!agePayload?.exists) return new Set();
 
           const ids = new Set();
-          Object.entries(ageSnapshot.val() || {}).forEach(([bucket, value]) => {
+          Object.entries(agePayload.value || {}).forEach(([bucket, value]) => {
             let isBucketAllowed = false;
 
             if (bucket === 'no') {
@@ -660,15 +667,21 @@ export const ProfileForm = ({
               activeGroups.map(([indexName, values]) =>
                 Promise.all(
                   (Array.isArray(values) ? values : [...values]).map(value =>
-                    get(refDb(database, `${SEARCH_KEY_ROOT}/${indexName}/${value}`))
+                    getCachedSearchKeyPayload(`${SEARCH_KEY_ROOT}/${indexName}/${value}`, async () => {
+                      const snapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/${indexName}/${value}`));
+                      return {
+                        exists: snapshot.exists(),
+                        value: snapshot.exists() ? snapshot.val() || {} : null,
+                      };
+                    })
                   )
                 )
               )
             );
             snapshots.forEach(groupSnapshots => {
-              groupSnapshots.forEach(snap => {
-                if (!snap.exists()) return;
-                Object.keys(snap.val() || {}).forEach(userId => matchedIds.add(userId));
+              groupSnapshots.forEach(payload => {
+                if (!payload?.exists) return;
+                Object.keys(payload.value || {}).forEach(userId => matchedIds.add(userId));
               });
             });
           }

--- a/src/utils/searchKeyCache.js
+++ b/src/utils/searchKeyCache.js
@@ -1,0 +1,24 @@
+import { createCache } from 'hooks/cardsCache';
+
+const { loadCache, saveCache } = createCache('searchKey');
+
+const normalizePath = path =>
+  String(path || '')
+    .trim()
+    .replace(/^\/+/, '');
+
+export const getCachedSearchKeyPayload = async (path, loader) => {
+  const normalizedPath = normalizePath(path);
+  if (!normalizedPath || typeof loader !== 'function') return null;
+
+  const cached = loadCache(normalizedPath);
+  if (cached && typeof cached.exists === 'boolean') {
+    return cached;
+  }
+
+  const loaded = await loader();
+  if (!loaded || typeof loaded.exists !== 'boolean') return null;
+
+  saveCache(normalizedPath, loaded);
+  return loaded;
+};


### PR DESCRIPTION
### Motivation

- Reduce repeated Firebase `get` calls for `searchKey` indexes to improve performance and lower read load.
- Centralize caching behavior for search-key reads so callers get normalized payloads and avoid duplicating cache logic.

### Description

- Add `src/utils/searchKeyCache.js` which provides `getCachedSearchKeyPayload(path, loader)` and uses `createCache('searchKey')` to load/save cached entries and normalize paths. 
- Replace direct `get(refDb(...))` calls in `src/components/Matching.jsx` with `getCachedSearchKeyPayload(...)` and update processing to use the returned `{ exists, value }` payloads instead of raw snapshots. 
- Replace direct `get(refDb(...))` calls in `src/components/ProfileForm.jsx` (age bucket and other search-key index reads) with `getCachedSearchKeyPayload(...)` and update logic to iterate `payload.value`. 
- Keep previous behavior when entries are missing by treating payloads with `exists: false` as absent.

### Testing

- Ran the project's test suite via `yarn test` and the tests completed successfully. 
- Built the project via `yarn build` to verify type/check and bundling and the build succeeded. 
- Ran `yarn lint` to ensure formatting and lint rules and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50e76b0b88326a3bf91c9f0a7158e)