### PR TITLE
Reduce unnecessary rerenders on /add when opened with userId query

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -639,10 +639,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const location = useLocation();
   const lastUrlUserIdRef = useRef(new URLSearchParams(location.search).get('userId'));
   const hasRestoredStoredEditUserRef = useRef(false);
-  const initialAccess = resolveAccess({
-    uid: auth.currentUser?.uid,
-    accessLevel: localStorage.getItem('accessLevel'),
-  });
 
   const [userNotFound, setUserNotFound] = useState(false);
 
@@ -840,7 +836,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState(() => {
     const params = new URLSearchParams(location.search);
-    const restoredUserId = initialAccess.canAccessAdd ? params.get('userId') || '' : '';
+    const restoredUserId = params.get('userId') || '';
 
     if (!restoredUserId) {
       return {};


### PR DESCRIPTION
### Motivation
* Opening `/add?userId=...` could start the page with an empty state and then patch `userId` via effects (because initial state depended on `initialAccess`), which caused extra rerenders and visible UI movement.

### Description
* Always hydrate `AddNewProfile` initial state from the URL by reading `userId` directly from `location.search` and remove the now-unused `initialAccess` check in `src/components/AddNewProfile.jsx` to avoid the extra state synchronization step.

### Testing
* Ran `npm run lint:js -- src/components/AddNewProfile.jsx` and lint completed successfully with no errors (only a non-blocking `browserslist` update notice).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef18a084688326bd1724dfcbcadb6f)