### PR TITLE
Fix LinkedIn contact URL handling in profile contacts

### DIFF
--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -50,6 +50,27 @@ const normalizeExternalUrl = value => {
   return `https://${rawValue}`;
 };
 
+
+const buildLinkedinUrl = value => {
+  const rawValue = String(value ?? '').trim();
+
+  if (!rawValue) {
+    return '';
+  }
+
+  if (/^[a-z][a-z\d+\-.]*:/i.test(rawValue)) {
+    return rawValue;
+  }
+
+  const normalizedValue = rawValue.replace(/^\/+/, '');
+
+  if (normalizedValue.startsWith('in/') || normalizedValue.startsWith('company/')) {
+    return `https://www.linkedin.com/${normalizedValue}`;
+  }
+
+  return `https://www.linkedin.com/in/${normalizedValue}`;
+};
+
 export const fieldContacts = (data, parentKey = '') => {
   if (!data || typeof data !== 'object') {
     console.error('Invalid data passed to renderContacts:', data);
@@ -63,7 +84,7 @@ export const fieldContacts = (data, parentKey = '') => {
     phone: value => `tel:${value}`,
     facebook: value => `https://facebook.com/${value}`,
     vk: value => `https://vk.com/${value}`,
-    linkedin: value => `https://www.linkedin.com/in/${value}`,
+    linkedin: value => buildLinkedinUrl(value),
     youtube: value => `https://www.youtube.com/@${value}`,
     otherLink: value => normalizeExternalUrl(value),
     email: value => `mailto:${value}`,
@@ -366,7 +387,7 @@ export const fieldContactsIcons = (
     phone: value => `tel:${value}`,
     facebook: value => `https://facebook.com/${value}`,
     vk: value => `https://vk.com/${value}`,
-    linkedin: value => `https://www.linkedin.com/in/${value}`,
+    linkedin: value => buildLinkedinUrl(value),
     youtube: value => `https://www.youtube.com/@${value}`,
     otherLink: value => normalizeExternalUrl(value),
     email: value => `mailto:${value}`,


### PR DESCRIPTION
### Motivation
- LinkedIn contact inputs were always transformed into `/in/<value>`, causing full LinkedIn URLs or `company/...` paths to open incorrectly.
- The change makes link generation robust to different user inputs (full URLs, path-style values, or plain nicknames).

### Description
- Added a `buildLinkedinUrl` helper in `src/components/smallCard/fieldContacts.js` to normalize LinkedIn values and preserve full URLs when provided.
- Updated the `links.linkedin` entry used by `fieldContacts` to call `buildLinkedinUrl` instead of hardcoding `/in/` behavior.
- Updated the `links.linkedin` entry used by `fieldContactsIcons` to use the same helper so icon and text rendering behave identically.
- The helper trims leading slashes, accepts full URLs (returns them unchanged), preserves `in/` and `company/` paths, and falls back to `https://www.linkedin.com/in/<value>` for simple nicknames.

### Testing
- Ran a production build with `npm run build`, which completed successfully and produced the optimized bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84e11fda88326847cd6466c3ea2db)