### PR TITLE
Fix empty searchKeySets buckets for age-filtered rule sets

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -214,11 +214,9 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     if (!normalizedIndexName) return writes;
 
     if (normalizedIndexName === 'age') {
-      const allowedAgeValues = [
-        (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
-          .map(value => normalizeAgeSearchKeyValue(value))
-          .filter(Boolean)
-      ];
+      const allowedAgeValues = (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+        .map(value => normalizeAgeSearchKeyValue(value))
+        .filter(Boolean);
       const sanitized = buildSanitizedBucketUsersMap({
         searchKeyFile,
         indexName: normalizedIndexName,


### PR DESCRIPTION
### Motivation
- Additional-access rule sets that included age filters produced no `searchKeySets` bucket writes because age values were wrapped in a nested array and looked up as the wrong key.
- The change restores correct lookup of `searchKey.age/<bucket>` so age-filtered rule sets produce bucket writes when valid.

### Description
- Updated `buildRuleBucketWrites` in `src/utils/newUsersFilterSetsIndex.js` to produce a flat array of normalized age values instead of a nested array by changing the `allowedAgeValues` construction.
- The `age` branch now passes `values` as `Array<string>` to `buildSanitizedBucketUsersMap`, restoring proper path generation and user-id mapping for age buckets.

### Testing
- Ran `npm run -s lint:js -- src/utils/newUsersFilterSetsIndex.js` which completed successfully (exit code 0) with only a `Browserslist` data warning.
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f374bc8be083269a3e8838870c955d)