### PR TITLE
Fix matching cache bleed between users and newUsers sources

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1495,6 +1495,7 @@ const Matching = () => {
   const [collectionSource, setCollectionSource] = useState(
     () => localStorage.getItem(COLLECTION_SOURCE_KEY) || 'users'
   );
+  const defaultListKey = `default:${collectionSource}`;
   const [filterResetToken, setFilterResetToken] = useState(0);
   const [comments, setComments] = useState({});
   const [showFilters, setShowFilters] = useState(false);
@@ -1867,7 +1868,7 @@ const Matching = () => {
           ]);
         }
 
-      const { cards: cached } = await getCardsByList('default');
+      const { cards: cached } = await getCardsByList(defaultListKey);
       if (cached.length && viewModeRef.current === startMode) {
         console.log('[loadInitial] using cache', cached.length);
         const filteredCached = cached.filter(
@@ -1875,7 +1876,7 @@ const Matching = () => {
         );
         loadedIdsRef.current = new Set(filteredCached.map(u => u.userId));
         setUsers(filteredCached);
-        setIdsForQuery('default', filteredCached.map(u => u.userId));
+        setIdsForQuery(defaultListKey, filteredCached.map(u => u.userId));
         await loadCommentsFor(filteredCached);
         if (viewModeRef.current !== startMode) return;
         setViewMode('default');
@@ -1906,7 +1907,7 @@ const Matching = () => {
         const map = new Map(prev.map(u => [u.userId, u]));
         res.users.forEach(u => map.set(u.userId, u));
         const result = Array.from(map.values());
-        setIdsForQuery('default', result.map(u => u.userId));
+        setIdsForQuery(defaultListKey, result.map(u => u.userId));
         return result;
       });
       await loadCommentsFor(res.users);
@@ -1918,7 +1919,7 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [fetchChunk]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
+  }, [defaultListKey, fetchChunk]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
 
   const reloadDefault = React.useCallback(() => {
     viewModeRef.current = 'default';
@@ -2116,7 +2117,7 @@ const Matching = () => {
         const map = new Map(prev.map(u => [u.userId, u]));
         collected.forEach(u => map.set(u.userId, u));
         const result = Array.from(map.values());
-        setIdsForQuery('default', result.map(u => u.userId));
+        setIdsForQuery(defaultListKey, result.map(u => u.userId));
         return result;
       });
       await loadCommentsFor(collected);
@@ -2131,7 +2132,7 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [hasMore, lastKey, viewMode, fetchChunk]);
+  }, [defaultListKey, hasMore, lastKey, viewMode, fetchChunk]);
 
   useEffect(() => {
     console.log('[useEffect] calling loadInitial');


### PR DESCRIPTION
### Motivation
- The matching list used a shared `default` cache key for both `users` and `newUsers`, which allowed stale `users` cards to appear after switching to the additional `newUsers` source and made the `userId`-length based filtering appear broken.

### Description
- Added `defaultListKey = `default:${collectionSource}`` in `src/components/Matching.jsx` and replaced uses of the literal `'default'` cache key with `defaultListKey` for `getCardsByList` and `setIdsForQuery`.
- Updated `loadInitial` and `loadMore` logic to read/write the source-aware cache key so each collection maintains its own cached list and cards no longer bleed between sources.
- Included `defaultListKey` in relevant hook dependency arrays so callbacks and effects are re-created when the selected collection source changes.

### Testing
- Ran `npx eslint src/components/Matching.jsx`, which completed successfully with no reported lint errors.
- No additional automated tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f575dab08326bb982bafd12c9585)