### PR TITLE
Fix additional-access reaction pagination and profile refresh handling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -155,7 +155,7 @@ const DEBUG_SHARED_OWNER_ID = 'stFMfZ8CqQX05L8vK9Yse6FdYIh1';
 const DEBUG_SHARED_NEW_USER_ID = 'ID0001';
 const ADDITIONAL_PROFILE_CACHE_TTL_MS = 45 * 1000;
 const ADDITIONAL_MATCHING_LOG_LIMIT = 300;
-const buildEmptyReactionPagination = () => ({ ids: [], nextOffset: 0, hasMore: false });
+const buildEmptyReactionPagination = () => ({ ids: [], nextOffset: 0, hasMore: false, accessSnapshotKey: '' });
 
 const shouldDebugAdditionalMatching = (...ids) =>
   ids.some(id => String(id || '').trim() === DEBUG_ADDITIONAL_MATCHING_USER_ID);
@@ -342,6 +342,21 @@ const stableAdditionalSignature = value => {
 const getRawRulesSignature = rawRules => stableAdditionalSignature(String(rawRules || ''));
 const getSearchKeySetsOfExactUserSignature = keys =>
   stableAdditionalSignature(sortAdditionalSearchKeySetKeys(normalizeSearchKeySetKeys(keys)));
+
+const buildAdditionalAccessSnapshotKey = ({
+  accessUserId = '',
+  collectionSource = '',
+  rawRules = '',
+  searchKeySetKeys = [],
+  searchKeySetsOfExactUser,
+} = {}) => stableAdditionalSignature({
+  accessUserId: String(accessUserId || '').trim(),
+  collectionSource,
+  rawRulesSignature: getRawRulesSignature(rawRules),
+  searchKeySetsOfExactUserSignature: getSearchKeySetsOfExactUserSignature(
+    searchKeySetsOfExactUser ?? searchKeySetKeys
+  ),
+});
 async function resolveAdditionalSearchKeySetKeysForMatching(profile, accessUserId) {
   const normalizedAccessUserId = String(accessUserId || '').trim();
   const keysFromProfile = getAdditionalSearchKeySetKeysFromProfile(profile);
@@ -1683,7 +1698,54 @@ const Matching = () => {
     additionalProfileRequestVersionRef.current = profileRequestVersion;
     const profilePath = `fetchUserById(${normalizedAccessUserId})`;
     try {
-      const profile = await fetchUserById(normalizedAccessUserId) || {};
+      const fetchedProfile = await fetchUserById(normalizedAccessUserId);
+      const profileFound = Boolean(fetchedProfile && typeof fetchedProfile === 'object');
+
+      if (!profileFound) {
+        const fallbackSearchKeySetsOfExactUser = areSearchKeySetKeysForAccessUserId(
+          state.currentSearchKeySetKeys,
+          normalizedAccessUserId
+        )
+          ? state.currentSearchKeySetKeys
+          : await resolveAdditionalSearchKeySetKeysForMatching(null, normalizedAccessUserId);
+        const fallbackCache = {
+          accessUserId: normalizedAccessUserId,
+          rawRulesSignature: getRawRulesSignature(state.currentAdditionalAccessRules),
+          searchKeySetsOfExactUserSignature: getSearchKeySetsOfExactUserSignature(fallbackSearchKeySetsOfExactUser),
+          collectionSource: state.collectionSource,
+          profile: cached?.profile || {},
+          accessLevel: cached?.accessLevel || '',
+          rawRules: state.currentAdditionalAccessRules || '',
+          searchKeySetsOfExactUser: fallbackSearchKeySetsOfExactUser,
+          cachedAt: cached?.cachedAt || Date.now(),
+          profilePath,
+          profileFound: false,
+        };
+
+        logAdditionalMatchingDebug(normalizedAccessUserId, 'profile refetch returned empty; keeping current access state', {
+          firebasePath: profilePath,
+          rawRules: fallbackCache.rawRules,
+          searchKeySetsOfExactUser: fallbackSearchKeySetsOfExactUser,
+          metadata: {
+            accessUserId: fallbackCache.accessUserId,
+            rawRulesSignature: fallbackCache.rawRulesSignature,
+            searchKeySetsOfExactUserSignature: fallbackCache.searchKeySetsOfExactUserSignature,
+            collectionSource: fallbackCache.collectionSource,
+          },
+          staleReasons,
+          paginationInvalidationReasons,
+        });
+
+        return {
+          ...fallbackCache,
+          cacheHit: true,
+          profileRefreshFailed: true,
+          staleReasons,
+          paginationInvalidationReasons: [],
+        };
+      }
+
+      const profile = fetchedProfile;
       const accessLevel = profile?.accessLevel || '';
       const additionalAccessRules = profile?.additionalAccessRules || '';
       const searchKeySetsOfExactUser = await resolveAdditionalSearchKeySetKeysForMatching(profile, normalizedAccessUserId);
@@ -1719,6 +1781,7 @@ const Matching = () => {
       const freshCache = {
         ...freshMetadata,
         profile,
+        profileFound: true,
         accessLevel,
         rawRules: additionalAccessRules,
         searchKeySetsOfExactUser,
@@ -2647,28 +2710,31 @@ const Matching = () => {
     }, {});
   }, []);
 
-  const getAccessibleReactionIds = React.useCallback(async reactionIds => {
+  const getAccessibleReactionIds = React.useCallback(async (reactionIds, accessSnapshot = {}) => {
     const uniqueIds = [...new Set((reactionIds || []).filter(Boolean))];
     if (collectionSource !== 'newUsers') {
       return uniqueIds.filter(isValidId);
     }
 
+    const rawRulesForRequest = accessSnapshot.rawRules ?? currentAdditionalAccessRules;
+    const parsedRulesForRequest = parseAdditionalAccessRuleGroups(rawRulesForRequest);
+    const searchKeySetsForRequest = accessSnapshot.searchKeySetsOfExactUser ?? currentSearchKeySetKeys;
     const newUserReactionIds = uniqueIds.filter(isShortId);
-    if (parsedAdditionalAccessRules.length === 0) {
+    if (parsedRulesForRequest.length === 0) {
       return newUserReactionIds;
     }
 
-    const viewerId = ownerId || getOwnerId();
+    const viewerId = accessSnapshot.accessUserId || ownerId || getOwnerId();
     if (!viewerId) return [];
 
-    const resolvedSearchKeySetKeys = areSearchKeySetKeysForAccessUserId(currentSearchKeySetKeys, viewerId)
-      ? currentSearchKeySetKeys
+    const resolvedSearchKeySetKeys = areSearchKeySetKeysForAccessUserId(searchKeySetsForRequest, viewerId)
+      ? searchKeySetsForRequest
       : await resolveAdditionalSearchKeySetKeysForMatching(null, viewerId);
 
     if (!resolvedSearchKeySetKeys.length) return [];
 
     const indexed = await getIndexedNewUsersIdsByRules({
-      rawRules: currentAdditionalAccessRules,
+      rawRules: rawRulesForRequest,
       accessUserId: viewerId,
       searchKeySetsOfExactUser: resolvedSearchKeySetKeys,
       fetchMissingBuckets: true,
@@ -2685,7 +2751,6 @@ const Matching = () => {
     currentAdditionalAccessRules,
     currentSearchKeySetKeys,
     ownerId,
-    parsedAdditionalAccessRules.length,
   ]);
 
   const loadReactionCardsPage = React.useCallback(async ({
@@ -2810,7 +2875,14 @@ const Matching = () => {
       const reactionMap = isFavoritesMode ? favMap : disMap;
       const listKey = isFavoritesMode ? 'favorite' : 'dislike';
       const fullReactionIds = Object.keys(reactionMap);
-      const reactionIds = await getAccessibleReactionIds(fullReactionIds);
+      const reactionAccessSnapshot = {
+        accessUserId: ownerId || getOwnerId(),
+        collectionSource,
+        rawRules: currentAdditionalAccessRules,
+        searchKeySetsOfExactUser: currentSearchKeySetKeys,
+      };
+      const reactionAccessSnapshotKey = buildAdditionalAccessSnapshotKey(reactionAccessSnapshot);
+      const reactionIds = await getAccessibleReactionIds(fullReactionIds, reactionAccessSnapshot);
       if (!canApplyReactionLoad()) return;
       setIdsForQuery(listKey, reactionIds);
       if (isFavoritesMode) setFavoriteIds(favMap);
@@ -2849,6 +2921,7 @@ const Matching = () => {
           ids: reactionIds,
           nextOffset: page.nextOffset,
           hasMore: nextHasMore,
+          accessSnapshotKey: reactionAccessSnapshotKey,
         },
       }));
       setHasMore(nextHasMore);
@@ -2942,14 +3015,41 @@ const Matching = () => {
           ? favoriteUsersRef.current
           : dislikeUsersRef.current;
         const currentPagination = reactionPaginationByType[viewMode] || buildEmptyReactionPagination();
-        const reactionIds = currentPagination.ids.length > 0
-          ? currentPagination.ids
-          : await getAccessibleReactionIds(Object.keys(reactionMap));
-        const loadedIds = reactionLoadedIdsRef.current[viewMode] || new Set();
+        const shouldRefreshReactionIds = collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0;
+        const freshProfileCache = shouldRefreshReactionIds
+          ? await ensureFreshAdditionalMatchingProfile({
+            accessUserId: ownerId,
+            reason: `load-more-${viewMode}-reaction-access`,
+          })
+          : null;
+
+        if (!canApplyLoadMoreResult()) return;
+
+        const reactionAccessSnapshot = {
+          accessUserId: ownerId || getOwnerId(),
+          collectionSource,
+          rawRules: freshProfileCache?.rawRules ?? currentAdditionalAccessRules,
+          searchKeySetsOfExactUser: freshProfileCache?.searchKeySetsOfExactUser ?? currentSearchKeySetKeys,
+        };
+        const reactionAccessSnapshotKey = buildAdditionalAccessSnapshotKey(reactionAccessSnapshot);
+        const didAccessSnapshotChange = Boolean(
+          shouldRefreshReactionIds &&
+          currentPagination.ids.length > 0 &&
+          currentPagination.accessSnapshotKey !== reactionAccessSnapshotKey
+        );
+        const reactionIds = shouldRefreshReactionIds || currentPagination.ids.length === 0
+          ? await getAccessibleReactionIds(Object.keys(reactionMap), reactionAccessSnapshot)
+          : currentPagination.ids;
+
+        if (!canApplyLoadMoreResult()) return;
+
+        const loadedIds = didAccessSnapshotChange
+          ? new Set()
+          : (reactionLoadedIdsRef.current[viewMode] || new Set());
         const page = await loadReactionCardsPage({
           reactionIds,
           reactionMap,
-          offset: currentPagination.ids.length > 0 ? currentPagination.nextOffset : 0,
+          offset: didAccessSnapshotChange || currentPagination.ids.length === 0 ? 0 : currentPagination.nextOffset,
           limit: LOAD_MORE,
           loadedIds,
         });
@@ -2973,6 +3073,7 @@ const Matching = () => {
             ids: reactionIds,
             nextOffset: page.nextOffset,
             hasMore: page.hasMore,
+            accessSnapshotKey: reactionAccessSnapshotKey,
           },
         }));
         setHasMore(page.hasMore);


### PR DESCRIPTION
### Motivation
- Prevent reaction tabs (favorites/dislikes) from permanently excluding cards when the viewer's `newUsers` access snapshot changes during load-more operations. 
- Avoid accidentally dropping existing additional-access rules when a forced profile refresh returns no profile object, which can incorrectly widen access. 
- Ensure reaction ID lookups use the most recent access snapshot immediately instead of waiting for React state to sync. 

### Description
- Add an `accessSnapshotKey` to reaction pagination objects and implement `buildAdditionalAccessSnapshotKey` to derive a stable signature for access snapshots used by `favorites`/`dislikes` pagination. 
- Pass an explicit access snapshot into `getAccessibleReactionIds` so reaction ID filtering uses the refreshed rules and search key sets returned by `ensureFreshAdditionalMatchingProfile`. 
- When a refreshed access snapshot differs from the stored snapshot for a reaction tab, reset that tab's `loadedIds` set and start pagination from offset `0` so cards pruned under prior snapshots can reappear. 
- When forced profile refresh returns no profile, create a fallback cache that preserves the current `additionalAccessRules` and search key sets and mark the refresh as failed, avoiding replacing current rules with an empty string.

### Testing
- Ran `npm run lint:js -- src/components/Matching.jsx` and the linter completed without errors. 
- Ran `npm run build` and the project compiled successfully into a production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e8ab94a483269200454e4a6bbb07)