### PR TITLE
Apply AND semantics for combined additional-access filters

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -704,18 +704,29 @@ export const ProfileForm = ({
         const matched = new Set();
         parsedRuleGroups.forEach(parsedRules => {
           const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
-          Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
+          const perFilterSets = Object.entries(bucketMap || {}).reduce((acc, [indexName, values]) => {
             const indexNode = localSearchKeyPayload?.[indexName];
-            if (!indexNode || typeof indexNode !== 'object') return;
+            if (!indexNode || typeof indexNode !== 'object') return acc;
             const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
+            if (!normalizedValues.length) return acc;
+            const idsForFilter = new Set();
             normalizedValues.forEach(value => {
               const bucket = indexNode?.[value];
               if (!bucket || typeof bucket !== 'object') return;
               Object.keys(bucket).forEach(userId => {
-                if (userId) matched.add(userId);
+                if (userId) idsForFilter.add(userId);
               });
             });
-          });
+            if (idsForFilter.size > 0) acc.push(idsForFilter);
+            return acc;
+          }, []);
+
+          if (!perFilterSets.length) return;
+
+          const groupIntersection = [...perFilterSets[0]].filter(userId =>
+            perFilterSets.every(set => set.has(userId))
+          );
+          groupIntersection.forEach(userId => matched.add(userId));
         });
         const userIds = [...matched];
         saveCachedAdditionalRulesPreview({ rawRules: effectiveRulesText, accessUserId, count: userIds.length, userIds });
@@ -812,18 +823,29 @@ export const ProfileForm = ({
       const matched = new Set();
       parsedRuleGroups.forEach(parsedRules => {
         const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
-        Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
+        const perFilterSets = Object.entries(bucketMap || {}).reduce((acc, [indexName, values]) => {
           const indexNode = localSearchKeyPayload?.[indexName];
-          if (!indexNode || typeof indexNode !== 'object') return;
+          if (!indexNode || typeof indexNode !== 'object') return acc;
           const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
+          if (!normalizedValues.length) return acc;
+          const idsForFilter = new Set();
           normalizedValues.forEach(value => {
             const bucket = indexNode?.[value];
             if (!bucket || typeof bucket !== 'object') return;
             Object.keys(bucket).forEach(userId => {
-              if (userId) matched.add(userId);
+              if (userId) idsForFilter.add(userId);
             });
           });
-        });
+          if (idsForFilter.size > 0) acc.push(idsForFilter);
+          return acc;
+        }, []);
+
+        if (!perFilterSets.length) return;
+
+        const groupIntersection = [...perFilterSets[0]].filter(userId =>
+          perFilterSets.every(set => set.has(userId))
+        );
+        groupIntersection.forEach(userId => matched.add(userId));
       });
       matchedByInputIndex[index + 1] = [...matched];
     }


### PR DESCRIPTION
### Motivation
- The available-cards preview count for Additional Access Rules became incorrect or missing when multiple filters (e.g. age and csection) were selected together because different filter categories were being unioned instead of intersected.

### Description
- Update `src/components/ProfileForm.jsx` so that for each parsed rule group IDs are collected per filter category and intersected (AND) before unioning results across groups (OR), restoring correct combined-filter semantics.
- Apply the same per-category intersection logic to `getIndexedMatchedUserIdsByInputIndex` to make indexing consistent with the preview logic.
- Preserve existing caching (`getCachedAdditionalRulesPreview` / `saveCachedAdditionalRulesPreview`) and loading state behavior.

### Testing
- Ran `npm run test -- --watch=false --runInBand src/utils/__tests__/parseUkTrigger.test.js` and the test run produced failures in an unrelated test file (2 failing tests); no new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b0f56ecc8326b8330bb8cb9f2e78)