### PR TITLE
Normalize IMT tokens for additional-access preview

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -805,8 +805,20 @@ const resolveImtSearchKeyBucketsFromGenericRules = parsedRules => {
     else buckets.add('36_plus');
   };
 
-  [...generic.imt].forEach(rawToken => {
+  const normalizeImtRuleToken = rawToken => {
     const token = String(rawToken || '').trim().toLowerCase();
+    if (!token) return '';
+    if (token === 'other') return '?';
+    if (token === 'empty') return 'no';
+    if (token === '<=28' || token === '<28') return 'le28';
+    if (token === '29-31') return '29_31';
+    if (token === '32-35') return '32_35';
+    if (token === '36+' || token === '>36' || token === '>=36') return '36_plus';
+    return token;
+  };
+
+  [...generic.imt].forEach(rawToken => {
+    const token = normalizeImtRuleToken(rawToken);
     if (!token) return;
 
     if (['le28', '29_31', '32_35', '36_plus', '?', 'no'].includes(token)) {
@@ -893,7 +905,14 @@ const deriveMetricBucketsFromImtRules = parsedRules => {
     return { height: [], weight: [] };
   }
 
-  const imtTokens = [...generic.imt].map(token => String(token || '').trim().toLowerCase()).filter(Boolean);
+  const imtTokens = [...generic.imt]
+    .map(token => String(token || '').trim().toLowerCase())
+    .map(token => {
+      if (token === 'other') return '?';
+      if (token === 'empty') return 'no';
+      return token;
+    })
+    .filter(Boolean);
   if (!imtTokens.length) return { height: [], weight: [] };
 
   const includeUnknown = imtTokens.includes('?');


### PR DESCRIPTION
### Motivation
- The additional-access preview could return zero available cards when IMT rule tokens arrived in non-canonical or legacy forms that weren't mapped to searchKey buckets.
- IMT-related rule values like `other`, `empty`, `29-31`, `32-35`, `36+`, `<=28` need normalization so the preview matcher can find matching users.

### Description
- Added `normalizeImtRuleToken` and used it in `src/utils/additionalAccessRules.js` to map common synonyms/legacy IMT tokens into canonical buckets (`?`, `no`, `29_31`, `32_35`, `36_plus`, `le28`).
- Updated `deriveMetricBucketsFromImtRules` to treat `other` and `empty` as `?` and `no` respectively when producing derived height/weight buckets.
- Preserved existing numeric and range parsing logic so explicit numeric IMT tokens still map to the correct buckets.

### Testing
- Ran the targeted test command `npm test -- --runInBand src/utils/__tests__/getFilteredCardsByList.test.js` and it passed.
- No other automated test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62a5625c48326ac18f7a9b96195ed)