### PR TITLE
Use customTextColor for inactive icons and force white icons on top action buttons

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -38,6 +38,7 @@ export const BtnDislike = ({
   const activeColor = color.reactionDislike;
   const inactiveOpacity = 0.7;
   const activeIconColor = '#fff';
+  const inactiveIconColor = customTextColor || color.reactionIdleIcon;
   const activeBorderColor = '#fff';
 
   const toggleDislike = async () => {
@@ -106,7 +107,7 @@ export const BtnDislike = ({
         border: isDisliked
           ? `4px solid ${activeBorderColor}`
           : customBorder || `2px solid ${color.reactionIdleBorder}`,
-        color: isDisliked ? activeIconColor : customTextColor || color.reactionIdleIcon,
+        color: isDisliked ? activeIconColor : inactiveIconColor,
         boxShadow: isDisliked
           ? `0 0 0 2px ${activeColor}`
           : customBoxShadow || 'none',
@@ -125,7 +126,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={iconSize} color={isDisliked ? activeIconColor : color.reactionIdleIcon} />
+      <FaTimes size={iconSize} color={isDisliked ? activeIconColor : inactiveIconColor} />
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -37,6 +37,7 @@ export const BtnFavorite = ({
   const activeColor = color.reactionLike;
   const inactiveOpacity = 0.7;
   const activeIconColor = '#fff';
+  const inactiveIconColor = customTextColor || color.reactionIdleIcon;
   const activeBorderColor = '#fff';
 
   const toggleFavorite = async () => {
@@ -101,7 +102,7 @@ export const BtnFavorite = ({
         border: isFavorite
           ? `4px solid ${activeBorderColor}`
           : customBorder || `2px solid ${color.reactionIdleBorder}`,
-        color: isFavorite ? activeIconColor : customTextColor || color.reactionIdleIcon,
+        color: isFavorite ? activeIconColor : inactiveIconColor,
         boxShadow: isFavorite
           ? `0 0 0 2px ${activeColor}`
           : customBoxShadow || 'none',
@@ -123,7 +124,7 @@ export const BtnFavorite = ({
       {isFavorite ? (
         <FaHeart size={iconSize} color={activeIconColor} />
       ) : (
-        <FaRegHeart size={iconSize} color={color.reactionIdleIcon} />
+        <FaRegHeart size={iconSize} color={inactiveIconColor} />
       )}
     </button>
   );

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -273,6 +273,7 @@ export const renderTopBlock = (
                   ...zoneActionButtonStyle,
                   backgroundColor: '#ef6c00',
                   border: 'none',
+                  color: '#fff',
                 }}
                 iconSize={18}
               />
@@ -302,6 +303,7 @@ export const renderTopBlock = (
                   ...zoneActionButtonStyle,
                   backgroundColor: '#f9a825',
                   border: 'none',
+                  color: '#fff',
                 }}
                 iconSize={18}
               />


### PR DESCRIPTION
### Motivation
- Ensure inactive icon color respects `customStyle.color` and is applied consistently across reaction buttons.
- Improve contrast for top zone action buttons by forcing white icon/text on colored backgrounds.

### Description
- Introduced `inactiveIconColor = customTextColor || color.reactionIdleIcon` in `BtnDislike` and `BtnFavorite` to centralize the inactive icon color selection.
- Replaced inline fallbacks with `inactiveIconColor` for the button `color` style and icon `color` props (`FaTimes` and `FaRegHeart`).
- Updated `renderTopBlock` to add `color: '#fff'` to the `customStyle` passed to the top zone action buttons to ensure icons are white on colored backgrounds.

### Testing
- Ran linting with `npm run lint` and the linter passed without errors.
- Executed unit tests with `npm test` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1ef6ef308326ae610b5049e32fa0)