### PR TITLE
Fix AddNewProfile blank state when edit-mode guard stalls

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1228,6 +1228,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     isEditingRef.current = !!state.userId;
   }, [state.userId]);
+  const stateUserIdRef = useRef(state.userId || '');
+
+  useEffect(() => {
+    stateUserIdRef.current = state.userId || '';
+  }, [state.userId]);
 
   const [users, setUsers] = useState({});
   const [hasMore, setHasMore] = useState(true); // Стан для перевірки, чи є ще користувачі
@@ -1250,8 +1255,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [, setCacheCount] = useState(0);
   const [, setBackendCount] = useState(0);
   const [profileSource, setProfileSource] = useState('');
-  const hasUrlUserId = Boolean(new URLSearchParams(location.search).get('userId'));
-  const isResolvingEditMode = hasUrlUserId && canAccessAdd && !state.userId;
+  const [isResolvingEditMode, setIsResolvingEditMode] = useState(false);
 
   useEffect(() => {
     const enteringEditMode = Boolean(state.userId) && !isEditingRef.current;
@@ -1313,12 +1317,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (urlUserId) {
       if (!canAccessAdd) {
+        setIsResolvingEditMode(false);
         return;
       }
+      setIsResolvingEditMode(!stateUserIdRef.current || stateUserIdRef.current !== urlUserId);
       setProfileSource('');
       setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
+      return;
     }
+    setIsResolvingEditMode(false);
   }, [canAccessAdd, location.search, setSearch, setState]);
+
+  useEffect(() => {
+    if (state.userId) {
+      setIsResolvingEditMode(false);
+    }
+  }, [state.userId]);
 
   useEffect(() => {
     const normalized = (search || '').trim();
@@ -3407,6 +3421,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const handleBackToPreviousList = useCallback(() => {
+    if (location.search.includes('userId=')) {
+      navigate({ pathname: location.pathname, search: '' }, { replace: true });
+    }
+
     const persistedRaw = localStorage.getItem(PREVIOUS_LIST_STATE_KEY);
     const persisted =
       !previousListStateRef.current && persistedRaw
@@ -3454,7 +3472,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setSearch(snapshot.search || '');
     setHasSearched(Boolean(snapshot.hasSearched) || Object.keys(restoredUsers).length > 0);
     setState({});
-  }, [setSearch, setState]);
+  }, [location.pathname, location.search, navigate, setSearch, setState]);
 
   useEffect(() => {
     if (!state?.userId) {


### PR DESCRIPTION
### Motivation
- The URL→state edit-mode resolve guard could indefinitely keep the component rendering `null` when `state.userId` was intentionally cleared while `?userId=` remained in the URL. 
- The change ensures the edit-resolution logic only applies during URL-driven initialization and that returning to list view clears stale query state.

### Description
- Replaced the derived `isResolvingEditMode` boolean with a controlled state `isResolvingEditMode` so resolution windows are scoped to URL sync runs and not re-triggered by local clears. 
- Added `stateUserIdRef` to track the last resolved `state.userId` and use it inside the URL sync effect to decide if resolution is pending without depending on `state.userId` directly. 
- Updated the URL sync effect to set/reset `isResolvingEditMode` based on the URL and `stateUserIdRef`, and to avoid re-entrancy by returning early after initializing edit mode. 
- Modified `handleBackToPreviousList` to clear the `userId` query param (`navigate({ pathname: location.pathname, search: '' }, { replace: true })`) before restoring the previous list state and adjusted effect dependencies accordingly.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx` and resolved linter warnings; the linter run completed successfully with no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc0b078308326b40b8aa0c9e5afb1)