### PR TITLE
Fix cleanup of searchKeySets when removing additional access rules

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -960,6 +960,25 @@ export const ProfileForm = ({
         rawRules !== undefined || Boolean(delCondition?.[ADDITIONAL_ACCESS_FIELD] !== undefined);
       if (shouldReindexAfterAdditionalRulesChange) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
+        const hasAnyAdditionalRules =
+          (Array.isArray(rawRules) && rawRules.some(item => String(item || '').trim())) ||
+          (!Array.isArray(rawRules) && String(rawRules || '').trim().length > 0);
+
+        if (!hasAnyAdditionalRules) {
+          await buildNewUsersFilterSetIndex({
+            rawRules: '',
+            accessUserId,
+            matchedUserIdsBySetKey: {},
+          });
+          toast('searchKeySets очищено: additional access rules видалено.');
+          Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
+            console.error('Failed to submit profile changes', error);
+            const details = error?.message || String(error);
+            toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
+          });
+          return;
+        }
+
         const matchedUserIdsByInputIndex =
           options?.matchedUserIdsByInputIndex && typeof options.matchedUserIdsByInputIndex === 'object'
             ? options.matchedUserIdsByInputIndex


### PR DESCRIPTION
### Motivation
- Deleting all `additionalAccessRules` from a profile left stale owner-specific records in the `searchKeySets` backend index because the index rebuild path was skipped when the rules list became empty.

### Description
- Update `submitWithNormalization` in `src/components/ProfileForm.jsx` to detect when `additionalAccessRules` are fully cleared via `hasAnyAdditionalRules`.
- When no rules remain, call `buildNewUsersFilterSetIndex` with `rawRules: ''` and an empty `matchedUserIdsBySetKey` to remove owner-specific `searchKeySets` buckets on the backend and show a confirmation `toast`.
- Continue submitting the profile changes via `handleSubmit` after index cleanup so the profile save flow remains unchanged.

### Testing
- Ran `npx eslint src/components/ProfileForm.jsx`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b84e55c483268a342feaf228c10b)