### PR TITLE
Merge late shared reaction candidates, preserve reaction pagination, and show shared-dislike indicator

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -77,7 +77,9 @@ import {
   buildSharedReactionCandidateIds,
   canShowMatchingUser,
   mergeMatchingCandidateUsers,
+  mergeSharedReactionCandidateUsers,
   loadReactionCardsPageRecords,
+  hasPendingSharedReactionCandidates,
   normalizeReactionMap,
   readReactionSnapshotMaps,
   resolvePrioritizedReactionMaps,
@@ -2461,10 +2463,11 @@ const Matching = () => {
       currentCollectionSource: collectionSourceRef.current,
     });
 
-    if (requestViewMode !== 'default') {
+    if (!['default', 'favorites', 'dislikes'].includes(requestViewMode)) {
       setSharedReactionCandidateUsers([]);
       return;
     }
+
     const candidateIds = [...new Set(sharedReactionIds.filter(Boolean))];
     debugSharedReactionsLog(viewerId, 'shared reaction ids found for candidate pool', {
       sharedReactionIds: summarizeIdsForDebug(candidateIds),
@@ -2576,7 +2579,11 @@ const Matching = () => {
       const { __matchingAccessAllowed, ...cacheUser } = user;
       updateCard(user.userId, cacheUser);
     });
-    setSharedReactionCandidateUsers(loadedUsers);
+    setSharedReactionCandidateUsers(prev => mergeSharedReactionCandidateUsers({
+      currentUsers: prev,
+      loadedUsers,
+      candidateIds,
+    }));
     await loadCommentsFor(loadedUsers);
 
     if (!canApplySharedCandidateResult()) {
@@ -3406,14 +3413,15 @@ const Matching = () => {
       dislikeUsersRef.current = disMap;
       setOwnFavoriteUsers(ownFavorites);
       setOwnDislikeUsers(ownDislikes);
-      setSharedReactionIds(buildSharedReactionCandidateIds({
+      const nextSharedReactionIds = buildSharedReactionCandidateIds({
         ownerIds: owners,
         ownOwnerId,
         favoriteSnapshots,
         dislikeSnapshots,
         favorites: favMap,
         dislikes: disMap,
-      }));
+      });
+      setSharedReactionIds(nextSharedReactionIds);
 
       syncFavorites(favMap);
       syncDislikes(disMap);
@@ -3449,15 +3457,22 @@ const Matching = () => {
       setUsers(page.users);
       await loadCommentsFor(page.users);
       if (!canApplyReactionLoad()) return;
+      const hasPendingSharedCandidates = hasPendingSharedReactionCandidates({
+        reactionIds,
+        sharedReactionIds: nextSharedReactionIds,
+        loadedIds,
+        reactionMap,
+      });
+      const nextHasMore = page.hasMore || hasPendingSharedCandidates;
       setReactionPaginationByType(prev => ({
         ...prev,
         [reactionType]: {
           ids: reactionIds,
           nextOffset: page.nextOffset,
-          hasMore: page.hasMore,
+          hasMore: nextHasMore,
         },
       }));
-      setHasMore(page.hasMore);
+      setHasMore(nextHasMore);
     } finally {
       if (canApplyReactionLoad()) {
         loadingRef.current = false;

--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -46,6 +46,7 @@ export const BtnDislike = ({
   const viewerFavoriteUsers = ownFavoriteUsers || favoriteUsers;
   const updateOwnFavoriteUsers = setOwnFavoriteUsers || setFavoriteUsers;
   const isDisliked = !!viewerDislikeUsers[userId];
+  const isSharedDisliked = !isDisliked && !!dislikeUsers[userId];
   const activeColor = color.reactionDislike;
   const resolvedActiveIconColor = activeIconColor || customTextColor || color.reactionIdleIcon;
   const resolvedInactiveIconColor = inactiveIconColor || '#fff';
@@ -138,9 +139,10 @@ export const BtnDislike = ({
         alignItems: 'center',
         justifyContent: 'center',
       }}
-      title={title}
+      title={isSharedDisliked ? `${title} (shared)` : title}
       aria-label={ariaLabel}
       aria-pressed={isDisliked}
+      data-shared-disliked={isSharedDisliked ? 'true' : undefined}
       disabled={!auth.currentUser}
       onClick={e => {
         e.stopPropagation();

--- a/src/components/smallCard/btnDislike.test.js
+++ b/src/components/smallCard/btnDislike.test.js
@@ -70,8 +70,8 @@ describe('BtnDislike', () => {
     expect(button).not.toBeNull();
     expect(button.style.background).toBe('rgb(255, 140, 0)');
     expect(button.getAttribute('aria-pressed')).toBe('false');
-    expect(button.getAttribute('data-shared-disliked')).toBeNull();
-    expect(button.getAttribute('title')).toBe('Дизлайк');
+    expect(button.getAttribute('data-shared-disliked')).toBe('true');
+    expect(button.getAttribute('title')).toBe('Дизлайк (shared)');
 
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -107,6 +107,7 @@ describe('BtnDislike', () => {
     const button = container.querySelector('button[aria-label="Дизлайк"]');
     expect(button).not.toBeNull();
     expect(button.getAttribute('aria-pressed')).toBe('true');
+    expect(button.getAttribute('data-shared-disliked')).toBeNull();
   });
 
 });

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -2,9 +2,12 @@ import {
   buildReactionCardsPage,
   buildSharedReactionCandidateIds,
   canShowMatchingUser,
+  hasPendingSharedReactionCandidates,
   loadReactionCardsPageRecords,
+  mergeSharedReactionCandidateUsers,
   resolvePrioritizedReactionMaps,
   shouldApplyReactionPageResult,
+  shouldApplySharedReactionCandidateResult,
 } from '../reactionPriority';
 
 describe('resolvePrioritizedReactionMaps', () => {
@@ -179,6 +182,47 @@ describe('mergeMatchingCandidateUsers', () => {
       sharedReactionCandidateUsers: [{ userId: 'ID0001', __sourceCollection: 'newUsers' }],
       isAdmin: false,
       viewMode: 'default',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+
+  it('keeps access-validated shared-only newUsers cards in reaction tabs when base users are empty', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [],
+      additionalNewUsers: [],
+      sharedReactionCandidateUsers: [{
+        userId: 'ID0001',
+        __sourceCollection: 'newUsers',
+        __matchingAccessAllowed: true,
+      }],
+      favoriteUsers: {},
+      dislikeUsers: { ID0001: true },
+      isAdmin: false,
+      viewMode: 'dislikes',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['ID0001']);
+  });
+
+  it('rejects shared-only newUsers reaction tab cards without searchKeySets access validation', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [],
+      additionalNewUsers: [],
+      sharedReactionCandidateUsers: [{ userId: 'ID0001', __sourceCollection: 'newUsers' }],
+      favoriteUsers: { ID0001: true },
+      dislikeUsers: {},
+      isAdmin: false,
+      viewMode: 'favorites',
       collectionSource: 'newUsers',
       hasAdditionalAccessRules: true,
     });
@@ -499,27 +543,269 @@ describe('mergeMatchingCandidateUsers', () => {
     expect(favoritesTab.map(user => user.userId)).toEqual(['sharedOnlyFavorite']);
     expect(dislikesTab).toEqual([]);
   });
+
+  it('injects shared reaction tab cards without duplicating base users', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const baseCard = { userId: 'sharedDislike', publish: true, __sourceCollection: 'users', name: 'base' };
+    const sharedCard = { userId: 'sharedDislike', publish: true, __sourceCollection: 'users', name: 'shared' };
+
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [baseCard],
+      sharedReactionCandidateUsers: [sharedCard, sharedCard],
+      favoriteUsers: {},
+      dislikeUsers: { sharedDislike: true },
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(dislikesTab.map(user => user.userId)).toEqual(['sharedDislike']);
+    expect(dislikesTab).toHaveLength(1);
+    expect(dislikesTab[0].name).toBe('shared');
+  });
+
 });
 
 
+
+describe('pre-merge shared reaction verification', () => {
+  const makeCard = userId => ({ userId, publish: true, __sourceCollection: 'users' });
+
+  it('keeps default deck free of own and shared effective reactions, including injected shared candidates', () => {
+    const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: {
+        viewer: { ownFavorite: true },
+        sharedOwner: { sharedFavorite: true },
+      },
+      dislikeSnapshots: {
+        viewer: { ownDislike: true },
+        sharedOwner: { sharedDislike: true },
+      },
+    });
+    const cards = ['neutral', 'ownFavorite', 'ownDislike', 'sharedFavorite', 'sharedDislike'].map(makeCard);
+
+    const defaultDeck = require('../reactionPriority').mergeMatchingCandidateUsers({
+      users: cards,
+      sharedReactionCandidateUsers: [makeCard('sharedFavorite'), makeCard('sharedDislike')],
+      favoriteUsers: favorites,
+      dislikeUsers: dislikes,
+      viewMode: 'default',
+      collectionSource: 'users',
+    });
+
+    expect(defaultDeck.map(user => user.userId)).toEqual(['neutral']);
+  });
+
+  it('does not reintroduce effective reactions during default loadMore/backfill filtering', async () => {
+    const sourceIds = ['ownFavorite', 'sharedFavorite', 'ownDislike', 'sharedDislike', 'neutral'];
+    const effectiveFavorites = { ownFavorite: true, sharedFavorite: true };
+    const effectiveDislikes = { ownDislike: true, sharedDislike: true };
+    const baseExclude = new Set([...Object.keys(effectiveFavorites), ...Object.keys(effectiveDislikes)]);
+    const fetchUsersByIds = jest.fn(async ids => Object.fromEntries(
+      ids.map(id => [id, makeCard(id)])
+    ));
+
+    const page = await loadReactionCardsPageRecords({
+      reactionIds: sourceIds,
+      limit: 5,
+      loadedIds: new Set(),
+      fetchUsersByIds,
+      filterUsers: users => users.filter(user => !baseExclude.has(user.userId)),
+    });
+
+    expect(page.users.map(user => user.userId)).toEqual(['neutral']);
+    expect(page.users.some(user => baseExclude.has(user.userId))).toBe(false);
+  });
+
+  it('shows own favorites, shared-only favorites, and own favorite overriding shared dislike in favorites tab', () => {
+    const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: {
+        viewer: { ownFavorite: true, ownFavoriteSharedDislike: true },
+        sharedOwner: { sharedFavorite: true },
+      },
+      dislikeSnapshots: {
+        sharedOwner: { ownFavoriteSharedDislike: true },
+      },
+    });
+
+    const favoritesTab = require('../reactionPriority').mergeMatchingCandidateUsers({
+      users: [makeCard('ownFavorite')],
+      sharedReactionCandidateUsers: [makeCard('sharedFavorite'), makeCard('ownFavoriteSharedDislike')],
+      favoriteUsers: favorites,
+      dislikeUsers: dislikes,
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    });
+
+    expect(favorites).toEqual({ sharedFavorite: true, ownFavorite: true, ownFavoriteSharedDislike: true });
+    expect(dislikes).toEqual({});
+    expect(favoritesTab.map(user => user.userId)).toEqual([
+      'ownFavorite',
+      'sharedFavorite',
+      'ownFavoriteSharedDislike',
+    ]);
+  });
+
+  it('shows own dislikes, shared-only dislikes, and own dislike overriding shared favorite in dislikes tab', () => {
+    const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: {
+        sharedOwner: { ownDislikeSharedFavorite: true },
+      },
+      dislikeSnapshots: {
+        viewer: { ownDislike: true, ownDislikeSharedFavorite: true },
+        sharedOwner: { sharedDislike: true },
+      },
+    });
+
+    const dislikesTab = require('../reactionPriority').mergeMatchingCandidateUsers({
+      users: [makeCard('ownDislike')],
+      sharedReactionCandidateUsers: [makeCard('sharedDislike'), makeCard('ownDislikeSharedFavorite')],
+      favoriteUsers: favorites,
+      dislikeUsers: dislikes,
+      viewMode: 'dislikes',
+      collectionSource: 'users',
+    });
+
+    expect(favorites).toEqual({});
+    expect(dislikes).toEqual({ sharedDislike: true, ownDislike: true, ownDislikeSharedFavorite: true });
+    expect(dislikesTab.map(user => user.userId)).toEqual([
+      'ownDislike',
+      'sharedDislike',
+      'ownDislikeSharedFavorite',
+    ]);
+  });
+
+  it('applies searchKeySets validation to shared newUsers favorites and dislikes', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+    const validatedFavorite = {
+      userId: 'ID0001',
+      __sourceCollection: 'newUsers',
+      __matchingAccessAllowed: true,
+    };
+    const validatedDislike = {
+      userId: 'ID0002',
+      __sourceCollection: 'newUsers',
+      __matchingAccessAllowed: true,
+    };
+    const unvalidatedFavorite = { userId: 'ID0003', __sourceCollection: 'newUsers' };
+    const unvalidatedDislike = { userId: 'ID0004', __sourceCollection: 'newUsers' };
+
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: [validatedFavorite, unvalidatedFavorite],
+      favoriteUsers: { ID0001: true, ID0003: true },
+      dislikeUsers: {},
+      viewMode: 'favorites',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+    const dislikesTab = mergeMatchingCandidateUsers({
+      users: [],
+      sharedReactionCandidateUsers: [validatedDislike, unvalidatedDislike],
+      favoriteUsers: {},
+      dislikeUsers: { ID0002: true, ID0004: true },
+      viewMode: 'dislikes',
+      collectionSource: 'newUsers',
+      hasAdditionalAccessRules: true,
+    });
+
+    expect(favoritesTab.map(user => user.userId)).toEqual(['ID0001']);
+    expect(dislikesTab.map(user => user.userId)).toEqual(['ID0002']);
+  });
+
+  it('ignores stale shared candidate results for changed tab, source, or version', () => {
+    const base = {
+      requestVersion: 9,
+      currentVersion: 9,
+      requestViewMode: 'dislikes',
+      currentViewMode: 'dislikes',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'users',
+    };
+
+    expect(shouldApplySharedReactionCandidateResult(base)).toBe(true);
+    expect(shouldApplySharedReactionCandidateResult({ ...base, currentVersion: 10 })).toBe(false);
+    expect(shouldApplySharedReactionCandidateResult({ ...base, currentViewMode: 'favorites' })).toBe(false);
+    expect(shouldApplySharedReactionCandidateResult({ ...base, currentCollectionSource: 'newUsers' })).toBe(false);
+  });
+
+  it('deduplicates when a card exists in both base users and shared reaction candidates', () => {
+    const { mergeMatchingCandidateUsers } = require('../reactionPriority');
+
+    const result = mergeMatchingCandidateUsers({
+      users: [makeCard('duplicate')],
+      sharedReactionCandidateUsers: [makeCard('duplicate'), makeCard('duplicate')],
+      favoriteUsers: { duplicate: true },
+      dislikeUsers: {},
+      viewMode: 'favorites',
+      collectionSource: 'users',
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['duplicate']);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('mergeSharedReactionCandidateUsers', () => {
+  it('adds late shared candidates without resetting existing candidate cards', () => {
+    const result = mergeSharedReactionCandidateUsers({
+      currentUsers: [{ userId: 'already-visible', publish: true }],
+      loadedUsers: [{ userId: 'late-shared', publish: true }],
+      candidateIds: ['already-visible', 'late-shared'],
+    });
+
+    expect(result.map(user => user.userId)).toEqual(['already-visible', 'late-shared']);
+  });
+
+  it('deduplicates candidate cards and prunes ids no longer in the shared candidate set', () => {
+    const result = mergeSharedReactionCandidateUsers({
+      currentUsers: [
+        { userId: 'stale-shared', publish: true },
+        { userId: 'duplicate-shared', name: 'old', publish: true },
+      ],
+      loadedUsers: [
+        { userId: 'duplicate-shared', name: 'new', publish: true },
+        { userId: 'duplicate-shared', name: 'newest', publish: true },
+      ],
+      candidateIds: ['duplicate-shared'],
+    });
+
+    expect(result).toEqual([{ userId: 'duplicate-shared', name: 'newest', publish: true }]);
+  });
+});
+
 describe('shouldApplySharedReactionCandidateResult', () => {
-  it('allows only the current default-mode shared candidate request to apply', () => {
-    const { shouldApplySharedReactionCandidateResult } = require('../reactionPriority');
+  it('allows current shared candidate requests in default and reaction tabs only', () => {
+    ['default', 'favorites', 'dislikes'].forEach(mode => {
+      expect(shouldApplySharedReactionCandidateResult({
+        requestVersion: 3,
+        currentVersion: 3,
+        requestViewMode: mode,
+        currentViewMode: mode,
+        requestCollectionSource: 'users',
+        currentCollectionSource: 'users',
+      })).toBe(true);
+    });
 
     expect(shouldApplySharedReactionCandidateResult({
       requestVersion: 3,
       currentVersion: 3,
-      requestViewMode: 'default',
-      currentViewMode: 'default',
+      requestViewMode: 'search',
+      currentViewMode: 'search',
       requestCollectionSource: 'users',
       currentCollectionSource: 'users',
-    })).toBe(true);
+    })).toBe(false);
 
     expect(shouldApplySharedReactionCandidateResult({
       requestVersion: 3,
       currentVersion: 4,
-      requestViewMode: 'default',
-      currentViewMode: 'default',
+      requestViewMode: 'dislikes',
+      currentViewMode: 'dislikes',
       requestCollectionSource: 'users',
       currentCollectionSource: 'users',
     })).toBe(false);
@@ -527,7 +813,7 @@ describe('shouldApplySharedReactionCandidateResult', () => {
     expect(shouldApplySharedReactionCandidateResult({
       requestVersion: 3,
       currentVersion: 3,
-      requestViewMode: 'default',
+      requestViewMode: 'favorites',
       currentViewMode: 'dislikes',
       requestCollectionSource: 'users',
       currentCollectionSource: 'users',
@@ -540,6 +826,33 @@ describe('shouldApplySharedReactionCandidateResult', () => {
       currentViewMode: 'default',
       requestCollectionSource: 'users',
       currentCollectionSource: 'newUsers',
+    })).toBe(false);
+  });
+});
+
+describe('hasPendingSharedReactionCandidates', () => {
+  it('keeps reaction tab hasMore true until unloaded shared reaction candidates can merge', () => {
+    expect(hasPendingSharedReactionCandidates({
+      reactionIds: ['shared-disliked'],
+      sharedReactionIds: ['shared-disliked'],
+      loadedIds: new Set(),
+      reactionMap: { 'shared-disliked': true },
+    })).toBe(true);
+  });
+
+  it('does not keep hasMore true after shared reaction candidates are loaded or inactive', () => {
+    expect(hasPendingSharedReactionCandidates({
+      reactionIds: ['shared-disliked'],
+      sharedReactionIds: ['shared-disliked'],
+      loadedIds: new Set(['shared-disliked']),
+      reactionMap: { 'shared-disliked': true },
+    })).toBe(false);
+
+    expect(hasPendingSharedReactionCandidates({
+      reactionIds: ['shared-disliked'],
+      sharedReactionIds: ['shared-disliked'],
+      loadedIds: new Set(),
+      reactionMap: {},
     })).toBe(false);
   });
 });

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -86,6 +86,8 @@ export const canShowMatchingUser = (user, { isAdmin = false } = {}) => {
   return user?.__sourceCollection === 'newUsers' || user?.publish === true;
 };
 
+const SHARED_REACTION_CANDIDATE_VIEW_MODES = new Set(['default', 'favorites', 'dislikes']);
+
 export const shouldApplySharedReactionCandidateResult = ({
   requestVersion,
   currentVersion,
@@ -94,11 +96,32 @@ export const shouldApplySharedReactionCandidateResult = ({
   requestCollectionSource,
   currentCollectionSource,
 } = {}) => (
-  requestViewMode === 'default' &&
-  currentViewMode === 'default' &&
+  SHARED_REACTION_CANDIDATE_VIEW_MODES.has(requestViewMode) &&
+  requestViewMode === currentViewMode &&
   requestCollectionSource === currentCollectionSource &&
   requestVersion === currentVersion
 );
+
+export const mergeSharedReactionCandidateUsers = ({
+  currentUsers = [],
+  loadedUsers = [],
+  candidateIds = [],
+} = {}) => {
+  const candidateIdSet = new Set((candidateIds || []).filter(Boolean));
+  const map = new Map(
+    (currentUsers || [])
+      .filter(user => user?.userId && candidateIdSet.has(user.userId))
+      .map(user => [user.userId, user])
+  );
+
+  (loadedUsers || []).forEach(user => {
+    if (user?.userId && candidateIdSet.has(user.userId)) {
+      map.set(user.userId, user);
+    }
+  });
+
+  return Array.from(map.values());
+};
 
 export const mergeMatchingCandidateUsers = ({
   users = [],
@@ -130,7 +153,11 @@ export const mergeMatchingCandidateUsers = ({
   if (hasAdditionalAccessRules) {
     baseUsers = baseUsers.filter(user => {
       if (user?.__sourceCollection !== 'newUsers') return true;
-      return collectionSource !== 'newUsers' || allowedBySetKey.has(user.userId);
+      return (
+        collectionSource !== 'newUsers' ||
+        allowedBySetKey.has(user.userId) ||
+        user?.__matchingAccessAllowed === true
+      );
     });
   }
 
@@ -183,6 +210,26 @@ export const mergeMatchingCandidateUsers = ({
 
 export const getReactionUserIds = reactionMap =>
   Object.keys(normalizeReactionMap(reactionMap));
+
+export const hasPendingSharedReactionCandidates = ({
+  reactionIds = [],
+  sharedReactionIds = [],
+  loadedIds = new Set(),
+  reactionMap = {},
+} = {}) => {
+  const activeReactionMap = normalizeReactionMap(reactionMap);
+  const sharedIds = new Set((sharedReactionIds || []).filter(Boolean));
+  const loaded = loadedIds instanceof Set
+    ? loadedIds
+    : new Set(Array.from(loadedIds || []).filter(Boolean));
+
+  return (reactionIds || []).some(id => (
+    id &&
+    sharedIds.has(id) &&
+    activeReactionMap[id] &&
+    !loaded.has(id)
+  ));
+};
 
 export const buildReactionCardsPage = ({
   reactionMap = {},


### PR DESCRIPTION
### Motivation
- Ensure shared reaction candidate cards can be merged into an existing candidate pool without wiping already-visible cards and keep reaction pagination open when unloaded shared candidates still need to merge. 
- Allow shared-candidate fetching to apply for reaction tabs (`default`, `favorites`, `dislikes`) while preventing stale results from different tab/source/version from applying. 
- Surface shared-only dislike state in the small card dislike button so users can see when a dislike is coming from another owner.

### Description
- Added `mergeSharedReactionCandidateUsers` and `hasPendingSharedReactionCandidates` helpers to `src/utils/reactionPriority.js` and expanded `shouldApplySharedReactionCandidateResult` to accept `default`, `favorites`, and `dislikes` view modes via a shared-mode set. 
- Updated `Matching.jsx` to set `sharedReactionIds` into a `nextSharedReactionIds` variable, use `mergeSharedReactionCandidateUsers` when updating `sharedReactionCandidateUsers`, restrict `loadSharedReactionCandidates` to allowed view modes, and compute `hasMore` using `hasPendingSharedReactionCandidates` so pagination stays true until shared candidates are merged or resolved. 
- Updated the dislike button `BtnDislike` to mark shared-only dislikes with `data-shared-disliked` and append ` (shared)` to the `title` when appropriate. 
- Added and updated unit tests in `src/utils/__tests__/reactionPriority.test.js` and adjusted `src/components/smallCard/btnDislike.test.js` to cover merging, pending-candidate behavior, view-mode application checks, and the shared-dislike UI indicator.

### Testing
- Ran the unit test suite covering changed areas including `src/utils/__tests__/reactionPriority.test.js` and `src/components/smallCard/btnDislike.test.js`. 
- New and updated tests exercise `mergeSharedReactionCandidateUsers`, `hasPendingSharedReactionCandidates`, `shouldApplySharedReactionCandidateResult`, pagination behavior, and `BtnDislike` shared-state rendering. 
- All affected tests passed locally during the rollout run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0449a2fc948326aca24d4173ac06eb)