### PR TITLE
Adjust matching comment input left padding to prevent placeholder clipping

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -485,7 +485,7 @@ const CommentInput = styled.textarea`
   margin: 0;
   display: block;
   box-sizing: border-box;
-  padding: 0 40px 0 0;
+  padding: 0 40px 0 8px;
   resize: none;
   overflow: hidden;
   height: 16px;


### PR DESCRIPTION
### Motivation
- The matching card comment textarea placeholder was visually cut off by the card's rounded border, so the input content needs to be moved slightly inward for better readability.

### Description
- Increased left padding in `CommentInput` from `0` to `8px` in `src/components/Matching.jsx` to shift the placeholder/content away from the rounded card edge.

### Testing
- Ran the linter with `npm run lint:js -- src/components/Matching.jsx` which completed successfully (no lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75a98e56c8326a9aec46d39ed5e61)