### PR TITLE
Adjust matching card stack radius and dynamic height behavior

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -467,7 +467,7 @@ const CardWrapper = styled.div`
   position: relative;
   width: 100%;
   border: 1px solid #e2e2e2;
-  border-radius: 0;
+  border-radius: 8px;
   box-sizing: border-box;
   overflow: hidden;
   background: #fff;
@@ -519,13 +519,15 @@ const ResizableCommentInput = ({ value, onChange, onBlur, onClick, ...rest }) =>
 const Card = styled.div`
   width: 100%;
   height: auto;
-  aspect-ratio: ${({ $small }) => ($small ? '4 / 5' : '3 / 4')};
-  min-height: ${({ $small }) => ($small ? '280px' : '340px')};
+  aspect-ratio: ${({ $hasPhoto, $small }) =>
+    $hasPhoto ? ($small ? '4 / 5' : '3 / 4') : 'auto'};
+  min-height: ${({ $hasPhoto, $small, $compactWithoutPhoto }) =>
+    !$hasPhoto && $compactWithoutPhoto ? '0' : $small ? '280px' : '340px'};
   padding-bottom: 0;
   background: linear-gradient(180deg, #fffaf2 0%, #f7f7f7 100%);
   background-size: cover;
   background-position: center;
-  border-radius: 0;
+  border-radius: 8px;
   position: relative;
   overflow: hidden;
   box-shadow:
@@ -1027,10 +1029,10 @@ const Id = styled.div`
 const InfoSlide = styled.div`
   width: 100%;
   height: auto;
-  min-height: 100%;
+  min-height: auto;
   background: linear-gradient(180deg, #fffaf2 0%, #f7f7f7 100%);
   color: #2c2d38;
-  overflow-y: auto;
+  overflow-y: visible;
   box-sizing: border-box;
   padding: 12px;
 `;


### PR DESCRIPTION
### Motivation
- Make the top/front card in matching stacks visually match the stacked cards behind it by using the same rounded corners so stacks look consistent.
- Allow stacks that contain only a text/info card to avoid reserving large image-like space so single cards do not waste vertical space.
- Ensure info slides can grow to their natural height so the stack height follows the tallest card (usually the info card) instead of forcing an internal scroll area.

### Description
- Updated `src/components/Matching.jsx` to set `border-radius: 8px` on the `CardWrapper` and the `Card` so the front card matches the stacked cards behind it.
- Changed the `Card` sizing rules to use `aspect-ratio` and `min-height` conditionally based on new props (`$hasPhoto` and `$compactWithoutPhoto`) so cards without photos can collapse to content height while photo cards keep their previous aspect/min-height behavior.
- Modified `InfoSlide` to use `min-height: auto` and `overflow-y: visible` so information slides expand naturally instead of forcing an internal scrollbar.

### Testing
- Ran `npm run lint:js -- src/components/Matching.jsx`, which completed successfully with only non-blocking npm/browserslist warnings.
- No unit tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68f6a57d88326a14072cb59a145c8)