### PR TITLE
Batch user fetches in Matching component to limit parallel DB reads

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -110,43 +110,55 @@ const readIndexedIds = async (indexName, values = []) => {
   return ids;
 };
 
-const fetchUsersAndNewUsersByIds = async ids => {
+const FETCH_USERS_BY_IDS_BATCH_SIZE = 100;
+
+const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BATCH_SIZE) => {
   if (!Array.isArray(ids) || ids.length === 0) return [];
 
   const uniqueIds = [...new Set(ids.filter(Boolean))];
-  const snapshots = await Promise.all(
-    uniqueIds.map(async userId => {
-      const [newUserResult, userResult] = await Promise.allSettled([
-        get(refDb(database, `newUsers/${userId}`)),
-        get(refDb(database, `users/${userId}`)),
-      ]);
+  const safeBatchSize = Math.max(1, Number(batchSize) || FETCH_USERS_BY_IDS_BATCH_SIZE);
+  const result = [];
+  let offset = 0;
 
-      const merged = { userId };
-      let hasAnyData = false;
+  while (offset < uniqueIds.length) {
+    const chunkIds = uniqueIds.slice(offset, offset + safeBatchSize);
+    const chunkSnapshots = await Promise.all(
+      chunkIds.map(async userId => {
+        const [newUserResult, userResult] = await Promise.allSettled([
+          get(refDb(database, `newUsers/${userId}`)),
+          get(refDb(database, `users/${userId}`)),
+        ]);
 
-      if (newUserResult.status === 'fulfilled' && newUserResult.value.exists()) {
-        Object.assign(merged, newUserResult.value.val() || {});
-        hasAnyData = true;
-      }
+        const merged = { userId };
+        let hasAnyData = false;
 
-      if (userResult.status === 'fulfilled' && userResult.value.exists()) {
-        Object.assign(merged, userResult.value.val() || {});
-        hasAnyData = true;
-      }
+        if (newUserResult.status === 'fulfilled' && newUserResult.value.exists()) {
+          Object.assign(merged, newUserResult.value.val() || {});
+          hasAnyData = true;
+        }
 
-      if (!hasAnyData) return null;
-      return {
-        merged,
-        hasNewUser: newUserResult.status === 'fulfilled' && newUserResult.value.exists(),
-        newUserData:
-          newUserResult.status === 'fulfilled' && newUserResult.value.exists()
-            ? newUserResult.value.val() || {}
-            : null,
-      };
-    })
-  );
+        if (userResult.status === 'fulfilled' && userResult.value.exists()) {
+          Object.assign(merged, userResult.value.val() || {});
+          hasAnyData = true;
+        }
 
-  return snapshots.filter(Boolean);
+        if (!hasAnyData) return null;
+        return {
+          merged,
+          hasNewUser: newUserResult.status === 'fulfilled' && newUserResult.value.exists(),
+          newUserData:
+            newUserResult.status === 'fulfilled' && newUserResult.value.exists()
+              ? newUserResult.value.val() || {}
+              : null,
+        };
+      })
+    );
+
+    result.push(...chunkSnapshots.filter(Boolean));
+    offset += safeBatchSize;
+  }
+
+  return result;
 };
 
 const fetchAdditionalNewUsersBySearchIndex = async parsedRuleGroups => {


### PR DESCRIPTION
### Motivation

- Prevent large numbers of simultaneous database reads when resolving user IDs which can cause timeouts or resource spikes by batching requests in `fetchUsersAndNewUsersByIds`.

### Description

- Introduce `FETCH_USERS_BY_IDS_BATCH_SIZE` and update `fetchUsersAndNewUsersByIds(ids, batchSize)` to process `uniqueIds` in chunks using a `while` loop and a safe `batchSize` value.
- Fetch `newUsers/{id}` and `users/{id}` for each id within each chunk as before, merge results into the same `merged` shape, and collect non-null snapshots across chunks.
- Preserve original semantics for `hasNewUser` and `newUserData` while returning a filtered array of merged snapshots.

### Testing

- Ran the project test suite with `yarn test` and static checks with `yarn lint`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51f5e76b0832687d6d90e86d127ea)