### PR TITLE
Parse additional-access rule entries, improve index keying and user-facing toasts, and enable multi-line Toaster styling

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -827,16 +827,20 @@ export const ProfileForm = ({
       const code = String(error?.code || '');
       if (code.includes('PERMISSION_DENIED')) {
         console.warn('Skipped additional access newUsers filter-set index rebuild due to permissions.', error);
+        const details = error?.message || String(error);
+        toast.error(
+          `Немає прав на запис у searchKeySets.\nПеревірте Firebase Rules для цього користувача.\n${details}`
+        );
       } else {
         console.error('Failed to update additional access newUsers filter-set index', error);
         const details = error?.message || String(error);
-        toast.error(`Не вдалося зберегти індексацію наборів фільтрів (${details})`);
+        toast.error(`Не вдалося зберегти індексацію наборів фільтрів.\n${details}`);
       }
     }
     Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
       console.error('Failed to submit profile changes', error);
       const details = error?.message || String(error);
-      toast.error(`Не вдалося зберегти зміни профілю (${details})`);
+      toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
     });
   }, [handleSubmit, state?.userId]);
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,16 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <PersistGate loading={null} persistor={persistor}>
         <BrowserRouter basename="/main">
           <App />
-          <Toaster />
+          <Toaster
+            toastOptions={{
+              style: {
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                overflowWrap: 'anywhere',
+                maxWidth: 'min(92vw, 520px)',
+              },
+            }}
+          />
         </BrowserRouter>
       </PersistGate>
     </Provider>

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -20,6 +20,25 @@ const splitRawRulesToSetTexts = rawRules => {
     .filter(Boolean);
 };
 
+const parseRawRulesToSetEntries = rawRules => {
+  if (Array.isArray(rawRules)) {
+    return rawRules
+      .map((item, index) => ({
+        text: String(item || '').trim(),
+        inputIndex: index + 1,
+      }))
+      .filter(entry => Boolean(entry.text));
+  }
+
+  return String(rawRules || '')
+    .split(/\r?\n\s*\r?\n+/)
+    .map((item, index) => ({
+      text: item.trim(),
+      inputIndex: index + 1,
+    }))
+    .filter(entry => Boolean(entry.text));
+};
+
 export const makeAdditionalRulesSetKey = (rawRules, accessUserId = '', setIndex = 1) => {
   const normalizedOwnerId = String(accessUserId || '').trim();
   if (!normalizedOwnerId) return '';
@@ -66,9 +85,9 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
       ? newUsersData
       : (await get(ref(database, 'newUsers'))).val() || {};
 
-  const ruleSetTexts = splitRawRulesToSetTexts(rawRules);
-  const nextSetPayloads = ruleSetTexts
-    .map((setText, index) => {
+  const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
+  const nextSetPayloads = ruleSetEntries
+    .map(({ text: setText, inputIndex }) => {
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
       if (parsedRuleGroups.length === 0) return null;
 
@@ -81,7 +100,8 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
 
       if (Object.keys(indexBuckets).length === 0) return null;
 
-      const ownerSetKey = `${normalizedAccessUserId}${SET_KEY_INDEX_SEPARATOR}${index + 1}`;
+      const ownerSetKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
+      if (!ownerSetKey) return null;
       return {
         setKey: ownerSetKey,
         indexBuckets,
@@ -178,10 +198,9 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   const normalizedAccessUserId = String(accessUserId || '').trim();
   if (!normalizedAccessUserId) return null;
 
-  const ruleSetTexts = splitRawRulesToSetTexts(rawRules);
-  const ownerPrefix = `${normalizedAccessUserId}${SET_KEY_INDEX_SEPARATOR}`;
-  const setEntries = ruleSetTexts
-    .map((setText, index) => {
+  const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
+  const setEntries = ruleSetEntries
+    .map(({ text: setText, inputIndex }) => {
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
       if (!parsedRuleGroups.length) return null;
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
@@ -192,7 +211,8 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       }, {});
       if (!Object.keys(indexBuckets).length) return null;
 
-      const setKey = `${ownerPrefix}${index + 1}`;
+      const setKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
+      if (!setKey) return null;
       const paths = Object.entries(indexBuckets).flatMap(([indexName, values]) =>
         values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
       );


### PR DESCRIPTION
### Motivation
- Ensure additional-access raw rules are parsed with input order preserved and support both string and array inputs for reliable set key generation.
- Make set key generation deterministic using the input index so rules map to stable database paths.
- Surface clearer, multi-line error messages to users when index rebuilds or profile submits fail, and handle permission-denied cases distinctly.
- Prevent long toast text from being clipped by enabling wrapping and a sensible max width in the global `Toaster`.

### Description
- Added `parseRawRulesToSetEntries` to normalize `rawRules` into `{ text, inputIndex }` entries for both string and array inputs in `src/utils/newUsersFilterSetsIndex.js`.
- Updated `buildNewUsersFilterSetIndex` and `getIndexedNewUsersIdsByRules` to use parsed entries and generate owner set keys via `makeAdditionalRulesSetKey` with the preserved `inputIndex`, and to skip empty/invalid keys.
- Reworked index payload construction to continue supporting bucket resolution and write aggregation while using the new parsed entries flow.
- Enhanced `submitWithNormalization` in `src/components/ProfileForm.jsx` to show Ukrainian, multi-line toasts with permission-specific message on `PERMISSION_DENIED` and improved detail formatting for other errors.
- Configured the global `Toaster` in `src/index.js` with `toastOptions` to enable `whiteSpace: 'pre-wrap'`, `wordBreak: 'break-word'`, `overflowWrap: 'anywhere'`, and a `maxWidth` of `min(92vw, 520px)` so error details render correctly.

### Testing
- Ran the unit test suite via `npm test`, and all tests passed.
- Ran the linter via `npm run lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdfa993388326821c80bca0e59b0e)