### PR TITLE
Handle empty/missing searchKeySets as empty access scope, add logging and tests

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -261,6 +261,14 @@ const fetchNewUsersByIdsForMatching = async (ids, batchSize = FETCH_USERS_BY_IDS
   return result;
 };
 
+const buildEmptyAdditionalSearchIndexResult = (reason, offset = 0) => ({
+  userIds: [],
+  users: [],
+  nextOffset: Math.max(0, Number(offset) || 0),
+  hasMore: false,
+  reason,
+});
+
 const fetchAdditionalNewUsersBySearchIndex = async ({
   rawRules,
   accessUserId,
@@ -270,15 +278,29 @@ const fetchAdditionalNewUsersBySearchIndex = async ({
   limit = FETCH_USERS_BY_IDS_BATCH_SIZE,
 }) => {
   const normalizedAccessUserId = String(accessUserId || '').trim();
+  const normalizedSearchKeySetKeys = normalizeSearchKeySetKeys(searchKeySetKeys);
 
   const indexRequestDebugData = {
     collectionSource,
     accessUserId: normalizedAccessUserId,
     rawRules,
-    searchKeySetKeys,
+    searchKeySetKeys: normalizedSearchKeySetKeys,
     offset,
     limit,
   };
+
+  if (collectionSource === 'newUsers' && normalizedSearchKeySetKeys.length === 0) {
+    const reason = 'no searchKeySets data';
+    console.info('[Matching][additionalNewUsers] access scope empty', {
+      ...indexRequestDebugData,
+      reason,
+    });
+    debugAdditionalToast(normalizedAccessUserId, 'access scope empty', {
+      ...indexRequestDebugData,
+      reason,
+    });
+    return buildEmptyAdditionalSearchIndexResult(reason, offset);
+  }
 
   console.info('[Matching][additionalNewUsers] getIndexedNewUsersIdsByRules request', indexRequestDebugData);
   debugAdditionalToast(normalizedAccessUserId, 'before getIndexedNewUsersIdsByRules', indexRequestDebugData);
@@ -286,8 +308,9 @@ const fetchAdditionalNewUsersBySearchIndex = async ({
   const indexed = await getIndexedNewUsersIdsByRules({
     rawRules,
     accessUserId: normalizedAccessUserId,
-    searchKeySetKeys,
+    searchKeySetKeys: normalizedSearchKeySetKeys,
     fetchMissingBuckets: true,
+    requireSearchKeySetKeys: collectionSource === 'newUsers',
     resultOffset: offset,
     resultLimit: limit,
     debugMatchingFlow: shouldDebugAdditionalMatching(normalizedAccessUserId),

--- a/src/utils/__tests__/newUsersFilterSetsIndex.test.js
+++ b/src/utils/__tests__/newUsersFilterSetsIndex.test.js
@@ -1,0 +1,101 @@
+const mockFirebaseGet = jest.fn();
+const mockFirebaseRef = jest.fn((database, path) => path);
+const mockPeekCachedSearchKeyPayload = jest.fn();
+const mockGetCachedSearchKeyPayload = jest.fn((path, loader) => loader());
+
+jest.mock('firebase/database', () => ({
+  get: (...args) => mockFirebaseGet(...args),
+  ref: (...args) => mockFirebaseRef(...args),
+  remove: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('components/config', () => ({
+  createAgeSearchKeyIndexInCollection: jest.fn(),
+  createContactSearchKeyIndexInCollection: jest.fn(),
+  createCsectionSearchKeyIndexInCollection: jest.fn(),
+  createFieldCountSearchKeyIndexInCollection: jest.fn(),
+  createImtHeightWeightSearchKeyIndexInCollection: jest.fn(),
+  createMaritalStatusSearchKeyIndexInCollection: jest.fn(),
+  createReactionSearchKeyIndexInCollection: jest.fn(),
+  createRoleSearchKeyIndexInCollection: jest.fn(),
+  createSearchKeyIndexInCollection: jest.fn(),
+  createUserIdSearchKeyIndexInCollection: jest.fn(),
+  database: { app: 'test-db' },
+}));
+
+jest.mock('../backendDownloadToast', () => ({
+  withAdminDownloadToast: promise => promise,
+}));
+
+jest.mock('../searchKeyCache', () => ({
+  getCachedSearchKeyPayload: (...args) => mockGetCachedSearchKeyPayload(...args),
+  peekCachedSearchKeyPayload: (...args) => mockPeekCachedSearchKeyPayload(...args),
+  saveCachedAdditionalRulesSetIndex: jest.fn(),
+}));
+
+const makeSnapshot = (exists, value = null) => ({
+  exists: () => exists,
+  val: () => value,
+});
+
+const loadModule = () => require('../newUsersFilterSetsIndex');
+
+describe('getIndexedNewUsersIdsByRules searchKeySets access scope', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFirebaseGet.mockResolvedValue(makeSnapshot(false));
+    mockFirebaseRef.mockImplementation((database, path) => path);
+    mockPeekCachedSearchKeyPayload.mockReturnValue(null);
+    mockGetCachedSearchKeyPayload.mockImplementation((path, loader) => loader());
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns empty and does not read global searchKey when exact user searchKeySets are missing', async () => {
+    const { getIndexedNewUsersIdsByRules } = loadModule();
+
+    const result = await getIndexedNewUsersIdsByRules({
+      rawRules: 'role: ed',
+      accessUserId: 'owner-1',
+      searchKeySetKeys: [],
+    });
+
+    expect(result.userIds).toEqual([]);
+    expect(result.reason).toBe('no searchKeySets data');
+    expect(mockFirebaseGet).not.toHaveBeenCalled();
+    expect(mockPeekCachedSearchKeyPayload).not.toHaveBeenCalledWith(expect.stringMatching(/^searchKey\//));
+    expect(mockGetCachedSearchKeyPayload).not.toHaveBeenCalledWith(expect.stringMatching(/^searchKey\//), expect.any(Function));
+    expect(console.info).toHaveBeenCalledWith(
+      '[searchKeySets][additionalNewUsers] access scope empty',
+      expect.objectContaining({ reason: 'no searchKeySets data' })
+    );
+  });
+
+  it('returns empty and does not fallback to global searchKey when setKey buckets are absent', async () => {
+    const { getIndexedNewUsersIdsByRules } = loadModule();
+
+    const result = await getIndexedNewUsersIdsByRules({
+      rawRules: 'csection: cs0',
+      accessUserId: 'owner-1',
+      searchKeySetKeys: ['owner-1_1'],
+    });
+
+    expect(result.userIds).toEqual([]);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/csection/cs0');
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith(expect.anything(), expect.stringMatching(/^searchKey\//));
+    expect(mockPeekCachedSearchKeyPayload).toHaveBeenCalledWith('searchKeySets/owner-1_1/csection/cs0');
+    expect(mockPeekCachedSearchKeyPayload).not.toHaveBeenCalledWith(expect.stringMatching(/^searchKey\//));
+    expect(mockGetCachedSearchKeyPayload).toHaveBeenCalledWith('searchKeySets/owner-1_1/csection/cs0', expect.any(Function));
+    expect(mockGetCachedSearchKeyPayload).not.toHaveBeenCalledWith(expect.stringMatching(/^searchKey\//), expect.any(Function));
+    expect(console.info).toHaveBeenCalledWith(
+      '[searchKeySets][additionalNewUsers] access scope empty',
+      expect.objectContaining({ reason: 'missing setKey' })
+    );
+  });
+});

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -909,6 +909,7 @@ export const getIndexedNewUsersIdsByRules = async ({
   accessUserId,
   searchKeySetKeys = [],
   fetchMissingBuckets = false,
+  requireSearchKeySetKeys = true,
   resultOffset = 0,
   resultLimit = Number.POSITIVE_INFINITY,
   debugMatchingFlow = false,
@@ -924,6 +925,12 @@ export const getIndexedNewUsersIdsByRules = async ({
     }
   };
 
+  const emitAccessScopeEmpty = (reason, data = {}) => {
+    const payload = { reason, ...data };
+    console.info('[searchKeySets][additionalNewUsers] access scope empty', payload);
+    emitDebug('access scope empty', payload);
+  };
+
   if (!normalizedAccessUserId) return null;
 
   const explicitSetKeys = normalizeSearchKeySetKeys(searchKeySetKeys);
@@ -931,6 +938,21 @@ export const getIndexedNewUsersIdsByRules = async ({
     accessUserId: normalizedAccessUserId,
     searchKeySetKeys: explicitSetKeys,
   });
+
+  if (requireSearchKeySetKeys && explicitSetKeys.length === 0) {
+    emitAccessScopeEmpty('no searchKeySets data', {
+      accessUserId: normalizedAccessUserId,
+      searchKeySetKeys: explicitSetKeys,
+    });
+    return {
+      setKeys: [],
+      userIds: [],
+      ownerId: normalizedAccessUserId,
+      nextOffset: Math.max(0, Number(resultOffset) || 0),
+      hasMore: false,
+      reason: 'no searchKeySets data',
+    };
+  }
 
   const ruleSetEntries = parseRawRulesToSetEntries(rawRules);
   const ruleBucketEntries = ruleSetEntries
@@ -979,6 +1001,11 @@ export const getIndexedNewUsersIdsByRules = async ({
   });
 
   if (!setEntries.length) {
+    emitAccessScopeEmpty('access scope empty', {
+      accessUserId: normalizedAccessUserId,
+      searchKeySetKeys: explicitSetKeys,
+      ruleBucketEntriesCount: ruleBucketEntries.length,
+    });
     emitDebug('final userIds before pagination', { userIds: [], count: 0 });
     emitDebug('returned userIds after pagination', { userIds: [], count: 0, offset: resultOffset, limit: resultLimit });
     return { setKeys: [], userIds: [], ownerId: normalizedAccessUserId };
@@ -1025,6 +1052,9 @@ export const getIndexedNewUsersIdsByRules = async ({
 
   for (const entry of setEntries) {
     const filterSets = [];
+    let existingBucketsForSet = 0;
+    let emptyBucketsForSet = 0;
+    let missingBucketsForSet = 0;
 
     for (const [indexName, values] of Object.entries(entry.indexBuckets)) {
       const idsForFilter = new Set();
@@ -1039,13 +1069,21 @@ export const getIndexedNewUsersIdsByRules = async ({
         const bucketValue = payload?.exists && payload.value && typeof payload.value === 'object'
           ? payload.value
           : {};
+        const bucketIdsCount = Object.keys(bucketValue).filter(Boolean).length;
+
+        if (payload?.exists) {
+          existingBucketsForSet += 1;
+          if (bucketIdsCount === 0) emptyBucketsForSet += 1;
+        } else {
+          missingBucketsForSet += 1;
+        }
 
         emitDebug('ids count from bucket', {
           path,
           setKey: entry.setKey,
           indexName,
           value,
-          idsCount: Object.keys(bucketValue).filter(Boolean).length,
+          idsCount: bucketIdsCount,
         });
 
         if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
@@ -1066,6 +1104,18 @@ export const getIndexedNewUsersIdsByRules = async ({
     if (!filterSets.length || filterSets.some(set => set.size === 0)) {
       // Empty or missing searchKeySets buckets mean this rule set allows no cards.
       // Do not fallback to searchKey/searchKeyFile/newUsers scans.
+      const reason = existingBucketsForSet === 0
+        ? 'missing setKey'
+        : emptyBucketsForSet > 0 || missingBucketsForSet > 0
+          ? 'empty bucket'
+          : 'access scope empty';
+      emitAccessScopeEmpty(reason, {
+        setKey: entry.setKey,
+        existingBuckets: existingBucketsForSet,
+        emptyBuckets: emptyBucketsForSet,
+        missingBuckets: missingBucketsForSet,
+        filters: filterSets.map(set => set.size),
+      });
       continue;
     }
 
@@ -1075,6 +1125,14 @@ export const getIndexedNewUsersIdsByRules = async ({
       .forEach(userId => {
         if (restSets.every(set => set.has(userId))) matchedUserIds.add(userId);
       });
+  }
+
+  if (matchedUserIds.size === 0) {
+    emitAccessScopeEmpty('access scope empty', {
+      accessUserId: normalizedAccessUserId,
+      setKeys: setEntries.map(entry => entry.setKey),
+      readPaths: resultPaths,
+    });
   }
 
   const finalUserIds = [...matchedUserIds];


### PR DESCRIPTION
### Motivation

- Ensure additional matching flow treats missing or empty `searchKeySetKeys` as an empty access scope and avoids unintended fallbacks or scans. 
- Improve observability and debug toasts for when index buckets are missing, empty, or otherwise prevent matches. 

### Description

- Added `buildEmptyAdditionalSearchIndexResult` and `normalizeSearchKeySetKeys` usage in `Matching.jsx`, and return early with debug logs/toasts when `searchKeySetKeys` is empty for `newUsers` queries. 
- Introduced `requireSearchKeySetKeys` parameter (default `true`) to `getIndexedNewUsersIdsByRules` and return a structured empty result with `reason: 'no searchKeySets data'` when explicit set keys are absent. 
- Added `emitAccessScopeEmpty` helper and enhanced bucket reading logic in `newUsersFilterSetsIndex.js` to track existing/empty/missing buckets and emit specific reasons (`missing setKey`, `empty bucket`, `access scope empty`) instead of falling back to global search keys. 
- Emit access-scope-empty debug when no matched IDs are found and persist previous pagination/hasMore behavior; added unit tests in `src/utils/__tests__/newUsersFilterSetsIndex.test.js` covering empty/missing set key behavior. 

### Testing

- Added Jest unit tests in `src/utils/__tests__/newUsersFilterSetsIndex.test.js` which verify that empty `searchKeySetKeys` returns an empty result and that missing set-key buckets do not fallback to global search keys; these tests passed. 
- Ran the test suite with `yarn test` and the new tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bbbaa36883268534d7ea18f9d4ad)