### PR TITLE
Fix Matching profile layout regressions: hide reward, restore contacts, role resolution & desktop nav

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -37,6 +37,9 @@ import {
   ModernBioText,
   ModernChip,
   ModernChipGrid,
+  ModernContactLinks,
+  ModernContactLink,
+  ModernDesktopNavButton,
   ModernFactPill,
   ModernGallery,
   ModernGalleryImage,
@@ -94,7 +97,11 @@ import { normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard } from '../ut
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
-import { FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload } from 'react-icons/fa';
+import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import { FaPhoneVolume, FaXTwitter } from 'react-icons/fa6';
+import { MdEmail } from 'react-icons/md';
+import { SiTiktok } from 'react-icons/si';
+import { getContactEntries, CONTACT_LINK_BUILDERS } from './contactMethods';
 import { handleEmptyFetch } from './loadMoreUtils';
 import {
   getHeroFields,
@@ -840,6 +847,95 @@ const ProfileChips = ({ fields, role }) => {
   );
 };
 
+const CONTACT_ICONS = {
+  phone: FaPhoneVolume,
+  email: MdEmail,
+  telegram: FaTelegramPlane,
+  whatsapp: FaWhatsapp,
+  viber: FaViber,
+  facebook: FaFacebookF,
+  instagram: FaInstagram,
+  tiktok: SiTiktok,
+  vk: FaVk,
+  linkedin: FaLinkedin,
+  youtube: FaYoutube,
+  twitter: FaXTwitter,
+  website: FaGlobe,
+  otherLink: FaGlobe,
+};
+
+const getContactLabel = key => ({
+  otherLink: 'Other link',
+}[key] || key.charAt(0).toUpperCase() + key.slice(1));
+
+const ProfileContactLinks = ({ user, role }) => {
+  const entries = getContactEntries(user);
+  if (!entries.length) return null;
+
+  return (
+    <ModernContactLinks onClick={e => e.stopPropagation()} onTouchStart={e => e.stopPropagation()} onTouchEnd={e => e.stopPropagation()}>
+      {entries.map(entry => {
+        const Icon = CONTACT_ICONS[entry.key] || FaGlobe;
+        const valueText = String(entry.value || '').trim();
+        const displayValue = entry.key === 'phone' ? `+${valueText.replace(/\s/g, '')}` : valueText;
+
+        return (
+          <ModernContactLink
+            key={`${entry.key}-${entry.index}-${valueText}`}
+            href={entry.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            $role={role}
+            title={`${getContactLabel(entry.key)}: ${displayValue}`}
+            aria-label={`${getContactLabel(entry.key)}: ${displayValue}`}
+          >
+            <Icon />
+            <span>{displayValue}</span>
+          </ModernContactLink>
+        );
+      })}
+      {getContactEntries({
+        telegram: [],
+        phone: user?.phone,
+      }).filter(entry => entry.key === 'phone').flatMap(entry => [
+        <ModernContactLink
+          key={`phone-telegram-${entry.index}`}
+          href={CONTACT_LINK_BUILDERS.telegramFromPhone(entry.value)}
+          target="_blank"
+          rel="noopener noreferrer"
+          $role={role}
+          title="Telegram from phone"
+          aria-label="Telegram from phone"
+        >
+          <FaTelegramPlane />
+        </ModernContactLink>,
+        <ModernContactLink
+          key={`phone-viber-${entry.index}`}
+          href={CONTACT_LINK_BUILDERS.viberFromPhone(entry.value)}
+          target="_blank"
+          rel="noopener noreferrer"
+          $role={role}
+          title="Viber from phone"
+          aria-label="Viber from phone"
+        >
+          <FaViber />
+        </ModernContactLink>,
+        <ModernContactLink
+          key={`phone-whatsapp-${entry.index}`}
+          href={CONTACT_LINK_BUILDERS.whatsappFromPhone(entry.value)}
+          target="_blank"
+          rel="noopener noreferrer"
+          $role={role}
+          title="WhatsApp from phone"
+          aria-label="WhatsApp from phone"
+        >
+          <FaWhatsapp />
+        </ModernContactLink>,
+      ])}
+    </ModernContactLinks>
+  );
+};
+
 const ProfileBio = ({ text }) => {
   const [expanded, setExpanded] = useState(false);
   if (!text) return null;
@@ -1035,7 +1131,11 @@ const SwipeableCard = ({
           {sections.map(section => (
             <ModernSection key={section.title}>
               <ModernSectionTitle>{section.title}</ModernSectionTitle>
-              <ProfileChips fields={section.fields} role={resolvedRole} />
+              {section.variant === 'contacts' ? (
+                <ProfileContactLinks user={user} role={resolvedRole} />
+              ) : (
+                <ProfileChips fields={section.fields} role={resolvedRole} />
+              )}
             </ModernSection>
           ))}
           {galleryPhotos.length > 0 && (
@@ -3152,6 +3252,26 @@ const Matching = () => {
     });
   }, [filteredUsers.length]);
 
+  useEffect(() => {
+    const handleKeyDown = event => {
+      const target = event.target;
+      const tagName = target?.tagName?.toLowerCase();
+      const isTyping = tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target?.isContentEditable;
+      if (isTyping) return;
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        navigateActiveProfile(1);
+      }
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        navigateActiveProfile(-1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [navigateActiveProfile]);
+
   const additionalFiltersDebugSignatureRef = useRef('');
   useEffect(() => {
     if (collectionSource !== 'newUsers') return;
@@ -3353,6 +3473,24 @@ const Matching = () => {
               return (
                 <CardContainer key={user.userId}>
                   <CardWrapper $role={role}>
+                    <ModernDesktopNavButton
+                      type="button"
+                      $side="left"
+                      onClick={e => { e.stopPropagation(); navigateActiveProfile(-1); }}
+                      disabled={activeProfileIndex === 0}
+                      aria-label="Previous profile"
+                    >
+                      <FaChevronLeft />
+                    </ModernDesktopNavButton>
+                    <ModernDesktopNavButton
+                      type="button"
+                      $side="right"
+                      onClick={e => { e.stopPropagation(); navigateActiveProfile(1); }}
+                      disabled={activeProfileIndex >= filteredUsers.length - 1}
+                      aria-label="Next profile"
+                    >
+                      <FaChevronRight />
+                    </ModernDesktopNavButton>
                     <SwipeableCard
                       user={user}
                       photo={photo}

--- a/src/components/Matching.profileLayoutRegression.test.js
+++ b/src/components/Matching.profileLayoutRegression.test.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('Matching redesigned profile regressions', () => {
+  const source = () => fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+
+  it('renders contacts through actionable links instead of generic profile chips', () => {
+    const matchingSource = source();
+
+    expect(matchingSource).toContain('const ProfileContactLinks = ({ user, role }) =>');
+    expect(matchingSource).toContain("section.variant === 'contacts'");
+    expect(matchingSource).toContain('<ProfileContactLinks user={user} role={resolvedRole} />');
+    expect(matchingSource).toContain('href={entry.href}');
+    expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.telegramFromPhone');
+    expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.viberFromPhone');
+    expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.whatsappFromPhone');
+  });
+
+  it('supports desktop next/previous navigation without reaction side effects', () => {
+    const matchingSource = source();
+
+    expect(matchingSource).toContain("event.key === 'ArrowRight'");
+    expect(matchingSource).toContain('navigateActiveProfile(1);');
+    expect(matchingSource).toContain("event.key === 'ArrowLeft'");
+    expect(matchingSource).toContain('navigateActiveProfile(-1);');
+    expect(matchingSource).toContain('aria-label="Previous profile"');
+    expect(matchingSource).toContain('aria-label="Next profile"');
+    expect(matchingSource).toContain('onNavigate(direction === \'left\' ? 1 : -1);');
+    expect(matchingSource).not.toContain('swipedRef.current = true;\n    setDir(direction);\n    handleRemove');
+  });
+});

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -960,6 +960,72 @@ export const ModernGalleryImage = styled.img`
   background: #2a251f;
 `;
 
+
+export const ModernContactLinks = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+export const ModernContactLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: ${({ $role }) => getRoleColors($role).light};
+  border: 1px solid ${({ $role }) => getRoleColors($role).border};
+  color: ${({ $role }) => getRoleColors($role).text};
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1;
+  text-decoration: none;
+
+  svg {
+    flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+export const ModernDesktopNavButton = styled.button`
+  position: absolute;
+  top: 50%;
+  ${({ $side }) => ($side === 'left' ? 'left: 8px;' : 'right: 8px;')}
+  transform: translateY(-50%);
+  z-index: 9;
+  width: 34px;
+  height: 54px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  border-radius: 999px;
+  background: rgba(21, 18, 15, 0.42);
+  color: rgba(255, 255, 255, 0.84);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: opacity 0.2s ease, background 0.2s ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background: rgba(21, 18, 15, 0.68);
+    color: #fff;
+  }
+
+  &:disabled {
+    opacity: 0.24;
+    cursor: default;
+  }
+`;
+
 export const ModernActionRail = styled.div`
   position: absolute;
   left: 0;

--- a/src/components/contactMethods.js
+++ b/src/components/contactMethods.js
@@ -1,0 +1,111 @@
+import { getCurrentValue } from './getCurrentValue';
+
+export const CONTACT_FIELDS = [
+  'phone',
+  'email',
+  'telegram',
+  'whatsapp',
+  'viber',
+  'facebook',
+  'instagram',
+  'tiktok',
+  'vk',
+  'linkedin',
+  'youtube',
+  'twitter',
+  'website',
+  'otherLink',
+];
+
+const hasProtocol = value => /^[a-z][a-z\d+\-.]*:/i.test(value);
+const stripAt = value => String(value || '').trim().replace(/^@/, '');
+const compactPhone = value => String(value || '').replace(/[\s()\-.]/g, '');
+const digitsOnlyPhone = value => compactPhone(value).replace(/^\+/, '');
+const buildPlatformUrl = (value, domain, pathPrefix = '') => {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) return '';
+  if (hasProtocol(rawValue)) return rawValue;
+  const withoutAt = stripAt(rawValue);
+  if (withoutAt.startsWith(`${domain}/`) || withoutAt.startsWith(`www.${domain}/`)) {
+    return normalizeExternalUrl(withoutAt);
+  }
+  return normalizeExternalUrl(`${domain}/${pathPrefix}${withoutAt}`);
+};
+
+export const normalizeExternalUrl = value => {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) return '';
+  if (hasProtocol(rawValue)) return rawValue;
+  return `https://${rawValue}`;
+};
+
+export const buildLinkedinUrl = value => {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) return '';
+  if (hasProtocol(rawValue)) return rawValue;
+  const normalizedValue = rawValue.replace(/^\/+/, '');
+  if (normalizedValue.startsWith('in/') || normalizedValue.startsWith('company/')) {
+    return `https://www.linkedin.com/${normalizedValue}`;
+  }
+  return `https://www.linkedin.com/in/${normalizedValue}`;
+};
+
+export const buildTwitterUrl = value => {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) return '';
+  if (hasProtocol(rawValue)) return rawValue;
+  return `https://x.com/${stripAt(rawValue)}`;
+};
+
+export const CONTACT_LINK_BUILDERS = {
+  phone: value => `tel:${compactPhone(value)}`,
+  email: value => `mailto:${String(value || '').trim()}`,
+  telegram: value => `https://t.me/${stripAt(value)}`,
+  whatsapp: value => `https://wa.me/${digitsOnlyPhone(value) || stripAt(value)}`,
+  viber: value => `viber://chat?number=%2B${digitsOnlyPhone(value)}`,
+  facebook: value => buildPlatformUrl(value, 'facebook.com'),
+  instagram: value => buildPlatformUrl(value, 'instagram.com'),
+  tiktok: value => buildPlatformUrl(value, 'www.tiktok.com', '@'),
+  vk: value => buildPlatformUrl(value, 'vk.com'),
+  linkedin: buildLinkedinUrl,
+  youtube: value => buildPlatformUrl(value, 'www.youtube.com', '@'),
+  twitter: buildTwitterUrl,
+  website: normalizeExternalUrl,
+  otherLink: normalizeExternalUrl,
+  telegramFromPhone: value => `https://t.me/${compactPhone(value)}`,
+  viberFromPhone: value => `viber://chat?number=%2B${digitsOnlyPhone(value)}`,
+  whatsappFromPhone: value => `https://wa.me/${digitsOnlyPhone(value)}`,
+};
+
+export const isHiddenTelegramValue = value => String(value ?? '').trim().startsWith('УК СМ');
+
+const valueList = value => {
+  const current = getCurrentValue(value);
+  if (Array.isArray(current)) return current;
+  return current ? [current] : [];
+};
+
+export const getContactValues = (data, key) => {
+  const values = valueList(data?.[key])
+    .map(value => (typeof value === 'string' ? value.trim() : value))
+    .filter(value => value !== null && value !== undefined && String(value).trim() !== '');
+
+  if (key === 'telegram') {
+    return values.filter(value => !isHiddenTelegramValue(value));
+  }
+
+  return values;
+};
+
+export const getAvailableContactFields = data =>
+  CONTACT_FIELDS.filter(key => getContactValues(data, key).length > 0);
+
+export const getContactEntries = data =>
+  CONTACT_FIELDS.flatMap(key =>
+    getContactValues(data, key).map((value, index) => ({
+      key,
+      value,
+      href: CONTACT_LINK_BUILDERS[key]?.(value) || '',
+      index,
+    }))
+  );

--- a/src/components/contactMethods.test.js
+++ b/src/components/contactMethods.test.js
@@ -1,0 +1,59 @@
+import {
+  CONTACT_FIELDS,
+  getAvailableContactFields,
+  getContactEntries,
+} from './contactMethods';
+
+describe('contactMethods', () => {
+  it('filters internal УК СМ telegram values', () => {
+    expect(getContactEntries({ telegram: ['УК СМ internal', '@public'] }))
+      .toEqual(expect.arrayContaining([expect.objectContaining({ key: 'telegram', value: '@public' })]));
+    expect(getContactEntries({ telegram: ['УК СМ internal'] })).toEqual([]);
+  });
+
+  it('builds actionable links for core contact methods', () => {
+    const entries = getContactEntries({
+      phone: '380 50 111 22 33',
+      email: 'mail@example.com',
+      telegram: '@agency',
+      whatsapp: '+380501112233',
+      viber: '+380501112233',
+      website: 'example.com',
+    });
+
+    expect(entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'phone', href: 'tel:380501112233' }),
+      expect.objectContaining({ key: 'email', href: 'mailto:mail@example.com' }),
+      expect.objectContaining({ key: 'telegram', href: 'https://t.me/agency' }),
+      expect.objectContaining({ key: 'whatsapp', href: 'https://wa.me/380501112233' }),
+      expect.objectContaining({ key: 'viber', href: 'viber://chat?number=%2B380501112233' }),
+      expect.objectContaining({ key: 'website', href: 'https://example.com' }),
+    ]));
+  });
+
+  it('keeps all previously supported social and link contacts', () => {
+    const user = {
+      facebook: 'fb-page',
+      tiktok: 'creator',
+      linkedin: 'in/person',
+      youtube: 'channel',
+      twitter: '@handle',
+      otherLink: 'other.example',
+    };
+
+    expect(CONTACT_FIELDS).toEqual(expect.arrayContaining([
+      'facebook', 'tiktok', 'linkedin', 'youtube', 'twitter', 'otherLink',
+    ]));
+    expect(getAvailableContactFields(user)).toEqual(expect.arrayContaining([
+      'facebook', 'tiktok', 'linkedin', 'youtube', 'twitter', 'otherLink',
+    ]));
+    expect(getContactEntries(user).map(entry => entry.href)).toEqual(expect.arrayContaining([
+      'https://facebook.com/fb-page',
+      'https://www.tiktok.com/@creator',
+      'https://www.linkedin.com/in/person',
+      'https://www.youtube.com/@channel',
+      'https://x.com/handle',
+      'https://other.example',
+    ]));
+  });
+});

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -2,6 +2,7 @@ import { getCurrentValue } from './getCurrentValue';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import { normalizeCountry, normalizeRegion } from './normalizeLocation';
 import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
+import { CONTACT_FIELDS, getContactValues } from './contactMethods';
 
 const EMPTY_VALUES = new Set(['', '-', '—', 'n/a', 'na', 'null', 'undefined', 'none', 'немає', 'нет']);
 
@@ -22,12 +23,12 @@ export const normalizeDisplayValue = value => {
 export const shouldRenderField = value => Boolean(normalizeDisplayValue(value));
 
 export const getProfileRole = user => {
-  const role = normalizeDisplayValue(user?.userRole || user?.role).toLowerCase();
-  if (role === 'ed') return 'ed';
-  if (role === 'ag') return 'ag';
-  if (role === 'ip') return 'ip';
+  const role = normalizeDisplayValue(user?.role || user?.userRole).toLowerCase();
+  if (['ed', 'egg donor', 'egg_donor'].includes(role)) return 'ed';
+  if (['ag', 'agency'].includes(role)) return 'ag';
+  if (['ip', 'intended parents', 'intended_parent'].includes(role)) return 'ip';
   if (user?.__sourceCollection === 'newUsers' && !role) return 'ed';
-  return role || 'other';
+  return 'other';
 };
 
 export const getRoleLabel = role => {
@@ -169,7 +170,6 @@ const sectionConfig = {
     { title: 'Donation experience', fields: [
       field('experience', 'Previous donation'), field('donationCount', 'Donation count'), field('donationsCount', 'Donations'),
       field('cSection', 'C-section', user => user?.cSection || user?.csection || user?.c_section || user?.cesareanSection, ['cSection', 'csection', 'c_section', 'cesareanSection']),
-      field('reward', 'Expected reward'),
     ] },
   ],
   ip: [
@@ -195,10 +195,13 @@ export const getHeroFields = (user, role = getProfileRole(user), { excludeKeys =
 export const getQuickFacts = (user, role = getProfileRole(user), { excludeKeys = [] } = {}) =>
   toDisplayFields(quickFacts[role] || quickFacts.other, user, excludeKeys).slice(0, 8);
 
-const contactFields = [
-  field('phone', 'Phone'), field('telegram', 'Telegram'), field('whatsapp', 'WhatsApp'), field('email', 'Email'),
-  field('vk', 'VK'), field('instagram', 'Instagram'), field('website', 'Website'),
-];
+const contactFields = CONTACT_FIELDS.map(key =>
+  field(
+    key,
+    key === 'otherLink' ? 'Other link' : key.charAt(0).toUpperCase() + key.slice(1),
+    user => getContactValues(user, key).join(', ')
+  )
+);
 
 export const getProfileSections = (user, role = getProfileRole(user), { excludeKeys = [] } = {}) => {
   const sections = (sectionConfig[role] || sectionConfig.other).map(section => ({

--- a/src/components/profileLayoutConfig.test.js
+++ b/src/components/profileLayoutConfig.test.js
@@ -92,4 +92,40 @@ describe('profileLayoutConfig', () => {
     expect(agencyDetails.fields.map(field => field.key)).toEqual(['agencyName']);
     expect(contacts.fields.map(field => field.key)).toEqual(['telegram', 'website']);
   });
+
+  it('does not render expected reward anywhere in Matching layout sections', () => {
+    const user = {
+      role: 'ed',
+      reward: '5000 EUR',
+      desiredReward: '6000 EUR',
+      height: 170,
+      weight: 60,
+      experience: 'Yes',
+    };
+
+    const hero = getHeroFields(user, 'ed');
+    const quickFacts = getQuickFacts(user, 'ed', { excludeKeys: collectKeys(hero) });
+    const sections = getProfileSections(user, 'ed', { excludeKeys: collectKeys([...hero, ...quickFacts]) });
+    const allFields = [...hero, ...quickFacts, ...sections.flatMap(section => section.fields)];
+
+    expect(allFields.map(field => field.key)).not.toEqual(expect.arrayContaining(['reward', 'desiredReward']));
+    expect(allFields.map(field => field.label.toLowerCase())).not.toEqual(expect.arrayContaining(['expected reward', 'desired reward']));
+    expect(allFields.map(field => field.value)).not.toEqual(expect.arrayContaining(['5000 EUR', '6000 EUR']));
+  });
+
+  it('prefers canonical role over stale userRole and normalizes aliases', () => {
+    const user = {
+      role: 'agency',
+      userRole: 'ed',
+      agencyName: 'Canonical Agency',
+      services: 'Matching',
+    };
+
+    expect(getProfileRole(user)).toBe('ag');
+    expect(getProfileSections(user).map(section => section.title)).toEqual(expect.arrayContaining(['Agency details']));
+    expect(getProfileRole({ role: 'egg_donor' })).toBe('ed');
+    expect(getProfileRole({ role: 'intended parents' })).toBe('ip');
+    expect(getProfileRole({ role: 'sm' })).toBe('other');
+  });
+
 });

--- a/src/components/smallCard/fieldContacts.js
+++ b/src/components/smallCard/fieldContacts.js
@@ -14,6 +14,11 @@ import { FaPhoneVolume, FaXTwitter } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getCurrentValue } from '../getCurrentValue';
+import {
+  CONTACT_LINK_BUILDERS,
+  getContactEntries,
+  getContactValues,
+} from '../contactMethods';
 import { color } from '../styles';
 
 const iconStyle = {
@@ -36,77 +41,13 @@ const phoneBtnStyle = {
   borderRadius: '50%',
 };
 
-const normalizeExternalUrl = value => {
-  const rawValue = String(value ?? '').trim();
-
-  if (!rawValue) {
-    return '';
-  }
-
-  if (/^[a-z][a-z\d+\-.]*:/i.test(rawValue)) {
-    return rawValue;
-  }
-
-  return `https://${rawValue}`;
-};
-
-
-const buildLinkedinUrl = value => {
-  const rawValue = String(value ?? '').trim();
-
-  if (!rawValue) {
-    return '';
-  }
-
-  if (/^[a-z][a-z\d+\-.]*:/i.test(rawValue)) {
-    return rawValue;
-  }
-
-  const normalizedValue = rawValue.replace(/^\/+/, '');
-
-  if (normalizedValue.startsWith('in/') || normalizedValue.startsWith('company/')) {
-    return `https://www.linkedin.com/${normalizedValue}`;
-  }
-
-  return `https://www.linkedin.com/in/${normalizedValue}`;
-};
-
-const buildTwitterUrl = value => {
-  const rawValue = String(value ?? '').trim();
-
-  if (!rawValue) {
-    return '';
-  }
-
-  if (/^[a-z][a-z\d+\-.]*:/i.test(rawValue)) {
-    return rawValue;
-  }
-
-  return `https://x.com/${rawValue.replace(/^@/, '')}`;
-};
-
 export const fieldContacts = (data, parentKey = '') => {
   if (!data || typeof data !== 'object') {
     console.error('Invalid data passed to renderContacts:', data);
     return null;
   }
 
-  const links = {
-    telegram: value => `https://t.me/${value}`,
-    instagram: value => `https://instagram.com/${value}`,
-    tiktok: value => `https://www.tiktok.com/@${value}`,
-    phone: value => `tel:${value}`,
-    facebook: value => `https://facebook.com/${value}`,
-    vk: value => `https://vk.com/${value}`,
-    linkedin: value => buildLinkedinUrl(value),
-    youtube: value => `https://www.youtube.com/@${value}`,
-    twitter: value => buildTwitterUrl(value),
-    otherLink: value => normalizeExternalUrl(value),
-    email: value => `mailto:${value}`,
-    telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
-    viberFromPhone: value => `viber://chat?number=%2B${value.replace(/\s+/g, '')}`,
-    whatsappFromPhone: value => `https://wa.me/${value.replace(/\s+/g, '')}`,
-  };
+  const links = CONTACT_LINK_BUILDERS;
 
   const icons = {
     facebook: <FaFacebookF style={iconStyle} />,
@@ -396,43 +337,14 @@ export const fieldContactsIcons = (
     return null;
   }
 
-  const links = {
-    telegram: value => `https://t.me/${value}`,
-    instagram: value => `https://instagram.com/${value}`,
-    tiktok: value => `https://www.tiktok.com/@${value}`,
-    phone: value => `tel:${value}`,
-    facebook: value => `https://facebook.com/${value}`,
-    vk: value => `https://vk.com/${value}`,
-    linkedin: value => buildLinkedinUrl(value),
-    youtube: value => `https://www.youtube.com/@${value}`,
-    twitter: value => buildTwitterUrl(value),
-    otherLink: value => normalizeExternalUrl(value),
-    email: value => `mailto:${value}`,
-    telegramFromPhone: value => `https://t.me/${value.replace(/\s+/g, '')}`,
-    viberFromPhone: value => `viber://chat?number=%2B${value.replace(/\s+/g, '')}`,
-    whatsappFromPhone: value => `https://wa.me/${value.replace(/\s+/g, '')}`,
-  };
+  const links = CONTACT_LINK_BUILDERS;
 
   const processed = Object.fromEntries(
     Object.entries(data).map(([k, v]) => [k, getCurrentValue(v)])
   );
 
-  // Filter out telegram links starting with "УК СМ"
-  const telegramValues = processed.telegram
-    ? Array.isArray(processed.telegram)
-      ? processed.telegram.filter(
-          v => v && !String(v).trim().startsWith('УК СМ')
-        )
-      : String(processed.telegram).trim().startsWith('УК СМ')
-        ? []
-        : [processed.telegram]
-    : [];
-
-  const phoneValues = processed.phone
-    ? Array.isArray(processed.phone)
-      ? processed.phone.filter(v => v)
-      : [processed.phone]
-    : [];
+  const telegramValues = getContactValues(data, 'telegram');
+  const phoneValues = getContactValues(data, 'phone');
 
   const iconStyle = {
     verticalAlign: 'middle',
@@ -632,6 +544,24 @@ export const fieldContactsIcons = (
       </a>
     );
   }
+
+
+  getContactEntries(data)
+    .filter(({ key }) => ['whatsapp', 'viber', 'website'].includes(key))
+    .forEach(({ key, href }, idx) => {
+      const Icon = key === 'whatsapp' ? FaWhatsapp : key === 'viber' ? FaViber : FaGlobe;
+      elements.push(
+        <a
+          key={`${key}-${idx}`}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={linkStyle}
+        >
+          <Icon style={iconStyle} />
+        </a>
+      );
+    });
 
   if (processed.otherLink) {
     const others = Array.isArray(processed.otherLink)


### PR DESCRIPTION
### Motivation
- Restore behavior lost after the redesign so Matching does not expose reward/expected reward fields to users while keeping underlying data intact. 
- Reuse previous contact normalization/filtering and link-building logic so contacts remain actionable, keep full supported contact list, and hide internal Telegram values that start with `УК СМ`.
- Prefer canonical `role` over stale `userRole` to avoid incorrect layout/badge selection.
- Re-enable simple desktop navigation (keyboard + small buttons) so mouse/keyboard users can move between profiles without triggering like/dislike.

### Description
- Removed `reward`/`Expected reward` from the Matching-rendered sections only while leaving the Firebase field untouched, by deleting the `field('reward', 'Expected reward')` entry in `getProfileSections` logic in `src/components/profileLayoutConfig.js` and keeping indexing/forms unchanged.
- Introduced a shared `src/components/contactMethods.js` module exposing `CONTACT_FIELDS`, `getContactValues`, `getContactEntries`, and `CONTACT_LINK_BUILDERS` to centralize contact normalization, telegram filtering (`isHiddenTelegramValue`), and URL builders for `tel:`, `mailto:`, Telegram, WhatsApp, Viber and social/website links.
- Rewired contacts rendering to use actionable compact links in Matching by adding `ProfileContactLinks` and styling (`ModernContactLinks`, `ModernContactLink`) in `src/components/Matching.jsx` / `Matching.styled.jsx`, and reused `CONTACT_LINK_BUILDERS` in `src/components/smallCard/fieldContacts.js` so icon path behavior is preserved.
- Restored canonical role precedence by changing `getProfileRole` to prefer `user.role` over `user.userRole` and normalize common aliases (`ed`, `egg donor`, `egg_donor` → `ed`; `ag`, `agency` → `ag`; `ip`, `intended parents`, `intended_parent` → `ip`) in `src/components/profileLayoutConfig.js`.
- Added desktop navigation: ArrowLeft/ArrowRight keyboard handlers and subtle `ModernDesktopNavButton` previous/next buttons that call the same `navigateActiveProfile` callback without invoking like/dislike, implemented in `src/components/Matching.jsx` and styled in `Matching.styled.jsx`.
- Extended supported contact methods by not hardcoding an allow-list and mapping `CONTACT_FIELDS` into profile section fields so previously supported social links (Facebook, TikTok, LinkedIn, YouTube, Twitter, otherLink, etc.) remain visible and actionable.
- Added regression tests for the above behaviors: `src/components/contactMethods.test.js`, additions to `src/components/profileLayoutConfig.test.js`, and `src/components/Matching.profileLayoutRegression.test.js` which assert reward hiding, telegram filtering, actionable links, full contact coverage, canonical role preference, and desktop navigation.

### Testing
- Ran targeted unit tests with `CI=true npm test -- --watchAll=false src/components/profileLayoutConfig.test.js src/components/contactMethods.test.js src/components/Matching.profileLayoutRegression.test.js` and all new/updated tests passed.
- Ran full test suite with `CI=true npm test -- --watchAll=false` and observed all test suites passing (`164` tests in this run passed).
- Ran lint with `npm run lint:js` and a production build with `npm run build`, both of which completed successfully (build compiled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f8fb2fb88326815758d8b4d18451)