### PR TITLE
Support paginated additional-access searchKeySets for newUsers and backfill UI filters

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -64,14 +64,11 @@ import {
   shouldUseServerComment,
 } from '../utils/commentsStorage';
 import {
-  isUserAllowedByAnyAdditionalAccessRule,
   parseAdditionalAccessRuleGroups,
-  resolveAdditionalAccessSearchKeyBuckets,
 } from 'utils/additionalAccessRules';
-import { getCachedSearchKeyPayload } from 'utils/searchKeyCache';
 import {
-  buildNewUsersFilterSetIndex,
   getIndexedNewUsersIdsByRules,
+  normalizeSearchKeySetKeys,
 } from 'utils/newUsersFilterSetsIndex';
 import { resolveMatchingMultiDataOwnerIds } from 'utils/multiDataAccess';
 import { resolvePrioritizedReactionMaps } from 'utils/reactionPriority';
@@ -96,44 +93,23 @@ const filterMatchingUsers = list => list.filter(u => isMatchingCardId(u?.userId)
 const compareUsersByLastLogin2 = (a = {}, b = {}) =>
   (b.lastLogin2 || '').localeCompare(a.lastLogin2 || '');
 
-const SEARCH_KEY_ROOT = 'searchKey';
-const USERS_SEARCH_KEY_ROOT = `${SEARCH_KEY_ROOT}/users`;
-const SEARCH_KEY_INDEX_NAMES = {
-  blood: 'blood',
-  maritalStatus: 'maritalStatus',
-  csection: 'csection',
-  age: 'age',
-};
-
-const readIndexedIds = async (indexName, values = [], rootPath = SEARCH_KEY_ROOT) => {
-  const uniqueValues = [...new Set(values.filter(Boolean))];
-  if (!indexName || uniqueValues.length === 0) return null;
-
-  const payloads = await Promise.all(
-    uniqueValues.map(value =>
-      getCachedSearchKeyPayload(`${rootPath}/${indexName}/${value}`, async () => {
-        const snapshot = await get(refDb(database, `${rootPath}/${indexName}/${value}`));
-        return {
-          exists: snapshot.exists(),
-          value: snapshot.exists() ? snapshot.val() || {} : null,
-        };
-      })
-    )
-  );
-
-  const ids = new Set();
-  payloads.forEach(payload => {
-    if (!payload?.exists) return;
-    Object.keys(payload.value || {}).forEach(userId => {
-      if (userId) ids.add(userId);
-    });
-  });
-  return ids;
-};
-
 const FETCH_USERS_BY_IDS_BATCH_SIZE = 100;
 
-const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BATCH_SIZE) => {
+const ADDITIONAL_SEARCH_KEY_SET_PROFILE_FIELDS = [
+  'searchKeySetKeys',
+  'searchKeySets',
+  'additionalSearchKeySetKeys',
+  'additionalAccessKeySets',
+  'additionalAccessSearchKeySets',
+  'keySets',
+];
+
+const getAdditionalSearchKeySetKeysFromProfile = profile =>
+  normalizeSearchKeySetKeys(
+    ADDITIONAL_SEARCH_KEY_SET_PROFILE_FIELDS.map(fieldName => profile?.[fieldName])
+  );
+
+const fetchNewUsersByIdsForMatching = async (ids, batchSize = FETCH_USERS_BY_IDS_BATCH_SIZE) => {
   if (!Array.isArray(ids) || ids.length === 0) return [];
 
   const uniqueIds = [...new Set(ids.filter(Boolean))];
@@ -145,32 +121,12 @@ const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BA
     const chunkIds = uniqueIds.slice(offset, offset + safeBatchSize);
     const chunkSnapshots = await Promise.all(
       chunkIds.map(async userId => {
-        const [newUserResult, userResult] = await Promise.allSettled([
-          get(refDb(database, `newUsers/${userId}`)),
-          get(refDb(database, `users/${userId}`)),
-        ]);
-
-        const merged = { userId };
-        let hasAnyData = false;
-
-        if (newUserResult.status === 'fulfilled' && newUserResult.value.exists()) {
-          Object.assign(merged, newUserResult.value.val() || {});
-          hasAnyData = true;
-        }
-
-        if (userResult.status === 'fulfilled' && userResult.value.exists()) {
-          Object.assign(merged, userResult.value.val() || {});
-          hasAnyData = true;
-        }
-
-        if (!hasAnyData) return null;
+        const snapshot = await get(refDb(database, `newUsers/${userId}`));
+        if (!snapshot.exists()) return null;
         return {
-          merged,
-          hasNewUser: newUserResult.status === 'fulfilled' && newUserResult.value.exists(),
-          newUserData:
-            newUserResult.status === 'fulfilled' && newUserResult.value.exists()
-              ? newUserResult.value.val() || {}
-              : null,
+          userId,
+          ...(snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {}),
+          __sourceCollection: 'newUsers',
         };
       })
     );
@@ -182,89 +138,31 @@ const fetchUsersAndNewUsersByIds = async (ids, batchSize = FETCH_USERS_BY_IDS_BA
   return result;
 };
 
-const fetchAdditionalNewUsersBySearchIndex = async ({ parsedRuleGroups, rawRules, accessUserId }) => {
-  if (!Array.isArray(parsedRuleGroups) || parsedRuleGroups.length === 0) return [];
+const fetchAdditionalNewUsersBySearchIndex = async ({
+  rawRules,
+  accessUserId,
+  searchKeySetKeys,
+  offset = 0,
+  limit = FETCH_USERS_BY_IDS_BATCH_SIZE,
+}) => {
+  const indexed = await getIndexedNewUsersIdsByRules({
+    rawRules,
+    accessUserId,
+    searchKeySetKeys,
+    fetchMissingBuckets: true,
+    resultOffset: offset,
+    resultLimit: limit,
+  });
 
-  try {
-    let indexed = await getIndexedNewUsersIdsByRules({
-      rawRules,
-      accessUserId,
-    });
-    if (!indexed) {
-      await buildNewUsersFilterSetIndex({
-        rawRules,
-        accessUserId,
-      });
-      indexed = await getIndexedNewUsersIdsByRules({
-        rawRules,
-        accessUserId,
-      });
-    }
-    if (indexed?.userIds) {
-      const indexedRows = await fetchUsersAndNewUsersByIds(indexed.userIds);
-      return indexedRows
-        .filter(row => row.hasNewUser)
-        .map(row => ({ ...row.merged, __sourceCollection: 'newUsers' }));
-    }
-  } catch (error) {
-    console.error('Failed to load preindexed additional access set; fallback to searchKey buckets', error);
-  }
+  const userIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
+  const users = await fetchNewUsersByIdsForMatching(userIds);
 
-  const matchedIdsSet = new Set();
-
-  for (const parsedRules of parsedRuleGroups) {
-    const buckets = resolveAdditionalAccessSearchKeyBuckets(parsedRules);
-    const activeSources = Object.entries(buckets || {})
-      .map(([indexName, values]) => ({
-        indexName: SEARCH_KEY_INDEX_NAMES[indexName] || indexName,
-        values: Array.isArray(values) ? values : [...(values || [])],
-      }))
-      .filter(source => source.values.length > 0);
-
-    if (activeSources.length === 0) continue;
-
-    const indexedSets = await Promise.all(
-      activeSources.map(source => readIndexedIds(source.indexName, source.values, USERS_SEARCH_KEY_ROOT))
-    );
-
-    const normalizedSets = indexedSets.filter(set => set instanceof Set);
-    if (normalizedSets.length === 0) continue;
-    if (normalizedSets.some(set => set.size === 0)) {
-      continue;
-    }
-
-    const [firstSet, ...restSets] = normalizedSets;
-    const matchedByCurrentRule = [...firstSet].filter(userId =>
-      restSets.every(set => set.has(userId))
-    );
-    matchedByCurrentRule.forEach(userId => matchedIdsSet.add(userId));
-  }
-
-  const matchedIds = [...matchedIdsSet];
-  if (matchedIds.length === 0) {
-    const newUsersSnapshot = await get(refDb(database, 'newUsers'));
-    if (!newUsersSnapshot.exists()) return [];
-
-    const newUsersMap = newUsersSnapshot.val() || {};
-    return Object.entries(newUsersMap)
-      .map(([userId, userData]) => ({
-        userId,
-        ...(userData && typeof userData === 'object' ? userData : {}),
-      }))
-      .filter(user => isUserAllowedByAnyAdditionalAccessRule(user, parsedRuleGroups))
-      .map(user => ({ ...user, __sourceCollection: 'newUsers' }));
-  }
-
-  const combinedRows = await fetchUsersAndNewUsersByIds(matchedIds);
-  return combinedRows
-    .filter(row => row.hasNewUser)
-    .filter(row =>
-      isUserAllowedByAnyAdditionalAccessRule(
-        { userId: row.merged.userId, ...(row.newUserData || {}) },
-        parsedRuleGroups
-      )
-    )
-    .map(row => ({ ...row.merged, __sourceCollection: 'newUsers' }));
+  return {
+    userIds,
+    users,
+    nextOffset: Number.isFinite(Number(indexed?.nextOffset)) ? indexed.nextOffset : userIds.length,
+    hasMore: Boolean(indexed?.hasMore),
+  };
 };
 
 const isSameCursor = (a, b) => {
@@ -274,7 +172,6 @@ const isSameCursor = (a, b) => {
 };
 
 const MATCHING_SEARCHKEY_FILTER_KEYS = ['userRole', 'maritalStatus', 'bloodGroup', 'rh', 'age'];
-const MATCHING_ROLE_SEARCH_KEY_BUCKETS = ['ed', 'ag', 'ip', '?', 'no'];
 
 const isFilterGroupActive = group =>
   group && typeof group === 'object' && Object.values(group).some(v => !v);
@@ -475,6 +372,24 @@ const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = null) => 
     return true;
   });
 };
+
+const applyMatchingUiFiltersToUsers = ({
+  users,
+  filters,
+  favoriteUsers,
+  roleIndexSets,
+  collectionSource,
+}) =>
+  applyMatchingSearchKeyFilters(
+    filterMain(
+      users.map(u => [u.userId, u]),
+      null,
+      getMatchingFiltersWithoutSearchKeyGroups(filters),
+      favoriteUsers
+    ).map(([, u]) => u),
+    filters,
+    roleIndexSets
+  ).filter(u => isAllowedIdForCollection(u.userId, collectionSource));
 
 const Container = styled.div`
   display: flex;
@@ -1667,6 +1582,7 @@ const InfoCardContent = ({ user, variant, isAdmin }) => {
 
 const INITIAL_LOAD = 6;
 const LOAD_MORE = 6;
+const ADDITIONAL_BACKFILL_MAX_PAGES = 3;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
 const COLLECTION_SOURCE_KEY = 'matchingCollectionSource';
@@ -1759,8 +1675,12 @@ const Matching = () => {
   const [currentAdditionalAccessRules, setCurrentAdditionalAccessRules] = useState(
     () => localStorage.getItem('additionalAccessRules') || ''
   );
+  const [currentSearchKeySetKeys, setCurrentSearchKeySetKeys] = useState(() =>
+    normalizeSearchKeySetKeys(localStorage.getItem('additionalSearchKeySetKeys') || '')
+  );
   const [additionalNewUsers, setAdditionalNewUsers] = useState([]);
-  const [roleIndexSets, setRoleIndexSets] = useState(null);
+  const [additionalNextOffset, setAdditionalNextOffset] = useState(0);
+  const [roleIndexSets] = useState(null);
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
   const parsedAdditionalAccessRules = useMemo(
@@ -1770,6 +1690,19 @@ const Matching = () => {
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
   const additionalRulesToastRef = useRef('');
+  const additionalFiltersSignature = useMemo(() => JSON.stringify(filters || {}), [filters]);
+  const resetAdditionalMatchingState = React.useCallback(({ resetHasMore = true, resetLoading = false } = {}) => {
+    setAdditionalNewUsers([]);
+    setAdditionalNextOffset(0);
+    setLastKey(null);
+    loadedIdsRef.current = new Set();
+    additionalRulesToastRef.current = '';
+    if (resetHasMore) setHasMore(true);
+    if (resetLoading) {
+      loadingRef.current = false;
+      setLoading(false);
+    }
+  }, []);
   const restoreRef = useRef(false);
   const scrollPositionRef = useRef(0);
   const saveScrollPosition = () => {
@@ -1946,18 +1879,23 @@ const Matching = () => {
             const profile = await fetchUserById(user.uid);
             const accessLevel = profile?.accessLevel || '';
             const additionalAccessRules = profile?.additionalAccessRules || '';
+            const searchKeySetKeys = getAdditionalSearchKeySetKeysFromProfile(profile);
 
             setCurrentAccessLevel(accessLevel);
             setCurrentAdditionalAccessRules(additionalAccessRules);
+            setCurrentSearchKeySetKeys(searchKeySetKeys);
             localStorage.setItem('accessLevel', accessLevel);
             localStorage.setItem('additionalAccessRules', additionalAccessRules);
+            localStorage.setItem('additionalSearchKeySetKeys', searchKeySetKeys.join(','));
             setMultiDataOwnerIds(resolveMatchingMultiDataOwnerIds({ viewerId: user.uid, profile }));
           } catch (error) {
             console.error('Failed to refresh access profile on Matching', error);
             const cachedAccessLevel = localStorage.getItem('accessLevel') || '';
             const cachedAdditionalAccessRules = localStorage.getItem('additionalAccessRules') || '';
+            const cachedSearchKeySetKeys = normalizeSearchKeySetKeys(localStorage.getItem('additionalSearchKeySetKeys') || '');
             setCurrentAccessLevel(cachedAccessLevel);
             setCurrentAdditionalAccessRules(cachedAdditionalAccessRules);
+            setCurrentSearchKeySetKeys(cachedSearchKeySetKeys);
           }
         };
 
@@ -1966,6 +1904,7 @@ const Matching = () => {
         localStorage.removeItem('ownerId');
         localStorage.removeItem('accessLevel');
         localStorage.removeItem('additionalAccessRules');
+        localStorage.removeItem('additionalSearchKeySetKeys');
         setOwnerId('');
         setMultiDataOwnerIds([]);
         setFavoriteUsers({});
@@ -1973,7 +1912,8 @@ const Matching = () => {
         setSharedComments({});
         setCurrentAccessLevel('');
         setCurrentAdditionalAccessRules('');
-        setAdditionalNewUsers([]);
+        setCurrentSearchKeySetKeys([]);
+        resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
         return;
       }
 
@@ -1985,7 +1925,7 @@ const Matching = () => {
     return () => {
       unsubscribeAuth();
     };
-  }, []);
+  }, [resetAdditionalMatchingState]);
 
   useEffect(() => {
     const ownerIds = getMatchingMultiDataOwnerIds();
@@ -2032,29 +1972,40 @@ const Matching = () => {
 
     const loadAdditionalNewUsers = async () => {
       if (collectionSource !== 'newUsers') {
-        setAdditionalNewUsers([]);
+        resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
         return;
       }
 
       if (!parsedAdditionalAccessRules || parsedAdditionalAccessRules.length === 0) {
-        setAdditionalNewUsers([]);
-        additionalRulesToastRef.current = '';
+        resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
         return;
       }
+
+      resetAdditionalMatchingState({ resetHasMore: true });
+      loadingRef.current = true;
+      setLoading(true);
 
       try {
         const loaded = await fetchAdditionalNewUsersBySearchIndex({
           parsedRuleGroups: parsedAdditionalAccessRules,
           rawRules: currentAdditionalAccessRules,
           accessUserId: ownerId,
+          searchKeySetKeys: currentSearchKeySetKeys,
+          offset: 0,
+          limit: INITIAL_LOAD,
         });
 
         if (!cancelled) {
-          setAdditionalNewUsers(loaded);
-          const toastSignature = `${currentAdditionalAccessRules}::${loaded.length}`;
+          setAdditionalNewUsers(loaded.users);
+          setAdditionalNextOffset(loaded.nextOffset);
+          loadedIdsRef.current = new Set(loaded.users.map(user => user.userId).filter(Boolean));
+          setHasMore(loaded.hasMore);
+          setLastKey(null);
+          await loadCommentsFor(loaded.users);
+          const toastSignature = `${currentAdditionalAccessRules}::${loaded.nextOffset}${loaded.hasMore ? '+' : ''}`;
           if (additionalRulesToastRef.current !== toastSignature) {
             toast(
-              `Додаткові правила доступу (newUsers): доступно ${loaded.length} карточок для matching.`,
+              `Додаткові правила доступу (newUsers): завантажено ${loaded.nextOffset}${loaded.hasMore ? '+' : ''} карточок для matching.`,
               { icon: 'ℹ️' }
             );
             additionalRulesToastRef.current = toastSignature;
@@ -2063,7 +2014,13 @@ const Matching = () => {
       } catch (error) {
         console.error('Failed to load additional newUsers for matching', error);
         if (!cancelled) {
-          setAdditionalNewUsers([]);
+          resetAdditionalMatchingState({ resetHasMore: false });
+          setHasMore(false);
+        }
+      } finally {
+        if (!cancelled) {
+          loadingRef.current = false;
+          setLoading(false);
         }
       }
     };
@@ -2073,49 +2030,16 @@ const Matching = () => {
     return () => {
       cancelled = true;
     };
-  }, [parsedAdditionalAccessRules, currentAdditionalAccessRules, collectionSource, ownerId]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadRoleIndexSets = async () => {
-      try {
-        const snapshots = await Promise.all(
-          MATCHING_ROLE_SEARCH_KEY_BUCKETS.map(async bucket => {
-            const payload = await getCachedSearchKeyPayload(
-              `${USERS_SEARCH_KEY_ROOT}/role/${bucket}`,
-              async () => {
-                const usersSnapshot = await get(refDb(database, `${USERS_SEARCH_KEY_ROOT}/role/${bucket}`));
-                return {
-                  exists: usersSnapshot.exists(),
-                  value: usersSnapshot.exists() ? usersSnapshot.val() || {} : null,
-                };
-              }
-            );
-            return [bucket, payload];
-          })
-        );
-
-        if (cancelled) return;
-
-        const nextSets = snapshots.reduce((acc, [bucket, payload]) => {
-          acc[bucket] = new Set(Object.keys(payload?.exists ? payload.value || {} : {}));
-          return acc;
-        }, {});
-
-        setRoleIndexSets(nextSets);
-      } catch (error) {
-        console.error('Failed to load role searchKey index for matching filters', error);
-        if (!cancelled) setRoleIndexSets(null);
-      }
-    };
-
-    loadRoleIndexSets();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  }, [
+    additionalFiltersSignature,
+    collectionSource,
+    currentAdditionalAccessRules,
+    currentSearchKeySetKeys,
+    loadCommentsFor,
+    ownerId,
+    parsedAdditionalAccessRules,
+    resetAdditionalMatchingState,
+  ]);
 
   const fetchChunk = React.useCallback(
     async (
@@ -2131,6 +2055,10 @@ const Matching = () => {
       let prevCursor;
 
       while (collected.length < limit) {
+        if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
+          break;
+        }
+
         const remaining = limit - collected.length;
         const sourceRes =
           collectionSource === 'newUsers'
@@ -2187,7 +2115,7 @@ const Matching = () => {
         excludedCount,
       };
     },
-    [collectionSource, filters, isAdmin, roleIndexSets]
+    [collectionSource, filters, isAdmin, parsedAdditionalAccessRules.length, roleIndexSets]
   );
 
   const loadInitial = React.useCallback(async () => {
@@ -2237,6 +2165,12 @@ const Matching = () => {
             ...Object.keys(localDis),
           ]);
         }
+      }
+
+      if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
+        setLastKey(null);
+        setViewMode('default');
+        return;
       }
 
       const { cards: cached } = await getCardsByList(defaultListKey);
@@ -2290,7 +2224,7 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [collectionSource, defaultListKey, fetchChunk, getMatchingMultiDataOwnerIds, loadCommentsFor]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
+  }, [collectionSource, defaultListKey, fetchChunk, getMatchingMultiDataOwnerIds, loadCommentsFor, parsedAdditionalAccessRules.length]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
 
   const reloadDefault = React.useCallback(() => {
     viewModeRef.current = 'default';
@@ -2430,7 +2364,7 @@ const Matching = () => {
     }
   };
 
-  const loadMore = React.useCallback(async () => {
+  const loadMore = React.useCallback(async ({ targetVisibleCount = 0, currentVisibleCount = 0 } = {}) => {
     if (!hasMore || loadingRef.current || viewMode !== 'default') {
       console.log('[loadMore] skip', { hasMore, loading: loadingRef.current, viewMode });
       return;
@@ -2443,6 +2377,67 @@ const Matching = () => {
         ...Object.keys(favoriteUsersRef.current),
         ...Object.keys(dislikeUsersRef.current),
       ]);
+
+      if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
+        const collected = [];
+        let nextOffset = additionalNextOffset;
+        let canLoadMoreAdditional = true;
+        let visibleCount = Math.max(0, Number(currentVisibleCount) || 0);
+        const requiredVisibleCount = Math.max(0, Number(targetVisibleCount) || 0);
+        let loadedPages = 0;
+
+        while (
+          canLoadMoreAdditional &&
+          loadedPages < ADDITIONAL_BACKFILL_MAX_PAGES &&
+          (collected.length === 0 || visibleCount < requiredVisibleCount)
+        ) {
+          loadedPages += 1;
+          // eslint-disable-next-line no-await-in-loop
+          const loaded = await fetchAdditionalNewUsersBySearchIndex({
+            rawRules: currentAdditionalAccessRules,
+            accessUserId: ownerId,
+            searchKeySetKeys: currentSearchKeySetKeys,
+            offset: nextOffset,
+            limit: LOAD_MORE,
+          });
+
+          const pageUsers = loaded.users.filter(user =>
+            user?.userId &&
+            !baseExclude.has(user.userId) &&
+            !loadedIdsRef.current.has(user.userId) &&
+            !collected.some(collectedUser => collectedUser.userId === user.userId)
+          );
+          collected.push(...pageUsers);
+
+          const candidateMap = new Map(additionalNewUsers.map(user => [user.userId, user]));
+          collected.forEach(user => candidateMap.set(user.userId, user));
+          visibleCount = applyMatchingUiFiltersToUsers({
+            users: Array.from(candidateMap.values()),
+            filters,
+            favoriteUsers: favoriteUsersRef.current,
+            roleIndexSets,
+            collectionSource,
+          }).length;
+
+          canLoadMoreAdditional = Boolean(loaded.hasMore) && loaded.nextOffset > nextOffset;
+          nextOffset = loaded.nextOffset;
+        }
+
+        collected.forEach(user => {
+          loadedIdsRef.current.add(user.userId);
+          updateCard(user.userId, user);
+        });
+        setAdditionalNewUsers(prev => {
+          const map = new Map(prev.map(user => [user.userId, user]));
+          collected.forEach(user => map.set(user.userId, user));
+          return Array.from(map.values());
+        });
+        await loadCommentsFor(collected);
+        setAdditionalNextOffset(nextOffset);
+        setHasMore(canLoadMoreAdditional);
+        setLastKey(null);
+        return;
+      }
 
       const collected = [];
       let cursor = lastKey;
@@ -2497,7 +2492,23 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [defaultListKey, hasMore, lastKey, viewMode, fetchChunk, loadCommentsFor]);
+  }, [
+    additionalNewUsers,
+    additionalNextOffset,
+    collectionSource,
+    currentAdditionalAccessRules,
+    currentSearchKeySetKeys,
+    defaultListKey,
+    fetchChunk,
+    filters,
+    hasMore,
+    lastKey,
+    loadCommentsFor,
+    ownerId,
+    parsedAdditionalAccessRules.length,
+    roleIndexSets,
+    viewMode,
+  ]);
 
   useEffect(() => {
     console.log('[useEffect] calling loadInitial');
@@ -2518,8 +2529,7 @@ const Matching = () => {
       const allowedBySetKey = new Set(additionalNewUsers.map(user => user.userId).filter(Boolean));
       baseUsers = baseUsers.filter(user => {
         if (user?.__sourceCollection !== 'newUsers') return true;
-        if (collectionSource === 'newUsers' && !allowedBySetKey.has(user.userId)) return false;
-        return isUserAllowedByAnyAdditionalAccessRule(user, parsedAdditionalAccessRules);
+        return collectionSource !== 'newUsers' || allowedBySetKey.has(user.userId);
       });
     }
 
@@ -2560,16 +2570,13 @@ const Matching = () => {
     collectionSource,
   ]);
 
-  const filteredUsers = applyMatchingSearchKeyFilters(
-    filterMain(
-      visibleUsers.map(u => [u.userId, u]),
-      null,
-      getMatchingFiltersWithoutSearchKeyGroups(filters),
-      favoriteUsers
-    ).map(([, u]) => u),
+  const filteredUsers = applyMatchingUiFiltersToUsers({
+    users: visibleUsers,
     filters,
-    roleIndexSets
-  ).filter(u => isAllowedIdForCollection(u.userId, collectionSource));
+    favoriteUsers,
+    roleIndexSets,
+    collectionSource,
+  });
 
   useEffect(() => {
     if (viewMode !== 'default') return;
@@ -2577,7 +2584,10 @@ const Matching = () => {
     if (!hasMore) return;
     if (filteredUsers.length >= INITIAL_LOAD) return;
 
-    loadMore();
+    loadMore({
+      currentVisibleCount: filteredUsers.length,
+      targetVisibleCount: INITIAL_LOAD,
+    });
   }, [filteredUsers.length, hasMore, loadMore, loading, viewMode]);
 
   useEffect(() => {
@@ -2638,8 +2648,8 @@ const Matching = () => {
               value="users"
               checked={collectionSource === 'users'}
               onChange={e => {
+                resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
                 setCollectionSource(e.target.value);
-                reloadDefault();
               }}
             />
             Основна (users)
@@ -2651,8 +2661,8 @@ const Matching = () => {
               value="newUsers"
               checked={collectionSource === 'newUsers'}
               onChange={e => {
+                resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
                 setCollectionSource(e.target.value);
-                reloadDefault();
               }}
             />
             Додаткова (newUsers)

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -18,7 +18,7 @@ import {
   resolveAdditionalAccessSearchKeyBuckets,
 } from './additionalAccessRules';
 import {
-  getCachedAdditionalRulesSetIndex,
+  getCachedSearchKeyPayload,
   peekCachedSearchKeyPayload,
   saveCachedAdditionalRulesSetIndex,
 } from './searchKeyCache';
@@ -33,6 +33,37 @@ const normalizePathSegment = value => {
   if (!raw) return '';
   const hasForbiddenChars = FORBIDDEN_RTDB_SEGMENT_CHARS.some(char => raw.includes(char));
   return hasForbiddenChars ? encodeKey(raw) : raw;
+};
+
+const normalizeSearchKeySetKey = value =>
+  normalizePathSegment(String(value || '').trim().replace(/^\/?searchKeySets\//, ''));
+
+export const normalizeSearchKeySetKeys = rawKeys => {
+  const collect = value => {
+    if (!value) return [];
+
+    if (typeof value === 'string') {
+      return value
+        .split(/[\n,;\s]+/)
+        .map(normalizeSearchKeySetKey)
+        .filter(Boolean);
+    }
+
+    if (Array.isArray(value)) {
+      return value.flatMap(collect);
+    }
+
+    if (typeof value === 'object') {
+      return Object.entries(value).flatMap(([key, valueByKey]) => {
+        if (valueByKey === true) return collect(key);
+        return collect(valueByKey);
+      });
+    }
+
+    return [];
+  };
+
+  return [...new Set(collect(rawKeys))];
 };
 
 const mergeSearchKeyBuckets = parsedRuleGroups => {
@@ -849,25 +880,31 @@ export const buildNewUsersFilterSetIndex = async ({
   };
 };
 
-export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) => {
+export const getIndexedNewUsersIdsByRules = async ({
+  rawRules,
+  accessUserId,
+  searchKeySetKeys = [],
+  fetchMissingBuckets = false,
+  resultOffset = 0,
+  resultLimit = Number.POSITIVE_INFINITY,
+}) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
   if (!normalizedAccessUserId) return null;
 
-  const cachedIndexedSet = getCachedAdditionalRulesSetIndex({
-    rawRules,
-    accessUserId: normalizedAccessUserId,
-  });
-
+  const explicitSetKeys = normalizeSearchKeySetKeys(searchKeySetKeys);
   const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
-  const setEntries = ruleSetEntries
+  const ruleBucketEntries = ruleSetEntries
     .map(({ text: setText, inputIndex }) => {
       const parsedRuleGroups = parseAdditionalAccessRuleGroups(setText);
       if (!parsedRuleGroups.length) return null;
-      const { bucketMap } = prepareAdditionalAccessBucketMapForSearchKey(mergeSearchKeyBuckets(parsedRuleGroups));
-      const indexBuckets = Object.entries(bucketMap || {}).reduce((acc, [indexName, rawValues]) => {
+
+      const bucketMap = mergeSearchKeyBuckets(parsedRuleGroups);
+      const { bucketMap: preparedBucketMap } = prepareAdditionalAccessBucketMapForSearchKey(bucketMap);
+      const indexBuckets = Object.entries(preparedBucketMap || {}).reduce((acc, [indexName, rawValues]) => {
         const normalizedIndexName = normalizePathSegment(indexName);
         if (!normalizedIndexName) return acc;
         if (normalizedIndexName === 'imt' || normalizedIndexName === 'users') return acc;
+
         const values = [
           ...new Set(
             (Array.isArray(rawValues) ? rawValues : [...(rawValues || [])])
@@ -880,132 +917,130 @@ export const getIndexedNewUsersIdsByRules = async ({ rawRules, accessUserId }) =
       }, {});
       if (!Object.keys(indexBuckets).length) return null;
 
-      const setKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
-      if (!setKey) return null;
-      const paths = Object.entries(indexBuckets).flatMap(([indexName, values]) =>
-        values.map(value => `${SEARCH_KEY_SETS_ROOT}/${setKey}/${indexName}/${value}`)
-      );
-      return { setKey, paths, indexBuckets };
+      const defaultSetKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
+      if (!defaultSetKey && explicitSetKeys.length === 0) return null;
+      return { defaultSetKey, indexBuckets };
     })
     .filter(Boolean);
-  if (!setEntries.length) return null;
 
-  const buildIndexedResultFromSetsMap = setsMap => {
-    if (!setsMap || typeof setsMap !== 'object') return null;
-
-    const userIds = new Set();
-    const setKeys = [];
-    for (const entry of setEntries) {
-      const setNode = setsMap?.[entry.setKey];
-      if (!setNode || typeof setNode !== 'object') return null;
-
-      Object.entries(entry.indexBuckets).forEach(([indexName, values]) => {
-        values.forEach(value => {
-          const bucketValue = setNode?.[indexName]?.[value];
-          if (!bucketValue || typeof bucketValue !== 'object') {
-            throw new Error('MISSING_BUCKET');
-          }
-          setKeys.push(`${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`);
-          Object.keys(bucketValue).forEach(userId => {
-            if (userId) userIds.add(userId);
-          });
-        });
-      });
-    }
-
-    return {
-      setKeys,
-      userIds: [...userIds],
-      ownerId: normalizedAccessUserId,
-    };
-  };
-
-  if (cachedIndexedSet) {
-    try {
-      const cachedResult = buildIndexedResultFromSetsMap(cachedIndexedSet);
-      if (cachedResult) return cachedResult;
-    } catch {
-      // ignore malformed or incomplete cache and fallback to searchKey cache payload lookup
-    }
-  }
-
-  const payloadsBySet = await Promise.all(
-    setEntries.map(async entry => {
-      const payloads = await Promise.all(
-        entry.paths.map(path => Promise.resolve(peekCachedSearchKeyPayload(path)))
-      );
-      return { setKey: entry.setKey, paths: entry.paths, payloads };
-    })
-  );
-
-  const hasMissingSetPayloads = payloadsBySet.some(item => item.payloads.some(payload => !payload?.exists));
-  if (hasMissingSetPayloads) {
-    const fallbackSearchKeyPayloads = await Promise.all(
-      setEntries.map(async entry => {
-        const paths = Object.entries(entry.indexBuckets).flatMap(([indexName, values]) =>
-          values.map(value => `searchKey/${indexName}/${value}`)
-        );
-        const payloads = await Promise.all(
-          paths.map(path => Promise.resolve(peekCachedSearchKeyPayload(path)))
-        );
-        return { paths, payloads };
-      })
-    );
-
-    if (fallbackSearchKeyPayloads.some(item => item.payloads.some(payload => !payload?.exists))) {
-      return null;
-    }
-
-    const userIds = new Set();
-    fallbackSearchKeyPayloads.forEach(item => {
-      item.payloads.forEach(payload => {
-        Object.keys(payload?.value || {}).forEach(userId => {
-          if (userId) userIds.add(userId);
-        });
-      });
-    });
-
-    return {
-      setKeys: fallbackSearchKeyPayloads.flatMap(item => item.paths),
-      userIds: [...userIds],
-      ownerId: normalizedAccessUserId,
-    };
-  }
-
-  const userIds = new Set();
-  const setsMap = {};
-  payloadsBySet.forEach(item => {
-    setsMap[item.setKey] = setsMap[item.setKey] && typeof setsMap[item.setKey] === 'object'
-      ? setsMap[item.setKey]
-      : {};
-    item.payloads.forEach(payload => {
-      Object.keys(payload?.value || {}).forEach(userId => {
-        if (userId) userIds.add(userId);
-      });
-    });
-    item.paths.forEach((path, pathIndex) => {
-      const [, setKey, indexName, value] = String(path).split('/');
-      if (!setKey || !indexName || !value) return;
-      const payloadValue = item.payloads[pathIndex]?.value;
-      if (!payloadValue || typeof payloadValue !== 'object') return;
-      if (!setsMap[setKey][indexName] || typeof setsMap[setKey][indexName] !== 'object') {
-        setsMap[setKey][indexName] = {};
-      }
-      setsMap[setKey][indexName][value] = payloadValue;
-    });
+  const setEntries = ruleBucketEntries.flatMap(entry => {
+    const setKeys = explicitSetKeys.length ? explicitSetKeys : [entry.defaultSetKey];
+    return setKeys.filter(Boolean).map(setKey => ({ setKey, indexBuckets: entry.indexBuckets }));
   });
 
-  const result = {
-    setKeys: payloadsBySet.flatMap(item => item.paths),
-    userIds: [...userIds],
-    ownerId: normalizedAccessUserId,
+  if (!setEntries.length) return { setKeys: [], userIds: [], ownerId: normalizedAccessUserId };
+
+  const readBucketPayload = async path => {
+    const cached = peekCachedSearchKeyPayload(path);
+    if (cached && typeof cached.exists === 'boolean') return cached;
+    if (!fetchMissingBuckets) return null;
+
+    try {
+      return await getCachedSearchKeyPayload(path, async () => {
+        const snapshot = await get(ref(database, path));
+        return {
+          exists: snapshot.exists(),
+          value: snapshot.exists() ? snapshot.val() || {} : null,
+        };
+      });
+    } catch (error) {
+      console.warn('[searchKeySets] Failed to read bucket; treating as empty without searchKey fallback', {
+        path,
+        error,
+      });
+      return { exists: false, value: null };
+    }
   };
+
+  const setsMap = {};
+  const resultPaths = [];
+  const pageUserIds = [];
+  const seenMatchedIds = new Set();
+  const safeResultOffset = Math.max(0, Number(resultOffset) || 0);
+  const numericResultLimit = Number(resultLimit);
+  const safeResultLimit = Number.isFinite(numericResultLimit)
+    ? Math.max(0, numericResultLimit)
+    : Number.POSITIVE_INFINITY;
+  let matchedIndex = 0;
+  let hasMore = false;
+
+  const addMatchedUserId = userId => {
+    if (!userId || seenMatchedIds.has(userId)) return false;
+    seenMatchedIds.add(userId);
+
+    if (matchedIndex < safeResultOffset) {
+      matchedIndex += 1;
+      return false;
+    }
+
+    if (pageUserIds.length < safeResultLimit) {
+      pageUserIds.push(userId);
+      matchedIndex += 1;
+      return false;
+    }
+
+    hasMore = true;
+    return true;
+  };
+
+  for (const entry of setEntries) {
+    const filterSets = [];
+
+    for (const [indexName, values] of Object.entries(entry.indexBuckets)) {
+      const idsForFilter = new Set();
+
+      for (const value of values) {
+        const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`;
+        resultPaths.push(path);
+
+        // eslint-disable-next-line no-await-in-loop
+        const payload = await readBucketPayload(path);
+        const bucketValue = payload?.exists && payload.value && typeof payload.value === 'object'
+          ? payload.value
+          : {};
+
+        if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
+        if (!setsMap[entry.setKey][indexName]) setsMap[entry.setKey][indexName] = {};
+        setsMap[entry.setKey][indexName][value] = bucketValue;
+
+        Object.keys(bucketValue)
+          .sort((a, b) => a.localeCompare(b))
+          .forEach(userId => {
+            if (userId) idsForFilter.add(userId);
+          });
+      }
+
+      filterSets.push(idsForFilter);
+    }
+
+    if (!filterSets.length || filterSets.some(set => set.size === 0)) {
+      // Empty or missing searchKeySets buckets mean this rule set allows no cards.
+      // Do not fallback to searchKey/searchKeyFile/newUsers scans.
+      continue;
+    }
+
+    const [firstSet, ...restSets] = filterSets;
+    for (const userId of firstSet) {
+      if (!restSets.every(set => set.has(userId))) continue;
+      if (addMatchedUserId(userId)) break;
+    }
+
+    if (hasMore) break;
+  }
+
   saveCachedAdditionalRulesSetIndex({
     rawRules,
     accessUserId: normalizedAccessUserId,
     setsMap,
   });
-  return result;
+
+  return {
+    setKeys: resultPaths,
+    userIds: pageUserIds,
+    ownerId: normalizedAccessUserId,
+    nextOffset: safeResultOffset + pageUserIds.length,
+    hasMore,
+  };
 };
 
 const getMatchedUserIdsFromSearchKey = async parsedRuleGroups => {


### PR DESCRIPTION
### Motivation
- Enable efficient, paginated retrieval of `newUsers` that match additional access rules (searchKeySets) to avoid full scans and large payload reads.
- Allow UI filter interplay with paginated additional-access results and backfill to reach a target number of visible cards.
- Persist and normalize searchKeySet keys from user profiles to control which `searchKeySets` are consulted.

### Description
- Added `normalizeSearchKeySetKeys` and related helpers in `src/utils/newUsersFilterSetsIndex.js` to normalize incoming set keys and expose a paginated `getIndexedNewUsersIdsByRules` API that supports `searchKeySetKeys`, `fetchMissingBuckets`, `resultOffset`, and `resultLimit` and returns `{ userIds, nextOffset, hasMore }`.
- Reworked bucket reading to use cached payloads with optional on-demand fetch of missing buckets and to produce paged user id results instead of monolithic sets; added `fetchNewUsersByIdsForMatching` to fetch `newUsers` by id only (no merging with `users`).
- In `Matching.jsx` added `currentSearchKeySetKeys`, `additionalNextOffset`, `additionalNewUsers`, `resetAdditionalMatchingState`, `ADDITIONAL_BACKFILL_MAX_PAGES`, and `applyMatchingUiFiltersToUsers` to manage paged additional-access results, merge them into visible lists, and apply UI filters consistently; updated localStorage handling for `additionalSearchKeySetKeys`.
- Modified `fetchAdditionalNewUsersBySearchIndex` to call the new paged index API and return structured results, and adjusted `loadInitial`/`loadMore` to short-circuit/default appropriately when `collectionSource === 'newUsers'` with additional access rules; implemented backfill loop in `loadMore` that fetches additional pages until a target visible count is reached or a maximum number of pages is fetched.
- Removed/flattened older searchKey bucket helpers and role index loading logic in favor of the new indexed and cached approach, and simplified `fetchUsersAndNewUsersByIds` to only fetch `newUsers` where appropriate.

### Testing
- Ran unit tests with `yarn test`, and the test suite passed. 
- Ran linter with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003600bf088326ac342f298e5e2b69)