### PR TITLE
Guard social blur normalization when social field is undefined

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2074,7 +2074,7 @@ ${entries.join('\n')}`;
 
                             const needsSocialCleanup = ['facebook', 'instagram'].includes(field.name);
                             const rawValue = state[field.name];
-                            const normalizedValue = needsSocialCleanup
+                            const normalizedValue = needsSocialCleanup && rawValue != null
                               ? inputUpdateValue(rawValue, field)
                               : rawValue;
 


### PR DESCRIPTION
### Motivation
- Prevent a blur-time runtime error when optional social keys (`facebook`/`instagram`) are missing because calling `inputUpdateValue` with `undefined` lets formatter string operations throw and breaks the blur-submit flow.

### Description
- Add a null/undefined guard in `src/components/ProfileForm.jsx` so `inputUpdateValue` is only invoked for social fields when `rawValue != null` (i.e. `facebook`/`instagram` values are present).

### Testing
- Ran `npm run lint` (repo has no `lint` script) and started `npm run build` to validate compilation; lint reported a missing script and the build process started successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212f990e8832697b1c0f4f41ea5cc)