### PR TITLE
Add builder-based searchKeySets indexer and caching for additional-rules indexing

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -26,6 +26,7 @@ import {
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
 import {
+  buildSearchKeySetIndexFromMatchedUsers,
   buildNewUsersFilterSetIndex,
   getIndexedNewUsersIdsByRules,
   makeAdditionalRulesSetKey,
@@ -894,10 +895,8 @@ export const ProfileForm = ({
           accessUserId,
           matchedUserIdsBySetKey,
         });
-        if (indexResult && Number(indexResult.writesCount || 0) === 0) {
-          toast(
-            'searchKeySets не оновлено: немає збігів newUsers для обраних фільтрів або не знайдено валідних правил.'
-          );
+        if (indexResult && Number(indexResult.writesCount || 0) === 0 && Number(indexResult?.setKeys?.length || 0) === 0) {
+          toast('searchKeySets не оновлено: не знайдено валідних правил.');
         }
       }
     } catch (error) {
@@ -990,6 +989,13 @@ export const ProfileForm = ({
 
       ruleInputs.forEach((rulesText, index) => {
         const inputIndex = index + 1;
+        const cachedRuleText = String(matchedRuleTextByInputIndexRef.current?.[inputIndex] || '').trim();
+        const cachedUserIds = matchedUserIdsByInputIndexRef.current?.[inputIndex];
+        if (cachedRuleText && cachedRuleText === rulesText && Array.isArray(cachedUserIds)) {
+          matchedUserIdsByInputIndex[inputIndex] = cachedUserIds;
+          return;
+        }
+
         const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
         if (!parsedRuleGroups.length) return;
 
@@ -1010,21 +1016,28 @@ export const ProfileForm = ({
         accessUserId,
         matchedUserIdsByInputIndex
       );
-      const indexResult = await buildNewUsersFilterSetIndex({
+      matchedRuleTextByInputIndexRef.current = ruleInputs.reduce((acc, rulesText, idx) => {
+        acc[idx + 1] = rulesText;
+        return acc;
+      }, {});
+      matchedRuleCacheAccessUserIdRef.current = accessUserId;
+      matchedUserIdsByInputIndexRef.current = {
+        ...matchedUserIdsByInputIndexRef.current,
+        ...matchedUserIdsByInputIndex,
+      };
+      const indexResult = await buildSearchKeySetIndexFromMatchedUsers({
         rawRules,
         accessUserId,
         newUsersData: newUsersMap,
         matchedUserIdsBySetKey,
       });
 
-      if (indexResult && Number(indexResult.writesCount || 0) === 0) {
-        toast(
-          'searchKeySets не оновлено: немає збігів newUsers для обраних фільтрів або не знайдено валідних правил.',
-          { id: toastId }
-        );
+      const setsCount = Number(indexResult?.setKeys?.length || 0);
+      const matchedCount = Number(indexResult?.userIds?.length || 0);
+      if (setsCount === 0) {
+        toast('searchKeySets не оновлено: не знайдено валідних правил.', { id: toastId });
       } else {
-        const setsCount = Number(indexResult?.setKeys?.length || 0);
-        toast.success(`Індексацію searchKeySets оновлено (${setsCount} наборів).`, { id: toastId });
+        toast.success(`Індексацію searchKeySets оновлено (${setsCount} наборів, ${matchedCount} карток).`, { id: toastId });
       }
 
       return indexResult;

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1,5 +1,17 @@
 import { get, ref, remove, update } from 'firebase/database';
-import { database } from 'components/config';
+import {
+  createAgeSearchKeyIndexInCollection,
+  createContactSearchKeyIndexInCollection,
+  createCsectionSearchKeyIndexInCollection,
+  createFieldCountSearchKeyIndexInCollection,
+  createImtHeightWeightSearchKeyIndexInCollection,
+  createMaritalStatusSearchKeyIndexInCollection,
+  createReactionSearchKeyIndexInCollection,
+  createRoleSearchKeyIndexInCollection,
+  createSearchKeyIndexInCollection,
+  createUserIdSearchKeyIndexInCollection,
+  database,
+} from 'components/config';
 import { encodeKey } from './searchIndexCandidates';
 import {
   isUserAllowedByAnyAdditionalAccessRule,
@@ -92,6 +104,86 @@ const buildUserIdsMapFromList = userIds =>
       acc[userId] = true;
       return acc;
     }, {});
+
+const SEARCH_KEY_SET_BUILDERS = [
+  createSearchKeyIndexInCollection,
+  createMaritalStatusSearchKeyIndexInCollection,
+  createCsectionSearchKeyIndexInCollection,
+  createContactSearchKeyIndexInCollection,
+  createRoleSearchKeyIndexInCollection,
+  createUserIdSearchKeyIndexInCollection,
+  createAgeSearchKeyIndexInCollection,
+  createImtHeightWeightSearchKeyIndexInCollection,
+  createReactionSearchKeyIndexInCollection,
+  createFieldCountSearchKeyIndexInCollection,
+];
+
+const pickUsersByIds = (usersMap, ids = []) =>
+  ids.reduce((acc, userId) => {
+    if (!userId) return acc;
+    acc[userId] = usersMap?.[userId] && typeof usersMap[userId] === 'object' ? usersMap[userId] : {};
+    return acc;
+  }, {});
+
+export const buildSearchKeySetIndexFromMatchedUsers = async ({
+  rawRules,
+  accessUserId,
+  newUsersData = null,
+  matchedUserIdsBySetKey = null,
+}) => {
+  const normalizedAccessUserId = String(accessUserId || '').trim();
+  if (!normalizedAccessUserId) return null;
+
+  const sourceNewUsers =
+    newUsersData && typeof newUsersData === 'object'
+      ? newUsersData
+      : (await get(ref(database, 'newUsers'))).val() || {};
+
+  const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
+  const setPayloads = ruleSetEntries
+    .map(({ text: setText, inputIndex }) => {
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
+      if (parsedRuleGroups.length === 0) return null;
+
+      const setKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
+      if (!setKey) return null;
+
+      const userIds = Array.isArray(matchedUserIdsBySetKey?.[setKey])
+        ? [...new Set(matchedUserIdsBySetKey[setKey].filter(Boolean))]
+        : Object.keys(mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups));
+
+      return { setKey, userIds };
+    })
+    .filter(Boolean);
+
+  for (const setPayload of setPayloads) {
+    // eslint-disable-next-line no-await-in-loop
+    await remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setPayload.setKey}`));
+
+    if (setPayload.userIds.length === 0) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const usersData = pickUsersByIds(sourceNewUsers, setPayload.userIds);
+    const options = {
+      usersData,
+      rootPath: `${SEARCH_KEY_SETS_ROOT}/${setPayload.setKey}`,
+    };
+
+    // eslint-disable-next-line no-await-in-loop
+    for (const builder of SEARCH_KEY_SET_BUILDERS) {
+      // eslint-disable-next-line no-await-in-loop
+      await builder('newUsers', undefined, options);
+    }
+  }
+
+  return {
+    setKeys: setPayloads.map(item => item.setKey),
+    userIds: [...new Set(setPayloads.flatMap(item => item.userIds))],
+    ownerId: normalizedAccessUserId,
+  };
+};
 
 export const buildNewUsersFilterSetIndex = async ({
   rawRules,


### PR DESCRIPTION
### Motivation
- Replace the previous monolithic indexing path with a builder-driven index creation to support multiple search-key index types and improve index updates. 
- Reduce redundant work by caching parsed rule text and matched user lists to avoid recomputing matches when the same rule input is reused.

### Description
- Added a new exported function `buildSearchKeySetIndexFromMatchedUsers` in `src/utils/newUsersFilterSetsIndex.js` that builds `searchKeySets` by running a list of index builders (`SEARCH_KEY_SET_BUILDERS`) for each matched set and returns `setKeys`, `userIds`, and `ownerId`.
- Updated imports in `newUsersFilterSetsIndex.js` to pull index builder functions and `database` from `components/config` and added helper utilities `pickUsersByIds` and `SEARCH_KEY_SET_BUILDERS` to orchestrate per-set indexing.
- Modified `ProfileForm.jsx` to use `buildSearchKeySetIndexFromMatchedUsers` when indexing additional rules, added short-circuit caching for `matchedRuleTextByInputIndexRef` and `matchedUserIdsByInputIndexRef` to reuse previously computed matches, and to persist these caches after index runs.
- Improved user feedback by adjusting toast messages and success text to include counts for created sets and matched cards, and tightened conditions that trigger different informational toasts.

### Testing
- Ran the project test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully. 
- Exercised the additional-rules indexing flow in a local dev build to verify `searchKeySets` are created and the toast messages reflect created sets and matched card counts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec99dc927083269c4495b18faa8fcd)