### PR TITLE
Add quick `pp` role button in top block role controls

### DIFF
--- a/src/components/smallCard/fieldRole.js
+++ b/src/components/smallCard/fieldRole.js
@@ -25,7 +25,7 @@ export const fieldRole = (userData, setUsers, setState, submitOptions = {}) => {
         }
         style={{ marginLeft: 0, textAlign: 'left', width: '6ch' }}
       />
-      {['ed', 'ip', 'ag'].map(role => (
+      {['ed', 'ip', 'ag', 'pp'].map(role => (
         <OrangeBtn
           key={role}
           onClick={() => handleSetRole(role)}


### PR DESCRIPTION
### Motivation
- Provide a one-click way to set the `pp` role from the small card top block quick-role controls so users can assign that role faster.

### Description
- Added `'pp'` to the quick role buttons array in `src/components/smallCard/fieldRole.js` (now `['ed','ip','ag','pp']`), which is consumed by `renderTopBlock` to render the role action buttons.

### Testing
- Ran `npx eslint src/components/smallCard/fieldRole.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea392290248326b1b0c52c343abd9b)