### PR TITLE
Improve favorite/dislike button active styling and support selective customStyle overrides

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -26,9 +26,19 @@ export const BtnDislike = ({
   title = 'Дизлайк',
   ariaLabel = 'Дизлайк',
 }) => {
+  const {
+    background: customBackground,
+    backgroundColor: customBackgroundColor,
+    border: customBorder,
+    color: customTextColor,
+    boxShadow: customBoxShadow,
+    ...restCustomStyle
+  } = customStyle;
   const isDisliked = !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
   const inactiveOpacity = 0.7;
+  const activeIconColor = '#fff';
+  const activeBorderColor = '#fff';
 
   const toggleDislike = async () => {
     if (!auth.currentUser) {
@@ -89,16 +99,23 @@ export const BtnDislike = ({
         width: '35px',
         height: '35px',
         borderRadius: '50%',
-        background: isDisliked ? color.reactionDislikeBg : color.accent5,
-        border: `2px solid ${isDisliked ? activeColor : color.reactionIdleBorder}`,
-        color: isDisliked ? activeColor : color.reactionIdleIcon,
+        ...restCustomStyle,
+        background: isDisliked
+          ? activeColor
+          : customBackground || customBackgroundColor || color.accent5,
+        border: isDisliked
+          ? `4px solid ${activeBorderColor}`
+          : customBorder || `2px solid ${color.reactionIdleBorder}`,
+        color: isDisliked ? activeIconColor : customTextColor || color.reactionIdleIcon,
+        boxShadow: isDisliked
+          ? `0 0 0 2px ${activeColor}`
+          : customBoxShadow || 'none',
         opacity: isDisliked ? 1 : inactiveOpacity,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        ...customStyle,
       }}
       title={title}
       aria-label={ariaLabel}
@@ -108,7 +125,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={iconSize} color={isDisliked ? activeColor : color.reactionIdleIcon} />
+      <FaTimes size={iconSize} color={isDisliked ? activeIconColor : color.reactionIdleIcon} />
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -25,9 +25,19 @@ export const BtnFavorite = ({
   title = 'В обране',
   ariaLabel = 'В обране',
 }) => {
+  const {
+    background: customBackground,
+    backgroundColor: customBackgroundColor,
+    border: customBorder,
+    color: customTextColor,
+    boxShadow: customBoxShadow,
+    ...restCustomStyle
+  } = customStyle;
   const isFavorite = !!favoriteUsers[userId];
   const activeColor = color.reactionLike;
   const inactiveOpacity = 0.7;
+  const activeIconColor = '#fff';
+  const activeBorderColor = '#fff';
 
   const toggleFavorite = async () => {
     if (!auth.currentUser) {
@@ -84,16 +94,23 @@ export const BtnFavorite = ({
         width: '35px',
         height: '35px',
         borderRadius: '50%',
-        background: isFavorite ? color.reactionLikeBg : color.accent5,
-        border: `2px solid ${isFavorite ? activeColor : color.reactionIdleBorder}`,
-        color: isFavorite ? activeColor : color.reactionIdleIcon,
+        ...restCustomStyle,
+        background: isFavorite
+          ? activeColor
+          : customBackground || customBackgroundColor || color.accent5,
+        border: isFavorite
+          ? `4px solid ${activeBorderColor}`
+          : customBorder || `2px solid ${color.reactionIdleBorder}`,
+        color: isFavorite ? activeIconColor : customTextColor || color.reactionIdleIcon,
+        boxShadow: isFavorite
+          ? `0 0 0 2px ${activeColor}`
+          : customBoxShadow || 'none',
         opacity: isFavorite ? 1 : inactiveOpacity,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        ...customStyle,
       }}
       title={title}
       aria-label={ariaLabel}
@@ -104,7 +121,7 @@ export const BtnFavorite = ({
       }}
     >
       {isFavorite ? (
-        <FaHeart size={iconSize} color={activeColor} />
+        <FaHeart size={iconSize} color={activeIconColor} />
       ) : (
         <FaRegHeart size={iconSize} color={color.reactionIdleIcon} />
       )}


### PR DESCRIPTION
### Motivation
- Make the favorite and dislike buttons use stronger, consistent active visuals (solid color, white icon and border, subtle ring) for better contrast and clarity.
- Allow callers to pass a `customStyle` object while preserving internal active/inactive styling by supporting selective overrides and applying remaining custom style properties.

### Description
- Destructures `customStyle` into known style tokens (`background`, `backgroundColor`, `border`, `color`, `boxShadow`) and applies the rest via `...restCustomStyle` in both `BtnDislike` and `BtnFavorite`.
- Changes active state styling to use the reaction color as the button background, a white border and white icon (`activeIconColor = '#fff'` and `activeBorderColor = '#fff'`), and adds an active `boxShadow` ring; inactive state falls back to provided `customStyle` values or existing color tokens.
- Removes the previous full spread of `customStyle` in favor of merging `restCustomStyle` first and using explicit fallbacks to maintain internal active visuals.
- Updates icon color usage for `FaTimes` and `FaHeart` to reflect the new `activeIconColor` when active.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafe8e5f188326a580a3c9049e0a66)