### PR TITLE
Fix matching card spacing and hero fact styling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -97,7 +97,7 @@ import { normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard } from '../ut
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
-import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight, FaMapMarkerAlt, FaRulerVertical, FaWeight, FaTint, FaEye, FaRegStar } from 'react-icons/fa';
 import { FaPhoneVolume, FaXTwitter } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
@@ -974,6 +974,39 @@ const ProfileBio = ({ text }) => {
   );
 };
 
+
+const HERO_FACT_UNITS = {
+  height: 'cm',
+  weight: 'kg',
+};
+
+const normalizeHeroFactLabel = label => String(label || '').toLowerCase();
+
+const getHeroFactIcon = item => {
+  const key = String(item?.key || '').toLowerCase();
+  const label = normalizeHeroFactLabel(item?.label);
+  if (key.includes('height') || label.includes('height')) return <FaRulerVertical />;
+  if (key.includes('weight') || label.includes('weight')) return <FaWeight />;
+  if (key.includes('blood') || key === 'rh' || label.includes('blood') || label === 'rh') return <FaTint />;
+  if (key.includes('eye') || label.includes('eye')) return <FaEye />;
+  return <FaRegStar />;
+};
+
+const formatHeroFact = item => {
+  const rawValue = String(item?.value || '').trim();
+  const preferredUnit = HERO_FACT_UNITS[item?.key];
+  if (!rawValue) return { value: '', unit: preferredUnit || '' };
+
+  if (preferredUnit) {
+    const withoutUnit = rawValue.replace(new RegExp(`\\s*${preferredUnit}$`, 'i'), '').trim();
+    return { value: withoutUnit || rawValue, unit: preferredUnit };
+  }
+
+  const unitMatch = rawValue.match(/^(.+?)\s*(cm|kg|кг|см)$/i);
+  if (unitMatch) return { value: unitMatch[1].trim(), unit: unitMatch[2] };
+  return { value: rawValue, unit: '' };
+};
+
 const SwipeableCard = ({
   user,
   photo,
@@ -1094,15 +1127,22 @@ const SwipeableCard = ({
           <ModernHeroContent>
             <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>
             <ModernHeroTitle>{title}</ModernHeroTitle>
-            {locationInfo && <ModernHeroLocation>{locationInfo}</ModernHeroLocation>}
+            {locationInfo && <ModernHeroLocation><FaMapMarkerAlt aria-hidden="true" />{locationInfo}</ModernHeroLocation>}
             {heroFields.length > 0 && (
               <ModernHeroFacts>
-                {heroFields.slice(0, 6).map(item => (
-                  <ModernFactPill key={`hero-${item.key}`}>
-                    <strong>{item.label}</strong>
-                    <span>{item.value}</span>
-                  </ModernFactPill>
-                ))}
+                {heroFields.slice(0, 6).map(item => {
+                  const fact = formatHeroFact(item);
+                  return (
+                    <ModernFactPill key={`hero-${item.key}`}>
+                      <span className="fact-icon" aria-hidden="true">{getHeroFactIcon(item)}</span>
+                      <span className="fact-copy">
+                        <strong>{item.label}</strong>
+                        <span className="fact-value">{fact.value}</span>
+                        {fact.unit && <span className="fact-unit">{fact.unit}</span>}
+                      </span>
+                    </ModernFactPill>
+                  );
+                })}
               </ModernHeroFacts>
             )}
           </ModernHeroContent>

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -96,10 +96,12 @@ describe('Matching shared reaction card UI', () => {
     expect(matchingSource).not.toContain('Дозавантажити карточки');
     expect(matchingSource).not.toContain('Більше карточок завтра');
     expect(matchingSource).not.toContain('<LoadMoreButton');
-    expect(styledSource).toContain('height: 56%;');
+    expect(styledSource).toContain('height: 52%;');
+    expect(styledSource).toContain('min-height: 66px;');
     expect(styledSource).toContain('linear-gradient(135deg, #ffcc73 0%, #f7931e 100%)');
     expect(styledSource).toContain('position: absolute;\n  left: 0;\n  right: 0;\n  bottom: 0;');
-    expect(styledSource).toContain('background: rgba(255, 255, 255, 0.055);');
+    expect(styledSource).toContain('linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 249, 238, 0.82) 100%)');
+    expect(styledSource).toContain('color: #f7931e;');
   });
 
 });

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -23,16 +23,20 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  min-height: 100dvh;
   padding: 0;
-  background-color: #f5f5f5;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(247, 147, 30, 0.11), transparent 32%),
+    linear-gradient(180deg, #17120e 0%, #0c0a09 100%);
 `;
 
 export const InnerContainer = styled.div`
   max-width: 480px;
   width: 100%;
-  background-color: #f0f0f0;
+  min-height: 100dvh;
+  background: transparent;
   padding: 0;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.22);
   border-radius: 8px;
   box-sizing: border-box;
   position: relative;
@@ -41,20 +45,21 @@ export const InnerContainer = styled.div`
   flex-direction: column;
 
   @media (max-width: 768px) {
-    background-color: #f5f5f5;
-    box-shadow: 0 4px 8px #f5f5f5;
+    box-shadow: none;
     border-radius: 0;
   }
 `;
 
 export const Grid = styled.div`
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: nowrap;
   gap: 0;
-  padding: 0 10px;
-  margin-bottom: 8px;
+  padding: 0 10px 10px;
+  margin-bottom: 0;
   justify-content: center;
   width: 100%;
+  min-height: 0;
   box-sizing: border-box;
   overflow: hidden;
 `;
@@ -69,8 +74,10 @@ export const LoadMoreFooter = styled.div`
 
 export const CardContainer = styled.div`
   position: relative;
+  display: flex;
   width: 100%;
   max-width: 100%;
+  min-height: 0;
 `;
 
 export const NextPhoto = styled.img`
@@ -124,8 +131,10 @@ export const ThirdInfoCard = styled(NextInfoCard)`
 
 export const CardWrapper = styled.div`
   position: relative;
+  display: flex;
   width: 100%;
   max-width: 100%;
+  min-height: 0;
   border: 1px solid ${props => props.$role ? getRoleColors(props.$role).border : 'rgba(214, 193, 163, 0.35)'};
   border-top: 3px solid ${props => props.$role ? getRoleColors(props.$role).accent : color.accent5};
   border-radius: ${STACK_CARD_RADIUS};
@@ -336,7 +345,9 @@ export const CardCount = styled.p`
   width: 100%;
   margin: 0;
   text-align: center;
-  color: black;
+  color: #fff8ec;
+  font-weight: 700;
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.28);
 `;
 
 export const LoadMoreButton = styled.button`
@@ -725,8 +736,9 @@ const slideRight = keyframes`
 
 export const AnimatedCard = styled(Card)`
   ${({ $activeProfile }) => $activeProfile && `
-    height: min(760px, calc(100dvh - 112px));
-    min-height: 480px;
+    flex: 1 1 auto;
+    height: auto;
+    min-height: min(480px, calc(100dvh - 66px));
     aspect-ratio: auto;
     padding-bottom: 0;
     background: transparent;
@@ -768,19 +780,19 @@ export const ModernProfileShell = styled.div`
 
 export const ModernProfileScroll = styled.div`
   position: absolute;
-  inset: 0 0 82px;
+  inset: 0 0 66px;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
-  scroll-padding-bottom: 28px;
+  scroll-padding-bottom: 18px;
 `;
 
 export const ModernHero = styled.div`
   position: relative;
-  min-height: clamp(330px, 58%, 455px);
-  height: 58%;
+  min-height: clamp(300px, 52%, 430px);
+  height: 52%;
   background:
     ${({ $image }) => $image ? `linear-gradient(180deg, rgba(12, 9, 7, 0) 0%, rgba(12, 9, 7, 0.04) 42%, rgba(12, 9, 7, 0.48) 78%, rgba(12, 9, 7, 0.72) 100%), url(${$image})` : 'radial-gradient(circle at 26% 16%, rgba(247, 147, 30, 0.54), transparent 30%), radial-gradient(circle at 78% 18%, rgba(255, 218, 145, 0.16), transparent 24%), linear-gradient(145deg, #3a281b 0%, #15110f 56%, #070605 100%)'};
   background-size: cover;
@@ -854,38 +866,109 @@ export const ModernHeroTitle = styled.h2`
 `;
 
 export const ModernHeroLocation = styled.p`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin: 7px 0 0;
-  color: rgba(255, 246, 232, 0.88);
+  color: rgba(255, 246, 232, 0.92);
   font-size: 15px;
-  font-weight: 600;
+  font-weight: 650;
+
+  svg {
+    flex: 0 0 auto;
+    color: #f7931e;
+    filter: drop-shadow(0 1px 5px rgba(0, 0, 0, 0.42));
+  }
 `;
 
 export const ModernHeroFacts = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 10px;
+  flex-wrap: nowrap;
+  gap: 8px;
+  margin-top: 12px;
+  padding-bottom: 2px;
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const ModernFactPill = styled.span`
+  flex: 0 0 74px;
+  min-height: 74px;
   display: inline-flex;
-  gap: 5px;
-  align-items: baseline;
-  max-width: 100%;
-  padding: 5px 8px;
-  border-radius: 999px;
-  color: #fff8ec;
-  background: rgba(22, 17, 12, 0.38);
-  border: 1px solid rgba(255, 204, 115, 0.18);
-  backdrop-filter: blur(12px);
-  font-size: 12px;
-  line-height: 1.1;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 7px;
+  padding: 9px 10px 8px;
+  border-radius: 18px;
+  color: #2a2118;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 249, 238, 0.82) 100%);
+  border: 1px solid rgba(255, 214, 148, 0.5);
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(14px);
+  text-shadow: none;
+  line-height: 1;
+
+  .fact-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #f7931e;
+    background: rgba(247, 147, 30, 0.12);
+    font-size: 12px;
+  }
+
+  .fact-copy {
+    display: grid;
+    grid-template-columns: minmax(0, auto) auto;
+    align-items: end;
+    column-gap: 3px;
+    row-gap: 2px;
+  }
 
   strong {
-    color: rgba(255, 204, 115, 0.82);
-    font-size: 10px;
+    grid-column: 1 / -1;
+    color: rgba(247, 108, 0, 0.88);
+    font-size: 9px;
+    font-weight: 850;
     text-transform: uppercase;
-    letter-spacing: 0.4px;
+    letter-spacing: 0.45px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .fact-value {
+    color: #241a12;
+    font-size: 22px;
+    font-weight: 900;
+    letter-spacing: -0.7px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .fact-unit {
+    align-self: end;
+    padding-bottom: 2px;
+    color: rgba(66, 49, 32, 0.68);
+    font-size: 10px;
+    font-weight: 800;
+    text-transform: lowercase;
+  }
+
+  @media (max-width: 380px) {
+    flex-basis: 68px;
+    min-height: 70px;
+    padding: 8px;
   }
 `;
 
@@ -1088,10 +1171,10 @@ export const ModernActionRail = styled.div`
   z-index: 8;
   display: flex;
   justify-content: space-between;
-  min-height: 82px;
+  min-height: 66px;
   box-sizing: border-box;
   align-items: center;
-  padding: 12px 46px 14px;
+  padding: 7px 48px 8px;
   pointer-events: none;
   background: linear-gradient(180deg, rgba(12, 9, 7, 0.72) 0%, rgba(12, 9, 7, 0.96) 100%);
   border-top: 1px solid rgba(255, 214, 148, 0.1);
@@ -1102,8 +1185,8 @@ export const ModernActionRail = styled.div`
 
   button {
     position: static !important;
-    width: 52px !important;
-    height: 52px !important;
+    width: 48px !important;
+    height: 48px !important;
     border-radius: 50% !important;
     box-shadow: 0 14px 32px rgba(0, 0, 0, 0.32) !important;
   }


### PR DESCRIPTION
### Motivation
- Remove the large white gap under the active Matching card and make the profile card fill available mobile viewport height with a consistent page background. 
- Reduce the visual weight of the bottom like/dislike action zone so it no longer consumes excessive vertical space.
- Restyle hero quick facts to match the light translucent mockup (icon, large value, small unit, compact pill) and add a location pin icon.

### Description
- Adjust layout sizing so Matching fills the viewport: set `Container`/`InnerContainer` to `min-height: 100dvh`, make the card area flexible (`Grid`, `CardContainer`, `CardWrapper` flex changes) and change `AnimatedCard` to use `flex: 1 1 auto` with `min-height: min(480px, calc(100dvh - 66px))` to remove bottom white space (`src/components/Matching.styled.jsx`).
- Compact the action rail by reducing reserved height/padding and button sizes: `ModernActionRail` min-height reduced and action button sizes changed to `48px` so like/dislike controls live inside the card height (`src/components/Matching.styled.jsx`).
- Restyle hero quick facts into small rounded translucent cards: add horizontal scroll on overflow, introduce `ModernFactPill` styling (icon block, prominent value, smaller unit), and limit to first 6 facts (`src/components/Matching.styled.jsx`).
- Add hero fact formatting and icons: introduce `HERO_FACT_UNITS`, `getHeroFactIcon`, and `formatHeroFact` helpers and render icon + value + unit inside fact pills (`src/components/Matching.jsx`).
- Add geolocation pin before hero location using `FaMapMarkerAlt` and tint it with the orange accent (`src/components/Matching.jsx` and `src/components/Matching.styled.jsx`).
- Minor hero/card tweaks: reduce hero height from `58%` to `52%`, decrease scroll inset/padding to better fit action rail, and refine shadows/background to maintain visual consistency (`src/components/Matching.styled.jsx`).
- Update shared-reaction UI unit test expectations to match new styling (`src/components/Matching.sharedReactions.test.js`).

### Testing
- Ran `npm test -- --runInBand --watchAll=false src/components/Matching.sharedReactions.test.js` and the test suite passed (all tests in that file succeeded). 
- Built the production bundle with `npm run build` and the build completed successfully.
- No visual regression automation was available in the environment (no browser binary), manual UI verification is recommended on a device/emulator to confirm pixel details (hero facts spacing, action rail compactness, and pin icon visibility).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055309e37883268b27dbf5e0871f0a)