### PR TITLE
Finalize Matching redesign: single-profile luxury UX, photo hydration & reaction access fixes

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -23,8 +23,6 @@ import {
   Grid,
   HeaderContainer,
   InnerContainer,
-  LoadMoreButton,
-  LoadMoreFooter,
   OwnerStatusMessage,
   SharedCommentText,
   SkeletonCardInner,
@@ -66,6 +64,7 @@ import {
   fetchUserComments,
   setUserComment,
   fetchUsersByIds,
+  getAllUserPhotos,
   database,
   auth,
   updateDataInNewUsersRTDB,
@@ -414,6 +413,18 @@ async function resolveAdditionalSearchKeySetKeysForMatching(profile, accessUserI
   return searchKeySetKeys;
 }
 
+const hasHydratedProfilePhotos = user => Array.isArray(user?.photos) && user.photos.some(Boolean);
+
+const hydrateMatchingProfilePhotos = async (userId, data = {}) => {
+  if (hasHydratedProfilePhotos(data)) return data;
+  const photos = await getAllUserPhotos(userId);
+  return {
+    ...data,
+    photos,
+    __photosHydrated: true,
+  };
+};
+
 const fetchNewUsersByIdsForMatching = async (ids, batchSize = FETCH_USERS_BY_IDS_BATCH_SIZE) => {
   if (!Array.isArray(ids) || ids.length === 0) return [];
 
@@ -428,9 +439,11 @@ const fetchNewUsersByIdsForMatching = async (ids, batchSize = FETCH_USERS_BY_IDS
       chunkIds.map(async userId => {
         const snapshot = await get(refDb(database, `newUsers/${userId}`));
         if (!snapshot.exists()) return null;
+        const rawData = snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {};
+        const hydratedData = await hydrateMatchingProfilePhotos(userId, rawData);
         return {
           userId,
-          ...(snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {}),
+          ...hydratedData,
           __sourceCollection: 'newUsers',
         };
       })
@@ -893,6 +906,7 @@ const SwipeableCard = ({
   const favoriteButtonWrapRef = useRef(null);
   const dislikeButtonWrapRef = useRef(null);
   const touchStart = useRef(null);
+  const swipeAxisRef = useRef(null);
   const swipedRef = useRef(false);
 
   useEffect(() => {
@@ -926,6 +940,7 @@ const SwipeableCard = ({
     if (!e.touches || e.touches.length !== 1) return;
     const touch = e.touches[0];
     touchStart.current = { x: touch.clientX, y: touch.clientY };
+    swipeAxisRef.current = null;
   };
 
   const handleTouchMove = e => {
@@ -933,7 +948,12 @@ const SwipeableCard = ({
     const touch = e.touches[0];
     const dx = touch.clientX - touchStart.current.x;
     const dy = touch.clientY - touchStart.current.y;
-    if (Math.abs(dx) > 16 && Math.abs(dx) > Math.abs(dy) * 1.25) e.preventDefault();
+    const absX = Math.abs(dx);
+    const absY = Math.abs(dy);
+    if (!swipeAxisRef.current && (absX > 10 || absY > 10)) {
+      swipeAxisRef.current = absX > absY * 1.35 ? 'x' : 'y';
+    }
+    if (swipeAxisRef.current === 'x') e.preventDefault();
   };
 
   const handleTouchEnd = e => {
@@ -942,7 +962,9 @@ const SwipeableCard = ({
     const dx = touch.clientX - touchStart.current.x;
     const dy = touch.clientY - touchStart.current.y;
     touchStart.current = null;
-    if (Math.abs(dx) < 72 || Math.abs(dx) < Math.abs(dy) * 1.35) return;
+    const axis = swipeAxisRef.current;
+    swipeAxisRef.current = null;
+    if (axis === 'y' || Math.abs(dx) < 72 || Math.abs(dx) < Math.abs(dy) * 1.35) return;
     const direction = dx > 0 ? 'right' : 'left';
     swipedRef.current = true;
     setDir(direction);
@@ -2445,7 +2467,7 @@ const Matching = () => {
     uniqueIds.forEach(id => {
       const cached = getCard(id);
       const cachedPhotos = Array.isArray(cached?.photos) ? cached.photos : [];
-      const canUseCachedCard = cached && cachedPhotos.length > 0 && (
+      const canUseCachedCard = cached && (cachedPhotos.length > 0 || cached.__photosHydrated === true) && (
         cached.__sourceCollection ||
         cached.publish === true ||
         !isShortId(id)
@@ -2787,7 +2809,9 @@ const Matching = () => {
           ? favoriteUsersRef.current
           : dislikeUsersRef.current;
         const currentPagination = reactionPaginationByType[viewMode] || buildEmptyReactionPagination();
-        const shouldRefreshReactionIds = collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0;
+        const fullReactionIds = Object.keys(reactionMap);
+        const hasAccessScopedNewUserReactionIds = [...fullReactionIds, ...(currentPagination.ids || [])].some(isShortId);
+        const shouldRefreshReactionIds = parsedAdditionalAccessRules.length > 0 && hasAccessScopedNewUserReactionIds;
         const freshProfileCache = shouldRefreshReactionIds
           ? await ensureFreshAdditionalMatchingProfile({
             accessUserId: ownerId,
@@ -2810,7 +2834,7 @@ const Matching = () => {
           currentPagination.accessSnapshotKey !== reactionAccessSnapshotKey
         );
         const reactionIds = shouldRefreshReactionIds || currentPagination.ids.length === 0
-          ? await getAccessibleReactionIds(Object.keys(reactionMap), reactionAccessSnapshot)
+          ? await getAccessibleReactionIds(fullReactionIds, reactionAccessSnapshot)
           : currentPagination.ids;
 
         if (!canApplyLoadMoreResult()) return;
@@ -2834,9 +2858,12 @@ const Matching = () => {
         reactionLoadedIdsRef.current[viewMode] = loadedIds;
         loadedIdsRef.current = new Set(loadedIds);
         setUsers(prev => {
-          const map = new Map(prev.map(user => [user.userId, user]));
+          const scopedPrev = didAccessSnapshotChange
+            ? prev.filter(user => reactionIds.includes(user.userId))
+            : prev;
+          const map = new Map(scopedPrev.map(user => [user.userId, user]));
           page.users.forEach(user => map.set(user.userId, user));
-          return Array.from(map.values());
+          return Array.from(map.values()).filter(user => reactionIds.includes(user.userId));
         });
         await loadCommentsFor(page.users);
         setReactionPaginationByType(prev => ({
@@ -3384,18 +3411,6 @@ const Matching = () => {
               <OwnerStatusMessage>Немає доступних профілів</OwnerStatusMessage>
             )}
           </Grid>
-
-          {(viewMode === 'default' || viewMode === 'favorites' || viewMode === 'dislikes') && (
-            <LoadMoreFooter>
-              <LoadMoreButton onClick={loadMore} disabled={loading || !hasMore}>
-                {loading
-                  ? 'Завантаження...'
-                  : hasMore
-                    ? 'Дозавантажити карточки'
-                    : 'Більше карточок завтра'}
-              </LoadMoreButton>
-            </LoadMoreFooter>
-          )}
 
           {showInfoModal && (
             <InfoModal onClose={() => setShowInfoModal(false)} text="dotsMenu" Context={dotsMenu} />

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -2,6 +2,16 @@ import fs from 'fs';
 import path from 'path';
 
 describe('Matching shared reaction card UI', () => {
+  it('renders a single active luxury profile without load-more controls', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('const activeProfile = filteredUsers[activeProfileIndex] || null;');
+    expect(source).toContain('data-testid="matching-profile-card"');
+    expect(source).not.toContain('Дозавантажити карточки');
+    expect(source).not.toContain('Більше карточок завтра');
+    expect(source).not.toContain('<LoadMoreButton');
+  });
+
   it('does not render overlay text for shared liked or disliked cards', () => {
     const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
 
@@ -17,6 +27,27 @@ describe('Matching shared reaction card UI', () => {
     expect(source).toContain('missingUserIds.length ? fetchUsersByIds(missingUserIds)');
     expect(source).toContain('missingNewUserIds.length ? fetchNewUsersByIdsForMatching(missingNewUserIds)');
     expect(source).not.toContain('const usersMap = await fetchUsersByIds(page.pageIds);');
+  });
+
+
+  it('hydrates uncached reaction cards with storage photos before caching', () => {
+    const matchingSource = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+    const configSource = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+
+    expect(matchingSource).toContain('const hydrateMatchingProfilePhotos = async (userId, data = {}) =>');
+    expect(matchingSource).toContain('const hydratedData = await hydrateMatchingProfilePhotos(userId, rawData);');
+    expect(matchingSource).toContain("cached.__photosHydrated === true");
+    expect(configSource).toContain('const hasHydratedPhotos = Array.isArray(mergedData.photos) && mergedData.photos.some(Boolean);');
+    expect(configSource).toContain('const photos = hasHydratedPhotos ? mergedData.photos : await getAllUserPhotos(id);');
+    expect(configSource).toContain('__photosHydrated: true');
+  });
+
+  it('refreshes mixed users-mode reaction ids when access-scoped newUsers are present', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+    expect(source).toContain('const hasAccessScopedNewUserReactionIds = [...fullReactionIds, ...(currentPagination.ids || [])].some(isShortId);');
+    expect(source).toContain('const shouldRefreshReactionIds = parsedAdditionalAccessRules.length > 0 && hasAccessScopedNewUserReactionIds;');
+    expect(source).toContain('return Array.from(map.values()).filter(user => reactionIds.includes(user.userId));');
   });
 
   it('guards stale default shared-candidate requests while allowing reaction tabs across collections', () => {

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -24,39 +24,37 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 0;
-  background-color: #f5f5f5;
+  min-height: 100dvh;
+  background:
+    radial-gradient(circle at 50% -10%, rgba(214, 146, 68, 0.2), transparent 34%),
+    linear-gradient(180deg, #1b1510 0%, #0c0b0d 100%);
 `;
 
 export const InnerContainer = styled.div`
   max-width: 480px;
   width: 100%;
-  background-color: #f0f0f0;
+  min-height: 100dvh;
+  background: transparent;
   padding: 0;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
+  box-shadow: none;
+  border-radius: 0;
   box-sizing: border-box;
   position: relative;
-
   display: flex;
   flex-direction: column;
-
-  @media (max-width: 768px) {
-    background-color: #f5f5f5;
-    box-shadow: 0 4px 8px #f5f5f5;
-    border-radius: 0;
-  }
 `;
 
 export const Grid = styled.div`
   display: flex;
   flex-wrap: nowrap;
   gap: 0;
-  padding: 0 10px;
-  margin-bottom: 8px;
+  padding: 0 10px 10px;
   justify-content: center;
   width: 100%;
   box-sizing: border-box;
   overflow: hidden;
+  flex: 1;
+  min-height: 0;
 `;
 
 export const LoadMoreFooter = styled.div`
@@ -126,15 +124,15 @@ export const CardWrapper = styled.div`
   position: relative;
   width: 100%;
   max-width: 100%;
-  border: 1px solid ${props => props.$role ? getRoleColors(props.$role).border : 'rgba(214, 193, 163, 0.35)'};
-  border-top: 3px solid ${props => props.$role ? getRoleColors(props.$role).accent : color.accent5};
-  border-radius: ${STACK_CARD_RADIUS};
+  height: 100%;
+  border: 1px solid rgba(218, 167, 95, 0.28);
+  border-radius: 26px;
   box-sizing: border-box;
   overflow: hidden;
-  background: #fffdfa;
+  background: #15120f;
   box-shadow:
-    0 14px 32px rgba(33, 26, 17, 0.12),
-    0 2px 8px rgba(33, 26, 17, 0.06);
+    0 24px 70px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
   z-index: 2;
 `;
 
@@ -329,14 +327,19 @@ export const HeaderContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px;
+  padding: 10px 12px 8px;
+  color: rgba(255, 247, 232, 0.88);
 `;
 
 export const CardCount = styled.p`
   width: 100%;
   margin: 0;
   text-align: center;
-  color: black;
+  color: rgba(255, 247, 232, 0.86);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
 `;
 
 export const LoadMoreButton = styled.button`
@@ -725,8 +728,8 @@ const slideRight = keyframes`
 
 export const AnimatedCard = styled(Card)`
   ${({ $activeProfile }) => $activeProfile && `
-    height: min(760px, calc(100dvh - 112px));
-    min-height: 480px;
+    height: min(820px, calc(100dvh - 64px));
+    min-height: 540px;
     aspect-ratio: auto;
     padding-bottom: 0;
     background: transparent;
@@ -757,9 +760,11 @@ export const OwnerStatusMessage = styled.p`
 export const ModernProfileShell = styled.div`
   position: relative;
   height: 100%;
-  background: #15120f;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(230, 166, 74, 0.16), transparent 34%),
+    linear-gradient(180deg, #1a1511 0%, #0f0d0e 100%);
   color: #fff;
-  border-radius: ${STACK_CARD_RADIUS};
+  border-radius: 26px;
   overflow: hidden;
   touch-action: pan-y;
 `;
@@ -776,15 +781,24 @@ export const ModernProfileScroll = styled.div`
 
 export const ModernHero = styled.div`
   position: relative;
-  min-height: min(430px, 62dvh);
+  min-height: clamp(330px, 56dvh, 480px);
   background:
-    ${({ $image }) => $image ? `linear-gradient(180deg, rgba(13, 10, 8, 0.05) 0%, rgba(13, 10, 8, 0.18) 45%, rgba(13, 10, 8, 0.9) 100%), url(${$image})` : 'radial-gradient(circle at 22% 18%, rgba(247, 147, 30, 0.44), transparent 32%), linear-gradient(145deg, #2a211b 0%, #111015 58%, #060507 100%)'};
+    ${({ $image }) => $image ? `linear-gradient(180deg, rgba(12, 9, 7, 0.03) 0%, rgba(12, 9, 7, 0.12) 42%, rgba(12, 9, 7, 0.72) 100%), url(${$image})` : 'radial-gradient(circle at 30% 18%, rgba(247, 147, 30, 0.38), transparent 28%), radial-gradient(circle at 82% 12%, rgba(255, 211, 126, 0.16), transparent 24%), linear-gradient(145deg, #3b2c20 0%, #181318 58%, #080708 100%)'};
   background-size: cover;
-  background-position: center;
+  background-position: center 22%;
   display: flex;
   align-items: flex-end;
-  padding: 22px 18px 88px;
+  padding: 24px 18px 96px;
   box-sizing: border-box;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: auto 0 0;
+    height: 46%;
+    background: linear-gradient(180deg, rgba(15, 12, 10, 0) 0%, rgba(15, 12, 10, 0.82) 100%);
+    pointer-events: none;
+  }
 `;
 
 export const ModernHeroFallbackMark = styled.div`
@@ -819,14 +833,14 @@ export const ModernRoleBadge = styled.span`
   align-items: center;
   width: fit-content;
   margin-bottom: 10px;
-  padding: 5px 10px;
+  padding: 5px 11px;
   border-radius: 999px;
-  color: #fff;
-  background: ${({ $role }) => getRoleColors($role).accent};
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-  font-size: 11px;
-  font-weight: 900;
-  letter-spacing: 0.7px;
+  color: #2a1705;
+  background: linear-gradient(135deg, #ffd58a 0%, #f7931e 100%);
+  box-shadow: 0 10px 26px rgba(247, 147, 30, 0.22);
+  font-size: 10px;
+  font-weight: 950;
+  letter-spacing: 0.8px;
   text-transform: uppercase;
 `;
 
@@ -859,81 +873,89 @@ export const ModernFactPill = styled.span`
   max-width: 100%;
   padding: 6px 9px;
   border-radius: 999px;
-  color: #fff;
-  background: rgba(255, 255, 255, 0.14);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  backdrop-filter: blur(10px);
+  color: #fff8ea;
+  background: rgba(22, 18, 14, 0.42);
+  border: 1px solid rgba(255, 213, 138, 0.28);
+  backdrop-filter: blur(12px);
   font-size: 12px;
   line-height: 1.1;
 
   strong {
-    color: rgba(255, 255, 255, 0.64);
-    font-size: 10px;
+    color: #ffd58a;
+    font-size: 9px;
     text-transform: uppercase;
-    letter-spacing: 0.4px;
+    letter-spacing: 0.45px;
   }
 `;
 
 export const ModernProfileBody = styled.div`
   position: relative;
   z-index: 3;
-  margin-top: -46px;
-  padding: 0 12px 92px;
+  margin-top: -58px;
+  padding: 0 12px 96px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 `;
 
 export const ModernSection = styled.section`
-  background: rgba(255, 253, 248, 0.97);
-  color: #242127;
+  background: rgba(31, 27, 23, 0.82);
+  color: #fff4df;
+  border: 1px solid rgba(255, 214, 150, 0.13);
   border-radius: 20px;
-  padding: 14px;
-  box-shadow: 0 16px 40px rgba(10, 8, 6, 0.17);
+  padding: 12px;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
 `;
 
 export const ModernSectionTitle = styled.h3`
-  margin: 0 0 10px;
-  color: #211d19;
-  font-size: 14px;
-  font-weight: 900;
-  letter-spacing: 0.2px;
+  margin: 0 0 8px;
+  color: #ffd58a;
+  font-size: 12px;
+  font-weight: 950;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
 `;
 
 export const ModernChipGrid = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+
+  @media (max-width: 380px) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 export const ModernChip = styled.div`
   display: inline-flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
   max-width: 100%;
-  padding: 8px 10px;
-  border-radius: 14px;
-  background: ${({ $role }) => getRoleColors($role).light};
-  border: 1px solid ${({ $role }) => getRoleColors($role).border};
-  color: #25222a;
-  font-size: 13px;
+  padding: 7px 9px;
+  border-radius: 13px;
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 214, 150, 0.13);
+  color: #fff3dd;
+  font-size: 12px;
   font-weight: 800;
-  line-height: 1.15;
+  line-height: 1.16;
 
   strong {
-    color: ${({ $role }) => getRoleColors($role).text};
-    font-size: 10px;
+    color: #dba55f;
+    font-size: 9px;
     text-transform: uppercase;
-    letter-spacing: 0.55px;
+    letter-spacing: 0.58px;
   }
 `;
 
 export const ModernBioText = styled.p`
   margin: 0;
-  color: #3d3a42;
+  color: rgba(255, 244, 223, 0.88);
   white-space: pre-line;
   font-size: 14px;
-  line-height: 1.48;
+  line-height: 1.44;
 `;
 
 export const ModernMoreButton = styled.button`
@@ -964,12 +986,26 @@ export const ModernActionRail = styled.div`
   position: absolute;
   left: 0;
   right: 0;
-  bottom: 14px;
+  bottom: 16px;
   z-index: 8;
   display: flex;
   justify-content: space-between;
-  padding: 0 18px;
+  padding: 0 22px;
   pointer-events: none;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: -9px;
+    width: min(250px, 62%);
+    height: 76px;
+    transform: translateX(-50%);
+    border-radius: 999px;
+    background: rgba(9, 8, 7, 0.44);
+    filter: blur(18px);
+    z-index: -1;
+  }
 
   & > span {
     pointer-events: auto;
@@ -977,9 +1013,10 @@ export const ModernActionRail = styled.div`
 
   button {
     position: static !important;
-    width: 52px !important;
-    height: 52px !important;
-    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28) !important;
+    width: 58px !important;
+    height: 58px !important;
+    border: 1px solid rgba(255, 255, 255, 0.18) !important;
+    box-shadow: 0 16px 34px rgba(0, 0, 0, 0.34) !important;
   }
 `;
 

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -12,6 +12,8 @@ describe('fetchUsersByIds merging', () => {
     expect(fetchUsersByIdsBody.indexOf('...(hasUser ? userSnap.val() : {})'))
       .toBeLessThan(fetchUsersByIdsBody.indexOf('...(hasNewUser ? newSnap.val() : {})'));
     expect(fetchUsersByIdsBody).toContain("__sourceCollection: hasNewUser ? 'newUsers' : 'users'");
+    expect(fetchUsersByIdsBody).toContain('const photos = hasHydratedPhotos ? mergedData.photos : await getAllUserPhotos(id);');
+    expect(fetchUsersByIdsBody).toContain('__photosHydrated: true');
   });
 
   it('marks fetchUserById records with their backing collection', () => {
@@ -24,7 +26,7 @@ describe('fetchUsersByIds merging', () => {
   it('strips client-only source markers before database writes', () => {
     const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
 
-    expect(source).toContain("const transientUserDataKeys = ['__sourceCollection']");
+    expect(source).toContain("const transientUserDataKeys = ['__sourceCollection', '__photosHydrated']");
     expect(source).toContain('const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo);');
     expect(source.match(/markForRealtimeDeletion: condition === 'update'/g)).toHaveLength(2);
   });

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1502,18 +1502,20 @@ export const fetchUsersByIds = async ids => {
         Promise.all([
           get(ref2(database, `newUsers/${id}`)),
           get(ref2(database, `users/${id}`)),
-        ]).then(([newSnap, userSnap]) => {
+        ]).then(async ([newSnap, userSnap]) => {
           const hasNewUser = newSnap.exists();
           const hasUser = userSnap.exists();
           if (!hasNewUser && !hasUser) return null;
 
-          const data = {
+          const mergedData = {
             userId: id,
             ...(hasUser ? userSnap.val() : {}),
             ...(hasNewUser ? newSnap.val() : {}),
             __sourceCollection: hasNewUser ? 'newUsers' : 'users',
           };
-          return [id, data];
+          const hasHydratedPhotos = Array.isArray(mergedData.photos) && mergedData.photos.some(Boolean);
+          const photos = hasHydratedPhotos ? mergedData.photos : await getAllUserPhotos(id);
+          return [id, { ...mergedData, photos, __photosHydrated: true }];
         })
       )
     );
@@ -2341,7 +2343,7 @@ const removeUndefined = obj => {
   return obj;
 };
 
-const transientUserDataKeys = ['__sourceCollection'];
+const transientUserDataKeys = ['__sourceCollection', '__photosHydrated'];
 
 const stripTransientUserDataFields = (payload, { markForRealtimeDeletion = false } = {}) => {
   const cleaned = removeUndefined(payload);

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -169,7 +169,6 @@ const sectionConfig = {
     { title: 'Donation experience', fields: [
       field('experience', 'Previous donation'), field('donationCount', 'Donation count'), field('donationsCount', 'Donations'),
       field('cSection', 'C-section', user => user?.cSection || user?.csection || user?.c_section || user?.cesareanSection, ['cSection', 'csection', 'c_section', 'cesareanSection']),
-      field('reward', 'Expected reward'),
     ] },
   ],
   ip: [

--- a/src/components/profileLayoutConfig.test.js
+++ b/src/components/profileLayoutConfig.test.js
@@ -50,6 +50,33 @@ describe('profileLayoutConfig', () => {
     expect(shouldRenderField(user.emptyValue)).toBe(false);
   });
 
+  it('removes expected reward from matching layout while preserving donor secondary fields', () => {
+    const user = {
+      userRole: 'ed',
+      height: 170,
+      weight: 60,
+      reward: '5000',
+      desiredReward: '6000',
+      breastSize: 'C',
+      clothingSize: 'M',
+      shoeSize: '38',
+      glasses: 'No',
+      chin: 'Soft',
+      lipsShape: 'Full',
+      noseShape: 'Straight',
+      cSection: 'No',
+    };
+
+    const hero = getHeroFields(user, 'ed');
+    const quickFacts = getQuickFacts(user, 'ed', { excludeKeys: collectKeys(hero) });
+    const sections = getProfileSections(user, 'ed', { excludeKeys: collectKeys([...hero, ...quickFacts]) });
+    const detailKeys = sectionFieldKeys(sections);
+    const allKeys = [...hero, ...quickFacts, ...sections.flatMap(section => section.fields)].map(field => field.key);
+
+    expect(allKeys).not.toEqual(expect.arrayContaining(['reward', 'desiredReward']));
+    expect(detailKeys).toEqual(expect.arrayContaining(['breastSize', 'clothingSize', 'shoeSize', 'glasses', 'chin', 'cSection']));
+  });
+
   it('keeps intended parents layout free of donor-only physical facts when absent', () => {
     const user = {
       userRole: 'ip',


### PR DESCRIPTION
### Motivation
- Move Matching from a CRM-like stacked list to a single active, premium profile card with a cleaner dark/gold visual hierarchy and immediate decision UX. 
- Remove noisy/low-priority fields (`Expected reward` and visible load-more CTA) from the Matching render while preserving donor fields needed by the app. 
- Ensure reaction tabs render photos for uncached /newUsers and /users cards and avoid stale access-scoped newUsers IDs leaking into users-mode reaction tabs. 

### Description
- Visual / UX: restyled the matching card and container to a single active profile experience with a larger readable hero, gradient overlay, compact translucent chips, grouped sections, and fixed circular action buttons; moved internal scroll into the profile shell and kept only one visible card at a time (`src/components/Matching.jsx`, `src/components/Matching.styled.jsx`).
- Removed UI noise: removed the visible load-more button/footer and removed `reward` from Matching layout generation while keeping donor secondary fields in `profileLayoutConfig` (`src/components/Matching.jsx`, `src/components/profileLayoutConfig.js`, `src/components/Matching.styled.jsx`).
- Photo hydration & caching: hydrate photos for uncached reaction cards from Storage for both `/newUsers` and `/users` fetch paths by adding `hydrateMatchingProfilePhotos` and marking hydrated entries with `__photosHydrated` to avoid duplicate fetches; strip this transient marker before DB writes by expanding `transientUserDataKeys` (`src/components/Matching.jsx`, `src/components/config.js`).
- Reaction access refresh: when loading reaction tabs, detect mixed reaction id sets that include access-scoped short `newUsers` ids and recompute/filter allowed newUsers ids (refresh access snapshot) so removed-access cards disappear; also filter visible reaction users when access snapshot changes (`src/components/Matching.jsx`, `src/utils/reactionPriority.js` usages). 
- Interaction polish: added axis detection/lock for touch handling to prevent horizontal swipe navigation from conflicting with vertical profile-scrolling and preserved swipe as navigation only (left = next, right = previous) (`src/components/Matching.jsx`).
- Tests: added/updated regression tests asserting single active profile rendering, no load-more strings, reaction hydration behavior, `__photosHydrated` handling, and reward removal (`src/components/Matching.sharedReactions.test.js`, `src/components/profileLayoutConfig.test.js`, `src/components/config.fetchUsersByIds.test.js`).

### Testing
- Ran focused unit tests: `CI=true npm test -- --runInBand src/components/profileLayoutConfig.test.js src/components/Matching.sharedReactions.test.js src/components/config.fetchUsersByIds.test.js` and all targeted suites passed (3 suites, 16 tests, all green). 
- Ran lint: `npm run lint:js -- src/components/Matching.jsx src/components/Matching.styled.jsx src/components/profileLayoutConfig.js src/components/config.js` and the lint run finished (no blocking errors; browserslist db warning shown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f81635a88326b5ce7b2d8d173a84)