### PR TITLE
Remove unused Contact styled component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1102,16 +1102,6 @@ const MoreInfo = styled.div`
   color: #3e3f4c;
 `;
 
-const Contact = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  font-size: 14px;
-  border-top: ${props => (props.$withBorder ? `1px solid rgba(0, 0, 0, 0.08)` : 'none')};
-  padding-top: ${props => (props.$withBorder ? '10px' : '0')};
-  margin-top: ${props => (props.$withBorder ? '6px' : '0')};
-`;
-
 const Icons = styled.div`
   display: flex;
   gap: 5px;


### PR DESCRIPTION
### Motivation
- Remove the unused `Contact` styled component in `src/components/Matching.jsx` to resolve the `no-unused-vars` ESLint warning and eliminate dead code.

### Description
- Deleted the `const Contact = styled.div`... block from `src/components/Matching.jsx` so `MoreInfo` now flows directly into the `Icons` styled component.

### Testing
- Ran `npm run lint:js -- src/components/Matching.jsx` and the linter completed with no `no-unused-vars` errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff241338dc8326ba5428aa298355cb)