### PR TITLE
Make additional access rules editable as draft text and open editor on double-click

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -559,6 +559,7 @@ export const ProfileForm = ({
   const [showAdditionalRulesModal, setShowAdditionalRulesModal] = useState(false);
   const [activeAdditionalRuleInputIndex, setActiveAdditionalRuleInputIndex] = useState(0);
   const [additionalRuleBuilder, setAdditionalRuleBuilder] = useState([]);
+  const [additionalRulesDraftText, setAdditionalRulesDraftText] = useState('');
   const [availableCardsCount, setAvailableCardsCount] = useState(0);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const autoAppliedOverlayForUserRef = useRef('');
@@ -570,10 +571,6 @@ export const ProfileForm = ({
     setAdditionalRuleBuilder(prev => [...prev, { key: firstAvailable, allowedValues: new Set() }]);
   }, [additionalRuleBuilder]);
 
-  const additionalRulesDraftText = useMemo(
-    () => buildAdditionalRulesTextFromBuilder(additionalRuleBuilder),
-    [additionalRuleBuilder]
-  );
   const additionalAccessFieldValue = state?.[ADDITIONAL_ACCESS_FIELD];
   const additionalRulesInputs = useMemo(() => {
     const rawValue = additionalAccessFieldValue;
@@ -590,6 +587,7 @@ export const ProfileForm = ({
   useEffect(() => {
     if (!showAdditionalRulesModal) return;
     const activeInputValue = additionalRulesInputs[activeAdditionalRuleInputIndex] || '';
+    setAdditionalRulesDraftText(activeInputValue);
     const parsed = parseAdditionalRulesTextToBuilder(activeInputValue);
     if (parsed.length > 0) {
       setAdditionalRuleBuilder(parsed);
@@ -600,11 +598,16 @@ export const ProfileForm = ({
 
   useEffect(() => {
     if (!showAdditionalRulesModal) return;
+    setAdditionalRulesDraftText(buildAdditionalRulesTextFromBuilder(additionalRuleBuilder));
+  }, [additionalRuleBuilder, showAdditionalRulesModal]);
+
+  useEffect(() => {
+    if (!showAdditionalRulesModal) return;
 
     let cancelled = false;
     const loadAvailableCards = async () => {
       const nextInputs = [...additionalRulesInputs];
-      nextInputs[activeAdditionalRuleInputIndex] = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+      nextInputs[activeAdditionalRuleInputIndex] = additionalRulesDraftText;
       const combinedDraftText = nextInputs.map(item => String(item || '').trim()).filter(Boolean).join('\n\n');
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(combinedDraftText);
       if (!parsedRuleGroups.length) {
@@ -736,6 +739,7 @@ export const ProfileForm = ({
   }, [
     activeAdditionalRuleInputIndex,
     additionalRuleBuilder,
+    additionalRulesDraftText,
     additionalRulesInputs,
     showAdditionalRulesModal,
   ]);
@@ -813,7 +817,7 @@ export const ProfileForm = ({
   };
 
   const applyAdditionalRulesFromBuilder = () => {
-    const rulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+    const rulesText = additionalRulesDraftText;
     setState(prevState => {
       const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
       const updatedValue = Array.isArray(currentValue)
@@ -1374,14 +1378,13 @@ ${entries.join('\n')}`;
                         value={value || ''}
                         $isDeletedOverlay={deletedOverlayFields.includes(field.name)}
                         onFocus={() => handleFieldFocus && handleFieldFocus(field.name)}
-                        readOnly={field.name === ADDITIONAL_ACCESS_FIELD}
-                        onClick={() => {
+                        onClick={event => {
                           if (field.name !== ADDITIONAL_ACCESS_FIELD) return;
+                          if (event.detail !== 2) return;
                           setActiveAdditionalRuleInputIndex(idx);
                           setShowAdditionalRulesModal(true);
                         }}
                         onChange={e => {
-                          if (field.name === ADDITIONAL_ACCESS_FIELD) return;
                           if (field.name === 'myComment') {
                             autoResizeMyComment(e.target);
                           }
@@ -1448,12 +1451,17 @@ ${entries.join('\n')}`;
                         name={field.name}
                         value={displayValue}
                         placeholder={ADDITIONAL_ACCESS_TEMPLATE}
-                        readOnly
                         onFocus={() => handleFieldFocus && handleFieldFocus(field.name)}
-                        onClick={() => {
+                        onClick={event => {
+                          if (event.detail !== 2) return;
                           setActiveAdditionalRuleInputIndex(0);
                           setShowAdditionalRulesModal(true);
                         }}
+                        onChange={e => {
+                          const value = e.target.value;
+                          setState(prevState => ({ ...prevState, [field.name]: value }));
+                        }}
+                        onBlur={() => handleBlur(field.name)}
                       />
                     </>
                   ) : (
@@ -1823,7 +1831,18 @@ ${entries.join('\n')}`;
               <button type="button" onClick={applyAdditionalRulesFromBuilder}>Застосувати</button>
             </AdditionalRuleActions>
 
-            <AdditionalRulePreview>{additionalRulesDraftText || ADDITIONAL_ACCESS_TEMPLATE}</AdditionalRulePreview>
+            <AdditionalRulePreview
+              value={additionalRulesDraftText}
+              placeholder={ADDITIONAL_ACCESS_TEMPLATE}
+              onChange={event => {
+                const nextText = event.target.value;
+                setAdditionalRulesDraftText(nextText);
+                const parsed = parseAdditionalRulesTextToBuilder(nextText);
+                if (parsed.length > 0) {
+                  setAdditionalRuleBuilder(parsed);
+                }
+              }}
+            />
             <AdditionalCardsTitle>
               Доступні карточки ({availableCardsCount}) {isLoadingAvailableCards ? '...завантаження' : ''}
             </AdditionalCardsTitle>
@@ -2138,13 +2157,16 @@ const AdditionalRuleActions = styled.div`
   gap: 8px;
 `;
 
-const AdditionalRulePreview = styled.pre`
+const AdditionalRulePreview = styled.textarea`
   margin-top: 14px;
   background: #fafafa;
   color: #1f1f1f;
   border: 1px solid #ddd;
   padding: 10px;
   white-space: pre-wrap;
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
 `;
 
 const AdditionalCardsTitle = styled.h4`


### PR DESCRIPTION
### Motivation
- Improve UX for building additional access rules by allowing inline editing of draft text, better synchronization with the rule builder, and more accurate preview counts.

### Description
- Added `additionalRulesDraftText` state and synced it with the active input and the parsed `additionalRuleBuilder` when the modal opens and when the builder changes.
- Changed preview and apply logic to use the draft text (`additionalRulesDraftText`) when computing available cards and when saving rules, and updated the available-cards loader to depend on the draft state.
- Replaced the read-only preview with an editable textarea (`AdditionalRulePreview`) that updates the draft text and re-parses into builder form on change, and made the main additional-access field and array items open the modal only on double-click (`event.detail` check).
- Minor UI adjustments to the preview textarea styling and event handlers to support editing and proper blur handling.

### Testing
- Ran unit tests with `npm test` and linting with `npm run lint`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d2c9c80c8326ae4df3226173cefb)