### PR TITLE
Fix PP social URL normalization

### DIFF
--- a/src/components/inputUpdatedValue.js
+++ b/src/components/inputUpdatedValue.js
@@ -6,6 +6,7 @@ import {
   formatOther,
   formatTelegram,
   formatTikTok,
+  formatTwitter,
   formatYoutube,
   formatVk,
   formatDate,
@@ -54,6 +55,8 @@ export const inputUpdateValue = (value, field, data) => {
       ? formatEmail(value)
       : field.name === 'tiktok'
       ? formatTikTok(value)
+      : field.name === 'twitter'
+      ? formatTwitter(value)
       : field.name === 'youtube'
       ? formatYoutube(value)
       : field.name === 'other'

--- a/src/components/inputValidations.js
+++ b/src/components/inputValidations.js
@@ -179,6 +179,11 @@ export const formatEmail = email => {
     return value.replace(/^@/g, '').toLowerCase();
   };
 
+  export const formatTwitter = value => {
+    value = removeSpaceAndNewLine(value);
+    return value.replace(/^@/g, '').toLowerCase();
+  };
+
   const extractYoutubeIdentifier = value => {
     const youtubeUrlMatch = value.match(
       /^(?:https?:\/\/)?(?:m\.|www\.)?(?:(?:youtube\.com)\/|(?:youtu\.be)\/)(.+)$/i,

--- a/src/utils/ppTechnicalInputTarget.js
+++ b/src/utils/ppTechnicalInputTarget.js
@@ -15,6 +15,38 @@ export const normalizeUrlForStorage = rawValue => {
   return trimmed;
 };
 
+const stripUrlSuffix = value =>
+  String(value || '')
+    .split(/[?#]/)[0]
+    .replace(/\/+$/, '')
+    .trim();
+
+const normalizeLinkedinStorageValue = value => {
+  const normalized = stripUrlSuffix(value).replace(/^@/, '');
+  if (!normalized) return '';
+
+  const segments = normalized.split('/').filter(Boolean);
+  if (!segments.length) return '';
+
+  const [firstSegment, secondSegment] = segments;
+  const lowerFirstSegment = firstSegment.toLowerCase();
+
+  if (lowerFirstSegment === 'company' && secondSegment) {
+    return `${lowerFirstSegment}/${secondSegment.replace(/^@/, '').toLowerCase()}`;
+  }
+
+  if (lowerFirstSegment === 'in' && secondSegment) {
+    return secondSegment.replace(/^@/, '').toLowerCase();
+  }
+
+  return firstSegment.replace(/^@/, '').toLowerCase();
+};
+
+const normalizeTwitterStorageValue = value =>
+  stripUrlSuffix(value)
+    .replace(/^@/, '')
+    .toLowerCase();
+
 export const resolvePpTechnicalInputSocialTarget = rawValue => {
   const trimmed = String(rawValue || '').trim();
   if (!trimmed) return null;
@@ -23,9 +55,9 @@ export const resolvePpTechnicalInputSocialTarget = rawValue => {
     { fieldName: 'instagram', pattern: /(?:https?:\/\/)?(?:www\.)?instagram\.com\/([^/?#]+)/i },
     { fieldName: 'facebook', pattern: /(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.com)\/([^/?#]+)/i, useRawValue: true },
     { fieldName: 'tiktok', pattern: /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/([^/?#]+)/i },
-    { fieldName: 'linkedin', pattern: /(?:https?:\/\/)?(?:www\.)?linkedin\.com\/([^/?#]+)/i },
+    { fieldName: 'linkedin', pattern: /(?:https?:\/\/)?(?:www\.)?linkedin\.com\/([^?#]+)/i, normalizeValue: normalizeLinkedinStorageValue },
     { fieldName: 'youtube', pattern: /(?:https?:\/\/)?(?:m\.|www\.)?(?:(?:youtube\.com)\/(?:@|c\/|channel\/|user\/)?|(?:youtu\.be)\/)([^/?#]+)/i },
-    { fieldName: 'twitter', pattern: /(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/([^/?#]+)/i },
+    { fieldName: 'twitter', pattern: /(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/@?([^/?#]+)/i, normalizeValue: normalizeTwitterStorageValue },
     { fieldName: 'telegram', pattern: /(?:https?:\/\/)?(?:www\.)?(?:t\.me|telegram\.me|telegram\.dog)\/([^/?#]+)/i },
   ];
 
@@ -33,7 +65,10 @@ export const resolvePpTechnicalInputSocialTarget = rawValue => {
     const match = trimmed.match(matcher.pattern);
     if (!match?.[1]) continue;
 
-    const normalizedValue = String(matcher.useRawValue ? trimmed : match[1]).replace(/^@/, '').trim();
+    const rawMatchedValue = String(matcher.useRawValue ? trimmed : match[1]).replace(/^@/, '').trim();
+    const normalizedValue = typeof matcher.normalizeValue === 'function'
+      ? matcher.normalizeValue(rawMatchedValue)
+      : rawMatchedValue;
     if (normalizedValue) {
       return { fieldName: matcher.fieldName, value: normalizedValue };
     }

--- a/src/utils/ppTechnicalInputTarget.test.js
+++ b/src/utils/ppTechnicalInputTarget.test.js
@@ -1,0 +1,33 @@
+import { resolvePpTechnicalInputTarget } from './ppTechnicalInputTarget';
+import { inputUpdateValue } from '../components/inputUpdatedValue';
+
+describe('resolvePpTechnicalInputTarget', () => {
+  it('keeps linkedin company paths instead of only saving the route segment', () => {
+    expect(
+      resolvePpTechnicalInputTarget('http://www.linkedin.com/company/tindall-gask-bentley-lawyers')
+    ).toEqual({
+      fieldName: 'linkedin',
+      value: 'company/tindall-gask-bentley-lawyers',
+    });
+  });
+
+  it('normalizes linkedin profile URLs to the profile id', () => {
+    expect(resolvePpTechnicalInputTarget('https://www.linkedin.com/in/Some-User/')).toEqual({
+      fieldName: 'linkedin',
+      value: 'some-user',
+    });
+  });
+
+  it('lowercases twitter handles from social URLs', () => {
+    expect(resolvePpTechnicalInputTarget('http://twitter.com/TGBlawyers')).toEqual({
+      fieldName: 'twitter',
+      value: 'tgblawyers',
+    });
+  });
+});
+
+describe('inputUpdateValue twitter normalization', () => {
+  it('lowercases twitter handles in regular twitter fields too', () => {
+    expect(inputUpdateValue('@TGBlawyers', { name: 'twitter' })).toBe('tgblawyers');
+  });
+});


### PR DESCRIPTION
### Motivation
- PP technical input parser treated the segment after `linkedin.com/` as a single token which turned `linkedin.com/company/<slug>` into just `company`, and Twitter handles from PP input were not lowercased which breaks downstream search.
- Shared field normalization did not include a dedicated Twitter formatter, so values like `TGBlawyers` remained capitalized when stored.

### Description
- Add URL suffix stripping and storage normalizers: `stripUrlSuffix`, `normalizeLinkedinStorageValue` and `normalizeTwitterStorageValue` and wire them into `resolvePpTechnicalInputSocialTarget` to preserve `company/<slug>` and normalize `/in/<id>` and Twitter handles (changes in `src/utils/ppTechnicalInputTarget.js`).
- Adjust LinkedIn and Twitter regexes in `resolvePpTechnicalInputSocialTarget` to capture the needed parts and call the new normalizers for storage.
- Add `formatTwitter` to `src/components/inputValidations.js` and hook it into the shared `inputUpdateValue` path in `src/components/inputUpdatedValue.js` so regular `twitter` fields are normalized to lowercase.
- Add unit tests covering LinkedIn company/profile parsing and Twitter lowercasing in `src/utils/ppTechnicalInputTarget.test.js`.

### Testing
- Ran `npm test -- --watchAll=false --runTestsByPath src/utils/ppTechnicalInputTarget.test.js` and the test suite passed.
- Ran `npm run lint:js` and ESLint completed without errors.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0431b68e188326b84caabe8f5fa988)