### PR TITLE
Keep searchId/equalTo fallback after early userId probe

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -965,7 +965,11 @@ const SearchBar = ({
   const processUserSearch = async (platform, parseFunction, inputData, options = {}) => {
     const trimmedInput = inputData.trim();
     const id = parseFunction(trimmedInput);
-    const { allowFallback = true, allowUkTrigger = false } = options;
+    const {
+      allowFallback = true,
+      allowUkTrigger = false,
+      continueOnMiss = false,
+    } = options;
 
     console.log('[SearchBar] Parser evaluation', {
       platform,
@@ -1175,6 +1179,7 @@ const SearchBar = ({
           });
         }
         setUserNotFound && setUserNotFound(true);
+        return !continueOnMiss;
       } else {
         setUserNotFound && setUserNotFound(false);
         notifySearchResult(result, finalRes, { preferredKeys: [platform] });
@@ -1183,8 +1188,8 @@ const SearchBar = ({
         } else {
           setUsers && setUsers(finalRes);
         }
+        return true;
       }
-      return true;
     }
     return false;
   };
@@ -1435,7 +1440,9 @@ const SearchBar = ({
     if (
       looksLikeExactUserId &&
       isSearchEnabled('userId') &&
-      await processUserSearch('userId', parseUserId, rawQuery)
+      await processUserSearch('userId', parseUserId, rawQuery, {
+        continueOnMiss: true,
+      })
     ) return;
 
     if (


### PR DESCRIPTION
### Motivation
- Prevent queries that look like a `userId` (but don't actually resolve) from short-circuiting the downstream `searchId` and `equalToAllCards` searches so those fallback paths can still return results.

### Description
- Added a `continueOnMiss` option to `processUserSearch` with default `false` to allow callers to probe a parser without making a failed parse terminal in the pipeline in `src/components/SearchBar.jsx`.
- Updated the not-found branch in `processUserSearch` to return `!continueOnMiss` so the function is non-terminal when `continueOnMiss: true` is passed.
- Changed the early `userId` probe to call `processUserSearch('userId', parseUserId, rawQuery, { continueOnMiss: true })` so `searchId` and `equalToAllCards` remain enabled when a parsed userId yields no results.
- Removed an unreachable return and kept behavior for other search flows unchanged by default.

### Testing
- Ran lint with `npm run -s lint:js`, which completed successfully (only a non-blocking Browserslist update notice was printed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7cf117708326be2da497a41d8e19)