### PR TITLE
Centralize name/age formatting and show age label for newUsers without name

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1242,10 +1242,7 @@ const SwipeableCard = ({
           <ProfileSection>
             <Info>
               <Title>{getRoleTitle(user)}</Title>
-          <DonorName>
-            {displayName}
-            {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
-          </DonorName>
+          <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
           <br />
           <LocationLine>
             <span>{locationInfo}</span>
@@ -1263,8 +1260,7 @@ const SwipeableCard = ({
   )}
       {current === 'main' && role !== 'ag' && (
         <BasicInfo>
-          {displayName}
-          {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
+          {formatNameAndAge(user, displayName)}
           <br />
           {locationInfo}
         </BasicInfo>
@@ -1391,6 +1387,17 @@ const getRoleTitle = user => {
   return '';
 };
 
+const formatNameAndAge = (user, displayName) => {
+  const age = user?.birth ? utilCalculateAge(user.birth) : '';
+  const sourceCollection = user?.__sourceCollection || '';
+
+  if (!displayName && age && sourceCollection === 'newUsers') {
+    return `${age} years old`;
+  }
+
+  return `${displayName}${age ? `, ${age}` : ''}`;
+};
+
 const InfoCardContent = ({ user, variant, isAdmin }) => {
   const moreInfo = getCurrentValue(user.moreInfo_main);
   const profession = getCurrentValue(user.profession);
@@ -1463,10 +1470,7 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
       <ProfileSection>
         <Info>
           <Title $isPotentialED={roleTitle === 'Potential ED'}>{roleTitle}</Title>
-          <DonorName>
-            {displayName}
-            {user.birth ? `, ${utilCalculateAge(user.birth)}` : ''}
-          </DonorName>
+          <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
           <br />
           <LocationLine>
             <span>{locationInfo}</span>


### PR DESCRIPTION
### Motivation
- Consolidate duplicated inline name/age rendering into a single helper to make formatting consistent across the matching card views.
- Ensure users coming from the `newUsers` source with no display name still show a meaningful age label (e.g. `25 years old`).

### Description
- Added `formatNameAndAge(user, displayName)` in `src/components/Matching.jsx` to centralize how name and age are rendered and to special-case `__sourceCollection === 'newUsers'` when `displayName` is empty.
- Replaced inline age formatting occurrences with `formatNameAndAge(...)` in the component render paths (profile/info/basic views) so all card views use the same logic.
- The function falls back to the previous behavior for existing users by returning `${displayName}${age ? `, ${age}` : ''}`.

### Testing
- Ran the test suite with `npm test` and the tests completed successfully.
- Ran the linter with `npm run lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67c3d906483268460794811c4620b)