### PR TITLE
Make grouped additional access rules editable in profile modal

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -582,6 +582,14 @@ export const ProfileForm = ({
     }
     return additionalRulesTextToInputs(rawValue);
   }, [additionalAccessFieldValue]);
+  const combinedAdditionalRulesDraftText = useMemo(() => {
+    const nextInputs = [...additionalRulesInputs];
+    nextInputs[activeAdditionalRuleInputIndex] = additionalRulesDraftText;
+    return nextInputs
+      .map(item => String(item || '').trim())
+      .filter(Boolean)
+      .join('\n\n');
+  }, [activeAdditionalRuleInputIndex, additionalRulesDraftText, additionalRulesInputs]);
   useEffect(() => {
     if (state?.userId) return;
     autoAppliedOverlayForUserRef.current = '';
@@ -822,6 +830,32 @@ export const ProfileForm = ({
       const updated = {
         ...prevState,
         [ADDITIONAL_ACCESS_FIELD]: updatedValue,
+      };
+      submitWithNormalization(updated, 'overwrite');
+      return updated;
+    });
+  };
+
+  const handleCombinedAdditionalRulesChange = event => {
+    const nextRawValue = event?.target?.value || '';
+    const nextInputs = additionalRulesTextToInputs(nextRawValue);
+    const nextIndex = Math.min(
+      activeAdditionalRuleInputIndex,
+      Math.max(nextInputs.length - 1, 0)
+    );
+    const nextBuilder = parseAdditionalRulesTextToBuilder(nextInputs[nextIndex] || '');
+
+    setActiveAdditionalRuleInputIndex(nextIndex);
+    setAdditionalRuleBuilder(
+      nextBuilder.length > 0
+        ? nextBuilder
+        : [{ key: ADDITIONAL_RULE_ORDER[0], allowedValues: new Set() }]
+    );
+
+    setState(prevState => {
+      const updated = {
+        ...prevState,
+        [ADDITIONAL_ACCESS_FIELD]: nextRawValue,
       };
       submitWithNormalization(updated, 'overwrite');
       return updated;
@@ -1823,7 +1857,10 @@ ${entries.join('\n')}`;
               <button type="button" onClick={applyAdditionalRulesFromBuilder}>Застосувати</button>
             </AdditionalRuleActions>
 
-            <AdditionalRulePreview>{additionalRulesDraftText || ADDITIONAL_ACCESS_TEMPLATE}</AdditionalRulePreview>
+            <AdditionalRulePreview
+              value={combinedAdditionalRulesDraftText || ADDITIONAL_ACCESS_TEMPLATE}
+              onChange={handleCombinedAdditionalRulesChange}
+            />
             <AdditionalCardsTitle>
               Доступні карточки ({availableCardsCount}) {isLoadingAvailableCards ? '...завантаження' : ''}
             </AdditionalCardsTitle>
@@ -2138,13 +2175,17 @@ const AdditionalRuleActions = styled.div`
   gap: 8px;
 `;
 
-const AdditionalRulePreview = styled.pre`
+const AdditionalRulePreview = styled.textarea`
   margin-top: 14px;
   background: #fafafa;
   color: #1f1f1f;
   border: 1px solid #ddd;
   padding: 10px;
   white-space: pre-wrap;
+  width: 100%;
+  min-height: 140px;
+  resize: vertical;
+  font-family: inherit;
 `;
 
 const AdditionalCardsTitle = styled.h4`


### PR DESCRIPTION
### Motivation
- Provide an editable textarea in the "Додаткові правила доступу" modal so admins can edit the grouped additional access rules directly in one place while keeping the existing builder controls.

### Description
- Replaced the non-editable preview with an editable textarea `AdditionalRulePreview` in `src/components/ProfileForm.jsx`. 
- Added `combinedAdditionalRulesDraftText` (computed via `useMemo`) to show the full grouped rules text including the active builder group in the textarea.
- Implemented `handleCombinedAdditionalRulesChange` to sync manual textarea edits back into `additionalAccessRules` and update the builder state for the currently active group. 
- Kept the `additionalAccessRules` field behavior unchanged: the main field still opens the modal and existing builder buttons (`+ Фільтр`, `Застосувати`) remain functional.

### Testing
- Ran `npm run test -- --watch=false --runInBand src/components/MedicationSchedule.test.jsx` which passed successfully. 
- Ran `npm run test -- --watch=false --runInBand src/utils/__tests__/parseUkTrigger.test.js` which failed on two pre-existing expectations in `parseUkTrigger` and is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ef66de248326890c508d90204081)