### PR TITLE
Fix searchId aggregation for new user cards

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1630,7 +1630,6 @@ export const searchUsersOnly = async (searchedValue, options = {}) => {
 export const makeNewUser = async (searchedValue, rawQuery = '') => {
   const db = getDatabase();
   const newUsersRef = ref2(db, 'newUsers');
-  const searchIdRef = ref2(db, 'searchId');
 
   const parsedQuery = parseUkTriggerQuery(rawQuery);
   const trimmedRawQuery = typeof rawQuery === 'string' ? rawQuery.trim() : '';
@@ -1686,16 +1685,13 @@ export const makeNewUser = async (searchedValue, rawQuery = '') => {
   await syncUserSearchKeyIndex(newUserId, {}, newUser);
 
   if (searchMeta) {
-    const { searchIdKey } = searchMeta;
-    const searchIdUpdates = { [searchIdKey]: newUserId };
+    const { searchKey, searchValue } = searchMeta;
+
+    await updateSearchId(searchKey, searchValue, newUserId, 'add');
 
     if (parsedQuery?.handle) {
-      const normalizedHandle = parsedQuery.handle.toLowerCase();
-      const handleKey = `telegram_${encodeKey(normalizedHandle)}`;
-      searchIdUpdates[handleKey] = newUserId;
+      await updateSearchId('telegram', parsedQuery.handle, newUserId, 'add');
     }
-
-    await update(searchIdRef, searchIdUpdates);
   }
 
   return {


### PR DESCRIPTION
### Motivation
- Creating a new user wrote `searchId` pairs directly which could overwrite an existing single `userId` value and prevent aggregation when multiple cards share the same contact (e.g. same Instagram nickname). 
- The intent is to ensure identical search keys accumulate multiple `userId`s so the search UI can return all matching cards instead of only one.

### Description
- Replaced direct `searchId` writes in `makeNewUser` with calls to `updateSearchId(searchKey, searchValue, newUserId, 'add')` so the server-side logic performs array conversion and de-duplication. 
- Also route parsed Telegram handle indexing through `updateSearchId('telegram', parsedQuery.handle, newUserId, 'add')` to preserve the same aggregation behavior. 
- Removed the now-unused local `searchIdRef` write and rely on the existing `updateSearchId` implementation in `src/components/config.js`.

### Testing
- Ran `npm run lint:js` (ESLint) which completed without errors. 
- Ran a code check with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8f518b408326928cfb82125292cc)