### PR TITLE
Rebuild additional-access filter index when field is deleted and normalize rawRules arg

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -891,7 +891,9 @@ export const ProfileForm = ({
         : nextState;
     try {
       const rawRules = payload?.[ADDITIONAL_ACCESS_FIELD];
-      if (rawRules !== undefined) {
+      const shouldReindexAfterAdditionalRulesChange =
+        rawRules !== undefined || Boolean(delCondition?.[ADDITIONAL_ACCESS_FIELD] !== undefined);
+      if (shouldReindexAfterAdditionalRulesChange) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
         const hasPrefilteredMatches =
           !!options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object';
@@ -936,7 +938,7 @@ export const ProfileForm = ({
           matchedUserIdsByInputIndexRef.current
         );
         const indexResult = await buildNewUsersFilterSetIndex({
-          rawRules,
+          rawRules: rawRules !== undefined ? rawRules : '',
           accessUserId,
           matchedUserIdsBySetKey,
         });


### PR DESCRIPTION
### Motivation
- Ensure new-users filter-set index is rebuilt not only when `ADDITIONAL_ACCESS_FIELD` is present in the submitted payload but also when it is being removed via `delCondition`. 
- Avoid passing `undefined` to `buildNewUsersFilterSetIndex` by normalizing `rawRules` to an empty string when appropriate.

### Description
- Added a `shouldReindexAfterAdditionalRulesChange` flag that triggers reindexing when `rawRules` exists or `delCondition` includes `ADDITIONAL_ACCESS_FIELD`.
- Preserve existing cache invalidation and matched-user merging logic while accounting for prefetched `matchedUserIdsByInputIndex` from `options`.
- Call `buildNewUsersFilterSetIndex` with `rawRules: rawRules !== undefined ? rawRules : ''` to ensure the callee receives a string rather than `undefined`.

### Testing
- Ran the automated test suite with `yarn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee414d00e483269cdcf0455d558272)