### PR TITLE
Chunked LAST_ACTION filtering (40-card batches) to fix checkbox slowdowns

### DIFF
--- a/src/components/lastActionLoad.js
+++ b/src/components/lastActionLoad.js
@@ -12,6 +12,7 @@ import { PAGE_SIZE, MAX_LOOKBACK_DAYS } from './constants';
 import normalizeLastAction from '../utils/normalizeLastAction';
 
 const LOOKBACK_BATCH_DAYS = 7;
+const FILTER_CHUNK_SIZE = 40;
 
 const toLastActionTimestamp = value => {
   const normalized = normalizeLastAction(value);
@@ -60,8 +61,9 @@ export async function fetchUsersByLastActionPaged(
   }
 
   const combined = [];
-  let filtered = [];
+  const filtered = [];
   let dayOffset = 0;
+  let rawCursor = 0;
   const seenIds = new Set();
 
   while (filtered.length < target && dayOffset < MAX_LOOKBACK_DAYS) {
@@ -108,13 +110,18 @@ export async function fetchUsersByLastActionPaged(
       combined.sort(compareByLastActionDesc);
     }
 
-    filtered = filterMainFn(
-      combined,
-      'LAST_ACTION',
-      filterSettings,
-      favoriteUsers,
-      dislikedUsers
-    );
+    while (filtered.length < target && rawCursor < combined.length) {
+      const chunk = combined.slice(rawCursor, rawCursor + FILTER_CHUNK_SIZE);
+      rawCursor += FILTER_CHUNK_SIZE;
+      const filteredChunk = filterMainFn(
+        chunk,
+        'LAST_ACTION',
+        filterSettings,
+        favoriteUsers,
+        dislikedUsers
+      );
+      filtered.push(...filteredChunk);
+    }
 
     if (onProgress) {
       const partial = filtered.slice(


### PR DESCRIPTION
### Motivation
- Users experienced very slow responses when checkbox filters (e.g. `role=pp`) were applied to LAST_ACTION (LA) loads because the loader repeatedly re-filtered a growing accumulated list. 
- The change aims to filter LA results incrementally inside bounded windows (40 cards) and continue fetching pages until the requested page size is satisfied.

### Description
- Updated `fetchUsersByLastActionPaged` in `src/components/lastActionLoad.js` to add `FILTER_CHUNK_SIZE = 40` and process LA results in fixed-size chunks.  
- Introduced a `rawCursor` pointer and replaced the full-array re-filtering with a loop that extracts `combined.slice(rawCursor, rawCursor + FILTER_CHUNK_SIZE)` and applies `filterMainFn` once per chunk, pushing results into the `filtered` array.  
- Kept existing pagination semantics (`startOffset`, `limit`, returned `lastKey`, `hasMore`) and preserved the `onProgress` callback behavior.  
- Changes are confined to a single file to minimize risk: `src/components/lastActionLoad.js`.

### Testing
- Executed `npm run build` and the project compiled successfully (production build created).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f0a729c48326a44f45616122c3e3)