### PR TITLE
Separate favorites/dislikes pagination, add reaction page race guards, and enforce newUsers access when paginating reactions

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -81,6 +81,7 @@ import {
   normalizeReactionMap,
   readReactionSnapshotMaps,
   resolvePrioritizedReactionMaps,
+  shouldApplyReactionPageResult,
   uniqueTruthyReactionIds,
 } from 'utils/reactionPriority';
 
@@ -90,6 +91,7 @@ const DEBUG_SHARED_OWNER_ID = 'stFMfZ8CqQX05L8vK9Yse6FdYIh1';
 const DEBUG_SHARED_NEW_USER_ID = 'ID0001';
 const ADDITIONAL_PROFILE_CACHE_TTL_MS = 45 * 1000;
 const ADDITIONAL_MATCHING_LOG_LIMIT = 300;
+const buildEmptyReactionPagination = () => ({ ids: [], nextOffset: 0, hasMore: false });
 
 const shouldDebugAdditionalMatching = (...ids) =>
   ids.some(id => String(id || '').trim() === DEBUG_ADDITIONAL_MATCHING_USER_ID);
@@ -666,6 +668,8 @@ const applyMatchingUiFiltersToUsers = ({
   users,
   filters,
   favoriteUsers,
+  dislikeUsers,
+  excludeReactionUsers = false,
   roleIndexSets,
   collectionSource,
 }) =>
@@ -674,8 +678,14 @@ const applyMatchingUiFiltersToUsers = ({
       users.map(u => [u.userId, u]),
       null,
       getMatchingFiltersWithoutSearchKeyGroups(filters),
-      favoriteUsers
-    ).map(([, u]) => u),
+      favoriteUsers,
+      dislikeUsers
+    )
+      .map(([, u]) => u)
+      .filter(u => (
+        !excludeReactionUsers ||
+        (!favoriteUsers[u.userId] && !dislikeUsers[u.userId])
+      )),
     filters,
     roleIndexSets
   ).filter(u => isAllowedIdForCollection(u.userId, collectionSource));
@@ -1974,11 +1984,9 @@ const Matching = () => {
   const [ownDislikeUsers, setOwnDislikeUsers] = useState({});
   const [sharedReactionIds, setSharedReactionIds] = useState([]);
   const [sharedReactionCandidateUsers, setSharedReactionCandidateUsers] = useState([]);
-  const [reactionPagination, setReactionPagination] = useState({
-    type: null,
-    ids: [],
-    nextOffset: 0,
-    hasMore: false,
+  const [reactionPaginationByType, setReactionPaginationByType] = useState({
+    favorites: buildEmptyReactionPagination(),
+    dislikes: buildEmptyReactionPagination(),
   });
   const favoriteUsersRef = useRef(favoriteUsers);
   const dislikeUsersRef = useRef(dislikeUsers);
@@ -2019,12 +2027,17 @@ const Matching = () => {
   );
   const loadingRef = useRef(false);
   const loadedIdsRef = useRef(new Set());
+  const reactionLoadedIdsRef = useRef({
+    favorites: new Set(),
+    dislikes: new Set(),
+  });
   const additionalRulesToastRef = useRef('');
   const additionalProfileCacheRef = useRef(null);
   const additionalProfileRequestVersionRef = useRef(0);
   const additionalMatchingFetchVersionRef = useRef(0);
   const additionalLoadMoreFetchVersionRef = useRef(0);
   const additionalMatchingApplyVersionRef = useRef(0);
+  const reactionLoadVersionRef = useRef(0);
   const matchingProfileStateRef = useRef({
     ownerId: null,
     collectionSource,
@@ -2042,6 +2055,32 @@ const Matching = () => {
       loadingRef.current = false;
       setLoading(false);
     }
+  }, []);
+  const resetReactionPaginationState = React.useCallback((reactionType = null) => {
+    if (reactionType === 'favorites' || reactionType === 'dislikes') {
+      reactionLoadedIdsRef.current[reactionType] = new Set();
+      setReactionPaginationByType(prev => ({
+        ...prev,
+        [reactionType]: buildEmptyReactionPagination(),
+      }));
+      return;
+    }
+
+    reactionLoadedIdsRef.current = {
+      favorites: new Set(),
+      dislikes: new Set(),
+    };
+    setReactionPaginationByType({
+      favorites: buildEmptyReactionPagination(),
+      dislikes: buildEmptyReactionPagination(),
+    });
+  }, []);
+  const invalidateReactionAsyncWork = React.useCallback(() => {
+    reactionLoadVersionRef.current += 1;
+    additionalLoadMoreFetchVersionRef.current += 1;
+    additionalMatchingApplyVersionRef.current += 1;
+    loadingRef.current = false;
+    setLoading(false);
   }, []);
   const restoreRef = useRef(false);
   const scrollPositionRef = useRef(0);
@@ -2188,10 +2227,10 @@ const Matching = () => {
     }
     setUsers(prev =>
       prev.filter(
-        u => !ownFavoriteUsers[u.userId] && !ownDislikeUsers[u.userId]
+        u => !favoriteUsers[u.userId] && !dislikeUsers[u.userId]
       )
     );
-  }, [ownFavoriteUsers, ownDislikeUsers, viewMode]);
+  }, [favoriteUsers, dislikeUsers, viewMode]);
 
 
 
@@ -2684,6 +2723,10 @@ const Matching = () => {
           requestedForCandidatePool: nextSharedReactionIds.includes(DEBUG_SHARED_NEW_USER_ID),
         },
       });
+      ownFavoriteUsersRef.current = ownFavorites;
+      ownDislikeUsersRef.current = ownDislikes;
+      favoriteUsersRef.current = favorites;
+      dislikeUsersRef.current = dislikes;
       setOwnFavoriteUsers(ownFavorites);
       setOwnDislikeUsers(ownDislikes);
       setSharedReactionIds(nextSharedReactionIds);
@@ -2907,7 +2950,8 @@ const Matching = () => {
                 sourceRes.users.map(u => [u.userId, u]),
                 null,
                 getMatchingFiltersWithoutSearchKeyGroups(activeFilters),
-                favoriteUsersRef.current
+                favoriteUsersRef.current,
+                dislikeUsersRef.current
               ).map(([, u]) => u),
               activeFilters,
               roleIndexSets
@@ -3013,6 +3057,10 @@ const Matching = () => {
             requestedForCandidatePool: nextSharedReactionIds.includes(DEBUG_SHARED_NEW_USER_ID),
           },
         });
+        ownFavoriteUsersRef.current = ownFavorites;
+        ownDislikeUsersRef.current = ownDislikes;
+        favoriteUsersRef.current = favIds;
+        dislikeUsersRef.current = disIds;
         setOwnFavoriteUsers(ownFavorites);
         setOwnDislikeUsers(ownDislikes);
         setSharedReactionIds(nextSharedReactionIds);
@@ -3021,13 +3069,17 @@ const Matching = () => {
         syncFavorites(favIds);
         syncDislikes(disIds);
         exclude = new Set([
-          ...Object.keys(ownFavorites),
-          ...Object.keys(ownDislikes),
+          ...Object.keys(favIds),
+          ...Object.keys(disIds),
         ]);
       } else {
         const localFav = getFavorites();
         const localDis = getDislikes();
         if (Object.keys(localFav).length || Object.keys(localDis).length) {
+          ownFavoriteUsersRef.current = localFav;
+          ownDislikeUsersRef.current = localDis;
+          favoriteUsersRef.current = localFav;
+          dislikeUsersRef.current = localDis;
           setOwnFavoriteUsers(localFav);
           setOwnDislikeUsers(localDis);
           setSharedReactionIds([]);
@@ -3101,9 +3153,25 @@ const Matching = () => {
 
   const reloadDefault = React.useCallback(() => {
     viewModeRef.current = 'default';
+    invalidateReactionAsyncWork();
+    resetReactionPaginationState();
     setViewMode('default');
     loadInitial();
-  }, [loadInitial]);
+  }, [invalidateReactionAsyncWork, loadInitial, resetReactionPaginationState]);
+
+
+  const handleFiltersChange = React.useCallback(nextFilters => {
+    filtersRef.current = nextFilters;
+    setFilters(nextFilters);
+    const currentMode = viewModeRef.current;
+    if (currentMode === 'favorites' || currentMode === 'dislikes') {
+      invalidateReactionAsyncWork();
+      resetReactionPaginationState(currentMode);
+      setUsers([]);
+      setLastKey(null);
+      setHasMore(true);
+    }
+  }, [invalidateReactionAsyncWork, resetReactionPaginationState]);
 
   const resetFiltersAndCache = React.useCallback(() => {
     localStorage.removeItem('matchingFilters');
@@ -3137,88 +3205,229 @@ const Matching = () => {
     }, {});
   }, []);
 
+  const getAccessibleReactionIds = React.useCallback(async reactionIds => {
+    const uniqueIds = [...new Set((reactionIds || []).filter(Boolean))];
+    if (collectionSource !== 'newUsers') {
+      return uniqueIds.filter(isValidId);
+    }
+
+    const newUserReactionIds = uniqueIds.filter(isShortId);
+    if (parsedAdditionalAccessRules.length === 0) {
+      return newUserReactionIds;
+    }
+
+    const viewerId = ownerId || getOwnerId();
+    if (!viewerId) return [];
+
+    const resolvedSearchKeySetKeys = areSearchKeySetKeysForAccessUserId(currentSearchKeySetKeys, viewerId)
+      ? currentSearchKeySetKeys
+      : await resolveAdditionalSearchKeySetKeysForMatching(null, viewerId);
+
+    if (!resolvedSearchKeySetKeys.length) return [];
+
+    const indexed = await getIndexedNewUsersIdsByRules({
+      rawRules: currentAdditionalAccessRules,
+      accessUserId: viewerId,
+      searchKeySetsOfExactUser: resolvedSearchKeySetKeys,
+      fetchMissingBuckets: true,
+      requireSearchKeySetKeys: true,
+      resultOffset: 0,
+      resultLimit: Number.POSITIVE_INFINITY,
+      debugMatchingFlow: shouldDebugAdditionalMatching(viewerId),
+      debugToast: (message, data) => debugAdditionalToast(viewerId, message, data),
+    });
+    const allowedIds = new Set(Array.isArray(indexed?.userIds) ? indexed.userIds : []);
+    return newUserReactionIds.filter(id => allowedIds.has(id));
+  }, [
+    collectionSource,
+    currentAdditionalAccessRules,
+    currentSearchKeySetKeys,
+    ownerId,
+    parsedAdditionalAccessRules.length,
+  ]);
+
+  const loadReactionCardsPage = React.useCallback(async ({
+    reactionIds,
+    offset = 0,
+    limit = LOAD_MORE,
+    loadedIds = new Set(),
+  }) => {
+    const collected = [];
+    let nextOffset = Math.max(0, Number(offset) || 0);
+    let hasMore = false;
+
+    while (collected.length < limit && nextOffset < reactionIds.length) {
+      const page = buildReactionCardsPage({
+        reactionIds,
+        offset: nextOffset,
+        limit: Math.max(1, limit - collected.length),
+        excludeIds: loadedIds,
+      });
+
+      nextOffset = page.nextOffset;
+      hasMore = page.hasMore;
+      if (page.pageIds.length === 0) {
+        if (!page.hasMore) break;
+        continue;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const usersMap = await fetchReactionCardsByIds(page.pageIds);
+      const candidates = page.pageIds
+        .map(id => usersMap[id])
+        .filter(Boolean)
+        .map(user => ({
+          ...user,
+          userId: user.userId,
+          ...(collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0
+            ? { __matchingAccessAllowed: true }
+            : {}),
+        }))
+        .filter(user => isMatchingCardId(user.userId))
+        .filter(user => isAllowedIdForCollection(user.userId, collectionSource))
+        .filter(user => canShowMatchingUser(user, { isAdmin }))
+        .filter(user => !loadedIds.has(user.userId));
+
+      const filteredCandidates = applyMatchingUiFiltersToUsers({
+        users: candidates,
+        filters: filtersRef.current || {},
+        favoriteUsers: favoriteUsersRef.current,
+        dislikeUsers: dislikeUsersRef.current,
+        excludeReactionUsers: false,
+        roleIndexSets,
+        collectionSource,
+      });
+
+      filteredCandidates.forEach(user => {
+        if (collected.length < limit && !loadedIds.has(user.userId)) {
+          loadedIds.add(user.userId);
+          collected.push(user);
+        }
+      });
+
+      if (!page.hasMore) break;
+    }
+
+    return {
+      users: collected.sort(compareUsersByLastLogin2),
+      nextOffset,
+      hasMore: hasMore || reactionIds.slice(nextOffset).some(id => id && !loadedIds.has(id)),
+    };
+  }, [
+    collectionSource,
+    fetchReactionCardsByIds,
+    isAdmin,
+    parsedAdditionalAccessRules.length,
+    roleIndexSets,
+  ]);
+
   const loadReactionCards = async reactionType => {
     const isFavoritesMode = reactionType === 'favorites';
+    reactionLoadVersionRef.current += 1;
+    const reactionLoadVersion = reactionLoadVersionRef.current;
+    const requestCollectionSource = collectionSource;
+    const canApplyReactionLoad = () => shouldApplyReactionPageResult({
+      requestVersion: reactionLoadVersion,
+      currentVersion: reactionLoadVersionRef.current,
+      requestViewMode: reactionType,
+      currentViewMode: viewModeRef.current,
+      requestCollectionSource,
+      currentCollectionSource: collectionSource,
+    });
+    viewModeRef.current = reactionType;
     setViewMode(reactionType);
+    loadingRef.current = true;
     setLoading(true);
     setUsers([]);
-    setReactionPagination({ type: reactionType, ids: [], nextOffset: 0, hasMore: false });
-    const owners = await waitForOwnerId();
-    if (!owners.length) {
-      setHasMore(false);
-      setLoading(false);
-      return;
-    }
-
-    const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
-      ownerIds: owners,
-      fetchFavoriteUsers,
-      fetchDislikeUsers,
-      onWarning: warning => debugSharedReactionsLog(getOwnerId(), 'reaction snapshot unavailable while loading reaction cards', warning, warning.error),
-    });
-    const ownOwnerId = getOwnerId();
-    const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
-      ownerIds: owners,
-      ownOwnerId,
-      favoriteSnapshots,
-      dislikeSnapshots,
-    });
-    const ownFavorites = normalizeReactionMap(favoriteSnapshots[ownOwnerId]);
-    const ownDislikes = normalizeReactionMap(dislikeSnapshots[ownOwnerId]);
-    setOwnFavoriteUsers(ownFavorites);
-    setOwnDislikeUsers(ownDislikes);
-    setSharedReactionIds(buildSharedReactionCandidateIds({
-      ownerIds: owners,
-      ownOwnerId,
-      favoriteSnapshots,
-      dislikeSnapshots,
-      favorites: favMap,
-      dislikes: disMap,
-    }));
-
-    syncFavorites(favMap);
-    syncDislikes(disMap);
-    setFavoriteUsers(favMap);
-    setDislikeUsers(disMap);
-
-    const reactionMap = isFavoritesMode ? favMap : disMap;
-    const listKey = isFavoritesMode ? 'favorite' : 'dislike';
-    const reactionIds = Object.keys(reactionMap);
-    setIdsForQuery(listKey, reactionIds);
-    if (isFavoritesMode) setFavoriteIds(favMap);
-
-    const page = buildReactionCardsPage({
-      reactionIds,
-      offset: 0,
-      limit: INITIAL_LOAD,
-    });
-    const usersMap = await fetchReactionCardsByIds(page.pageIds);
-    const list = page.pageIds
-      .map(id => usersMap[id])
-      .filter(Boolean)
-      .map(user => ({ ...user, userId: user.userId }))
-      .filter(user => isMatchingCardId(user.userId))
-      .filter(user => canShowMatchingUser(user, { isAdmin }))
-      .sort(compareUsersByLastLogin2);
-
-    list.forEach(user => updateCard(user.userId, user));
-    if (isFavoritesMode) {
-      cacheFavoriteUsers(Object.fromEntries(list.map(user => [user.userId, user])));
-    } else {
-      cacheDislikedUsers(Object.fromEntries(list.map(user => [user.userId, user])));
-    }
-    loadedIdsRef.current = new Set(list.map(u => u.userId));
-    setUsers(list);
-    await loadCommentsFor(list);
-    setReactionPagination({
-      type: reactionType,
-      ids: reactionIds,
-      nextOffset: page.nextOffset,
-      hasMore: page.hasMore,
-    });
-    setHasMore(page.hasMore);
     setLastKey(null);
-    setLoading(false);
+    setHasMore(false);
+    resetReactionPaginationState(reactionType);
+
+    try {
+      const owners = await waitForOwnerId();
+      if (!owners.length) {
+        setHasMore(false);
+        return;
+      }
+
+      const { favoriteSnapshots, dislikeSnapshots } = await readReactionSnapshotMaps({
+        ownerIds: owners,
+        fetchFavoriteUsers,
+        fetchDislikeUsers,
+        onWarning: warning => debugSharedReactionsLog(getOwnerId(), 'reaction snapshot unavailable while loading reaction cards', warning, warning.error),
+      });
+      const ownOwnerId = getOwnerId();
+      const { favorites: favMap, dislikes: disMap } = resolvePrioritizedReactionMaps({
+        ownerIds: owners,
+        ownOwnerId,
+        favoriteSnapshots,
+        dislikeSnapshots,
+      });
+      const ownFavorites = normalizeReactionMap(favoriteSnapshots[ownOwnerId]);
+      const ownDislikes = normalizeReactionMap(dislikeSnapshots[ownOwnerId]);
+      ownFavoriteUsersRef.current = ownFavorites;
+      ownDislikeUsersRef.current = ownDislikes;
+      favoriteUsersRef.current = favMap;
+      dislikeUsersRef.current = disMap;
+      setOwnFavoriteUsers(ownFavorites);
+      setOwnDislikeUsers(ownDislikes);
+      setSharedReactionIds(buildSharedReactionCandidateIds({
+        ownerIds: owners,
+        ownOwnerId,
+        favoriteSnapshots,
+        dislikeSnapshots,
+        favorites: favMap,
+        dislikes: disMap,
+      }));
+
+      syncFavorites(favMap);
+      syncDislikes(disMap);
+      setFavoriteUsers(favMap);
+      setDislikeUsers(disMap);
+
+      const reactionMap = isFavoritesMode ? favMap : disMap;
+      const listKey = isFavoritesMode ? 'favorite' : 'dislike';
+      const fullReactionIds = Object.keys(reactionMap);
+      const reactionIds = await getAccessibleReactionIds(fullReactionIds);
+      if (!canApplyReactionLoad()) return;
+      setIdsForQuery(listKey, reactionIds);
+      if (isFavoritesMode) setFavoriteIds(favMap);
+
+      const loadedIds = new Set();
+      const page = await loadReactionCardsPage({
+        reactionIds,
+        offset: 0,
+        limit: INITIAL_LOAD,
+        loadedIds,
+      });
+      if (!canApplyReactionLoad()) return;
+
+      page.users.forEach(user => updateCard(user.userId, user));
+      if (isFavoritesMode) {
+        cacheFavoriteUsers(Object.fromEntries(page.users.map(user => [user.userId, user])));
+      } else {
+        cacheDislikedUsers(Object.fromEntries(page.users.map(user => [user.userId, user])));
+      }
+      reactionLoadedIdsRef.current[reactionType] = loadedIds;
+      loadedIdsRef.current = new Set(page.users.map(user => user.userId));
+      setUsers(page.users);
+      await loadCommentsFor(page.users);
+      if (!canApplyReactionLoad()) return;
+      setReactionPaginationByType(prev => ({
+        ...prev,
+        [reactionType]: {
+          ids: reactionIds,
+          nextOffset: page.nextOffset,
+          hasMore: page.hasMore,
+        },
+      }));
+      setHasMore(page.hasMore);
+    } finally {
+      if (canApplyReactionLoad()) {
+        loadingRef.current = false;
+        setLoading(false);
+      }
+    }
   };
 
   const loadFavoriteCards = () => loadReactionCards('favorites');
@@ -3280,57 +3489,69 @@ const Matching = () => {
     const applyVersion = additionalMatchingApplyVersionRef.current + 1;
     additionalLoadMoreFetchVersionRef.current = loadMoreVersion;
     additionalMatchingApplyVersionRef.current = applyVersion;
+    const requestCollectionSource = collectionSource;
+    const requestViewMode = viewMode;
     const isLatestLoadMore = () => (
       loadMoreVersion === additionalLoadMoreFetchVersionRef.current &&
       applyVersion === additionalMatchingApplyVersionRef.current
+    );
+    const canApplyLoadMoreResult = () => (
+      isLatestLoadMore() &&
+      shouldApplyReactionPageResult({
+        requestVersion: applyVersion,
+        currentVersion: additionalMatchingApplyVersionRef.current,
+        requestViewMode,
+        currentViewMode: viewModeRef.current,
+        requestCollectionSource,
+        currentCollectionSource: collectionSource,
+      })
     );
     try {
       if (isReactionViewMode) {
         const reactionMap = viewMode === 'favorites'
           ? favoriteUsersRef.current
           : dislikeUsersRef.current;
-        const reactionIds = reactionPagination.type === viewMode
-          ? reactionPagination.ids
-          : Object.keys(reactionMap);
-        const page = buildReactionCardsPage({
+        const currentPagination = reactionPaginationByType[viewMode] || buildEmptyReactionPagination();
+        const reactionIds = currentPagination.ids.length > 0
+          ? currentPagination.ids
+          : await getAccessibleReactionIds(Object.keys(reactionMap));
+        const loadedIds = reactionLoadedIdsRef.current[viewMode] || new Set();
+        const page = await loadReactionCardsPage({
           reactionIds,
-          offset: reactionPagination.type === viewMode ? reactionPagination.nextOffset : 0,
+          offset: currentPagination.ids.length > 0 ? currentPagination.nextOffset : 0,
           limit: LOAD_MORE,
-          excludeIds: loadedIdsRef.current,
+          loadedIds,
         });
-        const usersMap = await fetchReactionCardsByIds(page.pageIds);
-        const list = page.pageIds
-          .map(id => usersMap[id])
-          .filter(Boolean)
-          .filter(user => isMatchingCardId(user.userId))
-          .filter(user => canShowMatchingUser(user, { isAdmin }))
-          .filter(user => !loadedIdsRef.current.has(user.userId))
-          .sort(compareUsersByLastLogin2);
 
-        list.forEach(user => {
-          loadedIdsRef.current.add(user.userId);
+        if (!canApplyLoadMoreResult()) return;
+
+        page.users.forEach(user => {
           updateCard(user.userId, user);
         });
+        reactionLoadedIdsRef.current[viewMode] = loadedIds;
+        loadedIdsRef.current = new Set(loadedIds);
         setUsers(prev => {
           const map = new Map(prev.map(user => [user.userId, user]));
-          list.forEach(user => map.set(user.userId, user));
+          page.users.forEach(user => map.set(user.userId, user));
           return Array.from(map.values());
         });
-        await loadCommentsFor(list);
-        setReactionPagination({
-          type: viewMode,
-          ids: reactionIds,
-          nextOffset: page.nextOffset,
-          hasMore: page.hasMore,
-        });
+        await loadCommentsFor(page.users);
+        setReactionPaginationByType(prev => ({
+          ...prev,
+          [viewMode]: {
+            ids: reactionIds,
+            nextOffset: page.nextOffset,
+            hasMore: page.hasMore,
+          },
+        }));
         setHasMore(page.hasMore);
         setLastKey(null);
         return;
       }
 
       const baseExclude = new Set([
-        ...Object.keys(ownFavoriteUsersRef.current),
-        ...Object.keys(ownDislikeUsersRef.current),
+        ...Object.keys(favoriteUsersRef.current),
+        ...Object.keys(dislikeUsersRef.current),
       ]);
 
       if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
@@ -3440,6 +3661,8 @@ const Matching = () => {
             users: Array.from(candidateMap.values()),
             filters,
             favoriteUsers: favoriteUsersRef.current,
+            dislikeUsers: dislikeUsersRef.current,
+            excludeReactionUsers: true,
             roleIndexSets,
             collectionSource,
           }).length;
@@ -3523,7 +3746,7 @@ const Matching = () => {
       }
       setLastKey(cursor);
     } finally {
-      if (isLatestLoadMore()) {
+      if (canApplyLoadMoreResult()) {
         loadingRef.current = false;
         setLoading(false);
       }
@@ -3537,14 +3760,15 @@ const Matching = () => {
     ensureFreshAdditionalMatchingProfile,
     defaultListKey,
     fetchChunk,
-    fetchReactionCardsByIds,
     filters,
+    getAccessibleReactionIds,
     hasMore,
     lastKey,
     loadCommentsFor,
     isAdmin,
     ownerId,
-    reactionPagination,
+    loadReactionCardsPage,
+    reactionPaginationByType,
     resetAdditionalMatchingState,
     parsedAdditionalAccessRules.length,
     roleIndexSets,
@@ -3570,8 +3794,12 @@ const Matching = () => {
     hasAdditionalAccessRules: parsedAdditionalAccessRules.length > 0,
     ownFavoriteUsers,
     ownDislikeUsers,
+    favoriteUsers,
+    dislikeUsers,
   }), [
     additionalNewUsers,
+    dislikeUsers,
+    favoriteUsers,
     ownDislikeUsers,
     ownFavoriteUsers,
     isAdmin,
@@ -3586,6 +3814,8 @@ const Matching = () => {
     users: visibleUsers,
     filters,
     favoriteUsers,
+    dislikeUsers,
+    excludeReactionUsers: viewMode === 'default',
     roleIndexSets,
     collectionSource,
   });
@@ -3687,7 +3917,9 @@ const Matching = () => {
               value="users"
               checked={collectionSource === 'users'}
               onChange={e => {
+                invalidateReactionAsyncWork();
                 resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
+                resetReactionPaginationState();
                 setCollectionSource(e.target.value);
               }}
             />
@@ -3700,7 +3932,9 @@ const Matching = () => {
               value="newUsers"
               checked={collectionSource === 'newUsers'}
               onChange={e => {
+                invalidateReactionAsyncWork();
                 resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
+                resetReactionPaginationState();
                 setCollectionSource(e.target.value);
               }}
             />
@@ -3711,7 +3945,7 @@ const Matching = () => {
           mode="matching"
           hideUserId
           hideCommentLength
-          onChange={setFilters}
+          onChange={handleFiltersChange}
           resetToken={filterResetToken}
           nonAdminAllActive={!isAdmin}
         />

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -46,7 +46,6 @@ export const BtnDislike = ({
   const viewerFavoriteUsers = ownFavoriteUsers || favoriteUsers;
   const updateOwnFavoriteUsers = setOwnFavoriteUsers || setFavoriteUsers;
   const isDisliked = !!viewerDislikeUsers[userId];
-  const isSharedDisliked = !isDisliked && !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
   const resolvedActiveIconColor = activeIconColor || customTextColor || color.reactionIdleIcon;
   const resolvedInactiveIconColor = inactiveIconColor || '#fff';
@@ -139,10 +138,9 @@ export const BtnDislike = ({
         alignItems: 'center',
         justifyContent: 'center',
       }}
-      title={isSharedDisliked ? `${title} (shared)` : title}
+      title={title}
       aria-label={ariaLabel}
       aria-pressed={isDisliked}
-      data-shared-disliked={isSharedDisliked ? 'true' : undefined}
       disabled={!auth.currentUser}
       onClick={e => {
         e.stopPropagation();

--- a/src/components/smallCard/btnDislike.test.js
+++ b/src/components/smallCard/btnDislike.test.js
@@ -70,7 +70,8 @@ describe('BtnDislike', () => {
     expect(button).not.toBeNull();
     expect(button.style.background).toBe('rgb(255, 140, 0)');
     expect(button.getAttribute('aria-pressed')).toBe('false');
-    expect(button.getAttribute('data-shared-disliked')).toBe('true');
+    expect(button.getAttribute('data-shared-disliked')).toBeNull();
+    expect(button.getAttribute('title')).toBe('Дизлайк');
 
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -81,4 +82,31 @@ describe('BtnDislike', () => {
     expect(setOwnDislikeUsers).toHaveBeenCalledWith({ card1: true });
     expect(setDislikeUsers).toHaveBeenCalledWith({ card1: true });
   });
+
+  it('marks BtnDislike active only for viewer-owned dislikes', async () => {
+    const mountComponent = ui => root.render(ui);
+
+    await act(async () => {
+      mountComponent(
+        <BtnDislike
+          userId="card2"
+          userData={{ userId: 'card2' }}
+          dislikeUsers={{ card2: true }}
+          ownDislikeUsers={{ card2: true }}
+          setDislikeUsers={jest.fn()}
+          setOwnDislikeUsers={jest.fn()}
+          favoriteUsers={{}}
+          ownFavoriteUsers={{}}
+          setFavoriteUsers={jest.fn()}
+          setOwnFavoriteUsers={jest.fn()}
+          multiDataOwnerId="viewer"
+        />
+      );
+    });
+
+    const button = container.querySelector('button[aria-label="Дизлайк"]');
+    expect(button).not.toBeNull();
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+  });
+
 });

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -3,6 +3,7 @@ import {
   buildSharedReactionCandidateIds,
   canShowMatchingUser,
   resolvePrioritizedReactionMaps,
+  shouldApplyReactionPageResult,
 } from '../reactionPriority';
 
 describe('resolvePrioritizedReactionMaps', () => {
@@ -184,6 +185,142 @@ describe('mergeMatchingCandidateUsers', () => {
     expect(result).toEqual([]);
   });
 
+
+  it('hides shared-only effective dislikes from the default deck but keeps them for dislikes tab', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const card = { userId: 'sharedDislikeOnly', publish: true, __sourceCollection: 'users' };
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [card],
+      sharedReactionCandidateUsers: [card],
+      favoriteUsers: {},
+      dislikeUsers: { sharedDislikeOnly: true },
+      ownFavoriteUsers: {},
+      ownDislikeUsers: {},
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: {},
+      dislikeUsers: { sharedDislikeOnly: true },
+      ownFavoriteUsers: {},
+      ownDislikeUsers: {},
+      isAdmin: false,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(defaultDeck).toEqual([]);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['sharedDislikeOnly']);
+  });
+
+  it('routes own favorite over shared dislike to favorites and away from default/dislikes', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const card = { userId: 'ownFavoriteSharedDislike', publish: true, __sourceCollection: 'users' };
+    const merged = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: { viewer: { ownFavoriteSharedDislike: true } },
+      dislikeSnapshots: { sharedOwner: { ownFavoriteSharedDislike: true } },
+    });
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: merged.favorites,
+      dislikeUsers: merged.dislikes,
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: merged.favorites,
+      dislikeUsers: merged.dislikes,
+      isAdmin: false,
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    }).filter(user => merged.favorites[user.userId]);
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: merged.favorites,
+      dislikeUsers: merged.dislikes,
+      isAdmin: false,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    }).filter(user => merged.dislikes[user.userId]);
+
+    expect(merged.favorites).toEqual({ ownFavoriteSharedDislike: true });
+    expect(merged.dislikes).toEqual({});
+    expect(defaultDeck).toEqual([]);
+    expect(favoritesTab.map(user => user.userId)).toEqual(['ownFavoriteSharedDislike']);
+    expect(dislikesTab).toEqual([]);
+  });
+
+  it('routes own dislike over shared favorite to dislikes and away from default/favorites', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const card = { userId: 'ownDislikeSharedFavorite', publish: true, __sourceCollection: 'users' };
+    const merged = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: { sharedOwner: { ownDislikeSharedFavorite: true } },
+      dislikeSnapshots: { viewer: { ownDislikeSharedFavorite: true } },
+    });
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: merged.favorites,
+      dislikeUsers: merged.dislikes,
+      ownDislikeUsers: { ownDislikeSharedFavorite: true },
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: merged.favorites,
+      dislikeUsers: merged.dislikes,
+      isAdmin: false,
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    }).filter(user => merged.favorites[user.userId]);
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [card],
+      favoriteUsers: merged.favorites,
+      dislikeUsers: merged.dislikes,
+      isAdmin: false,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    }).filter(user => merged.dislikes[user.userId]);
+
+    expect(merged.favorites).toEqual({});
+    expect(merged.dislikes).toEqual({ ownDislikeSharedFavorite: true });
+    expect(defaultDeck).toEqual([]);
+    expect(favoritesTab).toEqual([]);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['ownDislikeSharedFavorite']);
+  });
+
+  it('keeps default deck free of all effective favorite and dislike cards', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [
+        { userId: 'plainCard', publish: true, __sourceCollection: 'users' },
+        { userId: 'effectiveFavorite', publish: true, __sourceCollection: 'users' },
+        { userId: 'effectiveDislike', publish: true, __sourceCollection: 'users' },
+      ],
+      favoriteUsers: { effectiveFavorite: true },
+      dislikeUsers: { effectiveDislike: true },
+      isAdmin: false,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+
+    expect(defaultDeck.map(user => user.userId)).toEqual(['plainCard']);
+  });
+
   it('keeps shared effective dislike cards available in the dislikes tab', () => {
     const { mergeMatchingCandidateUsers } = require('../reactionPriority');
 
@@ -289,4 +426,147 @@ describe('readReactionSnapshotMaps', () => {
     }).sort()).toEqual(['sharedDislike', 'sharedFavorite']);
     expect(warnings).toHaveLength(2);
   });
+});
+
+
+describe('reaction pagination race guards', () => {
+  it('rejects async reaction page results after rapid tab switches, source changes, or newer requests', () => {
+    const base = {
+      requestVersion: 7,
+      currentVersion: 7,
+      requestViewMode: 'dislikes',
+      currentViewMode: 'dislikes',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'users',
+    };
+
+    expect(shouldApplyReactionPageResult(base)).toBe(true);
+    expect(shouldApplyReactionPageResult({ ...base, currentVersion: 8 })).toBe(false);
+    expect(shouldApplyReactionPageResult({ ...base, currentViewMode: 'favorites' })).toBe(false);
+    expect(shouldApplyReactionPageResult({ ...base, currentCollectionSource: 'newUsers' })).toBe(false);
+  });
+
+  it('can exhaust more than two pages of shared dislikes without duplicates', () => {
+    const reactionIds = Array.from({ length: 15 }, (_, index) => `shared-dislike-${index + 1}`);
+    const loaded = new Set();
+    const rendered = [];
+    let offset = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      const page = buildReactionCardsPage({
+        reactionIds,
+        offset,
+        limit: 6,
+        excludeIds: loaded,
+      });
+      page.pageIds.forEach(id => {
+        loaded.add(id);
+        rendered.push(id);
+      });
+      offset = page.nextOffset;
+      hasMore = page.hasMore;
+    }
+
+    expect(rendered).toEqual(reactionIds);
+    expect(new Set(rendered).size).toBe(reactionIds.length);
+    expect(offset).toBe(reactionIds.length);
+  });
+
+  it('keeps traversing reaction ids after filtered or inaccessible cards are skipped', () => {
+    const reactionIds = Array.from({ length: 9 }, (_, index) => `effective-dislike-${index + 1}`);
+    const hidden = new Set(['effective-dislike-1', 'effective-dislike-2', 'effective-dislike-4']);
+    const loaded = new Set();
+    const rendered = [];
+    let offset = 0;
+    let hasMore = true;
+
+    while (rendered.length < 3 && hasMore) {
+      const page = buildReactionCardsPage({ reactionIds, offset, limit: 3, excludeIds: loaded });
+      page.pageIds
+        .filter(id => !hidden.has(id))
+        .forEach(id => {
+          loaded.add(id);
+          rendered.push(id);
+        });
+      offset = page.nextOffset;
+      hasMore = page.hasMore || reactionIds.slice(offset).some(id => id && !loaded.has(id));
+    }
+
+    expect(rendered).toEqual(['effective-dislike-3', 'effective-dislike-5', 'effective-dislike-6']);
+    expect(hasMore).toBe(true);
+  });
+
+  it('keeps favorites and dislikes pagination offsets isolated across tab switches', () => {
+    const favoriteIds = Array.from({ length: 8 }, (_, index) => `favorite-${index + 1}`);
+    const dislikeIds = Array.from({ length: 8 }, (_, index) => `dislike-${index + 1}`);
+    const loadedByType = { favorites: new Set(), dislikes: new Set() };
+
+    const firstDislikes = buildReactionCardsPage({ reactionIds: dislikeIds, limit: 3, excludeIds: loadedByType.dislikes });
+    firstDislikes.pageIds.forEach(id => loadedByType.dislikes.add(id));
+    const firstFavorites = buildReactionCardsPage({ reactionIds: favoriteIds, limit: 3, excludeIds: loadedByType.favorites });
+    firstFavorites.pageIds.forEach(id => loadedByType.favorites.add(id));
+    const secondDislikes = buildReactionCardsPage({
+      reactionIds: dislikeIds,
+      offset: firstDislikes.nextOffset,
+      limit: 3,
+      excludeIds: loadedByType.dislikes,
+    });
+
+    expect(firstDislikes.pageIds).toEqual(['dislike-1', 'dislike-2', 'dislike-3']);
+    expect(firstFavorites.pageIds).toEqual(['favorite-1', 'favorite-2', 'favorite-3']);
+    expect(secondDislikes.pageIds).toEqual(['dislike-4', 'dislike-5', 'dislike-6']);
+  });
+
+  it('keeps accessible shared newUsers dislikes in dislikes tab but out of default deck', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const sharedNewUserDislike = {
+      userId: 'ID0001',
+      __sourceCollection: 'newUsers',
+      __matchingAccessAllowed: true,
+    };
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [],
+      additionalNewUsers: [],
+      sharedReactionCandidateUsers: [sharedNewUserDislike],
+      favoriteUsers: {},
+      dislikeUsers: { ID0001: true },
+      viewMode: 'default',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [sharedNewUserDislike],
+      additionalNewUsers: [sharedNewUserDislike],
+      favoriteUsers: {},
+      dislikeUsers: { ID0001: true },
+      viewMode: 'dislikes',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    }).filter(user => user.__matchingAccessAllowed && user.userId === 'ID0001');
+
+    expect(defaultDeck).toEqual([]);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['ID0001']);
+  });
+
+  it('returns to a neutral-only default deck after reaction tab pagination', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const paginatedReactionCards = [
+      { userId: 'effectiveFavorite', publish: true, __sourceCollection: 'users' },
+      { userId: 'effectiveDislike', publish: true, __sourceCollection: 'users' },
+      { userId: 'neutralCard', publish: true, __sourceCollection: 'users' },
+    ];
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: paginatedReactionCards,
+      favoriteUsers: { effectiveFavorite: true },
+      dislikeUsers: { effectiveDislike: true },
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+
+    expect(defaultDeck.map(user => user.userId)).toEqual(['neutralCard']);
+  });
+
 });

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -96,6 +96,8 @@ export const mergeMatchingCandidateUsers = ({
   hasAdditionalAccessRules = false,
   ownFavoriteUsers = {},
   ownDislikeUsers = {},
+  favoriteUsers = ownFavoriteUsers,
+  dislikeUsers = ownDislikeUsers,
 } = {}) => {
   let baseUsers = isAdmin ? users : users.filter(user => canShowMatchingUser(user, { isAdmin }));
 
@@ -150,7 +152,7 @@ export const mergeMatchingCandidateUsers = ({
   }
 
   return mergedUsers.filter(
-    user => !ownFavoriteUsers[user.userId] && !ownDislikeUsers[user.userId]
+    user => !favoriteUsers[user.userId] && !dislikeUsers[user.userId]
   );
 };
 
@@ -193,6 +195,19 @@ export const buildReactionCardsPage = ({
     total: ids.length,
   };
 };
+
+export const shouldApplyReactionPageResult = ({
+  requestVersion,
+  currentVersion,
+  requestViewMode,
+  currentViewMode,
+  requestCollectionSource,
+  currentCollectionSource,
+} = {}) => (
+  requestVersion === currentVersion &&
+  requestViewMode === currentViewMode &&
+  requestCollectionSource === currentCollectionSource
+);
 
 export const readReactionSnapshotMaps = async ({
   ownerIds = [],


### PR DESCRIPTION
### Motivation

- Prevent race conditions and stale results when switching reaction tabs or changing collection source while paginating, and to isolate pagination state per reaction type. 
- Ensure reaction-based feeds respect `newUsers` access rules and UI filters when loading favorites/dislikes pages. 
- Simplify UI filtering logic to consider both favorites and dislikes and remove shared-only visual flags from the dislike button.

### Description

- Introduced per-type reaction pagination and loaded-id tracking via `reactionPaginationByType`, `reactionLoadedIdsRef`, `reactionLoadVersionRef`, and helper `buildEmptyReactionPagination`. 
- Added a race guard `shouldApplyReactionPageResult` and used it in `loadReactionCards` and `loadMore` to reject stale async results when versions, view mode, or collection source change. 
- Implemented `getAccessibleReactionIds` to resolve accessible `newUsers` ids under additional access rules and `loadReactionCardsPage` to page through reaction ids while applying UI filters and excludes, and refactored `loadReactionCards` to use these helpers. 
- Updated UI/filter logic by extending `applyMatchingUiFiltersToUsers` and `mergeMatchingCandidateUsers` to consider both `favoriteUsers` and `dislikeUsers`, removed shared-data attributes from `BtnDislike`, and wired filter change handling with `handleFiltersChange`. 
- Added and adjusted unit tests in `src/utils/__tests__/reactionPriority.test.js` and `src/components/smallCard/btnDislike.test.js` to cover pagination behavior, race guards, and dislike button states.

### Testing

- Ran the unit test suite including `src/utils/__tests__/reactionPriority.test.js` and `src/components/smallCard/btnDislike.test.js` via the standard test command (`yarn test` / `npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a030100793083268b19ebf9c5824491)