### PR TITLE
Allow owners to update multiData comments and display normalized comment dates

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -915,6 +915,37 @@ export const setUserComment = async (cardId, text) => {
   }
 };
 
+export const updateCommentByOwner = async ({ ownerId, commentId, cardId, text }) => {
+  try {
+    const currentUser = auth.currentUser;
+    if (!currentUser) {
+      throw new Error('User not authenticated');
+    }
+    const safeOwnerId = String(ownerId || '').trim();
+    const safeCommentId = String(commentId || '').trim();
+    if (!safeOwnerId || !safeCommentId || !cardId || typeof text !== 'string') {
+      throw new Error('ownerId, commentId, cardId і text обовʼязкові');
+    }
+
+    const targetRef = ref2(database, `multiData/comments/${safeOwnerId}/${safeCommentId}`);
+    const snap = await get(targetRef);
+    if (!snap.exists()) {
+      return null;
+    }
+
+    const lastAction = Date.now();
+    await update(targetRef, {
+      cardId,
+      text,
+      lastAction,
+    });
+    return { commentId: safeCommentId, lastAction };
+  } catch (error) {
+    console.error('Error updating comment by owner:', error);
+    return null;
+  }
+};
+
 export const fetchUserComment = async (ownerId, cardId) => {
   try {
     const q = query(

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -18,7 +18,12 @@ import { fieldMaritalStatus } from './fieldMaritalStatus';
 import { fieldIMT } from './fieldIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
-import { fetchUserById, setUserComment as persistUserComment, fetchAllCommentsByCardId } from '../config';
+import {
+  fetchUserById,
+  setUserComment as persistUserComment,
+  updateCommentByOwner,
+  fetchAllCommentsByCardId
+} from '../config';
 import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
@@ -117,8 +122,9 @@ const multiCommentStyle = {
   fontStyle: 'italic',
   color: '#f3dfab',
   cursor: 'pointer',
-  textDecoration: 'underline',
-  textUnderlineOffset: '2px',
+  textDecoration: 'none',
+  fontSize: '60%',
+  lineHeight: 1.25,
 };
 
 const multiCommentRowStyle = {
@@ -250,7 +256,7 @@ const extractMultiDataComments = cardData => {
 
     if (typeof value === 'string') {
       const text = value.trim();
-      if (text) normalized.push({ commentId: `string-${sourceIndex}`, text, authorId: '' });
+      if (text) normalized.push({ commentId: `string-${sourceIndex}`, text, authorId: '', lastAction: 0 });
       return;
     }
 
@@ -258,7 +264,7 @@ const extractMultiDataComments = cardData => {
       value.forEach((item, itemIndex) => {
         if (typeof item === 'string') {
           const text = item.trim();
-          if (text) normalized.push({ commentId: `arr-${sourceIndex}-${itemIndex}`, text, authorId: '' });
+          if (text) normalized.push({ commentId: `arr-${sourceIndex}-${itemIndex}`, text, authorId: '', lastAction: 0 });
         } else if (item?.text) {
           const text = String(item.text).trim();
           if (text) {
@@ -266,6 +272,7 @@ const extractMultiDataComments = cardData => {
               commentId: item.commentId || `arr-${sourceIndex}-${itemIndex}`,
               text,
               authorId: item.authorId || '',
+              lastAction: item.lastAction || item.date || 0,
             });
           }
         }
@@ -277,7 +284,7 @@ const extractMultiDataComments = cardData => {
       Object.entries(value).forEach(([key, item]) => {
         if (typeof item === 'string') {
           const text = item.trim();
-          if (text) normalized.push({ commentId: key, text, authorId: '' });
+          if (text) normalized.push({ commentId: key, text, authorId: '', lastAction: 0 });
         } else if (item?.text) {
           const text = String(item.text).trim();
           if (text) {
@@ -285,6 +292,7 @@ const extractMultiDataComments = cardData => {
               commentId: item.commentId || key,
               text,
               authorId: item.authorId || '',
+              lastAction: item.lastAction || item.date || 0,
             });
           }
         }
@@ -315,6 +323,16 @@ const TopBlock = ({
   overlayFieldAdditions = {},
   onSubmitHistorySnapshot = null
 }) => {
+  const formatCommentDate = React.useCallback(value => {
+    if (!value) return '';
+    const parsed = typeof value === 'number' ? new Date(value) : new Date(String(value));
+    if (Number.isNaN(parsed.getTime())) return '';
+    const day = String(parsed.getDate()).padStart(2, '0');
+    const month = String(parsed.getMonth() + 1).padStart(2, '0');
+    const year = parsed.getFullYear();
+    return `${day}.${month}.${year}`;
+  }, []);
+
   const [editableComment, setEditableComment] = React.useState('');
   const [isCommentModalOpen, setIsCommentModalOpen] = React.useState(false);
   const [selectedComment, setSelectedComment] = React.useState(null);
@@ -393,6 +411,7 @@ const TopBlock = ({
   const saveMultiComment = async () => {
     const prepared = editableComment.trim();
     const targetCommentId = selectedComment?.commentId || '';
+    const targetOwnerId = selectedComment?.ownerId || selectedComment?.authorId || '';
     if (!targetCommentId) {
       toast.error('Не обрано коментар для редагування');
       return;
@@ -431,7 +450,14 @@ const TopBlock = ({
       setState(prev => ({ ...prev, ...optimisticCard }));
     }
 
-    const result = await persistUserComment(cardData.userId, prepared);
+    const result = targetOwnerId
+      ? await updateCommentByOwner({
+          ownerId: targetOwnerId,
+          commentId: targetCommentId,
+          cardId: cardData.userId,
+          text: prepared,
+        })
+      : await persistUserComment(cardData.userId, prepared);
     if (!result) {
       toast.error('Не вдалося зберегти коментар в multiData');
       return;
@@ -681,7 +707,7 @@ const TopBlock = ({
                 setIsCommentModalOpen(true);
               }}
             >
-              {comment.text}
+              {`${formatCommentDate(comment.lastAction) || '--.--.----'} - ${comment.text}`}
             </div>
           </div>
         ))}


### PR DESCRIPTION
### Motivation
- Add the ability for the actual owner of a comment to update that comment in `multiData` and improve how comment timestamps are handled and displayed.
- Normalize various multiData comment shapes so UI can reliably show and sort comments by `lastAction`.

### Description
- Add `updateCommentByOwner` in `src/components/config.js` which validates authentication, checks the target comment exists, updates `cardId`, `text`, and `lastAction`, and returns the update result or `null` on error.
- Import `updateCommentByOwner` into `src/components/smallCard/renderTopBlock.js` and conditionally call it for comments that have an `ownerId`/`authorId`, falling back to the original `persistUserComment` for local cases.
- Normalize `lastAction` in `extractMultiDataComments` for string/array/object comment shapes by populating `lastAction` (or falling back to `date` or `0`) so comments always expose a timestamp.
- Update UI presentation by changing `multiCommentStyle` (remove underline, adjust font size and line-height), add `formatCommentDate` helper, and prefix comment text with a formatted date in the TopBlock comment list while keeping optimistic updates to the local state when saving.

### Testing
- Ran the test suite with `npm test`, and existing unit tests completed successfully.
- Ran static checks with `npm run lint`, and linting passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0be6a47188326bc77870c50f906e8)