### PR TITLE
Adjust Potential ED title size on matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -808,7 +808,7 @@ const Title = styled.span`
   display: inline-block;
   text-transform: uppercase;
   letter-spacing: 0.4px;
-  font-size: 11px;
+  font-size: ${({ $isPotentialED }) => ($isPotentialED ? '20px' : '11px')};
 `;
 
 const DonorName = styled.strong`
@@ -1399,6 +1399,7 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
   const isEggDonor = role.includes('ed');
   const contacts = fieldContactsIcons(user, { phoneAsIcon: true, iconSize: 16 });
   const selectedFields = renderSelectedFields(user, { isAdmin }).filter(Boolean);
+  const roleTitle = getRoleTitle(user);
   const regionInfo = normalizeRegion(getCurrentValue(user.region));
   const cityInfo = getCurrentValue(user.city);
   const locationInfo = isEggDonor
@@ -1450,7 +1451,7 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
     <InfoSlide>
       <ProfileSection>
         <Info>
-          <Title>{getRoleTitle(user)}</Title>
+          <Title $isPotentialED={roleTitle === 'Potential ED'}>{roleTitle}</Title>
           <DonorName>
             {displayName}
             {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}


### PR DESCRIPTION
### Motivation
- Make cards that lack an explicit role (rendering as `Potential ED`) visually consistent by using the same font size as the candidate `DonorName` so the label is more prominent on matching cards.

### Description
- Update `Title` styled-component in `src/components/Matching.jsx` to support a conditional `font-size` via the prop `$isPotentialED` so it uses `20px` for `Potential ED` and `11px` otherwise.
- Compute `roleTitle` once inside `InfoCardContent` and pass `$isPotentialED={roleTitle === 'Potential ED'}` to `Title` so the conditional size is applied only when appropriate.
- No other UI layout changes were made; the change is limited to `src/components/Matching.jsx`.

### Testing
- Ran lint on the modified file with `npm run lint:js -- src/components/Matching.jsx`; the first run revealed issues, they were fixed, and the final lint run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66aba23708326939a690920ecd457)