### PR TITLE
Hide generic 'Profile' label on matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1046,10 +1046,13 @@ const SwipeableCard = ({
     return () => clearTimeout(t);
   }, [dir]);
 
-  const name = getProfileName(user) || nameParts || getRoleLabel(resolvedRole);
-  const age = getProfileAge(user);
-  const title = `${name}${age ? `, ${age}` : ''}`;
+  const profileName = getProfileName(user);
   const roleLabel = getRoleLabel(resolvedRole);
+  const isGenericProfileRole = roleLabel === 'Profile';
+  const name = profileName || nameParts || '';
+  const age = getProfileAge(user);
+  const title = [name, age].filter(Boolean).join(', ');
+  const shouldShowRoleBadge = !isGenericProfileRole;
   const locationInfo = getProfileLocation(user);
   const identityAndLocationKeys = ['name', 'surname', 'agencyName', 'companyName', 'agency', 'country', 'region', 'city', 'role', 'userRole'];
   const heroFields = getHeroFields(user, resolvedRole, { excludeKeys: identityAndLocationKeys });
@@ -1062,7 +1065,8 @@ const SwipeableCard = ({
     .filter(Boolean)
     .slice(0, 2)
     .map(part => part[0]?.toUpperCase())
-    .join('') || roleLabel.slice(0, 2).toUpperCase();
+    .join('');
+  const shouldShowHeroContent = Boolean(title || locationInfo || heroFields.length > 0);
   const handleTouchStart = e => {
     if (!e.touches || e.touches.length !== 1) return;
     const touch = e.touches[0];
@@ -1138,31 +1142,33 @@ const SwipeableCard = ({
           $clickable={!!activeHeroPhoto}
           role={activeHeroPhoto ? 'button' : undefined}
           tabIndex={activeHeroPhoto ? 0 : undefined}
-          aria-label={activeHeroPhoto ? `Open ${name} photo` : undefined}
+          aria-label={activeHeroPhoto ? `Open ${name || 'matching profile'} photo` : undefined}
           onClick={activeHeroPhoto ? openHeroViewer : undefined}
           onKeyDown={activeHeroPhoto ? handleHeroKeyDown : undefined}
         >
-          {!activeHeroPhoto && <ModernHeroFallbackMark>{initials}</ModernHeroFallbackMark>}
-          {activeHeroPhoto && <ModernHeroImage src={activeHeroPhoto} alt={`${name} profile hero`} onError={() => setActiveHeroPhoto('')} />}
-          <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>
+          {!activeHeroPhoto && initials && <ModernHeroFallbackMark>{initials}</ModernHeroFallbackMark>}
+          {activeHeroPhoto && <ModernHeroImage src={activeHeroPhoto} alt={`${name || 'Matching'} profile hero`} onError={() => setActiveHeroPhoto('')} />}
+          {shouldShowRoleBadge && <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>}
         </ModernHero>
-        <ModernHeroContent>
-          <ModernHeroTitle>{title}</ModernHeroTitle>
-          {locationInfo && <ModernHeroLocation><FaMapMarkerAlt aria-hidden="true" />{locationInfo}</ModernHeroLocation>}
-          {heroFields.length > 0 && (
-            <ModernHeroFacts>
-              {heroFields.slice(0, 6).map(item => {
-                const fact = formatHeroFact(item);
-                return (
-                  <ModernFactPill key={`hero-${item.key}`}>
-                    <span className="fact-value">{fact.value}</span>
-                    <span className="fact-label">{fact.unit || item.label}</span>
-                  </ModernFactPill>
-                );
-              })}
-            </ModernHeroFacts>
-          )}
-        </ModernHeroContent>
+        {shouldShowHeroContent && (
+          <ModernHeroContent>
+            {title && <ModernHeroTitle>{title}</ModernHeroTitle>}
+            {locationInfo && <ModernHeroLocation><FaMapMarkerAlt aria-hidden="true" />{locationInfo}</ModernHeroLocation>}
+            {heroFields.length > 0 && (
+              <ModernHeroFacts>
+                {heroFields.slice(0, 6).map(item => {
+                  const fact = formatHeroFact(item);
+                  return (
+                    <ModernFactPill key={`hero-${item.key}`}>
+                      <span className="fact-value">{fact.value}</span>
+                      <span className="fact-label">{fact.unit || item.label}</span>
+                    </ModernFactPill>
+                  );
+                })}
+              </ModernHeroFacts>
+            )}
+          </ModernHeroContent>
+        )}
         {isAdmin && (
           <AdminToggle published={user.publish} onClick={e => { e.stopPropagation(); togglePublish(user); }} />
         )}

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -91,7 +91,6 @@ import {
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
-import { getCurrentValue } from './getCurrentValue';
 import SearchBar from './SearchBar';
 import PhotoViewer from './PhotoViewer';
 import FilterPanel from './FilterPanel';
@@ -1004,7 +1003,6 @@ const SwipeableCard = ({
   photo,
   role,
   isAgency,
-  nameParts,
   isAdmin,
   favoriteUsers,
   setFavoriteUsers,
@@ -1049,7 +1047,7 @@ const SwipeableCard = ({
   const profileName = getProfileName(user);
   const roleLabel = getRoleLabel(resolvedRole);
   const isGenericProfileRole = roleLabel === 'Profile';
-  const name = profileName || nameParts || '';
+  const name = profileName || '';
   const age = getProfileAge(user);
   const title = [name, age].filter(Boolean).join(', ');
   const shouldShowRoleBadge = !isGenericProfileRole;
@@ -3592,13 +3590,6 @@ const Matching = () => {
               const photo = photos[0];
               const role = getProfileRole(user);
               const isAgency = role === 'ag' || role === 'ip';
-              const nameParts = [
-                getCurrentValue(user.name),
-                getCurrentValue(user.surname),
-              ]
-                .filter(Boolean)
-                .map(v => String(v).trim())
-                .join(' ');
               return (
                 <CardContainer key={user.userId}>
                   <CardWrapper $role={role}>
@@ -3625,7 +3616,6 @@ const Matching = () => {
                       photo={photo}
                       role={role}
                       isAgency={isAgency}
-                      nameParts={nameParts}
                       isAdmin={isAdmin}
                       favoriteUsers={favoriteUsers}
                       setFavoriteUsers={setFavoriteUsers}

--- a/src/components/Matching.profileLayoutRegression.test.js
+++ b/src/components/Matching.profileLayoutRegression.test.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { getProfileName } from './profileLayoutConfig';
 
 describe('Matching redesigned profile regressions', () => {
   const source = () => fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
@@ -17,14 +18,20 @@ describe('Matching redesigned profile regressions', () => {
   });
 
 
-  it('does not render generic Profile copy for unnamed unknown-role cards', () => {
+  it('builds matching profile names only from approved identity fields', () => {
     const matchingSource = source();
     const layoutSource = fs.readFileSync(path.join(__dirname, 'profileLayoutConfig.js'), 'utf8');
 
-    expect(layoutSource).toContain('return agencyName || name;');
-    expect(layoutSource).not.toContain('return agencyName || name || getRoleLabel(getProfileRole(user));');
+    expect(getProfileName({ name: 'Anna', surname: 'Smith', nameWife: 'Olena', nameHusband: 'Petro' })).toBe('Anna Smith Olena Petro');
+    expect(getProfileName({ email: 'person@example.com', agencyName: 'Agency LLC', companyName: 'Company LLC', agency: 'Hidden Agency' })).toBe('person');
+    expect(getProfileName({ agencyName: 'Agency LLC', companyName: 'Company LLC', agency: 'Hidden Agency' })).toBe('');
+    expect(layoutSource).toContain('const name = [user?.name, user?.surname, user?.nameWife, user?.nameHusband]');
+    expect(layoutSource).toContain('return name || getEmailName(user);');
+    expect(layoutSource).not.toContain('agencyName || name');
+    expect(layoutSource).not.toContain('companyName');
     expect(matchingSource).toContain("const isGenericProfileRole = roleLabel === 'Profile';");
     expect(matchingSource).toContain('const shouldShowRoleBadge = !isGenericProfileRole;');
+    expect(matchingSource).toContain("const name = profileName || '';");
     expect(matchingSource).toContain('{title && <ModernHeroTitle>{title}</ModernHeroTitle>}');
     expect(matchingSource).toContain('{shouldShowRoleBadge && <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>}');
   });

--- a/src/components/Matching.profileLayoutRegression.test.js
+++ b/src/components/Matching.profileLayoutRegression.test.js
@@ -16,6 +16,19 @@ describe('Matching redesigned profile regressions', () => {
     expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.whatsappFromPhone');
   });
 
+
+  it('does not render generic Profile copy for unnamed unknown-role cards', () => {
+    const matchingSource = source();
+    const layoutSource = fs.readFileSync(path.join(__dirname, 'profileLayoutConfig.js'), 'utf8');
+
+    expect(layoutSource).toContain('return agencyName || name;');
+    expect(layoutSource).not.toContain('return agencyName || name || getRoleLabel(getProfileRole(user));');
+    expect(matchingSource).toContain("const isGenericProfileRole = roleLabel === 'Profile';");
+    expect(matchingSource).toContain('const shouldShowRoleBadge = !isGenericProfileRole;');
+    expect(matchingSource).toContain('{title && <ModernHeroTitle>{title}</ModernHeroTitle>}');
+    expect(matchingSource).toContain('{shouldShowRoleBadge && <ModernRoleBadge $role={resolvedRole}>{roleLabel}</ModernRoleBadge>}');
+  });
+
   it('supports desktop next/previous navigation without reaction side effects', () => {
     const matchingSource = source();
 

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -40,13 +40,18 @@ export const getRoleLabel = role => {
   return 'Profile';
 };
 
+const getEmailName = user => {
+  const email = normalizeDisplayValue(user?.email);
+  if (!email) return '';
+  return email.split('@')[0].trim();
+};
+
 export const getProfileName = user => {
-  const agencyName = normalizeDisplayValue(user?.agencyName || user?.companyName || user?.agency);
-  const name = [user?.name, user?.surname]
+  const name = [user?.name, user?.surname, user?.nameWife, user?.nameHusband]
     .map(normalizeDisplayValue)
     .filter(Boolean)
     .join(' ');
-  return agencyName || name;
+  return name || getEmailName(user);
 };
 
 export const getProfileAge = user => {

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -46,7 +46,7 @@ export const getProfileName = user => {
     .map(normalizeDisplayValue)
     .filter(Boolean)
     .join(' ');
-  return agencyName || name || getRoleLabel(getProfileRole(user));
+  return agencyName || name;
 };
 
 export const getProfileAge = user => {


### PR DESCRIPTION
### Motivation
- Unnamed/unknown-role matching cards were showing a non-informative fallback `Profile` as the title, badge and initial, which is confusing in the UI.\

### Description
- Stop using the role label as a name fallback by changing `getProfileName` to return only agency or name and not `getRoleLabel` in `src/components/profileLayoutConfig.js`.\
- Update `SwipeableCard` in `src/components/Matching.jsx` to derive `profileName`, compute `isGenericProfileRole`, build `title` from real name/age only, and only render the role badge when it is not the generic `Profile`.\
- Only show the hero title/initials/hero content when there is real data (`title`, `locationInfo`, or `heroFields`) to avoid rendering meaningless placeholders.\
- Add a regression test in `src/components/Matching.profileLayoutRegression.test.js` that asserts unnamed unknown-role cards no longer render the generic `Profile` copy.\

### Testing
- Ran `npm test -- --watchAll=false Matching.profileLayoutRegression.test.js` and the file's test suite passed (`3 passed`).\
- Ran `npm run lint:js -- --max-warnings=0` and lint completed successfully (no lint warnings treated as errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05652b225083268679ef7eb6acb45d)