### PR TITLE
Add non-deduped debug toasts and logging for additional newUsers matching flow

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -81,15 +81,29 @@ const DEBUG_ADDITIONAL_MATCHING_USER_ID = 'vtDxkDMjCwYuTDqTUnZsO29bpQr1';
 const shouldDebugAdditionalMatching = (...ids) =>
   ids.some(id => String(id || '').trim() === DEBUG_ADDITIONAL_MATCHING_USER_ID);
 
+const formatDebugToastValue = value => {
+  if (Array.isArray(value)) {
+    const preview = value.slice(0, 8).map(item => String(item)).join(', ');
+    return `[${preview}${value.length > 8 ? ', …' : ''}] (${value.length})`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value);
+    const preview = entries
+      .slice(0, 6)
+      .map(([entryKey, entryValue]) => `${entryKey}: ${Array.isArray(entryValue) ? `[${entryValue.slice(0, 4).join(', ')}]` : String(entryValue)}`)
+      .join(', ');
+    return `{${preview}${entries.length > 6 ? ', …' : ''}}`;
+  }
+
+  return String(value);
+};
+
 const debugAdditionalToast = (accessUserId, message, data = {}) => {
   if (!shouldDebugAdditionalMatching(accessUserId)) return;
 
   const compact = Object.entries(data)
-    .map(([key, value]) => {
-      if (Array.isArray(value)) return `${key}: ${value.length}`;
-      if (value && typeof value === 'object') return `${key}: ${Object.keys(value).length}`;
-      return `${key}: ${value}`;
-    })
+    .map(([key, value]) => `${key}: ${formatDebugToastValue(value)}`)
     .join(', ');
 
   toast(`[ADD newUsers] ${message}${compact ? ` | ${compact}` : ''}`, {
@@ -251,18 +265,23 @@ const fetchAdditionalNewUsersBySearchIndex = async ({
   rawRules,
   accessUserId,
   searchKeySetKeys,
+  collectionSource = 'newUsers',
   offset = 0,
   limit = FETCH_USERS_BY_IDS_BATCH_SIZE,
 }) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
 
-  debugAdditionalToast(normalizedAccessUserId, 'index request', {
-    rawRules,
+  const indexRequestDebugData = {
+    collectionSource,
     accessUserId: normalizedAccessUserId,
+    rawRules,
     searchKeySetKeys,
     offset,
     limit,
-  });
+  };
+
+  console.info('[Matching][additionalNewUsers] getIndexedNewUsersIdsByRules request', indexRequestDebugData);
+  debugAdditionalToast(normalizedAccessUserId, 'before getIndexedNewUsersIdsByRules', indexRequestDebugData);
 
   const indexed = await getIndexedNewUsersIdsByRules({
     rawRules,
@@ -271,6 +290,8 @@ const fetchAdditionalNewUsersBySearchIndex = async ({
     fetchMissingBuckets: true,
     resultOffset: offset,
     resultLimit: limit,
+    debugMatchingFlow: shouldDebugAdditionalMatching(normalizedAccessUserId),
+    debugToast: (message, data) => debugAdditionalToast(normalizedAccessUserId, message, data),
   });
 
   const userIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
@@ -2153,6 +2174,7 @@ const Matching = () => {
           rawRules: currentAdditionalAccessRules,
           accessUserId: ownerId,
           searchKeySetKeys: resolvedSearchKeySetKeys,
+          collectionSource,
           offset: 0,
           limit: INITIAL_LOAD,
         });
@@ -2565,6 +2587,7 @@ const Matching = () => {
             rawRules: currentAdditionalAccessRules,
             accessUserId: ownerId,
             searchKeySetKeys: resolvedSearchKeySetKeys,
+            collectionSource,
             offset: nextOffset,
             limit: LOAD_MORE,
           });

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -911,11 +911,27 @@ export const getIndexedNewUsersIdsByRules = async ({
   fetchMissingBuckets = false,
   resultOffset = 0,
   resultLimit = Number.POSITIVE_INFINITY,
+  debugMatchingFlow = false,
+  debugToast,
 }) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
+  const emitDebug = (message, data = {}) => {
+    if (!debugMatchingFlow) return;
+
+    console.info('[getIndexedNewUsersIdsByRules][additionalNewUsers]', message, data);
+    if (typeof debugToast === 'function') {
+      debugToast(`getIndexed: ${message}`, data);
+    }
+  };
+
   if (!normalizedAccessUserId) return null;
 
   const explicitSetKeys = normalizeSearchKeySetKeys(searchKeySetKeys);
+  emitDebug('normalized searchKeySetKeys', {
+    accessUserId: normalizedAccessUserId,
+    searchKeySetKeys: explicitSetKeys,
+  });
+
   const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
   const ruleBucketEntries = ruleSetEntries
     .map(({ text: setText, inputIndex }) => {
@@ -943,20 +959,39 @@ export const getIndexedNewUsersIdsByRules = async ({
 
       const defaultSetKey = makeAdditionalRulesSetKey(setText, normalizedAccessUserId, inputIndex);
       if (!defaultSetKey && explicitSetKeys.length === 0) return null;
-      return { defaultSetKey, indexBuckets };
+      return { defaultSetKey, inputIndex, indexBuckets };
     })
     .filter(Boolean);
+
+  emitDebug('parsed rule buckets', {
+    ruleSetCount: ruleSetEntries.length,
+    bucketSetCount: ruleBucketEntries.length,
+    ruleBuckets: ruleBucketEntries.map(entry => ({
+      setKey: entry.defaultSetKey,
+      inputIndex: entry.inputIndex,
+      indexBuckets: entry.indexBuckets,
+    })),
+  });
 
   const setEntries = ruleBucketEntries.flatMap(entry => {
     const setKeys = explicitSetKeys.length ? explicitSetKeys : [entry.defaultSetKey];
     return [...new Set(setKeys.filter(Boolean))].map(setKey => ({ setKey, indexBuckets: entry.indexBuckets }));
   });
 
-  if (!setEntries.length) return { setKeys: [], userIds: [], ownerId: normalizedAccessUserId };
+  if (!setEntries.length) {
+    emitDebug('final userIds before pagination', { userIds: [], count: 0 });
+    emitDebug('returned userIds after pagination', { userIds: [], count: 0, offset: resultOffset, limit: resultLimit });
+    return { setKeys: [], userIds: [], ownerId: normalizedAccessUserId };
+  }
 
   const readBucketPayload = async path => {
     const cached = peekCachedSearchKeyPayload(path);
-    if (cached && typeof cached.exists === 'boolean') return cached;
+    if (cached && typeof cached.exists === 'boolean') {
+      emitDebug('cache hit', { path, exists: cached.exists });
+      return cached;
+    }
+
+    emitDebug('cache miss', { path });
 
     try {
       const payload = await getCachedSearchKeyPayload(path, async () => {
@@ -997,12 +1032,21 @@ export const getIndexedNewUsersIdsByRules = async ({
       for (const value of values) {
         const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`;
         resultPaths.push(path);
+        emitDebug('reading Firebase path', { path, setKey: entry.setKey, indexName, value });
 
         // eslint-disable-next-line no-await-in-loop
         const payload = await readBucketPayload(path);
         const bucketValue = payload?.exists && payload.value && typeof payload.value === 'object'
           ? payload.value
           : {};
+
+        emitDebug('ids count from bucket', {
+          path,
+          setKey: entry.setKey,
+          indexName,
+          value,
+          idsCount: Object.keys(bucketValue).filter(Boolean).length,
+        });
 
         if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
         if (!setsMap[entry.setKey][indexName]) setsMap[entry.setKey][indexName] = {};
@@ -1034,12 +1078,26 @@ export const getIndexedNewUsersIdsByRules = async ({
   }
 
   const finalUserIds = [...matchedUserIds];
+  emitDebug('final userIds before pagination', {
+    userIds: finalUserIds,
+    count: finalUserIds.length,
+  });
+
   const pageUserIds = finalUserIds.slice(
     safeResultOffset,
     safeResultLimit === Number.POSITIVE_INFINITY ? undefined : safeResultOffset + safeResultLimit
   );
   const nextOffset = safeResultOffset + pageUserIds.length;
   const hasMore = nextOffset < finalUserIds.length;
+
+  emitDebug('returned userIds after pagination', {
+    userIds: pageUserIds,
+    count: pageUserIds.length,
+    offset: safeResultOffset,
+    limit: safeResultLimit,
+    nextOffset,
+    hasMore,
+  });
 
   saveCachedAdditionalRulesSetIndex({
     rawRules,


### PR DESCRIPTION
### Motivation
- Make the additional `newUsers` matching flow observable when debugging by emitting non-deduped toast messages and console logs at key points so developers can inspect rule parsing, index reads and pagination without being suppressed by existing dedupe/silent summary logic.

### Description
- Add a compact value formatter and improved `debugAdditionalToast` that prints previews (not only counts) for arrays/objects and always calls `toast(...)` directly for matching debug (bypassing dedupe/silent summary). 
- Before calling the index lookup, emit a `console.info` and a debug toast with `collectionSource`, `accessUserId`, `rawRules`, `searchKeySetKeys`, `offset`, and `limit`, and pass an opt-in debug callback into `getIndexedNewUsersIdsByRules`.
- Instrument `getIndexedNewUsersIdsByRules` with opt-in `debugMatchingFlow` and `debugToast` parameters and emit debug events (console + optional toast) for normalized `searchKeySetKeys`, parsed rule buckets, each Firebase path read (`searchKeySets/{setKey}/{indexName}/{value}`), cache hit/miss, ids count per bucket, final matched ids before pagination, and returned ids after pagination.
- Propagate `collectionSource` into initial and load-more calls for the additional `newUsers` matching flow so debug toasts include the source context.

### Testing
- Ran `npm run lint:js -- --max-warnings=0` and it completed without lint warnings. (succeeded)
- Ran `npm run build` and the production build completed successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017f0b7c088326958d24560ff0476a)