### PR TITLE
Add confirmation modal before deleting participant comments

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -194,6 +194,12 @@ const inlineModalActionsStyle = {
   gap: '8px',
 };
 
+const deleteModalTextStyle = {
+  marginTop: '8px',
+  marginBottom: '12px',
+  lineHeight: 1.35,
+};
+
 const hasAgentOrIPRole = data =>
   data.userRole === 'ag' || data.userRole === 'ip' || data.role === 'ag' || data.role === 'ip';
 
@@ -333,6 +339,7 @@ const TopBlock = ({
   const [editableComment, setEditableComment] = React.useState('');
   const [isCommentModalOpen, setIsCommentModalOpen] = React.useState(false);
   const [selectedComment, setSelectedComment] = React.useState(null);
+  const [commentToDelete, setCommentToDelete] = React.useState(null);
   const [backendMultiComments, setBackendMultiComments] = React.useState([]);
   const isAdmin = isAdminUid(auth.currentUser?.uid);
   const cardData = React.useMemo(() => {
@@ -759,7 +766,7 @@ const TopBlock = ({
                 aria-label="Видалити оригінальний коментар"
                 onClick={event => {
                   event.stopPropagation();
-                  handleDeleteComment(comment);
+                  setCommentToDelete(comment);
                 }}
               >
                 ×
@@ -799,6 +806,44 @@ const TopBlock = ({
               </button>
               <button type="button" onClick={saveMultiComment}>
                 Зберегти
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {commentToDelete && (
+        <div
+          style={inlineModalOverlayStyle}
+          onClick={event => {
+            event.stopPropagation();
+            setCommentToDelete(null);
+          }}
+        >
+          <div
+            style={inlineModalCardStyle}
+            onClick={event => event.stopPropagation()}
+          >
+            <strong>Підтвердження видалення</strong>
+            <div style={deleteModalTextStyle}>
+              Ви впевнені, що хочете видалити цей коментар?
+            </div>
+            <div style={inlineModalActionsStyle}>
+              <button
+                type="button"
+                onClick={() => {
+                  setCommentToDelete(null);
+                }}
+              >
+                Скасувати
+              </button>
+              <button
+                type="button"
+                onClick={async () => {
+                  await handleDeleteComment(commentToDelete);
+                  setCommentToDelete(null);
+                }}
+              >
+                Видалити
               </button>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Prevent accidental deletion of participant comments in the top block by requiring explicit confirmation before invoking the delete flow.

### Description
- Added a `commentToDelete` state and `deleteModalTextStyle` in `src/components/smallCard/renderTopBlock.js` to hold pending deletion and style the modal text.
- Changed the delete button on participant comments to set `commentToDelete` instead of calling `handleDeleteComment` immediately.
- Implemented a confirmation modal overlay that invokes the existing `handleDeleteComment` when confirmed and closes on cancel or overlay click.

### Testing
- Ran `npm run lint:js -- src/components/smallCard/renderTopBlock.js` and the lint check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0db8845b08326a0cd665253a1d803)