### PR TITLE
Normalize phone search candidates and use parsed phone fallback in SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1392,7 +1392,11 @@ const SearchBar = ({
           }
 
           if (!res || Object.keys(res).length === 0) {
-            results[`new_${val}`] = { _notFound: true, searchVal: val };
+            const fallbackSearchVal = parsePhoneNumber(val) || val;
+            results[`new_${fallbackSearchVal}`] = {
+              _notFound: true,
+              searchVal: fallbackSearchVal,
+            };
           } else if ('userId' in res) {
             results[res.userId] = res;
           } else {

--- a/src/utils/searchIndexCandidates.js
+++ b/src/utils/searchIndexCandidates.js
@@ -29,6 +29,21 @@ export const buildSearchIndexCandidates = (searchKey, value) => {
     }
   }
 
+  if (searchKey === 'phone') {
+    const digitsOnly = rawValue.replace(/\D/g, '');
+    if (digitsOnly) {
+      candidates.add(digitsOnly);
+
+      if (digitsOnly.startsWith('0')) {
+        candidates.add(`38${digitsOnly}`);
+      }
+
+      if (digitsOnly.startsWith('80')) {
+        candidates.add(`3${digitsOnly}`);
+      }
+    }
+  }
+
   if (searchKey === 'telegram') {
     const baseValues = [...candidates];
     baseValues.forEach(entry => {


### PR DESCRIPTION
### Motivation
- Improve matching for phone-number based searches by normalizing variants with and without formatting and common local/country prefixes, and use a parsed phone fallback when marking a search as not found.

### Description
- Update `buildSearchIndexCandidates` to add a `digitsOnly` candidate for `searchKey === 'phone'` by stripping non-digits and include prefixed variants when the digits start with `0` or `80` (adding `38` or `3` respectively).
- Keep existing space-trimming and `telegram` encoding behavior, and ensure all candidates are returned lowercased via `buildSearchIndexCandidates`.
- Change `SearchBar.jsx` to use `parsePhoneNumber(val) || val` when creating the fallback not-found entry, so the results key and `searchVal` use the parsed phone form when available.

### Testing
- Ran the full test suite with `yarn test`, and all tests passed.
- Ran linting with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc6b0ca8c8326b5deb40675d84ff3)