### PR TITLE
Add matching backend traffic toggle for test matching user

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -57,6 +57,8 @@ import {
   ThirdPhoto,
   Title,
   TopActions,
+  BackendTrafficToggleButton,
+  BackendTrafficToggleStatus,
 } from './Matching.styled';
 import {
   fetchUsersByLastLogin2,
@@ -75,7 +77,13 @@ import {
   updateDataInFiresoreDB,
 } from './config';
 import { get as firebaseGet, onValue as firebaseOnValue, ref as refDb, query, orderByChild, orderByKey, startAt, endAt, limitToLast } from 'firebase/database';
-import { withAdminDownloadToast, wrapAdminOnValue } from 'utils/backendDownloadToast';
+import {
+  BACKEND_TRAFFIC_TRACKING_TEST_UID,
+  getBackendDownloadToastsEnabled,
+  setBackendDownloadToastsEnabled,
+  withAdminDownloadToast,
+  wrapAdminOnValue,
+} from 'utils/backendDownloadToast';
 
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
@@ -142,7 +150,7 @@ import {
 } from 'utils/reactionPriority';
 
 
-const DEBUG_ADDITIONAL_MATCHING_USER_ID = 'vtDxkDMjCwYuTDqTUnZsO29bpQr1';
+const DEBUG_ADDITIONAL_MATCHING_USER_ID = BACKEND_TRAFFIC_TRACKING_TEST_UID;
 const DEBUG_SHARED_OWNER_ID = 'stFMfZ8CqQX05L8vK9Yse6FdYIh1';
 const DEBUG_SHARED_NEW_USER_ID = 'ID0001';
 const ADDITIONAL_PROFILE_CACHE_TTL_MS = 45 * 1000;
@@ -1381,6 +1389,7 @@ const Matching = () => {
   const [showFilters, setShowFilters] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [ownerId, setOwnerId] = useState(null);
+  const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
   const [multiDataOwnerIds, setMultiDataOwnerIds] = useState([]);
   const [currentAccessLevel, setCurrentAccessLevel] = useState(() => localStorage.getItem('accessLevel') || '');
   const [currentAdditionalAccessRules, setCurrentAdditionalAccessRules] = useState(
@@ -3298,6 +3307,16 @@ const Matching = () => {
     return () => observer.disconnect();
   }, [hasMore, loadMore, preLastCardNode, viewMode]);
 
+  useEffect(() => {
+    setBackendDownloadToastsEnabled(downloadSizeToastsEnabled);
+  }, [downloadSizeToastsEnabled]);
+
+  const handleDownloadSizeToastsToggle = () => {
+    setDownloadSizeToastsEnabled(prev => !prev);
+  };
+
+  const showBackendTrafficToggle = ownerId === BACKEND_TRAFFIC_TRACKING_TEST_UID;
+
   const dotsMenu = () => (
     <>
       {(isAdmin || access.canAccessAdd || access.canAccessMatching) && (
@@ -3394,6 +3413,27 @@ const Matching = () => {
               >
                 <FaHeart />
               </ActionButton>
+              {showBackendTrafficToggle && (
+                <BackendTrafficToggleButton
+                  type="button"
+                  $active={downloadSizeToastsEnabled}
+                  aria-pressed={downloadSizeToastsEnabled}
+                  title={
+                    downloadSizeToastsEnabled
+                      ? 'Вимкнути тости щодо розміру завантаження з бекенду'
+                      : 'Увімкнути тости щодо розміру завантаження з бекенду'
+                  }
+                  aria-label={
+                    downloadSizeToastsEnabled
+                      ? 'Вимкнути тости щодо розміру завантаження з бекенду'
+                      : 'Увімкнути тости щодо розміру завантаження з бекенду'
+                  }
+                  onClick={handleDownloadSizeToastsToggle}
+                >
+                  📦
+                  <BackendTrafficToggleStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</BackendTrafficToggleStatus>
+                </BackendTrafficToggleButton>
+              )}
               <ActionButton onClick={() => setShowInfoModal('dotsMenu')}><FaEllipsisV /></ActionButton>
             </TopActions>
           </HeaderContainer>

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -295,6 +295,30 @@ export const ActionButton = styled.button`
   }
 `;
 
+
+export const BackendTrafficToggleButton = styled(ActionButton)`
+  width: auto;
+  min-width: 54px;
+  padding: 3px 8px;
+  gap: 5px;
+  color: ${({ $active }) => ($active ? '#fff' : color.accent3)};
+  background-color: ${({ $active }) => ($active ? color.accent5 : '#fff')};
+  border: 1px solid ${({ $active }) => ($active ? color.accent5 : color.gray)};
+  border-radius: 50px;
+  font-size: 14px;
+  font-weight: 700;
+
+  &:hover {
+    background-color: ${({ $active }) => ($active ? color.accent4 || color.accent5 : color.paleAccent2)};
+  }
+`;
+
+export const BackendTrafficToggleStatus = styled.span`
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+`;
+
 export const HeaderContainer = styled.div`
   position: relative;
   display: flex;

--- a/src/utils/__tests__/backendDownloadToast.test.js
+++ b/src/utils/__tests__/backendDownloadToast.test.js
@@ -54,6 +54,23 @@ describe('backendDownloadToast admin traffic tracker', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+
+  it('tracks backend payloads for the matching test user', () => {
+    const { tracker, toast } = loadTracker();
+    window.__getBackendDownloadToastUid = () => tracker.BACKEND_TRAFFIC_TRACKING_TEST_UID;
+
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ name: 'Matching test payload' }) },
+      { operation: 'get', source: 'Matching', path: 'newUsers' },
+    );
+    jest.advanceTimersByTime(1000);
+
+    const summary = window.backendTrafficStats.summary({ log: false });
+    expect(summary.totals.actualRequestCount).toBe(1);
+    expect(summary.totals.estimatedPayloadBytes).toBeGreaterThan(0);
+    expect(toast.success).toHaveBeenCalled();
+  });
+
   it('collects stats while silent mode suppresses toast output', () => {
     const { tracker, toast } = loadTracker();
     window.__getBackendDownloadToastUid = () => ADMIN_UID;

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -4,6 +4,8 @@ import { isAdminUid } from './accessLevel';
 export const ENABLE_BACKEND_TRAFFIC_TOAST = true;
 export const BACKEND_TRAFFIC_SILENT_MODE = false;
 export const BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY = 'backendDownloadSizeToastsEnabled';
+export const BACKEND_TRAFFIC_TRACKING_TEST_UID = 'vtDxkDMjCwYuTDqTUnZsO29bpQr1';
+const BACKEND_TRAFFIC_EXTRA_TRACKED_UIDS = [BACKEND_TRAFFIC_TRACKING_TEST_UID];
 
 const TOAST_GROUP_DELAY_MS = 750;
 const TOAST_DURATION_MS = 5000;
@@ -245,7 +247,7 @@ const shouldTrack = getUid => {
   if (!ENABLE_BACKEND_TRAFFIC_TOAST) return false;
   try {
     const uid = typeof getUid === 'function' ? getUid() : getUid;
-    return isAdminUid(uid);
+    return isAdminUid(uid) || BACKEND_TRAFFIC_EXTRA_TRACKED_UIDS.includes(uid);
   } catch (error) {
     return false;
   }


### PR DESCRIPTION
### Motivation
- Enable backend download-size tracking for a specific matching test user (`vtDxkDMjCwYuTDqTUnZsO29bpQr1`) so debugging matching traffic works like admin tracking.
- Surface a simple UI control in the Matching view to let that test user enable/disable backend download-size toast notifications from the right-side action menu.

### Description
- Added `BACKEND_TRAFFIC_TRACKING_TEST_UID` and allowed that UID to be treated like admins by `shouldTrack` in `src/utils/backendDownloadToast.js`.
- Reused the existing toast storage helpers `getBackendDownloadToastsEnabled` / `setBackendDownloadToastsEnabled` and exposed them in `Matching.jsx`, persisting the toggle state to the same storage key.
- Added a right-side toolbar button in `src/components/Matching.jsx` (shown only when `ownerId === BACKEND_TRAFFIC_TRACKING_TEST_UID`) that toggles backend download-size toasts and displays `📦 ON/OFF`.
- Added matching styles `BackendTrafficToggleButton` and `BackendTrafficToggleStatus` in `src/components/Matching.styled.jsx` to fit the existing TopActions layout.
- Added a unit test to `src/utils/__tests__/backendDownloadToast.test.js` asserting that the matching test UID is tracked and triggers toast output.

### Testing
- Ran the focused unit tests with `npm test -- --runTestsByPath src/utils/__tests__/backendDownloadToast.test.js --watchAll=false` and observed all tests in that file pass (6 passed).
- Ran linter with `npm run lint:js` which completed without lint errors reported.
- Built the project with `npm run build` which completed successfully and produced an optimized bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ddba049883268d452600e7428cba)