### PR TITLE
Support IMT-only additionalAccessRuleSet indexing

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -792,7 +792,7 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
       return acc;
     }, []);
 
-    if (!activeSources.length) continue;
+    if (!activeSources.length && !hasImtFilter) continue;
 
     // eslint-disable-next-line no-await-in-loop
     const sourceIdSets = await Promise.all(
@@ -814,10 +814,13 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
     );
 
     const normalizedSets = sourceIdSets.filter(set => set instanceof Set);
-    if (!normalizedSets.length || normalizedSets.some(set => set.size === 0)) continue;
+    if (normalizedSets.some(set => set.size === 0)) continue;
 
-    const [firstSet, ...restSets] = normalizedSets;
-    let groupMatchedIds = [...firstSet].filter(userId => restSets.every(set => set.has(userId)));
+    let groupMatchedIds = [];
+    if (normalizedSets.length) {
+      const [firstSet, ...restSets] = normalizedSets;
+      groupMatchedIds = [...firstSet].filter(userId => restSets.every(set => set.has(userId)));
+    }
 
     if (hasImtFilter) {
       const [heightPayload, weightPayload] = await Promise.all([
@@ -829,11 +832,20 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
         weight: weightPayload?.exists && typeof weightPayload?.value === 'object' ? weightPayload.value : {},
       };
       const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(metricSearchKeyFile);
+      if (!groupMatchedIds.length) {
+        const metricUserIds = new Set([
+          ...Object.keys(heightByUserId || {}),
+          ...Object.keys(weightByUserId || {}),
+        ]);
+        groupMatchedIds = [...metricUserIds];
+      }
       groupMatchedIds = groupMatchedIds.filter(userId => {
         const imtBuckets = resolveImtBucketsFromMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
         return imtBuckets.some(bucket => imtValues.includes(bucket));
       });
     }
+
+    if (!groupMatchedIds.length) continue;
 
     groupMatchedIds.forEach(userId => matchedIds.add(userId));
   }


### PR DESCRIPTION
### Motivation
- Rule groups containing only `imt` buckets previously short-circuited and produced no matches because the code required at least one non-IMT active source. 
- The goal is to index sets like `imt: le28,29_31` by deriving candidates from metric indexes (`height`/`weight`) and applying IMT bucketing.

### Description
- Relaxed the early-exit check so processing continues when there are no non-IMT `activeSources` but an IMT filter exists by changing the condition to `if (!activeSources.length && !hasImtFilter) continue` in `getMatchedUserIdsFromSearchKey`.
- Allowed empty `normalizedSets` to be handled by seeding `groupMatchedIds` only when non-IMT sources exist, otherwise leaving it empty initially.
- When an IMT filter is present and `groupMatchedIds` is empty, seeded candidate `userId`s from `searchKey/height` and `searchKey/weight`, then filtered them via `resolveImtBucketsFromMetricBuckets` against selected IMT buckets.
- Added an explicit skip if `groupMatchedIds` remains empty after IMT filtering to preserve the original short-circuit semantics for other failing cases (file modified: `src/utils/newUsersFilterSetsIndex.js`).

### Testing
- Ran linting with `npm run lint:js -- src/utils/newUsersFilterSetsIndex.js` and it completed without errors.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7994c47dc8326a6907a8a67f331a6)