### PR TITLE
Make multiData comments smaller, show date, and apply admin edits to original owner records

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -915,6 +915,46 @@ export const setUserComment = async (cardId, text) => {
   }
 };
 
+export const updateCommentByOwner = async ({ ownerId, commentId, cardId, text }) => {
+  try {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+    if (!ownerId || !commentId || !cardId || typeof text !== 'string') {
+      throw new Error('ownerId, commentId, cardId і text обовʼязкові');
+    }
+    const lastAction = Date.now();
+    await set(ref2(database, `multiData/comments/${ownerId}/${commentId}`), {
+      cardId,
+      text,
+      authorId: ownerId,
+      lastAction,
+    });
+    return { commentId, lastAction, ownerId };
+  } catch (error) {
+    console.error('Error updating comment by owner:', error);
+    return null;
+  }
+};
+
+export const deleteCommentByOwner = async ({ ownerId, commentId }) => {
+  try {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+    if (!ownerId || !commentId) {
+      throw new Error('ownerId і commentId обовʼязкові');
+    }
+    await remove(ref2(database, `multiData/comments/${ownerId}/${commentId}`));
+    return true;
+  } catch (error) {
+    console.error('Error deleting comment by owner:', error);
+    return false;
+  }
+};
+
 export const fetchUserComment = async (ownerId, cardId) => {
   try {
     const q = query(

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -18,10 +18,18 @@ import { fieldMaritalStatus } from './fieldMaritalStatus';
 import { fieldIMT } from './fieldIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
-import { fetchUserById, setUserComment as persistUserComment, fetchAllCommentsByCardId } from '../config';
+import {
+  fetchUserById,
+  setUserComment as persistUserComment,
+  fetchAllCommentsByCardId,
+  updateCommentByOwner,
+  deleteCommentByOwner,
+} from '../config';
 import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
+import { isAdminUid } from 'utils/accessLevel';
+import { auth } from '../config';
 import toast from 'react-hot-toast';
 
 const topBlockContainerStyle = { padding: '7px', position: 'relative' };
@@ -117,8 +125,8 @@ const multiCommentStyle = {
   fontStyle: 'italic',
   color: '#f3dfab',
   cursor: 'pointer',
-  textDecoration: 'underline',
-  textUnderlineOffset: '2px',
+  textDecoration: 'none',
+  fontSize: '60%',
 };
 
 const multiCommentRowStyle = {
@@ -139,6 +147,13 @@ const commentAuthorButtonStyle = {
   color: '#f3dfab',
   cursor: 'pointer',
   padding: 0,
+};
+
+const commentDeleteButtonStyle = {
+  ...commentAuthorButtonStyle,
+  color: '#ffb4b4',
+  fontSize: '14px',
+  fontWeight: 700,
 };
 
 const inlineModalOverlayStyle = {
@@ -319,6 +334,7 @@ const TopBlock = ({
   const [isCommentModalOpen, setIsCommentModalOpen] = React.useState(false);
   const [selectedComment, setSelectedComment] = React.useState(null);
   const [backendMultiComments, setBackendMultiComments] = React.useState([]);
+  const isAdmin = isAdminUid(auth.currentUser?.uid);
   const cardData = React.useMemo(() => {
     if (!userData) return null;
     return { ...userData, cycleStatus: getEffectiveCycleStatus(userData) };
@@ -393,8 +409,13 @@ const TopBlock = ({
   const saveMultiComment = async () => {
     const prepared = editableComment.trim();
     const targetCommentId = selectedComment?.commentId || '';
+    const currentUid = auth.currentUser?.uid || '';
     if (!targetCommentId) {
       toast.error('Не обрано коментар для редагування');
+      return;
+    }
+    if (selectedComment?.ownerId && selectedComment.ownerId !== currentUid && !isAdmin) {
+      toast.error('Недостатньо прав для редагування цього коментаря');
       return;
     }
     const updatedComments = (multiDataComments || []).map(comment =>
@@ -431,14 +452,60 @@ const TopBlock = ({
       setState(prev => ({ ...prev, ...optimisticCard }));
     }
 
-    const result = await persistUserComment(cardData.userId, prepared);
+    let result = null;
+    if (selectedComment?.ownerId && selectedComment?.commentId) {
+      result = await updateCommentByOwner({
+        ownerId: selectedComment.ownerId,
+        commentId: selectedComment.commentId,
+        cardId: cardData.userId,
+        text: prepared,
+      });
+    } else {
+      result = await persistUserComment(cardData.userId, prepared);
+    }
     if (!result) {
       toast.error('Не вдалося зберегти коментар в multiData');
       return;
     }
+    setBackendMultiComments(prev =>
+      prev.map(item =>
+        item.commentId === targetCommentId && (item.ownerId || '') === (selectedComment?.ownerId || '')
+          ? { ...item, text: prepared, lastAction: result.lastAction || Date.now() }
+          : item
+      )
+    );
     toast.success('Коментар в multiData збережено');
     setIsCommentModalOpen(false);
     setSelectedComment(null);
+  };
+
+  const handleDeleteComment = async comment => {
+    if (!isAdmin || !comment?.ownerId || !comment?.commentId) {
+      toast.error('Видалення недоступне');
+      return;
+    }
+    const isDeleted = await deleteCommentByOwner({
+      ownerId: comment.ownerId,
+      commentId: comment.commentId,
+    });
+    if (!isDeleted) {
+      toast.error('Не вдалося видалити коментар');
+      return;
+    }
+    setBackendMultiComments(prev =>
+      prev.filter(item => !(item.commentId === comment.commentId && item.ownerId === comment.ownerId))
+    );
+    toast.success('Коментар видалено');
+  };
+
+  const formatCommentDate = timestamp => {
+    if (!Number.isFinite(timestamp) || timestamp <= 0) return '';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '';
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = String(date.getFullYear());
+    return `${day}.${month}.${year}`;
   };
 
   const openAuthorCardForEdit = async authorId => {
@@ -681,8 +748,22 @@ const TopBlock = ({
                 setIsCommentModalOpen(true);
               }}
             >
-              {comment.text}
+              {`${formatCommentDate(comment.lastAction) || '--.--.----'} - ${comment.text}`}
             </div>
+            {isAdmin && comment.ownerId && (
+              <button
+                type="button"
+                style={commentDeleteButtonStyle}
+                title="Видалити оригінальний коментар"
+                aria-label="Видалити оригінальний коментар"
+                onClick={event => {
+                  event.stopPropagation();
+                  handleDeleteComment(comment);
+                }}
+              >
+                ×
+              </button>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
### Motivation
- Зменшити візуальну вагу мульти-датових коментарів і прибрати підкреслення для кращого читання в `renderTopBlock`.
- Показувати дату перед текстом коментаря у форматі `дд.мм.рррр - коментар` для одразуї орієнтації по часу.
- Дозволити адміну редагувати/видаляти оригінальні коментарі інших користувачів прямо в їхній гілці `multiData/comments/{ownerId}` замість створення дублюючих записів під акаунтом адміна.

### Description
- Додано два хелпери в `src/components/config.js`: `updateCommentByOwner({ ownerId, commentId, cardId, text })` для оновлення і `deleteCommentByOwner({ ownerId, commentId })` для видалення оригінального коментаря у `multiData/comments/{ownerId}`.
- У `src/components/smallCard/renderTopBlock.js` імпортовано нові хелпери, додано визначення `isAdmin` через `isAdminUid(auth.currentUser?.uid)` і перевірку прав при редагуванні, щоб блокувати зміну чужих коментарів не-адміном.
- Змінено стилі і верстку коментарів: прибрано підкреслення (`textDecoration: 'none'`), зменшено розмір шрифту приблизно на 40% (`fontSize: '60%'`), та додано форматування дати через `formatCommentDate` і вивід у вигляді `дд.мм.рррр - текст`.
- Зміни в логіці збереження: якщо вибраний коментар має `ownerId` та `commentId`, викликається `updateCommentByOwner(...)`, інакше використовується існуючий `setUserComment` (тепер під назвою `persistUserComment` у файлі); також зроблено оптимістичне оновлення локального стану `backendMultiComments` після збереження.
- Додано адмінський хрестик (`×`) поруч з кожним backend-коментарем для видалення оригіналу через `deleteCommentByOwner`, і обробку видалення в UI.

### Testing
- Запущено лінтер для затронутих файлів із командою `npm run lint:js -- src/components/smallCard/renderTopBlock.js src/components/config.js` і перевірка пройшла без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d44f415c83269b912d114853516f)