### PR TITLE
Filter base newUsers by additionalAccessRules in Matching to prevent leakage

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2220,12 +2220,20 @@ const Matching = () => {
 
 
   const visibleUsers = useMemo(() => {
-    const baseUsers = isAdmin
+    let baseUsers = isAdmin
       ? users
       : users.filter(user => user.__sourceCollection === 'newUsers' || user.publish === true);
 
+    const hasAdditionalAccessRules = parsedAdditionalAccessRules.length > 0;
+    if (hasAdditionalAccessRules) {
+      baseUsers = baseUsers.filter(user => {
+        if (user?.__sourceCollection !== 'newUsers') return true;
+        return isUserAllowedByAnyAdditionalAccessRule(user, parsedAdditionalAccessRules);
+      });
+    }
+
     const shouldInjectAdditionalCards =
-      parsedAdditionalAccessRules.length > 0 &&
+      hasAdditionalAccessRules &&
       additionalNewUsers.length > 0;
 
     if (!shouldInjectAdditionalCards) {


### PR DESCRIPTION
### Motivation
- Additional access rules were applied only when injecting `additionalNewUsers`, but the already-loaded base `newUsers` list in `Matching` was not filtered, allowing non-matching cards (e.g. ages outside `age: 18,19,20,21`) to appear.

### Description
- Update `visibleUsers` logic in `src/components/Matching.jsx` to compute `hasAdditionalAccessRules` and filter `baseUsers` so that records with `__sourceCollection === 'newUsers'` are vetted by `isUserAllowedByAnyAdditionalAccessRule(parsedAdditionalAccessRules)` while leaving `users` collection items unchanged.
- Reuse the `hasAdditionalAccessRules` flag for the existing injection condition so injection and base filtering are consistent.

### Testing
- Ran `npm test -- --watch=false --runInBand`, which reported no tests selected by CRA for changed files (no direct tests for this component change).
- Ran full suite with `CI=true npm test -- --watch=false --runInBand`, which executed the test suite (16 suites total) and produced 15 passed / 1 failed; the failing tests are in `parseUkTrigger.test.js` and are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67db7b5408326a8d47a84cbb188e9)