### PR TITLE
Make matching reactions global across profile collections

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -743,6 +743,7 @@ const applyMatchingUiFiltersToUsers = ({
   excludeReactionUsers = false,
   roleIndexSets,
   collectionSource,
+  viewMode = 'default',
 }) =>
   applyMatchingSearchKeyFilters(
     filterMain(
@@ -759,7 +760,11 @@ const applyMatchingUiFiltersToUsers = ({
       )),
     filters,
     roleIndexSets
-  ).filter(u => isAllowedIdForCollection(u.userId, collectionSource));
+  ).filter(u => (
+    viewMode === 'favorites' ||
+    viewMode === 'dislikes' ||
+    isAllowedIdForCollection(u.userId, collectionSource)
+  ));
 
 const getActiveMatchingFiltersDebug = filters => Object.entries(filters || {}).reduce((acc, [key, value]) => {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -1926,13 +1931,12 @@ const Matching = () => {
     const filteredInvalidIds = candidateIds.filter(id => !isMatchingCardId(id));
     const filteredByCollectionIds = [];
     const filteredByAccessIds = [];
+    const userCandidateIds = candidateIds.filter(isValidId);
+    const newUserCandidateIds = candidateIds.filter(isShortId);
     let allowedNewUserIds = [];
     let indexedAllowedNewUserIds = null;
 
-    if (collectionSource === 'newUsers') {
-      const newUserCandidateIds = candidateIds.filter(isShortId);
-      filteredByCollectionIds.push(...candidateIds.filter(id => !isShortId(id)));
-
+    if (newUserCandidateIds.length > 0) {
       if (parsedAdditionalAccessRules.length > 0) {
         const resolvedSearchKeySetKeys = areSearchKeySetKeysForAccessUserId(currentSearchKeySetKeys, viewerId)
           ? currentSearchKeySetKeys
@@ -1948,7 +1952,7 @@ const Matching = () => {
           const indexed = await getIndexedNewUsersIdsByRules({
             rawRules: currentAdditionalAccessRules,
             accessUserId: viewerId,
-            searchKeySetKeys: resolvedSearchKeySetKeys,
+            searchKeySetsOfExactUser: resolvedSearchKeySetKeys,
             fetchMissingBuckets: true,
             requireSearchKeySetKeys: true,
             resultOffset: 0,
@@ -1966,8 +1970,6 @@ const Matching = () => {
       } else {
         allowedNewUserIds = newUserCandidateIds;
       }
-    } else {
-      filteredByCollectionIds.push(...candidateIds.filter(id => !isValidId(id)));
     }
 
     const loadedUsers = [];
@@ -1975,7 +1977,7 @@ const Matching = () => {
       return;
     }
 
-    if (collectionSource === 'newUsers' && allowedNewUserIds.length > 0) {
+    if (allowedNewUserIds.length > 0) {
       const newUsersCards = await fetchNewUsersByIdsForMatching(allowedNewUserIds);
       if (!canApplySharedCandidateResult()) {
         return;
@@ -1983,35 +1985,31 @@ const Matching = () => {
       loadedUsers.push(
         ...newUsersCards.map(user => ({
           ...user,
+          __sourceCollection: 'newUsers',
           __matchingAccessAllowed: parsedAdditionalAccessRules.length > 0,
         }))
       );
     }
 
-    if (collectionSource !== 'newUsers') {
-      const userIds = candidateIds.filter(isValidId);
-      if (userIds.length > 0) {
-        if (!canApplySharedCandidateResult()) {
-          return;
-        }
-        const usersMap = await fetchUsersByIds(userIds);
-        if (!canApplySharedCandidateResult()) {
-          return;
-        }
-        loadedUsers.push(
-          ...userIds
-            .map(id => usersMap[id])
-            .filter(Boolean)
-            .map(user => ({ ...user, __sourceCollection: 'users' }))
-            .filter(user => canShowMatchingUser(user, { isAdmin }))
-        );
+    if (userCandidateIds.length > 0) {
+      const usersMap = await fetchUsersByIds(userCandidateIds);
+      if (!canApplySharedCandidateResult()) {
+        return;
       }
+      loadedUsers.push(
+        ...userCandidateIds
+          .map(id => usersMap[id])
+          .filter(Boolean)
+          .map(user => ({ ...user, __sourceCollection: 'users' }))
+          .filter(user => canShowMatchingUser(user, { isAdmin }))
+      );
     }
 
     const loadedIds = new Set(loadedUsers.map(user => user.userId).filter(Boolean));
-    const missingAllowedIds = collectionSource === 'newUsers'
-      ? allowedNewUserIds.filter(id => !loadedIds.has(id))
-      : candidateIds.filter(isValidId).filter(id => !loadedIds.has(id));
+    const missingAllowedIds = [
+      ...userCandidateIds,
+      ...allowedNewUserIds,
+    ].filter(id => !loadedIds.has(id));
 
     if (!canApplySharedCandidateResult()) {
       return;
@@ -2046,9 +2044,7 @@ const Matching = () => {
       allowedBySearchKeySetsCount: indexedAllowedNewUserIds ? indexedAllowedNewUserIds.size : null,
       id0001SelfCheck: {
         sharedReactionIdFound: candidateIds.includes(DEBUG_SHARED_NEW_USER_ID),
-        allowedBySearchKeySets: collectionSource === 'newUsers'
-          ? allowedNewUserIds.includes(DEBUG_SHARED_NEW_USER_ID)
-          : null,
+        allowedBySearchKeySets: allowedNewUserIds.includes(DEBUG_SHARED_NEW_USER_ID),
         filteredByAccessOrSearchKeySets: filteredByAccessIds.includes(DEBUG_SHARED_NEW_USER_ID),
         foundInCollection: loadedUsers.find(user => user.userId === DEBUG_SHARED_NEW_USER_ID)?.__sourceCollection || null,
         addedToCandidatePool: loadedIds.has(DEBUG_SHARED_NEW_USER_ID),
@@ -2688,50 +2684,78 @@ const Matching = () => {
   }, [reloadDefault]);
 
   const fetchReactionCardsByIds = React.useCallback(async ids => {
-    const entries = await Promise.all(
-      ids.map(async id => {
-        const cached = getCard(id);
-        const cachedPhotos = Array.isArray(cached?.photos) ? cached.photos : [];
-        const canUseCachedCard = cached && cachedPhotos.length > 0 && (
-          cached.__sourceCollection ||
-          cached.publish === true ||
-          !isShortId(id)
-        );
-        const user = canUseCachedCard ? cached : await fetchUserById(id);
-        return user ? [id, user] : null;
-      })
-    );
+    const uniqueIds = [...new Set((ids || []).filter(Boolean))];
+    const usersIds = uniqueIds.filter(isValidId);
+    const newUsersIds = uniqueIds.filter(isShortId);
+    const cachedEntries = new Map();
+    const missingUserIds = [];
+    const missingNewUserIds = [];
 
-    return entries.reduce((acc, entry) => {
-      if (!entry) return acc;
-      const [id, user] = entry;
-      acc[id] = user;
-      return acc;
-    }, {});
+    uniqueIds.forEach(id => {
+      const cached = getCard(id);
+      const cachedPhotos = Array.isArray(cached?.photos) ? cached.photos : [];
+      const canUseCachedCard = cached && cachedPhotos.length > 0 && (
+        cached.__sourceCollection ||
+        cached.publish === true ||
+        !isShortId(id)
+      );
+
+      if (canUseCachedCard) {
+        cachedEntries.set(id, {
+          ...cached,
+          userId: id,
+          __sourceCollection: cached.__sourceCollection || (isShortId(id) ? 'newUsers' : 'users'),
+        });
+      } else if (isShortId(id)) {
+        missingNewUserIds.push(id);
+      } else if (isValidId(id)) {
+        missingUserIds.push(id);
+      }
+    });
+
+    const [usersMap, newUsersCards] = await Promise.all([
+      missingUserIds.length ? fetchUsersByIds(missingUserIds) : Promise.resolve({}),
+      missingNewUserIds.length ? fetchNewUsersByIdsForMatching(missingNewUserIds) : Promise.resolve([]),
+    ]);
+
+    const result = {};
+    usersIds.forEach(id => {
+      const user = cachedEntries.get(id) || usersMap?.[id];
+      if (user) {
+        result[id] = { ...user, userId: id, __sourceCollection: 'users' };
+      }
+    });
+    newUsersIds.forEach(id => {
+      const user = cachedEntries.get(id) || newUsersCards.find(card => card.userId === id);
+      if (user) {
+        result[id] = { ...user, userId: id, __sourceCollection: 'newUsers' };
+      }
+    });
+
+    return result;
   }, []);
 
   const getAccessibleReactionIds = React.useCallback(async (reactionIds, accessSnapshot = {}) => {
     const uniqueIds = [...new Set((reactionIds || []).filter(Boolean))];
-    if (collectionSource !== 'newUsers') {
-      return uniqueIds.filter(isValidId);
-    }
+    const userReactionIds = uniqueIds.filter(isValidId);
+    const newUserReactionIds = uniqueIds.filter(isShortId);
+    if (newUserReactionIds.length === 0) return userReactionIds;
 
     const rawRulesForRequest = accessSnapshot.rawRules ?? currentAdditionalAccessRules;
     const parsedRulesForRequest = parseAdditionalAccessRuleGroups(rawRulesForRequest);
-    const searchKeySetsForRequest = accessSnapshot.searchKeySetsOfExactUser ?? currentSearchKeySetKeys;
-    const newUserReactionIds = uniqueIds.filter(isShortId);
     if (parsedRulesForRequest.length === 0) {
-      return newUserReactionIds;
+      return uniqueIds.filter(isMatchingCardId);
     }
 
+    const searchKeySetsForRequest = accessSnapshot.searchKeySetsOfExactUser ?? currentSearchKeySetKeys;
     const viewerId = accessSnapshot.accessUserId || ownerId || getOwnerId();
-    if (!viewerId) return [];
+    if (!viewerId) return userReactionIds;
 
     const resolvedSearchKeySetKeys = areSearchKeySetKeysForAccessUserId(searchKeySetsForRequest, viewerId)
       ? searchKeySetsForRequest
       : await resolveAdditionalSearchKeySetKeysForMatching(null, viewerId);
 
-    if (!resolvedSearchKeySetKeys.length) return [];
+    if (!resolvedSearchKeySetKeys.length) return userReactionIds;
 
     const indexed = await getIndexedNewUsersIdsByRules({
       rawRules: rawRulesForRequest,
@@ -2745,9 +2769,9 @@ const Matching = () => {
       debugToast: (message, data) => debugAdditionalToast(viewerId, message, data),
     });
     const allowedIds = new Set(Array.isArray(indexed?.userIds) ? indexed.userIds : []);
-    return newUserReactionIds.filter(id => allowedIds.has(id));
+    const allowedNewUserReactionIds = newUserReactionIds.filter(id => allowedIds.has(id));
+    return uniqueIds.filter(id => userReactionIds.includes(id) || allowedNewUserReactionIds.includes(id));
   }, [
-    collectionSource,
     currentAdditionalAccessRules,
     currentSearchKeySetKeys,
     ownerId,
@@ -2770,15 +2794,12 @@ const Matching = () => {
       mapUser: user => ({
         ...user,
         userId: user.userId,
-        ...(collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0
-          ? { __matchingAccessAllowed: true }
-          : {}),
+        ...(user.__sourceCollection === 'newUsers' ? { __matchingAccessAllowed: true } : {}),
       }),
       filterUsers: candidates => {
         const scopedCandidates = candidates
           .filter(user => activeReactionMap[user.userId])
           .filter(user => isMatchingCardId(user.userId))
-          .filter(user => isAllowedIdForCollection(user.userId, collectionSource))
           .filter(user => canShowMatchingUser(user, { isAdmin }))
           .filter(user => !loadedIds.has(user.userId));
 
@@ -2790,6 +2811,7 @@ const Matching = () => {
           excludeReactionUsers: false,
           roleIndexSets,
           collectionSource,
+          viewMode: viewModeRef.current,
         });
       },
     });
@@ -2802,7 +2824,6 @@ const Matching = () => {
     collectionSource,
     fetchReactionCardsByIds,
     isAdmin,
-    parsedAdditionalAccessRules.length,
     roleIndexSets,
   ]);
 
@@ -3349,6 +3370,7 @@ const Matching = () => {
     excludeReactionUsers: viewMode === 'default',
     roleIndexSets,
     collectionSource,
+    viewMode,
   });
 
   const additionalFiltersDebugSignatureRef = useRef('');

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -10,15 +10,16 @@ describe('Matching shared reaction card UI', () => {
     expect(source).not.toContain('ReactionOwnershipBadge');
   });
 
-  it('loads reaction tab cards through fetchUserById-compatible photo hydration', () => {
+  it('loads reaction tab cards through mixed users/newUsers fetch hydration', () => {
     const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
 
     expect(source).toContain('const fetchReactionCardsByIds = React.useCallback');
-    expect(source).toContain('await fetchUserById(id)');
+    expect(source).toContain('missingUserIds.length ? fetchUsersByIds(missingUserIds)');
+    expect(source).toContain('missingNewUserIds.length ? fetchNewUsersByIdsForMatching(missingNewUserIds)');
     expect(source).not.toContain('const usersMap = await fetchUsersByIds(page.pageIds);');
   });
 
-  it('guards stale default shared-candidate requests before applying them in reaction tabs', () => {
+  it('guards stale default shared-candidate requests while allowing reaction tabs across collections', () => {
     const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
 
     expect(source).toContain('const sharedReactionCandidateLoadVersionRef = useRef(0);');
@@ -51,6 +52,15 @@ describe('Matching shared reaction card UI', () => {
 
     expect(source).toContain(`setSharedReactionCandidateUsers([]);
     viewModeRef.current = 'search';`);
+  });
+
+
+  it('requires searchKeySets for newUsers reaction access instead of falling back to global searchKey', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('requireSearchKeySetKeys: true');
+    expect(source).not.toContain("refDb(database, 'searchKey')");
+    expect(source).not.toContain("ref2(database, 'searchKey')");
   });
 
 });

--- a/src/utils/__tests__/reactionPriority.test.js
+++ b/src/utils/__tests__/reactionPriority.test.js
@@ -4,6 +4,7 @@ import {
   canShowMatchingUser,
   hasPendingSharedReactionCandidates,
   loadReactionCardsPageRecords,
+  mergeMatchingCandidateUsers,
   mergeSharedReactionCandidateUsers,
   resolvePrioritizedReactionMaps,
   shouldApplyReactionPageResult,
@@ -718,7 +719,7 @@ describe('pre-merge shared reaction verification', () => {
     expect(dislikesTab.map(user => user.userId)).toEqual(['ID0002']);
   });
 
-  it('ignores stale shared candidate results for changed tab, source, or version', () => {
+  it('ignores stale shared candidate results for changed tab or version while reaction sources stay global', () => {
     const base = {
       requestVersion: 9,
       currentVersion: 9,
@@ -731,7 +732,7 @@ describe('pre-merge shared reaction verification', () => {
     expect(shouldApplySharedReactionCandidateResult(base)).toBe(true);
     expect(shouldApplySharedReactionCandidateResult({ ...base, currentVersion: 10 })).toBe(false);
     expect(shouldApplySharedReactionCandidateResult({ ...base, currentViewMode: 'favorites' })).toBe(false);
-    expect(shouldApplySharedReactionCandidateResult({ ...base, currentCollectionSource: 'newUsers' })).toBe(false);
+    expect(shouldApplySharedReactionCandidateResult({ ...base, currentCollectionSource: 'newUsers' })).toBe(true);
   });
 
   it('deduplicates when a card exists in both base users and shared reaction candidates', () => {
@@ -1014,7 +1015,7 @@ describe('readReactionSnapshotMaps', () => {
 
 
 describe('reaction pagination race guards', () => {
-  it('rejects async reaction page results after rapid tab switches, source changes, or newer requests', () => {
+  it('rejects async reaction page results after rapid tab switches or newer requests while reaction sources stay global', () => {
     const base = {
       requestVersion: 7,
       currentVersion: 7,
@@ -1027,7 +1028,7 @@ describe('reaction pagination race guards', () => {
     expect(shouldApplyReactionPageResult(base)).toBe(true);
     expect(shouldApplyReactionPageResult({ ...base, currentVersion: 8 })).toBe(false);
     expect(shouldApplyReactionPageResult({ ...base, currentViewMode: 'favorites' })).toBe(false);
-    expect(shouldApplyReactionPageResult({ ...base, currentCollectionSource: 'newUsers' })).toBe(false);
+    expect(shouldApplyReactionPageResult({ ...base, currentCollectionSource: 'newUsers' })).toBe(true);
   });
 
   it('can exhaust more than two pages of shared dislikes without duplicates', () => {
@@ -1155,4 +1156,106 @@ describe('reaction pagination race guards', () => {
     expect(defaultDeck.map(user => user.userId)).toEqual(['neutralCard']);
   });
 
+});
+
+describe('global cross-collection reaction overlay', () => {
+  const usersCard = { userId: 'firebasePushIdCard0001', publish: true, __sourceCollection: 'users' };
+  const newUsersCard = { userId: 'ID0001', __sourceCollection: 'newUsers', __matchingAccessAllowed: true };
+  const inaccessibleNewUsersCard = { userId: 'ID0002', __sourceCollection: 'newUsers' };
+
+  it('shows own /users and /newUsers favorites in both collection modes', () => {
+    ['users', 'newUsers'].forEach(collectionSource => {
+      const favoritesTab = mergeMatchingCandidateUsers({
+        users: [usersCard, newUsersCard],
+        favoriteUsers: { firebasePushIdCard0001: true, ID0001: true },
+        dislikeUsers: {},
+        viewMode: 'favorites',
+        collectionSource,
+        hasAdditionalAccessRules: true,
+      });
+
+      expect(favoritesTab.map(user => user.userId)).toEqual(['firebasePushIdCard0001', 'ID0001']);
+    });
+  });
+
+  it('shows shared /users and accessible /newUsers dislikes in both collection modes', () => {
+    ['users', 'newUsers'].forEach(collectionSource => {
+      const dislikesTab = mergeMatchingCandidateUsers({
+        users: [usersCard, newUsersCard],
+        favoriteUsers: {},
+        dislikeUsers: { firebasePushIdCard0001: true, ID0001: true },
+        viewMode: 'dislikes',
+        collectionSource,
+        hasAdditionalAccessRules: true,
+      });
+
+      expect(dislikesTab.map(user => user.userId)).toEqual(['firebasePushIdCard0001', 'ID0001']);
+    });
+  });
+
+  it('excludes all effective favorites and dislikes from the default deck in both collection modes', () => {
+    ['users', 'newUsers'].forEach(collectionSource => {
+      const defaultDeck = mergeMatchingCandidateUsers({
+        users: [
+          usersCard,
+          newUsersCard,
+          { userId: 'neutralUserCard0000001', publish: true, __sourceCollection: 'users' },
+          { userId: 'ID0099', __sourceCollection: 'newUsers', __matchingAccessAllowed: true },
+        ],
+        favoriteUsers: { firebasePushIdCard0001: true },
+        dislikeUsers: { ID0001: true },
+        viewMode: 'default',
+        collectionSource,
+        hasAdditionalAccessRules: true,
+      });
+
+      expect(defaultDeck.map(user => user.userId)).not.toEqual(expect.arrayContaining(['firebasePushIdCard0001', 'ID0001']));
+    });
+  });
+
+  it('keeps own reaction priority global across users and newUsers ids', () => {
+    const { favorites, dislikes } = resolvePrioritizedReactionMaps({
+      ownerIds: ['viewer', 'sharedOwner'],
+      ownOwnerId: 'viewer',
+      favoriteSnapshots: {
+        viewer: { ID0001: true },
+        sharedOwner: { firebasePushIdCard0001: true },
+      },
+      dislikeSnapshots: {
+        viewer: { ID0002: true },
+        sharedOwner: { ID0001: true, ID0002: true },
+      },
+    });
+
+    expect(favorites).toEqual({ firebasePushIdCard0001: true, ID0001: true });
+    expect(dislikes).toEqual({ ID0002: true });
+  });
+
+  it('does not leak newUsers reaction cards without allowed searchKeySets/access scope', () => {
+    const favoritesTab = mergeMatchingCandidateUsers({
+      users: [newUsersCard, inaccessibleNewUsersCard],
+      favoriteUsers: { ID0001: true, ID0002: true },
+      dislikeUsers: {},
+      viewMode: 'favorites',
+      collectionSource: 'users',
+      hasAdditionalAccessRules: true,
+    });
+
+    expect(favoritesTab.map(user => user.userId)).toEqual(['ID0001']);
+  });
+
+  it('does not make reaction async results stale merely because collectionSource changed', () => {
+    const base = {
+      requestVersion: 1,
+      currentVersion: 1,
+      requestViewMode: 'favorites',
+      currentViewMode: 'favorites',
+      requestCollectionSource: 'users',
+      currentCollectionSource: 'newUsers',
+    };
+
+    expect(shouldApplyReactionPageResult(base)).toBe(true);
+    expect(shouldApplySharedReactionCandidateResult(base)).toBe(true);
+    expect(shouldApplyReactionPageResult({ ...base, requestViewMode: 'default', currentViewMode: 'default' })).toBe(false);
+  });
 });

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -88,18 +88,30 @@ export const canShowMatchingUser = (user, { isAdmin = false } = {}) => {
 
 const SHARED_REACTION_CANDIDATE_VIEW_MODES = new Set(['default', 'favorites', 'dislikes']);
 
-export const shouldApplySharedReactionCandidateResult = ({
+const isReactionViewMode = viewMode => viewMode === 'favorites' || viewMode === 'dislikes';
+
+const isCurrentMatchingAsyncResult = ({
   requestVersion,
   currentVersion,
   requestViewMode,
   currentViewMode,
   requestCollectionSource,
   currentCollectionSource,
-} = {}) => (
-  SHARED_REACTION_CANDIDATE_VIEW_MODES.has(requestViewMode) &&
-  requestViewMode === currentViewMode &&
-  requestCollectionSource === currentCollectionSource &&
-  requestVersion === currentVersion
+} = {}) => {
+  if (requestVersion !== currentVersion || requestViewMode !== currentViewMode) return false;
+
+  // Reaction tabs are a global overlay across /users and /newUsers. Source changes
+  // must not make an otherwise current favorites/dislikes request stale. Keep the
+  // source guard only for the default base deck, where collectionSource selects
+  // the backing pool.
+  if (isReactionViewMode(requestViewMode)) return true;
+
+  return requestCollectionSource === currentCollectionSource;
+};
+
+export const shouldApplySharedReactionCandidateResult = options => (
+  SHARED_REACTION_CANDIDATE_VIEW_MODES.has(options?.requestViewMode) &&
+  isCurrentMatchingAsyncResult(options)
 );
 
 export const mergeSharedReactionCandidateUsers = ({
@@ -141,7 +153,6 @@ export const mergeMatchingCandidateUsers = ({
   const allowedBySetKey = new Set(additionalNewUsers.map(user => user.userId).filter(Boolean));
   const isAllowedNewUsersCandidate = user => (
     !hasAdditionalAccessRules ||
-    collectionSource !== 'newUsers' ||
     user?.__sourceCollection !== 'newUsers' ||
     allowedBySetKey.has(user.userId) ||
     user?.__matchingAccessAllowed === true
@@ -151,14 +162,7 @@ export const mergeMatchingCandidateUsers = ({
   );
 
   if (hasAdditionalAccessRules) {
-    baseUsers = baseUsers.filter(user => {
-      if (user?.__sourceCollection !== 'newUsers') return true;
-      return (
-        collectionSource !== 'newUsers' ||
-        allowedBySetKey.has(user.userId) ||
-        user?.__matchingAccessAllowed === true
-      );
-    });
+    baseUsers = baseUsers.filter(isAllowedNewUsersCandidate);
   }
 
   const shouldInjectAdditionalCards =
@@ -328,18 +332,7 @@ export const loadReactionCardsPageRecords = async ({
   };
 };
 
-export const shouldApplyReactionPageResult = ({
-  requestVersion,
-  currentVersion,
-  requestViewMode,
-  currentViewMode,
-  requestCollectionSource,
-  currentCollectionSource,
-} = {}) => (
-  requestVersion === currentVersion &&
-  requestViewMode === currentViewMode &&
-  requestCollectionSource === currentCollectionSource
-);
+export const shouldApplyReactionPageResult = options => isCurrentMatchingAsyncResult(options);
 
 export const readReactionSnapshotMaps = async ({
   ownerIds = [],


### PR DESCRIPTION
### Motivation
- Reactions (`favorites`/`dislikes`) must be a global overlay across both profile collections (`users` and `newUsers`) rather than being scoped to the selected `collectionSource` view. 
- Reaction tabs should show effective favorites/dislikes from both collections while `collectionSource` remains only a selector for the default/base deck.
- NewUsers access must be enforced by searchKeySets/additional access rules and never fall back to a global searchKey.
- Preserve existing owner-priority rules where own reactions override shared ones.

### Description
- Treat reaction tabs as a global overlay by relaxing source-based staleness guards and using a new `isCurrentMatchingAsyncResult` helper in `src/utils/reactionPriority.js` used by `shouldApplySharedReactionCandidateResult` and `shouldApplyReactionPageResult` to avoid making favorites/dislikes stale on `collectionSource` change.
- Update `mergeMatchingCandidateUsers` in `src/utils/reactionPriority.js` to stop treating `collectionSource` as a hard filter for reaction tabs and to validate injected `newUsers` candidates via access flags (`__matchingAccessAllowed`).
- Add a mixed fetch helper in `src/components/Matching.jsx` named `fetchReactionCardsByIds` which splits IDs by shape and fetches long IDs from `/users` with `fetchUsersByIds` and short IDs from `/newUsers` with `fetchNewUsersByIdsForMatching`, and ensures returned cards are annotated with `__sourceCollection`.
- Change shared-candidate loading in `src/components/Matching.jsx` to resolve candidate IDs across collections, apply `publish === true` checks for `/users`, and apply `searchKeySets`/additional-access validation for `/newUsers` without depending on the selected `collectionSource`.
- Update UI filtering function `applyMatchingUiFiltersToUsers` to accept `viewMode` so that favorites/dislikes tabs are not limited by `isAllowedIdForCollection` while the default deck still respects `collectionSource` and excludes effective reactions.
- Preserve existing reaction priority semantics (own > shared, shared dislike removes shared favorite) by reusing `resolvePrioritizedReactionMaps` and `buildSharedReactionCandidateIds`; mark `newUsers` cards with `__matchingAccessAllowed` when applicable.
- Tests updated/added to cover mixed id fetching, cross-collection favorites/dislikes visibility, default deck exclusion, priority semantics, and no-access leakage; small test text updates to reflect mixed fetch logic.

### Testing
- Ran the targeted unit tests with `npm test -- --runTestsByPath src/utils/__tests__/reactionPriority.test.js src/components/Matching.sharedReactions.test.js --watchAll=false` and all tests passed (`56 passed`).
- Ran lint with `npm run lint:js` and resolved the only lint warning; lint completed successfully.
- The change touches `src/components/Matching.jsx`, `src/utils/reactionPriority.js`, and related tests to ensure the described behavior is covered by automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04efb4a5648326aa5529b2c9ddf739)