### PR TITLE
Include explicit deleted keys when syncing user search index

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -341,7 +341,7 @@ const EditProfile = () => {
     if (updatedState?.userId?.length > 20) {
       const existingData = await fetchUserById(updatedState.userId) || {};
 
-      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState);
+      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, delCondition);
 
       const sanitizedExistingData = { ...existingData };
       if (delCondition) {
@@ -368,7 +368,7 @@ const EditProfile = () => {
       await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update', true);
     } else if (updatedState?.userId) {
       const existingData = await fetchUserById(updatedState.userId) || {};
-      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState);
+      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, delCondition);
       await updateDataInNewUsersRTDB(updatedState.userId, updatedState, 'update', true);
     }
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2518,10 +2518,10 @@ const extractIndexableFieldValues = rawValue => {
   return [];
 };
 
-export const syncUserSearchIdIndex = async (userId, prevData = {}, nextData = {}) => {
+export const syncUserSearchIdIndex = async (userId, prevData = {}, nextData = {}, deletedKeys = []) => {
   if (!userId) return;
 
-  for (const key of getSubmittedSearchIndexKeys(keysToCheck, nextData)) {
+  for (const key of getSubmittedSearchIndexKeys(keysToCheck, nextData, deletedKeys)) {
     if (key === 'getInTouch' || key === 'lastAction') continue;
 
     const prevCandidates = new Set(

--- a/src/utils/searchIndexSync.js
+++ b/src/utils/searchIndexSync.js
@@ -1,5 +1,22 @@
 export const hasOwn = (object, key) =>
   Object.prototype.hasOwnProperty.call(object || {}, key);
 
-export const getSubmittedSearchIndexKeys = (indexedKeys = [], nextData = {}) =>
-  indexedKeys.filter(key => hasOwn(nextData, key));
+const getExplicitlyDeletedKeys = deletedKeys => {
+  if (!deletedKeys) return [];
+
+  if (Array.isArray(deletedKeys)) {
+    return deletedKeys;
+  }
+
+  if (typeof deletedKeys === 'object') {
+    return Object.keys(deletedKeys);
+  }
+
+  return [];
+};
+
+export const getSubmittedSearchIndexKeys = (indexedKeys = [], nextData = {}, deletedKeys = []) => {
+  const explicitlyDeletedKeys = new Set(getExplicitlyDeletedKeys(deletedKeys));
+
+  return indexedKeys.filter(key => hasOwn(nextData, key) || explicitlyDeletedKeys.has(key));
+};


### PR DESCRIPTION
### Motivation

- Ensure the search index updates correctly when fields are deleted from a user record by making deleted keys participate in the diffing logic. 
- Propagate the deletion condition from the profile update flow into the search-index sync so removed values are unindexed. 

### Description

- Change `syncUserSearchIdIndex` signature to accept an additional `deletedKeys` parameter and pass it through to the indexing helper. 
- Update `getSubmittedSearchIndexKeys` to accept `deletedKeys` and treat array or object forms of deletions as explicit keys to process via a new `getExplicitlyDeletedKeys` helper. 
- Update callers in `EditProfile.jsx` to pass `delCondition` into `syncUserSearchIdIndex` in both update branches. 

### Testing

- Ran the project test suite with `npm test`, and all unit tests completed successfully. 
- Ran linting with `npm run lint`, and no lint errors were reported. 
- Verified index-sync logic with existing integration tests that cover search-index updates, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca22b6e2883269f712d73e4c5893c)