### PR TITLE
Keep URL `userId` query param in sync with active profile state

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1478,6 +1478,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     hasSearched,
   ]);
 
+
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const urlUserId = params.get('userId');
@@ -1508,6 +1509,32 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setIsResolvingEditMode(false);
     }
   }, [state.userId]);
+
+  useEffect(() => {
+    if (!canAccessAdd) return;
+
+    const params = new URLSearchParams(location.search);
+    const currentUserIdInUrl = params.get('userId') || '';
+    const activeUserId = String(state.userId || '').trim();
+
+    if (activeUserId) {
+      if (currentUserIdInUrl === activeUserId) return;
+      params.set('userId', activeUserId);
+      navigate(
+        { pathname: location.pathname, search: `?${params.toString()}` },
+        { replace: true }
+      );
+      return;
+    }
+
+    if (!currentUserIdInUrl) return;
+    params.delete('userId');
+    const nextSearch = params.toString();
+    navigate(
+      { pathname: location.pathname, search: nextSearch ? `?${nextSearch}` : '' },
+      { replace: true }
+    );
+  }, [canAccessAdd, location.pathname, location.search, navigate, state.userId]);
 
   useEffect(() => {
     const normalized = (search || '').trim();


### PR DESCRIPTION
### Motivation
- Ensure the URL reflects the currently active profile when adding/editing so deep links and browser navigation remain consistent.
- Avoid stale `userId` query parameters when the active profile changes or is cleared.

### Description
- Added a new `useEffect` that updates the `userId` query parameter to match `state.userId` and removes it when `state.userId` is empty, using `navigate(..., { replace: true })` to avoid history pollution.
- The effect is guarded by `canAccessAdd` and compares the trimmed values before updating to avoid unnecessary navigation calls.
- Kept existing logic that reads `userId` and `search` from `location.search` and resolves edit mode, while ensuring the new effect keeps the URL in sync after state changes.

### Testing
- Ran the project's unit tests and linters locally, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89fae81108326b153819f7ede7bb0)