### PR TITLE
Report bucket write counts during searchKeySets indexing and alert when empty

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1023,11 +1023,17 @@ export const ProfileForm = ({
       const setsCount = Number(indexResult?.setKeys?.length || 0);
       const matchedCount = Number(indexResult?.userIds?.length || 0);
       const writesCount = Number(indexResult?.writesCount || 0);
+      const bucketWritesCount = Number(indexResult?.bucketWritesCount || 0);
       if (setsCount === 0 && writesCount === 0) {
         toast('searchKeySets не оновлено: не знайдено валідних правил.', { id: toastId });
+      } else if (setsCount > 0 && bucketWritesCount === 0) {
+        toast.error(
+          `searchKeySets порожній після індексації: немає bucket-записів (наборів: ${setsCount}, карток: ${matchedCount}). Перевірте правила additionalAccessRules та відповідність індексам searchKey.`,
+          { id: toastId }
+        );
       } else {
         toast.success(
-          `5/5 Готово: індексацію searchKeySets оновлено (${setsCount} наборів, ${matchedCount} карток, ${writesCount} змін).`,
+          `5/5 Готово: індексацію searchKeySets оновлено (${setsCount} наборів, ${matchedCount} карток, ${writesCount} змін, ${bucketWritesCount} bucket-записів).`,
           { id: toastId }
         );
       }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -268,6 +268,7 @@ export const buildNewUsersFilterSetIndex = async ({
   const nextSetKeys = new Set(nextSetPayloads.map(item => item.setKey));
 
   const writes = {};
+  let bucketWritesCount = 0;
   existingSetKeys.forEach(setKey => {
     if (!nextSetKeys.has(setKey)) {
       writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}`] = null;
@@ -289,6 +290,7 @@ export const buildNewUsersFilterSetIndex = async ({
     });
 
     if (Object.keys(ruleBucketWrites).length) {
+      bucketWritesCount += Object.keys(ruleBucketWrites).length;
       // eslint-disable-next-line no-await-in-loop
       await update(ref(database), ruleBucketWrites);
     }
@@ -300,6 +302,7 @@ export const buildNewUsersFilterSetIndex = async ({
     userIds: aggregatedUserIds,
     ownerId: normalizedAccessUserId,
     writesCount: Object.keys(writes).length + nextSetPayloads.length,
+    bucketWritesCount,
   };
 };
 


### PR DESCRIPTION
### Motivation
- Surface the number of low-level bucket writes produced during `searchKeySets` indexing so operators can detect when sets exist but no bucket entries were written.
- Provide a clearer error message in the UI when indexing yields sets but no bucket records, guiding investigation into `additionalAccessRules` and `searchKey` indexes.

### Description
- Add `bucketWritesCount` accumulation to `buildNewUsersFilterSetIndex` by counting `ruleBucketWrites` written for each set and include it in the returned result object.
- Read `bucketWritesCount` in `ProfileForm.jsx` and include it in the success toast message shown after indexing completes and extract the value from `indexResult` with `const bucketWritesCount = Number(indexResult?.bucketWritesCount || 0);`.
- Add a new conditional that shows an error toast when there are `setCount > 0` but `bucketWritesCount === 0`, suggesting to check `additionalAccessRules` and `searchKey` index alignment.

### Testing
- Ran the existing unit test suite and the linter against the modified files, and they passed without failures.
- Performed automated build to validate exports and imports, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1df4be3c88326adbeccb3b9d82390)