### PR TITLE
Add local IMT indexing option in AddNewProfile index panel

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -719,6 +719,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     searchKeyUsersAll: false,
     searchKeySetReindex: false,
     searchLocalIdAndKey: false,
+    searchLocalImtHeightWeight: false,
   };
   const defaultSelectedSearchKeyIndexes = SEARCH_KEY_INDEX_OPTIONS.reduce((acc, option) => {
     acc[option.key] = true;
@@ -3525,6 +3526,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       !selectedIndexJobs.searchKeyUsersAll &&
       !selectedIndexJobs.searchKeySetReindex &&
       !selectedIndexJobs.searchLocalIdAndKey &&
+      !selectedIndexJobs.searchLocalImtHeightWeight &&
       !selectedIndexTypes.length
     ) {
       toast.error('Оберіть хоча б один індекс для запуску');
@@ -3552,6 +3554,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
       if (selectedIndexJobs.searchLocalIdAndKey) {
         openLocalIndexModal(selectedIndexTypes.length ? selectedIndexTypes : SEARCH_KEY_INDEX_OPTIONS.map(option => option.key));
+        return;
+      }
+
+      if (selectedIndexJobs.searchLocalImtHeightWeight) {
+        openLocalIndexModal(['imtHeightWeight']);
         return;
       }
 
@@ -4306,6 +4313,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     />
                     <SearchScopeLabelTextGroup>
                       <span>Локальна індексація searchId+searchKey (через JSON)</span>
+                    </SearchScopeLabelTextGroup>
+                  </SearchScopeLabel>
+                  <SearchScopeLabel>
+                    <input
+                      type="checkbox"
+                      checked={Boolean(selectedIndexJobs.searchLocalImtHeightWeight)}
+                      onChange={() => toggleIndexJobSelection('searchLocalImtHeightWeight')}
+                    />
+                    <SearchScopeLabelTextGroup>
+                      <span>Локальна індексація imt+height+weight (users + newUsers JSON)</span>
                     </SearchScopeLabelTextGroup>
                   </SearchScopeLabel>
                   <SearchScopeLabel>


### PR DESCRIPTION
### Motivation
- Provide a direct UI toggle to locally build IMT-related searchKey indexes (imt+height+weight) from `users` and `newUsers` JSON when running indexing from the Add New Profile panel.

### Description
- Added a new index job flag `searchLocalImtHeightWeight` to the AddNewProfile default/state handling and localStorage parsing in `src/components/AddNewProfile.jsx`.
- Added a checkbox in the "Індекси" modal labeled "Локальна індексація imt+height+weight (users + newUsers JSON)" that toggles the new flag.
- Updated `runSelectedIndexes` so the new flag is included in the "select at least one index" validation and opens the existing local-index modal with `['imtHeightWeight']` when selected.
- Reused existing local JSON indexing flow (`runLocalSearchIndexesWithCollections` / `openLocalIndexModal`) without backend/schema changes; all edits are contained in `src/components/AddNewProfile.jsx`.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx` which completed successfully (only npm/browserslist warnings, no lint errors).
- No additional automated unit tests were modified or required for this small UI/flow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f706598b808326bcb8aa25dc246df6)