### PR TITLE
Add `pp` role category to searchKey role filters and index mapping

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -4,7 +4,7 @@ import { REACTION_FILTER_DEFAULTS } from 'utils/reactionCategory';
 
 const defaultsAdd = {
   csection: { cs2plus: true, cs1: true, cs0: true, no: true, other: true },
-  role: { ed: true, sm: true, ag: true, ip: true, cl: true, other: true, empty: true },
+  role: { ed: true, sm: true, ag: true, ip: true, pp: true, cl: true, other: true, empty: true },
   maritalStatus: { married: true, unmarried: true, other: true, empty: true },
   bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },
   rh: { '+': true, '-': true, other: true, empty: true },

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -133,6 +133,7 @@ export const SearchFilters = ({
           { val: 'sm', label: 'sm' },
           { val: 'ag', label: 'ag' },
           { val: 'ip', label: 'ip' },
+          { val: 'pp', label: 'pp' },
           { val: 'cl', label: 'cl' },
           { val: 'other', label: '?' },
           ...(bloodSearchKeyMode

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2676,6 +2676,7 @@ export const normalizeRoleSearchKeyIndexValue = (roleValue, userRoleValue) => {
     if (normalized === 'sm') return 'sm';
     if (normalized === 'ag') return 'ag';
     if (normalized === 'ip') return 'ip';
+    if (normalized === 'pp') return 'pp';
     if (normalized === 'cl') return 'cl';
     return '?';
   };
@@ -2818,7 +2819,7 @@ const isBucketAllowedByFilters = (bucket, filterSettings = {}) => {
 
 const MARITAL_STATUS_SEARCH_KEY_BUCKETS = ['+', '-', '?', 'no'];
 const CONTACT_SEARCH_KEY_BUCKETS = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'];
-const ROLE_SEARCH_KEY_BUCKETS = ['ed', 'sm', 'ag', 'ip', 'cl', '?', 'no'];
+const ROLE_SEARCH_KEY_BUCKETS = ['ed', 'sm', 'ag', 'ip', 'pp', 'cl', '?', 'no'];
 const USER_ID_SEARCH_KEY_BUCKETS = ['vk', 'aa', 'ab', 'long', 'mid', 'other'];
 const IMT_SEARCH_KEY_BUCKETS = ['le28', '29_31', '32_35', '36_plus', '?', 'no'];
 
@@ -2848,7 +2849,7 @@ const isContactBucketAllowedByFilters = (bucket, filterSettings = {}) => {
 
 const getRoleFilterKey = bucket => {
   const normalizedBucket = String(bucket || '').trim().toLowerCase();
-  if (['ed', 'sm', 'ag', 'ip', 'cl'].includes(normalizedBucket)) return normalizedBucket;
+  if (['ed', 'sm', 'ag', 'ip', 'pp', 'cl'].includes(normalizedBucket)) return normalizedBucket;
   if (normalizedBucket === 'no') return 'empty';
   return 'other';
 };


### PR DESCRIPTION
### Motivation
- Introduce a new `pp` (potential partners) role category so it can be selected in the role checkboxes and be part of searchKey-based indexing and filtering.

### Description
- Enable `pp` by default in the role filter defaults in `FilterPanel.jsx` so the checkbox is present and checked.
- Add a `pp` option to the role UI options in `SearchFilters.jsx` so users can toggle this bucket in the filters.
- Update role normalization and indexing logic in `config.js` to recognize `pp`, include it in `ROLE_SEARCH_KEY_BUCKETS`, and map it in `getRoleFilterKey` so `pp` is indexed and filterable.

### Testing
- Ran the automated test suite with `npm run test -- --watchAll=false --runInBand`.
- Result: most tests passed but the suite reports `1 failed, 15 passed` (2 failing tests in `src/utils/__tests__/parseUkTrigger.test.js`) which are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b4713bbc83268425da64b80fd18c)