### PR TITLE
Fix IMT handling in searchKeySets (copy only height/weight buckets)

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -364,14 +364,16 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   };
 
   const imtCandidateUserIds = resolveImtCandidateUserIds();
-  const allowedUserIdsForWrites = hasImtFilter ? imtCandidateUserIds : normalizedUserIds;
   const imtAllowedUserIds = hasImtFilter ? filterUserIdsByImtBuckets(imtCandidateUserIds) : normalizedUserIds;
+  const allowedUserIdsForWrites = hasImtFilter
+    ? normalizedUserIds.filter(userId => imtAllowedUserIds.includes(userId))
+    : normalizedUserIds;
 
   const writes = Object.entries(bucketMap || {}).reduce((accWrites, [indexName, rawValues]) => {
-    if (hasImtFilter) return accWrites;
     const normalizedIndexName = normalizePathSegment(indexName);
     if (!normalizedIndexName) return accWrites;
     if (normalizedIndexName === 'imt') return accWrites;
+    if (hasImtFilter && !['height', 'weight'].includes(normalizedIndexName)) return accWrites;
 
     if (normalizedIndexName === 'age') {
       const allowedAgeValues = (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
@@ -419,12 +421,14 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   }, {});
 
   if (hasImtFilter) {
+    const copiedBucketCountByMetric = { height: 0, weight: 0 };
     ['height', 'weight'].forEach(metricIndexName => {
       const metricBuckets = buildMetricBucketsForAllowedUsers({
         searchKeyFile,
         indexName: metricIndexName,
-        allowedUserIds: imtAllowedUserIds,
+        allowedUserIds: allowedUserIdsForWrites,
       });
+      copiedBucketCountByMetric[metricIndexName] = Object.keys(metricBuckets).length;
       Object.entries(metricBuckets).forEach(([bucketValue, targetUserIds]) => {
         const path = `${normalizedRootPath}/${metricIndexName}/${bucketValue}`;
         writes[path] = targetUserIds.reduce((result, userId) => {
@@ -468,8 +472,13 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
       usersWithWeight,
       usersWithValidImt,
       usersInLe28,
-      usersPassedImt: imtAllowedUserIds.length,
+      imtSelectedTokens: imtValues,
+      allowedUserIdsCount: allowedUserIdsForWrites.length,
       bucketsWritten: Object.keys(writes).length,
+      copiedHeightBucketCount: copiedBucketCountByMetric.height,
+      copiedWeightBucketCount: copiedBucketCountByMetric.weight,
+      totalCopiedBucketPaths: copiedBucketCountByMetric.height + copiedBucketCountByMetric.weight,
+      hasImtBucketWrites: Object.keys(writes).some(path => String(path).includes('/imt/')),
       usersWritten: writtenUserIds.size,
       writtenHeightUsers: writtenHeightUsers.size,
       writtenWeightUsers: writtenWeightUsers.size,


### PR DESCRIPTION
### Motivation
- Виправити неправильну поведінку при застосуванні правила `imt`, коли код намагався створювати/очікувати `/imt/*` buckets у `searchKeySets`, що призводило до `buckets=0` навіть при наявності `userIds`.
- `imt` має бути тільки фільтром- допуском для відбору `allowedUserIds`, а не окремим індексом для копіювання у `searchKeySets`.
- Потрібно відтворювати структуру `searchKey` тільки для `height` та `weight` підмножини дозволених користувачів.

### Description
- Оновлено `buildRuleBucketWrites` у `src/utils/newUsersFilterSetsIndex.js` щоб розраховувати `imtAllowedUserIds` та `allowedUserIdsForWrites` як перетин prefiltered `userIds` з IMT-допущеними користувачами через `filterUserIdsByImtBuckets`.
- Заборонено запис для індексу `imt` і, при наявності IMT-фільтра, пропускаються всі індекси крім `height` та `weight` (копіюються лише оригінальні metric buckets для дозволених користувачів через `buildMetricBucketsForAllowedUsers`).
- Додано лічильники копій buckets і діагностику, що включає `imtSelectedTokens`, `allowedUserIdsCount`, `copiedHeightBucketCount`, `copiedWeightBucketCount`, `totalCopiedBucketPaths` та прапорець `hasImtBucketWrites` для перевірки, що `/imt/*` не пишеться.
- Збережено існуючу логіку запису для інших правил та `age`, але тепер ці записані `userId` фільтруються згідно з IMT-допуском коли потрібно.

### Testing
- Запущено `npx eslint src/utils/newUsersFilterSetsIndex.js`, лінтер пройшов без помилок (є лише стандартне `browserslist` попередження).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88745c60c8326a241c3c3b92b8408)