### PR TITLE
Use active draft when previewing additional access rules in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -671,12 +671,16 @@ export const ProfileForm = ({
   useEffect(() => {
     if (!showAdditionalRulesModal) return;
 
+    const effectiveRulesText = activeAdditionalRulesDraftText.trim()
+      ? activeAdditionalRulesDraftText
+      : previewAdditionalRulesText;
+
     let cancelled = false;
     const loadAvailableCards = async () => {
-      const parsedRuleGroups = parseAdditionalAccessRuleGroups(previewAdditionalRulesText);
+      const parsedRuleGroups = parseAdditionalAccessRuleGroups(effectiveRulesText);
       const accessUserId = String(state?.userId || '').trim();
       const cachedPreview = getCachedAdditionalRulesPreview({
-        rawRules: previewAdditionalRulesText,
+        rawRules: effectiveRulesText,
         accessUserId,
       });
       if (cachedPreview) {
@@ -686,7 +690,7 @@ export const ProfileForm = ({
 
       if (!parsedRuleGroups.length) {
         setAvailableCardsCount(0);
-        saveCachedAdditionalRulesPreview({ rawRules: previewAdditionalRulesText, accessUserId, count: 0, userIds: [] });
+        saveCachedAdditionalRulesPreview({ rawRules: effectiveRulesText, accessUserId, count: 0, userIds: [] });
         return;
       }
 
@@ -714,7 +718,7 @@ export const ProfileForm = ({
           });
         });
         const userIds = [...matched];
-        saveCachedAdditionalRulesPreview({ rawRules: previewAdditionalRulesText, accessUserId, count: userIds.length, userIds });
+        saveCachedAdditionalRulesPreview({ rawRules: effectiveRulesText, accessUserId, count: userIds.length, userIds });
         if (!cancelled) setAvailableCardsCount(userIds.length);
       } catch (error) {
         console.error('Failed to build additional access preview', error);
@@ -730,6 +734,7 @@ export const ProfileForm = ({
     };
   }, [
     previewAdditionalRulesText,
+    activeAdditionalRulesDraftText,
     showAdditionalRulesModal,
     state?.userId,
     localSearchKeyPayload,


### PR DESCRIPTION
### Motivation

- Ensure the additional-rules preview and available-cards calculation use the current active draft input when present rather than stale preview text.

### Description

- Introduced `effectiveRulesText` to prefer `activeAdditionalRulesDraftText` when it contains non-whitespace content, otherwise fall back to `previewAdditionalRulesText`.
- Updated parsing and caching calls (`parseAdditionalAccessRuleGroups` and `saveCachedAdditionalRulesPreview` / `getCachedAdditionalRulesPreview`) to use `effectiveRulesText` instead of `previewAdditionalRulesText` so lookups and cache keys reflect the active draft.
- Added `activeAdditionalRulesDraftText` to the effect dependency list that computes available cards so the effect runs when the active draft changes.

### Testing

- Ran the existing automated test suite via `yarn test` and linting via `yarn lint`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38d707d208326a2445cd266a5ad12)