### PR TITLE
Fix searchKeySets indexing diagnostics and path-safe bucket keys

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -818,10 +818,15 @@ export const ProfileForm = ({
       const rawRules = payload?.[ADDITIONAL_ACCESS_FIELD];
       if (rawRules !== undefined) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
-        await buildNewUsersFilterSetIndex({
+        const indexResult = await buildNewUsersFilterSetIndex({
           rawRules,
           accessUserId,
         });
+        if (indexResult && Number(indexResult.writesCount || 0) === 0) {
+          toast(
+            'searchKeySets не оновлено: немає збігів newUsers для обраних фільтрів або не знайдено валідних правил.'
+          );
+        }
       }
     } catch (error) {
       const code = String(error?.code || '');

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1,5 +1,6 @@
 import { get, ref, remove, update } from 'firebase/database';
 import { database } from 'components/config';
+import { encodeKey } from './searchIndexCandidates';
 import {
   isUserAllowedByAnyAdditionalAccessRule,
   parseAdditionalAccessRuleGroups,
@@ -8,6 +9,14 @@ import {
 
 export const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_INDEX_SEPARATOR = '_';
+const FORBIDDEN_RTDB_SEGMENT_CHARS = ['.', '#', '$', '/', '[', ']'];
+
+const normalizePathSegment = value => {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+  const hasForbiddenChars = FORBIDDEN_RTDB_SEGMENT_CHARS.some(char => raw.includes(char));
+  return hasForbiddenChars ? encodeKey(raw) : raw;
+};
 
 const splitRawRulesToSetTexts = rawRules => {
   if (Array.isArray(rawRules)) {
@@ -93,8 +102,17 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
 
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
       const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
-        const values = [...new Set((Array.isArray(rawValues) ? rawValues : [...(rawValues || [])]).filter(Boolean))];
-        if (values.length) acc[indexName] = values;
+        const normalizedIndexName = normalizePathSegment(indexName);
+        if (!normalizedIndexName) return acc;
+
+        const values = [
+          ...new Set(
+            (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+              .map(normalizePathSegment)
+              .filter(Boolean)
+          ),
+        ];
+        if (values.length) acc[normalizedIndexName] = values;
         return acc;
       }, {});
 
@@ -191,6 +209,7 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
     setKeys: [...nextSetKeys],
     userIds: aggregatedUserIds,
     ownerId: normalizedAccessUserId,
+    writesCount: Object.keys(writes).length,
   };
 };
 
@@ -205,8 +224,16 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       if (!parsedRuleGroups.length) return null;
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
       const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
-        const values = [...new Set((Array.isArray(rawValues) ? rawValues : [...(rawValues || [])]).filter(Boolean))];
-        if (values.length) acc[indexName] = values;
+        const normalizedIndexName = normalizePathSegment(indexName);
+        if (!normalizedIndexName) return acc;
+        const values = [
+          ...new Set(
+            (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+              .map(normalizePathSegment)
+              .filter(Boolean)
+          ),
+        ];
+        if (values.length) acc[normalizedIndexName] = values;
         return acc;
       }, {});
       if (!Object.keys(indexBuckets).length) return null;


### PR DESCRIPTION
### Motivation
- `searchKeySets` could remain empty silently because writes are only attempted when concrete `userId` matches exist, and invalid RTDB path characters in dynamic bucket keys could prevent writes or reads. 
- Users need clearer feedback when applying additional access rules produces no index writes so they understand why nothing appears in `searchKeySets`.

### Description
- Normalize dynamic RTDB path segments by importing `encodeKey` and adding `normalizePathSegment` to encode bucket keys that contain forbidden RTDB characters before writing or reading. 
- Apply path-segmentation normalization to both index names and values inside `buildNewUsersFilterSetIndex` and `getIndexedNewUsersIdsByRules` so generated paths are safe. 
- Return `writesCount` from `buildNewUsersFilterSetIndex` so callers can detect when no writes were produced. 
- Show an informational toast in `ProfileForm` when `buildNewUsersFilterSetIndex` returns `writesCount === 0` to explain why `searchKeySets` was not updated. 

### Testing
- Ran linting with `npm run lint:js -- src/components/ProfileForm.jsx src/utils/newUsersFilterSetsIndex.js` and it completed with no ESLint errors. 
- Verified the code change removes a previous ESLint warning by replacing a regex check with a character inclusion check in `newUsersFilterSetsIndex.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe7f56bf4832690a3b66a5a221e27)