### PR TITLE
Fix reaction-card photo hydration and access-scoped reaction pagination

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -59,6 +59,7 @@ import {
 import {
   fetchUsersByLastLogin2,
   fetchUserById,
+  getAllUserPhotos,
   fetchFavoriteUsers,
   fetchDislikeUsers,
   filterMain,
@@ -426,11 +427,15 @@ const fetchNewUsersByIdsForMatching = async (ids, batchSize = FETCH_USERS_BY_IDS
     const chunkIds = uniqueIds.slice(offset, offset + safeBatchSize);
     const chunkSnapshots = await Promise.all(
       chunkIds.map(async userId => {
-        const snapshot = await get(refDb(database, `newUsers/${userId}`));
+        const [snapshot, photos] = await Promise.all([
+          get(refDb(database, `newUsers/${userId}`)),
+          getAllUserPhotos(userId),
+        ]);
         if (!snapshot.exists()) return null;
         return {
           userId,
           ...(snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {}),
+          photos: Array.isArray(photos) ? photos : [],
           __sourceCollection: 'newUsers',
         };
       })
@@ -2787,7 +2792,15 @@ const Matching = () => {
           ? favoriteUsersRef.current
           : dislikeUsersRef.current;
         const currentPagination = reactionPaginationByType[viewMode] || buildEmptyReactionPagination();
-        const shouldRefreshReactionIds = collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0;
+        const reactionMapIds = Object.keys(reactionMap);
+        const hasAccessScopedNewUserReactionIds = [
+          ...reactionMapIds,
+          ...(currentPagination.ids || []),
+        ].some(isShortId);
+        const shouldRefreshReactionIds = Boolean(
+          parsedAdditionalAccessRules.length > 0 &&
+          (collectionSource === 'newUsers' || hasAccessScopedNewUserReactionIds)
+        );
         const freshProfileCache = shouldRefreshReactionIds
           ? await ensureFreshAdditionalMatchingProfile({
             accessUserId: ownerId,
@@ -2810,7 +2823,7 @@ const Matching = () => {
           currentPagination.accessSnapshotKey !== reactionAccessSnapshotKey
         );
         const reactionIds = shouldRefreshReactionIds || currentPagination.ids.length === 0
-          ? await getAccessibleReactionIds(Object.keys(reactionMap), reactionAccessSnapshot)
+          ? await getAccessibleReactionIds(reactionMapIds, reactionAccessSnapshot)
           : currentPagination.ids;
 
         if (!canApplyLoadMoreResult()) return;
@@ -2834,6 +2847,7 @@ const Matching = () => {
         reactionLoadedIdsRef.current[viewMode] = loadedIds;
         loadedIdsRef.current = new Set(loadedIds);
         setUsers(prev => {
+          if (didAccessSnapshotChange) return page.users;
           const map = new Map(prev.map(user => [user.userId, user]));
           page.users.forEach(user => map.set(user.userId, user));
           return Array.from(map.values());

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -19,6 +19,26 @@ describe('Matching shared reaction card UI', () => {
     expect(source).not.toContain('const usersMap = await fetchUsersByIds(page.pageIds);');
   });
 
+
+  it('hydrates uncached reaction cards with photos from both backing collections', () => {
+    const matchingSource = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+    const configSource = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+
+    expect(matchingSource).toContain('getAllUserPhotos(userId)');
+    expect(matchingSource).toContain('photos: Array.isArray(photos) ? photos : []');
+    expect(configSource).toContain('getAllUserPhotos(id)');
+    expect(configSource).toContain('photos: Array.isArray(photos) ? photos : []');
+  });
+
+  it('refreshes mixed users/newUsers reaction pagination when access scope changes in users mode', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('const hasAccessScopedNewUserReactionIds = [');
+    expect(source).toContain("(collectionSource === 'newUsers' || hasAccessScopedNewUserReactionIds)");
+    expect(source).toContain('currentPagination.accessSnapshotKey !== reactionAccessSnapshotKey');
+    expect(source).toContain('if (didAccessSnapshotChange) return page.users;');
+  });
+
   it('guards stale default shared-candidate requests while allowing reaction tabs across collections', () => {
     const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1502,7 +1502,8 @@ export const fetchUsersByIds = async ids => {
         Promise.all([
           get(ref2(database, `newUsers/${id}`)),
           get(ref2(database, `users/${id}`)),
-        ]).then(([newSnap, userSnap]) => {
+          getAllUserPhotos(id),
+        ]).then(([newSnap, userSnap, photos]) => {
           const hasNewUser = newSnap.exists();
           const hasUser = userSnap.exists();
           if (!hasNewUser && !hasUser) return null;
@@ -1511,6 +1512,7 @@ export const fetchUsersByIds = async ids => {
             userId: id,
             ...(hasUser ? userSnap.val() : {}),
             ...(hasNewUser ? newSnap.val() : {}),
+            photos: Array.isArray(photos) ? photos : [],
             __sourceCollection: hasNewUser ? 'newUsers' : 'users',
           };
           return [id, data];


### PR DESCRIPTION
### Motivation
- Reaction cards loaded from uncached `/newUsers` or `/users` could miss profile photos because matching-specific and general fetch helpers did not attach storage `photos` consistently. 
- Reaction pagination in users-mode could keep showing access-scoped `/newUsers` IDs after the viewer's additional-access/searchKeySets scope changed, leading to stale/inaccessible cards being shown.

### Description
- Hydrated photos for `/users` records by adding `getAllUserPhotos(id)` and attaching `photos` in `fetchUsersByIds` in `src/components/config.js` so uncached `/users` reaction cards include storage photos. 
- Hydrated photos for `/newUsers` matching fetches by importing `getAllUserPhotos` and attaching `photos` inside `fetchNewUsersByIdsForMatching` in `src/components/Matching.jsx` so uncached `/newUsers` reaction cards include storage photos. 
- Updated reaction load-more logic in `src/components/Matching.jsx` to detect when the reaction set contains mixed `/users` and access-scoped `/newUsers` IDs and to recompute/filter `newUsers` IDs whenever access snapshot/searchKeySets/rawRules may have changed, including when `collectionSource` is `users`. 
- When an access-snapshot change invalidates previously-visible reaction IDs, the visible user list is replaced with the refreshed page results to avoid retaining stale inaccessible cards. 
- Added regression tests to `src/components/Matching.sharedReactions.test.js` that assert hydration of photos and that mixed users/`newUsers` reaction pagination refreshes on access-scope changes.

### Testing
- Ran `npm test -- --watchAll=false Matching.sharedReactions.test.js` and the suite passed (new tests included). 
- Ran `npm test -- --watchAll=false src/utils/__tests__/reactionPriority.test.js` and the suite passed. 
- Ran `npm run lint:js` and `npm run build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f4709dd483268e5b4a64d09287e0)