### PR TITLE
Align bracketed SearchBar queries with single-query execution flow

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1488,41 +1488,6 @@ const SearchBar = ({
           cleanedValues: values,
         });
 
-        if (isCombinedSearchMode) {
-          const combinedGroupedResults = {};
-          let foundCombinedGroupedResults = false;
-
-          for (const val of values) {
-            const combinedResult = await runCombinedSearchForQuery(
-              val,
-              isStaleRequest,
-              combinedGroupedResults,
-            );
-            if (isStaleRequest()) return;
-            if (combinedResult.found) {
-              foundCombinedGroupedResults = true;
-            }
-          }
-
-          if (foundCombinedGroupedResults && Object.keys(combinedGroupedResults).length > 0) {
-            setUserNotFound && setUserNotFound(false);
-            setState && setState({});
-            setUsers && setUsers({ ...combinedGroupedResults });
-          } else {
-            setState && setState({});
-            setUsers && setUsers({});
-            setUserNotFound && setUserNotFound(true);
-          }
-
-          const term = values.map(v => v).sort().join(',');
-          const ids = Object.keys(combinedGroupedResults);
-          setIdsForQuery(
-            getCacheKey('search', normalizeQueryKey(`names=${term}`)),
-            ids,
-          );
-          return;
-        }
-
         const results = {};
         for (const val of values) {
           const perValueResults = {};


### PR DESCRIPTION
### Motivation
- Bracketed multi-value searches (`[ ... ]`) used a separate `isCombinedSearchMode` branch which diverged from the single-query execution path and could miss matches for values that are found when searched individually.
- The goal is to make bracketed-list searches behave the same as sequential single queries so results are consistent regardless of whether queries are supplied one-by-one or in `[...]` form.

### Description
- Removed the special `isCombinedSearchMode` branch in `SearchBar.writeData` that performed a different combined grouped search for bracketed inputs.
- Bracketed inputs are now processed by running each item through the same `runSingleQueryFlow` used for single queries, preserving per-value logic and fallbacks.
- Kept grouped caching and `_notFound` placeholders behavior, and still write the grouped cache key via `setIdsForQuery` when finishing grouped processing.
- Changes are limited to `src/components/SearchBar.jsx` and only alter the grouped-search control flow to align it with single-query logic.

### Testing
- Ran `npm test -- --watch=false --runInBand`, and Jest reported that there are no tests related to the changed files (test command completed without test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec42ee8e0483268222e6a3a77ffa16)