### PR TITLE
Add LA2 (LastAction2) load/sort mode and lastAction search-index support

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -114,6 +114,18 @@ import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { sortUsersByStimulationSchedule } from 'utils/stimulationScheduleSort';
 import { convertDriveLinkToImage } from 'utils/convertDriveLinkToImage';
 import { rebuildAllNewUsersFilterSetIndexes } from 'utils/newUsersFilterSetsIndex';
+import {
+  LAST_ACTION2_FILTER,
+  LAST_ACTION2_FILTER_STORAGE_KEY,
+  LAST_ACTION2_SORT_MODE,
+  LastAction2SortModeButton,
+  createInitialLA2State,
+  getLA2AcceptedOrder,
+  loadMoreUsersLastAction2 as loadMoreUsersLastAction2Mode,
+  resetLA2StateRef,
+  restoreLA2State,
+  serializeLA2State,
+} from './LastAction2Mode';
 
 const Container = styled.div`
   display: flex;
@@ -684,6 +696,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const LOAD_SORT_MODES = {
     GIT: 'GIT',
     LAST_ACTION: 'LA',
+    LAST_ACTION2: LAST_ACTION2_SORT_MODE,
     NO_GIT: 'NoGIT',
     SEARCH_ID_KEY_ONLY: 'SearchIdKeyOnly',
   };
@@ -698,6 +711,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     { key: 'imtHeightWeight', label: 'imt+height+weight' },
     { key: 'reaction', label: 'reaction' },
     { key: 'fieldCount', label: 'fields' },
+    { key: 'lastAction', label: 'lastAction' },
   ];
 
   const location = useLocation();
@@ -1137,15 +1151,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       if (syncedState?.userId) {
         try {
           const isUsersCollectionId = syncedState.userId.length > 20;
-          const searchKeySyncTask = isUsersCollectionId
-            ? syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState, {
+          const searchKeySyncTasks = [
+            syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState),
+          ];
+          if (isUsersCollectionId) {
+            searchKeySyncTasks.push(
+              syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState, {
                 rootPath: 'searchKey/users',
               })
-            : syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState);
+            );
+          }
 
           await Promise.all([
             syncUserSearchIdIndex(syncedState.userId, existingData || {}, syncedState),
-            searchKeySyncTask,
+            ...searchKeySyncTasks,
           ]);
         } catch (indexError) {
           const details = indexError?.message || String(indexError);
@@ -1429,6 +1448,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [dateOffset2, setDateOffset2] = useState(0);
   const [dateOffset21, setDateOffset21] = useState(0);
   const [dateOffsetLA, setDateOffsetLA] = useState(0);
+  const la2StateRef = useRef(createInitialLA2State());
   const initialFav = getFavorites();
   const [favoriteUsersData, setFavoriteUsersData] = useState(initialFav);
   const initialDis = getDislikes();
@@ -1460,6 +1480,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       dateOffset2,
       dateOffset21,
       dateOffsetLA,
+      la2State: currentFilter === LAST_ACTION2_FILTER ? serializeLA2State(la2StateRef.current) : undefined,
       loadSortMode,
       search,
       hasSearched,
@@ -1653,6 +1674,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       }
     }
 
+    if (currentFilter === LAST_ACTION2_FILTER) {
+      filtersRef.current = nextValue;
+      setUsers({});
+      setCurrentPage(1);
+      setHasMore(true);
+      setSearchLoading(true);
+      setHasSearched(true);
+      setTotalCount(0);
+      resetLA2StateRef(la2StateRef);
+      setFilters(nextValue);
+      return;
+    }
+
     if (currentFilter === 'LAST_ACTION') {
       filtersRef.current = nextValue;
       setUsers({});
@@ -1765,6 +1799,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     switch (mode) {
       case LOAD_SORT_MODES.LAST_ACTION:
         return 'LAST_ACTION';
+      case LOAD_SORT_MODES.LAST_ACTION2:
+        return LAST_ACTION2_FILTER;
       case LOAD_SORT_MODES.NO_GIT:
       case LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY:
         return 'DATE2.1';
@@ -1775,7 +1811,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const filterStorageKey =
-    loadSortMode === LOAD_SORT_MODES.LAST_ACTION ? 'addFiltersLA' : 'addFilters';
+    loadSortMode === LOAD_SORT_MODES.LAST_ACTION
+      ? 'addFiltersLA'
+      : loadSortMode === LOAD_SORT_MODES.LAST_ACTION2
+      ? LAST_ACTION2_FILTER_STORAGE_KEY
+      : 'addFilters';
 
   const searchIdAndSearchKeyOnlyMode = loadSortMode === LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY;
 
@@ -2157,6 +2197,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return;
     }
 
+    if (currentFilter === LAST_ACTION2_FILTER) {
+      loadMoreUsersLastAction2()
+        .then(({ cacheCount, backendCount }) => {
+          setCacheCount(cacheCount);
+          setBackendCount(backendCount);
+        })
+        .finally(() => setSearchLoading(false));
+      return;
+    }
+
     if (currentFilter === 'FAVORITE') {
       loadFavoriteUsers().finally(() => setSearchLoading(false));
       return;
@@ -2460,6 +2510,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
     return merged;
   };
+
+
+  const loadMoreUsersLastAction2 = (currentFilters = filters) =>
+    loadMoreUsersLastAction2Mode({
+      la2StateRef,
+      currentFilters,
+      currentPage,
+      hasMore,
+      isEditingRef,
+      fetchUserById,
+      mergeWithoutOverwrite,
+      cacheFetchedUsers,
+      setUsers,
+      setHasMore,
+      setTotalCount,
+    });
 
   useEffect(() => {
     const handleMoreActionsBackNavigation = () => {
@@ -2875,6 +2941,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setIdsForQuery(queryKey, [...new Set([...existingIds, ...loadedIds])]);
     return { cacheCount, backendCount, hasMore: more };
   };
+
   const loadMoreUsersLastAction = async (currentFilters = filters) => {
     let favRaw = getFavorites();
     let fav = Object.fromEntries(Object.entries(favRaw).filter(([, v]) => v));
@@ -3062,6 +3129,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             : await loadMoreUsers21()
           : currentFilter === 'LAST_ACTION'
           ? await loadMoreUsersLastAction()
+          : currentFilter === LAST_ACTION2_FILTER
+          ? await loadMoreUsersLastAction2()
           : await loadMoreUsers(currentFilter);
       cacheLoaded += cacheCount;
       backendLoaded += backendCount;
@@ -3774,6 +3843,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return ids;
     }
 
+    if (currentFilter === LAST_ACTION2_FILTER) {
+      const acceptedOrder = getLA2AcceptedOrder(la2StateRef);
+      return ids.sort((a, b) => acceptedOrder.indexOf(a) - acceptedOrder.indexOf(b));
+    }
+
     if (currentFilter === 'LAST_ACTION') {
       return ids.sort((a, b) => {
         const left = normalizeLastAction(users[a]?.lastAction) || 0;
@@ -3813,6 +3887,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setDateOffset2(0);
     setDateOffset21(0);
     setDateOffsetLA(0);
+    resetLA2StateRef(la2StateRef);
     setLastKey21(null);
     setDuplicates('');
     setIsDuplicateView(false);
@@ -3870,6 +3945,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setDateOffset2(snapshot.dateOffset2 || 0);
     setDateOffset21(snapshot.dateOffset21 || 0);
     setDateOffsetLA(snapshot.dateOffsetLA || 0);
+    if (snapshot.la2State) {
+      la2StateRef.current = restoreLA2State(snapshot.la2State);
+    }
     setLoadSortMode(snapshot.loadSortMode || 'SearchIdKeyOnly');
     setSearch(snapshot.search || '');
     setHasSearched(Boolean(snapshot.hasSearched) || Object.keys(restoredUsers).length > 0);
@@ -4286,6 +4364,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 />
                 LA
               </SortModeLabel>
+              <LastAction2SortModeButton
+                SortModeLabel={SortModeLabel}
+                loadSortMode={loadSortMode}
+                onChange={handleLoadSortModeChange}
+              />
               <SortModeLabel>
                 <input
                   type="radio"
@@ -4312,7 +4395,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction'] : undefined}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction', 'lastAction'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -47,6 +47,16 @@ const defaultsAdd = {
     other: true,
   },
   reaction: { ...REACTION_FILTER_DEFAULTS },
+  lastAction: {
+    today: false,
+    yesterday: false,
+    last3days: false,
+    last7days: false,
+    last14days: false,
+    last30days: false,
+    no: false,
+    '?': false,
+  },
 };
 
 const defaultsMatching = {

--- a/src/components/LastAction2Mode.jsx
+++ b/src/components/LastAction2Mode.jsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { get, ref } from 'firebase/database';
+import { cacheLoad2Users } from 'utils/load2Storage';
+import { getCard, serializeQueryFilters } from 'utils/cardIndex';
+import { PAGE_SIZE, database } from './config';
+
+export const LAST_ACTION2_SORT_MODE = 'LA2';
+export const LAST_ACTION2_FILTER = 'LAST_ACTION2';
+export const LAST_ACTION2_FILTER_STORAGE_KEY = 'addFiltersLA2';
+export const LAST_ACTION2_SEARCH_KEY_INDEX = 'lastAction';
+
+export const createInitialLA2State = (filtersKey = '') => ({
+  bucketCache: {},
+  filterBucketCache: {},
+  shownIds: new Set(),
+  acceptedIds: [],
+  bucketCursor: 0,
+  userCursorByBucket: {},
+  defaultDayOffset: 0,
+  hasMore: true,
+  filtersKey,
+});
+
+export const serializeLA2State = la2State => ({
+  acceptedIds: [...(la2State?.acceptedIds || [])],
+  shownIds: [...(la2State?.shownIds || [])],
+  bucketCursor: la2State?.bucketCursor || 0,
+  userCursorByBucket: la2State?.userCursorByBucket || {},
+  defaultDayOffset: la2State?.defaultDayOffset || 0,
+  hasMore: la2State?.hasMore !== false,
+  filtersKey: la2State?.filtersKey || '',
+});
+
+export const restoreLA2State = snapshot => ({
+  ...createInitialLA2State(snapshot?.filtersKey || ''),
+  ...(snapshot || {}),
+  shownIds: new Set(snapshot?.shownIds || []),
+  acceptedIds: snapshot?.acceptedIds || [],
+  bucketCache: {},
+  filterBucketCache: {},
+});
+
+export const resetLA2StateRef = la2StateRef => {
+  if (!la2StateRef) return;
+  la2StateRef.current = createInitialLA2State();
+};
+
+export const getLA2AcceptedOrder = la2StateRef => la2StateRef?.current?.acceptedIds || [];
+
+const toLocalIsoDate = date => {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+};
+
+const makeLastActionDateBucket = dayOffset => {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() - dayOffset);
+  return `d_${toLocalIsoDate(date)}`;
+};
+
+const getSelectedLastActionBuckets = currentFilters => {
+  const la = currentFilters?.lastAction || {};
+  const selected = Object.entries(la)
+    .filter(([, enabled]) => enabled === true)
+    .map(([key]) => key);
+  const buckets = [];
+  const addBucket = bucket => {
+    if (bucket && !buckets.includes(bucket)) buckets.push(bucket);
+  };
+  const addRange = days => {
+    for (let day = 0; day < days; day += 1) addBucket(makeLastActionDateBucket(day));
+  };
+
+  selected.forEach(key => {
+    if (key === 'today') addBucket(makeLastActionDateBucket(0));
+    if (key === 'yesterday') addBucket(makeLastActionDateBucket(1));
+    if (key === 'last3days') addRange(3);
+    if (key === 'last7days') addRange(7);
+    if (key === 'last14days') addRange(14);
+    if (key === 'last30days') addRange(30);
+    if (key === 'no') addBucket('no');
+    if (key === '?') addBucket('?');
+  });
+
+  return { buckets, hasExplicitBuckets: buckets.length > 0 };
+};
+
+const isFilterGroupAppliedForLA2 = group => {
+  if (!group || typeof group !== 'object') return false;
+  const values = Object.values(group);
+  if (!values.length) return false;
+  const enabledCount = values.filter(value => value === true).length;
+  return enabledCount > 0 && enabledCount < values.length;
+};
+
+const mapLA2FilterValueToBuckets = (filterName, value) => {
+  const direct = bucket => ({ indexName: filterName, bucket });
+  if (filterName === 'lastAction') return [];
+  if (filterName === 'role') return [direct(value === 'other' ? '?' : value === 'empty' ? 'no' : value)];
+  if (filterName === 'csection') return [direct(value === 'other' ? 'other' : value)];
+  if (filterName === 'contact') return [direct(value)];
+  if (filterName === 'imt') return [direct(value === 'other' ? '?' : value)];
+  if (filterName === 'maritalStatus') {
+    if (value === 'married') return [direct('+')];
+    if (value === 'unmarried') return [direct('-')];
+    if (value === 'empty') return [direct('no')];
+    return [direct('?')];
+  }
+  if (filterName === 'bloodGroup') {
+    return [{ indexName: 'blood', bucket: value === 'other' ? '?' : value === 'empty' ? 'no' : value }];
+  }
+  if (filterName === 'rh') {
+    return [{ indexName: 'blood', bucket: value === 'other' ? '?' : value === 'empty' ? 'no' : value }];
+  }
+  if (filterName === 'userId') return [direct(value)];
+  if (filterName === 'reaction') {
+    const map = { question: '?', none: 'no', special99: '99' };
+    if (map[value]) return [{ indexName: 'reaction', bucket: map[value] }];
+  }
+  return [];
+};
+
+const getLA2SearchKeyBucketIds = async (la2StateRef, indexName, bucket) => {
+  const cacheKey = `${indexName}/${bucket}`;
+  const cache = indexName === LAST_ACTION2_SEARCH_KEY_INDEX
+    ? la2StateRef.current.bucketCache
+    : la2StateRef.current.filterBucketCache;
+  if (cache[cacheKey]) return cache[cacheKey];
+
+  const snapshot = await get(ref(database, `searchKey/${indexName}/${bucket}`));
+  const ids = snapshot.exists() ? Object.keys(snapshot.val() || {}).filter(Boolean) : [];
+  const idSet = new Set(ids);
+  cache[cacheKey] = idSet;
+  return idSet;
+};
+
+const buildLA2AppliedFilters = currentFilters => {
+  return Object.entries(currentFilters || {})
+    .filter(([filterName, group]) => filterName !== 'lastAction' && isFilterGroupAppliedForLA2(group))
+    .map(([filterName, group]) => {
+      const buckets = Object.entries(group)
+        .filter(([, enabled]) => enabled === true)
+        .flatMap(([value]) => mapLA2FilterValueToBuckets(filterName, value))
+        .filter(({ indexName, bucket }) => indexName && bucket);
+      return { filterName, buckets };
+    })
+    .filter(group => group.buckets.length > 0);
+};
+
+const userPassesLA2SearchKeyFilters = async (la2StateRef, userId, appliedFilters) => {
+  for (const group of appliedFilters) {
+    let matchedGroup = false;
+    for (const bucketInfo of group.buckets) {
+      // eslint-disable-next-line no-await-in-loop
+      const bucketIds = await getLA2SearchKeyBucketIds(la2StateRef, bucketInfo.indexName, bucketInfo.bucket);
+      if (bucketIds.has(userId)) {
+        matchedGroup = true;
+        break;
+      }
+    }
+    if (!matchedGroup) return false;
+  }
+  return true;
+};
+
+const ensureLA2StateForFilters = (la2StateRef, currentFilters) => {
+  const filtersKey = serializeQueryFilters(currentFilters || {});
+  if (la2StateRef.current.filtersKey === filtersKey) return;
+  la2StateRef.current = createInitialLA2State(filtersKey);
+};
+
+export const loadMoreUsersLastAction2 = async ({
+  la2StateRef,
+  currentFilters = {},
+  currentPage = 1,
+  hasMore = true,
+  isEditingRef,
+  fetchUserById,
+  mergeWithoutOverwrite,
+  cacheFetchedUsers,
+  setUsers,
+  setHasMore,
+  setTotalCount,
+}) => {
+  if (isEditingRef?.current) return { cacheCount: 0, backendCount: 0, hasMore };
+  ensureLA2StateForFilters(la2StateRef, currentFilters);
+  const la2State = la2StateRef.current;
+  const targetAcceptedCount = Math.max(currentPage * PAGE_SIZE, la2State.acceptedIds.length + PAGE_SIZE);
+  const { buckets: presetBuckets, hasExplicitBuckets } = getSelectedLastActionBuckets(currentFilters);
+  const appliedFilters = buildLA2AppliedFilters(currentFilters);
+  let safety = 0;
+  const safetyLimit = 600;
+
+  while (la2State.acceptedIds.length < targetAcceptedCount && la2State.hasMore && safety < safetyLimit) {
+    safety += 1;
+    let bucket;
+    if (hasExplicitBuckets) {
+      bucket = presetBuckets[la2State.bucketCursor];
+      if (!bucket) {
+        la2State.hasMore = false;
+        break;
+      }
+    } else {
+      bucket = makeLastActionDateBucket(la2State.defaultDayOffset);
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const idsSet = await getLA2SearchKeyBucketIds(la2StateRef, LAST_ACTION2_SEARCH_KEY_INDEX, bucket);
+    const ids = [...idsSet];
+    const cursor = la2State.userCursorByBucket[bucket] || 0;
+    const slice = ids.slice(cursor, cursor + PAGE_SIZE);
+    la2State.userCursorByBucket[bucket] = cursor + slice.length;
+
+    for (const userId of slice) {
+      if (la2State.shownIds.has(userId)) continue;
+      // eslint-disable-next-line no-await-in-loop
+      const passes = await userPassesLA2SearchKeyFilters(la2StateRef, userId, appliedFilters);
+      if (!passes) continue;
+      la2State.shownIds.add(userId);
+      la2State.acceptedIds.push(userId);
+      if (la2State.acceptedIds.length >= targetAcceptedCount) break;
+    }
+
+    if (slice.length < PAGE_SIZE || la2State.userCursorByBucket[bucket] >= ids.length) {
+      if (hasExplicitBuckets) la2State.bucketCursor += 1;
+      else la2State.defaultDayOffset += 1;
+    }
+
+    if (!hasExplicitBuckets && la2State.defaultDayOffset > safetyLimit) {
+      la2State.hasMore = false;
+    }
+  }
+
+  const pageIds = la2State.acceptedIds.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+  const pageUsers = {};
+  await Promise.all(
+    pageIds.map(async userId => {
+      const cached = getCard(userId);
+      const user = cached || (await fetchUserById(userId));
+      if (user) pageUsers[userId] = user;
+    })
+  );
+
+  if (!isEditingRef?.current) setUsers(prev => mergeWithoutOverwrite(prev, pageUsers));
+  cacheFetchedUsers(pageUsers, cacheLoad2Users, currentFilters);
+  setHasMore(la2State.hasMore);
+  setTotalCount(Math.max(la2State.acceptedIds.length + (la2State.hasMore ? PAGE_SIZE : 0), la2State.acceptedIds.length));
+  return { cacheCount: 0, backendCount: Object.keys(pageUsers).length, hasMore: la2State.hasMore };
+};
+
+export const LastAction2SortModeButton = ({ SortModeLabel, loadSortMode, onChange }) => (
+  <SortModeLabel>
+    <input
+      type="radio"
+      name="load-sort-mode"
+      value={LAST_ACTION2_SORT_MODE}
+      checked={loadSortMode === LAST_ACTION2_SORT_MODE}
+      onChange={event => onChange(event.target.value)}
+    />
+    LA2
+  </SortModeLabel>
+);

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -116,6 +116,21 @@ export const SearchFilters = ({
         })),
       },
       {
+        filterName: 'lastAction',
+        label: 'LA',
+        compact: true,
+        options: [
+          { val: 'today', label: 'Today' },
+          { val: 'yesterday', label: 'Yesterday' },
+          { val: 'last3days', label: '3d' },
+          { val: 'last7days', label: '7d' },
+          { val: 'last14days', label: '14d' },
+          { val: 'last30days', label: '30d' },
+          { val: 'no', label: 'empty' },
+          { val: '?', label: 'unknown format' },
+        ],
+      },
+      {
         filterName: 'csection',
         label: 'C-section',
         options: [

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -78,6 +78,7 @@ const ROLE_SEARCH_KEY_INDEX = 'role';
 const USER_ID_SEARCH_KEY_INDEX = 'userId';
 const REACTION_SEARCH_KEY_INDEX = 'reaction';
 const FIELD_COUNT_SEARCH_KEY_INDEX = 'fields';
+const LAST_ACTION_SEARCH_KEY_INDEX = 'lastAction';
 const SEARCH_KEY_BATCH_UPLOAD_SIZE = 100;
 const SEARCH_INDEX_COLLECTION_CACHE_PREFIX = 'search-index:collection:v1:';
 const SEARCH_INDEX_COLLECTION_CACHE_TTL_MS = 60 * 60 * 1000;
@@ -92,6 +93,7 @@ const SEARCH_KEY_INDEX_TYPES = {
   imtHeightWeight: IMT_SEARCH_KEY_INDEX,
   reaction: REACTION_SEARCH_KEY_INDEX,
   fieldCount: FIELD_COUNT_SEARCH_KEY_INDEX,
+  lastAction: LAST_ACTION_SEARCH_KEY_INDEX,
 };
 
 const getSearchIndexCacheStorage = () => {
@@ -1681,6 +1683,7 @@ export const makeNewUser = async (searchedValue, rawQuery = '') => {
 
   // Записуємо нового користувача в базу даних
   await set(newUserRef, newUser);
+  await syncUserSearchKeyIndex(newUserId, {}, newUser);
 
   if (searchMeta) {
     const { searchIdKey } = searchMeta;
@@ -3041,6 +3044,62 @@ const collectFieldCountIdsByFilters = async (fieldsFilters, rootPaths = [SEARCH_
 };
 
 const AGE_DATE_PREFIX = 'd_';
+
+export const normalizeLastActionSearchKeyBucket = rawValue => {
+  if (rawValue === undefined || rawValue === null) return 'no';
+
+  const normalized = String(rawValue).trim();
+  if (!normalized) return 'no';
+
+  let parsedDate = null;
+  const isoMatch = normalized.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  const dotMatch = normalized.match(/^(\d{1,2})[./](\d{1,2})[./](\d{4})$/);
+
+  if (isoMatch) {
+    const [, yearRaw, monthRaw, dayRaw] = isoMatch;
+    const year = Number.parseInt(yearRaw, 10);
+    const month = Number.parseInt(monthRaw, 10);
+    const day = Number.parseInt(dayRaw, 10);
+    parsedDate = new Date(year, month - 1, day);
+    if (
+      parsedDate.getFullYear() !== year ||
+      parsedDate.getMonth() !== month - 1 ||
+      parsedDate.getDate() !== day
+    ) {
+      return '?';
+    }
+  } else if (dotMatch) {
+    const [, dayRaw, monthRaw, yearRaw] = dotMatch;
+    const year = Number.parseInt(yearRaw, 10);
+    const month = Number.parseInt(monthRaw, 10);
+    const day = Number.parseInt(dayRaw, 10);
+    parsedDate = new Date(year, month - 1, day);
+    if (
+      parsedDate.getFullYear() !== year ||
+      parsedDate.getMonth() !== month - 1 ||
+      parsedDate.getDate() !== day
+    ) {
+      return '?';
+    }
+  } else if (typeof rawValue === 'number' || /^\d+$/.test(normalized)) {
+    const timestamp = Number(rawValue);
+    if (!Number.isFinite(timestamp)) return '?';
+    parsedDate = new Date(timestamp);
+    if (Number.isNaN(parsedDate.getTime())) return '?';
+  } else {
+    const timestamp = Date.parse(normalized);
+    if (Number.isNaN(timestamp)) return '?';
+    parsedDate = new Date(timestamp);
+  }
+
+  return `${AGE_DATE_PREFIX}${toIsoDate(parsedDate)}`;
+};
+
+const getLastActionIndexSet = data => {
+  if (!data || typeof data !== 'object') return new Set(['no']);
+  return new Set([normalizeLastActionSearchKeyBucket(data.lastAction)]);
+};
+
 const GET_IN_TOUCH_SPECIAL_VALUES = new Set([
   '2099-99-99',
   '9999-99-99',
@@ -3584,6 +3643,8 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
 
   const prevFieldCountValues = getFieldCountIndexSet(prevData);
   const nextFieldCountValues = getFieldCountIndexSet(nextData);
+  const prevLastActionValues = getLastActionIndexSet(prevData);
+  const nextLastActionValues = getLastActionIndexSet(nextData);
 
   for (const value of prevFieldCountValues) {
     if (!nextFieldCountValues.has(value)) {
@@ -3596,6 +3657,20 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
     if (!prevFieldCountValues.has(value)) {
       // eslint-disable-next-line no-await-in-loop
       await updateLeaf(FIELD_COUNT_SEARCH_KEY_INDEX, value, 'add');
+    }
+  }
+
+  for (const value of prevLastActionValues) {
+    if (!nextLastActionValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateLeaf(LAST_ACTION_SEARCH_KEY_INDEX, value, 'remove');
+    }
+  }
+
+  for (const value of nextLastActionValues) {
+    if (!prevLastActionValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateLeaf(LAST_ACTION_SEARCH_KEY_INDEX, value, 'add');
     }
   }
 };
@@ -3876,6 +3951,35 @@ export const createFieldCountSearchKeyIndexInCollection = async (collection, onP
   );
 };
 
+
+export const createLastActionSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
+  if (collection !== 'newUsers' && searchKeyRoot === SEARCH_KEY_INDEX_ROOT) return;
+  const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
+  if (!usersData) return;
+
+  const userIds = Object.keys(usersData);
+  const totalUsers = userIds.length;
+  if (totalUsers === 0) return;
+
+  if (searchKeyRoot === SEARCH_KEY_INDEX_ROOT) {
+    await remove(ref2(database, `${searchKeyRoot}/${LAST_ACTION_SEARCH_KEY_INDEX}`));
+  }
+
+  await uploadChunkedSearchKeyIndexUpdates(
+    userIds,
+    totalUsers,
+    batchIds =>
+      batchIds.reduce((acc, userId) => {
+        const user = usersData[userId] || {};
+        const bucket = normalizeLastActionSearchKeyBucket(user.lastAction);
+        acc[`${searchKeyRoot}/${LAST_ACTION_SEARCH_KEY_INDEX}/${bucket}/${userId}`] = true;
+        return acc;
+      }, {}),
+    onProgress
+  );
+};
+
 const SEARCH_KEY_INDEX_BUILDERS = {
   [SEARCH_KEY_INDEX_TYPES.blood]: createSearchKeyIndexInCollection,
   [SEARCH_KEY_INDEX_TYPES.maritalStatus]: createMaritalStatusSearchKeyIndexInCollection,
@@ -3887,6 +3991,7 @@ const SEARCH_KEY_INDEX_BUILDERS = {
   [SEARCH_KEY_INDEX_TYPES.imtHeightWeight]: createImtHeightWeightSearchKeyIndexInCollection,
   [SEARCH_KEY_INDEX_TYPES.reaction]: createReactionSearchKeyIndexInCollection,
   [SEARCH_KEY_INDEX_TYPES.fieldCount]: createFieldCountSearchKeyIndexInCollection,
+  [SEARCH_KEY_INDEX_TYPES.lastAction]: createLastActionSearchKeyIndexInCollection,
 };
 
 export const createSelectedSearchKeyIndexesInCollection = async (collection, indexTypes = [], onProgress, options = {}) => {
@@ -4004,6 +4109,9 @@ const resolveSearchKeyValuesByIndexType = (indexType, userId, userData) => {
   }
   if (indexType === SEARCH_KEY_INDEX_TYPES.fieldCount) {
     return [{ indexName: FIELD_COUNT_SEARCH_KEY_INDEX, values: [normalizeFieldCountSearchKeyIndexValue(userData)] }];
+  }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.lastAction) {
+    return [{ indexName: LAST_ACTION_SEARCH_KEY_INDEX, values: [normalizeLastActionSearchKeyBucket(userData?.lastAction)] }];
   }
   return [];
 };


### PR DESCRIPTION
### Motivation
- Introduce an improved "Last Action" browsing mode (LA2) that pages users by lastAction date buckets and supports complex filters for efficient listing.
- Add search-index support for `lastAction` so LA2 can query buckets from the realtime index and be included in index-building utilities.

### Description
- Added new component `src/components/LastAction2Mode.jsx` that implements LA2 state, serialization/restoration, bucketed searchKey reads, filter matching and `loadMoreUsersLastAction2` logic; and exported helper UI `LastAction2SortModeButton` and constants `LAST_ACTION2_*` and `LAST_ACTION2_SORT_MODE`.
- Integrated LA2 into `AddNewProfile.jsx` by importing LA2 helpers, adding `la2StateRef` state, serializing/restoring LA2 state to `PREVIOUS_LIST_STATE_KEY`, wiring `loadMoreUsersLastAction2` into load flows and pagination, adding the LA2 radio button in the sort-mode control, adding `lastAction` to allowed filter keys and to sorting logic via `getLA2AcceptedOrder`, and resetting LA2 state where appropriate.
- Extended UI filters by adding `lastAction` defaults in `FilterPanel.jsx` and a compact `lastAction` group in `SearchFilters.jsx` to allow selecting today/yesterday/3/7/14/30d/no/unknown buckets.
- Added `lastAction` search key and utilities in `src/components/config.js` including `normalizeLastActionSearchKeyBucket`, `createLastActionSearchKeyIndexInCollection`, placing `lastAction` in `SEARCH_KEY_INDEX_TYPES`, and updated `syncUserSearchKeyIndex` and new-user creation to update the lastAction index bucket when users are created/updated.

### Testing
- Ran linting (`npm run lint`) and the existing unit test suite (`npm test`) locally and they completed without failures.
- Exercised basic LA2 flows in the development build: selecting LA2 sort mode, applying `lastAction` filters and paginating results to validate bucket reads and pagination (manual smoke tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb283e857883268826550371764cff)