### PR TITLE
Fix IMT additional access to populate weight/height search buckets

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -886,6 +886,34 @@ const resolveMetricSearchKeyBucketsFromGenericRules = (parsedRules, key) => {
   return uniq([...buckets]);
 };
 
+
+const deriveMetricBucketsFromImtRules = parsedRules => {
+  const generic = parsedRules?.generic;
+  if (!generic || typeof generic !== 'object' || !(generic.imt instanceof Set)) {
+    return { height: [], weight: [] };
+  }
+
+  const imtTokens = [...generic.imt].map(token => String(token || '').trim().toLowerCase()).filter(Boolean);
+  if (!imtTokens.length) return { height: [], weight: [] };
+
+  const includeUnknown = imtTokens.includes('?');
+  const includeNo = imtTokens.includes('no');
+
+  const height = ['lt163', '163_176', '177_180', '181_plus'];
+  const weight = ['lt55', '55_69', '70_84', '85_plus'];
+
+  if (includeUnknown) {
+    height.push('?');
+    weight.push('?');
+  }
+  if (includeNo) {
+    height.push('no');
+    weight.push('no');
+  }
+
+  return { height: uniq(height), weight: uniq(weight) };
+};
+
 const resolveMaritalStatusSearchKeyBuckets = parsedRules => {
   if (!parsedRules?.maritalStatus) return [];
 
@@ -959,16 +987,22 @@ const resolveAgeSearchKeyBuckets = parsedRules => {
   return uniq([...exactBirthDateBuckets, ...legacyAgeBuckets, ...extraBuckets]);
 };
 
-export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => ({
-  blood: uniq([...resolveBloodSearchKeyBuckets(parsedRules), ...resolveBloodBucketsFromGenericRules(parsedRules)]),
-  maritalStatus: resolveMaritalStatusSearchKeyBuckets(parsedRules),
-  csection: resolveCsectionSearchKeyBuckets(parsedRules),
-  age: resolveAgeSearchKeyBuckets(parsedRules),
-  ...(parsedRules?.generic || {}),
-  imt: resolveImtSearchKeyBucketsFromGenericRules(parsedRules),
-  height: resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, 'height'),
-  weight: resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, 'weight'),
-});
+export const resolveAdditionalAccessSearchKeyBuckets = parsedRules => {
+  const metricBucketsFromImt = deriveMetricBucketsFromImtRules(parsedRules);
+  const explicitHeightBuckets = resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, 'height');
+  const explicitWeightBuckets = resolveMetricSearchKeyBucketsFromGenericRules(parsedRules, 'weight');
+
+  return {
+    blood: uniq([...resolveBloodSearchKeyBuckets(parsedRules), ...resolveBloodBucketsFromGenericRules(parsedRules)]),
+    maritalStatus: resolveMaritalStatusSearchKeyBuckets(parsedRules),
+    csection: resolveCsectionSearchKeyBuckets(parsedRules),
+    age: resolveAgeSearchKeyBuckets(parsedRules),
+    ...(parsedRules?.generic || {}),
+    imt: resolveImtSearchKeyBucketsFromGenericRules(parsedRules),
+    height: uniq([...explicitHeightBuckets, ...metricBucketsFromImt.height]),
+    weight: uniq([...explicitWeightBuckets, ...metricBucketsFromImt.weight]),
+  };
+};
 
 export const createAllFalseFilterGroup = keys =>
   keys.reduce((acc, key) => {


### PR DESCRIPTION
### Motivation
- `imt` rules were treated as a wrapper over `weight` and `height` but did not contribute metric `height`/`weight` search buckets, causing index-based searches to miss candidates and show incorrect "available cards" counts.
- `csection` already resolves its own searchKey buckets directly, which is why it worked as a standalone filter while `imt` did not.

### Description
- Added `deriveMetricBucketsFromImtRules` to compute candidate `height` and `weight` buckets when `imt`-style rules are present, including `?` and `no` when explicitly included. 
- Updated `resolveAdditionalAccessSearchKeyBuckets` to merge explicit metric buckets from `height`/`weight` rules with IMT-derived metric buckets, while leaving existing `imt` bucket resolution intact. 
- Changes are localized to `src/utils/additionalAccessRules.js` and preserve existing generic rule handling.

### Testing
- Ran `npm -s run test -- --watch=false --runInBand`, which completed successfully and reported no tests related to the changed files. 
- Verified the modified `resolveAdditionalAccessSearchKeyBuckets` now returns merged `height` and `weight` buckets when `imt` rules are provided (static code inspection and diff reviewed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e64d374c8326b052c15394b54648)