### PR TITLE
Map newUsers cards with missing userRole to 'ed' for Matching filters

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -245,6 +245,11 @@ const toRoleCategory = user => {
 
   const directRole = normalizeRole(user?.role);
   const fallbackRole = normalizeRole(user?.userRole);
+
+  if (user?.__sourceCollection === 'newUsers' && fallbackRole === 'no') {
+    return 'ed';
+  }
+
   const resolved = directRole !== 'no' && directRole !== '?' ? directRole : fallbackRole;
 
   if (['ed', 'ag', 'ip'].includes(resolved)) return resolved;


### PR DESCRIPTION
### Motivation
- Ensure cards loaded from `newUsers` that have no `userRole` are treated as `ed` so they appear under the "ДО" checkbox in Matching filters.

### Description
- Modify `toRoleCategory` in `src/components/Matching.jsx` to return `'ed'` when `user.__sourceCollection === 'newUsers'` and the normalized `user.userRole` is empty (`'no'`), keeping the existing resolution logic otherwise.

### Testing
- Ran `npm run lint:js -- src/components/Matching.jsx` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e684bae3d88326b9c73047cc9c6f8e)