### PR TITLE
ProfileForm: show detailed error toasts, handle submit rejections, and guard empty additional rules

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -791,8 +791,14 @@ export const ProfileForm = ({
       }
     } catch (error) {
       console.error('Failed to update additional access newUsers filter-set index', error);
+      const details = error?.message || String(error);
+      toast.error(`Не вдалося зберегти індексацію наборів фільтрів (${details})`);
     }
-    handleSubmit(payload, overwrite, delCondition);
+    Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
+      console.error('Failed to submit profile changes', error);
+      const details = error?.message || String(error);
+      toast.error(`Не вдалося зберегти зміни профілю (${details})`);
+    });
   }, [handleSubmit]);
 
   const handleReindexAdditionalFilterSets = useCallback(async () => {
@@ -804,7 +810,8 @@ export const ProfileForm = ({
       );
     } catch (error) {
       console.error('Failed to rebuild additional access filter-set indexes', error);
-      toast.error('Не вдалося перебудувати індексацію наборів фільтрів');
+      const details = error?.message || String(error);
+      toast.error(`Не вдалося перебудувати індексацію наборів фільтрів (${details})`);
     } finally {
       setIsReindexingFilterSets(false);
     }
@@ -852,6 +859,10 @@ export const ProfileForm = ({
 
   const applyAdditionalRulesFromBuilder = () => {
     const rulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+    if (!rulesText.trim()) {
+      toast.error('Оберіть щонайменше один фільтр перед застосуванням');
+      return;
+    }
     setState(prevState => {
       const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
       const updatedValue = Array.isArray(currentValue)


### PR DESCRIPTION
### Motivation

- Surface actionable error information to users when indexing or submitting profile changes fails by showing toast messages with error details. 
- Prevent submitting or applying empty additional-access rules to avoid creating invalid/empty filter sets. 
- Ensure rejected promises from `handleSubmit` are caught so errors are logged and reported to the user. 

### Description

- Added detailed error toasts that include the error message when `buildNewUsersFilterSetIndex` fails. 
- Wrapped `handleSubmit(payload, overwrite, delCondition)` with `Promise.resolve(...).catch(...)` to catch and report rejected promises and log the error. 
- Included the error details in the toast shown when `rebuildAllNewUsersFilterSetIndexes` fails. 
- Added a guard in `applyAdditionalRulesFromBuilder` that prevents applying an empty rules text and shows a toast error `Оберіть щонайменше один фільтр перед застосуванням`. 

### Testing

- Ran the frontend unit tests with `yarn test` and the test suite passed. 
- Ran linting with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e919ce152c8326bffb6bb4cddd8ebb)