### PR TITLE
Support newUsers searchKey aliases and indexed filter sets for matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -90,7 +90,7 @@ const getRoleColors = role => ROLE_COLORS[role] || { accent: color.accent5, ligh
 const isShortId = id => typeof id === 'string' && id.length > 0 && id.length < 20;
 const isMatchingCardId = id => isValidId(id) || isShortId(id);
 const isAllowedIdForCollection = (id, collection = 'users') =>
-  collection === 'newUsers' ? isShortId(id) : isValidId(id);
+  collection === 'newUsers' ? isMatchingCardId(id) : isValidId(id);
 const filterMatchingUsers = list => list.filter(u => isMatchingCardId(u?.userId));
 
 const compareUsersByLastLogin2 = (a = {}, b = {}) =>
@@ -164,6 +164,10 @@ const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BA
         }
 
         if (!hasAnyData) return null;
+        // Keep the Firebase node key as the canonical card id. Some newUsers cards
+        // contain a nested `userId` map used for search buckets, and that map must
+        // not overwrite the id that matching uses for rendering and filtering.
+        merged.userId = userId;
         return {
           merged,
           hasNewUser: newUserResult.status === 'fulfilled' && newUserResult.value.exists(),
@@ -201,7 +205,7 @@ const fetchAdditionalNewUsersBySearchIndex = async ({ parsedRuleGroups, rawRules
       });
     }
     if (indexed?.userIds) {
-      const indexedRows = await fetchUsersAndNewUsersByIds(indexed.userIds);
+      const indexedRows = await fetchNewUsersByIndexedIds(indexed.userIds);
       return indexedRows
         .filter(row => row.hasNewUser)
         .map(row => ({ ...row.merged, __sourceCollection: 'newUsers' }));
@@ -248,8 +252,8 @@ const fetchAdditionalNewUsersBySearchIndex = async ({ parsedRuleGroups, rawRules
     const newUsersMap = newUsersSnapshot.val() || {};
     return Object.entries(newUsersMap)
       .map(([userId, userData]) => ({
-        userId,
         ...(userData && typeof userData === 'object' ? userData : {}),
+        userId,
       }))
       .filter(user => isUserAllowedByAnyAdditionalAccessRule(user, parsedRuleGroups))
       .map(user => ({ ...user, __sourceCollection: 'newUsers' }));
@@ -260,11 +264,46 @@ const fetchAdditionalNewUsersBySearchIndex = async ({ parsedRuleGroups, rawRules
     .filter(row => row.hasNewUser)
     .filter(row =>
       isUserAllowedByAnyAdditionalAccessRule(
-        { userId: row.merged.userId, ...(row.newUserData || {}) },
+        { ...(row.newUserData || {}), userId: row.merged.userId },
         parsedRuleGroups
       )
     )
     .map(row => ({ ...row.merged, __sourceCollection: 'newUsers' }));
+};
+
+
+const hasIndexedUserIdAlias = (userData, allowedIds) => {
+  if (!userData || typeof userData !== 'object' || !(allowedIds instanceof Set)) return false;
+
+  const rawUserId = userData.userId;
+  if (typeof rawUserId === 'string' && allowedIds.has(rawUserId)) return true;
+  if (!rawUserId || typeof rawUserId !== 'object' || Array.isArray(rawUserId)) return false;
+
+  return Object.values(rawUserId).some(bucketValue => {
+    if (!bucketValue || typeof bucketValue !== 'object' || Array.isArray(bucketValue)) return false;
+    return Object.keys(bucketValue).some(aliasId => allowedIds.has(aliasId));
+  });
+};
+
+const fetchNewUsersByIndexedIds = async ids => {
+  const directRows = await fetchUsersAndNewUsersByIds(ids);
+  const foundIds = new Set(directRows.filter(row => row.hasNewUser).map(row => row.merged.userId));
+  const missingIds = ids.filter(id => id && !foundIds.has(id));
+  if (missingIds.length === 0) return directRows;
+
+  const missingSet = new Set(missingIds);
+  const snapshot = await get(refDb(database, 'newUsers'));
+  if (!snapshot.exists()) return directRows;
+
+  const aliasRows = Object.entries(snapshot.val() || {})
+    .filter(([userId, userData]) => !foundIds.has(userId) && hasIndexedUserIdAlias(userData, missingSet))
+    .map(([userId, userData]) => ({
+      merged: { ...(userData && typeof userData === 'object' ? userData : {}), userId },
+      hasNewUser: true,
+      newUserData: userData && typeof userData === 'object' ? userData : {},
+    }));
+
+  return [...directRows, ...aliasRows];
 };
 
 const isSameCursor = (a, b) => {
@@ -329,6 +368,33 @@ const buildAllowedRoleIdsFromSearchKey = (roleFilters, roleIndexSets) => {
   }
 
   return { allowedIds, allIndexedIds };
+};
+
+
+const buildAllowedIdsFromIndexSets = (filterGroup, filterIndexSets, indexName, optionBuckets) => {
+  if (!isFilterGroupActive(filterGroup) || !filterIndexSets?.[indexName]) return null;
+
+  const allIndexedIds = new Set();
+  const allowedIds = new Set();
+
+  Object.entries(optionBuckets || {}).forEach(([option, buckets]) => {
+    const bucketList = Array.isArray(buckets) ? buckets : [buckets];
+    bucketList.forEach(bucket => {
+      const bucketSet = filterIndexSets[indexName]?.[bucket];
+      if (!(bucketSet instanceof Set)) return;
+      bucketSet.forEach(id => {
+        allIndexedIds.add(id);
+        if (filterGroup[option]) allowedIds.add(id);
+      });
+    });
+  });
+
+  return allIndexedIds.size ? { allowedIds, allIndexedIds } : null;
+};
+
+const shouldKeepByIndexedFilter = (user, indexedMeta) => {
+  if (!indexedMeta || !user?.userId || !indexedMeta.allIndexedIds.has(user.userId)) return null;
+  return indexedMeta.allowedIds.has(user.userId);
 };
 
 const toRoleCategory = (user, roleIndexSets = null) => {
@@ -436,40 +502,90 @@ const getMatchingFiltersWithoutSearchKeyGroups = filters => {
   return base;
 };
 
-const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = null) => {
+const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = null, filterIndexSets = null) => {
   const activeFilters = filters || {};
   const roleIndexFilterMeta = isFilterGroupActive(activeFilters.userRole)
     ? buildAllowedRoleIdsFromSearchKey(activeFilters.userRole, roleIndexSets)
     : null;
+  const roleFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.userRole, filterIndexSets, 'role', {
+    ed: ['ed'],
+    ag: ['ag'],
+    ip: ['ip'],
+    other: ['sm', 'cl', 'pp', '?', 'no'],
+  });
+  const maritalFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.maritalStatus, filterIndexSets, 'maritalStatus', {
+    married: ['married', '+'],
+    unmarried: ['unmarried', '-'],
+    other: ['other', '?'],
+    empty: ['empty', 'no'],
+  });
+  const bloodGroupFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.bloodGroup, filterIndexSets, 'blood', {
+    1: ['1', '1+', '1-'],
+    2: ['2', '2+', '2-'],
+    3: ['3', '3+', '3-'],
+    4: ['4', '4+', '4-'],
+    other: ['?', '+', '-'],
+    empty: ['no'],
+  });
+  const rhFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.rh, filterIndexSets, 'blood', {
+    '+': ['+', '1+', '2+', '3+', '4+'],
+    '-': ['-', '1-', '2-', '3-', '4-'],
+    other: ['?'],
+    empty: ['no'],
+  });
+  const ageFilterMeta = buildAllowedIdsFromIndexSets(activeFilters.age, filterIndexSets, 'age', {
+    le25: ['le21', '22_25', 'le25'],
+    '26_30': ['26_30'],
+    '31_33': ['31_33', '31_35'],
+    '34_36': ['34_36', '31_35', '36_38'],
+    '37_plus': ['37_plus', '37_42', '39_41', '42_plus', '43_plus'],
+    other: ['other', '?', 'no'],
+  });
 
   return users.filter(user => {
     if (isFilterGroupActive(activeFilters.userRole)) {
-      if (roleIndexFilterMeta && user?.userId && roleIndexFilterMeta.allIndexedIds.has(user.userId)) {
-        if (!roleIndexFilterMeta.allowedIds.has(user.userId)) return false;
-      } else {
-      const category = toRoleCategory(user, roleIndexSets);
-      if (!activeFilters.userRole[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, roleFilterMeta) ?? shouldKeepByIndexedFilter(user, roleIndexFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toRoleCategory(user, roleIndexSets);
+        if (!activeFilters.userRole[category]) return false;
       }
     }
 
     if (isFilterGroupActive(activeFilters.maritalStatus)) {
-      const category = toMaritalStatusCategory(user);
-      if (!activeFilters.maritalStatus[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, maritalFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toMaritalStatusCategory(user);
+        if (!activeFilters.maritalStatus[category]) return false;
+      }
     }
 
     if (isFilterGroupActive(activeFilters.bloodGroup)) {
-      const category = toBloodGroupCategory(user);
-      if (!activeFilters.bloodGroup[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, bloodGroupFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toBloodGroupCategory(user);
+        if (!activeFilters.bloodGroup[category]) return false;
+      }
     }
 
     if (isFilterGroupActive(activeFilters.rh)) {
-      const category = toRhCategory(user);
-      if (!activeFilters.rh[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, rhFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toRhCategory(user);
+        if (!activeFilters.rh[category]) return false;
+      }
     }
 
     if (isFilterGroupActive(activeFilters.age)) {
-      const category = toAgeCategory(user);
-      if (!activeFilters.age[category]) return false;
+      const indexedKeep = shouldKeepByIndexedFilter(user, ageFilterMeta);
+      if (indexedKeep === false) return false;
+      if (indexedKeep === null) {
+        const category = toAgeCategory(user);
+        if (!activeFilters.age[category]) return false;
+      }
     }
 
     return true;
@@ -1665,8 +1781,8 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
 };
 
 
-const INITIAL_LOAD = 6;
-const LOAD_MORE = 6;
+const INITIAL_LOAD = 5;
+const LOAD_MORE = 5;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
 const COLLECTION_SOURCE_KEY = 'matchingCollectionSource';
@@ -1721,7 +1837,7 @@ const fetchUsersByLastLogin2FromCollection = async (collection = 'users', limit 
   const lastEntry = entries[entries.length - 1];
 
   return {
-    users: entries.map(([id, data]) => ({ userId: id, ...data })),
+    users: entries.map(([id, data]) => ({ ...(data || {}), userId: id })),
     lastKey: lastEntry
       ? { date: lastEntry[1].lastLogin2 || '', userId: lastEntry[0] }
       : null,
@@ -1761,6 +1877,7 @@ const Matching = () => {
   );
   const [additionalNewUsers, setAdditionalNewUsers] = useState([]);
   const [roleIndexSets, setRoleIndexSets] = useState(null);
+  const [matchingFilterIndexSets, setMatchingFilterIndexSets] = useState(null);
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
   const parsedAdditionalAccessRules = useMemo(
@@ -2117,6 +2234,67 @@ const Matching = () => {
     };
   }, []);
 
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadMatchingFilterIndexSets = async () => {
+      if (collectionSource !== 'newUsers' || !ownerId) {
+        setMatchingFilterIndexSets(null);
+        return;
+      }
+
+      const ruleSetCount = Math.max(
+        1,
+        String(currentAdditionalAccessRules || '')
+          .split(/\r?\n\s*\r?\n+/)
+          .map(item => item.trim())
+          .filter(Boolean).length
+      );
+      const candidateSetKeys = Array.from(
+        { length: ruleSetCount },
+        (_, index) => `${ownerId}_${index + 1}`
+      );
+
+      try {
+        const snapshots = await Promise.all(
+          [...new Set(candidateSetKeys)].map(async setKey => {
+            const snap = await get(refDb(database, `searchKeySets/${setKey}`));
+            return snap.exists() ? snap.val() || {} : null;
+          })
+        );
+
+        if (cancelled) return;
+
+        const nextIndexSets = {};
+        snapshots.filter(Boolean).forEach(setNode => {
+          Object.entries(setNode || {}).forEach(([indexName, buckets]) => {
+            if (!buckets || typeof buckets !== 'object' || Array.isArray(buckets)) return;
+            if (!nextIndexSets[indexName]) nextIndexSets[indexName] = {};
+            Object.entries(buckets).forEach(([bucketName, bucketUsers]) => {
+              if (!bucketUsers || typeof bucketUsers !== 'object' || Array.isArray(bucketUsers)) return;
+              if (!nextIndexSets[indexName][bucketName]) nextIndexSets[indexName][bucketName] = new Set();
+              Object.keys(bucketUsers).forEach(userId => {
+                if (userId) nextIndexSets[indexName][bucketName].add(userId);
+              });
+            });
+          });
+        });
+
+        setMatchingFilterIndexSets(Object.keys(nextIndexSets).length ? nextIndexSets : null);
+      } catch (error) {
+        console.error('Failed to load matching filter index from searchKeySets', error);
+        if (!cancelled) setMatchingFilterIndexSets(null);
+      }
+    };
+
+    loadMatchingFilterIndexSets();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionSource, currentAdditionalAccessRules, ownerId]);
+
   const fetchChunk = React.useCallback(
     async (
       limit,
@@ -2146,7 +2324,8 @@ const Matching = () => {
                 favoriteUsersRef.current
               ).map(([, u]) => u),
               filters,
-              roleIndexSets
+              roleIndexSets,
+              collectionSource === 'newUsers' ? matchingFilterIndexSets : null
             ).filter(
               u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
             )
@@ -2187,7 +2366,7 @@ const Matching = () => {
         excludedCount,
       };
     },
-    [collectionSource, filters, isAdmin, roleIndexSets]
+    [collectionSource, filters, isAdmin, roleIndexSets, matchingFilterIndexSets]
   );
 
   const loadInitial = React.useCallback(async () => {
@@ -2568,7 +2747,8 @@ const Matching = () => {
       favoriteUsers
     ).map(([, u]) => u),
     filters,
-    roleIndexSets
+    roleIndexSets,
+    collectionSource === 'newUsers' ? matchingFilterIndexSets : null
   ).filter(u => isAllowedIdForCollection(u.userId, collectionSource));
 
   useEffect(() => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1461,6 +1461,9 @@ export const fetchUsersByIds = async ids => {
             ...(newSnap.exists() ? newSnap.val() : {}),
             ...(userSnap.exists() ? userSnap.val() : {}),
           };
+          // Preserve the database node key as the canonical id even when profile
+          // data has a nested `userId` object for searchKey buckets.
+          data.userId = id;
           return Object.keys(data).length > 1 ? [id, data] : null;
         })
       )

--- a/src/utils/additionalAccessRules.js
+++ b/src/utils/additionalAccessRules.js
@@ -232,6 +232,17 @@ const toRoleBucket = user => {
 };
 
 const toUserIdBuckets = userId => {
+  if (userId && typeof userId === 'object' && !Array.isArray(userId)) {
+    const buckets = Object.entries(userId).reduce((acc, [bucketName, bucketValue]) => {
+      if (!bucketValue) return acc;
+      if (typeof bucketValue === 'object' && !Array.isArray(bucketValue) && Object.keys(bucketValue).length === 0) return acc;
+      const normalizedBucket = String(bucketName || '').trim().toLowerCase();
+      if (normalizedBucket) acc.push(normalizedBucket);
+      return acc;
+    }, []);
+    return buckets.length ? [...new Set(buckets)] : ['other'];
+  }
+
   const normalized = String(userId || '').trim().toLowerCase();
   if (!normalized) return ['other'];
   const buckets = [];

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -882,37 +882,66 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
 
       const setKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
       if (!setKey) return null;
-      const paths = Object.entries(indexBuckets).flatMap(([indexName, values]) =>
-        values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
-      );
-      return { setKey, paths, indexBuckets };
+
+      return { setKey, candidateSetKeys: [setKey], indexBuckets };
     })
     .filter(Boolean);
   if (!setEntries.length) return null;
+
+  const collectIdsFromSetNode = (setNode, indexBuckets) => {
+    if (!setNode || typeof setNode !== 'object' || Array.isArray(setNode)) return null;
+
+    const userIds = new Set();
+    const bucketPaths = [];
+    let foundAnyBucket = false;
+
+    Object.entries(indexBuckets || {}).forEach(([indexName, values]) => {
+      values.forEach(value => {
+        const bucketValue = setNode?.[indexName]?.[value];
+        if (!bucketValue || typeof bucketValue !== 'object' || Array.isArray(bucketValue)) return;
+
+        foundAnyBucket = true;
+        bucketPaths.push(`${indexName}/${value}`);
+        Object.keys(bucketValue).forEach(userId => {
+          if (userId) userIds.add(userId);
+        });
+      });
+    });
+
+    if (!foundAnyBucket) return null;
+    return { userIds, bucketPaths };
+  };
 
   const buildIndexedResultFromSetsMap = setsMap => {
     if (!setsMap || typeof setsMap !== 'object') return null;
 
     const userIds = new Set();
     const setKeys = [];
-    for (const entry of setEntries) {
-      const setNode = setsMap?.[entry.setKey];
-      if (!setNode || typeof setNode !== 'object') return null;
+    let resolvedEntries = 0;
 
-      Object.entries(entry.indexBuckets).forEach(([indexName, values]) => {
-        values.forEach(value => {
-          const bucketValue = setNode?.[indexName]?.[value];
-          if (!bucketValue || typeof bucketValue !== 'object') {
-            throw new Error('MISSING_BUCKET');
-          }
-          setKeys.push(`${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`);
-          Object.keys(bucketValue).forEach(userId => {
-            if (userId) userIds.add(userId);
-          });
-        });
+    for (const entry of setEntries) {
+      let resolved = null;
+      let resolvedSetKey = '';
+
+      for (const candidateSetKey of entry.candidateSetKeys) {
+        const candidateNode = setsMap?.[candidateSetKey];
+        const candidateResult = collectIdsFromSetNode(candidateNode, entry.indexBuckets);
+        if (candidateResult) {
+          resolved = candidateResult;
+          resolvedSetKey = candidateSetKey;
+          break;
+        }
+      }
+
+      if (!resolved) return null;
+      resolvedEntries += 1;
+      resolved.userIds.forEach(userId => userIds.add(userId));
+      resolved.bucketPaths.forEach(bucketPath => {
+        setKeys.push(`${SEARCH_KEY_SETS_ROOT}/${resolvedSetKey}/${bucketPath}`);
       });
     }
 
+    if (resolvedEntries === 0) return null;
     return {
       setKeys,
       userIds: [...userIds],
@@ -921,20 +950,61 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   };
 
   if (cachedIndexedSet) {
-    try {
-      const cachedResult = buildIndexedResultFromSetsMap(cachedIndexedSet);
-      if (cachedResult) return cachedResult;
-    } catch {
-      // ignore malformed or incomplete cache and fallback to searchKey cache payload lookup
+    const cachedResult = buildIndexedResultFromSetsMap(cachedIndexedSet);
+    if (cachedResult) return cachedResult;
+  }
+
+  const ownerSetSnapshots = await Promise.all(
+    [...new Set(setEntries.flatMap(entry => entry.candidateSetKeys))].map(async setKey => {
+      const snapshot = await get(ref(database, `${SEARCH_KEY_SETS_ROOT}/${setKey}`));
+      return [
+        setKey,
+        {
+          exists: snapshot.exists(),
+          value: snapshot.exists() ? snapshot.val() || {} : null,
+        },
+      ];
+    })
+  );
+
+  const setsMap = ownerSetSnapshots.reduce((acc, [setKey, payload]) => {
+    if (payload?.exists && payload.value && typeof payload.value === 'object') {
+      acc[setKey] = payload.value;
     }
+    return acc;
+  }, {});
+
+  const firebaseResult = buildIndexedResultFromSetsMap(setsMap);
+  if (firebaseResult) {
+    saveCachedAdditionalRulesSetIndex({
+      rawRules,
+      accessUserId: normalizedAccessUserId,
+      setsMap,
+    });
+    return firebaseResult;
   }
 
   const payloadsBySet = await Promise.all(
     setEntries.map(async entry => {
-      const payloads = await Promise.all(
-        entry.paths.map(path => Promise.resolve(peekCachedSearchKeyPayload(path)))
+      const candidatePayloadGroups = await Promise.all(
+        entry.candidateSetKeys.map(async setKey => {
+          const paths = Object.entries(entry.indexBuckets).flatMap(([indexName, values]) =>
+            values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
+          );
+          const payloads = await Promise.all(
+            paths.map(async path => {
+              const snapshot = await get(ref(database, path));
+              return {
+                exists: snapshot.exists(),
+                value: snapshot.exists() ? snapshot.val() || {} : null,
+              };
+            })
+          );
+          return { setKey, paths, payloads };
+        })
       );
-      return { setKey: entry.setKey, paths: entry.paths, payloads };
+      const completeGroup = candidatePayloadGroups.find(item => item.payloads.every(payload => payload?.exists));
+      return completeGroup || candidatePayloadGroups[0];
     })
   );
 
@@ -973,10 +1043,10 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   }
 
   const userIds = new Set();
-  const setsMap = {};
+  const nextSetsMap = {};
   payloadsBySet.forEach(item => {
-    setsMap[item.setKey] = setsMap[item.setKey] && typeof setsMap[item.setKey] === 'object'
-      ? setsMap[item.setKey]
+    nextSetsMap[item.setKey] = nextSetsMap[item.setKey] && typeof nextSetsMap[item.setKey] === 'object'
+      ? nextSetsMap[item.setKey]
       : {};
     item.payloads.forEach(payload => {
       Object.keys(payload?.value || {}).forEach(userId => {
@@ -988,10 +1058,10 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       if (!setKey || !indexName || !value) return;
       const payloadValue = item.payloads[pathIndex]?.value;
       if (!payloadValue || typeof payloadValue !== 'object') return;
-      if (!setsMap[setKey][indexName] || typeof setsMap[setKey][indexName] !== 'object') {
-        setsMap[setKey][indexName] = {};
+      if (!nextSetsMap[setKey][indexName] || typeof nextSetsMap[setKey][indexName] !== 'object') {
+        nextSetsMap[setKey][indexName] = {};
       }
-      setsMap[setKey][indexName][value] = payloadValue;
+      nextSetsMap[setKey][indexName][value] = payloadValue;
     });
   });
 
@@ -1003,7 +1073,7 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
   saveCachedAdditionalRulesSetIndex({
     rawRules,
     accessUserId: normalizedAccessUserId,
-    setsMap,
+    setsMap: nextSetsMap,
   });
   return result;
 };


### PR DESCRIPTION
### Motivation

- Ensure matching treats the Firebase node key as the canonical card id and support `newUsers` documents that store search buckets as a nested `userId` map so indexed lookups don't miss aliased records.
- Use prebuilt `searchKeySets` indexes to accelerate and correctly apply searchKey-based filters across `newUsers` collection.
- Extend searchKey filtering to consider indexed buckets for `role`, `maritalStatus`, `bloodGroup`, `rh`, and `age` so filtering can short-circuit using indexes when available.

### Description

- Preserve the database node key as the canonical `userId` when merging `newUsers` and `users` payloads by forcing `merged.userId = userId` and by setting `data.userId = id` in `fetchUsersByIds`.
- Add `fetchNewUsersByIndexedIds` and `hasIndexedUserIdAlias` to resolve indexed id aliases stored as nested `userId` maps and merge those alias matches with direct lookups.
- Update `fetchAdditionalNewUsersBySearchIndex` to use `fetchNewUsersByIndexedIds` and to ensure candidate `newUsers` entries are validated against additional access rules with the canonical id.
- Extend `toUserIdBuckets` in `additionalAccessRules` to support object-shaped `userId` maps for bucket extraction.
- Refactor `newUsersFilterSetsIndex` to support candidate set keys, collect ids from `searchKeySets` nodes, prefer complete set groups, cache `setsMap`, and fall back to `searchKey` buckets when necessary.
- In `Matching.jsx`, add loading of `matchingFilterIndexSets` from `searchKeySets`, introduce `buildAllowedIdsFromIndexSets` and `shouldKeepByIndexedFilter`, and apply indexed short-circuiting in `applyMatchingSearchKeyFilters` for `role`, `maritalStatus`, `bloodGroup`, `rh`, and `age` filters.
- Adjust list load sizes by changing `INITIAL_LOAD` and `LOAD_MORE` from `6` to `5`, and ensure `fetchUsersByLastLogin2FromCollection` keeps the node key as `userId` in mapped results.
- Miscellaneous: small refactors and improved null/shape guards when reading cached/index payloads and composing index set maps.

### Testing

- Ran unit test suite with `yarn test` and the tests completed successfully.
- Ran linting with `yarn lint` and no lint errors were reported.
- Performed a production build with `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9796c85c8326954a649417d713eb)