### PR TITLE
Modernize Matching UI: new profile layout, touch navigation, and profileLayoutConfig with tests

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2,15 +2,12 @@ import React, { useEffect, useState, useRef, useLayoutEffect, useMemo } from 're
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { resolveAccess } from 'utils/accessLevel';
-import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import {
   ActionButton,
   AdminToggle,
   AnimatedCard,
-  BasicInfo,
   CardContainer,
   CardCount,
-  CardInfo,
   CardWrapper,
   ClickableId,
   CollectionSourceLabel,
@@ -18,45 +15,44 @@ import {
   CollectionSourceWrap,
   CommentBox,
   CommentInput,
-  Contact,
   Container,
-  DonorName,
-  EggDonorPhotoLocation,
   ExitButton,
   FilterContainer,
   FilterOverlay,
   FilterResetButton,
-  getRoleColors,
   Grid,
   HeaderContainer,
-  HeaderIdentityRow,
-  HeaderIdentityRowSpaced,
-  HeaderRow,
-  Icons,
-  IconsTrailing,
-  Info,
-  InfoSlide,
   InnerContainer,
   LoadMoreButton,
   LoadMoreFooter,
-  LocationLine,
-  MoreInfo,
-  NextInfoCard,
-  NextPhoto,
   OwnerStatusMessage,
-  ProfileSection,
-  RoleHeader,
   SharedCommentText,
   SkeletonCardInner,
   SkeletonInfo,
   SkeletonLine,
   SkeletonPhoto,
   SubmitButton,
-  Table,
-  ThirdInfoCard,
-  ThirdPhoto,
-  Title,
   TopActions,
+  ModernActionRail,
+  ModernBioText,
+  ModernChip,
+  ModernChipGrid,
+  ModernFactPill,
+  ModernGallery,
+  ModernGalleryImage,
+  ModernHero,
+  ModernHeroContent,
+  ModernHeroFacts,
+  ModernHeroFallbackMark,
+  ModernHeroLocation,
+  ModernHeroTitle,
+  ModernMoreButton,
+  ModernProfileBody,
+  ModernProfileScroll,
+  ModernProfileShell,
+  ModernRoleBadge,
+  ModernSection,
+  ModernSectionTitle,
   BackendTrafficToggleButton,
   BackendTrafficToggleStatus,
 } from './Matching.styled';
@@ -89,7 +85,6 @@ import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
-import { fieldContactsIcons } from './smallCard/fieldContacts';
 import SearchBar from './SearchBar';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -101,10 +96,17 @@ import InfoModal from './InfoModal';
 import { FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload } from 'react-icons/fa';
 import { handleEmptyFetch } from './loadMoreUtils';
 import {
-  normalizeCountry,
-  normalizeRegion,
-} from './normalizeLocation';
-import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
+  getHeroFields,
+  getProfileAge,
+  getProfileBio,
+  getProfileLocation,
+  getProfileName,
+  getProfilePhotos,
+  getProfileRole,
+  getProfileSections,
+  getQuickFacts,
+  getRoleLabel,
+} from './profileLayoutConfig';
 import {
   cacheFavoriteUsers,
   syncFavorites,
@@ -792,31 +794,50 @@ const MatchingSkeleton = ({ $small }) => (
   </CardWrapper>
 );
 
-// Fields to display in the details modal
-const FIELDS = [
-  { key: 'height', label: 'Height (cm)' },
-  { key: 'weight', label: 'Weight (kg)' },
-  { key: 'bmi', label: 'BMI' },
-  { key: 'clothingSize', label: 'Clothing size' },
-  { key: 'shoeSize', label: 'Shoe size' },
-  { key: 'blood', label: 'Rh' },
-  { key: 'eyeColor', label: 'Eyes' },
-  { key: 'glasses', label: 'Glasses' },
-  { key: 'race', label: 'Race' },
-  { key: 'hairColor', label: 'Hair color' },
-  { key: 'hairStructure', label: 'Hair structure' },
-  { key: 'chin', label: 'Chin' },
-  { key: 'breastSize', label: 'Breast size' },
-  { key: 'bodyType', label: 'Body type' },
-  { key: 'maritalStatus', label: 'Marital status' },
-  { key: 'ownKids', label: 'Own kids' },
-  { key: 'faceShape', label: 'Face shape' },
-  { key: 'noseShape', label: 'Nose shape' },
-  { key: 'lipsShape', label: 'Lips shape' },
-  { key: 'reward', label: 'Expected reward $' },
-  { key: 'experience', label: 'Donation exp' },
+
+const collectProfileFieldKeys = fields => [
+  ...new Set(
+    (fields || []).flatMap(field => [field.key, ...(field.sourceKeys || [])].filter(Boolean))
+  ),
 ];
-const MAIN_INFO_FIELDS_LIMIT = 15;
+
+const ProfileChips = ({ fields, role }) => {
+  if (!fields.length) return null;
+  return (
+    <ModernChipGrid>
+      {fields.map(field => (
+        <ModernChip key={`${field.key}-${field.label}`} $role={role}>
+          <strong>{field.label}</strong>
+          <span>{field.value}</span>
+        </ModernChip>
+      ))}
+    </ModernChipGrid>
+  );
+};
+
+const ProfileBio = ({ text }) => {
+  const [expanded, setExpanded] = useState(false);
+  if (!text) return null;
+  const shouldCollapse = text.length > 230;
+  const displayText = shouldCollapse && !expanded ? `${text.slice(0, 230).trim()}…` : text;
+  return (
+    <ModernSection>
+      <ModernSectionTitle>About</ModernSectionTitle>
+      <ModernBioText>{displayText}</ModernBioText>
+      {shouldCollapse && (
+        <ModernMoreButton
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            setExpanded(value => !value);
+          }}
+        >
+          {expanded ? 'less' : 'more'}
+        </ModernMoreButton>
+      )}
+    </ModernSection>
+  );
+};
 
 const SwipeableCard = ({
   user,
@@ -833,459 +854,189 @@ const SwipeableCard = ({
   setOwnFavoriteUsers,
   ownDislikeUsers,
   setOwnDislikeUsers,
-  viewMode,
   handleRemove,
   togglePublish,
   multiDataOwnerId,
+  onNavigate,
+  commentValue,
+  sharedCommentTexts = [],
+  onCommentChange,
+  onCommentBlur,
+  onAdminEdit,
 }) => {
-  const moreInfo = getCurrentValue(user.moreInfo_main);
-  const profession = getCurrentValue(user.profession);
-  const education = getCurrentValue(user.education);
-  const { mainFields, extraFields } = splitSelectedFields(user, { isAdmin });
-  const showDescriptionSlide = Boolean(
-    moreInfo || profession || education || extraFields.length > 0
-  );
-
-  const slides = React.useMemo(() => {
-    const photosArr = Array.isArray(user.photos)
-      ? user.photos.filter(Boolean).map(convertDriveLinkToImage)
-      : [getCurrentValue(user.photos)]
-          .filter(Boolean)
-          .map(convertDriveLinkToImage);
-    let base;
-    if (role === 'ag') {
-      base = ['main'];
-    } else {
-      base = photo ? ['main', 'info'] : ['info'];
-    }
-    if (showDescriptionSlide) base.push('description');
-    base.push(...photosArr.slice(1));
-    return base;
-  }, [user.photos, showDescriptionSlide, photo, role]);
-
-  const [index, setIndex] = useState(0);
+  const resolvedRole = getProfileRole(user) || role;
+  const photos = getProfilePhotos(user);
+  const heroPhoto = photo || photos[0] || '';
+  const galleryPhotos = photos.filter(item => item && item !== heroPhoto);
+  const [activeHeroPhoto, setActiveHeroPhoto] = useState(heroPhoto);
   const [dir, setDir] = useState(null);
-  const startX = useRef(null);
-  const wasSwiped = useRef(false);
+  const favoriteButtonWrapRef = useRef(null);
+  const dislikeButtonWrapRef = useRef(null);
+  const touchStart = useRef(null);
+  const swipedRef = useRef(false);
 
+  useEffect(() => {
+    setActiveHeroPhoto(heroPhoto);
+  }, [heroPhoto, user.userId]);
+
+  useEffect(() => {
+    if (!dir) return undefined;
+    const t = setTimeout(() => setDir(null), 260);
+    return () => clearTimeout(t);
+  }, [dir]);
+
+  const name = getProfileName(user) || nameParts || getRoleLabel(resolvedRole);
+  const age = getProfileAge(user);
+  const title = `${name}${age ? `, ${age}` : ''}`;
+  const roleLabel = getRoleLabel(resolvedRole);
+  const locationInfo = getProfileLocation(user);
+  const heroFields = getHeroFields(user, resolvedRole);
+  const heroFieldKeys = collectProfileFieldKeys(heroFields);
+  const quickFacts = getQuickFacts(user, resolvedRole, { excludeKeys: heroFieldKeys });
+  const usedSummaryFieldKeys = collectProfileFieldKeys([...heroFields, ...quickFacts]);
+  const sections = getProfileSections(user, resolvedRole, { excludeKeys: usedSummaryFieldKeys });
+  const bio = getProfileBio(user);
+  const initials = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(part => part[0]?.toUpperCase())
+    .join('') || roleLabel.slice(0, 2).toUpperCase();
   const handleTouchStart = e => {
-    if (slides.length <= 1) return;
-    if (e.touches && e.touches.length > 0) {
-      startX.current = e.touches[0].clientX;
-    }
+    if (!e.touches || e.touches.length !== 1) return;
+    const touch = e.touches[0];
+    touchStart.current = { x: touch.clientX, y: touch.clientY };
+  };
+
+  const handleTouchMove = e => {
+    if (!touchStart.current || !e.touches || e.touches.length !== 1) return;
+    const touch = e.touches[0];
+    const dx = touch.clientX - touchStart.current.x;
+    const dy = touch.clientY - touchStart.current.y;
+    if (Math.abs(dx) > 16 && Math.abs(dx) > Math.abs(dy) * 1.25) e.preventDefault();
   };
 
   const handleTouchEnd = e => {
-    if (slides.length <= 1) return;
-    if (startX.current === null) return;
-    const deltaX = e.changedTouches[0].clientX - startX.current;
-    if (deltaX > 50) {
-      setDir('right');
-      setIndex(i => (i - 1 + slides.length) % slides.length);
-      wasSwiped.current = true;
-      setTimeout(() => {
-        wasSwiped.current = false;
-      }, 50);
-    } else if (deltaX < -50) {
-      setDir('left');
-      setIndex(i => (i + 1) % slides.length);
-      wasSwiped.current = true;
-      setTimeout(() => {
-        wasSwiped.current = false;
-      }, 50);
+    if (!touchStart.current || !e.changedTouches || e.changedTouches.length !== 1) return;
+    const touch = e.changedTouches[0];
+    const dx = touch.clientX - touchStart.current.x;
+    const dy = touch.clientY - touchStart.current.y;
+    touchStart.current = null;
+    if (Math.abs(dx) < 72 || Math.abs(dx) < Math.abs(dy) * 1.35) return;
+    const direction = dx > 0 ? 'right' : 'left';
+    swipedRef.current = true;
+    setDir(direction);
+    if (typeof onNavigate === 'function') {
+      onNavigate(direction === 'left' ? 1 : -1);
     }
-    startX.current = null;
+    setTimeout(() => {
+      swipedRef.current = false;
+    }, 80);
   };
 
-  useEffect(() => {
-    if (dir) {
-      const t = setTimeout(() => setDir(null), 300);
-      return () => clearTimeout(t);
-    }
-  }, [dir]);
-
-  const handleClick = e => {
-    if (wasSwiped.current) {
-      wasSwiped.current = false;
-      return;
-    }
-    if (slides.length > 1) {
-      const rect = e.currentTarget.getBoundingClientRect();
-      const clickX = e.clientX - rect.left;
-      if (clickX > rect.width / 2) {
-        setDir('left');
-        setIndex(i => (i + 1) % slides.length);
-      } else {
-        setDir('right');
-        setIndex(i => (i - 1 + slides.length) % slides.length);
-      }
-    }
+  const handleClick = () => {
+    if (swipedRef.current) swipedRef.current = false;
   };
-
-  const current = slides[index];
-  const backgroundImage =
-    current === 'main'
-      ? photo
-      : current !== 'description' && current !== 'info'
-      ? current
-      : '';
-
-  const displayName = [
-    getCurrentValue(user.name),
-    getCurrentValue(user.surname),
-  ]
-    .filter(Boolean)
-    .map(v => String(v).trim())
-    .join(' ');
-  const isEggDonor = (role || '').includes('ed');
-  const contacts = fieldContactsIcons(user, { phoneAsIcon: true, iconSize: 16 });
-  const selectedFields = mainFields;
-  const regionInfo = normalizeRegion(getCurrentValue(user.region));
-  const cityInfo = getCurrentValue(user.city);
-  const locationInfo = isEggDonor
-    ? regionInfo || ''
-    : getCurrentValue(user.country)
-    ? [
-        normalizeCountry(getCurrentValue(user.country)),
-        cityInfo || regionInfo,
-      ]
-        .filter(Boolean)
-        .join(', ')
-    : cityInfo || regionInfo;
 
   return (
     <AnimatedCard
       $dir={dir}
       $small={isAgency}
-      $compactWithoutPhoto={!photo}
-      $hasPhoto={!!photo}
+      $compactWithoutPhoto={!activeHeroPhoto}
+      $hasPhoto={!!activeHeroPhoto}
       data-card
+      data-testid="matching-profile-card"
       onClick={handleClick}
       onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
-      $backgroundImage={backgroundImage}
+      $activeProfile
     >
-      {current === 'description' && (
-        <InfoSlide $reserveActionButtons={!photo} $role={role}>
-          {extraFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{extraFields}</Table>}
-          {education && (
-            <MoreInfo>
-              <strong>Education</strong>
-              <br />
-              {education}
-            </MoreInfo>
+      <ModernProfileShell>
+        <ModernProfileScroll>
+        <ModernHero $image={activeHeroPhoto}>
+          {!activeHeroPhoto && <ModernHeroFallbackMark>{initials}</ModernHeroFallbackMark>}
+          {activeHeroPhoto && <img src={activeHeroPhoto} alt="" style={{ display: 'none' }} onError={() => setActiveHeroPhoto('')} />}
+          <ModernHeroContent>
+            <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>
+            <ModernHeroTitle>{title}</ModernHeroTitle>
+            {locationInfo && <ModernHeroLocation>{locationInfo}</ModernHeroLocation>}
+            {heroFields.length > 0 && (
+              <ModernHeroFacts>
+                {heroFields.map(item => (
+                  <ModernFactPill key={`hero-${item.key}`}>
+                    <strong>{item.label}</strong>
+                    <span>{item.value}</span>
+                  </ModernFactPill>
+                ))}
+              </ModernHeroFacts>
+            )}
+          </ModernHeroContent>
+        </ModernHero>
+        {isAdmin && (
+          <AdminToggle published={user.publish} onClick={e => { e.stopPropagation(); togglePublish(user); }} />
+        )}
+        <ModernProfileBody>
+          {quickFacts.length > 0 && (
+            <ModernSection>
+              <ModernSectionTitle>Quick facts</ModernSectionTitle>
+              <ProfileChips fields={quickFacts} role={resolvedRole} />
+            </ModernSection>
           )}
-          {profession && (
-            <MoreInfo>
-              <strong>Profession</strong>
-              <br />
-              {profession}
-            </MoreInfo>
+          <ProfileBio text={bio} />
+          <ModernSection>
+            <ModernSectionTitle>Comment</ModernSectionTitle>
+            <CommentBox>
+              <ResizableCommentInput
+                plain
+                placeholder="Мій коментар / My comment"
+                value={commentValue || ''}
+                onClick={e => e.stopPropagation()}
+                onChange={e => onCommentChange && onCommentChange(e.target.value)}
+                onBlur={onCommentBlur}
+              />
+              {sharedCommentTexts.map((text, idx) => (
+                <SharedCommentText key={`${user.userId}-shared-comment-${idx}`}>
+                  {text}
+                </SharedCommentText>
+              ))}
+              {isAdmin && (
+                <ClickableId onClick={onAdminEdit}>
+                  ID: {user.userId ? user.userId.slice(0, 5) : ''}
+                </ClickableId>
+              )}
+            </CommentBox>
+          </ModernSection>
+          {sections.map(section => (
+            <ModernSection key={section.title}>
+              <ModernSectionTitle>{section.title}</ModernSectionTitle>
+              <ProfileChips fields={section.fields} role={resolvedRole} />
+            </ModernSection>
+          ))}
+          {galleryPhotos.length > 0 && (
+            <ModernSection>
+              <ModernSectionTitle>Gallery</ModernSectionTitle>
+              <ModernGallery>
+                {galleryPhotos.map(src => (
+                  <ModernGalleryImage key={src} src={src} alt={`${name} profile`} onError={event => { event.currentTarget.style.display = 'none'; }} />
+                ))}
+              </ModernGallery>
+            </ModernSection>
           )}
-          {moreInfo && (
-            <MoreInfo>
-              {moreInfo}
-            </MoreInfo>
-          )}
-        </InfoSlide>
-      )}
-      {current === 'info' && (
-        <InfoSlide $reserveActionButtons={!photo} $role={role}>
-          {photo ? (
-            <HeaderIdentityRowSpaced>
-              <Title $role={role}>{getRoleTitle(user)}</Title>
-              {contacts && <IconsTrailing>{contacts}</IconsTrailing>}
-            </HeaderIdentityRowSpaced>
-          ) : (
-            <ProfileSection>
-              <Info>
-                <HeaderIdentityRow>
-                  <Title $role={role}>{getRoleTitle(user)}</Title>
-                  <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
-                </HeaderIdentityRow>
-                <LocationLine>
-                  <span>{locationInfo}</span>
-                  {isEggDonor && contacts && <Icons>{contacts}</Icons>}
-                </LocationLine>
-              </Info>
-            </ProfileSection>
-          )}
-          {selectedFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{selectedFields}</Table>}
-          {!isEggDonor && !photo && contacts && (
-            <Contact $withBorder={selectedFields.length > 0}>
-              <Icons>{contacts}</Icons>
-            </Contact>
-          )}
-          {isEggDonor && photo && locationInfo && (
-            <EggDonorPhotoLocation>
-              <span>{locationInfo}</span>
-            </EggDonorPhotoLocation>
-          )}
-        </InfoSlide>
-      )}
-      {current === 'main' && role !== 'ag' && (
-        <BasicInfo>
-          {formatNameAndAge(user, displayName)}
-          <br />
-          {locationInfo}
-        </BasicInfo>
-      )}
-      {(current === 'main' || (!photo && current === 'info')) && isAdmin && (
-        <AdminToggle
-          published={user.publish}
-          onClick={e => {
-            e.stopPropagation();
-            togglePublish(user);
-          }}
-        />
-      )}
-      <BtnFavorite
-        userId={user.userId}
-        userData={user}
-        favoriteUsers={favoriteUsers}
-        setFavoriteUsers={setFavoriteUsers}
-        ownFavoriteUsers={ownFavoriteUsers}
-        setOwnFavoriteUsers={setOwnFavoriteUsers}
-        dislikeUsers={dislikeUsers}
-        setDislikeUsers={setDislikeUsers}
-        ownDislikeUsers={ownDislikeUsers}
-        setOwnDislikeUsers={setOwnDislikeUsers}
-        onRemove={handleRemove}
-        multiDataOwnerId={multiDataOwnerId}
-      />
-      <BtnDislike
-        userId={user.userId}
-        userData={user}
-        dislikeUsers={dislikeUsers}
-        setDislikeUsers={setDislikeUsers}
-        ownDislikeUsers={ownDislikeUsers}
-        setOwnDislikeUsers={setOwnDislikeUsers}
-        favoriteUsers={favoriteUsers}
-        setFavoriteUsers={setFavoriteUsers}
-        ownFavoriteUsers={ownFavoriteUsers}
-        setOwnFavoriteUsers={setOwnFavoriteUsers}
-        onRemove={handleRemove}
-        multiDataOwnerId={multiDataOwnerId}
-      />
-      {current === 'main' && isAgency && (
-        <CardInfo>
-          <HeaderRow>
-            <RoleHeader $role={role}>{role === 'ag' ? 'Agency' : 'Couple'}</RoleHeader>
-            {nameParts && <strong>{nameParts}</strong>}
-          </HeaderRow>
-          <LocationLine>
-            {locationInfo && <span>{locationInfo}</span>}
-            {contacts && <Icons>{contacts}</Icons>}
-          </LocationLine>
-        </CardInfo>
-      )}
-      {(current === 'info' || current === 'main') && null}
+        </ModernProfileBody>
+        </ModernProfileScroll>
+        <ModernActionRail>
+          <span ref={dislikeButtonWrapRef}>
+            <BtnDislike userId={user.userId} userData={user} dislikeUsers={dislikeUsers} setDislikeUsers={setDislikeUsers} ownDislikeUsers={ownDislikeUsers} setOwnDislikeUsers={setOwnDislikeUsers} favoriteUsers={favoriteUsers} setFavoriteUsers={setFavoriteUsers} ownFavoriteUsers={ownFavoriteUsers} setOwnFavoriteUsers={setOwnFavoriteUsers} onRemove={handleRemove} multiDataOwnerId={multiDataOwnerId} customStyle={{ background: 'rgba(24, 21, 18, 0.78)' }} />
+          </span>
+          <span ref={favoriteButtonWrapRef}>
+            <BtnFavorite userId={user.userId} userData={user} favoriteUsers={favoriteUsers} setFavoriteUsers={setFavoriteUsers} ownFavoriteUsers={ownFavoriteUsers} setOwnFavoriteUsers={setOwnFavoriteUsers} dislikeUsers={dislikeUsers} setDislikeUsers={setDislikeUsers} ownDislikeUsers={ownDislikeUsers} setOwnDislikeUsers={setOwnDislikeUsers} onRemove={handleRemove} multiDataOwnerId={multiDataOwnerId} customStyle={{ background: 'rgba(247, 147, 30, 0.95)' }} />
+          </span>
+        </ModernActionRail>
+      </ModernProfileShell>
     </AnimatedCard>
   );
 };
-
-const normalizeOwnKidsValue = value => {
-  const normalized = (value ?? '').toString().trim().toLowerCase();
-
-  if (normalized === '') return value;
-
-  if (['0', '-', 'no', 'ні', 'немає'].includes(normalized)) {
-    return 'No';
-  }
-
-  const numericValue = Number(normalized);
-  if (Number.isFinite(numericValue) && numericValue >= 1) {
-    return 'Yes';
-  }
-
-  return value;
-};
-
-const buildSelectedFields = (user, { isAdmin } = {}) => {
-  return FIELDS.map(field => {
-    if (field.key === 'reward' && !isAdmin) return null;
-
-    let value = user[field.key];
-    if (field.key === 'bmi') {
-      const { weight, height } = user;
-      if (weight && height) {
-        value = Math.round((weight / (height * height)) * 10000);
-      } else {
-        value = null;
-      }
-    }
-
-    value = getCurrentValue(value);
-
-    if (field.key === 'maritalStatus') {
-      const role = (user.userRole || '').toString().trim().toLowerCase();
-      if (role === 'ed' && value) {
-        const normalized = value.toString().trim().toLowerCase();
-        if (
-          ['yes', 'так', '+', 'married', 'заміжня', 'одружена'].includes(
-            normalized
-          )
-        ) {
-          value = 'Married';
-        } else if (
-          [
-            'no',
-            'ні',
-            '-',
-            'single',
-            'unmarried',
-            'незаміжня',
-            'не заміжня',
-          ].includes(normalized)
-        ) {
-          value = 'Single';
-        }
-      }
-    }
-
-    if (field.key === 'ownKids') {
-      value = normalizeOwnKidsValue(value);
-    }
-
-    if (value === undefined || value === '' || value === null) return null;
-
-    return (
-      <div key={field.key}>
-        <strong>{field.label}</strong>{' '}
-        {String(value)}
-      </div>
-    );
-  });
-};
-
-const splitSelectedFields = (user, { isAdmin } = {}) => {
-  const allFields = buildSelectedFields(user, { isAdmin }).filter(Boolean);
-  return {
-    mainFields: allFields.slice(0, MAIN_INFO_FIELDS_LIMIT),
-    extraFields: allFields.slice(MAIN_INFO_FIELDS_LIMIT),
-  };
-};
-
-const getInfoSlidesCount = user => {
-  const moreInfo = getCurrentValue(user.moreInfo_main);
-  const profession = getCurrentValue(user.profession);
-  const education = getCurrentValue(user.education);
-  const { extraFields } = splitSelectedFields(user);
-  const showDescriptionSlide = Boolean(
-    moreInfo || profession || education || extraFields.length > 0
-  );
-  return 1 + (showDescriptionSlide ? 1 : 0);
-};
-
-const getRoleTitle = user => {
-  const userRole = (user.userRole || '')
-    .toString()
-    .trim()
-    .toLowerCase();
-  const role = (user.userRole || user.role || '')
-    .toString()
-    .trim()
-    .toLowerCase();
-
-  if (role === 'ag') return 'Agency';
-  if (role === 'ip') return 'Intended parents';
-  if (role === 'ed') return 'Egg donor';
-  if (!userRole) return 'Potential ED';
-  return '';
-};
-
-const formatNameAndAge = (user, displayName) => {
-  const age = user?.birth ? utilCalculateAge(user.birth) : '';
-  const sourceCollection = user?.__sourceCollection || '';
-
-  if (!displayName && age && sourceCollection === 'newUsers') {
-    return `${age} years old`;
-  }
-
-  return `${displayName}${age ? `, ${age}` : ''}`;
-};
-
-const InfoCardContent = ({ user, variant, isAdmin }) => {
-  const moreInfo = getCurrentValue(user.moreInfo_main);
-  const profession = getCurrentValue(user.profession);
-  const education = getCurrentValue(user.education);
-  const { mainFields, extraFields } = splitSelectedFields(user, { isAdmin });
-
-  const displayName = [
-    getCurrentValue(user.name),
-    getCurrentValue(user.surname),
-  ]
-    .filter(Boolean)
-    .map(v => String(v).trim())
-    .join(' ');
-  const role = (user.userRole || user.role || '')
-    .toString()
-    .trim()
-    .toLowerCase();
-  const isEggDonor = role.includes('ed');
-  const contacts = fieldContactsIcons(user, { phoneAsIcon: true, iconSize: 16 });
-  const selectedFields = mainFields;
-  const roleTitle = getRoleTitle(user);
-  const regionInfo = normalizeRegion(getCurrentValue(user.region));
-  const cityInfo = getCurrentValue(user.city);
-  const locationInfo = isEggDonor
-    ? regionInfo || ''
-    : getCurrentValue(user.country)
-    ? [
-        normalizeCountry(getCurrentValue(user.country)),
-        cityInfo || regionInfo,
-      ]
-        .filter(Boolean)
-        .join(', ')
-    : cityInfo || regionInfo;
-
-  if (variant === 'description') {
-    return (
-      <InfoSlide $role={role}>
-        {extraFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{extraFields}</Table>}
-        {education && (
-          <MoreInfo>
-            <strong>Education</strong>
-            <br />
-            {education}
-          </MoreInfo>
-        )}
-        {profession && (
-          <MoreInfo>
-            <strong>Profession</strong>
-            <br />
-            {profession}
-          </MoreInfo>
-        )}
-        {moreInfo && <MoreInfo>{moreInfo}</MoreInfo>}
-      </InfoSlide>
-    );
-  }
-
-  return (
-    <InfoSlide $role={role}>
-      <ProfileSection>
-        <Info>
-          <HeaderIdentityRow>
-            <Title $role={role}>{roleTitle}</Title>
-            <DonorName>{formatNameAndAge(user, displayName)}</DonorName>
-          </HeaderIdentityRow>
-          <LocationLine>
-            <span>{locationInfo}</span>
-            {isEggDonor && contacts && <Icons>{contacts}</Icons>}
-          </LocationLine>
-        </Info>
-      </ProfileSection>
-      {selectedFields.length > 0 && <Table $roleColor={getRoleColors(role).text}>{selectedFields}</Table>}
-      {!isEggDonor && contacts && (
-        <Contact $withBorder={selectedFields.length > 0}>
-          <Icons>{contacts}</Icons>
-        </Contact>
-      )}
-    </InfoSlide>
-  );
-};
-
 
 const INITIAL_LOAD = 6;
 const LOAD_MORE = 6;
@@ -3210,10 +2961,6 @@ const Matching = () => {
     reloadDefault();
   }, [reloadDefault]);
 
-  const gridRef = useRef(null);
-  const [preLastCardNode, setPreLastCardNode] = useState(null);
-
-
   const visibleUsers = useMemo(() => mergeMatchingCandidateUsers({
     users,
     additionalNewUsers,
@@ -3249,6 +2996,24 @@ const Matching = () => {
     roleIndexSets,
     collectionSource,
   });
+
+  const [activeProfileIndex, setActiveProfileIndex] = useState(0);
+  const activeProfile = filteredUsers[activeProfileIndex] || null;
+
+  useEffect(() => {
+    setActiveProfileIndex(index => {
+      if (filteredUsers.length === 0) return 0;
+      return Math.min(index, filteredUsers.length - 1);
+    });
+  }, [filteredUsers.length]);
+
+  const navigateActiveProfile = React.useCallback((step) => {
+    setActiveProfileIndex(index => {
+      if (filteredUsers.length === 0) return 0;
+      const nextIndex = Math.max(0, Math.min(filteredUsers.length - 1, index + step));
+      return nextIndex;
+    });
+  }, [filteredUsers.length]);
 
   const additionalFiltersDebugSignatureRef = useRef('');
   useEffect(() => {
@@ -3291,21 +3056,12 @@ const Matching = () => {
 
   useEffect(() => {
     if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;
-    if (!hasMore || !preLastCardNode) return;
+    if (!hasMore || loadingRef.current || loading) return;
+    if (filteredUsers.length === 0) return;
+    if (activeProfileIndex < filteredUsers.length - 2) return;
 
-    const observer = new IntersectionObserver(
-      entries => {
-        if (entries[0]?.isIntersecting) {
-          loadMore();
-        }
-      },
-      { threshold: 0.1 }
-    );
-
-    observer.observe(preLastCardNode);
-
-    return () => observer.disconnect();
-  }, [hasMore, loadMore, preLastCardNode, viewMode]);
+    loadMore({ currentVisibleCount: filteredUsers.length });
+  }, [activeProfileIndex, filteredUsers.length, hasMore, loadMore, loading, viewMode]);
 
   useEffect(() => {
     setBackendDownloadToastsEnabled(downloadSizeToastsEnabled);
@@ -3395,7 +3151,7 @@ const Matching = () => {
       <Container>
         <InnerContainer>
           <HeaderContainer>
-            <CardCount>{filteredUsers.length} карточок</CardCount>
+            <CardCount>{filteredUsers.length ? `${activeProfileIndex + 1} / ${filteredUsers.length}` : '0'} карточок</CardCount>
             <TopActions>
               {viewMode !== 'default' && (
                 <ActionButton onClick={reloadDefault}><FaDownload /></ActionButton>
@@ -3443,42 +3199,13 @@ const Matching = () => {
             </OwnerStatusMessage>
           )}
 
-          <Grid ref={gridRef}>
-            {filteredUsers.map((user, index) => {
-              const photos = Array.isArray(user.photos)
-                ? user.photos.filter(Boolean).map(convertDriveLinkToImage)
-                : [getCurrentValue(user.photos)]
-                    .filter(Boolean)
-                    .map(convertDriveLinkToImage);
+          <Grid>
+            {activeProfile ? (() => {
+              const user = activeProfile;
+              const photos = getProfilePhotos(user);
               const photo = photos[0];
-              const nextPhoto = photos[1];
-              const thirdPhoto = photos[2];
-              const role = (user.role || user.userRole || '')
-                .toString()
-                .trim()
-                .toLowerCase();
+              const role = getProfileRole(user);
               const isAgency = role === 'ag' || role === 'ip';
-
-              const infoVariants = [];
-              if (role === 'ag') {
-                const moreInfo = getCurrentValue(user.moreInfo_main);
-                const profession = getCurrentValue(user.profession);
-                const education = getCurrentValue(user.education);
-                const { extraFields } = splitSelectedFields(user, { isAdmin });
-                const showDescriptionSlide = Boolean(
-                  moreInfo || profession || education || extraFields.length > 0
-                );
-                if (showDescriptionSlide) infoVariants.push('description');
-              } else {
-                const infoSlides = getInfoSlidesCount(user);
-                if (infoSlides >= 1) infoVariants.push('info');
-                if (infoSlides >= 2) infoVariants.push('description');
-                if (!photo) infoVariants.shift();
-              }
-
-              const nextVariant = nextPhoto ? null : infoVariants.shift();
-              const thirdVariant = thirdPhoto ? null : infoVariants.shift();
-
               const nameParts = [
                 getCurrentValue(user.name),
                 getCurrentValue(user.surname),
@@ -3487,87 +3214,52 @@ const Matching = () => {
                 .map(v => String(v).trim())
                 .join(' ');
               return (
-                <CardContainer
-                  key={user.userId}
-                  ref={
-                    index === filteredUsers.length - 2 ? setPreLastCardNode : null
-                  }
-                >
-                  {thirdVariant && (
-                    <ThirdInfoCard>
-                      <InfoCardContent user={user} variant={thirdVariant} isAdmin={isAdmin} />
-                    </ThirdInfoCard>
-                  )}
-                    {thirdPhoto && <ThirdPhoto src={thirdPhoto} alt="third" />}
-                    {nextVariant && (
-                      <NextInfoCard>
-                        <InfoCardContent user={user} variant={nextVariant} isAdmin={isAdmin} />
-                      </NextInfoCard>
-                    )}
-                    {nextPhoto && <NextPhoto src={nextPhoto} alt="next" />}
-                    <CardWrapper $role={role}>
-                      <SwipeableCard
-                        user={user}
-                        photo={photo}
-                        role={role}
-                        isAgency={isAgency}
-                        nameParts={nameParts}
-                        isAdmin={isAdmin}
-                        favoriteUsers={favoriteUsers}
-                        setFavoriteUsers={setFavoriteUsers}
-                        ownFavoriteUsers={ownFavoriteUsers}
-                        setOwnFavoriteUsers={setOwnFavoriteUsers}
-                        dislikeUsers={dislikeUsers}
-                        setDislikeUsers={setDislikeUsers}
-                        ownDislikeUsers={ownDislikeUsers}
-                        setOwnDislikeUsers={setOwnDislikeUsers}
-                        viewMode={viewMode}
-                        handleRemove={handleRemove}
-                        togglePublish={togglePublish}
-                        multiDataOwnerId={ownerId}
-                      />
-                      <CommentBox>
-                        <ResizableCommentInput
-                          plain
-                          placeholder="Мій коментар / My comment"
-                          value={comments[user.userId] || ''}
-                          onClick={e => e.stopPropagation()}
-                          onChange={e => {
-                            const val = e.target.value;
-                            setComments(prev => ({ ...prev, [user.userId]: val }));
-                          }}
-                          onBlur={async () => {
-                            if (auth.currentUser) {
-                              const text = comments[user.userId] || '';
-                              const res = await setUserComment(user.userId, text, ownerId);
-                              setLocalComment(user.userId, text, res?.lastAction);
-                            }
-                          }}
-                        />
-                        {(sharedComments[user.userId] || []).map((text, idx) => (
-                          <SharedCommentText key={`${user.userId}-shared-comment-${idx}`}>
-                            {text}
-                          </SharedCommentText>
-                        ))}
-                        {isAdmin && (
-                          <ClickableId
-                            onClick={() => {
-                              saveScrollPosition();
-                              navigate(`/edit/${user.userId}`, { state: user });
-                            }}
-                          >
-                            ID: {user.userId ? user.userId.slice(0, 5) : ''}
-                          </ClickableId>
-                        )}
-                      </CommentBox>
-                    </CardWrapper>
-                  </CardContainer>
-                );
-              })}
-          {loading &&
-            Array.from({ length: 4 }).map((_, idx) => (
-              <MatchingSkeleton key={`skeleton-${idx}`} />
-            ))}
+                <CardContainer key={user.userId}>
+                  <CardWrapper $role={role}>
+                    <SwipeableCard
+                      user={user}
+                      photo={photo}
+                      role={role}
+                      isAgency={isAgency}
+                      nameParts={nameParts}
+                      isAdmin={isAdmin}
+                      favoriteUsers={favoriteUsers}
+                      setFavoriteUsers={setFavoriteUsers}
+                      ownFavoriteUsers={ownFavoriteUsers}
+                      setOwnFavoriteUsers={setOwnFavoriteUsers}
+                      dislikeUsers={dislikeUsers}
+                      setDislikeUsers={setDislikeUsers}
+                      ownDislikeUsers={ownDislikeUsers}
+                      setOwnDislikeUsers={setOwnDislikeUsers}
+                      handleRemove={handleRemove}
+                      togglePublish={togglePublish}
+                      multiDataOwnerId={ownerId}
+                      onNavigate={navigateActiveProfile}
+                      commentValue={comments[user.userId] || ''}
+                      sharedCommentTexts={sharedComments[user.userId] || []}
+                      onCommentChange={val => {
+                        setComments(prev => ({ ...prev, [user.userId]: val }));
+                      }}
+                      onCommentBlur={async () => {
+                        if (auth.currentUser) {
+                          const text = comments[user.userId] || '';
+                          const res = await setUserComment(user.userId, text, ownerId);
+                          setLocalComment(user.userId, text, res?.lastAction);
+                        }
+                      }}
+                      onAdminEdit={() => {
+                        saveScrollPosition();
+                        navigate(`/edit/${user.userId}`, { state: user });
+                      }}
+                    />
+                  </CardWrapper>
+                </CardContainer>
+              );
+            })() : loading ? (
+              <MatchingSkeleton />
+            ) : (
+              <OwnerStatusMessage>Немає доступних профілів</OwnerStatusMessage>
+            )}
           </Grid>
 
           {(viewMode === 'default' || viewMode === 'favorites' || viewMode === 'dislikes') && (

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -49,11 +49,14 @@ export const InnerContainer = styled.div`
 
 export const Grid = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  flex-wrap: nowrap;
+  gap: 0;
   padding: 0 10px;
   margin-bottom: 8px;
   justify-content: center;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
 `;
 
 export const LoadMoreFooter = styled.div`
@@ -67,6 +70,7 @@ export const LoadMoreFooter = styled.div`
 export const CardContainer = styled.div`
   position: relative;
   width: 100%;
+  max-width: 100%;
 `;
 
 export const NextPhoto = styled.img`
@@ -121,6 +125,7 @@ export const ThirdInfoCard = styled(NextInfoCard)`
 export const CardWrapper = styled.div`
   position: relative;
   width: 100%;
+  max-width: 100%;
   border: 1px solid ${props => props.$role ? getRoleColors(props.$role).border : 'rgba(214, 193, 163, 0.35)'};
   border-top: 3px solid ${props => props.$role ? getRoleColors(props.$role).accent : color.accent5};
   border-radius: ${STACK_CARD_RADIUS};
@@ -719,6 +724,19 @@ const slideRight = keyframes`
 `;
 
 export const AnimatedCard = styled(Card)`
+  ${({ $activeProfile }) => $activeProfile && `
+    height: min(760px, calc(100dvh - 112px));
+    min-height: 480px;
+    aspect-ratio: auto;
+    padding-bottom: 0;
+    background: transparent;
+    box-shadow: none;
+    border: none;
+
+    &::after {
+      display: none;
+    }
+  `}
   ${({ $backgroundImage }) =>
     $backgroundImage
       ? `background-image: url(${$backgroundImage}); background-color: transparent;`
@@ -734,4 +752,249 @@ export const AnimatedCard = styled(Card)`
 export const OwnerStatusMessage = styled.p`
   text-align: center;
   padding: 0 10px;
+`;
+
+export const ModernProfileShell = styled.div`
+  position: relative;
+  height: 100%;
+  background: #15120f;
+  color: #fff;
+  border-radius: ${STACK_CARD_RADIUS};
+  overflow: hidden;
+  touch-action: pan-y;
+`;
+
+export const ModernProfileScroll = styled.div`
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+`;
+
+export const ModernHero = styled.div`
+  position: relative;
+  min-height: min(430px, 62dvh);
+  background:
+    ${({ $image }) => $image ? `linear-gradient(180deg, rgba(13, 10, 8, 0.05) 0%, rgba(13, 10, 8, 0.18) 45%, rgba(13, 10, 8, 0.9) 100%), url(${$image})` : 'radial-gradient(circle at 22% 18%, rgba(247, 147, 30, 0.44), transparent 32%), linear-gradient(145deg, #2a211b 0%, #111015 58%, #060507 100%)'};
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  align-items: flex-end;
+  padding: 22px 18px 88px;
+  box-sizing: border-box;
+`;
+
+export const ModernHeroFallbackMark = styled.div`
+  position: absolute;
+  inset: 72px 0 auto;
+  margin: auto;
+  width: 104px;
+  height: 104px;
+  border-radius: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 38px;
+  font-weight: 900;
+  letter-spacing: 1px;
+  background: rgba(255, 255, 255, 0.11);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(12px);
+`;
+
+export const ModernHeroContent = styled.div`
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.55);
+`;
+
+export const ModernRoleBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-bottom: 10px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  color: #fff;
+  background: ${({ $role }) => getRoleColors($role).accent};
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+`;
+
+export const ModernHeroTitle = styled.h2`
+  margin: 0;
+  color: #fff;
+  font-size: clamp(30px, 8vw, 42px);
+  line-height: 0.98;
+  font-weight: 900;
+`;
+
+export const ModernHeroLocation = styled.p`
+  margin: 8px 0 0;
+  color: rgba(255, 255, 255, 0.84);
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+export const ModernHeroFacts = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 14px;
+`;
+
+export const ModernFactPill = styled.span`
+  display: inline-flex;
+  gap: 5px;
+  align-items: baseline;
+  max-width: 100%;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(10px);
+  font-size: 12px;
+  line-height: 1.1;
+
+  strong {
+    color: rgba(255, 255, 255, 0.64);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+  }
+`;
+
+export const ModernProfileBody = styled.div`
+  position: relative;
+  z-index: 3;
+  margin-top: -46px;
+  padding: 0 12px 92px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const ModernSection = styled.section`
+  background: rgba(255, 253, 248, 0.97);
+  color: #242127;
+  border-radius: 20px;
+  padding: 14px;
+  box-shadow: 0 16px 40px rgba(10, 8, 6, 0.17);
+`;
+
+export const ModernSectionTitle = styled.h3`
+  margin: 0 0 10px;
+  color: #211d19;
+  font-size: 14px;
+  font-weight: 900;
+  letter-spacing: 0.2px;
+`;
+
+export const ModernChipGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+export const ModernChip = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 100%;
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: ${({ $role }) => getRoleColors($role).light};
+  border: 1px solid ${({ $role }) => getRoleColors($role).border};
+  color: #25222a;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1.15;
+
+  strong {
+    color: ${({ $role }) => getRoleColors($role).text};
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.55px;
+  }
+`;
+
+export const ModernBioText = styled.p`
+  margin: 0;
+  color: #3d3a42;
+  white-space: pre-line;
+  font-size: 14px;
+  line-height: 1.48;
+`;
+
+export const ModernMoreButton = styled.button`
+  margin: 8px 0 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: ${color.accent5};
+  font-weight: 900;
+  cursor: pointer;
+`;
+
+export const ModernGallery = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+`;
+
+export const ModernGalleryImage = styled.img`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 14px;
+  background: #2a251f;
+`;
+
+export const ModernActionRail = styled.div`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 14px;
+  z-index: 8;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 18px;
+  pointer-events: none;
+
+  & > span {
+    pointer-events: auto;
+  }
+
+  button {
+    position: static !important;
+    width: 52px !important;
+    height: 52px !important;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28) !important;
+  }
+`;
+
+export const ModernSwipeHint = styled.div`
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: rgba(255,255,255,0.82);
+  background: rgba(0,0,0,0.2);
+  border: 1px solid rgba(255,255,255,0.12);
+  font-size: 11px;
+  font-weight: 800;
+  backdrop-filter: blur(8px);
 `;

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -1,0 +1,215 @@
+import { getCurrentValue } from './getCurrentValue';
+import { utilCalculateAge } from './smallCard/utilCalculateAge';
+import { normalizeCountry, normalizeRegion } from './normalizeLocation';
+import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
+
+const EMPTY_VALUES = new Set(['', '-', '—', 'n/a', 'na', 'null', 'undefined', 'none', 'немає', 'нет']);
+
+export const normalizeDisplayValue = value => {
+  const current = getCurrentValue(value);
+  if (Array.isArray(current)) {
+    return current.map(normalizeDisplayValue).filter(Boolean).join(', ');
+  }
+  if (current && typeof current === 'object') {
+    return Object.values(current).map(normalizeDisplayValue).filter(Boolean).join(', ');
+  }
+  if (current === null || current === undefined) return '';
+  const normalized = String(current).trim();
+  if (!normalized || EMPTY_VALUES.has(normalized.toLowerCase())) return '';
+  return normalized;
+};
+
+export const shouldRenderField = value => Boolean(normalizeDisplayValue(value));
+
+export const getProfileRole = user => {
+  const role = normalizeDisplayValue(user?.userRole || user?.role).toLowerCase();
+  if (role === 'ed') return 'ed';
+  if (role === 'ag') return 'ag';
+  if (role === 'ip') return 'ip';
+  if (user?.__sourceCollection === 'newUsers' && !role) return 'ed';
+  return role || 'other';
+};
+
+export const getRoleLabel = role => {
+  if (role === 'ed') return 'Egg donor';
+  if (role === 'ag') return 'Agency';
+  if (role === 'ip') return 'Intended parents';
+  if (role === 'sm') return 'Surrogate mother';
+  if (role === 'cl') return 'Client';
+  return 'Profile';
+};
+
+export const getProfileName = user => {
+  const agencyName = normalizeDisplayValue(user?.agencyName || user?.companyName || user?.agency);
+  const name = [user?.name, user?.surname]
+    .map(normalizeDisplayValue)
+    .filter(Boolean)
+    .join(' ');
+  return agencyName || name || getRoleLabel(getProfileRole(user));
+};
+
+export const getProfileAge = user => {
+  if (!user?.birth) return '';
+  const age = utilCalculateAge(user.birth);
+  return age ? String(age) : '';
+};
+
+export const getProfileLocation = user => {
+  const country = normalizeCountry(normalizeDisplayValue(user?.country));
+  const region = normalizeRegion(normalizeDisplayValue(user?.region));
+  const city = normalizeDisplayValue(user?.city);
+  return [country, city || region].filter(Boolean).join(', ') || region || city;
+};
+
+export const getProfilePhotos = user => {
+  const rawPhotos = Array.isArray(user?.photos) ? user.photos : [user?.photos, user?.photo, user?.avatar];
+  return [...new Set(rawPhotos.map(normalizeDisplayValue).filter(Boolean).map(convertDriveLinkToImage))];
+};
+
+const field = (key, label, valueGetter, sourceKeys) => ({
+  key,
+  label,
+  valueGetter,
+  sourceKeys: sourceKeys || [key],
+});
+const valueFor = (user, item) => normalizeDisplayValue(item.valueGetter ? item.valueGetter(user) : user?.[item.key]);
+const isExcluded = (item, excludeKeys = []) => {
+  const excluded = new Set(excludeKeys || []);
+  return [item.key, ...(item.sourceKeys || [])].some(key => excluded.has(key));
+};
+const toDisplayFields = (items, user, excludeKeys = []) =>
+  items
+    .filter(item => !isExcluded(item, excludeKeys))
+    .map(item => ({ ...item, value: valueFor(user, item) }))
+    .filter(item => shouldRenderField(item.value));
+
+const bmiValue = user => {
+  const explicit = normalizeDisplayValue(user?.bmi);
+  if (explicit) return explicit;
+  const weight = Number(normalizeDisplayValue(user?.weight));
+  const height = Number(normalizeDisplayValue(user?.height));
+  if (!weight || !height) return '';
+  return String(Math.round((weight / (height * height)) * 10000));
+};
+
+const ownKidsValue = user => {
+  const raw = normalizeDisplayValue(user?.ownKids);
+  const compact = raw.toLowerCase();
+  if (!raw) return '';
+  if (['0', 'no', 'ні', 'нет'].includes(compact)) return 'No';
+  if (/^[1-9]/.test(compact) || ['yes', 'так', 'да'].includes(compact)) return 'Yes';
+  return raw;
+};
+
+const donorExperienceValue = user => {
+  const exp = normalizeDisplayValue(user?.experience || user?.donationExperience || user?.previousDonation);
+  const count = normalizeDisplayValue(user?.donationCount || user?.donationsCount);
+  if (exp && count) return `${exp} · ${count}`;
+  return exp || count;
+};
+
+const heroFields = {
+  ed: [
+    field('height', 'Height'),
+    field('weight', 'Weight'),
+    field('bmi', 'BMI', bmiValue, ['bmi']),
+    field('blood', 'Blood/Rh'),
+    field('eyeColor', 'Eyes'),
+    field('experience', 'Experience', donorExperienceValue, ['experience', 'donationExperience', 'previousDonation', 'donationCount', 'donationsCount']),
+  ],
+  ip: [
+    field('country', 'Country'),
+    field('city', 'City'),
+    field('maritalStatus', 'Family'),
+    field('programInterest', 'Program'),
+    field('lookingFor', 'Looking for'),
+  ],
+  ag: [
+    field('country', 'Country'),
+    field('city', 'City'),
+    field('services', 'Services'),
+    field('profession', 'Specialization'),
+  ],
+  other: [field('country', 'Country'), field('city', 'City'), field('role', 'Role')],
+};
+
+const quickFacts = {
+  ed: [
+    ...heroFields.ed,
+    field('rh', 'RH'),
+  ],
+  ip: [
+    field('country', 'Country'),
+    field('city', 'City'),
+    field('maritalStatus', 'Family status'),
+    field('programInterest', 'Program interest'),
+    field('budget', 'Budget'),
+  ],
+  ag: [
+    field('country', 'Country'),
+    field('city', 'City'),
+    field('services', 'Services'),
+    field('profession', 'Specialization'),
+  ],
+  other: [field('country', 'Country'), field('city', 'City'), field('profession', 'Profession')],
+};
+
+const sectionConfig = {
+  ed: [
+    { title: 'Appearance', fields: [
+      field('eyeColor', 'Eyes'), field('hairColor', 'Hair color'), field('hairStructure', 'Hair structure'),
+      field('faceShape', 'Face shape'), field('noseShape', 'Nose'), field('lipsShape', 'Lips'),
+      field('chin', 'Chin'), field('bodyType', 'Body type'), field('breastSize', 'Breast size'),
+      field('race', 'Race'), field('glasses', 'Glasses'),
+    ] },
+    { title: 'Main information', fields: [
+      field('education', 'Education'), field('profession', 'Profession'), field('maritalStatus', 'Marital status'),
+      field('ownKids', 'Own kids', ownKidsValue), field('clothingSize', 'Clothing'), field('shoeSize', 'Shoe'),
+    ] },
+    { title: 'Donation experience', fields: [
+      field('experience', 'Previous donation'), field('donationCount', 'Donation count'), field('donationsCount', 'Donations'),
+      field('cSection', 'C-section', user => user?.cSection || user?.csection || user?.c_section || user?.cesareanSection, ['cSection', 'csection', 'c_section', 'cesareanSection']),
+      field('reward', 'Expected reward'),
+    ] },
+  ],
+  ip: [
+    { title: 'Main information', fields: [
+      field('country', 'Country'), field('city', 'City'), field('region', 'Region'), field('maritalStatus', 'Family status'),
+      field('programInterest', 'Program interest'), field('lookingFor', 'Looking for'), field('budget', 'Budget'),
+    ] },
+  ],
+  ag: [
+    { title: 'Agency details', fields: [
+      field('agencyName', 'Agency name'), field('country', 'Country'), field('city', 'City'), field('services', 'Services'),
+      field('profession', 'Specialization'),
+    ] },
+  ],
+  other: [
+    { title: 'Main information', fields: [field('country', 'Country'), field('city', 'City'), field('profession', 'Profession'), field('education', 'Education')] },
+  ],
+};
+
+export const getHeroFields = (user, role = getProfileRole(user), { excludeKeys = [] } = {}) =>
+  toDisplayFields(heroFields[role] || heroFields.other, user, excludeKeys).slice(0, 6);
+
+export const getQuickFacts = (user, role = getProfileRole(user), { excludeKeys = [] } = {}) =>
+  toDisplayFields(quickFacts[role] || quickFacts.other, user, excludeKeys).slice(0, 8);
+
+const contactFields = [
+  field('phone', 'Phone'), field('telegram', 'Telegram'), field('whatsapp', 'WhatsApp'), field('email', 'Email'),
+  field('vk', 'VK'), field('instagram', 'Instagram'), field('website', 'Website'),
+];
+
+export const getProfileSections = (user, role = getProfileRole(user), { excludeKeys = [] } = {}) => {
+  const sections = (sectionConfig[role] || sectionConfig.other).map(section => ({
+    ...section,
+    fields: toDisplayFields(section.fields, user, excludeKeys),
+  })).filter(section => section.fields.length > 0);
+
+  const contacts = toDisplayFields(contactFields, user, excludeKeys);
+  if (contacts.length > 0) sections.push({ title: 'Contacts', fields: contacts, variant: 'contacts' });
+  return sections;
+};
+
+export const getProfileBio = user =>
+  normalizeDisplayValue(user?.moreInfo_main || user?.comment || user?.description || user?.about || user?.bio);

--- a/src/components/profileLayoutConfig.test.js
+++ b/src/components/profileLayoutConfig.test.js
@@ -1,0 +1,95 @@
+import {
+  getHeroFields,
+  getProfilePhotos,
+  getProfileRole,
+  getProfileSections,
+  getQuickFacts,
+  shouldRenderField,
+} from './profileLayoutConfig';
+
+jest.mock('./smallCard/utilCalculateAge', () => ({ utilCalculateAge: () => 29 }));
+jest.mock('./normalizeLocation', () => ({
+  normalizeCountry: value => value,
+  normalizeRegion: value => value,
+}));
+jest.mock('../utils/convertDriveLinkToImage', () => ({ convertDriveLinkToImage: value => value }));
+
+const collectKeys = fields => [...new Set(fields.flatMap(field => [field.key, ...(field.sourceKeys || [])]))];
+const sectionFieldKeys = sections => sections.flatMap(section => section.fields.map(field => field.key));
+
+describe('profileLayoutConfig', () => {
+  it('builds egg donor photo, hero facts, and donor groups while hiding empty fields', () => {
+    const user = {
+      userRole: 'ed',
+      photos: ['hero.jpg', 'gallery.jpg'],
+      height: 170,
+      weight: 60,
+      blood: 'O+',
+      eyeColor: 'Green',
+      hairColor: '-',
+      breastSize: 'B',
+      ownKids: '0',
+      education: 'University',
+      experience: 'Yes',
+      cSection: 'No',
+      emptyValue: '-',
+    };
+
+    const hero = getHeroFields(user, 'ed');
+    const quickFacts = getQuickFacts(user, 'ed', { excludeKeys: collectKeys(hero) });
+    const sections = getProfileSections(user, 'ed', { excludeKeys: collectKeys([...hero, ...quickFacts]) });
+    const detailKeys = sectionFieldKeys(sections);
+
+    expect(getProfileRole(user)).toBe('ed');
+    expect(getProfilePhotos(user)).toEqual(['hero.jpg', 'gallery.jpg']);
+    expect(hero.map(field => field.key)).toEqual(['height', 'weight', 'bmi', 'blood', 'eyeColor', 'experience']);
+    expect(quickFacts.map(field => field.key)).toEqual([]);
+    expect(sections.map(section => section.title)).toEqual(expect.arrayContaining(['Appearance', 'Main information', 'Donation experience']));
+    expect(detailKeys).toEqual(expect.arrayContaining(['breastSize', 'ownKids', 'education', 'cSection']));
+    expect(detailKeys).not.toEqual(expect.arrayContaining(hero.map(field => field.key)));
+    expect(shouldRenderField(user.emptyValue)).toBe(false);
+  });
+
+  it('keeps intended parents layout free of donor-only physical facts when absent', () => {
+    const user = {
+      userRole: 'ip',
+      country: 'Ukraine',
+      city: 'Kyiv',
+      maritalStatus: 'Married',
+      programInterest: 'Egg donation',
+      height: '',
+      weight: '',
+    };
+
+    const hero = getHeroFields(user, 'ip');
+    const quickFactKeys = getQuickFacts(user, 'ip', { excludeKeys: collectKeys(hero) }).map(field => field.key);
+    const detailKeys = sectionFieldKeys(getProfileSections(user, 'ip', { excludeKeys: collectKeys(hero) }));
+    expect(quickFactKeys).toEqual([]);
+    expect([...quickFactKeys, ...detailKeys]).not.toEqual(expect.arrayContaining(['height', 'weight', 'bmi', 'breastSize']));
+  });
+
+  it('prioritizes agency-specific sections and keeps contacts in the Contacts section only', () => {
+    const user = {
+      role: 'ag',
+      agencyName: 'Bright Future',
+      country: 'USA',
+      city: 'Austin',
+      services: 'Donor matching',
+      website: 'https://example.com',
+      telegram: '@agency',
+      photos: [],
+    };
+
+    const hero = getHeroFields(user, 'ag');
+    const quickFacts = getQuickFacts(user, 'ag', { excludeKeys: collectKeys(hero) });
+    const sections = getProfileSections(user, 'ag', { excludeKeys: collectKeys([...hero, ...quickFacts]) });
+    const agencyDetails = sections.find(section => section.title === 'Agency details');
+    const contacts = sections.find(section => section.title === 'Contacts');
+
+    expect(getProfileRole(user)).toBe('ag');
+    expect(getProfilePhotos(user)).toEqual([]);
+    expect(hero.map(field => field.key)).toEqual(['country', 'city', 'services']);
+    expect(agencyDetails.fields.map(field => field.key)).toEqual(['agencyName']);
+    expect(contacts.fields.map(field => field.key)).toEqual(['telegram', 'website']);
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the legacy multi-slide card UI with a modern single-profile layout to improve readability and mobile touch navigation.
- Centralize profile field/photo/label normalization and presentation logic to make the UI code simpler and easier to test.
- Simplify load-more and swipe behavior so loading triggers when the active profile approaches the end of the list.

### Description
- Introduces `profileLayoutConfig.js` which centralizes profile normalization and presentation helpers (`getProfileName`, `getProfilePhotos`, `getHeroFields`, `getQuickFacts`, `getProfileSections`, `getProfileRole`, `getProfileBio`, etc.).
- Reworks `Matching.jsx` to use a modern profile presentation: replaces slide/info variants with `ModernHero`, `ModernProfileBody`, `ProfileChips`, `ProfileBio`, a gallery and an action rail, and moves comment handling into the card component.
- Adds single-card navigation state (`activeProfileIndex`) with `navigateActiveProfile` and new touch/swipe handlers that call `onNavigate` to jump profiles; updates load-more logic to request more when the active index is near the list end.
- Extends `Matching.styled.jsx` with many new styled components and styles for the modern layout (`ModernHero`, `ModernChip`, `ModernSection`, `ModernActionRail`, etc.) and adjusts layout CSS (no wrap grid, overflow handling, sizing).
- Removes old ad-hoc field rendering and slide logic, replaces multiple imports with the new config utilities, and adapts favorites/dislikes/comment flows to the new structure.
- Adds unit tests `profileLayoutConfig.test.js` that validate role detection, hero/quick facts/sections composition, photo extraction, and hiding of empty values.

### Testing
- Ran the new Jest unit tests for `profileLayoutConfig.test.js` (3 specs) and they passed.
- Ran the project test runner for the changed component area and verified the added unit tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e48915188326ad401976588f97da)