### PR TITLE
Hide phenotype responsibility inputs for pp/cl roles

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -95,6 +95,22 @@ const nestedIndentStyle = {
 };
 
 const ADDITIONAL_ACCESS_FIELD = 'additionalAccessRules';
+const PHENOTYPE_RESPONSIBILITY_FIELDS = new Set([
+  'eyeColor',
+  'hairColor',
+  'glasses',
+  'hairStructure',
+  'race',
+  'bodyType',
+  'faceShape',
+  'noseShape',
+  'lipsShape',
+  'chin',
+  'phenotype',
+  'phenotypicCharacteristics',
+  'phenotypeResponsibility',
+  'responsibility',
+]);
 const SEARCH_KEY_ROOT = 'searchKey';
 const ADDITIONAL_RULE_LABELS = {
   age: 'Вік',
@@ -1741,6 +1757,11 @@ ${entries.join('\n')}`;
     ...normalizedFieldsToRender.filter(field => !priorityOrder.includes(field.name)),
   ];
 
+  const normalizedRole = String(state?.role || state?.userRole || '')
+    .trim()
+    .toLowerCase();
+  const shouldHidePhenotypeResponsibilityInputs = ['pp', 'cl'].includes(normalizedRole);
+
   const handleOpenModal = fieldName => {
     setSelectedField(fieldName);
     setShowInfoModal('pickerOptions');
@@ -1810,6 +1831,10 @@ ${entries.join('\n')}`;
       {sortedFieldsToRender
         .filter(field => !['myComment', 'writer'].includes(field.name))
         .filter(field => (isAdmin ? true : field.name !== ADDITIONAL_ACCESS_FIELD))
+        .filter(field => {
+          if (!shouldHidePhenotypeResponsibilityInputs) return true;
+          return !PHENOTYPE_RESPONSIBILITY_FIELDS.has(field.name);
+        })
         .map((field, index) => {
           const overlayEntries = getOverlayEntriesForField(field.name);
           const hasOverlaySuggestions = overlayEntries.length > 0;


### PR DESCRIPTION
### Motivation
- Profiles with roles `pp` (potential parents) or `cl` (clinic) must not show phenotype / responsibility-related inputs in the profile form UI.

### Description
- Added `PHENOTYPE_RESPONSIBILITY_FIELDS` (a `Set`) to `src/components/ProfileForm.jsx` that enumerates phenotype/responsibility-related field keys.
- Compute `normalizedRole` from `state.role` / `state.userRole` and, when it equals `pp` or `cl`, filter out those fields from the `sortedFieldsToRender` rendering pipeline so they are not rendered.

### Testing
- Ran `npm run -s lint:js -- src/components/ProfileForm.jsx`, which completed successfully (with a standard `caniuse-lite` update warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcd7980248326b19776efcea6ba8e)