### PR TITLE
Fix opening `www` links from `renderTopBlock` contact list

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -34,6 +34,20 @@ const phoneBtnStyle = {
   borderRadius: '50%',
 };
 
+const normalizeExternalUrl = value => {
+  const rawValue = String(value ?? '').trim();
+
+  if (!rawValue) {
+    return '';
+  }
+
+  if (/^[a-z][a-z\d+\-.]*:/i.test(rawValue)) {
+    return rawValue;
+  }
+
+  return `https://${rawValue}`;
+};
+
 export const fieldContacts = (data, parentKey = '') => {
   if (!data || typeof data !== 'object') {
     console.error('Invalid data passed to renderContacts:', data);
@@ -47,7 +61,7 @@ export const fieldContacts = (data, parentKey = '') => {
     phone: value => `tel:${value}`,
     facebook: value => `https://facebook.com/${value}`,
     vk: value => `https://vk.com/${value}`,
-    otherLink: value => `${value}`,
+    otherLink: value => normalizeExternalUrl(value),
     email: value => `mailto:${value}`,
     telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
     viberFromPhone: value => `viber://chat?number=%2B${value.replace(/\s+/g, '')}`,
@@ -346,7 +360,7 @@ export const fieldContactsIcons = (
     phone: value => `tel:${value}`,
     facebook: value => `https://facebook.com/${value}`,
     vk: value => `https://vk.com/${value}`,
-    otherLink: value => `${value}`,
+    otherLink: value => normalizeExternalUrl(value),
     email: value => `mailto:${value}`,
     telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
     viberFromPhone: value => `viber://chat?number=%2B${value.replace(/\s+/g, '')}`,


### PR DESCRIPTION
### Motivation
- Links in the top block contacts (`otherLink`) that started with `www.` were rendered without a protocol (e.g. `href="www.example.com"`) and were treated as relative URLs by the browser, so they did not open correctly.
- The link rendering logic lives in `src/components/smallCard/fieldContacts.js`, which is used by `renderTopBlock`.

### Description
- Added a helper `normalizeExternalUrl` in `src/components/smallCard/fieldContacts.js` that returns an empty string for empty values, preserves values that already include a protocol, and prepends `https://` to values missing a protocol.
- Replaced the `otherLink` mapping in both `fieldContacts` and `fieldContactsIcons` to use `normalizeExternalUrl` so `www.example.com` becomes `https://www.example.com` before rendering anchor `href`.
- The change preserves existing behavior for values that already include a protocol and for empty inputs.

### Testing
- Ran `npm run lint:js` and it completed successfully (only non-critical environment warnings about `browserslist`).
- No unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86a831ac08326963b853ee08c7d19)