### PR TITLE
Add dedicated `searchKeySets` root for additional-access filter sets and update lookups

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -92,6 +92,7 @@ const nestedIndentStyle = {
 
 const ADDITIONAL_ACCESS_FIELD = 'additionalAccessRules';
 const SEARCH_KEY_ROOT = 'searchKey';
+const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const ADDITIONAL_RULE_LABELS = {
   age: 'Вік',
   csection: 'КС',
@@ -631,9 +632,9 @@ export const ProfileForm = ({
         const indexedSetKey = makeAdditionalRulesSetKey(combinedDraftText);
         if (indexedSetKey) {
           const indexedPayload = await getCachedSearchKeyPayload(
-            `${SEARCH_KEY_ROOT}/${indexedSetKey}`,
+            `${SEARCH_KEY_SETS_ROOT}/${indexedSetKey}`,
             async () => {
-              const indexedSnapshot = await get(refDb(database, `${SEARCH_KEY_ROOT}/${indexedSetKey}`));
+              const indexedSnapshot = await get(refDb(database, `${SEARCH_KEY_SETS_ROOT}/${indexedSetKey}`));
               return {
                 exists: indexedSnapshot.exists(),
                 value: indexedSnapshot.exists() ? indexedSnapshot.val() || {} : null,
@@ -642,7 +643,7 @@ export const ProfileForm = ({
           );
 
           if (indexedPayload?.exists) {
-            const indexedUserIds = Object.keys(indexedPayload.value?.userIds || {});
+            const indexedUserIds = Object.keys(indexedPayload.value || {});
             if (!cancelled) {
               setAvailableCardsCount(indexedUserIds.length);
             }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -7,6 +7,7 @@ import {
 } from './additionalAccessRules';
 
 const SEARCH_KEY_ROOT = 'searchKey';
+const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_MAX_LENGTH = 512;
 
 const toStableRulesText = raw =>
@@ -97,12 +98,7 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
 
   const userIds = mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups);
 
-  await set(ref(database, `${SEARCH_KEY_ROOT}/${setKey}`), {
-    setKey,
-    rulesText,
-    updatedAt: new Date().toISOString(),
-    userIds,
-  });
+  await set(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`), userIds);
 
   return { setKey, userIds: Object.keys(userIds) };
 };
@@ -111,27 +107,41 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules }) => {
   const setKey = makeAdditionalRulesSetKey(rawRules);
   if (!setKey) return null;
 
-  const setSnap = await get(ref(database, `${SEARCH_KEY_ROOT}/${setKey}`));
-  if (!setSnap.exists()) return null;
+  const [newSetSnap, legacySetSnap] = await Promise.all([
+    get(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`)),
+    get(ref(database, `${SEARCH_KEY_ROOT}/${setKey}`)),
+  ]);
 
-  const payload = setSnap.val() || {};
-  const userIds = Object.keys(payload.userIds || {});
-  return { setKey, userIds };
+  if (newSetSnap.exists()) {
+    const payload = newSetSnap.val() || {};
+    return { setKey, userIds: Object.keys(payload || {}) };
+  }
+
+  if (!legacySetSnap.exists()) return null;
+
+  const legacyPayload = legacySetSnap.val() || {};
+  return { setKey, userIds: Object.keys(legacyPayload.userIds || {}) };
 };
 
 export const rebuildAllNewUsersFilterSetIndexes = async () => {
-  const [usersSnap, newUsersSnap, searchKeySnap] = await Promise.all([
+  const [usersSnap, newUsersSnap, searchKeySnap, searchKeySetsSnap] = await Promise.all([
     get(ref(database, 'users')),
     get(ref(database, 'newUsers')),
     get(ref(database, SEARCH_KEY_ROOT)),
+    get(ref(database, SEARCH_KEY_SETS_ROOT)),
   ]);
 
   const usersMap = usersSnap.exists() ? usersSnap.val() || {} : {};
   const newUsersMap = newUsersSnap.exists() ? newUsersSnap.val() || {} : {};
   const searchKeyMap = searchKeySnap.exists() ? searchKeySnap.val() || {} : {};
+  const searchKeySetsMap = searchKeySetsSnap.exists() ? searchKeySetsSnap.val() || {} : {};
 
   const oldSetKeys = Object.keys(searchKeyMap).filter(key => String(key).startsWith('set_'));
-  await Promise.all(oldSetKeys.map(key => remove(ref(database, `${SEARCH_KEY_ROOT}/${key}`))));
+  const oldSetKeysInDedicatedRoot = Object.keys(searchKeySetsMap).filter(key => String(key).startsWith('set_'));
+  await Promise.all([
+    ...oldSetKeys.map(key => remove(ref(database, `${SEARCH_KEY_ROOT}/${key}`))),
+    ...oldSetKeysInDedicatedRoot.map(key => remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${key}`))),
+  ]);
 
   const allRules = Object.values(usersMap)
     .map(user => user?.additionalAccessRules)


### PR DESCRIPTION
### Motivation
- Separate indexed additional-access filter sets into a dedicated database path to simplify storage format and lookups.
- Ensure new reads prefer the new `searchKeySets` root while remaining compatible with the legacy `searchKey` format.
- Remove legacy metadata wrapper around stored set user IDs to make indexing and lookup cheaper and more consistent.

### Description
- Introduced `SEARCH_KEY_SETS_ROOT = 'searchKeySets'` and switched set writes to that root in `buildNewUsersFilterSetIndex`, storing only the user ID map instead of an object with metadata.
- Updated `getIndexedNewUsersIdsByRules` to prefer the new `searchKeySets` entry and fall back to the legacy `searchKey` format for backward compatibility.
- Updated `rebuildAllNewUsersFilterSetIndexes` to read both `searchKey` and `searchKeySets`, and to remove old set keys from both roots during rebuilds.
- Updated `ProfileForm.jsx` lookup logic to check the `searchKeySets` root for precomputed set indexes and to interpret the stored value as a direct user ID map when present.

### Testing
- Ran the automated test suite via `npm test`, and all tests passed.
- Ran linters (`eslint`) and type checks, and there were no new lint/type errors reported.
- Exercised the rebuild and lookup flows against a dev Firebase instance to verify reads/writes to `searchKeySets` and legacy fallback behavior (manual integration assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e931af2bac832693ae2cdf75df2881)