### PR TITLE
Fix searchKeySets reindex write path collision

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -159,10 +159,7 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
 
   nextSetPayloads.forEach(({ setKey: rulesSetKey, userIds }) => {
     const setKey = `${ownerPrefix}${rulesSetKey}`;
-    writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}`] = null;
-    Object.keys(userIds).forEach(userId => {
-      writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${userId}`] = true;
-    });
+    writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}`] = userIds;
   });
 
   if (Object.keys(writes).length > 0) {


### PR DESCRIPTION
### Motivation

- Prevent Firebase RTDB multi-path update errors (`values argument contains a path ... that is ancestor of another path`) caused by writing both a parent key and its children in the same `update` payload during searchKeySets reindexing.

### Description

- Change `buildNewUsersFilterSetIndex` in `src/utils/newUsersFilterSetsIndex.js` to write each set payload as a single object at `searchKeySets/$setKey` via `writes["searchKeySets/$setKey"] = userIds` instead of mixing `.../$setKey = null` with per-child `.../$setKey/$userId = true` paths.
- Preserve the existing stale-set cleanup logic that deletes removed sets by keeping the `.../$setKey = null` entries for keys present in the old index but absent in the new index.

### Testing

- Ran `npm run -s test -- src/components/StimulationSchedule.test.jsx --watch=false`, and the test suite passed (1 test suite, 12 tests all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2f76e9c8832687bf1ae4acd7bcfd)