### PR TITLE
Normalize additional rule keys and include metric buckets for IMT/BMI filters

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -223,6 +223,15 @@ const ADDITIONAL_RULE_OPTION_DESCRIPTIONS = {
   },
 };
 
+const normalizeAdditionalRuleKey = rawKey => {
+  const normalized = String(rawKey || '').trim().toLowerCase();
+  if (!normalized) return '';
+
+  if (normalized === 'імт' || normalized === 'imt' || normalized === 'bmi') return 'imt';
+  if (normalized === 'blood' || normalized === 'bloodgroup') return 'bloodGroup';
+  return normalized;
+};
+
 const parseAdditionalRulesTextToBuilder = raw => {
   const lines = String(raw || '')
     .split(/\r?\n/)
@@ -233,7 +242,7 @@ const parseAdditionalRulesTextToBuilder = raw => {
     .map(line => {
       const [keyRaw, ...rest] = line.split(':');
       if (!keyRaw || rest.length === 0) return null;
-      const key = keyRaw.trim();
+      const key = normalizeAdditionalRuleKey(keyRaw);
       const rawTokens = rest
         .join(':')
         .split(',')
@@ -263,14 +272,20 @@ const parseAdditionalRulesTextToBuilder = raw => {
       }
       return { key, allowedValues };
     })
-    .filter(Boolean);
+    .filter(rule => Boolean(rule?.key));
 };
 
 const buildAdditionalRulesTextFromBuilder = rules =>
   rules
-    .filter(rule => rule?.key && rule.allowedValues instanceof Set && rule.allowedValues.size > 0)
+    .filter(rule => {
+      const normalizedKey = normalizeAdditionalRuleKey(rule?.key);
+      if (!normalizedKey) return false;
+      if (!Object.prototype.hasOwnProperty.call(ADDITIONAL_ACCESS_FILTER_OPTIONS, normalizedKey)) return false;
+      return rule.allowedValues instanceof Set && rule.allowedValues.size > 0;
+    })
     .map(rule => {
-      if (rule.key !== 'age') return `${rule.key}: ${[...rule.allowedValues].join(',')}`;
+      const normalizedKey = normalizeAdditionalRuleKey(rule.key);
+      if (normalizedKey !== 'age') return `${normalizedKey}: ${[...rule.allowedValues].join(',')}`;
 
       const selected = rule.allowedValues;
       const numericAges = new Set();
@@ -285,7 +300,7 @@ const buildAdditionalRulesTextFromBuilder = rules =>
       if (selected.has('42_plus')) tokens.push('42_plus');
       if (selected.has('?')) tokens.push('?');
       if (selected.has('no')) tokens.push('no');
-      return `${rule.key}: ${tokens.join(',')}`;
+      return `${normalizedKey}: ${tokens.join(',')}`;
     })
     .join('\n');
 

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -201,6 +201,23 @@ const buildSanitizedBucketUsersMap = ({ searchKeyFile, indexName, values, allowe
   }, {});
 };
 
+const buildMetricBucketsForAllowedUsers = ({ searchKeyFile, indexName, allowedUserIds }) => {
+  const normalizedAllowedIds = new Set((Array.isArray(allowedUserIds) ? allowedUserIds : []).filter(Boolean));
+  if (!searchKeyFile || normalizedAllowedIds.size === 0) return {};
+
+  const indexNode = searchKeyFile?.[indexName];
+  if (!indexNode || typeof indexNode !== 'object') return {};
+
+  return Object.entries(indexNode).reduce((acc, [bucketValue, usersMap]) => {
+    if (!usersMap || typeof usersMap !== 'object') return acc;
+    const filteredUserIds = Object.keys(usersMap).filter(userId => normalizedAllowedIds.has(userId));
+    if (filteredUserIds.length > 0) {
+      acc[bucketValue] = filteredUserIds;
+    }
+    return acc;
+  }, {});
+};
+
 const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyFile = null }) => {
   const normalizedRootPath = String(rootPath || '').trim();
   if (!normalizedRootPath) return {};
@@ -208,10 +225,16 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
 
   const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
   const bucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
+  const hasImtFilter = (() => {
+    const imtValues = bucketMap?.imt;
+    if (imtValues instanceof Set) return imtValues.size > 0;
+    if (Array.isArray(imtValues)) return imtValues.length > 0;
+    return false;
+  })();
 
-  return Object.entries(bucketMap || {}).reduce((writes, [indexName, rawValues]) => {
+  const writes = Object.entries(bucketMap || {}).reduce((accWrites, [indexName, rawValues]) => {
     const normalizedIndexName = normalizePathSegment(indexName);
-    if (!normalizedIndexName) return writes;
+    if (!normalizedIndexName) return accWrites;
 
     if (normalizedIndexName === 'age') {
       const allowedAgeValues = (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
@@ -225,12 +248,12 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
       });
       Object.entries(sanitized).forEach(([ageValue, targetUserIds]) => {
         const path = `${normalizedRootPath}/${normalizedIndexName}/${ageValue}`;
-        writes[path] = targetUserIds.reduce((acc, userId) => {
-          acc[userId] = true;
-          return acc;
+        accWrites[path] = targetUserIds.reduce((result, userId) => {
+          result[userId] = true;
+          return result;
         }, {});
       });
-      return writes;
+      return accWrites;
     }
 
     const values = [
@@ -240,7 +263,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
           .filter(Boolean)
       ),
     ];
-    if (!values.length) return writes;
+    if (!values.length) return accWrites;
 
     const sanitized = buildSanitizedBucketUsersMap({
       searchKeyFile,
@@ -250,13 +273,32 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     });
     Object.entries(sanitized).forEach(([value, targetUserIds]) => {
       const path = `${normalizedRootPath}/${normalizedIndexName}/${value}`;
-      writes[path] = targetUserIds.reduce((acc, userId) => {
-        acc[userId] = true;
-        return acc;
+      accWrites[path] = targetUserIds.reduce((result, userId) => {
+        result[userId] = true;
+        return result;
       }, {});
     });
-    return writes;
+    return accWrites;
   }, {});
+
+  if (hasImtFilter) {
+    ['height', 'weight'].forEach(metricIndexName => {
+      const metricBuckets = buildMetricBucketsForAllowedUsers({
+        searchKeyFile,
+        indexName: metricIndexName,
+        allowedUserIds: normalizedUserIds,
+      });
+      Object.entries(metricBuckets).forEach(([bucketValue, targetUserIds]) => {
+        const path = `${normalizedRootPath}/${metricIndexName}/${bucketValue}`;
+        writes[path] = targetUserIds.reduce((result, userId) => {
+          result[userId] = true;
+          return result;
+        }, {});
+      });
+    });
+  }
+
+  return writes;
 };
 
 export const buildSearchKeySetIndexFromMatchedUsers = async ({


### PR DESCRIPTION
### Motivation
- Ensure additional access rule keys are normalized from multiple synonyms (e.g. `імт`, `bmi`, `imt`, `blood`, `bloodgroup`) so parsing and serialization are consistent.
- When IMT/BMI-based filters are used, include corresponding metric buckets (`height` and `weight`) in the generated writes so users are matched via height/weight indices.

### Description
- Added `normalizeAdditionalRuleKey` to canonicalize rule keys and added mappings for `імт`/`imt`/`bmi` -> `imt` and `blood`/`bloodgroup` -> `bloodGroup`.
- Updated `parseAdditionalRulesTextToBuilder` and `buildAdditionalRulesTextFromBuilder` in `ProfileForm.jsx` to use the normalizer and to filter out invalid/empty keys, and to validate keys against `ADDITIONAL_ACCESS_FILTER_OPTIONS` when building text.
- Introduced `buildMetricBucketsForAllowedUsers` in `newUsersFilterSetsIndex.js` to extract metric bucket membership for allowed users from the search key file.
- Modified `buildRuleBucketWrites` to detect IMT filters and, when present, augment the generated write objects with `height` and `weight` bucket writes derived from allowed user IDs, along with small refactors for safer accumulator handling and normalization.

### Testing
- Ran the project's linting and unit test suite locally; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d2eabb4083269fb59d2d984fc840)