### PR TITLE
Exclude liked/disliked cards from injected `newUsers` in Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2294,22 +2294,35 @@ const Matching = () => {
       hasAdditionalAccessRules &&
       additionalNewUsers.length > 0;
 
-    if (!shouldInjectAdditionalCards) {
-      return baseUsers;
+    const byId = new Map(baseUsers.map(user => [user.userId, user]));
+    if (shouldInjectAdditionalCards) {
+      additionalNewUsers.forEach(user => {
+        const existing = byId.get(user.userId);
+        if (existing) {
+          byId.set(user.userId, { ...existing, ...user });
+        } else {
+          byId.set(user.userId, user);
+        }
+      });
     }
 
-    const byId = new Map(baseUsers.map(user => [user.userId, user]));
-    additionalNewUsers.forEach(user => {
-      const existing = byId.get(user.userId);
-      if (existing) {
-        byId.set(user.userId, { ...existing, ...user });
-      } else {
-        byId.set(user.userId, user);
-      }
-    });
+    const mergedUsers = Array.from(byId.values());
+    if (viewMode !== 'default') {
+      return mergedUsers;
+    }
 
-    return Array.from(byId.values());
-  }, [additionalNewUsers, isAdmin, parsedAdditionalAccessRules, users]);
+    return mergedUsers.filter(
+      user => !favoriteUsers[user.userId] && !dislikeUsers[user.userId]
+    );
+  }, [
+    additionalNewUsers,
+    dislikeUsers,
+    favoriteUsers,
+    isAdmin,
+    parsedAdditionalAccessRules,
+    users,
+    viewMode,
+  ]);
 
   const filteredUsers = applyMatchingSearchKeyFilters(
     filterMain(


### PR DESCRIPTION
### Motivation
- The Matching page behaved inconsistently when `additionalNewUsers` were injected: liked/disliked cards could reappear because reaction-based pruning was applied to the `users` state earlier, while `additionalNewUsers` were merged later. This change aligns behaviour so the final visible list is filtered the same way for both `users` and injected `newUsers`.

### Description
- In `src/components/Matching.jsx` adjusted the `visibleUsers` `useMemo` to build a unified `mergedUsers` map first (merging `additionalNewUsers` into `baseUsers`) and then apply reaction-based exclusion when `viewMode === 'default'`.
- Removed the early return that returned `baseUsers` before injection so injected cards are considered together with loaded cards.
- Added `favoriteUsers`, `dislikeUsers`, and `viewMode` to the `useMemo` dependency list so the merged/filtered list updates when reactions or mode change.
- Behavior for `favorites`/`dislikes` modes is preserved by applying the reaction exclusion only in default mode.

### Testing
- Ran unit test command `npm run -s test -- --watch=false --runInBand`, which reported "No tests found related to files changed since last commit." (no failing tests for this change).
- Built the project with `npm run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e761d9d8388326a7271fad0191123c)