### PR TITLE
Guard localStorage writes, cap persisted userIds, and simplify accessLevel resolution

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -872,7 +872,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [userIdToDelete, setUserIdToDelete] = useState(null);
   const navigate = useNavigate();
-  const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
+  const access = resolveAccess({
+    uid: auth.currentUser?.uid,
+    accessLevel: localStorage.getItem('accessLevel'),
+  });
   const isAdmin = access.isAdmin;
   const canAccessAdd = access.canAccessAdd;
   const [stimulationScheduleProfiles, setStimulationScheduleProfiles] = useState([]);
@@ -1280,7 +1283,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     };
 
     previousListStateRef.current = snapshot;
-    localStorage.setItem(PREVIOUS_LIST_STATE_KEY, JSON.stringify(snapshot));
+    try {
+      const persistedSnapshot = {
+        ...snapshot,
+        userIds: Array.isArray(snapshot.userIds)
+          ? snapshot.userIds.slice(0, 200)
+          : [],
+        isUserIdsTruncated: Array.isArray(snapshot.userIds)
+          ? snapshot.userIds.length > 200
+          : false,
+      };
+      localStorage.setItem(PREVIOUS_LIST_STATE_KEY, JSON.stringify(persistedSnapshot));
+    } catch (error) {
+      console.warn('[AddNewProfile] Failed to persist previous list snapshot', error);
+    }
   }, [
     state.userId,
     users,
@@ -1505,11 +1521,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     if (state?.userId) {
-      localStorage.setItem(EDIT_PROFILE_USER_ID_KEY, state.userId);
+      try {
+        localStorage.setItem(EDIT_PROFILE_USER_ID_KEY, state.userId);
+      } catch (error) {
+        console.warn('[AddNewProfile] Failed to persist edit user id', error);
+      }
       return;
     }
 
-    localStorage.removeItem(EDIT_PROFILE_USER_ID_KEY);
+    try {
+      localStorage.removeItem(EDIT_PROFILE_USER_ID_KEY);
+    } catch (error) {
+      console.warn('[AddNewProfile] Failed to clear edit user id', error);
+    }
   }, [state?.userId, EDIT_PROFILE_USER_ID_KEY]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation

- Prevent uncaught exceptions from `localStorage` operations from breaking the profile editor and log failures for easier debugging.
- Avoid persisting very large `userIds` arrays to `localStorage` to reduce storage footprint and risk of quota errors.
- Simplify how `accessLevel` is resolved by consistently using the persisted value from `localStorage` rather than falling back to component state.

### Description

- Changed `resolveAccess` call to always use `localStorage.getItem('accessLevel')` for the `accessLevel` argument instead of `state.accessLevel || localStorage.getItem('accessLevel')`.
- Wrapped `localStorage.setItem`/`removeItem` calls for `PREVIOUS_LIST_STATE_KEY` and `EDIT_PROFILE_USER_ID_KEY` in `try/catch` blocks and emit `console.warn` on failure to avoid throwing during render/effects.
- When persisting the previous list snapshot, cap `userIds` to the first 200 entries and add `isUserIdsTruncated: true/false` to the persisted payload to indicate truncation.

### Testing

- Ran the automated unit test suite via `npm test` and all tests passed.
- Ran linting via `npm run lint` and no lint errors were reported.
- Performed a production build via `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5bc2272c83268e3db7aae392fb9c)