### PR TITLE
Remove unused isAdmin dependency from matching load-more callback

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3765,7 +3765,6 @@ const Matching = () => {
     hasMore,
     lastKey,
     loadCommentsFor,
-    isAdmin,
     ownerId,
     loadReactionCardsPage,
     reactionPaginationByType,


### PR DESCRIPTION
### Motivation
- Resolve the `react-hooks/exhaustive-deps` warning by removing an unnecessary dependency so the load-more callback does not change spuriously.

### Description
- Remove `isAdmin` from the dependency array of the load-more `useCallback` in `src/components/Matching.jsx` (around L3754-L3775) while keeping all other dependencies unchanged.

### Testing
- Ran `npm run lint:js -- src/components/Matching.jsx` and `git diff --check`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041334821c832690de0287a55acdba)