### PR TITLE
Remove totalCount tracking and simplify pagination/counting logic

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -25,7 +25,6 @@ import {
   loadDuplicateUsers,
   removeCardAndSearchId,
   fetchAllUsersFromRTDB,
-  fetchTotalNewUsersCount,
   fetchFilteredUsersByPage,
   indexLastLogin,
   fetchUsersByLastActionPaged,
@@ -1520,7 +1519,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [hasMore, setHasMore] = useState(true); // Стан для перевірки, чи є ще користувачі
   const [lastKey, setLastKey] = useState(null); // Стан для зберігання останнього ключа
   const [lastKey21, setLastKey21] = useState(null);
-  const [totalCount, setTotalCount] = useState(0);
   const [searchLoading, setSearchLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -1555,7 +1553,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       userIds,
       currentFilter,
       currentPage,
-      totalCount,
       hasMore,
       lastKey: lastKey ?? null,
       lastKey21: lastKey21 ?? null,
@@ -1575,7 +1572,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     users,
     currentFilter,
     currentPage,
-    totalCount,
     hasMore,
     lastKey,
     lastKey21,
@@ -1671,7 +1667,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     if (!normalized) {
       setSearchLoading(false);
       setHasSearched(false);
-      setTotalCount(0);
       setCurrentPage(1);
       setSearchBarQueryActive(false);
       setLastSearchBarQuery('');
@@ -1679,14 +1674,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
     setSearchLoading(true);
     setHasSearched(true);
-    setTotalCount(0);
     setCurrentPage(1);
     setSearchBarQueryActive(true);
     setLastSearchBarQuery(normalized);
   }, [
     setSearchLoading,
     setHasSearched,
-    setTotalCount,
     setCurrentPage,
     setSearchBarQueryActive,
     setLastSearchBarQuery,
@@ -1748,7 +1741,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         filtersRef.current = nextValue;
         setFilters(nextValue);
         setUsers(filteredUsers);
-        setTotalCount(Object.keys(filteredUsers).length);
         setCurrentPage(1);
         setSearchLoading(false);
         setHasSearched(true);
@@ -1763,7 +1755,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setHasMore(true);
       setSearchLoading(true);
       setHasSearched(true);
-      setTotalCount(0);
       resetLA2StateRef(la2StateRef);
       setFilters(nextValue);
       return;
@@ -1777,7 +1768,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setDateOffsetLA(0);
       setSearchLoading(true);
       setHasSearched(true);
-      setTotalCount(0);
       setFilters(nextValue);
       return;
     }
@@ -1785,7 +1775,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     filtersRef.current = nextValue;
     setSearchLoading(true);
     setHasSearched(true);
-    setTotalCount(0);
     setFilters(nextValue);
   }, [
     currentFilter,
@@ -1798,7 +1787,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setFilters,
     setHasSearched,
     setSearchLoading,
-    setTotalCount,
     setUsers,
     users,
   ]);
@@ -1850,8 +1838,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     if (!searchBarQueryActive) return;
-    const count = userNotFound ? 0 : state.userId ? 1 : Object.keys(users || {}).length;
-    setTotalCount(count);
     if (searchLoading) {
       setSearchLoading(false);
     }
@@ -1859,10 +1845,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     searchBarQueryActive,
     searchLoading,
     setSearchLoading,
-    setTotalCount,
-    state.userId,
-    userNotFound,
-    users,
   ]);
 
   const cacheFetchedUsers = useCallback(
@@ -2186,7 +2168,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setLastKey(null);
     setLastKey21(null);
     setHasMore(true);
-    setTotalCount(0);
     setCurrentPage(1);
     setCacheCount(0);
     setBackendCount(0);
@@ -2222,7 +2203,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           return acc;
         }, {});
         setUsers(cachedUsers);
-        setTotalCount(ids.length);
         setCacheCount(cachedCards.length);
         setBackendCount(0);
         setSearchLoading(false);
@@ -2250,7 +2230,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           const derivedIds = Object.keys(derivedUsers);
           setIdsForQuery(queryKey, derivedIds);
           setUsers(derivedUsers);
-          setTotalCount(derivedIds.length);
           setCacheCount(derivedIds.length);
           setBackendCount(0);
           setSearchLoading(false);
@@ -2309,7 +2288,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         return acc;
       }, {});
       setUsers(cachedUsers);
-      setTotalCount(ids.length);
       setCacheCount(cards.length);
       setBackendCount(0);
       setSearchLoading(false);
@@ -2607,7 +2585,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       cacheFetchedUsers,
       setUsers,
       setHasMore,
-      setTotalCount,
     });
 
   useEffect(() => {
@@ -2683,9 +2660,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     // console.log('res :>> ', res);
     // Перевіряємо, чи є користувачі у відповіді
     if (res && typeof res.users === 'object' && Object.keys(res.users).length > 0) {
-      if (res.totalCount !== undefined) {
-        setTotalCount(res.totalCount);
-      }
       // console.log('222 :>> ');
       // console.log('res.users :>> ', res.users);
 
@@ -2803,7 +2777,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     setDateOffset21(res?.lastKey ?? dateOffset21);
     setHasMore(Boolean(res?.hasMore));
-    setTotalCount(res?.totalCount || 0);
 
     const backendCount = Object.keys(normalizedUsers).length;
     const filtersKey = serializeQueryFilters(currentFilters);
@@ -3087,7 +3060,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const nextOffset = dateOffsetLA + slice.length;
       setDateOffsetLA(nextOffset);
       setHasMore(hasCachedMore);
-      setTotalCount(prev => Math.max(prev, sortedCachedArr.length));
       return { cacheCount, backendCount, hasMore: hasCachedMore };
     }
 
@@ -3180,15 +3152,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const nextOffset = Number.isFinite(res.dateOffsetLA) ? res.dateOffsetLA : res.lastKey;
       setDateOffsetLA(nextOffset);
       setHasMore(res.hasMore);
-      setTotalCount(prev =>
-        Math.max(prev, nextOffset + (res.hasMore ? PAGE_SIZE : 0), sortedCachedArr.length),
-      );
       backendCount += Object.keys(filteredUsers).length;
       return { cacheCount, backendCount, hasMore: res.hasMore };
     }
 
     setHasMore(false);
-    setTotalCount(prev => Math.max(prev, dateOffsetLA + slice.length, sortedCachedArr.length));
     if (slice.length > 0) {
       setDateOffsetLA(prev => prev + slice.length);
     }
@@ -3337,7 +3305,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setHasMore(false);
     setLastKey(null);
     setCurrentPage(1);
-    setTotalCount(0);
     setCacheCount(0);
     setBackendCount(0);
 
@@ -3377,8 +3344,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setUsers(normalized);
       setHasMore(false);
       setLastKey(null);
-        setCurrentPage(1);
-      setTotalCount(ids.length);
+      setCurrentPage(1);
       setCacheCount(cacheCount);
       setBackendCount(backendCount);
 
@@ -3392,7 +3358,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setCurrentPage,
       setHasMore,
       setLastKey,
-      setTotalCount,
       setUsers,
     ],
   );
@@ -3521,7 +3486,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setHasMore(false);
     setLastKey(null);
     setCurrentPage(1);
-    setTotalCount(sortedUsers.length);
     setCacheCount(0);
     setBackendCount(sortedUsers.length);
   };
@@ -3654,9 +3618,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setIsDuplicateView(true);
   };
 
-  const handleInfo = async () => {
-    const count = await fetchTotalNewUsersCount();
-    alert(`Total cards in newUsers: ${count}`);
+  const handleInfo = () => {
+    alert(`Loaded cards: ${Object.keys(users || {}).length}`);
   };
 
   const handleClearCache = () => {
@@ -3917,9 +3880,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
 
   const shouldPaginate = searchBarQueryActive
-    ? totalCount > PAGE_SIZE
+    ? Object.keys(users || {}).length > PAGE_SIZE
     : currentFilter !== 'FAVORITE' && currentFilter !== 'CYCLE_FAVORITE';
-  const totalPages = shouldPaginate ? Math.ceil(totalCount / PAGE_SIZE) || 1 : 1;
   const getSortedIds = () => {
     const ids = Object.keys(users);
     if (isDuplicateView || currentFilter === 'CYCLE_FAVORITE') {
@@ -3954,6 +3916,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const sortedIds = getSortedIds();
+  const loadedPages = Math.ceil(sortedIds.length / PAGE_SIZE) || 1;
+  const totalPages = shouldPaginate ? Math.max(loadedPages, hasMore ? currentPage + 1 : currentPage) : 1;
   const displayedUserIds = shouldPaginate
     ? sortedIds.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
     : sortedIds;
@@ -4015,7 +3979,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (Object.keys(restoredUsers).length) {
       setUsers(restoredUsers);
-      setTotalCount(snapshot.totalCount || Object.keys(restoredUsers).length);
       setHasSearched(true);
       setUserNotFound(false);
     }
@@ -4402,10 +4365,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             {(searchLoading || hasSearched) && !userNotFound && (
               <p style={{ textAlign: 'center', color: 'black' }}>
                 Знайдено{' '}
-                {searchLoading || (searchBarQueryActive && totalCount === 0) ? (
+                {searchLoading ? (
                   <span className="spinner" />
                 ) : (
-                  totalCount
+                  Object.keys(users || {}).length
                 )}{' '}
                 карток.
               </p>

--- a/src/components/LastAction2Mode.jsx
+++ b/src/components/LastAction2Mode.jsx
@@ -206,7 +206,6 @@ export const loadMoreUsersLastAction2 = async ({
   cacheFetchedUsers,
   setUsers,
   setHasMore,
-  setTotalCount,
 }) => {
   if (isEditingRef?.current) return { cacheCount: 0, backendCount: 0, hasMore };
   ensureLA2StateForFilters(la2StateRef, currentFilters);
@@ -270,7 +269,6 @@ export const loadMoreUsersLastAction2 = async ({
   if (!isEditingRef?.current) setUsers(prev => mergeWithoutOverwrite(prev, pageUsers));
   cacheFetchedUsers(pageUsers, cacheLoad2Users, currentFilters);
   setHasMore(la2State.hasMore);
-  setTotalCount(Math.max(la2State.acceptedIds.length + (la2State.hasMore ? PAGE_SIZE : 0), la2State.acceptedIds.length));
   return { cacheCount: 0, backendCount: Object.keys(pageUsers).length, hasMore: la2State.hasMore };
 };
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4517,7 +4517,6 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
     users,
     lastKey: nextOffset,
     hasMore,
-    totalCount: sortedIds.length,
     loadedIds: pageIds,
   };
 };
@@ -5167,21 +5166,10 @@ export const fetchPaginatedNewUsers = async (
       return acc;
     }, {});
 
-    let totalCount;
-    if (!lastKey) {
-      totalCount = await fetchTotalFilteredUsersCount(
-        filterForload,
-        filterSettings,
-        favoriteUsers,
-        options,
-      );
-    }
-
     return {
       users: finalUsers,
       lastKey: nextKey,
       hasMore: !!nextKey,
-      totalCount,
     };
   } catch (error) {
     console.error('Error fetching paginated filtered users:', error);
@@ -5886,35 +5874,6 @@ export const fetchAllFilteredUsers = async (
   }
 };
 
-export const fetchTotalFilteredUsersCount = async (
-  filterForload,
-  filterSettings = {},
-  favoriteUsers = {},
-  options = {},
-) => {
-  const allUsers = await fetchAllFilteredUsers(
-    filterForload,
-    filterSettings,
-    favoriteUsers,
-    options,
-  );
-  return Object.keys(allUsers).length;
-};
-
-export const fetchTotalNewUsersCount = async () => {
-  try {
-    const snapshot = await get(ref2(database, 'newUsers'));
-    if (snapshot.exists()) {
-      const data = snapshot.val();
-      return Object.keys(data).length;
-    }
-    return 0;
-  } catch (error) {
-    console.error('Error fetching total newUsers count:', error);
-    return 0;
-  }
-};
-
 export const fetchAllUsersFromRTDB = async () => {
   try {
     // Отримуємо дані з двох колекцій
@@ -6083,7 +6042,7 @@ export async function fetchSortedUsersByDate(limit = PAGE_SIZE, offset = 0) {
   // Records with special future dates are skipped
 
   const sliced = result.slice(offset, offset + limit);
-  return { data: Object.fromEntries(sliced), totalCount: result.length };
+  return { data: Object.fromEntries(sliced) };
 }
 
 export { fetchFilteredUsersByPage } from './dateLoad';


### PR DESCRIPTION
### Motivation

- Reduce complexity and duplication by removing the separate `totalCount` state and server-side total count plumbing and instead derive counts from loaded users and pagination state. 
- Avoid extra backend calls and stale total counters that were inconsistently updated across multiple load paths.

### Description

- Removed `totalCount` state and all `setTotalCount` updates from `src/components/AddNewProfile.jsx` and adjusted related effects and callbacks to rely on `Object.keys(users || {}).length` and `hasMore` for pagination and display. 
- Updated pagination calculation to compute `totalPages` from loaded user ids and `hasMore` (`loadedPages` + heuristics) and changed UI text and info handlers to reflect loaded cards count instead of backend total. 
- Eliminated server-side/response `totalCount` usage by removing `totalCount` from responses and consumers in `src/components/config.js` (including removal of `fetchTotalNewUsersCount` and `fetchTotalFilteredUsersCount`). 
- Stopped writing `totalCount` in `LastAction2Mode.jsx` and adjusted `loadMoreUsersLastAction2` and other load helpers to no longer set total counts; ensured cache/fetch behaviors still set `hasMore`, offsets and users. 
- Updated helper functions and callers (`fetchPaginatedNewUsers`, `fetchUsersBySearchKeyBloodPaged`, `fetchSortedUsersByDate`, and other fetch flows) to no longer return or expect `totalCount`.

### Testing

- Ran the project test suite with `yarn test` and observed no failing tests. 
- Ran linting with `yarn lint` and observed no lint errors. 
- Built the project with `yarn build` to ensure production build succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005795d6d08326af6fdfb4fcf45831)