### PR TITLE
Respect phone toggle in grouped fallback normalization

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1392,7 +1392,9 @@ const SearchBar = ({
           }
 
           if (!res || Object.keys(res).length === 0) {
-            const fallbackSearchVal = parsePhoneNumber(val) || val;
+            const fallbackSearchVal = isSearchEnabled('phone')
+              ? parsePhoneNumber(val) || val
+              : val;
             results[`new_${fallbackSearchVal}`] = {
               _notFound: true,
               searchVal: fallbackSearchVal,


### PR DESCRIPTION
### Motivation
- Prevent unconditional `parsePhoneNumber` from rewriting unmatched numeric-like search terms when the `phone` search key is disabled, which caused the "+ create" flow to use a transformed value instead of the user's original input.

### Description
- Guard the grouped fallback normalization so `parsePhoneNumber(val)` is only applied when `isSearchEnabled('phone')`, preserving the original `val` otherwise in `src/components/SearchBar.jsx`.

### Testing
- Ran linter with `npm run lint:js -- src/components/SearchBar.jsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd44e43bc8326b4538357ad75eb67)