### PR TITLE
Move undo/redo controls to the top actions row

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3327,6 +3327,58 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       <InnerContainer>
         {isLoggedIn && (
           <TopButtons>
+            {state.userId && (
+              <>
+                <EditActionButton
+                  type="button"
+                  onClick={handleUndoProfileChanges}
+                  title="Відмінити останню зміну"
+                  aria-label="Відмінити останню зміну"
+                  disabled={!canUndoChanges}
+                >
+                  <EditActionIcon viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M9 7L5 11L9 15"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M6 11H14C17.314 11 20 13.686 20 17"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </EditActionIcon>
+                </EditActionButton>
+                <EditActionButton
+                  type="button"
+                  onClick={handleRedoProfileChanges}
+                  title="Відмінити відміну"
+                  aria-label="Повернути зміну"
+                  disabled={!canRedoChanges}
+                >
+                  <EditActionIcon viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M15 7L19 11L15 15"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M18 11H10C6.686 11 4 13.686 4 17"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </EditActionIcon>
+                </EditActionButton>
+              </>
+            )}
             <DotsButton
               onClick={() => {
                 setShowInfoModal('dotsMenu');
@@ -3466,56 +3518,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         )}
         {state.userId ? (
           <>
-            <TopButtons style={{ marginBottom: '8px' }}>
-              <EditActionButton
-                type="button"
-                onClick={handleUndoProfileChanges}
-                title="Відмінити останню зміну"
-                aria-label="Відмінити останню зміну"
-                disabled={!canUndoChanges}
-              >
-                <EditActionIcon viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path
-                    d="M9 7L5 11L9 15"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M6 11H14C17.314 11 20 13.686 20 17"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </EditActionIcon>
-              </EditActionButton>
-              <EditActionButton
-                type="button"
-                onClick={handleRedoProfileChanges}
-                title="Відмінити відміну"
-                aria-label="Повернути зміну"
-                disabled={!canRedoChanges}
-              >
-                <EditActionIcon viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path
-                    d="M15 7L19 11L15 15"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M18 11H10C6.686 11 4 13.686 4 17"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </EditActionIcon>
-              </EditActionButton>
-            </TopButtons>
             <div style={{ ...coloredCard(), marginBottom: '8px' }}>
               {renderTopBlock(
                 state,


### PR DESCRIPTION
### Motivation
- Group the profile edit actions (undo / redo) with the three-dots menu so related controls are in one horizontal action row and the UI is visually aligned.
- Remove the duplicated standalone undo/redo block that appeared above the profile card to avoid redundant controls.

### Description
- Moved the undo (`handleUndoProfileChanges`) and redo (`handleRedoProfileChanges`) buttons into the existing top `TopButtons` row next to the `DotsButton` in `src/components/AddNewProfile.jsx`.
- Removed the previous separate `TopButtons` block that rendered undo/redo above the profile card so the controls are no longer duplicated.
- Kept existing handlers, titles, `aria-label`s, icons, disabled-state logic and conditional rendering (`state.userId` / `canUndoChanges` / `canRedoChanges`) unchanged.
- Adjusted markup so the undo/redo buttons only render in the top row when a profile is loaded.

### Testing
- Ran lint on the modified file with `npm run -s lint:js -- src/components/AddNewProfile.jsx` and it completed without lint errors (only a `caniuse-lite` update warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74f4f65c88326ad8e33d03132e23f)