### PR TITLE
Fix repeated search not-found cards

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -755,7 +755,9 @@ const SearchBar = ({
       !output ||
       Object.keys(output).length === 0
     ) return;
-    mergeSearchResultMap(collector.results, output);
+
+    const targetResults = collector.currentResults || collector.results;
+    mergeSearchResultMap(targetResults, output);
   };
 
   const applyUsers = (nextUsers, requestId = null) => {
@@ -940,6 +942,37 @@ const SearchBar = ({
       return;
     }
     Object.assign(acc, res);
+  };
+
+  const buildRepeatedNotFoundItem = value => ({
+    _notFound: true,
+    searchVal: value,
+  });
+
+  const addRepeatedSearchItem = (collector, key, item) => {
+    const orderedKey = collector.orderedItems.some(entry => entry.key === key)
+      ? `${key}_${collector.orderedItems.length}`
+      : key;
+    collector.orderedItems.push({ key: orderedKey, item });
+  };
+
+  const flushRepeatedSearchValue = (collector, value, index) => {
+    const currentResults = collector.currentResults || {};
+    const resultEntries = Object.entries(currentResults);
+
+    if (resultEntries.length > 0) {
+      resultEntries.forEach(([key, item]) => {
+        addRepeatedSearchItem(collector, key, item);
+      });
+      mergeSearchResultMap(collector.results, currentResults);
+      return;
+    }
+
+    addRepeatedSearchItem(
+      collector,
+      `new_${index}_${value}`,
+      buildRepeatedNotFoundItem(value),
+    );
   };
 
   const runEqualToAllCardsSearch = async (
@@ -1418,6 +1451,9 @@ const SearchBar = ({
       const collector = {
         requestId,
         results: {},
+        orderedItems: [],
+        currentResults: {},
+        currentValue: null,
         states: {},
         users: {},
         lastState: undefined,
@@ -1427,13 +1463,21 @@ const SearchBar = ({
       repeatedSearchCollectorRef.current = collector;
 
       try {
-        for (const value of repeatedValues) {
+        for (const [index, value] of repeatedValues.entries()) {
+          collector.currentValue = value;
+          collector.currentResults = {};
+          collector.lastState = undefined;
+          collector.lastUsers = undefined;
+          collector.lastUserNotFound = false;
+
           await writeData(value, {
             requestId,
             suppressHistory: true,
             suppressSearchExecuted: true,
           });
           if (isStaleRequest()) return;
+
+          flushRepeatedSearchValue(collector, value, index);
         }
       } finally {
         if (repeatedSearchCollectorRef.current?.requestId === requestId) {
@@ -1444,18 +1488,14 @@ const SearchBar = ({
 
       if (isStaleRequest()) return;
 
-      const mergedResults = collector.results;
-      const hasMergedResults = Object.keys(mergedResults).length > 0;
+      const orderedResults = collector.orderedItems.reduce((acc, { key, item }) => {
+        acc[key] = item;
+        return acc;
+      }, {});
 
-      if (hasMergedResults) {
-        setUserNotFound && setUserNotFound(false);
-        setState && setState({});
-        setUsers && setUsers({ ...mergedResults });
-      } else {
-        setUserNotFound && setUserNotFound(true);
-        setState && setState({});
-        setUsers && setUsers({});
-      }
+      setUserNotFound && setUserNotFound(false);
+      setState && setState({});
+      setUsers && setUsers(orderedResults);
       return;
     }
 

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -133,7 +133,11 @@ const UsersList = ({
     const res = await makeNewUser({ name: value }, value);
     setUsers(prev => {
       const copy = { ...prev };
-      delete copy[`new_${value}`];
+      Object.entries(copy).forEach(([key, item]) => {
+        if (item?._notFound && item.searchVal === value) {
+          delete copy[key];
+        }
+      });
       return { ...copy, [res.userId]: res };
     });
   };


### PR DESCRIPTION
### Motivation
- Repeated/bracketed searches lost per-value empty results and only showed merged found users, preventing the UI from rendering "not found" create-card placeholders for individual values. 
- The collector for repeated searches needed to be scoped per `requestId` and preserve per-value results (including empty results) in original input order.

### Description
- In `SearchBar.jsx` changed `collectSearchOutput` to merge into a per-value `collector.currentResults` when present so each inner search result is tracked separately. 
- Added helper functions `buildRepeatedNotFoundItem`, `addRepeatedSearchItem`, and `flushRepeatedSearchValue` and extended the repeated-search `collector` with `orderedItems`/`currentResults` to collect either found cards or a `_notFound` placeholder for each original value. 
- During repeated execution each value is processed with `writeData` and then flushed into `collector.orderedItems` as either found cards or a create-card placeholder keyed to preserve order (e.g. `new_<index>_<value>`), and final output is an ordered object built from those items. 
- Updated `UsersList.jsx` `handleCreate` to remove any matching `_notFound` placeholders by comparing `item._notFound` and `item.searchVal` so creating a new user removes the corresponding not-found placeholder regardless of the ordered placeholder key.

### Testing
- Ran lint on the modified files with `npx eslint src/components/SearchBar.jsx src/components/UsersList.jsx` which completed without blocking errors. 
- Built the app with `npm run build` which produced a successful production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6955926c832685e9f4b75245247a)