### PR TITLE
Add photo viewer and improve hero/gallery UI with accessibility and style tweaks

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -47,6 +47,7 @@ import {
   ModernHeroContent,
   ModernHeroFacts,
   ModernHeroFallbackMark,
+  ModernHeroImage,
   ModernHeroLocation,
   ModernHeroTitle,
   ModernMoreButton,
@@ -97,6 +98,7 @@ import { normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard } from '../ut
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
+import PhotoViewer from './PhotoViewer';
 import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { FaPhoneVolume, FaXTwitter } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
@@ -1002,8 +1004,9 @@ const SwipeableCard = ({
   const resolvedRole = getProfileRole(user) || role;
   const photos = getProfilePhotos(user);
   const heroPhoto = photo || photos[0] || '';
-  const galleryPhotos = photos.filter(item => item && item !== heroPhoto);
+  const allPhotos = [heroPhoto, ...photos].filter(Boolean).filter((item, index, list) => list.indexOf(item) === index);
   const [activeHeroPhoto, setActiveHeroPhoto] = useState(heroPhoto);
+  const [viewerIndex, setViewerIndex] = useState(null);
   const [dir, setDir] = useState(null);
   const favoriteButtonWrapRef = useRef(null);
   const dislikeButtonWrapRef = useRef(null);
@@ -1027,6 +1030,8 @@ const SwipeableCard = ({
   const locationInfo = getProfileLocation(user);
   const identityAndLocationKeys = ['name', 'surname', 'agencyName', 'companyName', 'agency', 'country', 'region', 'city', 'role', 'userRole'];
   const heroFields = getHeroFields(user, resolvedRole, { excludeKeys: identityAndLocationKeys });
+  const displayedHeroFields = heroFields.slice(0, 3);
+  const bodyHeroFields = heroFields.slice(3);
   const usedSummaryFieldKeys = collectProfileFieldKeys(heroFields);
   const sections = getProfileSections(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys] });
   const bio = getProfileBio(user);
@@ -1072,8 +1077,26 @@ const SwipeableCard = ({
     if (swipedRef.current) swipedRef.current = false;
   };
 
+  const openPhotoViewer = index => event => {
+    if (event) event.stopPropagation();
+    if (swipedRef.current || index < 0 || !allPhotos[index]) return;
+    setViewerIndex(index);
+  };
+
+  const openHeroViewer = event => {
+    const heroIndex = allPhotos.indexOf(activeHeroPhoto);
+    openPhotoViewer(heroIndex === -1 ? 0 : heroIndex)(event);
+  };
+
+  const handleHeroKeyDown = event => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    openHeroViewer(event);
+  };
+
   return (
-    <AnimatedCard
+    <>
+      <AnimatedCard
       $dir={dir}
       $small={isAgency}
       $compactWithoutPhoto={!activeHeroPhoto}
@@ -1088,16 +1111,24 @@ const SwipeableCard = ({
     >
       <ModernProfileShell>
         <ModernProfileScroll>
-        <ModernHero $image={activeHeroPhoto}>
+        <ModernHero
+          $image={activeHeroPhoto}
+          $clickable={!!activeHeroPhoto}
+          role={activeHeroPhoto ? 'button' : undefined}
+          tabIndex={activeHeroPhoto ? 0 : undefined}
+          aria-label={activeHeroPhoto ? `Open ${name} photo` : undefined}
+          onClick={activeHeroPhoto ? openHeroViewer : undefined}
+          onKeyDown={activeHeroPhoto ? handleHeroKeyDown : undefined}
+        >
           {!activeHeroPhoto && <ModernHeroFallbackMark>{initials}</ModernHeroFallbackMark>}
-          {activeHeroPhoto && <img src={activeHeroPhoto} alt="" style={{ display: 'none' }} onError={() => setActiveHeroPhoto('')} />}
+          {activeHeroPhoto && <ModernHeroImage src={activeHeroPhoto} alt={`${name} profile hero`} onError={() => setActiveHeroPhoto('')} />}
           <ModernHeroContent>
             <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>
             <ModernHeroTitle>{title}</ModernHeroTitle>
             {locationInfo && <ModernHeroLocation>{locationInfo}</ModernHeroLocation>}
             {heroFields.length > 0 && (
               <ModernHeroFacts>
-                {heroFields.slice(0, 6).map(item => (
+                {displayedHeroFields.map(item => (
                   <ModernFactPill key={`hero-${item.key}`}>
                     <strong>{item.label}</strong>
                     <span>{item.value}</span>
@@ -1112,6 +1143,12 @@ const SwipeableCard = ({
         )}
         <ModernProfileBody>
           <ProfileBio text={bio} />
+          {bodyHeroFields.length > 0 && (
+            <ModernSection>
+              <ModernSectionTitle>Key details</ModernSectionTitle>
+              <ProfileChips fields={bodyHeroFields} role={resolvedRole} />
+            </ModernSection>
+          )}
           {sections.filter(section => section.variant !== 'contacts').map(section => (
             <ModernSection key={section.title}>
               <ModernSectionTitle>{section.title}</ModernSectionTitle>
@@ -1122,12 +1159,19 @@ const SwipeableCard = ({
               )}
             </ModernSection>
           ))}
-          {galleryPhotos.length > 0 && (
+          {allPhotos.length > 0 && (
             <ModernSection>
               <ModernSectionTitle>Gallery</ModernSectionTitle>
               <ModernGallery>
-                {galleryPhotos.map(src => (
-                  <ModernGalleryImage key={src} src={src} alt={`${name} profile`} onError={event => { event.currentTarget.style.display = 'none'; }} />
+                {allPhotos.map((src, index) => (
+                  <ModernGalleryImage
+                    type="button"
+                    key={src}
+                    onClick={openPhotoViewer(index)}
+                    aria-label={`Open ${name} photo ${index + 1}`}
+                  >
+                    <img src={src} alt={`${name} profile ${index + 1}`} onError={event => { event.currentTarget.closest('button').style.display = 'none'; }} />
+                  </ModernGalleryImage>
                 ))}
               </ModernGallery>
             </ModernSection>
@@ -1172,7 +1216,11 @@ const SwipeableCard = ({
           </span>
         </ModernActionRail>
       </ModernProfileShell>
-    </AnimatedCard>
+      </AnimatedCard>
+      {viewerIndex !== null && allPhotos.length > 0 && (
+        <PhotoViewer photos={allPhotos} index={viewerIndex} onClose={() => setViewerIndex(null)} />
+      )}
+    </>
   );
 };
 

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -96,10 +96,13 @@ describe('Matching shared reaction card UI', () => {
     expect(matchingSource).not.toContain('Дозавантажити карточки');
     expect(matchingSource).not.toContain('Більше карточок завтра');
     expect(matchingSource).not.toContain('<LoadMoreButton');
-    expect(styledSource).toContain('height: 56%;');
+    expect(matchingSource).toContain('const allPhotos = [heroPhoto, ...photos]');
+    expect(matchingSource).toContain('const bodyHeroFields = heroFields.slice(3);');
+    expect(matchingSource).toContain('<PhotoViewer photos={allPhotos} index={viewerIndex}');
+    expect(styledSource).toContain('height: 64%;');
     expect(styledSource).toContain('linear-gradient(135deg, #ffcc73 0%, #f7931e 100%)');
     expect(styledSource).toContain('position: absolute;\n  left: 0;\n  right: 0;\n  bottom: 0;');
-    expect(styledSource).toContain('background: rgba(255, 255, 255, 0.055);');
+    expect(styledSource).toContain('background: rgba(26, 23, 20, 0.82);');
   });
 
 });

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -779,25 +779,41 @@ export const ModernProfileScroll = styled.div`
 
 export const ModernHero = styled.div`
   position: relative;
-  min-height: clamp(330px, 58%, 455px);
-  height: 58%;
-  background:
-    ${({ $image }) => $image ? `linear-gradient(180deg, rgba(12, 9, 7, 0) 0%, rgba(12, 9, 7, 0.04) 42%, rgba(12, 9, 7, 0.48) 78%, rgba(12, 9, 7, 0.72) 100%), url(${$image})` : 'radial-gradient(circle at 26% 16%, rgba(247, 147, 30, 0.54), transparent 30%), radial-gradient(circle at 78% 18%, rgba(255, 218, 145, 0.16), transparent 24%), linear-gradient(145deg, #3a281b 0%, #15110f 56%, #070605 100%)'};
-  background-size: cover;
-  background-position: center 18%;
+  min-height: clamp(370px, 64%, 505px);
+  height: 64%;
+  background: ${({ $image }) => $image
+    ? 'linear-gradient(180deg, #17120e 0%, #0c0a09 100%)'
+    : 'radial-gradient(circle at 26% 16%, rgba(247, 147, 30, 0.54), transparent 30%), radial-gradient(circle at 78% 18%, rgba(255, 218, 145, 0.16), transparent 24%), linear-gradient(145deg, #3a281b 0%, #15110f 56%, #070605 100%)'};
   display: flex;
   align-items: flex-end;
   padding: 20px 18px 22px;
   box-sizing: border-box;
+  overflow: hidden;
+  cursor: ${({ $clickable }) => ($clickable ? 'zoom-in' : 'default')};
 
   &::after {
     content: '';
     position: absolute;
     inset: auto 0 0;
-    height: 38%;
-    background: linear-gradient(180deg, transparent 0%, rgba(9, 7, 5, 0.62) 100%);
+    height: 34%;
+    background: linear-gradient(180deg, transparent 0%, rgba(9, 7, 5, 0.36) 46%, rgba(9, 7, 5, 0.66) 100%);
     pointer-events: none;
   }
+
+  &:focus-visible {
+    outline: 3px solid rgba(247, 147, 30, 0.75);
+    outline-offset: -5px;
+  }
+`;
+
+export const ModernHeroImage = styled.img`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 16%;
+  display: block;
 `;
 
 export const ModernHeroFallbackMark = styled.div`
@@ -847,7 +863,7 @@ export const ModernHeroTitle = styled.h2`
   margin: 0;
   color: #fff;
   max-width: 92%;
-  font-size: clamp(30px, 7.2vw, 42px);
+  font-size: clamp(28px, 6.8vw, 40px);
   line-height: 0.98;
   font-weight: 850;
   text-wrap: balance;
@@ -998,16 +1014,39 @@ export const ModernMoreButton = styled.button`
 
 export const ModernGallery = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
 `;
 
-export const ModernGalleryImage = styled.img`
+export const ModernGalleryImage = styled.button`
   width: 100%;
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
-  border-radius: 14px;
+  aspect-ratio: 4 / 5;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 214, 148, 0.14);
+  border-radius: 16px;
   background: #2a251f;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.22);
+  cursor: zoom-in;
+
+  img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: cover;
+    object-position: center 18%;
+    transition: transform 0.18s ease;
+  }
+
+  &:hover img,
+  &:focus-visible img {
+    transform: scale(1.03);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(247, 147, 30, 0.65);
+    outline-offset: 2px;
+  }
 `;
 
 

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -102,6 +102,8 @@ const ownKidsValue = user => {
   return raw;
 };
 
+
+
 const donorExperienceValue = user => {
   const exp = normalizeDisplayValue(user?.experience || user?.donationExperience || user?.previousDonation);
   const count = normalizeDisplayValue(user?.donationCount || user?.donationsCount);


### PR DESCRIPTION
### Motivation
- Provide an in-place photo viewer for profile photos and improve gallery ergonomics and accessibility for hero images.
- Surface a clearer set of primary hero fields and move extra hero details into the profile body to improve information hierarchy.
- Refresh visual styling and interactive affordances for hero and gallery elements to match updated design intent.

### Description
- Add `PhotoViewer` support by introducing `viewerIndex` state, `openPhotoViewer`/`openHeroViewer` handlers and rendering `<PhotoViewer photos={allPhotos} index={viewerIndex} onClose=... />` when open.
- Consolidate hero/gallery photo list into `const allPhotos = [heroPhoto, ...photos]` and ensure unique entries are used for viewer and gallery rendering.
- Make the hero clickable and keyboard-accessible by rendering `ModernHeroImage`, adding `role`, `tabIndex`, `aria-label`, `onClick`, `onKeyDown`, and `:focus-visible` outline styles.
- Split hero field presentation into `displayedHeroFields = heroFields.slice(0, 3)` and `bodyHeroFields = heroFields.slice(3)` and render extra hero details under a `Key details` section.
- Convert gallery tiles to interactive buttons (`ModernGalleryImage` now a styled `button`) that contain `img` elements and support click/open behavior, hover/focus transforms, and improved layout and spacing.
- Update `Matching.styled.jsx` visuals including hero sizing, overlay gradient adjustments, `ModernHeroImage` component, gallery grid from 3 to 2 columns, and gallery tile styling including focus states and shadows.
- Minor formatting/whitespace tweaks in `profileLayoutConfig.js`.
- Update tests to assert new UI strings and style changes in `Matching.sharedReactions.test.js`.

### Testing
- Updated unit assertions in `src/components/Matching.sharedReactions.test.js` to reflect new code paths and styling, and ran that test file which passed.
- Ran the component unit test suite (`yarn test`) which succeeded with the updated expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a050e2300f883269d5d9a6fe4f07107)