### PR TITLE
Локальна модальна індексація `searchId`/`searchKey` через JSON (users + newUsers)

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -36,6 +36,8 @@ import {
   syncUserSearchIdIndex,
   syncUserSearchKeyIndex,
   createSelectedSearchKeyIndexesInCollection,
+  buildSearchIdIndexPayloadFromCollections,
+  buildSearchKeyIndexPayloadFromCollections,
   fetchUsersBySearchKeyBloodPaged,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -93,7 +95,7 @@ import SearchBar, { detectSearchParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { PAGE_SIZE, database } from './config';
-import { onValue, push, ref } from 'firebase/database';
+import { get, onValue, push, ref } from 'firebase/database';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
 // import { aiHandler } from './aiHandler';
 import {
@@ -572,6 +574,32 @@ const IndexModalList = styled.div`
   margin-bottom: 10px;
 `;
 
+const LocalIndexOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  padding: 16px;
+`;
+
+const LocalIndexModal = styled.div`
+  width: min(560px, 100%);
+  background: #fff;
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.2);
+`;
+
+const LocalIndexActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+`;
+
 const EXCEL_COMMENTS_OWNER_ID = 'stFMfZ8CqQX05L8vK9Yse6FdYIh1';
 
 const extractSurnameAndName = fullName => {
@@ -690,6 +718,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     stimulationShortcuts: true,
     searchKeyUsersAll: false,
     searchKeySetReindex: false,
+    searchLocalIdAndKey: false,
   };
   const defaultSelectedSearchKeyIndexes = SEARCH_KEY_INDEX_OPTIONS.reduce((acc, option) => {
     acc[option.key] = true;
@@ -709,6 +738,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isExcelImporting, setIsExcelImporting] = useState(false);
   const excelImportInputRef = useRef(null);
   const [showSearchKeyIndexPanel, setShowSearchKeyIndexPanel] = useState(false);
+  const [showLocalIndexModal, setShowLocalIndexModal] = useState(false);
+  const [pendingLocalIndexTypes, setPendingLocalIndexTypes] = useState([]);
+  const [pendingLocalUsersData, setPendingLocalUsersData] = useState(null);
+  const [pendingLocalNewUsersData, setPendingLocalNewUsersData] = useState(null);
+  const localUsersFileInputRef = useRef(null);
+  const localNewUsersFileInputRef = useRef(null);
   const [selectedIndexJobs, setSelectedIndexJobs] = useState(() => {
     const storedRaw = localStorage.getItem(INDEX_SELECTION_STORAGE_KEY);
     if (!storedRaw) return defaultSelectedIndexJobs;
@@ -3369,6 +3404,104 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }));
   };
 
+  const runLocalSearchIndexesWithCollections = useCallback(
+    async ({ usersData, newUsersData, indexTypes }) => {
+      const collectionsMap = {
+        users: usersData || {},
+        newUsers: newUsersData || {},
+      };
+
+      const searchIdPayload = buildSearchIdIndexPayloadFromCollections(collectionsMap);
+      const searchKeyPayload = buildSearchKeyIndexPayloadFromCollections(collectionsMap, indexTypes);
+
+      const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+      downloadJsonFile(`searchId-index-${stamp}.json`, searchIdPayload);
+      downloadJsonFile(`searchKey-index-${stamp}.json`, searchKeyPayload);
+    },
+    [downloadJsonFile],
+  );
+
+  const openLocalIndexModal = useCallback(indexTypes => {
+    setPendingLocalIndexTypes(indexTypes);
+    setPendingLocalUsersData(null);
+    setPendingLocalNewUsersData(null);
+    setShowLocalIndexModal(true);
+  }, []);
+
+  const handleDownloadCollectionsForLocalIndex = useCallback(async () => {
+    const toastId = 'download-local-index-collections';
+    toast.loading('Завантаження users та newUsers...', { id: toastId });
+    try {
+      const [usersData, newUsersData] = await Promise.all([
+        get(ref(database, 'users')).then(snapshot => (snapshot.exists() ? snapshot.val() || {} : {})),
+        get(ref(database, 'newUsers')).then(snapshot => (snapshot.exists() ? snapshot.val() || {} : {})),
+      ]);
+      const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+      downloadJsonFile(`users-${stamp}.json`, usersData || {});
+      downloadJsonFile(`newUsers-${stamp}.json`, newUsersData || {});
+      toast.success('Колекції users/newUsers завантажено', { id: toastId });
+    } catch (error) {
+      toast.error(`Не вдалося завантажити колекції: ${error?.message || 'невідома помилка'}`, { id: toastId });
+    }
+  }, [downloadJsonFile]);
+
+  const handlePickUsersFileForLocalIndex = useCallback(() => {
+    if (localUsersFileInputRef.current) {
+      localUsersFileInputRef.current.value = '';
+      localUsersFileInputRef.current.click();
+    }
+  }, []);
+
+  const handlePickNewUsersFileForLocalIndex = useCallback(() => {
+    if (localNewUsersFileInputRef.current) {
+      localNewUsersFileInputRef.current.value = '';
+      localNewUsersFileInputRef.current.click();
+    }
+  }, []);
+
+  const handleLocalCollectionFileSelected = useCallback(async (event, collection) => {
+    const file = event?.target?.files?.[0];
+    if (!file) return;
+
+    try {
+      const parsed = JSON.parse(await file.text());
+      if (!parsed || typeof parsed !== 'object') {
+        toast.error(`Некоректний JSON для ${collection}`);
+        return;
+      }
+
+      if (collection === 'users') {
+        setPendingLocalUsersData(parsed);
+      } else {
+        setPendingLocalNewUsersData(parsed);
+      }
+      toast.success(`Файл ${collection}.json прочитано`);
+    } catch (error) {
+      toast.error(`Не вдалося прочитати ${collection}.json: ${error?.message || 'невідома помилка'}`);
+    }
+  }, []);
+
+  const handleApplyLocalIndexing = useCallback(async () => {
+    if (!pendingLocalUsersData || !pendingLocalNewUsersData) {
+      toast.error('Спочатку оберіть обидва локальні файли: users.json і newUsers.json');
+      return;
+    }
+
+    const toastId = 'local-index-build';
+    toast.loading('Формуємо локальні JSON індекси searchId/searchKey...', { id: toastId });
+    try {
+      await runLocalSearchIndexesWithCollections({
+        usersData: pendingLocalUsersData,
+        newUsersData: pendingLocalNewUsersData,
+        indexTypes: pendingLocalIndexTypes,
+      });
+      toast.success('Локальні JSON індекси завантажено на пристрій', { id: toastId });
+      setShowLocalIndexModal(false);
+    } catch (error) {
+      toast.error(`Помилка локальної індексації: ${error?.message || 'невідома помилка'}`, { id: toastId });
+    }
+  }, [pendingLocalNewUsersData, pendingLocalUsersData, pendingLocalIndexTypes, runLocalSearchIndexesWithCollections]);
+
   const runSelectedIndexes = async () => {
     const selectedIndexTypes = SEARCH_KEY_INDEX_OPTIONS.filter(option => selectedSearchKeyIndexes[option.key]).map(
       option => option.key,
@@ -3379,6 +3512,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       !selectedIndexJobs.stimulationShortcuts &&
       !selectedIndexJobs.searchKeyUsersAll &&
       !selectedIndexJobs.searchKeySetReindex &&
+      !selectedIndexJobs.searchLocalIdAndKey &&
       !selectedIndexTypes.length
     ) {
       toast.error('Оберіть хоча б один індекс для запуску');
@@ -3402,6 +3536,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           `searchKeySet оновлено: ${stats.indexedRuleSets}/${stats.totalRuleSets} наборів.`,
           { id: toastId },
         );
+      }
+
+      if (selectedIndexJobs.searchLocalIdAndKey) {
+        openLocalIndexModal(selectedIndexTypes.length ? selectedIndexTypes : SEARCH_KEY_INDEX_OPTIONS.map(option => option.key));
+        return;
       }
 
       if (selectedIndexJobs.searchKeyUsersAll) {
@@ -4150,6 +4289,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   <SearchScopeLabel>
                     <input
                       type="checkbox"
+                      checked={Boolean(selectedIndexJobs.searchLocalIdAndKey)}
+                      onChange={() => toggleIndexJobSelection('searchLocalIdAndKey')}
+                    />
+                    <SearchScopeLabelTextGroup>
+                      <span>Локальна індексація searchId+searchKey (через JSON)</span>
+                    </SearchScopeLabelTextGroup>
+                  </SearchScopeLabel>
+                  <SearchScopeLabel>
+                    <input
+                      type="checkbox"
                       checked={Boolean(selectedIndexJobs.searchKeyUsersAll)}
                       onChange={() => toggleIndexJobSelection('searchKeyUsersAll')}
                     />
@@ -4223,6 +4372,45 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           CompareCards={compareCards}
           MoreActions={moreActions}
         />
+      )}
+      {showLocalIndexModal && (
+        <LocalIndexOverlay onClick={() => setShowLocalIndexModal(false)}>
+          <LocalIndexModal onClick={event => event.stopPropagation()}>
+            <h3>Локальна індексація searchId / searchKey</h3>
+            <p>1) Викачайте users та newUsers. 2) Оберіть ці файли локально. 3) Створіть JSON індекси.</p>
+            <LocalIndexActions>
+              <button type="button" onClick={handleDownloadCollectionsForLocalIndex}>
+                1) Викачати колекції users + newUsers
+              </button>
+              <button type="button" onClick={handlePickUsersFileForLocalIndex}>
+                2) Обрати users.json {pendingLocalUsersData ? '✅' : ''}
+              </button>
+              <button type="button" onClick={handlePickNewUsersFileForLocalIndex}>
+                3) Обрати newUsers.json {pendingLocalNewUsersData ? '✅' : ''}
+              </button>
+              <button type="button" onClick={handleApplyLocalIndexing}>
+                4) Побудувати і скачати JSON індекси searchId/searchKey
+              </button>
+              <button type="button" onClick={() => setShowLocalIndexModal(false)}>
+                Скасувати
+              </button>
+            </LocalIndexActions>
+            <input
+              ref={localUsersFileInputRef}
+              type="file"
+              accept="application/json,.json"
+              style={{ display: 'none' }}
+              onChange={event => handleLocalCollectionFileSelected(event, 'users')}
+            />
+            <input
+              ref={localNewUsersFileInputRef}
+              type="file"
+              accept="application/json,.json"
+              style={{ display: 'none' }}
+              onChange={event => handleLocalCollectionFileSelected(event, 'newUsers')}
+            />
+          </LocalIndexModal>
+        </LocalIndexOverlay>
       )}
     </Container>
   );

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3784,6 +3784,120 @@ export const createSelectedSearchKeyIndexesInCollection = async (collection, ind
   }
 };
 
+const toPlainObjectFromSetMap = indexMap =>
+  Object.entries(indexMap).reduce((acc, [key, value]) => {
+    if (value instanceof Set) {
+      const ids = [...value].filter(Boolean);
+      if (ids.length === 1) {
+        acc[key] = ids[0];
+      } else if (ids.length > 1) {
+        acc[key] = ids;
+      }
+      return acc;
+    }
+
+    if (value && typeof value === 'object') {
+      const nested = toPlainObjectFromSetMap(value);
+      if (nested && Object.keys(nested).length > 0) {
+        acc[key] = nested;
+      }
+    }
+
+    return acc;
+  }, {});
+
+export const buildSearchIdIndexPayloadFromCollections = collectionsMap => {
+  const searchIdMap = {};
+
+  Object.entries(collectionsMap || {}).forEach(([, usersMap]) => {
+    Object.entries(usersMap || {}).forEach(([userId, userData]) => {
+      if (!userId || !userData || typeof userData !== 'object') return;
+
+      keysToCheck.forEach(key => {
+        if (key === 'getInTouch' || key === 'lastAction') return;
+        const candidates = extractIndexableFieldValues(userData[key]).flatMap(value =>
+          buildSearchIndexCandidates(key, value)
+        );
+        candidates.forEach(candidate => {
+          if (!candidate) return;
+          const searchIdKey = `${key}_${encodeKey(String(candidate).toLowerCase())}`;
+          if (!searchIdMap[searchIdKey]) {
+            searchIdMap[searchIdKey] = new Set();
+          }
+          searchIdMap[searchIdKey].add(userId);
+        });
+      });
+    });
+  });
+
+  return toPlainObjectFromSetMap(searchIdMap);
+};
+
+const resolveSearchKeyValuesByIndexType = (indexType, userId, userData) => {
+  if (indexType === SEARCH_KEY_INDEX_TYPES.blood) {
+    return [{ indexName: BLOOD_SEARCH_KEY_INDEX, values: [...getBloodIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.maritalStatus) {
+    return [{ indexName: MARITAL_STATUS_SEARCH_KEY_INDEX, values: [...getMaritalStatusIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.csection) {
+    return [{ indexName: CSECTION_SEARCH_KEY_INDEX, values: [...getCsectionIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.contact) {
+    return [{ indexName: CONTACT_SEARCH_KEY_INDEX, values: [...getContactIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.role) {
+    return [{ indexName: ROLE_SEARCH_KEY_INDEX, values: [...getRoleIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.userId) {
+    return [{ indexName: USER_ID_SEARCH_KEY_INDEX, values: [...getUserIdIndexSet(userData?.userId || userId)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.age) {
+    return [{ indexName: AGE_SEARCH_KEY_INDEX, values: [...getAgeIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.imtHeightWeight) {
+    return [
+      { indexName: IMT_SEARCH_KEY_INDEX, values: [normalizeImtSearchKeyIndexValue(userData)] },
+      { indexName: HEIGHT_SEARCH_KEY_INDEX, values: [...normalizeMetricIndexValues(userData?.height)] },
+      { indexName: WEIGHT_SEARCH_KEY_INDEX, values: [...normalizeMetricIndexValues(userData?.weight)] },
+    ];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.reaction) {
+    return [{ indexName: REACTION_SEARCH_KEY_INDEX, values: [...getReactionIndexSet(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.fieldCount) {
+    return [{ indexName: FIELD_COUNT_SEARCH_KEY_INDEX, values: [normalizeFieldCountSearchKeyIndexValue(userData)] }];
+  }
+  return [];
+};
+
+export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexTypes = []) => {
+  const uniqueIndexTypes = [...new Set(indexTypes)].filter(indexType => Boolean(SEARCH_KEY_INDEX_BUILDERS[indexType]));
+  if (!uniqueIndexTypes.length) return {};
+
+  const payload = {};
+
+  Object.entries(collectionsMap || {}).forEach(([collectionName, usersMap]) => {
+    const rootPath = collectionName === 'users' ? 'searchKey/users' : 'searchKey';
+
+    Object.entries(usersMap || {}).forEach(([userId, userData]) => {
+      if (!userId || !userData || typeof userData !== 'object') return;
+
+      uniqueIndexTypes.forEach(indexType => {
+        const entries = resolveSearchKeyValuesByIndexType(indexType, userId, userData);
+        entries.forEach(({ indexName, values }) => {
+          values.filter(Boolean).forEach(value => {
+            const path = resolveSearchKeyLeafPath(rootPath, indexName, value, userId);
+            payload[path] = true;
+          });
+        });
+      });
+    });
+  });
+
+  return payload;
+};
+
 export const fetchUsersBySearchKeyBloodPaged = async ({
   filterSettings = {},
   offset = 0,


### PR DESCRIPTION
### Motivation
- Зменшити навантаження на бекенд при побудові індексів `searchId`/`searchKey` та надати адміну можливість формувати індекси локально. 
- Надати UX за прикладом `additionalAccessRules`: пропонувати скачати колекції `users` та `newUsers`, застосувати їх для індексацій і зберегти результати на пристрої у вигляді JSON для ручного завантаження на бекенд. 
- Забезпечити однакову логіку нормалізації та bucket-формування індексів, щоб локально згенеровані JSON відповіли серверній логіці індексації.

### Description
- Додано утиліти в `src/components/config.js`: `buildSearchIdIndexPayloadFromCollections(collectionsMap)` та `buildSearchKeyIndexPayloadFromCollections(collectionsMap, indexTypes)` для побудови payload-ів індексів з локальних колекцій, що повторно використовують існуючу нормалізацію і bucket-логіку. 
- У `src/components/AddNewProfile.jsx` додано модальне вікно та стан для локальної індексації (`showLocalIndexModal`, file inputs, pending data), чекбокс-джоб `searchLocalIdAndKey`, та обробники для: 1) скачування `users`/`newUsers`, 2) вибору локальних JSON-файлів, 3) валідації і 4) генерації/завантаження `searchId`/`searchKey` JSON-файлів. 
- Додано допоміжні UI-компоненти стилізованих елементів модалки та кнопок (`LocalIndexOverlay`, `LocalIndexModal`, `LocalIndexActions`) і інтеграцію з наявним toast-повідомленням для індикації статусів операцій. 
- Під час локальної побудови індексів результати зберігаються клієнтською функцією завантаження (`downloadJsonFile`) у вигляді файлів `searchId-index-<stamp>.json` та `searchKey-index-<stamp>.json` для ручного аплоаду на бекенд.

### Testing
- Виконано автоматичну перевірку lint: `npm run lint:js -- src/components/AddNewProfile.jsx src/components/config.js`, перевірка завершилась успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0897feef083269a627be0b66526a0)