### PR TITLE
Make top blue action button act as Back in edit mode

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -48,11 +48,6 @@ const Container = styled.div`
   margin: 0 auto;
 `;
 
-const BackButton = styled.button`
-  align-self: flex-start;
-  margin-bottom: 10px;
-`;
-
 const SkeletonCard = styled.div`
   width: 100%;
   border-radius: 12px;
@@ -629,7 +624,6 @@ const EditProfile = () => {
 
   return (
     <Container>
-      <BackButton onClick={() => navigate(-1)}>Back</BackButton>
       {shouldShowEditorSkeleton ? (
         <TopBlockSkeleton />
       ) : (
@@ -651,6 +645,8 @@ const EditProfile = () => {
             undefined,
             null,
             overlayFieldAdditions,
+            null,
+            () => navigate(-1)
           )}
         </div>
       )}

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -184,7 +184,8 @@ export const renderTopBlock = (
   setSearch = null,
   additionalActions = null,
   overlayFieldAdditions = {},
-  onSubmitHistorySnapshot = null
+  onSubmitHistorySnapshot = null,
+  onBackToList = null
 ) => {
   if (!userData) return null;
 
@@ -291,18 +292,33 @@ export const renderTopBlock = (
               </button>
             )}
             {idx === 4 &&
-              isFromListOfUsers &&
-              typeof setSearch === 'function' &&
-              btnEdit(
-                cardData,
-                setSearch,
-                setState,
-                { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-                  <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-                </svg>
-              )}
+              (isFromListOfUsers && typeof setSearch === 'function'
+                ? btnEdit(
+                    cardData,
+                    setSearch,
+                    setState,
+                    { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+                      <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+                    </svg>
+                  )
+                : typeof onBackToList === 'function' && (
+                    <button
+                      type="button"
+                      style={{ ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' }}
+                      onClick={event => {
+                        event.stopPropagation();
+                        onBackToList();
+                      }}
+                      aria-label="Назад до списку"
+                      title="Назад до списку"
+                    >
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <path d="M15 6l-6 6 6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </button>
+                  ))}
             {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
             {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>


### PR DESCRIPTION
### Motivation
- The UI should use the top blue action button as a context-aware control: in the users list it stays as `Edit`, and in the single-profile edit flow it becomes a `Back` arrow that returns to the previous list.

### Description
- Added a new `onBackToList` parameter to `renderTopBlock` and updated the idx===4 (blue) button to render `btnEdit` when invoked from the list (`isFromListOfUsers`) or a Back-arrow button that calls `onBackToList` otherwise in `src/components/smallCard/renderTopBlock.js`.
- Removed the standalone `BackButton` styled-component from `EditProfile` and stopped rendering it, instead passing `() => navigate(-1)` into `renderTopBlock` from `src/components/EditProfile.jsx` so navigation is handled by the blue button.
- Kept existing `btnEdit` behavior for the list flow and preserved all other top-button actions and styling.
- Files changed: `src/components/smallCard/renderTopBlock.js` and `src/components/EditProfile.jsx`.

### Testing
- Ran linting with `npm run lint:js`, which completed successfully.
- No runtime or unit tests were modified; this is a UI behavior change only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea539d7fd883269db42e7aa902a7b6)