### PR TITLE
Restore last opened AddNewProfile card from localStorage

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -638,6 +638,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const location = useLocation();
   const lastUrlUserIdRef = useRef(new URLSearchParams(location.search).get('userId'));
+  const hasRestoredStoredEditUserRef = useRef(false);
   const initialAccess = resolveAccess({
     uid: auth.currentUser?.uid,
     accessLevel: localStorage.getItem('accessLevel'),
@@ -1324,6 +1325,23 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       lastUrlUserIdRef.current = null;
     }
   }, [canAccessAdd, location.search, setSearch, setState]);
+
+  useEffect(() => {
+    if (hasRestoredStoredEditUserRef.current) return;
+    hasRestoredStoredEditUserRef.current = true;
+
+    if (!canAccessAdd) return;
+
+    const params = new URLSearchParams(location.search);
+    if (params.get('userId')) return;
+    if (state?.userId) return;
+
+    const storedUserId = localStorage.getItem(EDIT_PROFILE_USER_ID_KEY);
+    if (!storedUserId) return;
+
+    setProfileSource('');
+    setState(prev => (prev?.userId === storedUserId ? prev : { userId: storedUserId }));
+  }, [canAccessAdd, location.search, state?.userId, setState, EDIT_PROFILE_USER_ID_KEY]);
 
   useEffect(() => {
     const normalized = (search || '').trim();


### PR DESCRIPTION
### Motivation
- Restore the previously opened edit card when returning to the AddNewProfile view if there is no `userId` in the URL and no active card in component state, improving the user experience.

### Description
- Add a one-time `useRef` (`hasRestoredStoredEditUserRef`) and `useEffect` in `src/components/AddNewProfile.jsx` that reads the `addNewProfileEditUserId` key from `localStorage` and sets the component `state` to `{ userId: storedUserId }` when `canAccessAdd` is true and there is no `userId` in the URL or in `state`.
- Preserve existing URL-based behavior and do not overwrite an existing active `state.userId`, giving direct links higher priority.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx` which completed without reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1ae7700c832691372cd2cb855f63)