### PR TITLE
Make shared reactions affect default deck visibility and show ownership badges

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1361,6 +1361,23 @@ const HeaderRow = styled.div`
   flex-wrap: wrap;
 `;
 
+
+const ReactionOwnershipBadge = styled.div`
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 6;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: ${props => (props.$type === 'dislike' ? 'rgba(239, 68, 68, 0.92)' : 'rgba(236, 72, 153, 0.92)')};
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
+  pointer-events: none;
+`;
+
 const AdminToggle = styled.div`
   position: absolute;
   top: 5px;
@@ -1564,6 +1581,19 @@ const SwipeableCard = ({
         .filter(Boolean)
         .join(', ')
     : cityInfo || regionInfo;
+  const isOwnFavorite = Boolean(ownFavoriteUsers?.[user.userId]);
+  const isOwnDislike = Boolean(ownDislikeUsers?.[user.userId]);
+  const isEffectiveFavorite = Boolean(favoriteUsers?.[user.userId]);
+  const isEffectiveDislike = Boolean(dislikeUsers?.[user.userId]);
+  const reactionBadge = isOwnFavorite
+    ? { label: 'Liked by you', type: 'favorite', ownership: 'own' }
+    : isOwnDislike
+      ? { label: 'Disliked by you', type: 'dislike', ownership: 'own' }
+      : isEffectiveFavorite
+        ? { label: 'Liked by shared owner', type: 'favorite', ownership: 'shared' }
+        : isEffectiveDislike
+          ? { label: 'Disliked by shared owner', type: 'dislike', ownership: 'shared' }
+          : null;
 
   return (
     <AnimatedCard
@@ -1577,6 +1607,15 @@ const SwipeableCard = ({
       onTouchEnd={handleTouchEnd}
       style={style}
     >
+      {reactionBadge && (
+        <ReactionOwnershipBadge
+          $type={reactionBadge.type}
+          data-reaction-ownership={reactionBadge.ownership}
+          data-reaction-type={reactionBadge.type}
+        >
+          {reactionBadge.label}
+        </ReactionOwnershipBadge>
+      )}
       {current === 'description' && (
         <InfoSlide $reserveActionButtons={!photo} $role={role}>
           {extraFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{extraFields}</Table>}
@@ -3018,8 +3057,8 @@ const Matching = () => {
         syncFavorites(favIds);
         syncDislikes(disIds);
         exclude = new Set([
-          ...Object.keys(ownFavorites),
-          ...Object.keys(ownDislikes),
+          ...Object.keys(favIds),
+          ...Object.keys(disIds),
         ]);
       } else {
         const localFav = getFavorites();
@@ -3274,8 +3313,8 @@ const Matching = () => {
     );
     try {
       const baseExclude = new Set([
-        ...Object.keys(ownFavoriteUsersRef.current),
-        ...Object.keys(ownDislikeUsersRef.current),
+        ...Object.keys(favoriteUsersRef.current),
+        ...Object.keys(dislikeUsersRef.current),
       ]);
 
       if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
@@ -3510,10 +3549,14 @@ const Matching = () => {
     viewMode,
     collectionSource,
     hasAdditionalAccessRules: parsedAdditionalAccessRules.length > 0,
+    favoriteUsers,
+    dislikeUsers,
     ownFavoriteUsers,
     ownDislikeUsers,
   }), [
     additionalNewUsers,
+    dislikeUsers,
+    favoriteUsers,
     ownDislikeUsers,
     ownFavoriteUsers,
     isAdmin,

--- a/src/components/smallCard/btnDislike.test.js
+++ b/src/components/smallCard/btnDislike.test.js
@@ -81,4 +81,56 @@ describe('BtnDislike', () => {
     expect(setOwnDislikeUsers).toHaveBeenCalledWith({ card1: true });
     expect(setDislikeUsers).toHaveBeenCalledWith({ card1: true });
   });
+
+  it('becomes viewer-owned active after the shared-only dislike is saved locally', async () => {
+    const setDislikeUsers = jest.fn();
+    const setOwnDislikeUsers = jest.fn();
+    const mountComponent = ui => root.render(ui);
+
+    await act(async () => {
+      mountComponent(
+        <BtnDislike
+          userId="card1"
+          userData={{ userId: 'card1' }}
+          dislikeUsers={{ card1: true }}
+          ownDislikeUsers={{}}
+          setDislikeUsers={setDislikeUsers}
+          setOwnDislikeUsers={setOwnDislikeUsers}
+          favoriteUsers={{}}
+          ownFavoriteUsers={{}}
+          setFavoriteUsers={jest.fn()}
+          setOwnFavoriteUsers={jest.fn()}
+          multiDataOwnerId="viewer"
+        />
+      );
+    });
+
+    const button = container.querySelector('button[aria-label="Дизлайк"]');
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await act(async () => {
+      mountComponent(
+        <BtnDislike
+          userId="card1"
+          userData={{ userId: 'card1' }}
+          dislikeUsers={{ card1: true }}
+          ownDislikeUsers={{ card1: true }}
+          setDislikeUsers={setDislikeUsers}
+          setOwnDislikeUsers={setOwnDislikeUsers}
+          favoriteUsers={{}}
+          ownFavoriteUsers={{}}
+          setFavoriteUsers={jest.fn()}
+          setOwnFavoriteUsers={jest.fn()}
+          multiDataOwnerId="viewer"
+        />
+      );
+    });
+
+    const activeButton = container.querySelector('button[aria-label="Дизлайк"]');
+    expect(activeButton.getAttribute('aria-pressed')).toBe('true');
+    expect(activeButton.getAttribute('data-shared-disliked')).toBeNull();
+  });
+
 });

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -119,9 +119,48 @@ describe('resolvePrioritizedReactionMaps', () => {
     ).toEqual([]);
   });
 
+
+  it('uses own favorite as the effective reaction over a shared dislike', () => {
+    const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: {
+        viewer: { card1: true },
+      },
+      dislikeSnapshots: {
+        sharedOwner: { card1: true },
+      },
+    });
+
+    expect(favorites).toEqual({ card1: true });
+    expect(dislikes).toEqual({});
+  });
+
 });
 
 describe('mergeMatchingCandidateUsers', () => {
+
+  it('excludes shared-only effective reactions from the default deck', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [
+        { userId: 'neutral', publish: true, __sourceCollection: 'users' },
+        { userId: 'sharedDislikeOnly', publish: true, __sourceCollection: 'users' },
+        { userId: 'ownFavorite', publish: true, __sourceCollection: 'users' },
+      ],
+      favoriteUsers: { ownFavorite: true },
+      dislikeUsers: { sharedDislikeOnly: true },
+      ownFavoriteUsers: { ownFavorite: true },
+      ownDislikeUsers: {},
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['neutral']);
+  });
+
   it('does not inject unpublished users cards from shared reactions for non-admin viewers', () => {
     const { mergeMatchingCandidateUsers } = require('../reactionPriority');
 

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -94,6 +94,8 @@ export const mergeMatchingCandidateUsers = ({
   viewMode = 'default',
   collectionSource = 'users',
   hasAdditionalAccessRules = false,
+  favoriteUsers,
+  dislikeUsers,
   ownFavoriteUsers = {},
   ownDislikeUsers = {},
 } = {}) => {
@@ -149,8 +151,11 @@ export const mergeMatchingCandidateUsers = ({
     return baseUsers;
   }
 
+  const defaultExcludeFavorites = favoriteUsers || ownFavoriteUsers;
+  const defaultExcludeDislikes = dislikeUsers || ownDislikeUsers;
+
   return mergedUsers.filter(
-    user => !ownFavoriteUsers[user.userId] && !ownDislikeUsers[user.userId]
+    user => !defaultExcludeFavorites[user.userId] && !defaultExcludeDislikes[user.userId]
   );
 };
 


### PR DESCRIPTION
### Motivation
- Shared favorites/dislikes must act as effective matching decisions but yield to the viewer's own reaction when present.
- Default deck should exclude cards based on the effective merged reaction maps instead of only the viewer's own reactions to avoid duplication and incorrect UX.
- UI must show ownership (own vs shared) while keeping button active state tied only to the viewer's own reactions and not to shared maps.

### Description
- Change default-deck filtering to use effective merged reaction maps by updating `mergeMatchingCandidateUsers` to accept and respect `favoriteUsers`/`dislikeUsers` (merged) when `viewMode === 'default'` instead of only `ownFavoriteUsers`/`ownDislikeUsers` (file: `src/utils/reactionPriority.js`).
- Apply merged reaction maps during Matching initial load and load-more flows by excluding IDs from the result using merged `favIds`/`disIds` and using `favoriteUsersRef`/`dislikeUsersRef` for dynamic excludes (file: `src/components/Matching.jsx`).
- Add a compact ownership badge rendered on cards indicating `Liked by you` / `Disliked by you` or `Liked by shared owner` / `Disliked by shared owner`, while preserving the existing button ownership logic (file: `src/components/Matching.jsx`).
- Add and update unit tests to cover priority/merge behavior and UI/button interaction: new/updated tests in `src/utils/__tests__/reactionPriority.test.js` and `src/components/smallCard/btnDislike.test.js`, while keeping `BtnFavorite`/`BtnDislike` button ownership semantics unchanged.

### Testing
- Ran unit tests: `npm test -- --runInBand --watchAll=false src/utils/__tests__/reactionPriority.test.js src/components/smallCard/btnFavorite.test.js src/components/smallCard/btnDislike.test.js`, and all suites passed.
- Built production bundle with `npm run build` and the build completed successfully.
- The changes include regression tests validating shared-only exclusion from default deck, own-over-shared priority, newUsers access protections, unpublished candidate rejection, snapshot-tolerance, and shared-click-to-own behavior, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02481a34208326915e6ce444df26fc)