### PR TITLE
Fallback to root `searchKey` buckets when `searchKeySets` are missing

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -399,8 +399,46 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
     })
   );
 
-  if (payloadsBySet.some(item => item.payloads.some(payload => !payload?.exists))) {
-    return null;
+  const hasMissingSetPayloads = payloadsBySet.some(item => item.payloads.some(payload => !payload?.exists));
+  if (hasMissingSetPayloads) {
+    const fallbackSearchKeyPayloads = await Promise.all(
+      setEntries.map(async entry => {
+        const paths = Object.entries(entry.indexBuckets).flatMap(([indexName, values]) =>
+          values.map(value => `searchKey/${indexName}/${value}`)
+        );
+        const payloads = await Promise.all(
+          paths.map(path =>
+            getCachedSearchKeyPayload(path, async () => {
+              const snapshot = await get(ref(database, path));
+              return {
+                exists: snapshot.exists(),
+                value: snapshot.exists() ? snapshot.val() || {} : null,
+              };
+            })
+          )
+        );
+        return { paths, payloads };
+      })
+    );
+
+    if (fallbackSearchKeyPayloads.some(item => item.payloads.some(payload => !payload?.exists))) {
+      return null;
+    }
+
+    const userIds = new Set();
+    fallbackSearchKeyPayloads.forEach(item => {
+      item.payloads.forEach(payload => {
+        Object.keys(payload?.value || {}).forEach(userId => {
+          if (userId) userIds.add(userId);
+        });
+      });
+    });
+
+    return {
+      setKeys: fallbackSearchKeyPayloads.flatMap(item => item.paths),
+      userIds: [...userIds],
+      ownerId: normalizedAccessUserId,
+    };
   }
 
   const userIds = new Set();


### PR DESCRIPTION
### Motivation

- Users saw a toast "Індексів searchKey не знайдено. Спершу запустіть загальну індексацію" when creating additional access rules even though root `searchKey` buckets exist in RTDB; the code was treating missing `searchKeySets` entries as a hard failure.

### Description

- Added a fallback in `getIndexedNewUsersIdsByRules` to read from root `searchKey/<index>/<value>` buckets when the `searchKeySets/<setKey>/...` payloads are missing. 
- The fallback aggregates user IDs from the root `searchKey` buckets and returns a compatible result shape (`setKeys`, `userIds`, `ownerId`) so additional-access rules can be saved without a false "missing searchKey index" error. 
- Preserved the existing fast-path that uses cached `searchKeySets` payloads and the cache behavior when available. 
- Changed file: `src/utils/newUsersFilterSetsIndex.js`.

### Testing

- Ran `npx eslint src/utils/newUsersFilterSetsIndex.js` and it completed without lint errors (environment warnings from `npm/browserslist` are unrelated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef12ee03288326917b90f1d554cefa)