### PR TITLE
Make favorite/dislike icon colors configurable and enforce full opacity

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -22,6 +22,8 @@ export const BtnDislike = ({
   favoriteUsers = {},
   setFavoriteUsers,
   customStyle = {},
+  inactiveIconColor = '#fff',
+  activeIconColor = color.reactionIdleIcon,
   iconSize = 18,
   title = 'Дизлайк',
   ariaLabel = 'Дизлайк',
@@ -36,9 +38,8 @@ export const BtnDislike = ({
   } = customStyle;
   const isDisliked = !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
-  const inactiveOpacity = 0.7;
-  const activeIconColor = '#fff';
-  const inactiveIconColor = customTextColor || color.reactionIdleIcon;
+  const resolvedActiveIconColor = activeIconColor || customTextColor || color.reactionIdleIcon;
+  const resolvedInactiveIconColor = inactiveIconColor || '#fff';
   const activeBorderColor = '#fff';
 
   const toggleDislike = async () => {
@@ -107,11 +108,11 @@ export const BtnDislike = ({
         border: isDisliked
           ? `4px solid ${activeBorderColor}`
           : customBorder || `2px solid ${color.reactionIdleBorder}`,
-        color: isDisliked ? activeIconColor : inactiveIconColor,
+        color: isDisliked ? resolvedActiveIconColor : resolvedInactiveIconColor,
         boxShadow: isDisliked
           ? `0 0 0 2px ${activeColor}`
           : customBoxShadow || 'none',
-        opacity: isDisliked ? 1 : inactiveOpacity,
+        opacity: 1,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
@@ -126,7 +127,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={iconSize} color={isDisliked ? activeIconColor : inactiveIconColor} />
+      <FaTimes size={iconSize} color={isDisliked ? resolvedActiveIconColor : resolvedInactiveIconColor} />
     </button>
   );
 };

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -21,6 +21,8 @@ export const BtnFavorite = ({
   dislikeUsers = {},
   setDislikeUsers,
   customStyle = {},
+  inactiveIconColor = '#fff',
+  activeIconColor = color.reactionIdleIcon,
   iconSize = 18,
   title = 'В обране',
   ariaLabel = 'В обране',
@@ -35,9 +37,8 @@ export const BtnFavorite = ({
   } = customStyle;
   const isFavorite = !!favoriteUsers[userId];
   const activeColor = color.reactionLike;
-  const inactiveOpacity = 0.7;
-  const activeIconColor = '#fff';
-  const inactiveIconColor = customTextColor || color.reactionIdleIcon;
+  const resolvedActiveIconColor = activeIconColor || customTextColor || color.reactionIdleIcon;
+  const resolvedInactiveIconColor = inactiveIconColor || '#fff';
   const activeBorderColor = '#fff';
 
   const toggleFavorite = async () => {
@@ -102,11 +103,11 @@ export const BtnFavorite = ({
         border: isFavorite
           ? `4px solid ${activeBorderColor}`
           : customBorder || `2px solid ${color.reactionIdleBorder}`,
-        color: isFavorite ? activeIconColor : inactiveIconColor,
+        color: isFavorite ? resolvedActiveIconColor : resolvedInactiveIconColor,
         boxShadow: isFavorite
           ? `0 0 0 2px ${activeColor}`
           : customBoxShadow || 'none',
-        opacity: isFavorite ? 1 : inactiveOpacity,
+        opacity: 1,
         zIndex: 1,
         cursor: 'pointer',
         display: 'flex',
@@ -122,9 +123,9 @@ export const BtnFavorite = ({
       }}
     >
       {isFavorite ? (
-        <FaHeart size={iconSize} color={activeIconColor} />
+        <FaHeart size={iconSize} color={resolvedActiveIconColor} />
       ) : (
-        <FaRegHeart size={iconSize} color={inactiveIconColor} />
+        <FaRegHeart size={iconSize} color={resolvedInactiveIconColor} />
       )}
     </button>
   );

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -593,8 +593,9 @@ const TopBlock = ({
                   ...zoneActionButtonStyle,
                   backgroundColor: '#ef6c00',
                   border: 'none',
-                  color: '#fff',
                 }}
+                inactiveIconColor="#fff"
+                activeIconColor="#1f2937"
                 iconSize={18}
               />
             )}
@@ -623,8 +624,9 @@ const TopBlock = ({
                   ...zoneActionButtonStyle,
                   backgroundColor: '#f9a825',
                   border: 'none',
-                  color: '#fff',
                 }}
+                inactiveIconColor="#fff"
+                activeIconColor="#1f2937"
                 iconSize={18}
               />
             )}


### PR DESCRIPTION
### Motivation
- Make the favorite and dislike buttons support customizable active/inactive icon colors and ensure the icon contrast/visibility is consistent by removing the semi-transparent state.

### Description
- Add `inactiveIconColor` and `activeIconColor` props to `BtnDislike` and `BtnFavorite` with sensible defaults and derive `resolvedActiveIconColor`/`resolvedInactiveIconColor` to fall back to `customTextColor` or theme colors when needed.
- Replace direct uses of the old `activeIconColor`/`inactiveIconColor` variables with the resolved values for both button `color` and rendered icons via `FaTimes`, `FaHeart`, and `FaRegHeart`.
- Remove the conditional `opacity` logic and set `opacity: 1` to keep buttons fully opaque, and update `renderTopBlock` to pass explicit `inactiveIconColor` and `activeIconColor` values instead of embedding `color` in `customStyle`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b3d76994832687cdeb29b4008cae)