### PR TITLE
Use `canAccessAdd` capability instead of admin checks and adjust userId URL handling in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -802,7 +802,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState(() => {
     const params = new URLSearchParams(location.search);
-    const urlUserId = initialAccess.isAdmin ? params.get('userId') : null;
+    const urlUserId = initialAccess.canAccessAdd ? params.get('userId') : null;
     const restoredUserId = urlUserId || localStorage.getItem(EDIT_PROFILE_USER_ID_KEY) || '';
 
     if (!restoredUserId) {
@@ -837,6 +837,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const navigate = useNavigate();
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
   const isAdmin = access.isAdmin;
+  const canAccessAdd = access.canAccessAdd;
   const [stimulationScheduleProfiles, setStimulationScheduleProfiles] = useState([]);
   const [stimulationShortcutIds, setStimulationShortcutIdsState] = useState(() =>
     getStoredStimulationShortcutIds(),
@@ -1239,12 +1240,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (hasSearchParam) {
       setSearch(prev => (prev === urlSearchValue ? prev : urlSearchValue));
-    } else if (urlUserId && isAdmin) {
+    } else if (urlUserId && canAccessAdd) {
       setSearch(prev => (prev ? prev : urlUserId));
     }
 
     if (urlUserId) {
-      if (!isAdmin) {
+      if (!canAccessAdd) {
         lastUrlUserIdRef.current = null;
         return;
       }
@@ -1256,7 +1257,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     } else {
       lastUrlUserIdRef.current = null;
     }
-  }, [isAdmin, location.search, setSearch, setState]);
+  }, [canAccessAdd, location.search, setSearch, setState]);
 
   useEffect(() => {
     const normalized = (search || '').trim();
@@ -1312,13 +1313,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         if (nextSearchString !== location.search) {
           navigate({ pathname: location.pathname, search: nextSearchString }, { replace: true });
         }
-      }
-    } else if (currentUserId) {
-      params.delete('userId');
-      const nextSearch = params.toString();
-      const nextSearchString = nextSearch ? `?${nextSearch}` : '';
-      if (nextSearchString !== location.search) {
-        navigate({ pathname: location.pathname, search: nextSearchString }, { replace: true });
       }
     }
   }, [state.userId, location.pathname, location.search, navigate]);


### PR DESCRIPTION
### Motivation

- Make access gating for adding/editing profiles rely on the `canAccessAdd` capability instead of the previous `isAdmin` flag to better represent authorization rules.
- Ensure URL-driven profile loading respects the new capability and avoid unintended removal of `userId` query parameters during state synchronization.

### Description

- Replaced checks against `isAdmin` with `canAccessAdd` when reading `userId` from the URL and when deciding to set the search and state from URL params in `src/components/AddNewProfile.jsx`.
- Exposed `canAccessAdd` from the resolved `access` object via `const canAccessAdd = access.canAccessAdd;` and used it where appropriate inside the component.
- Updated the initial state URL read to use `initialAccess.canAccessAdd` instead of `initialAccess.isAdmin` when restoring `userId` from `location.search` or localStorage.
- Removed the branch that automatically deleted the `userId` query parameter when `state.userId` became falsy to avoid unexpected URL mutation.

### Testing

- Ran the frontend unit test suite with `npm test`, and all tests passed.
- Ran the linter with `npm run lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61108ab308326a9e289f56c3f25ee)