### PR TITLE
IMT: use exact height/weight values for additionalAccessRuleSet filtering and add diagnostics

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -126,6 +126,26 @@ export const resolveImtBucketsFromMetricBuckets = (heightBucket, weightBucket) =
     .map(([bucket]) => bucket);
 };
 
+const resolveImtTokensFromExactMetrics = (heightValue, weightValue) => {
+  const normalizedHeight = String(heightValue ?? '').trim();
+  const normalizedWeight = String(weightValue ?? '').trim();
+  if (!normalizedHeight || !normalizedWeight) return [];
+  if (normalizedHeight === 'no' || normalizedWeight === 'no') return ['no'];
+  if (normalizedHeight === '?' || normalizedWeight === '?') return ['?'];
+
+  const height = Number.parseFloat(normalizedHeight.replace(',', '.'));
+  const weight = Number.parseFloat(normalizedWeight.replace(',', '.'));
+  if (!Number.isFinite(height) || !Number.isFinite(weight) || height <= 0 || weight <= 0) return ['?'];
+
+  const bmi = weight / Math.pow(height / 100, 2);
+  if (!Number.isFinite(bmi) || bmi <= 0) return ['?'];
+
+  if (bmi <= 28) return ['le28'];
+  if (bmi <= 31) return ['29_31'];
+  if (bmi <= 35) return ['32_35'];
+  return ['36_plus'];
+};
+
 const augmentBucketsWithImtMetricWrappers = bucketMap => {
   if (!bucketMap || typeof bucketMap !== 'object') return bucketMap;
 
@@ -268,11 +288,10 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
 
   const filterUserIdsByImtBuckets = candidateUserIds => {
     if (!hasImtFilter) return [...candidateUserIds];
-    const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(searchKeyFile);
 
     return [...candidateUserIds].filter(userId => {
-      const imtBuckets = resolveImtBucketsFromMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
-      return imtBuckets.some(bucket => imtValues.includes(bucket));
+      const imtTokens = resolveImtTokensFromExactMetrics(heightByUserId[userId], weightByUserId[userId]);
+      return imtTokens.some(token => imtValues.includes(token));
     });
   };
 
@@ -341,15 +360,16 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
 
     const usersWithWeight = imtCandidateUserIds.filter(userId => Boolean(weightByUserId[userId])).length;
     const usersWithValidImt = imtCandidateUserIds.filter(userId => {
-      const buckets = resolveImtBucketsFromMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
-      return buckets.some(bucket => ['le28', '29_31', '32_35', '36_plus'].includes(bucket));
+      const tokens = resolveImtTokensFromExactMetrics(heightByUserId[userId], weightByUserId[userId]);
+      return tokens.some(token => ['le28', '29_31', '32_35', '36_plus'].includes(token));
     }).length;
-    const usersInLe28 = imtCandidateUserIds.filter(userId => {
-      const buckets = resolveImtBucketsFromMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
-      return buckets.includes('le28');
+    const usersWithUnknownHeightWeight = imtCandidateUserIds.filter(userId => {
+      const heightValue = String(heightByUserId[userId] ?? '').trim();
+      const weightValue = String(weightByUserId[userId] ?? '').trim();
+      return ['?', 'no'].includes(heightValue) || ['?', 'no'].includes(weightValue);
     }).length;
-      const writtenHeightUsers = new Set();
-      const writtenWeightUsers = new Set();
+    const writtenHeightUsers = new Set();
+    const writtenWeightUsers = new Set();
     Object.entries(writes).forEach(([path, usersMap]) => {
       const parts = String(path).split('/');
       const metric = parts[parts.length - 2];
@@ -366,9 +386,10 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
         heightUsers: Object.keys(heightByUserId || {}).length,
         usersWithWeight,
         usersWithValidImt,
-        usersInLe28,
+        usersWithUnknownHeightWeight,
         imtSelectedTokens: imtValues,
         allowedUserIdsCount: allowedUserIdsForWrites.length,
+        allowedUserIdsPreview: allowedUserIdsForWrites.slice(0, 5),
         copiedFieldsCount: copiedFields.size,
         totalCopiedBuckets: copiedBuckets.size,
         totalCopiedUserRecords: copiedUserRecords,
@@ -377,6 +398,8 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
         usersWritten: writtenUserIds.size,
         writtenHeightUsers: writtenHeightUsers.size,
         writtenWeightUsers: writtenWeightUsers.size,
+        finalSearchKeySetFields: [...new Set(Object.keys(writes).map(path => String(path).split('/').slice(-2, -1)[0]))],
+        finalRecordsCount: copiedUserRecords,
         samplePaths: Object.keys(writes)
           .filter(path => path.includes('/height/') || path.includes('/weight/'))
           .slice(0, 10),


### PR DESCRIPTION
### Motivation

- IMT is a virtual filter and should select users based on exact `searchKey.height` and `searchKey.weight` values (e.g. `165`, `58`) rather than treating them as bucket ranges. 
- The previous bucket-based approach produced incorrect inclusion logic for IMT checkboxes and could create confusion when building `searchKeySets`.

### Description

- Added `resolveImtTokensFromExactMetrics(heightValue, weightValue)` that computes BMI from exact metric values and returns tokens `le28`, `29_31`, `32_35`, `36_plus`, `?`, or `no` as appropriate. 
- Replaced bucket-based IMT matching in `buildRuleBucketWrites` so `filterUserIdsByImtBuckets` uses exact `heightByUserId[userId]` and `weightByUserId[userId]` and compares returned tokens to selected `imt` values. 
- Ensured `searchKeySets` writes remain in the original `field -> exactValue -> userId: true` structure and `imt` index is skipped (IMT is used only as a selection condition). 
- Extended diagnostics logged to the console to include counts for total `height` users, users with matching `weight`, users with valid numeric metrics, users with unknown metrics, selected IMT values, allowed user count and first 5 allowed IDs, final `searchKeySet` fields, and final records count.

### Testing

- Ran linter with `npx eslint src/utils/newUsersFilterSetsIndex.js` which completed successfully (only non-blocking npm/browserslist warning in stdout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9bdc84c508326acf11b4924c83025)