### PR TITLE
Preview only active additional-access input and update available-cards label

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -616,11 +616,7 @@ export const ProfileForm = ({
   useEffect(() => {
     if (!showAdditionalRulesModal) return;
     const activeInputValue = additionalRulesInputs[activeAdditionalRuleInputIndex] || '';
-    const combinedAppliedText = additionalRulesInputs
-      .map(item => String(item || '').trim())
-      .filter(Boolean)
-      .join('\n\n');
-    setPreviewAdditionalRulesText(combinedAppliedText);
+    setPreviewAdditionalRulesText(String(activeInputValue || '').trim());
     const parsed = parseAdditionalRulesTextToBuilder(activeInputValue);
     if (parsed.length > 0) {
       setAdditionalRuleBuilder(parsed);
@@ -1005,7 +1001,7 @@ export const ProfileForm = ({
     );
 
     setActiveAdditionalRuleInputIndex(nextActiveIndex);
-    setPreviewAdditionalRulesText(nextInputs.join('\n\n'));
+    setPreviewAdditionalRulesText(String(nextInputs[nextActiveIndex] || '').trim());
 
     setState(prevState => {
       const updated = { ...prevState };
@@ -1189,10 +1185,7 @@ export const ProfileForm = ({
     setPreviewAdditionalRulesText(prev => {
       const nextInputs = additionalRulesTextToInputs(prev);
       nextInputs[activeAdditionalRuleInputIndex] = rulesText;
-      return nextInputs
-        .map(item => String(item || '').trim())
-        .filter(Boolean)
-        .join('\n\n');
+      return String(nextInputs[activeAdditionalRuleInputIndex] || '').trim();
     });
   };
 
@@ -1212,12 +1205,8 @@ export const ProfileForm = ({
       ...prevState,
       [ADDITIONAL_ACCESS_FIELD]: updatedValue,
     }));
-    setPreviewAdditionalRulesText(
-      (Array.isArray(updatedValue) ? updatedValue : additionalRulesTextToInputs(updatedValue))
-        .map(item => String(item || '').trim())
-        .filter(Boolean)
-        .join('\n\n')
-    );
+    const updatedInputs = Array.isArray(updatedValue) ? updatedValue : additionalRulesTextToInputs(updatedValue);
+    setPreviewAdditionalRulesText(String(updatedInputs[activeAdditionalRuleInputIndex] || '').trim());
 
     await indexAdditionalRulesForUser(updatedValue);
   };
@@ -2320,7 +2309,7 @@ ${entries.join('\n')}`;
               onChange={handleCombinedAdditionalRulesChange}
             />
             <AdditionalCardsTitle>
-              Доступні карточки ({availableCardsCount}) {isLoadingAvailableCards ? '...завантаження' : ''}
+              Доступні карточки для активного набору ({availableCardsCount}) {isLoadingAvailableCards ? '...завантаження' : ''}
             </AdditionalCardsTitle>
           </AdditionalRulesModal>
         </AdditionalRulesOverlay>


### PR DESCRIPTION
### Motivation

- Make the additional-rules preview show only the currently active input instead of concatenating all inputs to reduce user confusion when multiple inputs exist.
- Ensure preview state is consistent after removing or indexing inputs so users see the effective rules for the active input.
- Clarify the UI label to indicate that available cards are computed for the active rule set.

### Description

- Updated preview updates to use the active input value (trimmed) via `setPreviewAdditionalRulesText` in the modal open effect, `handleRemoveAdditionalAccessRuleInput`, and `indexAdditionalRulesFromBuilder` instead of joining all inputs with `\n\n`.
- Adjusted `AdditionalCardsTitle` text from `Доступні карточки ({availableCardsCount})` to `Доступні карточки для активного набору ({availableCardsCount})`.
- Preserved existing parsing and builder logic (`parseAdditionalRulesTextToBuilder`, `buildAdditionalRulesTextFromBuilder`) while scoping previews and indexing to the active input index.

### Testing

- Ran unit tests with `yarn test` and they passed.
- Ran linting with `yarn lint` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee17c28c808326b5310bbbb1e59576)