### PR TITLE
Adjust matching card role label and no-photo sizing

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -512,9 +512,14 @@ const ResizableCommentInput = ({ value, onChange, onBlur, onClick, ...rest }) =>
 
 const Card = styled.div`
   width: 100%;
-  height: ${({ $small }) => {
+  height: ${({ $small, $hasPhoto }) => {
+    if (!$hasPhoto) return 'auto';
     const base = $small ? 30 : 50;
     return `${base}vh`;
+  }};
+  min-height: ${({ $small, $hasPhoto }) => {
+    if ($hasPhoto) return 'unset';
+    return $small ? '220px' : 'unset';
   }};
   background: linear-gradient(135deg, orange, yellow);
   background-size: cover;
@@ -523,6 +528,7 @@ const Card = styled.div`
   position: relative;
   overflow: hidden;
   &::after {
+    display: ${({ $hasPhoto }) => ($hasPhoto ? 'block' : 'none')};
     content: '';
     position: absolute;
     bottom: 0;
@@ -1309,6 +1315,7 @@ const getRoleTitle = user => {
     .trim()
     .toLowerCase();
 
+  if (!role) return 'Potential ED';
   if (role === 'ag') return 'Agency';
   if (role === 'ip') return 'Intended parents';
   if (role === 'ed') return 'Egg donor';


### PR DESCRIPTION
### Motivation
- Matching cards sometimes have no `userRole` and therefore show no role label, and cards without photos reserve large vertical space which creates an unwanted gap between content and action buttons.

### Description
- Add a fallback role title `Potential ED` in `getRoleTitle` when neither `userRole` nor `role` is present (`src/components/Matching.jsx`).
- Make card height flexible for no-photo cards by switching to `height: auto` when `$hasPhoto` is false and add a `min-height` for small cards to avoid collapse (`Card` styled component in `src/components/Matching.jsx`).
- Disable the bottom gradient overlay for cards without photos by conditionally rendering the `::after` pseudo-element based on `$hasPhoto`.

### Testing
- Ran `npx eslint src/components/Matching.jsx` and the lint check completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6299755ec83269d5d894b3666d290)