### PR TITLE
Reduce vertical padding in matching profile data cells

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -890,7 +890,7 @@ const Table = styled.div`
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 10px;
-    padding: 8px;
+    padding: 5.6px 8px;
   }
 
   & strong {


### PR DESCRIPTION
### Motivation
- Reduce vertical padding in the matching modal profile data cells (e.g., `Height (cm) 168`) so more fields can fit on a single screen.

### Description
- Adjusted inner cell padding in `src/components/Matching.jsx` for the details `Table` from `8px` to `5.6px 8px` (vertical reduced by ~30%, horizontal unchanged).

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69456ddd4832698ab8644795d47cb)