### PR TITLE
Make myComment clear button and RTDB link icon use three-dots accent color

### DIFF
--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -71,7 +71,7 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
             cursor: 'pointer',
             border: 'none',
             background: 'transparent',
-            color: 'inherit',
+            color: '#ebe0c2',
             fontSize: '18px',
             lineHeight: 1,
             padding: 0,

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -73,7 +73,7 @@ const commentRtdbLinkStyle = {
   justifyContent: 'center',
   width: '18px',
   height: '18px',
-  color: '#fff',
+  color: '#ebe0c2',
   backgroundColor: 'rgba(30, 30, 30, 0.7)',
   borderRadius: '4px',
   textDecoration: 'none',


### PR DESCRIPTION
### Motivation
- The clear (×) button inside the `myComment` textarea was inheriting a color that made it hard to see, and the backend RTDB link icon used a different color than the details toggle (three dots), causing inconsistent visibility and styling.

### Description
- Set the RTDB link icon color to the same accent color `#ebe0c2` in `src/components/smallCard/renderTopBlock.js` and set the clear-comment button color to `#ebe0c2` in `src/components/smallCard/FieldComment.js` so both match the details toggle.

### Testing
- Ran the production build with `npm run build` and it completed successfully (compiled and produced the `build` folder).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c2310b5483268aa5a663a50a4cfb)