### PR TITLE
Handle removal/clearing of additional access rules and wire UI actions to unified handler

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -959,6 +959,48 @@ export const ProfileForm = ({
     setAdditionalRuleBuilder(prev => prev.filter((_, ruleIndex) => ruleIndex !== index));
   };
 
+  const handleRemoveAdditionalAccessRuleInput = useCallback((removeIndex = null, action = 'clear') => {
+    const currentInputs = additionalRulesInputs.map(item => String(item || '').trim()).filter(Boolean);
+    const shouldRemoveByIndex = Number.isInteger(removeIndex);
+    const nextInputs = shouldRemoveByIndex
+      ? currentInputs.filter((_, idx) => idx !== removeIndex)
+      : [];
+    const nextActiveIndex = Math.min(
+      shouldRemoveByIndex ? removeIndex : 0,
+      Math.max(nextInputs.length - 1, 0)
+    );
+
+    setActiveAdditionalRuleInputIndex(nextActiveIndex);
+    setPreviewAdditionalRulesText(nextInputs.join('\n\n'));
+
+    setState(prevState => {
+      const updated = { ...prevState };
+      const previousValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
+      const removedValue = shouldRemoveByIndex
+        ? Array.isArray(previousValue)
+          ? previousValue[removeIndex]
+          : previousValue
+        : previousValue;
+
+      if (nextInputs.length === 0) {
+        delete updated[ADDITIONAL_ACCESS_FIELD];
+      } else if (nextInputs.length === 1) {
+        updated[ADDITIONAL_ACCESS_FIELD] = nextInputs[0];
+      } else {
+        updated[ADDITIONAL_ACCESS_FIELD] = nextInputs;
+      }
+
+      matchedUserIdsByInputIndexRef.current = {};
+      matchedRuleTextByInputIndexRef.current = {};
+      const delCondition =
+        action === 'del' || removedValue !== undefined
+          ? { [ADDITIONAL_ACCESS_FIELD]: removedValue }
+          : undefined;
+      submitWithNormalization(updated, 'overwrite', delCondition);
+      return updated;
+    });
+  }, [additionalRulesInputs, setState, submitWithNormalization]);
+
   const indexAdditionalRulesForUser = useCallback(async rawRules => {
     const accessUserId = String(state?.userId || '').trim();
     if (!accessUserId) {
@@ -1698,12 +1740,20 @@ ${entries.join('\n')}`;
     if (!normalizedPath) return false;
 
     if (!normalizedPath.includes('.')) {
+      if (normalizedPath === ADDITIONAL_ACCESS_FIELD) {
+        handleRemoveAdditionalAccessRuleInput(null, 'del');
+        return true;
+      }
       handleDelKeyValue(normalizedPath);
       return true;
     }
 
     const [fieldName, nestedIndex] = normalizedPath.split('.');
     if (/^\d+$/.test(nestedIndex)) {
+      if (fieldName === ADDITIONAL_ACCESS_FIELD) {
+        handleRemoveAdditionalAccessRuleInput(Number(nestedIndex), 'clear');
+        return true;
+      }
       handleClear(fieldName, Number(nestedIndex));
       return true;
     }
@@ -1788,7 +1838,13 @@ ${entries.join('\n')}`;
                           <ClearButton
                           type="button"
                           onMouseDown={e => e.preventDefault()}
-                          onClick={() => handleClear(field.name, idx)}
+                          onClick={() => {
+                            if (field.name === ADDITIONAL_ACCESS_FIELD) {
+                              handleRemoveAdditionalAccessRuleInput(idx, 'clear');
+                              return;
+                            }
+                            handleClear(field.name, idx);
+                          }}
                         >
                           &times;
                         </ClearButton>
@@ -1925,7 +1981,13 @@ ${entries.join('\n')}`;
                     <ClearButton
                       type="button"
                       onMouseDown={e => e.preventDefault()}
-                      onClick={() => handleClear(field.name)}
+                      onClick={() => {
+                        if (field.name === ADDITIONAL_ACCESS_FIELD) {
+                          handleRemoveAdditionalAccessRuleInput(null, 'clear');
+                          return;
+                        }
+                        handleClear(field.name);
+                      }}
                     >
                       &times;
                     </ClearButton>
@@ -1933,7 +1995,13 @@ ${entries.join('\n')}`;
                   {field.name !== 'lastAction' && state[field.name] && (
                     <DelKeyValueBTN
                       onMouseDown={e => e.preventDefault()}
-                      onClick={() => handleDelKeyValue(field.name)}
+                      onClick={() => {
+                        if (field.name === ADDITIONAL_ACCESS_FIELD) {
+                          handleRemoveAdditionalAccessRuleInput(null, 'del');
+                          return;
+                        }
+                        handleDelKeyValue(field.name);
+                      }}
                     >
                       del
                     </DelKeyValueBTN>


### PR DESCRIPTION
### Motivation
- Provide consistent removal and clearing behavior for the `ADDITIONAL_ACCESS_FIELD` across profile view actions and per-field clear/del buttons.
- Ensure state normalization and submit behavior run when additional access rule inputs are removed and that related match caches are reset.

### Description
- Add a new `handleRemoveAdditionalAccessRuleInput` `useCallback` that normalizes `additionalRulesInputs`, updates `activeAdditionalRuleInputIndex` and `previewAdditionalRulesText`, mutates `state[ADDITIONAL_ACCESS_FIELD]` into either removed, single string, array, or deleted, resets `matchedUserIdsByInputIndexRef` and `matchedRuleTextByInputIndexRef`, and calls `submitWithNormalization` with an optional delete condition.
- Route profile view removals to the new handler when the removed key is `ADDITIONAL_ACCESS_FIELD` in `handleProfileViewRemove`.
- Update `ClearButton` and `DelKeyValueBTN` click handlers in the form rendering to call `handleRemoveAdditionalAccessRuleInput` for `ADDITIONAL_ACCESS_FIELD` instead of the generic `handleClear`/`handleDelKeyValue` so clearing and deletion behave correctly for additional access inputs.

### Testing
- Ran the project unit test suite with `yarn test`, and all tests passed.
- Ran linting with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecee4db5d4832684353c7ae0f596e1)