### PR TITLE
Preserve per-value search context for bracketed/repeated searches (fix create payload)

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -922,6 +922,12 @@ const SearchBar = ({
       ...meta,
       params,
     });
+
+    // Repeated [] search keeps a per-value create context for not-found
+    // placeholders, so fallback labels (for example the final name search)
+    // must not replace the parent add payload.
+    if (repeatedSearchCollectorRef.current) return;
+
     onSearchKey && onSearchKey(params);
   };
 
@@ -944,9 +950,66 @@ const SearchBar = ({
     Object.assign(acc, res);
   };
 
-  const buildRepeatedNotFoundItem = value => ({
+  const buildRepeatedSearchContext = value => {
+    const rawValue = typeof value === 'string' ? value : '';
+    const trimmedValue = rawValue.trim();
+    if (!trimmedValue) return null;
+
+    if (isSearchEnabled('searchId')) {
+      const parsedSearchIdValue = parseSearchIdExact(trimmedValue);
+      if (parsedSearchIdValue) {
+        const searchIdPrefixStrategy = resolveSearchIdPrefixStrategy(trimmedValue, searchOptions);
+        const [primarySearchKey] = searchIdPrefixStrategy.primaryPrefixes || [];
+
+        if (primarySearchKey) {
+          return {
+            searchMode: 'searchId',
+            searchKey: primarySearchKey,
+            searchValue: parsedSearchIdValue,
+            rawSearchValue: rawValue,
+          };
+        }
+      }
+    }
+
+    if (isSearchEnabled('equalToAllCards')) {
+      const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);
+      const selectedEqualToKeys = Array.isArray(searchOptions?.equalToKeys)
+        ? searchOptions.equalToKeys.filter(key => allEqualToKeys.includes(key))
+        : [];
+      const equalToExecutionPlan = resolveEqualToExecutionKeys({
+        allKeys: allEqualToKeys,
+        selectedKeys: selectedEqualToKeys,
+        rawQuery: trimmedValue,
+      });
+      const [primaryEqualToKey] = equalToExecutionPlan.primaryKeys || [];
+      const [primaryEqualToValue] = primaryEqualToKey
+        ? getParsedCandidatesForKey(primaryEqualToKey, trimmedValue)
+        : [];
+
+      if (primaryEqualToKey && primaryEqualToValue) {
+        return {
+          searchMode: 'equalToAllCards',
+          searchKey: primaryEqualToKey,
+          searchValue: primaryEqualToValue,
+          rawSearchValue: rawValue,
+        };
+      }
+    }
+
+    const detectedParams = detectSearchParams(trimmedValue);
+    return {
+      searchMode: detectedParams?.key === 'name' ? 'name' : 'detected',
+      searchKey: detectedParams?.key || 'name',
+      searchValue: detectedParams?.value || trimmedValue,
+      rawSearchValue: rawValue,
+    };
+  };
+
+  const buildRepeatedNotFoundItem = (value, searchContext = null) => ({
     _notFound: true,
     searchVal: value,
+    ...(searchContext || {}),
   });
 
   const addRepeatedSearchItem = (collector, key, item) => {
@@ -971,7 +1034,7 @@ const SearchBar = ({
     addRepeatedSearchItem(
       collector,
       `new_${index}_${value}`,
-      buildRepeatedNotFoundItem(value),
+      buildRepeatedNotFoundItem(value, collector.searchContexts?.[index]),
     );
   };
 
@@ -1459,6 +1522,7 @@ const SearchBar = ({
         lastState: undefined,
         lastUsers: undefined,
         lastUserNotFound: false,
+        searchContexts: {},
       };
       repeatedSearchCollectorRef.current = collector;
 
@@ -1466,6 +1530,7 @@ const SearchBar = ({
         for (const [index, value] of repeatedValues.entries()) {
           collector.currentValue = value;
           collector.currentResults = {};
+          collector.searchContexts[index] = buildRepeatedSearchContext(value);
           collector.lastState = undefined;
           collector.lastUsers = undefined;
           collector.lastUserNotFound = false;

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -129,12 +129,16 @@ const UsersList = ({
 }) => {
   const entries = Object.entries(users);
 
-  const handleCreate = async value => {
-    const res = await makeNewUser({ name: value }, value);
+  const handleCreate = async item => {
+    const value = item?.searchVal || '';
+    const searchKey = item?.searchKey || 'name';
+    const searchValue = item?.searchValue || value;
+    const rawSearchValue = item?.rawSearchValue || value;
+    const res = await makeNewUser({ [searchKey]: searchValue }, rawSearchValue);
     setUsers(prev => {
       const copy = { ...prev };
-      Object.entries(copy).forEach(([key, item]) => {
-        if (item?._notFound && item.searchVal === value) {
+      Object.entries(copy).forEach(([key, existingItem]) => {
+        if (existingItem === item || (existingItem?._notFound && existingItem.searchVal === value)) {
           delete copy[key];
         }
       });
@@ -170,7 +174,7 @@ const UsersList = ({
               }}
             >
               <span>{userData.searchVal}</span>
-              <svg onClick={() => handleCreate(userData.searchVal)} width="40" height="40" viewBox="0 0 40 40" style={{ cursor: 'pointer' }}>
+              <svg onClick={() => handleCreate(userData)} width="40" height="40" viewBox="0 0 40 40" style={{ cursor: 'pointer' }}>
                 <rect x="18" y="8" width="4" height="24" fill="white" />
                 <rect x="8" y="18" width="24" height="4" fill="white" />
               </svg>


### PR DESCRIPTION
### Motivation
- Bracketed/repeated searches (`[a, b]`) lost the original intended search payload for individual values when no match was found, causing the created contact to use the final fallback `name` instead of the selected `searchId`/platform (e.g., `instagram`).
- The goal is to keep per-value primary search context so the not-found placeholder and the `+` create action produce the correct key/value (including `rawSearchValue`).
- Prevent fallback `name` labels or later fallback steps from overwriting an explicitly-detected `searchId` + key for repeated items.

### Description
- Added `buildRepeatedSearchContext` in `src/components/SearchBar.jsx` to determine and return the per-value intended payload (`searchMode`, `searchKey`, `searchValue`, `rawSearchValue`) using existing parsing/selection logic (searchId prefixes and equalTo execution plan).
- Store per-value contexts in the repeated-search `collector.searchContexts` while processing `[]` grouped values, and include that context in not-found placeholders created for each value.
- Prevent fallback search labels from overwriting parent add payload during repeated processing by returning early in `emitSearchLabel` when a repeated-search collector is active.
- Enhance `buildRepeatedNotFoundItem` to include the stored per-value search context so placeholders carry `searchKey/searchValue/rawSearchValue` when rendered.
- Update `src/components/UsersList.jsx` `handleCreate` to accept the placeholder item (not just a string) and call `makeNewUser` with the preserved `searchKey/searchValue/rawSearchValue` instead of always creating `{ name: value }`.
- Changes affect `SearchBar.jsx` and `UsersList.jsx` to ensure behavior for single-value and repeated bracketed searches is consistent.

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runInBand`, all test suites passed (`16` suites, `73` tests passed). ✅
- Built the production bundle with `npm run build`, compilation succeeded and build artifacts were produced. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6d7c6ec88326a7082d84632a81ed)