### PR TITLE
Fix PP technical TikTok URL detection

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2113,15 +2113,15 @@ ${entries.join('\n')}`;
         const looksLikeEmail = EMAIL_REGEX.test(rawValue);
         const resolvedTechnicalTarget = resolvePpTechnicalInputTarget(rawValue);
 
-        if (looksLikeEmail) {
-          nextState.email = appendFieldValue(prevState.email, rawValue);
-        } else if (looksLikePhone) {
-          nextState.phone = appendFieldValue(prevState.phone, normalizedPhone);
-        } else if (resolvedTechnicalTarget) {
+        if (resolvedTechnicalTarget) {
           nextState[resolvedTechnicalTarget.fieldName] = appendFieldValue(
             prevState[resolvedTechnicalTarget.fieldName],
             resolvedTechnicalTarget.value
           );
+        } else if (looksLikeEmail) {
+          nextState.email = appendFieldValue(prevState.email, rawValue);
+        } else if (looksLikePhone) {
+          nextState.phone = appendFieldValue(prevState.phone, normalizedPhone);
         } else {
           nextState.name = appendFieldValue(prevState.name, rawValue);
         }


### PR DESCRIPTION
### Motivation
- The PP technical input mistakenly classified some social profile URLs (e.g. TikTok links) as emails, so paste/detection should prefer resolved social/profile targets before email heuristics.

### Description
- Reordered detection in `src/components/ProfileForm.jsx` so `resolvePpTechnicalInputTarget(rawValue)` is applied before `EMAIL_REGEX` and phone checks, ensuring social URL targets (like TikTok) populate the correct contact field.

### Testing
- Ran `npm test -- --watchAll=false` and all test suites passed (16/16 suites, 73 tests total).
- Ran `npm run lint:js` and linter completed successfully (no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5ed121a88326b86b16394d8b2d07)