### PR TITLE
Add toggle and persistence for backend download-size toasts

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -95,7 +95,12 @@ import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { PAGE_SIZE, database } from './config';
 import { get as firebaseGet, onValue as firebaseOnValue, push, ref } from 'firebase/database';
-import { withAdminDownloadToast, wrapAdminOnValue } from 'utils/backendDownloadToast';
+import {
+  getBackendDownloadToastsEnabled,
+  setBackendDownloadToastsEnabled,
+  withAdminDownloadToast,
+  wrapAdminOnValue,
+} from 'utils/backendDownloadToast';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
 // import { aiHandler } from './aiHandler';
 import {
@@ -407,6 +412,23 @@ const EditActionButton = styled.button`
 const EditActionIcon = styled.svg`
   width: 20px;
   height: 20px;
+`;
+
+const DownloadSizeToastToggleButton = styled(EditActionButton)`
+  width: auto;
+  min-width: 40px;
+  padding: 0 10px;
+  gap: 6px;
+  color: ${({ $active }) => ($active ? color.accent : color.accent5)};
+  background-color: ${({ $active }) => ($active ? color.paleAccent2 : 'transparent')};
+  border-color: ${({ $active }) => ($active ? color.paleAccent5 : 'transparent')};
+  font-size: 13px;
+  font-weight: 700;
+`;
+
+const DownloadSizeToastStatus = styled.span`
+  font-size: 11px;
+  font-weight: 700;
 `;
 
 // const iconMap = {
@@ -828,6 +850,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [searchBarQueryActive, setSearchBarQueryActive] = useState(false);
   const [lastSearchBarQuery, setLastSearchBarQuery] = useState('');
   const [isExcelImporting, setIsExcelImporting] = useState(false);
+  const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
   const excelImportInputRef = useRef(null);
   const [showSearchKeyIndexPanel, setShowSearchKeyIndexPanel] = useState(false);
   const [showLocalIndexModal, setShowLocalIndexModal] = useState(false);
@@ -3866,6 +3889,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   }, [searchIdAndSearchKeyOnlyMode]);
 
+  useEffect(() => {
+    setBackendDownloadToastsEnabled(downloadSizeToastsEnabled);
+  }, [downloadSizeToastsEnabled]);
+
+  const handleDownloadSizeToastsToggle = () => {
+    setDownloadSizeToastsEnabled(prev => !prev);
+  };
+
   const fieldsToRender = getFieldsToRender(state);
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
@@ -4128,6 +4159,25 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 </EditActionButton>
               </>
             )}
+            <DownloadSizeToastToggleButton
+              type="button"
+              $active={downloadSizeToastsEnabled}
+              aria-pressed={downloadSizeToastsEnabled}
+              title={
+                downloadSizeToastsEnabled
+                  ? 'Вимкнути тости щодо розміру завантаження файлів'
+                  : 'Увімкнути тости щодо розміру завантаження файлів'
+              }
+              aria-label={
+                downloadSizeToastsEnabled
+                  ? 'Вимкнути тости щодо розміру завантаження файлів'
+                  : 'Увімкнути тости щодо розміру завантаження файлів'
+              }
+              onClick={handleDownloadSizeToastsToggle}
+            >
+              📦
+              <DownloadSizeToastStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</DownloadSizeToastStatus>
+            </DownloadSizeToastToggleButton>
             <DotsButton
               onClick={() => {
                 setShowInfoModal('dotsMenu');

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -3,6 +3,7 @@ import { isAdminUid } from './accessLevel';
 
 export const ENABLE_BACKEND_TRAFFIC_TOAST = true;
 export const BACKEND_TRAFFIC_SILENT_MODE = false;
+export const BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY = 'backendDownloadSizeToastsEnabled';
 
 const TOAST_GROUP_DELAY_MS = 750;
 const TOAST_DURATION_MS = 5000;
@@ -23,6 +24,38 @@ const PROPERTY_OVERHEAD_BYTES = 4;
 const WRAPPED_ON_VALUE_FLAG = Symbol.for('knowme.backendTraffic.wrapAdminOnValue');
 
 const formatRows = rows => (Array.isArray(rows) ? rows : []);
+
+const getStoredBackendDownloadToastsEnabled = () => {
+  if (typeof localStorage === 'undefined') return true;
+
+  const storedValue = localStorage.getItem(BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY);
+  return storedValue !== 'false';
+};
+
+export const getBackendDownloadToastsEnabled = () => {
+  if (BACKEND_TRAFFIC_SILENT_MODE) return false;
+
+  if (typeof window !== 'undefined' && typeof window.__BACKEND_TRAFFIC_SILENT_MODE === 'boolean') {
+    return !window.__BACKEND_TRAFFIC_SILENT_MODE;
+  }
+
+  return getStoredBackendDownloadToastsEnabled();
+};
+
+export const setBackendDownloadToastsEnabled = enabled => {
+  const normalizedEnabled = Boolean(enabled);
+
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY, normalizedEnabled ? 'true' : 'false');
+  }
+
+  if (typeof window !== 'undefined') {
+    window.__BACKEND_TRAFFIC_SILENT_MODE = !normalizedEnabled;
+  }
+
+  return normalizedEnabled;
+};
+
 
 export const formatBytes = bytes => {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 KB';
@@ -410,9 +443,7 @@ const shouldEstimateAndToast = (runtime, request) => {
   return shouldEstimate;
 };
 
-const isSilentMode = () =>
-  BACKEND_TRAFFIC_SILENT_MODE ||
-  (typeof window !== 'undefined' && window.__BACKEND_TRAFFIC_SILENT_MODE === true);
+const isSilentMode = () => !getBackendDownloadToastsEnabled();
 
 const scheduleToast = request => {
   if (isSilentMode()) return;


### PR DESCRIPTION
### Motivation
- Provide a user-controllable switch to enable/disable informational toasts about backend download sizes and persist that preference.
- Centralize and expose runtime controls for silencing download-size toasts used by backend traffic utilities.

### Description
- Added `getBackendDownloadToastsEnabled`, `setBackendDownloadToastsEnabled`, and `BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY` to `utils/backendDownloadToast.js` and implemented localStorage + `window.__BACKEND_TRAFFIC_SILENT_MODE` syncing.
- Replaced the previous silent-mode check with `isSilentMode()` that reads the new `getBackendDownloadToastsEnabled()` flag.
- In `AddNewProfile.jsx` imported the new functions and added a UI toggle (`DownloadSizeToastToggleButton`) that shows current state (`ON`/`OFF`) and updates the setting via `setBackendDownloadToastsEnabled` on change.
- Persisted initial toggle state from `getBackendDownloadToastsEnabled()` and wired a `useEffect` to apply changes to the global setting when the toggle updates.

### Testing
- Ran unit tests with `yarn test`, all tests passed.
- Performed linting with `yarn lint`, no lint errors reported.
- Built the frontend with `yarn build` to verify integration, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0173b832048326989ee7fa2843969c)