### PR TITLE
Prefer local searchKey cache for additional access set lookups

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -18,6 +18,7 @@ import {
   parseAdditionalAccessRuleGroups,
   resolveAdditionalAccessSearchKeyBuckets,
 } from './additionalAccessRules';
+import { getCachedSearchKeyPayload } from './searchKeyCache';
 
 export const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_INDEX_SEPARATOR = '_';
@@ -350,28 +351,38 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
     .filter(Boolean);
   if (!setEntries.length) return null;
 
-  const snapshotsBySet = await Promise.all(
+  const payloadsBySet = await Promise.all(
     setEntries.map(async entry => {
-      const snapshots = await Promise.all(entry.paths.map(path => get(ref(database, path))));
-      return { setKey: entry.setKey, paths: entry.paths, snapshots };
+      const payloads = await Promise.all(
+        entry.paths.map(path =>
+          getCachedSearchKeyPayload(path, async () => {
+            const snapshot = await get(ref(database, path));
+            return {
+              exists: snapshot.exists(),
+              value: snapshot.exists() ? snapshot.val() || {} : null,
+            };
+          })
+        )
+      );
+      return { setKey: entry.setKey, paths: entry.paths, payloads };
     })
   );
 
-  if (snapshotsBySet.some(item => item.snapshots.some(snapshot => !snapshot.exists()))) {
+  if (payloadsBySet.some(item => item.payloads.some(payload => !payload?.exists))) {
     return null;
   }
 
   const userIds = new Set();
-  snapshotsBySet.forEach(item => {
-    item.snapshots.forEach(snapshot => {
-      Object.keys(snapshot.val() || {}).forEach(userId => {
+  payloadsBySet.forEach(item => {
+    item.payloads.forEach(payload => {
+      Object.keys(payload?.value || {}).forEach(userId => {
         if (userId) userIds.add(userId);
       });
     });
   });
 
   return {
-    setKeys: snapshotsBySet.flatMap(item => item.paths),
+    setKeys: payloadsBySet.flatMap(item => item.paths),
     userIds: [...userIds],
     ownerId: normalizedAccessUserId,
   };


### PR DESCRIPTION
### Motivation
- Reduce realtime DB reads when resolving `additionalAccessRules` by preferring a local cached payload for `searchKeySets` lookups. 
- Align `getIndexedNewUsersIdsByRules` with existing cached-read patterns used elsewhere (use `getCachedSearchKeyPayload` where appropriate).

### Description
- Added import of `getCachedSearchKeyPayload` and replaced direct `get(ref(...))` calls with `getCachedSearchKeyPayload(path, loader)` in `getIndexedNewUsersIdsByRules` in `src/utils/newUsersFilterSetsIndex.js`.
- Changed the local variable naming to `payloadsBySet` and adapted logic to read `payload.value` and `payload.exists` instead of raw snapshots. 
- Preserved previous behavior of returning `null` when any required bucket is missing and kept the same `userIds` aggregation and return shape. 

### Testing
- Ran the linter with `npm run lint:js -- src/utils/newUsersFilterSetsIndex.js` and it completed without error (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1b54f80083269a771fc147d9a70d)