### PR TITLE
Preload and merge cached 'load2' cards into LAST_ACTION paging; track cache/backend counts

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2633,8 +2633,44 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     if (isEditingRef.current)
       return { cacheCount: 0, backendCount: 0, hasMore };
 
+    const { cards: cachedArr, fromCache } = await getLoad2Cards(
+      currentFilters,
+      id => fetchUserById(id),
+    );
+    const sortedCachedArr = [...cachedArr].sort(
+      (a, b) => normalizeLastAction(b?.lastAction) - normalizeLastAction(a?.lastAction),
+    );
+
+    let cacheCount = 0;
+    let backendCount = 0;
+
+    const slice = sortedCachedArr.slice(dateOffsetLA, dateOffsetLA + PAGE_SIZE);
+    if (slice.length > 0) {
+      const cachedUsers = slice.reduce((acc, user) => {
+        acc[user.userId] = user;
+        return acc;
+      }, {});
+
+      cacheFetchedUsers(cachedUsers, cacheLoad2Users, currentFilters);
+      if (!isEditingRef.current) {
+        setUsers(prev => mergeWithoutOverwrite(prev, cachedUsers));
+      }
+      if (fromCache) cacheCount += slice.length;
+      else backendCount += slice.length;
+    }
+
+    const hasCachedMore = sortedCachedArr.length > dateOffsetLA + slice.length;
+    if (slice.length === PAGE_SIZE || hasCachedMore) {
+      const nextOffset = dateOffsetLA + slice.length;
+      setDateOffsetLA(nextOffset);
+      setHasMore(hasCachedMore);
+      setTotalCount(prev => Math.max(prev, sortedCachedArr.length));
+      return { cacheCount, backendCount, hasMore: hasCachedMore };
+    }
+
+    const backendOffset = dateOffsetLA + slice.length;
     const res = await fetchUsersByLastActionPaged(
-      dateOffsetLA,
+      backendOffset,
       PAGE_SIZE,
       undefined,
       id => fetchUserById(id),
@@ -2655,15 +2691,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setDateOffsetLA(res.lastKey);
       setHasMore(res.hasMore);
       setTotalCount(prev =>
-        Math.max(prev, res.lastKey + (res.hasMore ? PAGE_SIZE : 0)),
+        Math.max(prev, res.lastKey + (res.hasMore ? PAGE_SIZE : 0), sortedCachedArr.length),
       );
-      const backendCount = Object.keys(filteredUsers).length;
-      return { cacheCount: 0, backendCount, hasMore: res.hasMore };
+      backendCount += Object.keys(filteredUsers).length;
+      return { cacheCount, backendCount, hasMore: res.hasMore };
     }
 
     setHasMore(false);
-    setTotalCount(prev => Math.max(prev, dateOffsetLA));
-    return { cacheCount: 0, backendCount: 0, hasMore: false };
+    setTotalCount(prev => Math.max(prev, dateOffsetLA + slice.length, sortedCachedArr.length));
+    if (slice.length > 0) {
+      setDateOffsetLA(prev => prev + slice.length);
+    }
+    return { cacheCount, backendCount, hasMore: false };
   };
 
   const handlePageChange = async page => {


### PR DESCRIPTION
### Motivation

- Improve responsiveness for the `LAST_ACTION` paging path by returning cached cards before hitting the backend and correctly accounting for cache vs backend counts.
- Ensure `totalCount` and paging offsets reflect both cached and backend-provided entries so UI pagination is accurate.

### Description

- Added a call to `getLoad2Cards` and sorted its `cards` by `lastAction` to prefer most-recent cached items before backend fetches. 
- Sliced the sorted cached array by `dateOffsetLA` and `PAGE_SIZE`, then cached those users via `cacheFetchedUsers` and merged them into state with `mergeWithoutOverwrite` when not editing. 
- Tracked `cacheCount` and `backendCount`, returned early when cached results satisfy the page, and computed `backendOffset` as `dateOffsetLA + slice.length` for the backend fetch. 
- Adjusted `setTotalCount` and `setDateOffsetLA` to consider the length of cached arrays (`sortedCachedArr.length`) and to increment offsets when only cached items were used.

### Testing

- Ran the automated test suite with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e870d787b883268dd3d2f21bb6d279)