### PR TITLE
Preserve newer cached comments

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -61,6 +61,7 @@ import {
   saveComments,
   setLocalComment,
   pruneComments,
+  shouldUseServerComment,
 } from '../utils/commentsStorage';
 import {
   isUserAllowedByAnyAdditionalAccessRule,
@@ -1904,7 +1905,7 @@ const Matching = () => {
       const ownComments = ownEntry?.comments?.[id] || [];
       const ownServer = [...ownComments].sort((a, b) => (b.lastAction || 0) - (a.lastAction || 0))[0];
       const local = cache[id];
-      if (ownServer) {
+      if (shouldUseServerComment(ownServer, local)) {
         newStore[id] = ownServer;
         commentsMap[id] = ownServer.text;
       } else if (local) {

--- a/src/utils/__tests__/commentsStorage.test.js
+++ b/src/utils/__tests__/commentsStorage.test.js
@@ -1,0 +1,23 @@
+import { shouldUseServerComment } from '../commentsStorage';
+
+describe('shouldUseServerComment', () => {
+  it('keeps a newer local comment instead of replacing it with stale server data', () => {
+    const local = { text: 'fresh local edit', lastAction: 2000 };
+    const server = { text: 'stale server text', lastAction: 1000 };
+
+    expect(shouldUseServerComment(server, local)).toBe(false);
+  });
+
+  it('uses a server comment only when it is newer than the local cache', () => {
+    const local = { text: 'old local text', lastAction: 1000 };
+    const server = { text: 'fresh server text', lastAction: 2000 };
+
+    expect(shouldUseServerComment(server, local)).toBe(true);
+  });
+
+  it('uses the server comment when there is no local cache', () => {
+    const server = { text: 'server text', lastAction: 1000 };
+
+    expect(shouldUseServerComment(server, undefined)).toBe(true);
+  });
+});

--- a/src/utils/commentsStorage.js
+++ b/src/utils/commentsStorage.js
@@ -34,6 +34,12 @@ export const setLocalComment = (id, text, lastAction = Date.now()) => {
   saveComments(comments);
 };
 
+export const shouldUseServerComment = (server, local) => {
+  if (!server) return false;
+  if (!local) return true;
+  return (server.lastAction || 0) > (local.lastAction || 0);
+};
+
 export const pruneComments = ids => {
   const existing = loadComments();
   const pruned = {};


### PR DESCRIPTION
### Motivation
- Prevent fresher local edits from being overwritten by stale server comment data when loading comments.

### Description
- Add `shouldUseServerComment(server, local)` in `src/utils/commentsStorage.js` to only prefer a server comment when it exists and its `lastAction` is greater than the local `lastAction`, while still accepting server data when no local cache exists.
- Use `shouldUseServerComment` in `loadCommentsFor` inside `src/components/Matching.jsx` to decide whether to use the own-server comment or the cached local comment when building `newStore` and `commentsMap`.
- Add unit tests in `src/utils/__tests__/commentsStorage.test.js` that verify server-vs-local precedence for newer local edits, newer server updates, and the no-local-cache case.

### Testing
- Ran the new unit tests with `npm test -- --watchAll=false src/utils/__tests__/commentsStorage.test.js`, and the test suite passed (1 test file, 3 tests all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe320608b483268cbcf5b9d40a6ed0)