### PR TITLE
Use cached searchKey set indexes for additional-access rule indexing and simplify indexing flow

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -595,9 +595,6 @@ export const ProfileForm = ({
   const [availableCardsCount, setAvailableCardsCount] = useState(0);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const [isIndexingAdditionalRules, setIsIndexingAdditionalRules] = useState(false);
-  const matchedUserIdsByInputIndexRef = useRef({});
-  const matchedRuleTextByInputIndexRef = useRef({});
-  const matchedRuleCacheAccessUserIdRef = useRef('');
   const autoAppliedOverlayForUserRef = useRef('');
 
   const addEmptyAdditionalFilter = useCallback(() => {
@@ -884,6 +881,42 @@ export const ProfileForm = ({
     return Object.keys(matchedBySetKey).length > 0 ? matchedBySetKey : null;
   }, []);
 
+  const getIndexedMatchedUserIdsByInputIndex = useCallback(async rawRules => {
+    const accessUserId = String(state?.userId || '').trim();
+    if (!accessUserId) {
+      toast.error('Не знайдено userId для індексації');
+      return null;
+    }
+
+    const ruleInputs = Array.isArray(rawRules)
+      ? rawRules.map(item => String(item || '').trim()).filter(Boolean)
+      : String(rawRules || '')
+        .split(/\r?\n\s*\r?\n+/)
+        .map(item => item.trim())
+        .filter(Boolean);
+    if (!ruleInputs.length) {
+      toast.error('Немає правил для індексації');
+      return null;
+    }
+
+    const matchedByInputIndex = {};
+    for (let index = 0; index < ruleInputs.length; index += 1) {
+      const rulesText = ruleInputs[index];
+      // eslint-disable-next-line no-await-in-loop
+      const indexed = await getIndexedNewUsersIdsByRules({
+        rawRules: rulesText,
+        accessUserId,
+      });
+      if (!indexed?.userIds) {
+        toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.');
+        return null;
+      }
+      matchedByInputIndex[index + 1] = [...new Set((indexed.userIds || []).filter(Boolean))];
+    }
+
+    return matchedByInputIndex;
+  }, [state?.userId]);
+
   const submitWithNormalization = useCallback(async (nextState, overwrite, delCondition, options = {}) => {
     const payload =
       nextState && typeof nextState === 'object'
@@ -895,47 +928,24 @@ export const ProfileForm = ({
         rawRules !== undefined || Boolean(delCondition?.[ADDITIONAL_ACCESS_FIELD] !== undefined);
       if (shouldReindexAfterAdditionalRulesChange) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
-        const hasPrefilteredMatches =
-          !!options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object';
-        const currentRuleInputs = Array.isArray(rawRules)
-          ? rawRules.map(item => String(item || '').trim())
-          : String(rawRules || '')
-            .split(/\r?\n\s*\r?\n+/)
-            .map(item => item.trim());
-        const nextRuleTextByInputIndex = currentRuleInputs.reduce((acc, rulesText, idx) => {
-          acc[idx + 1] = rulesText;
-          return acc;
-        }, {});
+        const matchedUserIdsByInputIndex =
+          options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object'
+            ? options.matchedUserIdsByInputIndex
+            : await getIndexedMatchedUserIdsByInputIndex(rawRules);
 
-        if (matchedRuleCacheAccessUserIdRef.current !== accessUserId) {
-          matchedUserIdsByInputIndexRef.current = {};
-          matchedRuleTextByInputIndexRef.current = {};
+        if (!matchedUserIdsByInputIndex) {
+          Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
+            console.error('Failed to submit profile changes', error);
+            const details = error?.message || String(error);
+            toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
+          });
+          return;
         }
-
-        const prevRuleTextByInputIndex = matchedRuleTextByInputIndexRef.current;
-        Object.keys(matchedUserIdsByInputIndexRef.current).forEach(rawInputIndex => {
-          const inputIndex = Number(rawInputIndex);
-          const prevRuleText = prevRuleTextByInputIndex[inputIndex] || '';
-          const nextRuleText = nextRuleTextByInputIndex[inputIndex] || '';
-          if (!nextRuleText || prevRuleText !== nextRuleText) {
-            delete matchedUserIdsByInputIndexRef.current[inputIndex];
-          }
-        });
-
-        if (hasPrefilteredMatches) {
-          matchedUserIdsByInputIndexRef.current = {
-            ...matchedUserIdsByInputIndexRef.current,
-            ...options.matchedUserIdsByInputIndex,
-          };
-        }
-
-        matchedRuleCacheAccessUserIdRef.current = accessUserId;
-        matchedRuleTextByInputIndexRef.current = nextRuleTextByInputIndex;
 
         const matchedUserIdsBySetKey = buildMatchedUserIdsBySetKey(
           rawRules,
           accessUserId,
-          matchedUserIdsByInputIndexRef.current
+          matchedUserIdsByInputIndex
         );
         const indexResult = await buildNewUsersFilterSetIndex({
           rawRules: rawRules !== undefined ? rawRules : '',
@@ -954,6 +964,8 @@ export const ProfileForm = ({
         toast.error(
           `Немає прав на запис у searchKeySets.\nПеревірте Firebase Rules для цього користувача.\n${details}`
         );
+      } else if (code.includes('MISSING_SEARCHKEY_INDEX')) {
+        toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.');
       } else {
         console.error('Failed to update additional access newUsers filter-set index', error);
         const details = error?.message || String(error);
@@ -965,7 +977,7 @@ export const ProfileForm = ({
       const details = error?.message || String(error);
       toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
     });
-  }, [buildMatchedUserIdsBySetKey, handleSubmit, state?.userId]);
+  }, [buildMatchedUserIdsBySetKey, getIndexedMatchedUserIdsByInputIndex, handleSubmit, state?.userId]);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;
@@ -1038,8 +1050,6 @@ export const ProfileForm = ({
         updated[ADDITIONAL_ACCESS_FIELD] = nextInputs;
       }
 
-      matchedUserIdsByInputIndexRef.current = {};
-      matchedRuleTextByInputIndexRef.current = {};
       const delCondition =
         action === 'del' || removedValue !== undefined
           ? { [ADDITIONAL_ACCESS_FIELD]: removedValue }
@@ -1051,82 +1061,34 @@ export const ProfileForm = ({
 
   const indexAdditionalRulesForUser = useCallback(async rawRules => {
     const accessUserId = String(state?.userId || '').trim();
-    if (!accessUserId) {
-      toast.error('Не знайдено userId для індексації');
-      return null;
-    }
-
-    const ruleInputs = Array.isArray(rawRules)
-      ? rawRules.map(item => String(item || '').trim()).filter(Boolean)
-      : String(rawRules || '')
-        .split(/\r?\n\s*\r?\n+/)
-        .map(item => item.trim())
-        .filter(Boolean);
-    if (!ruleInputs.length) {
-      toast.error('Немає правил для індексації');
-      return null;
-    }
+    if (!accessUserId) return null;
 
     setIsIndexingAdditionalRules(true);
     const toastId = 'additional-rules-indexing';
     let stage = 'start';
     const stageToast = message => toast.loading(message, { id: toastId });
-    stageToast('1/5 Індексація searchKeySets: старт...');
+    stageToast('1/3 Індексація searchKeySets: старт...');
 
     try {
-      stage = 'load-new-users';
-      stageToast('2/5 Завантаження пулу newUsers...');
-      const newUsersSnapshot = await get(refDb(database, 'newUsers'));
-      const newUsersMap = newUsersSnapshot.exists() ? newUsersSnapshot.val() || {} : {};
-      const matchedUserIdsByInputIndex = {};
-
-      stage = 'compute-matches';
-      stageToast('3/5 Обчислення пулів користувачів по правилах...');
-      ruleInputs.forEach((rulesText, index) => {
-        const inputIndex = index + 1;
-        const cachedRuleText = String(matchedRuleTextByInputIndexRef.current?.[inputIndex] || '').trim();
-        const cachedUserIds = matchedUserIdsByInputIndexRef.current?.[inputIndex];
-        if (cachedRuleText && cachedRuleText === rulesText && Array.isArray(cachedUserIds)) {
-          matchedUserIdsByInputIndex[inputIndex] = cachedUserIds;
-          return;
-        }
-
-        const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
-        if (!parsedRuleGroups.length) return;
-
-        const matchedUserIds = Object.entries(newUsersMap)
-          .filter(([userId, userData]) =>
-            isUserAllowedByAnyAdditionalAccessRule(
-              { userId, ...(userData && typeof userData === 'object' ? userData : {}) },
-              parsedRuleGroups
-            )
-          )
-          .map(([userId]) => userId);
-
-        matchedUserIdsByInputIndex[inputIndex] = matchedUserIds;
-      });
+      stage = 'load-searchkey';
+      stageToast('2/3 Читання пулів із searchKey...');
+      const matchedUserIdsByInputIndex = await getIndexedMatchedUserIdsByInputIndex(rawRules);
+      if (!matchedUserIdsByInputIndex) {
+        toast('searchKeySets не оновлено: відсутні індекси searchKey.', { id: toastId });
+        return null;
+      }
 
       const matchedUserIdsBySetKey = buildMatchedUserIdsBySetKey(
         rawRules,
         accessUserId,
         matchedUserIdsByInputIndex
       );
-      matchedRuleTextByInputIndexRef.current = ruleInputs.reduce((acc, rulesText, idx) => {
-        acc[idx + 1] = rulesText;
-        return acc;
-      }, {});
-      matchedRuleCacheAccessUserIdRef.current = accessUserId;
-      matchedUserIdsByInputIndexRef.current = {
-        ...matchedUserIdsByInputIndexRef.current,
-        ...matchedUserIdsByInputIndex,
-      };
 
       stage = 'write-index';
-      stageToast('4/5 Запис індексів у searchKeySets...');
+      stageToast('3/3 Запис індексів у searchKeySets...');
       const indexResult = await buildNewUsersFilterSetIndex({
         rawRules,
         accessUserId,
-        newUsersData: newUsersMap,
         matchedUserIdsBySetKey,
       });
 
@@ -1151,6 +1113,8 @@ export const ProfileForm = ({
           `Помилка на етапі "${stage}": немає прав на запис у searchKeySets.\nПеревірте Firebase Rules для цього користувача.\n${details}`,
           { id: toastId }
         );
+      } else if (code.includes('MISSING_SEARCHKEY_INDEX')) {
+        toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.', { id: toastId });
       } else {
         toast.error(`Помилка на етапі "${stage}": не вдалося виконати індексацію наборів фільтрів.\n${details}`, { id: toastId });
       }
@@ -1158,7 +1122,7 @@ export const ProfileForm = ({
     } finally {
       setIsIndexingAdditionalRules(false);
     }
-  }, [buildMatchedUserIdsBySetKey, state?.userId]);
+  }, [buildMatchedUserIdsBySetKey, getIndexedMatchedUserIdsByInputIndex, state?.userId]);
 
   const applyAdditionalRulesFromBuilder = async () => {
     const rulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
@@ -1167,22 +1131,9 @@ export const ProfileForm = ({
       return;
     }
 
-    let matchedUserIds = [];
-    try {
-      const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
-      const newUsersSnapshot = await get(refDb(database, 'newUsers'));
-      const newUsersMap = newUsersSnapshot.exists() ? newUsersSnapshot.val() || {} : {};
-      matchedUserIds = Object.entries(newUsersMap)
-        .filter(([userId, userData]) =>
-          isUserAllowedByAnyAdditionalAccessRule(
-            { userId, ...(userData && typeof userData === 'object' ? userData : {}) },
-            parsedRuleGroups
-          )
-        )
-        .map(([userId]) => userId);
-    } catch (error) {
-      console.error('Failed to precompute additional access matched users for indexing', error);
-    }
+    const matchedByInputIndex = await getIndexedMatchedUserIdsByInputIndex(rulesText);
+    if (!matchedByInputIndex) return;
+    const matchedUserIds = matchedByInputIndex[1] || [];
 
     setState(prevState => {
       const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -18,7 +18,11 @@ import {
   parseAdditionalAccessRuleGroups,
   resolveAdditionalAccessSearchKeyBuckets,
 } from './additionalAccessRules';
-import { getCachedSearchKeyPayload } from './searchKeyCache';
+import {
+  getCachedAdditionalRulesSetIndex,
+  getCachedSearchKeyPayload,
+  saveCachedAdditionalRulesSetIndex,
+} from './searchKeyCache';
 
 export const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_INDEX_SEPARATOR = '_';
@@ -230,17 +234,11 @@ export const buildSearchKeySetIndexFromMatchedUsers = async ({
 
 export const buildNewUsersFilterSetIndex = async ({
   rawRules,
-  newUsersData = null,
   accessUserId,
   matchedUserIdsBySetKey = null,
 }) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
   if (!normalizedAccessUserId) return null;
-
-  const sourceNewUsers =
-    newUsersData && typeof newUsersData === 'object'
-      ? newUsersData
-      : (await get(ref(database, 'newUsers'))).val() || {};
 
   const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
   const nextSetPayloads = ruleSetEntries
@@ -254,7 +252,15 @@ export const buildNewUsersFilterSetIndex = async ({
       const userIds =
         Array.isArray(prefilteredIds)
           ? buildUserIdsMapFromList(prefilteredIds)
-          : mapMatchingIdsByRules(sourceNewUsers, parsedRuleGroups);
+          : null;
+      if (!userIds) {
+        return {
+          setKey: ownerSetKey,
+          userIds: null,
+          parsedRuleGroups,
+          missingSearchKeyIndex: true,
+        };
+      }
 
       return {
         setKey: ownerSetKey,
@@ -263,6 +269,11 @@ export const buildNewUsersFilterSetIndex = async ({
       };
     })
     .filter(Boolean);
+  if (nextSetPayloads.some(item => item.missingSearchKeyIndex)) {
+    const error = new Error('Missing searchKey index for one or more additional access rule sets');
+    error.code = 'MISSING_SEARCHKEY_INDEX';
+    throw error;
+  }
 
   const rootSnap = await get(ref(database, SEARCH_KEY_SETS_ROOT));
   const rootMap = rootSnap.exists() ? rootSnap.val() || {} : {};
@@ -284,22 +295,12 @@ export const buildNewUsersFilterSetIndex = async ({
     // eslint-disable-next-line no-await-in-loop
     await remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`));
 
-    const pickedUsers = pickUsersByIds(sourceNewUsers, Object.keys(userIds || {}));
-    const options = {
-      usersData: pickedUsers,
-      rootPath: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
-    };
+    const rootPath = `${SEARCH_KEY_SETS_ROOT}/${setKey}`;
     const ruleBucketWrites = buildRuleBucketWrites({
-      rootPath: options.rootPath,
+      rootPath,
       parsedRuleGroups,
       userIds: Object.keys(userIds || {}),
     });
-
-    // eslint-disable-next-line no-await-in-loop
-    for (const builder of SEARCH_KEY_SET_BUILDERS) {
-      // eslint-disable-next-line no-await-in-loop
-      await builder('newUsers', undefined, options);
-    }
 
     if (Object.keys(ruleBucketWrites).length) {
       // eslint-disable-next-line no-await-in-loop
@@ -319,6 +320,11 @@ export const buildNewUsersFilterSetIndex = async ({
 export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
   if (!normalizedAccessUserId) return null;
+
+  const cachedIndexedSet = getCachedAdditionalRulesSetIndex({
+    rawRules,
+    accessUserId: normalizedAccessUserId,
+  });
 
   const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
   const setEntries = ruleSetEntries
@@ -346,10 +352,49 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       const paths = Object.entries(indexBuckets).flatMap(([indexName, values]) =>
         values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
       );
-      return { setKey, paths };
+      return { setKey, paths, indexBuckets };
     })
     .filter(Boolean);
   if (!setEntries.length) return null;
+
+  const buildIndexedResultFromSetsMap = setsMap => {
+    if (!setsMap || typeof setsMap !== 'object') return null;
+
+    const userIds = new Set();
+    const setKeys = [];
+    for (const entry of setEntries) {
+      const setNode = setsMap?.[entry.setKey];
+      if (!setNode || typeof setNode !== 'object') return null;
+
+      Object.entries(entry.indexBuckets).forEach(([indexName, values]) => {
+        values.forEach(value => {
+          const bucketValue = setNode?.[indexName]?.[value];
+          if (!bucketValue || typeof bucketValue !== 'object') {
+            throw new Error('MISSING_BUCKET');
+          }
+          setKeys.push(`${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`);
+          Object.keys(bucketValue).forEach(userId => {
+            if (userId) userIds.add(userId);
+          });
+        });
+      });
+    }
+
+    return {
+      setKeys,
+      userIds: [...userIds],
+      ownerId: normalizedAccessUserId,
+    };
+  };
+
+  if (cachedIndexedSet) {
+    try {
+      const cachedResult = buildIndexedResultFromSetsMap(cachedIndexedSet);
+      if (cachedResult) return cachedResult;
+    } catch {
+      // ignore malformed or incomplete cache and fallback to backend
+    }
+  }
 
   const payloadsBySet = await Promise.all(
     setEntries.map(async entry => {
@@ -373,19 +418,39 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   }
 
   const userIds = new Set();
+  const setsMap = {};
   payloadsBySet.forEach(item => {
+    setsMap[item.setKey] = setsMap[item.setKey] && typeof setsMap[item.setKey] === 'object'
+      ? setsMap[item.setKey]
+      : {};
     item.payloads.forEach(payload => {
       Object.keys(payload?.value || {}).forEach(userId => {
         if (userId) userIds.add(userId);
       });
     });
+    item.paths.forEach((path, pathIndex) => {
+      const [, setKey, indexName, value] = String(path).split('/');
+      if (!setKey || !indexName || !value) return;
+      const payloadValue = item.payloads[pathIndex]?.value;
+      if (!payloadValue || typeof payloadValue !== 'object') return;
+      if (!setsMap[setKey][indexName] || typeof setsMap[setKey][indexName] !== 'object') {
+        setsMap[setKey][indexName] = {};
+      }
+      setsMap[setKey][indexName][value] = payloadValue;
+    });
   });
 
-  return {
+  const result = {
     setKeys: payloadsBySet.flatMap(item => item.paths),
     userIds: [...userIds],
     ownerId: normalizedAccessUserId,
   };
+  saveCachedAdditionalRulesSetIndex({
+    rawRules,
+    accessUserId: normalizedAccessUserId,
+    setsMap,
+  });
+  return result;
 };
 
 export const rebuildAllNewUsersFilterSetIndexes = async () => {

--- a/src/utils/searchKeyCache.js
+++ b/src/utils/searchKeyCache.js
@@ -61,3 +61,28 @@ export const saveCachedAdditionalRulesPreview = ({ rawRules, accessUserId, count
     userIds: normalizedIds,
   });
 };
+
+export const buildAdditionalRulesSetIndexCacheKey = ({ rawRules, accessUserId }) => {
+  const normalizedRules = normalizeRulesText(rawRules);
+  const normalizedAccessUserId = String(accessUserId || '').trim() || 'anonymous';
+  if (!normalizedRules) return null;
+  return `additionalRulesSetIndex:${normalizedAccessUserId}:${encodeURIComponent(normalizedRules)}`;
+};
+
+export const getCachedAdditionalRulesSetIndex = ({ rawRules, accessUserId }) => {
+  const cacheKey = buildAdditionalRulesSetIndexCacheKey({ rawRules, accessUserId });
+  if (!cacheKey) return null;
+
+  const cached = loadCache(cacheKey);
+  if (!cached || typeof cached !== 'object') return null;
+  return cached;
+};
+
+export const saveCachedAdditionalRulesSetIndex = ({ rawRules, accessUserId, setsMap }) => {
+  const cacheKey = buildAdditionalRulesSetIndexCacheKey({ rawRules, accessUserId });
+  if (!cacheKey) return;
+
+  if (!setsMap || typeof setsMap !== 'object' || Array.isArray(setsMap)) return;
+  if (Object.keys(setsMap).length === 0) return;
+  saveCache(cacheKey, setsMap);
+};


### PR DESCRIPTION
### Motivation
- Reduce scanning of the full `newUsers` collection and reuse cached searchKey set payloads when computing additional-access rule matches.
- Simplify stateful client-side caching logic and centralize caching of indexed sets to avoid repeated computations and improve indexing performance.

### Description
- Added `getIndexedMatchedUserIdsByInputIndex` in `ProfileForm.jsx` to fetch precomputed matched user ids via the indexed `searchKeySets` and replaced several local ref-based caches with this centralized flow.
- Updated `submitWithNormalization`, `indexAdditionalRulesForUser`, `applyAdditionalRulesFromBuilder`, and other flows in `ProfileForm.jsx` to use the new indexed lookup and to surface clear error messages when searchKey indexes are missing.
- Refactored `buildNewUsersFilterSetIndex` and `getIndexedNewUsersIdsByRules` in `src/utils/newUsersFilterSetsIndex.js` to rely on indexed `searchKeySets` buckets, to produce a `MISSING_SEARCHKEY_INDEX` error when an index is not available, and to throw that error early rather than scanning `newUsers` inline.
- Extended `src/utils/searchKeyCache.js` with `buildAdditionalRulesSetIndexCacheKey`, `getCachedAdditionalRulesSetIndex`, and `saveCachedAdditionalRulesSetIndex` to cache and reuse the sets map returned for additional-access rules, and to persist the sets map for faster subsequent lookups.

### Testing
- Ran the existing test suite with `yarn test` and fixed code issues; all unit tests completed successfully.
- Ran linter via `yarn lint` to enforce code style and ensure no new warnings; linter passed.
- Executed the additional rules indexing flows locally against a dev RTDB environment to verify the new cached lookup and the `MISSING_SEARCHKEY_INDEX` error path; indexing and error handling behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4f7e004c8326b28f27031908fa0e)