### PR TITLE
Move edit-mode back arrow into renderTopBlock blue action button

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3557,29 +3557,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               <>
                 <EditActionButton
                   type="button"
-                  onClick={handleBackToPreviousList}
-                  title="Назад до попереднього списку"
-                  aria-label="Назад до попереднього списку"
-                >
-                  <EditActionIcon viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M11 7L6 12L11 17"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M6 12H18"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </EditActionIcon>
-                </EditActionButton>
-                <EditActionButton
-                  type="button"
                   onClick={handleUndoProfileChanges}
                   title="Відмінити останню зміну"
                   aria-label="Відмінити останню зміну"
@@ -3785,6 +3762,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 null,
                 null,
                 handleTopBlockSubmitHistorySnapshot,
+                handleBackToPreviousList,
               )}
             </div>
             {shouldShowSchedule && state && (

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -184,7 +184,8 @@ export const renderTopBlock = (
   setSearch = null,
   additionalActions = null,
   overlayFieldAdditions = {},
-  onSubmitHistorySnapshot = null
+  onSubmitHistorySnapshot = null,
+  onBackAction = null
 ) => {
   if (!userData) return null;
 
@@ -291,18 +292,34 @@ export const renderTopBlock = (
               </button>
             )}
             {idx === 4 &&
-              isFromListOfUsers &&
-              typeof setSearch === 'function' &&
-              btnEdit(
-                cardData,
-                setSearch,
-                setState,
-                { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-                  <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-                </svg>
-              )}
+              (isFromListOfUsers && typeof setSearch === 'function'
+                ? btnEdit(
+                    cardData,
+                    setSearch,
+                    setState,
+                    { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+                      <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+                    </svg>
+                  )
+                : typeof onBackAction === 'function' && (
+                    <button
+                      type="button"
+                      style={{ ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' }}
+                      onClick={event => {
+                        event.stopPropagation();
+                        onBackAction();
+                      }}
+                      aria-label="Назад до попереднього списку"
+                      title="Назад до попереднього списку"
+                    >
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <path d="M11 7L6 12L11 17" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                        <path d="M6 12H18" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </button>
+                  ))}
             {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
             {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>


### PR DESCRIPTION
### Motivation
- Make the blue action button in the top block behave contextually: show the normal Edit action when a card is rendered inside a list, and show a Back action when a single profile is opened in edit mode.

### Description
- Added optional `onBackAction` callback parameter to `renderTopBlock` and updated its signature to accept it.
- Reworked the blue slot (zone `idx === 4`) in `renderTopBlock` to render either `btnEdit(...)` for list mode or a Back button that calls `onBackAction()` when provided.
- Removed the separate Back button from the `AddNewProfile` top toolbar and wired `handleBackToPreviousList` to the `renderTopBlock` call site in `AddNewProfile.jsx` so the back behavior is rendered inside the card UI.
- Changes are in `src/components/smallCard/renderTopBlock.js` and `src/components/AddNewProfile.jsx`.

### Testing
- Ran linting with `npx eslint src/components/smallCard/renderTopBlock.js src/components/AddNewProfile.jsx` which completed without errors (warnings only) and returned successfully.
- Code was committed after the change and verified with a local diff/commit (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4f7253148326aaee982d1b30e617)