### PR TITLE
Add detailed searchKeySets debug toasts and diagnostics

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -978,6 +978,69 @@ export const ProfileForm = ({
           matchedUserIdsBySetKey,
           searchKeyFile: localSearchKeyPayload,
         });
+        const lastSetDebug = indexResult?.debug?.lastSetDebug || {};
+        const selectedRulesSummary = Array.isArray(lastSetDebug?.imtValues) && lastSetDebug.imtValues.length
+          ? `imt=${lastSetDebug.imtValues.join(',')}`
+          : 'imt=none';
+        toast(`1/8 Rules parsed: ${selectedRulesSummary}`);
+        toast(`2/8 Allowed users: ${Number(lastSetDebug?.allowedUserIdsCount || 0)}`);
+        const searchKeyFields = Array.isArray(lastSetDebug?.searchKeyFields) ? lastSetDebug.searchKeyFields : [];
+        toast(`3/8 searchKey fields: ${searchKeyFields.join(', ') || 'none'}`);
+        toast(`4/8 Start copying filtered searchKey, allowed=${Number(lastSetDebug?.allowedUserIdsCount || 0)}`);
+        const copiedByField = lastSetDebug?.copiedByField && typeof lastSetDebug.copiedByField === 'object'
+          ? lastSetDebug.copiedByField
+          : {};
+        ['height', 'weight', 'age'].forEach(field => {
+          const stats = copiedByField[field];
+          if (stats) {
+            toast(`5/8 Copied ${field}: buckets=${Number(stats.buckets || 0)}, records=${Number(stats.records || 0)}`);
+          }
+        });
+        if (Array.isArray(lastSetDebug?.skippedFields) && lastSetDebug.skippedFields.includes('imt')) {
+          toast('5/8 Skipped imt field');
+        }
+        const filteredFields = Array.isArray(lastSetDebug?.filteredFields) ? lastSetDebug.filteredFields : [];
+        toast(
+          `6/8 Filtered set ready: fields=${filteredFields.length}, buckets=${Number(lastSetDebug?.copiedBuckets || 0)}, records=${Number(lastSetDebug?.copiedRecords || 0)}`
+        );
+        const backendRequests = Array.isArray(lastSetDebug?.backendRequests) ? lastSetDebug.backendRequests : [];
+        const removeCount = backendRequests.filter(item => item?.type === 'remove').length;
+        const setCount = backendRequests.filter(item => item?.type === 'set').length;
+        toast(`7/8 Backend requests: remove=${removeCount}, set=${setCount}, payloadRecords=${Number(lastSetDebug?.copiedRecords || 0)}`);
+        if (lastSetDebug?.setKey) {
+          toast(`8/8 Saved searchKeySets/${lastSetDebug.setKey}: records=${Number(lastSetDebug?.copiedRecords || 0)}`);
+        }
+        if (Number(lastSetDebug?.allowedUserIdsCount || 0) === 0) {
+          toast.error('STOP: allowedUserIds=0. Перевір tokens/rules/searchKey.imt');
+        }
+        if (!searchKeyFields.length) {
+          toast.error('STOP: searchKey empty or not loaded');
+        }
+        if ((searchKeyFields.length === 1 && searchKeyFields[0] === 'imt') || !searchKeyFields.includes('height') || !searchKeyFields.includes('weight')) {
+          toast.error('STOP: searchKey missing height/weight fields');
+        }
+        if (Number(lastSetDebug?.copiedRecords || 0) === 0 && Number(lastSetDebug?.allowedUserIdsCount || 0) > 0) {
+          toast.error('STOP: copiedRecords=0. allowedUserIds є, але жоден userId не знайдений у searchKey buckets');
+        }
+        if (removeCount > 0 && setCount === 0) {
+          toast.error('STOP: only remove request created. set/update missing');
+        }
+        const hasSetPayload = backendRequests.some(item => item?.type === 'set' && item?.payload && Object.keys(item.payload).length > 0);
+        if (!hasSetPayload) {
+          toast.error('STOP: payload empty before backend write');
+        }
+        console.log('[searchKeySets debug]', {
+          selectedRules: lastSetDebug?.selectedRules,
+          allowedUserIdsCount: Number(lastSetDebug?.allowedUserIdsCount || 0),
+          allowedSample: Array.isArray(lastSetDebug?.allowedSample) ? lastSetDebug.allowedSample.slice(0, 10) : [],
+          searchKeyFields,
+          skippedFields: Array.isArray(lastSetDebug?.skippedFields) ? lastSetDebug.skippedFields : [],
+          copiedByField,
+          copiedRecords: Number(lastSetDebug?.copiedRecords || 0),
+          copiedBuckets: Number(lastSetDebug?.copiedBuckets || 0),
+          filteredFields,
+          backendRequests,
+        });
         if (indexResult && Number(indexResult.writesCount || 0) === 0 && Number(indexResult?.setKeys?.length || 0) === 0) {
           toast('searchKeySets не оновлено: не знайдено валідних правил.');
         }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -227,46 +227,10 @@ const SEARCH_KEY_SET_BUILDERS = [
 ];
 
 
-const buildAgeKeysByUserIdFromSearchKey = async (userIds, searchKeyFile = null) => {
-  const normalizedIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
-  if (normalizedIds.length === 0) return {};
-
-  const normalizedSearchKeyFile =
-    searchKeyFile && typeof searchKeyFile === 'object' && !Array.isArray(searchKeyFile)
-      ? searchKeyFile
-      : null;
-  const ageIndex =
-    normalizedSearchKeyFile && typeof normalizedSearchKeyFile?.age === 'object'
-      ? normalizedSearchKeyFile.age
-      : null;
-
-  if (!ageIndex || typeof ageIndex !== 'object') return {};
-
-  const pending = new Set(normalizedIds);
-  const ageKeysByUserId = {};
-
-  Object.entries(ageIndex).forEach(([ageKey, usersMap]) => {
-    if (!(usersMap && typeof usersMap === 'object')) return;
-    if (pending.size === 0) return;
-
-    Object.keys(usersMap).forEach(userId => {
-      if (!pending.has(userId)) return;
-      ageKeysByUserId[userId] = ageKey;
-      pending.delete(userId);
-    });
-  });
-
-  return ageKeysByUserId;
-};
-
-
-
-
-
 const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyFile = null, rawText = '' }) => {
   const normalizedRootPath = String(rootPath || '').trim();
-  if (!normalizedRootPath) return {};
-  if (!searchKeyFile || typeof searchKeyFile !== 'object' || Array.isArray(searchKeyFile)) return {};
+  if (!normalizedRootPath) return { writes: {}, debugInfo: null };
+  if (!searchKeyFile || typeof searchKeyFile !== 'object' || Array.isArray(searchKeyFile)) return { writes: {}, debugInfo: null };
 
   const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
   const baseBucketMap = augmentBucketsWithImtMetricWrappers(mergeSearchKeyBuckets(parsedRuleGroups));
@@ -334,10 +298,17 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   const copiedBuckets = new Set();
   let copiedUserRecords = 0;
 
+  const copiedByField = {};
+  const skippedFields = [];
   Object.entries(searchKeyFile || {}).forEach(([indexName, bucketsMap]) => {
     const normalizedIndexName = normalizePathSegment(indexName);
-    if (!normalizedIndexName || normalizedIndexName === 'imt' || normalizedIndexName === 'users') return;
+    if (!normalizedIndexName || normalizedIndexName === 'users') return;
+    if (normalizedIndexName === 'imt') {
+      skippedFields.push('imt');
+      return;
+    }
     if (!bucketsMap || typeof bucketsMap !== 'object' || Array.isArray(bucketsMap)) return;
+    if (!copiedByField[normalizedIndexName]) copiedByField[normalizedIndexName] = { buckets: 0, records: 0 };
 
     Object.entries(bucketsMap).forEach(([bucketValue, usersMap]) => {
       if (!usersMap || typeof usersMap !== 'object' || Array.isArray(usersMap)) return;
@@ -354,6 +325,8 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
       copiedFields.add(normalizedIndexName);
       copiedBuckets.add(path);
       copiedUserRecords += filteredUserIds.length;
+      copiedByField[normalizedIndexName].buckets += 1;
+      copiedByField[normalizedIndexName].records += filteredUserIds.length;
     });
   });
 
@@ -419,7 +392,22 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     }
   }
 
-  return writes;
+  return {
+    writes,
+    debugInfo: {
+      selectedRules: parsedRuleGroups,
+      allowedUserIdsCount: allowedUserIdsForWrites.length,
+      allowedSample: [...normalizedAllowedIds].slice(0, 10),
+      searchKeyFields: Object.keys(searchKeyFile || {}),
+      skippedFields,
+      copiedByField,
+      copiedRecords: copiedUserRecords,
+      copiedBuckets: copiedBuckets.size,
+      filteredFields: [...copiedFields],
+      hasImtFilter,
+      imtValues,
+    },
+  };
 };
 
 export const buildSearchKeySetIndexFromMatchedUsers = async ({
@@ -461,9 +449,6 @@ export const buildSearchKeySetIndexFromMatchedUsers = async ({
     throw error;
   }
 
-  const allUserIds = [...new Set(setPayloads.flatMap(item => item.userIds || []).filter(Boolean))];
-  const ageKeysByUserId = await buildAgeKeysByUserIdFromSearchKey(allUserIds, searchKeyFile);
-
   for (const setPayload of setPayloads) {
     // eslint-disable-next-line no-await-in-loop
     await remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setPayload.setKey}`));
@@ -476,11 +461,10 @@ export const buildSearchKeySetIndexFromMatchedUsers = async ({
     const options = {
       rootPath: `${SEARCH_KEY_SETS_ROOT}/${setPayload.setKey}`,
     };
-    const ruleBucketWrites = buildRuleBucketWrites({
+    const { writes: ruleBucketWrites } = buildRuleBucketWrites({
       rootPath: options.rootPath,
       parsedRuleGroups: setPayload.parsedRuleGroups,
       userIds: setPayload.userIds,
-      ageKeysByUserId,
       searchKeyFile,
     });
 
@@ -591,7 +575,7 @@ export const buildNewUsersFilterSetIndex = async ({
     await remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`));
 
     const rootPath = `${SEARCH_KEY_SETS_ROOT}/${setKey}`;
-    const ruleBucketWrites = buildRuleBucketWrites({
+    const { writes: ruleBucketWrites, debugInfo } = buildRuleBucketWrites({
       rootPath,
       parsedRuleGroups,
       userIds: Object.keys(userIds || {}),
@@ -604,6 +588,7 @@ export const buildNewUsersFilterSetIndex = async ({
       parsedRuleGroupsCount: Array.isArray(parsedRuleGroups) ? parsedRuleGroups.length : 0,
       bucketWritesCount: Object.keys(ruleBucketWrites).length,
       bucketPathsPreview: Object.keys(ruleBucketWrites).slice(0, 12),
+      debugInfo,
     });
 
     const filteredSearchKeySet = Object.entries(ruleBucketWrites).reduce((acc, [path, payload]) => {
@@ -636,6 +621,12 @@ export const buildNewUsersFilterSetIndex = async ({
       path: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
       payload: filteredSearchKeySet,
     });
+    debug.lastSetDebug = {
+      ...(debugInfo || {}),
+      filteredFields: Object.keys(filteredSearchKeySet || {}),
+      backendRequests: debug.backendRequests,
+      setKey,
+    };
     console.log('backendRequests:', debug.backendRequests);
 
     const writesCountForSet = Object.keys(ruleBucketWrites).length;


### PR DESCRIPTION
### Motivation
- Make the `Зберегти набір у searchKeySets` flow transparent by surfacing exact counts at each step to quickly locate where data is lost (allowed users, searchKey load, missing fields, copying, payload formation, backend requests).

### Description
- Added 8 step-by-step toast messages in `src/components/ProfileForm.jsx` showing parsed rules, allowed users, searchKey fields, copy start, per-field copy stats, filtered set summary, backend request counts, and final saved records.
- Implemented explicit STOP error toasts for failure modes: `allowedUserIds=0`, `searchKey` empty, missing `height/weight`, `copiedRecords=0`, remove-only backend requests, and empty payload before write.
- Extended `buildRuleBucketWrites` in `src/utils/newUsersFilterSetsIndex.js` to return `{ writes, debugInfo }` including `copiedByField`, `skippedFields`, `allowedUserIdsCount`, `copiedRecords`, `copiedBuckets`, `imtValues` and other diagnostics, and propagated this debug info into `buildNewUsersFilterSetIndex` as `debug.lastSetDebug` so the UI can display real numbers.
- Added structured `console.log('[searchKeySets debug]', {...})` in the component with `selectedRules`, `allowedUserIdsCount`, `allowedSample`, `searchKeyFields`, `skippedFields`, `copiedByField`, `copiedRecords`, `copiedBuckets`, `filteredFields`, and `backendRequests` for full inspection.

### Testing
- Ran `npx eslint src/components/ProfileForm.jsx src/utils/newUsersFilterSetsIndex.js` and lint passed with no errors (only environment/browserslist warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ef0429f883269f05aab01ebbb0cb)