### PR TITLE
Fix reaction tab isolation and restore paginated reaction loading

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -74,10 +74,10 @@ import {
   resolveMatchingMultiDataOwnerIds,
 } from 'utils/multiDataAccess';
 import {
-  buildReactionCardsPage,
   buildSharedReactionCandidateIds,
   canShowMatchingUser,
   mergeMatchingCandidateUsers,
+  loadReactionCardsPageRecords,
   normalizeReactionMap,
   readReactionSnapshotMaps,
   resolvePrioritizedReactionMaps,
@@ -2440,6 +2440,10 @@ const Matching = () => {
 
   const loadSharedReactionCandidates = React.useCallback(async () => {
     const viewerId = ownerId || getOwnerId();
+    if (viewMode === 'favorites' || viewMode === 'dislikes') {
+      setSharedReactionCandidateUsers([]);
+      return;
+    }
     const candidateIds = [...new Set(sharedReactionIds.filter(Boolean))];
     debugSharedReactionsLog(viewerId, 'shared reaction ids found for candidate pool', {
       sharedReactionIds: summarizeIdsForDebug(candidateIds),
@@ -2559,6 +2563,7 @@ const Matching = () => {
     isAdmin,
     parsedAdditionalAccessRules.length,
     sharedReactionIds,
+    viewMode,
   ]);
 
   useEffect(() => {
@@ -3248,70 +3253,48 @@ const Matching = () => {
 
   const loadReactionCardsPage = React.useCallback(async ({
     reactionIds,
+    reactionMap = {},
     offset = 0,
     limit = LOAD_MORE,
     loadedIds = new Set(),
   }) => {
-    const collected = [];
-    let nextOffset = Math.max(0, Number(offset) || 0);
-    let hasMore = false;
+    const activeReactionMap = normalizeReactionMap(reactionMap);
+    const page = await loadReactionCardsPageRecords({
+      reactionIds,
+      offset,
+      limit,
+      loadedIds,
+      fetchUsersByIds: fetchReactionCardsByIds,
+      mapUser: user => ({
+        ...user,
+        userId: user.userId,
+        ...(collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0
+          ? { __matchingAccessAllowed: true }
+          : {}),
+      }),
+      filterUsers: candidates => {
+        const scopedCandidates = candidates
+          .filter(user => activeReactionMap[user.userId])
+          .filter(user => isMatchingCardId(user.userId))
+          .filter(user => isAllowedIdForCollection(user.userId, collectionSource))
+          .filter(user => canShowMatchingUser(user, { isAdmin }))
+          .filter(user => !loadedIds.has(user.userId));
 
-    while (collected.length < limit && nextOffset < reactionIds.length) {
-      const page = buildReactionCardsPage({
-        reactionIds,
-        offset: nextOffset,
-        limit: Math.max(1, limit - collected.length),
-        excludeIds: loadedIds,
-      });
-
-      nextOffset = page.nextOffset;
-      hasMore = page.hasMore;
-      if (page.pageIds.length === 0) {
-        if (!page.hasMore) break;
-        continue;
-      }
-
-      // eslint-disable-next-line no-await-in-loop
-      const usersMap = await fetchReactionCardsByIds(page.pageIds);
-      const candidates = page.pageIds
-        .map(id => usersMap[id])
-        .filter(Boolean)
-        .map(user => ({
-          ...user,
-          userId: user.userId,
-          ...(collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0
-            ? { __matchingAccessAllowed: true }
-            : {}),
-        }))
-        .filter(user => isMatchingCardId(user.userId))
-        .filter(user => isAllowedIdForCollection(user.userId, collectionSource))
-        .filter(user => canShowMatchingUser(user, { isAdmin }))
-        .filter(user => !loadedIds.has(user.userId));
-
-      const filteredCandidates = applyMatchingUiFiltersToUsers({
-        users: candidates,
-        filters: filtersRef.current || {},
-        favoriteUsers: favoriteUsersRef.current,
-        dislikeUsers: dislikeUsersRef.current,
-        excludeReactionUsers: false,
-        roleIndexSets,
-        collectionSource,
-      });
-
-      filteredCandidates.forEach(user => {
-        if (collected.length < limit && !loadedIds.has(user.userId)) {
-          loadedIds.add(user.userId);
-          collected.push(user);
-        }
-      });
-
-      if (!page.hasMore) break;
-    }
+        return applyMatchingUiFiltersToUsers({
+          users: scopedCandidates,
+          filters: filtersRef.current || {},
+          favoriteUsers: favoriteUsersRef.current,
+          dislikeUsers: dislikeUsersRef.current,
+          excludeReactionUsers: false,
+          roleIndexSets,
+          collectionSource,
+        });
+      },
+    });
 
     return {
-      users: collected.sort(compareUsersByLastLogin2),
-      nextOffset,
-      hasMore: hasMore || reactionIds.slice(nextOffset).some(id => id && !loadedIds.has(id)),
+      ...page,
+      users: page.users.sort(compareUsersByLastLogin2),
     };
   }, [
     collectionSource,
@@ -3339,6 +3322,7 @@ const Matching = () => {
     loadingRef.current = true;
     setLoading(true);
     setUsers([]);
+    setSharedReactionCandidateUsers([]);
     setLastKey(null);
     setHasMore(false);
     resetReactionPaginationState(reactionType);
@@ -3396,6 +3380,7 @@ const Matching = () => {
       const loadedIds = new Set();
       const page = await loadReactionCardsPage({
         reactionIds,
+        reactionMap,
         offset: 0,
         limit: INITIAL_LOAD,
         loadedIds,
@@ -3518,6 +3503,7 @@ const Matching = () => {
         const loadedIds = reactionLoadedIdsRef.current[viewMode] || new Set();
         const page = await loadReactionCardsPage({
           reactionIds,
+          reactionMap,
           offset: currentPagination.ids.length > 0 ? currentPagination.nextOffset : 0,
           limit: LOAD_MORE,
           loadedIds,

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -2,6 +2,7 @@ import {
   buildReactionCardsPage,
   buildSharedReactionCandidateIds,
   canShowMatchingUser,
+  loadReactionCardsPageRecords,
   resolvePrioritizedReactionMaps,
   shouldApplyReactionPageResult,
 } from '../reactionPriority';
@@ -339,6 +340,107 @@ describe('mergeMatchingCandidateUsers', () => {
 
     expect(result.map(user => user.userId)).toEqual(['sharedDislikeOnly']);
   });
+
+
+  it('isolates active reaction tabs even when given a combined shared candidate pool', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const cards = [
+      { userId: 'effectiveFavorite', publish: true, __sourceCollection: 'users' },
+      { userId: 'effectiveDislike', publish: true, __sourceCollection: 'users' },
+    ];
+
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: cards,
+      favoriteUsers: { effectiveFavorite: true },
+      dislikeUsers: { effectiveDislike: true },
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    });
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: cards,
+      favoriteUsers: { effectiveFavorite: true },
+      dislikeUsers: { effectiveDislike: true },
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(favoritesTab.map(user => user.userId)).toEqual(['effectiveFavorite']);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['effectiveDislike']);
+  });
+
+  it('routes shared-only dislike to dislikes only and keeps it out of default/favorites', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const sharedDislike = { userId: 'sharedOnlyDislike', publish: true, __sourceCollection: 'users' };
+    const favoriteUsers = {};
+    const dislikeUsers = { sharedOnlyDislike: true };
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [sharedDislike],
+      sharedReactionCandidateUsers: [sharedDislike],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: [sharedDislike],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    });
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: [sharedDislike],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(defaultDeck).toEqual([]);
+    expect(favoritesTab).toEqual([]);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['sharedOnlyDislike']);
+  });
+
+  it('routes shared-only favorite to favorites only and keeps it out of default/dislikes', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const sharedFavorite = { userId: 'sharedOnlyFavorite', publish: true, __sourceCollection: 'users' };
+    const favoriteUsers = { sharedOnlyFavorite: true };
+    const dislikeUsers = {};
+
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [sharedFavorite],
+      sharedReactionCandidateUsers: [sharedFavorite],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: [sharedFavorite],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    });
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: [sharedFavorite],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(defaultDeck).toEqual([]);
+    expect(favoritesTab.map(user => user.userId)).toEqual(['sharedOnlyFavorite']);
+    expect(dislikesTab).toEqual([]);
+  });
 });
 
 describe('reaction card pagination', () => {
@@ -383,6 +485,74 @@ describe('reaction card pagination', () => {
     expect(page.pageIds).toEqual(reactionIds.slice(6));
     expect(page.nextOffset).toBe(8);
     expect(page.hasMore).toBe(false);
+  });
+
+
+  it('fetches reaction user records page-by-page without hydrating the full reaction list', async () => {
+    const pageSize = 6;
+    const reactionIds = Array.from({ length: pageSize * 2 + 2 }, (_, index) => `dislike-${index + 1}`);
+    const fetchCalls = [];
+    const fetchUsersByIds = jest.fn(async ids => {
+      fetchCalls.push([...ids]);
+      return Object.fromEntries(ids.map(id => [id, { userId: id, publish: true, __sourceCollection: 'users' }]));
+    });
+    const loaded = new Set();
+
+    const firstPage = await loadReactionCardsPageRecords({
+      reactionIds,
+      limit: pageSize,
+      loadedIds: loaded,
+      fetchUsersByIds,
+    });
+    const secondPage = await loadReactionCardsPageRecords({
+      reactionIds,
+      offset: firstPage.nextOffset,
+      limit: pageSize,
+      loadedIds: loaded,
+      fetchUsersByIds,
+    });
+
+    expect(firstPage.users.map(user => user.userId)).toEqual(reactionIds.slice(0, pageSize));
+    expect(firstPage.hasMore).toBe(true);
+    expect(secondPage.users.map(user => user.userId)).toEqual(reactionIds.slice(pageSize, pageSize * 2));
+    expect(fetchCalls).toEqual([
+      reactionIds.slice(0, pageSize),
+      reactionIds.slice(pageSize, pageSize * 2),
+    ]);
+    expect(fetchCalls.flat()).toHaveLength(pageSize * 2);
+    expect(new Set([...firstPage.users, ...secondPage.users].map(user => user.userId)).size).toBe(pageSize * 2);
+  });
+
+  it('backfills skipped reaction ids only until the visible page is filled', async () => {
+    const reactionIds = Array.from({ length: 12 }, (_, index) => `effective-dislike-${index + 1}`);
+    const hidden = new Set(['effective-dislike-1', 'effective-dislike-2', 'effective-dislike-4']);
+    const fetchCalls = [];
+    const fetchUsersByIds = jest.fn(async ids => {
+      fetchCalls.push([...ids]);
+      return Object.fromEntries(ids.map(id => [id, { userId: id, publish: true, __sourceCollection: 'users' }]));
+    });
+
+    const page = await loadReactionCardsPageRecords({
+      reactionIds,
+      limit: 3,
+      loadedIds: new Set(),
+      fetchUsersByIds,
+      filterUsers: users => users.filter(user => !hidden.has(user.userId)),
+    });
+
+    expect(page.users.map(user => user.userId)).toEqual([
+      'effective-dislike-3',
+      'effective-dislike-5',
+      'effective-dislike-6',
+    ]);
+    expect(fetchCalls).toEqual([
+      ['effective-dislike-1', 'effective-dislike-2', 'effective-dislike-3'],
+      ['effective-dislike-4', 'effective-dislike-5'],
+      ['effective-dislike-6'],
+    ]);
+    expect(fetchCalls.flat()).toHaveLength(6);
+    expect(fetchCalls.flat()).not.toEqual(reactionIds);
+    expect(page.hasMore).toBe(true);
   });
 });
 

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -145,8 +145,16 @@ export const mergeMatchingCandidateUsers = ({
   sharedReactionCandidateUsers.forEach(injectCandidate);
 
   const mergedUsers = Array.from(byId.values()).filter(canInjectCandidate);
-  if (viewMode !== 'default') {
-    return mergedUsers;
+  if (viewMode === 'favorites') {
+    return mergedUsers.filter(
+      user => Boolean(favoriteUsers[user.userId]) && !dislikeUsers[user.userId]
+    );
+  }
+
+  if (viewMode === 'dislikes') {
+    return mergedUsers.filter(
+      user => Boolean(dislikeUsers[user.userId]) && !favoriteUsers[user.userId]
+    );
   }
 
   return mergedUsers.filter(
@@ -191,6 +199,67 @@ export const buildReactionCardsPage = ({
     nextOffset: cursor,
     hasMore,
     total: ids.length,
+  };
+};
+
+
+export const loadReactionCardsPageRecords = async ({
+  reactionIds = [],
+  offset = 0,
+  limit = 6,
+  loadedIds = new Set(),
+  fetchUsersByIds,
+  mapUser = user => user,
+  filterUsers = users => users,
+} = {}) => {
+  if (typeof fetchUsersByIds !== 'function') {
+    throw new TypeError('fetchUsersByIds is required');
+  }
+
+  const collected = [];
+  let nextOffset = Math.max(0, Number(offset) || 0);
+  let hasMore = false;
+  const safeLimit = Math.max(0, Number(limit) || 0);
+
+  while (collected.length < safeLimit && nextOffset < reactionIds.length) {
+    const page = buildReactionCardsPage({
+      reactionIds,
+      offset: nextOffset,
+      limit: Math.max(1, safeLimit - collected.length),
+      excludeIds: loadedIds,
+    });
+
+    nextOffset = page.nextOffset;
+    hasMore = page.hasMore;
+    if (page.pageIds.length === 0) {
+      if (!page.hasMore) break;
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const usersMap = await fetchUsersByIds(page.pageIds);
+    const mappedUsers = page.pageIds
+      .map(id => usersMap?.[id])
+      .filter(Boolean)
+      .map(mapUser)
+      .filter(Boolean)
+      .filter(user => user?.userId && !loadedIds.has(user.userId));
+
+    const filteredUsers = filterUsers(mappedUsers) || [];
+    filteredUsers.forEach(user => {
+      if (collected.length < safeLimit && user?.userId && !loadedIds.has(user.userId)) {
+        loadedIds.add(user.userId);
+        collected.push(user);
+      }
+    });
+
+    if (!page.hasMore) break;
+  }
+
+  return {
+    users: collected,
+    nextOffset,
+    hasMore: hasMore || reactionIds.slice(nextOffset).some(id => id && !loadedIds.has(id)),
   };
 };
 


### PR DESCRIPTION
### Motivation
- Prevent favorites/dislikes cross-contamination caused by injecting a combined shared candidate pool into both reaction tabs. 
- Restore traffic-saving, page-by-page reaction card loading to avoid hydrating full reaction lists on tab open. 
- Preserve existing access rules for `newUsers` while keeping reaction tab loading efficient and isolated.

### Description
- Scope merged reaction candidates by active mode in `mergeMatchingCandidateUsers` so `viewMode === 'favorites'` returns only effective favorites and `viewMode === 'dislikes'` returns only effective dislikes, while the `default` deck excludes all effective favorites/dislikes. 
- Introduce `loadReactionCardsPageRecords` to perform paginated user-record fetches from a list of reaction IDs, backfilling only until the visible page is filled and preserving `hasMore` based on untraversed IDs. 
- Update `Matching` to stop preloading the combined shared reaction candidate pool while in a reaction tab, clear `sharedReactionCandidateUsers` when entering a reaction tab, and pass the active `reactionMap` into the paginated loader so only matching-mode records are fetched and rendered. 
- Keep `getAccessibleReactionIds` behavior for `newUsers` (searchKeySets access) intact so `newUsers` records still require search-key access when additional access rules are active. 
- Add regression tests covering cross-tab isolation, shared-only favorite/dislike routing, page-by-page backend fetch behavior, backfill-limited scanning, and pagination/duplicate protections.

### Testing
- Ran unit tests with `npm test -- --runInBand src/utils/__tests__/reactionPriority.test.js src/components/Matching.sharedReactions.test.js --watchAll=false` and all tests passed. 
- Ran lint with `npm run lint:js` and it succeeded (no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0425b67cd48326abb7aaea3eb7e67f)