### PR TITLE
Always show contact action and hide cycle field for `pp` and agent/ip roles

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -116,6 +116,9 @@ const detailsToggleStyle = {
 const hasAgentOrIPRole = data =>
   data.userRole === 'ag' || data.userRole === 'ip' || data.role === 'ag' || data.role === 'ip';
 
+const hasRoleWithoutCycle = data =>
+  data.userRole === 'pp' || data.role === 'pp' || hasAgentOrIPRole(data);
+
 const buildRtdbLink = userId =>
   `https://console.firebase.google.com/u/0/project/webringitapp/database/webringitapp-default-rtdb/data/~2FnewUsers~2F${encodeURIComponent(userId || '')}`;
 
@@ -193,7 +196,7 @@ export const renderTopBlock = (
   const cardData = { ...userData, cycleStatus: getEffectiveCycleStatus(userData) };
   const region = normalizeRegion(cardData.region);
   const showSideActions = !additionalActions;
-  const isAgentOrIP = hasAgentOrIPRole(cardData);
+  const hasHiddenCycleFieldRole = hasRoleWithoutCycle(cardData);
 
   const renderOverlayEntries = fieldNames => {
     const normalizedFieldNames = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
@@ -381,10 +384,9 @@ export const renderTopBlock = (
             {cardData.userId}
           </a>
         )}
-        {!isAgentOrIP &&
-          fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, submitOptions)}
+        {fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, submitOptions)}
         {fieldRole(cardData, setUsers, setState, submitOptions)}
-        {!isAgentOrIP && <FieldLastCycle userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />}
+        {!hasHiddenCycleFieldRole && <FieldLastCycle userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />}
         <div>{fieldDeliveryInfo(setUsers, setState, cardData, submitOptions)}</div>
         {renderOverlayEntries(['lastDelivery', 'ownKids'])}
         <div>


### PR DESCRIPTION
### Motivation

- Ensure the "Get in touch" control is always available on the top block regardless of agent/IP roles.  
- Treat the `pp` role the same as agent/IP when deciding to hide the cycle field so the last cycle is not shown for those roles.  

### Description

- Added a new helper `hasRoleWithoutCycle` that returns true for `userRole === 'pp'`, `role === 'pp'`, or agent/IP roles by delegating to the existing role check.  
- Replaced the previous `isAgentOrIP` usage with `hasRoleWithoutCycle` and updated the variable name to `hasHiddenCycleFieldRole`.  
- Removed the agent/IP guard around `fieldGetInTouch` so `fieldGetInTouch(cardData, ...)` is always rendered.  
- Updated the `FieldLastCycle` rendering to use the new `hasHiddenCycleFieldRole` check so `FieldLastCycle` is hidden for `pp` and agent/IP roles.  

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3f3185c48326aa2c42770da418e0)