### PR TITLE
Restore stored edit user only on hard reload to prevent sticky /add redirect

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1328,6 +1328,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (!canAccessAdd) return;
 
+    const navigationEntry = performance.getEntriesByType('navigation')?.[0];
+    const isPageReload = navigationEntry?.type === 'reload';
+    if (!isPageReload) return;
+
     const params = new URLSearchParams(location.search);
     if (params.get('userId')) return;
     if (state?.userId) return;


### PR DESCRIPTION
### Motivation
- Navigating away from `/add?userId=...` could cause the app to reopen the previously edited profile because the stored `addNewProfileEditUserId` was restored unconditionally, producing a sticky redirect back to the same card. 

### Description
- Added a reload-only guard in `src/components/AddNewProfile.jsx` using `performance.getEntriesByType('navigation')?.[0].type === 'reload'` to only restore the edit `userId` after a hard page reload, while keeping existing `location.search` and `state.userId` checks. 

### Testing
- Ran `npm test -- --watch=false` which completed (no tests related to the change were found). 
- Ran `npm run build` which compiled successfully and produced the production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e0a3f388326874e04c4fbb2dfad)