### PR TITLE
Fix matching cards not disappearing after like in newUsers

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1281,7 +1281,7 @@ const SwipeableCard = ({
         setFavoriteUsers={setFavoriteUsers}
         dislikeUsers={dislikeUsers}
         setDislikeUsers={setDislikeUsers}
-        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+        onRemove={handleRemove}
       />
       <BtnDislike
         userId={user.userId}
@@ -1290,7 +1290,7 @@ const SwipeableCard = ({
         setDislikeUsers={setDislikeUsers}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
-        onRemove={viewMode !== 'default' ? handleRemove : undefined}
+        onRemove={handleRemove}
       />
       {current === 'main' && isAgency && (
         <CardInfo>

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -49,6 +49,7 @@ export const BtnFavorite = ({
         setFavoriteIds(updatedFav);
         updateCachedUser(userData || { userId });
         setFavorite(userId, true);
+        if (onRemove) onRemove(userId);
         if (dislikeUsers[userId]) {
           try {
             await removeDislikeUser(userId);
@@ -59,7 +60,6 @@ export const BtnFavorite = ({
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
           setDislike(userId, false);
-          if (onRemove) onRemove(userId);
         }
       } catch (error) {
         console.error('Failed to add favorite:', error);


### PR DESCRIPTION
### Motivation
- Liking a card in the matching view did not always remove it from the visible list for `newUsers` because the removal callback was only passed conditionally and the favorite button did not call the removal callback immediately after a like.

### Description
- Always pass the `handleRemove` callback into `BtnFavorite` and `BtnDislike` in `src/components/Matching.jsx` so reaction buttons can remove the card from the UI regardless of `viewMode` or collection source.
- Invoke `onRemove(userId)` immediately when adding a favorite in `src/components/smallCard/btnFavorite.js` so the liked card is removed from the matching list without waiting for backend sync.

### Testing
- Ran `npm test -- --watch=false --runInBand`, which completed normally and reported `No tests found related to files changed since last commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6953e5c2483269c9d334ec2626350)