### PR TITLE
Add LinkedIn and YouTube contact support across search, UI, and indexing

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -806,6 +806,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         { key: 'email', label: 'email', supportsSearchId: true, supportsEqualTo: true },
         { key: 'vk', label: 'vk', supportsSearchId: true, supportsEqualTo: true },
         { key: 'tiktok', label: 'tiktok', supportsSearchId: true, supportsEqualTo: true },
+        { key: 'linkedin', label: 'linkedin', supportsSearchId: true, supportsEqualTo: true },
+        { key: 'youtube', label: 'youtube', supportsSearchId: true, supportsEqualTo: true },
         { key: 'other', label: 'other', supportsSearchId: true, supportsEqualTo: true },
         { key: 'myComment', label: 'myComment', supportsSearchId: false, supportsEqualTo: true },
         { key: 'name', label: 'name', supportsSearchId: true, supportsEqualTo: true },
@@ -828,7 +830,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     'partialUserId',
     ...SEARCH_KEY_OPTIONS.map(option => option.key),
   ];
-  const CONTACT_SEARCH_KEYS = ['phone', 'telegram', 'instagram', 'facebook', 'email', 'vk', 'tiktok', 'other'];
+  const CONTACT_SEARCH_KEYS = ['phone', 'telegram', 'instagram', 'facebook', 'email', 'vk', 'tiktok', 'linkedin', 'youtube', 'other'];
 
   const defaultEnabledSearchKeys = SEARCH_SCOPE_BLOCKS.flatMap(block => block.options).reduce(
     (acc, option) => {
@@ -1064,7 +1066,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
+    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'vk', 'userId'];
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     const now = Date.now();

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -63,7 +63,7 @@ export const database = getDatabase(app);
 
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 
-const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'other', 'vk', 'name', 'surname', 'lastAction', 'getInTouch'];
+const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'other', 'vk', 'name', 'surname', 'lastAction', 'getInTouch'];
 const SEARCH_KEY_INDEX_ROOT = 'searchKey';
 const SEARCH_KEY_USERS_INDEX_ROOT = `${SEARCH_KEY_INDEX_ROOT}/users`;
 const BLOOD_SEARCH_KEY_INDEX = 'blood';
@@ -2949,7 +2949,7 @@ const isBucketAllowedByFilters = (bucket, filterSettings = {}) => {
 };
 
 const MARITAL_STATUS_SEARCH_KEY_BUCKETS = ['+', '-', '?', 'no'];
-const CONTACT_SEARCH_KEY_BUCKETS = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'];
+const CONTACT_SEARCH_KEY_BUCKETS = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email'];
 const ROLE_SEARCH_KEY_BUCKETS = ['ed', 'sm', 'ag', 'ip', 'pp', 'cl', '?', 'no'];
 const USER_ID_SEARCH_KEY_BUCKETS = ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'];
 const IMT_SEARCH_KEY_BUCKETS = ['le28', '29_31', '32_35', '36_plus', '?', 'no'];
@@ -4443,6 +4443,8 @@ const getContactIndexSet = data => {
     contactSet.add('telegram2');
   }
   if (hasContactValue(data.tiktok)) contactSet.add('tiktok');
+  if (hasContactValue(data.linkedin)) contactSet.add('linkedin');
+  if (hasContactValue(data.youtube)) contactSet.add('youtube');
   if (hasContactValue(data.email)) contactSet.add('email');
 
   return contactSet;
@@ -4607,6 +4609,8 @@ export const filterMain = (
         telegram: hasTelegramNonUk(value.telegram),
         telegram2: isTelegramUkOnly(value.telegram),
         tiktok: hasContactValue(value.tiktok),
+        linkedin: hasContactValue(value.linkedin),
+        youtube: hasContactValue(value.youtube),
         email: hasContactValue(value.email),
       };
       const allowedContacts = Object.entries(filterSettings.contact)

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -158,6 +158,8 @@ export const pickerFields = [
   { name: 'facebook', placeholder: 'facebook_nickname', svg: 'facebook-f', ukrainianHint:'Facebook' },
   { name: 'instagram', placeholder: 'instagram_nickname', svg: 'instagram', ukrainianHint:'Instagram' },
   { name: 'tiktok', placeholder: 'tiktok_nickname', svg: 'tiktok', ukrainianHint:'TikTok' },
+  { name: 'linkedin', placeholder: 'linkedin_nickname', svg: 'no', ukrainianHint:'LinkedIn' },
+  { name: 'youtube', placeholder: 'youtube_nickname', svg: 'no', ukrainianHint:'YouTube' },
   { name: 'vk', placeholder: '0107655', hint: '0107655', svg: 'vk', ukrainianHint:'VK' },
   { name: 'country', placeholder: 'Країна', hint: 'country', svg: 'no', width: '33%', ukrainian: 'Країна', ukrainianHint: 'країна проживання' },
   { name: 'region', placeholder: 'Область', hint: 'region', svg: 'no', width: '33%', ukrainian: 'Область', ukrainianHint: 'область' },

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -427,7 +427,7 @@ export const handleSubmit = (userData, condition, removeKeys = []) => {
     'cycleStatus',
     'stimulationSchedule',
   ];
-  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
+  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'vk', 'userId'];
   const commonFields = [
     'lastAction',
     'lastLogin2',
@@ -506,7 +506,7 @@ export const handleSubmitAll = async (userData, overwrite) => {
     'cycleStatus',
     'stimulationSchedule',
   ];
-  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
+  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'vk', 'userId'];
   const commonFields = [
     'lastAction',
     'lastLogin2',

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -7,6 +7,8 @@ import {
   FaWhatsapp,
   FaVk,
   FaGlobe,
+  FaLinkedin,
+  FaYoutube,
 } from 'react-icons/fa';
 import { FaPhoneVolume } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
@@ -61,6 +63,8 @@ export const fieldContacts = (data, parentKey = '') => {
     phone: value => `tel:${value}`,
     facebook: value => `https://facebook.com/${value}`,
     vk: value => `https://vk.com/${value}`,
+    linkedin: value => `https://www.linkedin.com/in/${value}`,
+    youtube: value => `https://www.youtube.com/@${value}`,
     otherLink: value => normalizeExternalUrl(value),
     email: value => `mailto:${value}`,
     telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
@@ -77,6 +81,8 @@ export const fieldContacts = (data, parentKey = '') => {
     whatsappFromPhone: <FaWhatsapp style={iconStyle} />,
     tiktok: <SiTiktok style={iconStyle} />,
     vk: <FaVk style={iconStyle} />,
+    linkedin: <FaLinkedin style={iconStyle} />,
+    youtube: <FaYoutube style={iconStyle} />,
     otherLink: <FaGlobe style={iconStyle} />,
     phone: <FaPhoneVolume style={iconStyle} />,
     email: <MdEmail style={iconStyle} />,
@@ -360,6 +366,8 @@ export const fieldContactsIcons = (
     phone: value => `tel:${value}`,
     facebook: value => `https://facebook.com/${value}`,
     vk: value => `https://vk.com/${value}`,
+    linkedin: value => `https://www.linkedin.com/in/${value}`,
+    youtube: value => `https://www.youtube.com/@${value}`,
     otherLink: value => normalizeExternalUrl(value),
     email: value => `mailto:${value}`,
     telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
@@ -541,6 +549,34 @@ export const fieldContactsIcons = (
         style={linkStyle}
       >
         <FaVk style={iconStyle} />
+      </a>
+    );
+  }
+
+  if (processed.linkedin) {
+    elements.push(
+      <a
+        key="linkedin"
+        href={links.linkedin(processed.linkedin)}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={linkStyle}
+      >
+        <FaLinkedin style={iconStyle} />
+      </a>
+    );
+  }
+
+  if (processed.youtube) {
+    elements.push(
+      <a
+        key="youtube"
+        href={links.youtube(processed.youtube)}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={linkStyle}
+      >
+        <FaYoutube style={iconStyle} />
       </a>
     );
   }

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -726,7 +726,7 @@ const TopBlock = ({
         <div style={contactsWrapperStyle}>
           {fieldContacts(cardData)}
         </div>
-        {renderOverlayEntries(['phone', 'phone2', 'phone3', 'telegram', 'email', 'facebook', 'instagram', 'tiktok', 'vk'])}
+        {renderOverlayEntries(['phone', 'phone2', 'phone3', 'telegram', 'email', 'facebook', 'instagram', 'tiktok', 'linkedin', 'youtube', 'vk'])}
       </div>
       {fieldWriter(cardData, setUsers, setState, submitOptions)}
       <div style={commentFieldWrapperStyle}>

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -155,7 +155,7 @@ export const ADDITIONAL_ACCESS_FILTER_OPTIONS = {
   maritalStatus: ['+', '-', '?', 'no'],
   imt: ['le28', '29_31', '32_35', '36_plus', '?', 'no'],
   role: ['ed', 'sm', 'ag', 'ip', 'cl', '?', 'no'],
-  contact: ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'],
+  contact: ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email'],
   userId: ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'],
   reaction: ['past', 'future', '99', '?', 'no'],
   height: ['lt163', '163_176', '177_180', '181_plus', '?', 'no'],
@@ -182,7 +182,7 @@ export const ADDITIONAL_ACCESS_TEMPLATE = `age: 18,19,20,21,22,23,24,25,26,27,28
 blood: 1+,1-,1,2+,2-,2,3+,3-,3,4+,4-,4,?,no
 maritalStatus: +,-,?,no
 csection: cs2plus,cs1,cs0,other,no
-contact: vk,instagram,facebook,phone,telegram,telegram2,tiktok,email
+contact: vk,instagram,facebook,phone,telegram,telegram2,tiktok,linkedin,youtube,email
 role: ed,sm,ag,ip,cl,?,no
 userId: vk,aa,ab,id,long,mid,other
 imt: le28,29_31,32_35,36_plus,?,no
@@ -249,7 +249,7 @@ const toMetricBucket = (value, ranges) => {
 };
 
 const toContactBuckets = user => {
-  const keys = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'email'];
+  const keys = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email'];
   return keys.filter(key => String(user?.[key] || '').trim() !== '');
 };
 


### PR DESCRIPTION
### Motivation
- Extend contact channel coverage to include `linkedin` and `youtube` so users can store, search and render these profiles like existing social/contact keys.

### Description
- Added `linkedin` and `youtube` to search key definitions and UI toggles in `AddNewProfile.jsx` and included them in `TOGGLEABLE_SEARCH_KEYS` and `CONTACT_SEARCH_KEYS` arrays.
- Extended indexing and configuration in `config.js` and `additionalAccessRules.js` by adding `linkedin` and `youtube` to `keysToCheck`, `CONTACT_SEARCH_KEY_BUCKETS`, and `ADDITIONAL_ACCESS_FILTER_OPTIONS.contact` so they participate in search/index buckets and access rules.
- Updated data handling in submit flows by adding `linkedin` and `youtube` to `contacts` arrays in `smallCard/actions.js` and `AddNewProfile` submit logic so these fields are included in payloads and RTDB updates.
- Added form fields and UI rendering: `pickerFields` now includes `linkedin` and `youtube` in `formFields.js`, contact link templates, icons, and icon rendering for both channels were implemented in `smallCard/fieldContacts.js`, and `renderOverlayEntries` was updated to show these keys in `smallCard/renderTopBlock.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2107f3754832697d5af826d404d7f)