### PR TITLE
Move RTDB open action to userId and remove duplicate comment RTDB button

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -80,23 +80,6 @@ const commentFieldWrapperStyle = {
   position: 'relative',
 };
 
-const commentRtdbLinkStyle = {
-  position: 'absolute',
-  top: '4px',
-  right: '10px',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '18px',
-  height: '18px',
-  color: '#ebe0c2',
-  backgroundColor: 'rgba(30, 30, 30, 0.7)',
-  borderRadius: '4px',
-  textDecoration: 'none',
-  opacity: 0.95,
-  zIndex: 5,
-};
-
 const detailsToggleStyle = {
   position: 'absolute',
   bottom: '10px',
@@ -205,11 +188,6 @@ export const renderTopBlock = (
   };
 
   const submitOptions = { onSubmitHistorySnapshot };
-  const commentLinkStyle = {
-    ...commentRtdbLinkStyle,
-    right: cardData.myComment ? '36px' : commentRtdbLinkStyle.right,
-  };
-
   return (
     <div style={topBlockContainerStyle}>
       <div style={topButtonsRowStyle}>
@@ -226,7 +204,18 @@ export const renderTopBlock = (
       <div>
         {cardData.lastAction && formatDateToDisplay(normalizeLastAction(cardData.lastAction))}
         {cardData.lastAction && ', '}
-        {cardData.userId}
+        {cardData.userId && (
+          <a
+            href={buildRtdbLink(cardData.userId)}
+            target="_blank"
+            rel="noreferrer"
+            title="Відкрити профіль в Firebase RTDB"
+            onClick={event => event.stopPropagation()}
+            style={{ color: 'inherit', textDecoration: 'underline' }}
+          >
+            {cardData.userId}
+          </a>
+        )}
         {!isAgentOrIP &&
           fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, favoriteUsers, setFavoriteUsers, dislikeUsers, setDislikeUsers, submitOptions)}
         {fieldRole(cardData, setUsers, setState, submitOptions)}
@@ -255,25 +244,6 @@ export const renderTopBlock = (
       </div>
       {fieldWriter(cardData, setUsers, setState, submitOptions)}
       <div style={commentFieldWrapperStyle}>
-        {cardData.userId && (
-          <a
-            href={buildRtdbLink(cardData.userId)}
-            target="_blank"
-            rel="noreferrer"
-            title="Відкрити профіль в Firebase RTDB"
-            onClick={event => event.stopPropagation()}
-            style={commentLinkStyle}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <rect x="3" y="3" width="18" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.7" />
-              <rect x="3" y="10" width="18" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.7" />
-              <rect x="3" y="17" width="18" height="4" rx="1.5" stroke="currentColor" strokeWidth="1.7" />
-              <circle cx="7" cy="5.5" r="0.9" fill="currentColor" />
-              <circle cx="7" cy="12.5" r="0.9" fill="currentColor" />
-              <circle cx="7" cy="19" r="0.9" fill="currentColor" />
-            </svg>
-          </a>
-        )}
         <FieldComment userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />
       </div>
 


### PR DESCRIPTION
### Motivation
- Make the backend-open action available when clicking the visible `userId` in the top block so users can open the Firebase RTDB for a card from the most obvious place.
- Remove a duplicated RTDB-opening control that was rendered next to the `myComment` input to avoid redundant UI and simplify the comment area.

### Description
- Updated `src/components/smallCard/renderTopBlock.js` to render `cardData.userId` as a clickable `<a>` that opens the Firebase RTDB path (`buildRtdbLink`) in a new tab and calls `event.stopPropagation()` to avoid triggering card click handlers.
- Removed the RTDB SVG button previously rendered inside the comment area and the related `commentRtdbLinkStyle`/`commentLinkStyle` constants since they are no longer used.
- Kept `FieldComment` intact so the comment input remains, but without the duplicated backend-open control.

### Testing
- Ran `npm run -s lint:js -- src/components/smallCard/renderTopBlock.js`, which completed successfully (no lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea05e5d6808326b81d49efe8d4aa5f)