### PR TITLE
Refine BMI bucket logic and add fallback in IMT token resolver

### DIFF
--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -140,10 +140,11 @@ const resolveImtTokensFromExactMetrics = (heightValue, weightValue) => {
   const bmi = weight / Math.pow(height / 100, 2);
   if (!Number.isFinite(bmi) || bmi <= 0) return ['?'];
 
-  if (bmi <= 28) return ['le28'];
-  if (bmi <= 31) return ['29_31'];
-  if (bmi <= 35) return ['32_35'];
-  return ['36_plus'];
+  if (bmi < 29) return ['le28'];
+  if (bmi >= 29 && bmi <= 31) return ['29_31'];
+  if (bmi >= 32 && bmi <= 35) return ['32_35'];
+  if (bmi >= 36) return ['36_plus'];
+  return ['?'];
 };
 
 const augmentBucketsWithImtMetricWrappers = bucketMap => {


### PR DESCRIPTION
### Motivation
- Ensure BMI values are evaluated against explicit ranges when resolving IMT tokens and provide a clear fallback for values that don't match any defined bucket.

### Description
- Replace the previous chained `<=` comparisons with explicit range checks in `resolveImtTokensFromExactMetrics` using `<` and `>=` to define bucket intervals.
- Add a final `return ['?']` fallback for BMI values that do not fall into any explicit range.
- No other parsing or normalization logic in `resolveImtTokensFromExactMetrics` was changed.

### Testing
- Ran the unit test suite including tests covering IMT/BMI token resolution; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9eb1459948326a797745c0271521c)