### PR TITLE
Fix /add deep-link redirect by waiting for access resolution

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -19,6 +19,7 @@ export const App = () => {
   const [isAdmin, setIsAdmin] = useState(null);
   const [canAccessAdd, setCanAccessAdd] = useState(false);
   const [canAccessMatching, setCanAccessMatching] = useState(false);
+  const [isAccessResolved, setIsAccessResolved] = useState(false);
   // console.log('isLoggedIn :>> ', isLoggedIn);
 
   const navigate = useNavigate();
@@ -32,7 +33,7 @@ export const App = () => {
   }, []);
 
   useEffect(() => {
-    if (!isLoggedIn || isAdmin !== false) {
+    if (!isLoggedIn || !isAccessResolved || isAdmin !== false) {
       return;
     }
 
@@ -43,7 +44,7 @@ export const App = () => {
     if (isRootRoute || isUnauthorizedAddRoute || isUnauthorizedMatchingRoute) {
       navigate('/my-profile');
     }
-  }, [isLoggedIn, navigate, isAdmin, location.pathname, canAccessAdd, canAccessMatching]);
+  }, [isLoggedIn, isAccessResolved, navigate, isAdmin, location.pathname, canAccessAdd, canAccessMatching]);
 
   // Special page for admin
   useEffect(() => {
@@ -63,12 +64,14 @@ export const App = () => {
         setCanAccessAdd(access.canAccessAdd);
         setCanAccessMatching(access.canAccessMatching);
         localStorage.setItem('accessLevel', accessLevel);
+        setIsAccessResolved(true);
       } else {
         localStorage.removeItem('ownerId');
         localStorage.removeItem('accessLevel');
         setIsAdmin(false);
         setCanAccessAdd(false);
         setCanAccessMatching(false);
+        setIsAccessResolved(true);
       }
     });
     return () => unsubscribe();


### PR DESCRIPTION
### Motivation
- Prevent a premature redirect that briefly shows the edit card for deep-links like `/add?userId=...` by ensuring route-guard logic waits until access rights are resolved.

### Description
- Added `isAccessResolved` state in `App` to mark when Firebase auth/access checks complete.
- Updated the redirect guard to require `isAccessResolved === true` before navigating away from `/add` or `/`.
- Set `isAccessResolved` to `true` in both authenticated and unauthenticated branches of the `onAuthStateChanged` handler in `src/components/App.jsx`.

### Testing
- Ran `npm run -s build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ba8defa483268021de32e971a8bb)