### PR TITLE
Fix IMT filtering in searchKeySets and ensure payload matches UI

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -30,12 +30,35 @@ import {
   buildNewUsersFilterSetIndex,
   makeAdditionalRulesSetKey,
   collectMetricBucketsByUserId,
-  resolveImtBucketsFromMetricBuckets,
+  prepareAdditionalAccessBucketMapForSearchKey,
+  resolveImtTokensFromExactMetrics,
 } from 'utils/newUsersFilterSetsIndex';
 import {
   getCachedAdditionalRulesPreview,
   saveCachedAdditionalRulesPreview,
 } from 'utils/searchKeyCache';
+
+const getImtAllowedUserIdsFromSearchKey = (searchKeyPayload, imtValues) => {
+  const normalizedImtValues = [...new Set((Array.isArray(imtValues) ? imtValues : []).filter(Boolean))];
+  if (!normalizedImtValues.length || !searchKeyPayload || typeof searchKeyPayload !== 'object') return new Set();
+
+  const heightIdx = searchKeyPayload?.height;
+  const weightIdx = searchKeyPayload?.weight;
+  if (!heightIdx || typeof heightIdx !== 'object' || !weightIdx || typeof weightIdx !== 'object') {
+    return new Set();
+  }
+
+  const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId({ height: heightIdx, weight: weightIdx });
+  const metricUsers = new Set([
+    ...Object.keys(heightByUserId || {}),
+    ...Object.keys(weightByUserId || {}),
+  ]);
+
+  return new Set([...metricUsers].filter(userId => {
+    const imtBuckets = resolveImtTokensFromExactMetrics(heightByUserId[userId], weightByUserId[userId]);
+    return imtBuckets.some(bucket => normalizedImtValues.includes(bucket));
+  }));
+};
 
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
@@ -795,8 +818,11 @@ export const ProfileForm = ({
       try {
         const matched = new Set();
         parsedRuleGroups.forEach(parsedRules => {
-          const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
+          const { bucketMap, hasImtFilter, imtValues } = prepareAdditionalAccessBucketMapForSearchKey(
+            resolveAdditionalAccessSearchKeyBuckets(parsedRules)
+          );
           const perFilterSets = Object.entries(bucketMap || {}).reduce((acc, [indexName, values]) => {
+            if (indexName === 'imt' || indexName === 'users') return acc;
             const indexNode = localSearchKeyPayload?.[indexName];
             if (!indexNode || typeof indexNode !== 'object') return acc;
             const normalizedValues = [...new Set((Array.isArray(values) ? values : [...(values || [])]).filter(Boolean))];
@@ -809,11 +835,15 @@ export const ProfileForm = ({
                 if (userId) idsForFilter.add(userId);
               });
             });
-            if (idsForFilter.size > 0) acc.push(idsForFilter);
+            acc.push(idsForFilter);
             return acc;
           }, []);
 
-          if (!perFilterSets.length) return;
+          if (hasImtFilter) {
+            perFilterSets.push(getImtAllowedUserIdsFromSearchKey(localSearchKeyPayload, imtValues));
+          }
+
+          if (!perFilterSets.length || perFilterSets.some(set => set.size === 0)) return;
 
           const groupIntersection = [...perFilterSets[0]].filter(userId =>
             perFilterSets.every(set => set.has(userId))
@@ -916,52 +946,38 @@ export const ProfileForm = ({
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(rulesText);
       const matched = new Set();
       parsedRuleGroups.forEach(parsedRules => {
-        const bucketMap = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
-        Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
+        const { bucketMap, hasImtFilter, imtValues } = prepareAdditionalAccessBucketMapForSearchKey(
+          resolveAdditionalAccessSearchKeyBuckets(parsedRules)
+        );
+        const perFilterSets = Object.entries(bucketMap || {}).reduce((acc, [indexName, values]) => {
+          if (indexName === 'imt' || indexName === 'users') return acc;
           const indexNode = localSearchKeyPayload?.[indexName];
-          if (!indexNode || typeof indexNode !== 'object') return;
+          if (!indexNode || typeof indexNode !== 'object') return acc;
           const normalizedValues = [...new Set(
             (Array.isArray(values) ? values : [...(values || [])]).filter(Boolean)
           )];
+          if (!normalizedValues.length) return acc;
+          const idsForFilter = new Set();
           normalizedValues.forEach(value => {
             const bucket = indexNode?.[value];
             if (!bucket || typeof bucket !== 'object') return;
-            Object.keys(bucket).forEach(userId => { if (userId) matched.add(userId); });
+            Object.keys(bucket).forEach(userId => { if (userId) idsForFilter.add(userId); });
           });
-        });
-      });
+          acc.push(idsForFilter);
+          return acc;
+        }, []);
 
-      // IMT: searchKey не має індексу /imt/ — обчислюємо з height/weight
-      const imtLineMatch = rulesText.match(/(?:^|\n)\s*imt\s*:\s*([^\n]+)/i);
-      if (imtLineMatch) {
-        const imtValues = imtLineMatch[1]
-          .split(',')
-          .map(t => t.trim())
-          .filter(Boolean);
-        const heightIdx = localSearchKeyPayload?.height;
-        const weightIdx = localSearchKeyPayload?.weight;
-        if (
-          imtValues.length > 0 &&
-          heightIdx && typeof heightIdx === 'object' &&
-          weightIdx && typeof weightIdx === 'object'
-        ) {
-          const pseudoFile = { height: heightIdx, weight: weightIdx };
-          const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(pseudoFile);
-          const allMetricUsers = new Set([
-            ...Object.keys(heightByUserId),
-            ...Object.keys(weightByUserId),
-          ]);
-          allMetricUsers.forEach(uid => {
-            const imtBuckets = resolveImtBucketsFromMetricBuckets(
-              heightByUserId[uid],
-              weightByUserId[uid]
-            );
-            if (imtBuckets.some(b => imtValues.includes(b))) {
-              matched.add(uid);
-            }
-          });
+        if (hasImtFilter) {
+          perFilterSets.push(getImtAllowedUserIdsFromSearchKey(localSearchKeyPayload, imtValues));
         }
-      }
+
+        if (!perFilterSets.length || perFilterSets.some(set => set.size === 0)) return;
+
+        const groupIntersection = [...perFilterSets[0]].filter(userId =>
+          perFilterSets.every(set => set.has(userId))
+        );
+        groupIntersection.forEach(userId => matched.add(userId));
+      });
       matchedByInputIndex[index + 1] = [...matched];
     }
 
@@ -1029,10 +1045,21 @@ export const ProfileForm = ({
           ? `imt=${lastSetDebug.imtValues.join(',')}`
           : 'imt=none';
         toast(`1/8 Rules parsed: ${selectedRulesSummary}`);
-        toast(`2/8 Allowed users: ${Number(lastSetDebug?.allowedUserIdsCount || 0)}`);
+        const finalAllowedCount = Number(lastSetDebug?.finalAllowedCount ?? lastSetDebug?.allowedUserIdsCount ?? 0);
+        const payloadUsersCount = Number(lastSetDebug?.payloadUsers ?? 0);
+        const payloadRecordsCount = Number(lastSetDebug?.payloadRecords ?? lastSetDebug?.copiedRecords ?? 0);
+        const payloadBucketsCount = Number(lastSetDebug?.payloadBuckets ?? lastSetDebug?.copiedBuckets ?? 0);
+        toast(
+          `Rules: imtAllowed=${lastSetDebug?.imtAllowedCount ?? '-'}, ageAllowed=${lastSetDebug?.ageAllowedCount ?? '-'}, finalAllowed=${finalAllowedCount}`
+        );
+        if (lastSetDebug?.hasImtFilter) {
+          toast(
+            `IMT: allowed=${lastSetDebug?.imtAllowedCount ?? '-'}, skipped derived height/weight buckets=${lastSetDebug?.skippedDerivedMetricBuckets ? 'true' : 'false'}`
+          );
+        }
         const searchKeyFields = Array.isArray(lastSetDebug?.searchKeyFields) ? lastSetDebug.searchKeyFields : [];
         toast(`3/8 searchKey fields: ${searchKeyFields.join(', ') || 'none'}`);
-        toast(`4/8 Start copying filtered searchKey, allowed=${Number(lastSetDebug?.allowedUserIdsCount || 0)}`);
+        toast(`Start copying filtered searchKey, finalAllowed=${finalAllowedCount}`);
         const copiedByField = lastSetDebug?.copiedByField && typeof lastSetDebug.copiedByField === 'object'
           ? lastSetDebug.copiedByField
           : {};
@@ -1047,16 +1074,16 @@ export const ProfileForm = ({
         }
         const filteredFields = Array.isArray(lastSetDebug?.filteredFields) ? lastSetDebug.filteredFields : [];
         toast(
-          `6/8 Filtered set ready: fields=${filteredFields.length}, buckets=${Number(lastSetDebug?.copiedBuckets || 0)}, records=${Number(lastSetDebug?.copiedRecords || 0)}`
+          `Filtered set ready: payloadUsers=${payloadUsersCount}, finalAllowed=${finalAllowedCount}, buckets=${payloadBucketsCount}, records=${payloadRecordsCount}`
         );
         const backendRequests = Array.isArray(lastSetDebug?.backendRequests) ? lastSetDebug.backendRequests : [];
         const removeCount = backendRequests.filter(item => item?.type === 'remove').length;
         const setCount = backendRequests.filter(item => item?.type === 'set').length;
-        toast(`7/8 Backend requests: remove=${removeCount}, set=${setCount}, payloadRecords=${Number(lastSetDebug?.copiedRecords || 0)}`);
+        toast(`Backend requests: remove=${removeCount}, set=${setCount}, payloadUsers=${payloadUsersCount}, payloadRecords=${payloadRecordsCount}`);
         if (lastSetDebug?.setKey) {
-          toast(`8/8 Saved searchKeySets/${lastSetDebug.setKey}: records=${Number(lastSetDebug?.copiedRecords || 0)}`);
+          toast.success(`Saved searchKeySets/${lastSetDebug.setKey}: users=${payloadUsersCount}, records=${payloadRecordsCount}`);
         }
-        if (Number(lastSetDebug?.allowedUserIdsCount || 0) === 0) {
+        if (finalAllowedCount === 0) {
           toast.error('STOP: allowedUserIds=0. Перевір tokens/rules/searchKey.imt');
         }
         if (!searchKeyFields.length) {
@@ -1065,7 +1092,7 @@ export const ProfileForm = ({
         if ((searchKeyFields.length === 1 && searchKeyFields[0] === 'imt') || !searchKeyFields.includes('height') || !searchKeyFields.includes('weight')) {
           toast.error('STOP: searchKey missing height/weight fields');
         }
-        if (Number(lastSetDebug?.copiedRecords || 0) === 0 && Number(lastSetDebug?.allowedUserIdsCount || 0) > 0) {
+        if (payloadRecordsCount === 0 && finalAllowedCount > 0) {
           toast.error('STOP: copiedRecords=0. allowedUserIds є, але жоден userId не знайдений у searchKey buckets');
         }
         if (removeCount > 0 && setCount === 0) {
@@ -1078,12 +1105,14 @@ export const ProfileForm = ({
         console.log('[searchKeySets debug]', {
           selectedRules: lastSetDebug?.selectedRules,
           allowedUserIdsCount: Number(lastSetDebug?.allowedUserIdsCount || 0),
+          finalAllowedCount,
+          payloadUsers: payloadUsersCount,
           allowedSample: Array.isArray(lastSetDebug?.allowedSample) ? lastSetDebug.allowedSample.slice(0, 10) : [],
           searchKeyFields,
           skippedFields: Array.isArray(lastSetDebug?.skippedFields) ? lastSetDebug.skippedFields : [],
           copiedByField,
-          copiedRecords: Number(lastSetDebug?.copiedRecords || 0),
-          copiedBuckets: Number(lastSetDebug?.copiedBuckets || 0),
+          copiedRecords: payloadRecordsCount,
+          copiedBuckets: payloadBucketsCount,
           filteredFields,
           backendRequests,
         });
@@ -1106,6 +1135,9 @@ export const ProfileForm = ({
       } else if (code.includes('EMPTY_FILTERED_SEARCHKEY_SET')) {
         const details = error?.message || String(error);
         toast.error(`Набір очищено, але нові дані не сформовані.\n${details}`);
+      } else if (code.includes('SEARCH_KEY_SET_PAYLOAD_MISMATCH')) {
+        const details = error?.message || String(error);
+        toast.error(details);
       } else {
         console.error('Failed to update additional access newUsers filter-set index', error);
         const details = error?.message || String(error);
@@ -1269,8 +1301,8 @@ export const ProfileForm = ({
         .slice(0, 2)
         .map(
           set =>
-            `${set?.setKey || 'unknown'}: users=${Number(set?.matchedUserIdsCount || 0)}, buckets=${Number(
-              set?.bucketWritesCount || 0
+            `${set?.setKey || 'unknown'}: payloadUsers=${Number(set?.debugInfo?.payloadUsers ?? 0)}, finalAllowed=${Number(set?.debugInfo?.finalAllowedCount ?? 0)}, buckets=${Number(
+              set?.debugInfo?.payloadBuckets ?? set?.bucketWritesCount ?? 0
             )}`
         )
         .join(' | ');
@@ -1318,6 +1350,8 @@ export const ProfileForm = ({
         toast.error('Індексів searchKey не знайдено. Спершу запустіть загальну індексацію.', { id: toastId });
       } else if (code.includes('EMPTY_FILTERED_SEARCHKEY_SET')) {
         toast.error(`Набір очищено, але нові дані не сформовані.\n${details}`, { id: toastId });
+      } else if (code.includes('SEARCH_KEY_SET_PAYLOAD_MISMATCH')) {
+        toast.error(details, { id: toastId });
       } else {
         toast.error(`Помилка на етапі "${stage}": не вдалося виконати індексацію наборів фільтрів.\n${details}`, { id: toastId });
       }

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -81,12 +81,87 @@ const IMT_BUCKET_RANGES = {
   '36_plus': { min: 36, max: Infinity },
 };
 
-const countRecords = node => {
-  if (!node || typeof node !== 'object') return 0;
-  return Object.values(node).reduce((total, value) => {
-    if (!value || typeof value !== 'object') return total;
-    return total + Object.keys(value).length;
+const collectUniqueUserIds = tree => {
+  const ids = new Set();
+
+  Object.values(tree || {}).forEach(fieldMap => {
+    Object.values(fieldMap || {}).forEach(bucketMap => {
+      Object.keys(bucketMap || {}).forEach(userId => {
+        if (userId) ids.add(userId);
+      });
+    });
+  });
+
+  return ids;
+};
+
+const countBuckets = tree => Object.values(tree || {}).reduce((sum, fieldMap) => {
+  return sum + Object.keys(fieldMap || {}).length;
+}, 0);
+
+const countRecords = tree => Object.values(tree || {}).reduce((total, fieldMap) => {
+  return total + Object.values(fieldMap || {}).reduce((fieldTotal, bucketMap) => {
+    return fieldTotal + Object.keys(bucketMap || {}).length;
   }, 0);
+}, 0);
+
+const intersectUserIdSets = userIdSets => {
+  const sets = (Array.isArray(userIdSets) ? userIdSets : [])
+    .filter(setValue => setValue instanceof Set);
+  if (!sets.length) return new Set();
+
+  const [smallestSet, ...remainingSets] = [...sets].sort((a, b) => a.size - b.size);
+  return new Set(
+    [...smallestSet].filter(userId => remainingSets.every(setValue => setValue.has(userId)))
+  );
+};
+
+const collectSearchKeyUserIdsForBuckets = (searchKeyFile, indexName, values) => {
+  const ids = new Set();
+  const normalizedIndexName = normalizePathSegment(indexName);
+  const indexNode = searchKeyFile?.[normalizedIndexName];
+  if (!normalizedIndexName || !indexNode || typeof indexNode !== 'object' || Array.isArray(indexNode)) return ids;
+
+  const normalizedValues = [
+    ...new Set((Array.isArray(values) ? values : [...(values || [])]).map(normalizePathSegment).filter(Boolean)),
+  ];
+
+  normalizedValues.forEach(value => {
+    const usersMap = indexNode?.[value];
+    if (!usersMap || typeof usersMap !== 'object' || Array.isArray(usersMap)) return;
+    Object.keys(usersMap).forEach(userId => {
+      if (userId) ids.add(userId);
+    });
+  });
+
+  return ids;
+};
+
+const buildSearchKeySetFromAllowedUsers = (searchKey, finalAllowedUserIds) => {
+  const result = {};
+
+  if (!searchKey || !finalAllowedUserIds || finalAllowedUserIds.size === 0) {
+    return result;
+  }
+
+  Object.entries(searchKey).forEach(([fieldName, fieldBuckets]) => {
+    if (fieldName === 'imt') return;
+    if (!fieldBuckets || typeof fieldBuckets !== 'object' || Array.isArray(fieldBuckets)) return;
+
+    Object.entries(fieldBuckets).forEach(([bucketName, bucketUsers]) => {
+      if (!bucketUsers || typeof bucketUsers !== 'object' || Array.isArray(bucketUsers)) return;
+
+      Object.keys(bucketUsers).forEach(userId => {
+        if (!finalAllowedUserIds.has(userId)) return;
+
+        if (!result[fieldName]) result[fieldName] = {};
+        if (!result[fieldName][bucketName]) result[fieldName][bucketName] = {};
+        result[fieldName][bucketName][userId] = true;
+      });
+    });
+  });
+
+  return result;
 };
 
 export const collectMetricBucketsByUserId = searchKeyFile => {
@@ -126,7 +201,7 @@ export const resolveImtBucketsFromMetricBuckets = (heightBucket, weightBucket) =
     .map(([bucket]) => bucket);
 };
 
-const resolveImtTokensFromExactMetrics = (heightValue, weightValue) => {
+export const resolveImtTokensFromExactMetrics = (heightValue, weightValue) => {
   const normalizedHeight = String(heightValue ?? '').trim();
   const normalizedWeight = String(weightValue ?? '').trim();
   if (!normalizedHeight || !normalizedWeight) return [];
@@ -147,27 +222,44 @@ const resolveImtTokensFromExactMetrics = (heightValue, weightValue) => {
   return ['?'];
 };
 
-const augmentBucketsWithImtMetricWrappers = bucketMap => {
-  if (!bucketMap || typeof bucketMap !== 'object') return bucketMap;
+const normalizeBucketValues = values => [
+  ...new Set((Array.isArray(values) ? values : [...(values || [])]).map(normalizePathSegment).filter(Boolean)),
+];
 
-  const imtBuckets = bucketMap.imt;
-  const hasImtBuckets =
-    (imtBuckets instanceof Set && imtBuckets.size > 0) ||
-    (Array.isArray(imtBuckets) && imtBuckets.length > 0);
+const hasBucketValues = values =>
+  (values instanceof Set && values.size > 0) ||
+  (Array.isArray(values) && values.length > 0);
 
-  if (!hasImtBuckets) return bucketMap;
+export const prepareAdditionalAccessBucketMapForSearchKey = bucketMap => {
+  if (!bucketMap || typeof bucketMap !== 'object') {
+    return { bucketMap: {}, hasImtFilter: false, imtValues: [], skippedDerivedMetricBuckets: false };
+  }
 
+  const imtValues = normalizeBucketValues(bucketMap.imt || []);
+  const hasImtFilter = imtValues.length > 0;
   const nextBucketMap = { ...bucketMap };
-  ['height', 'weight'].forEach(metricKey => {
-    const existing = nextBucketMap[metricKey];
-    const hasExisting =
-      (existing instanceof Set && existing.size > 0) ||
-      (Array.isArray(existing) && existing.length > 0);
-    if (hasExisting) return;
-    nextBucketMap[metricKey] = new Set(METRIC_BUCKETS_BY_INDEX[metricKey]);
-  });
+  let skippedDerivedMetricBuckets = false;
 
-  return nextBucketMap;
+  if (hasImtFilter) {
+    ['height', 'weight'].forEach(metricKey => {
+      const metricValues = normalizeBucketValues(nextBucketMap[metricKey] || []);
+      if (!metricValues.length) return;
+
+      const derivedMetricBuckets = new Set(METRIC_BUCKETS_BY_INDEX[metricKey] || []);
+      const realSearchKeyValues = metricValues.filter(value => !derivedMetricBuckets.has(value));
+      if (realSearchKeyValues.length !== metricValues.length) {
+        skippedDerivedMetricBuckets = true;
+      }
+
+      if (realSearchKeyValues.length) {
+        nextBucketMap[metricKey] = new Set(realSearchKeyValues);
+      } else {
+        delete nextBucketMap[metricKey];
+      }
+    });
+  }
+
+  return { bucketMap: nextBucketMap, hasImtFilter, imtValues, skippedDerivedMetricBuckets };
 };
 
 const splitRawRulesToSetTexts = rawRules => {
@@ -254,38 +346,31 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
   if (!searchKeyFile || typeof searchKeyFile !== 'object' || Array.isArray(searchKeyFile)) return { writes: {}, debugInfo: null };
 
   const normalizedUserIds = [...new Set((Array.isArray(userIds) ? userIds : []).filter(Boolean))];
-  const baseBucketMap = augmentBucketsWithImtMetricWrappers(mergeSearchKeyBuckets(parsedRuleGroups));
+  const rawBucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
+  let bucketMapWithFallbackImt = rawBucketMap;
 
-  const existingImt = baseBucketMap?.imt;
-  const hasExistingImt =
-    (existingImt instanceof Set && existingImt.size > 0) ||
-    (Array.isArray(existingImt) && existingImt.length > 0);
+  const existingImt = rawBucketMap?.imt;
+  const hasExistingImt = hasBucketValues(existingImt);
 
-  let bucketMap = baseBucketMap;
   if (!hasExistingImt && rawText) {
     const imtLineMatch = String(rawText).match(/(?:^|\n)\s*imt\s*:\s*([^\n]+)/i);
     if (imtLineMatch) {
       const imtTokens = imtLineMatch[1].split(',').map(t => t.trim()).filter(Boolean);
       if (imtTokens.length > 0) {
-        bucketMap = {
-          ...baseBucketMap,
+        bucketMapWithFallbackImt = {
+          ...rawBucketMap,
           imt: new Set(imtTokens),
-          height: (baseBucketMap.height instanceof Set && baseBucketMap.height.size > 0)
-            ? baseBucketMap.height
-            : new Set(METRIC_BUCKETS_BY_INDEX.height),
-          weight: (baseBucketMap.weight instanceof Set && baseBucketMap.weight.size > 0)
-            ? baseBucketMap.weight
-            : new Set(METRIC_BUCKETS_BY_INDEX.weight),
         };
       }
     }
   }
 
-  const imtValuesRaw = bucketMap?.imt;
-  const imtValues = [
-    ...new Set((Array.isArray(imtValuesRaw) ? imtValuesRaw : [...(imtValuesRaw || [])]).map(normalizePathSegment)),
-  ];
-  const hasImtFilter = imtValues.length > 0;
+  const {
+    bucketMap,
+    hasImtFilter,
+    imtValues,
+    skippedDerivedMetricBuckets,
+  } = prepareAdditionalAccessBucketMapForSearchKey(bucketMapWithFallbackImt);
 
   const filterUserIdsByImtBuckets = candidateUserIds => {
     if (!hasImtFilter) return [...candidateUserIds];
@@ -308,45 +393,64 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
 
   const imtCandidateUserIds = resolveImtCandidateUserIds();
   const imtAllowedUserIds = hasImtFilter ? filterUserIdsByImtBuckets(imtCandidateUserIds) : normalizedUserIds;
-  const allowedUserIdsForWrites = hasImtFilter
-    ? imtAllowedUserIds
-    : normalizedUserIds;
-  const normalizedAllowedIds = new Set(allowedUserIdsForWrites.filter(Boolean));
+  const prefilterUserIdsSet = new Set(normalizedUserIds.filter(Boolean));
+  const activeRuleUserIdSets = [];
+  const ruleAllowedCounts = {};
+
+  if (prefilterUserIdsSet.size > 0) {
+    activeRuleUserIdSets.push(prefilterUserIdsSet);
+    ruleAllowedCounts.prefilter = prefilterUserIdsSet.size;
+  }
+
+  Object.entries(bucketMap || {}).forEach(([indexName, values]) => {
+    const normalizedIndexName = normalizePathSegment(indexName);
+    if (!normalizedIndexName || normalizedIndexName === 'users' || normalizedIndexName === 'imt') return;
+
+    const normalizedValues = [
+      ...new Set((Array.isArray(values) ? values : [...(values || [])]).map(normalizePathSegment).filter(Boolean)),
+    ];
+    if (!normalizedValues.length) return;
+
+    const fieldAllowedUserIds = collectSearchKeyUserIdsForBuckets(
+      searchKeyFile,
+      normalizedIndexName,
+      normalizedValues
+    );
+    activeRuleUserIdSets.push(fieldAllowedUserIds);
+    ruleAllowedCounts[normalizedIndexName] = fieldAllowedUserIds.size;
+  });
+
+  if (hasImtFilter) {
+    const imtAllowedUserIdsSet = new Set(imtAllowedUserIds.filter(Boolean));
+    activeRuleUserIdSets.push(imtAllowedUserIdsSet);
+    ruleAllowedCounts.imt = imtAllowedUserIdsSet.size;
+  }
+
+  const finalAllowedUserIds = activeRuleUserIdSets.length
+    ? intersectUserIdSets(activeRuleUserIdSets)
+    : prefilterUserIdsSet;
+  const allowedUserIdsForWrites = [...finalAllowedUserIds];
+  const normalizedAllowedIds = finalAllowedUserIds;
+
+  const filteredSearchKeySet = buildSearchKeySetFromAllowedUsers(searchKeyFile, normalizedAllowedIds);
+  const payloadUserIds = collectUniqueUserIds(filteredSearchKeySet);
+  const payloadBuckets = countBuckets(filteredSearchKeySet);
+  const copiedUserRecords = countRecords(filteredSearchKeySet);
 
   const writes = {};
-  const copiedFields = new Set();
+  const copiedFields = new Set(Object.keys(filteredSearchKeySet || {}));
   const copiedBuckets = new Set();
-  let copiedUserRecords = 0;
-
   const copiedByField = {};
-  const skippedFields = [];
-  Object.entries(searchKeyFile || {}).forEach(([indexName, bucketsMap]) => {
-    const normalizedIndexName = normalizePathSegment(indexName);
-    if (!normalizedIndexName || normalizedIndexName === 'users') return;
-    if (normalizedIndexName === 'imt') {
-      skippedFields.push('imt');
-      return;
-    }
-    if (!bucketsMap || typeof bucketsMap !== 'object' || Array.isArray(bucketsMap)) return;
-    if (!copiedByField[normalizedIndexName]) copiedByField[normalizedIndexName] = { buckets: 0, records: 0 };
+  const skippedFields = Object.prototype.hasOwnProperty.call(searchKeyFile || {}, 'imt') ? ['imt'] : [];
 
-    Object.entries(bucketsMap).forEach(([bucketValue, usersMap]) => {
-      if (!usersMap || typeof usersMap !== 'object' || Array.isArray(usersMap)) return;
-      const filteredUserIds = Object.keys(usersMap).filter(userId => (
-        Boolean(userId) && normalizedAllowedIds.has(userId)
-      ));
-      if (!filteredUserIds.length) return;
-
-      const path = `${normalizedRootPath}/${normalizedIndexName}/${normalizePathSegment(bucketValue)}`;
-      writes[path] = filteredUserIds.reduce((result, userId) => {
-        result[userId] = true;
-        return result;
-      }, {});
-      copiedFields.add(normalizedIndexName);
+  Object.entries(filteredSearchKeySet || {}).forEach(([indexName, bucketsMap]) => {
+    if (!copiedByField[indexName]) copiedByField[indexName] = { buckets: 0, records: 0 };
+    Object.entries(bucketsMap || {}).forEach(([bucketValue, usersMap]) => {
+      const path = `${normalizedRootPath}/${indexName}/${bucketValue}`;
+      writes[path] = usersMap;
       copiedBuckets.add(path);
-      copiedUserRecords += filteredUserIds.length;
-      copiedByField[normalizedIndexName].buckets += 1;
-      copiedByField[normalizedIndexName].records += filteredUserIds.length;
+      copiedByField[indexName].buckets += 1;
+      copiedByField[indexName].records += Object.keys(usersMap || {}).length;
     });
   });
 
@@ -389,6 +493,10 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
         usersWithValidImt,
         usersWithUnknownHeightWeight,
         imtSelectedTokens: imtValues,
+        imtAllowedCount: hasImtFilter ? imtAllowedUserIds.length : null,
+        ageAllowedCount: ruleAllowedCounts.age ?? null,
+        finalAllowedCount: finalAllowedUserIds.size,
+        payloadUsers: payloadUserIds.size,
         allowedUserIdsCount: allowedUserIdsForWrites.length,
         allowedUserIdsPreview: allowedUserIdsForWrites.slice(0, 5),
         copiedFieldsCount: copiedFields.size,
@@ -396,6 +504,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
         totalCopiedUserRecords: copiedUserRecords,
         bucketsWritten: Object.keys(writes).length,
         hasImtBucketWrites: Object.keys(writes).some(path => String(path).includes('/imt/')),
+        skippedDerivedMetricBuckets,
         usersWritten: writtenUserIds.size,
         writtenHeightUsers: writtenHeightUsers.size,
         writtenWeightUsers: writtenWeightUsers.size,
@@ -406,21 +515,21 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
           .slice(0, 10),
       });
 
-    const heightBucketsCount = Object.keys(writes).filter(path => path.includes('/height/')).length;
-    const weightBucketsCount = Object.keys(writes).filter(path => path.includes('/weight/')).length;
-    if (allowedUserIdsForWrites.length > 0 && copiedUserRecords === 0) {
-      throw new Error('Allowed users знайдені, але buckets не сформовані');
-    }
-    if (allowedUserIdsForWrites.length > 0 && (heightBucketsCount === 0 || weightBucketsCount === 0)) {
-      throw new Error('Allowed users знайдені, але buckets height/weight не сформовані');
-    }
   }
 
   return {
     writes,
+    finalAllowedUserIds,
     debugInfo: {
       selectedRules: parsedRuleGroups,
       allowedUserIdsCount: allowedUserIdsForWrites.length,
+      finalAllowedCount: finalAllowedUserIds.size,
+      imtAllowedCount: hasImtFilter ? imtAllowedUserIds.length : null,
+      ageAllowedCount: ruleAllowedCounts.age ?? null,
+      ruleAllowedCounts,
+      payloadUsers: payloadUserIds.size,
+      payloadBuckets,
+      payloadRecords: copiedUserRecords,
       allowedSample: [...normalizedAllowedIds].slice(0, 10),
       searchKeyFields: Object.keys(searchKeyFile || {}),
       skippedFields,
@@ -430,6 +539,7 @@ const buildRuleBucketWrites = ({ rootPath, parsedRuleGroups, userIds, searchKeyF
       filteredFields: [...copiedFields],
       hasImtFilter,
       imtValues,
+      skippedDerivedMetricBuckets,
     },
   };
 };
@@ -599,84 +709,84 @@ export const buildNewUsersFilterSetIndex = async ({
     await remove(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`));
 
     const rootPath = `${SEARCH_KEY_SETS_ROOT}/${setKey}`;
-    const { writes: ruleBucketWrites, debugInfo } = buildRuleBucketWrites({
+    const { writes: ruleBucketWrites, debugInfo, finalAllowedUserIds } = buildRuleBucketWrites({
       rootPath,
       parsedRuleGroups,
       userIds: Object.keys(userIds || {}),
       searchKeyFile,
       rawText,
     });
+    const saveAllowedUserIds = finalAllowedUserIds instanceof Set
+      ? finalAllowedUserIds
+      : new Set(Object.keys(userIds || {}).filter(Boolean));
+
+    const filteredSearchKeySet = buildSearchKeySetFromAllowedUsers(
+      searchKeyFile,
+      saveAllowedUserIds
+    );
+    const debugFilteredFields = Object.keys(filteredSearchKeySet || {});
+    const payloadUserIds = collectUniqueUserIds(filteredSearchKeySet || {});
+    const debugRecordsCount = countRecords(filteredSearchKeySet || {});
+    const debugBucketsCount = countBuckets(filteredSearchKeySet || {});
+    const finalAllowedCount = saveAllowedUserIds.size;
+
     debug.sets.push({
       setKey,
       matchedUserIdsCount: Object.keys(userIds || {}).length,
       parsedRuleGroupsCount: Array.isArray(parsedRuleGroups) ? parsedRuleGroups.length : 0,
-      bucketWritesCount: Object.keys(ruleBucketWrites).length,
-      bucketPathsPreview: Object.keys(ruleBucketWrites).slice(0, 12),
-      debugInfo,
+      bucketWritesCount: debugBucketsCount,
+      bucketPathsPreview: Object.entries(filteredSearchKeySet || {})
+        .flatMap(([fieldName, bucketsMap]) => Object.keys(bucketsMap || {}).map(bucketName => `${fieldName}/${bucketName}`))
+        .slice(0, 12),
+      debugInfo: {
+        ...(debugInfo || {}),
+        finalAllowedCount,
+        payloadUsers: payloadUserIds.size,
+        payloadBuckets: debugBucketsCount,
+        payloadRecords: debugRecordsCount,
+      },
     });
-
-    const filteredSearchKeySet = Object.entries(ruleBucketWrites).reduce((acc, [path, payload]) => {
-      const prefix = `${SEARCH_KEY_SETS_ROOT}/${setKey}/`;
-
-      if (!path.startsWith(prefix) || payload == null) return acc;
-
-      const relativePath = path.slice(prefix.length);
-      const [indexName, bucketName] = relativePath.split('/');
-
-      if (!indexName || !bucketName) return acc;
-
-      if (indexName === 'imt') return acc;
-
-      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return acc;
-
-      const userIds = Object.keys(payload).filter(Boolean);
-
-      if (!userIds.length) return acc;
-
-      if (!acc[indexName]) acc[indexName] = {};
-      if (!acc[indexName][bucketName]) acc[indexName][bucketName] = {};
-
-      userIds.forEach(userId => {
-        acc[indexName][bucketName][userId] = true;
-      });
-
-      return acc;
-    }, {});
-
-    const debugFilteredFields = Object.keys(filteredSearchKeySet || {});
-    const debugRecordsCount = countRecords(filteredSearchKeySet || {});
-    const debugBucketsCount = debugFilteredFields.reduce((sum, field) => {
-      return sum + Object.keys(filteredSearchKeySet[field] || {}).length;
-    }, 0);
 
     console.log('[searchKeySets][debug] build result', {
       setKey,
-      ruleBucketWritesPaths: Object.keys(ruleBucketWrites),
-      ruleBucketWritesCount: Object.keys(ruleBucketWrites).length,
+      legacyRuleBucketWritesPaths: Object.keys(ruleBucketWrites),
+      payloadBucketsCount: debugBucketsCount,
       filteredFields: debugFilteredFields,
       bucketsCount: debugBucketsCount,
       recordsCount: debugRecordsCount,
-      firstPayload: Object.entries(ruleBucketWrites || {})[0],
+      payloadUsers: payloadUserIds.size,
+      finalAllowedCount,
+      source: 'searchKeyFile+finalAllowedUserIds',
     });
 
-    if (!filteredSearchKeySet || Object.keys(filteredSearchKeySet).length === 0) {
-      console.error('[searchKeySets][EMPTY_FILTERED_SEARCHKEY_SET]', {
-        setKey,
-        rawText,
-        matchedUserIdsCount: Object.keys(userIds || {}).length,
-        ruleBucketWritesPaths: Object.keys(ruleBucketWrites || {}),
-        ruleBucketWritesPreview: Object.entries(ruleBucketWrites || {}).slice(0, 5),
+    if (payloadUserIds.size === 0 || debugRecordsCount === 0) {
+      console.error('[searchKeySets] EMPTY PAYLOAD', {
+        finalAllowedCount,
         searchKeyFields: Object.keys(searchKeyFile || {}),
-        hasHeight: Boolean(searchKeyFile?.height),
-        hasWeight: Boolean(searchKeyFile?.weight),
-        heightKeysSample: Object.keys(searchKeyFile?.height || {}).slice(0, 10),
-        weightKeysSample: Object.keys(searchKeyFile?.weight || {}).slice(0, 10),
+        payloadUserIds: payloadUserIds.size,
+        payloadRecords: debugRecordsCount,
+        payloadBuckets: debugBucketsCount,
       });
 
       const error = new Error(
-        `filteredSearchKeySet empty: matched=${Object.keys(userIds || {}).length}, writes=${Object.keys(ruleBucketWrites || {}).length}`
+        `filteredSearchKeySet empty: matched=${finalAllowedCount}, payloadUsers=${payloadUserIds.size}, records=${debugRecordsCount}`
       );
       error.code = 'EMPTY_FILTERED_SEARCHKEY_SET';
+      throw error;
+    }
+
+    if (payloadUserIds.size !== finalAllowedCount) {
+      console.error('Mismatch before save', {
+        uiAvailableCount: finalAllowedCount,
+        finalAllowedCount,
+        payloadUsers: payloadUserIds.size,
+        selectedRules: debugInfo?.selectedRules,
+        imtAllowedCount: debugInfo?.imtAllowedCount,
+        ageAllowedCount: debugInfo?.ageAllowedCount,
+      });
+
+      const error = new Error(`Mismatch before save: final=${finalAllowedCount}, payload=${payloadUserIds.size}`);
+      error.code = 'SEARCH_KEY_SET_PAYLOAD_MISMATCH';
       throw error;
     }
 
@@ -684,7 +794,8 @@ export const buildNewUsersFilterSetIndex = async ({
       setId: setKey,
       hasPayload: !!filteredSearchKeySet,
       fields: Object.keys(filteredSearchKeySet),
-      totalRecords: countRecords(filteredSearchKeySet),
+      payloadUsers: payloadUserIds.size,
+      totalRecords: debugRecordsCount,
     });
 
     debug.backendRequests.push({
@@ -695,17 +806,23 @@ export const buildNewUsersFilterSetIndex = async ({
     debug.lastSetDebug = {
       ...(debugInfo || {}),
       filteredFields: Object.keys(filteredSearchKeySet || {}),
+      finalAllowedCount,
+      payloadUsers: payloadUserIds.size,
+      payloadBuckets: debugBucketsCount,
+      payloadRecords: debugRecordsCount,
       backendRequests: debug.backendRequests,
       setKey,
     };
     console.log('backendRequests:', debug.backendRequests);
 
-    const writesCountForSet = Object.keys(ruleBucketWrites).length;
+    const writesCountForSet = debugBucketsCount;
     bucketWritesCount += writesCountForSet;
     console.info('[searchKeySets] Firebase write start', {
       path: `${SEARCH_KEY_SETS_ROOT}/${setKey}`,
       setKey,
       writesCount: writesCountForSet,
+      payloadUsers: payloadUserIds.size,
+      payloadRecords: debugRecordsCount,
     });
     // eslint-disable-next-line no-await-in-loop
     await set(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`), filteredSearchKeySet);
@@ -715,7 +832,13 @@ export const buildNewUsersFilterSetIndex = async ({
     });
   }
 
-  const aggregatedUserIds = [...new Set(nextSetPayloads.flatMap(item => Object.keys(item.userIds)))];
+  const aggregatedUserIds = [
+    ...new Set(
+      debug.backendRequests
+        .filter(item => item?.type === 'set')
+        .flatMap(item => [...collectUniqueUserIds(item?.payload || {})])
+    ),
+  ];
   return {
     setKeys: [...nextSetKeys],
     userIds: aggregatedUserIds,
@@ -740,7 +863,7 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
     .map(({ text: setText, inputIndex }) => {
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
       if (!parsedRuleGroups.length) return null;
-      const bucketMap = augmentBucketsWithImtMetricWrappers(mergeSearchKeyBuckets(parsedRuleGroups));
+      const { bucketMap } = prepareAdditionalAccessBucketMapForSearchKey(mergeSearchKeyBuckets(parsedRuleGroups));
       const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
         const normalizedIndexName = normalizePathSegment(indexName);
         if (!normalizedIndexName) return acc;
@@ -890,12 +1013,9 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
   const matchedIds = new Set();
 
   for (const parsedRules of groups) {
-    const bucketMap = augmentBucketsWithImtMetricWrappers(resolveAdditionalAccessSearchKeyBuckets(parsedRules));
-    const imtValuesRaw = bucketMap?.imt;
-    const imtValues = [
-      ...new Set((Array.isArray(imtValuesRaw) ? imtValuesRaw : [...(imtValuesRaw || [])]).map(normalizePathSegment)),
-    ];
-    const hasImtFilter = imtValues.length > 0;
+    const { bucketMap, hasImtFilter, imtValues } = prepareAdditionalAccessBucketMapForSearchKey(
+      resolveAdditionalAccessSearchKeyBuckets(parsedRules)
+    );
     const activeSources = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
       const normalizedIndexName = normalizePathSegment(indexName);
       if (!normalizedIndexName) return acc;
@@ -954,7 +1074,7 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
         weight: weightPayload?.exists && typeof weightPayload?.value === 'object' ? weightPayload.value : {},
       };
       const { heightByUserId, weightByUserId } = collectMetricBucketsByUserId(metricSearchKeyFile);
-      if (!groupMatchedIds.length) {
+      if (!normalizedSets.length) {
         const metricUserIds = new Set([
           ...Object.keys(heightByUserId || {}),
           ...Object.keys(weightByUserId || {}),
@@ -962,7 +1082,7 @@ const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {
         groupMatchedIds = [...metricUserIds];
       }
       groupMatchedIds = groupMatchedIds.filter(userId => {
-        const imtBuckets = resolveImtBucketsFromMetricBuckets(heightByUserId[userId], weightByUserId[userId]);
+        const imtBuckets = resolveImtTokensFromExactMetrics(heightByUserId[userId], weightByUserId[userId]);
         return imtBuckets.some(bucket => imtValues.includes(bucket));
       });
     }


### PR DESCRIPTION
### Motivation
- IMT is a virtual filter and derived height/weight category buckets (e.g. `height/lt163`, `weight/55_69`) must not be used as real `searchKey` intersections because real `searchKey` stores exact metric values (e.g. `height/149`).
- Prior logic used derived metric buckets or intermediate prefilter sets which produced mismatched diagnostics and saved payloads (e.g. UI shows 2 available cards but saved payload contained many more users).
- Save flow must build payload from the original `searchKey` constrained by a single source-of-truth `finalAllowedUserIds` so UI counts and backend payload users always match.

### Description
- Added `prepareAdditionalAccessBucketMapForSearchKey` to sanitize bucket maps when IMT is present by removing derived metric category buckets and returning `hasImtFilter`, `imtValues`, and `skippedDerivedMetricBuckets` metadata.
- Exported `resolveImtTokensFromExactMetrics` and introduced `getImtAllowedUserIdsFromSearchKey` so IMT is resolved from exact `height`/`weight` values (per-user) instead of using fake derived buckets.
- Reworked `buildRuleBucketWrites` to compute `finalAllowedUserIds` as the intersection of prefilter + per-field allowed sets + IMT-exact-user-set, and to build write `payload` via `buildSearchKeySetFromAllowedUsers(searchKeyFile, finalAllowedUserIds)` (i.e. payload always comes from original `searchKey` + final allowed set and never from `ruleBucketWrites`).
- Improved diagnostics and toasts to report `imtAllowedCount`, `skippedDerivedMetricBuckets`, `finalAllowedCount`, `payloadUsers`, `payloadBuckets`, and `payloadRecords`, and added a pre-save mismatch check that throws `SEARCH_KEY_SET_PAYLOAD_MISMATCH` if `payloadUsers.size !== finalAllowedCount` while preserving the remove-then-set backend write sequence.
- Updated preview/matching and indexing paths (`ProfileForm` and matching helper code) to use the prepared bucket map and exact IMT resolution so UI preview counts match saved payloads for IMT-only and IMT+other-filter cases.

### Testing
- Ran lint with `npm run lint:js` and it completed without errors.
- Ran unit tests with `CI=true npm test -- --watchAll=false` and all test suites passed (Test Suites: 16 passed, Tests: 73 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa47fa6d5c832695ed9155df7c4978)