### PR TITLE
Prioritize and merge favorites/dislikes across multiple data owners

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -74,6 +74,7 @@ import {
   getIndexedNewUsersIdsByRules,
 } from 'utils/newUsersFilterSetsIndex';
 import { resolveMatchingMultiDataOwnerIds } from 'utils/multiDataAccess';
+import { resolvePrioritizedReactionMaps } from 'utils/reactionPriority';
 
 // Filter out users with invalid identifiers; Firebase push IDs are usually 20 chars.
 const isValidId = id => typeof id === 'string' && id.length >= 20;
@@ -1986,7 +1987,18 @@ const Matching = () => {
 
     const favoriteSnapshots = {};
     const dislikeSnapshots = {};
-    const mergeSnapshots = snapshots => Object.assign({}, ...Object.values(snapshots));
+    const applyPrioritizedReactionMaps = () => {
+      const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+        ownerIds,
+        ownOwnerId: getOwnerId(),
+        favoriteSnapshots,
+        dislikeSnapshots,
+      });
+      setFavoriteUsers(favorites);
+      syncFavorites(favorites);
+      setDislikeUsers(dislikes);
+      syncDislikes(dislikes);
+    };
 
     const unsubs = ownerIds.flatMap(effectiveOwnerId => {
       const favRef = refDb(database, `multiData/favorites/${effectiveOwnerId}`);
@@ -1994,15 +2006,11 @@ const Matching = () => {
 
       const unsubFav = onValue(favRef, snap => {
         favoriteSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
-        const data = mergeSnapshots(favoriteSnapshots);
-        setFavoriteUsers(data);
-        syncFavorites(data);
+        applyPrioritizedReactionMaps();
       });
       const unsubDis = onValue(disRef, snap => {
         dislikeSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
-        const data = mergeSnapshots(dislikeSnapshots);
-        setDislikeUsers(data);
-        syncDislikes(data);
+        applyPrioritizedReactionMaps();
       });
 
       return [unsubFav, unsubDis];
@@ -2196,8 +2204,14 @@ const Matching = () => {
           Promise.all(owners.map(owner => fetchFavoriteUsers(owner))),
           Promise.all(owners.map(owner => fetchDislikeUsers(owner))),
         ]);
-        const favIds = Object.assign({}, ...favMaps);
-        const disIds = Object.assign({}, ...disMaps);
+        const favoriteSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, favMaps[index]]));
+        const dislikeSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, disMaps[index]]));
+        const { favorites: favIds, dislikes: disIds } = resolvePrioritizedReactionMaps({
+          ownerIds: owners,
+          ownOwnerId: getOwnerId(),
+          favoriteSnapshots,
+          dislikeSnapshots,
+        });
         setFavoriteUsers(favIds);
         setDislikeUsers(disIds);
         syncFavorites(favIds);
@@ -2297,11 +2311,24 @@ const Matching = () => {
       return;
     }
 
-    const favoriteDataByOwner = await Promise.all(owners.map(owner => fetchFavoriteUsersData(owner)));
-    const favUsers = Object.assign({}, ...favoriteDataByOwner);
-    const favMap = Object.fromEntries(Object.keys(favUsers).map(id => [id, true]));
+    const [favoriteMaps, dislikeMaps] = await Promise.all([
+      Promise.all(owners.map(owner => fetchFavoriteUsers(owner))),
+      Promise.all(owners.map(owner => fetchDislikeUsers(owner))),
+    ]);
+    const favoriteSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, favoriteMaps[index]]));
+    const dislikeSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, dislikeMaps[index]]));
+    const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
+      ownerIds: owners,
+      ownOwnerId: getOwnerId(),
+      favoriteSnapshots,
+      dislikeSnapshots,
+    });
+    const favDataByOwner = await Promise.all(owners.map(owner => fetchFavoriteUsersData(owner)));
+    const favUsers = Object.assign({}, ...favDataByOwner);
     syncFavorites(favMap);
+    syncDislikes(disMap);
     setFavoriteUsers(favMap);
+    setDislikeUsers(disMap);
     setFavoriteIds(favMap);
     cacheFavoriteUsers(favUsers);
     setIdsForQuery('favorite', Object.keys(favMap));
@@ -2325,10 +2352,23 @@ const Matching = () => {
       return;
     }
 
+    const [favoriteMaps, dislikeMaps] = await Promise.all([
+      Promise.all(owners.map(owner => fetchFavoriteUsers(owner))),
+      Promise.all(owners.map(owner => fetchDislikeUsers(owner))),
+    ]);
+    const favoriteSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, favoriteMaps[index]]));
+    const dislikeSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, dislikeMaps[index]]));
+    const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
+      ownerIds: owners,
+      ownOwnerId: getOwnerId(),
+      favoriteSnapshots,
+      dislikeSnapshots,
+    });
     const dislikeDataByOwner = await Promise.all(owners.map(owner => fetchDislikeUsersData(owner)));
     const loaded = Object.assign({}, ...dislikeDataByOwner);
-    const disMap = Object.fromEntries(Object.keys(loaded).map(id => [id, true]));
     cacheDislikedUsers(loaded);
+    syncFavorites(favMap);
+    setFavoriteUsers(favMap);
     syncDislikes(disMap);
     setDislikeUsers(disMap);
     setIdsForQuery('dislike', Object.keys(disMap));

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -1,0 +1,49 @@
+const isTruthyReactionValue = value => {
+  if (typeof value === 'boolean') return value;
+  return Boolean(value);
+};
+
+export const normalizeReactionMap = map => {
+  if (!map || typeof map !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(map).filter(([id, value]) => id && isTruthyReactionValue(value))
+  );
+};
+
+const mergeReactionMaps = maps =>
+  Object.assign({}, ...maps.map(map => normalizeReactionMap(map)));
+
+export const resolvePrioritizedReactionMaps = ({
+  ownerIds = [],
+  ownOwnerId,
+  favoriteSnapshots = {},
+  dislikeSnapshots = {},
+} = {}) => {
+  const normalizedOwnOwnerId = String(ownOwnerId || '').trim();
+  const orderedOwnerIds = [...new Set(ownerIds.filter(Boolean))];
+  const sharedOwnerIds = orderedOwnerIds.filter(ownerId => ownerId !== normalizedOwnOwnerId);
+
+  const sharedFavorites = mergeReactionMaps(sharedOwnerIds.map(ownerId => favoriteSnapshots[ownerId]));
+  const sharedDislikes = mergeReactionMaps(sharedOwnerIds.map(ownerId => dislikeSnapshots[ownerId]));
+  const ownFavorites = normalizeReactionMap(favoriteSnapshots[normalizedOwnOwnerId]);
+  const ownDislikes = normalizeReactionMap(dislikeSnapshots[normalizedOwnOwnerId]);
+
+  const favorites = { ...sharedFavorites };
+  const dislikes = { ...sharedDislikes };
+
+  Object.keys(dislikes).forEach(userId => {
+    delete favorites[userId];
+  });
+
+  Object.keys(ownFavorites).forEach(userId => {
+    favorites[userId] = ownFavorites[userId];
+    delete dislikes[userId];
+  });
+
+  Object.keys(ownDislikes).forEach(userId => {
+    dislikes[userId] = ownDislikes[userId];
+    delete favorites[userId];
+  });
+
+  return { favorites, dislikes };
+};


### PR DESCRIPTION
### Motivation
- Ensure consistent handling of favorites and dislikes when matching data is aggregated from multiple `ownerId`s and make the current user's reactions take priority.
- Prevent conflicting reactions (a user both liked and disliked) by giving local owner state precedence over shared state and resolving shared conflicts deterministically.

### Description
- Added `src/utils/reactionPriority.js` implementing `normalizeReactionMap`, `mergeReactionMaps`, and `resolvePrioritizedReactionMaps` to normalize maps and compute final `favorites`/`dislikes` with local owner precedence and conflict resolution.  
- Integrated the new resolver into `src/components/Matching.jsx` by importing `resolvePrioritizedReactionMaps` and replacing ad-hoc snapshot merges with a centralized `applyPrioritizedReactionMaps` handler used by realtime listeners.  
- Updated initial and view-specific loaders (`loadInitial`, `loadFavoriteCards`, `loadDislikeCards`) to fetch per-owner snapshots and derive final `favorite`/`dislike` maps via `resolvePrioritizedReactionMaps`, then sync and set state consistently.  
- Ensured syncing both favorites and dislikes in the updated flows so the local cache and RTDB remain consistent after priority resolution.  

### Testing
- Ran the project's test suite with `yarn test` and the build with `yarn build`, and both completed successfully.  
- Verified that realtime listeners and initial loaders now use `resolvePrioritizedReactionMaps` to produce consistent `favorites`/`dislikes` outputs under multi-owner scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3f3073648326b0db7ab2de992337)