### PR TITLE
Avoid raw CSS interpolation for matching card photos

### DIFF
--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -694,11 +694,24 @@ const slideRight = keyframes`
   }
 `;
 
-export const AnimatedCard = styled(Card)`
-  ${({ $backgroundImage }) =>
-    $backgroundImage
-      ? `background-image: url(${$backgroundImage}); background-color: transparent;`
-      : 'background-color: #fff;'}
+const escapeCssUrl = value =>
+  String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\a ')
+    .replace(/\r/g, '\\d ')
+    .replace(/\f/g, '\\c ');
+
+const getBackgroundImageStyle = backgroundImage =>
+  backgroundImage ? `url("${escapeCssUrl(backgroundImage)}")` : undefined;
+
+export const AnimatedCard = styled(Card).attrs(({ $backgroundImage, style }) => ({
+  style: {
+    ...style,
+    backgroundImage: getBackgroundImageStyle($backgroundImage),
+  },
+}))`
+  background-color: ${({ $backgroundImage }) => ($backgroundImage ? 'transparent' : '#fff')};
   animation: ${({ $dir }) =>
     $dir === 'left'
       ? slideLeft


### PR DESCRIPTION
### Motivation
- Prevent user-controlled photo URLs from breaking out of CSS `url(...)` and injecting or corrupting stylesheet declarations by avoiding raw string interpolation in styled-components.

### Description
- Added an `escapeCssUrl` helper that quotes and escapes characters in photo URLs before use in CSS.
- Added `getBackgroundImageStyle` to produce a safe `url("...")` value and removed direct template interpolation of `$backgroundImage` in the stylesheet.
- Applied the background image via `styled(Card).attrs(...)` by assigning `style.backgroundImage` while merging any existing `style`, and preserved the conditional `background-color` fallback.
- All modifications are in `src/components/Matching.styled.jsx` and replace the previous raw `background-image: url(${...})` interpolation.

### Testing
- Ran `npm run lint:js` and it completed successfully.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e01bfdbc8326b12e6eb1ee47db9a)