### PR TITLE
Determine IMT bucket per user from height/weight and simplify IMT handling

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -69,13 +69,6 @@ const METRIC_BUCKETS_BY_INDEX = {
   weight: ['lt55', '55_69', '70_84', '85_plus', '?', 'no'],
 };
 
-const IMT_BUCKET_RANGES = {
-  le28: { min: -Infinity, max: 28 },
-  '29_31': { min: 29, max: 31 },
-  '32_35': { min: 32, max: 35 },
-  '36_plus': { min: 36, max: Infinity },
-};
-
 const HEIGHT_BUCKET_RANGES = {
   lt163: { min: 120, max: 162.99 },
   '163_176': { min: 163, max: 176 },
@@ -88,6 +81,47 @@ const WEIGHT_BUCKET_RANGES = {
   '55_69': { min: 55, max: 69 },
   '70_84': { min: 70, max: 84 },
   '85_plus': { min: 85, max: 220 },
+};
+
+const collectMetricBucketsByUserId = searchKeyFile => {
+  const heightIndex = searchKeyFile?.height && typeof searchKeyFile.height === 'object' ? searchKeyFile.height : {};
+  const weightIndex = searchKeyFile?.weight && typeof searchKeyFile.weight === 'object' ? searchKeyFile.weight : {};
+  const heightByUserId = {};
+  const weightByUserId = {};
+
+  Object.entries(heightIndex).forEach(([bucket, usersMap]) => {
+    if (!usersMap || typeof usersMap !== 'object') return;
+    Object.keys(usersMap).forEach(userId => {
+      if (userId && !heightByUserId[userId]) heightByUserId[userId] = bucket;
+    });
+  });
+
+  Object.entries(weightIndex).forEach(([bucket, usersMap]) => {
+    if (!usersMap || typeof usersMap !== 'object') return;
+    Object.keys(usersMap).forEach(userId => {
+      if (userId && !weightByUserId[userId]) weightByUserId[userId] = bucket;
+    });
+  });
+
+  return { heightByUserId, weightByUserId };
+};
+
+const resolveImtBucketFromMetricBuckets = (heightBucket, weightBucket) => {
+  if (!heightBucket || !weightBucket) return null;
+  if (heightBucket === 'no' || weightBucket === 'no') return 'no';
+  if (heightBucket === '?' || weightBucket === '?') return '?';
+  const hr = HEIGHT_BUCKET_RANGES[heightBucket];
+  const wr = WEIGHT_BUCKET_RANGES[weightBucket];
+  if (!hr || !wr) return '?';
+
+  const representativeHeightM = ((hr.min + hr.max) / 2) / 100;
+  const representativeWeight = (wr.min + wr.max) / 2;
+  const bmi = representativeWeight / representativeHeightM ** 2;
+
+  if (bmi <= 28) return 'le28';
+  if (bmi <= 31) return '29_31';
+  if (bmi <= 35) return '32_35';
+  return '36_plus';
 };
 
 const augmentBucketsWithImtMetricWrappers = bucketMap => {
@@ -279,55 +313,14 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     ...new Set((Array.isArray(imtValuesRaw) ? imtValuesRaw : [...(imtValuesRaw || [])]).map(normalizePathSegment)),
   ];
   const hasImtFilter = imtValues.length > 0;
-  const deriveImtBucketsByMetricBuckets = (heightBucket, weightBucket) => {
-    if (!heightBucket || !weightBucket) return [];
-    if (heightBucket === 'no' || weightBucket === 'no') return ['no'];
-    if (heightBucket === '?' || weightBucket === '?') return ['?'];
-    const hr = HEIGHT_BUCKET_RANGES[heightBucket];
-    const wr = WEIGHT_BUCKET_RANGES[weightBucket];
-    if (!hr || !wr) return ['?'];
-    const minBmi = wr.min / ((hr.max / 100) ** 2);
-    const maxBmi = wr.max / ((hr.min / 100) ** 2);
-    return Object.entries(IMT_BUCKET_RANGES)
-      .filter(([, range]) => !(maxBmi < range.min || minBmi > range.max))
-      .map(([bucket]) => bucket);
-  };
-
   const filterUserIdsByImtBuckets = candidateUserIds => {
     if (!hasImtFilter) return [...candidateUserIds];
-    const includeUnknown = imtValues.includes('?');
-    const includeNo = imtValues.includes('no');
-    const ranges = imtValues.map(token => IMT_BUCKET_RANGES[token]).filter(Boolean);
-
-    const heightIndex = searchKeyFile?.height && typeof searchKeyFile.height === 'object' ? searchKeyFile.height : {};
-    const weightIndex = searchKeyFile?.weight && typeof searchKeyFile.weight === 'object' ? searchKeyFile.weight : {};
-    const heightByUserId = {};
-    const weightByUserId = {};
-    Object.entries(heightIndex).forEach(([bucket, usersMap]) => {
-      if (!usersMap || typeof usersMap !== 'object') return;
-      Object.keys(usersMap).forEach(userId => {
-        if (userId) heightByUserId[userId] = bucket;
-      });
-    });
-    Object.entries(weightIndex).forEach(([bucket, usersMap]) => {
-      if (!usersMap || typeof usersMap !== 'object') return;
-      Object.keys(usersMap).forEach(userId => {
-        if (userId) weightByUserId[userId] = bucket;
-      });
-    });
+    const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(searchKeyFile);
 
     return [...candidateUserIds].filter(userId => {
-      const h = heightByUserId[userId];
-      const w = weightByUserId[userId];
-      if (!h || !w) return false;
-      if (includeUnknown && (h === '?' || w === '?')) return true;
-      if (includeNo && (h === 'no' || w === 'no')) return true;
-      const hr = HEIGHT_BUCKET_RANGES[h];
-      const wr = WEIGHT_BUCKET_RANGES[w];
-      if (!hr || !wr || !ranges.length) return false;
-      const minBmi = wr.min / ((hr.max / 100) ** 2);
-      const maxBmi = wr.max / ((hr.min / 100) ** 2);
-      return ranges.some(range => !(maxBmi < range.min || minBmi > range.max));
+      const imtBucket = resolveImtBucketFromMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
+      if (!imtBucket) return false;
+      return imtValues.includes(imtBucket);
     });
   };
 
@@ -384,37 +377,6 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   }, {});
 
   if (hasImtFilter) {
-    const heightIndex = searchKeyFile?.height && typeof searchKeyFile.height === 'object' ? searchKeyFile.height : {};
-    const weightIndex = searchKeyFile?.weight && typeof searchKeyFile.weight === 'object' ? searchKeyFile.weight : {};
-    const heightByUserId = {};
-    const weightByUserId = {};
-    Object.entries(heightIndex).forEach(([bucket, usersMap]) => {
-      if (!usersMap || typeof usersMap !== 'object') return;
-      Object.keys(usersMap).forEach(userId => {
-        if (userId) heightByUserId[userId] = bucket;
-      });
-    });
-    Object.entries(weightIndex).forEach(([bucket, usersMap]) => {
-      if (!usersMap || typeof usersMap !== 'object') return;
-      Object.keys(usersMap).forEach(userId => {
-        if (userId) weightByUserId[userId] = bucket;
-      });
-    });
-
-    const imtWritesByBucket = {};
-    imtAllowedUserIds.forEach(userId => {
-      const buckets = deriveImtBucketsByMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
-      if (!buckets.length) return;
-      buckets.forEach(bucket => {
-        if (!imtValues.includes(bucket)) return;
-        if (!imtWritesByBucket[bucket]) imtWritesByBucket[bucket] = {};
-        imtWritesByBucket[bucket][userId] = true;
-      });
-    });
-    Object.entries(imtWritesByBucket).forEach(([bucket, usersMap]) => {
-      writes[`${normalizedRootPath}/imt/${bucket}`] = usersMap;
-    });
-
     ['height', 'weight'].forEach(metricIndexName => {
       const metricBuckets = buildMetricBucketsForAllowedUsers({
         searchKeyFile,


### PR DESCRIPTION
### Motivation

- Replace complex IMT range-overlap logic with a deterministic per-user IMT derivation based on representative height/weight buckets to simplify filtering and avoid computing all possible IMT intersections.
- Consolidate repeated logic that extracted height/weight bucket membership into a reusable routine and add guards against malformed `searchKeyFile` shapes.

### Description

- Added `collectMetricBucketsByUserId` to extract a single height/weight bucket per user and `resolveImtBucketFromMetricBuckets` to map those buckets to a single IMT bucket using representative BMI values. 
- Removed the `IMT_BUCKET_RANGES` constant and the `deriveImtBucketsByMetricBuckets` range-overlap function, and switched IMT filtering to check a single resolved IMT bucket per user. 
- Reused the new helpers in `filterUserIdsByImtBuckets` and removed the previous duplicated height/weight bucket extraction blocks; preserved creation of metric buckets for allowed users while avoiding writing IMT index entries directly. 
- Added defensive checks for `searchKeyFile` shapes and ensured height/weight bucket extraction records the first encountered bucket per user to stabilize mapping.

### Testing

- Ran unit tests with `yarn test` and the test suite completed successfully. 
- Ran linting with `yarn lint` and there were no lint errors. 
- Verified build with `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73dc13920832698d98b12c9b3a572)