### PR TITLE
Fix additional access age counter for legacy searchKey bucket formats

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -778,12 +778,23 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
   const normalizedAges = parsedRules?.age
     ? [...parsedRules.age].filter(age => Number.isFinite(age) && age >= 18)
     : [];
+
   const exactBirthDateBuckets = normalizedAges.flatMap(age => getBirthDateBucketsForAge(age));
+
+  // Legacy age index compatibility:
+  // older datasets can be indexed by raw age tokens ("18", "19", ...)
+  // and by grouped buckets ("le21", "22_25", ...), not only by birth-date keys.
+  const legacyAgeBuckets = normalizedAges.map(age => String(age));
+  normalizedAges.forEach(age => {
+    legacyAgeBuckets.push(ageToBucket(age));
+  });
+
   const extraBuckets = [];
   if (parsedRules?.age42plus) {
     extraBuckets.push(
       ...Array.from({ length: 70 }, (_, idx) => idx + 42).flatMap(age => getBirthDateBucketsForAge(age))
     );
+    extraBuckets.push('42_plus', '43_plus');
   }
   if (parsedRules?.ageUnknown) {
     extraBuckets.push('?');
@@ -791,7 +802,8 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
   if (parsedRules?.ageNo) {
     extraBuckets.push('no');
   }
-  return uniq([...exactBirthDateBuckets, ...extraBuckets]);
+
+  return uniq([...exactBirthDateBuckets, ...legacyAgeBuckets, ...extraBuckets]);
 };
 
 export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({


### PR DESCRIPTION
### Motivation
- The available-cards preview counter could show `0` when `searchKeySets.age` used legacy formats instead of date-based buckets, because the resolver only generated `d_YYYY-MM-DD` keys for ages. 
- The change aims to make frontend preview matching compatible with older index formats so existing records are counted correctly.

### Description
- Updated `resolveAgeSearchKeyBuckets` in `src/utils/additionalAccessRules.js` to include legacy age tokens by adding raw age strings and grouped buckets generated via `ageToBucket` to the search key list. 
- When `age42plus` is set, the resolver now also includes `42_plus` and `43_plus` compatibility tokens in addition to the date-based buckets. 
- The final return value now unions `exactBirthDateBuckets`, legacy age buckets, and extra buckets and de-duplicates them with `uniq` so all index formats are considered.

### Testing
- Ran the test runner with `npm test -- --watch=false --runInBand`, which executed successfully but reported "No tests found related to files changed since last commit." 
- No new unit tests were added in this change and existing test coverage did not need modification for the index-compatibility fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b639ce28832687f146913bc2229c)