### PR TITLE
Restrict IMT fallback to IMT-only groups

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -832,7 +832,7 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
         weight: weightPayload?.exists && typeof weightPayload?.value === 'object' ? weightPayload.value : {},
       };
       const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(metricSearchKeyFile);
-      if (!groupMatchedIds.length) {
+      if (!groupMatchedIds.length && !activeSources.length) {
         const metricUserIds = new Set([
           ...Object.keys(heightByUserId || {}),
           ...Object.keys(weightByUserId || {}),


### PR DESCRIPTION
### Motivation
- When a group's source intersection is empty, the IMT fallback previously seeded candidates from all metric user IDs even if non-IMT sources were present, which could reintroduce users that only satisfy IMT and violate the intended non-IMT constraints.

### Description
- Add a guard so the IMT repopulation only runs when the group has IMT filters and no non-IMT `activeSources` by changing the condition to `if (!groupMatchedIds.length && !activeSources.length)` in `src/utils/newUsersFilterSetsIndex.js`.

### Testing
- Ran `npx eslint src/utils/newUsersFilterSetsIndex.js`, which completed successfully (only non-blocking npm/browserslist warnings were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a71bccb48326b620f65b30d83895)