### PR TITLE
Fix stale AddNewProfile hydration from localStorage

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -666,7 +666,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
     const urlUserId = params.get('userId');
     if (urlUserId) return urlUserId;
-    return localStorage.getItem(SEARCH_KEY) || '';
+    return '';
   });
   const [searchBarQueryActive, setSearchBarQueryActive] = useState(false);
   const [lastSearchBarQuery, setLastSearchBarQuery] = useState('');
@@ -838,8 +838,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState(() => {
     const params = new URLSearchParams(location.search);
-    const urlUserId = initialAccess.canAccessAdd ? params.get('userId') : null;
-    const restoredUserId = urlUserId || localStorage.getItem(EDIT_PROFILE_USER_ID_KEY) || '';
+    const restoredUserId = initialAccess.canAccessAdd ? params.get('userId') || '' : '';
 
     if (!restoredUserId) {
       return {};
@@ -891,17 +890,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => () => {
     isMountedRef.current = false;
   }, []);
-
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    if (params.has('search') || params.has('userId')) {
-      return;
-    }
-    const storedSearch = localStorage.getItem(SEARCH_KEY);
-    if (storedSearch) {
-      setSearch(storedSearch);
-    }
-  }, [location.search]);
 
   const handleBlur = () => {
     setState(prevState => {


### PR DESCRIPTION
### Motivation
- Opening the Add page could briefly show a previously opened card or search because the component initially restored `search` and last edited `userId` from `localStorage`, causing a visible state “jump” when cache/backend data arrived.

### Description
- Initialize `search` to an empty string instead of reading `localStorage` so the Add page is empty by default when there is no `?search=` URL parameter.
- Stop hydrating `state` from the persisted `addNewProfileEditUserId` key and only honor the explicit `?userId=` URL parameter for profile hydration.
- Remove the follow-up `useEffect` that re-applied persisted `search` from `localStorage` when URL params were missing.
- Change applied in `src/components/AddNewProfile.jsx` to make initial Add page state deterministic (empty unless URL explicitly requests data).

### Testing
- Ran `npm run lint:js -- src/components/AddNewProfile.jsx` and lint completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea369d3218832680518fd3b6481d73)