### PR TITLE
Enhance active Like/Dislike button contrast and border

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -29,6 +29,7 @@ export const BtnDislike = ({
   const isDisliked = !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
   const inactiveOpacity = 0.7;
+  const activeIconColor = '#fff';
 
   const toggleDislike = async () => {
     if (!auth.currentUser) {
@@ -89,16 +90,18 @@ export const BtnDislike = ({
         width: '35px',
         height: '35px',
         borderRadius: '50%',
-        background: isDisliked ? color.reactionDislikeBg : color.accent5,
-        border: `2px solid ${isDisliked ? activeColor : color.reactionIdleBorder}`,
-        color: isDisliked ? activeColor : color.reactionIdleIcon,
+        ...customStyle,
+        background: isDisliked ? activeColor : customStyle.background || color.accent5,
+        border: isDisliked
+          ? `4px solid ${activeColor}`
+          : customStyle.border || `2px solid ${color.reactionIdleBorder}`,
+        color: isDisliked ? activeIconColor : customStyle.color || color.reactionIdleIcon,
         opacity: isDisliked ? 1 : inactiveOpacity,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        ...customStyle,
       }}
       title={title}
       aria-label={ariaLabel}
@@ -108,7 +111,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={iconSize} color={isDisliked ? activeColor : color.reactionIdleIcon} />
+      <FaTimes size={iconSize} color={isDisliked ? activeIconColor : color.reactionIdleIcon} />
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -28,6 +28,7 @@ export const BtnFavorite = ({
   const isFavorite = !!favoriteUsers[userId];
   const activeColor = color.reactionLike;
   const inactiveOpacity = 0.7;
+  const activeIconColor = '#fff';
 
   const toggleFavorite = async () => {
     if (!auth.currentUser) {
@@ -84,16 +85,18 @@ export const BtnFavorite = ({
         width: '35px',
         height: '35px',
         borderRadius: '50%',
-        background: isFavorite ? color.reactionLikeBg : color.accent5,
-        border: `2px solid ${isFavorite ? activeColor : color.reactionIdleBorder}`,
-        color: isFavorite ? activeColor : color.reactionIdleIcon,
+        ...customStyle,
+        background: isFavorite ? activeColor : customStyle.background || color.accent5,
+        border: isFavorite
+          ? `4px solid ${activeColor}`
+          : customStyle.border || `2px solid ${color.reactionIdleBorder}`,
+        color: isFavorite ? activeIconColor : customStyle.color || color.reactionIdleIcon,
         opacity: isFavorite ? 1 : inactiveOpacity,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        ...customStyle,
       }}
       title={title}
       aria-label={ariaLabel}
@@ -104,7 +107,7 @@ export const BtnFavorite = ({
       }}
     >
       {isFavorite ? (
-        <FaHeart size={iconSize} color={activeColor} />
+        <FaHeart size={iconSize} color={activeIconColor} />
       ) : (
         <FaRegHeart size={iconSize} color={color.reactionIdleIcon} />
       )}


### PR DESCRIPTION
### Motivation
- Improve visual feedback for active Like/Dislike buttons on the top card so active state is clearly visible (thicker border and higher-contrast icon) as requested in UI design.
- Ensure active styling remains visible when `renderTopBlock` passes custom styles (e.g. `border: 'none'`) from the caller.

### Description
- Updated `BtnFavorite` to use a solid active background (`color.reactionLike`), a thicker `4px` active border, and a high-contrast white icon when active, while preserving `customStyle` fallbacks (`src/components/smallCard/btnFavorite.js`).
- Updated `BtnDislike` to use a solid active background (`color.reactionDislike`), a thicker `4px` active border, and a high-contrast white icon when active, while preserving `customStyle` fallbacks (`src/components/smallCard/btnDislike.js`).
- Reordered style spread so `customStyle` is respected but active visual properties (background/border/icon color) are enforced for active states.

### Testing
- Ran `npx eslint src/components/smallCard/btnFavorite.js src/components/smallCard/btnDislike.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafe8e5f188326a580a3c9049e0a66)