### PR TITLE
Add PP technical helper input with trigger parsing and auto-submit

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -11,6 +11,7 @@ import {
   formatDateToDisplay,
   formatDateAndFormula,
 } from 'components/inputValidations';
+import { parseUkTriggerQuery } from 'utils/parseUkTrigger';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { patchOverlayField } from 'utils/multiAccountEdits';
 import toast from 'react-hot-toast';
@@ -1920,6 +1921,40 @@ ${entries.join('\n')}`;
         .map(value => value.trim().toLowerCase())
         .filter(Boolean);
   const shouldHideFieldsForClPp = roleTokens.some(role => ['pp', 'cl'].includes(role));
+  const shouldShowPpTechnicalInput = roleTokens.includes('pp');
+  const [ppTechnicalInput, setPpTechnicalInput] = useState('');
+
+  const handlePpTechnicalInputSubmit = useCallback(() => {
+    const rawValue = String(ppTechnicalInput || '').trim();
+    if (!rawValue) return;
+
+    const parsed = parseUkTriggerQuery(rawValue);
+
+    setState(prevState => {
+      const nextState = { ...prevState };
+
+      if (!parsed) {
+        nextState.name = rawValue;
+      } else {
+        const { contactType, contactValues, name, surname } = parsed;
+
+        if (contactType) {
+          nextState[contactType] = contactValues;
+        }
+        if (name) {
+          nextState.name = name;
+        }
+        if (surname) {
+          nextState.surname = surname;
+        }
+      }
+
+      submitWithNormalization(nextState, 'overwrite');
+      return nextState;
+    });
+
+    setPpTechnicalInput('');
+  }, [ppTechnicalInput, setState, submitWithNormalization]);
 
   const handleOpenModal = fieldName => {
     setSelectedField(fieldName);
@@ -2006,8 +2041,26 @@ ${entries.join('\n')}`;
               ? formatDateToDisplay(state.getInTouch)
               : state[field.name] || '';
           return (
+            <React.Fragment key={index}>
+            {shouldShowPpTechnicalInput && field.name === 'name' && (
+              <PickerContainer>
+                <FieldMainRow>
+                  <InputDiv>
+                    <InputFieldContainer fieldName="ppTechnicalInput" value={ppTechnicalInput}>
+                      <InputField
+                        fieldName="ppTechnicalInput"
+                        name="ppTechnicalInput"
+                        value={ppTechnicalInput}
+                        onChange={e => setPpTechnicalInput(e?.target?.value || '')}
+                        onBlur={handlePpTechnicalInputSubmit}
+                        placeholder="Технічний інпут для PP"
+                      />
+                    </InputFieldContainer>
+                  </InputDiv>
+                </FieldMainRow>
+              </PickerContainer>
+            )}
             <PickerContainer
-              key={index}
               style={hasOverlaySuggestions ? { flexDirection: 'column', alignItems: 'stretch' } : undefined}
             >
               <FieldMainRow>
@@ -2407,8 +2460,9 @@ ${entries.join('\n')}`;
                 </Button>
               </OverlayEntryRow>
             ))}
-          </PickerContainer>
-        );
+            </PickerContainer>
+            </React.Fragment>
+          );
         })}
       <KeyValueRow>
         <CustomInput


### PR DESCRIPTION
### Motivation
- Allow users with role `pp` to paste a trigger-like string into a small technical input that is parsed and mapped into the correct profile form fields automatically. 
- Ensure the helper input is technical (not visible in normal workflows), writes values under the correct keys (including array/scalar contact fields), falls back to `name` when parsing fails, clears itself and triggers immediate submit.

### Description
- Imported `parseUkTriggerQuery` and added `ppTechnicalInput` state plus `handlePpTechnicalInputSubmit` that runs the parser and maps parsed `contactType`/`contactValues` and `name`/`surname` into the form state, or writes the raw value to `name` when parsing fails, then calls `submitWithNormalization` and clears the input. 
- Rendered the technical input immediately before the `name` field when `roleTokens` includes `pp`, with `onBlur` and `onChange` handlers wired to the new state and submit handler, and a placeholder `Технічний інпут для PP`. 
- Kept existing form normalization and submit flow by reusing `submitWithNormalization` so behavior is consistent with other field updates.

### Testing
- Ran lint on the file with `npm run lint:js -- src/components/ProfileForm.jsx` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84e05e42c8326ab8f2bfaecdff461)