### PR TITLE
Sort LA2 cards using lastAction index timestamps

### DIFF
--- a/src/components/LastAction2Mode.jsx
+++ b/src/components/LastAction2Mode.jsx
@@ -120,6 +120,11 @@ const mapLA2FilterValueToBuckets = (filterName, value) => {
   return [];
 };
 
+const getSortableLastActionValue = value => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
 const getLA2SearchKeyBucketIds = async (la2StateRef, indexName, bucket) => {
   const cacheKey = `${indexName}/${bucket}`;
   const cache = indexName === LAST_ACTION2_SEARCH_KEY_INDEX
@@ -128,7 +133,19 @@ const getLA2SearchKeyBucketIds = async (la2StateRef, indexName, bucket) => {
   if (cache[cacheKey]) return cache[cacheKey];
 
   const snapshot = await get(ref(database, `searchKey/${indexName}/${bucket}`));
-  const ids = snapshot.exists() ? Object.keys(snapshot.val() || {}).filter(Boolean) : [];
+  const bucketValue = snapshot.exists() ? snapshot.val() || {} : {};
+  const ids = Object.entries(bucketValue)
+    .filter(([userId]) => Boolean(userId))
+    .sort((a, b) => {
+      if (indexName !== LAST_ACTION2_SEARCH_KEY_INDEX) return 0;
+
+      const right = getSortableLastActionValue(b[1]);
+      const left = getSortableLastActionValue(a[1]);
+      if (right !== left) return right - left;
+
+      return String(a[0]).localeCompare(String(b[0]));
+    })
+    .map(([userId]) => userId);
   const idSet = new Set(ids);
   cache[cacheKey] = idSet;
   return idSet;

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3047,11 +3047,11 @@ const collectFieldCountIdsByFilters = async (fieldsFilters, rootPaths = [SEARCH_
 
 const AGE_DATE_PREFIX = 'd_';
 
-export const normalizeLastActionSearchKeyBucket = rawValue => {
-  if (rawValue === undefined || rawValue === null) return 'no';
+const parseLastActionDate = rawValue => {
+  if (rawValue === undefined || rawValue === null) return { status: 'empty', date: null };
 
   const normalized = String(rawValue).trim();
-  if (!normalized) return 'no';
+  if (!normalized) return { status: 'empty', date: null };
 
   let parsedDate = null;
   const isoMatch = normalized.match(/^(\d{4})-(\d{2})-(\d{2})/);
@@ -3062,13 +3062,22 @@ export const normalizeLastActionSearchKeyBucket = rawValue => {
     const year = Number.parseInt(yearRaw, 10);
     const month = Number.parseInt(monthRaw, 10);
     const day = Number.parseInt(dayRaw, 10);
-    parsedDate = new Date(year, month - 1, day);
+    const dateOnly = new Date(year, month - 1, day);
     if (
-      parsedDate.getFullYear() !== year ||
-      parsedDate.getMonth() !== month - 1 ||
-      parsedDate.getDate() !== day
+      dateOnly.getFullYear() !== year ||
+      dateOnly.getMonth() !== month - 1 ||
+      dateOnly.getDate() !== day
     ) {
-      return '?';
+      return { status: 'invalid', date: null };
+    }
+
+    const includesTime = normalized.length > isoMatch[0].length;
+    if (includesTime) {
+      const timestamp = Date.parse(normalized);
+      if (Number.isNaN(timestamp)) return { status: 'invalid', date: null };
+      parsedDate = new Date(timestamp);
+    } else {
+      parsedDate = dateOnly;
     }
   } else if (dotMatch) {
     const [, dayRaw, monthRaw, yearRaw] = dotMatch;
@@ -3081,20 +3090,35 @@ export const normalizeLastActionSearchKeyBucket = rawValue => {
       parsedDate.getMonth() !== month - 1 ||
       parsedDate.getDate() !== day
     ) {
-      return '?';
+      return { status: 'invalid', date: null };
     }
   } else if (typeof rawValue === 'number' || /^\d+$/.test(normalized)) {
     const timestamp = Number(rawValue);
-    if (!Number.isFinite(timestamp)) return '?';
+    if (!Number.isFinite(timestamp)) return { status: 'invalid', date: null };
     parsedDate = new Date(timestamp);
-    if (Number.isNaN(parsedDate.getTime())) return '?';
+    if (Number.isNaN(parsedDate.getTime())) return { status: 'invalid', date: null };
   } else {
     const timestamp = Date.parse(normalized);
-    if (Number.isNaN(timestamp)) return '?';
+    if (Number.isNaN(timestamp)) return { status: 'invalid', date: null };
     parsedDate = new Date(timestamp);
   }
 
-  return `${AGE_DATE_PREFIX}${toIsoDate(parsedDate)}`;
+  return { status: 'valid', date: parsedDate };
+};
+
+export const normalizeLastActionSearchKeyBucket = rawValue => {
+  const parsed = parseLastActionDate(rawValue);
+  if (parsed.status === 'empty') return 'no';
+  if (parsed.status === 'invalid') return '?';
+
+  return `${AGE_DATE_PREFIX}${toIsoDate(parsed.date)}`;
+};
+
+export const normalizeLastActionSearchKeyValue = rawValue => {
+  const parsed = parseLastActionDate(rawValue);
+  if (parsed.status !== 'valid') return true;
+
+  return parsed.date.getTime();
 };
 
 const getLastActionIndexSet = data => {
@@ -3451,7 +3475,7 @@ const updateSearchKeyLeaf = async (indexName, value, userId, action, options = {
   const indexRef = ref2(database, resolveSearchKeyLeafPath(options?.rootPath, indexName, value, userId));
 
   if (action === 'add') {
-    await set(indexRef, true);
+    await set(indexRef, options?.leafValue ?? true);
     return;
   }
 
@@ -3647,6 +3671,8 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   const nextFieldCountValues = getFieldCountIndexSet(nextData);
   const prevLastActionValues = getLastActionIndexSet(prevData);
   const nextLastActionValues = getLastActionIndexSet(nextData);
+  const prevLastActionLeafValue = normalizeLastActionSearchKeyValue(prevData?.lastAction);
+  const nextLastActionLeafValue = normalizeLastActionSearchKeyValue(nextData?.lastAction);
 
   for (const value of prevFieldCountValues) {
     if (!nextFieldCountValues.has(value)) {
@@ -3670,9 +3696,12 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   }
 
   for (const value of nextLastActionValues) {
-    if (!prevLastActionValues.has(value)) {
+    if (!prevLastActionValues.has(value) || prevLastActionLeafValue !== nextLastActionLeafValue) {
       // eslint-disable-next-line no-await-in-loop
-      await updateLeaf(LAST_ACTION_SEARCH_KEY_INDEX, value, 'add');
+      await updateSearchKeyLeaf(LAST_ACTION_SEARCH_KEY_INDEX, value, userId, 'add', {
+        ...options,
+        leafValue: nextLastActionLeafValue,
+      });
     }
   }
 };
@@ -3975,7 +4004,8 @@ export const createLastActionSearchKeyIndexInCollection = async (collection, onP
       batchIds.reduce((acc, userId) => {
         const user = usersData[userId] || {};
         const bucket = normalizeLastActionSearchKeyBucket(user.lastAction);
-        acc[`${searchKeyRoot}/${LAST_ACTION_SEARCH_KEY_INDEX}/${bucket}/${userId}`] = true;
+        acc[`${searchKeyRoot}/${LAST_ACTION_SEARCH_KEY_INDEX}/${bucket}/${userId}`] =
+          normalizeLastActionSearchKeyValue(user.lastAction);
         return acc;
       }, {}),
     onProgress
@@ -4150,7 +4180,10 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
         const entries = resolveSearchKeyValuesByIndexType(indexType, userId, userData);
         entries.forEach(({ indexName, values }) => {
           values.filter(Boolean).forEach(value => {
-            assignNestedLeaf(payload, [...rootSegments, indexName, value, userId], true);
+            const leafValue = indexType === SEARCH_KEY_INDEX_TYPES.lastAction
+              ? normalizeLastActionSearchKeyValue(userData?.lastAction)
+              : true;
+            assignNestedLeaf(payload, [...rootSegments, indexName, value, userId], leafValue);
           });
         });
       });


### PR DESCRIPTION
### Motivation
- LA2 showed cards in arbitrary order inside the same date-bucket because `searchKey/lastAction/<bucket>/<userId>` stored only `true`, preventing accurate sorting by precise `lastAction` timestamp. 
- The goal is to make LA2 present cards in correct descending `lastAction` order while keeping the fast bucket/index approach. 

### Description
- Add `parseLastActionDate`, `normalizeLastActionSearchKeyBucket`, and `normalizeLastActionSearchKeyValue` helpers and store normalized `lastAction` timestamps as leaf values in `searchKey/lastAction/<bucket>/<userId>` when building/updating indexes (file: `src/components/config.js`).
- Make `updateSearchKeyLeaf` accept an optional `leafValue` so most searchKey leaves continue writing `true` while `lastAction` can write a numeric timestamp (file: `src/components/config.js`).
- Update incremental sync and full index builder to write timestamp leaf values and to rewrite the leaf when `lastAction` changes within the same bucket, and change LA2 loader to read bucket entries and sort IDs by stored timestamp (descending) with a stable tie-breaker by `userId` (file: `src/components/LastAction2Mode.jsx` and `src/components/config.js`).

### Testing
- Ran linter with `npm run lint:js -- --max-warnings=0` and it completed successfully. 
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd870ced88326808ea58e41b3e31e)