### PR TITLE
Ensure searchId index is synced on profile edits (covers PP technical input)

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -8,6 +8,7 @@ import {
   updateDataInRealtimeDB,
   updateDataInFiresoreDB,
   removeKeyFromFirebase,
+  syncUserSearchIdIndex,
   auth,
 } from './config';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -338,7 +339,9 @@ const EditProfile = () => {
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (updatedState?.userId?.length > 20) {
-      const { existingData } = await fetchUserById(updatedState.userId);
+      const existingData = await fetchUserById(updatedState.userId) || {};
+
+      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState);
 
       const sanitizedExistingData = { ...existingData };
       if (delCondition) {
@@ -362,9 +365,11 @@ const EditProfile = () => {
         )
       );
 
-      await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update');
+      await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update', true);
     } else if (updatedState?.userId) {
-      await updateDataInNewUsersRTDB(updatedState.userId, updatedState, 'update');
+      const existingData = await fetchUserById(updatedState.userId) || {};
+      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState);
+      await updateDataInNewUsersRTDB(updatedState.userId, updatedState, 'update', true);
     }
 
     try {
@@ -564,6 +569,9 @@ const EditProfile = () => {
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (mergedCard?.userId?.length > 20) {
+      const existingData = await fetchUserById(mergedCard.userId) || {};
+      await syncUserSearchIdIndex(mergedCard.userId, existingData, mergedCard);
+
       const cleanedState = Object.fromEntries(
         Object.entries(mergedCard).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
       );
@@ -574,11 +582,13 @@ const EditProfile = () => {
           [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
-      await updateDataInNewUsersRTDB(mergedCard.userId, cleanedStateForNewUsers, 'update');
+      await updateDataInNewUsersRTDB(mergedCard.userId, cleanedStateForNewUsers, 'update', true);
       return;
     }
 
-    await updateDataInNewUsersRTDB(mergedCard.userId, mergedCard, 'update');
+    const existingData = await fetchUserById(mergedCard.userId) || {};
+    await syncUserSearchIdIndex(mergedCard.userId, existingData, mergedCard);
+    await updateDataInNewUsersRTDB(mergedCard.userId, mergedCard, 'update', true);
   };
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);


### PR DESCRIPTION
### Motivation
- Values entered via the PP technical input were applied to `state` but the shared `searchId` index was not always updated because profile save flow did not run the common index sync; this could leave `searchId` stale for inserted contacts/name/surname.

### Description
- Imported and used `syncUserSearchIdIndex` in profile save flows to diff and update `searchId` based on previous vs new card values by fetching the existing card with `fetchUserById` and calling `syncUserSearchIdIndex` before persistence.
- Applied the sync in both the main admin save path and the overlay/canonical persist path so merged/accepted changes are indexed as well.
- Passed `skipIndexing=true` to `updateDataInNewUsersRTDB` where `syncUserSearchIdIndex` has already been executed to avoid duplicate inline indexing writes.
- Changes are limited to `src/components/EditProfile.jsx` and do not modify the shared `updateSearchId`/index helpers themselves.

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runInBand` and all test suites passed: `16` test suites and `73` tests succeeded.
- Built the production bundle with `npm run build` which completed successfully and produced the optimized build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc97ca36c483269a31bbf330340a04)