### PR TITLE
Fix edit form falling back to Add mode when URL userId unchanged

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1316,7 +1316,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         lastUrlUserIdRef.current = null;
         return;
       }
-      if (lastUrlUserIdRef.current !== urlUserId) {
+      if (lastUrlUserIdRef.current !== urlUserId || state?.userId !== urlUserId) {
         lastUrlUserIdRef.current = urlUserId;
         setProfileSource('');
         setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
@@ -1324,7 +1324,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     } else {
       lastUrlUserIdRef.current = null;
     }
-  }, [canAccessAdd, location.search, setSearch, setState]);
+  }, [canAccessAdd, location.search, setSearch, setState, state?.userId]);
 
   useEffect(() => {
     if (hasRestoredStoredEditUserRef.current) return;


### PR DESCRIPTION
### Motivation
- When visiting `/add?userId=...` the edit form could briefly appear then fall back to Add mode because the URL check only restored edit state when the URL userId changed, so a transient local `state` reset left the component out of edit mode.

### Description
- Update the URL-sync `useEffect` in `AddNewProfile` to also restore when `state?.userId !== urlUserId` and add `state?.userId` to the effect dependencies so URL and local state remain synchronized.

### Testing
- Ran lint: `npm run lint:js -- src/components/AddNewProfile.jsx` and it completed successfully (no lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0ff84c9c8326b44ef757fddefdec)