### PR TITLE
Fix fallback profile-refresh race and pagination invalidation

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -40,6 +40,10 @@ import InfoModal from './InfoModal';
 import { FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload } from 'react-icons/fa';
 import { handleEmptyFetch } from './loadMoreUtils';
 import {
+  buildFallbackProfileRefreshMetadata,
+  buildProfilePaginationInvalidationReasons,
+} from 'utils/matchingProfileRefreshMetadata';
+import {
   normalizeCountry,
   normalizeRegion,
 } from './normalizeLocation';
@@ -2436,37 +2440,32 @@ const Matching = () => {
       const fetchedProfile = await fetchUserById(normalizedAccessUserId);
       const profileFound = Boolean(fetchedProfile && typeof fetchedProfile === 'object');
       if (!profileFound) {
-        const fallbackRawRules = state.currentAdditionalAccessRules || '';
-        const fallbackSearchKeySetKeys = state.currentSearchKeySetKeys || [];
-        const fallbackAccessSnapshotKey = getMatchingAccessSnapshotKey({
-          accessUserId: normalizedAccessUserId,
-          rawRules: fallbackRawRules,
-          searchKeySetKeys: fallbackSearchKeySetKeys,
+        const fallbackMetadata = buildFallbackProfileRefreshMetadata({
+          cached,
+          latestCache: additionalProfileCacheRef.current,
+          state,
+          normalizedAccessUserId,
+          staleReasons,
+          requestVersion: profileRequestVersion,
+          latestRequestVersion: additionalProfileRequestVersionRef.current,
+          profilePath,
+          buildAccessSnapshotKey: getMatchingAccessSnapshotKey,
+          parseRules: parseAdditionalAccessRuleGroups,
+          getRawRulesSignature,
+          getSearchKeySetsOfExactUserSignature,
         });
-        logAdditionalMatchingDebug(normalizedAccessUserId, 'profile refetch returned no profile; keeping current rules', {
+        logAdditionalMatchingDebug(normalizedAccessUserId, fallbackMetadata?.staleFallbackIgnored
+          ? 'ignored stale empty profile refetch fallback'
+          : 'profile refetch returned no profile; keeping current rules', {
           firebasePath: profilePath,
           staleReasons,
-          rawRules: fallbackRawRules,
-          searchKeySetsOfExactUser: fallbackSearchKeySetKeys,
+          rawRules: fallbackMetadata?.rawRules,
+          searchKeySetsOfExactUser: fallbackMetadata?.searchKeySetsOfExactUser,
+          paginationInvalidationReasons: fallbackMetadata?.paginationInvalidationReasons || [],
+          requestVersion: profileRequestVersion,
+          latestVersion: additionalProfileRequestVersionRef.current,
         });
-        return {
-          ...(cached || {}),
-          accessUserId: normalizedAccessUserId,
-          rawRules: fallbackRawRules,
-          searchKeySetsOfExactUser: fallbackSearchKeySetKeys,
-          rawRulesSignature: getRawRulesSignature(fallbackRawRules),
-          searchKeySetsOfExactUserSignature: getSearchKeySetsOfExactUserSignature(fallbackSearchKeySetKeys),
-          collectionSource: state.collectionSource,
-          cacheHit: false,
-          refreshed: false,
-          refreshSucceeded: false,
-          profileFound: false,
-          parsedRules: parseAdditionalAccessRuleGroups(fallbackRawRules),
-          accessSnapshotKey: fallbackAccessSnapshotKey,
-          staleReasons,
-          paginationInvalidationReasons: [],
-          profilePath,
-        };
+        return fallbackMetadata;
       }
       const profile = fetchedProfile;
       const accessLevel = profile?.accessLevel || '';
@@ -2492,19 +2491,16 @@ const Matching = () => {
         searchKeySetsOfExactUserSignature: getSearchKeySetsOfExactUserSignature(searchKeySetsOfExactUser),
         collectionSource: state.collectionSource,
       };
-      const confirmedPaginationInvalidationReasons = [];
-      if (!cached) confirmedPaginationInvalidationReasons.push('missing-cache');
-      if (cached && cached.accessUserId !== freshMetadata.accessUserId) confirmedPaginationInvalidationReasons.push('accessUserId-changed');
-      if (cached && cached.rawRulesSignature !== freshMetadata.rawRulesSignature) confirmedPaginationInvalidationReasons.push('rawRulesSignature-changed');
-      if (cached && cached.searchKeySetsOfExactUserSignature !== freshMetadata.searchKeySetsOfExactUserSignature) {
-        confirmedPaginationInvalidationReasons.push('searchKeySetsOfExactUserSignature-changed');
-      }
-      if (cached && cached.collectionSource !== freshMetadata.collectionSource) confirmedPaginationInvalidationReasons.push('collectionSource-changed');
 
       const accessSnapshotKey = getMatchingAccessSnapshotKey({
         accessUserId: normalizedAccessUserId,
         rawRules: additionalAccessRules,
         searchKeySetKeys: searchKeySetsOfExactUser,
+      });
+      const confirmedPaginationInvalidationReasons = buildProfilePaginationInvalidationReasons({
+        cached,
+        metadata: freshMetadata,
+        accessSnapshotKey,
       });
       const freshCache = {
         ...freshMetadata,
@@ -2545,37 +2541,32 @@ const Matching = () => {
         paginationInvalidationReasons: confirmedPaginationInvalidationReasons,
       };
     } catch (error) {
-      const fallbackRawRules = state.currentAdditionalAccessRules || '';
-      const fallbackSearchKeySetKeys = state.currentSearchKeySetKeys || [];
-      const fallbackAccessSnapshotKey = getMatchingAccessSnapshotKey({
-        accessUserId: normalizedAccessUserId,
-        rawRules: fallbackRawRules,
-        searchKeySetKeys: fallbackSearchKeySetKeys,
-      });
-      logAdditionalMatchingDebug(normalizedAccessUserId, 'profile refetch failed; keeping current rules', {
-        firebasePath: profilePath,
-        rawRules: fallbackRawRules,
-        searchKeySetsOfExactUser: fallbackSearchKeySetKeys,
+      const fallbackMetadata = buildFallbackProfileRefreshMetadata({
+        cached,
+        latestCache: additionalProfileCacheRef.current,
+        state,
+        normalizedAccessUserId,
         staleReasons,
-      }, error);
-      return {
-        ...(cached || {}),
-        accessUserId: normalizedAccessUserId,
-        rawRules: fallbackRawRules,
-        searchKeySetsOfExactUser: fallbackSearchKeySetKeys,
-        rawRulesSignature: getRawRulesSignature(fallbackRawRules),
-        searchKeySetsOfExactUserSignature: getSearchKeySetsOfExactUserSignature(fallbackSearchKeySetKeys),
-        collectionSource: state.collectionSource,
-        cacheHit: false,
-        refreshed: false,
-        refreshSucceeded: false,
-        profileFound: false,
-        parsedRules: parseAdditionalAccessRuleGroups(fallbackRawRules),
-        accessSnapshotKey: fallbackAccessSnapshotKey,
-        staleReasons,
-        paginationInvalidationReasons: [],
+        requestVersion: profileRequestVersion,
+        latestRequestVersion: additionalProfileRequestVersionRef.current,
         profilePath,
-      };
+        buildAccessSnapshotKey: getMatchingAccessSnapshotKey,
+        parseRules: parseAdditionalAccessRuleGroups,
+        getRawRulesSignature,
+        getSearchKeySetsOfExactUserSignature,
+      });
+      logAdditionalMatchingDebug(normalizedAccessUserId, fallbackMetadata?.staleFallbackIgnored
+        ? 'ignored stale failed profile refetch fallback'
+        : 'profile refetch failed; keeping current rules', {
+        firebasePath: profilePath,
+        rawRules: fallbackMetadata?.rawRules,
+        searchKeySetsOfExactUser: fallbackMetadata?.searchKeySetsOfExactUser,
+        staleReasons,
+        paginationInvalidationReasons: fallbackMetadata?.paginationInvalidationReasons || [],
+        requestVersion: profileRequestVersion,
+        latestVersion: additionalProfileRequestVersionRef.current,
+      }, error);
+      return fallbackMetadata;
     }
   }, [applyFreshAdditionalProfileState]);
 

--- a/src/utils/__tests__/matchingProfileRefreshMetadata.test.js
+++ b/src/utils/__tests__/matchingProfileRefreshMetadata.test.js
@@ -1,0 +1,146 @@
+import {
+  buildFallbackProfileRefreshMetadata,
+  buildProfilePaginationInvalidationReasons,
+} from '../matchingProfileRefreshMetadata';
+
+const signature = value => JSON.stringify(value ?? '');
+const rulesSignature = rawRules => signature(String(rawRules || ''));
+const keysSignature = keys => signature([...(keys || [])].sort());
+const snapshotKey = ({ accessUserId, rawRules, searchKeySetKeys }) => signature({
+  accessUserId,
+  rawRules: rawRules || '',
+  searchKeySetKeys: [...(searchKeySetKeys || [])].sort(),
+});
+const parseRules = rawRules => rawRules ? [{ rawRules }] : [];
+
+describe('matching profile refresh metadata', () => {
+  it('invalidates pagination when fallback rules/search key snapshot differs from cached metadata', () => {
+    const cached = {
+      accessUserId: 'viewer-1',
+      rawRules: 'old-rules',
+      searchKeySetsOfExactUser: ['viewer-1_old'],
+      rawRulesSignature: rulesSignature('old-rules'),
+      searchKeySetsOfExactUserSignature: keysSignature(['viewer-1_old']),
+      collectionSource: 'newUsers',
+      accessSnapshotKey: snapshotKey({
+        accessUserId: 'viewer-1',
+        rawRules: 'old-rules',
+        searchKeySetKeys: ['viewer-1_old'],
+      }),
+    };
+
+    const fallback = buildFallbackProfileRefreshMetadata({
+      cached,
+      latestCache: cached,
+      state: {
+        currentAdditionalAccessRules: 'new-restrictive-rules',
+        currentSearchKeySetKeys: ['viewer-1_new'],
+        collectionSource: 'newUsers',
+      },
+      normalizedAccessUserId: 'viewer-1',
+      staleReasons: ['force-refresh'],
+      requestVersion: 3,
+      latestRequestVersion: 3,
+      profilePath: 'fetchUserById(viewer-1)',
+      buildAccessSnapshotKey: snapshotKey,
+      parseRules,
+      getRawRulesSignature: rulesSignature,
+      getSearchKeySetsOfExactUserSignature: keysSignature,
+    });
+
+    expect(fallback.rawRules).toBe('new-restrictive-rules');
+    expect(fallback.searchKeySetsOfExactUser).toEqual(['viewer-1_new']);
+    expect(fallback.paginationInvalidationReasons).toEqual(expect.arrayContaining([
+      'rawRulesSignature-changed',
+      'searchKeySetsOfExactUserSignature-changed',
+      'accessSnapshotKey-changed',
+    ]));
+    expect(fallback.paginationInvalidationReasons.length).toBeGreaterThan(0);
+  });
+
+  it('returns the latest cache instead of building stale fallback metadata for late failed/null refreshes', () => {
+    const oldCached = {
+      accessUserId: 'viewer-1',
+      rawRules: 'old-rules',
+      searchKeySetsOfExactUser: ['viewer-1_old'],
+      rawRulesSignature: rulesSignature('old-rules'),
+      searchKeySetsOfExactUserSignature: keysSignature(['viewer-1_old']),
+      collectionSource: 'newUsers',
+      accessSnapshotKey: snapshotKey({
+        accessUserId: 'viewer-1',
+        rawRules: 'old-rules',
+        searchKeySetKeys: ['viewer-1_old'],
+      }),
+    };
+    const latestCache = {
+      accessUserId: 'viewer-1',
+      rawRules: 'new-rules-from-request-b',
+      searchKeySetsOfExactUser: ['viewer-1_new'],
+      rawRulesSignature: rulesSignature('new-rules-from-request-b'),
+      searchKeySetsOfExactUserSignature: keysSignature(['viewer-1_new']),
+      collectionSource: 'newUsers',
+      accessSnapshotKey: snapshotKey({
+        accessUserId: 'viewer-1',
+        rawRules: 'new-rules-from-request-b',
+        searchKeySetKeys: ['viewer-1_new'],
+      }),
+    };
+
+    const fallback = buildFallbackProfileRefreshMetadata({
+      cached: oldCached,
+      latestCache,
+      state: {
+        currentAdditionalAccessRules: 'old-captured-request-a-rules',
+        currentSearchKeySetKeys: ['viewer-1_request_a'],
+        collectionSource: 'newUsers',
+      },
+      normalizedAccessUserId: 'viewer-1',
+      staleReasons: ['force-refresh'],
+      requestVersion: 4,
+      latestRequestVersion: 5,
+      profilePath: 'fetchUserById(viewer-1)',
+      buildAccessSnapshotKey: snapshotKey,
+      parseRules,
+      getRawRulesSignature: rulesSignature,
+      getSearchKeySetsOfExactUserSignature: keysSignature,
+    });
+
+    expect(fallback.rawRules).toBe('new-rules-from-request-b');
+    expect(fallback.searchKeySetsOfExactUser).toEqual(['viewer-1_new']);
+    expect(fallback.staleResponse).toBe(true);
+    expect(fallback.staleFallbackIgnored).toBe(true);
+  });
+
+  it('uses the same invalidation comparison for successful refresh metadata', () => {
+    const cached = {
+      accessUserId: 'viewer-1',
+      rawRulesSignature: rulesSignature('old-rules'),
+      searchKeySetsOfExactUserSignature: keysSignature(['viewer-1_old']),
+      collectionSource: 'newUsers',
+      accessSnapshotKey: snapshotKey({
+        accessUserId: 'viewer-1',
+        rawRules: 'old-rules',
+        searchKeySetKeys: ['viewer-1_old'],
+      }),
+    };
+
+    expect(buildProfilePaginationInvalidationReasons({
+      cached,
+      metadata: {
+        accessUserId: 'viewer-1',
+        rawRulesSignature: rulesSignature('new-rules'),
+        searchKeySetsOfExactUserSignature: keysSignature(['viewer-1_new']),
+        collectionSource: 'newUsers',
+      },
+      accessSnapshotKey: snapshotKey({
+        accessUserId: 'viewer-1',
+        rawRules: 'new-rules',
+        searchKeySetKeys: ['viewer-1_new'],
+      }),
+    })).toEqual(expect.arrayContaining([
+      'rawRulesSignature-changed',
+      'searchKeySetsOfExactUserSignature-changed',
+      'accessSnapshotKey-changed',
+    ]));
+  });
+});

--- a/src/utils/matchingProfileRefreshMetadata.js
+++ b/src/utils/matchingProfileRefreshMetadata.js
@@ -1,0 +1,86 @@
+export const buildProfilePaginationInvalidationReasons = ({
+  cached,
+  metadata,
+  accessSnapshotKey,
+} = {}) => {
+  const reasons = [];
+
+  if (!cached) {
+    reasons.push('missing-cache');
+    return reasons;
+  }
+
+  if (cached.accessUserId !== metadata?.accessUserId) reasons.push('accessUserId-changed');
+  if (cached.rawRulesSignature !== metadata?.rawRulesSignature) reasons.push('rawRulesSignature-changed');
+  if (cached.searchKeySetsOfExactUserSignature !== metadata?.searchKeySetsOfExactUserSignature) {
+    reasons.push('searchKeySetsOfExactUserSignature-changed');
+  }
+  if (cached.collectionSource !== metadata?.collectionSource) reasons.push('collectionSource-changed');
+  if (cached.accessSnapshotKey && accessSnapshotKey && cached.accessSnapshotKey !== accessSnapshotKey) {
+    reasons.push('accessSnapshotKey-changed');
+  }
+
+  return [...new Set(reasons)];
+};
+
+export const buildFallbackProfileRefreshMetadata = ({
+  cached,
+  latestCache,
+  state = {},
+  normalizedAccessUserId,
+  staleReasons = [],
+  requestVersion,
+  latestRequestVersion,
+  profilePath,
+  buildAccessSnapshotKey,
+  parseRules,
+  getRawRulesSignature,
+  getSearchKeySetsOfExactUserSignature,
+} = {}) => {
+  if (requestVersion !== latestRequestVersion) {
+    return latestCache
+      ? {
+          ...latestCache,
+          cacheHit: true,
+          staleResponse: true,
+          staleFallbackIgnored: true,
+          staleReasons,
+          paginationInvalidationReasons: [],
+        }
+      : null;
+  }
+
+  const fallbackRawRules = state.currentAdditionalAccessRules || '';
+  const fallbackSearchKeySetKeys = state.currentSearchKeySetKeys || [];
+  const fallbackAccessSnapshotKey = buildAccessSnapshotKey({
+    accessUserId: normalizedAccessUserId,
+    rawRules: fallbackRawRules,
+    searchKeySetKeys: fallbackSearchKeySetKeys,
+  });
+  const fallbackMetadata = {
+    accessUserId: normalizedAccessUserId,
+    rawRulesSignature: getRawRulesSignature(fallbackRawRules),
+    searchKeySetsOfExactUserSignature: getSearchKeySetsOfExactUserSignature(fallbackSearchKeySetKeys),
+    collectionSource: state.collectionSource,
+  };
+
+  return {
+    ...(cached || {}),
+    ...fallbackMetadata,
+    rawRules: fallbackRawRules,
+    searchKeySetsOfExactUser: fallbackSearchKeySetKeys,
+    cacheHit: false,
+    refreshed: false,
+    refreshSucceeded: false,
+    profileFound: false,
+    parsedRules: parseRules(fallbackRawRules),
+    accessSnapshotKey: fallbackAccessSnapshotKey,
+    staleReasons,
+    paginationInvalidationReasons: buildProfilePaginationInvalidationReasons({
+      cached,
+      metadata: fallbackMetadata,
+      accessSnapshotKey: fallbackAccessSnapshotKey,
+    }),
+    profilePath,
+  };
+};


### PR DESCRIPTION
### Motivation
- Resolve two bugs in matching profile refresh flow: a fallback refresh returning empty `paginationInvalidationReasons` when local rules changed, and late/failed fallback responses overwriting newer cached profiles.
- Ensure pagination resets when the effective access snapshot changes so `load-more` doesn't continue an old offset under new rules.
- Prevent stale fallback responses from rolling Matching back to older access snapshots after a newer successful refresh wins the request-version race.

### Description
- Added `src/utils/matchingProfileRefreshMetadata.js` with `buildProfilePaginationInvalidationReasons` and `buildFallbackProfileRefreshMetadata` to centralize invalidation and stale-fallback logic. 
- Updated `src/components/Matching.jsx` to import and use the new helpers for both the successful refresh invalidation calculation and the no-profile / catch fallback paths, preserving `paginationInvalidationReasons` when fallback rules differ and ignoring stale fallback responses using the request-version guard.
- Improved logging to report `paginationInvalidationReasons`, `requestVersion` and `staleFallbackIgnored` when a fallback is used or ignored.
- Added unit tests in `src/utils/__tests__/matchingProfileRefreshMetadata.test.js` that cover fallback invalidation, stale-fallback suppression, and reuse of the invalidation comparison for successful refreshes.

### Testing
- Ran the targeted test suite with `CI=true npm test -- --runTestsByPath src/utils/__tests__/matchingProfileRefreshMetadata.test.js --watchAll=false`, and all tests passed.
- Ran linting with `npm run lint:js -- src/components/Matching.jsx src/utils/matchingProfileRefreshMetadata.js src/utils/__tests__/matchingProfileRefreshMetadata.test.js`, which completed successfully (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b89dfee48326b1c7cfeb02ff0556)