### PR TITLE
Defer additional access cards recalculation until apply

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -564,6 +564,7 @@ export const ProfileForm = ({
   const [showAdditionalRulesModal, setShowAdditionalRulesModal] = useState(false);
   const [activeAdditionalRuleInputIndex, setActiveAdditionalRuleInputIndex] = useState(0);
   const [additionalRuleBuilder, setAdditionalRuleBuilder] = useState([]);
+  const [previewAdditionalRulesText, setPreviewAdditionalRulesText] = useState('');
   const [availableCardsCount, setAvailableCardsCount] = useState(0);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const autoAppliedOverlayForUserRef = useRef('');
@@ -603,6 +604,11 @@ export const ProfileForm = ({
   useEffect(() => {
     if (!showAdditionalRulesModal) return;
     const activeInputValue = additionalRulesInputs[activeAdditionalRuleInputIndex] || '';
+    const combinedAppliedText = additionalRulesInputs
+      .map(item => String(item || '').trim())
+      .filter(Boolean)
+      .join('\n\n');
+    setPreviewAdditionalRulesText(combinedAppliedText);
     const parsed = parseAdditionalRulesTextToBuilder(activeInputValue);
     if (parsed.length > 0) {
       setAdditionalRuleBuilder(parsed);
@@ -616,11 +622,7 @@ export const ProfileForm = ({
 
     let cancelled = false;
     const loadAvailableCards = async () => {
-      const combinedAppliedText = additionalRulesInputs
-        .map(item => String(item || '').trim())
-        .filter(Boolean)
-        .join('\n\n');
-      const parsedRuleGroups = parseAdditionalAccessRuleGroups(combinedAppliedText);
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(previewAdditionalRulesText);
       if (!parsedRuleGroups.length) {
         setAvailableCardsCount(0);
         return;
@@ -628,7 +630,7 @@ export const ProfileForm = ({
 
       setIsLoadingAvailableCards(true);
       try {
-        const indexedSetKey = makeAdditionalRulesSetKey(combinedAppliedText);
+        const indexedSetKey = makeAdditionalRulesSetKey(previewAdditionalRulesText);
         if (indexedSetKey) {
           const indexedPayload = await getCachedSearchKeyPayload(
             `${SEARCH_KEY_SETS_ROOT}/${indexedSetKey}`,
@@ -781,7 +783,7 @@ export const ProfileForm = ({
       cancelled = true;
     };
   }, [
-    additionalRulesInputs,
+    previewAdditionalRulesText,
     showAdditionalRulesModal,
   ]);
 
@@ -895,6 +897,14 @@ export const ProfileForm = ({
       };
       submitWithNormalization(updated, 'overwrite');
       return updated;
+    });
+    setPreviewAdditionalRulesText(prev => {
+      const nextInputs = additionalRulesTextToInputs(prev);
+      nextInputs[activeAdditionalRuleInputIndex] = rulesText;
+      return nextInputs
+        .map(item => String(item || '').trim())
+        .filter(Boolean)
+        .join('\n\n');
     });
   };
 


### PR DESCRIPTION
### Motivation
- Prevent immediate recalculation of "Доступні карточки" while the user is editing draft additional-access filters via checkboxes in the modal.
- Keep the expensive preview/count work tied to the applied preview text so changes only trigger recalculation after the user presses "Застосувати".

### Description
- Added a new state `previewAdditionalRulesText` in `ProfileForm` to hold the rules used for preview counting and decouple it from draft checkbox edits in the builder.
- Initialize `previewAdditionalRulesText` from currently applied additional-access inputs when the modal opens and set the builder from the active input.
- Changed the available-cards loader effect to depend on `previewAdditionalRulesText` instead of `additionalRulesInputs` so toggling checkboxes does not immediately trigger recalculation.
- On `applyAdditionalRulesFromBuilder` update both the persisted `ADDITIONAL_ACCESS_FIELD` and `previewAdditionalRulesText` so the preview/count is recomputed only after the user confirms.
- Modified file: `src/components/ProfileForm.jsx`.

### Testing
- Ran `npm run lint:js -- src/components/ProfileForm.jsx` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea51fd51c48326b521a47dc346b472)