### PR TITLE
refactor(ui): visual redesign of filter chips and action buttons on AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -409,56 +409,98 @@ const EditActionIcon = styled.svg`
 
 
 const Button = styled.button`
-  width: 35px; /* Встановіть ширину, яка визначатиме розмір кнопки */
-  height: 35px; /* Встановіть висоту, яка повинна дорівнювати ширині */
-  padding: 3px; /* Видаліть внутрішні відступи */
-  border: none;
-  background-color: ${color.accent5};
-  color: white;
-  border-radius: 50px;
+  padding: 0 12px;
+  height: 30px;
+  border: 1.5px solid #e5e5e5;
+  background: #fff;
+  color: #444;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 12px;
-  flex: 0 0 35px;
-  display: flex;
+  font-weight: 500;
+  flex-shrink: 0;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition:
-    background-color 0.3s ease,
-    box-shadow 0.3s ease;
-  margin-right: 10px;
+  white-space: nowrap;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 
   &:hover {
-    background-color: ${color.accent}; /* Колір кнопки при наведенні */
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); /* Тінь при наведенні */
+    background: #FFF3E0;
+    border-color: #FF8C00;
+    color: #CC5500;
   }
 
   &:active {
-    transform: scale(0.98); /* Легкий ефект при натисканні */
+    transform: scale(0.97);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
   }
 `;
 
 const ButtonsContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 6px;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  margin: 8px 0;
 `;
 
 const SortModeContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
+  gap: 4px;
   margin: 8px 0;
-  color: #1f1f1f;
+  padding: 8px 12px;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 10px;
+`;
+
+const SortModeTitle = styled.span`
+  font-size: 10px;
+  font-weight: 700;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-right: 4px;
 `;
 
 const SortModeLabel = styled.label`
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 13px;
-  color: #1f1f1f;
+  font-size: 12px;
+  color: #444;
+  cursor: pointer;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1.5px solid transparent;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+
+  input[type='radio'] {
+    display: none;
+  }
+
+  &:has(input:checked) {
+    background: #FFF3E0;
+    border-color: #FF8C00;
+    color: #CC5500;
+    font-weight: 600;
+  }
+
+  &:hover:not(:has(input:checked)) {
+    background: #f5f5f5;
+    border-color: #ddd;
+  }
 `;
 
 
@@ -4354,7 +4396,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               <p style={{ textAlign: 'center', color: 'black' }}>No result</p>
             )}
             <SortModeContainer>
-              <span>Сортування:</span>
+              <SortModeTitle>Сортування</SortModeTitle>
               <SortModeLabel>
                 <input
                   type="radio"

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -1,6 +1,48 @@
 import React from 'react';
+import styled from 'styled-components';
 
-export const CheckboxGroup = ({ label, filterName, options, filters, onChange, compact = false }) => {
+const GroupWrapper = styled.div`
+  margin-bottom: 10px;
+`;
+
+const GroupLabel = styled.span`
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 5px;
+  line-height: 1;
+`;
+
+const ChipsRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+`;
+
+const Chip = styled.button`
+  padding: 3px 9px;
+  border-radius: 20px;
+  border: 1.5px solid ${({ $active }) => ($active ? '#FF8C00' : '#e0e0e0')};
+  background: ${({ $active }) => ($active ? '#FFF3E0' : '#fafafa')};
+  color: ${({ $active }) => ($active ? '#CC5500' : '#666')};
+  font-size: 12px;
+  font-weight: ${({ $active }) => ($active ? '600' : '400')};
+  cursor: pointer;
+  line-height: 1.5;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  display: inline-flex;
+  align-items: center;
+
+  &:hover {
+    border-color: #FF8C00;
+    color: #CC5500;
+  }
+`;
+
+export const CheckboxGroup = ({ label, filterName, options, filters, onChange }) => {
   const handleToggle = option => {
     onChange({
       ...filters,
@@ -12,15 +54,20 @@ export const CheckboxGroup = ({ label, filterName, options, filters, onChange, c
   };
 
   return (
-      <div style={{ marginBottom: compact ? '4px' : '8px' }}>
-        {label && <span style={{ marginRight: compact ? '4px' : '8px' }}>{label}:</span>}
+    <GroupWrapper>
+      {label && <GroupLabel>{label}</GroupLabel>}
+      <ChipsRow>
         {options.map(({ val, label: optionLabel }) => (
-          <label key={val} style={{ marginLeft: compact ? '4px' : '10px', color: 'black' }}>
-            <input type="checkbox" checked={filters[filterName][val]} onChange={() => handleToggle(val)} />
+          <Chip
+            key={val}
+            $active={filters[filterName][val]}
+            onClick={() => handleToggle(val)}
+            type="button"
+          >
             {optionLabel}
-          </label>
+          </Chip>
         ))}
-      <hr style={{ borderColor: '#ccc', borderWidth: '1px', borderStyle: 'solid', margin: '4px 0' }} />
-    </div>
+      </ChipsRow>
+    </GroupWrapper>
   );
 };

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
+import styled from 'styled-components';
 import { FaFacebookF, FaInstagram, FaPhoneVolume, FaTelegramPlane, FaVk } from 'react-icons/fa';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { FaXTwitter } from 'react-icons/fa6';
 import { CheckboxGroup } from './CheckboxGroup';
 import { REACTION_FILTER_OPTIONS } from 'utils/reactionCategory';
+
+const FiltersCard = styled.div`
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  padding: 12px 14px 4px;
+  margin: 8px 0;
+`;
 
 export const SearchFilters = ({
   filters,
@@ -324,7 +333,7 @@ export const SearchFilters = ({
   }
 
   return (
-    <div style={{ margin: '10px 0', color: 'black' }}>
+    <FiltersCard>
       {groups.map(group => (
         <CheckboxGroup
           key={group.filterName}
@@ -336,6 +345,6 @@ export const SearchFilters = ({
           compact={group.compact}
         />
       ))}
-    </div>
+    </FiltersCard>
   );
 };

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -224,26 +224,30 @@ export const coloredCard = index => {
 };
 
 export const OrangeBtn = styled.button`
-  width: 35px; /* Встановіть ширину, яка визначатиме розмір кнопки */
-  height: 35px; /* Встановіть висоту, яка повинна дорівнювати ширині */
-  padding: 3px; /* Видаліть внутрішні відступи */
-  border: none;
-  background-color: ${color.accent5};
-  color: white;
-  border-radius: 50px;
+  padding: 0 12px;
+  height: 30px;
+  border: 1.5px solid #e5e5e5;
+  background: #fff;
+  color: #444;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 12px;
-  flex: 0 1 auto;
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-  margin-right: 10px;
+  font-weight: 500;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 
   &:hover {
-    background-color: ${color.accent}; /* Колір кнопки при наведенні */
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); /* Тінь при наведенні */
+    background: #FFF3E0;
+    border-color: #FF8C00;
+    color: #CC5500;
   }
 
   &:active {
-    transform: scale(0.98); /* Легкий ефект при натисканні */
+    transform: scale(0.97);
   }
 `;
 


### PR DESCRIPTION
- CheckboxGroup: replace native checkboxes with pill/chip toggle buttons
  (styled-components, orange accent on active state, no more <hr> separators)
- SearchFilters: wrap filter groups in a white card (border-radius: 10px)
- AddNewProfile: Button redesigned from 35×35 orange circles to pill-shaped
  buttons with padding and subtle border; ButtonsContainer gets card-style
  wrapper; SortModeContainer/Label updated to segmented-control look
  with :has(input:checked) highlight
- OrangeBtn (shared): updated to match the new pill-button style

https://claude.ai/code/session_017cDM4rDojCb37kd7YLJ6RH