### PR TITLE
Include IMT-derived users for bucket writes when no explicit userIds provided

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -327,7 +327,22 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     });
   };
 
-  const imtAllowedUserIds = hasImtFilter ? filterUserIdsByImtBuckets(normalizedUserIds) : normalizedUserIds;
+  const resolveImtCandidateUserIds = () => {
+    if (!hasImtFilter) return normalizedUserIds;
+    if (normalizedUserIds.length > 0) return normalizedUserIds;
+
+    const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(searchKeyFile);
+    return [
+      ...new Set([
+        ...Object.keys(heightByUserId || {}),
+        ...Object.keys(weightByUserId || {}),
+      ]),
+    ];
+  };
+
+  const imtCandidateUserIds = resolveImtCandidateUserIds();
+  const allowedUserIdsForWrites = hasImtFilter ? imtCandidateUserIds : normalizedUserIds;
+  const imtAllowedUserIds = hasImtFilter ? filterUserIdsByImtBuckets(imtCandidateUserIds) : normalizedUserIds;
 
   const writes = Object.entries(bucketMap || {}).reduce((accWrites, [indexName, rawValues]) => {
     const normalizedIndexName = normalizePathSegment(indexName);
@@ -342,7 +357,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
         searchKeyFile,
         indexName: normalizedIndexName,
         values: allowedAgeValues,
-        allowedUserIds: normalizedUserIds,
+        allowedUserIds: allowedUserIdsForWrites,
       });
       Object.entries(sanitized).forEach(([ageValue, targetUserIds]) => {
         const path = `${normalizedRootPath}/${normalizedIndexName}/${ageValue}`;
@@ -367,7 +382,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
       searchKeyFile,
       indexName: normalizedIndexName,
       values,
-      allowedUserIds: normalizedUserIds,
+      allowedUserIds: allowedUserIdsForWrites,
     });
     Object.entries(sanitized).forEach(([value, targetUserIds]) => {
       const path = `${normalizedRootPath}/${normalizedIndexName}/${value}`;


### PR DESCRIPTION
### Motivation

- Ensure IMT (height/weight) filters are respected even when the incoming `userIds` array is empty by deriving candidate users from metric buckets. 
- Prevent missing bucket writes for non-IMT indexes when an IMT filter is present but no explicit `userIds` were supplied. 
- Maintain existing behavior of filtering metric buckets (height/weight) by the IMT values.

### Description

- Add `resolveImtCandidateUserIds` to collect candidate user IDs from `heightByUserId` and `weightByUserId` when `userIds` is empty and an IMT filter exists. 
- Introduce `imtCandidateUserIds`, `allowedUserIdsForWrites`, and keep `imtAllowedUserIds` to separate the set used for non-IMT writes vs the set used to actually match IMT buckets. 
- Use `allowedUserIdsForWrites` when calling `buildSanitizedBucketUsersMap` so non-IMT index paths are populated with users derived from metric buckets when appropriate. 
- Preserve existing safeguards around `rootPath` and `searchKeyFile` validation and keep metric bucket writes for `height`/`weight` using the filtered `imtAllowedUserIds`.

### Testing

- Ran unit test suite with `yarn test` which includes search-key and index-building tests, and all tests passed. 
- Ran linter with `yarn lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b273bb3083268d30d110e8aef26a)