### PR TITLE
Handle wrapped `searchKey` payload for additional-access card count

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -92,6 +92,13 @@ const nestedIndentStyle = {
 };
 
 const ADDITIONAL_ACCESS_FIELD = 'additionalAccessRules';
+const getSearchKeyIndexes = payload => {
+  if (!payload || typeof payload !== 'object') return null;
+  if (payload.searchKey && typeof payload.searchKey === 'object') {
+    return payload.searchKey;
+  }
+  return payload;
+};
 const PHENOTYPE_FIELDS = [
   'eyeColor',
   'hairColor',
@@ -694,7 +701,8 @@ export const ProfileForm = ({
         return;
       }
 
-      if (!localSearchKeyPayload || typeof localSearchKeyPayload !== 'object') {
+      const searchKeyIndexes = getSearchKeyIndexes(localSearchKeyPayload);
+      if (!searchKeyIndexes) {
         setAvailableCardsCount(0);
         return;
       }
@@ -705,7 +713,7 @@ export const ProfileForm = ({
         parsedRuleGroups.forEach(parsedRules => {
           const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
           Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-            const indexNode = localSearchKeyPayload?.[indexName];
+            const indexNode = searchKeyIndexes?.[indexName];
             if (!indexNode || typeof indexNode !== 'object') return;
             const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
             normalizedValues.forEach(value => {
@@ -800,7 +808,8 @@ export const ProfileForm = ({
       return null;
     }
 
-    if (!localSearchKeyPayload || typeof localSearchKeyPayload !== 'object') {
+    const searchKeyIndexes = getSearchKeyIndexes(localSearchKeyPayload);
+    if (!searchKeyIndexes) {
       toast.error('Спершу підвантажте локальний файл searchKey.');
       return null;
     }
@@ -813,7 +822,7 @@ export const ProfileForm = ({
       parsedRuleGroups.forEach(parsedRules => {
         const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
         Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-          const indexNode = localSearchKeyPayload?.[indexName];
+          const indexNode = searchKeyIndexes?.[indexName];
           if (!indexNode || typeof indexNode !== 'object') return;
           const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
           normalizedValues.forEach(value => {
@@ -1133,7 +1142,8 @@ export const ProfileForm = ({
   };
 
   const resolveMatchedIdsFromSearchKeyPayload = useCallback((rulesText, payload) => {
-    if (!payload || typeof payload !== 'object') return null;
+    const searchKeyIndexes = getSearchKeyIndexes(payload);
+    if (!searchKeyIndexes) return null;
 
     const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
     if (!parsedRuleGroups.length) return { 1: [] };
@@ -1142,7 +1152,7 @@ export const ProfileForm = ({
     parsedRuleGroups.forEach(parsedRules => {
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
       Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-        const indexNode = payload?.[indexName];
+        const indexNode = searchKeyIndexes?.[indexName];
         if (!indexNode || typeof indexNode !== 'object') return;
         const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
         normalizedValues.forEach(value => {


### PR DESCRIPTION
### Motivation
- The additional-access preview counter showed `0` when uploaded `searchKey` JSON used a wrapped shape (`{ searchKey: { ... } }`) instead of flat indexes (`{ age: ..., blood: ... }`).
- Fix aims to normalize the payload shape on the frontend so index lookups succeed regardless of file layout.

### Description
- Added helper `getSearchKeyIndexes(payload)` to normalize search key payload shape and placed it in `src/components/ProfileForm.jsx`.
- Replaced direct `localSearchKeyPayload` lookups with `searchKeyIndexes` in the additional-access preview flow used by the modal counter.
- Applied the same normalization in `getIndexedMatchedUserIdsByInputIndex` to support indexing and in `resolveMatchedIdsFromSearchKeyPayload` used when processing an uploaded file.
- No backend or data model changes; only frontend lookup normalization for search key payload shape.

### Testing
- Ran the targeted test suite: `npm test -- --runInBand src/utils/__tests__/load2Storage.test.js` and it passed (1 suite, 2 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a97bd9ec8326a4d41b8431c430ee)