### PR TITLE
Normalize wrapped searchKey payload before indexing

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -138,6 +138,14 @@ const HIDDEN_FOR_CL_PP_FIELDS = new Set([
   ...MEDICAL_LIFESTYLE_FIELDS,
 ]);
 const SEARCH_KEY_ROOT = 'searchKey';
+const normalizeSearchKeyPayload = payload => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const wrappedPayload = payload?.[SEARCH_KEY_ROOT];
+  if (wrappedPayload && typeof wrappedPayload === 'object' && !Array.isArray(wrappedPayload)) {
+    return wrappedPayload;
+  }
+  return payload;
+};
 const ADDITIONAL_RULE_LABELS = {
   age: 'Вік',
   csection: 'КС',
@@ -1155,7 +1163,8 @@ export const ProfileForm = ({
   };
 
   const resolveMatchedIdsFromSearchKeyPayload = useCallback((rulesText, payload) => {
-    if (!payload || typeof payload !== 'object') return null;
+    const normalizedPayload = normalizeSearchKeyPayload(payload);
+    if (!normalizedPayload) return null;
 
     const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
     if (!parsedRuleGroups.length) return { 1: [] };
@@ -1164,7 +1173,7 @@ export const ProfileForm = ({
     parsedRuleGroups.forEach(parsedRules => {
       const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
       Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
-        const indexNode = payload?.[indexName];
+        const indexNode = normalizedPayload?.[indexName];
         if (!indexNode || typeof indexNode !== 'object') return;
         const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
         normalizedValues.forEach(value => {
@@ -1245,8 +1254,9 @@ export const ProfileForm = ({
     try {
       const raw = await file.text();
       const parsed = JSON.parse(raw);
-      setLocalSearchKeyPayload(parsed);
-      const matchedByInputIndex = resolveMatchedIdsFromSearchKeyPayload(pendingRulesToApply, parsed);
+      const normalizedPayload = normalizeSearchKeyPayload(parsed);
+      setLocalSearchKeyPayload(normalizedPayload);
+      const matchedByInputIndex = resolveMatchedIdsFromSearchKeyPayload(pendingRulesToApply, normalizedPayload);
       if (!matchedByInputIndex) {
         toast.error('Некоректний файл searchKey.');
         return;


### PR DESCRIPTION
### Motivation
- Fix a regression where uploaded `{ searchKey: ... }` wrapped JSON files were accepted for matching but the unnormalized object was still passed to downstream indexing, causing empty bucket writes and corrupt/empty `searchKeySets`.

### Description
- Add `normalizeSearchKeyPayload` helper to unwrap payloads in the `{ searchKey: ... }` shape and return the root bucket map or `null` for invalid payloads in `src/components/ProfileForm.jsx`.
- Update `resolveMatchedIdsFromSearchKeyPayload` to validate and read from the normalized payload instead of the raw input so bucket lookups target the expected top-level index nodes.
- Normalize the parsed file in `handleSearchKeyFileSelected` before calling `setLocalSearchKeyPayload` and before resolving matches so later indexing (`buildNewUsersFilterSetIndex`) receives the correct shape.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f437cd7c848326ade843331935583a)