### PR TITLE
Add admin 'Clear cache' button to MyProfile dots menu

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -31,6 +31,7 @@ import { useAutoResize } from '../hooks/useAutoResize';
 import { resolveAccess } from 'utils/accessLevel';
 import { normalizePhoneState } from './inputValidations';
 import { authNotifications } from './authNotifications';
+import { clearAllCardsCache } from 'utils/cache';
 
 const Container = styled.div`
   display: flex;
@@ -585,6 +586,10 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
+  const handleClearCache = () => {
+    clearAllCardsCache();
+  };
+
   const isValidEmail = email => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailPattern.test(email);
@@ -966,6 +971,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         )}
         <SubmitButton onClick={() => setShowInfoModal('delProfile')}>Видалити анкету</SubmitButton>
         <SubmitButton onClick={() => setShowInfoModal('viewProfile')}>Переглянути анкету</SubmitButton>
+        {isAdmin && <SubmitButton onClick={handleClearCache}>Очистити кеш</SubmitButton>}
         {!isEmailVerified && <VerifyEmail />}
         {isSessionActive && <ExitButton onClick={handleExit}>exit</ExitButton>}
       </>


### PR DESCRIPTION
### Motivation
- Provide admins a quick way to clear local cards/queries cache from the `/my-profile` three-dots menu to help with cache-related troubleshooting.

### Description
- Import `clearAllCardsCache` from `utils/cache`, add `handleClearCache` that calls it, and expose an admin-only `Очистити кеш` button in the dots menu of `src/components/MyProfile.jsx`.

### Testing
- Ran `npm run lint:js -- src/components/MyProfile.jsx` and the lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef574c1f508326a743eda522dbd206)