### PR TITLE
Strip client-only __sourceCollection marker before saving users

### DIFF
--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -20,4 +20,13 @@ describe('fetchUsersByIds merging', () => {
     expect(source).toContain("__sourceCollection: 'newUsers'");
     expect(source).toContain("__sourceCollection: 'users'");
   });
+
+  it('strips client-only source markers before database writes', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+
+    expect(source).toContain("const transientUserDataKeys = ['__sourceCollection']");
+    expect(source).toContain('const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo);');
+    expect(source.match(/markForRealtimeDeletion: condition === 'update'/g)).toHaveLength(2);
+  });
+
 });

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2295,8 +2295,11 @@ export const getUserCards = async () => {
 };
 
 export const updateDataInFiresoreDB = async (userId, uploadedInfo, condition, delCondition) => {
-  const cleanedUploadedInfo = removeUndefined(uploadedInfo);
-  const keysToDelete = delCondition ? Object.keys(delCondition) : [];
+  const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo);
+  const keysToDelete = [
+    ...(delCondition ? Object.keys(delCondition) : []),
+    ...transientUserDataKeys,
+  ];
   const basePayload = { ...cleanedUploadedInfo };
   keysToDelete.forEach(key => {
     delete basePayload[key];
@@ -2338,6 +2341,25 @@ const removeUndefined = obj => {
   return obj;
 };
 
+const transientUserDataKeys = ['__sourceCollection'];
+
+const stripTransientUserDataFields = (payload, { markForRealtimeDeletion = false } = {}) => {
+  const cleaned = removeUndefined(payload);
+  if (typeof cleaned !== 'object' || cleaned === null || Array.isArray(cleaned)) {
+    return cleaned;
+  }
+
+  const nextPayload = { ...cleaned };
+  transientUserDataKeys.forEach(key => {
+    delete nextPayload[key];
+    if (markForRealtimeDeletion) {
+      nextPayload[key] = null;
+    }
+  });
+
+  return nextPayload;
+};
+
 const normalizePhoneForStorage = value => {
   if (value === undefined || value === null) return value;
 
@@ -2365,7 +2387,9 @@ const sanitizeUploadedInfoPhones = uploadedInfo => {
 export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) => {
   try {
     const userRefRTDB = ref2(database, `users/${userId}`);
-    const cleanedUploadedInfo = removeUndefined(uploadedInfo);
+    const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo, {
+      markForRealtimeDeletion: condition === 'update',
+    });
     if (condition === 'update') {
       await update(userRefRTDB, cleanedUploadedInfo);
     } else {
@@ -2468,7 +2492,9 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
     console.log('currentUserData :>> ', currentUserData);
 
     // if (condition === 'update' && !(Object.keys(uploadedInfo).length < Object.keys(currentUserData).length)) {
-    const cleanedUploadedInfo = removeUndefined(uploadedInfo);
+    const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo, {
+      markForRealtimeDeletion: condition === 'update',
+    });
 
     if (condition === 'update') {
       console.log('update :>> ');


### PR DESCRIPTION
### Motivation
- Client adds `__sourceCollection` on reads to indicate whether a card came from `newUsers` or `users`, but that transient marker must not be persisted back to databases. 
- Edit flows could accidentally include this client-only field in save payloads because it lives in the UI state. 
- The change prevents accidental leaks of read-only markers into Firestore/Realtime Database and ensures previously leaked markers get cleaned up on updates.

### Description
- Introduced `transientUserDataKeys` with `['__sourceCollection']` and a helper `stripTransientUserDataFields(payload, { markForRealtimeDeletion })` to remove these keys from write payloads. 
- Applied `stripTransientUserDataFields` before writes in `updateDataInFiresoreDB`, `updateDataInRealtimeDB`, and `updateDataInNewUsersRTDB`, and when doing RTDB `update` the transient key is explicitly set to `null` so old values are removed. 
- Added a unit assertion to `src/components/config.fetchUsersByIds.test.js` that verifies the transient key is still present on reads but that the new strip/delete behavior appears in the save paths.

### Testing
- Ran the specific unit tests with `npm test -- --watchAll=false src/components/config.fetchUsersByIds.test.js` and all tests passed. 
- Built the production bundle with `npm run build` which completed successfully and produced the optimized build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b53822488326bff6f2da714ce47e)