### PR TITLE
Add users-only SearchKey indexing checkbox (writes to searchKey/users)

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -651,6 +651,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const defaultSelectedIndexJobs = {
     lastLogin: true,
     stimulationShortcuts: true,
+    searchKeyUsersAll: false,
   };
   const defaultSelectedSearchKeyIndexes = SEARCH_KEY_INDEX_OPTIONS.reduce((acc, option) => {
     acc[option.key] = true;
@@ -3165,11 +3166,32 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       await runStimulationShortcutIndexing();
     }
 
+    if (selectedIndexJobs.searchKeyUsersAll) {
+      const toastId = 'index-searchkey-users-all-progress';
+      const allSearchKeyIndexTypes = SEARCH_KEY_INDEX_OPTIONS.map(option => option.key);
+      toast.loading('Indexing searchKey/users all indexes...', { id: toastId });
+      await createSelectedSearchKeyIndexesInCollection(
+        'users',
+        allSearchKeyIndexTypes,
+        (progress, meta) => {
+          const indexLabel = meta?.indexType || '';
+          toast.loading(`Indexing searchKey/users/${indexLabel} ${progress}%`, { id: toastId });
+        },
+        { rootPath: 'searchKey/users' },
+      );
+      toast.success('Всі searchKey/users індекси для users побудовано', { id: toastId });
+    }
+
     const selectedIndexTypes = SEARCH_KEY_INDEX_OPTIONS.filter(option => selectedSearchKeyIndexes[option.key]).map(
       option => option.key,
     );
 
-    if (!selectedIndexJobs.lastLogin && !selectedIndexJobs.stimulationShortcuts && !selectedIndexTypes.length) {
+    if (
+      !selectedIndexJobs.lastLogin &&
+      !selectedIndexJobs.stimulationShortcuts &&
+      !selectedIndexJobs.searchKeyUsersAll &&
+      !selectedIndexTypes.length
+    ) {
       toast.error('Оберіть хоча б один індекс для запуску');
       return;
     }
@@ -3776,6 +3798,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     />
                     <SearchScopeLabelTextGroup>
                       <span>Індексувати ярлики стимуляції</span>
+                    </SearchScopeLabelTextGroup>
+                  </SearchScopeLabel>
+                  <SearchScopeLabel>
+                    <input
+                      type="checkbox"
+                      checked={Boolean(selectedIndexJobs.searchKeyUsersAll)}
+                      onChange={() => toggleIndexJobSelection('searchKeyUsersAll')}
+                    />
+                    <SearchScopeLabelTextGroup>
+                      <span>Всі searchKey індекси лише для users → searchKey/users</span>
                     </SearchScopeLabelTextGroup>
                   </SearchScopeLabel>
                   {SEARCH_KEY_INDEX_OPTIONS.map(option => (

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3192,9 +3192,14 @@ const collectReactionIdsByFilters = async (
   return reactionIds;
 };
 
-const updateSearchKeyLeaf = async (indexName, value, userId, action) => {
+const resolveSearchKeyLeafPath = (rootPath, indexName, value, userId) => {
+  const safeRootPath = rootPath || SEARCH_KEY_INDEX_ROOT;
+  return `${safeRootPath}/${indexName}/${value}/${userId}`;
+};
+
+const updateSearchKeyLeaf = async (indexName, value, userId, action, options = {}) => {
   if (!indexName || !value || !userId) return;
-  const indexRef = ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${indexName}/${value}/${userId}`);
+  const indexRef = ref2(database, resolveSearchKeyLeafPath(options?.rootPath, indexName, value, userId));
 
   if (action === 'add') {
     await set(indexRef, true);
@@ -3420,7 +3425,7 @@ export const createSearchKeyIndexInCollection = async (collection, onProgress, o
       batchIds.map(async userId => {
         const user = usersData[userId] || {};
         const bloodValue = normalizeBloodIndexValue(user.blood);
-        await updateSearchKeyLeaf(BLOOD_SEARCH_KEY_INDEX, bloodValue, userId, 'add');
+        await updateSearchKeyLeaf(BLOOD_SEARCH_KEY_INDEX, bloodValue, userId, 'add', options);
       })
     );
 
@@ -3432,6 +3437,7 @@ export const createSearchKeyIndexInCollection = async (collection, onProgress, o
 export const createMaritalStatusSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3440,7 +3446,7 @@ export const createMaritalStatusSearchKeyIndexInCollection = async (collection, 
   const updates = userIds.reduce((acc, userId) => {
     const user = usersData[userId] || {};
     const maritalStatusValue = normalizeMaritalStatusIndexValue(user.maritalStatus);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${MARITAL_STATUS_SEARCH_KEY_INDEX}/${maritalStatusValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${MARITAL_STATUS_SEARCH_KEY_INDEX}/${maritalStatusValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3460,6 +3466,7 @@ export const createMaritalStatusSearchKeyIndexInCollection = async (collection, 
 export const createCsectionSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3468,7 +3475,7 @@ export const createCsectionSearchKeyIndexInCollection = async (collection, onPro
   const updates = userIds.reduce((acc, userId) => {
     const user = usersData[userId] || {};
     const csectionValue = normalizeCsectionIndexValue(user.csection);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${CSECTION_SEARCH_KEY_INDEX}/${csectionValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${CSECTION_SEARCH_KEY_INDEX}/${csectionValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3488,6 +3495,7 @@ export const createCsectionSearchKeyIndexInCollection = async (collection, onPro
 export const createContactSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3497,7 +3505,7 @@ export const createContactSearchKeyIndexInCollection = async (collection, onProg
     const user = usersData[userId] || {};
     const contactValues = getContactIndexSet(user);
     contactValues.forEach(contactValue => {
-      acc[`${SEARCH_KEY_INDEX_ROOT}/${CONTACT_SEARCH_KEY_INDEX}/${contactValue}/${userId}`] = true;
+      acc[`${searchKeyRoot}/${CONTACT_SEARCH_KEY_INDEX}/${contactValue}/${userId}`] = true;
     });
     return acc;
   }, {});
@@ -3518,6 +3526,7 @@ export const createContactSearchKeyIndexInCollection = async (collection, onProg
 export const createRoleSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3526,7 +3535,7 @@ export const createRoleSearchKeyIndexInCollection = async (collection, onProgres
   const updates = userIds.reduce((acc, userId) => {
     const user = usersData[userId] || {};
     const roleValue = normalizeRoleSearchKeyIndexValue(user.role, user.userRole);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${ROLE_SEARCH_KEY_INDEX}/${roleValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${ROLE_SEARCH_KEY_INDEX}/${roleValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3546,6 +3555,7 @@ export const createRoleSearchKeyIndexInCollection = async (collection, onProgres
 export const createUserIdSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3555,7 +3565,7 @@ export const createUserIdSearchKeyIndexInCollection = async (collection, onProgr
     const user = usersData[userId] || {};
     const userIdValues = getUserIdIndexSet(user.userId || userId);
     userIdValues.forEach(userIdValue => {
-      acc[`${SEARCH_KEY_INDEX_ROOT}/${USER_ID_SEARCH_KEY_INDEX}/${userIdValue}/${userId}`] = true;
+      acc[`${searchKeyRoot}/${USER_ID_SEARCH_KEY_INDEX}/${userIdValue}/${userId}`] = true;
     });
     return acc;
   }, {});
@@ -3576,6 +3586,7 @@ export const createUserIdSearchKeyIndexInCollection = async (collection, onProgr
 export const createAgeSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3584,7 +3595,7 @@ export const createAgeSearchKeyIndexInCollection = async (collection, onProgress
   const updates = userIds.reduce((acc, userId) => {
     const user = usersData[userId] || {};
     const ageValue = normalizeAgeBirthDateIndexValue(user.birth);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${AGE_SEARCH_KEY_INDEX}/${ageValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${AGE_SEARCH_KEY_INDEX}/${ageValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3604,6 +3615,7 @@ export const createAgeSearchKeyIndexInCollection = async (collection, onProgress
 export const createImtHeightWeightSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3614,9 +3626,9 @@ export const createImtHeightWeightSearchKeyIndexInCollection = async (collection
     const imtValue = normalizeImtSearchKeyIndexValue(user);
     const heightValue = normalizeMetricIndexValue(user.height);
     const weightValue = normalizeMetricIndexValue(user.weight);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${IMT_SEARCH_KEY_INDEX}/${imtValue}/${userId}`] = true;
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${HEIGHT_SEARCH_KEY_INDEX}/${heightValue}/${userId}`] = true;
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${WEIGHT_SEARCH_KEY_INDEX}/${weightValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${IMT_SEARCH_KEY_INDEX}/${imtValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${HEIGHT_SEARCH_KEY_INDEX}/${heightValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${WEIGHT_SEARCH_KEY_INDEX}/${weightValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3636,6 +3648,7 @@ export const createImtHeightWeightSearchKeyIndexInCollection = async (collection
 export const createReactionSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3644,7 +3657,7 @@ export const createReactionSearchKeyIndexInCollection = async (collection, onPro
   const updates = userIds.reduce((acc, userId) => {
     const user = usersData[userId] || {};
     const reactionValue = normalizeReactionSearchKeyIndexValue(user.getInTouch);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${REACTION_SEARCH_KEY_INDEX}/${reactionValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${REACTION_SEARCH_KEY_INDEX}/${reactionValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3664,6 +3677,7 @@ export const createReactionSearchKeyIndexInCollection = async (collection, onPro
 export const createFieldCountSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
   const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
   if (!usersData) return;
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
 
   const userIds = Object.keys(usersData);
   const totalUsers = userIds.length;
@@ -3672,7 +3686,7 @@ export const createFieldCountSearchKeyIndexInCollection = async (collection, onP
   const updates = userIds.reduce((acc, userId) => {
     const user = usersData[userId] || {};
     const fieldCountValue = normalizeFieldCountSearchKeyIndexValue(user);
-    acc[`${SEARCH_KEY_INDEX_ROOT}/${FIELD_COUNT_SEARCH_KEY_INDEX}/${fieldCountValue}/${userId}`] = true;
+    acc[`${searchKeyRoot}/${FIELD_COUNT_SEARCH_KEY_INDEX}/${fieldCountValue}/${userId}`] = true;
     return acc;
   }, {});
 
@@ -3702,7 +3716,7 @@ const SEARCH_KEY_INDEX_BUILDERS = {
   [SEARCH_KEY_INDEX_TYPES.fieldCount]: createFieldCountSearchKeyIndexInCollection,
 };
 
-export const createSelectedSearchKeyIndexesInCollection = async (collection, indexTypes = [], onProgress) => {
+export const createSelectedSearchKeyIndexesInCollection = async (collection, indexTypes = [], onProgress, options = {}) => {
   if (!collection || !Array.isArray(indexTypes) || indexTypes.length === 0) return;
 
   const uniqueIndexTypes = [...new Set(indexTypes)].filter(indexType => SEARCH_KEY_INDEX_BUILDERS[indexType]);
@@ -3730,7 +3744,7 @@ export const createSelectedSearchKeyIndexesInCollection = async (collection, ind
         : undefined;
 
     // eslint-disable-next-line no-await-in-loop
-    await SEARCH_KEY_INDEX_BUILDERS[indexType](collection, progressReporter, { usersData });
+    await SEARCH_KEY_INDEX_BUILDERS[indexType](collection, progressReporter, { usersData, ...options });
   }
 };
 


### PR DESCRIPTION
### Motivation
- Provide an easy way to build all available SearchKey indexes but only for the `users` collection and store them under `searchKey/users` (so existing `searchKey` root remains unchanged).

### Description
- `src/components/AddNewProfile.jsx`: added new index job key `searchKeyUsersAll` to `defaultSelectedIndexJobs`, persisted via the existing `selectedIndexJobs` mechanism, added a checkbox in the `Індекси` modal, and extended `runSelectedIndexes` to run all SearchKey index builders for the `users` collection when enabled by calling `createSelectedSearchKeyIndexesInCollection('users', allIndexTypes, ..., { rootPath: 'searchKey/users' })` and showing a dedicated progress toast.
- `src/components/config.js`: introduced `resolveSearchKeyLeafPath` and updated `updateSearchKeyLeaf` to accept an `options.rootPath` so writes can target a custom root; updated every index builder and batched update payloads to use `options.rootPath` (defaulting to `SEARCH_KEY_INDEX_ROOT`) and forwarded `options` from `createSelectedSearchKeyIndexesInCollection` to individual builders to preserve backward compatibility.
- Kept default behavior unchanged: when `rootPath` is not provided the code still writes to `searchKey/...` as before.

### Testing
- Ran linter: `npx eslint src/components/AddNewProfile.jsx src/components/config.js` and it completed successfully (only environment/npm/browserslist warnings appeared, no lint errors).
- Verified changes were committed and built into the repo (files modified: `src/components/AddNewProfile.jsx`, `src/components/config.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a37433488326a0cc7b8366b3dc68)