### PR TITLE
Improve Additional Access Rules modal clarity and mobile visibility

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2435,20 +2435,22 @@ ${entries.join('\n')}`;
 
             <AdditionalRuleActions>
               <button type="button" onClick={addEmptyAdditionalFilter}>+ Фільтр</button>
-              <button type="button" onClick={applyAdditionalRulesFromBuilder}>Застосувати</button>
+              <button type="button" onClick={applyAdditionalRulesFromBuilder}>
+                Оновити правила / підвантажити SearchKey
+              </button>
               <button
                 type="button"
                 onClick={indexAdditionalRulesFromBuilder}
                 disabled={isIndexingAdditionalRules}
               >
-                {isIndexingAdditionalRules ? 'Індексація...' : 'Індексувати'}
+                {isIndexingAdditionalRules ? 'Оновлення індексів...' : 'Оновити індекси'}
               </button>
               <button
                 type="button"
                 onClick={saveAdditionalRulesToSearchKeySets}
                 disabled={isIndexingAdditionalRules}
               >
-                {isIndexingAdditionalRules ? 'Збереження...' : 'Зберегти'}
+                {isIndexingAdditionalRules ? 'Збереження...' : 'Зберегти набір у searchKeySets'}
               </button>
             </AdditionalRuleActions>
 
@@ -2460,6 +2462,11 @@ ${entries.join('\n')}`;
               {availableCardsCount === null
                 ? 'Доступні карточки для активного набору: завантажте локальний файл searchKey'
                 : `Доступні карточки для активного набору (${availableCardsCount})`} {isLoadingAvailableCards ? '...завантаження' : ''}
+            </AdditionalCardsTitle>
+            <AdditionalCardsTitle>
+              {localSearchKeyPayload && typeof localSearchKeyPayload === 'object'
+                ? 'Локальний searchKey: файл підвантажено ✅'
+                : 'Локальний searchKey: файл ще не підвантажено'}
             </AdditionalCardsTitle>
           </AdditionalRulesModal>
         </AdditionalRulesOverlay>
@@ -2741,7 +2748,7 @@ const AdditionalRulesModal = styled.div`
   color: #e8f0fa;
   width: min(720px, 100vw);
   height: 100vh;
-  padding: 20px 16px 32px;
+  padding: 20px 16px calc(32px + env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   overflow-x: hidden;
   position: relative;


### PR DESCRIPTION
### Motivation
- Prevent the bottom information in the "Additional Access Rules" modal from being hidden by mobile system navigation bars by making the modal safe-area aware.
- Make it explicit when a local `searchKey` payload is loaded so admins do not have to re-upload or guess its state.
- Clarify button labels to better match the actual actions (apply/download/index/save) and reduce ambiguity between indexing and saving.
- Preserve the existing reactive behavior that recalculates the "Available cards for active set (N)" preview when rule checkboxes change.

### Description
- Added safe-area aware bottom padding to the additional rules modal (`padding: 20px 16px calc(32px + env(safe-area-inset-bottom, 0px))`) to avoid UI being covered on phones (file: `src/components/ProfileForm.jsx`).
- Inserted an explicit local searchKey status row displaying whether a local `searchKey` file is loaded or not (file: `src/components/ProfileForm.jsx`).
- Updated action button labels in the modal to clearer text: `Застосувати` → `Оновити правила / підвантажити SearchKey`, `Індексувати` → `Оновити індекси`, and `Зберегти` → `Зберегти набір у searchKeySets` (file: `src/components/ProfileForm.jsx`).
- No behavioral changes to the preview/counting logic were introduced; the existing reactive computation that updates `availableCardsCount` when rule inputs change remains intact (file: `src/components/ProfileForm.jsx`).

### Testing
- Ran `npm test -- --watch=false --runInBand src/utils/__tests__/cycleStatus.test.js` and the suite passed (1 suite, 3 tests).
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46ca3e5b483268ca484015cc8f4c7)