### PR TITLE
Fix ProfileForm crashes when form state is temporarily null

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1764,7 +1764,7 @@ ${entries.join('\n')}`;
           id={profileState.userId}
           style={{ display: 'none', textAlign: 'left', marginBottom: '8px' }}
         >
-          {renderAllFields(state, '', {
+          {renderAllFields(profileState, '', {
             userId: profileState?.userId,
             setUsers: setState,
             onRemoveKey: handleProfileViewRemove,
@@ -1972,7 +1972,7 @@ ${entries.join('\n')}`;
                               }
                             }
 
-                            submitWithNormalization(state, 'overwrite');
+                            submitWithNormalization(profileState, 'overwrite');
                           },
                         })}
                   />
@@ -2213,7 +2213,7 @@ ${entries.join('\n')}`;
           <option value="users">users</option>
           <option value="newUsers">newUsers</option>
         </CollectionToggle>
-        <Photos state={state} setState={setState} collection={collection} />
+        <Photos state={profileState} setState={setState} collection={collection} />
       </PhotosBlock>
       {(canManageAccessLevel || !isAdmin) && (
         <OverlayDebugButton type="button" onClick={handleOverlayDebugAlert}>


### PR DESCRIPTION
### Motivation
- ProfileForm could crash when the incoming `state` is temporarily `null` because parts of the component passed the raw `state` into utilities or child components that call `Object.keys` or otherwise assume an object.
- Prevent transient null-state regressions visible after recent refactors that introduced a `profileState` fallback.

### Description
- Use the normalized `profileState = state || {}` when rendering the hidden profile snapshot via `renderAllFields` to avoid passing `null` into that helper (`src/components/ProfileForm.jsx`).
- Call `submitWithNormalization(profileState, 'overwrite')` on blur handlers to avoid forwarding a transient `null` `state` to submit logic.
- Pass `profileState` into the `Photos` child component to prevent `Photos` from calling `Object.keys(state)` on a `null` value.
- Small lint-driven cleanups and a short commit message; changes are confined to `src/components/ProfileForm.jsx`.

### Testing
- Ran the linter with `npm run lint:js -- src/components/ProfileForm.jsx` and it completed without errors (no blocking ESLint issues).
- Committed the fix and created the PR titled `Fix ProfileForm crashes when form state is temporarily null`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5770bf3883269bd0feaa6f5dbbd4)