### PR TITLE
Fix AddNewProfile access resolution in edit mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -872,7 +872,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [userIdToDelete, setUserIdToDelete] = useState(null);
   const navigate = useNavigate();
-  const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
+  const access = resolveAccess({
+    uid: auth.currentUser?.uid,
+    accessLevel: localStorage.getItem('accessLevel'),
+  });
   const isAdmin = access.isAdmin;
   const canAccessAdd = access.canAccessAdd;
   const [stimulationScheduleProfiles, setStimulationScheduleProfiles] = useState([]);


### PR DESCRIPTION
### Motivation
- Opening a card in edit mode could set `state.accessLevel` (the opened card's access level) into the access resolver, which sometimes downgraded the UI permissions and caused add/feed functionality to stop working until re-login.

### Description
- Use `localStorage.getItem('accessLevel')` when calling `resolveAccess` in `src/components/AddNewProfile.jsx` so access is determined from the logged-in user's stored access level rather than the currently opened card's `state`.

### Testing
- Ran `npm run lint:js -- src/components/AddNewProfile.jsx` and ESLint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5bc2272c83268e3db7aae392fb9c)