### PR TITLE
Short-circuit grouped (bracketed) searches to match single-query behavior

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1033,8 +1033,6 @@ const SearchBar = ({
     resultMap = {},
     forcedEqualToKeys = null,
   ) => {
-    let found = false;
-
     if (isSearchEnabled('partialUserId')) {
       const partialPerValueResult = await runPartialUserIdSearch(
         rawQuery,
@@ -1043,7 +1041,7 @@ const SearchBar = ({
       );
       if (isStaleRequest()) return { found: false, results: resultMap };
       if (partialPerValueResult.found) {
-        found = true;
+        return { found: true, results: resultMap };
       }
     }
 
@@ -1058,7 +1056,7 @@ const SearchBar = ({
       );
       if (isStaleRequest()) return { found: false, results: resultMap };
       if (userIdExactResult.found) {
-        found = true;
+        return { found: true, results: resultMap };
       }
     }
 
@@ -1070,7 +1068,7 @@ const SearchBar = ({
       );
       if (isStaleRequest()) return { found: false, results: resultMap };
       if (searchIdResult.found) {
-        found = true;
+        return { found: true, results: resultMap };
       }
     }
 
@@ -1083,7 +1081,7 @@ const SearchBar = ({
       );
       if (isStaleRequest()) return { found: false, results: resultMap };
       if (equalToResult.found) {
-        found = true;
+        return { found: true, results: resultMap };
       }
     }
 
@@ -1113,20 +1111,20 @@ const SearchBar = ({
       );
       if (isStaleRequest()) return { found: false, results: resultMap };
       if (platformResult.found) {
-        found = true;
+        return { found: true, results: resultMap };
       }
     }
 
-    if (!found && isSearchEnabled('name')) {
+    if (isSearchEnabled('name')) {
       const nameResult = await cachedSearch({ name: rawQuery });
       if (isStaleRequest()) return { found: false, results: resultMap };
       if (nameResult && Object.keys(nameResult).length > 0) {
         mergeSearchResultMap(resultMap, nameResult);
-        found = true;
+        return { found: true, results: resultMap };
       }
     }
 
-    return { found, results: resultMap };
+    return { found: false, results: resultMap };
   };
 
   const cachedSearch = async (params, extraOptions = {}) => {


### PR DESCRIPTION
### Motivation
- Grouped bracketed searches (queries like `[...]`) were much slower because per-value execution continued running fallback branches after the first successful match, creating extra RTDB queries and latency.

### Description
- Update `runSingleQueryFlow` in `src/components/SearchBar.jsx` to short-circuit and `return { found: true, results: resultMap }` immediately when any search branch finds results, instead of setting a `found` flag and continuing.
- Remove the accumulated `found`-flow behavior so grouped (`[...]`) execution now follows the same early-exit logic as single-value searches, reducing unnecessary network round-trips.

### Testing
- Lint: ran `npm run lint:js -- src/components/SearchBar.jsx` and it passed.
- Unit tests: ran `CI=true npm test -- --watch=false --runInBand src/utils/__tests__/parseUkTrigger.test.js` which failed with 2 pre-existing unrelated failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5730e1d08326968be33904dac50e)