### PR TITLE
Restore per-filter intersection when preindexing matched additional-access IDs

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -607,35 +607,59 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
 };
 
 const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
-  const bucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
-  const paths = Object.entries(bucketMap || {}).flatMap(([indexName, rawValues]) => {
-    const normalizedIndexName = normalizePathSegment(indexName);
-    if (!normalizedIndexName) return [];
+  const groups = Array.isArray(parsedRuleGroups) ? parsedRuleGroups : [parsedRuleGroups];
+  const matchedIds = new Set();
 
-    const values = [
-      ...new Set(
-        (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
-          .map(normalizePathSegment)
-          .filter(Boolean)
-      ),
-    ];
-    return values.map(value => `searchKey/${normalizedIndexName}/${value}`);
-  });
+  for (const parsedRules of groups) {
+    const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
+    const activeSources = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
+      const normalizedIndexName = normalizePathSegment(indexName);
+      if (!normalizedIndexName) return acc;
 
-  if (!paths.length) return [];
+      const values = [
+        ...new Set(
+          (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
+            .map(normalizePathSegment)
+            .filter(Boolean)
+        ),
+      ];
+      if (!values.length) return acc;
 
-  const snapshots = await Promise.all(
-    paths.map(path => Promise.resolve(peekCachedSearchKeyPayload(path)))
-  );
+      acc.push({ indexName: normalizedIndexName, values });
+      return acc;
+    }, []);
 
-  const ids = new Set();
-  snapshots.forEach(payload => {
-    if (!payload?.exists || !payload.value || typeof payload.value !== 'object') return;
-    Object.keys(payload.value).forEach(userId => {
-      if (userId) ids.add(userId);
-    });
-  });
-  return [...ids];
+    if (!activeSources.length) continue;
+
+    // eslint-disable-next-line no-await-in-loop
+    const sourceIdSets = await Promise.all(
+      activeSources.map(async ({ indexName, values }) => {
+        const paths = values.map(value => `searchKey/${indexName}/${value}`);
+        const payloads = await Promise.all(
+          paths.map(path => Promise.resolve(peekCachedSearchKeyPayload(path)))
+        );
+
+        const idsBySource = new Set();
+        payloads.forEach(payload => {
+          if (!payload?.exists || !payload.value || typeof payload.value !== 'object') return;
+          Object.keys(payload.value).forEach(userId => {
+            if (userId) idsBySource.add(userId);
+          });
+        });
+        return idsBySource;
+      })
+    );
+
+    const normalizedSets = sourceIdSets.filter(set => set instanceof Set);
+    if (!normalizedSets.length || normalizedSets.some(set => set.size === 0)) continue;
+
+    const [firstSet, ...restSets] = normalizedSets;
+    [...firstSet]
+      .filter(userId => restSets.every(set => set.has(userId)))
+      .forEach(userId => matchedIds.add(userId));
+  }
+
+  return [...matchedIds];
 };
 
 export const rebuildAllNewUsersFilterSetIndexes = async () => {


### PR DESCRIPTION
### Motivation
- Preindexing of additional-access rule sets previously merged all searchKey buckets and unioned IDs, which converted combined filters from AND to OR and allowed users who matched only a subset of filters to be persisted.
- The change restores correct semantics so that combined filters (within a rule) require matching all active sources before being included in preindexed sets.

### Description
- Rewrote `getMatchedUserIdsFromSearchKey` in `src/utils/newUsersFilterSetsIndex.js` to iterate parsed rule groups and handle each group independently.
- For each group the code now resolves buckets with `resolveAdditionalAccessSearchKeyBuckets`, fetches payloads per source, unions IDs within a source, and intersects IDs across active sources to preserve AND semantics.
- Matched IDs from each rule group are then unioned into the final result to preserve OR semantics across groups, and the function returns an array of unique IDs.
- This aligns the preindexing logic with the runtime lookup behavior in `fetchAdditionalNewUsersBySearchIndex` and prevents partial matches from entering `searchKeySets`.

### Testing
- Ran `npm run -s lint`, which exited with code 1 so linting failed in this environment and needs follow-up.
- Ran `npm run -s` which completed with exit code 0 in this environment, but no unit tests were executed or reported here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f437c894188326a2d834b07ff26243)