### PR TITLE
Support strict grouped search key filtering in SearchBar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -680,6 +680,31 @@ const SearchBar = ({
     return Boolean(effectiveEnabledSearchKeys[key]);
   };
 
+  const resolveGroupedStrictKeySet = () => {
+    const effectiveEnabledSearchKeys =
+      enabledSearchKeys && typeof enabledSearchKeys === 'object'
+        ? enabledSearchKeys
+        : searchOptions?.enabledSearchKeys;
+
+    if (!effectiveEnabledSearchKeys || typeof effectiveEnabledSearchKeys !== 'object') {
+      return null;
+    }
+
+    const strictKeys = [
+      'userId',
+      'facebook',
+      'instagram',
+      'telegram',
+      'email',
+      'tiktok',
+      'phone',
+      'vk',
+      'other',
+    ].filter(key => Boolean(effectiveEnabledSearchKeys[key]));
+
+    return strictKeys.length > 0 ? new Set(strictKeys) : null;
+  };
+
   const loadCachedResult = (key, value) => {
     if (typeof value === 'string' && value.startsWith('[') && value.endsWith(']')) {
       const inside = value.slice(1, -1);
@@ -1267,8 +1292,11 @@ const SearchBar = ({
       }
       return;
     }
+    const groupedStrictKeySet = resolveGroupedStrictKeySet();
     const isCombinedSearchMode =
-      isSearchEnabled('searchId') && isSearchEnabled('equalToAllCards');
+      !groupedStrictKeySet &&
+      isSearchEnabled('searchId') &&
+      isSearchEnabled('equalToAllCards');
 
     if (trimmed && trimmed.startsWith('[') && trimmed.endsWith(']')) {
       const hasCache = loadCachedResult('name', trimmed);
@@ -1330,14 +1358,16 @@ const SearchBar = ({
           ['phone', parsePhoneNumber],
           ['vk', parseVk],
           ['other', parseOtherContact],
-        ].filter(([key]) => isSearchEnabled(key));
+        ].filter(([key]) => {
+          if (groupedStrictKeySet) return groupedStrictKeySet.has(key);
+          return isSearchEnabled(key);
+        });
 
         const results = {};
         for (const val of values) {
           let res = null;
           const combinedPerValueResults = {};
           let foundCombinedPerValue = false;
-
           if (!isCombinedSearchMode && isSearchEnabled('partialUserId')) {
             const partialPerValueResult = await runPartialUserIdSearch(
               val,


### PR DESCRIPTION
### Motivation
- Ensure grouped (bracket) searches honor a strict set of enabled search keys when `enabledSearchKeys` or `searchOptions.enabledSearchKeys` is provided so searches only run the intended parsers.
- Avoid combining search strategies (`equalToAllCards` / `searchId`) when a strict grouped key set is in effect to prevent unexpected combined results.

### Description
- Add `resolveGroupedStrictKeySet` helper to compute a `Set` of strict grouped keys from `enabledSearchKeys` or `searchOptions.enabledSearchKeys`.
- Change `isCombinedSearchMode` to be disabled when a grouped strict key set exists by checking `!groupedStrictKeySet`.
- Filter `groupedSearchStrategies` to use the strict key set when present, otherwise fall back to `isSearchEnabled(key)`.
- Maintain existing grouped search flow and caching behavior when no strict set is provided.

### Testing
- Ran the project's test suite with `yarn test` and all tests passed.
- Ran linting with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd2bc55b48326ae540c7797df6981)