### PR TITLE
Preserve reaction card profile data

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3114,6 +3114,29 @@ const Matching = () => {
     toast.success('Фільтри та кеш скинуто');
   }, [reloadDefault]);
 
+  const fetchReactionCardsByIds = React.useCallback(async ids => {
+    const entries = await Promise.all(
+      ids.map(async id => {
+        const cached = getCard(id);
+        const cachedPhotos = Array.isArray(cached?.photos) ? cached.photos : [];
+        const canUseCachedCard = cached && cachedPhotos.length > 0 && (
+          cached.__sourceCollection ||
+          cached.publish === true ||
+          !isShortId(id)
+        );
+        const user = canUseCachedCard ? cached : await fetchUserById(id);
+        return user ? [id, user] : null;
+      })
+    );
+
+    return entries.reduce((acc, entry) => {
+      if (!entry) return acc;
+      const [id, user] = entry;
+      acc[id] = user;
+      return acc;
+    }, {});
+  }, []);
+
   const loadReactionCards = async reactionType => {
     const isFavoritesMode = reactionType === 'favorites';
     setViewMode(reactionType);
@@ -3169,7 +3192,7 @@ const Matching = () => {
       offset: 0,
       limit: INITIAL_LOAD,
     });
-    const usersMap = await fetchUsersByIds(page.pageIds);
+    const usersMap = await fetchReactionCardsByIds(page.pageIds);
     const list = page.pageIds
       .map(id => usersMap[id])
       .filter(Boolean)
@@ -3275,7 +3298,7 @@ const Matching = () => {
           limit: LOAD_MORE,
           excludeIds: loadedIdsRef.current,
         });
-        const usersMap = await fetchUsersByIds(page.pageIds);
+        const usersMap = await fetchReactionCardsByIds(page.pageIds);
         const list = page.pageIds
           .map(id => usersMap[id])
           .filter(Boolean)
@@ -3514,6 +3537,7 @@ const Matching = () => {
     ensureFreshAdditionalMatchingProfile,
     defaultListKey,
     fetchChunk,
+    fetchReactionCardsByIds,
     filters,
     hasMore,
     lastKey,

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -9,4 +9,12 @@ describe('Matching shared reaction card UI', () => {
     expect(source).not.toContain('Disliked by shared owner');
     expect(source).not.toContain('ReactionOwnershipBadge');
   });
+
+  it('loads reaction tab cards through fetchUserById-compatible photo hydration', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('const fetchReactionCardsByIds = React.useCallback');
+    expect(source).toContain('await fetchUserById(id)');
+    expect(source).not.toContain('const usersMap = await fetchUsersByIds(page.pageIds);');
+  });
 });

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('fetchUsersByIds merging', () => {
+  it('keeps newUsers fields and source marker ahead of users records', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+    const fetchUsersByIdsBody = source.slice(
+      source.indexOf('export const fetchUsersByIds'),
+      source.indexOf('const addUserFromUsers')
+    );
+
+    expect(fetchUsersByIdsBody.indexOf('...(hasUser ? userSnap.val() : {})'))
+      .toBeLessThan(fetchUsersByIdsBody.indexOf('...(hasNewUser ? newSnap.val() : {})'));
+    expect(fetchUsersByIdsBody).toContain("__sourceCollection: hasNewUser ? 'newUsers' : 'users'");
+  });
+
+  it('marks fetchUserById records with their backing collection', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+
+    expect(source).toContain("__sourceCollection: 'newUsers'");
+    expect(source).toContain("__sourceCollection: 'users'");
+  });
+});

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1503,12 +1503,17 @@ export const fetchUsersByIds = async ids => {
           get(ref2(database, `newUsers/${id}`)),
           get(ref2(database, `users/${id}`)),
         ]).then(([newSnap, userSnap]) => {
+          const hasNewUser = newSnap.exists();
+          const hasUser = userSnap.exists();
+          if (!hasNewUser && !hasUser) return null;
+
           const data = {
             userId: id,
-            ...(newSnap.exists() ? newSnap.val() : {}),
-            ...(userSnap.exists() ? userSnap.val() : {}),
+            ...(hasUser ? userSnap.val() : {}),
+            ...(hasNewUser ? newSnap.val() : {}),
+            __sourceCollection: hasNewUser ? 'newUsers' : 'users',
           };
-          return Object.keys(data).length > 1 ? [id, data] : null;
+          return [id, data];
         })
       )
     );
@@ -5230,12 +5235,14 @@ export const fetchUserById = async userId => {
           ...userSnapshotInUsers.val(),
           ...newUserSnapshot.val(),
           photos,
+          __sourceCollection: 'newUsers',
         };
       }
       return {
         userId,
         ...newUserSnapshot.val(),
         photos,
+        __sourceCollection: 'newUsers',
       };
     }
 
@@ -5248,6 +5255,7 @@ export const fetchUserById = async userId => {
         userId,
         ...userSnapshot.val(),
         photos,
+        __sourceCollection: 'users',
       };
     }
 

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -1,6 +1,7 @@
 import {
   buildReactionCardsPage,
   buildSharedReactionCandidateIds,
+  canShowMatchingUser,
   resolvePrioritizedReactionMaps,
 } from '../reactionPriority';
 
@@ -120,6 +121,13 @@ describe('resolvePrioritizedReactionMaps', () => {
     ).toEqual([]);
   });
 
+});
+
+
+describe('canShowMatchingUser', () => {
+  it('allows newUsers reaction records for non-admin viewers even without publish', () => {
+    expect(canShowMatchingUser({ userId: 'ID0001', __sourceCollection: 'newUsers' }, { isAdmin: false })).toBe(true);
+  });
 });
 
 describe('mergeMatchingCandidateUsers', () => {


### PR DESCRIPTION
### Motivation
- Ensure favorites/dislikes reaction tabs show stored avatar photos for cold-cache cards by routing hydration through the `fetchUserById`-compatible path when cached photos are missing. 
- Keep `newUsers` reaction cards visible to non-admin viewers by preserving a `__sourceCollection` marker so visibility checks accept `newUsers` records. 
- Preserve `newUsers` fields precedence when a profile exists in both `users` and `newUsers` so reaction tabs reflect the most recent/migrated card data.

### Description
- Add `fetchReactionCardsByIds` (in `src/components/Matching.jsx`) and use it for both initial reaction page and reaction `loadMore` so cached cards are only reused when they include photos and trustworthy visibility metadata; otherwise the helper falls back to `fetchUserById` for photo hydration.
- Update `fetchUsersByIds` (in `src/components/config.js`) to attach `__sourceCollection` and to merge `users` first then `newUsers` last so `newUsers` fields override `users` when both exist.
- Mark `fetchUserById` results with `__sourceCollection` for both `newUsers` and `users` while keeping `getAllUserPhotos` hydration intact.
- Tighten cache usage: only reuse a cached card for reaction tabs when it has `photos` and either a `__sourceCollection`, `publish === true`, or the id is not a short (newUsers) id.
- Add regression tests: `src/components/Matching.sharedReactions.test.js`, `src/components/config.fetchUsersByIds.test.js`, and a small addition in `src/utils/__tests__/reactionPriority.test.js` to cover hydration, merge/source behavior, and `newUsers` visibility.

### Testing
- Ran targeted tests with `npm test -- --runInBand --watchAll=false src/utils/__tests__/reactionPriority.test.js src/components/Matching.sharedReactions.test.js src/components/config.fetchUsersByIds.test.js` and they passed.
- Ran full test suite with `npm test -- --runInBand --watchAll=false` which completed successfully (25 test suites, 103 tests passed).
- Ran lint with `npm run lint:js`; lint executed (only a `browserslist` update warning was printed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ff1f213083268a3be7fcf1788922)