### PR TITLE
Always overwrite parsed UK-trigger name fields

### DIFF
--- a/src/utils/parseUkTrigger.js
+++ b/src/utils/parseUkTrigger.js
@@ -43,8 +43,8 @@ export const parseUkTriggerQuery = rawQuery => {
     searchPair: { telegram: normalizedQuery },
   };
 
-  if (name) result.name = name;
-  if (surname) result.surname = surname;
+  result.name = name;
+  result.surname = surname;
 
   return result;
 };


### PR DESCRIPTION
### Motivation
- Prevent stale profile fields when a UK trigger includes only a handle or a single name by ensuring parsed name parts explicitly clear missing values instead of leaving old data in place.

### Description
- In `src/utils/parseUkTrigger.js` changed conditional assignments to unconditionally set `result.name = name` and `result.surname = surname` so empty parsed values will overwrite existing fields.

### Testing
- Ran `CI=true npm test -- --runTestsByPath src/utils/__tests__/parseUkTrigger.test.js` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f855bb09a08326bdeb473c5a7c2851)