### PR TITLE
Track admin backend traffic and wrap Firebase reads with toasts

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -95,7 +95,8 @@ import SearchBar, { detectSearchParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { PAGE_SIZE, database } from './config';
-import { get, onValue, push, ref } from 'firebase/database';
+import { get as firebaseGet, onValue as firebaseOnValue, push, ref } from 'firebase/database';
+import { withAdminDownloadToast, wrapAdminOnValue } from 'utils/backendDownloadToast';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
 // import { aiHandler } from './aiHandler';
 import {
@@ -126,6 +127,18 @@ import {
   restoreLA2State,
   serializeLA2State,
 } from './LastAction2Mode';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'AddNewProfile',
+    path: args[0],
+  });
+
+const onValue = wrapAdminOnValue(firebaseOnValue, {
+  operation: 'onValue',
+  source: 'AddNewProfile',
+});
 
 const Container = styled.div`
   display: flex;

--- a/src/components/LastAction2Mode.jsx
+++ b/src/components/LastAction2Mode.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
-import { get, ref } from 'firebase/database';
+import { get as firebaseGet, ref } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import { cacheLoad2Users } from 'utils/load2Storage';
 import { getCard, serializeQueryFilters } from 'utils/cardIndex';
 import { PAGE_SIZE, database } from './config';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'LastAction2',
+    path: args[0],
+  });
 
 export const LAST_ACTION2_SORT_MODE = 'LA2';
 export const LAST_ACTION2_FILTER = 'LAST_ACTION2';

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -23,7 +23,9 @@ import {
   updateDataInRealtimeDB,
   updateDataInFiresoreDB,
 } from './config';
-import { get, onValue, ref as refDb, query, orderByChild, endAt, limitToLast } from 'firebase/database';
+import { get as firebaseGet, onValue as firebaseOnValue, ref as refDb, query, orderByChild, endAt, limitToLast } from 'firebase/database';
+import { withAdminDownloadToast, wrapAdminOnValue } from 'utils/backendDownloadToast';
+
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
@@ -75,6 +77,18 @@ import {
 } from 'utils/newUsersFilterSetsIndex';
 import { resolveMatchingMultiDataOwnerIds } from 'utils/multiDataAccess';
 import { resolvePrioritizedReactionMaps } from 'utils/reactionPriority';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'Matching',
+    path: args[0],
+  });
+
+const onValue = wrapAdminOnValue(firebaseOnValue, {
+  operation: 'onValue',
+  source: 'Matching',
+});
 
 // Filter out users with invalid identifiers; Firebase push IDs are usually 20 chars.
 const isValidId = id => typeof id === 'string' && id.length >= 20;

--- a/src/components/MedicationsPage.jsx
+++ b/src/components/MedicationsPage.jsx
@@ -2,7 +2,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
-import { onValue } from 'firebase/database';
+import { onValue as firebaseOnValue } from 'firebase/database';
+import { wrapAdminOnValue } from 'utils/backendDownloadToast';
 import { FiCopy, FiImage, FiTrash2, FiUpload, FiX } from 'react-icons/fi';
 import PhotoViewer from './PhotoViewer';
 import MedicationSchedule from './MedicationSchedule';
@@ -19,6 +20,11 @@ import {
 import { formatMedicationScheduleForClipboard } from '../utils/medicationClipboard';
 import { isMedicationPhotoUrl } from '../utils/photoFilters';
 import { MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
+
+const onValue = wrapAdminOnValue(firebaseOnValue, {
+  operation: 'onValue',
+  source: 'MedicationsPage',
+});
 
 const normalizePhotosArray = rawPhotos => {
   if (Array.isArray(rawPhotos)) {

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,6 +1,8 @@
 import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react';
 import styled, { css } from 'styled-components';
-import { endAt, get, orderByKey, query, ref as refDb, startAt } from 'firebase/database';
+import { endAt, get as firebaseGet, orderByKey, query, ref as refDb, startAt } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import Photos from './Photos';
 import { inputUpdateValue } from './inputUpdatedValue';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -39,6 +41,13 @@ import {
   saveCachedAdditionalRulesPreview,
 } from 'utils/searchKeyCache';
 import { MULTI_DATA_ACCESS_FIELD } from 'utils/multiDataAccess';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'ProfileForm',
+    path: args[0],
+  });
 
 const getImtAllowedUserIdsFromSearchKey = (searchKeyPayload, imtValues) => {
   const normalizedImtValues = [...new Set((Array.isArray(imtValues) ? imtValues : []).filter(Boolean))];

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,11 +1,11 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
-import { collection, doc, getDoc, getDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll } from 'firebase/storage';
+import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
-  get,
+  get as firebaseGet,
   remove,
   set,
   update,
@@ -43,6 +43,7 @@ import {
 } from '../utils/searchKeyUtils';
 import { resolveEqualToSearchKeys } from '../utils/searchKeyCheckboxFilters';
 import { searchByIndexOn } from './searchByIndexOn';
+import { withAdminDownloadToast } from '../utils/backendDownloadToast';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -64,6 +65,52 @@ export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
 export const database = getDatabase(app);
+
+const getCurrentAdminUid = () => auth.currentUser?.uid;
+
+if (typeof window !== 'undefined') {
+  window.__getBackendDownloadToastUid = getCurrentAdminUid;
+}
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    getUid: getCurrentAdminUid,
+    operation: 'get',
+    source: 'config',
+    path: args[0],
+  });
+
+const getDoc = (...args) =>
+  withAdminDownloadToast(firebaseGetDoc(...args), {
+    getUid: getCurrentAdminUid,
+    operation: 'getDoc',
+    source: 'config',
+    path: args[0],
+  });
+
+const getDocs = (...args) =>
+  withAdminDownloadToast(firebaseGetDocs(...args), {
+    getUid: getCurrentAdminUid,
+    operation: 'getDocs',
+    source: 'config',
+    path: args[0],
+  });
+
+const listAll = (...args) =>
+  withAdminDownloadToast(firebaseListAll(...args), {
+    getUid: getCurrentAdminUid,
+    operation: 'listAll',
+    source: 'config',
+    path: args[0],
+  });
+
+const getDownloadURL = (...args) =>
+  withAdminDownloadToast(firebaseGetDownloadURL(...args), {
+    getUid: getCurrentAdminUid,
+    operation: 'Storage URL metadata',
+    source: 'config',
+    path: args[0],
+  });
 
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -1,5 +1,14 @@
-import { getDatabase, ref as ref2, query, orderByChild, equalTo, limitToFirst, get } from 'firebase/database';
+import { getDatabase, ref as ref2, query, orderByChild, equalTo, limitToFirst, get as firebaseGet } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import { PAGE_SIZE, INVALID_DATE_TOKENS, MAX_LOOKBACK_DAYS } from './constants';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'dateLoad',
+    path: args[0],
+  });
 
 export async function defaultFetchByDate(dateStr, limit) {
   const db = getDatabase();

--- a/src/components/lastActionLoad.js
+++ b/src/components/lastActionLoad.js
@@ -6,10 +6,19 @@ import {
   startAt,
   endAt,
   limitToLast,
-  get,
+  get as firebaseGet,
 } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import { PAGE_SIZE, MAX_LOOKBACK_DAYS } from './constants';
 import normalizeLastAction from '../utils/normalizeLastAction';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'lastActionLoad',
+    path: args[0],
+  });
 
 const LOOKBACK_BATCH_DAYS = 7;
 const FILTER_CHUNK_SIZE = 40;

--- a/src/components/lastLoginLoad.js
+++ b/src/components/lastLoginLoad.js
@@ -6,9 +6,18 @@ import {
   orderByChild,
   equalTo,
   limitToFirst,
-  get,
+  get as firebaseGet,
 } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import { PAGE_SIZE, MAX_LOOKBACK_DAYS } from './constants';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'lastLoginLoad',
+    path: args[0],
+  });
 
 export async function defaultFetchByLastLogin(dateStr, limit) {
   const db = getDatabase();

--- a/src/utils/__tests__/backendDownloadToast.test.js
+++ b/src/utils/__tests__/backendDownloadToast.test.js
@@ -1,0 +1,134 @@
+const ADMIN_UID = '3LiD7JGCJTSJoVMU7fdR1ZrcIZH2';
+
+const loadTracker = () => {
+  jest.resetModules();
+  const toast = jest.fn();
+  toast.success = jest.fn();
+  toast.error = jest.fn();
+  jest.doMock('react-hot-toast', () => ({ __esModule: true, default: toast }));
+  const tracker = require('../backendDownloadToast');
+  return { tracker, toast };
+};
+
+const resetWindowTrackerState = () => {
+  delete window.backendTrafficStats;
+  delete window.__backendTrafficTrackerRuntime;
+  delete window.__getBackendDownloadToastUid;
+  delete window.__BACKEND_TRAFFIC_SILENT_MODE;
+};
+
+describe('backendDownloadToast admin traffic tracker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetWindowTrackerState();
+    jest.spyOn(console, 'table').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.dontMock('react-hot-toast');
+    resetWindowTrackerState();
+    jest.restoreAllMocks();
+  });
+
+  it('does not estimate payloads or show toasts for non-admin users', () => {
+    const { tracker, toast } = loadTracker();
+    window.__getBackendDownloadToastUid = () => 'regular-user';
+
+    tracker.recordAdminBackendTraffic(
+      {
+        exists: () => true,
+        val: () => {
+          throw new Error('payload estimation should not run');
+        },
+      },
+      { operation: 'get', source: 'Matching', path: 'users' },
+    );
+
+    jest.advanceTimersByTime(1000);
+
+    expect(window.backendTrafficStats).toBeUndefined();
+    expect(toast).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('collects stats while silent mode suppresses toast output', () => {
+    const { tracker, toast } = loadTracker();
+    window.__getBackendDownloadToastUid = () => ADMIN_UID;
+    window.__BACKEND_TRAFFIC_SILENT_MODE = true;
+
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ name: 'Admin payload' }) },
+      { operation: 'get', source: 'AddNewProfile', path: 'newUsers' },
+    );
+    jest.advanceTimersByTime(1000);
+
+    const summary = window.backendTrafficStats.summary({ log: false });
+    expect(summary.totals.actualRequestCount).toBe(1);
+    expect(summary.totals.estimatedPayloadBytes).toBeGreaterThan(0);
+    expect(toast).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('returns a JSON-friendly export object with repeated request analytics', () => {
+    const { tracker } = loadTracker();
+    window.__getBackendDownloadToastUid = () => ADMIN_UID;
+
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ count: 1 }) },
+      { operation: 'getDocs', source: 'ProfileForm', path: 'searchKey' },
+    );
+    jest.advanceTimersByTime(300);
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ count: 2 }) },
+      { operation: 'getDocs', source: 'ProfileForm', path: 'searchKey' },
+    );
+
+    const exported = window.backendTrafficStats.export();
+    expect(exported.exportedAt).toEqual(expect.any(String));
+    expect(exported.totals.startedAt).toEqual(expect.any(String));
+    expect(exported.totals.lastResetAt).toEqual(expect.any(String));
+    expect(exported.topRepeatedRequests[0]).toMatchObject({
+      source: 'ProfileForm',
+      operation: 'getDocs',
+      path: 'searchKey',
+    });
+    expect(() => JSON.stringify(exported)).not.toThrow();
+  });
+
+  it('tracks onValue subscriptions and ignores duplicate unsubscribe calls', () => {
+    const { tracker } = loadTracker();
+    window.__getBackendDownloadToastUid = () => ADMIN_UID;
+    const rawUnsubscribe = jest.fn();
+    const rawOnValue = jest.fn((target, callback) => {
+      callback({ exists: () => true, val: () => ({ ready: true }) });
+      return rawUnsubscribe;
+    });
+    const wrappedOnValue = tracker.wrapAdminOnValue(rawOnValue, {
+      operation: 'onValue',
+      source: 'Matching',
+    });
+
+    const unsubscribe = wrappedOnValue('multiData/favorites', jest.fn());
+    expect(window.backendTrafficStats.activeSubscriptions).toBe(1);
+
+    unsubscribe();
+    unsubscribe();
+
+    expect(rawUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(window.backendTrafficStats.activeSubscriptions).toBe(0);
+    expect(window.backendTrafficStats.subscriptionEvents.map(event => event.type)).toEqual(['start', 'end']);
+  });
+
+  it('does not wrap an already wrapped onValue function twice', () => {
+    const { tracker } = loadTracker();
+    const rawOnValue = jest.fn(() => jest.fn());
+    const once = tracker.wrapAdminOnValue(rawOnValue, { source: 'Matching' });
+    const twice = tracker.wrapAdminOnValue(once, { source: 'Matching' });
+
+    expect(twice).toBe(once);
+  });
+});

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -1,0 +1,584 @@
+import toast from 'react-hot-toast';
+import { isAdminUid } from './accessLevel';
+
+export const ENABLE_BACKEND_TRAFFIC_TOAST = true;
+export const BACKEND_TRAFFIC_SILENT_MODE = false;
+
+const TOAST_GROUP_DELAY_MS = 750;
+const TOAST_DURATION_MS = 5000;
+const CONSOLE_SUMMARY_DELAY_MS = 15000;
+const DEDUPE_WINDOW_MS = 250;
+const SAMPLE_MIN_INTERVAL_MS = 1000;
+const TRACK_EVERY_N_REQUEST = 3;
+const LARGE_PAYLOAD_BYTES = 1024 * 1024;
+const CRITICAL_PAYLOAD_BYTES = 5 * 1024 * 1024;
+const MAX_RECENT_REQUESTS = 100;
+const MAX_TRACKED_KEYS = 500;
+const MAX_ESTIMATE_NODES = 1200;
+const MAX_ESTIMATE_DEPTH = 6;
+const MAX_STRING_BYTES = 2048;
+const OBJECT_OVERHEAD_BYTES = 16;
+const ARRAY_OVERHEAD_BYTES = 12;
+const PROPERTY_OVERHEAD_BYTES = 4;
+const WRAPPED_ON_VALUE_FLAG = Symbol.for('knowme.backendTraffic.wrapAdminOnValue');
+
+const formatRows = rows => (Array.isArray(rows) ? rows : []);
+
+export const formatBytes = bytes => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 KB';
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.max(kb, 0.01).toFixed(kb >= 100 ? 0 : kb >= 10 ? 1 : 2)} KB`;
+  return `${(kb / 1024).toFixed(2)} MB`;
+};
+
+const getNowIso = () => new Date().toISOString();
+
+const createInitialStats = () => {
+  const startedAt = getNowIso();
+
+  return {
+    startedAt,
+    lastResetAt: startedAt,
+    estimatedPayloadBytes: 0,
+    actualRequestCount: 0,
+    totalBytes: 0,
+    totalRequests: 0,
+    estimatedRequestCount: 0,
+    sampledRequestCount: 0,
+    dedupedRequestCount: 0,
+    byOperation: {},
+    byPath: {},
+    bySource: {},
+    byRequestKey: {},
+    activeSubscriptions: 0,
+    subscriptionEvents: [],
+    largestRequest: null,
+    recentRequests: [],
+    reset() {
+      this.lastResetAt = getNowIso();
+      this.estimatedPayloadBytes = 0;
+      this.actualRequestCount = 0;
+      this.totalBytes = 0;
+      this.totalRequests = 0;
+      this.estimatedRequestCount = 0;
+      this.sampledRequestCount = 0;
+      this.dedupedRequestCount = 0;
+      this.byOperation = {};
+      this.byPath = {};
+      this.bySource = {};
+      this.byRequestKey = {};
+      this.activeSubscriptions = 0;
+      this.subscriptionEvents = [];
+      this.largestRequest = null;
+      this.recentRequests = [];
+    },
+    summary({ log = true } = {}) {
+      const operationRows = Object.entries(this.byOperation).map(([operation, data]) => ({
+        operation,
+        actualRequests: data.actualRequestCount,
+        estimatedRequests: data.estimatedRequestCount,
+        total: formatBytes(data.estimatedPayloadBytes),
+        avgKbPerRequest: Number(((data.estimatedPayloadBytes / Math.max(data.actualRequestCount, 1)) / 1024).toFixed(2)),
+        largest: formatBytes(data.largestBytes || 0),
+      }));
+      const topHeaviestPaths = Object.entries(this.byPath)
+        .sort(([, a], [, b]) => b.estimatedPayloadBytes - a.estimatedPayloadBytes)
+        .slice(0, 10)
+        .map(([path, data]) => ({
+          path,
+          actualRequests: data.actualRequestCount,
+          total: formatBytes(data.estimatedPayloadBytes),
+          largest: formatBytes(data.largestBytes || 0),
+        }));
+      const topSpammedSources = Object.entries(this.bySource)
+        .sort(([, a], [, b]) => b.actualRequestCount - a.actualRequestCount)
+        .slice(0, 10)
+        .map(([source, data]) => ({
+          source,
+          actualRequests: data.actualRequestCount,
+          total: formatBytes(data.estimatedPayloadBytes),
+          avgKbPerRequest: Number(((data.estimatedPayloadBytes / Math.max(data.actualRequestCount, 1)) / 1024).toFixed(2)),
+        }));
+      const largestOperations = Object.entries(this.byOperation)
+        .sort(([, a], [, b]) => (b.largestBytes || 0) - (a.largestBytes || 0))
+        .slice(0, 10)
+        .map(([operation, data]) => ({
+          operation,
+          largest: formatBytes(data.largestBytes || 0),
+          actualRequests: data.actualRequestCount,
+          total: formatBytes(data.estimatedPayloadBytes),
+        }));
+      const topRepeatedRequests = Object.entries(this.byRequestKey)
+        .sort(([, a], [, b]) => b.actualRequestCount - a.actualRequestCount)
+        .slice(0, 10)
+        .map(([key, data]) => ({
+          key,
+          source: data.source,
+          operation: data.operation,
+          path: data.path,
+          actualRequests: data.actualRequestCount,
+          estimatedRequests: data.estimatedRequestCount,
+          total: formatBytes(data.estimatedPayloadBytes),
+        }));
+      const durationMs = Math.max(Date.now() - Date.parse(this.lastResetAt || this.startedAt || getNowIso()), 1);
+      const durationHours = durationMs / 36e5;
+
+      if (log && typeof console !== 'undefined' && console.table) {
+        console.table(formatRows(operationRows));
+        console.table(formatRows(topHeaviestPaths));
+        console.table(formatRows(topSpammedSources));
+        console.table(formatRows(topRepeatedRequests));
+      }
+
+      return {
+        totals: {
+          actualRequestCount: this.actualRequestCount,
+          estimatedRequestCount: this.estimatedRequestCount,
+          estimatedPayloadBytes: this.estimatedPayloadBytes,
+          estimatedPayload: formatBytes(this.estimatedPayloadBytes),
+          sampledRequestCount: this.sampledRequestCount,
+          dedupedRequestCount: this.dedupedRequestCount,
+          activeSubscriptions: this.activeSubscriptions,
+          startedAt: this.startedAt,
+          lastResetAt: this.lastResetAt,
+          durationMs,
+          trafficPerHour: formatBytes(this.estimatedPayloadBytes / Math.max(durationHours, 1 / 3600)),
+          requestsPerHour: Number((this.actualRequestCount / Math.max(durationHours, 1 / 3600)).toFixed(2)),
+        },
+        byOperation: operationRows,
+        topHeaviestPaths,
+        topSpammedSources,
+        largestOperations,
+        topRepeatedRequests,
+        activeSubscriptions: this.activeSubscriptions,
+        subscriptionEvents: this.subscriptionEvents,
+        largestRequest: this.largestRequest,
+      };
+    },
+    export() {
+      return {
+        exportedAt: getNowIso(),
+        ...this.summary({ log: false }),
+        recentRequests: [...this.recentRequests],
+      };
+    },
+  };
+};
+
+const createRuntime = () => ({
+  pendingToast: null,
+  pendingToastTimer: null,
+  lastConsoleSummaryAt: 0,
+  lastSeenByKey: new Map(),
+  samplingByKey: new Map(),
+});
+
+const cleanupRuntime = runtime => {
+  if (runtime?.pendingToastTimer) clearTimeout(runtime.pendingToastTimer);
+  if (runtime) {
+    runtime.pendingToast = null;
+    runtime.pendingToastTimer = null;
+  }
+};
+
+const getRuntime = () => {
+  if (typeof window === 'undefined') return moduleRuntime;
+  if (window.__backendTrafficTrackerRuntime) return window.__backendTrafficTrackerRuntime;
+  window.__backendTrafficTrackerRuntime = createRuntime();
+  return window.__backendTrafficTrackerRuntime;
+};
+
+let moduleRuntime = createRuntime();
+
+if (typeof window !== 'undefined') {
+  cleanupRuntime(window.__backendTrafficTrackerRuntime);
+  window.__backendTrafficTrackerRuntime = createRuntime();
+}
+
+export const cleanupBackendTrafficTracker = () => cleanupRuntime(getRuntime());
+
+const getStats = () => {
+  if (typeof window === 'undefined') return createInitialStats();
+  if (!window.backendTrafficStats) window.backendTrafficStats = createInitialStats();
+  return window.backendTrafficStats;
+};
+
+const getDefaultUid = () => {
+  if (typeof window === 'undefined') return null;
+  return window.__getBackendDownloadToastUid?.() || null;
+};
+
+const shouldTrack = getUid => {
+  if (!ENABLE_BACKEND_TRAFFIC_TOAST) return false;
+  try {
+    const uid = typeof getUid === 'function' ? getUid() : getUid;
+    return isAdminUid(uid);
+  } catch (error) {
+    return false;
+  }
+};
+
+const getStringByteLength = value => {
+  const text = String(value ?? '');
+  const sliced = text.length > MAX_STRING_BYTES ? text.slice(0, MAX_STRING_BYTES) : text;
+  const bytes = typeof TextEncoder !== 'undefined'
+    ? new TextEncoder().encode(sliced).length
+    : unescape(encodeURIComponent(sliced)).length;
+  if (text.length <= MAX_STRING_BYTES) return bytes;
+  return Math.round((bytes / sliced.length) * text.length);
+};
+
+const estimateValueBytes = (value, state = { nodes: 0 }, depth = 0) => {
+  if (value === null || value === undefined) return 4;
+  if (state.nodes >= MAX_ESTIMATE_NODES || depth > MAX_ESTIMATE_DEPTH) return OBJECT_OVERHEAD_BYTES;
+  state.nodes += 1;
+
+  const type = typeof value;
+  if (type === 'string') return getStringByteLength(value);
+  if (type === 'number') return 8;
+  if (type === 'boolean') return 4;
+  if (type !== 'object') return getStringByteLength(value);
+
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (sum, item) => sum + estimateValueBytes(item, state, depth + 1),
+      ARRAY_OVERHEAD_BYTES,
+    );
+  }
+
+  return Object.entries(value).reduce(
+    (sum, [key, item]) => sum + getStringByteLength(key) + PROPERTY_OVERHEAD_BYTES + estimateValueBytes(item, state, depth + 1),
+    OBJECT_OVERHEAD_BYTES,
+  );
+};
+
+const estimateSnapshotBytes = result => {
+  if (!result) return 0;
+
+  if (typeof result.val === 'function') {
+    return result.exists?.() === false ? 0 : estimateValueBytes(result.val());
+  }
+
+  if (typeof result.data === 'function') {
+    return result.exists?.() === false ? 0 : estimateValueBytes(result.data());
+  }
+
+  if (Array.isArray(result.docs)) {
+    return result.docs.reduce((sum, doc) => {
+      const data = typeof doc.data === 'function' ? doc.data() : doc;
+      return sum + estimateValueBytes(data);
+    }, ARRAY_OVERHEAD_BYTES);
+  }
+
+  if (Array.isArray(result.items) || Array.isArray(result.prefixes)) {
+    const itemsBytes = (result.items || []).reduce(
+      (sum, item) => sum + getStringByteLength(item.fullPath || item.name || ''),
+      ARRAY_OVERHEAD_BYTES,
+    );
+    const prefixesBytes = (result.prefixes || []).reduce(
+      (sum, item) => sum + getStringByteLength(item.fullPath || item.name || ''),
+      ARRAY_OVERHEAD_BYTES,
+    );
+    return itemsBytes + prefixesBytes;
+  }
+
+  return estimateValueBytes(result);
+};
+
+export const getBackendPath = target => {
+  if (!target) return 'unknown';
+  if (typeof target === 'string') return target;
+  if (target.path) return target.path;
+  if (target.fullPath) return `storage/${target.fullPath}`;
+  if (target._path?.segments) return target._path.segments.join('/');
+  if (target._query?.path?.segments) return target._query.path.segments.join('/');
+  if (target._delegate) return getBackendPath(target._delegate);
+  if (typeof target.toString === 'function') {
+    const raw = target.toString();
+    if (raw && raw !== '[object Object]') {
+      try {
+        const url = new URL(raw);
+        return decodeURIComponent(url.pathname.replace(/^\//, '')) || raw;
+      } catch (error) {
+        return raw;
+      }
+    }
+  }
+  return 'unknown';
+};
+
+const getSeverity = bytes => {
+  if (bytes >= CRITICAL_PAYLOAD_BYTES) return 'critical';
+  if (bytes >= LARGE_PAYLOAD_BYTES) return 'warning';
+  return 'normal';
+};
+
+const getRequestKey = request => `${request.source}|${request.operation}|${request.path}`;
+const getDedupeKey = request => `${getRequestKey(request)}|${request.signature || ''}`;
+
+const makeMessage = request => {
+  const source = request.source ? `[${request.source}] ` : '';
+  const severity = getSeverity(request.bytes);
+  const prefix = severity === 'critical' ? 'CRITICAL PAYLOAD ' : severity === 'warning' ? 'LARGE PAYLOAD ' : 'Backend ';
+  return `${source}${prefix}${request.operation} ${request.path}: ${formatBytes(request.bytes)}`;
+};
+
+const incrementBucket = (bucket, key, { actual = 0, estimated = 0, bytes = 0, meta = {} } = {}) => {
+  const normalizedKey = key || 'unknown';
+  const data = bucket[normalizedKey] || {
+    actualRequestCount: 0,
+    estimatedRequestCount: 0,
+    estimatedPayloadBytes: 0,
+    largestBytes: 0,
+    ...meta,
+  };
+  data.actualRequestCount += actual;
+  data.estimatedRequestCount += estimated;
+  data.estimatedPayloadBytes += bytes;
+  data.largestBytes = Math.max(data.largestBytes || 0, bytes || 0);
+  bucket[normalizedKey] = data;
+};
+
+const updateActualStats = request => {
+  const stats = getStats();
+  stats.actualRequestCount += 1;
+  stats.totalRequests = stats.actualRequestCount;
+  incrementBucket(stats.byOperation, request.operation, { actual: 1 });
+  incrementBucket(stats.byPath, request.path, { actual: 1 });
+  incrementBucket(stats.bySource, request.source || 'unknown', { actual: 1 });
+  incrementBucket(stats.byRequestKey, getRequestKey(request), {
+    actual: 1,
+    meta: { source: request.source || 'unknown', operation: request.operation, path: request.path },
+  });
+  pruneObjectBucket(stats.byRequestKey);
+  return stats;
+};
+
+const updateEstimatedStats = (request, stats) => {
+  stats.estimatedPayloadBytes += request.bytes;
+  stats.totalBytes = stats.estimatedPayloadBytes;
+  stats.estimatedRequestCount += 1;
+  incrementBucket(stats.byOperation, request.operation, { estimated: 1, bytes: request.bytes });
+  incrementBucket(stats.byPath, request.path, { estimated: 1, bytes: request.bytes });
+  incrementBucket(stats.bySource, request.source || 'unknown', { estimated: 1, bytes: request.bytes });
+  incrementBucket(stats.byRequestKey, getRequestKey(request), {
+    estimated: 1,
+    bytes: request.bytes,
+    meta: { source: request.source || 'unknown', operation: request.operation, path: request.path },
+  });
+  if (!stats.largestRequest || request.bytes > stats.largestRequest.bytes) stats.largestRequest = request;
+  stats.recentRequests.push(request);
+  if (stats.recentRequests.length > MAX_RECENT_REQUESTS) {
+    stats.recentRequests.splice(0, stats.recentRequests.length - MAX_RECENT_REQUESTS);
+  }
+  return stats;
+};
+
+const pruneMap = map => {
+  if (map.size <= MAX_TRACKED_KEYS) return;
+  const firstKey = map.keys().next().value;
+  if (firstKey) map.delete(firstKey);
+};
+
+const pruneObjectBucket = bucket => {
+  const keys = Object.keys(bucket);
+  if (keys.length <= MAX_TRACKED_KEYS) return;
+  delete bucket[keys[0]];
+};
+
+const isDuplicateDevRequest = (runtime, request) => {
+  const key = getDedupeKey(request);
+  const now = Date.now();
+  const lastAt = runtime.lastSeenByKey.get(key);
+  runtime.lastSeenByKey.set(key, now);
+  pruneMap(runtime.lastSeenByKey);
+  return Boolean(lastAt && now - lastAt <= DEDUPE_WINDOW_MS);
+};
+
+const shouldEstimateAndToast = (runtime, request) => {
+  const key = getRequestKey(request);
+  const now = Date.now();
+  const state = runtime.samplingByKey.get(key) || { count: 0, lastEstimatedAt: 0 };
+  state.count += 1;
+  const shouldEstimate =
+    state.count <= TRACK_EVERY_N_REQUEST ||
+    state.count % TRACK_EVERY_N_REQUEST === 1 ||
+    now - state.lastEstimatedAt >= SAMPLE_MIN_INTERVAL_MS;
+  if (shouldEstimate) state.lastEstimatedAt = now;
+  runtime.samplingByKey.set(key, state);
+  pruneMap(runtime.samplingByKey);
+  return shouldEstimate;
+};
+
+const isSilentMode = () =>
+  BACKEND_TRAFFIC_SILENT_MODE ||
+  (typeof window !== 'undefined' && window.__BACKEND_TRAFFIC_SILENT_MODE === true);
+
+const scheduleToast = request => {
+  if (isSilentMode()) return;
+  const runtime = getRuntime();
+  runtime.pendingToast = runtime.pendingToast || { bytes: 0, requests: 0, sources: new Set(), operations: new Set(), lastRequest: null, maxSeverity: 'normal' };
+  runtime.pendingToast.bytes += request.bytes;
+  runtime.pendingToast.requests += 1;
+  if (request.source) runtime.pendingToast.sources.add(request.source);
+  runtime.pendingToast.operations.add(request.operation);
+  runtime.pendingToast.lastRequest = request;
+  const severity = getSeverity(request.bytes);
+  if (severity === 'critical' || (severity === 'warning' && runtime.pendingToast.maxSeverity === 'normal')) {
+    runtime.pendingToast.maxSeverity = severity;
+  }
+
+  if (runtime.pendingToastTimer) return;
+  runtime.pendingToastTimer = setTimeout(() => {
+    const batch = runtime.pendingToast;
+    runtime.pendingToast = null;
+    runtime.pendingToastTimer = null;
+    if (!batch) return;
+    const isSingleRequest = batch.requests === 1;
+    const sources = [...batch.sources].slice(0, 3).join(', ');
+    const operations = [...batch.operations].slice(0, 4).join('/');
+    const groupedContext = [sources && `[${sources}${batch.sources.size > 3 ? ', …' : ''}]`, operations]
+      .filter(Boolean)
+      .join(' ');
+    const message = isSingleRequest
+      ? makeMessage(batch.lastRequest)
+      : `Backend traffic${groupedContext ? ` ${groupedContext}` : ''}: ${formatBytes(batch.bytes)} (${batch.requests} tracked / sampled requests)`;
+    const toastFn = batch.maxSeverity === 'critical' ? toast.error : batch.maxSeverity === 'warning' ? toast : toast.success;
+    toastFn(message, { duration: TOAST_DURATION_MS, icon: batch.maxSeverity === 'normal' ? '📦' : '⚠️' });
+  }, TOAST_GROUP_DELAY_MS);
+};
+
+const maybeLogConsoleSummary = stats => {
+  if (typeof console === 'undefined' || !console.table) return;
+  const runtime = getRuntime();
+  const now = Date.now();
+  if (now - runtime.lastConsoleSummaryAt < CONSOLE_SUMMARY_DELAY_MS) return;
+  runtime.lastConsoleSummaryAt = now;
+  stats.summary();
+};
+
+const makeRequestShell = ({ operation = 'get', source = '', path = 'unknown' } = {}) => ({
+  operation,
+  source,
+  path: getBackendPath(path),
+  at: getNowIso(),
+});
+
+export const recordAdminBackendTraffic = (result, options = {}) => {
+  const { getUid = getDefaultUid } = options;
+  if (!shouldTrack(getUid)) return;
+
+  try {
+    const runtime = getRuntime();
+    const requestShell = makeRequestShell(options);
+    requestShell.signature = result?.key || result?.size || result?.docs?.length || result?.items?.length || '';
+
+    if (isDuplicateDevRequest(runtime, requestShell)) {
+      getStats().dedupedRequestCount += 1;
+      return;
+    }
+
+    const stats = updateActualStats(requestShell);
+    if (!shouldEstimateAndToast(runtime, requestShell)) {
+      stats.sampledRequestCount += 1;
+      return;
+    }
+
+    const request = {
+      ...requestShell,
+      bytes: estimateSnapshotBytes(result),
+    };
+    updateEstimatedStats(request, stats);
+    scheduleToast(request);
+    maybeLogConsoleSummary(stats);
+  } catch (error) {
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('Backend traffic tracking failed', error);
+    }
+  }
+};
+
+const recordSubscriptionEvent = (type, request) => {
+  const stats = getStats();
+  stats.activeSubscriptions = Math.max(0, stats.activeSubscriptions + (type === 'start' ? 1 : -1));
+  stats.subscriptionEvents.push({
+    type,
+    source: request.source || 'unknown',
+    operation: request.operation,
+    path: request.path,
+    at: getNowIso(),
+    activeSubscriptions: stats.activeSubscriptions,
+  });
+  if (stats.subscriptionEvents.length > MAX_RECENT_REQUESTS) {
+    stats.subscriptionEvents.splice(0, stats.subscriptionEvents.length - MAX_RECENT_REQUESTS);
+  }
+};
+
+const trackSubscriptionStart = options => {
+  if (!shouldTrack(options.getUid || getDefaultUid)) return null;
+  try {
+    const request = makeRequestShell(options);
+    recordSubscriptionEvent('start', request);
+    return request;
+  } catch (error) {
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('Backend subscription tracking failed', error);
+    }
+    return null;
+  }
+};
+
+const trackSubscriptionEnd = request => {
+  if (!request) return;
+  try {
+    recordSubscriptionEvent('end', request);
+  } catch (error) {
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('Backend subscription cleanup tracking failed', error);
+    }
+  }
+};
+
+export const withAdminDownloadToast = async (promise, options = {}) => {
+  const result = await promise;
+  recordAdminBackendTraffic(result, options);
+  return result;
+};
+
+export const wrapAdminOnValue = (onValueFn, options = {}) => {
+  if (onValueFn?.[WRAPPED_ON_VALUE_FLAG]) return onValueFn;
+
+  const wrappedOnValue = (target, callback, cancelCallbackOrOptions, optionsArg) => {
+    const trackingOptions = {
+      ...options,
+      operation: options.operation || 'onValue',
+      path: options.path || target,
+    };
+    const trackedCallback = snapshot => {
+      recordAdminBackendTraffic(snapshot, trackingOptions);
+      return callback(snapshot);
+    };
+
+    let unsubscribe;
+    if (optionsArg !== undefined) {
+      unsubscribe = onValueFn(target, trackedCallback, cancelCallbackOrOptions, optionsArg);
+    } else if (cancelCallbackOrOptions !== undefined) {
+      unsubscribe = onValueFn(target, trackedCallback, cancelCallbackOrOptions);
+    } else {
+      unsubscribe = onValueFn(target, trackedCallback);
+    }
+
+    if (typeof unsubscribe !== 'function') return unsubscribe;
+    const subscriptionRequest = trackSubscriptionStart(trackingOptions);
+    let didUnsubscribe = false;
+    return (...unsubscribeArgs) => {
+      if (didUnsubscribe) return undefined;
+      didUnsubscribe = true;
+      trackSubscriptionEnd(subscriptionRequest);
+      return unsubscribe(...unsubscribeArgs);
+    };
+  };
+
+  wrappedOnValue[WRAPPED_ON_VALUE_FLAG] = true;
+  return wrappedOnValue;
+};

--- a/src/utils/multiAccountEdits.js
+++ b/src/utils/multiAccountEdits.js
@@ -1,5 +1,14 @@
-import { get, ref as ref2, remove, set, update } from 'firebase/database';
+import { get as firebaseGet, ref as ref2, remove, set, update } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import { database } from 'components/config';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'multiAccountEdits',
+    path: args[0],
+  });
 
 const EDITS_ROOT = 'multiData/edits';
 const TECHNICAL_FIELD_NAMES = new Set(['lastAction', 'cachedAt']);

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1,4 +1,6 @@
-import { get, ref, remove, set, update } from 'firebase/database';
+import { get as firebaseGet, ref, remove, set, update } from 'firebase/database';
+import { withAdminDownloadToast } from 'utils/backendDownloadToast';
+
 import {
   createAgeSearchKeyIndexInCollection,
   createContactSearchKeyIndexInCollection,
@@ -22,6 +24,13 @@ import {
   peekCachedSearchKeyPayload,
   saveCachedAdditionalRulesSetIndex,
 } from './searchKeyCache';
+
+const get = (...args) =>
+  withAdminDownloadToast(firebaseGet(...args), {
+    operation: 'get',
+    source: 'newUsersFilterSetsIndex',
+    path: args[0],
+  });
 
 export const SEARCH_KEY_SETS_ROOT = 'searchKeySets';
 const SET_KEY_INDEX_SEPARATOR = '_';


### PR DESCRIPTION
### Motivation
- Provide visibility into backend read traffic for admin users and surface large or repeated payloads as toasts. 
- Estimate payload sizes for Firebase responses and collect analytics about requests and subscriptions to help debug performance hotspots.
- Instrument existing data-access points to record and optionally notify about heavy or repeated downloads.

### Description
- Adds a new tracker utility `src/utils/backendDownloadToast.js` that exposes `withAdminDownloadToast`, `wrapAdminOnValue`, and `recordAdminBackendTraffic` for estimating payload sizes, deduping requests, grouping toasts, and tracking active subscriptions. 
- Integrates the tracker across codebase by wrapping Firebase read calls and subscriptions (replacing direct `get`/`onValue` usage with wrapped variants) in components and utilities including `AddNewProfile.jsx`, `LastAction2Mode.jsx`, `Matching.jsx`, `MedicationsPage.jsx`, `ProfileForm.jsx`, `dateLoad.js`, `lastActionLoad.js`, `lastLoginLoad.js`, `multiAccountEdits.js`, `newUsersFilterSetsIndex.js`, and `config.js`. 
- Exposes admin UID accessor on `window.__getBackendDownloadToastUid` from `config.js` and wraps Firestore/Storage helper functions (`getDoc`, `getDocs`, `listAll`, `getDownloadURL`) to include tracking metadata. 
- Adds unit tests for the tracker at `src/utils/__tests__/backendDownloadToast.test.js` that validate sampling, silent mode, subscription tracking, and export functionality. 

### Testing
- Ran the new unit tests in `src/utils/__tests__/backendDownloadToast.test.js` and they succeeded. 
- Existing application test suite was exercised and no regressions were observed in the modified modules during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004376a1ec8326a3462ea68e7d51d3)