### PR TITLE
Fix shared reaction candidates in reaction tabs

### DIFF
--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -518,7 +518,7 @@ describe('reaction pagination race guards', () => {
     expect(secondDislikes.pageIds).toEqual(['dislike-4', 'dislike-5', 'dislike-6']);
   });
 
-  it('keeps accessible shared newUsers dislikes in dislikes tab but out of default deck', () => {
+  it('keeps accessible shared-only newUsers dislikes in dislikes tab but out of default deck', () => {
     const { mergeMatchingCandidateUsers } = require('../reactionPriority');
     const sharedNewUserDislike = {
       userId: 'ID0001',
@@ -537,10 +537,12 @@ describe('reaction pagination race guards', () => {
       hasAdditionalAccessRules: true,
     });
     const dislikesTab = mergeMatchingCandidateUsers({
-      users: [sharedNewUserDislike],
-      additionalNewUsers: [sharedNewUserDislike],
+      users: [],
+      additionalNewUsers: [],
+      sharedReactionCandidateUsers: [sharedNewUserDislike],
       favoriteUsers: {},
       dislikeUsers: { ID0001: true },
+      ownDislikeUsers: {},
       viewMode: 'dislikes',
       collectionSource: 'newUsers',
       hasAdditionalAccessRules: true,

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -142,13 +142,11 @@ export const mergeMatchingCandidateUsers = ({
     additionalNewUsers.forEach(injectCandidate);
   }
 
-  if (viewMode === 'default') {
-    sharedReactionCandidateUsers.forEach(injectCandidate);
-  }
+  sharedReactionCandidateUsers.forEach(injectCandidate);
 
   const mergedUsers = Array.from(byId.values()).filter(canInjectCandidate);
   if (viewMode !== 'default') {
-    return baseUsers;
+    return mergedUsers;
   }
 
   return mergedUsers.filter(


### PR DESCRIPTION
### Motivation
- A refactor caused shared-only disliked cards to be excluded from both the default deck and the reaction tabs because `sharedReactionCandidateUsers` were only injected when `viewMode === 'default'` and non-default modes returned `baseUsers` early.
- Reaction tabs must be able to merge shared reaction candidate users so shared-only favorites/dislikes appear in their respective tabs while the default deck remains neutral-only.

### Description
- Always inject `sharedReactionCandidateUsers` into the candidate set instead of restricting injection to `viewMode === 'default'` (change in `src/utils/reactionPriority.js`).
- For non-default `viewMode`, return the merged candidate list (`mergedUsers`) instead of returning the original `baseUsers`, allowing reaction tabs to show injected candidates.
- Preserve existing default-deck behavior by still filtering out effective `favoriteUsers`/`dislikeUsers` when `viewMode === 'default'`, and keep additional `newUsers` access rules unchanged.
- Update test coverage to assert the regression: add/adjust a test ensuring an accessible shared-only `newUsers` dislike is absent from the default deck but visible in the dislikes tab (`src/utils/__tests__/reactionPriority.test.js`).

### Testing
- Ran the focused unit tests with `CI=true npm test -- --runInBand src/utils/__tests__/reactionPriority.test.js src/components/smallCard/btnDislike.test.js` and all tests passed.
- Test result: 2 test suites, 24 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041681b9648326a37c80697c11916b)