### PR TITLE
Matching: show Exp instead of Eyes, dedupe Key details, and make contacts collapsible

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -39,8 +39,10 @@ import {
   ModernBioText,
   ModernChip,
   ModernChipGrid,
+  ModernContactDetails,
   ModernContactLinks,
   ModernContactLink,
+  ModernContactSummary,
   ModernFieldList,
   ModernFieldRow,
   ModernDesktopNavButton,
@@ -109,6 +111,7 @@ import { getContactEntries, CONTACT_LINK_BUILDERS } from './contactMethods';
 import { handleEmptyFetch } from './loadMoreUtils';
 import {
   getHeroFields,
+  getQuickFacts,
   getProfileAge,
   getProfileBio,
   getProfileLocation,
@@ -1053,9 +1056,10 @@ const SwipeableCard = ({
   const locationInfo = getProfileLocation(user);
   const identityAndLocationKeys = ['name', 'surname', 'agencyName', 'companyName', 'agency', 'country', 'region', 'city', 'role', 'userRole'];
   const heroFields = getHeroFields(user, resolvedRole, { excludeKeys: identityAndLocationKeys });
-  const bodyHeroFields = heroFields.slice(3);
   const usedSummaryFieldKeys = collectProfileFieldKeys(heroFields);
-  const sections = getProfileSections(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys] });
+  const bodyHeroFields = getQuickFacts(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys] });
+  const usedBodyFieldKeys = collectProfileFieldKeys(bodyHeroFields);
+  const sections = getProfileSections(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys, ...usedBodyFieldKeys] });
   const bio = getProfileBio(user);
   const initials = name
     .split(/\s+/)
@@ -1186,8 +1190,10 @@ const SwipeableCard = ({
           ))}
           {sections.filter(section => section.variant === 'contacts').map(section => (
             <ModernSection key={section.title}>
-              <ModernSectionTitle>{section.title}</ModernSectionTitle>
-              <ProfileContactLinks user={user} role={resolvedRole} />
+              <ModernContactDetails onClick={e => e.stopPropagation()} onTouchStart={e => e.stopPropagation()} onTouchEnd={e => e.stopPropagation()}>
+                <ModernContactSummary>Show contacts</ModernContactSummary>
+                <ProfileContactLinks user={user} role={resolvedRole} />
+              </ModernContactDetails>
             </ModernSection>
           ))}
           <ModernSection>

--- a/src/components/Matching.profileLayoutRegression.test.js
+++ b/src/components/Matching.profileLayoutRegression.test.js
@@ -10,10 +10,20 @@ describe('Matching redesigned profile regressions', () => {
     expect(matchingSource).toContain('const ProfileContactLinks = ({ user, role }) =>');
     expect(matchingSource).toContain("section.variant === 'contacts'");
     expect(matchingSource).toContain('<ProfileContactLinks user={user} role={resolvedRole} />');
+    expect(matchingSource).toContain('<ModernContactSummary>Show contacts</ModernContactSummary>');
     expect(matchingSource).toContain('href={entry.href}');
     expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.telegramFromPhone');
     expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.viberFromPhone');
     expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.whatsappFromPhone');
+  });
+
+
+  it('keeps Key details from repeating hero fields', () => {
+    const matchingSource = source();
+
+    expect(matchingSource).toContain('const bodyHeroFields = getQuickFacts(user, resolvedRole');
+    expect(matchingSource).toContain('const usedBodyFieldKeys = collectProfileFieldKeys(bodyHeroFields);');
+    expect(matchingSource).not.toContain('const bodyHeroFields = heroFields.slice(3);');
   });
 
   it('supports desktop next/previous navigation without reaction side effects', () => {

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -1295,8 +1295,46 @@ export const ModernMoreButton = styled.button`
   cursor: pointer;
 `;
 
+export const ModernContactDetails = styled.details`
+  border: 1px solid var(--matching-contact-border);
+  border-radius: 16px;
+  background: var(--matching-card-bg);
+  overflow: hidden;
+`;
+
+export const ModernContactSummary = styled.summary`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  color: var(--matching-contact-text);
+  font-size: 13px;
+  font-weight: 900;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::after {
+    content: '⌄';
+    color: var(--matching-accent);
+    font-size: 16px;
+    line-height: 1;
+    transition: transform 0.18s ease;
+  }
+
+  ${ModernContactDetails}[open] &::after {
+    transform: rotate(180deg);
+  }
+`;
+
 export const ModernContactLinks = styled.div`
   display: flex;
+  padding: 0 12px 12px;
   flex-wrap: wrap;
   gap: 8px;
 `;

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -117,8 +117,7 @@ const heroFields = {
     field('weight', 'Weight'),
     field('bmi', 'BMI', bmiValue, ['bmi']),
     field('blood', 'Blood/Rh'),
-    field('eyeColor', 'Eyes'),
-    field('experience', 'Experience', donorExperienceValue, ['experience', 'donationExperience', 'previousDonation', 'donationCount', 'donationsCount']),
+    field('experience', 'Exp', donorExperienceValue, ['experience', 'donationExperience', 'previousDonation', 'donationCount', 'donationsCount']),
   ],
   ip: [
     field('country', 'Country'),

--- a/src/components/profileLayoutConfig.test.js
+++ b/src/components/profileLayoutConfig.test.js
@@ -42,7 +42,8 @@ describe('profileLayoutConfig', () => {
 
     expect(getProfileRole(user)).toBe('ed');
     expect(getProfilePhotos(user)).toEqual(['hero.jpg', 'gallery.jpg']);
-    expect(hero.map(field => field.key)).toEqual(['height', 'weight', 'bmi', 'blood', 'eyeColor', 'experience']);
+    expect(hero.map(field => field.key)).toEqual(['height', 'weight', 'bmi', 'blood', 'experience']);
+    expect(hero.find(field => field.key === 'experience')?.label).toBe('Exp');
     expect(quickFacts.map(field => field.key)).toEqual([]);
     expect(sections.map(section => section.title)).toEqual(expect.arrayContaining(['Appearance', 'Main information', 'Donation experience']));
     expect(detailKeys).toEqual(expect.arrayContaining(['breastSize', 'ownKids', 'education', 'cSection']));


### PR DESCRIPTION
### Motivation
- Reduce duplicate profile facts and improve clarity by showing donor experience in the hero facts instead of eye color. 
- Prevent repeating fields between hero facts and lower detail sections. 
- Move potentially verbose contacts behind a collapsible control to keep cards compact.

### Description
- Replace the hero `eyeColor / Eyes` fact with `experience` labeled `Exp` in the donor hero facts. (edited `src/components/profileLayoutConfig.js`)
- Populate the “Key details” area from `getQuickFacts` (which excludes already-displayed hero fields) instead of slicing the hero array, and exclude these quick-fact keys from lower sections to avoid repeats. (edited `src/components/Matching.jsx`)
- Wrap contacts in a native collapsible block with a `Show contacts` summary and keep actionable contact links inside it, plus corresponding styled components. (edited `src/components/Matching.jsx` and `src/components/Matching.styled.jsx`)
- Update tests to assert the `Exp` label, the new `getQuickFacts` usage preventing repetition, and the `Show contacts` summary. (edited `src/components/profileLayoutConfig.test.js` and `src/components/Matching.profileLayoutRegression.test.js`)

### Testing
- Ran unit tests with `npm test -- --runTestsByPath src/components/profileLayoutConfig.test.js src/components/Matching.profileLayoutRegression.test.js --watchAll=false` and both test suites passed. 
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05672a45d083268822f7425e02d645)