### PR TITLE
Add backend traffic toggle to Matching for test user and enable test-UID tracking

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -22,7 +22,12 @@ import {
   updateDataInFiresoreDB,
 } from './config';
 import { get as firebaseGet, onValue as firebaseOnValue, ref as refDb, query, orderByChild, orderByKey, startAt, endAt, limitToLast } from 'firebase/database';
-import { withAdminDownloadToast, wrapAdminOnValue } from 'utils/backendDownloadToast';
+import {
+  getBackendDownloadToastsEnabled,
+  setBackendDownloadToastsEnabled,
+  withAdminDownloadToast,
+  wrapAdminOnValue,
+} from 'utils/backendDownloadToast';
 
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
@@ -1033,6 +1038,21 @@ const ActionButton = styled.button`
   }
 `;
 
+const BackendTrafficToggleButton = styled(ActionButton)`
+  width: auto;
+  min-width: 35px;
+  padding: 3px 8px;
+  gap: 4px;
+  background-color: ${({ $active }) => ($active ? color.accent : color.accent5)};
+  font-size: 12px;
+  font-weight: 700;
+`;
+
+const BackendTrafficToggleStatus = styled.span`
+  font-size: 10px;
+  line-height: 1;
+`;
+
 const HeaderContainer = styled.div`
   position: relative;
   display: flex;
@@ -2026,6 +2046,7 @@ const Matching = () => {
   const [sharedComments, setSharedComments] = useState({});
   const [showFilters, setShowFilters] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
+  const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
   const [ownerId, setOwnerId] = useState(null);
   const [multiDataOwnerIds, setMultiDataOwnerIds] = useState([]);
   const [currentAccessLevel, setCurrentAccessLevel] = useState(() => localStorage.getItem('accessLevel') || '');
@@ -2041,6 +2062,7 @@ const Matching = () => {
   const [roleIndexSets] = useState(null);
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
+  const canToggleBackendTrafficToasts = ownerId === DEBUG_ADDITIONAL_MATCHING_USER_ID;
   const parsedAdditionalAccessRules = useMemo(
     () => parseAdditionalAccessRuleGroups(currentAdditionalAccessRules),
     [currentAdditionalAccessRules]
@@ -2054,6 +2076,14 @@ const Matching = () => {
   useEffect(() => {
     matchingAccessSnapshotKeyRef.current = matchingAccessSnapshotKey;
   }, [matchingAccessSnapshotKey]);
+
+  useEffect(() => {
+    setBackendDownloadToastsEnabled(downloadSizeToastsEnabled);
+  }, [downloadSizeToastsEnabled]);
+
+  const handleDownloadSizeToastsToggle = () => {
+    setDownloadSizeToastsEnabled(prev => !prev);
+  };
   const markMatchingAccessValidated = React.useCallback(
     (user, accessSnapshotKey = matchingAccessSnapshotKeyRef.current) =>
       markUserMatchingAccessValidated(user, accessSnapshotKey),
@@ -4352,6 +4382,27 @@ const Matching = () => {
             <TopActions>
               {viewMode !== 'default' && (
                 <ActionButton onClick={reloadDefault}><FaDownload /></ActionButton>
+              )}
+              {canToggleBackendTrafficToasts && (
+                <BackendTrafficToggleButton
+                  type="button"
+                  $active={downloadSizeToastsEnabled}
+                  aria-pressed={downloadSizeToastsEnabled}
+                  title={
+                    downloadSizeToastsEnabled
+                      ? 'Вимкнути відстежування розміру трафіку з бекенду'
+                      : 'Увімкнути відстежування розміру трафіку з бекенду'
+                  }
+                  aria-label={
+                    downloadSizeToastsEnabled
+                      ? 'Вимкнути відстежування розміру трафіку з бекенду'
+                      : 'Увімкнути відстежування розміру трафіку з бекенду'
+                  }
+                  onClick={handleDownloadSizeToastsToggle}
+                >
+                  📦
+                  <BackendTrafficToggleStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</BackendTrafficToggleStatus>
+                </BackendTrafficToggleButton>
               )}
               <ActionButton onClick={() => setShowFilters(s => !s)}><FaFilter /></ActionButton>
               <ActionButton

--- a/src/utils/__tests__/backendDownloadToast.test.js
+++ b/src/utils/__tests__/backendDownloadToast.test.js
@@ -1,4 +1,5 @@
 const ADMIN_UID = '3LiD7JGCJTSJoVMU7fdR1ZrcIZH2';
+const BACKEND_TRAFFIC_TEST_UID = 'vtDxkDMjCwYuTDqTUnZsO29bpQr1';
 
 const loadTracker = () => {
   jest.resetModules();
@@ -52,6 +53,23 @@ describe('backendDownloadToast admin traffic tracker', () => {
     expect(toast).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('tracks payloads for the matching test user', () => {
+    const { tracker, toast } = loadTracker();
+    window.__getBackendDownloadToastUid = () => BACKEND_TRAFFIC_TEST_UID;
+
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ name: 'Matching test payload' }) },
+      { operation: 'get', source: 'Matching', path: 'users/test-user' },
+    );
+    jest.advanceTimersByTime(1000);
+
+    expect(window.backendTrafficStats.summary({ log: false }).totals.actualRequestCount).toBe(1);
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining('[Matching] Backend get users/test-user'),
+      expect.objectContaining({ icon: '📦' }),
+    );
   });
 
   it('collects stats while silent mode suppresses toast output', () => {

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -4,6 +4,7 @@ import { isAdminUid } from './accessLevel';
 export const ENABLE_BACKEND_TRAFFIC_TOAST = true;
 export const BACKEND_TRAFFIC_SILENT_MODE = false;
 export const BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY = 'backendDownloadSizeToastsEnabled';
+export const BACKEND_TRAFFIC_TEST_UIDS = ['vtDxkDMjCwYuTDqTUnZsO29bpQr1'];
 
 const TOAST_GROUP_DELAY_MS = 750;
 const TOAST_DURATION_MS = 5000;
@@ -245,7 +246,7 @@ const shouldTrack = getUid => {
   if (!ENABLE_BACKEND_TRAFFIC_TOAST) return false;
   try {
     const uid = typeof getUid === 'function' ? getUid() : getUid;
-    return isAdminUid(uid);
+    return isAdminUid(uid) || BACKEND_TRAFFIC_TEST_UIDS.includes(uid);
   } catch (error) {
     return false;
   }


### PR DESCRIPTION
### Motivation
- Add a right-side toggle in the Matching UI to enable/disable backend-download-size toasts for a specific test user (`vtDxkDMjCwYuTDqTUnZsO29bpQr1`) reusing the existing logic already present in `AddNewProfile`. 

### Description
- Added a compact `📦 ON/OFF` toggle button to the Matching right-side action menu and wired it to `getBackendDownloadToastsEnabled` / `setBackendDownloadToastsEnabled` to persist the state. 
- Restricted the toggle visibility to the requested test user by checking `ownerId === DEBUG_ADDITIONAL_MATCHING_USER_ID` and placed the control in `TopActions` (file `src/components/Matching.jsx`).
- Extended the backend traffic tracker to treat the test UID as a tracked user by adding `BACKEND_TRAFFIC_TEST_UIDS` and including it in the `shouldTrack` check (file `src/utils/backendDownloadToast.js`).
- Added a unit test to `src/utils/__tests__/backendDownloadToast.test.js` that verifies the test UID triggers stats collection and toasts, and updated imports/usages where needed.

### Testing
- Ran unit tests with `npm test -- --runTestsByPath src/utils/__tests__/backendDownloadToast.test.js --watchAll=false`, and the modified test suite passed (all tests green). 
- Built the production bundle with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d45431e083269c7a23a94f977407)