### PR TITLE
Remove forced /add edit redirects from AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1329,19 +1329,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     if (hasRestoredStoredEditUserRef.current) return;
     hasRestoredStoredEditUserRef.current = true;
-
-    if (!canAccessAdd) return;
-
-    const params = new URLSearchParams(location.search);
-    if (params.get('userId')) return;
-    if (state?.userId) return;
-
-    const storedUserId = localStorage.getItem(EDIT_PROFILE_USER_ID_KEY);
-    if (!storedUserId) return;
-
-    setProfileSource('');
-    setState(prev => (prev?.userId === storedUserId ? prev : { userId: storedUserId }));
-  }, [canAccessAdd, location.search, state?.userId, setState, EDIT_PROFILE_USER_ID_KEY]);
+  }, []);
 
   useEffect(() => {
     const normalized = (search || '').trim();
@@ -1385,21 +1373,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setLastSearchBarQuery,
   ]);
 
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const currentUserId = params.get('userId');
-
-    if (state.userId) {
-      if (currentUserId !== state.userId) {
-        params.set('userId', state.userId);
-        const nextSearch = params.toString();
-        const nextSearchString = nextSearch ? `?${nextSearch}` : '';
-        if (nextSearchString !== location.search) {
-          navigate({ pathname: location.pathname, search: nextSearchString }, { replace: true });
-        }
-      }
-    }
-  }, [state.userId, location.pathname, location.search, navigate]);
+  // Removed auto-redirect that forced `?userId=` into URL on every state change.
+  // It could trap navigation and return the user back to edit mode.
 
   const handleFilterChange = useCallback(nextFilters => {
     const nextValue = nextFilters ?? {};


### PR DESCRIPTION
### Motivation
- The `/add` page could trap navigation by automatically restoring a stored `userId` and by rewriting the URL with `?userId=` on every state change, causing the app to redirect back into the same edit view.

### Description
- Removed the `useEffect` that restored `userId` from `localStorage` and forced the component into edit mode when mounting.
- Removed the `useEffect` that updated the URL with `?userId=` and called `navigate(..., { replace: true })` on `state.userId` changes.
- Kept the effect that reads `userId` from `location.search` so direct links like `/add?userId=...` still hydrate the editor state.
- Added an inline comment noting the removed auto-redirect behavior to prevent future regressions.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx`, which completed successfully (exit code 0) with only standard Browserslist warnings.
- No unit tests were changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3e3efe688326b7a08496d6977dc1)