### PR TITLE
Write searchKeySets at per-user leaf nodes and clean up stale userIds

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -93,6 +93,21 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
     })
     .filter(Boolean);
 
+  const expectedBySetIndexValue = nextSetPayloads.reduce((acc, setPayload) => {
+    const setMap = {};
+    Object.entries(setPayload.indexBuckets || {}).forEach(([indexName, values]) => {
+      const valueMap = {};
+      values.forEach(value => {
+        valueMap[value] = new Set(Object.keys(setPayload.userIds || {}));
+      });
+      if (Object.keys(valueMap).length > 0) {
+        setMap[indexName] = valueMap;
+      }
+    });
+    acc[setPayload.setKey] = setMap;
+    return acc;
+  }, {});
+
   const rootSnap = await get(ref(database, SEARCH_KEY_SETS_ROOT));
   const rootMap = rootSnap.exists() ? rootSnap.val() || {} : {};
   const ownerPrefix = `${encodeSetKeyPayload(normalizedAccessUserId)}${SET_KEY_INDEX_SEPARATOR}`;
@@ -112,10 +127,10 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
     const setPayload = rootMap?.[setKey];
     if (!setPayload || typeof setPayload !== 'object') return;
 
-    const expectedIndexes = nextSetPayloads.find(item => item.setKey === setKey)?.indexBuckets || {};
+    const expectedIndexes = expectedBySetIndexValue[setKey] || {};
     Object.keys(setPayload).forEach(indexName => {
-      const expectedValues = new Set(expectedIndexes[indexName] || []);
-      if (!expectedValues.size) {
+      const expectedValues = expectedIndexes[indexName] || {};
+      if (!Object.keys(expectedValues).length) {
         writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}`] = null;
         return;
       }
@@ -123,9 +138,19 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
       const indexPayload = setPayload[indexName];
       if (!indexPayload || typeof indexPayload !== 'object') return;
       Object.keys(indexPayload).forEach(valueKey => {
-        if (!expectedValues.has(valueKey)) {
+        const expectedUserIds = expectedValues[valueKey];
+        if (!expectedUserIds) {
           writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${valueKey}`] = null;
+          return;
         }
+
+        const valuePayload = indexPayload[valueKey];
+        if (!valuePayload || typeof valuePayload !== 'object') return;
+        Object.keys(valuePayload).forEach(userId => {
+          if (!expectedUserIds.has(userId)) {
+            writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${valueKey}/${userId}`] = null;
+          }
+        });
       });
     });
   });
@@ -133,7 +158,9 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
   nextSetPayloads.forEach(({ setKey, indexBuckets, userIds }) => {
     Object.entries(indexBuckets).forEach(([indexName, values]) => {
       values.forEach(value => {
-        writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`] = userIds;
+        Object.keys(userIds || {}).forEach(userId => {
+          writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}/${userId}`] = true;
+        });
       });
     });
   });


### PR DESCRIPTION
### Motivation
- The previous indexing wrote entire objects at `searchKeySets/$setKey/$indexName/$value`, but Firebase rules expect per-user leaf writes at `.../$value/$userId = true`, causing writes to be rejected and `searchKeySets` to remain empty.
- The index must support multiple filter blocks per user (setKey = `$accessUserId_$inputIndex`) and keep user-level entries consistent when rules change.
- We need cleanup of stale data not only for removed set/index/value branches but also for outdated `userId` entries under existing values.

### Description
- Changed `buildNewUsersFilterSetIndex` to write leaf entries as `searchKeySets/$setKey/$indexName/$value/$userId = true` instead of writing a single object at `$value`.
- Added `expectedBySetIndexValue` construction to compute expected `userId` sets per `setKey/indexName/value` and use it to remove stale `userId` children when present.
- Adjusted cleanup logic to delete stale sets, stale indexes, stale values, and stale `userId` nodes under values based on the expected payload.
- Preserved `setKey` format as `accessUserId_inputIndex` where `inputIndex` is the ordinal of each `additionalAccessRules` block.

### Testing
- Ran `npm run test -- --watch=false --runTestsByPath src/utils/__tests__/cache.test.js` and the suite passed (1 test suite, 3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd2af7eb88326ba1a5cc83ac8e5a7)