### PR TITLE
Add preindexed newUsers filter-set index and integrate into Matching/ProfileForm

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -68,6 +68,10 @@ import {
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
 import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
+import {
+  buildNewUsersFilterSetIndex,
+  getIndexedNewUsersIdsByRules,
+} from 'utils/newUsersFilterSetsIndex';
 
 // Filter out users with invalid identifiers; Firebase push IDs are usually 20 chars.
 const isValidId = id => typeof id === 'string' && id.length >= 20;
@@ -81,6 +85,7 @@ const compareUsersByLastLogin2 = (a = {}, b = {}) =>
   (b.lastLogin2 || '').localeCompare(a.lastLogin2 || '');
 
 const SEARCH_KEY_ROOT = 'searchKey';
+const USERS_SEARCH_KEY_ROOT = `${SEARCH_KEY_ROOT}/users`;
 const SEARCH_KEY_INDEX_NAMES = {
   blood: 'blood',
   maritalStatus: 'maritalStatus',
@@ -88,14 +93,14 @@ const SEARCH_KEY_INDEX_NAMES = {
   age: 'age',
 };
 
-const readIndexedIds = async (indexName, values = []) => {
+const readIndexedIds = async (indexName, values = [], rootPath = SEARCH_KEY_ROOT) => {
   const uniqueValues = [...new Set(values.filter(Boolean))];
   if (!indexName || uniqueValues.length === 0) return null;
 
   const payloads = await Promise.all(
     uniqueValues.map(value =>
-      getCachedSearchKeyPayload(`${SEARCH_KEY_ROOT}/${indexName}/${value}`, async () => {
-        const snapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/${indexName}/${value}`));
+      getCachedSearchKeyPayload(`${rootPath}/${indexName}/${value}`, async () => {
+        const snapshot = await get(refDb(database, `${rootPath}/${indexName}/${value}`));
         return {
           exists: snapshot.exists(),
           value: snapshot.exists() ? snapshot.val() || {} : null,
@@ -165,8 +170,30 @@ const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BA
   return result;
 };
 
-const fetchAdditionalNewUsersBySearchIndex = async parsedRuleGroups => {
+const fetchAdditionalNewUsersBySearchIndex = async ({ parsedRuleGroups, rawRules }) => {
   if (!Array.isArray(parsedRuleGroups) || parsedRuleGroups.length === 0) return [];
+
+  try {
+    let indexed = await getIndexedNewUsersIdsByRules({
+      rawRules,
+    });
+    if (!indexed) {
+      await buildNewUsersFilterSetIndex({
+        rawRules,
+      });
+      indexed = await getIndexedNewUsersIdsByRules({
+        rawRules,
+      });
+    }
+    if (indexed?.userIds) {
+      const indexedRows = await fetchUsersAndNewUsersByIds(indexed.userIds);
+      return indexedRows
+        .filter(row => row.hasNewUser)
+        .map(row => ({ ...row.merged, __sourceCollection: 'newUsers' }));
+    }
+  } catch (error) {
+    console.error('Failed to load preindexed additional access set; fallback to searchKey buckets', error);
+  }
 
   const matchedIdsSet = new Set();
 
@@ -182,7 +209,7 @@ const fetchAdditionalNewUsersBySearchIndex = async parsedRuleGroups => {
     if (activeSources.length === 0) continue;
 
     const indexedSets = await Promise.all(
-      activeSources.map(source => readIndexedIds(source.indexName, source.values))
+      activeSources.map(source => readIndexedIds(source.indexName, source.values, USERS_SEARCH_KEY_ROOT))
     );
 
     const normalizedSets = indexedSets.filter(set => set instanceof Set);
@@ -1924,6 +1951,11 @@ const Matching = () => {
     let cancelled = false;
 
     const loadAdditionalNewUsers = async () => {
+      if (collectionSource !== 'newUsers') {
+        setAdditionalNewUsers([]);
+        return;
+      }
+
       if (!parsedAdditionalAccessRules || parsedAdditionalAccessRules.length === 0) {
         setAdditionalNewUsers([]);
         additionalRulesToastRef.current = '';
@@ -1931,7 +1963,10 @@ const Matching = () => {
       }
 
       try {
-        const loaded = await fetchAdditionalNewUsersBySearchIndex(parsedAdditionalAccessRules);
+        const loaded = await fetchAdditionalNewUsersBySearchIndex({
+          parsedRuleGroups: parsedAdditionalAccessRules,
+          rawRules: currentAdditionalAccessRules,
+        });
 
         if (!cancelled) {
           setAdditionalNewUsers(loaded);
@@ -1957,7 +1992,7 @@ const Matching = () => {
     return () => {
       cancelled = true;
     };
-  }, [parsedAdditionalAccessRules, currentAdditionalAccessRules]);
+  }, [parsedAdditionalAccessRules, currentAdditionalAccessRules, collectionSource]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1967,12 +2002,12 @@ const Matching = () => {
         const snapshots = await Promise.all(
           MATCHING_ROLE_SEARCH_KEY_BUCKETS.map(async bucket => {
             const payload = await getCachedSearchKeyPayload(
-              `${SEARCH_KEY_ROOT}/role/${bucket}`,
+              `${USERS_SEARCH_KEY_ROOT}/role/${bucket}`,
               async () => {
-                const snapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/role/${bucket}`));
+                const usersSnapshot = await get(refDb(database, `${USERS_SEARCH_KEY_ROOT}/role/${bucket}`));
                 return {
-                  exists: snapshot.exists(),
-                  value: snapshot.exists() ? snapshot.val() || {} : null,
+                  exists: usersSnapshot.exists(),
+                  value: usersSnapshot.exists() ? usersSnapshot.val() || {} : null,
                 };
               }
             );
@@ -2396,14 +2431,17 @@ const Matching = () => {
 
     const hasAdditionalAccessRules = parsedAdditionalAccessRules.length > 0;
     if (hasAdditionalAccessRules) {
+      const allowedBySetKey = new Set(additionalNewUsers.map(user => user.userId).filter(Boolean));
       baseUsers = baseUsers.filter(user => {
         if (user?.__sourceCollection !== 'newUsers') return true;
+        if (collectionSource === 'newUsers' && !allowedBySetKey.has(user.userId)) return false;
         return isUserAllowedByAnyAdditionalAccessRule(user, parsedAdditionalAccessRules);
       });
     }
 
     const shouldInjectAdditionalCards =
       viewMode === 'default' &&
+      collectionSource === 'newUsers' &&
       hasAdditionalAccessRules &&
       additionalNewUsers.length > 0;
 
@@ -2435,6 +2473,7 @@ const Matching = () => {
     parsedAdditionalAccessRules,
     users,
     viewMode,
+    collectionSource,
   ]);
 
   const filteredUsers = applyMatchingSearchKeyFilters(

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -25,6 +25,10 @@ import {
   parseAdditionalAccessRuleGroups,
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
+import {
+  buildNewUsersFilterSetIndex,
+  rebuildAllNewUsersFilterSetIndexes,
+} from 'utils/newUsersFilterSetsIndex';
 import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
 
 export const getFieldsToRender = state => {
@@ -560,6 +564,7 @@ export const ProfileForm = ({
   const [activeAdditionalRuleInputIndex, setActiveAdditionalRuleInputIndex] = useState(0);
   const [additionalRuleBuilder, setAdditionalRuleBuilder] = useState([]);
   const [availableCardsCount, setAvailableCardsCount] = useState(0);
+  const [isReindexingFilterSets, setIsReindexingFilterSets] = useState(false);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const autoAppliedOverlayForUserRef = useRef('');
 
@@ -772,13 +777,38 @@ export const ProfileForm = ({
     return { ...draftState, getInTouch: normalized };
   };
 
-  const submitWithNormalization = useCallback((nextState, overwrite, delCondition) => {
+  const submitWithNormalization = useCallback(async (nextState, overwrite, delCondition) => {
     const payload =
       nextState && typeof nextState === 'object'
         ? normalizeGetInTouchForSubmit(nextState)
         : nextState;
+    try {
+      const rawRules = payload?.[ADDITIONAL_ACCESS_FIELD];
+      if (rawRules !== undefined) {
+        await buildNewUsersFilterSetIndex({
+          rawRules,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to update additional access newUsers filter-set index', error);
+    }
     handleSubmit(payload, overwrite, delCondition);
   }, [handleSubmit]);
+
+  const handleReindexAdditionalFilterSets = useCallback(async () => {
+    setIsReindexingFilterSets(true);
+    try {
+      const stats = await rebuildAllNewUsersFilterSetIndexes();
+      toast.success(
+        `Індексацію завершено: ${stats.indexedRuleSets}/${stats.totalRuleSets} наборів збережено.`
+      );
+    } catch (error) {
+      console.error('Failed to rebuild additional access filter-set indexes', error);
+      toast.error('Не вдалося перебудувати індексацію наборів фільтрів');
+    } finally {
+      setIsReindexingFilterSets(false);
+    }
+  }, []);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;
@@ -1855,6 +1885,15 @@ ${entries.join('\n')}`;
             <AdditionalRuleActions>
               <button type="button" onClick={addEmptyAdditionalFilter}>+ Фільтр</button>
               <button type="button" onClick={applyAdditionalRulesFromBuilder}>Застосувати</button>
+              <button
+                type="button"
+                onClick={handleReindexAdditionalFilterSets}
+                disabled={isReindexingFilterSets}
+              >
+                {isReindexingFilterSets
+                  ? 'Індексація наборів фільтрів...'
+                  : 'Індексація наборів фільтрів'}
+              </button>
             </AdditionalRuleActions>
 
             <AdditionalRulePreview

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1,0 +1,146 @@
+import { get, ref, remove, set } from 'firebase/database';
+import { database } from 'components/config';
+import {
+  isUserAllowedByAnyAdditionalAccessRule,
+  parseAdditionalAccessRuleGroups,
+  resolveAdditionalAccessSearchKeyBuckets,
+} from './additionalAccessRules';
+
+const SEARCH_KEY_ROOT = 'searchKey';
+
+const toStableRulesText = raw =>
+  Array.isArray(raw)
+    ? raw.map(item => String(item || '').trim()).filter(Boolean).join('\n\n')
+    : String(raw || '').trim();
+
+const sanitizeToken = value =>
+  String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[.#$[\]/]/g, '-')
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_+\-?]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '');
+
+const buildGroupToken = parsedRules => {
+  const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
+  const parts = Object.keys(bucketMap || {})
+    .sort()
+    .map(filterKey => {
+      const values = Array.isArray(bucketMap[filterKey])
+        ? bucketMap[filterKey]
+        : [...(bucketMap[filterKey] || [])];
+      const uniqueValues = [...new Set(values.map(sanitizeToken).filter(Boolean))].sort();
+      if (!uniqueValues.length) return '';
+      return `${sanitizeToken(filterKey)}_${uniqueValues.join('-')}`;
+    })
+    .filter(Boolean);
+
+  return parts.join('__');
+};
+
+export const makeAdditionalRulesSetKey = rawRules => {
+  const rulesText = toStableRulesText(rawRules);
+  const parsedGroups = parseAdditionalAccessRuleGroups(rulesText);
+  if (!parsedGroups.length) return '';
+
+  const groupTokens = parsedGroups
+    .map(buildGroupToken)
+    .filter(Boolean)
+    .sort();
+
+  if (!groupTokens.length) return '';
+  return `set_${groupTokens.join('__or__')}`;
+};
+
+const mapMatchingIdsByRules = (newUsersData, parsedRuleGroups) => {
+  const ids = {};
+  Object.entries(newUsersData || {}).forEach(([userId, userData]) => {
+    const row = { userId, ...(userData && typeof userData === 'object' ? userData : {}) };
+    if (isUserAllowedByAnyAdditionalAccessRule(row, parsedRuleGroups)) {
+      ids[userId] = true;
+    }
+  });
+  return ids;
+};
+
+export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = null }) => {
+  const rulesText = toStableRulesText(rawRules);
+  const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
+  if (parsedRuleGroups.length === 0) return null;
+
+  const setKey = makeAdditionalRulesSetKey(rulesText);
+  if (!setKey) return null;
+
+  const sourceNewUsers =
+    newUsersData && typeof newUsersData === 'object'
+      ? newUsersData
+      : (await get(ref(database, 'newUsers'))).val() || {};
+
+  const userIds = mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups);
+
+  await set(ref(database, `${SEARCH_KEY_ROOT}/${setKey}`), {
+    setKey,
+    rulesText,
+    updatedAt: new Date().toISOString(),
+    userIds,
+  });
+
+  return { setKey, userIds: Object.keys(userIds) };
+};
+
+export const getIndexedNewUsersIdsByRules = async ({ rawRules }) => {
+  const setKey = makeAdditionalRulesSetKey(rawRules);
+  if (!setKey) return null;
+
+  const setSnap = await get(ref(database, `${SEARCH_KEY_ROOT}/${setKey}`));
+  if (!setSnap.exists()) return null;
+
+  const payload = setSnap.val() || {};
+  const userIds = Object.keys(payload.userIds || {});
+  return { setKey, userIds };
+};
+
+export const rebuildAllNewUsersFilterSetIndexes = async () => {
+  const [usersSnap, newUsersSnap, searchKeySnap] = await Promise.all([
+    get(ref(database, 'users')),
+    get(ref(database, 'newUsers')),
+    get(ref(database, SEARCH_KEY_ROOT)),
+  ]);
+
+  const usersMap = usersSnap.exists() ? usersSnap.val() || {} : {};
+  const newUsersMap = newUsersSnap.exists() ? newUsersSnap.val() || {} : {};
+  const searchKeyMap = searchKeySnap.exists() ? searchKeySnap.val() || {} : {};
+
+  const oldSetKeys = Object.keys(searchKeyMap).filter(key => String(key).startsWith('set_'));
+  await Promise.all(oldSetKeys.map(key => remove(ref(database, `${SEARCH_KEY_ROOT}/${key}`))));
+
+  const allRules = Object.values(usersMap)
+    .map(user => user?.additionalAccessRules)
+    .filter(rawRules =>
+      Array.isArray(rawRules)
+        ? rawRules.some(item => String(item || '').trim())
+        : String(rawRules || '').trim() !== ''
+    );
+
+  const uniqueRulesMap = new Map();
+  allRules.forEach(rawRules => {
+    const setKey = makeAdditionalRulesSetKey(rawRules);
+    if (setKey) uniqueRulesMap.set(setKey, rawRules);
+  });
+
+  let indexedSets = 0;
+  for (const rawRules of uniqueRulesMap.values()) {
+    const indexed = await buildNewUsersFilterSetIndex({
+      rawRules,
+      newUsersData: newUsersMap,
+    });
+    if (indexed?.setKey) indexedSets += 1;
+  }
+
+  return {
+    totalRuleSets: uniqueRulesMap.size,
+    indexedRuleSets: indexedSets,
+  };
+};


### PR DESCRIPTION
### Motivation
- Improve performance of additional-access lookups for `newUsers` by preindexing rule-based filter sets to avoid scanning buckets at runtime.
- Provide UI and tooling to build and rebuild these preindexed filter-set indexes when `additionalAccessRules` change.

### Description
- Add new utility `src/utils/newUsersFilterSetsIndex.js` which implements `makeAdditionalRulesSetKey`, `buildNewUsersFilterSetIndex`, `getIndexedNewUsersIdsByRules`, and `rebuildAllNewUsersFilterSetIndexes` and stores computed `set_<...>` entries under `searchKey` in the database.
- Update `Matching.jsx` to attempt loading `newUsers` matches from the preindexed sets via `getIndexedNewUsersIdsByRules`, falling back to the existing `searchKey` buckets logic on error or miss, and ensure `readIndexedIds` can read from a configurable root path via a `rootPath` parameter.
- Restrict additional-newUsers injection and filtering by `collectionSource` and use a local `allowedBySetKey` to short-circuit permission checks for `newUsers` when appropriate; adjust related `useEffect` dependencies and `SEARCH_KEY` roots for role buckets to `USERS_SEARCH_KEY_ROOT`.
- Update `ProfileForm.jsx` to trigger `buildNewUsersFilterSetIndex` during submit when `additionalAccessRules` change, add a `Reindex` control and `handleReindexAdditionalFilterSets` which calls `rebuildAllNewUsersFilterSetIndexes`, and provide UI state for reindexing progress.

### Testing
- No new automated tests were added for the index utilities in this change.
- Manual smoke checks were performed by invoking the `additionalAccessRules` update flow and using the reindex button to ensure `buildNewUsersFilterSetIndex` and `rebuildAllNewUsersFilterSetIndexes` run without thrown errors in the app runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7dae1987c8326a039fbe24171d84a)