### PR TITLE
Skip toast on PERMISSION_DENIED, clean RTDB payloads, and encode new-users filter-set keys

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -822,9 +822,14 @@ export const ProfileForm = ({
         });
       }
     } catch (error) {
-      console.error('Failed to update additional access newUsers filter-set index', error);
-      const details = error?.message || String(error);
-      toast.error(`Не вдалося зберегти індексацію наборів фільтрів (${details})`);
+      const code = String(error?.code || '');
+      if (code.includes('PERMISSION_DENIED')) {
+        console.warn('Skipped additional access newUsers filter-set index rebuild due to permissions.', error);
+      } else {
+        console.error('Failed to update additional access newUsers filter-set index', error);
+        const details = error?.message || String(error);
+        toast.error(`Не вдалося зберегти індексацію наборів фільтрів (${details})`);
+      }
     }
     Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
       console.error('Failed to submit profile changes', error);

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2257,17 +2257,19 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
     console.log('currentUserData :>> ', currentUserData);
 
     // if (condition === 'update' && !(Object.keys(uploadedInfo).length < Object.keys(currentUserData).length)) {
+    const cleanedUploadedInfo = removeUndefined(uploadedInfo);
+
     if (condition === 'update') {
       console.log('update :>> ');
-      await update(userRefRTDB, { ...uploadedInfo });
+      await update(userRefRTDB, { ...cleanedUploadedInfo });
     } else {
       console.log('set :>> ');
-      await set(userRefRTDB, { ...uploadedInfo });
+      await set(userRefRTDB, { ...cleanedUploadedInfo });
     }
 
-    if (uploadedInfo.lastLogin2 !== undefined) {
+    if (cleanedUploadedInfo.lastLogin2 !== undefined) {
       try {
-        await update(ref2(database, `users/${userId}`), { lastLogin2: uploadedInfo.lastLogin2 });
+        await update(ref2(database, `users/${userId}`), { lastLogin2: cleanedUploadedInfo.lastLogin2 });
       } catch (e) {
         console.error('Error updating lastLogin2 in users:', e);
       }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -8,7 +8,6 @@ import {
 
 const SEARCH_KEY_SETS_ROOT = 'searchKeySet';
 const LEGACY_SEARCH_KEY_SETS_ROOT = 'searchKeySets';
-const SET_KEY_MAX_LENGTH = 512;
 
 const toStableRulesText = raw =>
   Array.isArray(raw)
@@ -25,14 +24,13 @@ const sanitizeToken = value =>
     .replace(/-+/g, '-')
     .replace(/^[-_]+|[-_]+$/g, '');
 
-const hashRulesText = value => {
-  const input = String(value || '');
-  let hash = 2166136261;
-  for (let i = 0; i < input.length; i += 1) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
+const encodeSetKeyPayload = value => encodeURIComponent(String(value || ''));
+const decodeSetKeyPayload = value => {
+  try {
+    return decodeURIComponent(String(value || ''));
+  } catch {
+    return String(value || '');
   }
-  return (hash >>> 0).toString(36);
 };
 
 const buildGroupToken = parsedRules => {
@@ -64,12 +62,16 @@ export const makeAdditionalRulesSetKey = rawRules => {
 
   if (!groupTokens.length) return '';
 
-  const baseKey = `set_${groupTokens.join('__or__')}`;
-  if (baseKey.length <= SET_KEY_MAX_LENGTH) {
-    return baseKey;
-  }
+  const payload = groupTokens.join('__or__');
+  return `set_${encodeSetKeyPayload(payload)}`;
+};
 
-  return `set_h_${hashRulesText(rulesText)}`;
+export const decodeAdditionalRulesSetKey = setKey => {
+  const raw = String(setKey || '');
+  if (raw.startsWith('set_')) {
+    return decodeSetKeyPayload(raw.slice('set_'.length));
+  }
+  return raw;
 };
 
 const mapMatchingIdsByRules = (newUsersData, parsedRuleGroups) => {


### PR DESCRIPTION
### Motivation
- Prevent alarming error toasts when index rebuilds fail due to insufficient permissions by treating permission-denied errors as non-critical. 
- Ensure values written to Realtime Database do not contain `undefined` entries to avoid accidental missing fields or DB inconsistencies. 
- Make filter-set keys stable and reversible by encoding the full token payload instead of relying on a custom hashing/truncation approach.

### Description
- Update `submitWithNormalization` in `ProfileForm.jsx` to detect `error.code` containing `PERMISSION_DENIED` and log a warning instead of showing an error toast, while preserving the existing error handling for other failures. 
- Introduce `removeUndefined` usage in `src/components/config.js` to produce `cleanedUploadedInfo` and use it for `update`/`set` calls and `lastLogin2` checks/updates so `undefined` properties are removed before writing to RTDB. 
- Replace the previous hash/truncation key scheme in `src/utils/newUsersFilterSetsIndex.js` with URL-safe encoding via `encodeSetKeyPayload` and add `decodeAdditionalRulesSetKey` to recover the original payload; remove the `SET_KEY_MAX_LENGTH` truncation logic and legacy hash function. 
- Add a safe `decodeURIComponent` fallback to avoid decode errors when parsing keys.

### Testing
- Ran unit and integration test suite via `npm test`, and all tests passed. 
- Ran linting with `npm run lint`, and no lint errors were reported. 
- Verified production build with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea44edfaac8326a99a6eb7b7386c46)