### PR TITLE
Excel import: normalize 9-digit phones, produce nested comments/dislikes JSON with push IDs

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -93,7 +93,7 @@ import SearchBar, { detectSearchParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { PAGE_SIZE, database } from './config';
-import { onValue, ref } from 'firebase/database';
+import { onValue, push, ref } from 'firebase/database';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
 // import { aiHandler } from './aiHandler';
 import {
@@ -588,7 +588,7 @@ const extractSurnameAndName = fullName => {
 
 const normalizeExcelPhone = rawPhone => {
   const normalized = normalizePhoneState({ phone: rawPhone });
-  const phone = normalized?.phone;
+  let phone = normalized?.phone;
 
   if (phone === undefined || phone === null) {
     return '';
@@ -598,7 +598,13 @@ const normalizeExcelPhone = rawPhone => {
     return phone[0] || '';
   }
 
-  return String(phone).trim();
+  phone = String(phone).trim();
+
+  if (/^\d{9}$/.test(phone)) {
+    return `380${phone}`;
+  }
+
+  return phone;
 };
 
 export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
@@ -951,9 +957,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
         const dataRows = rows.slice(2);
         const usersJson = {};
-        const commentsJson = {};
-        const directoryJson = {};
+        const commentsJson = { [EXCEL_COMMENTS_OWNER_ID]: {} };
+        const dislikesJson = { [EXCEL_COMMENTS_OWNER_ID]: {} };
         const todayTimestamp = Date.now();
+        const commentsOwnerRef = ref(database, `multiData/comments/${EXCEL_COMMENTS_OWNER_ID}`);
 
         dataRows.forEach((row, index) => {
           const rowArray = Array.isArray(row) ? row : [];
@@ -973,19 +980,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             ...(phone ? { phone } : {}),
           };
 
-          commentsJson[`${EXCEL_COMMENTS_OWNER_ID}/${userId}`] = {
+          const commentId = push(commentsOwnerRef).key || `comment-${userId}`;
+
+          commentsJson[EXCEL_COMMENTS_OWNER_ID][commentId] = {
             authorId: EXCEL_COMMENTS_OWNER_ID,
             cardId: userId,
-            lastAction: { [todayTimestamp]: true },
+            lastAction: todayTimestamp,
             text: commentText,
           };
 
-          directoryJson[`${EXCEL_COMMENTS_OWNER_ID}/${userId}`] = true;
+          dislikesJson[EXCEL_COMMENTS_OWNER_ID][userId] = true;
         });
 
         downloadJsonFile('users-cards.json', usersJson);
         downloadJsonFile('users-comments.json', commentsJson);
-        downloadJsonFile('users-comments-directory.json', directoryJson);
+        downloadJsonFile('users-dislikes.json', dislikesJson);
         toast.success(`Готово: ${dataRows.length} рядків оброблено`);
       } catch (error) {
         console.error('[AddNewProfile] Excel import failed', error);


### PR DESCRIPTION
### Motivation
- Ensure phone numbers imported from Excel are normalized to the expected international format and to prepare structured multiData payloads for comments and dislikes suitable for Firebase usage.
- Generate stable comment IDs using Firebase `push` semantics and simplify the `lastAction` shape for comments to be a timestamp instead of a nested object.
- Replace the previous flat comments/directory exports with nested JSON objects keyed by the comments owner to match the backend multiData layout.

### Description
- Added `push` to the Firebase imports and use `push(commentsOwnerRef).key` to create comment IDs during Excel import with a fallback key when needed.
- Updated `normalizeExcelPhone` to trim values safely, handle arrays, and prefix 9-digit numbers with `380` so phones like `XXXXXXXXX` become `380XXXXXXXXX`.
- Reworked Excel import payloads to initialize `commentsJson` and `dislikesJson` as nested objects keyed by `EXCEL_COMMENTS_OWNER_ID` and populate `commentsJson[owner][commentId]` and `dislikesJson[owner][userId]` accordingly.
- Changed comment `lastAction` to store a timestamp number instead of an object keyed by timestamp, and renamed the exported dislikes file to `users-dislikes.json` (formerly a directory file).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07fd5a7188326b217f32e4af146d8)