### PR TITLE
Normalize YouTube handles/URLs and wire up youtube input handling

### DIFF
--- a/src/components/inputUpdatedValue.js
+++ b/src/components/inputUpdatedValue.js
@@ -6,6 +6,7 @@ import {
   formatOther,
   formatTelegram,
   formatTikTok,
+  formatYoutube,
   formatVk,
   formatDate,
   removeSpacesLeaveEnter,
@@ -53,6 +54,8 @@ export const inputUpdateValue = (value, field, data) => {
       ? formatEmail(value)
       : field.name === 'tiktok'
       ? formatTikTok(value)
+      : field.name === 'youtube'
+      ? formatYoutube(value)
       : field.name === 'other'
       ? formatOther(value)
       : field.name === 'experience'

--- a/src/components/inputValidations.js
+++ b/src/components/inputValidations.js
@@ -179,6 +179,18 @@ export const formatEmail = email => {
     return value.replace(/^@/g, '').toLowerCase();
   };
 
+  export const formatYoutube = value => {
+    let normalized = removeSpaceAndNewLine(String(value ?? '').trim());
+
+    normalized = normalized
+      .replace(/^https?:\/\/(?:m\.|www\.)?(?:youtube\.com|youtu\.be)\//i, '')
+      .replace(/^@/g, '');
+
+    normalized = normalized.split(/[/?#]/)[0];
+
+    return normalized.toLowerCase();
+  };
+
   export const formatOther = value => {
     value = removeSpaceAndNewLine(value);
     return value.toLowerCase();


### PR DESCRIPTION
### Motivation
- Support a `youtube` input field by normalizing YouTube URLs and handles consistently with other social media fields.

### Description
- Add a new `formatYoutube` helper to `inputValidations.js` that strips protocol/host, removes leading `@`, splits on common separators and returns a lowercase identifier. 
- Import and use `formatYoutube` in `inputUpdatedValue.js` by handling `field.name === 'youtube'` and routing its value through the formatter.

### Testing
- Ran the project test suite with `yarn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf037841483268a57357327aaca4f)