### PR TITLE
Support searchKey-wrapped payloads and include legacy age buckets in access rules

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -92,6 +92,13 @@ const nestedIndentStyle = {
 };
 
 const ADDITIONAL_ACCESS_FIELD = 'additionalAccessRules';
+const getSearchKeyIndexes = payload => {
+  if (!payload || typeof payload !== 'object') return null;
+  if (payload.searchKey && typeof payload.searchKey === 'object') {
+    return payload.searchKey;
+  }
+  return payload;
+};
 const PHENOTYPE_FIELDS = [
   'eyeColor',
   'hairColor',
@@ -694,7 +701,8 @@ export const ProfileForm = ({
         return;
       }
 
-      if (!localSearchKeyPayload || typeof localSearchKeyPayload !== 'object') {
+      const searchKeyIndexes = getSearchKeyIndexes(localSearchKeyPayload);
+      if (!searchKeyIndexes) {
         setAvailableCardsCount(0);
         return;
       }
@@ -705,7 +713,7 @@ export const ProfileForm = ({
         parsedRuleGroups.forEach(parsedRules => {
           const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
           Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-            const indexNode = localSearchKeyPayload?.[indexName];
+            const indexNode = searchKeyIndexes?.[indexName];
             if (!indexNode || typeof indexNode !== 'object') return;
             const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
             normalizedValues.forEach(value => {
@@ -800,7 +808,8 @@ export const ProfileForm = ({
       return null;
     }
 
-    if (!localSearchKeyPayload || typeof localSearchKeyPayload !== 'object') {
+    const searchKeyIndexes = getSearchKeyIndexes(localSearchKeyPayload);
+    if (!searchKeyIndexes) {
       toast.error('Спершу підвантажте локальний файл searchKey.');
       return null;
     }
@@ -813,7 +822,7 @@ export const ProfileForm = ({
       parsedRuleGroups.forEach(parsedRules => {
         const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
         Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-          const indexNode = localSearchKeyPayload?.[indexName];
+          const indexNode = searchKeyIndexes?.[indexName];
           if (!indexNode || typeof indexNode !== 'object') return;
           const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
           normalizedValues.forEach(value => {
@@ -1133,7 +1142,8 @@ export const ProfileForm = ({
   };
 
   const resolveMatchedIdsFromSearchKeyPayload = useCallback((rulesText, payload) => {
-    if (!payload || typeof payload !== 'object') return null;
+    const searchKeyIndexes = getSearchKeyIndexes(payload);
+    if (!searchKeyIndexes) return null;
 
     const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
     if (!parsedRuleGroups.length) return { 1: [] };
@@ -1142,7 +1152,7 @@ export const ProfileForm = ({
     parsedRuleGroups.forEach(parsedRules => {
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
       Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-        const indexNode = payload?.[indexName];
+        const indexNode = searchKeyIndexes?.[indexName];
         if (!indexNode || typeof indexNode !== 'object') return;
         const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
         normalizedValues.forEach(value => {

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -779,6 +779,7 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
     ? [...parsedRules.age].filter(age => Number.isFinite(age) && age >= 18)
     : [];
   const exactBirthDateBuckets = normalizedAges.flatMap(age => getBirthDateBucketsForAge(age));
+  const legacyAgeBuckets = normalizedAges.flatMap(age => [String(age), ageToBucket(age)]);
   const extraBuckets = [];
   if (parsedRules?.age42plus) {
     extraBuckets.push(
@@ -791,7 +792,7 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
   if (parsedRules?.ageNo) {
     extraBuckets.push('no');
   }
-  return uniq([...exactBirthDateBuckets, ...extraBuckets]);
+  return uniq([...exactBirthDateBuckets, ...legacyAgeBuckets, ...extraBuckets]);
 };
 
 export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({


### PR DESCRIPTION
### Motivation
- Make additional-access preview and indexing tolerant of a `searchKey` wrapper in the payload structure returned from the database.
- Ensure age-based search key resolution continues to match legacy bucket formats so older `searchKey` files still resolve correctly.

### Description
- Added a helper `getSearchKeyIndexes` and used it in `src/components/ProfileForm.jsx` to accept either a raw index map or an object containing a `searchKey` field when resolving search-key buckets in `loadAvailableCards`, `getIndexedMatchedUserIdsByInputIndex`, and `resolveMatchedIdsFromSearchKeyPayload`.
- Replaced direct `localSearchKeyPayload` object checks with the normalized `searchKeyIndexes` value to prevent failures when payloads are wrapped.
- Updated `src/utils/additionalAccessRules.js` so `resolveAgeSearchKeyBuckets` emits legacy age buckets (`String(age)` and `ageToBucket(age)`) in addition to birth-date buckets and extras, and added them to the returned set to maintain compatibility with older index formats.

### Testing
- Ran the project test suite with `yarn test` and the tests passed.
- Executed linting with `yarn lint` and static checks passed.
- Built the application with `yarn build` to verify there are no bundling errors and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a97bd9ec8326a4d41b8431c430ee)