### PR TITLE
Respect enabled search checkboxes without extra name fallback

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1416,7 +1416,7 @@ const SearchBar = ({
             }
           }
 
-          if (!res) {
+          if (!res && isSearchEnabled('name')) {
             res = await cachedSearch({ name: val });
             if (isStaleRequest()) return;
           }
@@ -1679,6 +1679,13 @@ const SearchBar = ({
         allowFallback: Boolean(searchOptions?.autoOtherFallback),
       })
     ) return;
+
+    if (!isSearchEnabled('name')) {
+      setUserNotFound && setUserNotFound(true);
+      setState && setState({});
+      setUsers && setUsers({});
+      return;
+    }
 
     const nameTrim = rawQuery.trim();
     console.log('[SearchBar] Defaulting to name search', {


### PR DESCRIPTION
### Motivation
- Search was making extra `name` lookups even when the user had not enabled the `name` checkbox, causing slow grouped searches (e.g. multiple phone values in `[...]`) and unnecessary queries.
- The change aims to ensure searches run only within the explicitly enabled keys (e.g. `searchId + phone`) to avoid wasted work and latency.

### Description
- Limit grouped (`[...]`) search fallback so `name` lookup runs only when `isSearchEnabled('name')` is true by guarding the `cachedSearch({ name: ... })` call.
- Prevent unconditional final fallback to `name` when `name` is disabled by returning early with `not found` and clearing state/users.
- The change was applied in `src/components/SearchBar.jsx` and removes unnecessary `name` queries for disabled search-key configurations.

### Testing
- Ran `npm run lint:js -- src/components/SearchBar.jsx` and lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebde055d608326998de6682af2e4fa)