### PR TITLE
Виправити фільтрацію ролей SearchKey для чекбоксів matching (userRole)

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2853,8 +2853,14 @@ const getRoleFilterKey = bucket => {
   return 'other';
 };
 
+const resolveRoleFilters = filterSettings => {
+  if (filterSettings?.role && typeof filterSettings.role === 'object') return filterSettings.role;
+  if (filterSettings?.userRole && typeof filterSettings.userRole === 'object') return filterSettings.userRole;
+  return undefined;
+};
+
 const isRoleBucketAllowedByFilters = (bucket, filterSettings = {}) => {
-  const roleFilters = filterSettings?.role;
+  const roleFilters = resolveRoleFilters(filterSettings);
   const shouldApplyRole = hasExplicitFilterSelection(roleFilters);
   if (!shouldApplyRole) return true;
 
@@ -3819,7 +3825,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   const indexedImtUserIds = collectIdsFromSnapshots(imtSnapshots);
   const shouldApplyMaritalStatusFilter = hasExplicitFilterSelection(filterSettings?.maritalStatus);
   const shouldApplyContactFilter = hasExplicitFilterSelection(filterSettings?.contact);
-  const shouldApplyRoleFilter = hasExplicitFilterSelection(filterSettings?.role);
+  const shouldApplyRoleFilter = hasExplicitFilterSelection(resolveRoleFilters(filterSettings));
   const shouldApplyUserIdFilter = hasExplicitFilterSelection(filterSettings?.userId);
   const shouldApplyAgeFilter = ageUserIds instanceof Set;
   const shouldApplyImtFilter = imtUserIds instanceof Set;


### PR DESCRIPTION
### Motivation
- У matching-режимі чекбокси ролей зберігаються під `filters.userRole`, але логіка побудови результатів по SearchKey перевіряла тільки `filterSettings.role`, через що рольовий фільтр інколи ігнорувався і картки з `ag` показувались під чекбоксом `ДО`.
- Мета зміни — щоб SearchKey-пошук коректно враховував вибір чекбоксів ролей в matching-режимі та не пропускав непотрібні картки.

### Description
- Додано `resolveRoleFilters(filterSettings)` яка повертає `filterSettings.role` або, якщо його нема, `filterSettings.userRole` для уніфікованого доступу до налаштувань ролей.
- Замінив прямі звернення до `filterSettings.role` у `isRoleBucketAllowedByFilters` на використання нового резолвера, щоб відбір bucket-ів для ролей враховував `userRole` у matching-режимі.
- Використав той самий резолвер при визначенні `shouldApplyRoleFilter` в `fetchUsersBySearchKeyBloodPaged`, щоб рольовий фільтр активувався правильно під час побудови фінального списку користувачів.

### Testing
- Прогнав лінтер на зміненому файлі командою `npm run -s lint:js -- src/components/config.js`, перевірка пройшла з єдиним інформаційним повідомленням про застарілу базу Browserslist (не блокує).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78c89b604832695e2b0a5ade12fab)