### PR TITLE
Normalize common IMT typo and adjust IMT filter set matching logic

### DIFF
--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -808,6 +808,8 @@ const resolveImtSearchKeyBucketsFromGenericRules = parsedRules => {
   const normalizeImtRuleToken = rawToken => {
     const token = String(rawToken || '').trim().toLowerCase();
     if (!token) return '';
+    // Часта опечатка: "1e28" (цифра 1) замість "le28" (літера l)
+    if (token === '1e28') return 'le28';
     if (token === 'other') return '?';
     if (token === 'empty') return 'no';
     if (token === '<=28' || token === '<28') return 'le28';

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -829,7 +829,7 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
     );
 
     const normalizedSets = sourceIdSets.filter(set => set instanceof Set);
-    if (normalizedSets.some(set => set.size === 0)) continue;
+    if (!hasImtFilter && normalizedSets.some(set => set.size === 0)) continue;
 
     let groupMatchedIds = [];
     if (normalizedSets.length) {
@@ -847,7 +847,7 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
         weight: weightPayload?.exists && typeof weightPayload?.value === 'object' ? weightPayload.value : {},
       };
       const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(metricSearchKeyFile);
-      if (!groupMatchedIds.length && !activeSources.length) {
+      if (!groupMatchedIds.length) {
         const metricUserIds = new Set([
           ...Object.keys(heightByUserId || {}),
           ...Object.keys(weightByUserId || {}),


### PR DESCRIPTION
### Motivation

- Normalize a frequent user-provided IMT token typo so IMT bucket resolution is more robust.
- Allow IMT-based searches to produce results from metric buckets even when other search-key sets are present or empty.

### Description

- Added `normalizeImtRuleToken` mapping to treat the common typo `1e28` (digit one) as `le28` to correctly resolve IMT buckets. 
- Kept existing canonical mappings for `other`, `empty`, `<=28`, `29-31`, `32-35`, and `36+` variants and numeric range parsing.
- Modified `getMatchedUserIdsFromSearchKey` so that an empty `normalizedSets` entry only short-circuits when there is no IMT filter by changing the condition to `if (!hasImtFilter && normalizedSets.some(set => set.size === 0)) continue`.
- When an IMT filter is present, ensure metric-based user IDs are used if the intersection produced no matches by removing the `&& !activeSources.length` requirement in the metric fallback.

### Testing

- Ran the existing unit test suite with `yarn test`, and all tests passed. 
- Ran linting with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b8a3367c8326a9796a039b1b83f2)