### PR TITLE
Fix IMT searchKeySets indexing without prefilter dependency

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -353,17 +353,15 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     });
   };
 
+  const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(searchKeyFile);
+
   const resolveImtCandidateUserIds = () => {
     if (!hasImtFilter) return normalizedUserIds;
-    if (normalizedUserIds.length > 0) return normalizedUserIds;
 
-    const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(searchKeyFile);
-    return [
-      ...new Set([
-        ...Object.keys(heightByUserId || {}),
-        ...Object.keys(weightByUserId || {}),
-      ]),
-    ];
+    const heightUserIds = Object.keys(heightByUserId || {});
+    const weightUserIds = Object.keys(weightByUserId || {});
+    const weightUserIdsSet = new Set(weightUserIds);
+    return heightUserIds.filter(userId => weightUserIdsSet.has(userId));
   };
 
   const imtCandidateUserIds = resolveImtCandidateUserIds();
@@ -371,6 +369,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   const imtAllowedUserIds = hasImtFilter ? filterUserIdsByImtBuckets(imtCandidateUserIds) : normalizedUserIds;
 
   const writes = Object.entries(bucketMap || {}).reduce((accWrites, [indexName, rawValues]) => {
+    if (hasImtFilter) return accWrites;
     const normalizedIndexName = normalizePathSegment(indexName);
     if (!normalizedIndexName) return accWrites;
     if (normalizedIndexName === 'imt') return accWrites;
@@ -434,6 +433,23 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
           return result;
         }, {});
       });
+    });
+
+    const writtenUserIds = new Set();
+    Object.values(writes).forEach(usersMap => {
+      Object.keys(usersMap || {}).forEach(userId => {
+        if (userId) writtenUserIds.add(userId);
+      });
+    });
+
+    console.info('[searchKeySets][IMT] Diagnostics', {
+      rootPath: normalizedRootPath,
+      heightUsers: Object.keys(heightByUserId || {}).length,
+      weightUsers: Object.keys(weightByUserId || {}).length,
+      usersWithHeightAndWeight: imtCandidateUserIds.length,
+      usersPassedImt: imtAllowedUserIds.length,
+      bucketsWritten: Object.keys(writes).length,
+      usersWritten: writtenUserIds.size,
     });
   }
 


### PR DESCRIPTION
### Motivation
- Виправити баг, коли IMT-фільтр не працював якщо префільтр `matchedUserIds` був порожнім, внаслідок чого `searchKeySets` видалявся без повторного створення і в результаті записувався лише `remove` для набору.
- IMT має працювати незалежно від префільтра та обчислюватись напряму з базових індексів `searchKey/height` і `searchKey/weight`.

### Description
- Змінено логіку побудови кандидатів для IMT у `src/utils/newUsersFilterSetsIndex.js` так, щоб брати `userId` напряму з `height` та `weight` та використовувати їх перетин (тільки користувачі, які мають і height, і weight). 
- Забезпечено, що при наявності IMT-фільтра не записуються інші індекси (включно з `imt`) — у `searchKeySets/{setId}` записуються лише `height/*` і `weight/*`, IMT залишається лише фільтром. 
- Додано діагностичний лог `console.info('[searchKeySets][IMT] Diagnostics', {...})`, який виводить кількість користувачів у `height`, у `weight`, кількість з обома метриками, скільки пройшло IMT та скільки bucket-ів і userId записано. 
- Підтримано видалення вузла перед індексацією (`remove(ref(database, \\`searchKeySets/{setId}\\`)`) і подальше оновлення лише валідними bucket-ами.

### Testing
- Запущено лінтер: `npm run lint:js -- src/utils/newUsersFilterSetsIndex.js` — успішно (ESLint пройшов без помилок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84dea6288832696b106982c286fd3)