### PR TITLE
Include ages 18-21 in <=21 additional access rules

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -186,10 +186,10 @@ const parseAdditionalRulesTextToBuilder = raw => {
         const numericAges = new Set(
           rawTokens
           .map(token => Number.parseInt(token, 10))
-          .filter(age => Number.isFinite(age) && age >= 21)
+          .filter(age => Number.isFinite(age) && age >= 18)
         );
         const normalizedAgeTokens = new Set();
-        if (numericAges.has(21)) normalizedAgeTokens.add('le21');
+        if ([18, 19, 20, 21].every(age => numericAges.has(age))) normalizedAgeTokens.add('le21');
         if ([22, 23, 24, 25].every(age => numericAges.has(age))) normalizedAgeTokens.add('22_25');
         if ([26, 27, 28, 29, 30].every(age => numericAges.has(age))) normalizedAgeTokens.add('26_30');
         if ([31, 32, 33, 34, 35].every(age => numericAges.has(age))) normalizedAgeTokens.add('31_35');
@@ -215,7 +215,7 @@ const buildAdditionalRulesTextFromBuilder = rules =>
 
       const selected = rule.allowedValues;
       const numericAges = new Set();
-      if (selected.has('le21')) numericAges.add(21);
+      if (selected.has('le21')) [18, 19, 20, 21].forEach(age => numericAges.add(age));
       if (selected.has('22_25')) [22, 23, 24, 25].forEach(age => numericAges.add(age));
       if (selected.has('26_30')) [26, 27, 28, 29, 30].forEach(age => numericAges.add(age));
       if (selected.has('31_35')) [31, 32, 33, 34, 35].forEach(age => numericAges.add(age));

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -178,7 +178,7 @@ const parseCsectionCount = value => {
   return null;
 };
 
-export const ADDITIONAL_ACCESS_TEMPLATE = `age: 21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42_plus,?,no
+export const ADDITIONAL_ACCESS_TEMPLATE = `age: 18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42_plus,?,no
 blood: 1+,1-,1,2+,2-,2,3+,3-,3,4+,4-,4,?,no
 maritalStatus: +,-,?,no
 csection: cs2plus,cs1,cs0,other,no
@@ -382,7 +382,7 @@ export const parseAdditionalAccessRules = raw => {
       tokens.forEach(token => {
         const normalizedToken = String(token || '').trim().toLowerCase();
         if (normalizedToken === 'le21') {
-          addAgeRange(21, 21);
+          addAgeRange(18, 21);
           return;
         }
         if (normalizedToken === '22_25') {
@@ -440,7 +440,7 @@ export const parseAdditionalAccessRules = raw => {
         if (AGE_BUCKET_KEYS.has(normalizedToken)) return;
 
         const parsedAge = Number.parseInt(normalizedToken, 10);
-        if (Number.isFinite(parsedAge) && parsedAge >= 21) {
+        if (Number.isFinite(parsedAge) && parsedAge >= 18) {
           allowedAges.add(parsedAge);
           if (parsedAge >= 42) allow42Plus = true;
         }


### PR DESCRIPTION
### Motivation
- The additional access rules UI and parser treated the `le21` bucket as only age `21` and rejected numeric ages below `21`, but the modal should allow ages 18–21 for `<=21` rules.

### Description
- Update parsing so the `le21` token expands to the full range `18..21` instead of only `21` in `src/utils/additionalAccessRules.js`.
- Accept explicit numeric ages starting from `18` (was `21`) when parsing `age` tokens in `parseAdditionalAccessRules` in `src/utils/additionalAccessRules.js`.
- Update builder and serializer logic in `src/components/ProfileForm.jsx` so the builder recognizes `le21` when the numeric set contains `18,19,20,21` and serializes `le21` back to those ages.
- Update `ADDITIONAL_ACCESS_TEMPLATE` example to include `18,19,20,21,...` for the `age` line.

### Testing
- Ran `npm run test -- --runInBand --passWithNoTests src/utils/additionalAccessRules.js`, which exited successfully with `No tests found` (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53e206b748326bef5534428d44b7b)