### PR TITLE
Fix addNewProfile crash when navigation timing API is unsupported

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1328,7 +1328,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (!canAccessAdd) return;
 
-    const navigationEntry = performance.getEntriesByType('navigation')?.[0];
+    const navigationEntry = window?.performance?.getEntriesByType?.('navigation')?.[0];
     const isPageReload = navigationEntry?.type === 'reload';
     if (!isPageReload) return;
 


### PR DESCRIPTION
### Motivation
- Prevent `AddNewProfile` from throwing in environments where the Navigation Timing API (`performance.getEntriesByType`) is not available so the add/edit page does not crash on load.

### Description
- In `src/components/AddNewProfile.jsx` use optional chaining when reading the navigation entry (`window?.performance?.getEntriesByType?.('navigation')?.[0]`) so reload detection gracefully falls back instead of causing a runtime error.

### Testing
- Ran `npm run build`; the first build failed due to an intermediate use of `globalThis` triggering an eslint `no-undef` error, and after switching to `window?.performance...` the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef32f2df288326b5635927b22328bd)