### PR TITLE
Кешувати прев’ю додаткових правил доступу в localStorage

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -30,7 +30,11 @@ import {
   getIndexedNewUsersIdsByRules,
   makeAdditionalRulesSetKey,
 } from 'utils/newUsersFilterSetsIndex';
-import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
+import {
+  getCachedAdditionalRulesPreview,
+  getCachedSearchKeyPayload,
+  saveCachedAdditionalRulesPreview,
+} from 'utils/searchKeyCache';
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -634,20 +638,41 @@ export const ProfileForm = ({
     let cancelled = false;
     const loadAvailableCards = async () => {
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(previewAdditionalRulesText);
+      const accessUserId = String(state?.userId || '').trim();
+      const cachedPreview = getCachedAdditionalRulesPreview({
+        rawRules: previewAdditionalRulesText,
+        accessUserId,
+      });
+      if (cachedPreview) {
+        setAvailableCardsCount(cachedPreview.count);
+        return;
+      }
+
       if (!parsedRuleGroups.length) {
         setAvailableCardsCount(0);
+        saveCachedAdditionalRulesPreview({
+          rawRules: previewAdditionalRulesText,
+          accessUserId,
+          count: 0,
+          userIds: [],
+        });
         return;
       }
 
       setIsLoadingAvailableCards(true);
       try {
-        const accessUserId = String(state?.userId || '').trim();
         const indexed = await getIndexedNewUsersIdsByRules({
           rawRules: previewAdditionalRulesText,
           accessUserId,
         });
 
         if (indexed?.userIds) {
+          saveCachedAdditionalRulesPreview({
+            rawRules: previewAdditionalRulesText,
+            accessUserId,
+            count: indexed.userIds.length,
+            userIds: indexed.userIds,
+          });
           if (!cancelled) {
             setAvailableCardsCount(indexed.userIds.length);
           }
@@ -742,7 +767,7 @@ export const ProfileForm = ({
         }
 
         const matchedIdList = [...matchedIds];
-        let matchedCount = 0;
+        const finalMatchedIds = [];
         const BATCH_SIZE = 150;
 
         for (let index = 0; index < matchedIdList.length; index += BATCH_SIZE) {
@@ -762,11 +787,23 @@ export const ProfileForm = ({
             })
           );
 
-          matchedCount += rows.filter(user => user && isUserAllowedByAnyAdditionalAccessRule(user, parsedRuleGroups)).length;
+          rows.forEach(user => {
+            if (!user) return;
+            if (isUserAllowedByAnyAdditionalAccessRule(user, parsedRuleGroups)) {
+              finalMatchedIds.push(user.userId);
+            }
+          });
         }
 
+        const uniqueMatchedUserIds = [...new Set(finalMatchedIds.filter(Boolean))];
+        saveCachedAdditionalRulesPreview({
+          rawRules: previewAdditionalRulesText,
+          accessUserId,
+          count: uniqueMatchedUserIds.length,
+          userIds: uniqueMatchedUserIds,
+        });
         if (!cancelled) {
-          setAvailableCardsCount(matchedCount);
+          setAvailableCardsCount(uniqueMatchedUserIds.length);
         }
       } catch (error) {
         console.error('Failed to build additional access preview', error);

--- a/src/utils/searchKeyCache.js
+++ b/src/utils/searchKeyCache.js
@@ -22,3 +22,42 @@ export const getCachedSearchKeyPayload = async (path, loader) => {
   saveCache(normalizedPath, loaded);
   return loaded;
 };
+
+const normalizeRulesText = rawRules =>
+  String(rawRules || '')
+    .replace(/\r\n/g, '\n')
+    .trim();
+
+export const buildAdditionalRulesCacheKey = ({ rawRules, accessUserId }) => {
+  const normalizedRules = normalizeRulesText(rawRules);
+  const normalizedAccessUserId = String(accessUserId || '').trim() || 'anonymous';
+  if (!normalizedRules) return null;
+  return `additionalRulesPreview:${normalizedAccessUserId}:${encodeURIComponent(normalizedRules)}`;
+};
+
+export const getCachedAdditionalRulesPreview = ({ rawRules, accessUserId }) => {
+  const cacheKey = buildAdditionalRulesCacheKey({ rawRules, accessUserId });
+  if (!cacheKey) return null;
+  const cached = loadCache(cacheKey);
+  if (!cached || typeof cached !== 'object') return null;
+
+  const userIds = Array.isArray(cached.userIds) ? cached.userIds.filter(Boolean) : [];
+  const count = Number.isFinite(cached.count) ? cached.count : userIds.length;
+  return {
+    count,
+    userIds,
+  };
+};
+
+export const saveCachedAdditionalRulesPreview = ({ rawRules, accessUserId, count, userIds }) => {
+  const cacheKey = buildAdditionalRulesCacheKey({ rawRules, accessUserId });
+  if (!cacheKey) return;
+
+  const normalizedIds = Array.isArray(userIds) ? [...new Set(userIds.filter(Boolean))] : [];
+  const normalizedCount = Number.isFinite(count) ? count : normalizedIds.length;
+
+  saveCache(cacheKey, {
+    count: normalizedCount,
+    userIds: normalizedIds,
+  });
+};


### PR DESCRIPTION
### Motivation
- Уникнути повторних звернень до індексів/бекенду при перегляді «Доступні карточки» шляхом повторного використання результатів підрахунку з локального кешу.
- Зберегти не лише число підходящих карток, а й повний список `userIds` для подальших операцій, щоб не перераховувати весь індекс щоразу.

### Description
- Додано хелпери в `src/utils/searchKeyCache.js`: `buildAdditionalRulesCacheKey`, `getCachedAdditionalRulesPreview` та `saveCachedAdditionalRulesPreview`, які використовують існуючий `createCache('searchKey')` для збереження прев’ю правил (count + `userIds`).
- Оновлено `src/components/ProfileForm.jsx` щоб перед обчисленням перевіряти кеш через `getCachedAdditionalRulesPreview` і повертати результат з локального сховища при наявності.
- При отриманні результатів з індексу або після повного обходу `newUsers`/`users` збережено у кеш як `count`, так і список унікальних `userIds`, а для порожніх наборів правил також зберігається пустий запис.
- Існуюча логіка `getCachedSearchKeyPayload` для по-значень індексів не змінювалася і продовжує використовуватись для читання bucket-індексів.

### Testing
- Запущено лінтер командою `npm run lint:js -- src/components/ProfileForm.jsx src/utils/searchKeyCache.js`, яка завершилася успішно (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1b9f5a688326b9535f56e40fa0eb)