### PR TITLE
Omit empty surname in parseUkTrigger output and adjust tests

### DIFF
--- a/src/utils/__tests__/parseUkTrigger.test.js
+++ b/src/utils/__tests__/parseUkTrigger.test.js
@@ -37,7 +37,6 @@ describe('parseUkTriggerQuery', () => {
       contactType: 'telegram',
       contactValues: ['УК СМ @just_nickname', 'just_nickname'],
       name: '',
-      surname: '',
       handle: 'just_nickname',
       searchPair: { telegram: 'УК СМ @just_nickname' },
     });
@@ -73,7 +72,6 @@ describe('parseUkTriggerQuery', () => {
       contactType: 'telegram',
       contactValues: ['УК АГЕНТ Надія @nadia_agent', 'nadia_agent'],
       name: 'Надія',
-      surname: '',
       handle: 'nadia_agent',
       searchPair: { telegram: 'УК АГЕНТ Надія @nadia_agent' },
     });

--- a/src/utils/parseUkTrigger.js
+++ b/src/utils/parseUkTrigger.js
@@ -94,7 +94,9 @@ export const parseUkTriggerQuery = rawQuery => {
   };
 
   result.name = name;
-  result.surname = surname;
+  if (surname) {
+    result.surname = surname;
+  }
 
   return result;
 };


### PR DESCRIPTION
### Motivation
- Avoid emitting an empty `surname` property from `parseUkTriggerQuery` when no surname is present, producing a cleaner and more semantically accurate result object.

### Description
- Change `parseUkTriggerQuery` to only attach `surname` to the returned object when `surname` is non-empty, and update `src/utils/__tests__/parseUkTrigger.test.js` to stop expecting `surname: ''` in cases without a surname.

### Testing
- Ran the updated unit tests for `src/utils/__tests__/parseUkTrigger.test.js` and the full test suite, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b67c12288326be9e8b3c6db1871f)