### PR TITLE
Support 'ID' userId prefix in searchKey indexing and filters

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -35,7 +35,7 @@ const defaultsAdd = {
     no: true,
   },
   contact: { vk: true, instagram: true, facebook: true, phone: true, telegram: true, telegram2: true, tiktok: true, email: true },
-  userId: { vk: true, aa: true, ab: true, long: true, mid: true, other: true },
+  userId: { vk: true, aa: true, ab: true, id: true, long: true, mid: true, other: true },
   fields: { le5: true, f6_10: true, f11_20: true, f20_plus: true },
   commentLength: {
     w0_9: true,

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -261,6 +261,7 @@ export const SearchFilters = ({
           { val: 'vk', label: 'vk' },
           { val: 'aa', label: 'aa' },
           { val: 'ab', label: 'ab' },
+          { val: 'id', label: 'ID' },
           { val: 'long', label: '>20' },
           { val: 'mid', label: '>8<20' },
           { val: 'other', label: '?' },

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2760,6 +2760,7 @@ const getUserIdIndexSet = userId => {
   if (normalizedId.startsWith('vk')) userIdVariants.add('vk');
   if (normalizedId.startsWith('aa')) userIdVariants.add('aa');
   if (normalizedId.startsWith('ab')) userIdVariants.add('ab');
+  if (normalizedId.startsWith('id')) userIdVariants.add('id');
   if (normalizedId.length > 20) userIdVariants.add('long');
   if (normalizedId.length > 8 && normalizedId.length <= 20) userIdVariants.add('mid');
   if (userIdVariants.size === 0) userIdVariants.add('other');
@@ -2874,7 +2875,7 @@ const isBucketAllowedByFilters = (bucket, filterSettings = {}) => {
 const MARITAL_STATUS_SEARCH_KEY_BUCKETS = ['+', '-', '?', 'no'];
 const CONTACT_SEARCH_KEY_BUCKETS = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'];
 const ROLE_SEARCH_KEY_BUCKETS = ['ed', 'sm', 'ag', 'ip', 'pp', 'cl', '?', 'no'];
-const USER_ID_SEARCH_KEY_BUCKETS = ['vk', 'aa', 'ab', 'long', 'mid', 'other'];
+const USER_ID_SEARCH_KEY_BUCKETS = ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'];
 const IMT_SEARCH_KEY_BUCKETS = ['le28', '29_31', '32_35', '36_plus', '?', 'no'];
 
 const getMaritalStatusFilterKey = bucket => {

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -156,7 +156,7 @@ export const ADDITIONAL_ACCESS_FILTER_OPTIONS = {
   imt: ['le28', '29_31', '32_35', '36_plus', '?', 'no'],
   role: ['ed', 'sm', 'ag', 'ip', 'cl', '?', 'no'],
   contact: ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'],
-  userId: ['vk', 'aa', 'ab', 'long', 'mid', 'other'],
+  userId: ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'],
   reaction: ['past', 'future', '99', '?', 'no'],
   height: ['lt163', '163_176', '177_180', '181_plus', '?', 'no'],
   weight: ['lt55', '55_69', '70_84', '85_plus', '?', 'no'],
@@ -184,7 +184,7 @@ maritalStatus: +,-,?,no
 csection: cs2plus,cs1,cs0,other,no
 contact: vk,instagram,facebook,phone,telegram,telegram2,tiktok,email
 role: ed,sm,ag,ip,cl,?,no
-userId: vk,aa,ab,long,mid,other
+userId: vk,aa,ab,id,long,mid,other
 imt: le28,29_31,32_35,36_plus,?,no
 ageBirthDate: d_2001-01-30,?,no
 reaction: d_2026-04-18,99,?,no
@@ -210,6 +210,7 @@ const toUserIdBuckets = userId => {
   if (normalized.startsWith('vk')) buckets.push('vk');
   if (normalized.startsWith('aa')) buckets.push('aa');
   if (normalized.startsWith('ab')) buckets.push('ab');
+  if (normalized.startsWith('id')) buckets.push('id');
   if (normalized.length > 20) buckets.push('long');
   if (normalized.length > 8 && normalized.length <= 20) buckets.push('mid');
   if (!buckets.length) buckets.push('other');


### PR DESCRIPTION
### Motivation
- Add a checkbox to filter `userId` values that start with the `ID` prefix and ensure this bucket is considered when building `searchKey` indexes and `searchKeySets` used by additional access rules.

### Description
- Added an `id` option to the `userId` filter UI in `src/components/SearchFilters.jsx` so admins can select the `ID` prefix bucket in the filters.
- Enabled `userId.id` in the default filter state in `src/components/FilterPanel.jsx` so the new checkbox is on by default.
- Extended `getUserIdIndexSet` and `USER_ID_SEARCH_KEY_BUCKETS` in `src/components/config.js` to detect normalized `userId` values starting with `id` and include the `id` bucket during indexed reads/writes.
- Updated `src/utils/additionalAccessRules.js` to include `id` in `ADDITIONAL_ACCESS_FILTER_OPTIONS`, the `ADDITIONAL_ACCESS_TEMPLATE`, and the `toUserIdBuckets` mapping so `searchKeySets`/additional access indexing accounts for `ID`-prefixed IDs.

### Testing
- Ran the linter with `npm run lint:js`, which completed successfully (only non-blocking npm/browserslist warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08aa77cd08326afb1d67cbfb9023d)