### PR TITLE
Matching: Remove rounded card styling and top accent, simplify Card sizing

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -467,7 +467,7 @@ const CardWrapper = styled.div`
   position: relative;
   width: 100%;
   border: 1px solid #e2e2e2;
-  border-radius: 8px;
+  border-radius: 0;
   box-sizing: border-box;
   overflow: hidden;
   background: #fff;
@@ -519,13 +519,13 @@ const ResizableCommentInput = ({ value, onChange, onBlur, onClick, ...rest }) =>
 const Card = styled.div`
   width: 100%;
   height: auto;
-  aspect-ratio: ${({ $compactWithoutPhoto, $small }) => ($compactWithoutPhoto ? 'auto' : $small ? '4 / 5' : '3 / 4')};
-  min-height: ${({ $small, $compactWithoutPhoto }) => ($compactWithoutPhoto ? '0' : $small ? '280px' : '340px')};
-  padding-bottom: ${({ $compactWithoutPhoto }) => ($compactWithoutPhoto ? '56px' : '0')};
+  aspect-ratio: ${({ $small }) => ($small ? '4 / 5' : '3 / 4')};
+  min-height: ${({ $small }) => ($small ? '280px' : '340px')};
+  padding-bottom: 0;
   background: linear-gradient(180deg, #fffaf2 0%, #f7f7f7 100%);
   background-size: cover;
   background-position: center;
-  border-radius: 20px;
+  border-radius: 0;
   position: relative;
   overflow: hidden;
   box-shadow:
@@ -533,18 +533,7 @@ const Card = styled.div`
     0 0 0 1px rgba(255, 255, 255, 0.75);
   border: 1px solid rgba(255, 255, 255, 0.8);
   isolation: isolate;
-  margin-bottom: 10px;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
-    background: linear-gradient(90deg, ${color.accent} 0%, ${color.accent2} 50%, ${color.accent} 100%);
-    z-index: 2;
-  }
+  margin-bottom: 0;
 
   &::after {
     content: '';


### PR DESCRIPTION
### Motivation

- Simplify the visual card layout by removing rounded corners and decorative top accent for a flush, uniform appearance.
- Reduce complexity in sizing logic by eliminating the `$compactWithoutPhoto` branch and relying only on the `$small` flag for aspect ratio and minimum height.
- Align container and card spacing with surrounding layout by removing extra margins and padding adjustments.

### Description

- Changed `CardWrapper` border radius from `8px` to `0` to remove rounded corners.
- Simplified `Card` sizing by removing the `$compactWithoutPhoto` conditional and using `aspect-ratio` and `min-height` based only on the `$small` prop, set `padding-bottom: 0`, and removed the top accent `::before` bar.
- Set `Card` `border-radius` to `0`, removed the `margin-bottom` and preserved the existing background, shadow, and `::after` overlay behavior.
- Kept the `ResizableCommentInput` and `CommentInput` behavior intact while updating container styling to match the flattened card visuals.

### Testing

- Ran the project test suite with `yarn test` and the lint check with `yarn lint`, and both completed successfully.
- Verified UI snapshot/local style preview to ensure no runtime errors after style changes and that components render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68ac038f48326a199477beb5c0750)