### PR TITLE
Add Twitter field and smarter ppTechnicalInput parsing; append contact values and normalize phones/emails

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -10,6 +10,7 @@ import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import {
   formatDateToDisplay,
   formatDateAndFormula,
+  normalizePhoneValue,
 } from 'components/inputValidations';
 import { parseUkTriggerQuery } from 'utils/parseUkTrigger';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
@@ -112,6 +113,22 @@ const PHENOTYPE_FIELDS = [
   'responsibility',
 ];
 const ANTHROPOMETRY_FIELDS = ['height', 'weight', 'imt', 'clothingSize', 'shoeSize', 'breastSize'];
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+const appendFieldValue = (currentValue, nextValue) => {
+  const normalizedNextValue = String(nextValue ?? '').trim();
+  if (!normalizedNextValue) return currentValue;
+
+  if (Array.isArray(currentValue)) {
+    return [...currentValue, normalizedNextValue];
+  }
+
+  const normalizedCurrentValue = String(currentValue ?? '').trim();
+  if (!normalizedCurrentValue) {
+    return normalizedNextValue;
+  }
+
+  return [normalizedCurrentValue, normalizedNextValue];
+};
 const REPRODUCTIVE_FIELDS = [
   'birth',
   'ownKids',
@@ -1934,18 +1951,39 @@ ${entries.join('\n')}`;
       const nextState = { ...prevState };
 
       if (!parsed) {
-        nextState.name = rawValue;
+        const normalizedPhone = normalizePhoneValue(rawValue);
+        const strippedPhoneCandidate = String(rawValue).replace(/[^\d+]/g, '');
+        const looksLikePhone =
+          Boolean(normalizedPhone) && /^[+]?\d[\d\s().-]*$/.test(strippedPhoneCandidate || rawValue);
+        const looksLikeEmail = EMAIL_REGEX.test(rawValue);
+
+        if (looksLikeEmail) {
+          nextState.email = appendFieldValue(prevState.email, rawValue);
+        } else if (looksLikePhone) {
+          nextState.phone = appendFieldValue(prevState.phone, normalizedPhone);
+        } else {
+          nextState.name = appendFieldValue(prevState.name, rawValue);
+        }
       } else {
         const { contactType, contactValues, name, surname } = parsed;
 
         if (contactType) {
-          nextState[contactType] = contactValues;
+          if (contactType === 'phone') {
+            const rawPhoneValue = Array.isArray(contactValues) ? contactValues[0] : contactValues;
+            nextState.phone = appendFieldValue(prevState.phone, normalizePhoneValue(rawPhoneValue));
+          } else if (contactType === 'email') {
+            const rawEmailValue = Array.isArray(contactValues) ? contactValues[0] : contactValues;
+            nextState.email = appendFieldValue(prevState.email, String(rawEmailValue || '').trim());
+          } else {
+            const rawContactValue = Array.isArray(contactValues) ? contactValues[0] : contactValues;
+            nextState[contactType] = appendFieldValue(prevState[contactType], rawContactValue);
+          }
         }
         if (name) {
-          nextState.name = name;
+          nextState.name = appendFieldValue(prevState.name, name);
         }
         if (surname) {
-          nextState.surname = surname;
+          nextState.surname = appendFieldValue(prevState.surname, surname);
         }
       }
 
@@ -2241,7 +2279,7 @@ ${entries.join('\n')}`;
                               }
                             }
 
-                            const needsSocialCleanup = ['facebook', 'instagram'].includes(field.name);
+                            const needsSocialCleanup = ['facebook', 'instagram', 'twitter'].includes(field.name);
                             const rawValue = state[field.name];
                             const normalizedValue = needsSocialCleanup && rawValue != null
                               ? inputUpdateValue(rawValue, field)
@@ -2720,7 +2758,7 @@ const InputField = styled.input`
   border-radius: 0;
   padding-left: ${({ fieldName, value }) => {
     if (fieldName === 'phone') return '20px';
-    if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok') return '25px';
+    if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok' || fieldName === 'twitter') return '25px';
     if (fieldName === 'facebook') return /^\d+$/.test(value) ? '20px' : '25px';
     if (fieldName === 'vk') return /^\d+$/.test(value) || value === '' ? '23px' : '10px';
     return '10px';
@@ -2769,7 +2807,7 @@ const Hint = styled.label`
   position: absolute;
   padding-left: ${({ fieldName }) => {
     if (fieldName === 'phone') return '20px';
-    if (fieldName === 'telegram' || fieldName === 'facebook' || fieldName === 'instagram' || fieldName === 'tiktok') return '25px';
+    if (fieldName === 'telegram' || fieldName === 'facebook' || fieldName === 'instagram' || fieldName === 'tiktok' || fieldName === 'twitter') return '25px';
     if (fieldName === 'vk') return '23px';
     return '10px';
   }};
@@ -2824,7 +2862,7 @@ const InputFieldContainer = styled.div`
   &::before {
     content: ${({ fieldName, value }) => {
       if (fieldName === 'phone') return "'+'";
-      if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok') return "'@'";
+      if (fieldName === 'telegram' || fieldName === 'instagram' || fieldName === 'tiktok' || fieldName === 'twitter') return "'@'";
       if (fieldName === 'facebook') return /^\d+$/.test(value) ? "'='" : "'@'";
       if (fieldName === 'vk') return /^\d+$/.test(value) || value === '' || value === undefined ? "'id'" : "''";
       return "''";

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -158,6 +158,7 @@ export const pickerFields = [
   { name: 'facebook', placeholder: 'facebook_nickname', svg: 'facebook-f', ukrainianHint:'Facebook' },
   { name: 'instagram', placeholder: 'instagram_nickname', svg: 'instagram', ukrainianHint:'Instagram' },
   { name: 'tiktok', placeholder: 'tiktok_nickname', svg: 'tiktok', ukrainianHint:'TikTok' },
+  { name: 'twitter', placeholder: 'twitter_nickname', svg: 'no', ukrainianHint:'Twitter / X' },
   { name: 'linkedin', placeholder: 'linkedin_nickname', svg: 'no', ukrainianHint:'LinkedIn' },
   { name: 'youtube', placeholder: 'youtube_nickname', svg: 'no', ukrainianHint:'YouTube' },
   { name: 'vk', placeholder: '0107655', hint: '0107655', svg: 'vk', ukrainianHint:'VK' },

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -183,7 +183,7 @@ export const ADDITIONAL_ACCESS_FILTER_OPTIONS = {
   maritalStatus: ['+', '-', '?', 'no'],
   imt: ['le28', '29_31', '32_35', '36_plus', '?', 'no'],
   role: ['ed', 'sm', 'ag', 'ip', 'cl', '?', 'no'],
-  contact: ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email'],
+  contact: ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email', 'twitter'],
   userId: ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'],
   reaction: ['past', 'future', '99', '?', 'no'],
   height: ['lt163', '163_176', '177_180', '181_plus', '?', 'no'],
@@ -210,7 +210,7 @@ export const ADDITIONAL_ACCESS_TEMPLATE = `age: 18,19,20,21,22,23,24,25,26,27,28
 blood: 1+,1-,1,2+,2-,2,3+,3-,3,4+,4-,4,?,no
 maritalStatus: +,-,?,no
 csection: cs2plus,cs1,cs0,other,no
-contact: vk,instagram,facebook,phone,telegram,telegram2,tiktok,linkedin,youtube,email
+contact: vk,instagram,facebook,phone,telegram,telegram2,tiktok,linkedin,youtube,email,twitter
 role: ed,sm,ag,ip,cl,?,no
 userId: vk,aa,ab,id,long,mid,other
 imt: le28,29_31,32_35,36_plus,?,no
@@ -277,7 +277,7 @@ const toMetricBucket = (value, ranges) => {
 };
 
 const toContactBuckets = user => {
-  const keys = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email'];
+  const keys = ['vk', 'instagram', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email', 'twitter'];
   return keys.filter(key => String(user?.[key] || '').trim() !== '');
 };
 


### PR DESCRIPTION
### Motivation
- Add support for Twitter as a contact field and include it in contact-related rules and UI affordances.  
- Improve how technical input (`ppTechnicalInput`) is interpreted so phone/email/name fragments are detected and appended instead of blindly overwriting existing fields.  
- Normalize phone and email values when parsing/adding contacts to reduce fragmented data and UI inconsistencies.

### Description
- Introduced `EMAIL_REGEX` and an `appendFieldValue` helper to append new parsed values to existing string/array fields without losing previous data.  
- Enhanced `ppTechnicalInput` handling to detect email vs phone vs generic text, use `normalizePhoneValue` for phone normalization, and append parsed `name`/`surname`/contact values to existing `state` entries; still supports parsed `contactType` results.  
- Added `twitter` to `pickerFields`, `additionalAccessRules` contact keys and templates, and contact bucketization (`toContactBuckets`), and included `twitter` in social-cleanup, input padding, and input prefix (`@`) styles in styled components.  
- Minor UI tweaks to input padding and hint prefixes so Twitter displays consistently alongside other social nicknames.

### Testing
- Ran unit tests with `yarn test` and code linting with `yarn lint`, and both completed successfully.  
- Verified relevant contact-related buckets and templates updated in automated rule-parsing logic by running existing rule parser tests, which passed.  
- No automated failures introduced by style/component changes according to the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89302b3d48326b83d0541705f9e5c)