### PR TITLE
Persist PP technical input fields (name/surname & contacts) to newUsers

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1076,7 +1076,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'vk', 'userId'];
+    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
+    const ppTechnicalInputFields = ['name', 'surname', ...contacts];
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     const now = Date.now();
@@ -1175,7 +1176,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
         const cleanedStateForNewUsers = Object.fromEntries(
           Object.entries(syncedState).filter(([key]) =>
-            [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
+            [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
           )
         );
 

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -333,7 +333,8 @@ const EditProfile = () => {
     }
 
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
+    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
+    const ppTechnicalInputFields = ['name', 'surname', ...contacts];
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (updatedState?.userId?.length > 20) {
@@ -357,7 +358,7 @@ const EditProfile = () => {
 
       const cleanedStateForNewUsers = Object.fromEntries(
         Object.entries(updatedState).filter(([key]) =>
-          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
+          [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
 
@@ -559,7 +560,8 @@ const EditProfile = () => {
 
   const persistCanonicalByRules = async mergedCard => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'vk', 'userId'];
+    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
+    const ppTechnicalInputFields = ['name', 'surname', ...contacts];
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (mergedCard?.userId?.length > 20) {
@@ -570,7 +572,7 @@ const EditProfile = () => {
       await updateDataInFiresoreDB(mergedCard.userId, cleanedState, 'check');
       const cleanedStateForNewUsers = Object.fromEntries(
         Object.entries(mergedCard).filter(([key]) =>
-          [...fieldsForNewUsersOnly, ...contacts, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
+          [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
       await updateDataInNewUsersRTDB(mergedCard.userId, cleanedStateForNewUsers, 'update');

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -427,7 +427,8 @@ export const handleSubmit = (userData, condition, removeKeys = []) => {
     'cycleStatus',
     'stimulationSchedule',
   ];
-  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'vk', 'userId'];
+  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
+  const ppTechnicalInputFields = ['name', 'surname', ...contacts];
   const commonFields = [
     'lastAction',
     'lastLogin2',
@@ -458,7 +459,7 @@ export const handleSubmit = (userData, condition, removeKeys = []) => {
   // Фільтруємо ключі, щоб видалити зайві поля
   const cleanedStateForNewUsers = Object.fromEntries(
     Object.entries(uploadedInfo).filter(([key]) =>
-      [...fieldsForNewUsersOnly, ...contacts, ...commonFields, ...dublicateFields].includes(key)
+      [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, ...commonFields, ...dublicateFields].includes(key)
     )
   );
 
@@ -506,7 +507,8 @@ export const handleSubmitAll = async (userData, overwrite) => {
     'cycleStatus',
     'stimulationSchedule',
   ];
-  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'vk', 'userId'];
+  const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
+  const ppTechnicalInputFields = ['name', 'surname', ...contacts];
   const commonFields = [
     'lastAction',
     'lastLogin2',
@@ -536,7 +538,7 @@ export const handleSubmitAll = async (userData, overwrite) => {
 
     const cleanedStateForNewUsers = Object.fromEntries(
       Object.entries(uploadedInfo).filter(([key]) =>
-        [...fieldsForNewUsersOnly, ...contacts, ...commonFields].includes(key)
+        [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, ...commonFields].includes(key)
       )
     );
 


### PR DESCRIPTION
### Motivation
- The PP (private profile) technical input parses identity/contact tokens but those parsed `name`/`surname` and some contact types were filtered out before writing to `newUsers`, so PP-entered values did not reach the backend. 
- The change ensures all fields the PP technical input can resolve are whitelisted for persistence to the lightweight `newUsers` record used by indexing and quick views. 
- The fix is applied consistently in profile submit flows and small-card helpers to avoid divergent behavior between different save paths. 

### Description
- Added a `ppTechnicalInputFields` whitelist (`['name','surname', ...contacts]`) and used it when building `cleanedStateForNewUsers` in `src/components/AddNewProfile.jsx`, `src/components/EditProfile.jsx`, and `src/components/smallCard/actions.js`. 
- Expanded the `contacts` arrays to include contact types that `resolvePpTechnicalInputTarget` can produce (`twitter`, `line`, `otherLink`, `other`, and ensured `linkedin`/`youtube` are included) so these values pass the `newUsers` filter. 
- Replaced occurrences of `[..., ...contacts, ...]` with `[..., ...ppTechnicalInputFields, ...]` where appropriate so parsed PP technical-input identity and contact fields are preserved for `updateDataInNewUsersRTDB`. 

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runInBand`, and all test suites passed (`16 passed`, `73 tests`).
- Built a production bundle with `npm run build`, and the build completed successfully (optimized build produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0f31932c83269e98d8fee1eb1a07)