### PR TITLE
Preserve nested searchKey structure in local index export

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3877,9 +3877,25 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
   if (!uniqueIndexTypes.length) return {};
 
   const payload = {};
+  const assignNestedLeaf = (target, pathSegments, leafValue) => {
+    if (!target || !Array.isArray(pathSegments) || pathSegments.length === 0) return;
+    let node = target;
+    pathSegments.forEach((segment, index) => {
+      if (!segment) return;
+      const isLeaf = index === pathSegments.length - 1;
+      if (isLeaf) {
+        node[segment] = leafValue;
+        return;
+      }
+      if (!node[segment] || typeof node[segment] !== 'object') {
+        node[segment] = {};
+      }
+      node = node[segment];
+    });
+  };
 
   Object.entries(collectionsMap || {}).forEach(([collectionName, usersMap]) => {
-    const rootPath = collectionName === 'users' ? 'searchKey/users' : 'searchKey';
+    const rootSegments = collectionName === 'users' ? ['users'] : [];
 
     Object.entries(usersMap || {}).forEach(([userId, userData]) => {
       if (!userId || !userData || typeof userData !== 'object') return;
@@ -3888,8 +3904,7 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
         const entries = resolveSearchKeyValuesByIndexType(indexType, userId, userData);
         entries.forEach(({ indexName, values }) => {
           values.filter(Boolean).forEach(value => {
-            const path = resolveSearchKeyLeafPath(rootPath, indexName, value, userId);
-            payload[path] = true;
+            assignNestedLeaf(payload, [...rootSegments, indexName, value, userId], true);
           });
         });
       });


### PR DESCRIPTION
### Motivation
- Local JSON exports for `searchKey` previously used slash-delimited path keys which can break backend importers that expect Firebase-like nested objects. 
- Keep the existing on-disk shape for `searchKey`/`searchId` payloads so imported data does not break backend consumers.

### Description
- Reworked `buildSearchKeyIndexPayloadFromCollections` in `src/components/config.js` to build a nested object tree instead of producing flat slash-delimited keys. 
- Added a helper `assignNestedLeaf(target, pathSegments, leafValue)` to deterministically build nested nodes from path segments. 
- Ensure `users` collection entries are placed under the `users` branch (i.e. `searchKey.users...`) while other collections (e.g. `newUsers`) remain at the root-level branches, preserving the expected structure when imported.

### Testing
- Ran ESLint via `npm run lint:js -- src/components/config.js` and it completed successfully. 
- Verified the modified file is updated at `src/components/config.js` and the new payload shape is returned from `buildSearchKeyIndexPayloadFromCollections` during local index generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0903bdd9483269de24c9f589daad9)