### PR TITLE
Preserve edit mode on AddNewProfile refresh by removing URL redirect effect

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -638,10 +638,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const location = useLocation();
   const lastUrlUserIdRef = useRef(new URLSearchParams(location.search).get('userId'));
-  const initialAccess = resolveAccess({
-    uid: auth.currentUser?.uid,
-    accessLevel: localStorage.getItem('accessLevel'),
-  });
 
   const [userNotFound, setUserNotFound] = useState(false);
 
@@ -839,7 +835,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState(() => {
     const params = new URLSearchParams(location.search);
-    const restoredUserId = initialAccess.canAccessAdd ? params.get('userId') || '' : '';
+    const restoredUserId = params.get('userId') || '';
 
     if (!restoredUserId) {
       return {};
@@ -874,7 +870,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const navigate = useNavigate();
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
   const isAdmin = access.isAdmin;
-  const canAccessAdd = access.canAccessAdd;
   const [stimulationScheduleProfiles, setStimulationScheduleProfiles] = useState([]);
   const [stimulationShortcutIds, setStimulationShortcutIdsState] = useState(() =>
     getStoredStimulationShortcutIds(),
@@ -1306,24 +1301,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (hasSearchParam) {
       setSearch(prev => (prev === urlSearchValue ? prev : urlSearchValue));
-    } else if (urlUserId && canAccessAdd) {
+    } else if (urlUserId) {
       setSearch(prev => (prev ? prev : urlUserId));
     }
 
     if (urlUserId) {
-      if (!canAccessAdd) {
-        lastUrlUserIdRef.current = null;
-        return;
-      }
       if (lastUrlUserIdRef.current !== urlUserId) {
         lastUrlUserIdRef.current = urlUserId;
         setProfileSource('');
         setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
       }
-    } else {
-      lastUrlUserIdRef.current = null;
+      return;
     }
-  }, [canAccessAdd, location.search, setSearch, setState]);
+
+    lastUrlUserIdRef.current = null;
+  }, [location.search, setSearch, setState]);
 
   useEffect(() => {
     const normalized = (search || '').trim();
@@ -1366,22 +1358,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setSearchBarQueryActive,
     setLastSearchBarQuery,
   ]);
-
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const currentUserId = params.get('userId');
-
-    if (state.userId) {
-      if (currentUserId !== state.userId) {
-        params.set('userId', state.userId);
-        const nextSearch = params.toString();
-        const nextSearchString = nextSearch ? `?${nextSearch}` : '';
-        if (nextSearchString !== location.search) {
-          navigate({ pathname: location.pathname, search: nextSearchString }, { replace: true });
-        }
-      }
-    }
-  }, [state.userId, location.pathname, location.search, navigate]);
 
   const handleFilterChange = useCallback(nextFilters => {
     const nextValue = nextFilters ?? {};


### PR DESCRIPTION
### Motivation
- Users lost edit context when reloading an edit page (`AddNewProfile` with `?userId=...`) because URL-derived `userId` restoration was gated by access checks and an effect rewrote the URL via `navigate(..., { replace: true })`, causing an apparent redirect back to add mode.
- The intent is to keep the editor in the same edit state after a page refresh and to avoid side-effectful URL rewrites that reset component state.

### Description
- Changed `AddNewProfile` initial state so restored `userId` is taken from the query string unconditionally with `const restoredUserId = params.get('userId') || ''` instead of gating by access.
- Removed the `initialAccess` variable and eliminated dependency on `canAccessAdd` for URL-to-state restoration to ensure stable edit-mode recovery from `?userId=`.
- Simplified the `useEffect` that synced `location.search` into component state to no longer reset `userId` based on access and to avoid resetting when auth/access resolution changes.
- Removed the `useEffect` that rewrote the browser URL with `navigate({ pathname, search }, { replace: true })`, eliminating the redirect-like behavior.

### Testing
- Built the project with `npm run build`, and the build completed successfully and produced the optimized output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4809d0e883269227c4337219f7d7)