### PR TITLE
Restore edit-profile userId from localStorage and clear search/state when URL params removed

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -732,6 +732,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
     const urlUserId = params.get('userId');
     if (urlUserId) return urlUserId;
+    const persistedEditUserId = localStorage.getItem(EDIT_PROFILE_USER_ID_KEY) || '';
+    if (persistedEditUserId) return persistedEditUserId;
     return '';
   });
   const [searchBarQueryActive, setSearchBarQueryActive] = useState(false);
@@ -917,7 +919,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const [state, setState] = useState(() => {
     const params = new URLSearchParams(location.search);
-    const restoredUserId = initialAccess.canAccessAdd ? params.get('userId') || '' : '';
+    const restoredUserIdFromUrl = params.get('userId') || '';
+    const restoredUserIdFromCache = localStorage.getItem(EDIT_PROFILE_USER_ID_KEY) || '';
+    const restoredUserId = initialAccess.canAccessAdd
+      ? (restoredUserIdFromUrl || restoredUserIdFromCache)
+      : '';
 
     if (!restoredUserId) {
       return {};
@@ -1489,6 +1495,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setSearch(prev => (prev === urlSearchValue ? prev : urlSearchValue));
     } else if (urlUserId && canAccessAdd) {
       setSearch(prev => (prev ? prev : urlUserId));
+    } else if (!urlUserId) {
+      setSearch(prev => (prev ? '' : prev));
     }
 
     if (urlUserId) {
@@ -1500,6 +1508,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setProfileSource('');
       setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
       return;
+    }
+    if (!hasSearchParam && stateUserIdRef.current) {
+      setState({});
     }
     setIsResolvingEditMode(false);
   }, [canAccessAdd, location.search, setSearch, setState]);


### PR DESCRIPTION
### Motivation
- Persist the edit-profile `userId` across sessions so the AddNewProfile UI can restore edit mode even when the URL lacks a `userId` parameter.
- Ensure component state stays consistent with URL changes by clearing `search` and internal `state` when `userId`/`search` params are removed.

### Description
- Read `EDIT_PROFILE_USER_ID_KEY` from `localStorage` during `search` initialisation to prefill the search field when no URL `search` param is present.
- When initializing component `state`, prefer the URL `userId` but fall back to the cached `EDIT_PROFILE_USER_ID_KEY` from `localStorage` if present.
- On `location.search` updates, clear `search` when no `userId` is present and clear `state` when there is no `search` param but an existing `stateUserIdRef.current` value.
- Changes are contained to `src/components/AddNewProfile.jsx` and do not alter other persisted keys or index selection logic.

### Testing
- Ran unit tests with `yarn test` and the test suite completed successfully.
- Performed a production build with `yarn build` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b6abc1648326a78cc4c43a26a302)