### PR TITLE
Resolve blood-group buckets from generic rules and add Ukrainian alias

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -156,6 +156,7 @@ const ADDITIONAL_ACCESS_KEY_ALIASES = {
   age: 'age',
   blood: 'blood',
   кров: 'bloodGroup',
+  'групакрові': 'bloodGroup',
   bloodgroup: 'bloodGroup',
   rh: 'rh',
   'резус': 'rh',
@@ -732,6 +733,62 @@ const resolveBloodSearchKeyBuckets = parsedRules => {
   return uniq(buckets);
 };
 
+const resolveBloodBucketsFromGenericRules = parsedRules => {
+  const generic = parsedRules?.generic;
+  if (!generic || typeof generic !== 'object') return [];
+
+  const rhSet = generic.rh instanceof Set ? generic.rh : new Set();
+  const bloodGroupSet = generic.bloodGroup instanceof Set ? generic.bloodGroup : new Set();
+  if (rhSet.size === 0 && bloodGroupSet.size === 0) return [];
+
+  const normalizedRh = [...rhSet].map(item => String(item || '').trim().toLowerCase());
+  const normalizedGroups = [...bloodGroupSet].map(item => String(item || '').trim().toLowerCase());
+
+  const hasRhPlus = normalizedRh.includes('+');
+  const hasRhMinus = normalizedRh.includes('-');
+  const hasRhUnknown = normalizedRh.includes('?');
+  const hasRhNo = normalizedRh.includes('no');
+  const selectedGroups = normalizedGroups.filter(group => /^[1-4]$/.test(group));
+  const hasGroupUnknown = normalizedGroups.includes('?');
+  const hasGroupNo = normalizedGroups.includes('no');
+
+  const buckets = [];
+  const groupsForRh = selectedGroups.length ? selectedGroups : ALL_BLOOD_GROUPS;
+  if (hasRhPlus) {
+    groupsForRh.forEach(group => buckets.push(`${group}+`));
+    if (!selectedGroups.length || hasGroupUnknown) buckets.push('+');
+  }
+  if (hasRhMinus) {
+    groupsForRh.forEach(group => buckets.push(`${group}-`));
+    if (!selectedGroups.length || hasGroupUnknown) buckets.push('-');
+  }
+
+  if ((hasRhPlus || hasRhMinus) && hasGroupNo) {
+    buckets.push('no');
+  }
+
+  if (selectedGroups.length) {
+    const includeGroupOnly = rhSet.size === 0 || hasRhNo || hasRhUnknown;
+    if (includeGroupOnly) buckets.push(...selectedGroups);
+  }
+
+  if (hasGroupUnknown) {
+    if (hasRhPlus) buckets.push('+');
+    if (hasRhMinus) buckets.push('-');
+    if (hasRhUnknown || rhSet.size === 0) buckets.push('?');
+  }
+
+  if (hasRhUnknown && (selectedGroups.length === 0 || hasGroupUnknown)) {
+    buckets.push('?');
+  }
+
+  if (hasRhNo && (selectedGroups.length === 0 || hasGroupNo)) {
+    buckets.push('no');
+  }
+
+  return uniq(buckets);
+};
+
 const resolveMaritalStatusSearchKeyBuckets = parsedRules => {
   if (!parsedRules?.maritalStatus) return [];
 
@@ -806,7 +863,7 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
 };
 
 export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({
-  blood: resolveBloodSearchKeyBuckets(parsedRules),
+  blood: uniq([...resolveBloodSearchKeyBuckets(parsedRules), ...resolveBloodBucketsFromGenericRules(parsedRules)]),
   maritalStatus: resolveMaritalStatusSearchKeyBuckets(parsedRules),
   csection: resolveCsectionSearchKeyBuckets(parsedRules),
   age: resolveAgeSearchKeyBuckets(parsedRules),


### PR DESCRIPTION
### Motivation
- Ensure blood-related search buckets are derived when blood criteria are provided under the generic rule namespace to improve matching of search queries.
- Add a Ukrainian alias for blood group keys to support localized input.

### Description
- Added Ukrainian alias `'групакрові'` mapping to `bloodGroup` in `ADDITIONAL_ACCESS_KEY_ALIASES` in `src/utils/additionalAccessRules.js`.
- Implemented `resolveBloodBucketsFromGenericRules(parsedRules)` to compute blood/rh buckets from `parsedRules.generic.bloodGroup` and `parsedRules.generic.rh` with normalization and comprehensive bucket logic.
- Merged the new resolver into `resolveAdditionalAccessSearchKeyBuckets` so `blood` buckets include both explicit blood rules and generic-derived buckets using `uniq`.

### Testing
- Ran the project test suite with `yarn test`, and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b247e7508326bcc0167fa300d075)