### PR TITLE
Normalize IMT additional-access tokens for searchKeySets

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -789,6 +789,49 @@ const resolveBloodBucketsFromGenericRules = parsedRules => {
   return uniq(buckets);
 };
 
+
+const resolveImtSearchKeyBucketsFromGenericRules = parsedRules => {
+  const generic = parsedRules?.generic;
+  if (!generic || typeof generic !== 'object' || !(generic.imt instanceof Set)) return [];
+
+  const buckets = new Set();
+
+  const addBucketByNumber = value => {
+    if (!Number.isFinite(value) || value <= 0) return;
+    const rounded = Math.round(value);
+    if (rounded <= 28) buckets.add('le28');
+    else if (rounded <= 31) buckets.add('29_31');
+    else if (rounded <= 35) buckets.add('32_35');
+    else buckets.add('36_plus');
+  };
+
+  [...generic.imt].forEach(rawToken => {
+    const token = String(rawToken || '').trim().toLowerCase();
+    if (!token) return;
+
+    if (['le28', '29_31', '32_35', '36_plus', '?', 'no'].includes(token)) {
+      buckets.add(token);
+      return;
+    }
+
+    const rangeMatch = token.match(/^(\d+(?:[.,]\d+)?)\s*[_-]\s*(\d+(?:[.,]\d+)?)$/);
+    if (rangeMatch) {
+      const start = Number.parseFloat(rangeMatch[1].replace(',', '.'));
+      const end = Number.parseFloat(rangeMatch[2].replace(',', '.'));
+      if (Number.isFinite(start) && Number.isFinite(end)) {
+        addBucketByNumber(Math.min(start, end));
+        addBucketByNumber(Math.max(start, end));
+      }
+      return;
+    }
+
+    const numeric = Number.parseFloat(token.replace(',', '.'));
+    addBucketByNumber(numeric);
+  });
+
+  return uniq([...buckets]);
+};
+
 const resolveMaritalStatusSearchKeyBuckets = parsedRules => {
   if (!parsedRules?.maritalStatus) return [];
 
@@ -868,6 +911,7 @@ export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({
   csection: resolveCsectionSearchKeyBuckets(parsedRules),
   age: resolveAgeSearchKeyBuckets(parsedRules),
   ...(parsedRules?.generic || {}),
+  imt: resolveImtSearchKeyBucketsFromGenericRules(parsedRules),
 });
 
 export const createAllFalseFilterGroup = keys =>


### PR DESCRIPTION
### Motivation
- Ensure IMT-based additional access rules can participate in the SearchKey prefiltering step by converting generic IMT tokens into the same index buckets used by the searchKey index.
- Preserve IMT as a derived metric (from `weight`/`height` or explicit `imt`) while enabling additional-access rule tokens to match existing `searchKeySets` indexes.

### Description
- Added `resolveImtSearchKeyBucketsFromGenericRules` which normalizes generic `imt` rule tokens into search-key buckets (`le28`, `29_31`, `32_35`, `36_plus`) and preserves `?`/`no` tokens.
- The new resolver accepts numeric tokens, decimal values (comma or dot), and numeric ranges, mapping them to corresponding IMT buckets.
- Wired the IMT resolver into `resolveAdditionalAccessSearchKeyBuckets` so `imt` is included in the returned bucket map used to build `searchKeySets`.

### Testing
- Ran linter on the changed file with `npx --yes eslint src/utils/additionalAccessRules.js`, which completed successfully.
- Ran the project script `npm run -s eslint -- src/utils/additionalAccessRules.js`, which returned a non-zero exit code in this environment (no output); the `npx` invocation above was used for validation instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50ee43b548326bd37fe46f9f3c591)