### PR TITLE
Generate additional rules set keys from rules text hash and simplify decoding

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -60,14 +60,28 @@ const parseRawRulesToSetEntries = rawRules => {
     .filter(entry => Boolean(entry.text));
 };
 
-export const makeAdditionalRulesSetKey = (rawRules, accessUserId = '', setIndex = 1) => {
+const hashRuleText = rulesText => {
+  const source = String(rulesText || '').trim();
+  if (!source) return '';
+
+  let hash = 5381;
+  for (let idx = 0; idx < source.length; idx += 1) {
+    hash = (hash * 33) ^ source.charCodeAt(idx);
+  }
+
+  return Math.abs(hash >>> 0).toString(36);
+};
+
+export const makeAdditionalRulesSetKey = (rawRules, accessUserId = '') => {
   const normalizedOwnerId = String(accessUserId || '').trim();
   if (!normalizedOwnerId) return '';
 
-  const normalizedSetIndex = Number.isFinite(Number(setIndex)) ? Math.max(1, Number(setIndex)) : 1;
   const rulesText = String(rawRules || '').trim();
   if (!rulesText) return '';
-  return `${normalizedOwnerId}${SET_KEY_INDEX_SEPARATOR}${normalizedSetIndex}`;
+  const rulesHash = hashRuleText(rulesText);
+  if (!rulesHash) return '';
+
+  return `${normalizedOwnerId}${SET_KEY_INDEX_SEPARATOR}${rulesHash}`;
 };
 
 export const decodeAdditionalRulesSetKey = encodedSetKey => {
@@ -78,12 +92,8 @@ export const decodeAdditionalRulesSetKey = encodedSetKey => {
   if (separatorIndex <= 0) return '';
 
   const ownerId = raw.slice(0, separatorIndex);
-  const setIndexToken = raw.slice(separatorIndex + 1);
-  const numericIndex = Number.parseInt(setIndexToken, 10);
-  const normalizedSetIndex = Number.isFinite(numericIndex) && numericIndex > 0 ? numericIndex : 1;
-
   if (!ownerId) return '';
-  return `${ownerId}${SET_KEY_INDEX_SEPARATOR}${normalizedSetIndex}`;
+  return raw;
 };
 
 const mapMatchingIdsByRules = (newUsersData, parsedRuleGroups) => {


### PR DESCRIPTION
### Motivation
- Replace numeric set index with a deterministic identifier derived from the rules text so keys are stable per owner and content.
- Simplify decoding logic by treating the trailing token as an opaque identifier instead of a parsed numeric index.

### Description
- Added `hashRuleText` helper that computes a compact base36 hash from the rules text.
- Updated `makeAdditionalRulesSetKey` to remove the `setIndex` parameter and to return keys as `{owner}{SEPARATOR}{hash}` using `hashRuleText` after normalizing inputs.
- Simplified `decodeAdditionalRulesSetKey` to validate the owner and separator and return the raw key without attempting numeric parsing or normalization of an index.

### Testing
- Ran the existing unit test suite with `yarn test` and the tests passed.
- Ran the linter with `yarn lint` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd71de8e4832687d2074e46ce3247)