### PR TITLE
Auto-refresh available cards preview when additional filter checkboxes change

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -679,9 +679,12 @@ export const ProfileForm = ({
   useEffect(() => {
     if (!showAdditionalRulesModal) return;
 
-    const effectiveRulesText = activeAdditionalRulesDraftText.trim()
-      ? activeAdditionalRulesDraftText
-      : previewAdditionalRulesText;
+    const builderRulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder);
+    const effectiveRulesText = builderRulesText.trim()
+      ? builderRulesText
+      : activeAdditionalRulesDraftText.trim()
+        ? activeAdditionalRulesDraftText
+        : previewAdditionalRulesText;
 
     let cancelled = false;
     const loadAvailableCards = async () => {
@@ -757,6 +760,7 @@ export const ProfileForm = ({
     showAdditionalRulesModal,
     state?.userId,
     localSearchKeyPayload,
+    additionalRuleBuilder,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure the "Доступні карточки для активного набору (N)" preview updates immediately when toggling additional-rule checkboxes, removing the need to press "Оновити індекси" to see the new count.

### Description
- Update `src/components/ProfileForm.jsx` so the preview uses builder-derived rules by computing `builderRulesText = buildAdditionalRulesTextFromBuilder(additionalRuleBuilder)` and choosing it as the primary `effectiveRulesText` before falling back to existing drafts.
- Add `additionalRuleBuilder` to the dependency list of the preview `useEffect` so checkbox changes trigger recalculation automatically.

### Testing
- Ran `npm run -s test -- --watchAll=false`; test run completed with 16 suites where 15 passed and 1 failed; the failures are 2 assertions in `src/utils/__tests__/parseUkTrigger.test.js` and are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5055a2f348326b40bd2fc6ae11fef)