### PR TITLE
Refactor top-card action buttons, expose search setter, and simplify GetInTouch field

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -3,7 +3,6 @@ import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import { btnCompare } from './smallCard/btnCompare';
-import { btnEdit } from './smallCard/btnEdit';
 import { btnMore } from './smallCard/btnMore';
 import { renderAllFields } from './ProfileForm';
 // import { btnExportUsers } from './topBtns/btnExportUsers';
@@ -15,6 +14,7 @@ const UserCard = ({
   userData,
   setUsers,
   setShowInfoModal,
+  setSearch,
   setState,
   setUserIdToDelete,
   onOpenMedications,
@@ -50,6 +50,7 @@ const UserCard = ({
           currentFilter,
           isDateInRange,
           onOpenMedications,
+          setSearch,
           actions
         )}
       </div>
@@ -174,6 +175,7 @@ const UsersList = ({
               setShowInfoModal={setShowInfoModal}
               userData={userData}
               setUsers={setUsers}
+              setSearch={setSearch}
               setState={setState}
               setUserIdToDelete={setUserIdToDelete}
               onOpenMedications={onOpenMedications}
@@ -185,9 +187,6 @@ const UsersList = ({
               isDateInRange={isDateInRange}
               actions={
                 <>
-                  {btnEdit(userData, setSearch, setState, {
-                    backgroundColor: '#FF8C00',
-                  })}
                   {btnCompare(index, users, setUsers, setShowInfoModal, setCompare)}
                   {btnMore(userData, onOpenMoreActions)}
                 </>

--- a/src/components/smallCard/btnDel.js
+++ b/src/components/smallCard/btnDel.js
@@ -6,11 +6,17 @@ export const btnDel = (
   setShowInfoModal,
   setUserIdToDelete,
   isFromListOfUsers = false,
+  content = 'del',
+  customStyle = {},
 ) => (
   <CardMenuBtn
     style={{
       backgroundColor: 'red',
       position: 'static',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      ...customStyle,
     }}
     onClick={e => {
       e.stopPropagation(); // Запобігаємо активації кліку картки
@@ -20,6 +26,6 @@ export const btnDel = (
       setShowInfoModal('delConfirm');
     }}
   >
-    del
+    {content}
   </CardMenuBtn>
 );

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -19,6 +19,8 @@ export const BtnDislike = ({
   onRemove,
   favoriteUsers = {},
   setFavoriteUsers,
+  customStyle = {},
+  iconSize = 18,
 }) => {
   const isDisliked = !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
@@ -86,6 +88,7 @@ export const BtnDislike = ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        ...customStyle,
       }}
       disabled={!auth.currentUser}
       onClick={e => {
@@ -93,7 +96,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={18} color={isDisliked ? activeColor : color.reactionIdleIcon} />
+      <FaTimes size={iconSize} color={isDisliked ? activeColor : color.reactionIdleIcon} />
     </button>
   );
 };

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -5,7 +5,7 @@ import { normalizeQueryKey, setIdsForQuery } from '../../utils/cardIndex';
 import { saveCard } from '../../utils/cardsStorage';
 
 // Use already loaded card data instead of re-fetching from the server
-export const btnEdit = (userData, setSearch, setState, style = {}) => {
+export const btnEdit = (userData, setSearch, setState, style = {}, content = 'edit') => {
   const handleCardClick = () => {
     if (userData) {
       setSearch(`${userData.userId}`);
@@ -29,7 +29,7 @@ export const btnEdit = (userData, setSearch, setState, style = {}) => {
         handleCardClick();
       }}
     >
-      edit
+      {content}
     </CardMenuBtn>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -19,6 +19,8 @@ export const BtnFavorite = ({
   onRemove,
   dislikeUsers = {},
   setDislikeUsers,
+  customStyle = {},
+  iconSize = 18,
 }) => {
   const isFavorite = !!favoriteUsers[userId];
   const activeColor = color.reactionLike;
@@ -85,6 +87,7 @@ export const BtnFavorite = ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        ...customStyle,
       }}
       disabled={!auth.currentUser}
       onClick={e => {
@@ -93,9 +96,9 @@ export const BtnFavorite = ({
       }}
     >
       {isFavorite ? (
-        <FaHeart size={18} color={activeColor} />
+        <FaHeart size={iconSize} color={activeColor} />
       ) : (
-        <FaRegHeart size={18} color={color.reactionIdleIcon} />
+        <FaRegHeart size={iconSize} color={color.reactionIdleIcon} />
       )}
     </button>
   );

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -4,18 +4,7 @@ import {
   formatDateAndFormula,
   formatDateToServer,
 } from 'components/inputValidations';
-import { OrangeBtn, UnderlinedInput, color } from 'components/styles';
-import {
-  addDislikeUser,
-  removeDislikeUser,
-  addFavoriteUser,
-  removeFavoriteUser,
-  auth,
-} from '../config';
-import { updateCachedUser, setFavoriteIds } from 'utils/cache';
-import { setFavorite } from 'utils/favoritesStorage';
-import { setDislike } from 'utils/dislikesStorage';
-import { FaTimes, FaHeart, FaRegHeart } from 'react-icons/fa';
+import { OrangeBtn, UnderlinedInput } from 'components/styles';
 
 export const fieldGetInTouch = (
   userData,
@@ -23,24 +12,8 @@ export const fieldGetInTouch = (
   setState,
   currentFilter,
   isDateInRange,
-  favoriteUsers = {},
-  setFavoriteUsers = () => {},
-  dislikeUsers = {},
-  setDislikeUsers = () => {},
   submitOptions = {},
 ) => {
-  const handleSendToEnd = () => {
-    handleChange(
-      setUsers,
-      setState,
-      userData.userId,
-      'getInTouch',
-      '2099-99-99',
-      true,
-      { currentFilter, isDateInRange, ...submitOptions },
-    );
-  };
-
   const handleAddDays = days => {
     const currentDate = new Date();
     currentDate.setDate(currentDate.getDate() + days);
@@ -60,9 +33,6 @@ export const fieldGetInTouch = (
       { currentFilter, isDateInRange, ...submitOptions },
     );
   };
-
-  const isFavorite = !!favoriteUsers[userData.userId];
-  const isDisliked = !!dislikeUsers[userData.userId];
 
   const targetId = userData?.userId;
 
@@ -106,109 +76,6 @@ export const fieldGetInTouch = (
 
         return prev;
       });
-    }
-  };
-
-  const handleDislike = async e => {
-    e.stopPropagation();
-    if (!auth.currentUser) {
-      alert('Please sign in to manage dislikes');
-      return;
-    }
-    if (isDisliked) {
-      try {
-        await removeDislikeUser(userData.userId);
-        const updated = { ...dislikeUsers };
-        delete updated[userData.userId];
-        setDislikeUsers(updated);
-        setDislike(userData.userId, false);
-        handleChange(
-          setUsers,
-          setState,
-          userData.userId,
-          'getInTouch',
-          '',
-          true,
-          { currentFilter, isDateInRange, ...submitOptions },
-        );
-      } catch (error) {
-        console.error('Failed to remove dislike:', error);
-      }
-    } else {
-      handleSendToEnd();
-      try {
-        await addDislikeUser(userData.userId);
-        const updated = { ...dislikeUsers, [userData.userId]: true };
-        setDislikeUsers(updated);
-        setDislike(userData.userId, true);
-        if (favoriteUsers[userData.userId]) {
-          try {
-            await removeFavoriteUser(userData.userId);
-          } catch (err) {
-            console.error('Failed to remove favorite when adding dislike:', err);
-          }
-          const upd = { ...favoriteUsers };
-          delete upd[userData.userId];
-          setFavoriteUsers(upd);
-          setFavoriteIds(upd);
-          setFavorite(userData.userId, false);
-          updateCachedUser(userData, { removeFavorite: true });
-        }
-      } catch (error) {
-        console.error('Failed to add dislike:', error);
-      }
-    }
-  };
-
-  const handleLike = async e => {
-    e.stopPropagation();
-    if (!auth.currentUser) {
-      alert('Please sign in to manage favorites');
-      return;
-    }
-    if (isFavorite) {
-      try {
-        await removeFavoriteUser(userData.userId);
-        const updated = { ...favoriteUsers };
-        delete updated[userData.userId];
-        setFavoriteUsers(updated);
-        setFavoriteIds(updated);
-        setFavorite(userData.userId, false);
-        updateCachedUser(userData, { removeFavorite: true });
-      } catch (error) {
-        console.error('Failed to remove favorite:', error);
-      }
-    } else {
-      try {
-        await addFavoriteUser(userData.userId);
-        const updated = { ...favoriteUsers, [userData.userId]: true };
-        setFavoriteUsers(updated);
-        setFavoriteIds(updated);
-        setFavorite(userData.userId, true);
-        updateCachedUser(userData);
-        if (dislikeUsers[userData.userId]) {
-          try {
-            await removeDislikeUser(userData.userId);
-          } catch (err) {
-            console.error('Failed to remove dislike when adding favorite:', err);
-          }
-          const upd = { ...dislikeUsers };
-          delete upd[userData.userId];
-          setDislikeUsers(upd);
-          setDislike(userData.userId, false);
-          handleChange(
-            setUsers,
-            setState,
-            userData.userId,
-            'getInTouch',
-            '',
-            true,
-            { currentFilter, isDateInRange, ...submitOptions },
-          );
-        }
-      } catch (error) {
-        console.error('Failed to add favorite:', error);
-      }
     }
   };
 
@@ -315,40 +182,6 @@ export const fieldGetInTouch = (
       <ActionButton label="3м" days={90} onClick={handleAddDays} />
       <ActionButton label="6м" days={180} onClick={handleAddDays} />
       <ActionButton label="1р" days={365} onClick={handleAddDays} />
-      <OrangeBtn
-        onClick={handleDislike}
-        style={{
-          width: '25px',
-          height: '25px',
-          marginLeft: '5px',
-          marginRight: 0,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          border: `${isDisliked ? 2 : 0}px solid ${color.iconActive}`,
-        }}
-      >
-        <FaTimes size={18} color={isDisliked ? color.iconActive : color.white} />
-      </OrangeBtn>
-      <OrangeBtn
-        onClick={handleLike}
-        style={{
-          width: '25px',
-          height: '25px',
-          marginLeft: '5px',
-          marginRight: 0,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          border: `${isFavorite ? 2 : 0}px solid ${color.iconInactive}`,
-        }}
-      >
-        {isFavorite ? (
-          <FaHeart size={18} color={color.iconInactive} />
-        ) : (
-          <FaRegHeart size={18} color={color.white} />
-        )}
-      </OrangeBtn>
     </div>
   );
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
+import { btnEdit } from './btnEdit';
+import { BtnFavorite } from './btnFavorite';
+import { BtnDislike } from './btnDislike';
 import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
@@ -33,15 +36,29 @@ const topButtonsRowStyle = {
 const topButtonsZoneStyle = {
   border: 'none',
   borderRadius: '6px',
-  minHeight: '24px',
+  minHeight: '32px',
   cursor: 'default',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 };
 
 const topButtonsZones = ['#5c6bc0', '#26a69a', '#ffb74d', '#ef5350'];
 
+const zoneActionButtonStyle = {
+  position: 'static',
+  width: '26px',
+  height: '26px',
+  minHeight: '26px',
+  borderRadius: '6px',
+  border: 'none',
+  margin: 0,
+  padding: 0,
+};
+
 const actionButtonsContainerStyle = {
   position: 'absolute',
-  top: '10px',
+  top: '52px',
   right: '10px',
   display: 'flex',
   flexDirection: 'column',
@@ -175,6 +192,7 @@ export const renderTopBlock = (
   currentFilter,
   isDateInRange,
   onOpenMedications,
+  setSearch = null,
   additionalActions = null,
   overlayFieldAdditions = {},
   onSubmitHistorySnapshot = null
@@ -213,13 +231,65 @@ export const renderTopBlock = (
   return (
     <div style={topBlockContainerStyle}>
       <div style={topButtonsRowStyle}>
-        {topButtonsZones.map((color, idx) => (
-          <button key={`top-zone-${idx}`} type="button" aria-label={`top-zone-${idx + 1}`} style={{ ...topButtonsZoneStyle, backgroundColor: color }} />
+        {topButtonsZones.map((zoneColor, idx) => (
+          <div key={`top-zone-${idx}`} aria-label={`top-zone-${idx + 1}`} style={{ ...topButtonsZoneStyle, backgroundColor: zoneColor }}>
+            {idx === 0 &&
+              showSaveDeleteButtons &&
+              btnDel(
+                cardData,
+                setShowInfoModal,
+                setUserIdToDelete,
+                isFromListOfUsers,
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M4 7h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <path d="M7 7l1 12a1 1 0 0 0 1 .9h6a1 1 0 0 0 1-.9L17 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <path d="M10 11v5M14 11v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </svg>,
+                { ...zoneActionButtonStyle, backgroundColor: '#ef5350', color: '#fff' }
+              )}
+            {idx === 1 && (
+              <BtnFavorite
+                userId={cardData.userId}
+                userData={cardData}
+                favoriteUsers={favoriteUsers}
+                setFavoriteUsers={setFavoriteUsers}
+                dislikeUsers={dislikeUsers}
+                setDislikeUsers={setDislikeUsers}
+                customStyle={zoneActionButtonStyle}
+                iconSize={15}
+              />
+            )}
+            {idx === 2 &&
+              isFromListOfUsers &&
+              typeof setSearch === 'function' &&
+              btnEdit(
+                cardData,
+                setSearch,
+                setState,
+                { ...zoneActionButtonStyle, backgroundColor: '#ff9800', color: '#fff' },
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+                  <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+                </svg>
+              )}
+            {idx === 3 && (
+              <BtnDislike
+                userId={cardData.userId}
+                userData={cardData}
+                dislikeUsers={dislikeUsers}
+                setDislikeUsers={setDislikeUsers}
+                favoriteUsers={favoriteUsers}
+                setFavoriteUsers={setFavoriteUsers}
+                customStyle={zoneActionButtonStyle}
+                iconSize={15}
+              />
+            )}
+          </div>
         ))}
       </div>
       <div style={actionButtonsContainerStyle}>
         {showSaveDeleteButtons && btnExport(cardData)}
-        {showSaveDeleteButtons && btnDel(cardData, setShowInfoModal, setUserIdToDelete, isFromListOfUsers)}
         {btnMedications(cardData, onOpenMedications)}
         {additionalActions}
       </div>
@@ -228,7 +298,7 @@ export const renderTopBlock = (
         {cardData.lastAction && ', '}
         {cardData.userId}
         {!isAgentOrIP &&
-          fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, favoriteUsers, setFavoriteUsers, dislikeUsers, setDislikeUsers, submitOptions)}
+          fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, submitOptions)}
         {fieldRole(cardData, setUsers, setState, submitOptions)}
         {!isAgentOrIP && <FieldLastCycle userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />}
         <div>{fieldDeliveryInfo(setUsers, setState, cardData, submitOptions)}</div>


### PR DESCRIPTION
### Motivation

- Make top action buttons more consistent, icon-friendly and style-customizable for card list UX.  
- Allow opening/editing a user from the list by exposing the search setter to top-block buttons.  
- Simplify and decouple the GetInTouch UI by removing embedded favorite/dislike actions and related side-effects.

### Description

- Added `setSearch` prop propagation: `UsersList` now passes `setSearch` into `UserCard` and `renderTopBlock` so top-zone actions can trigger a search/edit flow.  
- Reworked top button layout in `renderTopBlock` to render four colored zones and placed action controls inside them, adding icons and using a shared `zoneActionButtonStyle`; increased zone `minHeight` and centered content.  
- Introduced richer, reusable action controls: `btnEdit` now accepts custom `content` (icon/text) and `btnDel` accepts `content` and `customStyle`; `BtnFavorite` and `BtnDislike` now accept `customStyle` and `iconSize` and apply those to their buttons.  
- Removed the inline favorite/dislike controls and all related imports/handlers from `fieldGetInTouch`, keeping it focused on date input and relative-day buttons; cleaned up unused code and imports.  
- Adjusted action buttons container positioning (`top` moved to `52px`) and updated a few style defaults (e.g., zone min height, zone button sizing and alignment).  

### Testing

- Ran the project build with `yarn build` and the frontend compiled successfully.  
- Ran the test suite with `yarn test` and unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea066ee0a88326a24104b3f7b11a5f)