### PR TITLE
Set NoGIT+IdKey as default sort mode in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1239,7 +1239,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [hasSearched, setHasSearched] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [currentFilter, setCurrentFilter] = useState('');
-  const [loadSortMode, setLoadSortMode] = useState(LOAD_SORT_MODES.GIT);
+  const [loadSortMode, setLoadSortMode] = useState(LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY);
   const [loadRequestId, setLoadRequestId] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
   const [dateOffset21, setDateOffset21] = useState(0);
@@ -3471,7 +3471,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setDateOffset2(snapshot.dateOffset2 || 0);
     setDateOffset21(snapshot.dateOffset21 || 0);
     setDateOffsetLA(snapshot.dateOffsetLA || 0);
-    setLoadSortMode(snapshot.loadSortMode || 'GIT');
+    setLoadSortMode(snapshot.loadSortMode || 'SearchIdKeyOnly');
     setSearch(snapshot.search || '');
     setHasSearched(Boolean(snapshot.hasSearched) || Object.keys(restoredUsers).length > 0);
     setState({});


### PR DESCRIPTION
### Motivation
- Make the AddNewProfile list default to the NoGIT+IdKey sorting mode as requested (use `NoGIT+IdKey` by default). 

### Description
- Change the initial `loadSortMode` state from `LOAD_SORT_MODES.GIT` to `LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY` in `src/components/AddNewProfile.jsx`. 
- Change the restored list-state fallback so `snapshot.loadSortMode` defaults to `'SearchIdKeyOnly'` when absent. 
- Use a string fallback for the restored state to avoid a React hook lint dependency warning. 

### Testing
- Ran `npm run lint:js -- src/components/AddNewProfile.jsx` and fixed the lint warning; the final lint check completed with no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcc1744c883268c37ff1e526b16a7)