### PR TITLE
Normalize PP technical input values and preserve Facebook URL parsing

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -153,6 +153,21 @@ const appendFieldValue = (currentValue, nextValue) => {
   return [normalizedCurrentValue, normalizedNextValue];
 };
 
+const normalizePpTechnicalTargetValue = (fieldName, value) => {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) return '';
+
+  if (fieldName === 'phone') {
+    return normalizePhoneValue(rawValue);
+  }
+
+  if (fieldName === 'otherLink') {
+    return rawValue;
+  }
+
+  return inputUpdateValue(rawValue, { name: fieldName });
+};
+
 const REPRODUCTIVE_FIELDS = [
   'birth',
   'ownKids',
@@ -2119,9 +2134,13 @@ ${entries.join('\n')}`;
         });
 
         if (resolvedTechnicalTarget) {
+          const normalizedTechnicalValue = normalizePpTechnicalTargetValue(
+            resolvedTechnicalTarget.fieldName,
+            resolvedTechnicalTarget.value
+          );
           nextState[resolvedTechnicalTarget.fieldName] = appendFieldValue(
             prevState[resolvedTechnicalTarget.fieldName],
-            resolvedTechnicalTarget.value
+            normalizedTechnicalValue
           );
         }
       } else {

--- a/src/utils/ppTechnicalInputTarget.js
+++ b/src/utils/ppTechnicalInputTarget.js
@@ -21,7 +21,7 @@ export const resolvePpTechnicalInputSocialTarget = rawValue => {
 
   const socialUrlMatchers = [
     { fieldName: 'instagram', pattern: /(?:https?:\/\/)?(?:www\.)?instagram\.com\/([^/?#]+)/i },
-    { fieldName: 'facebook', pattern: /(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.com)\/([^/?#]+)/i },
+    { fieldName: 'facebook', pattern: /(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.com)\/([^/?#]+)/i, useRawValue: true },
     { fieldName: 'tiktok', pattern: /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/([^/?#]+)/i },
     { fieldName: 'linkedin', pattern: /(?:https?:\/\/)?(?:www\.)?linkedin\.com\/([^/?#]+)/i },
     { fieldName: 'youtube', pattern: /(?:https?:\/\/)?(?:m\.|www\.)?(?:youtube\.com|youtu\.be)\/([^/?#]+)/i },
@@ -33,7 +33,7 @@ export const resolvePpTechnicalInputSocialTarget = rawValue => {
     const match = trimmed.match(matcher.pattern);
     if (!match?.[1]) continue;
 
-    const normalizedValue = String(match[1]).replace(/^@/, '').trim();
+    const normalizedValue = String(matcher.useRawValue ? trimmed : match[1]).replace(/^@/, '').trim();
     if (normalizedValue) {
       return { fieldName: matcher.fieldName, value: normalizedValue };
     }


### PR DESCRIPTION
### Motivation
- Ensure technical contact values parsed from the PP input are normalized consistently before being appended to profile state.
- Preserve full Facebook URL behavior when users paste a Facebook link or handle tricky input formats.

### Description
- Add `normalizePpTechnicalTargetValue` in `ProfileForm.jsx` to normalize values per field (phone via `normalizePhoneValue`, `otherLink` preserved, others via `inputUpdateValue`).
- Use the new normalizer when resolving non-parsed PP technical targets so appended values are normalized before storing in state.
- Update `resolvePpTechnicalInputSocialTarget` in `src/utils/ppTechnicalInputTarget.js` to mark the Facebook matcher with `useRawValue: true` and select the raw trimmed input when `useRawValue` is set.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Ran linters with `yarn lint` and no lint errors remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda79b27688326acb039f79a49e60b)