### PR TITLE
Add RTDB shortcut icon to comment input

### DIFF
--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -2,6 +2,9 @@ import { handleChange, removeField } from './actions';
 import { useRef } from 'react';
 import { useAutoResize } from '../../hooks/useAutoResize';
 
+const buildRtdbLink = userId =>
+  `https://console.firebase.google.com/u/0/project/webringitapp/database/webringitapp-default-rtdb/data/~2FnewUsers~2F${encodeURIComponent(userId || '')}`;
+
 export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} }) => {
   // console.log('userData in RenderCommentInput :>> ', userData);
   const textareaRef = useRef(null);
@@ -52,9 +55,37 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
           resize: 'none',
           overflow: 'hidden',
           padding: '5px',
-          paddingRight: userData.myComment ? '22px' : '5px',
+          paddingRight: userData.myComment ? '44px' : '26px',
         }}
       />
+      {userData.userId && (
+        <a
+          href={buildRtdbLink(userData.userId)}
+          target="_blank"
+          rel="noreferrer"
+          title="Відкрити профіль в Firebase RTDB"
+          onClick={event => event.stopPropagation()}
+          style={{
+            position: 'absolute',
+            top: '4px',
+            right: userData.myComment ? '24px' : '6px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'inherit',
+            opacity: 0.75,
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.7" />
+            <rect x="3" y="10" width="18" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.7" />
+            <rect x="3" y="17" width="18" height="4" rx="1.5" stroke="currentColor" strokeWidth="1.7" />
+            <circle cx="7" cy="5.5" r="0.9" fill="currentColor" />
+            <circle cx="7" cy="12.5" r="0.9" fill="currentColor" />
+            <circle cx="7" cy="19" r="0.9" fill="currentColor" />
+          </svg>
+        </a>
+      )}
       {userData.myComment && (
         <button
           type="button"


### PR DESCRIPTION
### Motivation
- Provide a quick link from the comment input to the user record in Firebase RTDB so reviewers can open the raw entry in the Firebase console.

### Description
- Add `buildRtdbLink` to generate per-user RTDB console URLs and render a small server-style SVG link in the comment input area at the top-right. (`src/components/smallCard/FieldComment.js`)
- Adjust `textarea` `paddingRight` to avoid overlap with the new icon and the clear (`×`) button, and stop event propagation when the link is clicked so it doesn't trigger parent handlers.

### Testing
- Ran lint on the modified file with `npm run -s lint:js -- src/components/smallCard/FieldComment.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a7be297c8326ab95e5a0473edb25)