### PR TITLE
Fix IMT filter default selection in additional access builder

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -979,9 +979,12 @@ export const ProfileForm = ({
   };
 
   const handleAdditionalRuleKeyChange = (index, nextKey) => {
+    const defaultAllowedValues =
+      nextKey === 'imt' ? new Set(['le28', '29_31', '32_35', '36_plus']) : new Set();
+
     setAdditionalRuleBuilder(prev =>
       prev.map((rule, ruleIndex) =>
-        ruleIndex === index ? { key: nextKey, allowedValues: new Set() } : rule
+        ruleIndex === index ? { key: nextKey, allowedValues: new Set(defaultAllowedValues) } : rule
       )
     );
   };


### PR DESCRIPTION
### Motivation
- Selecting the IMT filter previously produced a "Оберіть щонайменше один фільтр" validation error because the additional-rules builder created an IMT rule with no selected range tokens, while IMT is a derived metric that should start with sensible defaults.

### Description
- Initialize `allowedValues` with IMT buckets (`le28`, `29_31`, `32_35`, `36_plus`) when `handleAdditionalRuleKeyChange` receives `nextKey === 'imt'` in `src/components/ProfileForm.jsx`, leaving other keys unchanged.

### Testing
- Ran `npm run -s lint` in this environment and it returned a non-zero exit code (lint check failed/was not fully configured here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63ef1b7088326bb44385923825866)