### PR TITLE
Detect and normalize social links/URLs from PP technical input

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -129,6 +129,52 @@ const appendFieldValue = (currentValue, nextValue) => {
 
   return [normalizedCurrentValue, normalizedNextValue];
 };
+
+const normalizeUrlForStorage = rawValue => {
+  const trimmed = String(rawValue || '').trim();
+  if (!trimmed) return '';
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/^www\./i.test(trimmed) || /^[\w-]+(\.[\w-]+)+/i.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+
+  return trimmed;
+};
+
+const resolvePpTechnicalInputTarget = rawValue => {
+  const trimmed = String(rawValue || '').trim();
+  if (!trimmed) return null;
+
+  const socialUrlMatchers = [
+    { fieldName: 'instagram', pattern: /(?:https?:\/\/)?(?:www\.)?instagram\.com\/([^/?#]+)/i },
+    { fieldName: 'facebook', pattern: /(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.com)\/([^/?#]+)/i },
+    { fieldName: 'tiktok', pattern: /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/([^/?#]+)/i },
+    { fieldName: 'linkedin', pattern: /(?:https?:\/\/)?(?:www\.)?linkedin\.com\/([^/?#]+)/i },
+    { fieldName: 'youtube', pattern: /(?:https?:\/\/)?(?:m\.|www\.)?(?:youtube\.com|youtu\.be)\/([^/?#]+)/i },
+    { fieldName: 'twitter', pattern: /(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/([^/?#]+)/i },
+    { fieldName: 'telegram', pattern: /(?:https?:\/\/)?(?:www\.)?(?:t\.me|telegram\.me|telegram\.dog)\/([^/?#]+)/i },
+  ];
+
+  for (const matcher of socialUrlMatchers) {
+    const match = trimmed.match(matcher.pattern);
+    if (!match?.[1]) continue;
+
+    const normalizedValue = String(match[1]).replace(/^@/, '').trim();
+    if (normalizedValue) {
+      return { fieldName: matcher.fieldName, value: normalizedValue };
+    }
+  }
+
+  if (/^(https?:\/\/|www\.)/i.test(trimmed) || /^[\w-]+(\.[\w-]+)+/i.test(trimmed)) {
+    return { fieldName: 'otherLink', value: normalizeUrlForStorage(trimmed) };
+  }
+
+  return null;
+};
 const REPRODUCTIVE_FIELDS = [
   'birth',
   'ownKids',
@@ -2028,15 +2074,20 @@ ${entries.join('\n')}`;
 
       if (!parsed) {
         const normalizedPhone = normalizePhoneValue(rawValue);
-        const strippedPhoneCandidate = String(rawValue).replace(/[^\d+]/g, '');
         const looksLikePhone =
-          Boolean(normalizedPhone) && /^[+]?\d[\d\s().-]*$/.test(strippedPhoneCandidate || rawValue);
+          Boolean(normalizedPhone) && /^[+]?\d[\d\s().-]*$/.test(rawValue);
         const looksLikeEmail = EMAIL_REGEX.test(rawValue);
+        const resolvedTechnicalTarget = resolvePpTechnicalInputTarget(rawValue);
 
         if (looksLikeEmail) {
           nextState.email = appendFieldValue(prevState.email, rawValue);
         } else if (looksLikePhone) {
           nextState.phone = appendFieldValue(prevState.phone, normalizedPhone);
+        } else if (resolvedTechnicalTarget) {
+          nextState[resolvedTechnicalTarget.fieldName] = appendFieldValue(
+            prevState[resolvedTechnicalTarget.fieldName],
+            resolvedTechnicalTarget.value
+          );
         } else {
           nextState.name = appendFieldValue(prevState.name, rawValue);
         }


### PR DESCRIPTION
### Motivation
- Support extracting social handles and generic URLs from the PP technical input and storing them in the correct profile fields while normalizing URLs for storage.
- Improve detection robustness for phone and email fallbacks when `parseUkTriggerQuery` does not match.
- Consolidate parsing logic to map inputs to existing contact fields instead of only treating unknown inputs as names.

### Description
- Added `normalizeUrlForStorage` to normalize and prefix URLs with `https://` when appropriate.
- Added `resolvePpTechnicalInputTarget` to detect and extract usernames from social URLs for `instagram`, `facebook`, `tiktok`, `linkedin`, `youtube`, `twitter`, and `telegram`, and to map bare URLs to `otherLink` with normalization.
- Updated `handlePpTechnicalInputSubmit` to call the resolver and append resolved values into the corresponding `state` fields, and adjusted phone-detection regex to test against the raw input.
- Preserved existing `parseUkTriggerQuery` handling and fallbacks to append `email`, `phone`, or `name` when applicable.

### Testing
- Ran the unit test suite with `yarn test` and all tests passed.
- Ran linting/style checks with `yarn lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e1b88b708326965e03c6dbafcba6)