### PR TITLE
Remove legacy '42_plus' and '43_plus' age bucket tokens from age bucket resolution

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -794,7 +794,6 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
     extraBuckets.push(
       ...Array.from({ length: 70 }, (_, idx) => idx + 42).flatMap(age => getBirthDateBucketsForAge(age))
     );
-    extraBuckets.push('42_plus', '43_plus');
   }
   if (parsedRules?.ageUnknown) {
     extraBuckets.push('?');


### PR DESCRIPTION
### Motivation
- Stop emitting legacy string tokens `"42_plus"` and `"43_plus"` from age bucket resolution in favor of explicit birth-date buckets to avoid incorrect/duplicate indexing.

### Description
- Remove the line that pushed `"42_plus"` and `"43_plus"` into `extraBuckets` inside `resolveAgeSearchKeyBuckets` in `src/utils/additionalAccessRules.js` so only computed birth-date buckets and other legacy tokens are returned.

### Testing
- Ran the project test suite with `yarn test` and linting, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f437b5e3bc8326aa528a14a96bab15)