### PR TITLE
Fix overlap between contact and dislike controls on matching cards without photos

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -522,7 +522,7 @@ const Card = styled.div`
   aspect-ratio: ${({ $hasPhoto, $small }) =>
     $hasPhoto ? ($small ? '4 / 5' : '3 / 4') : 'auto'};
   min-height: ${({ $hasPhoto, $small, $compactWithoutPhoto }) =>
-    !$hasPhoto && $compactWithoutPhoto ? '0' : $small ? '280px' : '340px'};
+    !$hasPhoto && $compactWithoutPhoto ? ($small ? '320px' : '380px') : $small ? '280px' : '340px'};
   padding-bottom: 0;
   background: linear-gradient(180deg, #fffaf2 0%, #f7f7f7 100%);
   background-size: cover;
@@ -1035,6 +1035,7 @@ const InfoSlide = styled.div`
   overflow-y: visible;
   box-sizing: border-box;
   padding: 12px;
+  padding-bottom: ${({ $reserveActionButtons }) => ($reserveActionButtons ? '56px' : '12px')};
 `;
 
 const slideLeft = keyframes`
@@ -1207,7 +1208,7 @@ const SwipeableCard = ({
       style={style}
     >
       {current === 'description' && (
-        <InfoSlide>
+        <InfoSlide $reserveActionButtons={!photo}>
           {education && (
             <MoreInfo>
               <strong>Education</strong>
@@ -1238,7 +1239,7 @@ const SwipeableCard = ({
         </InfoSlide>
       )}
       {current === 'info' && (
-        <InfoSlide>
+        <InfoSlide $reserveActionButtons={!photo}>
           <ProfileSection>
             <Info>
               <Title>{getRoleTitle(user)}</Title>


### PR DESCRIPTION
### Motivation
- Matching cards without photos had insufficient vertical space so contact icons could overlap the dislike button, causing visual overlap and an uncomfortable tap target.
- The change aims to reserve space for action buttons and avoid contact icons colliding with the dislike control on no-photo cards.

### Description
- Increased the no-photo card `min-height` in `src/components/Matching.jsx` so compact no-photo cards use `320px` / `380px` instead of collapsing to `0` and ensure a consistent action area.
- Added a conditional `padding-bottom` to `InfoSlide` (`padding-bottom: ${({ $reserveActionButtons }) => ($reserveActionButtons ? '56px' : '12px')};`) to reserve space for action buttons when needed.
- Passed the new `$reserveActionButtons` prop to `InfoSlide` instances for the `description` and `info` slides whenever the profile has no photo (`$reserveActionButtons={!photo}`).

### Testing
- Ran lint on the modified file with `npm run lint:js -- src/components/Matching.jsx`, which completed without errors.
- Changes are a visual/layout fix applied to `src/components/Matching.jsx` and require manual/visual validation in the app to confirm spacing across screen sizes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e694cca3f0832694b3823044b78562)