### PR TITLE
Support array c-section rules, lower age threshold to 18, and return newUsers when search index yields no matches

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -195,12 +195,23 @@ const fetchAdditionalNewUsersBySearchIndex = async parsedRuleGroups => {
   }
 
   const matchedIds = [...matchedIdsSet];
-  if (matchedIds.length === 0) return [];
+  if (matchedIds.length === 0) {
+    const newUsersSnapshot = await get(refDb(database, 'newUsers'));
+    if (!newUsersSnapshot.exists()) return [];
+
+    const newUsersMap = newUsersSnapshot.val() || {};
+    return Object.entries(newUsersMap)
+      .map(([userId, userData]) => ({
+        userId,
+        ...(userData && typeof userData === 'object' ? userData : {}),
+      }))
+      .filter(user => isUserAllowedByAnyAdditionalAccessRule(user, parsedRuleGroups))
+      .map(user => ({ ...user, __sourceCollection: 'newUsers' }));
+  }
 
   const combinedRows = await fetchUsersAndNewUsersByIds(matchedIds);
   return combinedRows
     .filter(row => row.hasNewUser)
-    .filter(row => isValidId(row.merged?.userId))
     .filter(row =>
       isUserAllowedByAnyAdditionalAccessRule(
         { userId: row.merged.userId, ...(row.newUserData || {}) },

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -335,7 +335,7 @@ const getUserBucketsByRuleKey = (user, key) => {
 };
 
 
-const normalizeCsectionRuleBucket = value => {
+const normalizeSingleCsectionRuleBucket = value => {
   if (value === null || value === undefined) return 'no';
 
   const normalized = String(value).trim().toLowerCase();
@@ -353,6 +353,23 @@ const normalizeCsectionRuleBucket = value => {
 
   if (['-', 'no', 'ні', 'minus'].includes(token)) return 'cs0';
   return 'other';
+};
+
+const normalizeCsectionRuleBucket = value => {
+  if (Array.isArray(value)) {
+    const normalizedItems = value
+      .filter(item => item !== null && item !== undefined && String(item).trim() !== '')
+      .map(item => normalizeSingleCsectionRuleBucket(item));
+
+    if (normalizedItems.length === 0) return 'no';
+    if (normalizedItems.includes('cs2plus')) return 'cs2plus';
+    if (normalizedItems.includes('cs1')) return 'cs1';
+    if (normalizedItems.includes('cs0')) return 'cs0';
+    if (normalizedItems.includes('no')) return 'no';
+    return 'other';
+  }
+
+  return normalizeSingleCsectionRuleBucket(value);
 };
 
 export const parseAdditionalAccessRules = raw => {
@@ -414,19 +431,19 @@ export const parseAdditionalAccessRules = raw => {
           return;
         }
         if (normalizedToken === 'le25') {
-          addAgeRange(21, 25);
+          addAgeRange(18, 25);
           return;
         }
         if (normalizedToken === '31_33') {
-          addAgeRange(21, 33);
+          addAgeRange(31, 33);
           return;
         }
         if (normalizedToken === '34_36') {
-          addAgeRange(21, 36);
+          addAgeRange(34, 36);
           return;
         }
         if (normalizedToken === '37_42') {
-          addAgeRange(21, 42);
+          addAgeRange(37, 42);
           return;
         }
         if (normalizedToken === 'no') {
@@ -719,7 +736,7 @@ const resolveCsectionSearchKeyBuckets = parsedRules => {
 const resolveAgeSearchKeyBuckets = parsedRules => {
   const numericBuckets = parsedRules?.age
     ? [...parsedRules.age]
-      .filter(age => Number.isFinite(age) && age >= 21)
+      .filter(age => Number.isFinite(age) && age >= 18)
       .map(age => ageToBucket(age))
     : [];
   const extraBuckets = [];


### PR DESCRIPTION
### Motivation
- Ensure c-section rules can accept array values and resolve to an aggregate bucket instead of only single tokens.
- Correct age parsing and bucket resolution to include adults from 18 years old and fix several token-to-range mappings.
- When search-index matching yields no IDs, fall back to evaluating all `newUsers` entries against additional access rules so relevant users aren't missed.

### Description
- Added `normalizeSingleCsectionRuleBucket` and updated `normalizeCsectionRuleBucket` to accept array inputs and prioritize aggregated buckets (`cs2plus`, `cs1`, `cs0`, `no`, `other`).
- Fixed age token handling in `parseAdditionalAccessRules` by adjusting ranges for `le25`, `31_33`, `34_36`, and `37_42` to their intended ranges and preserved special tokens handling.
- Lowered the minimum age threshold in `resolveAgeSearchKeyBuckets` from `21` to `18` so age buckets include 18+.
- Updated `fetchAdditionalNewUsersBySearchIndex` to, when no matched IDs are found, read all `newUsers` from the database and filter them with `isUserAllowedByAnyAdditionalAccessRule`, returning entries tagged with `__sourceCollection: 'newUsers'`.
- Removed an explicit `isValidId` filter on merged rows so returned merged user rows are not excluded by that check.

### Testing
- Ran unit tests with `yarn test`, and all tests passed.
- Ran linter with `yarn lint`, and linting passed without errors.
- Built the project with `yarn build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d3fd900c83269e798e885cb07bfd)