### PR TITLE
Derive and write IMT buckets from height/weight indices

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -279,20 +279,18 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     ...new Set((Array.isArray(imtValuesRaw) ? imtValuesRaw : [...(imtValuesRaw || [])]).map(normalizePathSegment)),
   ];
   const hasImtFilter = imtValues.length > 0;
-  const deriveImtBucketByMetricBuckets = (heightBucket, weightBucket) => {
-    if (!heightBucket || !weightBucket) return null;
-    if (heightBucket === 'no' || weightBucket === 'no') return 'no';
-    if (heightBucket === '?' || weightBucket === '?') return '?';
+  const deriveImtBucketsByMetricBuckets = (heightBucket, weightBucket) => {
+    if (!heightBucket || !weightBucket) return [];
+    if (heightBucket === 'no' || weightBucket === 'no') return ['no'];
+    if (heightBucket === '?' || weightBucket === '?') return ['?'];
     const hr = HEIGHT_BUCKET_RANGES[heightBucket];
     const wr = WEIGHT_BUCKET_RANGES[weightBucket];
-    if (!hr || !wr) return '?';
+    if (!hr || !wr) return ['?'];
     const minBmi = wr.min / ((hr.max / 100) ** 2);
     const maxBmi = wr.max / ((hr.min / 100) ** 2);
-    if (maxBmi <= 28) return 'le28';
-    if (minBmi >= 29 && maxBmi <= 31) return '29_31';
-    if (minBmi >= 32 && maxBmi <= 35) return '32_35';
-    if (minBmi >= 36) return '36_plus';
-    return '?';
+    return Object.entries(IMT_BUCKET_RANGES)
+      .filter(([, range]) => !(maxBmi < range.min || minBmi > range.max))
+      .map(([bucket]) => bucket);
   };
 
   const filterUserIdsByImtBuckets = candidateUserIds => {
@@ -405,11 +403,13 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
 
     const imtWritesByBucket = {};
     imtAllowedUserIds.forEach(userId => {
-      const bucket = deriveImtBucketByMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
-      if (!bucket) return;
-      if (!imtValues.includes(bucket)) return;
-      if (!imtWritesByBucket[bucket]) imtWritesByBucket[bucket] = {};
-      imtWritesByBucket[bucket][userId] = true;
+      const buckets = deriveImtBucketsByMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
+      if (!buckets.length) return;
+      buckets.forEach(bucket => {
+        if (!imtValues.includes(bucket)) return;
+        if (!imtWritesByBucket[bucket]) imtWritesByBucket[bucket] = {};
+        imtWritesByBucket[bucket][userId] = true;
+      });
     });
     Object.entries(imtWritesByBucket).forEach(([bucket, usersMap]) => {
       writes[`${normalizedRootPath}/imt/${bucket}`] = usersMap;

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -279,6 +279,21 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     ...new Set((Array.isArray(imtValuesRaw) ? imtValuesRaw : [...(imtValuesRaw || [])]).map(normalizePathSegment)),
   ];
   const hasImtFilter = imtValues.length > 0;
+  const deriveImtBucketByMetricBuckets = (heightBucket, weightBucket) => {
+    if (!heightBucket || !weightBucket) return null;
+    if (heightBucket === 'no' || weightBucket === 'no') return 'no';
+    if (heightBucket === '?' || weightBucket === '?') return '?';
+    const hr = HEIGHT_BUCKET_RANGES[heightBucket];
+    const wr = WEIGHT_BUCKET_RANGES[weightBucket];
+    if (!hr || !wr) return '?';
+    const minBmi = wr.min / ((hr.max / 100) ** 2);
+    const maxBmi = wr.max / ((hr.min / 100) ** 2);
+    if (maxBmi <= 28) return 'le28';
+    if (minBmi >= 29 && maxBmi <= 31) return '29_31';
+    if (minBmi >= 32 && maxBmi <= 35) return '32_35';
+    if (minBmi >= 36) return '36_plus';
+    return '?';
+  };
 
   const filterUserIdsByImtBuckets = candidateUserIds => {
     if (!hasImtFilter) return [...candidateUserIds];
@@ -371,6 +386,35 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   }, {});
 
   if (hasImtFilter) {
+    const heightIndex = searchKeyFile?.height && typeof searchKeyFile.height === 'object' ? searchKeyFile.height : {};
+    const weightIndex = searchKeyFile?.weight && typeof searchKeyFile.weight === 'object' ? searchKeyFile.weight : {};
+    const heightByUserId = {};
+    const weightByUserId = {};
+    Object.entries(heightIndex).forEach(([bucket, usersMap]) => {
+      if (!usersMap || typeof usersMap !== 'object') return;
+      Object.keys(usersMap).forEach(userId => {
+        if (userId) heightByUserId[userId] = bucket;
+      });
+    });
+    Object.entries(weightIndex).forEach(([bucket, usersMap]) => {
+      if (!usersMap || typeof usersMap !== 'object') return;
+      Object.keys(usersMap).forEach(userId => {
+        if (userId) weightByUserId[userId] = bucket;
+      });
+    });
+
+    const imtWritesByBucket = {};
+    imtAllowedUserIds.forEach(userId => {
+      const bucket = deriveImtBucketByMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
+      if (!bucket) return;
+      if (!imtValues.includes(bucket)) return;
+      if (!imtWritesByBucket[bucket]) imtWritesByBucket[bucket] = {};
+      imtWritesByBucket[bucket][userId] = true;
+    });
+    Object.entries(imtWritesByBucket).forEach(([bucket, usersMap]) => {
+      writes[`${normalizedRootPath}/imt/${bucket}`] = usersMap;
+    });
+
     ['height', 'weight'].forEach(metricIndexName => {
       const metricBuckets = buildMetricBucketsForAllowedUsers({
         searchKeyFile,


### PR DESCRIPTION
### Motivation

- Ensure IMT (BMI) bucket entries are derived and populated from existing `height` and `weight` indices so users are correctly indexed when IMT filters are used.
- Handle special bucket tokens like `no` and `?` and provide a deterministic mapping from metric buckets to IMT buckets.

### Description

- Added a helper `deriveImtBucketByMetricBuckets` to compute an IMT bucket from height and weight bucket keys and handle `no`/`?` cases and unknown ranges. 
- In `buildRuleBucketWrites` the code now builds `heightByUserId` and `weightByUserId` maps and computes `imtWritesByBucket` by iterating `imtAllowedUserIds` and deriving each user’s IMT bucket, then writes entries to `
`${normalizedRootPath}/imt/${bucket}``.
- Kept existing logic that writes `height` and `weight` metric bucket entries by reusing `buildMetricBucketsForAllowedUsers` and attaching those writes to the result. 
- Added guard checks and normalization to ensure indices are objects before iterating.

### Testing

- Ran the repository test suite with `yarn test` and the full suite passed. 
- Ran linting with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65601082483268f602f30aebf6dbd)