### PR TITLE
Add height and weight bucket resolution from generic rules

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -832,6 +832,60 @@ const resolveImtSearchKeyBucketsFromGenericRules = parsedRules => {
   return uniq([...buckets]);
 };
 
+const resolveMetricSearchKeyBucketsFromGenericRules = (parsedRules, key) => {
+  const generic = parsedRules?.generic;
+  const rawSet = generic?.[key];
+  if (!generic || typeof generic !== 'object' || !(rawSet instanceof Set)) return [];
+
+  const buckets = new Set();
+
+  const addBucketByNumber = value => {
+    if (!Number.isFinite(value) || value <= 0) return;
+    if (key === 'height') {
+      if (value < 163) buckets.add('lt163');
+      else if (value <= 176) buckets.add('163_176');
+      else if (value <= 180) buckets.add('177_180');
+      else buckets.add('181_plus');
+      return;
+    }
+
+    if (value < 55) buckets.add('lt55');
+    else if (value <= 69) buckets.add('55_69');
+    else if (value <= 84) buckets.add('70_84');
+    else buckets.add('85_plus');
+  };
+
+  const allowed = key === 'height'
+    ? ['lt163', '163_176', '177_180', '181_plus', '?', 'no']
+    : ['lt55', '55_69', '70_84', '85_plus', '?', 'no'];
+
+  [...rawSet].forEach(rawToken => {
+    const token = String(rawToken || '').trim().toLowerCase();
+    if (!token) return;
+
+    if (allowed.includes(token)) {
+      buckets.add(token);
+      return;
+    }
+
+    const rangeMatch = token.match(/^(\d+(?:[.,]\d+)?)\s*[_-]\s*(\d+(?:[.,]\d+)?)$/);
+    if (rangeMatch) {
+      const start = Number.parseFloat(rangeMatch[1].replace(',', '.'));
+      const end = Number.parseFloat(rangeMatch[2].replace(',', '.'));
+      if (Number.isFinite(start) && Number.isFinite(end)) {
+        addBucketByNumber(Math.min(start, end));
+        addBucketByNumber(Math.max(start, end));
+      }
+      return;
+    }
+
+    const numeric = Number.parseFloat(token.replace(',', '.'));
+    addBucketByNumber(numeric);
+  });
+
+  return uniq([...buckets]);
+};
+
 const resolveMaritalStatusSearchKeyBuckets = parsedRules => {
   if (!parsedRules?.maritalStatus) return [];
 
@@ -912,6 +966,8 @@ export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({
   age: resolveAgeSearchKeyBuckets(parsedRules),
   ...(parsedRules?.generic || {}),
   imt: resolveImtSearchKeyBucketsFromGenericRules(parsedRules),
+  height: resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, 'height'),
+  weight: resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, 'weight'),
 });
 
 export const createAllFalseFilterGroup = keys =>


### PR DESCRIPTION
### Motivation
- Enable parsing of `height` and `weight` entries from the `generic` rules set into the same kind of bucket tokens used elsewhere. 
- Support numeric tokens, ranges, and explicit bucket tokens (including unknown/empty markers) for these metrics. 

### Description
- Added `resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, key)` to parse `generic[key]` (expects a `Set`) into metric buckets for `height` and `weight` using numeric values, ranges, and explicit tokens. 
- Implemented metric-specific bucket thresholds and labels for `height` (`lt163`, `163_176`, `177_180`, `181_plus`) and `weight` (`lt55`, `55_69`, `70_84`, `85_plus`), and preserved `?` and `no` tokens. 
- Handles range expressions like `160-170` or `160_170`, decimal numbers with commas, and ignores non-finite or non-positive numbers. 
- Wired the new resolver into `resolveAdditionalAccessSearchKeyBuckets` under the `height` and `weight` keys. 

### Testing
- Ran the project test suite with `yarn test` and the changes did not introduce failures. 
- Ran targeted tests for `additionalAccessRules` utilities with `yarn test src/utils/additionalAccessRules.test.js` and they passed. 
- Verified basic parsing scenarios for single numbers, ranges, explicit bucket tokens, and malformed inputs via unit tests, all succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5aa3fb23883269c6bfa8261784a16)