### PR TITLE
Speed up userId search using local card cache

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1030,6 +1030,27 @@ const SearchBar = ({
     }
 
     if (id) {
+      if (platform === 'userId') {
+        const cachedCardByUserId = getCard(id);
+        if (cachedCardByUserId) {
+          const userIdCacheKey = getCacheKey(
+            'search',
+            normalizeQueryKey(`userId=${id}`),
+          );
+          setIdsForQuery(userIdCacheKey, [id]);
+          setUserNotFound && setUserNotFound(false);
+          emitSearchLabel({ userId: id }, {
+            mode: platform,
+            stage: 'local-card-cache',
+          });
+          notifySearchResult({ userId: id }, cachedCardByUserId, {
+            preferredKeys: ['userId'],
+          });
+          setState && setState(cachedCardByUserId);
+          return true;
+        }
+      }
+
       const hasCache = loadCachedResult(platform, id);
       const freshCache = hasCache && isCacheFresh(platform, id);
       const result = { [platform]: id };


### PR DESCRIPTION
### Motivation
- Searching by `userId` could still trigger backend queries even when the card itself was already stored in the local `cards` cache, causing an unnecessary delay.
- Provide an immediate UI response for `userId` lookups by prioritizing the local card cache before falling back to existing query/index logic.

### Description
- Added a fast-path in `SearchBar` for `platform === 'userId'` that checks `getCard(id)` and returns early when a cached card exists.
- When a cached card is found the code updates the query mapping via `setIdsForQuery(getCacheKey('search', normalizeQueryKey(`userId=${id}`)), [id])`, emits a search label with `emitSearchLabel`, calls `notifySearchResult`, and sets the UI state via `setState` without invoking backend searches.
- Preserves the original behavior for uncached `userId` values and for all other search platforms.
- File changed: `src/components/SearchBar.jsx`.

### Testing
- Ran linting with `npm run lint:js -- src/components/SearchBar.jsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb62aadf5c832693ed0c15387b9114)