### PR TITLE
Refine top navigation buttons in renderTopBlock

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -26,23 +26,26 @@ import toast from 'react-hot-toast';
 const topBlockContainerStyle = { padding: '7px', position: 'relative' };
 
 const topButtonsRowStyle = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
-  gap: '6px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: '8px',
   marginBottom: '8px',
 };
 
 const topButtonsZoneStyle = {
   border: 'none',
-  borderRadius: '6px',
-  minHeight: '32px',
+  borderRadius: '12px',
   cursor: 'pointer',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '100%',
-  height: '100%',
+  width: '40px',
+  height: '40px',
+  flex: '0 0 40px',
   padding: 0,
+  boxShadow: '0 6px 14px rgba(17, 24, 39, 0.2)',
+  transition: 'transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease',
 };
 
 const topButtonsZones = ['#d32f2f', '#ef6c00', '#f9a825', '#2e7d32', '#0288d1', '#1565c0', '#6a1b9a'];
@@ -51,11 +54,12 @@ const zoneActionButtonStyle = {
   position: 'static',
   width: '100%',
   height: '100%',
-  minHeight: '32px',
-  borderRadius: '6px',
+  minHeight: '40px',
+  borderRadius: '12px',
   border: 'none',
   margin: 0,
   padding: 0,
+  boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.2)',
 };
 
 const actionButtonsContainerStyle = {
@@ -299,8 +303,6 @@ export const renderTopBlock = (
                   <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
                 </svg>
               )}
-            )}
-
             {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
             {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>


### PR DESCRIPTION
### Motivation
- Remove a stray closing artifact that was rendering next to SVG icons in the top navigation. 
- Make the top navigation buttons visually consistent and improve their layout and aesthetics for a cleaner UI. 

### Description
- Replaced the grid layout with a horizontal `flex` row using `justifyContent: 'space-between'` so buttons are spaced evenly. 
- Made each top-zone button square and standard-sized by setting `width`, `height` and `flex` to `40px` and changed corner radius to `12px`. 
- Added soft outer shadow and a subtle inset highlight plus a `transition` for hover/interaction polish via `boxShadow` and `transition` styles. 
- Fixed JSX markup by removing the stray `)}` artifact that previously appeared next to SVG/button descriptions. 

### Testing
- Ran `npm run lint:js -- src/components/smallCard/renderTopBlock.js` which completed successfully (ESLint ran, with a browserslist warning but no blocking errors). 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea20e501388326b5d69b779d055a0f)