### PR TITLE
Separate SearchId, EqualTo and SearchKey flows; add SearchKey date buckets for lastAction/getInTouch

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -712,6 +712,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     { key: 'reaction', label: 'reaction' },
     { key: 'fieldCount', label: 'fields' },
     { key: 'lastAction', label: 'lastAction' },
+    { key: 'getInTouch', label: 'getInTouch' },
   ];
 
   const location = useLocation();
@@ -809,6 +810,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       options: [
         { key: 'searchId', label: 'searchId (точний)' },
         { key: 'equalToAllCards', label: 'equalTo по всіх карточках (за поточним ключем)' },
+        { key: 'searchKey', label: 'searchKey bucket/date' },
         { key: 'partialUserId', label: 'userId (частковий збіг)' },
       ],
     },
@@ -833,8 +835,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         { key: 'name', label: 'name', supportsSearchId: true, supportsEqualTo: true },
         { key: 'surname', label: 'surname', supportsSearchId: true, supportsEqualTo: true },
         { key: 'cycleStatus', label: 'cycleStatus', supportsSearchId: false, supportsEqualTo: true },
-        { key: 'getInTouch', label: 'getInTouch', supportsSearchId: true, supportsEqualTo: true, isDate: true },
-        { key: 'lastAction', label: 'lastAction', supportsSearchId: true, supportsEqualTo: true, isDate: true },
+        { key: 'getInTouch', label: 'getInTouch', supportsSearchId: false, supportsEqualTo: true, supportsSearchKey: true, isDate: true },
+        { key: 'lastAction', label: 'lastAction', supportsSearchId: false, supportsEqualTo: true, supportsSearchKey: true, isDate: true },
         { key: 'lastLogin2', label: 'lastLogin2', supportsSearchId: false, supportsEqualTo: true, isDate: true },
         { key: 'createdAt', label: 'createdAt', supportsSearchId: false, supportsEqualTo: true, isDate: true },
         { key: 'lastCycle', label: 'lastCycle', supportsSearchId: false, supportsEqualTo: true, isDate: true },
@@ -847,6 +849,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const TOGGLEABLE_SEARCH_KEYS = [
     'searchId',
     'equalToAllCards',
+    'searchKey',
     'partialUserId',
     ...SEARCH_KEY_OPTIONS.map(option => option.key),
   ];
@@ -856,7 +859,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     (acc, option) => {
       // equalTo-пошук має вмикатись тільки явним чекбоксом користувача.
       // Раніше через дефолт `true` для всіх ключів цей режим запускався неочікувано.
-      acc[option.key] = option.key !== 'equalToAllCards';
+      acc[option.key] = option.key !== 'equalToAllCards' && option.key !== 'searchKey';
       return acc;
     },
     {},
@@ -888,6 +891,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const selectedEqualToKeys = SEARCH_KEY_OPTIONS
     .filter(option => option.supportsEqualTo && enabledSearchKeys[option.key])
+    .map(option => option.label);
+
+  const selectedSearchKeyFields = SEARCH_KEY_OPTIONS
+    .filter(option => option.supportsSearchKey && enabledSearchKeys[option.key])
     .map(option => option.label);
 
   const enabledContactSearchCount = CONTACT_SEARCH_KEYS.filter(key => enabledSearchKeys[key]).length;
@@ -1824,6 +1831,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         ...enabledSearchKeys,
         searchId: true,
         equalToAllCards: true,
+        searchKey: true,
         // Не вимикаємо partialUserId примусово: якщо чекбокс увімкнений,
         // користувач очікує пошук по ключах users/newUsers.
         partialUserId: enabledSearchKeys.partialUserId,
@@ -4129,6 +4137,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             searchOptions={{
               searchIdPrefixes: selectedSearchIdPrefixes,
               equalToKeys: selectedEqualToKeys,
+              searchKeyFields: selectedSearchKeyFields,
               autoOtherFallback: shouldAutoRunOtherFallback,
               enabledSearchKeys: effectiveEnabledSearchKeys,
             }}
@@ -4172,11 +4181,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
                       return options.map((option, index) => {
                       const isSearchModeOption = block.id === 'search-keys';
-                      const searchIdModeOnly = enabledSearchKeys.searchId && !enabledSearchKeys.equalToAllCards;
-                      const equalToModeOnly = enabledSearchKeys.equalToAllCards && !enabledSearchKeys.searchId;
+                      const searchIdModeOnly = enabledSearchKeys.searchId && !enabledSearchKeys.equalToAllCards && !enabledSearchKeys.searchKey;
+                      const equalToModeOnly = enabledSearchKeys.equalToAllCards && !enabledSearchKeys.searchId && !enabledSearchKeys.searchKey;
+                      const searchKeyModeOnly = enabledSearchKeys.searchKey && !enabledSearchKeys.searchId && !enabledSearchKeys.equalToAllCards;
                       const disabled = isSearchModeOption && (
                         (searchIdModeOnly && !option.supportsSearchId) ||
-                        (equalToModeOnly && !option.supportsEqualTo)
+                        (equalToModeOnly && !option.supportsEqualTo) ||
+                        (searchKeyModeOnly && !option.supportsSearchKey)
                       );
 
                       const isFirstDateOption = option.isDate && options[index - 1] && !options[index - 1].isDate;
@@ -4395,7 +4406,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               onChange={handleFilterChange}
               storageKey={filterStorageKey}
               bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction', 'lastAction'] : undefined}
+              allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction', 'lastAction', 'getInTouch'] : undefined}
             />
             <ButtonsContainer>
               {userNotFound && (

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -15,7 +15,7 @@ import {
 } from '../utils/cardIndex';
 import { updateCard, searchCachedCards } from '../utils/cardsStorage';
 import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
-import { normalizeSearchIdInput } from '../utils/searchKeyUtils';
+import { SEARCH_ID_INDEXED_FIELDS, normalizeSearchIdInput } from '../utils/searchKeyUtils';
 
 const SearchIcon = (
   <svg
@@ -379,45 +379,9 @@ const inferSearchIdPrefix = input => {
   return null;
 };
 
-const SEARCH_ID_PREFIX_KEYS = [
-  'instagram',
-  'facebook',
-  'email',
-  'phone',
-  'telegram',
-  'tiktok',
-  'linkedin',
-  'youtube',
-  'twitter',
-  'line',
-  'otherLink',
-  'other',
-  'vk',
-  'name',
-  'surname',
-  'lastAction',
-  'getInTouch',
-];
+const SEARCH_ID_PREFIX_KEYS = [...SEARCH_ID_INDEXED_FIELDS];
 
-const SEARCH_ID_SCOPED_PLATFORMS = new Set([
-  'instagram',
-  'facebook',
-  'email',
-  'phone',
-  'telegram',
-  'tiktok',
-  'linkedin',
-  'youtube',
-  'twitter',
-  'line',
-  'otherLink',
-  'other',
-  'vk',
-  'name',
-  'surname',
-  'lastAction',
-  'getInTouch',
-]);
+const SEARCH_ID_SCOPED_PLATFORMS = new Set(SEARCH_ID_PREFIX_KEYS);
 
 const resolveSearchIdPrefixStrategy = (input, searchOptions = {}) => {
   const configuredPrefixes = Array.isArray(searchOptions?.searchIdPrefixes)
@@ -610,8 +574,14 @@ const EQUAL_TO_SEARCH_PARSERS = {
   lastLogin: value => value?.trim(),
 };
 
+const SEARCH_KEY_BUCKET_SEARCH_PARSERS = {
+  lastAction: value => value?.trim(),
+  getInTouch: value => value?.trim(),
+};
+
 const SEARCH_KEY_PARSERS = {
   ...EQUAL_TO_SEARCH_PARSERS,
+  ...SEARCH_KEY_BUCKET_SEARCH_PARSERS,
   searchId: parseSearchIdExact,
 };
 
@@ -1002,6 +972,19 @@ const SearchBar = ({
       }
     }
 
+    if (isSearchEnabled('searchKey')) {
+      const [primarySearchKeyField] = Object.keys(SEARCH_KEY_BUCKET_SEARCH_PARSERS);
+      const [primarySearchKeyValue] = getParsedCandidatesForKey(primarySearchKeyField, trimmedValue);
+      if (primarySearchKeyField && primarySearchKeyValue) {
+        return {
+          searchMode: 'searchKey',
+          searchKey: primarySearchKeyField,
+          searchValue: primarySearchKeyValue,
+          rawSearchValue: rawValue,
+        };
+      }
+    }
+
     if (isSearchEnabled('equalToAllCards')) {
       const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);
       const selectedEqualToKeys = Array.isArray(searchOptions?.equalToKeys)
@@ -1108,6 +1091,42 @@ const SearchBar = ({
     return { found, results: resultMap };
   };
 
+
+  const runSearchKeyBucketSearch = async (rawQuery, isStaleRequest, resultMap = {}) => {
+    const allSearchKeyFields = Object.keys(SEARCH_KEY_BUCKET_SEARCH_PARSERS);
+    const selectedSearchKeyFields = Array.isArray(searchOptions?.searchKeyFields)
+      ? searchOptions.searchKeyFields.filter(key => allSearchKeyFields.includes(key))
+      : [];
+    const executionPlan = resolveExecutionPlan({
+      allKeys: allSearchKeyFields,
+      selectedKeys: selectedSearchKeyFields,
+      detectedKey: null,
+      rawQuery,
+      dateLikeKeys: new Set(allSearchKeyFields),
+    });
+    const keysToTry = [
+      ...(executionPlan.primaryKeys || []),
+      ...(executionPlan.fallbackKeys || []),
+    ];
+
+    let found = false;
+    for (const searchKeyField of keysToTry) {
+      const candidates = getParsedCandidatesForKey(searchKeyField, rawQuery);
+      for (const parsedValue of candidates) {
+        const res = await cachedSearch(
+          { [searchKeyField]: parsedValue },
+          { forceSearchKeyBucket: true, searchKeyFields: [searchKeyField] },
+        );
+        if (isStaleRequest()) return { found, results: resultMap };
+        if (!res || Object.keys(res).length === 0) continue;
+        found = true;
+        mergeSearchResultMap(resultMap, res);
+      }
+    }
+
+    return { found, results: resultMap };
+  };
+
   const runPartialUserIdSearch = async (rawQuery, isStaleRequest, resultMap = {}) => {
     const parsedUserId = parseUserId(rawQuery);
     if (!parsedUserId) return { found: false, results: resultMap };
@@ -1163,6 +1182,14 @@ const SearchBar = ({
         foundCombinedResults = true;
         mergeSearchResultMap(resultMap, searchIdResult);
       });
+    }
+
+    if (isSearchEnabled('searchKey')) {
+      const searchKeyResult = await runSearchKeyBucketSearch(rawQuery, isStaleRequest, resultMap);
+      if (isStaleRequest()) return { found: false, results: resultMap };
+      if (searchKeyResult.found) {
+        foundCombinedResults = true;
+      }
     }
 
     const equalToResult = await runEqualToAllCardsSearch(rawQuery, isStaleRequest, resultMap);
@@ -1634,6 +1661,17 @@ const SearchBar = ({
       isSearchEnabled('searchId') &&
       await processUserSearch('searchId', parseSearchIdExact, rawQuery, { requestId })
     ) return;
+
+    if (isSearchEnabled('searchKey')) {
+      const searchKeyResult = await runSearchKeyBucketSearch(rawQuery, isStaleRequest);
+      if (isStaleRequest()) return;
+      if (searchKeyResult.found) {
+        applyUserNotFound(false, requestId);
+        applyState({}, requestId);
+        applyUsers({ ...searchKeyResult.results }, requestId);
+        return;
+      }
+    }
 
     if (isSearchEnabled('equalToAllCards')) {
       const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -33,7 +33,9 @@ import { getReactionCategory } from 'utils/reactionCategory';
 import { buildSearchIndexCandidates, encodeKey } from '../utils/searchIndexCandidates';
 import { getSubmittedSearchIndexKeys } from '../utils/searchIndexSync';
 import {
+  SEARCH_ID_INDEXED_FIELDS,
   buildSearchIdCandidateKeys,
+  buildSearchIdRecordKey,
   getEqualToCandidates,
   makeSearchKeyValue,
   normalizeSearchIdInput,
@@ -65,7 +67,7 @@ export const database = getDatabase(app);
 
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 
-const keysToCheck = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'name', 'surname', 'lastAction', 'getInTouch'];
+const keysToCheck = [...SEARCH_ID_INDEXED_FIELDS];
 const SEARCH_KEY_INDEX_ROOT = 'searchKey';
 const SEARCH_KEY_USERS_INDEX_ROOT = `${SEARCH_KEY_INDEX_ROOT}/users`;
 const BLOOD_SEARCH_KEY_INDEX = 'blood';
@@ -81,6 +83,7 @@ const USER_ID_SEARCH_KEY_INDEX = 'userId';
 const REACTION_SEARCH_KEY_INDEX = 'reaction';
 const FIELD_COUNT_SEARCH_KEY_INDEX = 'fields';
 const LAST_ACTION_SEARCH_KEY_INDEX = 'lastAction';
+const GET_IN_TOUCH_SEARCH_KEY_INDEX = 'getInTouch';
 const SEARCH_KEY_BATCH_UPLOAD_SIZE = 100;
 const SEARCH_INDEX_COLLECTION_CACHE_PREFIX = 'search-index:collection:v1:';
 const SEARCH_INDEX_COLLECTION_CACHE_TTL_MS = 60 * 60 * 1000;
@@ -96,6 +99,7 @@ const SEARCH_KEY_INDEX_TYPES = {
   reaction: REACTION_SEARCH_KEY_INDEX,
   fieldCount: FIELD_COUNT_SEARCH_KEY_INDEX,
   lastAction: LAST_ACTION_SEARCH_KEY_INDEX,
+  getInTouch: GET_IN_TOUCH_SEARCH_KEY_INDEX,
 };
 
 const getSearchIndexCacheStorage = () => {
@@ -1687,7 +1691,7 @@ export const makeNewUser = async (searchedValue, rawQuery = '') => {
   await set(newUserRef, newUser);
   await syncUserSearchKeyIndex(newUserId, {}, newUser);
 
-  if (searchMeta) {
+  if (searchMeta?.searchIdKey) {
     const { searchIdKey } = searchMeta;
     const searchIdUpdates = { [searchIdKey]: newUserId };
 
@@ -1899,6 +1903,45 @@ const executeSearchBySearchIdIndex = async (
 };
 
 const SEARCH_COLLECTIONS = ['newUsers', 'users'];
+
+const SEARCH_KEY_DATE_FIELDS = new Set([LAST_ACTION_SEARCH_KEY_INDEX, GET_IN_TOUCH_SEARCH_KEY_INDEX]);
+
+const normalizeDateSearchBucketFromQuery = rawSearchValue => {
+  const parsed = parseLastActionDate(rawSearchValue);
+  if (parsed.status !== 'valid') return null;
+  return `${AGE_DATE_PREFIX}${toIsoDate(parsed.date)}`;
+};
+
+const collectUserIdsBySearchKeyBucket = async (field, rawSearchValue) => {
+  if (!SEARCH_KEY_DATE_FIELDS.has(field)) return [];
+  const bucket = normalizeDateSearchBucketFromQuery(rawSearchValue);
+  if (!bucket) return [];
+
+  const snapshot = await get(ref2(database, `${SEARCH_KEY_INDEX_ROOT}/${field}/${bucket}`));
+  if (!snapshot.exists()) return [];
+
+  return Object.entries(snapshot.val() || {})
+    .filter(([userId, enabled]) => Boolean(userId) && enabled)
+    .map(([userId]) => userId);
+};
+
+const executeSearchBySearchKeyBucket = async (searchKeys, rawSearchValue, uniqueUserIds, users) => {
+  if (!Array.isArray(searchKeys) || searchKeys.length === 0) return;
+
+  for (const key of searchKeys) {
+    // eslint-disable-next-line no-await-in-loop
+    const userIds = await collectUserIdsBySearchKeyBucket(key, rawSearchValue);
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all(
+      userIds.map(async userId => {
+        if (uniqueUserIds.has(userId)) return;
+        uniqueUserIds.add(userId);
+        await addUserToResults(userId, users);
+      })
+    );
+  }
+};
+
 const executeSearchByEqualToFields = async (searchKeys, rawSearchValue, uniqueUserIds, users) => {
   if (!Array.isArray(searchKeys) || searchKeys.length === 0) return;
 
@@ -2060,6 +2103,8 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     searchIdPrefixes,
     equalToKeys,
     forceEqualToAllCards = false,
+    forceSearchKeyBucket = false,
+    searchKeyFields,
     forcePartialUserIdSearch = false,
     allowTelegramPrefixMatches = false,
   } = options;
@@ -2091,13 +2136,18 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     // Для exact-пошуку по searchId не запускаємо date-пошук по полях картки
     // (getInTouch/lastAction/...): інакше запити на кшталт
     // "УК СМ Лилит 12.04.2026" можуть некоректно підтягувати date-збіги.
-    const isDateSearch = searchKey === 'searchId'
+    const isDateSearch = (searchKey === 'searchId' || forceSearchKeyBucket)
       ? false
       : await searchByDate(searchValue, uniqueUserIds, users);
     if (isDev) console.log('fetchNewUsersCollectionInRTDB → isDateSearch:', isDateSearch);
     if (!isDateSearch) {
       if (forcePartialUserIdSearch) {
         await searchUserByPartialUserId(searchValue, users);
+      } else if (forceSearchKeyBucket) {
+        const selectedSearchKeyFields = Array.isArray(searchKeyFields)
+          ? searchKeyFields.filter(key => SEARCH_KEY_DATE_FIELDS.has(key))
+          : [...SEARCH_KEY_DATE_FIELDS];
+        await executeSearchBySearchKeyBucket(selectedSearchKeyFields, searchValue, uniqueUserIds, users);
       } else if (forceEqualToAllCards) {
         const selectedEqualToKeys = resolveEqualToSearchKeys(equalToKeys);
         await executeSearchByEqualToFields(selectedEqualToKeys, searchValue, uniqueUserIds, users);
@@ -2430,8 +2480,8 @@ export const updateSearchId = async (searchKey, searchValue, userId, action) => 
       return;
     }
 
-    if (searchKey === 'getInTouch' || searchKey === 'lastAction') {
-      if (isDev) console.log('Пропускаємо непотрібні ключі :>> ', searchKey);
+    if (!SEARCH_ID_INDEXED_FIELDS.has(searchKey)) {
+      if (isDev) console.log('Пропускаємо не-searchId ключ :>> ', searchKey);
       return;
     }
 
@@ -2523,7 +2573,6 @@ export const syncUserSearchIdIndex = async (userId, prevData = {}, nextData = {}
   if (!userId) return;
 
   for (const key of getSubmittedSearchIndexKeys(keysToCheck, nextData, deletedKeys)) {
-    if (key === 'getInTouch' || key === 'lastAction') continue;
 
     const prevCandidates = new Set(
       extractIndexableFieldValues(prevData[key]).flatMap(value => buildSearchIndexCandidates(key, value))
@@ -3126,6 +3175,20 @@ const getLastActionIndexSet = data => {
   return new Set([normalizeLastActionSearchKeyBucket(data.lastAction)]);
 };
 
+
+const normalizeDateSearchKeyBucket = rawValue => {
+  const parsed = parseLastActionDate(rawValue);
+  if (parsed.status === 'empty') return 'no';
+  if (parsed.status === 'invalid') return '?';
+
+  return `${AGE_DATE_PREFIX}${toIsoDate(parsed.date)}`;
+};
+
+const getGetInTouchIndexSet = data => {
+  if (!data || typeof data !== 'object') return new Set(['no']);
+  return new Set([normalizeDateSearchKeyBucket(data.getInTouch)]);
+};
+
 const GET_IN_TOUCH_SPECIAL_VALUES = new Set([
   '2099-99-99',
   '9999-99-99',
@@ -3671,8 +3734,8 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   const nextFieldCountValues = getFieldCountIndexSet(nextData);
   const prevLastActionValues = getLastActionIndexSet(prevData);
   const nextLastActionValues = getLastActionIndexSet(nextData);
-  const prevLastActionLeafValue = normalizeLastActionSearchKeyValue(prevData?.lastAction);
-  const nextLastActionLeafValue = normalizeLastActionSearchKeyValue(nextData?.lastAction);
+  const prevGetInTouchValues = getGetInTouchIndexSet(prevData);
+  const nextGetInTouchValues = getGetInTouchIndexSet(nextData);
 
   for (const value of prevFieldCountValues) {
     if (!nextFieldCountValues.has(value)) {
@@ -3696,12 +3759,23 @@ export const syncUserSearchKeyIndex = async (userId, prevData = {}, nextData = {
   }
 
   for (const value of nextLastActionValues) {
-    if (!prevLastActionValues.has(value) || prevLastActionLeafValue !== nextLastActionLeafValue) {
+    if (!prevLastActionValues.has(value)) {
       // eslint-disable-next-line no-await-in-loop
-      await updateSearchKeyLeaf(LAST_ACTION_SEARCH_KEY_INDEX, value, userId, 'add', {
-        ...options,
-        leafValue: nextLastActionLeafValue,
-      });
+      await updateLeaf(LAST_ACTION_SEARCH_KEY_INDEX, value, 'add');
+    }
+  }
+
+  for (const value of prevGetInTouchValues) {
+    if (!nextGetInTouchValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateLeaf(GET_IN_TOUCH_SEARCH_KEY_INDEX, value, 'remove');
+    }
+  }
+
+  for (const value of nextGetInTouchValues) {
+    if (!prevGetInTouchValues.has(value)) {
+      // eslint-disable-next-line no-await-in-loop
+      await updateLeaf(GET_IN_TOUCH_SEARCH_KEY_INDEX, value, 'add');
     }
   }
 };
@@ -4004,8 +4078,36 @@ export const createLastActionSearchKeyIndexInCollection = async (collection, onP
       batchIds.reduce((acc, userId) => {
         const user = usersData[userId] || {};
         const bucket = normalizeLastActionSearchKeyBucket(user.lastAction);
-        acc[`${searchKeyRoot}/${LAST_ACTION_SEARCH_KEY_INDEX}/${bucket}/${userId}`] =
-          normalizeLastActionSearchKeyValue(user.lastAction);
+        acc[`${searchKeyRoot}/${LAST_ACTION_SEARCH_KEY_INDEX}/${bucket}/${userId}`] = true;
+        return acc;
+      }, {}),
+    onProgress
+  );
+};
+
+
+export const createGetInTouchSearchKeyIndexInCollection = async (collection, onProgress, options = {}) => {
+  const searchKeyRoot = options?.rootPath || SEARCH_KEY_INDEX_ROOT;
+  if (collection !== 'newUsers' && searchKeyRoot === SEARCH_KEY_INDEX_ROOT) return;
+  const usersData = options?.usersData || (await loadCollectionWithIndexCache(collection));
+  if (!usersData) return;
+
+  const userIds = Object.keys(usersData);
+  const totalUsers = userIds.length;
+  if (totalUsers === 0) return;
+
+  if (searchKeyRoot === SEARCH_KEY_INDEX_ROOT) {
+    await remove(ref2(database, `${searchKeyRoot}/${GET_IN_TOUCH_SEARCH_KEY_INDEX}`));
+  }
+
+  await uploadChunkedSearchKeyIndexUpdates(
+    userIds,
+    totalUsers,
+    batchIds =>
+      batchIds.reduce((acc, userId) => {
+        const user = usersData[userId] || {};
+        const bucket = normalizeDateSearchKeyBucket(user.getInTouch);
+        acc[`${searchKeyRoot}/${GET_IN_TOUCH_SEARCH_KEY_INDEX}/${bucket}/${userId}`] = true;
         return acc;
       }, {}),
     onProgress
@@ -4024,6 +4126,7 @@ const SEARCH_KEY_INDEX_BUILDERS = {
   [SEARCH_KEY_INDEX_TYPES.reaction]: createReactionSearchKeyIndexInCollection,
   [SEARCH_KEY_INDEX_TYPES.fieldCount]: createFieldCountSearchKeyIndexInCollection,
   [SEARCH_KEY_INDEX_TYPES.lastAction]: createLastActionSearchKeyIndexInCollection,
+  [SEARCH_KEY_INDEX_TYPES.getInTouch]: createGetInTouchSearchKeyIndexInCollection,
 };
 
 export const createSelectedSearchKeyIndexesInCollection = async (collection, indexTypes = [], onProgress, options = {}) => {
@@ -4088,7 +4191,6 @@ export const buildSearchIdIndexPayloadFromCollections = collectionsMap => {
       if (!userId || !userData || typeof userData !== 'object') return;
 
       keysToCheck.forEach(key => {
-        if (key === 'getInTouch' || key === 'lastAction') return;
         const candidates = extractIndexableFieldValues(userData[key]).flatMap(value =>
           buildSearchIndexCandidates(key, normalizeSearchIdInput(key, value))
         );
@@ -4145,6 +4247,9 @@ const resolveSearchKeyValuesByIndexType = (indexType, userId, userData) => {
   if (indexType === SEARCH_KEY_INDEX_TYPES.lastAction) {
     return [{ indexName: LAST_ACTION_SEARCH_KEY_INDEX, values: [normalizeLastActionSearchKeyBucket(userData?.lastAction)] }];
   }
+  if (indexType === SEARCH_KEY_INDEX_TYPES.getInTouch) {
+    return [{ indexName: GET_IN_TOUCH_SEARCH_KEY_INDEX, values: [normalizeDateSearchKeyBucket(userData?.getInTouch)] }];
+  }
   return [];
 };
 
@@ -4180,10 +4285,7 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
         const entries = resolveSearchKeyValuesByIndexType(indexType, userId, userData);
         entries.forEach(({ indexName, values }) => {
           values.filter(Boolean).forEach(value => {
-            const leafValue = indexType === SEARCH_KEY_INDEX_TYPES.lastAction
-              ? normalizeLastActionSearchKeyValue(userData?.lastAction)
-              : true;
-            assignNestedLeaf(payload, [...rootSegments, indexName, value, userId], leafValue);
+            assignNestedLeaf(payload, [...rootSegments, indexName, value, userId], true);
           });
         });
       });
@@ -4500,8 +4602,8 @@ export const removeSpecificSearchId = async (userId, searchedValue) => {
   const db = getDatabase();
 
   const [searchKey, searchValue] = Object.entries(searchedValue)[0];
-  const normalizedValue = normalizeSearchIdInput(searchKey, searchValue).toLowerCase();
-  const searchIdKey = `${searchKey}_${encodeKey(normalizedValue)}`; // Формуємо ключ для пошуку у searchId
+  const searchIdKey = buildSearchIdRecordKey({ [searchKey]: searchValue }); // Формуємо ключ для пошуку у searchId
+  if (!searchIdKey) return;
   console.log(`searchIdKey`, searchIdKey);
   // Отримуємо всі пари в searchId
   const searchIdSnapshot = await get(ref2(db, `searchId`));

--- a/src/utils/searchKeyCheckboxFilters.js
+++ b/src/utils/searchKeyCheckboxFilters.js
@@ -1,22 +1,5 @@
-const SEARCH_ID_CHECKBOX_KEYS = [
-  'instagram',
-  'facebook',
-  'email',
-  'phone',
-  'telegram',
-  'tiktok',
-  'linkedin',
-  'youtube',
-  'twitter',
-  'line',
-  'otherLink',
-  'other',
-  'vk',
-  'name',
-  'surname',
-  'lastAction',
-  'getInTouch',
-];
+import { getSearchIdIndexedFields } from './searchKeyUtils';
+const SEARCH_ID_CHECKBOX_KEYS = getSearchIdIndexedFields();
 
 const EQUAL_TO_INDEX_KEYS = [
   'instagram',

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -1,7 +1,43 @@
 import { normalizePhoneValue } from '../components/inputValidations';
 import { parseUkTriggerQuery } from './parseUkTrigger';
 import { encodeKey } from './searchIndexCandidates';
-import { getSearchIdPrefixes } from './searchKeyCheckboxFilters';
+
+
+export const SEARCH_ID_INDEXED_FIELDS = new Set([
+  'instagram',
+  'facebook',
+  'email',
+  'phone',
+  'telegram',
+  'tiktok',
+  'linkedin',
+  'youtube',
+  'twitter',
+  'line',
+  'otherLink',
+  'other',
+  'vk',
+  'name',
+  'surname',
+]);
+
+export const getSearchIdIndexedFields = () => [...SEARCH_ID_INDEXED_FIELDS];
+
+export const isSearchIdIndexedField = field => SEARCH_ID_INDEXED_FIELDS.has(field);
+
+export const getSearchIdPrefixes = searchIdPrefixes => {
+  const fallback = getSearchIdIndexedFields();
+  if (!Array.isArray(searchIdPrefixes) || searchIdPrefixes.length === 0) {
+    return fallback;
+  }
+
+  const normalizedPrefixes = searchIdPrefixes
+    .map(prefix => (typeof prefix === 'string' ? prefix.trim() : ''))
+    .filter(Boolean);
+
+  const allowedPrefixes = fallback.filter(prefix => normalizedPrefixes.includes(prefix));
+  return allowedPrefixes.length > 0 ? allowedPrefixes : fallback;
+};
 
 const SOCIAL_SEARCH_KEYS = new Set([
   'telegram',
@@ -149,11 +185,29 @@ export const shouldSkipBroadFallbackForExactSearchId = searchKey => {
   return true;
 };
 
+export const buildSearchIdRecordKey = searchedValue => {
+  if (!searchedValue || typeof searchedValue !== 'object' || Array.isArray(searchedValue)) {
+    return null;
+  }
+
+  const entries = Object.entries(searchedValue);
+  if (entries.length !== 1) return null;
+
+  const [[searchKey, searchValue]] = entries;
+  if (!SEARCH_ID_INDEXED_FIELDS.has(searchKey)) return null;
+  if (typeof searchValue !== 'string') return null;
+
+  const normalizedSearchValue = normalizeSearchIdInput(searchKey, searchValue);
+  if (!normalizedSearchValue) return null;
+
+  return `${searchKey}_${encodeKey(normalizedSearchValue).toLowerCase()}`;
+};
+
 export const makeSearchKeyValue = searchedValue => {
   const [searchKey, searchValue] = Object.entries(searchedValue)[0];
   const normalizedSearchValue = normalizeSearchIdInput(searchKey, searchValue);
   const modifiedSearchValue = encodeKey(normalizedSearchValue);
-  const searchIdKey = `${searchKey}_${modifiedSearchValue.toLowerCase()}`;
+  const searchIdKey = buildSearchIdRecordKey({ [searchKey]: searchValue });
 
   return {
     searchKey,


### PR DESCRIPTION
### Motivation
- Упорядкувати три різні пошукові підсистеми — `SearchId`, `EqualTo` та `SearchKey` — і припинити перехресне змішування індексів (особливо для дат/role). 
- Заборонити створення `searchId` записів для технічних/датних полів (`lastAction`, `getInTouch`, `role`) та зробити їх частиною окремого `searchKey` bucket/date індексу.
- Мати єдине джерело істини для полів, які індексуються у `searchId` щоб уникнути розбігів у whitelists/checkbox-списках.

### Description
- Додано глобальний список `SEARCH_ID_INDEXED_FIELDS` у `src/utils/searchKeyUtils.js` та експортовано допоміжні функції (`getSearchIdIndexedFields`, `isSearchIdIndexedField`, `getSearchIdPrefixes`) для використання повсюдно; замінено локальні масиви префіксів на використання цього списку.  
- Реалізовано строгий builder `buildSearchIdRecordKey` та оновлено `makeSearchKeyValue` у `src/utils/searchKeyUtils.js` щоб приймати тільки object з однією парою та повертати `null` для непідтримуваних полів/типів; `searchId` створюється тільки для полів з `SEARCH_ID_INDEXED_FIELDS`. 
- Прибрано `lastAction`/`getInTouch`/`role` з `SearchId` потоків: оновлено `syncUserSearchIdIndex`, `updateSearchId`, `buildSearchIdIndexPayloadFromCollections` та інші місця у `src/components/config.js` щоб не створювати `searchId/lastAction_...`, `searchId/getInTouch_...` або `searchId/role_...` записів. 
- Додано окрему `SearchKey` bucket/date логіку для дат: нормалізація дати → `d_YYYY-MM-DD` buckets і пошук/індексація в `searchKey/{field}/{bucket}/{userId}: true`; реалізовано `collectUserIdsBySearchKeyBucket`, `executeSearchBySearchKeyBucket`, індексацію `lastAction` і нову індексацію `getInTouch`, а також builder `createGetInTouchSearchKeyIndexInCollection`. 
- Search UI / routing: додано окремий режим/перемикач `searchKey` у `AddNewProfile.jsx`/`SearchBar.jsx`, нові parsers `SEARCH_KEY_BUCKET_SEARCH_PARSERS`, нова функція `runSearchKeyBucketSearch` і виклики `forceSearchKeyBucket`/`searchKeyFields` при виконанні запитів; передача `searchKeyFields` з UI у пошук. 
- Інші зміни: в `searchKeyCheckboxFilters.js` використовується централізований список префіксів; `buildSearchIdIndexPayloadFromCollections` тепер формує payload тільки по `SEARCH_ID_INDEXED_FIELDS`; payloads для searchKey використовують leaf `true` у bucket-шляхах (не значення-в-лeаф як timestamp для lastAction). 

### Testing
- Запущено ESLint: `npm run lint:js` — без критичних помилок.
- Запущено unit-тести: `npm test -- --watchAll=false` — всі тест-сьюти пройшли (16 suites, 73 tests passed).
- Побудовано production-бандл: `npm run build` — збірка успішна (build completed).

Коміт: "Separate SearchId EqualTo and SearchKey flows" (зміни у файлах `src/utils/searchKeyUtils.js`, `src/utils/searchKeyCheckboxFilters.js`, `src/components/config.js`, `src/components/SearchBar.jsx`, `src/components/AddNewProfile.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe085c8e688326b27b01dacea12698)