### PR TITLE
Prioritize exact userId search path in SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1431,6 +1431,13 @@ const SearchBar = ({
       }
     }
 
+    const looksLikeExactUserId = Boolean(parseUserId(rawQuery));
+    if (
+      looksLikeExactUserId &&
+      isSearchEnabled('userId') &&
+      await processUserSearch('userId', parseUserId, rawQuery)
+    ) return;
+
     if (
       isSearchEnabled('searchId') &&
       await processUserSearch('searchId', parseSearchIdExact, rawQuery)
@@ -1589,6 +1596,7 @@ const SearchBar = ({
 
 
     if (
+      !looksLikeExactUserId &&
       isSearchEnabled('userId') &&
       await processUserSearch('userId', parseUserId, rawQuery)
     ) return;


### PR DESCRIPTION
### Motivation
- Search felt slow for direct `userId` queries because broader indexed lookups (`searchId` / `equalToAllCards`) could run before the direct `userId` path, triggering extra backend work.
- Prefer the fast cached/direct `userId` path when the input clearly looks like an exact `userId` to reduce perceived latency.

### Description
- Detects exact userId-like input using `parseUserId(rawQuery)` and assigns `looksLikeExactUserId` before the main search branches in `src/components/SearchBar.jsx`.
- If `looksLikeExactUserId` is true the code now runs `processUserSearch('userId', parseUserId, rawQuery)` before `searchId` and `equalToAllCards` branches to prioritize the direct lookup.
- Prevents a second redundant `userId` search by keeping the downstream `userId` branch guarded with `!looksLikeExactUserId` so non-exact inputs still fall back to the original logic.

### Testing
- Ran lint for the modified file with `npm run lint:js -- src/components/SearchBar.jsx` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb73519ff88326b1e62540618671ab)