### PR TITLE
Normalize additional access rule keys (fix userId mapping)

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -335,13 +335,36 @@ const ADDITIONAL_RULE_OPTION_DESCRIPTIONS = {
   },
 };
 
+const ADDITIONAL_RULE_KEY_ALIASES = {
+  age: 'age',
+  'вік': 'age',
+  csection: 'csection',
+  'кс': 'csection',
+  blood: 'bloodGroup',
+  bloodgroup: 'bloodGroup',
+  'групакрові': 'bloodGroup',
+  'кров': 'bloodGroup',
+  rh: 'rh',
+  'резус': 'rh',
+  maritalstatus: 'maritalStatus',
+  'сімейнийстан': 'maritalStatus',
+  imt: 'imt',
+  'імт': 'imt',
+  bmi: 'imt',
+  role: 'role',
+  contact: 'contact',
+  userid: 'userId',
+  reaction: 'reaction',
+  height: 'height',
+  weight: 'weight',
+  agebirthdate: 'ageBirthDate',
+};
+
 const normalizeAdditionalRuleKey = rawKey => {
-  const normalized = String(rawKey || '').trim().toLowerCase();
+  const normalized = String(rawKey || '').trim().toLowerCase().replace(/\s+/g, '');
   if (!normalized) return '';
 
-  if (normalized === 'імт' || normalized === 'imt' || normalized === 'bmi') return 'imt';
-  if (normalized === 'blood' || normalized === 'bloodgroup') return 'bloodGroup';
-  return normalized;
+  return ADDITIONAL_RULE_KEY_ALIASES[normalized] || normalized;
 };
 
 const parseAdditionalRulesTextToBuilder = raw => {


### PR DESCRIPTION
### Motivation
- The additional-access UI normalized keys (e.g. `userId`) to a lowercased token (like `userid`) which did not match the canonical camelCase keys used in `ADDITIONAL_ACCESS_FILTER_OPTIONS`, causing built rules to be dropped and the UI to report “Оберіть щонайменше один фільтр…”.

### Description
- Add an alias map `ADDITIONAL_RULE_KEY_ALIASES` and update `normalizeAdditionalRuleKey` to strip spaces and map incoming rule keys (including Ukrainian labels) to canonical filter keys such as `userId`, `maritalStatus`, and `ageBirthDate` in `src/components/ProfileForm.jsx`.
- Preserve existing special-cases (like `imt` / `bmi` and blood aliases) by including them in the new alias map so parsing and rule building produce the expected tokens (for example `userId: id`).

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runInBand`, all test suites passed (`17` suites, `76` tests, all passing). 
- Built production bundle with `npm run build`, which compiled successfully and produced the optimized build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4b389f3083268cc11877be27e56c)