### PR TITLE
refactor(ui): compact profile cards with role-based color themes

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -78,6 +78,15 @@ import { resolvePrioritizedReactionMaps } from 'utils/reactionPriority';
 
 // Filter out users with invalid identifiers; Firebase push IDs are usually 20 chars.
 const isValidId = id => typeof id === 'string' && id.length >= 20;
+
+const ROLE_COLORS = {
+  ed: { accent: '#c2185b', light: 'rgba(194,24,91,0.07)', border: 'rgba(194,24,91,0.22)', text: '#9c1057', tag: 'rgba(252,228,236,0.9)' },
+  ag: { accent: '#1565c0', light: 'rgba(21,101,192,0.07)', border: 'rgba(21,101,192,0.22)', text: '#0d47a1', tag: 'rgba(227,242,253,0.9)' },
+  ip: { accent: '#00695c', light: 'rgba(0,105,92,0.07)', border: 'rgba(0,105,92,0.22)', text: '#004d40', tag: 'rgba(224,242,241,0.9)' },
+  sm: { accent: '#6a1b9a', light: 'rgba(106,27,154,0.07)', border: 'rgba(106,27,154,0.22)', text: '#4a148c', tag: 'rgba(243,229,245,0.9)' },
+  cl: { accent: '#0277bd', light: 'rgba(2,119,189,0.07)', border: 'rgba(2,119,189,0.22)', text: '#01579b', tag: 'rgba(225,245,254,0.9)' },
+};
+const getRoleColors = role => ROLE_COLORS[role] || { accent: color.accent5, light: 'rgba(247,147,30,0.08)', border: 'rgba(247,147,30,0.25)', text: color.accent3, tag: 'rgba(255,243,224,0.9)' };
 const isShortId = id => typeof id === 'string' && id.length > 0 && id.length < 20;
 const isMatchingCardId = id => isValidId(id) || isShortId(id);
 const isAllowedIdForCollection = (id, collection = 'users') =>
@@ -572,7 +581,8 @@ const ThirdInfoCard = styled(NextInfoCard)`
 const CardWrapper = styled.div`
   position: relative;
   width: 100%;
-  border: 1px solid rgba(214, 193, 163, 0.35);
+  border: 1px solid ${props => props.$role ? getRoleColors(props.$role).border : 'rgba(214, 193, 163, 0.35)'};
+  border-top: 3px solid ${props => props.$role ? getRoleColors(props.$role).accent : color.accent5};
   border-radius: ${STACK_CARD_RADIUS};
   box-sizing: border-box;
   overflow: hidden;
@@ -640,7 +650,7 @@ const Card = styled.div`
   aspect-ratio: ${({ $hasPhoto, $small }) =>
     $hasPhoto ? ($small ? '4 / 5' : '3 / 4') : 'auto'};
   min-height: ${({ $hasPhoto, $small, $compactWithoutPhoto }) =>
-    !$hasPhoto && $compactWithoutPhoto ? ($small ? '320px' : '380px') : $small ? '280px' : '340px'};
+    !$hasPhoto && $compactWithoutPhoto ? ($small ? '180px' : '220px') : $small ? '260px' : '320px'};
   padding-bottom: 0;
   background: linear-gradient(180deg, #fffaf2 0%, #f8f5ef 100%);
   background-size: cover;
@@ -919,7 +929,7 @@ const CollectionSourceLabel = styled.label`
 // during builds, so the unused definitions have been removed.
 
 const Title = styled.span`
-  color: ${color.accent3};
+  color: ${props => getRoleColors(props.$role).text};
   font-weight: 800;
   margin-bottom: 4px;
   margin-right: 4px;
@@ -927,8 +937,8 @@ const Title = styled.span`
   text-transform: uppercase;
   letter-spacing: 0.6px;
   font-size: 10px;
-  background: rgba(247, 147, 30, 0.12);
-  border: 1px solid rgba(247, 147, 30, 0.3);
+  background: ${props => getRoleColors(props.$role).tag};
+  border: 1px solid ${props => getRoleColors(props.$role).border};
   border-radius: 8px;
   padding: 3px 8px;
 `;
@@ -952,9 +962,9 @@ const DonorName = styled.strong`
 const ProfileSection = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 10px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-  padding-bottom: 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+  padding-bottom: 8px;
 `;
 
 const Info = styled.div`
@@ -1000,31 +1010,31 @@ const MAIN_INFO_FIELDS_LIMIT = 15;
 const Table = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  row-gap: 6px;
-  column-gap: 6px;
-  font-size: 14px;
-  margin-bottom: 10px;
-  background: rgba(255, 255, 255, 0.86);
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 14px;
-  padding: 8px;
+  row-gap: 5px;
+  column-gap: 5px;
+  font-size: 13px;
+  margin-bottom: 8px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
+  padding: 7px;
 
   & > div {
-    line-height: 1.2;
+    line-height: 1.15;
     display: flex;
     flex-direction: column;
     background: #fbf9f5;
-    border: 1px solid rgba(0, 0, 0, 0.06);
-    border-radius: 10px;
-    padding: 5.6px 8px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    border-radius: 8px;
+    padding: 4px 7px;
   }
 
   & strong {
-    font-size: 9px;
-    color: ${color.accent3};
+    font-size: 8px;
+    color: ${props => props.$roleColor || color.accent3};
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin-bottom: 3px;
+    margin-bottom: 2px;
   }
 
   & > div > span,
@@ -1058,29 +1068,30 @@ const Contact = styled.div`
 
 const Icons = styled.div`
   display: flex;
-  gap: 6px;
+  gap: 5px;
   font-size: inherit;
   color: ${color.accent5};
   align-items: center;
+  flex-wrap: wrap;
 
   & a {
-    width: 34px !important;
-    height: 34px !important;
-    border-radius: 10px;
-    background: rgba(247, 147, 30, 0.12);
-    border: 1px solid rgba(247, 147, 30, 0.26) !important;
+    width: 30px !important;
+    height: 30px !important;
+    border-radius: 8px;
+    background: rgba(247, 147, 30, 0.1);
+    border: 1px solid rgba(247, 147, 30, 0.22) !important;
     transition: all 0.15s ease;
   }
 
   & a:hover {
-    background: rgba(255, 108, 0, 0.2);
-    border-color: rgba(255, 108, 0, 0.42) !important;
+    background: rgba(255, 108, 0, 0.18);
+    border-color: rgba(255, 108, 0, 0.38) !important;
     transform: translateY(-1px);
   }
 
   & svg {
-    width: 15px !important;
-    height: 15px !important;
+    width: 13px !important;
+    height: 13px !important;
   }
 `;
 
@@ -1157,12 +1168,15 @@ const InfoSlide = styled.div`
   width: 100%;
   height: auto;
   min-height: auto;
-  background: linear-gradient(180deg, #fffdf8 0%, #f6f2eb 100%);
+  background: ${props =>
+    props.$role
+      ? `linear-gradient(160deg, #fffdf8 0%, ${getRoleColors(props.$role).light} 100%)`
+      : 'linear-gradient(180deg, #fffdf8 0%, #f6f2eb 100%)'};
   color: #2c2d38;
   overflow-y: visible;
   box-sizing: border-box;
-  padding: 12px;
-  padding-bottom: ${({ $reserveActionButtons }) => ($reserveActionButtons ? '56px' : '12px')};
+  padding: 10px 12px;
+  padding-bottom: ${({ $reserveActionButtons }) => ($reserveActionButtons ? '56px' : '10px')};
 `;
 
 const slideLeft = keyframes`
@@ -1338,8 +1352,8 @@ const SwipeableCard = ({
       style={style}
     >
       {current === 'description' && (
-        <InfoSlide $reserveActionButtons={!photo}>
-          {extraFields.length > 0 && <Table>{extraFields}</Table>}
+        <InfoSlide $reserveActionButtons={!photo} $role={role}>
+          {extraFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{extraFields}</Table>}
           {education && (
             <MoreInfo>
               <strong>Education</strong>
@@ -1356,38 +1370,42 @@ const SwipeableCard = ({
           )}
           {moreInfo && (
             <MoreInfo>
-              {role === 'ag' ? (
-                moreInfo
-              ) : (
-                <>
-                  <strong>More information</strong>
-                  <br />
-                  {moreInfo}
-                </>
-              )}
+              {moreInfo}
             </MoreInfo>
           )}
         </InfoSlide>
       )}
       {current === 'info' && (
-        <InfoSlide $reserveActionButtons={!photo}>
-          <ProfileSection>
-            <Info>
-              <HeaderIdentityRow>
-                <Title>{getRoleTitle(user)}</Title>
-                <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
-              </HeaderIdentityRow>
-              <LocationLine>
-                <span>{locationInfo}</span>
-                {isEggDonor && contacts && <Icons>{contacts}</Icons>}
-              </LocationLine>
-            </Info>
-          </ProfileSection>
-          {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
-          {!isEggDonor && contacts && (
+        <InfoSlide $reserveActionButtons={!photo} $role={role}>
+          {photo ? (
+            <HeaderIdentityRow style={{ marginBottom: '8px' }}>
+              <Title $role={role}>{getRoleTitle(user)}</Title>
+              {contacts && <Icons style={{ marginLeft: 'auto' }}>{contacts}</Icons>}
+            </HeaderIdentityRow>
+          ) : (
+            <ProfileSection>
+              <Info>
+                <HeaderIdentityRow>
+                  <Title $role={role}>{getRoleTitle(user)}</Title>
+                  <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
+                </HeaderIdentityRow>
+                <LocationLine>
+                  <span>{locationInfo}</span>
+                  {isEggDonor && contacts && <Icons>{contacts}</Icons>}
+                </LocationLine>
+              </Info>
+            </ProfileSection>
+          )}
+          {selectedFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{selectedFields}</Table>}
+          {!isEggDonor && !photo && contacts && (
             <Contact $withBorder={selectedFields.length > 0}>
               <Icons>{contacts}</Icons>
             </Contact>
+          )}
+          {isEggDonor && photo && locationInfo && (
+            <LocationLine style={{ marginTop: '4px', fontSize: '11px', opacity: 0.7 }}>
+              <span>{locationInfo}</span>
+            </LocationLine>
           )}
         </InfoSlide>
       )}
@@ -1430,7 +1448,7 @@ const SwipeableCard = ({
       {current === 'main' && isAgency && (
         <CardInfo>
           <HeaderRow>
-            <RoleHeader>{role === 'ag' ? 'Agency' : 'Couple'}</RoleHeader>
+            <RoleHeader $role={role}>{role === 'ag' ? 'Agency' : 'Couple'}</RoleHeader>
             {nameParts && <strong>{nameParts}</strong>}
           </HeaderRow>
           <LocationLine>
@@ -1601,8 +1619,8 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
 
   if (variant === 'description') {
     return (
-      <InfoSlide>
-        {extraFields.length > 0 && <Table>{extraFields}</Table>}
+      <InfoSlide $role={role}>
+        {extraFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{extraFields}</Table>}
         {education && (
           <MoreInfo>
             <strong>Education</strong>
@@ -1617,29 +1635,17 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
             {profession}
           </MoreInfo>
         )}
-        {moreInfo && (
-          <MoreInfo>
-            {role === 'ag' ? (
-              moreInfo
-            ) : (
-              <>
-                <strong>More information</strong>
-                <br />
-                {moreInfo}
-              </>
-            )}
-          </MoreInfo>
-        )}
+        {moreInfo && <MoreInfo>{moreInfo}</MoreInfo>}
       </InfoSlide>
     );
   }
 
   return (
-    <InfoSlide>
+    <InfoSlide $role={role}>
       <ProfileSection>
         <Info>
           <HeaderIdentityRow>
-            <Title $isPotentialED={roleTitle === 'Potential ED'}>{roleTitle}</Title>
+            <Title $role={role}>{roleTitle}</Title>
             <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
           </HeaderIdentityRow>
           <LocationLine>
@@ -1648,7 +1654,7 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
           </LocationLine>
         </Info>
       </ProfileSection>
-      {selectedFields.length > 0 && <Table>{selectedFields}</Table>}
+      {selectedFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{selectedFields}</Table>}
       {!isEggDonor && contacts && (
         <Contact $withBorder={selectedFields.length > 0}>
           <Icons>{contacts}</Icons>
@@ -2753,7 +2759,7 @@ const Matching = () => {
                       </NextInfoCard>
                     )}
                     {nextPhoto && <NextPhoto src={nextPhoto} alt="next" />}
-                    <CardWrapper>
+                    <CardWrapper $role={role}>
                       <SwipeableCard
                         user={user}
                         photo={photo}

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -32,10 +32,11 @@ const UserCard = ({
     cycleStatus: effectiveStatus ?? userData?.cycleStatus,
   };
   const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveStatus);
+  const role = userData?.role || userData?.userRole;
 
   return (
     <div>
-      <div style={{ ...coloredCard(), marginBottom: '8px' }}>
+      <div style={{ ...coloredCard(role), marginBottom: '8px' }}>
         {renderTopBlock(
           userData,
           setUsers,
@@ -56,7 +57,7 @@ const UserCard = ({
         )}
       </div>
       {shouldShowSchedule && (
-        <div style={{ ...coloredCard(), marginBottom: '8px' }}>
+        <div style={{ ...coloredCard(role), marginBottom: '8px' }}>
           <StimulationSchedule
             userData={scheduleUserData}
             setUsers={setUsers}
@@ -148,11 +149,13 @@ const UsersList = ({
 
   return (
     <div style={styles.container}>
-      {entries.map(([userId, userData], index) => (
+      {entries.map(([userId, userData], index) => {
+        const entryRole = userData?.role || userData?.userRole;
+        return (
         <FadeContainer
           key={userId}
           className={`fade-in${userData._pendingRemove ? ' fade-out' : ''}`}
-          style={{ ...coloredCard(index) }}
+          style={{ ...coloredCard(entryRole || index) }}
           onAnimationEnd={() => {
             if (userData._pendingRemove) {
               setUsers(prev => {
@@ -203,7 +206,8 @@ const UsersList = ({
             />
           )}
         </FadeContainer>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -32,54 +32,50 @@ import { isAdminUid } from 'utils/accessLevel';
 import { auth } from '../config';
 import toast from 'react-hot-toast';
 
-const topBlockContainerStyle = { padding: '7px', position: 'relative' };
+const topBlockContainerStyle = { padding: '8px', position: 'relative' };
 
 const topButtonsRowStyle = {
   display: 'flex',
-  justifyContent: 'space-between',
   alignItems: 'center',
-  gap: '8px',
-  marginBottom: '8px',
+  gap: '5px',
+  marginBottom: '7px',
 };
 
 const topButtonsZoneStyle = {
   border: 'none',
-  borderRadius: '12px',
+  borderRadius: '9px',
   cursor: 'pointer',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '40px',
-  height: '40px',
-  flex: '0 0 40px',
+  width: '30px',
+  height: '30px',
+  flex: '0 0 30px',
   padding: 0,
-  boxShadow: '0 6px 14px rgba(17, 24, 39, 0.2)',
-  transition: 'transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease',
+  boxShadow: '0 3px 8px rgba(17, 24, 39, 0.25)',
+  transition: 'transform 0.15s ease, box-shadow 0.15s ease',
 };
 
-const topButtonsZones = ['#d32f2f', '#ef6c00', '#f9a825', '#2e7d32', '#0288d1', '#1565c0', '#6a1b9a'];
+const topButtonsZones = ['#d32f2f', '#ef6c00', '#f9a825', '#2e7d32', '#0288d1'];
 
 const zoneActionButtonStyle = {
   position: 'static',
   width: '100%',
   height: '100%',
-  minHeight: '40px',
-  borderRadius: '12px',
+  minHeight: '30px',
+  borderRadius: '9px',
   border: 'none',
   margin: 0,
   padding: 0,
   boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.2)',
 };
 
-const actionButtonsContainerStyle = {
-  position: 'absolute',
-  top: '88px',
-  right: '10px',
+const secondaryActionsStyle = {
+  marginLeft: 'auto',
   display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-end',
-  gap: '6px',
-  zIndex: 999,
+  alignItems: 'center',
+  gap: '5px',
+  flexShrink: 0,
 };
 
 const addedOverlayEntryStyle = {
@@ -102,14 +98,21 @@ const identityMetaStyle = {
 };
 
 const cardHeaderStyle = {
-  marginBottom: '8px',
+  marginBottom: '6px',
+};
+
+const cardNameRowStyle = {
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: '6px',
+  flexWrap: 'wrap',
+  marginBottom: '2px',
 };
 
 const cardNameStyle = {
   fontSize: '15px',
   fontWeight: 700,
   lineHeight: 1.25,
-  marginBottom: '2px',
 };
 
 const cardIdRowStyle = {
@@ -121,20 +124,35 @@ const cardIdRowStyle = {
   flexWrap: 'wrap',
 };
 
+const roleBadgeStyle = role => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '1px 7px',
+  borderRadius: '10px',
+  fontSize: '10px',
+  fontWeight: 700,
+  letterSpacing: '0.6px',
+  textTransform: 'uppercase',
+  background: 'rgba(255,255,255,0.22)',
+  color: '#fff',
+  flexShrink: 0,
+  border: `1px solid rgba(255,255,255,0.3)`,
+});
+
 const statusRowStyle = {
   display: 'flex',
   flexDirection: 'column',
   gap: '3px',
   padding: '5px 0',
-  borderTop: '1px solid rgba(255,255,255,0.08)',
-  borderBottom: '1px solid rgba(255,255,255,0.08)',
-  margin: '6px 0',
+  borderTop: '1px solid rgba(255,255,255,0.1)',
+  borderBottom: '1px solid rgba(255,255,255,0.1)',
+  margin: '5px 0',
 };
 
 const bioSectionStyle = {
   display: 'flex',
   flexDirection: 'column',
-  gap: '3px',
+  gap: '2px',
 };
 
 const bioRowStyle = {
@@ -142,33 +160,34 @@ const bioRowStyle = {
   alignItems: 'center',
   flexWrap: 'wrap',
   gap: '4px',
+  fontSize: '13px',
 };
 
 const contactsSectionStyle = {
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-  gap: '3px',
+  gap: '2px',
   marginTop: '4px',
 };
 
 const commentsSectionStyle = {
-  marginTop: '8px',
-  padding: '6px 8px',
-  borderRadius: '8px',
-  background: 'rgba(255,255,255,0.06)',
+  marginTop: '6px',
+  padding: '5px 7px',
+  borderRadius: '7px',
+  background: 'rgba(255,255,255,0.07)',
   display: 'flex',
   flexDirection: 'column',
-  gap: '4px',
+  gap: '3px',
 };
 
 const detailsToggleStyle = {
   position: 'absolute',
-  bottom: '10px',
-  right: '10px',
+  bottom: '8px',
+  right: '8px',
   cursor: 'pointer',
   color: '#ebe0c2',
-  opacity: 0.7,
+  opacity: 0.6,
   lineHeight: 1,
   display: 'flex',
   alignItems: 'center',
@@ -617,10 +636,15 @@ const TopBlock = ({
     setState(authorCard);
   };
 
+  const cardRole = cardData.role || cardData.userRole;
+
   return (
     <div style={topBlockContainerStyle}>
       <div style={cardHeaderStyle}>
-        <div style={cardNameStyle}>{buildName(cardData)}</div>
+        <div style={cardNameRowStyle}>
+          <div style={cardNameStyle}>{buildName(cardData)}</div>
+          {cardRole && <span style={roleBadgeStyle(cardRole)}>{cardRole}</span>}
+        </div>
         {renderOverlayEntries(['surname', 'name', 'fathersname'])}
         <div style={cardIdRowStyle}>
           {cardData.lastAction && <span>{formatDateToDisplay(normalizeLastAction(cardData.lastAction))}</span>}
@@ -652,7 +676,7 @@ const TopBlock = ({
                 setShowInfoModal,
                 setUserIdToDelete,
                 isFromListOfUsers,
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                   <path d="M4 7h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                   <path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                   <path d="M7 7l1 12a1 1 0 0 0 1 .9h6a1 1 0 0 0 1-.9L17 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
@@ -699,7 +723,7 @@ const TopBlock = ({
                 }}
                 inactiveIconColor="#fff"
                 activeIconColor="#1f2937"
-                iconSize={18}
+                iconSize={15}
               />
             )}
             {idx === 2 && (
@@ -730,7 +754,7 @@ const TopBlock = ({
                 }}
                 inactiveIconColor="#fff"
                 activeIconColor="#1f2937"
-                iconSize={18}
+                iconSize={15}
               />
             )}
             {idx === 3 && (
@@ -746,7 +770,7 @@ const TopBlock = ({
                 aria-label="Ліки"
                 title="Ліки"
               >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                   <path d="M8.5 8.5l7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
                   <path d="M6.2 10.8a3.25 3.25 0 0 1 4.6-4.6l6.9 6.9a3.25 3.25 0 1 1-4.6 4.6l-6.9-6.9z" stroke="currentColor" strokeWidth="2" />
                 </svg>
@@ -776,20 +800,18 @@ const TopBlock = ({
                   setSearch,
                   setState,
                   { ...zoneActionButtonStyle, backgroundColor: '#0288d1', color: '#fff' },
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                     <path d="M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
                     <path d="M13 7l4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
                   </svg>
                 )
               ))}
-            {idx === 5 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#1565c0', color: '#fff' }} aria-label="Додаткова синя кнопка" title="Додаткова синя кнопка" />}
-            {idx === 6 && <button type="button" style={{ ...zoneActionButtonStyle, backgroundColor: '#6a1b9a', color: '#fff' }} aria-label="Додаткова фіолетова кнопка" title="Додаткова фіолетова кнопка" />}
           </div>
         ))}
-      </div>
-      <div style={actionButtonsContainerStyle}>
-        {showSideActions && btnExport(cardData)}
-        {additionalActions}
+        <div style={secondaryActionsStyle}>
+          {showSideActions && btnExport(cardData)}
+          {additionalActions}
+        </div>
       </div>
       <div style={statusRowStyle}>
         {fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, submitOptions)}

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -207,17 +207,38 @@ export const FadeContainer = styled.div`
 
 const gradients = ['linear-gradient(to right, #fc466b, #3f5efb)', 'linear-gradient(to right, #6a11cb, #2575fc)', 'linear-gradient(to right, #ff7e5f, #feb47b)'];
 
-export const coloredCard = index => {
-  const exactIndex = index % gradients.length;
-  const randomIndex = Math.floor(Math.random() * gradients.length);
+const roleGradients = {
+  ed: 'linear-gradient(135deg, #b5336a 0%, #e91e63 60%, #f06292 100%)',
+  ag: 'linear-gradient(135deg, #1a237e 0%, #1565c0 60%, #1e88e5 100%)',
+  ip: 'linear-gradient(135deg, #004d40 0%, #00695c 60%, #00897b 100%)',
+  pp: 'linear-gradient(135deg, #4527a0 0%, #6a1b9a 60%, #8e24aa 100%)',
+};
+
+export const roleAccentColors = {
+  ed: '#e91e63',
+  ag: '#1565c0',
+  ip: '#00897b',
+  pp: '#8e24aa',
+};
+
+export const coloredCard = (indexOrRole) => {
+  if (typeof indexOrRole === 'string' && roleGradients[indexOrRole]) {
+    return {
+      position: 'relative',
+      background: roleGradients[indexOrRole],
+      width: '100%',
+      marginTop: '10px',
+      marginBottom: '20px',
+    };
+  }
+
+  const index = indexOrRole;
+  const exactIndex = typeof index === 'number' ? index % gradients.length : Math.floor(Math.random() * gradients.length);
 
   return {
     position: 'relative',
-    background: index !== undefined ? gradients[exactIndex] : gradients[randomIndex],
+    background: gradients[exactIndex],
     width: '100%',
-    // margin: index !== undefined
-    // ? '5px'
-    // : 0,
     marginTop: index !== undefined ? '10px' : 0,
     marginBottom: index !== undefined ? '20px' : '10px',
   };


### PR DESCRIPTION
- Add role-based gradient palettes: ed=pink, ag=blue, ip=teal, pp=purple
- Cards now take the gradient of their role instead of list index
- Reduce action buttons from 7 to 5 (remove 2 always-empty placeholder buttons)
- Shrink button size 40px→30px with tighter gaps
- Move compare/more/export buttons inline with the action row (no more absolute positioning)
- Add role badge pill in card header for quick visual identification
- Tighten all section gaps and padding for denser data display

https://claude.ai/code/session_01DUYbp9XeTmqBHL5jdSw6QJ