### PR TITLE
Restore shared candidates on default mode return

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2450,7 +2450,7 @@ const Matching = () => {
     const viewerId = ownerId || getOwnerId();
     const requestVersion = sharedReactionCandidateLoadVersionRef.current + 1;
     sharedReactionCandidateLoadVersionRef.current = requestVersion;
-    const requestViewMode = viewModeRef.current;
+    const requestViewMode = viewMode;
     const requestCollectionSource = collectionSource;
     const canApplySharedCandidateResult = () => shouldApplySharedReactionCandidateResult({
       requestVersion,
@@ -2614,6 +2614,7 @@ const Matching = () => {
     isAdmin,
     parsedAdditionalAccessRules.length,
     sharedReactionIds,
+    viewMode,
   ]);
 
   useEffect(() => {

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -32,6 +32,20 @@ describe('Matching shared reaction card UI', () => {
     loadedUsers.forEach`);
   });
 
+
+  it('reloads shared candidates when returning to default mode without shared id changes', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('const requestViewMode = viewMode;');
+    expect(source).toContain(`sharedReactionIds,
+    viewMode,
+  ]);
+
+  useEffect(() => {
+    loadSharedReactionCandidates();
+  }, [loadSharedReactionCandidates]);`);
+  });
+
   it('clears shared candidates when entering search so search renders only returned results', () => {
     const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
 


### PR DESCRIPTION
### Motivation
- Returning to `viewMode === 'default'` did not always reload shared reaction candidates because the loader callback was not recreated on mode change, causing an empty `sharedReactionCandidateUsers` pool after switching back from non-default modes.

### Description
- Capture the concrete React `viewMode` in `loadSharedReactionCandidates` by setting `requestViewMode = viewMode` so the callback reflects the mode at call time.  
- Add `viewMode` to the `useCallback` dependency list so the loader is recreated on mode changes and the `useEffect` that calls it reruns when returning to default.  
- Preserve the existing stale-result guard using `sharedReactionCandidateLoadVersionRef`, `viewModeRef.current`, and `collectionSourceRef.current` so async race conditions are still rejected.  
- Add a small regression source-level assertion in `src/components/Matching.sharedReactions.test.js` to ensure the new `viewMode` dependency and `requestViewMode` capture exist in the codebase.

### Testing
- Ran `npm test -- --runTestsByPath src/components/Matching.sharedReactions.test.js --watchAll=false` and the suite passed.  
- Ran `npm test -- --runTestsByPath src/utils/__tests__/reactionPriority.test.js --watchAll=false` and the suite passed.  
- Ran `npm run lint:js` and linter completed without errors (with a browserslist advisory).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0439b3d1a083268dd07efe8a567342)