### PR TITLE
Improve `renderTopBlock` visual styling while preserving functionality

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -33,14 +33,21 @@ import { auth } from '../config';
 import toast from 'react-hot-toast';
 import styles from './renderTopBlock.module.css';
 
-const topBlockContainerStyle = { padding: '7px', position: 'relative' };
+const topBlockContainerStyle = {
+  padding: '10px 10px 8px',
+  position: 'relative',
+  borderRadius: '14px',
+  background: 'linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(0,0,0,0.08) 100%)',
+  border: '1px solid rgba(255,255,255,0.08)',
+  boxShadow: '0 10px 24px rgba(0,0,0,0.2)',
+};
 
 const topButtonsRowStyle = {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
   gap: '8px',
-  marginBottom: '8px',
+  marginBottom: '10px',
 };
 
 const topButtonsZoneStyle = {
@@ -54,8 +61,9 @@ const topButtonsZoneStyle = {
   height: '40px',
   flex: '0 0 40px',
   padding: 0,
-  boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.22)',
   transition: 'transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease',
+  overflow: 'hidden',
 };
 
 const topButtonsZones = ['#d32f2f', '#ef6c00', '#f9a825', '#2e7d32', '#0288d1', '#1565c0', '#6a1b9a'];
@@ -74,13 +82,17 @@ const zoneActionButtonStyle = {
 
 const actionButtonsContainerStyle = {
   position: 'absolute',
-  top: '52px',
-  right: '10px',
+  top: '60px',
+  right: '12px',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-end',
   gap: '6px',
   zIndex: 999,
+  padding: '6px',
+  borderRadius: '10px',
+  background: 'rgba(0, 0, 0, 0.22)',
+  backdropFilter: 'blur(4px)',
 };
 
 const addedOverlayEntryStyle = {
@@ -115,13 +127,15 @@ const commentFieldWrapperStyle = {
 
 const detailsToggleStyle = {
   position: 'absolute',
-  bottom: '10px',
-  right: '10px',
+  bottom: '8px',
+  right: '8px',
   cursor: 'pointer',
   color: '#ebe0c2',
-  fontSize: '22px',
+  fontSize: '20px',
   padding: '4px 8px',
-  borderRadius: '6px',
+  borderRadius: '10px',
+  border: '1px solid rgba(255, 255, 255, 0.2)',
+  background: 'rgba(255, 255, 255, 0.06)',
 };
 
 const multiCommentStyle = {
@@ -560,7 +574,7 @@ const TopBlock = ({
   };
 
   return (
-    <div style={topBlockContainerStyle}>
+    <div style={topBlockContainerStyle} className={styles.topBlockContainer}>
       <div style={topButtonsRowStyle}>
         {topButtonsZones.map((zoneColor, idx) => (
           <div
@@ -710,7 +724,7 @@ const TopBlock = ({
           </div>
         ))}
       </div>
-      <div style={actionButtonsContainerStyle}>
+      <div style={actionButtonsContainerStyle} className={styles.sideActionsPanel}>
         {showSideActions && btnExport(cardData)}
         {additionalActions}
       </div>

--- a/src/components/smallCard/renderTopBlock.module.css
+++ b/src/components/smallCard/renderTopBlock.module.css
@@ -3,6 +3,23 @@
   transform: scale(1.05);
 }
 
+.topBlockContainer {
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.topBlockContainer:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+}
+
+.sideActionsPanel {
+  transition: background 0.2s ease;
+}
+
+.sideActionsPanel:hover {
+  background: rgba(0, 0, 0, 0.3);
+}
+
 .detailsToggleHover:hover {
   background: rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
### Motivation
- Refresh the visual presentation of the top block to make it look more like a polished card (subtle gradient, rounded corners and elevation) while keeping all existing behavior unchanged. 
- Make the top action zones and side actions visually clearer with improved spacing and hover feedback. 

### Description
- Adjusted inline style object `topBlockContainerStyle` to add padding, `borderRadius`, subtle `background` gradient, `border` and stronger `boxShadow`, and applied the class `styles.topBlockContainer` in the JSX; changes are in `src/components/smallCard/renderTopBlock.js`. 
- Updated `topButtonsRowStyle` and `topButtonsZoneStyle` to refine spacing, increase zone shadow and add `overflow: 'hidden'` to clean up icon rendering without touching any button handlers. 
- Modified `actionButtonsContainerStyle` to reposition and restyle the side actions panel with padding, rounded corners, translucent background and `backdropFilter`, and added `className={styles.sideActionsPanel}` in the JSX. 
- Refined `detailsToggleStyle` visual parameters (size, radius, border and subtle background) and added CSS hover transitions in `src/components/smallCard/renderTopBlock.module.css` with `.topBlockContainer` and `.sideActionsPanel` rules; no logic, data flow or event handling was changed. 

### Testing
- Verified repository diff with `git diff` to confirm only style changes in `src/components/smallCard/renderTopBlock.js` and `src/components/smallCard/renderTopBlock.module.css`. 
- Committed the updates with `git add` and `git commit` which completed successfully. 
- No automated unit or integration tests were run as this is a UI-only styling change and no test files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2253eb4908326953f8925d8cbb6af)