### PR TITLE
Normalize ownKids value rendering in Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1322,6 +1322,23 @@ const SwipeableCard = ({
   );
 };
 
+const normalizeOwnKidsValue = value => {
+  const normalized = (value ?? '').toString().trim().toLowerCase();
+
+  if (normalized === '') return value;
+
+  if (['0', '-', 'no', 'ні', 'немає'].includes(normalized)) {
+    return 'No';
+  }
+
+  const numericValue = Number(normalized);
+  if (Number.isFinite(numericValue) && numericValue >= 1) {
+    return 'Yes';
+  }
+
+  return value;
+};
+
 const buildSelectedFields = (user, { isAdmin } = {}) => {
   return FIELDS.map(field => {
     if (field.key === 'reward' && !isAdmin) return null;
@@ -1362,6 +1379,10 @@ const buildSelectedFields = (user, { isAdmin } = {}) => {
           value = 'Single';
         }
       }
+    }
+
+    if (field.key === 'ownKids') {
+      value = normalizeOwnKidsValue(value);
     }
 
     if (value === undefined || value === '' || value === null) return null;


### PR DESCRIPTION
### Motivation
- Normalize the display of the `ownKids` field in matching cards so that numeric counts are shown as `Yes` when >= 1 and common negative markers are shown as `No`, while leaving other values unchanged.

### Description
- Add `normalizeOwnKidsValue` helper in `src/components/Matching.jsx` to map values to `Yes`/`No` according to the specified rules.
- Apply the helper in `buildSelectedFields` for the `ownKids` field before filtering out empty values so the UI displays the normalized result.
- Preserve existing behavior for all other fields and preserve original values when they do not match the normalization rules.

### Testing
- Ran `npx eslint src/components/Matching.jsx` which completed successfully (warnings only).
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73af848508326b9f2d96142e35ebb)