### PR TITLE
Ensure LA mode sorts cards by lastAction (descending)

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3219,6 +3219,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return ids;
     }
 
+    if (currentFilter === 'LAST_ACTION') {
+      return ids.sort((a, b) => {
+        const left = normalizeLastAction(users[a]?.lastAction) || 0;
+        const right = normalizeLastAction(users[b]?.lastAction) || 0;
+        return right - left;
+      });
+    }
+
     const reactionSortDirection = getSearchKeyReactionSortDirection(filters?.reaction);
     if (reactionSortDirection) {
       return ids.sort((a, b) => {


### PR DESCRIPTION
### Motivation
- When loading in LA mode the UI-level sorting step was still ordering cards by other criteria, which could break the intended `lastAction` ordering returned by the backend.

### Description
- Add an explicit branch in `getSortedIds` to sort `ids` by `lastAction` in descending order when `currentFilter === 'LAST_ACTION'` using `normalizeLastAction`.
- Preserve existing sorting behavior for duplicate/cycle-favorite and reaction-based modes.
- Modified file: `src/components/AddNewProfile.jsx`.

### Testing
- Ran lint on the modified file with `npm run lint:js -- src/components/AddNewProfile.jsx` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7591b47648326b63166416ff3c536)