### PR TITLE
Add left padding to comment textarea to prevent placeholder clipping

### DIFF
--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -52,6 +52,7 @@ export const FieldComment = ({ userData, setUsers, setState }) => {
           resize: 'none',
           overflow: 'hidden',
           padding: '5px',
+          paddingLeft: '8px',
           paddingRight: userData.myComment ? '22px' : '5px',
         }}
       />


### PR DESCRIPTION
### Motivation
- Placeholder text in the comment `textarea` was visually clipped by the element's rounded border, so the input content needed a small left inset.

### Description
- Added `paddingLeft: '8px'` to the comment `textarea` in `src/components/smallCard/FieldComment.js` while keeping the existing dynamic `paddingRight` for the clear button.

### Testing
- Ran `npm run lint:js -- src/components/smallCard/FieldComment.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e756e0ecf4832681b748260f7ae75e)