### PR TITLE
Fix matching reaction tab regressions

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -82,6 +82,7 @@ import {
   readReactionSnapshotMaps,
   resolvePrioritizedReactionMaps,
   shouldApplyReactionPageResult,
+  shouldApplySharedReactionCandidateResult,
   uniqueTruthyReactionIds,
 } from 'utils/reactionPriority';
 
@@ -2000,6 +2001,7 @@ const Matching = () => {
   const [collectionSource, setCollectionSource] = useState(
     () => localStorage.getItem(COLLECTION_SOURCE_KEY) || 'users'
   );
+  const collectionSourceRef = useRef(collectionSource);
   const defaultListKey = `default:${collectionSource}`;
   const [filterResetToken, setFilterResetToken] = useState(0);
   const [comments, setComments] = useState({});
@@ -2038,6 +2040,7 @@ const Matching = () => {
   const additionalLoadMoreFetchVersionRef = useRef(0);
   const additionalMatchingApplyVersionRef = useRef(0);
   const reactionLoadVersionRef = useRef(0);
+  const sharedReactionCandidateLoadVersionRef = useRef(0);
   const matchingProfileStateRef = useRef({
     ownerId: null,
     collectionSource,
@@ -2077,6 +2080,7 @@ const Matching = () => {
   }, []);
   const invalidateReactionAsyncWork = React.useCallback(() => {
     reactionLoadVersionRef.current += 1;
+    sharedReactionCandidateLoadVersionRef.current += 1;
     additionalLoadMoreFetchVersionRef.current += 1;
     additionalMatchingApplyVersionRef.current += 1;
     loadingRef.current = false;
@@ -2094,6 +2098,7 @@ const Matching = () => {
     viewModeRef.current = viewMode;
   }, [viewMode]);
   useEffect(() => {
+    collectionSourceRef.current = collectionSource;
     localStorage.setItem(COLLECTION_SOURCE_KEY, collectionSource);
   }, [collectionSource]);
   useEffect(() => {
@@ -2169,9 +2174,12 @@ const Matching = () => {
     const filtered = arr.filter(u => isValidId(u?.userId));
     setUsers(filtered);
     setHasMore(false);
-    await loadCommentsFor(filtered);
     setLastKey(null);
+    invalidateReactionAsyncWork();
+    setSharedReactionCandidateUsers([]);
+    viewModeRef.current = 'search';
     setViewMode('search');
+    await loadCommentsFor(filtered);
   };
 
   useEffect(() => {
@@ -2440,7 +2448,20 @@ const Matching = () => {
 
   const loadSharedReactionCandidates = React.useCallback(async () => {
     const viewerId = ownerId || getOwnerId();
-    if (viewMode === 'favorites' || viewMode === 'dislikes') {
+    const requestVersion = sharedReactionCandidateLoadVersionRef.current + 1;
+    sharedReactionCandidateLoadVersionRef.current = requestVersion;
+    const requestViewMode = viewModeRef.current;
+    const requestCollectionSource = collectionSource;
+    const canApplySharedCandidateResult = () => shouldApplySharedReactionCandidateResult({
+      requestVersion,
+      currentVersion: sharedReactionCandidateLoadVersionRef.current,
+      requestViewMode,
+      currentViewMode: viewModeRef.current,
+      requestCollectionSource,
+      currentCollectionSource: collectionSourceRef.current,
+    });
+
+    if (requestViewMode !== 'default') {
       setSharedReactionCandidateUsers([]);
       return;
     }
@@ -2451,7 +2472,9 @@ const Matching = () => {
     });
 
     if (!viewerId || candidateIds.length === 0) {
-      setSharedReactionCandidateUsers([]);
+      if (canApplySharedCandidateResult()) {
+        setSharedReactionCandidateUsers([]);
+      }
       return;
     }
 
@@ -2470,6 +2493,10 @@ const Matching = () => {
           ? currentSearchKeySetKeys
           : await resolveAdditionalSearchKeySetKeysForMatching(null, viewerId);
 
+        if (!canApplySharedCandidateResult()) {
+          return;
+        }
+
         if (resolvedSearchKeySetKeys.length === 0) {
           filteredByAccessIds.push(...newUserCandidateIds);
         } else {
@@ -2484,6 +2511,9 @@ const Matching = () => {
             debugMatchingFlow: shouldDebugAdditionalMatching(viewerId),
             debugToast: (message, data) => debugAdditionalToast(viewerId, message, data),
           });
+          if (!canApplySharedCandidateResult()) {
+            return;
+          }
           indexedAllowedNewUserIds = new Set(Array.isArray(indexed?.userIds) ? indexed.userIds : []);
           allowedNewUserIds = newUserCandidateIds.filter(id => indexedAllowedNewUserIds.has(id));
           filteredByAccessIds.push(...newUserCandidateIds.filter(id => !indexedAllowedNewUserIds.has(id)));
@@ -2496,8 +2526,15 @@ const Matching = () => {
     }
 
     const loadedUsers = [];
+    if (!canApplySharedCandidateResult()) {
+      return;
+    }
+
     if (collectionSource === 'newUsers' && allowedNewUserIds.length > 0) {
       const newUsersCards = await fetchNewUsersByIdsForMatching(allowedNewUserIds);
+      if (!canApplySharedCandidateResult()) {
+        return;
+      }
       loadedUsers.push(
         ...newUsersCards.map(user => ({
           ...user,
@@ -2509,7 +2546,13 @@ const Matching = () => {
     if (collectionSource !== 'newUsers') {
       const userIds = candidateIds.filter(isValidId);
       if (userIds.length > 0) {
+        if (!canApplySharedCandidateResult()) {
+          return;
+        }
         const usersMap = await fetchUsersByIds(userIds);
+        if (!canApplySharedCandidateResult()) {
+          return;
+        }
         loadedUsers.push(
           ...userIds
             .map(id => usersMap[id])
@@ -2525,12 +2568,20 @@ const Matching = () => {
       ? allowedNewUserIds.filter(id => !loadedIds.has(id))
       : candidateIds.filter(isValidId).filter(id => !loadedIds.has(id));
 
+    if (!canApplySharedCandidateResult()) {
+      return;
+    }
+
     loadedUsers.forEach(user => {
       const { __matchingAccessAllowed, ...cacheUser } = user;
       updateCard(user.userId, cacheUser);
     });
     setSharedReactionCandidateUsers(loadedUsers);
     await loadCommentsFor(loadedUsers);
+
+    if (!canApplySharedCandidateResult()) {
+      return;
+    }
 
     debugSharedReactionsLog(viewerId, 'shared reaction candidate pool resolved', {
       sharedReactionIds: summarizeIdsForDebug(candidateIds),
@@ -2563,7 +2614,6 @@ const Matching = () => {
     isAdmin,
     parsedAdditionalAccessRules.length,
     sharedReactionIds,
-    viewMode,
   ]);
 
   useEffect(() => {
@@ -3905,6 +3955,7 @@ const Matching = () => {
                 invalidateReactionAsyncWork();
                 resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
                 resetReactionPaginationState();
+                collectionSourceRef.current = e.target.value;
                 setCollectionSource(e.target.value);
               }}
             />
@@ -3920,6 +3971,7 @@ const Matching = () => {
                 invalidateReactionAsyncWork();
                 resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });
                 resetReactionPaginationState();
+                collectionSourceRef.current = e.target.value;
                 setCollectionSource(e.target.value);
               }}
             />

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -17,4 +17,26 @@ describe('Matching shared reaction card UI', () => {
     expect(source).toContain('await fetchUserById(id)');
     expect(source).not.toContain('const usersMap = await fetchUsersByIds(page.pageIds);');
   });
+
+  it('guards stale default shared-candidate requests before applying them in reaction tabs', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('const sharedReactionCandidateLoadVersionRef = useRef(0);');
+    expect(source).toContain('const canApplySharedCandidateResult = () => shouldApplySharedReactionCandidateResult({');
+    expect(source).toContain('currentViewMode: viewModeRef.current');
+    expect(source).toContain('currentCollectionSource: collectionSourceRef.current');
+    expect(source).toContain(`if (!canApplySharedCandidateResult()) {
+      return;
+    }
+
+    loadedUsers.forEach`);
+  });
+
+  it('clears shared candidates when entering search so search renders only returned results', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain(`setSharedReactionCandidateUsers([]);
+    viewModeRef.current = 'search';`);
+  });
+
 });

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -303,6 +303,64 @@ describe('mergeMatchingCandidateUsers', () => {
     expect(dislikesTab.map(user => user.userId)).toEqual(['ownDislikeSharedFavorite']);
   });
 
+
+  it('keeps reacted cards in search results while preserving default and reaction tab isolation', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const favoriteCard = { userId: 'favoriteCard', publish: true, __sourceCollection: 'users' };
+    const dislikeCard = { userId: 'dislikeCard', publish: true, __sourceCollection: 'users' };
+    const neutralCard = { userId: 'neutralCard', publish: true, __sourceCollection: 'users' };
+    const favoriteUsers = { favoriteCard: true };
+    const dislikeUsers = { dislikeCard: true };
+
+    const searchResults = mergeMatchingCandidateUsers({
+      users: [favoriteCard, dislikeCard, neutralCard],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'search',
+      collectionSource: 'users',
+    });
+    const defaultDeck = mergeMatchingCandidateUsers({
+      users: [favoriteCard, dislikeCard, neutralCard],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [favoriteCard, dislikeCard, neutralCard],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    });
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [favoriteCard, dislikeCard, neutralCard],
+      favoriteUsers,
+      dislikeUsers,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(searchResults.map(user => user.userId)).toEqual(['favoriteCard', 'dislikeCard', 'neutralCard']);
+    expect(defaultDeck.map(user => user.userId)).toEqual(['neutralCard']);
+    expect(favoritesTab.map(user => user.userId)).toEqual(['favoriteCard']);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['dislikeCard']);
+  });
+
+  it('does not apply default deck reaction exclusion to unknown non-default modes', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [{ userId: 'reactedCard', publish: true, __sourceCollection: 'users' }],
+      favoriteUsers: { reactedCard: true },
+      dislikeUsers: {},
+      viewMode: 'custom-non-default',
+      collectionSource: 'users',
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['reactedCard']);
+  });
+
   it('keeps default deck free of all effective favorite and dislike cards', () => {
     const { mergeMatchingCandidateUsers } = require('../reactionPriority');
 
@@ -440,6 +498,49 @@ describe('mergeMatchingCandidateUsers', () => {
     expect(defaultDeck).toEqual([]);
     expect(favoritesTab.map(user => user.userId)).toEqual(['sharedOnlyFavorite']);
     expect(dislikesTab).toEqual([]);
+  });
+});
+
+
+describe('shouldApplySharedReactionCandidateResult', () => {
+  it('allows only the current default-mode shared candidate request to apply', () => {
+    const { shouldApplySharedReactionCandidateResult } = require('../reactionPriority');
+
+    expect(shouldApplySharedReactionCandidateResult({
+      requestVersion: 3,
+      currentVersion: 3,
+      requestViewMode: 'default',
+      currentViewMode: 'default',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'users',
+    })).toBe(true);
+
+    expect(shouldApplySharedReactionCandidateResult({
+      requestVersion: 3,
+      currentVersion: 4,
+      requestViewMode: 'default',
+      currentViewMode: 'default',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'users',
+    })).toBe(false);
+
+    expect(shouldApplySharedReactionCandidateResult({
+      requestVersion: 3,
+      currentVersion: 3,
+      requestViewMode: 'default',
+      currentViewMode: 'dislikes',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'users',
+    })).toBe(false);
+
+    expect(shouldApplySharedReactionCandidateResult({
+      requestVersion: 3,
+      currentVersion: 3,
+      requestViewMode: 'default',
+      currentViewMode: 'default',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'newUsers',
+    })).toBe(false);
   });
 });
 

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -86,6 +86,20 @@ export const canShowMatchingUser = (user, { isAdmin = false } = {}) => {
   return user?.__sourceCollection === 'newUsers' || user?.publish === true;
 };
 
+export const shouldApplySharedReactionCandidateResult = ({
+  requestVersion,
+  currentVersion,
+  requestViewMode,
+  currentViewMode,
+  requestCollectionSource,
+  currentCollectionSource,
+} = {}) => (
+  requestViewMode === 'default' &&
+  currentViewMode === 'default' &&
+  requestCollectionSource === currentCollectionSource &&
+  requestVersion === currentVersion
+);
+
 export const mergeMatchingCandidateUsers = ({
   users = [],
   additionalNewUsers = [],
@@ -157,9 +171,13 @@ export const mergeMatchingCandidateUsers = ({
     );
   }
 
-  return mergedUsers.filter(
-    user => !favoriteUsers[user.userId] && !dislikeUsers[user.userId]
-  );
+  if (viewMode === 'default') {
+    return mergedUsers.filter(
+      user => !favoriteUsers[user.userId] && !dislikeUsers[user.userId]
+    );
+  }
+
+  return mergedUsers;
 };
 
 


### PR DESCRIPTION
### Motivation
- Prevent stale default-mode shared-candidate loads from repopulating Favorites/Dislikes/Search after view/collection changes and preserve prior behavior that search mode should not drop reacted cards.
- Ensure reaction tab pagination remains the only source of hydration for reaction tabs and avoid cross-tab contamination or duplicate cards.

### Description
- Add `shouldApplySharedReactionCandidateResult` in `src/utils/reactionPriority.js` to verify request version, view mode, and collection source before applying shared-candidate results. 
- Make `mergeMatchingCandidateUsers` treat `viewMode === 'default'` as the only case where favorite/dislike exclusion is applied so `search` and other non-default modes preserve reacted cards. 
- Make `loadSharedReactionCandidates` version- and mode-aware in `src/components/Matching.jsx` by introducing `sharedReactionCandidateLoadVersionRef`, `collectionSourceRef`, a `canApplySharedCandidateResult` guard, and multiple early-return checks to discard stale async results. 
- Wire `invalidateReactionAsyncWork` to bump the shared-candidate version and clear shared candidates when switching to non-default/search modes, and update `applySearchResults` to clear shared candidates and set `viewModeRef` to `search` before continuing. 
- Update collection source handling to keep `collectionSourceRef` in sync when the radio changes so stale collection results are discarded safely. 
- Add regression tests covering: preserving reacted cards in `search`, preventing stale shared-candidate application, and ensuring search clears shared candidates (changes in `src/utils/__tests__/reactionPriority.test.js` and `src/components/Matching.sharedReactions.test.js`).

### Testing
- Ran unit tests for the modified suites with `CI=true npm test -- --runInBand src/utils/__tests__/reactionPriority.test.js src/components/Matching.sharedReactions.test.js` and both test suites passed. 
- Ran lint with `npm run lint:js` with no blocking errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a042bb56e888326952ba13a2a47119b)