### PR TITLE
Fail fast on empty filtered searchKeySets and switch to full-set writes with diagnostics

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -994,6 +994,8 @@ export const ProfileForm = ({
         toast.error('Спершу підвантажте локальний файл searchKey перед збереженням.');
       } else if (code.includes('MISSING_SEARCHKEY_INDEX')) {
         toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.');
+      } else if (code.includes('EMPTY_FILTERED_SEARCHKEY_SET')) {
+        toast.error('Набір очищено, але нові дані не сформовані');
       } else {
         console.error('Failed to update additional access newUsers filter-set index', error);
         const details = error?.message || String(error);
@@ -1148,6 +1150,9 @@ export const ProfileForm = ({
       const matchedCount = Number(indexResult?.userIds?.length || 0);
       const writesCount = Number(indexResult?.writesCount || 0);
       const bucketWritesCount = Number(indexResult?.bucketWritesCount || 0);
+      const backendRequests = Array.isArray(indexResult?.debug?.backendRequests)
+        ? indexResult.debug.backendRequests
+        : [];
       const removedSetsCount = Number(indexResult?.debug?.removedSetKeys?.length || 0);
       const debugSets = Array.isArray(indexResult?.debug?.sets) ? indexResult.debug.sets : [];
       const debugPreview = debugSets
@@ -1165,6 +1170,11 @@ export const ProfileForm = ({
       );
       if (setsCount === 0 && writesCount === 0) {
         toast('searchKeySets не оновлено: не знайдено валідних правил.', { id: toastId });
+      } else if (
+        backendRequests.length === 1 &&
+        backendRequests[0]?.type === 'remove'
+      ) {
+        toast.error('Набір очищено, але нові дані не сформовані', { id: toastId });
       } else if (setsCount > 0 && bucketWritesCount === 0) {
         const bucketPathHints = debugSets
           .flatMap(set => (Array.isArray(set?.bucketPathsPreview) ? set.bucketPathsPreview : []))
@@ -1196,6 +1206,8 @@ export const ProfileForm = ({
         toast.error('Локальний файл searchKey не підвантажено. Індексація searchKeySets зупинена.', { id: toastId });
       } else if (code.includes('MISSING_SEARCHKEY_INDEX')) {
         toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.', { id: toastId });
+      } else if (code.includes('EMPTY_FILTERED_SEARCHKEY_SET')) {
+        toast.error('Набір очищено, але нові дані не сформовані', { id: toastId });
       } else {
         toast.error(`Помилка на етапі "${stage}": не вдалося виконати індексацію наборів фільтрів.\n${details}`, { id: toastId });
       }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1,4 +1,4 @@
-import { get, ref, remove, update } from 'firebase/database';
+import { get, ref, remove, set, update } from 'firebase/database';
 import {
   createAgeSearchKeyIndexInCollection,
   createContactSearchKeyIndexInCollection,
@@ -79,6 +79,14 @@ const IMT_BUCKET_RANGES = {
   '29_31': { min: 29, max: 31 },
   '32_35': { min: 32, max: 35 },
   '36_plus': { min: 36, max: Infinity },
+};
+
+const countRecords = node => {
+  if (!node || typeof node !== 'object') return 0;
+  return Object.values(node).reduce((total, value) => {
+    if (!value || typeof value !== 'object') return total;
+    return total + Object.keys(value).length;
+  }, 0);
 };
 
 export const collectMetricBucketsByUserId = searchKeyFile => {
@@ -598,25 +606,51 @@ export const buildNewUsersFilterSetIndex = async ({
       bucketPathsPreview: Object.keys(ruleBucketWrites).slice(0, 12),
     });
 
-    if (Object.keys(ruleBucketWrites).length) {
-      bucketWritesCount += Object.keys(ruleBucketWrites).length;
-      debug.backendRequests.push({
-        type: 'update',
-        path: '/',
-        payload: { ...ruleBucketWrites },
-      });
-      console.info('[searchKeySets] Firebase write start', {
-        path: '/',
-        setKey,
-        writesCount: Object.keys(ruleBucketWrites).length,
-      });
-      // eslint-disable-next-line no-await-in-loop
-      await update(ref(database), ruleBucketWrites);
-      console.info('[searchKeySets] Firebase write success', {
-        path: '/',
-        setKey,
-      });
+    const filteredSearchKeySet = Object.entries(ruleBucketWrites).reduce((acc, [path, payload]) => {
+      const prefix = `${SEARCH_KEY_SETS_ROOT}/${setKey}/`;
+      if (!path.startsWith(prefix) || payload == null) return acc;
+      const relativePath = path.slice(prefix.length);
+      const [indexName, bucketName, userId] = relativePath.split('/');
+      if (!indexName || !bucketName || !userId) return acc;
+      if (!acc[indexName]) acc[indexName] = {};
+      if (!acc[indexName][bucketName]) acc[indexName][bucketName] = {};
+      acc[indexName][bucketName][userId] = payload;
+      return acc;
+    }, {});
+
+    if (!filteredSearchKeySet || Object.keys(filteredSearchKeySet).length === 0) {
+      const error = new Error('filteredSearchKeySet empty — nothing to save');
+      error.code = 'EMPTY_FILTERED_SEARCHKEY_SET';
+      throw error;
     }
+
+    console.log('WRITE PAYLOAD:', {
+      setId: setKey,
+      hasPayload: !!filteredSearchKeySet,
+      fields: Object.keys(filteredSearchKeySet),
+      totalRecords: countRecords(filteredSearchKeySet),
+    });
+
+    debug.backendRequests.push({
+      type: 'set',
+      path: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
+      payload: filteredSearchKeySet,
+    });
+    console.log('backendRequests:', debug.backendRequests);
+
+    const writesCountForSet = Object.keys(ruleBucketWrites).length;
+    bucketWritesCount += writesCountForSet;
+    console.info('[searchKeySets] Firebase write start', {
+      path: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
+      setKey,
+      writesCount: writesCountForSet,
+    });
+    // eslint-disable-next-line no-await-in-loop
+    await set(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`), filteredSearchKeySet);
+    console.info('[searchKeySets] Firebase write success', {
+      path: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
+      setKey,
+    });
   }
 
   const aggregatedUserIds = [...new Set(nextSetPayloads.flatMap(item => Object.keys(item.userIds)))];


### PR DESCRIPTION
### Motivation
- Prevent saving empty or partial searchKeySets and make failures visible to the UI when no valid bucket records are produced.
- Improve backend-write semantics and diagnostics to avoid broken/partial index state and provide clearer error handling.

### Description
- Import `set` from `firebase/database` and add a `countRecords` helper to measure write payload size.
- Build a `filteredSearchKeySet` for each set and throw an error with code `EMPTY_FILTERED_SEARCHKEY_SET` when it contains no records to save.
- Replace the previous per-path `update` approach with a single `set(ref(database, ...), filteredSearchKeySet)` per set and record `debug.backendRequests` entries (`remove` and `set`) for diagnostics; keep `remove` for clearing the previous set before writing.
- Update `ProfileForm` to handle the new `EMPTY_FILTERED_SEARCHKEY_SET` error and to surface a dedicated toast when the backend diagnostics show only a `remove` request (set was cleared but no new data formed).

### Testing
- Ran lint via `npm run lint` and the test suite via `npm test`, and both completed successfully.
- Executed a local smoke test of `buildNewUsersFilterSetIndex` to confirm it throws `EMPTY_FILTERED_SEARCHKEY_SET` for empty filtered payloads and that the UI displays the corresponding toast message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a44755388326b099b9735aa58676)