### PR TITLE
Fix empty searchKeySets bucket writes for additionalAccessRules

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -34,6 +34,26 @@ const normalizePathSegment = value => {
   return hasForbiddenChars ? encodeKey(raw) : raw;
 };
 
+const mergeSearchKeyBuckets = parsedRuleGroups => {
+  const groups = Array.isArray(parsedRuleGroups) ? parsedRuleGroups : [parsedRuleGroups];
+  return groups.reduce((acc, rules) => {
+    const bucketMap = resolveAdditionalAccessSearchKeyBuckets(rules);
+    Object.entries(bucketMap || {}).forEach(([indexName, rawValues]) => {
+      const nextValues = Array.isArray(rawValues) ? rawValues : [...(rawValues || [])];
+      if (!nextValues.length) return;
+      if (!acc[indexName]) {
+        acc[indexName] = new Set();
+      }
+      nextValues.forEach(value => {
+        if (value !== undefined && value !== null && String(value).trim()) {
+          acc[indexName].add(value);
+        }
+      });
+    });
+    return acc;
+  }, {});
+};
+
 const splitRawRulesToSetTexts = rawRules => {
   if (Array.isArray(rawRules)) {
     return rawRules.map(item => String(item || '').trim()).filter(Boolean);
@@ -116,7 +136,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds }) => {
   if (!normalizedRootPath) return {};
 
   const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
-  const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
+  const bucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
 
   return Object.entries(bucketMap || {}).reduce((writes, [indexName, rawValues]) => {
     const normalizedIndexName = normalizePathSegment(indexName);
@@ -333,7 +353,7 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
     .map(({ text: setText, inputIndex }) => {
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
       if (!parsedRuleGroups.length) return null;
-      const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
+      const bucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
       const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
         const normalizedIndexName = normalizePathSegment(indexName);
         if (!normalizedIndexName) return acc;
@@ -494,7 +514,7 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
 };
 
 const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
-  const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups);
+  const bucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
   const paths = Object.entries(bucketMap || {}).flatMap(([indexName, rawValues]) => {
     const normalizedIndexName = normalizePathSegment(indexName);
     if (!normalizedIndexName) return [];


### PR DESCRIPTION
### Motivation
- Передача масиву `parsedRuleGroups` у `resolveAdditionalAccessSearchKeyBuckets` призводила до повернення порожніх bucket-ів, через що `bucketWritesCount` залишався `0` і `searchKeySets` не отримували записів.

### Description
- Додано хелпер `mergeSearchKeyBuckets` який об’єднує buckets для всіх груп правил і повертає єдиний мап індексів.
- Замінено виклики `resolveAdditionalAccessSearchKeyBuckets(parsedRuleGroups)` на `mergeSearchKeyBuckets(parsedRuleGroups)` у місцях, де `parsedRuleGroups` може бути масивом, зокрема при формуванні `buildRuleBucketWrites`, при побудові `setEntries` у `getIndexedNewUsersIdsByRules`, та в `getMatchedUserIdsFromSearchKey`.
- Зміни застосовано в `src/utils/newUsersFilterSetsIndex.js` без зміни формату `searchKey` або RTDB-структури, лише об’єднання bucket-ів перед генерацією шляхів/записів.

### Testing
- Запущено лінтер командою `npm run lint:js -- src/utils/newUsersFilterSetsIndex.js` і перевірка пройшла успішно без помилок.
- Ніяких автоматичних unit-тестів не змінювалось або не запускалось у цьому PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2140c95f48326a346efcb868df9d9)