### PR TITLE
Fix additional-rule searchKeySets indexing and add step-by-step toasts

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -26,7 +26,6 @@ import {
   resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
 import {
-  buildSearchKeySetIndexFromMatchedUsers,
   buildNewUsersFilterSetIndex,
   getIndexedNewUsersIdsByRules,
   makeAdditionalRulesSetKey,
@@ -980,13 +979,19 @@ export const ProfileForm = ({
 
     setIsIndexingAdditionalRules(true);
     const toastId = 'additional-rules-indexing';
-    toast.loading('Індексація searchKeySets...', { id: toastId });
+    let stage = 'start';
+    const stageToast = message => toast.loading(message, { id: toastId });
+    stageToast('1/5 Індексація searchKeySets: старт...');
 
     try {
+      stage = 'load-new-users';
+      stageToast('2/5 Завантаження пулу newUsers...');
       const newUsersSnapshot = await get(refDb(database, 'newUsers'));
       const newUsersMap = newUsersSnapshot.exists() ? newUsersSnapshot.val() || {} : {};
       const matchedUserIdsByInputIndex = {};
 
+      stage = 'compute-matches';
+      stageToast('3/5 Обчислення пулів користувачів по правилах...');
       ruleInputs.forEach((rulesText, index) => {
         const inputIndex = index + 1;
         const cachedRuleText = String(matchedRuleTextByInputIndexRef.current?.[inputIndex] || '').trim();
@@ -1025,7 +1030,10 @@ export const ProfileForm = ({
         ...matchedUserIdsByInputIndexRef.current,
         ...matchedUserIdsByInputIndex,
       };
-      const indexResult = await buildSearchKeySetIndexFromMatchedUsers({
+
+      stage = 'write-index';
+      stageToast('4/5 Запис індексів у searchKeySets...');
+      const indexResult = await buildNewUsersFilterSetIndex({
         rawRules,
         accessUserId,
         newUsersData: newUsersMap,
@@ -1034,10 +1042,14 @@ export const ProfileForm = ({
 
       const setsCount = Number(indexResult?.setKeys?.length || 0);
       const matchedCount = Number(indexResult?.userIds?.length || 0);
-      if (setsCount === 0) {
+      const writesCount = Number(indexResult?.writesCount || 0);
+      if (setsCount === 0 && writesCount === 0) {
         toast('searchKeySets не оновлено: не знайдено валідних правил.', { id: toastId });
       } else {
-        toast.success(`Індексацію searchKeySets оновлено (${setsCount} наборів, ${matchedCount} карток).`, { id: toastId });
+        toast.success(
+          `5/5 Готово: індексацію searchKeySets оновлено (${setsCount} наборів, ${matchedCount} карток, ${writesCount} змін).`,
+          { id: toastId }
+        );
       }
 
       return indexResult;
@@ -1046,11 +1058,11 @@ export const ProfileForm = ({
       const details = error?.message || String(error);
       if (code.includes('PERMISSION_DENIED')) {
         toast.error(
-          `Немає прав на запис у searchKeySets.\nПеревірте Firebase Rules для цього користувача.\n${details}`,
+          `Помилка на етапі "${stage}": немає прав на запис у searchKeySets.\nПеревірте Firebase Rules для цього користувача.\n${details}`,
           { id: toastId }
         );
       } else {
-        toast.error(`Не вдалося виконати індексацію наборів фільтрів.\n${details}`, { id: toastId });
+        toast.error(`Помилка на етапі "${stage}": не вдалося виконати індексацію наборів фільтрів.\n${details}`, { id: toastId });
       }
       return null;
     } finally {

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -266,7 +266,17 @@ export const buildNewUsersFilterSetIndex = async ({
 
   existingSetKeys.forEach(setKey => {
     if (!nextSetKeys.has(setKey)) {
-      writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}`] = null;
+      const setPayload = rootMap?.[setKey];
+      if (!setPayload || typeof setPayload !== 'object') return;
+      Object.entries(setPayload).forEach(([indexName, indexPayload]) => {
+        if (!indexPayload || typeof indexPayload !== 'object') return;
+        Object.entries(indexPayload).forEach(([valueKey, valuePayload]) => {
+          if (!valuePayload || typeof valuePayload !== 'object') return;
+          Object.keys(valuePayload).forEach(userId => {
+            writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${valueKey}/${userId}`] = null;
+          });
+        });
+      });
       return;
     }
 
@@ -276,17 +286,16 @@ export const buildNewUsersFilterSetIndex = async ({
     const expectedIndexes = expectedBySetIndexValue[setKey] || {};
     Object.keys(setPayload).forEach(indexName => {
       const expectedValues = expectedIndexes[indexName] || {};
-      if (!Object.keys(expectedValues).length) {
-        writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}`] = null;
-        return;
-      }
-
       const indexPayload = setPayload[indexName];
       if (!indexPayload || typeof indexPayload !== 'object') return;
       Object.keys(indexPayload).forEach(valueKey => {
         const expectedUserIds = expectedValues[valueKey];
         if (!expectedUserIds) {
-          writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${valueKey}`] = null;
+          const valuePayload = indexPayload[valueKey];
+          if (!valuePayload || typeof valuePayload !== 'object') return;
+          Object.keys(valuePayload).forEach(userId => {
+            writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${valueKey}/${userId}`] = null;
+          });
           return;
         }
 


### PR DESCRIPTION
### Motivation
- Indexing via the "Індексувати" flow failed with `PERMISSION_DENIED` because cleanup previously attempted writes on parent paths instead of the allowed leaf (`searchKeySets/$keySet/$indexName/$value/$userId`).
- The manual index flow diverged from the submit/apply flow and needed to use the same leaf-oriented writer to avoid rule violations and make behavior consistent.

### Description
- Update `buildNewUsersFilterSetIndex` so cleanup writes delete only leaf user nodes (`.../$userId = null`) instead of parent nodes, producing RTDB writes that comply with the rules; changes in `src/utils/newUsersFilterSetsIndex.js`.
- Switch the ProfileForm manual index action to call the same index builder used in submit flow (`buildNewUsersFilterSetIndex`) and remove the previous inconsistent path; changes in `src/components/ProfileForm.jsx`.
- Add staged toasts and a `stage` variable in `ProfileForm` to show progress steps (`1/5`..`5/5`) and include the failing stage in error messages for easier debugging.
- Clean up an unused/old index builder import and report the number of leaf writes in the success toast.

### Testing
- Ran ESLint on the modified files with `npx eslint src/components/ProfileForm.jsx src/utils/newUsersFilterSetsIndex.js` and the linter completed without errors.
- Changes were committed and verified locally; no automated unit test failures were observed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecad4ac6ac83268c4f24dbc9844588)