### PR TITLE
Add onRemoveKey hook and remove overlay values from state on overlay dismiss in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -359,11 +359,18 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
     return null;
   }
 
-  const { userId, setUsers, stateUpdater } = options;
+  const { userId, setUsers, stateUpdater, onRemoveKey } = options;
   const effectiveSetUsers = typeof setUsers === 'function' ? setUsers : stateUpdater;
   const canRemove = typeof effectiveSetUsers === 'function';
 
   const handleRemove = keyPath => {
+    if (typeof onRemoveKey === 'function') {
+      const handled = onRemoveKey(keyPath);
+      if (handled) {
+        return;
+      }
+    }
+
     if (!canRemove) {
       return;
     }
@@ -1057,7 +1064,26 @@ export const ProfileForm = ({
     }
   }, [state?.userId]);
 
+  const removeOverlayValueFromState = useCallback((fieldName, entryValue) => {
+    if (!fieldName) return;
+
+    const currentValue = state?.[fieldName];
+
+    if (Array.isArray(currentValue)) {
+      const entryIndex = currentValue.findIndex(value => value === entryValue);
+      if (entryIndex !== -1) {
+        handleClear(fieldName, entryIndex);
+      }
+      return;
+    }
+
+    if (currentValue === entryValue || (typeof currentValue === 'string' && String(currentValue).trim() === String(entryValue).trim())) {
+      handleDelKeyValue(fieldName);
+    }
+  }, [handleClear, handleDelKeyValue, state]);
+
   const handleOverlayDismiss = async (fieldName, entry) => {
+    removeOverlayValueFromState(fieldName, entry?.value);
     dismissOverlayEntry(fieldName, entry);
     await removeOverlayEntryFromBackend(fieldName, entry);
   };
@@ -1436,6 +1462,24 @@ ${entries.join('\n')}`;
     handleCloseModal();
   };
 
+  const handleProfileViewRemove = keyPath => {
+    const normalizedPath = String(keyPath || '').trim();
+    if (!normalizedPath) return false;
+
+    if (!normalizedPath.includes('.')) {
+      handleDelKeyValue(normalizedPath);
+      return true;
+    }
+
+    const [fieldName, nestedIndex] = normalizedPath.split('.');
+    if (/^\d+$/.test(nestedIndex)) {
+      handleClear(fieldName, Number(nestedIndex));
+      return true;
+    }
+
+    return false;
+  };
+
   return (
     <>
       {state.userId && (
@@ -1443,7 +1487,11 @@ ${entries.join('\n')}`;
           id={state.userId}
           style={{ display: 'none', textAlign: 'left', marginBottom: '8px' }}
         >
-          {renderAllFields(state, '', { userId: state?.userId, setUsers: setState })}
+          {renderAllFields(state, '', {
+            userId: state?.userId,
+            setUsers: setState,
+            onRemoveKey: handleProfileViewRemove,
+          })}
         </div>
       )}
       {sortedFieldsToRender


### PR DESCRIPTION
### Motivation

- Provide a way for the profile view renderer to delegate/remove keys using a callback and ensure overlay suggestions are properly removed from component state when dismissed.

### Description

- Added an `onRemoveKey` option to `renderAllFields` and invoke it from the `handleRemove` path so external handlers can intercept removals via `onRemoveKey(keyPath)`.
- Implemented `removeOverlayValueFromState` which clears an overlay value from local `state` for both array and scalar fields and wired it into `handleOverlayDismiss` so dismissing an overlay also updates component state.
- Added `handleProfileViewRemove` helper that normalizes a `keyPath` and removes either a top-level key via `handleDelKeyValue` or an indexed array entry via `handleClear`, and passed it into `renderAllFields` as `onRemoveKey`.

### Testing

- Ran the project's automated unit tests with `npm test`, which completed successfully.
- Ran linting via `yarn lint`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea568504508326b0921de62c260cea)