### PR TITLE
Adjust matching comment placeholder left inset

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -485,7 +485,7 @@ const CommentInput = styled.textarea`
   margin: 0;
   display: block;
   box-sizing: border-box;
-  padding: 0 40px 0 0;
+  padding: 0 40px 0 10px;
   resize: none;
   overflow: hidden;
   height: 16px;


### PR DESCRIPTION
### Motivation
- The comment placeholder `"Мій коментар / My comment"` on matching cards was visually clipped by the card border-radius, so the placeholder needs a small horizontal offset.

### Description
- Increase the left inset for the comment textarea in `src/components/Matching.jsx` by changing `padding: 0 40px 0 0;` to `padding: 0 40px 0 10px;` on `CommentInput` to shift the placeholder right.

### Testing
- Ran `npm run -s lint:js` and the lint task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e762fc58a08326b548565af1a36ca2)