### PR TITLE
Fix IMT matching/indexing fallbacks for additional access rules

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -867,40 +867,37 @@ export const ProfileForm = ({
         });
       });
 
-      parsedRuleGroups.forEach(parsedRules => {
-        const rawBucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
-        const imtRawValues = rawBucketMap?.imt;
-        if (!imtRawValues) return;
-
-        const imtValues = new Set(
-          (Array.isArray(imtRawValues) ? imtRawValues : [...(imtRawValues || [])])
-            .map(v => String(v || '').trim())
-            .filter(Boolean)
-        );
-        if (imtValues.size === 0) return;
-
-        const heightIndex = localSearchKeyPayload?.height;
-        const weightIndex = localSearchKeyPayload?.weight;
-        if (!heightIndex || !weightIndex) return;
-
-        const pseudoSearchKeyFile = { height: heightIndex, weight: weightIndex };
-        const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(pseudoSearchKeyFile);
-
-        const allMetricUserIds = new Set([
-          ...Object.keys(heightByUserId || {}),
-          ...Object.keys(weightByUserId || {}),
-        ]);
-
-        allMetricUserIds.forEach(userId => {
-          const imtBuckets = resolveImtBucketsFromMetricBuckets(
-            heightByUserId[userId],
-            weightByUserId[userId]
-          );
-          if (imtBuckets.some(bucket => imtValues.has(bucket))) {
-            matched.add(userId);
-          }
-        });
-      });
+      // IMT: searchKey не має індексу /imt/ — обчислюємо з height/weight
+      const imtLineMatch = rulesText.match(/(?:^|\n)\s*imt\s*:\s*([^\n]+)/i);
+      if (imtLineMatch) {
+        const imtValues = imtLineMatch[1]
+          .split(',')
+          .map(t => t.trim())
+          .filter(Boolean);
+        const heightIdx = localSearchKeyPayload?.height;
+        const weightIdx = localSearchKeyPayload?.weight;
+        if (
+          imtValues.length > 0 &&
+          heightIdx && typeof heightIdx === 'object' &&
+          weightIdx && typeof weightIdx === 'object'
+        ) {
+          const pseudoFile = { height: heightIdx, weight: weightIdx };
+          const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(pseudoFile);
+          const allMetricUsers = new Set([
+            ...Object.keys(heightByUserId),
+            ...Object.keys(weightByUserId),
+          ]);
+          allMetricUsers.forEach(uid => {
+            const imtBuckets = resolveImtBucketsFromMetricBuckets(
+              heightByUserId[uid],
+              weightByUserId[uid]
+            );
+            if (imtBuckets.some(b => imtValues.includes(b))) {
+              matched.add(uid);
+            }
+          });
+        }
+      }
       matchedByInputIndex[index + 1] = [...matched];
     }
 

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -304,13 +304,39 @@ const buildMetricBucketsForAllowedUsers = ({ searchKeyFile, indexName, allowedUs
   }, {});
 };
 
-const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyFile = null }) => {
+const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyFile = null, rawText = '' }) => {
   const normalizedRootPath = String(rootPath || '').trim();
   if (!normalizedRootPath) return {};
   if (!searchKeyFile || typeof searchKeyFile !== 'object' || Array.isArray(searchKeyFile)) return {};
 
   const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
-  const bucketMap = augmentBucketsWithImtMetricWrappers(mergeSearchKeyBuckets(parsedRuleGroups));
+  const baseBucketMap = augmentBucketsWithImtMetricWrappers(mergeSearchKeyBuckets(parsedRuleGroups));
+
+  const existingImt = baseBucketMap?.imt;
+  const hasExistingImt =
+    (existingImt instanceof Set && existingImt.size > 0) ||
+    (Array.isArray(existingImt) && existingImt.length > 0);
+
+  let bucketMap = baseBucketMap;
+  if (!hasExistingImt && rawText) {
+    const imtLineMatch = String(rawText).match(/(?:^|\n)\s*imt\s*:\s*([^\n]+)/i);
+    if (imtLineMatch) {
+      const imtTokens = imtLineMatch[1].split(',').map(t => t.trim()).filter(Boolean);
+      if (imtTokens.length > 0) {
+        bucketMap = {
+          ...baseBucketMap,
+          imt: new Set(imtTokens),
+          height: (baseBucketMap.height instanceof Set && baseBucketMap.height.size > 0)
+            ? baseBucketMap.height
+            : new Set(METRIC_BUCKETS_BY_INDEX.height),
+          weight: (baseBucketMap.weight instanceof Set && baseBucketMap.weight.size > 0)
+            ? baseBucketMap.weight
+            : new Set(METRIC_BUCKETS_BY_INDEX.weight),
+        };
+      }
+    }
+  }
+
   const imtValuesRaw = bucketMap?.imt;
   const imtValues = [
     ...new Set((Array.isArray(imtValuesRaw) ? imtValuesRaw : [...(imtValuesRaw || [])]).map(normalizePathSegment)),
@@ -535,6 +561,7 @@ export const buildNewUsersFilterSetIndex = async ({
         setKey: ownerSetKey,
         userIds,
         parsedRuleGroups,
+        rawText: setText,
       };
     })
     .filter(Boolean);
@@ -572,7 +599,7 @@ export const buildNewUsersFilterSetIndex = async ({
     await update(ref(database), writes);
   }
 
-  for (const { setKey, userIds, parsedRuleGroups } of nextSetPayloads) {
+  for (const { setKey, userIds, parsedRuleGroups, rawText } of nextSetPayloads) {
     // eslint-disable-next-line no-await-in-loop
     debug.backendRequests.push({
       type: 'remove',
@@ -587,6 +614,7 @@ export const buildNewUsersFilterSetIndex = async ({
       parsedRuleGroups,
       userIds: Object.keys(userIds || {}),
       searchKeyFile,
+      rawText,
     });
     debug.sets.push({
       setKey,


### PR DESCRIPTION
### Motivation
- IMT-based additional-access rules sometimes failed to match users because `imt` was not exposed by `resolveAdditionalAccessSearchKeyBuckets`, causing fallback logic to miss candidates and produce empty writes. 
- The rule text may contain an `imt:` line that should be used as a fallback to derive IMT buckets from `height`/`weight` when indexes lack `/imt/`.

### Description
- Preserve the raw additional-rules text (`rawText`) in `buildNewUsersFilterSetIndex` payloads and pass it into `buildRuleBucketWrites` so the original rule line can be inspected during indexing.  
- Extend `buildRuleBucketWrites` signature with `rawText` and implement an IMT fallback that parses `imt:` directly from rule text, injects `imt` into the bucket map, and ensures `height`/`weight` metric wrappers are present so metric bucket writes are produced.  
- Update `ProfileForm` `getIndexedMatchedUserIdsByInputIndex` to parse `imt:` from the rules text and compute matched users by deriving IMT buckets via `collectMetricBucketsByUserId` and `resolveImtBucketsFromMetricBuckets`, avoiding reliance on a `/imt/` index.  

### Testing
- No automated unit tests were added; changes were validated with local repository sanity checks and by inspecting diffs to ensure the changed call sites and signatures are consistent.  
- Local static inspection confirmed the modified functions and the new `rawText` flow are present and the indexing logic now includes the IMT fallback path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82dc855648326bd481c5a36fc3480)