### PR TITLE
Support viewer-owned reaction overrides and robust shared-reaction merging

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -79,7 +79,10 @@ import {
 } from 'utils/multiDataAccess';
 import {
   buildSharedReactionCandidateIds,
+  canShowMatchingUser,
+  mergeMatchingCandidateUsers,
   normalizeReactionMap,
+  readReactionSnapshotMaps,
   resolvePrioritizedReactionMaps,
   uniqueTruthyReactionIds,
 } from 'utils/reactionPriority';
@@ -1436,6 +1439,10 @@ const SwipeableCard = ({
   setFavoriteUsers,
   dislikeUsers,
   setDislikeUsers,
+  ownFavoriteUsers,
+  setOwnFavoriteUsers,
+  ownDislikeUsers,
+  setOwnDislikeUsers,
   viewMode,
   handleRemove,
   togglePublish,
@@ -1649,8 +1656,12 @@ const SwipeableCard = ({
         userData={user}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
+        ownFavoriteUsers={ownFavoriteUsers}
+        setOwnFavoriteUsers={setOwnFavoriteUsers}
         dislikeUsers={dislikeUsers}
         setDislikeUsers={setDislikeUsers}
+        ownDislikeUsers={ownDislikeUsers}
+        setOwnDislikeUsers={setOwnDislikeUsers}
         onRemove={handleRemove}
         multiDataOwnerId={multiDataOwnerId}
       />
@@ -1659,8 +1670,12 @@ const SwipeableCard = ({
         userData={user}
         dislikeUsers={dislikeUsers}
         setDislikeUsers={setDislikeUsers}
+        ownDislikeUsers={ownDislikeUsers}
+        setOwnDislikeUsers={setOwnDislikeUsers}
         favoriteUsers={favoriteUsers}
         setFavoriteUsers={setFavoriteUsers}
+        ownFavoriteUsers={ownFavoriteUsers}
+        setOwnFavoriteUsers={setOwnFavoriteUsers}
         onRemove={handleRemove}
         multiDataOwnerId={multiDataOwnerId}
       />
@@ -2437,7 +2452,12 @@ const Matching = () => {
     const loadedUsers = [];
     if (collectionSource === 'newUsers' && allowedNewUserIds.length > 0) {
       const newUsersCards = await fetchNewUsersByIdsForMatching(allowedNewUserIds);
-      loadedUsers.push(...newUsersCards);
+      loadedUsers.push(
+        ...newUsersCards.map(user => ({
+          ...user,
+          __matchingAccessAllowed: parsedAdditionalAccessRules.length > 0,
+        }))
+      );
     }
 
     if (collectionSource !== 'newUsers') {
@@ -2449,6 +2469,7 @@ const Matching = () => {
             .map(id => usersMap[id])
             .filter(Boolean)
             .map(user => ({ ...user, __sourceCollection: 'users' }))
+            .filter(user => canShowMatchingUser(user, { isAdmin }))
         );
       }
     }
@@ -2458,7 +2479,10 @@ const Matching = () => {
       ? allowedNewUserIds.filter(id => !loadedIds.has(id))
       : candidateIds.filter(isValidId).filter(id => !loadedIds.has(id));
 
-    loadedUsers.forEach(user => updateCard(user.userId, user));
+    loadedUsers.forEach(user => {
+      const { __matchingAccessAllowed, ...cacheUser } = user;
+      updateCard(user.userId, cacheUser);
+    });
     setSharedReactionCandidateUsers(loadedUsers);
     await loadCommentsFor(loadedUsers);
 
@@ -2490,6 +2514,7 @@ const Matching = () => {
     currentSearchKeySetKeys,
     loadCommentsFor,
     ownerId,
+    isAdmin,
     parsedAdditionalAccessRules.length,
     sharedReactionIds,
   ]);
@@ -2599,13 +2624,18 @@ const Matching = () => {
     const loadedDislikeOwnerIds = new Set();
     const applyPrioritizedReactionMaps = () => {
       const ownOwnerId = getOwnerId();
-      const hasLoadedReactionSnapshots = ownerIds.every(
-        ownerId => loadedFavoriteOwnerIds.has(ownerId) && loadedDislikeOwnerIds.has(ownerId)
-      );
-      if (!hasLoadedReactionSnapshots) return;
-      const sharedOwnerIds = ownerIds.filter(id => id !== ownOwnerId);
+      const hasLoadedOwnReactionSnapshots =
+        ownOwnerId &&
+        loadedFavoriteOwnerIds.has(ownOwnerId) &&
+        loadedDislikeOwnerIds.has(ownOwnerId);
+      if (!hasLoadedOwnReactionSnapshots) return;
+      const availableOwnerIds = ownerIds.filter(ownerId => (
+        ownerId === ownOwnerId ||
+        (loadedFavoriteOwnerIds.has(ownerId) && loadedDislikeOwnerIds.has(ownerId))
+      ));
+      const sharedOwnerIds = availableOwnerIds.filter(id => id !== ownOwnerId);
       const { favorites, dislikes } = resolvePrioritizedReactionMaps({
-        ownerIds,
+        ownerIds: availableOwnerIds,
         ownOwnerId,
         favoriteSnapshots,
         dislikeSnapshots,
@@ -2613,7 +2643,7 @@ const Matching = () => {
       const ownFavorites = normalizeReactionMap(favoriteSnapshots[ownOwnerId]);
       const ownDislikes = normalizeReactionMap(dislikeSnapshots[ownOwnerId]);
       const nextSharedReactionIds = buildSharedReactionCandidateIds({
-        ownerIds,
+        ownerIds: availableOwnerIds,
         ownOwnerId,
         favoriteSnapshots,
         dislikeSnapshots,
@@ -2622,6 +2652,7 @@ const Matching = () => {
       });
       debugSharedReactionsLog(ownOwnerId, 'priority merge applied for shared reactions', {
         ownerIds,
+        availableOwnerIds,
         sharedOwnerIds,
         sharedFavoritesFound: countTruthyReactionEntries(
           sharedOwnerIds.map(sharedOwnerId => favoriteSnapshots[sharedOwnerId])
@@ -2663,16 +2694,29 @@ const Matching = () => {
       const favRef = refDb(database, `multiData/favorites/${effectiveOwnerId}`);
       const disRef = refDb(database, `multiData/dislikes/${effectiveOwnerId}`);
 
+      const markOwnerSnapshotLoaded = (snapshotStore, loadedOwnerIds, type, error) => {
+        snapshotStore[effectiveOwnerId] = {};
+        loadedOwnerIds.add(effectiveOwnerId);
+        if (error) {
+          debugSharedReactionsLog(getOwnerId(), `shared ${type} snapshot unavailable`, {
+            ownerId: effectiveOwnerId,
+            type,
+            message: error.message || String(error),
+          }, error);
+        }
+        applyPrioritizedReactionMaps();
+      };
+
       const unsubFav = onValue(favRef, snap => {
         favoriteSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
         loadedFavoriteOwnerIds.add(effectiveOwnerId);
         applyPrioritizedReactionMaps();
-      });
+      }, error => markOwnerSnapshotLoaded(favoriteSnapshots, loadedFavoriteOwnerIds, 'favorites', error));
       const unsubDis = onValue(disRef, snap => {
         dislikeSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
         loadedDislikeOwnerIds.add(effectiveOwnerId);
         applyPrioritizedReactionMaps();
-      });
+      }, error => markOwnerSnapshotLoaded(dislikeSnapshots, loadedDislikeOwnerIds, 'dislikes', error));
 
       return [unsubFav, unsubDis];
     });
@@ -2923,12 +2967,12 @@ const Matching = () => {
       const owners = getMatchingMultiDataOwnerIds();
       let exclude = new Set();
       if (owners.length) {
-        const [favMaps, disMaps] = await Promise.all([
-          Promise.all(owners.map(owner => fetchFavoriteUsers(owner))),
-          Promise.all(owners.map(owner => fetchDislikeUsers(owner))),
-        ]);
-        const favoriteSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, favMaps[index]]));
-        const dislikeSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, disMaps[index]]));
+        const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
+          ownerIds: owners,
+          fetchFavoriteUsers,
+          fetchDislikeUsers,
+          onWarning: warning => debugSharedReactionsLog(getOwnerId(), 'initial shared reaction snapshot unavailable', warning, warning.error),
+        });
         const ownOwnerId = getOwnerId();
         const { favorites: favIds, dislikes: disIds } = resolvePrioritizedReactionMaps({
           ownerIds: owners,
@@ -3077,12 +3121,12 @@ const Matching = () => {
       return;
     }
 
-    const [favoriteMaps, dislikeMaps] = await Promise.all([
-      Promise.all(owners.map(owner => fetchFavoriteUsers(owner))),
-      Promise.all(owners.map(owner => fetchDislikeUsers(owner))),
-    ]);
-    const favoriteSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, favoriteMaps[index]]));
-    const dislikeSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, dislikeMaps[index]]));
+    const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
+      ownerIds: owners,
+      fetchFavoriteUsers,
+      fetchDislikeUsers,
+      onWarning: warning => debugSharedReactionsLog(getOwnerId(), 'reaction snapshot unavailable while loading reaction cards', warning, warning.error),
+    });
     const ownOwnerId = getOwnerId();
     const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
       ownerIds: owners,
@@ -3129,12 +3173,12 @@ const Matching = () => {
       return;
     }
 
-    const [favoriteMaps, dislikeMaps] = await Promise.all([
-      Promise.all(owners.map(owner => fetchFavoriteUsers(owner))),
-      Promise.all(owners.map(owner => fetchDislikeUsers(owner))),
-    ]);
-    const favoriteSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, favoriteMaps[index]]));
-    const dislikeSnapshots = Object.fromEntries(owners.map((owner, index) => [owner, dislikeMaps[index]]));
+    const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
+      ownerIds: owners,
+      fetchFavoriteUsers,
+      fetchDislikeUsers,
+      onWarning: warning => debugSharedReactionsLog(getOwnerId(), 'reaction snapshot unavailable while loading reaction cards', warning, warning.error),
+    });
     const ownOwnerId = getOwnerId();
     const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
       ownerIds: owners,
@@ -3458,54 +3502,17 @@ const Matching = () => {
   const [preLastCardNode, setPreLastCardNode] = useState(null);
 
 
-  const visibleUsers = useMemo(() => {
-    let baseUsers = isAdmin
-      ? users
-      : users.filter(user => user.__sourceCollection === 'newUsers' || user.publish === true);
-
-    const hasAdditionalAccessRules = parsedAdditionalAccessRules.length > 0;
-    if (hasAdditionalAccessRules) {
-      const allowedBySetKey = new Set(additionalNewUsers.map(user => user.userId).filter(Boolean));
-      baseUsers = baseUsers.filter(user => {
-        if (user?.__sourceCollection !== 'newUsers') return true;
-        return collectionSource !== 'newUsers' || allowedBySetKey.has(user.userId);
-      });
-    }
-
-    const shouldInjectAdditionalCards =
-      viewMode === 'default' &&
-      collectionSource === 'newUsers' &&
-      hasAdditionalAccessRules &&
-      additionalNewUsers.length > 0;
-
-    const byId = new Map(baseUsers.map(user => [user.userId, user]));
-    const injectCandidate = user => {
-      if (!user?.userId) return;
-      const existing = byId.get(user.userId);
-      if (existing) {
-        byId.set(user.userId, { ...existing, ...user });
-      } else {
-        byId.set(user.userId, user);
-      }
-    };
-
-    if (shouldInjectAdditionalCards) {
-      additionalNewUsers.forEach(injectCandidate);
-    }
-
-    if (viewMode === 'default') {
-      sharedReactionCandidateUsers.forEach(injectCandidate);
-    }
-
-    const mergedUsers = Array.from(byId.values());
-    if (viewMode !== 'default') {
-      return baseUsers;
-    }
-
-    return mergedUsers.filter(
-      user => !ownFavoriteUsers[user.userId] && !ownDislikeUsers[user.userId]
-    );
-  }, [
+  const visibleUsers = useMemo(() => mergeMatchingCandidateUsers({
+    users,
+    additionalNewUsers,
+    sharedReactionCandidateUsers,
+    isAdmin,
+    viewMode,
+    collectionSource,
+    hasAdditionalAccessRules: parsedAdditionalAccessRules.length > 0,
+    ownFavoriteUsers,
+    ownDislikeUsers,
+  }), [
     additionalNewUsers,
     ownDislikeUsers,
     ownFavoriteUsers,
@@ -3753,8 +3760,12 @@ const Matching = () => {
                         isAdmin={isAdmin}
                         favoriteUsers={favoriteUsers}
                         setFavoriteUsers={setFavoriteUsers}
+                        ownFavoriteUsers={ownFavoriteUsers}
+                        setOwnFavoriteUsers={setOwnFavoriteUsers}
                         dislikeUsers={dislikeUsers}
                         setDislikeUsers={setDislikeUsers}
+                        ownDislikeUsers={ownDislikeUsers}
+                        setOwnDislikeUsers={setOwnDislikeUsers}
                         viewMode={viewMode}
                         handleRemove={handleRemove}
                         togglePublish={togglePublish}

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -16,11 +16,15 @@ export const BtnDislike = ({
   userData = {},
   dislikeUsers = {},
   setDislikeUsers,
+  ownDislikeUsers,
+  setOwnDislikeUsers,
   onDislikeAdded,
   onDislikeRemoved,
   onRemove,
   favoriteUsers = {},
   setFavoriteUsers,
+  ownFavoriteUsers,
+  setOwnFavoriteUsers,
   customStyle = {},
   inactiveIconColor = '#fff',
   activeIconColor = color.reactionIdleIcon,
@@ -37,7 +41,12 @@ export const BtnDislike = ({
     boxShadow: customBoxShadow,
     ...restCustomStyle
   } = customStyle;
-  const isDisliked = !!dislikeUsers[userId];
+  const viewerDislikeUsers = ownDislikeUsers || dislikeUsers;
+  const updateOwnDislikeUsers = setOwnDislikeUsers || setDislikeUsers;
+  const viewerFavoriteUsers = ownFavoriteUsers || favoriteUsers;
+  const updateOwnFavoriteUsers = setOwnFavoriteUsers || setFavoriteUsers;
+  const isDisliked = !!viewerDislikeUsers[userId];
+  const isSharedDisliked = !isDisliked && !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
   const resolvedActiveIconColor = activeIconColor || customTextColor || color.reactionIdleIcon;
   const resolvedInactiveIconColor = inactiveIconColor || '#fff';
@@ -51,6 +60,9 @@ export const BtnDislike = ({
     if (isDisliked) {
       try {
         await removeDislikeUser(userId, multiDataOwnerId);
+        const updatedOwn = { ...viewerDislikeUsers };
+        delete updatedOwn[userId];
+        if (updateOwnDislikeUsers) updateOwnDislikeUsers(updatedOwn);
         const updated = { ...dislikeUsers };
         delete updated[userId];
         setDislikeUsers(updated);
@@ -66,6 +78,8 @@ export const BtnDislike = ({
     } else {
       try {
         await addDislikeUser(userId, multiDataOwnerId);
+        const updatedOwn = { ...viewerDislikeUsers, [userId]: true };
+        if (updateOwnDislikeUsers) updateOwnDislikeUsers(updatedOwn);
         const updated = { ...dislikeUsers, [userId]: true };
         setDislikeUsers(updated);
         setDislike(userId, true);
@@ -73,12 +87,17 @@ export const BtnDislike = ({
         if (typeof onDislikeAdded === 'function') {
           await onDislikeAdded(userId);
         }
-        if (favoriteUsers[userId]) {
-          try {
-            await removeFavoriteUser(userId, multiDataOwnerId);
-          } catch (err) {
-            console.error('Failed to remove favorite when adding dislike:', err);
+        if (favoriteUsers[userId] || viewerFavoriteUsers[userId]) {
+          if (viewerFavoriteUsers[userId]) {
+            try {
+              await removeFavoriteUser(userId, multiDataOwnerId);
+            } catch (err) {
+              console.error('Failed to remove favorite when adding dislike:', err);
+            }
           }
+          const updatedOwnFavorites = { ...viewerFavoriteUsers };
+          delete updatedOwnFavorites[userId];
+          if (updateOwnFavoriteUsers) updateOwnFavoriteUsers(updatedOwnFavorites);
           const upd = { ...favoriteUsers };
           delete upd[userId];
           if (setFavoriteUsers) setFavoriteUsers(upd);
@@ -120,8 +139,10 @@ export const BtnDislike = ({
         alignItems: 'center',
         justifyContent: 'center',
       }}
-      title={title}
+      title={isSharedDisliked ? `${title} (shared)` : title}
       aria-label={ariaLabel}
+      aria-pressed={isDisliked}
+      data-shared-disliked={isSharedDisliked ? 'true' : undefined}
       disabled={!auth.currentUser}
       onClick={e => {
         e.stopPropagation();

--- a/src/components/smallCard/btnDislike.test.js
+++ b/src/components/smallCard/btnDislike.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { BtnDislike } from './btnDislike';
+import { addDislikeUser, removeDislikeUser } from '../config';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('../config', () => ({
+  addDislikeUser: jest.fn(() => Promise.resolve()),
+  removeDislikeUser: jest.fn(() => Promise.resolve()),
+  removeFavoriteUser: jest.fn(() => Promise.resolve()),
+  auth: { currentUser: { uid: 'viewer' } },
+}));
+
+jest.mock('utils/dislikesStorage', () => ({
+  setDislike: jest.fn(),
+  cacheDislikedUsers: jest.fn(),
+}));
+
+jest.mock('utils/favoritesStorage', () => ({
+  setFavorite: jest.fn(),
+}));
+
+jest.mock('utils/cardsStorage', () => ({
+  removeCardFromList: jest.fn(),
+}));
+
+describe('BtnDislike', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.removeChild(container);
+  });
+
+  it('uses viewer-owned dislikes for active state and creates own dislike for shared-only disliked cards', async () => {
+    const setDislikeUsers = jest.fn();
+    const setOwnDislikeUsers = jest.fn();
+
+    await act(async () => {
+      root.render(
+        <BtnDislike
+          userId="card1"
+          userData={{ userId: 'card1' }}
+          dislikeUsers={{ card1: true }}
+          ownDislikeUsers={{}}
+          setDislikeUsers={setDislikeUsers}
+          setOwnDislikeUsers={setOwnDislikeUsers}
+          favoriteUsers={{}}
+          ownFavoriteUsers={{}}
+          setFavoriteUsers={jest.fn()}
+          setOwnFavoriteUsers={jest.fn()}
+          multiDataOwnerId="viewer"
+        />
+      );
+    });
+
+    const button = container.querySelector('button[aria-label="Дизлайк"]');
+    expect(button).not.toBeNull();
+    expect(button.style.background).toBe('rgb(255, 140, 0)');
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+    expect(button.getAttribute('data-shared-disliked')).toBe('true');
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(addDislikeUser).toHaveBeenCalledWith('card1', 'viewer');
+    expect(removeDislikeUser).not.toHaveBeenCalled();
+    expect(setOwnDislikeUsers).toHaveBeenCalledWith({ card1: true });
+    expect(setDislikeUsers).toHaveBeenCalledWith({ card1: true });
+  });
+});

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -16,10 +16,14 @@ export const BtnFavorite = ({
   userData = {},
   favoriteUsers = {},
   setFavoriteUsers,
+  ownFavoriteUsers,
+  setOwnFavoriteUsers,
   onRemove,
   onDislikeRemoved,
   dislikeUsers = {},
   setDislikeUsers,
+  ownDislikeUsers,
+  setOwnDislikeUsers,
   customStyle = {},
   inactiveIconColor = '#fff',
   activeIconColor = color.reactionIdleIcon,
@@ -36,7 +40,12 @@ export const BtnFavorite = ({
     boxShadow: customBoxShadow,
     ...restCustomStyle
   } = customStyle;
-  const isFavorite = !!favoriteUsers[userId];
+  const viewerFavoriteUsers = ownFavoriteUsers || favoriteUsers;
+  const updateOwnFavoriteUsers = setOwnFavoriteUsers || setFavoriteUsers;
+  const viewerDislikeUsers = ownDislikeUsers || dislikeUsers;
+  const updateOwnDislikeUsers = setOwnDislikeUsers || setDislikeUsers;
+  const isFavorite = !!viewerFavoriteUsers[userId];
+  const isSharedFavorite = !isFavorite && !!favoriteUsers[userId];
   const activeColor = color.reactionLike;
   const resolvedActiveIconColor = activeIconColor || customTextColor || color.reactionIdleIcon;
   const resolvedInactiveIconColor = inactiveIconColor || '#fff';
@@ -50,7 +59,11 @@ export const BtnFavorite = ({
     if (isFavorite) {
       try {
         await removeFavoriteUser(userId, multiDataOwnerId);
-        const updated = { ...favoriteUsers, [userId]: false };
+        const updatedOwn = { ...viewerFavoriteUsers };
+        delete updatedOwn[userId];
+        if (updateOwnFavoriteUsers) updateOwnFavoriteUsers(updatedOwn);
+        const updated = { ...favoriteUsers };
+        delete updated[userId];
         setFavoriteUsers(updated);
         setFavoriteIds(Object.fromEntries(Object.entries(updated).filter(([, v]) => v)));
         updateCachedUser(userData || { userId }, { removeFavorite: true });
@@ -62,18 +75,25 @@ export const BtnFavorite = ({
     } else {
       try {
         await addFavoriteUser(userId, multiDataOwnerId);
+        const updatedOwnFav = { ...viewerFavoriteUsers, [userId]: true };
+        if (updateOwnFavoriteUsers) updateOwnFavoriteUsers(updatedOwnFav);
         const updatedFav = { ...favoriteUsers, [userId]: true };
         setFavoriteUsers(updatedFav);
         setFavoriteIds(updatedFav);
         updateCachedUser(userData || { userId });
         setFavorite(userId, true);
         if (onRemove) onRemove(userId);
-        if (dislikeUsers[userId]) {
-          try {
-            await removeDislikeUser(userId, multiDataOwnerId);
-          } catch (err) {
-            console.error('Failed to remove dislike when adding favorite:', err);
+        if (dislikeUsers[userId] || viewerDislikeUsers[userId]) {
+          if (viewerDislikeUsers[userId]) {
+            try {
+              await removeDislikeUser(userId, multiDataOwnerId);
+            } catch (err) {
+              console.error('Failed to remove dislike when adding favorite:', err);
+            }
           }
+          const updatedOwnDislikes = { ...viewerDislikeUsers };
+          delete updatedOwnDislikes[userId];
+          if (updateOwnDislikeUsers) updateOwnDislikeUsers(updatedOwnDislikes);
           const upd = { ...dislikeUsers };
           delete upd[userId];
           if (setDislikeUsers) setDislikeUsers(upd);
@@ -115,8 +135,10 @@ export const BtnFavorite = ({
         alignItems: 'center',
         justifyContent: 'center',
       }}
-      title={title}
+      title={isSharedFavorite ? `${title} (shared)` : title}
       aria-label={ariaLabel}
+      aria-pressed={isFavorite}
+      data-shared-favorite={isSharedFavorite ? 'true' : undefined}
       disabled={!auth.currentUser}
       onClick={e => {
         e.stopPropagation();

--- a/src/components/smallCard/btnFavorite.test.js
+++ b/src/components/smallCard/btnFavorite.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { BtnFavorite } from './btnFavorite';
+import { addFavoriteUser, removeDislikeUser } from '../config';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('../config', () => ({
+  addFavoriteUser: jest.fn(() => Promise.resolve()),
+  removeFavoriteUser: jest.fn(() => Promise.resolve()),
+  removeDislikeUser: jest.fn(() => Promise.resolve()),
+  auth: { currentUser: { uid: 'viewer' } },
+}));
+
+jest.mock('utils/cache', () => ({
+  updateCachedUser: jest.fn(),
+  setFavoriteIds: jest.fn(),
+}));
+
+jest.mock('utils/favoritesStorage', () => ({
+  setFavorite: jest.fn(),
+}));
+
+jest.mock('utils/dislikesStorage', () => ({
+  setDislike: jest.fn(),
+}));
+
+describe('BtnFavorite', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.removeChild(container);
+  });
+
+  it('creates viewer-owned favorite and locally overrides a shared-only dislike', async () => {
+    const setFavoriteUsers = jest.fn();
+    const setOwnFavoriteUsers = jest.fn();
+    const setDislikeUsers = jest.fn();
+    const setOwnDislikeUsers = jest.fn();
+
+    await act(async () => {
+      root.render(
+        <BtnFavorite
+          userId="ID0001"
+          userData={{ userId: 'ID0001' }}
+          favoriteUsers={{}}
+          ownFavoriteUsers={{}}
+          setFavoriteUsers={setFavoriteUsers}
+          setOwnFavoriteUsers={setOwnFavoriteUsers}
+          dislikeUsers={{ ID0001: true }}
+          ownDislikeUsers={{}}
+          setDislikeUsers={setDislikeUsers}
+          setOwnDislikeUsers={setOwnDislikeUsers}
+          multiDataOwnerId="viewer"
+        />
+      );
+    });
+
+    const button = container.querySelector('button[aria-label="В обране"]');
+    expect(button).not.toBeNull();
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(addFavoriteUser).toHaveBeenCalledWith('ID0001', 'viewer');
+    expect(removeDislikeUser).not.toHaveBeenCalled();
+    expect(setOwnFavoriteUsers).toHaveBeenCalledWith({ ID0001: true });
+    expect(setFavoriteUsers).toHaveBeenCalledWith({ ID0001: true });
+    expect(setOwnDislikeUsers).toHaveBeenCalledWith({});
+    expect(setDislikeUsers).toHaveBeenCalledWith({});
+  });
+});

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -120,3 +120,100 @@ describe('resolvePrioritizedReactionMaps', () => {
   });
 
 });
+
+describe('mergeMatchingCandidateUsers', () => {
+  it('does not inject unpublished users cards from shared reactions for non-admin viewers', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [{ userId: 'publishedBase', publish: true, __sourceCollection: 'users' }],
+      sharedReactionCandidateUsers: [
+        { userId: 'unpublishedShared', publish: false, __sourceCollection: 'users' },
+        { userId: 'publishedShared', publish: true, __sourceCollection: 'users' },
+      ],
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['publishedBase', 'publishedShared']);
+  });
+
+  it('keeps an allowed shared ID0001 newUsers candidate after searchKeySets access filtering', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [],
+      additionalNewUsers: [],
+      sharedReactionCandidateUsers: [{
+        userId: 'ID0001',
+        __sourceCollection: 'newUsers',
+        __matchingAccessAllowed: true,
+      }],
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['ID0001']);
+  });
+
+  it('does not inject a shared ID0001 newUsers candidate without searchKeySets access', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [],
+      additionalNewUsers: [],
+      sharedReactionCandidateUsers: [{ userId: 'ID0001', __sourceCollection: 'newUsers' }],
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('readReactionSnapshotMaps', () => {
+  it('keeps viewer reactions when a shared owner snapshot is unavailable', async () => {
+    const { readReactionSnapshotMaps, resolvePrioritizedReactionMaps, buildSharedReactionCandidateIds } = require('../reactionPriority');
+    const warnings = [];
+    const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
+      ownerIds: ['viewer', 'sharedAllowed', 'sharedDenied'],
+      fetchFavoriteUsers: owner => {
+        if (owner === 'viewer') return Promise.resolve({ ownFavorite: true });
+        if (owner === 'sharedAllowed') return Promise.resolve({ sharedFavorite: true });
+        return Promise.reject(new Error('permission denied'));
+      },
+      fetchDislikeUsers: owner => {
+        if (owner === 'viewer') return Promise.resolve({ ownDislike: true });
+        if (owner === 'sharedAllowed') return Promise.resolve({ sharedDislike: true });
+        return Promise.reject(new Error('permission denied'));
+      },
+      onWarning: warning => warnings.push(warning),
+    });
+
+    const merged = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedAllowed', 'sharedDenied'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots,
+      dislikeSnapshots,
+    });
+
+    expect(favoriteSnapshots.viewer).toEqual({ ownFavorite: true });
+    expect(dislikeSnapshots.viewer).toEqual({ ownDislike: true });
+    expect(merged.favorites).toEqual({ sharedFavorite: true, ownFavorite: true });
+    expect(merged.dislikes).toEqual({ sharedDislike: true, ownDislike: true });
+    expect(buildSharedReactionCandidateIds({
+      ownerIds: ['viewer', 'sharedAllowed', 'sharedDenied'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots,
+      dislikeSnapshots,
+      favorites: merged.favorites,
+      dislikes: merged.dislikes,
+    }).sort()).toEqual(['sharedDislike', 'sharedFavorite']);
+    expect(warnings).toHaveLength(2);
+  });
+});

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -79,3 +79,114 @@ export const resolvePrioritizedReactionMaps = ({
 
   return { favorites, dislikes };
 };
+
+
+export const canShowMatchingUser = (user, { isAdmin = false } = {}) => {
+  if (isAdmin) return true;
+  return user?.__sourceCollection === 'newUsers' || user?.publish === true;
+};
+
+export const mergeMatchingCandidateUsers = ({
+  users = [],
+  additionalNewUsers = [],
+  sharedReactionCandidateUsers = [],
+  isAdmin = false,
+  viewMode = 'default',
+  collectionSource = 'users',
+  hasAdditionalAccessRules = false,
+  ownFavoriteUsers = {},
+  ownDislikeUsers = {},
+} = {}) => {
+  let baseUsers = isAdmin ? users : users.filter(user => canShowMatchingUser(user, { isAdmin }));
+
+  const allowedBySetKey = new Set(additionalNewUsers.map(user => user.userId).filter(Boolean));
+  const isAllowedNewUsersCandidate = user => (
+    !hasAdditionalAccessRules ||
+    collectionSource !== 'newUsers' ||
+    user?.__sourceCollection !== 'newUsers' ||
+    allowedBySetKey.has(user.userId) ||
+    user?.__matchingAccessAllowed === true
+  );
+  const canInjectCandidate = user => (
+    canShowMatchingUser(user, { isAdmin }) && isAllowedNewUsersCandidate(user)
+  );
+
+  if (hasAdditionalAccessRules) {
+    baseUsers = baseUsers.filter(user => {
+      if (user?.__sourceCollection !== 'newUsers') return true;
+      return collectionSource !== 'newUsers' || allowedBySetKey.has(user.userId);
+    });
+  }
+
+  const shouldInjectAdditionalCards =
+    viewMode === 'default' &&
+    collectionSource === 'newUsers' &&
+    hasAdditionalAccessRules &&
+    additionalNewUsers.length > 0;
+
+  const byId = new Map(baseUsers.map(user => [user.userId, user]));
+  const injectCandidate = user => {
+    if (!user?.userId) return;
+    if (!canInjectCandidate(user)) return;
+    const existing = byId.get(user.userId);
+    if (existing) {
+      byId.set(user.userId, { ...existing, ...user });
+    } else {
+      byId.set(user.userId, user);
+    }
+  };
+
+  if (shouldInjectAdditionalCards) {
+    additionalNewUsers.forEach(injectCandidate);
+  }
+
+  if (viewMode === 'default') {
+    sharedReactionCandidateUsers.forEach(injectCandidate);
+  }
+
+  const mergedUsers = Array.from(byId.values()).filter(canInjectCandidate);
+  if (viewMode !== 'default') {
+    return baseUsers;
+  }
+
+  return mergedUsers.filter(
+    user => !ownFavoriteUsers[user.userId] && !ownDislikeUsers[user.userId]
+  );
+};
+
+export const readReactionSnapshotMaps = async ({
+  ownerIds = [],
+  fetchFavoriteUsers,
+  fetchDislikeUsers,
+  onWarning,
+} = {}) => {
+  const favoriteSnapshots = {};
+  const dislikeSnapshots = {};
+  const orderedOwnerIds = [...new Set(ownerIds.filter(Boolean))];
+  await Promise.all(orderedOwnerIds.flatMap(ownerId => [
+    Promise.resolve()
+      .then(() => fetchFavoriteUsers(ownerId))
+      .then(value => {
+        favoriteSnapshots[ownerId] = value || {};
+      })
+      .catch(error => {
+        favoriteSnapshots[ownerId] = {};
+        if (typeof onWarning === 'function') {
+          onWarning({ ownerId, type: 'favorites', error });
+        }
+      }),
+    Promise.resolve()
+      .then(() => fetchDislikeUsers(ownerId))
+      .then(value => {
+        dislikeSnapshots[ownerId] = value || {};
+      })
+      .catch(error => {
+        dislikeSnapshots[ownerId] = {};
+        if (typeof onWarning === 'function') {
+          onWarning({ ownerId, type: 'dislikes', error });
+        }
+      }),
+  ]));
+
+  return { favoriteSnapshots, dislikeSnapshots };
+};


### PR DESCRIPTION
### Motivation
- Improve handling of shared reactions so viewers can have local (own) favorites/dislikes that override shared-only reactions and avoid leaking unpublished/newUsers candidates without access.
- Make reaction snapshot loading more robust to partial failures and surface warnings instead of breaking the matching flow.
- Consolidate candidate merging and visibility logic to simplify `Matching` component and ensure consistent filtering for admins vs regular viewers.

### Description
- Added utility functions in `utils/reactionPriority.js`: `canShowMatchingUser`, `mergeMatchingCandidateUsers`, and `readReactionSnapshotMaps` to centralize visibility rules, merging of candidate pools, and resilient fetching of reaction snapshots with warning callbacks.
- Updated `Matching.jsx` to use the new utilities: mark `__matchingAccessAllowed` for fetched `newUsers`, avoid caching that flag, use `canShowMatchingUser` when loading users, call `readReactionSnapshotMaps` where initial `Promise.all` was used, and replace the in-component visible-users logic with a call to `mergeMatchingCandidateUsers`.
- Improved shared reaction application: require viewer's own snapshots to be loaded before applying priority, allow partial availability of other owners if both their favorites/dislikes were fetched, and add error handlers that log warnings when a snapshot is unavailable in realtime listeners.
- Enhanced small-card components to support viewer-owned overrides by adding `ownFavoriteUsers`, `ownDislikeUsers`, `setOwnFavoriteUsers`, and `setOwnDislikeUsers` props and updating `BtnFavorite` and `BtnDislike` logic to update both local viewer state and shared state when toggling reactions, and annotate buttons with `aria-pressed` and `data-shared-*` attributes and adjusted `title` for shared-only state.
- Added/tests: new unit tests for `btnFavorite` and `btnDislike` behavior (`src/components/smallCard/btnFavorite.test.js`, `src/components/smallCard/btnDislike.test.js`) and extended `reactionPriority` tests (`src/utils/__tests__/reactionPriority.test.js`) covering `mergeMatchingCandidateUsers` and `readReactionSnapshotMaps` scenarios.

### Testing
- Ran unit tests under Jest including `reactionPriority.test.js`, `btnFavorite.test.js`, and `btnDislike.test.js`, and these tests passed locally.
- Verified component-level behavior covered by the new tests that simulate viewer-owned reaction toggles and shared-snapshot failure scenarios, and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022c12aa2c832686e6a2b377428a1e)