### PR TITLE
Make matching cards responsive in height for users collection

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -513,12 +513,9 @@ const ResizableCommentInput = ({ value, onChange, onBlur, onClick, ...rest }) =>
 
 const Card = styled.div`
   width: 100%;
-  height: ${({ $small, $compactWithoutPhoto }) => {
-    if ($compactWithoutPhoto) return 'auto';
-    const base = $small ? 30 : 50;
-    return `${base}vh`;
-  }};
-  min-height: ${({ $compactWithoutPhoto }) => ($compactWithoutPhoto ? '0' : 'unset')};
+  height: auto;
+  aspect-ratio: ${({ $compactWithoutPhoto, $small }) => ($compactWithoutPhoto ? 'auto' : $small ? '4 / 5' : '3 / 4')};
+  min-height: ${({ $small, $compactWithoutPhoto }) => ($compactWithoutPhoto ? '0' : $small ? '280px' : '340px')};
   padding-bottom: ${({ $compactWithoutPhoto }) => ($compactWithoutPhoto ? '56px' : '0')};
   background: linear-gradient(180deg, #fffaf2 0%, #f7f7f7 100%);
   background-size: cover;
@@ -569,7 +566,9 @@ const loadingWave = keyframes`
 const SkeletonCardInner = styled.div`
   position: relative;
   width: 100%;
-  height: ${({ $small }) => ($small ? '30vh' : '50vh')};
+  height: auto;
+  aspect-ratio: ${({ $small }) => ($small ? '4 / 5' : '3 / 4')};
+  min-height: ${({ $small }) => ($small ? '280px' : '340px')};
   overflow: hidden;
   &::after {
     content: '';


### PR DESCRIPTION
### Motivation
- Unify card appearance between `newUsers` and `users` in the Matching view and ensure card containers are "резинові" (stretchable) by height for different screen sizes.

### Description
- Replaced rigid `vh`-based heights with `height: auto`, `aspect-ratio` and `min-height` rules for the main `Card` component in `src/components/Matching.jsx` to provide adaptive heights for both small and regular cards.
- Applied the same responsive approach to the skeleton placeholder `SkeletonCardInner` so placeholders match real card sizing.
- Adjusted values to use `4/5` or `3/4` aspect ratios and minimum heights (`280px` / `340px`) depending on card type to keep layout stable across viewports.

### Testing
- Ran linter with `npm run lint:js -- src/components/Matching.jsx` which completed successfully (no lint failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68226cbc88326a184464d2e496a40)