### PR TITLE
Add debug info and improved toasts for searchKeySets indexing

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1011,6 +1011,20 @@ export const ProfileForm = ({
         accessUserId,
         matchedUserIdsByInputIndex
       );
+      const matchedSetEntries = Object.entries(matchedUserIdsBySetKey || {});
+      const matchedSetsCount = matchedSetEntries.length;
+      const matchedUsersTotal = matchedSetEntries.reduce(
+        (sum, [, ids]) => sum + (Array.isArray(ids) ? ids.length : 0),
+        0
+      );
+      const matchedPreview = matchedSetEntries
+        .slice(0, 2)
+        .map(([setKey, ids]) => `${setKey}: ${(Array.isArray(ids) ? ids.length : 0)} ids`)
+        .join(' | ');
+      toast(
+        `2.5/3 Префільтр searchKey: наборів ${matchedSetsCount}, сумарно userIds ${matchedUsersTotal}${matchedPreview ? ` (${matchedPreview})` : ''}`,
+        { id: `${toastId}-prefilter` }
+      );
 
       stage = 'write-index';
       stageToast('3/3 Запис індексів у searchKeySets...');
@@ -1024,11 +1038,32 @@ export const ProfileForm = ({
       const matchedCount = Number(indexResult?.userIds?.length || 0);
       const writesCount = Number(indexResult?.writesCount || 0);
       const bucketWritesCount = Number(indexResult?.bucketWritesCount || 0);
+      const removedSetsCount = Number(indexResult?.debug?.removedSetKeys?.length || 0);
+      const debugSets = Array.isArray(indexResult?.debug?.sets) ? indexResult.debug.sets : [];
+      const debugPreview = debugSets
+        .slice(0, 2)
+        .map(
+          set =>
+            `${set?.setKey || 'unknown'}: users=${Number(set?.matchedUserIdsCount || 0)}, buckets=${Number(
+              set?.bucketWritesCount || 0
+            )}`
+        )
+        .join(' | ');
+      toast(
+        `3.5/5 Діагностика searchKeySets: очищено наборів ${removedSetsCount}, нових наборів ${debugSets.length}${debugPreview ? ` (${debugPreview})` : ''}`,
+        { id: `${toastId}-debug` }
+      );
       if (setsCount === 0 && writesCount === 0) {
         toast('searchKeySets не оновлено: не знайдено валідних правил.', { id: toastId });
       } else if (setsCount > 0 && bucketWritesCount === 0) {
+        const bucketPathHints = debugSets
+          .flatMap(set => (Array.isArray(set?.bucketPathsPreview) ? set.bucketPathsPreview : []))
+          .slice(0, 5)
+          .join('\n');
         toast.error(
-          `searchKeySets порожній після індексації: немає bucket-записів (наборів: ${setsCount}, карток: ${matchedCount}). Перевірте правила additionalAccessRules та відповідність індексам searchKey.`,
+          `searchKeySets порожній після індексації: немає bucket-записів (наборів: ${setsCount}, карток: ${matchedCount}).\n` +
+            `Підказка: перевірте searchKey bucket-и для поточних токенів.\n` +
+            `${bucketPathHints || 'Preview bucket paths: (empty)'}`,
           { id: toastId }
         );
       } else {

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -269,9 +269,14 @@ export const buildNewUsersFilterSetIndex = async ({
 
   const writes = {};
   let bucketWritesCount = 0;
+  const debug = {
+    removedSetKeys: [],
+    sets: [],
+  };
   existingSetKeys.forEach(setKey => {
     if (!nextSetKeys.has(setKey)) {
       writes[`${SEARCH_KEY_SETS_ROOT}/${setKey}`] = null;
+      debug.removedSetKeys.push(setKey);
     }
   });
   if (Object.keys(writes).length > 0) {
@@ -288,6 +293,13 @@ export const buildNewUsersFilterSetIndex = async ({
       parsedRuleGroups,
       userIds: Object.keys(userIds || {}),
     });
+    debug.sets.push({
+      setKey,
+      matchedUserIdsCount: Object.keys(userIds || {}).length,
+      parsedRuleGroupsCount: Array.isArray(parsedRuleGroups) ? parsedRuleGroups.length : 0,
+      bucketWritesCount: Object.keys(ruleBucketWrites).length,
+      bucketPathsPreview: Object.keys(ruleBucketWrites).slice(0, 12),
+    });
 
     if (Object.keys(ruleBucketWrites).length) {
       bucketWritesCount += Object.keys(ruleBucketWrites).length;
@@ -303,6 +315,7 @@ export const buildNewUsersFilterSetIndex = async ({
     ownerId: normalizedAccessUserId,
     writesCount: Object.keys(writes).length + nextSetPayloads.length,
     bucketWritesCount,
+    debug,
   };
 };
 


### PR DESCRIPTION
### Motivation
- Improve observability and diagnostics when building and writing `searchKeySets` indexes to help debug empty buckets and missing data. 
- Provide operators with quick previews of matched sets, counts, and bucket path hints during the indexing flow. 
- Capture debug metadata during index construction to assist troubleshooting and allow better UI messages. 

### Description
- Enhanced the UI indexing flow in `indexAdditionalRulesForUser` (`ProfileForm.jsx`) to show a pre-filter summary toast with matched sets and total userIds and a debug toast summarizing removed/created sets and a small preview of set stats. 
- Improved error and success toasts to include bucket path hints when there are zero bucket writes and preserved permission/index-specific error handling. 
- Added a `debug` payload to `buildNewUsersFilterSetIndex` (`newUsersFilterSetsIndex.js`) that collects `removedSetKeys` and per-set diagnostics (`matchedUserIdsCount`, `parsedRuleGroupsCount`, `bucketWritesCount`, and `bucketPathsPreview`) and returns it with the index result. 

### Testing
- Ran the test suite including unit tests and `eslint` checks, and they passed. 
- Executed the indexing flow locally to verify toasts and that the `debug` fields are produced in the index result. 
- Verified that permission and missing-index error branches still show the appropriate error toasts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20799185c8326921f2d89613d7879)