### PR TITLE
Fix stale UI after compare overwrite actions

### DIFF
--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -88,29 +88,31 @@ export const btnCompare = (
   
     if (users[targetUserId]) {
       const updatedUsers = { ...users };
+      const updatedTargetUser = { ...updatedUsers[targetUserId] };
   
       if (key === 'getInTouch' || key === 'lastCycle' || key === 'myComment') {
-        updatedUsers[targetUserId][key] = currentVal || nextVal;
+        updatedTargetUser[key] = currentVal || nextVal;
       } else {
         const mergedValue = mergeValues(key, currentVal, nextVal);
   
         if (mergedValue.includes(',')) {
           // Зберігаємо правильний порядок масиву
-          updatedUsers[targetUserId][key] = mergedValue.split(',').map((item) => item.trim());
+          updatedTargetUser[key] = mergedValue.split(',').map((item) => item.trim());
         } else {
-          updatedUsers[targetUserId][key] = mergedValue;
+          updatedTargetUser[key] = mergedValue;
         }
       }
   
       // Видаляємо `duplicate` перед збереженням
-      if (updatedUsers[targetUserId]?.hasOwnProperty('duplicate')) {
-        delete updatedUsers[targetUserId].duplicate;
+      if (updatedTargetUser?.hasOwnProperty('duplicate')) {
+        delete updatedTargetUser.duplicate;
       }
   
+      updatedUsers[targetUserId] = updatedTargetUser;
       setUsers(updatedUsers);
-      handleSubmitAll(updatedUsers[targetUserId], 'overwrite');
+      handleSubmitAll(updatedTargetUser, 'overwrite');
   
-      console.log('Updated user data:', updatedUsers[targetUserId]);
+      console.log('Updated user data:', updatedTargetUser);
     } else {
       console.error(`User with ID ${targetUserId} not found`);
     }


### PR DESCRIPTION
### Motivation
- The compare overwrite handler mutated a nested user object directly which could keep the same reference for the nested object and prevent React from rerendering memoized parts of the UI.
- The change ensures updates produce new nested references so the frontend reflects overwrites immediately.

### Description
- Updated `src/components/smallCard/btnCompare.js` to clone the target user into `updatedTargetUser` before applying field changes in the `handleClick` flow.
- Reassigned the cloned `updatedTargetUser` into the top-level `updatedUsers` object and passed the cloned object to `handleSubmitAll`, keeping persistence behavior unchanged.
- Left the merge logic and special-case handling for `myComment`, `getInTouch`, and `lastCycle` intact while avoiding in-place mutation of nested objects.

### Testing
- Ran `npm run build` and the production build completed successfully.
- No unit tests were modified or added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f893dc2f7c8326b8eb8f4406633d55)