### PR TITLE
Fix low-contrast collection source selector in Matching filters

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -779,10 +779,13 @@ const CollectionSourceWrap = styled.div`
   border: 1px solid ${color.gray3};
   border-radius: 8px;
   padding: 10px;
+  background: #fff;
+  color: #2c2d38;
 `;
 const CollectionSourceTitle = styled.p`
   margin: 0 0 8px;
   font-weight: 600;
+  color: #2c2d38;
 `;
 const CollectionSourceLabel = styled.label`
   display: flex;
@@ -790,6 +793,11 @@ const CollectionSourceLabel = styled.label`
   gap: 8px;
   margin: 0 0 6px;
   cursor: pointer;
+  color: #2c2d38;
+
+  input {
+    accent-color: ${color.accent5};
+  }
 `;
 
 // Components below were previously defined for a modal that is no longer


### PR DESCRIPTION
### Motivation
- The collection source chooser (`users` / `newUsers`) in the Matching filter panel could blend with the surrounding background, making labels and radios hard to read.

### Description
- Updated `src/components/Matching.jsx` to give the collection source block an explicit white background and readable text color by adding `background: #fff` and `color: #2c2d38` to `CollectionSourceWrap`.
- Set `color: #2c2d38` for `CollectionSourceTitle` and `CollectionSourceLabel` so labels remain legible on any background.
- Made radio inputs more visible by adding `input { accent-color: ${color.accent5}; }` inside `CollectionSourceLabel`.

### Testing
- Ran the linter with `npm run lint:js -- src/components/Matching.jsx` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e684212d3c832693793e0e0e5f3e7f)