### PR TITLE
Add placeholder colored top button row inside renderTopBlock

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -23,6 +23,22 @@ import toast from 'react-hot-toast';
 
 const topBlockContainerStyle = { padding: '7px', position: 'relative' };
 
+const topButtonsRowStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+  gap: '6px',
+  marginBottom: '8px',
+};
+
+const topButtonsZoneStyle = {
+  border: 'none',
+  borderRadius: '6px',
+  minHeight: '24px',
+  cursor: 'default',
+};
+
+const topButtonsZones = ['#5c6bc0', '#26a69a', '#ffb74d', '#ef5350'];
+
 const actionButtonsContainerStyle = {
   position: 'absolute',
   top: '10px',
@@ -196,6 +212,11 @@ export const renderTopBlock = (
 
   return (
     <div style={topBlockContainerStyle}>
+      <div style={topButtonsRowStyle}>
+        {topButtonsZones.map((color, idx) => (
+          <button key={`top-zone-${idx}`} type="button" aria-label={`top-zone-${idx + 1}`} style={{ ...topButtonsZoneStyle, backgroundColor: color }} />
+        ))}
+      </div>
       <div style={actionButtonsContainerStyle}>
         {showSaveDeleteButtons && btnExport(cardData)}
         {showSaveDeleteButtons && btnDel(cardData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}


### PR DESCRIPTION
### Motivation
- Додати візуальний пустий блок кнопок поверх картки в `renderTopBlock` як контейнер для майбутніх зон/кнопок, при цьому блок має бути всередині існуючого контейнера і не розривати поточну верстку.

### Description
- Додано стилі `topButtonsRowStyle` і `topButtonsZoneStyle` та масив кольорів `topButtonsZones` у `src/components/smallCard/renderTopBlock.js`.
- Вставлено JSX рядок над існуючими діями зі створенням 4 рівних зон-кнопок через `topButtonsZones.map(...)`, причому кнопки є заповнювачами без обробників (порожні зони, кожна свого кольору).
- Блок розміщено всередині контейнера `topBlockContainerStyle`, щоб залишити його тісно пов’язаним із `renderTopBlock`.

### Testing
- Запущено `npx eslint src/components/smallCard/renderTopBlock.js` і перевірка пройшла успішно (попередження `browserslist` не перешкодили лінтингу).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea026726048326a5ec80f5fc1c1be9)