### PR TITLE
Guard profile URL userId handling for admins in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -603,6 +603,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const location = useLocation();
   const lastUrlUserIdRef = useRef(new URLSearchParams(location.search).get('userId'));
+  const initialAccess = resolveAccess({
+    uid: auth.currentUser?.uid,
+    accessLevel: localStorage.getItem('accessLevel'),
+  });
 
   const [userNotFound, setUserNotFound] = useState(false);
 
@@ -797,7 +801,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState(() => {
     const params = new URLSearchParams(location.search);
-    const urlUserId = params.get('userId');
+    const urlUserId = initialAccess.isAdmin ? params.get('userId') : null;
     const restoredUserId = urlUserId || localStorage.getItem(EDIT_PROFILE_USER_ID_KEY) || '';
 
     if (!restoredUserId) {
@@ -1234,11 +1238,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (hasSearchParam) {
       setSearch(prev => (prev === urlSearchValue ? prev : urlSearchValue));
-    } else if (urlUserId) {
+    } else if (urlUserId && isAdmin) {
       setSearch(prev => (prev ? prev : urlUserId));
     }
 
     if (urlUserId) {
+      if (!isAdmin) {
+        lastUrlUserIdRef.current = null;
+        return;
+      }
       if (lastUrlUserIdRef.current !== urlUserId) {
         lastUrlUserIdRef.current = urlUserId;
         setProfileSource('');
@@ -1247,7 +1255,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     } else {
       lastUrlUserIdRef.current = null;
     }
-  }, [location.search, setSearch, setState]);
+  }, [isAdmin, location.search, setSearch, setState]);
 
   useEffect(() => {
     const normalized = (search || '').trim();


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from influencing the profile editor state via a `userId` query parameter in the URL.
- Ensure `lastUrlUserIdRef` and the component `state` are not populated from the URL for users without admin access.
- Derive access rights from the current auth state and persisted `accessLevel` to make the decision consistent at initialization.

### Description
- Added an `initialAccess` object by calling `resolveAccess` with `auth.currentUser?.uid` and `localStorage.getItem('accessLevel')` to determine admin status early.
- Only allow reading `userId` from the URL when `initialAccess.isAdmin` is true during initial `state` setup.
- Updated the `location.search` effect to ignore `userId` for non-admins, clear `lastUrlUserIdRef`, and bail out when a non-admin tries to use the `userId` param, and added the admin flag to the effect dependencies.

### Testing
- Ran unit tests with `yarn test` and they passed.
- Ran linting with `yarn lint` and no errors were reported.
- Performed a development build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53f03a3648326b882b646326fbeb8)