### PR TITLE
Remove underline from userId link in renderTopBlock

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -281,7 +281,7 @@ export const renderTopBlock = (
             rel="noreferrer"
             title="Відкрити профіль в Firebase RTDB"
             onClick={event => event.stopPropagation()}
-            style={{ color: 'inherit', textDecoration: 'underline' }}
+            style={{ color: 'inherit', textDecoration: 'none' }}
           >
             {cardData.userId}
           </a>


### PR DESCRIPTION
### Motivation
- Make the `userId` link in the top card block visually consistent by removing the default underline.

### Description
- Update `src/components/smallCard/renderTopBlock.js` to set the anchor style to `textDecoration: 'none'` for the element that renders `cardData.userId`.

### Testing
- No automated tests were run for this small style-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0b8832e88326b4e59664e631de52)