### PR TITLE
Preserve `partialUserId` checkbox in SEARCH_ID_KEY_ONLY mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1527,7 +1527,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         ...enabledSearchKeys,
         searchId: true,
         equalToAllCards: true,
-        partialUserId: false,
+        // Не вимикаємо partialUserId примусово: якщо чекбокс увімкнений,
+        // користувач очікує пошук по ключах users/newUsers.
+        partialUserId: enabledSearchKeys.partialUserId,
       }
     : enabledSearchKeys;
 


### PR DESCRIPTION
### Motivation
- The `SEARCH_ID_KEY_ONLY` mode previously forced `partialUserId` off, which could silently disable partial `userId` searches against `users`/`newUsers` and produce no results.

### Description
- Restore `partialUserId` behavior by using `enabledSearchKeys.partialUserId` in the `effectiveEnabledSearchKeys` when `SEARCH_ID_KEY_ONLY` is active and add an inline comment; changed file `src/components/AddNewProfile.jsx`.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90baf204c8326a63363d01154af69)