### PR TITLE
Preserve local card fields and use cached canonical card in EditProfile

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -143,6 +143,32 @@ const normalizeEditorOverlayFields = fields => {
   }, {});
 };
 
+const mergeCardStatePreservingKnownFields = (prevState, nextCardState) => {
+  if (!nextCardState || typeof nextCardState !== 'object') {
+    return prevState || nextCardState;
+  }
+
+  if (!prevState || typeof prevState !== 'object') {
+    return nextCardState;
+  }
+
+  return {
+    ...prevState,
+    ...nextCardState,
+  };
+};
+
+const getCanonicalCardFromCache = cardUserId => {
+  if (!cardUserId) return null;
+  const cachedCard = getCard(cardUserId);
+  if (!cachedCard || typeof cachedCard !== 'object') return null;
+
+  return {
+    ...cachedCard,
+    userId: cachedCard.userId || cardUserId,
+  };
+};
+
 const EditProfile = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
@@ -171,7 +197,7 @@ const EditProfile = () => {
     let canonical = {};
 
     try {
-      canonical = await getCanonicalCard(userId);
+      canonical = getCanonicalCardFromCache(userId) || (await getCanonicalCard(userId));
 
       if (isAdmin) {
         overlays = await getOverlaysForCard(userId);
@@ -220,12 +246,14 @@ const EditProfile = () => {
       ? applyOverlayToCard(canonical, normalizedOwnFields)
       : canonical;
 
-    setState({
+    const normalizedIncomingState = {
       ...cardForEditor,
       userId: cardForEditor?.userId || userId,
       lastAction: normalizeLastAction(cardForEditor?.lastAction),
       lastDelivery: formatDateToDisplay(cardForEditor?.lastDelivery),
-    });
+    };
+
+    setState(prevState => mergeCardStatePreservingKnownFields(prevState, normalizedIncomingState));
 
     const visibleOverlays = overlays;
 
@@ -289,7 +317,9 @@ const EditProfile = () => {
     const canWriteMain = isAdminUid(editorUserId);
 
     if (!canWriteMain) {
-      const canonical = await getCanonicalCard(updatedState.userId);
+      const canonical =
+        getCanonicalCardFromCache(updatedState.userId) ||
+        (await getCanonicalCard(updatedState.userId));
       const overlayFields = buildOverlayFromDraft(canonical, updatedState);
       await saveOverlayForUserCard({
         editorUserId,


### PR DESCRIPTION
### Motivation
- Prevent losing local/transient fields when the profile card is refreshed and avoid unnecessary network calls by preferring a cached canonical card.

### Description
- Add `mergeCardStatePreservingKnownFields` to merge incoming card state into the previous state while preserving other known fields from `prevState`.
- Add `getCanonicalCardFromCache` to obtain a cached card via `getCard` and ensure `userId` is populated.
- Update `refreshOverlays` to prefer the cached canonical card (`getCanonicalCardFromCache`) before awaiting `getCanonicalCard` and replace the direct `setState({...})` call with a merge-based `setState(prev => mergeCardStatePreservingKnownFields(prev, normalizedIncomingState))`.
- Update `remoteUpdate` to use the cache fallback when loading the canonical card for overlay saves.

### Testing
- Ran the existing test suite with `npm test` and linting with `npm run lint`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86b279a0083268865bff7baf0d080)