### PR TITLE
Preserve additional-access bucket schema in rebuilt searchKeySets

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -125,6 +125,38 @@ const pickUsersByIds = (usersMap, ids = []) =>
     return acc;
   }, {});
 
+const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds }) => {
+  const normalizedRootPath = String(rootPath || '').trim();
+  if (!normalizedRootPath) return {};
+
+  const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
+  const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
+
+  return Object.entries(bucketMap || {}).reduce((writes, [indexName, rawValues]) => {
+    const normalizedIndexName = normalizePathSegment(indexName);
+    if (!normalizedIndexName) return writes;
+
+    const values = [
+      ...new Set(
+        (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+          .map(normalizePathSegment)
+          .filter(Boolean)
+      ),
+    ];
+    if (!values.length) return writes;
+
+    values.forEach(value => {
+      const path = `${normalizedRootPath}/${normalizedIndexName}/${value}`;
+      writes[path] = normalizedUserIds.reduce((acc, userId) => {
+        acc[userId] = true;
+        return acc;
+      }, {});
+    });
+
+    return writes;
+  }, {});
+};
+
 export const buildSearchKeySetIndexFromMatchedUsers = async ({
   rawRules,
   accessUserId,
@@ -152,7 +184,7 @@ export const buildSearchKeySetIndexFromMatchedUsers = async ({
         ? [...new Set(matchedUserIdsBySetKey[setKey].filter(Boolean))]
         : Object.keys(mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups));
 
-      return { setKey, userIds };
+      return { setKey, userIds, parsedRuleGroups };
     })
     .filter(Boolean);
 
@@ -170,11 +202,21 @@ export const buildSearchKeySetIndexFromMatchedUsers = async ({
       usersData,
       rootPath: `${SEARCH_KEY_SETS_ROOT}/${setPayload.setKey}`,
     };
+    const ruleBucketWrites = buildRuleBucketWrites({
+      rootPath: options.rootPath,
+      parsedRuleGroups: setPayload.parsedRuleGroups,
+      userIds: setPayload.userIds,
+    });
 
     // eslint-disable-next-line no-await-in-loop
     for (const builder of SEARCH_KEY_SET_BUILDERS) {
       // eslint-disable-next-line no-await-in-loop
       await builder('newUsers', undefined, options);
+    }
+
+    if (Object.keys(ruleBucketWrites).length) {
+      // eslint-disable-next-line no-await-in-loop
+      await update(ref(database), ruleBucketWrites);
     }
   }
 
@@ -216,6 +258,7 @@ export const buildNewUsersFilterSetIndex = async ({
       return {
         setKey: ownerSetKey,
         userIds,
+        parsedRuleGroups,
       };
     })
     .filter(Boolean);
@@ -236,7 +279,7 @@ export const buildNewUsersFilterSetIndex = async ({
     await update(ref(database), writes);
   }
 
-  for (const { setKey, userIds } of nextSetPayloads) {
+  for (const { setKey, userIds, parsedRuleGroups } of nextSetPayloads) {
     // eslint-disable-next-line no-await-in-loop
     await remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`));
 
@@ -245,11 +288,21 @@ export const buildNewUsersFilterSetIndex = async ({
       usersData: pickedUsers,
       rootPath: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
     };
+    const ruleBucketWrites = buildRuleBucketWrites({
+      rootPath: options.rootPath,
+      parsedRuleGroups,
+      userIds: Object.keys(userIds || {}),
+    });
 
     // eslint-disable-next-line no-await-in-loop
     for (const builder of SEARCH_KEY_SET_BUILDERS) {
       // eslint-disable-next-line no-await-in-loop
       await builder('newUsers', undefined, options);
+    }
+
+    if (Object.keys(ruleBucketWrites).length) {
+      // eslint-disable-next-line no-await-in-loop
+      await update(ref(database), ruleBucketWrites);
     }
   }
 


### PR DESCRIPTION
### Motivation

- Rebuilding search key sets via the `SEARCH_KEY_SET_BUILDERS` loop created generic search-key entries but did not recreate additional-access rule buckets (for example `age/26_30`, `bloodGroup/1`, `rh/+`), and `getIndexedNewUsersIdsByRules` returns `null` when those expected bucket paths are missing.  

### Description

- Add `buildRuleBucketWrites` helper that derives additional-access bucket paths from `resolveAdditionalAccessSearchKeyBuckets`, normalizes index and value segments with `normalizePathSegment`, and prepares `{ userId: true }` writes for each expected path.  
- Carry `parsedRuleGroups` through set payloads and invoke `buildRuleBucketWrites` after the existing `SEARCH_KEY_SET_BUILDERS` loop so rule-specific bucket paths are written under each set root.  
- Apply this schema preservation in both rebuild flows: `buildSearchKeySetIndexFromMatchedUsers` and `buildNewUsersFilterSetIndex` in `src/utils/newUsersFilterSetsIndex.js`.  
- Use `update(ref(database), ...)` to persist the additional bucket writes so rebuilt sets remain readable by indexed lookups.  

### Testing

- Ran linter with `npm run lint:js -- src/utils/newUsersFilterSetsIndex.js`, which completed successfully.  
- Verified the patch compiles locally by running the repository lint command and committing the change to ensure no syntax errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc686a95c8326831098033bfe5c51)