### PR TITLE
Fix myComment clear action visibility and undo/redo tracking

### DIFF
--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -61,7 +61,7 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
           aria-label="Очистити коментар"
           onClick={event => {
             event.stopPropagation();
-            removeField(userData.userId, 'myComment', setUsers, setState);
+            removeField(userData.userId, 'myComment', setUsers, setState, 'myComment', submitOptions);
           }}
           style={{
             position: 'absolute',

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -291,6 +291,7 @@ export const removeField = (
   setUsers,
   setState,
   removedKey = nestedKey,
+  options = {},
 ) => {
   const keys = nestedKey.split('.');
 
@@ -373,6 +374,13 @@ export const removeField = (
 
   const removalKey = removedKey ?? nestedKey;
   const removalList = removalKey ? [removalKey] : [];
+  const triggerHistorySnapshot = payload => {
+    if (typeof options?.onSubmitHistorySnapshot !== 'function') {
+      return;
+    }
+    const snapshot = payload && typeof payload === 'object' ? { ...payload } : payload;
+    options.onSubmitHistorySnapshot(snapshot);
+  };
 
   setUsers(prev => {
     const isMultiple =
@@ -389,7 +397,8 @@ export const removeField = (
       }
       const updatedUser = value ?? {};
       const newState = { ...prev, [userId]: updatedUser };
-          handleSubmit({ ...updatedUser, userId }, 'overwrite', removalList);
+      triggerHistorySnapshot({ ...updatedUser, userId });
+      handleSubmit({ ...updatedUser, userId }, 'overwrite', removalList);
       return newState;
     }
 
@@ -402,6 +411,7 @@ export const removeField = (
     if (!resolvedUserId) {
       return updated;
     }
+    triggerHistorySnapshot({ ...updated, userId: resolvedUserId });
     handleSubmit({ ...updated, userId: resolvedUserId }, 'overwrite', removalList);
     return updated;
   });

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -189,6 +189,10 @@ export const renderTopBlock = (
   };
 
   const submitOptions = { onSubmitHistorySnapshot };
+  const commentLinkStyle = {
+    ...commentRtdbLinkStyle,
+    right: cardData.myComment ? '36px' : commentRtdbLinkStyle.right,
+  };
 
   return (
     <div style={topBlockContainerStyle}>
@@ -237,7 +241,7 @@ export const renderTopBlock = (
             rel="noreferrer"
             title="Відкрити профіль в Firebase RTDB"
             onClick={event => event.stopPropagation()}
-            style={commentRtdbLinkStyle}
+            style={commentLinkStyle}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
               <rect x="3" y="3" width="18" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.7" />


### PR DESCRIPTION
### Motivation
- The RTDB quick-link in the top block was absolutely positioned on the right and could overlap the comment clear (`×`) button when `myComment` exists, making the button invisible. 
- Clearing `myComment` from the top block did not record a history snapshot, so the undo/redo arrows did not pick up this action. 
- The `removeField` path did not accept history options to emit `onSubmitHistorySnapshot` before persisting removals.

### Description
- Pass `submitOptions` into the `removeField` call inside `FieldComment` so the clear action carries history options (`FieldComment.js`).
- Extend `removeField` to accept an `options` parameter and call `options.onSubmitHistorySnapshot(...)` (via `triggerHistorySnapshot`) before `handleSubmit` in both multi-user and single-user update flows (`actions.js`).
- Move the RTDB quick-link slightly left when a comment exists by adding `commentLinkStyle` and using `right: cardData.myComment ? '36px' : commentRtdbLinkStyle.right` to avoid overlapping the clear button (`renderTopBlock.js`).
- Modified files: `src/components/smallCard/FieldComment.js`, `src/components/smallCard/actions.js`, `src/components/smallCard/renderTopBlock.js`.

### Testing
- Ran `npm run test -- --watch=false --runInBand src/utils/__tests__/cardsStorage.test.js` and the suite passed (`1` test suite, `6` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8bcc37c04832690eed016b3defe8b)