### PR TITLE
Не повертати лайкнуті/дизлайкнуті картки `newUsers` у default view

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2225,6 +2225,12 @@ const Matching = () => {
       ? users
       : users.filter(user => user.__sourceCollection === 'newUsers' || user.publish === true);
 
+    if (viewMode === 'default') {
+      baseUsers = baseUsers.filter(
+        user => !favoriteUsers[user.userId] && !dislikeUsers[user.userId]
+      );
+    }
+
     const hasAdditionalAccessRules = parsedAdditionalAccessRules.length > 0;
     if (hasAdditionalAccessRules) {
       baseUsers = baseUsers.filter(user => {
@@ -2243,6 +2249,9 @@ const Matching = () => {
 
     const byId = new Map(baseUsers.map(user => [user.userId, user]));
     additionalNewUsers.forEach(user => {
+      if (viewMode === 'default' && (favoriteUsers[user.userId] || dislikeUsers[user.userId])) {
+        return;
+      }
       const existing = byId.get(user.userId);
       if (existing) {
         byId.set(user.userId, { ...existing, ...user });
@@ -2252,7 +2261,15 @@ const Matching = () => {
     });
 
     return Array.from(byId.values());
-  }, [additionalNewUsers, isAdmin, parsedAdditionalAccessRules, users]);
+  }, [
+    additionalNewUsers,
+    dislikeUsers,
+    favoriteUsers,
+    isAdmin,
+    parsedAdditionalAccessRules,
+    users,
+    viewMode,
+  ]);
 
   const filteredUsers = applyMatchingSearchKeyFilters(
     filterMain(


### PR DESCRIPTION
### Motivation
- У `default` режимі картка з `newUsers` видалялася локально при лайку/дизлайку, але могла повернутися через інжекцію `additionalNewUsers`, тому поведінка відрізнялася від колекції `users`.

### Description
- Додається фільтрація реакцій (`favoriteUsers`/`dislikeUsers`) для базового списку в `Matching` перед рендером у `default` режимі (`src/components/Matching.jsx`).
- Під час інжекції `additionalNewUsers` пропускаються вже лайкнуті/дизлайкнуті користувачі, щоб вони не поверталися у список у `default` режимі.
- Оновлено залежності `useMemo` (включено `favoriteUsers`, `dislikeUsers`, `viewMode`) щоб перерахунок списку відбувався при зміні реакцій або режиму перегляду.

### Testing
- Запущено лінтер командою `npm run lint:js -- src/components/Matching.jsx`, команда виконалась успішно з неблокуючими попередженнями `browserslist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682eaafe48326aa8d28334d2c3b58)