### PR TITLE
Add Save button to persist additionalAccessRules and update searchKeySets

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1207,6 +1207,34 @@ export const ProfileForm = ({
     await indexAdditionalRulesForUser(updatedValue);
   };
 
+  const saveAdditionalRulesToSearchKeySets = async () => {
+    const rulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+    if (!rulesText.trim()) {
+      toast.error('Оберіть щонайменше один фільтр перед збереженням');
+      return;
+    }
+
+    const currentValue = state?.[ADDITIONAL_ACCESS_FIELD];
+    const updatedValue = Array.isArray(currentValue)
+      ? currentValue.map((item, idx) => (idx === activeAdditionalRuleInputIndex ? rulesText : item))
+      : rulesText;
+
+    setState(prevState => ({
+      ...prevState,
+      [ADDITIONAL_ACCESS_FIELD]: updatedValue,
+    }));
+
+    await submitWithNormalization(
+      {
+        ...state,
+        [ADDITIONAL_ACCESS_FIELD]: updatedValue,
+      },
+      'overwrite'
+    );
+
+    await indexAdditionalRulesForUser(updatedValue);
+  };
+
   const handleCombinedAdditionalRulesChange = event => {
     const nextActiveRulesText = event?.target?.value || '';
     const nextBuilder = parseAdditionalRulesTextToBuilder(nextActiveRulesText);
@@ -2311,6 +2339,13 @@ ${entries.join('\n')}`;
                 disabled={isIndexingAdditionalRules}
               >
                 {isIndexingAdditionalRules ? 'Індексація...' : 'Індексувати'}
+              </button>
+              <button
+                type="button"
+                onClick={saveAdditionalRulesToSearchKeySets}
+                disabled={isIndexingAdditionalRules}
+              >
+                {isIndexingAdditionalRules ? 'Збереження...' : 'Зберегти'}
               </button>
             </AdditionalRuleActions>
 


### PR DESCRIPTION
### Motivation
- Зараз натискання «Застосувати» оновлює локальний стан і викликає `submitWithNormalization`, але не гарантує явного збереження `additionalAccessRules` у бекенді та подальшого запису в `searchKeySets`, тому зміни не відображаються в індексі.
- Потрібна явна послідовність: зберегти поле профілю в бекенді, а потім запустити індексацію `searchKeySets`, щоб адмініни бачили зміни відразу.

### Description
- Додано новий хендлер `saveAdditionalRulesToSearchKeySets` у `src/components/ProfileForm.jsx`, який будує `rulesText` з конструктора, оновлює `additionalAccessRules` у компонентному стані та викликає `submitWithNormalization` з оновленим значенням, а потім запускає `indexAdditionalRulesForUser`.
- Додано кнопку «Зберегти» поруч з «Індексувати» в модалці додаткових правил, яка викликає `saveAdditionalRulesToSearchKeySets` і відображає `'Збереження...'` під час виконання.
- Логіка зберігання повторно використовує існуючі допоміжні функції (`buildAdditionalRulesTextFromBuilder`, `submitWithNormalization`, `indexAdditionalRulesForUser`) без змін у вже наявних індексаційних утилітах.

### Testing
- Пройшов перевірку лінтер командою `npm run lint:js -- src/components/ProfileForm.jsx` без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d36cf51c8326bf8e7356334c05ef)