### PR TITLE
Reset additional-access prefilter cache when rule text or owner changes

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -575,6 +575,8 @@ export const ProfileForm = ({
   const [availableCardsCount, setAvailableCardsCount] = useState(0);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const matchedUserIdsByInputIndexRef = useRef({});
+  const matchedRuleTextByInputIndexRef = useRef({});
+  const matchedRuleCacheAccessUserIdRef = useRef('');
   const autoAppliedOverlayForUserRef = useRef('');
 
   const addEmptyAdditionalFilter = useCallback(() => {
@@ -844,12 +846,43 @@ export const ProfileForm = ({
       const rawRules = payload?.[ADDITIONAL_ACCESS_FIELD];
       if (rawRules !== undefined) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
-        if (options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object') {
+        const hasPrefilteredMatches =
+          !!options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object';
+        const currentRuleInputs = Array.isArray(rawRules)
+          ? rawRules.map(item => String(item || '').trim())
+          : String(rawRules || '')
+            .split(/\r?\n\s*\r?\n+/)
+            .map(item => item.trim());
+        const nextRuleTextByInputIndex = currentRuleInputs.reduce((acc, rulesText, idx) => {
+          acc[idx + 1] = rulesText;
+          return acc;
+        }, {});
+
+        if (matchedRuleCacheAccessUserIdRef.current !== accessUserId) {
+          matchedUserIdsByInputIndexRef.current = {};
+          matchedRuleTextByInputIndexRef.current = {};
+        }
+
+        const prevRuleTextByInputIndex = matchedRuleTextByInputIndexRef.current;
+        Object.keys(matchedUserIdsByInputIndexRef.current).forEach(rawInputIndex => {
+          const inputIndex = Number(rawInputIndex);
+          const prevRuleText = prevRuleTextByInputIndex[inputIndex] || '';
+          const nextRuleText = nextRuleTextByInputIndex[inputIndex] || '';
+          if (!nextRuleText || prevRuleText !== nextRuleText) {
+            delete matchedUserIdsByInputIndexRef.current[inputIndex];
+          }
+        });
+
+        if (hasPrefilteredMatches) {
           matchedUserIdsByInputIndexRef.current = {
             ...matchedUserIdsByInputIndexRef.current,
             ...options.matchedUserIdsByInputIndex,
           };
         }
+
+        matchedRuleCacheAccessUserIdRef.current = accessUserId;
+        matchedRuleTextByInputIndexRef.current = nextRuleTextByInputIndex;
+
         const matchedUserIdsBySetKey = buildMatchedUserIdsBySetKey(
           rawRules,
           accessUserId,


### PR DESCRIPTION
### Motivation

- `submitWithNormalization` previously merged `matchedUserIdsByInputIndexRef` without invalidation, allowing stale prefiltered user IDs to be reused when rule text changed or when subsequent submits omitted the prefilter payload. This produced incorrect `searchKeySets` membership during indexing. 

### Description

- Add cache metadata refs `matchedRuleTextByInputIndexRef` and `matchedRuleCacheAccessUserIdRef` in `src/components/ProfileForm.jsx` to scope prefiltered matches by access user and rule text.  
- In `submitWithNormalization`, normalize current rule inputs and compute a `nextRuleTextByInputIndex` map.  
- Invalidate entries in `matchedUserIdsByInputIndexRef` when the `accessUserId` changes, when an input index becomes empty, or when the rule text for an input index differs from the cached text.  
- Preserve the explicit merge behavior only when `options.matchedUserIdsByInputIndex` is provided, then rebuild `matchedUserIdsBySetKey` and call `buildNewUsersFilterSetIndex` with the sanitized cache.  

### Testing

- Ran `npx eslint src/components/ProfileForm.jsx` and it completed without errors (warnings only from environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5591d9888326a279e664282bd54a)