### PR TITLE
Fix matching photo viewer lint errors

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -91,6 +91,7 @@ import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
 import { getCurrentValue } from './getCurrentValue';
 import SearchBar from './SearchBar';
+import PhotoViewer from './PhotoViewer';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { getCacheKey, clearAllCardsCache, setFavoriteIds } from "../utils/cache";
@@ -1062,7 +1063,6 @@ const SwipeableCard = ({
   const locationInfo = getProfileLocation(user);
   const identityAndLocationKeys = ['name', 'surname', 'agencyName', 'companyName', 'agency', 'country', 'region', 'city', 'role', 'userRole'];
   const heroFields = getHeroFields(user, resolvedRole, { excludeKeys: identityAndLocationKeys });
-  const displayedHeroFields = heroFields.slice(0, 3);
   const bodyHeroFields = heroFields.slice(3);
   const usedSummaryFieldKeys = collectProfileFieldKeys(heroFields);
   const sections = getProfileSections(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys] });


### PR DESCRIPTION
### Motivation
- Fix lint errors in `Matching.jsx` caused by an undefined `PhotoViewer` component reference and an unused `displayedHeroFields` variable.

### Description
- Add `import PhotoViewer from './PhotoViewer';` and remove the unused `displayedHeroFields` assignment in `src/components/Matching.jsx` to satisfy ESLint rules.

### Testing
- Ran `npx eslint src/components/Matching.jsx` which completed without linter errors (only a `browserslist` update warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0557bbbbbc8326964f27e67b053602)