### PR TITLE
Restyle smallCard UI: badges, top controls, modals and export button

### DIFF
--- a/src/components/smallCard/btnExport.js
+++ b/src/components/smallCard/btnExport.js
@@ -4,14 +4,28 @@ import { CardMenuBtn } from 'components/styles';
 export const btnExport = userData => (
   <CardMenuBtn
     style={{
-      backgroundColor: 'green',
+      backgroundColor: '#1b5e20',
       position: 'static',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '28px',
+      height: '28px',
+      borderRadius: '8px',
+      padding: 0,
+      fontSize: '10px',
+      color: '#a5d6a7',
     }}
     onClick={e => {
       e.stopPropagation(); // Запобігаємо активації кліку картки
       saveToContact(userData);
     }}
+    aria-label="Зберегти контакт"
+    title="Зберегти контакт"
   >
-    save
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 16l-4-4h2.5V4h3v8H16l-4 4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round"/>
+      <path d="M4 18h16" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+    </svg>
   </CardMenuBtn>
 );

--- a/src/components/smallCard/fieldBirth.js
+++ b/src/components/smallCard/fieldBirth.js
@@ -5,6 +5,6 @@ export const fieldBirth = birth => {
   const age = utilCalculateAge(birth);
 
   return age !== null ? (
-    <AttentionDiv style={{ backgroundColor: 'lightblue' }}>{age}р</AttentionDiv>
+    <AttentionDiv style={{ backgroundColor: 'rgba(41,182,246,0.18)', color: '#81d4fa', border: '1px solid rgba(41,182,246,0.25)' }}>{age}р</AttentionDiv>
   ) : null;
 };

--- a/src/components/smallCard/fieldBlood.js
+++ b/src/components/smallCard/fieldBlood.js
@@ -5,8 +5,9 @@ export const fieldBlood = blood => {
   return (
     <AttentionDiv
       style={{
-        backgroundColor: 'yellow',
-        color: 'black',
+        backgroundColor: 'rgba(229,57,53,0.18)',
+        color: '#ef9a9a',
+        border: '1px solid rgba(229,57,53,0.25)',
       }}
     >
       РК {blood}

--- a/src/components/smallCard/fieldIMT.js
+++ b/src/components/smallCard/fieldIMT.js
@@ -4,6 +4,6 @@ import { utilCalculateIMT } from './utilCalculateIMT';
 export const fieldIMT = (weight, height) => {
   const imt = utilCalculateIMT(weight, height);
   return imt && imt !== 'N/A' ? (
-    <AttentionDiv style={{ backgroundColor: 'purple' }}>{imt}</AttentionDiv>
+    <AttentionDiv style={{ backgroundColor: 'rgba(123,31,162,0.22)', color: '#ce93d8', border: '1px solid rgba(123,31,162,0.3)' }}>{imt}</AttentionDiv>
   ) : null;
 };

--- a/src/components/smallCard/fieldMaritalStatus.js
+++ b/src/components/smallCard/fieldMaritalStatus.js
@@ -17,6 +17,6 @@ export const fieldMaritalStatus = maritalStatus => {
       text = maritalStatus || '';
   }
   return text ? (
-    <AttentionDiv style={{ backgroundColor: 'orange' }}>{text}</AttentionDiv>
+    <AttentionDiv style={{ backgroundColor: 'rgba(255,152,0,0.18)', color: '#ffcc80', border: '1px solid rgba(255,152,0,0.25)' }}>{text}</AttentionDiv>
   ) : null;
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -44,17 +44,17 @@ const topButtonsRowStyle = {
 
 const topButtonsZoneStyle = {
   border: 'none',
-  borderRadius: '12px',
+  borderRadius: '10px',
   cursor: 'pointer',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '40px',
-  height: '40px',
-  flex: '0 0 40px',
+  width: '38px',
+  height: '38px',
+  flex: '0 0 38px',
   padding: 0,
-  boxShadow: '0 6px 14px rgba(17, 24, 39, 0.2)',
-  transition: 'transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.22)',
+  transition: 'transform 0.15s ease, filter 0.15s ease',
 };
 
 const topButtonsZones = ['#d32f2f', '#ef6c00', '#f9a825', '#2e7d32', '#0288d1', '#1565c0', '#6a1b9a'];
@@ -63,12 +63,12 @@ const zoneActionButtonStyle = {
   position: 'static',
   width: '100%',
   height: '100%',
-  minHeight: '40px',
-  borderRadius: '12px',
+  minHeight: '38px',
+  borderRadius: '10px',
   border: 'none',
   margin: 0,
   padding: 0,
-  boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.2)',
+  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.18)',
 };
 
 const actionButtonsContainerStyle = {
@@ -118,7 +118,14 @@ const detailsToggleStyle = {
   right: '10px',
   cursor: 'pointer',
   color: '#ebe0c2',
-  fontSize: '18px',
+  fontSize: '20px',
+  padding: '3px 9px',
+  borderRadius: '6px',
+  border: 'none',
+  background: 'transparent',
+  lineHeight: 1,
+  letterSpacing: '2px',
+  transition: 'background 0.15s, color 0.15s',
 };
 
 const multiCommentStyle = {
@@ -126,14 +133,19 @@ const multiCommentStyle = {
   color: '#f3dfab',
   cursor: 'pointer',
   textDecoration: 'none',
-  fontSize: '60%',
+  fontSize: '11px',
+  lineHeight: 1.4,
+  transition: 'color 0.12s',
 };
 
 const multiCommentRowStyle = {
-  marginTop: '6px',
+  marginTop: '5px',
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   gap: '6px',
+  background: 'rgba(243,223,171,0.06)',
+  borderRadius: '7px',
+  padding: '4px 6px',
 };
 
 const commentAuthorButtonStyle = {
@@ -159,32 +171,38 @@ const commentDeleteButtonStyle = {
 const inlineModalOverlayStyle = {
   position: 'fixed',
   inset: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  backgroundColor: 'rgba(0, 0, 0, 0.62)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   zIndex: 3000,
   padding: '16px',
+  backdropFilter: 'blur(4px)',
+  WebkitBackdropFilter: 'blur(4px)',
 };
 
 const inlineModalCardStyle = {
-  width: 'min(92vw, 560px)',
-  background: '#fff',
-  color: '#111',
-  borderRadius: '12px',
-  padding: '14px',
-  boxShadow: '0 18px 40px rgba(0, 0, 0, 0.35)',
+  width: 'min(92vw, 520px)',
+  background: '#111827',
+  color: '#e8f0fa',
+  borderRadius: '14px',
+  padding: '18px',
+  boxShadow: '0 20px 50px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.07)',
 };
 
 const inlineModalTextareaStyle = {
   width: '100%',
   minHeight: '120px',
-  borderRadius: '8px',
-  border: '1px solid #c7c7c7',
+  borderRadius: '10px',
+  border: '1px solid rgba(255,255,255,0.12)',
+  background: 'rgba(255,255,255,0.05)',
+  color: '#e8f0fa',
   padding: '10px',
   resize: 'vertical',
-  fontSize: '14px',
+  fontSize: '13px',
   boxSizing: 'border-box',
+  outline: 'none',
+  fontFamily: 'inherit',
 };
 
 const inlineModalActionsStyle = {
@@ -536,10 +554,27 @@ const TopBlock = ({
 
   return (
     <div style={topBlockContainerStyle}>
+      <style>{`
+  .top-zone-btn:hover {
+    transform: scale(1.07) translateY(-1px);
+    filter: brightness(1.15);
+  }
+  .top-zone-btn:active {
+    transform: scale(0.94);
+  }
+  .details-toggle:hover {
+    background: rgba(255,255,255,0.12) !important;
+    color: #fff !important;
+  }
+  .multi-comment-text:hover {
+    color: #fff;
+  }
+`}</style>
       <div style={topButtonsRowStyle}>
         {topButtonsZones.map((zoneColor, idx) => (
           <div
             key={`top-zone-${idx}`}
+            className="top-zone-btn"
             aria-label={`top-zone-${idx + 1}`}
             style={{ ...topButtonsZoneStyle, backgroundColor: zoneColor }}
           >
@@ -679,8 +714,8 @@ const TopBlock = ({
                   </svg>
                 )
               ))}
-            {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
-            {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
+            {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff', opacity: 0, pointerEvents: 'none' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
+            {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff', opacity: 0, pointerEvents: 'none' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>
         ))}
       </div>
@@ -749,6 +784,7 @@ const TopBlock = ({
               </svg>
             </button>
             <div
+              className="multi-comment-text"
               style={multiCommentStyle}
               title="Редагувати коментар multiData"
               onClick={event => {
@@ -799,6 +835,17 @@ const TopBlock = ({
             <div style={inlineModalActionsStyle}>
               <button
                 type="button"
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  background: 'transparent',
+                  color: '#8fa8c0',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  fontFamily: 'inherit',
+                }}
                 onClick={() => {
                   setIsCommentModalOpen(false);
                   setSelectedComment(null);
@@ -806,7 +853,22 @@ const TopBlock = ({
               >
                 Скасувати
               </button>
-              <button type="button" onClick={saveMultiComment}>
+              <button
+                type="button"
+                style={{
+                  padding: '8px 18px',
+                  borderRadius: '8px',
+                  border: 'none',
+                  background: 'linear-gradient(135deg, #2e7d32, #388e3c)',
+                  color: '#fff',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 600,
+                  fontFamily: 'inherit',
+                  boxShadow: '0 3px 10px rgba(46,125,50,0.35)',
+                }}
+                onClick={saveMultiComment}
+              >
                 Зберегти
               </button>
             </div>
@@ -832,6 +894,17 @@ const TopBlock = ({
             <div style={inlineModalActionsStyle}>
               <button
                 type="button"
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  background: 'transparent',
+                  color: '#8fa8c0',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  fontFamily: 'inherit',
+                }}
                 onClick={() => {
                   setCommentToDelete(null);
                 }}
@@ -840,6 +913,18 @@ const TopBlock = ({
               </button>
               <button
                 type="button"
+                style={{
+                  padding: '8px 18px',
+                  borderRadius: '8px',
+                  border: 'none',
+                  background: 'linear-gradient(135deg, #b71c1c, #e53935)',
+                  color: '#fff',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 600,
+                  fontFamily: 'inherit',
+                  boxShadow: '0 3px 10px rgba(183,28,28,0.35)',
+                }}
                 onClick={async () => {
                   await handleDeleteComment(commentToDelete);
                   setCommentToDelete(null);
@@ -852,7 +937,9 @@ const TopBlock = ({
         </div>
       )}
 
-      <div
+      <button
+        type="button"
+        className="details-toggle"
         onClick={async e => {
           e.stopPropagation();
           const details = document.getElementById(cardData.userId);
@@ -910,7 +997,7 @@ const TopBlock = ({
         style={detailsToggleStyle}
       >
         ...
-      </div>
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation

- Refresh the visual language of small card components to improve contrast, accessibility and interaction feedback.
- Replace plaintext export control with an icon button and add semantic labels for screen readers.

### Description

- Restyled the export button in `btnExport` to use a compact icon button with updated sizing, colors, `aria-label` and `title` attributes and replaced the `save` text with an inline SVG icon.
- Updated attention badges in `fieldBirth`, `fieldBlood`, `fieldIMT` and `fieldMaritalStatus` to use translucent `rgba(...)` backgrounds, adjusted text colors and added subtle borders for better contrast.
- Overhauled `renderTopBlock` UI: reduced zone sizes, adjusted radii and shadows, tightened transitions, added hover/active CSS (inlined via a `<style>` tag), and improved button/row layout and spacing.
- Improved inline modal visuals and behavior in `renderTopBlock` by adding dark-mode friendly card/textarea styles, new action button styles, backdrop blur, and replacing the details toggle `div` with a semantic `button` including class-based hover styles.
- Hid placeholder action zones (indices 5 and 6) visually by setting `opacity: 0` and `pointerEvents: 'none'`, and added minor structural changes to multi-comment rows and interactive elements for clearer affordances.

### Testing

- Built the project locally with `npm run build` which completed successfully.
- Executed the test suite with `npm test` and ran linting via `npm run lint`, and both completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aef095788326be8d13a665fa07ed)