### PR TITLE
a11y: add aria-pressed to ScopeChip toggles

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -4266,6 +4266,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                           <ScopeChip
                             type="button"
                             $active={Boolean(enabledSearchKeys[option.key])}
+                            aria-pressed={Boolean(enabledSearchKeys[option.key])}
                             disabled={disabled}
                             onClick={() => handleSearchScopeChange(option.key, disabled)}
                           >


### PR DESCRIPTION
Screen readers could not determine which search scopes were active
because the visual-only $active styling has no ARIA equivalent.
aria-pressed exposes the toggled state to assistive technology.

https://claude.ai/code/session_015JRUr97a3fib9eXNByrgKU