### PR TITLE
Normalize and resolve age search key values for additional access rule sets

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -27,6 +27,16 @@ export const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_INDEX_SEPARATOR = '_';
 const FORBIDDEN_RTDB_SEGMENT_CHARS = ['.', '#', '$', '/', '[', ']'];
 
+
+const AGE_SEARCH_KEY_VALUE_PATTERN = /^d_\d{4}-\d{2}-\d{2}$/;
+
+const normalizeAgeSearchKeyValue = value => {
+  const normalized = normalizePathSegment(value);
+  if (!normalized) return '';
+  if (normalized === '?' || normalized === 'no') return normalized;
+  return AGE_SEARCH_KEY_VALUE_PATTERN.test(normalized) ? normalized : '';
+};
+
 const normalizePathSegment = value => {
   const raw = String(value ?? '').trim();
   if (!raw) return '';
@@ -136,14 +146,21 @@ const buildAgeKeysByUserIdFromSearchKey = async userIds => {
   const normalizedIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
   if (normalizedIds.length === 0) return {};
 
-  const payload = peekCachedSearchKeyPayload('searchKey/age');
+  const agePayload = peekCachedSearchKeyPayload('searchKey/age');
+  const rootPayload = peekCachedSearchKeyPayload('searchKey');
+  const ageIndex =
+    agePayload?.exists && agePayload.value && typeof agePayload.value === 'object'
+      ? agePayload.value
+      : rootPayload?.exists && rootPayload.value && typeof rootPayload.value?.age === 'object'
+      ? rootPayload.value.age
+      : null;
 
-  if (!payload?.exists || !payload.value || typeof payload.value !== 'object') return {};
+  if (!ageIndex || typeof ageIndex !== 'object') return {};
 
   const pending = new Set(normalizedIds);
   const ageKeysByUserId = {};
 
-  Object.entries(payload.value).forEach(([ageKey, usersMap]) => {
+  Object.entries(ageIndex).forEach(([ageKey, usersMap]) => {
     if (!(usersMap && typeof usersMap === 'object')) return;
     if (pending.size === 0) return;
 
@@ -169,10 +186,17 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, ageKeysByU
     if (!normalizedIndexName) return writes;
 
     if (normalizedIndexName === 'age') {
+      const allowedAgeValues = new Set(
+        (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+          .map(value => normalizeAgeSearchKeyValue(value))
+          .filter(Boolean)
+      );
+
       normalizedUserIds.forEach(userId => {
-        const ageKey = normalizePathSegment(ageKeysByUserId?.[userId] || 'no');
-        if (!ageKey) return;
-        const path = `${normalizedRootPath}/${normalizedIndexName}/${ageKey}`;
+        const resolvedAgeValue = normalizeAgeSearchKeyValue(ageKeysByUserId?.[userId]);
+        const ageValue = resolvedAgeValue || (allowedAgeValues.has('no') ? 'no' : '');
+        if (!ageValue) return;
+        const path = `${normalizedRootPath}/${normalizedIndexName}/${ageValue}`;
         if (!writes[path]) writes[path] = {};
         writes[path][userId] = true;
       });


### PR DESCRIPTION
### Motivation
- Ensure age search key values are consistently encoded and validated when building search key sets so RTDB path segments contain no forbidden characters.
- Support reading cached age indexes from either the dedicated `searchKey/age` payload or the root `searchKey` payload with an `age` property.
- Correct handling of special age tokens like `no` and `?` and prevent invalid age formats from being written to indexes.

### Description
- Added `AGE_SEARCH_KEY_VALUE_PATTERN` and `normalizeAgeSearchKeyValue` to validate and normalize age search key values, preserving `?` and `no` and encoding forbidden characters via `normalizePathSegment` when needed.  
- Added logic to read the cached age index from `peekCachedSearchKeyPayload('searchKey/age')` or fall back to `peekCachedSearchKeyPayload('searchKey').age` when present.  
- When building bucket writes for the `age` index, compute an `allowedAgeValues` set from rule buckets, resolve each user's age against cached keys, and prefer allowed `no` values as a fallback; skip writes for invalid or empty age values.  
- Kept existing behavior for non-age indexes, while centralizing normalization and forbidden-character handling via `normalizePathSegment` and the new normalization helper.

### Testing
- Ran the repository unit test suite focused on search index utilities including `newUsersFilterSetsIndex` tests, and the tests passed.  
- Ran linting and static checks with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25d381d088326b17e8c48aa142991)