### PR TITLE
Refactor bracketed grouped search to reuse checkbox/equalTo logic

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -854,11 +854,18 @@ const SearchBar = ({
     Object.assign(acc, res);
   };
 
-  const runEqualToAllCardsSearch = async (rawQuery, isStaleRequest, resultMap = {}) => {
+  const runEqualToAllCardsSearch = async (
+    rawQuery,
+    isStaleRequest,
+    resultMap = {},
+    forcedEqualToKeys = null,
+  ) => {
     const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);
-    const selectedEqualToKeys = Array.isArray(searchOptions?.equalToKeys)
-      ? searchOptions.equalToKeys.filter(key => allEqualToKeys.includes(key))
-      : [];
+    const selectedEqualToKeys = Array.isArray(forcedEqualToKeys)
+      ? forcedEqualToKeys.filter(key => allEqualToKeys.includes(key))
+      : Array.isArray(searchOptions?.equalToKeys)
+        ? searchOptions.equalToKeys.filter(key => allEqualToKeys.includes(key))
+        : [];
     const equalToExecutionPlan = resolveEqualToExecutionKeys({
       allKeys: allEqualToKeys,
       selectedKeys: selectedEqualToKeys,
@@ -1347,81 +1354,49 @@ const SearchBar = ({
           return;
         }
 
-        const groupedSearchStrategies = [
-          ['searchId', parseSearchIdExact],
-          ['userId', parseUserId],
-          ['facebook', parseFacebookId],
-          ['instagram', parseInstagramId],
-          ['telegram', parseTelegramId],
-          ['email', parseEmail],
-          ['tiktok', parseTikTokLink],
-          ['phone', parsePhoneNumber],
-          ['vk', parseVk],
-          ['other', parseOtherContact],
-        ].filter(([key]) => {
-          if (groupedStrictKeySet) return groupedStrictKeySet.has(key);
-          return isSearchEnabled(key);
-        });
-
         const results = {};
         for (const val of values) {
-          let res = null;
-          const combinedPerValueResults = {};
-          let foundCombinedPerValue = false;
-          if (!isCombinedSearchMode && isSearchEnabled('partialUserId')) {
+          let found = false;
+          const perValueResults = {};
+
+          if (isSearchEnabled('partialUserId')) {
             const partialPerValueResult = await runPartialUserIdSearch(
               val,
               isStaleRequest,
+              perValueResults,
             );
             if (isStaleRequest()) return;
             if (partialPerValueResult.found) {
-              res = partialPerValueResult.results;
+              found = true;
             }
           }
 
-          for (const [key, parser] of groupedSearchStrategies) {
-            if (res && Object.keys(res).length > 0) {
-              break;
-            }
-            const parsedValue = parser(val);
-            if (!parsedValue) continue;
-
-            const groupedResult = await cachedSearch({ [key]: parsedValue });
-            if (isStaleRequest()) return;
-            if (groupedResult && Object.keys(groupedResult).length > 0) {
-              if (isCombinedSearchMode) {
-                foundCombinedPerValue = true;
-                mergeSearchResultMap(combinedPerValueResults, groupedResult);
-                continue;
-              }
-
-              res = groupedResult;
-              break;
-            }
-          }
-
-          if (isCombinedSearchMode) {
-            const equalToCombinedResult = await runEqualToAllCardsSearch(
+          if (isSearchEnabled('equalToAllCards')) {
+            const forcedEqualToKeys = groupedStrictKeySet
+              ? Array.from(groupedStrictKeySet)
+              : null;
+            const equalToResult = await runEqualToAllCardsSearch(
               val,
               isStaleRequest,
-              combinedPerValueResults,
+              perValueResults,
+              forcedEqualToKeys,
             );
             if (isStaleRequest()) return;
-            if (equalToCombinedResult.found) {
-              foundCombinedPerValue = true;
-            }
-
-            if (foundCombinedPerValue && Object.keys(combinedPerValueResults).length > 0) {
-              res = combinedPerValueResults;
+            if (equalToResult.found) {
+              found = true;
             }
           }
 
-          if (!res && isSearchEnabled('name')) {
-            res = await cachedSearch({ name: val });
+          if (!found && isSearchEnabled('name')) {
+            const nameResult = await cachedSearch({ name: val });
             if (isStaleRequest()) return;
+            if (nameResult && Object.keys(nameResult).length > 0) {
+              mergeSearchResultMap(perValueResults, nameResult);
+              found = true;
+            }
           }
 
-          if (!res || Object.keys(res).length === 0) {
+          if (!found || Object.keys(perValueResults).length === 0) {
             const fallbackSearchVal = isSearchEnabled('phone')
               ? parsePhoneNumber(val) || val
               : val;
@@ -1429,10 +1404,8 @@ const SearchBar = ({
               _notFound: true,
               searchVal: fallbackSearchVal,
             };
-          } else if ('userId' in res) {
-            results[res.userId] = res;
           } else {
-            Object.assign(results, res);
+            Object.assign(results, perValueResults);
           }
         }
         setUsers && setUsers(results);


### PR DESCRIPTION
### Motivation
- Зменшити затримку пошуку для запитів у квадратних дужках `[...]` замінивши повільну послідовну логіку на існуючу логіку чекбоксів/`equalTo` яка швидше масштабується для множинних значень.

### Description
- Залишено парсер та детекцію масивів: `parseGroupedSearchValues` та гілку `if (trimmed.startsWith('[') && trimmed.endsWith(']'))` залишили без зміни формату вхідних даних.
- Перероблено обробку групових запитів так, щоб для кожного значення масиву застосовувалась поточна логіка чекбоксів/`equalTo` (через розширення `runEqualToAllCardsSearch` додатковим параметром `forcedEqualToKeys`) і результати агрегувались разом; реалізація знаходиться в `src/components/SearchBar.jsx`.
- Видалено стару повільну логіку, а саме послідовний `groupedSearchStrategies` (перебір `searchId`, `userId`, `facebook`, `instagram`, `telegram`, `email`, `tiktok`, `phone`, `vk`, `other`) і повʼязані per-value конструкції (`combinedPerValueResults`, `foundCombinedPerValue` та ранній `break`), які виокремлювали перше співпадіння та викликали багато послідовних запитів для масивів.
- Додано агрегацію результатів для кожного елемента масиву з fallback-логікою: `partialUserId` → `equalToAllCards` (через чекбокси) → `name`, потім формування кеш-ключа `names=...` для збереження результатів.

### Testing
- Запущено лінтер: `npm run lint:js -- src/components/SearchBar.jsx` і команда виконалась успішно (лише інформаційні попередження від `browserslist`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe2300f508326beabb7a9598d1cff)