### PR TITLE
Refactor inline modal button styles into reusable style objects

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -222,22 +222,28 @@ const inlineModalActionsStyle = {
   gap: '8px',
 };
 
+
 const inlineModalCancelButtonStyle = {
-  background: 'transparent',
-  color: '#374151',
-  border: '1px solid #9ca3af',
-  borderRadius: '8px',
   padding: '8px 16px',
+  borderRadius: '8px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  background: 'transparent',
+  color: '#8fa8c0',
   cursor: 'pointer',
+  fontSize: '13px',
+  fontWeight: 500,
+  fontFamily: 'inherit',
 };
 
 const inlineModalSaveButtonStyle = {
-  background: '#2e7d32',
-  color: '#fff',
-  border: 'none',
+  padding: '8px 18px',
   borderRadius: '8px',
-  padding: '8px 16px',
+  border: 'none',
+  color: '#fff',
   cursor: 'pointer',
+  fontSize: '13px',
+  fontWeight: 600,
+  fontFamily: 'inherit',
 };
 
 const deleteModalTextStyle = {
@@ -859,17 +865,7 @@ const TopBlock = ({
             <div style={inlineModalActionsStyle}>
               <button
                 type="button"
-                style={{
-                  padding: '8px 16px',
-                  borderRadius: '8px',
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  background: 'transparent',
-                  color: '#8fa8c0',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  fontWeight: 500,
-                  fontFamily: 'inherit',
-                }}
+                style={inlineModalCancelButtonStyle}
                 onClick={() => {
                   setIsCommentModalOpen(false);
                   setSelectedComment(null);
@@ -880,15 +876,8 @@ const TopBlock = ({
               <button
                 type="button"
                 style={{
-                  padding: '8px 18px',
-                  borderRadius: '8px',
-                  border: 'none',
+                  ...inlineModalSaveButtonStyle,
                   background: 'linear-gradient(135deg, #2e7d32, #388e3c)',
-                  color: '#fff',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  fontWeight: 600,
-                  fontFamily: 'inherit',
                   boxShadow: '0 4px 12px rgba(46,125,50,0.35)',
                 }}
                 onClick={saveMultiComment}
@@ -918,17 +907,7 @@ const TopBlock = ({
             <div style={inlineModalActionsStyle}>
               <button
                 type="button"
-                style={{
-                  padding: '8px 16px',
-                  borderRadius: '8px',
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  background: 'transparent',
-                  color: '#8fa8c0',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  fontWeight: 500,
-                  fontFamily: 'inherit',
-                }}
+                style={inlineModalCancelButtonStyle}
                 onClick={() => {
                   setCommentToDelete(null);
                 }}
@@ -938,15 +917,8 @@ const TopBlock = ({
               <button
                 type="button"
                 style={{
-                  padding: '8px 18px',
-                  borderRadius: '8px',
-                  border: 'none',
+                  ...inlineModalSaveButtonStyle,
                   background: 'linear-gradient(135deg, #c62828, #e53935)',
-                  color: '#fff',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  fontWeight: 600,
-                  fontFamily: 'inherit',
                   boxShadow: '0 4px 12px rgba(198,40,40,0.35)',
                 }}
                 onClick={async () => {


### PR DESCRIPTION
### Motivation
- Reduce duplicated inline style definitions for modal buttons and make button appearance consistent across comment and delete confirmation modals.
- Improve maintainability by centralizing typography and spacing for inline modal actions.

### Description
- Updated `inlineModalCancelButtonStyle` and `inlineModalSaveButtonStyle` to include shared properties like `padding`, `borderRadius`, `fontSize`, `fontWeight`, and `fontFamily` and adjusted colors/borders to match the app theme.
- Replaced duplicated inline style objects in the comment and delete confirmation modal buttons with `style={inlineModalCancelButtonStyle}` and `style={{...inlineModalSaveButtonStyle, background: 'linear-gradient(...)', boxShadow: '...'}}` to preserve per-button gradients.
- Removed several inline style literals in JSX and consolidated them into the new style constants to simplify the component.

### Testing
- Ran the project's test suite with `yarn test` and all tests completed successfully.
- Performed a production build with `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23b8bd0c4832694aa7031b8cdba94)