### PR TITLE
Fix searchKeySets final filter payload and diagnostics

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1029,10 +1029,16 @@ export const ProfileForm = ({
           ? `imt=${lastSetDebug.imtValues.join(',')}`
           : 'imt=none';
         toast(`1/8 Rules parsed: ${selectedRulesSummary}`);
-        toast(`2/8 Allowed users: ${Number(lastSetDebug?.allowedUserIdsCount || 0)}`);
+        const finalAllowedCount = Number(lastSetDebug?.finalAllowedCount ?? lastSetDebug?.allowedUserIdsCount ?? 0);
+        const payloadUsersCount = Number(lastSetDebug?.payloadUsers ?? 0);
+        const payloadRecordsCount = Number(lastSetDebug?.payloadRecords ?? lastSetDebug?.copiedRecords ?? 0);
+        const payloadBucketsCount = Number(lastSetDebug?.payloadBuckets ?? lastSetDebug?.copiedBuckets ?? 0);
+        toast(
+          `Rules: imtAllowed=${lastSetDebug?.imtAllowedCount ?? '-'}, ageAllowed=${lastSetDebug?.ageAllowedCount ?? '-'}, finalAllowed=${finalAllowedCount}`
+        );
         const searchKeyFields = Array.isArray(lastSetDebug?.searchKeyFields) ? lastSetDebug.searchKeyFields : [];
         toast(`3/8 searchKey fields: ${searchKeyFields.join(', ') || 'none'}`);
-        toast(`4/8 Start copying filtered searchKey, allowed=${Number(lastSetDebug?.allowedUserIdsCount || 0)}`);
+        toast(`Start copying filtered searchKey, finalAllowed=${finalAllowedCount}`);
         const copiedByField = lastSetDebug?.copiedByField && typeof lastSetDebug.copiedByField === 'object'
           ? lastSetDebug.copiedByField
           : {};
@@ -1047,16 +1053,16 @@ export const ProfileForm = ({
         }
         const filteredFields = Array.isArray(lastSetDebug?.filteredFields) ? lastSetDebug.filteredFields : [];
         toast(
-          `6/8 Filtered set ready: fields=${filteredFields.length}, buckets=${Number(lastSetDebug?.copiedBuckets || 0)}, records=${Number(lastSetDebug?.copiedRecords || 0)}`
+          `Filtered set ready: payloadUsers=${payloadUsersCount}, finalAllowed=${finalAllowedCount}, buckets=${payloadBucketsCount}, records=${payloadRecordsCount}`
         );
         const backendRequests = Array.isArray(lastSetDebug?.backendRequests) ? lastSetDebug.backendRequests : [];
         const removeCount = backendRequests.filter(item => item?.type === 'remove').length;
         const setCount = backendRequests.filter(item => item?.type === 'set').length;
-        toast(`7/8 Backend requests: remove=${removeCount}, set=${setCount}, payloadRecords=${Number(lastSetDebug?.copiedRecords || 0)}`);
+        toast(`Backend requests: remove=${removeCount}, set=${setCount}, payloadUsers=${payloadUsersCount}, payloadRecords=${payloadRecordsCount}`);
         if (lastSetDebug?.setKey) {
-          toast(`8/8 Saved searchKeySets/${lastSetDebug.setKey}: records=${Number(lastSetDebug?.copiedRecords || 0)}`);
+          toast.success(`Saved searchKeySets/${lastSetDebug.setKey}: users=${payloadUsersCount}, records=${payloadRecordsCount}`);
         }
-        if (Number(lastSetDebug?.allowedUserIdsCount || 0) === 0) {
+        if (finalAllowedCount === 0) {
           toast.error('STOP: allowedUserIds=0. Перевір tokens/rules/searchKey.imt');
         }
         if (!searchKeyFields.length) {
@@ -1065,7 +1071,7 @@ export const ProfileForm = ({
         if ((searchKeyFields.length === 1 && searchKeyFields[0] === 'imt') || !searchKeyFields.includes('height') || !searchKeyFields.includes('weight')) {
           toast.error('STOP: searchKey missing height/weight fields');
         }
-        if (Number(lastSetDebug?.copiedRecords || 0) === 0 && Number(lastSetDebug?.allowedUserIdsCount || 0) > 0) {
+        if (payloadRecordsCount === 0 && finalAllowedCount > 0) {
           toast.error('STOP: copiedRecords=0. allowedUserIds є, але жоден userId не знайдений у searchKey buckets');
         }
         if (removeCount > 0 && setCount === 0) {
@@ -1078,12 +1084,14 @@ export const ProfileForm = ({
         console.log('[searchKeySets debug]', {
           selectedRules: lastSetDebug?.selectedRules,
           allowedUserIdsCount: Number(lastSetDebug?.allowedUserIdsCount || 0),
+          finalAllowedCount,
+          payloadUsers: payloadUsersCount,
           allowedSample: Array.isArray(lastSetDebug?.allowedSample) ? lastSetDebug.allowedSample.slice(0, 10) : [],
           searchKeyFields,
           skippedFields: Array.isArray(lastSetDebug?.skippedFields) ? lastSetDebug.skippedFields : [],
           copiedByField,
-          copiedRecords: Number(lastSetDebug?.copiedRecords || 0),
-          copiedBuckets: Number(lastSetDebug?.copiedBuckets || 0),
+          copiedRecords: payloadRecordsCount,
+          copiedBuckets: payloadBucketsCount,
           filteredFields,
           backendRequests,
         });
@@ -1106,6 +1114,9 @@ export const ProfileForm = ({
       } else if (code.includes('EMPTY_FILTERED_SEARCHKEY_SET')) {
         const details = error?.message || String(error);
         toast.error(`Набір очищено, але нові дані не сформовані.\n${details}`);
+      } else if (code.includes('SEARCH_KEY_SET_PAYLOAD_MISMATCH')) {
+        const details = error?.message || String(error);
+        toast.error(details);
       } else {
         console.error('Failed to update additional access newUsers filter-set index', error);
         const details = error?.message || String(error);
@@ -1269,8 +1280,8 @@ export const ProfileForm = ({
         .slice(0, 2)
         .map(
           set =>
-            `${set?.setKey || 'unknown'}: users=${Number(set?.matchedUserIdsCount || 0)}, buckets=${Number(
-              set?.bucketWritesCount || 0
+            `${set?.setKey || 'unknown'}: payloadUsers=${Number(set?.debugInfo?.payloadUsers ?? 0)}, finalAllowed=${Number(set?.debugInfo?.finalAllowedCount ?? 0)}, buckets=${Number(
+              set?.debugInfo?.payloadBuckets ?? set?.bucketWritesCount ?? 0
             )}`
         )
         .join(' | ');
@@ -1318,6 +1329,8 @@ export const ProfileForm = ({
         toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.', { id: toastId });
       } else if (code.includes('EMPTY_FILTERED_SEARCHKEY_SET')) {
         toast.error(`Набір очищено, але нові дані не сформовані.\n${details}`, { id: toastId });
+      } else if (code.includes('SEARCH_KEY_SET_PAYLOAD_MISMATCH')) {
+        toast.error(details, { id: toastId });
       } else {
         toast.error(`Помилка на етапі "${stage}": не вдалося виконати індексацію наборів фільтрів.\n${details}`, { id: toastId });
       }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -81,12 +81,85 @@ const IMT_BUCKET_RANGES = {
   '36_plus': { min: 36, max: Infinity },
 };
 
-const countRecords = node => {
-  if (!node || typeof node !== 'object') return 0;
-  return Object.values(node).reduce((total, value) => {
-    if (!value || typeof value !== 'object') return total;
-    return total + Object.keys(value).length;
+const collectUniqueUserIds = tree => {
+  const ids = new Set();
+
+  Object.values(tree || {}).forEach(fieldMap => {
+    Object.values(fieldMap || {}).forEach(bucketMap => {
+      Object.keys(bucketMap || {}).forEach(userId => {
+        if (userId) ids.add(userId);
+      });
+    });
+  });
+
+  return ids;
+};
+
+const countBuckets = tree => Object.values(tree || {}).reduce((sum, fieldMap) => {
+  return sum + Object.keys(fieldMap || {}).length;
+}, 0);
+
+const countRecords = tree => Object.values(tree || {}).reduce((total, fieldMap) => {
+  return total + Object.values(fieldMap || {}).reduce((fieldTotal, bucketMap) => {
+    return fieldTotal + Object.keys(bucketMap || {}).length;
   }, 0);
+}, 0);
+
+const intersectUserIdSets = userIdSets => {
+  const sets = (Array.isArray(userIdSets) ? userIdSets : [])
+    .filter(setValue => setValue instanceof Set);
+  if (!sets.length) return new Set();
+
+  const [smallestSet, ...remainingSets] = [...sets].sort((a, b) => a.size - b.size);
+  return new Set(
+    [...smallestSet].filter(userId => remainingSets.every(setValue => setValue.has(userId)))
+  );
+};
+
+const collectSearchKeyUserIdsForBuckets = (searchKeyFile, indexName, values) => {
+  const ids = new Set();
+  const normalizedIndexName = normalizePathSegment(indexName);
+  const indexNode = searchKeyFile?.[normalizedIndexName];
+  if (!normalizedIndexName || !indexNode || typeof indexNode !== 'object' || Array.isArray(indexNode)) return ids;
+
+  const normalizedValues = [
+    ...new Set((Array.isArray(values) ? values : [...(values || [])]).map(normalizePathSegment).filter(Boolean)),
+  ];
+
+  normalizedValues.forEach(value => {
+    const usersMap = indexNode?.[value];
+    if (!usersMap || typeof usersMap !== 'object' || Array.isArray(usersMap)) return;
+    Object.keys(usersMap).forEach(userId => {
+      if (userId) ids.add(userId);
+    });
+  });
+
+  return ids;
+};
+
+const buildFilteredSearchKeySet = (searchKeyFile, finalAllowedUserIds) => {
+  const normalizedAllowedIds = finalAllowedUserIds instanceof Set ? finalAllowedUserIds : new Set();
+
+  return Object.entries(searchKeyFile || {}).reduce((acc, [field, fieldMap]) => {
+    const normalizedField = normalizePathSegment(field);
+    if (!normalizedField || normalizedField === 'users' || normalizedField === 'imt') return acc;
+    if (!fieldMap || typeof fieldMap !== 'object' || Array.isArray(fieldMap)) return acc;
+
+    Object.entries(fieldMap).forEach(([bucket, bucketMap]) => {
+      if (!bucketMap || typeof bucketMap !== 'object' || Array.isArray(bucketMap)) return;
+
+      Object.keys(bucketMap).forEach(userId => {
+        if (!userId || !normalizedAllowedIds.has(userId)) return;
+        const normalizedBucket = normalizePathSegment(bucket);
+        if (!normalizedBucket) return;
+        if (!acc[normalizedField]) acc[normalizedField] = {};
+        if (!acc[normalizedField][normalizedBucket]) acc[normalizedField][normalizedBucket] = {};
+        acc[normalizedField][normalizedBucket][userId] = true;
+      });
+    });
+
+    return acc;
+  }, {});
 };
 
 export const collectMetricBucketsByUserId = searchKeyFile => {
@@ -254,7 +327,8 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   if (!searchKeyFile || typeof searchKeyFile !== 'object' || Array.isArray(searchKeyFile)) return { writes: {}, debugInfo: null };
 
   const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
-  const baseBucketMap = augmentBucketsWithImtMetricWrappers(mergeSearchKeyBuckets(parsedRuleGroups));
+  const rawBucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
+  const baseBucketMap = augmentBucketsWithImtMetricWrappers(rawBucketMap);
 
   const existingImt = baseBucketMap?.imt;
   const hasExistingImt =
@@ -308,45 +382,64 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
 
   const imtCandidateUserIds = resolveImtCandidateUserIds();
   const imtAllowedUserIds = hasImtFilter ? filterUserIdsByImtBuckets(imtCandidateUserIds) : normalizedUserIds;
-  const allowedUserIdsForWrites = hasImtFilter
-    ? imtAllowedUserIds
-    : normalizedUserIds;
-  const normalizedAllowedIds = new Set(allowedUserIdsForWrites.filter(Boolean));
+  const prefilterUserIdsSet = new Set(normalizedUserIds.filter(Boolean));
+  const activeRuleUserIdSets = [];
+  const ruleAllowedCounts = {};
+
+  if (prefilterUserIdsSet.size > 0) {
+    activeRuleUserIdSets.push(prefilterUserIdsSet);
+    ruleAllowedCounts.prefilter = prefilterUserIdsSet.size;
+  }
+
+  Object.entries(rawBucketMap || {}).forEach(([indexName, values]) => {
+    const normalizedIndexName = normalizePathSegment(indexName);
+    if (!normalizedIndexName || normalizedIndexName === 'users' || normalizedIndexName === 'imt') return;
+
+    const normalizedValues = [
+      ...new Set((Array.isArray(values) ? values : [...(values || [])]).map(normalizePathSegment).filter(Boolean)),
+    ];
+    if (!normalizedValues.length) return;
+
+    const fieldAllowedUserIds = collectSearchKeyUserIdsForBuckets(
+      searchKeyFile,
+      normalizedIndexName,
+      normalizedValues
+    );
+    activeRuleUserIdSets.push(fieldAllowedUserIds);
+    ruleAllowedCounts[normalizedIndexName] = fieldAllowedUserIds.size;
+  });
+
+  if (hasImtFilter) {
+    const imtAllowedUserIdsSet = new Set(imtAllowedUserIds.filter(Boolean));
+    activeRuleUserIdSets.push(imtAllowedUserIdsSet);
+    ruleAllowedCounts.imt = imtAllowedUserIdsSet.size;
+  }
+
+  const finalAllowedUserIds = activeRuleUserIdSets.length
+    ? intersectUserIdSets(activeRuleUserIdSets)
+    : prefilterUserIdsSet;
+  const allowedUserIdsForWrites = [...finalAllowedUserIds];
+  const normalizedAllowedIds = finalAllowedUserIds;
+
+  const filteredSearchKeySet = buildFilteredSearchKeySet(searchKeyFile, normalizedAllowedIds);
+  const payloadUserIds = collectUniqueUserIds(filteredSearchKeySet);
+  const payloadBuckets = countBuckets(filteredSearchKeySet);
+  const copiedUserRecords = countRecords(filteredSearchKeySet);
 
   const writes = {};
-  const copiedFields = new Set();
+  const copiedFields = new Set(Object.keys(filteredSearchKeySet || {}));
   const copiedBuckets = new Set();
-  let copiedUserRecords = 0;
-
   const copiedByField = {};
-  const skippedFields = [];
-  Object.entries(searchKeyFile || {}).forEach(([indexName, bucketsMap]) => {
-    const normalizedIndexName = normalizePathSegment(indexName);
-    if (!normalizedIndexName || normalizedIndexName === 'users') return;
-    if (normalizedIndexName === 'imt') {
-      skippedFields.push('imt');
-      return;
-    }
-    if (!bucketsMap || typeof bucketsMap !== 'object' || Array.isArray(bucketsMap)) return;
-    if (!copiedByField[normalizedIndexName]) copiedByField[normalizedIndexName] = { buckets: 0, records: 0 };
+  const skippedFields = Object.prototype.hasOwnProperty.call(searchKeyFile || {}, 'imt') ? ['imt'] : [];
 
-    Object.entries(bucketsMap).forEach(([bucketValue, usersMap]) => {
-      if (!usersMap || typeof usersMap !== 'object' || Array.isArray(usersMap)) return;
-      const filteredUserIds = Object.keys(usersMap).filter(userId => (
-        Boolean(userId) && normalizedAllowedIds.has(userId)
-      ));
-      if (!filteredUserIds.length) return;
-
-      const path = `${normalizedRootPath}/${normalizedIndexName}/${normalizePathSegment(bucketValue)}`;
-      writes[path] = filteredUserIds.reduce((result, userId) => {
-        result[userId] = true;
-        return result;
-      }, {});
-      copiedFields.add(normalizedIndexName);
+  Object.entries(filteredSearchKeySet || {}).forEach(([indexName, bucketsMap]) => {
+    if (!copiedByField[indexName]) copiedByField[indexName] = { buckets: 0, records: 0 };
+    Object.entries(bucketsMap || {}).forEach(([bucketValue, usersMap]) => {
+      const path = `${normalizedRootPath}/${indexName}/${bucketValue}`;
+      writes[path] = usersMap;
       copiedBuckets.add(path);
-      copiedUserRecords += filteredUserIds.length;
-      copiedByField[normalizedIndexName].buckets += 1;
-      copiedByField[normalizedIndexName].records += filteredUserIds.length;
+      copiedByField[indexName].buckets += 1;
+      copiedByField[indexName].records += Object.keys(usersMap || {}).length;
     });
   });
 
@@ -389,6 +482,10 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
         usersWithValidImt,
         usersWithUnknownHeightWeight,
         imtSelectedTokens: imtValues,
+        imtAllowedCount: hasImtFilter ? imtAllowedUserIds.length : null,
+        ageAllowedCount: ruleAllowedCounts.age ?? null,
+        finalAllowedCount: finalAllowedUserIds.size,
+        payloadUsers: payloadUserIds.size,
         allowedUserIdsCount: allowedUserIdsForWrites.length,
         allowedUserIdsPreview: allowedUserIdsForWrites.slice(0, 5),
         copiedFieldsCount: copiedFields.size,
@@ -421,6 +518,13 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
     debugInfo: {
       selectedRules: parsedRuleGroups,
       allowedUserIdsCount: allowedUserIdsForWrites.length,
+      finalAllowedCount: finalAllowedUserIds.size,
+      imtAllowedCount: hasImtFilter ? imtAllowedUserIds.length : null,
+      ageAllowedCount: ruleAllowedCounts.age ?? null,
+      ruleAllowedCounts,
+      payloadUsers: payloadUserIds.size,
+      payloadBuckets,
+      payloadRecords: copiedUserRecords,
       allowedSample: [...normalizedAllowedIds].slice(0, 10),
       searchKeyFields: Object.keys(searchKeyFile || {}),
       skippedFields,
@@ -644,10 +748,25 @@ export const buildNewUsersFilterSetIndex = async ({
     }, {});
 
     const debugFilteredFields = Object.keys(filteredSearchKeySet || {});
+    const payloadUserIds = collectUniqueUserIds(filteredSearchKeySet || {});
     const debugRecordsCount = countRecords(filteredSearchKeySet || {});
-    const debugBucketsCount = debugFilteredFields.reduce((sum, field) => {
-      return sum + Object.keys(filteredSearchKeySet[field] || {}).length;
-    }, 0);
+    const debugBucketsCount = countBuckets(filteredSearchKeySet || {});
+    const finalAllowedCount = Number(debugInfo?.finalAllowedCount ?? debugInfo?.allowedUserIdsCount ?? 0);
+
+    if (payloadUserIds.size !== finalAllowedCount) {
+      console.error('Mismatch before save', {
+        uiAvailableCount: finalAllowedCount,
+        finalAllowedCount,
+        payloadUsers: payloadUserIds.size,
+        selectedRules: debugInfo?.selectedRules,
+        imtAllowedCount: debugInfo?.imtAllowedCount,
+        ageAllowedCount: debugInfo?.ageAllowedCount,
+      });
+
+      const error = new Error(`Mismatch before save: final=${finalAllowedCount}, payload=${payloadUserIds.size}`);
+      error.code = 'SEARCH_KEY_SET_PAYLOAD_MISMATCH';
+      throw error;
+    }
 
     console.log('[searchKeySets][debug] build result', {
       setKey,
@@ -684,7 +803,8 @@ export const buildNewUsersFilterSetIndex = async ({
       setId: setKey,
       hasPayload: !!filteredSearchKeySet,
       fields: Object.keys(filteredSearchKeySet),
-      totalRecords: countRecords(filteredSearchKeySet),
+      payloadUsers: payloadUserIds.size,
+      totalRecords: debugRecordsCount,
     });
 
     debug.backendRequests.push({
@@ -695,6 +815,9 @@ export const buildNewUsersFilterSetIndex = async ({
     debug.lastSetDebug = {
       ...(debugInfo || {}),
       filteredFields: Object.keys(filteredSearchKeySet || {}),
+      payloadUsers: payloadUserIds.size,
+      payloadBuckets: debugBucketsCount,
+      payloadRecords: debugRecordsCount,
       backendRequests: debug.backendRequests,
       setKey,
     };
@@ -706,6 +829,8 @@ export const buildNewUsersFilterSetIndex = async ({
       path: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
       setKey,
       writesCount: writesCountForSet,
+      payloadUsers: payloadUserIds.size,
+      payloadRecords: debugRecordsCount,
     });
     // eslint-disable-next-line no-await-in-loop
     await set(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`), filteredSearchKeySet);
@@ -715,7 +840,13 @@ export const buildNewUsersFilterSetIndex = async ({
     });
   }
 
-  const aggregatedUserIds = [...new Set(nextSetPayloads.flatMap(item => Object.keys(item.userIds)))];
+  const aggregatedUserIds = [
+    ...new Set(
+      debug.backendRequests
+        .filter(item => item?.type === 'set')
+        .flatMap(item => [...collectUniqueUserIds(item?.payload || {})])
+    ),
+  ];
   return {
     setKeys: [...nextSetKeys],
     userIds: aggregatedUserIds,


### PR DESCRIPTION
### Motivation
- Saving `searchKeySets` used an IMT-prefilter instead of the final intersection of all active additional-access rule groups, causing mismatches between UI "Доступні карточки" and saved backend payload size.
- Diagnostics/toasts displayed intermediate prefilter counts (e.g. IMT) rather than actual payload users, misleading debugging output.
- The `imt` virtual field must not be written into `searchKeySets` while still participating in filtering logic.

### Description
- Added helper utilities in `src/utils/newUsersFilterSetsIndex.js`: `collectUniqueUserIds`, `countBuckets`, `countRecords`, `intersectUserIdSets`, `collectSearchKeyUserIdsForBuckets`, and `buildFilteredSearchKeySet` to compute final payloads and metrics from the `searchKey` file.
- Reworked `buildRuleBucketWrites` to compute `rawBucketMap`, collect per-field allowed user-id sets, compute `finalAllowedUserIds` as the intersection of prefilter, per-field sets and IMT-derived users, and produce `filteredSearchKeySet` from `finalAllowedUserIds` instead of using `imtAllowedUserIds` alone.
- Build Firebase `writes` from `filteredSearchKeySet` (skipping `imt` buckets), keep remove-then-set write ordering, and compute `aggregatedUserIds` from the actual `set` payloads.
- Added pre-save validation that compares `collectUniqueUserIds(filteredSearchKeySet).size` to `finalAllowedCount` and throws a `SEARCH_KEY_SET_PAYLOAD_MISMATCH` error on mismatch to avoid saving inconsistent payloads.
- Extended debug metadata (`debugInfo` / `debug.lastSetDebug`) with `finalAllowedCount`, `imtAllowedCount`, `ageAllowedCount`, `payloadUsers`, `payloadBuckets`, and `payloadRecords` so diagnostics reflect the actual saved payload.
- Updated UI diagnostics in `src/components/ProfileForm.jsx` to use the new debug fields and show `finalAllowed`, `payloadUsers`, `payloadRecords` and to display the mismatch error message when it occurs.

### Testing
- Ran `npm test -- --watchAll=false` and all test suites passed (`16` suites, `73` tests total, all passing).
- Ran `npm run lint:js` and the linter completed successfully (reported browserslist update notice but no lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa47fa6d5c832695ed9155df7c4978)