### PR TITLE
Filter search index sync to only submitted fields and add helper util

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -31,6 +31,7 @@ import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
 import { getCacheKey } from '../utils/cache';
 import { getReactionCategory } from 'utils/reactionCategory';
 import { buildSearchIndexCandidates, encodeKey } from '../utils/searchIndexCandidates';
+import { getSubmittedSearchIndexKeys } from '../utils/searchIndexSync';
 import {
   buildSearchIdCandidateKeys,
   getEqualToCandidates,
@@ -2520,7 +2521,7 @@ const extractIndexableFieldValues = rawValue => {
 export const syncUserSearchIdIndex = async (userId, prevData = {}, nextData = {}) => {
   if (!userId) return;
 
-  for (const key of keysToCheck) {
+  for (const key of getSubmittedSearchIndexKeys(keysToCheck, nextData)) {
     if (key === 'getInTouch' || key === 'lastAction') continue;
 
     const prevCandidates = new Set(

--- a/src/utils/searchIndexSync.js
+++ b/src/utils/searchIndexSync.js
@@ -1,0 +1,5 @@
+export const hasOwn = (object, key) =>
+  Object.prototype.hasOwnProperty.call(object || {}, key);
+
+export const getSubmittedSearchIndexKeys = (indexedKeys = [], nextData = {}) =>
+  indexedKeys.filter(key => hasOwn(nextData, key));


### PR DESCRIPTION
### Motivation
- Avoid unnecessary or erroneous sync operations for search index keys that are not present in incoming user data by only iterating keys that were actually submitted in the update payload.

### Description
- Added a new utility `src/utils/searchIndexSync.js` that exports `hasOwn` and `getSubmittedSearchIndexKeys` to detect which indexed keys exist on the incoming data.
- Updated `src/components/config.js` to import `getSubmittedSearchIndexKeys` and use it in `syncUserSearchIdIndex` so the loop iterates `getSubmittedSearchIndexKeys(keysToCheck, nextData)` instead of the full `keysToCheck` list.
- This change keeps existing logic for computing `prevCandidates`/`nextCandidates` and calling `updateSearchId` unchanged but restricts operations to only submitted fields.

### Testing
- Ran the project test suite with `yarn test` and linting with `yarn lint`, and both completed successfully.
- Verified the modified `syncUserSearchIdIndex` logic by exercising update flows in unit tests to ensure no regressions in search index add/remove operations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9e36b2788326bee89711d7edd322)