### PR TITLE
Increase AddNewProfile search history options to 15

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3652,6 +3652,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               autoOtherFallback: shouldAutoRunOtherFallback,
               enabledSearchKeys: effectiveEnabledSearchKeys,
             }}
+            searchHistoryLimit={15}
           />
           <SearchSettingsButton
             type="button"

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -651,6 +651,7 @@ const SearchBar = ({
   dislikeUsers = {},
   enabledSearchKeys,
   searchOptions,
+  searchHistoryLimit = 5,
 }) => {
   const activeSearchRequestRef = useRef(0);
   const [internalSearch, setInternalSearch] = useState(
@@ -764,7 +765,7 @@ const SearchBar = ({
       const newHistory = [
         trimmedVal,
         ...prev.filter(v => v !== trimmedVal),
-      ].slice(0, 5);
+      ].slice(0, searchHistoryLimit);
       saveHistoryCache('queries', newHistory);
       return newHistory;
     });


### PR DESCRIPTION
### Motivation
- Allow the AddNewProfile search input to retain more recent queries by expanding the saved search history from 5 to 15 entries.

### Description
- Introduce a `searchHistoryLimit` prop (default `5`) on `SearchBar` and use it when trimming history, and set `searchHistoryLimit={15}` where `SearchBar` is used in `AddNewProfile` (files changed: `src/components/SearchBar.jsx`, `src/components/AddNewProfile.jsx`).

### Testing
- Ran `npx eslint src/components/SearchBar.jsx src/components/AddNewProfile.jsx` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb42479d8483268da217d2bc1d67a6)