### PR TITLE
Refine smallCard visual styling for top block and form controls

### DIFF
--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -14,7 +14,18 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
   // autoResize will adjust height on mount and when value changes
 
   return (
-    <div
+    <div>
+      <style>{`
+        .field-comment-textarea::placeholder {
+          color: rgba(255,255,255,0.3);
+          font-style: italic;
+        }
+        .field-comment-textarea:focus {
+          border-color: rgba(255,255,255,0.2);
+          background: rgba(255,255,255,0.07);
+        }
+      `}</style>
+      <div
       style={{
         display: 'flex', // Використовуємо flexbox
         justifyContent: 'center', // Центрування по горизонталі
@@ -25,6 +36,7 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
       }}
     >
       <textarea
+        className="field-comment-textarea"
         ref={textareaRef}
         placeholder="Додайте коментар"
         value={userData.myComment || ''}
@@ -51,8 +63,17 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
           // minHeight: '40px',
           resize: 'none',
           overflow: 'hidden',
-          padding: '5px',
+          padding: '7px 10px',
           paddingRight: userData.myComment ? '42px' : '26px',
+          borderRadius: '8px',
+          border: '1px solid rgba(255,255,255,0.1)',
+          background: 'rgba(255,255,255,0.04)',
+          color: 'inherit',
+          fontSize: '12px',
+          lineHeight: 1.45,
+          fontFamily: 'inherit',
+          outline: 'none',
+          boxSizing: 'border-box',
         }}
       />
       {userData.myComment && (
@@ -80,6 +101,7 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
           &times;
         </button>
       )}
+      </div>
     </div>
   );
 };

--- a/src/components/smallCard/btnDel.js
+++ b/src/components/smallCard/btnDel.js
@@ -13,7 +13,7 @@ export const btnDel = (
 ) => (
   <CardMenuBtn
     style={{
-      backgroundColor: 'red',
+      backgroundColor: '#d32f2f',
       position: 'static',
       display: 'inline-flex',
       alignItems: 'center',

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -106,8 +106,8 @@ export const BtnDislike = ({
           ? activeColor
           : customBackground || customBackgroundColor || color.accent5,
         border: isDisliked
-          ? `4px solid ${activeBorderColor}`
-          : customBorder || `2px solid ${color.reactionIdleBorder}`,
+          ? `3px solid ${activeBorderColor}`
+          : customBorder || `1px solid rgba(255,255,255,0.2)`,
         color: isDisliked ? resolvedActiveIconColor : resolvedInactiveIconColor,
         boxShadow: isDisliked
           ? `0 0 0 2px ${activeColor}`

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -101,8 +101,8 @@ export const BtnFavorite = ({
           ? activeColor
           : customBackground || customBackgroundColor || color.accent5,
         border: isFavorite
-          ? `4px solid ${activeBorderColor}`
-          : customBorder || `2px solid ${color.reactionIdleBorder}`,
+          ? `3px solid ${activeBorderColor}`
+          : customBorder || `1px solid rgba(255,255,255,0.2)`,
         color: isFavorite ? resolvedActiveIconColor : resolvedInactiveIconColor,
         boxShadow: isFavorite
           ? `0 0 0 2px ${activeColor}`

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -25,15 +25,17 @@ const iconStyle = {
 const phoneBtnStyle = {
   color: 'inherit',
   textDecoration: 'none',
-  marginLeft: '4px',
+  marginLeft: '3px',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
   width: '20px',
   height: '20px',
   lineHeight: '0',
-  border: `1px solid ${color.white}`,
+  border: `1px solid rgba(255,255,255,0.2)`,
   borderRadius: '50%',
+  opacity: 0.75,
+  transition: 'opacity 0.15s',
 };
 
 const normalizeExternalUrl = value => {

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -81,6 +81,7 @@ export const fieldGetInTouch = (
 
   const ActionButton = ({ label, days, onClick }) => (
     <OrangeBtn
+      className="get-in-touch-btn"
       onClick={() => (onClick ? onClick(days) : null)}
       style={{
         width: '25px' /* Встановіть ширину, яка визначатиме розмір кнопки */,
@@ -94,7 +95,12 @@ export const fieldGetInTouch = (
   );
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center' }}>
+    <div>
+      <style>{`
+        .get-in-touch-btn:hover { opacity: 0.75; }
+        .get-in-touch-btn:active { transform: scale(0.93); }
+      `}</style>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
       <UnderlinedInput
         type="text"
         value={formatDateToDisplay(formatDateAndFormula(userData.getInTouch)) || ''}
@@ -182,6 +188,7 @@ export const fieldGetInTouch = (
       <ActionButton label="3м" days={90} onClick={handleAddDays} />
       <ActionButton label="6м" days={180} onClick={handleAddDays} />
       <ActionButton label="1р" days={365} onClick={handleAddDays} />
+      </div>
     </div>
   );
 };

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -554,6 +554,13 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
             style={{
               cursor: 'pointer',
               color: 'white',
+              padding: '1px 7px',
+              borderRadius: '20px',
+              fontSize: '11px',
+              fontWeight: 500,
+              background: 'rgba(255,255,255,0.12)',
+              border: '1px solid rgba(255,255,255,0.2)',
+              display: 'inline-block',
             }}
           >
             місячні

--- a/src/components/smallCard/fieldRole.js
+++ b/src/components/smallCard/fieldRole.js
@@ -29,7 +29,15 @@ export const fieldRole = (userData, setUsers, setState, submitOptions = {}) => {
         <OrangeBtn
           key={role}
           onClick={() => handleSetRole(role)}
-          style={{ width: '25px', height: '25px', marginLeft: '5px', marginRight: 0 }}
+          style={{
+            width: '25px',
+            height: '25px',
+            marginLeft: '5px',
+            marginRight: 0,
+            opacity: userData.role === role ? 1 : 0.45,
+            fontWeight: userData.role === role ? 700 : 400,
+            boxShadow: userData.role === role ? '0 0 0 2px rgba(255,255,255,0.4)' : 'none',
+          }}
         >
           {role}
         </OrangeBtn>

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -45,25 +45,24 @@ const topBlockContainerStyle = {
 
 const topButtonsRowStyle = {
   display: 'grid',
-  gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
+  gridTemplateColumns: 'repeat(5, max-content)',
   gap: '8px',
   marginBottom: '10px',
 };
 
 const topButtonsZoneStyle = {
   border: 'none',
-  borderRadius: '12px',
+  borderRadius: '10px',
   cursor: 'pointer',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '100%',
-  height: '42px',
-  minWidth: 0,
+  width: '38px',
+  height: '38px',
+  flex: '0 0 38px',
   padding: 0,
-  boxShadow: '0 6px 14px rgba(0,0,0,0.24)',
-  transition: 'transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease',
-  overflow: 'hidden',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.18)',
+  transition: 'transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease',
 };
 
 const topButtonsZones = ['#d32f2f', '#ef6c00', '#f9a825', '#2e7d32', '#0288d1', '#1565c0', '#6a1b9a'];
@@ -126,15 +125,17 @@ const commentFieldWrapperStyle = {
 
 const detailsToggleStyle = {
   position: 'absolute',
-  bottom: '8px',
-  right: '8px',
+  bottom: '10px',
+  right: '10px',
   cursor: 'pointer',
   color: '#ebe0c2',
   fontSize: '20px',
-  padding: '4px 8px',
-  borderRadius: '10px',
-  border: '1px solid rgba(255, 255, 255, 0.2)',
-  background: 'rgba(255, 255, 255, 0.06)',
+  padding: '4px 10px',
+  borderRadius: '6px',
+  border: 'none',
+  background: 'transparent',
+  lineHeight: 1,
+  letterSpacing: '2px',
 };
 
 const multiCommentStyle = {
@@ -143,15 +144,16 @@ const multiCommentStyle = {
   cursor: 'pointer',
   textDecoration: 'none',
   fontSize: '11px',
+  lineHeight: 1.4,
 };
 
 const multiCommentRowStyle = {
-  marginTop: '6px',
+  marginTop: '5px',
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   gap: '6px',
-  background: 'rgba(243, 223, 171, 0.08)',
-  borderRadius: '6px',
+  background: 'rgba(243,223,171,0.06)',
+  borderRadius: '7px',
   padding: '4px 8px',
 };
 
@@ -178,33 +180,39 @@ const commentDeleteButtonStyle = {
 const inlineModalOverlayStyle = {
   position: 'fixed',
   inset: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  backgroundColor: 'rgba(0, 0, 0, 0.6)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   zIndex: 3000,
   padding: '16px',
+  backdropFilter: 'blur(4px)',
+  WebkitBackdropFilter: 'blur(4px)',
 };
 
 const inlineModalCardStyle = {
   width: 'min(92vw, 560px)',
-  background: '#fff',
-  color: '#111',
-  borderRadius: '12px',
-  padding: '14px',
-  boxShadow: '0 18px 40px rgba(0, 0, 0, 0.35)',
+  background: '#1e2d3d',
+  color: '#e8f0fa',
+  borderRadius: '14px',
+  padding: '18px',
+  boxShadow: '0 20px 50px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.07)',
   animation: 'fadeInUp 0.2s ease',
 };
 
 const inlineModalTextareaStyle = {
   width: '100%',
   minHeight: '120px',
-  borderRadius: '8px',
-  border: '1px solid #c7c7c7',
+  borderRadius: '10px',
+  border: '1px solid rgba(255,255,255,0.12)',
+  background: 'rgba(255,255,255,0.05)',
+  color: '#e8f0fa',
   padding: '10px',
   resize: 'vertical',
   fontSize: '14px',
   boxSizing: 'border-box',
+  outline: 'none',
+  fontFamily: 'inherit',
 };
 
 const inlineModalActionsStyle = {
@@ -574,13 +582,26 @@ const TopBlock = ({
 
   return (
     <div style={topBlockContainerStyle} className={styles.topBlockContainer}>
+      <style>{`
+        .top-zone-btn:hover {
+          transform: scale(1.07) translateY(-1px);
+          filter: brightness(1.15);
+        }
+        .top-zone-btn:active {
+          transform: scale(0.95);
+        }
+        .details-toggle-btn:hover {
+          background: rgba(255,255,255,0.1) !important;
+          color: #fff !important;
+        }
+      `}</style>
       <div style={topButtonsRowStyle}>
         {topButtonsZones.map((zoneColor, idx) => (
           <div
             key={`top-zone-${idx}`}
             aria-label={`top-zone-${idx + 1}`}
-            className={styles.topButtonsZoneHover}
-            style={{ ...topButtonsZoneStyle, backgroundColor: zoneColor, display: idx === 5 || idx === 6 ? 'none' : 'flex' }}
+            className={`top-zone-btn ${styles.topButtonsZoneHover}`}
+            style={{ ...topButtonsZoneStyle, backgroundColor: zoneColor, display: 'flex' }}
           >
             {idx === 0 &&
               btnDel(
@@ -718,8 +739,8 @@ const TopBlock = ({
                   </svg>
                 )
               ))}
-            {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
-            {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
+            {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff', opacity: 0, pointerEvents: 'none' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
+            {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff', opacity: 0, pointerEvents: 'none' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>
         ))}
       </div>
@@ -838,7 +859,17 @@ const TopBlock = ({
             <div style={inlineModalActionsStyle}>
               <button
                 type="button"
-                style={inlineModalCancelButtonStyle}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  background: 'transparent',
+                  color: '#8fa8c0',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  fontFamily: 'inherit',
+                }}
                 onClick={() => {
                   setIsCommentModalOpen(false);
                   setSelectedComment(null);
@@ -846,7 +877,22 @@ const TopBlock = ({
               >
                 Скасувати
               </button>
-              <button type="button" style={inlineModalSaveButtonStyle} onClick={saveMultiComment}>
+              <button
+                type="button"
+                style={{
+                  padding: '8px 18px',
+                  borderRadius: '8px',
+                  border: 'none',
+                  background: 'linear-gradient(135deg, #2e7d32, #388e3c)',
+                  color: '#fff',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 600,
+                  fontFamily: 'inherit',
+                  boxShadow: '0 4px 12px rgba(46,125,50,0.35)',
+                }}
+                onClick={saveMultiComment}
+              >
                 Зберегти
               </button>
             </div>
@@ -872,7 +918,17 @@ const TopBlock = ({
             <div style={inlineModalActionsStyle}>
               <button
                 type="button"
-                style={inlineModalCancelButtonStyle}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  background: 'transparent',
+                  color: '#8fa8c0',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  fontFamily: 'inherit',
+                }}
                 onClick={() => {
                   setCommentToDelete(null);
                 }}
@@ -881,6 +937,18 @@ const TopBlock = ({
               </button>
               <button
                 type="button"
+                style={{
+                  padding: '8px 18px',
+                  borderRadius: '8px',
+                  border: 'none',
+                  background: 'linear-gradient(135deg, #c62828, #e53935)',
+                  color: '#fff',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 600,
+                  fontFamily: 'inherit',
+                  boxShadow: '0 4px 12px rgba(198,40,40,0.35)',
+                }}
                 onClick={async () => {
                   await handleDeleteComment(commentToDelete);
                   setCommentToDelete(null);
@@ -893,7 +961,8 @@ const TopBlock = ({
         </div>
       )}
 
-      <div
+      <button
+        type="button"
         onClick={async e => {
           e.stopPropagation();
           const details = document.getElementById(cardData.userId);
@@ -948,11 +1017,11 @@ const TopBlock = ({
             toastFn(toastMsg);
           }
         }}
-        className={styles.detailsToggleHover}
+        className={`details-toggle-btn ${styles.detailsToggleHover}`}
         style={detailsToggleStyle}
       >
-        ...
-      </div>
+        ···
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Improve the visual appearance of the smallCard top block and related form controls to better match the dark theme and provide usable hover/active affordances while preserving all existing logic and behaviour.
- Make placeholder/unused top-zone buttons visually inert and make modal and inline comment UX more polished without changing props, hooks, or data flow.

### Description
- `renderTopBlock.js`: resized and softened top-zone buttons, switched grid sizing, added scoped `<style>` for `.top-zone-btn` hover/active, hid placeholder zones (idx 5/6) via `opacity`/`pointerEvents`, converted the details toggle to a `<button>` with class `.details-toggle-btn` and added hover style, darkened inline modals, added overlay blur, increased modal card radius/padding, updated modal textarea and action button styles, and refined multi-comment row styling.
- `FieldComment.js`: added `field-comment-textarea` class, styled placeholder/focus via embedded `<style>`, and updated textarea padding, radius, border, background and typography to match dark theme.
- `fieldRole.js`: added visual indication for active role buttons using `style` (opacity, fontWeight, boxShadow) without changing behavior.
- `fieldGetInTouch.js`: added `gap` to the action container and injected scoped hover/active styles for quick action buttons via `get-in-touch-btn` class.
- `fieldLastCycle.js`: styled the `місячні` status into a pill (background, border, padding, font weight) without changing the click handler.
- `btnDel.js`, `btnDislike.js`, `btnFavorite.js`: softened delete button color and reduced active/idle border thicknesses for dislike/favorite buttons.
- `fieldContacts.js`: adjusted `phoneBtnStyle` border, margin, opacity and transition for contact icon buttons.

### Testing
- Ran project linter (`npm run -s lint`) which exited with a non-zero status (lint failed) in this environment. 
- No automated unit tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f230db025c8326ab285298fa17d7ee)