### PR TITLE
Make top blue button contextual and move back action into it

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3557,29 +3557,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               <>
                 <EditActionButton
                   type="button"
-                  onClick={handleBackToPreviousList}
-                  title="Назад до попереднього списку"
-                  aria-label="Назад до попереднього списку"
-                >
-                  <EditActionIcon viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M11 7L6 12L11 17"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M6 12H18"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </EditActionIcon>
-                </EditActionButton>
-                <EditActionButton
-                  type="button"
                   onClick={handleUndoProfileChanges}
                   title="Відмінити останню зміну"
                   aria-label="Відмінити останню зміну"
@@ -3783,6 +3760,29 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 isDateInRange,
                 openMedicationsModal,
                 null,
+                {
+                  onClick: handleBackToPreviousList,
+                  title: 'Назад до попереднього списку',
+                  ariaLabel: 'Назад до попереднього списку',
+                  icon: (
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <path
+                        d="M11 7L6 12L11 17"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M6 12H18"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  ),
+                },
                 null,
                 handleTopBlockSubmitHistorySnapshot,
               )}

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -650,6 +650,7 @@ const EditProfile = () => {
             handleOpenMedications,
             undefined,
             null,
+            null,
             overlayFieldAdditions,
           )}
         </div>

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -51,6 +51,7 @@ const UserCard = ({
           isDateInRange,
           onOpenMedications,
           setSearch,
+          null,
           actions
         )}
       </div>

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -182,6 +182,7 @@ export const renderTopBlock = (
   isDateInRange,
   onOpenMedications,
   setSearch = null,
+  topBlueAction = null,
   additionalActions = null,
   overlayFieldAdditions = {},
   onSubmitHistorySnapshot = null
@@ -291,18 +292,35 @@ export const renderTopBlock = (
               </button>
             )}
             {idx === 4 &&
-              isFromListOfUsers &&
-              typeof setSearch === 'function' &&
-              btnEdit(
-                cardData,
-                setSearch,
-                setState,
-                { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-                  <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-                </svg>
-              )}
+              (topBlueAction ? (
+                <button
+                  type="button"
+                  onClick={event => {
+                    event.stopPropagation();
+                    if (typeof topBlueAction.onClick === 'function') {
+                      topBlueAction.onClick(cardData);
+                    }
+                  }}
+                  style={{ ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' }}
+                  aria-label={topBlueAction.ariaLabel || topBlueAction.title || 'Синя кнопка'}
+                  title={topBlueAction.title || topBlueAction.ariaLabel || 'Синя кнопка'}
+                >
+                  {topBlueAction.icon}
+                </button>
+              ) : (
+                isFromListOfUsers &&
+                typeof setSearch === 'function' &&
+                btnEdit(
+                  cardData,
+                  setSearch,
+                  setState,
+                  { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+                    <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+                  </svg>
+                )
+              ))}
             {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
             {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>


### PR DESCRIPTION
### Motivation
- The blue action button in the top-right of a card should be contextual: in list mode it stays as Edit, while in single-card edit mode it becomes a Back action to return to the previous list. 
- Centralize this behavior so the small-card top block (`renderTopBlock`) can render the correct action depending on the caller instead of having a separate Back button in `AddNewProfile`.

### Description
- Added an optional `topBlueAction` parameter to `renderTopBlock` to allow callers to supply a custom blue-button action object (`{ onClick, title, ariaLabel, icon }`).
- Replaced the hard-coded blue button in `renderTopBlock` with a conditional that renders `topBlueAction` when provided, otherwise falls back to the existing Edit behavior (via `btnEdit`).
- Removed the separate Back toolbar button from `AddNewProfile` and wired its `handleBackToPreviousList` into `renderTopBlock` by passing a `topBlueAction` object (arrow icon + handler) when in single-card edit mode.
- Updated other `renderTopBlock` call sites (`UsersList`, `EditProfile`) to preserve argument order and pass `null` for the new `topBlueAction` where no custom behavior is required.
- Files changed: `src/components/smallCard/renderTopBlock.js`, `src/components/AddNewProfile.jsx`, `src/components/UsersList.jsx`, `src/components/EditProfile.jsx`.

### Testing
- Ran ESLint on the modified files with `npx eslint src/components/AddNewProfile.jsx src/components/smallCard/renderTopBlock.js src/components/UsersList.jsx src/components/EditProfile.jsx`, which completed successfully (exit code 0) with only non-critical `browserslist`/npm warnings reported by the environment.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5c9e91288326905617bb0d2cbab1)