### PR TITLE
Stop auto-creating cycleStatus

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1216,7 +1216,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             ...serverData,
             lastAction: serverLast,
             lastDelivery: formatDateToDisplay(serverData.lastDelivery),
-            cycleStatus: serverData.cycleStatus || 'menstruation',
           };
           updateCachedUser(formattedServer);
           cacheFetchedUsers(
@@ -3755,9 +3754,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const fieldsToRender = getFieldsToRender(state);
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
-  const scheduleUserData = state
-    ? { ...state, cycleStatus: effectiveCycleStatus ?? state.cycleStatus }
-    : state;
+  const scheduleUserData = state;
   const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveCycleStatus);
 
 

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -463,7 +463,6 @@ const EditProfile = () => {
           ...serverData,
           lastAction: serverLast,
           lastDelivery: formatDateToDisplay(serverData.lastDelivery),
-          cycleStatus: serverData.cycleStatus || 'menstruation',
         };
         updateCachedUser(formattedServerData);
         setState(formattedServerData);
@@ -583,9 +582,7 @@ const EditProfile = () => {
   };
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
-  const scheduleUserData = state
-    ? { ...state, cycleStatus: effectiveCycleStatus ?? state.cycleStatus }
-    : state;
+  const scheduleUserData = state;
   const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveCycleStatus);
 
   const overlayFieldAdditions = useMemo(() => {

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -210,11 +210,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
   const processLastCycle = value => {
     const val = value.trim();
     const date = parseDate(val);
-    const normalizedStatus = status || (val ? 'menstruation' : '');
-
-    if (!status && normalizedStatus) {
-      setStatus(normalizedStatus);
-    }
+    const normalizedStatus = status;
 
     if (date) {
       const lastCycleFormatted = formatDateToServer(formatDate(date));


### PR DESCRIPTION
### Motivation
- Prevent implicitly adding `cycleStatus` to local state/payload when backend `serverData` doesn't include it, and avoid using a hard fallback `'menstruation'` that writes a display-only default into persisted state.
- Ensure `cycleStatus` is only persisted after an explicit user action in the UI (status click/change), while still allowing the UI to render a display-only effective status when appropriate.

### Description
- Removed the fallback that set `cycleStatus: serverData.cycleStatus || 'menstruation'` after fetching refreshed server data, so missing `cycleStatus` is no longer injected into `state`/cache (changed in `src/components/AddNewProfile.jsx` and `src/components/EditProfile.jsx`).
- Stopped creating a copy of state with an injected `cycleStatus` for the schedule UI; schedule components now receive the actual `state` without an inserted display-only `cycleStatus` (`scheduleUserData = state`) in `AddNewProfile.jsx` and `EditProfile.jsx`.
- Prevented automatic assignment of `cycleStatus = 'menstruation'` when parsing/processing `lastCycle`; `processLastCycle` now uses the existing `status` and only persists `cycleStatus` when the user already has it or when they explicitly change it in the UI (changed in `src/components/smallCard/fieldLastCycle.js`).

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runTestsByPath src/utils/__tests__/cycleStatus.test.js` and all tests passed.
- Ran linter with `npm run lint:js` and it completed successfully.
- Built a production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2157d10483269d3afa244f61b771)