### PR TITLE
Add dislike/favorite callbacks and update top block to sync getInTouch field

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -16,6 +16,8 @@ export const BtnDislike = ({
   userData = {},
   dislikeUsers = {},
   setDislikeUsers,
+  onDislikeAdded,
+  onDislikeRemoved,
   onRemove,
   favoriteUsers = {},
   setFavoriteUsers,
@@ -41,6 +43,9 @@ export const BtnDislike = ({
         setDislikeUsers(updated);
         setDislike(userId, false);
         removeCardFromList(userId, 'dislike');
+        if (typeof onDislikeRemoved === 'function') {
+          await onDislikeRemoved(userId);
+        }
         if (onRemove) onRemove(userId);
       } catch (error) {
         console.error('Failed to remove dislike:', error);
@@ -52,6 +57,9 @@ export const BtnDislike = ({
         setDislikeUsers(updated);
         setDislike(userId, true);
         cacheDislikedUsers({ [userId]: userData });
+        if (typeof onDislikeAdded === 'function') {
+          await onDislikeAdded(userId);
+        }
         if (favoriteUsers[userId]) {
           try {
             await removeFavoriteUser(userId);

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -17,6 +17,7 @@ export const BtnFavorite = ({
   favoriteUsers = {},
   setFavoriteUsers,
   onRemove,
+  onDislikeRemoved,
   dislikeUsers = {},
   setDislikeUsers,
   customStyle = {},
@@ -64,6 +65,9 @@ export const BtnFavorite = ({
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
           setDislike(userId, false);
+          if (typeof onDislikeRemoved === 'function') {
+            await onDislikeRemoved(userId);
+          }
         }
       } catch (error) {
         console.error('Failed to add favorite:', error);

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -8,6 +8,7 @@ import { fieldDeliveryInfo } from './fieldDeliveryInfo';
 import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
 import { fieldGetInTouch } from './fieldGetInTouch';
+import { handleChange } from './actions';
 import { fieldRole } from './fieldRole';
 import { FieldLastCycle } from './fieldLastCycle';
 import { FieldComment } from './FieldComment';
@@ -237,13 +238,35 @@ export const renderTopBlock = (
                 { ...zoneActionButtonStyle, backgroundColor: '#d32f2f', color: '#fff' }
               )}
             {idx === 1 && (
-                <BtnDislike
+              <BtnDislike
                 title="Дизлайк"
                 ariaLabel="Дизлайк"
                 userId={cardData.userId}
                 userData={cardData}
                 dislikeUsers={dislikeUsers}
                 setDislikeUsers={setDislikeUsers}
+                onDislikeAdded={() =>
+                  handleChange(
+                    setUsers,
+                    setState,
+                    cardData.userId,
+                    'getInTouch',
+                    '2099-99-99',
+                    true,
+                    { currentFilter, isDateInRange, ...submitOptions },
+                  )
+                }
+                onDislikeRemoved={() =>
+                  handleChange(
+                    setUsers,
+                    setState,
+                    cardData.userId,
+                    'getInTouch',
+                    '',
+                    true,
+                    { currentFilter, isDateInRange, ...submitOptions },
+                  )
+                }
                 favoriteUsers={favoriteUsers}
                 setFavoriteUsers={setFavoriteUsers}
                 customStyle={{
@@ -264,6 +287,17 @@ export const renderTopBlock = (
                 setFavoriteUsers={setFavoriteUsers}
                 dislikeUsers={dislikeUsers}
                 setDislikeUsers={setDislikeUsers}
+                onDislikeRemoved={() =>
+                  handleChange(
+                    setUsers,
+                    setState,
+                    cardData.userId,
+                    'getInTouch',
+                    '',
+                    true,
+                    { currentFilter, isDateInRange, ...submitOptions },
+                  )
+                }
                 customStyle={{
                   ...zoneActionButtonStyle,
                   backgroundColor: '#f9a825',


### PR DESCRIPTION
### Motivation
- Ensure UI/state in the top block is synchronized when a user is disliked or when a dislike is removed as a side-effect of favoriting, by propagating those events to the parent logic. 

### Description
- Added `onDislikeAdded` and `onDislikeRemoved` props to `BtnDislike` and invoke them after successful add/remove operations. 
- Added `onDislikeRemoved` prop to `BtnFavorite` and invoke it when a dislike is removed while adding a favorite. 
- Imported and wired `handleChange` in `renderTopBlock` and passed handlers to `BtnDislike` and `BtnFavorite` to update the `getInTouch` field (`'2099-99-99'` when disliked and `''` when removed). 
- Kept existing local cache/storage updates and `onRemove` behavior intact while adding the callback invocations. 

### Testing
- Ran unit tests with `yarn test` and they completed successfully. 
- Ran linting with `yarn lint` and no new lint errors were reported. 
- Performed a build check with `yarn build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf2b1e34483268e2839143f109507)