### PR TITLE
Centralize edit-history snapshot logic and propagate submitOptions to smallCard fields

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -582,6 +582,39 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     (left, right) => JSON.stringify(toComparableHistoryState(left)) === JSON.stringify(toComparableHistoryState(right)),
     [toComparableHistoryState],
   );
+  const registerHistorySnapshot = useCallback(
+    snapshotState => {
+      if (!snapshotState?.userId) return;
+
+      const history = editHistoryRef.current;
+
+      if (history.userId !== snapshotState.userId) {
+        editHistoryRef.current = {
+          userId: snapshotState.userId,
+          current: cloneProfileState(snapshotState),
+          undoStack: [],
+          redoStack: [],
+        };
+        historyNavigationRef.current = false;
+        setHistoryVersion(prev => prev + 1);
+      } else if (!history.current) {
+        history.current = cloneProfileState(snapshotState);
+        historyNavigationRef.current = false;
+        setHistoryVersion(prev => prev + 1);
+      } else if (!areHistorySnapshotsEqual(history.current, snapshotState)) {
+        if (!historyNavigationRef.current) {
+          history.undoStack.push(cloneProfileState(history.current));
+          history.redoStack = [];
+          setHistoryVersion(prev => prev + 1);
+        }
+        history.current = cloneProfileState(snapshotState);
+        historyNavigationRef.current = false;
+      } else if (historyNavigationRef.current) {
+        historyNavigationRef.current = false;
+      }
+    },
+    [areHistorySnapshotsEqual, cloneProfileState],
+  );
 
   const LOAD_SORT_MODES = {
     GIT: 'GIT',
@@ -896,34 +929,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       delete syncedState.lastDelivery;
     }
 
-    if (syncedState?.userId) {
-      const history = editHistoryRef.current;
-
-      if (history.userId !== syncedState.userId) {
-        editHistoryRef.current = {
-          userId: syncedState.userId,
-          current: cloneProfileState(syncedState),
-          undoStack: [],
-          redoStack: [],
-        };
-        historyNavigationRef.current = false;
-        setHistoryVersion(prev => prev + 1);
-      } else if (!history.current) {
-        history.current = cloneProfileState(syncedState);
-        historyNavigationRef.current = false;
-        setHistoryVersion(prev => prev + 1);
-      } else if (!areHistorySnapshotsEqual(history.current, syncedState)) {
-        if (!historyNavigationRef.current) {
-          history.undoStack.push(cloneProfileState(history.current));
-          history.redoStack = [];
-          setHistoryVersion(prev => prev + 1);
-        }
-        history.current = cloneProfileState(syncedState);
-        historyNavigationRef.current = false;
-      } else if (historyNavigationRef.current) {
-        historyNavigationRef.current = false;
-      }
-    }
+    registerHistorySnapshot(syncedState);
 
     if (!isAdmin) {
       if (!syncedState?.userId) {
@@ -3290,6 +3296,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   }, [cloneProfileState, state]);
 
+  const handleTopBlockSubmitHistorySnapshot = useCallback(
+    submittedState => {
+      if (!submittedState || typeof submittedState !== 'object') return;
+      registerHistorySnapshot(submittedState);
+    },
+    [registerHistorySnapshot],
+  );
+
   const handleUndoProfileChanges = async () => {
     if (!state?.userId) return;
     const history = editHistoryRef.current;
@@ -3533,6 +3547,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 currentFilter,
                 isDateInRange,
                 openMedicationsModal,
+                null,
+                {},
+                handleTopBlockSubmitHistorySnapshot,
               )}
             </div>
             {shouldShowSchedule && state && (

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -2,7 +2,7 @@ import { handleChange, removeField } from './actions';
 import { useRef } from 'react';
 import { useAutoResize } from '../../hooks/useAutoResize';
 
-export const FieldComment = ({ userData, setUsers, setState }) => {
+export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} }) => {
   // console.log('userData in RenderCommentInput :>> ', userData);
   const textareaRef = useRef(null);
   const autoResize = useAutoResize(textareaRef, userData.myComment);
@@ -41,7 +41,7 @@ export const FieldComment = ({ userData, setUsers, setState }) => {
             'myComment',
             currentComment,
             true,
-            {},
+            submitOptions,
           );
         }}
         style={{

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -17,6 +17,19 @@ export const handleChange = (
   click,
   options = {}
 ) => {
+  const triggerHistorySnapshot = payload => {
+    if (typeof options?.onSubmitHistorySnapshot !== 'function') {
+      return;
+    }
+    const snapshot = payload && typeof payload === 'object' ? { ...payload } : payload;
+    options.onSubmitHistorySnapshot(snapshot);
+  };
+
+  const submitWithHistory = (payload, removalList = []) => {
+    triggerHistorySnapshot(payload);
+    handleSubmit(payload, 'overwrite', removalList);
+  };
+
   const formatValue = (k, v) => {
     if (k === 'getInTouch' || k === 'lastCycle') return formatDateAndFormula(v);
     if (k === 'lastDelivery') return formatDateToServer(v);
@@ -41,7 +54,7 @@ export const handleChange = (
       return;
     }
 
-    handleSubmit({ ...payload, userId: resolvedId }, 'overwrite', removalList);
+    submitWithHistory({ ...payload, userId: resolvedId }, removalList);
   };
 
   if (typeof key === 'object' && key !== null) {
@@ -89,9 +102,8 @@ export const handleChange = (
           delete newState[key];
         });
         clickFlag &&
-          handleSubmit(
+          submitWithHistory(
             { ...newState, userId: userId || newState.userId },
-            'overwrite',
             removeKeys,
           );
         return newState;
@@ -108,8 +120,7 @@ export const handleChange = (
             delete newState[userId][key];
           }
         });
-        clickFlag &&
-          handleSubmit({ ...newState[userId], userId }, 'overwrite', removeKeys);
+        clickFlag && submitWithHistory({ ...newState[userId], userId }, removeKeys);
         return newState;
       }
     };
@@ -186,9 +197,8 @@ export const handleChange = (
           newState.lastAction = Date.now();
         }
         click &&
-          handleSubmit(
+          submitWithHistory(
             { ...newState, userId: userId || newState.userId },
-            'overwrite',
             removalKeys,
           );
         return newState;
@@ -214,9 +224,8 @@ export const handleChange = (
           [userId]: updatedUser,
         };
         click &&
-          handleSubmit(
+          submitWithHistory(
             { ...newState[userId], userId },
-            'overwrite',
             removalKeys,
           );
         return newState;
@@ -249,9 +258,8 @@ export const handleChange = (
         [userId]: updatedUser,
       };
       click &&
-        handleSubmit(
+        submitWithHistory(
           { ...newState[userId], userId },
-          'overwrite',
           removalKeys,
         );
       return newState;

--- a/src/components/smallCard/fieldDeliveryInfo.js
+++ b/src/components/smallCard/fieldDeliveryInfo.js
@@ -3,7 +3,7 @@ import { utilCalculateMonthsAgo } from './utilCalculateMonthsAgo';
 import { AttentionButton } from 'components/styles';
 import { formatDateToDisplay } from 'components/inputValidations';
 
-export const fieldDeliveryInfo = (setUsers, setState, userData) => {
+export const fieldDeliveryInfo = (setUsers, setState, userData, submitOptions = {}) => {
   const { ownKids, lastDelivery, csection } = userData;
   const formattedLastDelivery = formatDateToDisplay(lastDelivery);
 
@@ -126,6 +126,7 @@ export const fieldDeliveryInfo = (setUsers, setState, userData) => {
               'getInTouch',
               formatDate(whenGetInTouch),
               true,
+              submitOptions,
             );
           }}
         >

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -27,6 +27,7 @@ export const fieldGetInTouch = (
   setFavoriteUsers = () => {},
   dislikeUsers = {},
   setDislikeUsers = () => {},
+  submitOptions = {},
 ) => {
   const handleSendToEnd = () => {
     handleChange(
@@ -36,7 +37,7 @@ export const fieldGetInTouch = (
       'getInTouch',
       '2099-99-99',
       true,
-      { currentFilter, isDateInRange },
+      { currentFilter, isDateInRange, ...submitOptions },
     );
   };
 
@@ -56,7 +57,7 @@ export const fieldGetInTouch = (
       'getInTouch',
       formattedDate,
       true,
-      { currentFilter, isDateInRange },
+      { currentFilter, isDateInRange, ...submitOptions },
     );
   };
 
@@ -128,7 +129,7 @@ export const fieldGetInTouch = (
           'getInTouch',
           '',
           true,
-          { currentFilter, isDateInRange },
+          { currentFilter, isDateInRange, ...submitOptions },
         );
       } catch (error) {
         console.error('Failed to remove dislike:', error);
@@ -202,7 +203,7 @@ export const fieldGetInTouch = (
             'getInTouch',
             '',
             true,
-            { currentFilter, isDateInRange },
+            { currentFilter, isDateInRange, ...submitOptions },
           );
         }
       } catch (error) {
@@ -277,7 +278,7 @@ export const fieldGetInTouch = (
               'getInTouch',
               '',
               true,
-              { currentFilter, isDateInRange },
+              { currentFilter, isDateInRange, ...submitOptions },
             );
             return;
           }
@@ -300,7 +301,7 @@ export const fieldGetInTouch = (
             'getInTouch',
             serverFormattedDate,
             true,
-            { currentFilter, isDateInRange },
+            { currentFilter, isDateInRange, ...submitOptions },
           );
         }}
         style={{

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -158,12 +158,21 @@ const formatDate = date => {
   return `${day}.${month}.${year}`;
 };
 
-export const FieldLastCycle = ({ userData, setUsers, setState }) => {
+export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {} }) => {
   const [status, setStatus] = React.useState(userData.cycleStatus ?? '');
   const submittedRef = React.useRef(false);
   const [localValue, setLocalValue] = React.useState(formatDateToDisplay(userData.lastCycle) || '');
   const [showConfirm, setShowConfirm] = React.useState(false);
   const pendingValueRef = React.useRef('');
+  const submitWithHistory = React.useCallback(
+    (payload, removeKeys = []) => {
+      if (typeof submitOptions?.onSubmitHistorySnapshot === 'function') {
+        submitOptions.onSubmitHistorySnapshot(payload);
+      }
+      handleSubmit(payload, 'overwrite', removeKeys);
+    },
+    [submitOptions],
+  );
 
   const nextCycle = React.useMemo(() => calculateNextDate(userData.lastCycle), [userData.lastCycle]);
 
@@ -233,7 +242,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
           cycleStatus: normalizedStatus,
         };
         handleChange(setUsers, setState, userData.userId, updates);
-        handleSubmit({ userId: userData.userId, ...updates }, 'overwrite');
+        submitWithHistory({ userId: userData.userId, ...updates });
         submittedRef.current = true;
       } else {
         const updates = normalizedStatus
@@ -273,11 +282,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
         if ('getInTouch' in updates && !updates.getInTouch) {
           removalKeys.push('getInTouch');
         }
-        handleSubmit(
-          { userId: userData.userId, ...updates },
-          'overwrite',
-          removalKeys,
-        );
+        submitWithHistory({ userId: userData.userId, ...updates }, removalKeys);
         submittedRef.current = true;
       }
     } else {
@@ -286,7 +291,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
         ? { lastCycle: serverFormattedDate, cycleStatus: normalizedStatus }
         : { lastCycle: serverFormattedDate };
       handleChange(setUsers, setState, userData.userId, updates);
-      handleSubmit({ userId: userData.userId, ...updates }, 'overwrite');
+        submitWithHistory({ userId: userData.userId, ...updates });
       submittedRef.current = true;
     }
   };
@@ -334,7 +339,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
       }
 
       handleChange(setUsers, setState, userData.userId, updates);
-      handleSubmit({ userId: userData.userId, ...updates }, 'overwrite');
+      submitWithHistory({ userId: userData.userId, ...updates });
       submittedRef.current = true;
       return newState;
     });
@@ -370,14 +375,11 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
           false,
           {},
         );
-        handleSubmit(
-          { userId: userData.userId, stimulationSchedule: undefined },
-          'overwrite',
-        );
+        submitWithHistory({ userId: userData.userId, stimulationSchedule: undefined });
       }
     }
     if (!submittedRef.current) {
-      handleSubmit({ userId: userData.userId }, 'overwrite');
+      submitWithHistory({ userId: userData.userId });
     }
     submittedRef.current = false;
   };
@@ -402,14 +404,11 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
                   false,
                   {},
                 );
-                handleSubmit(
-                  { userId: userData.userId, stimulationSchedule: undefined },
-                  'overwrite',
-                );
+                submitWithHistory({ userId: userData.userId, stimulationSchedule: undefined });
               }
             }
             if (!submittedRef.current) {
-              handleSubmit({ userId: userData.userId }, 'overwrite');
+              submitWithHistory({ userId: userData.userId });
             }
             submittedRef.current = false;
           }}
@@ -441,10 +440,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
         false,
         {},
       );
-      handleSubmit(
-        { userId: userData.userId, stimulationSchedule: undefined },
-        'overwrite',
-      );
+      submitWithHistory({ userId: userData.userId, stimulationSchedule: undefined });
     } else {
       handleChange(
         setUsers,
@@ -455,12 +451,9 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
         false,
         {},
       );
-      handleSubmit(
-        { userId: userData.userId, stimulationSchedule: scheduleString },
-        'overwrite',
-      );
+      submitWithHistory({ userId: userData.userId, stimulationSchedule: scheduleString });
     }
-  }, [setUsers, setState, userData]);
+  }, [setUsers, setState, submitWithHistory, userData]);
 
   const handleSetToday = () => {
     const today = new Date();
@@ -486,14 +479,11 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
           false,
           {},
         );
-        handleSubmit(
-          { userId: userData.userId, stimulationSchedule: undefined },
-          'overwrite',
-        );
+        submitWithHistory({ userId: userData.userId, stimulationSchedule: undefined });
       }
     }
     if (!submittedRef.current) {
-      handleSubmit({ userId: userData.userId }, 'overwrite');
+      submitWithHistory({ userId: userData.userId });
     }
     submittedRef.current = false;
   };
@@ -581,7 +571,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState }) => {
                   'getInTouch',
                   nextCycle,
                   true,
-                  {},
+                  submitOptions,
                 )
               }
               style={{ backgroundColor: '#007BFF' }}

--- a/src/components/smallCard/fieldRole.js
+++ b/src/components/smallCard/fieldRole.js
@@ -1,9 +1,9 @@
 import { handleChange } from './actions';
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
-export const fieldRole = (userData, setUsers, setState) => {
+export const fieldRole = (userData, setUsers, setState, submitOptions = {}) => {
   const handleSetRole = role => {
-    handleChange(setUsers, setState, userData.userId, 'role', role, true, {});
+    handleChange(setUsers, setState, userData.userId, 'role', role, true, submitOptions);
   };
 
   return (
@@ -20,7 +20,7 @@ export const fieldRole = (userData, setUsers, setState) => {
             'role',
             e.target.value,
             true,
-            {},
+            submitOptions,
           )
         }
         style={{ marginLeft: 0, textAlign: 'left', width: '6ch' }}

--- a/src/components/smallCard/fieldWritter.js
+++ b/src/components/smallCard/fieldWritter.js
@@ -1,7 +1,7 @@
 import { handleChange } from './actions';
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
-export const fieldWriter = (userData, setUsers, setState) => {
+export const fieldWriter = (userData, setUsers, setState, submitOptions = {}) => {
   const handleCodeClick = code => {
     let currentWriter = userData.writer || '';
     let updatedCodes = currentWriter?.split(', ').filter(item => item !== code); // Видаляємо, якщо є
@@ -13,7 +13,7 @@ export const fieldWriter = (userData, setUsers, setState) => {
       'writer',
       updatedCodes.join(', '),
       true,
-      {},
+      submitOptions,
     );
   };
   return (
@@ -32,7 +32,7 @@ export const fieldWriter = (userData, setUsers, setState) => {
               'writer',
               e.target.value,
               true,
-              {},
+              submitOptions,
             )
           }
           style={{

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -136,7 +136,8 @@ export const renderTopBlock = (
   isDateInRange,
   onOpenMedications,
   additionalActions = null,
-  overlayFieldAdditions = {}
+  overlayFieldAdditions = {},
+  onSubmitHistorySnapshot = null
 ) => {
   if (!userData) return null;
 
@@ -163,6 +164,8 @@ export const renderTopBlock = (
     ));
   };
 
+  const submitOptions = { onSubmitHistorySnapshot };
+
   return (
     <div style={topBlockContainerStyle}>
       <div style={actionButtonsContainerStyle}>
@@ -176,10 +179,10 @@ export const renderTopBlock = (
         {cardData.lastAction && ', '}
         {cardData.userId}
         {!isAgentOrIP &&
-          fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, favoriteUsers, setFavoriteUsers, dislikeUsers, setDislikeUsers)}
-        {fieldRole(cardData, setUsers, setState)}
-        {!isAgentOrIP && <FieldLastCycle userData={cardData} setUsers={setUsers} setState={setState} />}
-        <div>{fieldDeliveryInfo(setUsers, setState, cardData)}</div>
+          fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, favoriteUsers, setFavoriteUsers, dislikeUsers, setDislikeUsers, submitOptions)}
+        {fieldRole(cardData, setUsers, setState, submitOptions)}
+        {!isAgentOrIP && <FieldLastCycle userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />}
+        <div>{fieldDeliveryInfo(setUsers, setState, cardData, submitOptions)}</div>
         {renderOverlayEntries(['lastDelivery', 'ownKids'])}
         <div>
           {cardData.birth && `${cardData.birth} - `}
@@ -201,8 +204,8 @@ export const renderTopBlock = (
         </div>
         {renderOverlayEntries(['phone', 'phone2', 'phone3', 'telegram', 'email', 'facebook', 'instagram', 'tiktok', 'vk'])}
       </div>
-      {fieldWriter(cardData, setUsers, setState)}
-      <FieldComment userData={cardData} setUsers={setUsers} setState={setState} />
+      {fieldWriter(cardData, setUsers, setState, submitOptions)}
+      <FieldComment userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />
 
       <div
         onClick={async e => {


### PR DESCRIPTION
### Motivation
- Consolidate and centralize the logic that registers edit-history snapshots to avoid duplicated code paths and ensure consistent undo/redo behavior when various UI fields trigger saves.
- Allow small-card field components to trigger history snapshots when they submit changes by passing a unified `submitOptions.onSubmitHistorySnapshot` callback through the render tree.
- Ensure history navigation flags and versioning are maintained consistently across different submission flows.

### Description
- Added `registerHistorySnapshot` to centralize snapshot registration and replaced the inline history registration code in `handleSubmit` with a call to `registerHistorySnapshot` (in `src/components/AddNewProfile.jsx`).
- Added `handleTopBlockSubmitHistorySnapshot` to expose snapshot submission from the top block and wired `historyNavigationRef` / `setHistoryVersion` updates inside `registerHistorySnapshot`.
- Updated `actions.handleChange` (`src/components/smallCard/actions.js`) to accept `options.onSubmitHistorySnapshot`, trigger it before calling `handleSubmit`, and provide a `submitWithHistory` wrapper (which calls the provided snapshot hook and then proceeds to submit).
- Propagated a `submitOptions` object throughout top-block and small-card field renderers: updated `renderTopBlock` to accept and forward `onSubmitHistorySnapshot`, and updated the following field components to accept and pass `submitOptions`: `FieldComment`, `fieldDeliveryInfo`, `fieldGetInTouch`, `FieldLastCycle`, `fieldRole`, `fieldWriter` (and their usages) so UI actions call `handleChange`/`handleSubmit` via the history-aware path.
- Replaced direct `handleSubmit` invocations in various small-card field files with the history-aware `submitWithHistory` or by passing `submitOptions` so `handleChange` triggers snapshot registration.

### Testing
- Ran the existing automated unit test suite (`Jest`) against the modified codebase and the suite passed.
- Ran project linting (`ESLint`) and the codebase passed lint checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e757b7c16883269150e92e9620b14d)