### PR TITLE
Treat availableCardsCount as unknown when searchKey missing and fix active additional rules draft selection

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -626,7 +626,7 @@ export const ProfileForm = ({
   const [activeAdditionalRuleInputIndex, setActiveAdditionalRuleInputIndex] = useState(0);
   const [additionalRuleBuilder, setAdditionalRuleBuilder] = useState([]);
   const [previewAdditionalRulesText, setPreviewAdditionalRulesText] = useState('');
-  const [availableCardsCount, setAvailableCardsCount] = useState(0);
+  const [availableCardsCount, setAvailableCardsCount] = useState(null);
   const [isLoadingAvailableCards, setIsLoadingAvailableCards] = useState(false);
   const [isIndexingAdditionalRules, setIsIndexingAdditionalRules] = useState(false);
   const [showSearchKeySourceModal, setShowSearchKeySourceModal] = useState(false);
@@ -657,7 +657,7 @@ export const ProfileForm = ({
   const activeAdditionalRulesDraftText = useMemo(() => {
     const activeInputValue = String(additionalRulesInputs[activeAdditionalRuleInputIndex] || '');
     if (!activeInputValue.trim()) return additionalRulesDraftText;
-    return additionalRulesDraftText || activeInputValue;
+    return activeInputValue;
   }, [activeAdditionalRuleInputIndex, additionalRulesDraftText, additionalRulesInputs]);
   useEffect(() => {
     if (state?.userId) return;
@@ -703,7 +703,7 @@ export const ProfileForm = ({
       }
 
       if (!localSearchKeyPayload || typeof localSearchKeyPayload !== 'object') {
-        setAvailableCardsCount(0);
+        setAvailableCardsCount(null);
         return;
       }
 
@@ -741,7 +741,7 @@ export const ProfileForm = ({
         if (!cancelled) setAvailableCardsCount(userIds.length);
       } catch (error) {
         console.error('Failed to build additional access preview', error);
-        if (!cancelled) setAvailableCardsCount(0);
+        if (!cancelled) setAvailableCardsCount(null);
       } finally {
         if (!cancelled) setIsLoadingAvailableCards(false);
       }
@@ -2457,7 +2457,9 @@ ${entries.join('\n')}`;
               onChange={handleCombinedAdditionalRulesChange}
             />
             <AdditionalCardsTitle>
-              Доступні карточки для активного набору ({availableCardsCount}) {isLoadingAvailableCards ? '...завантаження' : ''}
+              {availableCardsCount === null
+                ? 'Доступні карточки для активного набору: завантажте локальний файл searchKey'
+                : `Доступні карточки для активного набору (${availableCardsCount})`} {isLoadingAvailableCards ? '...завантаження' : ''}
             </AdditionalCardsTitle>
           </AdditionalRulesModal>
         </AdditionalRulesOverlay>


### PR DESCRIPTION
### Motivation
- Improve UX by distinguishing an unknown available-cards state from a zero count when the local `searchKey` payload is not loaded or an error occurs.
- Prevent misleading display of `0` available cards while the data source is absent or failed to load.
- Ensure the active additional rules editor uses the currently selected input value consistently when previewing rules.

### Description
- Initialize `availableCardsCount` to `null` instead of `0` and set it to `null` when `localSearchKeyPayload` is missing or on errors during preview generation.
- Replace `return additionalRulesDraftText || activeInputValue;` with `return activeInputValue;` in `activeAdditionalRulesDraftText` to prefer the active input value.
- Update the `AdditionalCardsTitle` rendering to show a prompt to load a local `searchKey` when `availableCardsCount === null`, otherwise display the count.
- Preserve existing caching, loading indicator, and preview-building logic while making the count semantics explicit.

### Testing
- Ran unit tests with `yarn test` (Jest) and all tests passed.
- Ran static checks with `yarn lint` and no lint errors were reported.
- Performed an app build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f441d338648326986a040c0f763e87)