### PR TITLE
Fix reaction list behavior in Matching when additional newUsers mode is enabled

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2291,6 +2291,7 @@ const Matching = () => {
     }
 
     const shouldInjectAdditionalCards =
+      viewMode === 'default' &&
       hasAdditionalAccessRules &&
       additionalNewUsers.length > 0;
 
@@ -2308,7 +2309,7 @@ const Matching = () => {
 
     const mergedUsers = Array.from(byId.values());
     if (viewMode !== 'default') {
-      return mergedUsers;
+      return baseUsers;
     }
 
     return mergedUsers.filter(


### PR DESCRIPTION
### Motivation
- Cards from `additionalNewUsers` were being merged into non-default views (favorites/dislikes), causing a card removed from those lists to reappear when additional newUsers injection ran.

### Description
- Limit injection of `additionalNewUsers` to `viewMode === 'default'` by requiring this in `shouldInjectAdditionalCards`.
- For non-default views return the filtered `baseUsers` (no merge), so explicit reaction lists (`favorites`/`dislikes`) remain source-consistent; change made in `src/components/Matching.jsx`.

### Testing
- Ran linter with `npm run lint:js -- src/components/Matching.jsx` which completed successfully with only a `caniuse-lite` update warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77945b8d0832693e8d72d4c86524d)