### PR TITLE
Add owner-based comment update/delete APIs and admin-delete/edit support in TopBlock

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -915,6 +915,46 @@ export const setUserComment = async (cardId, text) => {
   }
 };
 
+export const updateCommentByOwner = async ({ ownerId, commentId, cardId, text }) => {
+  try {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+    if (!ownerId || !commentId || !cardId || typeof text !== 'string') {
+      throw new Error('ownerId, commentId, cardId і text обовʼязкові');
+    }
+    const lastAction = Date.now();
+    await set(ref2(database, `multiData/comments/${ownerId}/${commentId}`), {
+      cardId,
+      text,
+      authorId: ownerId,
+      lastAction,
+    });
+    return { commentId, lastAction, ownerId };
+  } catch (error) {
+    console.error('Error updating comment by owner:', error);
+    return null;
+  }
+};
+
+export const deleteCommentByOwner = async ({ ownerId, commentId }) => {
+  try {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+    if (!ownerId || !commentId) {
+      throw new Error('ownerId і commentId обовʼязкові');
+    }
+    await remove(ref2(database, `multiData/comments/${ownerId}/${commentId}`));
+    return true;
+  } catch (error) {
+    console.error('Error deleting comment by owner:', error);
+    return false;
+  }
+};
+
 export const fetchUserComment = async (ownerId, cardId) => {
   try {
     const q = query(

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -18,10 +18,18 @@ import { fieldMaritalStatus } from './fieldMaritalStatus';
 import { fieldIMT } from './fieldIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
-import { fetchUserById, setUserComment as persistUserComment, fetchAllCommentsByCardId } from '../config';
+import {
+  fetchUserById,
+  setUserComment as persistUserComment,
+  fetchAllCommentsByCardId,
+  updateCommentByOwner,
+  deleteCommentByOwner,
+} from '../config';
 import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
+import { isAdminUid } from 'utils/accessLevel';
+import { auth } from '../config';
 import toast from 'react-hot-toast';
 
 const topBlockContainerStyle = { padding: '7px', position: 'relative' };
@@ -117,8 +125,8 @@ const multiCommentStyle = {
   fontStyle: 'italic',
   color: '#f3dfab',
   cursor: 'pointer',
-  textDecoration: 'underline',
-  textUnderlineOffset: '2px',
+  textDecoration: 'none',
+  fontSize: '60%',
 };
 
 const multiCommentRowStyle = {
@@ -139,6 +147,13 @@ const commentAuthorButtonStyle = {
   color: '#f3dfab',
   cursor: 'pointer',
   padding: 0,
+};
+
+const commentDeleteButtonStyle = {
+  ...commentAuthorButtonStyle,
+  color: '#ffb4b4',
+  fontSize: '14px',
+  fontWeight: 700,
 };
 
 const inlineModalOverlayStyle = {
@@ -319,6 +334,7 @@ const TopBlock = ({
   const [isCommentModalOpen, setIsCommentModalOpen] = React.useState(false);
   const [selectedComment, setSelectedComment] = React.useState(null);
   const [backendMultiComments, setBackendMultiComments] = React.useState([]);
+  const isAdmin = isAdminUid(auth.currentUser?.uid);
   const cardData = React.useMemo(() => {
     if (!userData) return null;
     return { ...userData, cycleStatus: getEffectiveCycleStatus(userData) };
@@ -335,7 +351,7 @@ const TopBlock = ({
       authorId: item.authorId || item.ownerId || '',
       ownerId: item.ownerId || '',
       source: 'backend',
-      lastAction: item.lastAction || 0,
+      lastAction: Number(item.lastAction) || 0,
     }));
     const combined = [...fromLocal, ...fromBackend];
     const uniq = new Map();
@@ -393,8 +409,13 @@ const TopBlock = ({
   const saveMultiComment = async () => {
     const prepared = editableComment.trim();
     const targetCommentId = selectedComment?.commentId || '';
+    const currentUid = auth.currentUser?.uid || '';
     if (!targetCommentId) {
       toast.error('Не обрано коментар для редагування');
+      return;
+    }
+    if (selectedComment?.ownerId && selectedComment.ownerId !== currentUid && !isAdmin) {
+      toast.error('Недостатньо прав для редагування цього коментаря');
       return;
     }
     const updatedComments = (multiDataComments || []).map(comment =>
@@ -431,14 +452,61 @@ const TopBlock = ({
       setState(prev => ({ ...prev, ...optimisticCard }));
     }
 
-    const result = await persistUserComment(cardData.userId, prepared);
+    let result = null;
+    if (selectedComment?.ownerId && selectedComment?.commentId) {
+      result = await updateCommentByOwner({
+        ownerId: selectedComment.ownerId,
+        commentId: selectedComment.commentId,
+        cardId: cardData.userId,
+        text: prepared,
+      });
+    } else {
+      result = await persistUserComment(cardData.userId, prepared);
+    }
     if (!result) {
       toast.error('Не вдалося зберегти коментар в multiData');
       return;
     }
+    setBackendMultiComments(prev =>
+      prev.map(item =>
+        item.commentId === targetCommentId && (item.ownerId || '') === (selectedComment?.ownerId || '')
+          ? { ...item, text: prepared, lastAction: result.lastAction || Date.now() }
+          : item
+      )
+    );
     toast.success('Коментар в multiData збережено');
     setIsCommentModalOpen(false);
     setSelectedComment(null);
+  };
+
+  const handleDeleteComment = async comment => {
+    if (!isAdmin || !comment?.ownerId || !comment?.commentId) {
+      toast.error('Видалення недоступне');
+      return;
+    }
+    const isDeleted = await deleteCommentByOwner({
+      ownerId: comment.ownerId,
+      commentId: comment.commentId,
+    });
+    if (!isDeleted) {
+      toast.error('Не вдалося видалити коментар');
+      return;
+    }
+    setBackendMultiComments(prev =>
+      prev.filter(item => !(item.commentId === comment.commentId && item.ownerId === comment.ownerId))
+    );
+    toast.success('Коментар видалено');
+  };
+
+  const formatCommentDate = timestamp => {
+    const normalizedTimestamp = Number(timestamp);
+    if (!Number.isFinite(normalizedTimestamp) || normalizedTimestamp <= 0) return '';
+    const date = new Date(normalizedTimestamp);
+    if (Number.isNaN(date.getTime())) return '';
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = String(date.getFullYear());
+    return `${day}.${month}.${year}`;
   };
 
   const openAuthorCardForEdit = async authorId => {
@@ -681,8 +749,22 @@ const TopBlock = ({
                 setIsCommentModalOpen(true);
               }}
             >
-              {comment.text}
+              {`${formatCommentDate(comment.lastAction) || '--.--.----'} - ${comment.text}`}
             </div>
+            {isAdmin && comment.ownerId && (
+              <button
+                type="button"
+                style={commentDeleteButtonStyle}
+                title="Видалити оригінальний коментар"
+                aria-label="Видалити оригінальний коментар"
+                onClick={event => {
+                  event.stopPropagation();
+                  handleDeleteComment(comment);
+                }}
+              >
+                ×
+              </button>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
### Motivation
- Enable updating and removing multiData comments that belong to other users by using owner-scoped operations. 
- Expose admin controls in the UI to allow privileged users to remove original comments and to surface comment timestamps for clarity.

### Description
- Added `updateCommentByOwner` and `deleteCommentByOwner` helper functions in `src/components/config.js` to set/remove comments at `multiData/comments/{ownerId}/{commentId}` and to perform basic auth and argument validation. 
- Updated `src/components/smallCard/renderTopBlock.js` to import the new functions and `isAdminUid`/`auth`, normalize `lastAction` to `Number`, and format the comment date via a new `formatCommentDate` helper. 
- Implemented admin-only delete UI with `handleDeleteComment` that calls `deleteCommentByOwner`, and added logic in `saveMultiComment` to call `updateCommentByOwner` when editing a comment owned by another user while enforcing permissions. 
- Minor style adjustments to `multiCommentStyle` and added `commentDeleteButtonStyle`, plus optimistic UI updates to `backendMultiComments` after successful backend operations.

### Testing
- Ran the test suite with `npm test`, and the tests completed successfully. 
- Ran linting with `npm run lint`, which passed without errors. 
- Verified a production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d44f415c83269b912d114853516f)