### PR TITLE
Use indexed searchKey sets for matching filters and preserve canonical userId

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -164,6 +164,10 @@ const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BA
         }
 
         if (!hasAnyData) return null;
+        // Keep the Firebase node key as the canonical card id. Some newUsers cards
+        // contain a nested `userId` map used for search buckets, and that map must
+        // not overwrite the id that matching uses for rendering and filtering.
+        merged.userId = userId;
         return {
           merged,
           hasNewUser: newUserResult.status === 'fulfilled' && newUserResult.value.exists(),
@@ -331,6 +335,33 @@ const buildAllowedRoleIdsFromSearchKey = (roleFilters, roleIndexSets) => {
   return { allowedIds, allIndexedIds };
 };
 
+
+const buildAllowedIdsFromIndexSets = (filterGroup, filterIndexSets, indexName, optionBuckets) => {
+  if (!isFilterGroupActive(filterGroup) || !filterIndexSets?.[indexName]) return null;
+
+  const allIndexedIds = new Set();
+  const allowedIds = new Set();
+
+  Object.entries(optionBuckets || {}).forEach(([option, buckets]) => {
+    const bucketList = Array.isArray(buckets) ? buckets : [buckets];
+    bucketList.forEach(bucket => {
+      const bucketSet = filterIndexSets[indexName]?.[bucket];
+      if (!(bucketSet instanceof Set)) return;
+      bucketSet.forEach(id => {
+        allIndexedIds.add(id);
+        if (filterGroup[option]) allowedIds.add(id);
+      });
+    });
+  });
+
+  return allIndexedIds.size ? { allowedIds, allIndexedIds } : null;
+};
+
+const shouldKeepByIndexedFilter = (user, indexedMeta) => {
+  if (!indexedMeta || !user?.userId || !indexedMeta.allIndexedIds.has(user.userId)) return null;
+  return indexedMeta.allowedIds.has(user.userId);
+};
+
 const toRoleCategory = (user, roleIndexSets = null) => {
   const indexedCategory = resolveRoleCategoryFromSearchKey(user?.userId, roleIndexSets);
   if (indexedCategory) return indexedCategory;
@@ -436,40 +467,90 @@ const getMatchingFiltersWithoutSearchKeyGroups = filters => {
   return base;
 };
 
-const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = null) => {
+const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = null, filterIndexSets = null) => {
   const activeFilters = filters || {};
   const roleIndexFilterMeta = isFilterGroupActive(activeFilters.userRole)
     ? buildAllowedRoleIdsFromSearchKey(activeFilters.userRole, roleIndexSets)
     : null;
+  const roleFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.userRole, filterIndexSets, 'role', {
+    ed: ['ed'],
+    ag: ['ag'],
+    ip: ['ip'],
+    other: ['sm', 'cl', 'pp', '?', 'no'],
+  });
+  const maritalFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.maritalStatus, filterIndexSets, 'maritalStatus', {
+    married: ['married', '+'],
+    unmarried: ['unmarried', '-'],
+    other: ['other', '?'],
+    empty: ['empty', 'no'],
+  });
+  const bloodGroupFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.bloodGroup, filterIndexSets, 'blood', {
+    1: ['1', '1+', '1-'],
+    2: ['2', '2+', '2-'],
+    3: ['3', '3+', '3-'],
+    4: ['4', '4+', '4-'],
+    other: ['?', '+', '-'],
+    empty: ['no'],
+  });
+  const rhFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.rh, filterIndexSets, 'blood', {
+    '+': ['+', '1+', '2+', '3+', '4+'],
+    '-': ['-', '1-', '2-', '3-', '4-'],
+    other: ['?'],
+    empty: ['no'],
+  });
+  const ageFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.age, filterIndexSets, 'age', {
+    le25: ['le21', '22_25', 'le25'],
+    '26_30': ['26_30'],
+    '31_33': ['31_33', '31_35'],
+    '34_36': ['34_36', '31_35', '36_38'],
+    '37_plus': ['37_plus', '37_42', '39_41', '42_plus', '43_plus'],
+    other: ['other', '?', 'no'],
+  });
 
   return users.filter(user => {
     if (isFilterGroupActive(activeFilters.userRole)) {
-      if (roleIndexFilterMeta && user?.userId && roleIndexFilterMeta.allIndexedIds.has(user.userId)) {
-        if (!roleIndexFilterMeta.allowedIds.has(user.userId)) return false;
-      } else {
-      const category = toRoleCategory(user, roleIndexSets);
-      if (!activeFilters.userRole[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, roleFilterMeta) ?? shouldKeepByIndexedFilter(user, roleIndexFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toRoleCategory(user, roleIndexSets);
+        if (!activeFilters.userRole[category]) return false;
       }
     }
 
     if (isFilterGroupActive(activeFilters.maritalStatus)) {
-      const category = toMaritalStatusCategory(user);
-      if (!activeFilters.maritalStatus[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, maritalFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toMaritalStatusCategory(user);
+        if (!activeFilters.maritalStatus[category]) return false;
+      }
     }
 
     if (isFilterGroupActive(activeFilters.bloodGroup)) {
-      const category = toBloodGroupCategory(user);
-      if (!activeFilters.bloodGroup[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, bloodGroupFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toBloodGroupCategory(user);
+        if (!activeFilters.bloodGroup[category]) return false;
+      }
     }
 
     if (isFilterGroupActive(activeFilters.rh)) {
-      const category = toRhCategory(user);
-      if (!activeFilters.rh[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, rhFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toRhCategory(user);
+        if (!activeFilters.rh[category]) return false;
+      }
     }
 
     if (isFilterGroupActive(activeFilters.age)) {
-      const category = toAgeCategory(user);
-      if (!activeFilters.age[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, ageFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toAgeCategory(user);
+        if (!activeFilters.age[category]) return false;
+      }
     }
 
     return true;
@@ -1665,8 +1746,8 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
 };
 
 
-const INITIAL_LOAD = 6;
-const LOAD_MORE = 6;
+const INITIAL_LOAD = 5;
+const LOAD_MORE = 5;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
 const COLLECTION_SOURCE_KEY = 'matchingCollectionSource';
@@ -1761,6 +1842,7 @@ const Matching = () => {
   );
   const [additionalNewUsers, setAdditionalNewUsers] = useState([]);
   const [roleIndexSets, setRoleIndexSets] = useState(null);
+  const [matchingFilterIndexSets, setMatchingFilterIndexSets] = useState(null);
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
   const parsedAdditionalAccessRules = useMemo(
@@ -2117,6 +2199,67 @@ const Matching = () => {
     };
   }, []);
 
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadMatchingFilterIndexSets = async () => {
+      if (collectionSource !== 'newUsers' || !ownerId) {
+        setMatchingFilterIndexSets(null);
+        return;
+      }
+
+      const ruleSetCount = Math.max(
+        1,
+        String(currentAdditionalAccessRules || '')
+          .split(/\r?\n\s*\r?\n+/)
+          .map(item => item.trim())
+          .filter(Boolean).length
+      );
+      const candidateSetKeys = Array.from(
+        { length: ruleSetCount },
+        (_, index) => `${ownerId}_${index + 1}`
+      );
+
+      try {
+        const snapshots = await Promise.all(
+          [...new Set(candidateSetKeys)].map(async setKey => {
+            const snap = await get(refDb(database, `searchKeySets/${setKey}`));
+            return snap.exists() ? snap.val() || {} : null;
+          })
+        );
+
+        if (cancelled) return;
+
+        const nextIndexSets = {};
+        snapshots.filter(Boolean).forEach(setNode => {
+          Object.entries(setNode || {}).forEach(([indexName, buckets]) => {
+            if (!buckets || typeof buckets !== 'object' || Array.isArray(buckets)) return;
+            if (!nextIndexSets[indexName]) nextIndexSets[indexName] = {};
+            Object.entries(buckets).forEach(([bucketName, bucketUsers]) => {
+              if (!bucketUsers || typeof bucketUsers !== 'object' || Array.isArray(bucketUsers)) return;
+              if (!nextIndexSets[indexName][bucketName]) nextIndexSets[indexName][bucketName] = new Set();
+              Object.keys(bucketUsers).forEach(userId => {
+                if (userId) nextIndexSets[indexName][bucketName].add(userId);
+              });
+            });
+          });
+        });
+
+        setMatchingFilterIndexSets(Object.keys(nextIndexSets).length ? nextIndexSets : null);
+      } catch (error) {
+        console.error('Failed to load matching filter index from searchKeySets', error);
+        if (!cancelled) setMatchingFilterIndexSets(null);
+      }
+    };
+
+    loadMatchingFilterIndexSets();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionSource, currentAdditionalAccessRules, ownerId]);
+
   const fetchChunk = React.useCallback(
     async (
       limit,
@@ -2146,7 +2289,8 @@ const Matching = () => {
                 favoriteUsersRef.current
               ).map(([, u]) => u),
               filters,
-              roleIndexSets
+              roleIndexSets,
+              collectionSource === 'newUsers' ? matchingFilterIndexSets : null
             ).filter(
               u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
             )
@@ -2187,7 +2331,7 @@ const Matching = () => {
         excludedCount,
       };
     },
-    [collectionSource, filters, isAdmin, roleIndexSets]
+    [collectionSource, filters, isAdmin, roleIndexSets, matchingFilterIndexSets]
   );
 
   const loadInitial = React.useCallback(async () => {
@@ -2568,7 +2712,8 @@ const Matching = () => {
       favoriteUsers
     ).map(([, u]) => u),
     filters,
-    roleIndexSets
+    roleIndexSets,
+    collectionSource === 'newUsers' ? matchingFilterIndexSets : null
   ).filter(u => isAllowedIdForCollection(u.userId, collectionSource));
 
   useEffect(() => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1461,6 +1461,9 @@ export const fetchUsersByIds = async ids => {
             ...(newSnap.exists() ? newSnap.val() : {}),
             ...(userSnap.exists() ? userSnap.val() : {}),
           };
+          // Preserve the database node key as the canonical id even when profile
+          // data has a nested `userId` object for searchKey buckets.
+          data.userId = id;
           return Object.keys(data).length > 1 ? [id, data] : null;
         })
       )

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -19,6 +19,7 @@ import {
 } from './additionalAccessRules';
 import {
   getCachedAdditionalRulesSetIndex,
+  getCachedSearchKeyPayload,
   peekCachedSearchKeyPayload,
   saveCachedAdditionalRulesSetIndex,
 } from './searchKeyCache';
@@ -882,37 +883,66 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
 
       const setKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
       if (!setKey) return null;
-      const paths = Object.entries(indexBuckets).flatMap(([indexName, values]) =>
-        values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
-      );
-      return { setKey, paths, indexBuckets };
+
+      return { setKey, candidateSetKeys: [setKey], indexBuckets };
     })
     .filter(Boolean);
   if (!setEntries.length) return null;
+
+  const collectIdsFromSetNode = (setNode, indexBuckets) => {
+    if (!setNode || typeof setNode !== 'object' || Array.isArray(setNode)) return null;
+
+    const userIds = new Set();
+    const bucketPaths = [];
+    let foundAnyBucket = false;
+
+    Object.entries(indexBuckets || {}).forEach(([indexName, values]) => {
+      values.forEach(value => {
+        const bucketValue = setNode?.[indexName]?.[value];
+        if (!bucketValue || typeof bucketValue !== 'object' || Array.isArray(bucketValue)) return;
+
+        foundAnyBucket = true;
+        bucketPaths.push(`${indexName}/${value}`);
+        Object.keys(bucketValue).forEach(userId => {
+          if (userId) userIds.add(userId);
+        });
+      });
+    });
+
+    if (!foundAnyBucket) return null;
+    return { userIds, bucketPaths };
+  };
 
   const buildIndexedResultFromSetsMap = setsMap => {
     if (!setsMap || typeof setsMap !== 'object') return null;
 
     const userIds = new Set();
     const setKeys = [];
-    for (const entry of setEntries) {
-      const setNode = setsMap?.[entry.setKey];
-      if (!setNode || typeof setNode !== 'object') return null;
+    let resolvedEntries = 0;
 
-      Object.entries(entry.indexBuckets).forEach(([indexName, values]) => {
-        values.forEach(value => {
-          const bucketValue = setNode?.[indexName]?.[value];
-          if (!bucketValue || typeof bucketValue !== 'object') {
-            throw new Error('MISSING_BUCKET');
-          }
-          setKeys.push(`${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`);
-          Object.keys(bucketValue).forEach(userId => {
-            if (userId) userIds.add(userId);
-          });
-        });
+    for (const entry of setEntries) {
+      let resolved = null;
+      let resolvedSetKey = '';
+
+      for (const candidateSetKey of entry.candidateSetKeys) {
+        const candidateNode = setsMap?.[candidateSetKey];
+        const candidateResult = collectIdsFromSetNode(candidateNode, entry.indexBuckets);
+        if (candidateResult) {
+          resolved = candidateResult;
+          resolvedSetKey = candidateSetKey;
+          break;
+        }
+      }
+
+      if (!resolved) return null;
+      resolvedEntries += 1;
+      resolved.userIds.forEach(userId => userIds.add(userId));
+      resolved.bucketPaths.forEach(bucketPath => {
+        setKeys.push(`${SEARCH_KEY_SETS_ROOT}/${resolvedSetKey}/${bucketPath}`);
       });
     }
 
+    if (resolvedEntries === 0) return null;
     return {
       setKeys,
       userIds: [...userIds],
@@ -921,20 +951,61 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   };
 
   if (cachedIndexedSet) {
-    try {
-      const cachedResult = buildIndexedResultFromSetsMap(cachedIndexedSet);
-      if (cachedResult) return cachedResult;
-    } catch {
-      // ignore malformed or incomplete cache and fallback to searchKey cache payload lookup
+    const cachedResult = buildIndexedResultFromSetsMap(cachedIndexedSet);
+    if (cachedResult) return cachedResult;
+  }
+
+  const ownerSetSnapshots = await Promise.all(
+    [...new Set(setEntries.flatMap(entry => entry.candidateSetKeys))].map(async setKey => {
+      const payload = await getCachedSearchKeyPayload(`${SEARCH_KEY_SETS_ROOT}/${setKey}`, async () => {
+        const snapshot = await get(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`));
+        return {
+          exists: snapshot.exists(),
+          value: snapshot.exists() ? snapshot.val() || {} : null,
+        };
+      });
+      return [setKey, payload];
+    })
+  );
+
+  const setsMap = ownerSetSnapshots.reduce((acc, [setKey, payload]) => {
+    if (payload?.exists && payload.value && typeof payload.value === 'object') {
+      acc[setKey] = payload.value;
     }
+    return acc;
+  }, {});
+
+  const firebaseResult = buildIndexedResultFromSetsMap(setsMap);
+  if (firebaseResult) {
+    saveCachedAdditionalRulesSetIndex({
+      rawRules,
+      accessUserId: normalizedAccessUserId,
+      setsMap,
+    });
+    return firebaseResult;
   }
 
   const payloadsBySet = await Promise.all(
     setEntries.map(async entry => {
-      const payloads = await Promise.all(
-        entry.paths.map(path => Promise.resolve(peekCachedSearchKeyPayload(path)))
+      const candidatePayloadGroups = await Promise.all(
+        entry.candidateSetKeys.map(async setKey => {
+          const paths = Object.entries(entry.indexBuckets).flatMap(([indexName, values]) =>
+            values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
+          );
+          const payloads = await Promise.all(
+            paths.map(path => getCachedSearchKeyPayload(path, async () => {
+              const snapshot = await get(ref(database, path));
+              return {
+                exists: snapshot.exists(),
+                value: snapshot.exists() ? snapshot.val() || {} : null,
+              };
+            }))
+          );
+          return { setKey, paths, payloads };
+        })
       );
-      return { setKey: entry.setKey, paths: entry.paths, payloads };
+      const completeGroup = candidatePayloadGroups.find(item => item.payloads.every(payload => payload?.exists));
+      return completeGroup || candidatePayloadGroups[0];
     })
   );
 
@@ -973,10 +1044,10 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   }
 
   const userIds = new Set();
-  const setsMap = {};
+  const nextSetsMap = {};
   payloadsBySet.forEach(item => {
-    setsMap[item.setKey] = setsMap[item.setKey] && typeof setsMap[item.setKey] === 'object'
-      ? setsMap[item.setKey]
+    nextSetsMap[item.setKey] = nextSetsMap[item.setKey] && typeof nextSetsMap[item.setKey] === 'object'
+      ? nextSetsMap[item.setKey]
       : {};
     item.payloads.forEach(payload => {
       Object.keys(payload?.value || {}).forEach(userId => {
@@ -988,10 +1059,10 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       if (!setKey || !indexName || !value) return;
       const payloadValue = item.payloads[pathIndex]?.value;
       if (!payloadValue || typeof payloadValue !== 'object') return;
-      if (!setsMap[setKey][indexName] || typeof setsMap[setKey][indexName] !== 'object') {
-        setsMap[setKey][indexName] = {};
+      if (!nextSetsMap[setKey][indexName] || typeof nextSetsMap[setKey][indexName] !== 'object') {
+        nextSetsMap[setKey][indexName] = {};
       }
-      setsMap[setKey][indexName][value] = payloadValue;
+      nextSetsMap[setKey][indexName][value] = payloadValue;
     });
   });
 
@@ -1003,7 +1074,7 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   saveCachedAdditionalRulesSetIndex({
     rawRules,
     accessUserId: normalizedAccessUserId,
-    setsMap,
+    setsMap: nextSetsMap,
   });
   return result;
 };


### PR DESCRIPTION
### Motivation
- Improve matching/filtering performance and correctness by leveraging precomputed searchKey index sets for filters when loading from `newUsers` searchKey sets. 
- Ensure the canonical Firebase node key is preserved as the card `userId` so nested `userId` maps used for search buckets do not overwrite the rendering/filter id. 
- Slightly adjust initial pagination sizes for matching list rendering.

### Description
- Preserve canonical id by explicitly setting `merged.userId = userId` in `fetchUsersAndNewUsersByIds` and `data.userId = id` in `fetchUsersByIds` so database node keys are authoritative. 
- Add `buildAllowedIdsFromIndexSets` and `shouldKeepByIndexedFilter` helpers to evaluate indexed filter metadata. 
- Extend `applyMatchingSearchKeyFilters` to accept `filterIndexSets` and short-circuit filtering for `userRole`, `maritalStatus`, `bloodGroup`, `rh`, and `age` using indexed ID sets when available. 
- Load `matchingFilterIndexSets` in a new `useEffect` when `collectionSource === 'newUsers'` and `ownerId` is present by reading `searchKeySets/{ownerId}_{n}` and building in-memory bucket sets. 
- Wire `matchingFilterIndexSets` through `fetchChunk` and `filteredUsers` so `newUsers` loads use the index sets. 
- Revamp `getIndexedNewUsersIdsByRules` to support candidate set keys, collect IDs from the first matching candidate group, use `getCachedSearchKeyPayload` for cached payloads, and save improved cache results via `saveCachedAdditionalRulesSetIndex`. 
- Rename/adjust intermediate variables and fallback logic to prefer complete candidate groups and to handle missing payloads robustly. 
- Change initial pagination constants `INITIAL_LOAD` and `LOAD_MORE` from `6` to `5`.

### Testing
- Ran the project unit test suite with `npm test`, and existing tests relevant to matching, index utilities, and searchKey cache passed. 
- Ran linter with `npm run lint`, and no lint errors were reported. 
- Executed relevant integration/smoke flows for loading `newUsers` matching lists (automated tests), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9796c85c8326954a649417d713eb)