### PR TITLE
Prefilter and normalize additional-access rule set indexing for newUsers

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -28,6 +28,7 @@ import {
 import {
   buildNewUsersFilterSetIndex,
   getIndexedNewUsersIdsByRules,
+  makeAdditionalRulesSetKey,
 } from 'utils/newUsersFilterSetsIndex';
 import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
 
@@ -573,6 +574,7 @@ export const ProfileForm = ({
   const [previewAdditionalRulesText, setPreviewAdditionalRulesText] = useState('');
   const [availableCardsCount, setAvailableCardsCount] = useState(0);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
+  const matchedUserIdsByInputIndexRef = useRef({});
   const autoAppliedOverlayForUserRef = useRef('');
 
   const addEmptyAdditionalFilter = useCallback(() => {
@@ -809,7 +811,31 @@ export const ProfileForm = ({
     return { ...draftState, getInTouch: normalized };
   };
 
-  const submitWithNormalization = useCallback(async (nextState, overwrite, delCondition) => {
+  const buildMatchedUserIdsBySetKey = useCallback((rawRules, accessUserId, matchedByInputIndex) => {
+    const normalizedAccessUserId = String(accessUserId || '').trim();
+    if (!normalizedAccessUserId || !matchedByInputIndex || typeof matchedByInputIndex !== 'object') return null;
+
+    const ruleInputs = Array.isArray(rawRules)
+      ? rawRules.map(item => String(item || '').trim())
+      : String(rawRules || '')
+        .split(/\r?\n\s*\r?\n+/)
+        .map(item => item.trim());
+
+    const matchedBySetKey = {};
+    ruleInputs.forEach((rulesText, index) => {
+      if (!rulesText) return;
+      const inputIndex = index + 1;
+      const setKey = makeAdditionalRulesSetKey(rulesText, normalizedAccessUserId, inputIndex);
+      if (!setKey) return;
+      const userIds = matchedByInputIndex[inputIndex];
+      if (!Array.isArray(userIds)) return;
+      matchedBySetKey[setKey] = userIds;
+    });
+
+    return Object.keys(matchedBySetKey).length > 0 ? matchedBySetKey : null;
+  }, []);
+
+  const submitWithNormalization = useCallback(async (nextState, overwrite, delCondition, options = {}) => {
     const payload =
       nextState && typeof nextState === 'object'
         ? normalizeGetInTouchForSubmit(nextState)
@@ -818,10 +844,27 @@ export const ProfileForm = ({
       const rawRules = payload?.[ADDITIONAL_ACCESS_FIELD];
       if (rawRules !== undefined) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
-        await buildNewUsersFilterSetIndex({
+        if (options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object') {
+          matchedUserIdsByInputIndexRef.current = {
+            ...matchedUserIdsByInputIndexRef.current,
+            ...options.matchedUserIdsByInputIndex,
+          };
+        }
+        const matchedUserIdsBySetKey = buildMatchedUserIdsBySetKey(
           rawRules,
           accessUserId,
+          matchedUserIdsByInputIndexRef.current
+        );
+        const indexResult = await buildNewUsersFilterSetIndex({
+          rawRules,
+          accessUserId,
+          matchedUserIdsBySetKey,
         });
+        if (indexResult && Number(indexResult.writesCount || 0) === 0) {
+          toast(
+            'searchKeySets не оновлено: немає збігів newUsers для обраних фільтрів або не знайдено валідних правил.'
+          );
+        }
       }
     } catch (error) {
       const code = String(error?.code || '');
@@ -842,7 +885,7 @@ export const ProfileForm = ({
       const details = error?.message || String(error);
       toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
     });
-  }, [handleSubmit, state?.userId]);
+  }, [buildMatchedUserIdsBySetKey, handleSubmit, state?.userId]);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;
@@ -884,12 +927,30 @@ export const ProfileForm = ({
     setAdditionalRuleBuilder(prev => prev.filter((_, ruleIndex) => ruleIndex !== index));
   };
 
-  const applyAdditionalRulesFromBuilder = () => {
+  const applyAdditionalRulesFromBuilder = async () => {
     const rulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
     if (!rulesText.trim()) {
       toast.error('Оберіть щонайменше один фільтр перед застосуванням');
       return;
     }
+
+    let matchedUserIds = [];
+    try {
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
+      const newUsersSnapshot = await get(refDb(database, 'newUsers'));
+      const newUsersMap = newUsersSnapshot.exists() ? newUsersSnapshot.val() || {} : {};
+      matchedUserIds = Object.entries(newUsersMap)
+        .filter(([userId, userData]) =>
+          isUserAllowedByAnyAdditionalAccessRule(
+            { userId, ...(userData && typeof userData === 'object' ? userData : {}) },
+            parsedRuleGroups
+          )
+        )
+        .map(([userId]) => userId);
+    } catch (error) {
+      console.error('Failed to precompute additional access matched users for indexing', error);
+    }
+
     setState(prevState => {
       const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
       const updatedValue = Array.isArray(currentValue)
@@ -899,7 +960,11 @@ export const ProfileForm = ({
         ...prevState,
         [ADDITIONAL_ACCESS_FIELD]: updatedValue,
       };
-      submitWithNormalization(updated, 'overwrite');
+      submitWithNormalization(updated, 'overwrite', undefined, {
+        matchedUserIdsByInputIndex: {
+          [activeAdditionalRuleInputIndex + 1]: matchedUserIds,
+        },
+      });
       return updated;
     });
     setPreviewAdditionalRulesText(prev => {

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1,5 +1,6 @@
 import { get, ref, remove, update } from 'firebase/database';
 import { database } from 'components/config';
+import { encodeKey } from './searchIndexCandidates';
 import {
   isUserAllowedByAnyAdditionalAccessRule,
   parseAdditionalAccessRuleGroups,
@@ -8,6 +9,14 @@ import {
 
 export const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_INDEX_SEPARATOR = '_';
+const FORBIDDEN_RTDB_SEGMENT_CHARS = ['.', '#', '$', '/', '[', ']'];
+
+const normalizePathSegment = value => {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+  const hasForbiddenChars = FORBIDDEN_RTDB_SEGMENT_CHARS.some(char => raw.includes(char));
+  return hasForbiddenChars ? encodeKey(raw) : raw;
+};
 
 const splitRawRulesToSetTexts = rawRules => {
   if (Array.isArray(rawRules)) {
@@ -76,7 +85,20 @@ const mapMatchingIdsByRules = (newUsersData, parsedRuleGroups) => {
   return ids;
 };
 
-export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = null, accessUserId }) => {
+const buildUserIdsMapFromList = userIds =>
+  (Array.isArray(userIds) ? userIds : [])
+    .filter(Boolean)
+    .reduce((acc, userId) => {
+      acc[userId] = true;
+      return acc;
+    }, {});
+
+export const buildNewUsersFilterSetIndex = async ({
+  rawRules,
+  newUsersData = null,
+  accessUserId,
+  matchedUserIdsBySetKey = null,
+}) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
   if (!normalizedAccessUserId) return null;
 
@@ -93,8 +115,17 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
 
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
       const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
-        const values = [...new Set((Array.isArray(rawValues) ? rawValues : [...(rawValues || [])]).filter(Boolean))];
-        if (values.length) acc[indexName] = values;
+        const normalizedIndexName = normalizePathSegment(indexName);
+        if (!normalizedIndexName) return acc;
+
+        const values = [
+          ...new Set(
+            (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+              .map(normalizePathSegment)
+              .filter(Boolean)
+          ),
+        ];
+        if (values.length) acc[normalizedIndexName] = values;
         return acc;
       }, {});
 
@@ -102,10 +133,16 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
 
       const ownerSetKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
       if (!ownerSetKey) return null;
+      const prefilteredIds = matchedUserIdsBySetKey?.[ownerSetKey];
+      const userIds =
+        Array.isArray(prefilteredIds)
+          ? buildUserIdsMapFromList(prefilteredIds)
+          : mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups);
+
       return {
         setKey: ownerSetKey,
         indexBuckets,
-        userIds: mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups),
+        userIds,
       };
     })
     .filter(Boolean);
@@ -191,6 +228,7 @@ export const buildNewUsersFilterSetIndex = async ({ rawRules, newUsersData = nul
     setKeys: [...nextSetKeys],
     userIds: aggregatedUserIds,
     ownerId: normalizedAccessUserId,
+    writesCount: Object.keys(writes).length,
   };
 };
 
@@ -205,8 +243,16 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       if (!parsedRuleGroups.length) return null;
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
       const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
-        const values = [...new Set((Array.isArray(rawValues) ? rawValues : [...(rawValues || [])]).filter(Boolean))];
-        if (values.length) acc[indexName] = values;
+        const normalizedIndexName = normalizePathSegment(indexName);
+        if (!normalizedIndexName) return acc;
+        const values = [
+          ...new Set(
+            (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+              .map(normalizePathSegment)
+              .filter(Boolean)
+          ),
+        ];
+        if (values.length) acc[normalizedIndexName] = values;
         return acc;
       }, {});
       if (!Object.keys(indexBuckets).length) return null;
@@ -271,10 +317,34 @@ export const rebuildAllNewUsersFilterSetIndexes = async () => {
     }
 
     totalRuleSets += setTexts.length;
+
+    // Подвійна послідовна індексація:
+    // 1) формуємо попередньо відфільтрований набір newUsers для кожного setKey (як у модалці "Додаткові правила доступу")
+    // 2) записуємо searchKeySets з урахуванням цих наборів
+    const matchedUserIdsBySetKey = {};
+    const ruleEntries = parseRawRulesToSetEntries(rawRules);
+    ruleEntries.forEach(({ text: setText, inputIndex }) => {
+      const setKey = makeAdditionalRulesSetKey(setText, userId, inputIndex);
+      if (!setKey) return;
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
+      if (!parsedRuleGroups.length) return;
+
+      const matchedUserIds = Object.entries(newUsersMap)
+        .filter(([newUserId, newUserData]) =>
+          isUserAllowedByAnyAdditionalAccessRule(
+            { userId: newUserId, ...(newUserData && typeof newUserData === 'object' ? newUserData : {}) },
+            parsedRuleGroups
+          )
+        )
+        .map(([newUserId]) => newUserId);
+      matchedUserIdsBySetKey[setKey] = matchedUserIds;
+    });
+
     const indexed = await buildNewUsersFilterSetIndex({
       rawRules,
       newUsersData: newUsersMap,
       accessUserId: userId,
+      matchedUserIdsBySetKey,
     });
     if (indexed?.setKeys?.length) indexedSets += indexed.setKeys.length;
   }


### PR DESCRIPTION
### Motivation

- Improve efficiency and robustness of building search-key sets for `additionalAccessRules` by precomputing matched `newUsers` and avoiding invalid RTDB path segments.
- Allow the profile form UI to pass precomputed matched user lists to the index builder to reduce redundant scanning and writes.

### Description

- Added `makeAdditionalRulesSetKey` import and a `matchedUserIdsByInputIndexRef` to `ProfileForm.jsx`, and implemented `buildMatchedUserIdsBySetKey` to translate per-input matched IDs into set-key keyed maps.
- Extended `submitWithNormalization` to accept an `options` object and merge `matchedUserIdsByInputIndex` into a ref so precomputed matches are forwarded to the indexer; updated `applyAdditionalRulesFromBuilder` to precompute matched `newUsers` for the active rules input and pass them into submit flow. 
- Changed `buildNewUsersFilterSetIndex` signature to accept `matchedUserIdsBySetKey`, added `buildUserIdsMapFromList`, normalized RTDB path segments via `normalizePathSegment` (using `encodeKey` when forbidden characters are present), and used prefiltered IDs when provided to avoid scanning all `newUsers`; function now returns `writesCount`.
- Normalized index names/values in `getIndexedNewUsersIdsByRules` and updated `rebuildAllNewUsersFilterSetIndexes` to perform a two-step indexing: precompute matched `newUsers` per set key and then call the index builder with those prefiltered sets.

### Testing

- Ran the existing test suite with `yarn test` and all tests passed.
- Performed a smoke check of the index build flow by invoking the updated indexing logic on a local dataset and observed expected `writesCount` return values without RTDB path errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe7f56bf4832690a3b66a5a221e27)