### PR TITLE
Matching: fallback role 'Potential ED' and compact layout for no-photo cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -512,10 +512,13 @@ const ResizableCommentInput = ({ value, onChange, onBlur, onClick, ...rest }) =>
 
 const Card = styled.div`
   width: 100%;
-  height: ${({ $small }) => {
+  height: ${({ $small, $compactWithoutPhoto }) => {
+    if ($compactWithoutPhoto) return 'auto';
     const base = $small ? 30 : 50;
     return `${base}vh`;
   }};
+  min-height: ${({ $compactWithoutPhoto }) => ($compactWithoutPhoto ? '0' : 'unset')};
+  padding-bottom: ${({ $compactWithoutPhoto }) => ($compactWithoutPhoto ? '56px' : '0')};
   background: linear-gradient(145deg, #252538, #1e1e30);
   background-size: cover;
   background-position: center;
@@ -1014,7 +1017,8 @@ const Id = styled.div`
 
 const InfoSlide = styled.div`
   width: 100%;
-  height: 100%;
+  height: auto;
+  min-height: 100%;
   background: linear-gradient(145deg, #252538, #1e1e30);
   color: #f0f0f5;
   overflow-y: auto;
@@ -1183,6 +1187,7 @@ const SwipeableCard = ({
     <AnimatedCard
       $dir={dir}
       $small={isAgency}
+      $compactWithoutPhoto={!photo}
       $hasPhoto={!!photo}
       data-card
       onClick={handleClick}
@@ -1359,6 +1364,10 @@ const getInfoSlidesCount = user => {
 };
 
 const getRoleTitle = user => {
+  const userRole = (user.userRole || '')
+    .toString()
+    .trim()
+    .toLowerCase();
   const role = (user.userRole || user.role || '')
     .toString()
     .trim()
@@ -1367,6 +1376,7 @@ const getRoleTitle = user => {
   if (role === 'ag') return 'Agency';
   if (role === 'ip') return 'Intended parents';
   if (role === 'ed') return 'Egg donor';
+  if (!userRole) return 'Potential ED';
   return '';
 };
 


### PR DESCRIPTION
### Motivation
- Matching cards that miss `userRole` shouldn't display an empty role header, and cards without photos should not leave large empty vertical space between content and the like/dislike buttons.

### Description
- Added a fallback role label returning `Potential ED` when `user.userRole` is missing in `getRoleTitle` to ensure a visible role prefix. (`src/components/Matching.jsx`)
- Made card height content-driven when there is no photo by introducing a `$compactWithoutPhoto` prop that switches `height` to `auto`, sets `min-height`, and adds `padding-bottom` to reserve space for reaction buttons. (`src/components/Matching.jsx`)
- Updated `InfoSlide` to use `height: auto` with `min-height: 100%` so slides render correctly in both fixed-height and compact/no-photo modes. (`src/components/Matching.jsx`)
- Passed the new `$compactWithoutPhoto` prop into the `AnimatedCard` usage so cards without photos use the compact layout. (`src/components/Matching.jsx`)

### Testing
- Ran lint on the modified file with `npm run lint:js -- src/components/Matching.jsx`, which completed successfully (no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6438cf4d0832694f9506a0ab8eb4f)