### PR TITLE
Normalize social inputs on blur and fix telegram field typo in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2011,7 +2011,7 @@ ${entries.join('\n')}`;
                             let value = e?.target?.value;
                             if (field.name === 'publish') {
                               value = value.toLowerCase() === 'true';
-                            } else if (field.name === 'telgram') {
+                            } else if (field.name === 'telegram') {
                               value = e?.target?.value;
                             }
                             setState(prevState => ({
@@ -2037,7 +2037,25 @@ ${entries.join('\n')}`;
                               }
                             }
 
-                            submitWithNormalization(state, 'overwrite');
+                            const needsSocialCleanup = ['facebook', 'instagram'].includes(field.name);
+                            const rawValue = state[field.name];
+                            const normalizedValue = needsSocialCleanup
+                              ? inputUpdateValue(rawValue, field)
+                              : rawValue;
+
+                            const nextState =
+                              normalizedValue === rawValue
+                                ? state
+                                : {
+                                    ...state,
+                                    [field.name]: normalizedValue,
+                                  };
+
+                            if (normalizedValue !== rawValue) {
+                              setState(nextState);
+                            }
+
+                            submitWithNormalization(nextState, 'overwrite');
                           },
                         })}
                   />


### PR DESCRIPTION
### Motivation
- Ensure social network inputs are normalized before being submitted so stored values are consistent and any automatic cleanup runs before persistence.
- Fix a typo in the input name handling to correctly capture the Telegram field (`telgram` -> `telegram`).

### Description
- Corrected the input name check from `telgram` to `telegram` in the `onChange` handler of `ProfileForm.jsx`.
- On field `onBlur`, added normalization for social fields `facebook` and `instagram` by calling `inputUpdateValue` and computing `normalizedValue` before submitting.
- Update component state with the normalized value when it differs from the raw value, then call `submitWithNormalization` with the next state to ensure the persisted data matches the cleaned value.
- Preserved existing special-case behaviors for `myComment`, `moreInfo_main`, `publish`, `getInTouch`, and additional access handling.

### Testing
- Ran unit tests with `yarn test`, and all tests passed locally.
- Ran linting with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f210b603dc8326b580990e678490f4)