### PR TITLE
Fix grouped searchbar behavior for bracketed phone lists

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1449,9 +1449,12 @@ const SearchBar = ({
         });
 
         const results = {};
-        const groupedExecutionKeys = groupedStrictKeySet
-          ? ['equalToAllCards']
-          : resolveGroupedSearchExecutionKeys();
+        // Для grouped-пошуку (з квадратними дужками) використовуємо той самий
+        // набір ключів, що і для звичайного пошуку по одному значенню.
+        // Інакше при увімкненому strict-наборі grouped режим запускав тільки
+        // equalToAllCards і пропускав searchId, через що частина телефонів
+        // могла не знаходитися, хоча поштучний пошук їх знаходив.
+        const groupedExecutionKeys = resolveGroupedSearchExecutionKeys();
 
         const perValueSearchResults = await Promise.all(
           values.map(async val => {


### PR DESCRIPTION
### Motivation
- Grouped queries using `[...]` were running a restricted execution path that forced `equalToAllCards` when a strict key set was enabled, which skipped the `searchId` checks and caused some phone numbers to be missed even though single-value searches found them.

### Description
- Replace the special-case `groupedExecutionKeys` assignment with `resolveGroupedSearchExecutionKeys()` in `src/components/SearchBar.jsx` so grouped (bracketed) searches use the same execution keys as single-value searches and retain `searchId` evaluation.

### Testing
- Ran the test suite with `npm test -- --watchAll=false --runInBand` and observed all existing tests except two failing assertions in `src/utils/__tests__/parseUkTrigger.test.js`, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6a722af08326a1be68ad93bac2b6)