### PR TITLE
Verify shared dislike pagination invariants

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -8,8 +8,6 @@ import { color } from './styles';
 import {
   fetchUsersByLastLogin2,
   fetchUserById,
-  fetchFavoriteUsersData,
-  fetchDislikeUsersData,
   fetchFavoriteUsers,
   fetchDislikeUsers,
   filterMain,
@@ -50,13 +48,11 @@ import {
   cacheFavoriteUsers,
   syncFavorites,
   getFavorites,
-  getFavoriteCards,
 } from '../utils/favoritesStorage';
 import {
   cacheDislikedUsers,
   syncDislikes,
   getDislikes,
-  getDislikedCards,
 } from '../utils/dislikesStorage';
 import {
   loadComments,
@@ -78,6 +74,7 @@ import {
   resolveMatchingMultiDataOwnerIds,
 } from 'utils/multiDataAccess';
 import {
+  buildReactionCardsPage,
   buildSharedReactionCandidateIds,
   canShowMatchingUser,
   mergeMatchingCandidateUsers,
@@ -232,8 +229,6 @@ const isShortId = id => typeof id === 'string' && id.length > 0 && id.length < 2
 const isMatchingCardId = id => isValidId(id) || isShortId(id);
 const isAllowedIdForCollection = (id, collection = 'users') =>
   collection === 'newUsers' ? isShortId(id) : isValidId(id);
-const filterMatchingUsers = list => list.filter(u => isMatchingCardId(u?.userId));
-
 const compareUsersByLastLogin2 = (a = {}, b = {}) =>
   (b.lastLogin2 || '').localeCompare(a.lastLogin2 || '');
 
@@ -671,6 +666,7 @@ const applyMatchingUiFiltersToUsers = ({
   users,
   filters,
   favoriteUsers,
+  dislikeUsers,
   roleIndexSets,
   collectionSource,
 }) =>
@@ -679,7 +675,8 @@ const applyMatchingUiFiltersToUsers = ({
       users.map(u => [u.userId, u]),
       null,
       getMatchingFiltersWithoutSearchKeyGroups(filters),
-      favoriteUsers
+      favoriteUsers,
+      dislikeUsers
     ).map(([, u]) => u),
     filters,
     roleIndexSets
@@ -1362,21 +1359,6 @@ const HeaderRow = styled.div`
 `;
 
 
-const ReactionOwnershipBadge = styled.div`
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  z-index: 6;
-  padding: 4px 8px;
-  border-radius: 999px;
-  background: ${props => (props.$type === 'dislike' ? 'rgba(239, 68, 68, 0.92)' : 'rgba(236, 72, 153, 0.92)')};
-  color: #fff;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
-  pointer-events: none;
-`;
 
 const AdminToggle = styled.div`
   position: absolute;
@@ -1581,20 +1563,6 @@ const SwipeableCard = ({
         .filter(Boolean)
         .join(', ')
     : cityInfo || regionInfo;
-  const isOwnFavorite = Boolean(ownFavoriteUsers?.[user.userId]);
-  const isOwnDislike = Boolean(ownDislikeUsers?.[user.userId]);
-  const isEffectiveFavorite = Boolean(favoriteUsers?.[user.userId]);
-  const isEffectiveDislike = Boolean(dislikeUsers?.[user.userId]);
-  const reactionBadge = isOwnFavorite
-    ? { label: 'Liked by you', type: 'favorite', ownership: 'own' }
-    : isOwnDislike
-      ? { label: 'Disliked by you', type: 'dislike', ownership: 'own' }
-      : isEffectiveFavorite
-        ? { label: 'Liked by shared owner', type: 'favorite', ownership: 'shared' }
-        : isEffectiveDislike
-          ? { label: 'Disliked by shared owner', type: 'dislike', ownership: 'shared' }
-          : null;
-
   return (
     <AnimatedCard
       $dir={dir}
@@ -1607,15 +1575,6 @@ const SwipeableCard = ({
       onTouchEnd={handleTouchEnd}
       style={style}
     >
-      {reactionBadge && (
-        <ReactionOwnershipBadge
-          $type={reactionBadge.type}
-          data-reaction-ownership={reactionBadge.ownership}
-          data-reaction-type={reactionBadge.type}
-        >
-          {reactionBadge.label}
-        </ReactionOwnershipBadge>
-      )}
       {current === 'description' && (
         <InfoSlide $reserveActionButtons={!photo} $role={role}>
           {extraFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{extraFields}</Table>}
@@ -2016,6 +1975,12 @@ const Matching = () => {
   const [ownDislikeUsers, setOwnDislikeUsers] = useState({});
   const [sharedReactionIds, setSharedReactionIds] = useState([]);
   const [sharedReactionCandidateUsers, setSharedReactionCandidateUsers] = useState([]);
+  const [reactionPagination, setReactionPagination] = useState({
+    type: null,
+    ids: [],
+    nextOffset: 0,
+    hasMore: false,
+  });
   const favoriteUsersRef = useRef(favoriteUsers);
   const dislikeUsersRef = useRef(dislikeUsers);
   const ownFavoriteUsersRef = useRef(ownFavoriteUsers);
@@ -3150,12 +3115,15 @@ const Matching = () => {
     toast.success('Фільтри та кеш скинуто');
   }, [reloadDefault]);
 
-  const loadFavoriteCards = async () => {
-    setViewMode('favorites');
+  const loadReactionCards = async reactionType => {
+    const isFavoritesMode = reactionType === 'favorites';
+    setViewMode(reactionType);
     setLoading(true);
     setUsers([]);
+    setReactionPagination({ type: reactionType, ids: [], nextOffset: 0, hasMore: false });
     const owners = await waitForOwnerId();
     if (!owners.length) {
+      setHasMore(false);
       setLoading(false);
       return;
     }
@@ -3173,8 +3141,10 @@ const Matching = () => {
       favoriteSnapshots,
       dislikeSnapshots,
     });
-    setOwnFavoriteUsers(normalizeReactionMap(favoriteSnapshots[ownOwnerId]));
-    setOwnDislikeUsers(normalizeReactionMap(dislikeSnapshots[ownOwnerId]));
+    const ownFavorites = normalizeReactionMap(favoriteSnapshots[ownOwnerId]);
+    const ownDislikes = normalizeReactionMap(dislikeSnapshots[ownOwnerId]);
+    setOwnFavoriteUsers(ownFavorites);
+    setOwnDislikeUsers(ownDislikes);
     setSharedReactionIds(buildSharedReactionCandidateIds({
       ownerIds: owners,
       ownOwnerId,
@@ -3183,75 +3153,55 @@ const Matching = () => {
       favorites: favMap,
       dislikes: disMap,
     }));
-    const favDataByOwner = await Promise.all(owners.map(owner => fetchFavoriteUsersData(owner)));
-    const favUsers = Object.assign({}, ...favDataByOwner);
+
     syncFavorites(favMap);
     syncDislikes(disMap);
     setFavoriteUsers(favMap);
     setDislikeUsers(disMap);
-    setFavoriteIds(favMap);
-    cacheFavoriteUsers(favUsers);
-    setIdsForQuery('favorite', Object.keys(favMap));
-    const { cards: favCards } = await getFavoriteCards(id => fetchUserById(id));
-    const list = filterMatchingUsers(favCards).sort(compareUsersByLastLogin2);
-    loadedIdsRef.current = new Set(list.map(u => u.userId));
-    setUsers(list);
-    await loadCommentsFor(list);
-    setHasMore(false);
-    setLastKey(null);
-    setLoading(false);
-  };
 
-  const loadDislikeCards = async () => {
-    setViewMode('dislikes');
-    setLoading(true);
-    setUsers([]);
-    const owners = await waitForOwnerId();
-    if (!owners.length) {
-      setLoading(false);
-      return;
+    const reactionMap = isFavoritesMode ? favMap : disMap;
+    const listKey = isFavoritesMode ? 'favorite' : 'dislike';
+    const reactionIds = Object.keys(reactionMap);
+    setIdsForQuery(listKey, reactionIds);
+    if (isFavoritesMode) setFavoriteIds(favMap);
+
+    const page = buildReactionCardsPage({
+      reactionIds,
+      offset: 0,
+      limit: INITIAL_LOAD,
+    });
+    const usersMap = await fetchUsersByIds(page.pageIds);
+    const list = page.pageIds
+      .map(id => usersMap[id])
+      .filter(Boolean)
+      .map(user => ({ ...user, userId: user.userId }))
+      .filter(user => isMatchingCardId(user.userId))
+      .filter(user => canShowMatchingUser(user, { isAdmin }))
+      .sort(compareUsersByLastLogin2);
+
+    list.forEach(user => updateCard(user.userId, user));
+    if (isFavoritesMode) {
+      cacheFavoriteUsers(Object.fromEntries(list.map(user => [user.userId, user])));
+    } else {
+      cacheDislikedUsers(Object.fromEntries(list.map(user => [user.userId, user])));
     }
-
-    const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
-      ownerIds: owners,
-      fetchFavoriteUsers,
-      fetchDislikeUsers,
-      onWarning: warning => debugSharedReactionsLog(getOwnerId(), 'reaction snapshot unavailable while loading reaction cards', warning, warning.error),
-    });
-    const ownOwnerId = getOwnerId();
-    const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
-      ownerIds: owners,
-      ownOwnerId,
-      favoriteSnapshots,
-      dislikeSnapshots,
-    });
-    setOwnFavoriteUsers(normalizeReactionMap(favoriteSnapshots[ownOwnerId]));
-    setOwnDislikeUsers(normalizeReactionMap(dislikeSnapshots[ownOwnerId]));
-    setSharedReactionIds(buildSharedReactionCandidateIds({
-      ownerIds: owners,
-      ownOwnerId,
-      favoriteSnapshots,
-      dislikeSnapshots,
-      favorites: favMap,
-      dislikes: disMap,
-    }));
-    const dislikeDataByOwner = await Promise.all(owners.map(owner => fetchDislikeUsersData(owner)));
-    const loaded = Object.assign({}, ...dislikeDataByOwner);
-    cacheDislikedUsers(loaded);
-    syncFavorites(favMap);
-    setFavoriteUsers(favMap);
-    syncDislikes(disMap);
-    setDislikeUsers(disMap);
-    setIdsForQuery('dislike', Object.keys(disMap));
-    const { cards: disCards } = await getDislikedCards(id => fetchUserById(id));
-    const list = filterMatchingUsers(disCards).sort(compareUsersByLastLogin2);
     loadedIdsRef.current = new Set(list.map(u => u.userId));
     setUsers(list);
     await loadCommentsFor(list);
-    setHasMore(false);
+    setReactionPagination({
+      type: reactionType,
+      ids: reactionIds,
+      nextOffset: page.nextOffset,
+      hasMore: page.hasMore,
+    });
+    setHasMore(page.hasMore);
     setLastKey(null);
     setLoading(false);
   };
+
+  const loadFavoriteCards = () => loadReactionCards('favorites');
+
+  const loadDislikeCards = () => loadReactionCards('dislikes');
 
   const searchUsers = async params => {
     const [key, value] = Object.entries(params)[0] || [];
@@ -3296,7 +3246,8 @@ const Matching = () => {
   };
 
   const loadMore = React.useCallback(async ({ targetVisibleCount = 0, currentVisibleCount = 0 } = {}) => {
-    if (!hasMore || loadingRef.current || viewMode !== 'default') {
+    const isReactionViewMode = viewMode === 'favorites' || viewMode === 'dislikes';
+    if (!hasMore || loadingRef.current || (viewMode !== 'default' && !isReactionViewMode)) {
       console.log('[loadMore] skip', { hasMore, loading: loadingRef.current, viewMode });
       return;
     }
@@ -3312,6 +3263,49 @@ const Matching = () => {
       applyVersion === additionalMatchingApplyVersionRef.current
     );
     try {
+      if (isReactionViewMode) {
+        const reactionMap = viewMode === 'favorites'
+          ? favoriteUsersRef.current
+          : dislikeUsersRef.current;
+        const reactionIds = reactionPagination.type === viewMode
+          ? reactionPagination.ids
+          : Object.keys(reactionMap);
+        const page = buildReactionCardsPage({
+          reactionIds,
+          offset: reactionPagination.type === viewMode ? reactionPagination.nextOffset : 0,
+          limit: LOAD_MORE,
+          excludeIds: loadedIdsRef.current,
+        });
+        const usersMap = await fetchUsersByIds(page.pageIds);
+        const list = page.pageIds
+          .map(id => usersMap[id])
+          .filter(Boolean)
+          .filter(user => isMatchingCardId(user.userId))
+          .filter(user => canShowMatchingUser(user, { isAdmin }))
+          .filter(user => !loadedIdsRef.current.has(user.userId))
+          .sort(compareUsersByLastLogin2);
+
+        list.forEach(user => {
+          loadedIdsRef.current.add(user.userId);
+          updateCard(user.userId, user);
+        });
+        setUsers(prev => {
+          const map = new Map(prev.map(user => [user.userId, user]));
+          list.forEach(user => map.set(user.userId, user));
+          return Array.from(map.values());
+        });
+        await loadCommentsFor(list);
+        setReactionPagination({
+          type: viewMode,
+          ids: reactionIds,
+          nextOffset: page.nextOffset,
+          hasMore: page.hasMore,
+        });
+        setHasMore(page.hasMore);
+        setLastKey(null);
+        return;
+      }
+
       const baseExclude = new Set([
         ...Object.keys(favoriteUsersRef.current),
         ...Object.keys(dislikeUsersRef.current),
@@ -3424,6 +3418,7 @@ const Matching = () => {
             users: Array.from(candidateMap.values()),
             filters,
             favoriteUsers: favoriteUsersRef.current,
+            dislikeUsers: dislikeUsersRef.current,
             roleIndexSets,
             collectionSource,
           }).length;
@@ -3525,7 +3520,9 @@ const Matching = () => {
     hasMore,
     lastKey,
     loadCommentsFor,
+    isAdmin,
     ownerId,
+    reactionPagination,
     resetAdditionalMatchingState,
     parsedAdditionalAccessRules.length,
     roleIndexSets,
@@ -3571,6 +3568,7 @@ const Matching = () => {
     users: visibleUsers,
     filters,
     favoriteUsers,
+    dislikeUsers,
     roleIndexSets,
     collectionSource,
   });
@@ -3603,7 +3601,7 @@ const Matching = () => {
   }, [collectionSource, filteredUsers, filters, ownerId, parsedAdditionalAccessRules.length, visibleUsers]);
 
   useEffect(() => {
-    if (viewMode !== 'default') return;
+    if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;
     if (loadingRef.current || loading) return;
     if (!hasMore) return;
     if (filteredUsers.length >= INITIAL_LOAD) return;
@@ -3615,7 +3613,7 @@ const Matching = () => {
   }, [filteredUsers.length, hasMore, loadMore, loading, viewMode]);
 
   useEffect(() => {
-    if (viewMode !== 'default') return;
+    if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;
     if (!hasMore || !preLastCardNode) return;
 
     const observer = new IntersectionObserver(
@@ -3859,7 +3857,7 @@ const Matching = () => {
             ))}
           </Grid>
 
-          {viewMode === 'default' && (
+          {(viewMode === 'default' || viewMode === 'favorites' || viewMode === 'dislikes') && (
             <LoadMoreFooter>
               <LoadMoreButton onClick={loadMore} disabled={loading || !hasMore}>
                 {loading

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('Matching shared reaction card UI', () => {
+  it('does not render overlay text for shared liked or disliked cards', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).not.toContain('Liked by shared owner');
+    expect(source).not.toContain('Disliked by shared owner');
+    expect(source).not.toContain('ReactionOwnershipBadge');
+  });
+});

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -1,5 +1,7 @@
 import {
+  buildReactionCardsPage,
   buildSharedReactionCandidateIds,
+  mergeMatchingCandidateUsers,
   resolvePrioritizedReactionMaps,
 } from '../reactionPriority';
 
@@ -141,8 +143,6 @@ describe('resolvePrioritizedReactionMaps', () => {
 describe('mergeMatchingCandidateUsers', () => {
 
   it('excludes shared-only effective reactions from the default deck', () => {
-    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
-
     const result = mergeMatchingCandidateUsers({
       users: [
         { userId: 'neutral', publish: true, __sourceCollection: 'users' },
@@ -162,8 +162,6 @@ describe('mergeMatchingCandidateUsers', () => {
   });
 
   it('does not inject unpublished users cards from shared reactions for non-admin viewers', () => {
-    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
-
     const result = mergeMatchingCandidateUsers({
       users: [{ userId: 'publishedBase', publish: true, __sourceCollection: 'users' }],
       sharedReactionCandidateUsers: [
@@ -179,8 +177,6 @@ describe('mergeMatchingCandidateUsers', () => {
   });
 
   it('keeps an allowed shared ID0001 newUsers candidate after searchKeySets access filtering', () => {
-    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
-
     const result = mergeMatchingCandidateUsers({
       users: [],
       additionalNewUsers: [],
@@ -199,8 +195,6 @@ describe('mergeMatchingCandidateUsers', () => {
   });
 
   it('does not inject a shared ID0001 newUsers candidate without searchKeySets access', () => {
-    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
-
     const result = mergeMatchingCandidateUsers({
       users: [],
       additionalNewUsers: [],
@@ -212,6 +206,124 @@ describe('mergeMatchingCandidateUsers', () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  it('keeps shared effective dislike cards available in the dislikes tab', () => {
+    const result = mergeMatchingCandidateUsers({
+      users: [
+        { userId: 'sharedDislikeOnly', publish: true, __sourceCollection: 'users' },
+      ],
+      favoriteUsers: {},
+      dislikeUsers: { sharedDislikeOnly: true },
+      ownFavoriteUsers: {},
+      ownDislikeUsers: {},
+      isAdmin: false,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['sharedDislikeOnly']);
+  });
+
+  it('self-checks shared dislike UX and paging invariants', () => {
+    const reactionIds = Array.from({ length: 8 }, (_, index) => `shared-dislike-${index + 1}`);
+    const sharedDislikeId = reactionIds[0];
+    const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: {},
+      dislikeSnapshots: {
+        viewer: {},
+        sharedOwner: Object.fromEntries(reactionIds.map(userId => [userId, true])),
+      },
+    });
+
+    expect(dislikes[sharedDislikeId]).toBe(true);
+    expect(favorites[sharedDislikeId]).toBeUndefined();
+
+    const cards = reactionIds.map(userId => ({ userId, publish: true, __sourceCollection: 'users' }));
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: cards,
+      favoriteUsers: favorites,
+      dislikeUsers: dislikes,
+      ownFavoriteUsers: {},
+      ownDislikeUsers: {},
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+    expect(defaultDeck.map(user => user.userId)).not.toContain(sharedDislikeId);
+
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: cards.slice(0, 6),
+      favoriteUsers: favorites,
+      dislikeUsers: dislikes,
+      ownFavoriteUsers: {},
+      ownDislikeUsers: {},
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+    expect(dislikesTab.map(user => user.userId)).toContain(sharedDislikeId);
+
+    const firstPage = buildReactionCardsPage({ reactionMap: dislikes, limit: 6 });
+    expect(firstPage.pageIds).toEqual(reactionIds.slice(0, 6));
+    expect(firstPage.hasMore).toBe(true);
+
+    const nextPage = buildReactionCardsPage({
+      reactionMap: dislikes,
+      offset: firstPage.nextOffset,
+      limit: 6,
+      excludeIds: firstPage.pageIds,
+    });
+    expect(nextPage.pageIds).toEqual(reactionIds.slice(6));
+    expect(nextPage.hasMore).toBe(false);
+
+    const loadedIds = [...firstPage.pageIds, ...nextPage.pageIds];
+    expect(new Set(loadedIds).size).toBe(loadedIds.length);
+  });
+});
+
+describe('reaction card pagination', () => {
+  it('keeps hasMore true while more effective disliked ids exist after the first page', () => {
+    const reactionIds = Array.from({ length: 8 }, (_, index) => `disliked-${index + 1}`);
+
+    const page = buildReactionCardsPage({
+      reactionIds,
+      limit: 6,
+    });
+
+    expect(page.pageIds).toEqual(reactionIds.slice(0, 6));
+    expect(page.nextOffset).toBe(6);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it('returns additional shared disliked cards for loadMore after the first page', () => {
+    const reactionIds = Array.from({ length: 8 }, (_, index) => `shared-disliked-${index + 1}`);
+    const firstPage = buildReactionCardsPage({ reactionIds, limit: 6 });
+
+    const nextPage = buildReactionCardsPage({
+      reactionIds,
+      offset: firstPage.nextOffset,
+      limit: 6,
+      excludeIds: firstPage.pageIds,
+    });
+
+    expect(nextPage.pageIds).toEqual(reactionIds.slice(6));
+    expect(nextPage.hasMore).toBe(false);
+  });
+
+  it('does not let fetchedIds or excludeIds conflicts block later reaction pages', () => {
+    const reactionIds = Array.from({ length: 8 }, (_, index) => `effective-dislike-${index + 1}`);
+
+    const page = buildReactionCardsPage({
+      reactionIds,
+      offset: 0,
+      limit: 6,
+      excludeIds: reactionIds.slice(0, 6),
+    });
+
+    expect(page.pageIds).toEqual(reactionIds.slice(6));
+    expect(page.nextOffset).toBe(8);
+    expect(page.hasMore).toBe(false);
   });
 });
 

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -159,6 +159,46 @@ export const mergeMatchingCandidateUsers = ({
   );
 };
 
+
+export const getReactionUserIds = reactionMap =>
+  Object.keys(normalizeReactionMap(reactionMap));
+
+export const buildReactionCardsPage = ({
+  reactionMap = {},
+  reactionIds,
+  offset = 0,
+  limit = 6,
+  excludeIds = [],
+} = {}) => {
+  const ids = Array.isArray(reactionIds)
+    ? [...new Set(reactionIds.filter(Boolean))]
+    : getReactionUserIds(reactionMap);
+  const exclude = new Set(
+    Array.from(excludeIds || [])
+      .map(id => String(id || '').trim())
+      .filter(Boolean)
+  );
+  const safeLimit = Math.max(0, Number(limit) || 0);
+  let cursor = Math.max(0, Number(offset) || 0);
+  const pageIds = [];
+
+  while (cursor < ids.length && pageIds.length < safeLimit) {
+    const id = ids[cursor];
+    cursor += 1;
+    if (!id || exclude.has(id)) continue;
+    pageIds.push(id);
+  }
+
+  const hasMore = ids.slice(cursor).some(id => id && !exclude.has(id));
+
+  return {
+    pageIds,
+    nextOffset: cursor,
+    hasMore,
+    total: ids.length,
+  };
+};
+
 export const readReactionSnapshotMaps = async ({
   ownerIds = [],
   fetchFavoriteUsers,


### PR DESCRIPTION
### Motivation
- Remove the large shared-reaction overlay that obscured card content and ensure shared/effective disliked cards are included in dislikes/favorites tabs while preserving own-only ownership state. 
- Fix infinite-scroll / lazy-load behavior where dislikes/favorites tabs stalled after the first page due to mismatched pagination, exclude/dedupe and merged reaction logic. 

### Description
- Removed the overlay `ReactionOwnershipBadge` and related JSX so shared-liked/shared-disliked cards no longer render a large text badge over the card. 
- Threaded `dislikeUsers` into UI filtering (`applyMatchingUiFiltersToUsers`) and into additional-candidate backfill calls so effective shared dislikes are honored by filters and visible-count calculations. 
- Introduced reaction paging utilities and flow: exported `getReactionUserIds` / `buildReactionCardsPage` in `reactionPriority`, added `reactionPagination` state, refactored `loadReactionCards` (unified favorites/dislikes load) and extended `loadMore` to page reaction tabs using `buildReactionCardsPage` with proper `excludeIds`/`loadedIdsRef` handling. 
- Added regression tests: `src/components/Matching.sharedReactions.test.js` (no overlay text) and extended `src/utils/__tests__/reactionPriority.test.js` with a self-check covering shared dislike existence, default deck exclusion, dislikes-tab visibility, first/next page pagination, `hasMore`, and duplicate prevention. 

### Testing
- Ran the targeted unit suites with `npm test -- --runInBand --watchAll=false src/utils/__tests__/reactionPriority.test.js src/components/smallCard/btnDislike.test.js src/components/Matching.sharedReactions.test.js` and all selected tests passed. 
- Linted changed files with `npx eslint src/components/Matching.jsx src/utils/reactionPriority.js src/utils/__tests__/reactionPriority.test.js src/components/smallCard/btnDislike.test.js src/components/Matching.sharedReactions.test.js --max-warnings=0` and the lint run completed without blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0250e12cc883269ffe21f8e2bf0ac0)