### PR TITLE
Refactor ModernContact link styles for pill layout and updated theme tokens

### DIFF
--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -1337,30 +1337,31 @@ export const ModernContactSummary = styled.summary`
 
 export const ModernContactLinks = styled.div`
   display: flex;
+  padding: 0 12px 12px;
   flex-wrap: wrap;
   gap: 8px;
 `;
 
 export const ModernContactLink = styled.a`
   display: inline-flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 6px;
   max-width: 100%;
-  padding: 7px 10px;
-  border-radius: 13px;
-  background: var(--matching-chip-bg);
-  border: 1px solid var(--matching-chip-border);
-  color: var(--matching-chip-text);
-  font-size: 15px;
-  font-weight: 600;
-  line-height: 1.15;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: var(--matching-card-bg);
+  border: none;
+  color: var(--matching-contact-text);
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1;
   text-decoration: none;
 
   svg {
     flex: 0 0 auto;
     width: 14px;
     height: 14px;
-    color: var(--matching-chip-label);
+    color: var(--matching-accent);
   }
 
   span {


### PR DESCRIPTION
### Motivation
- Improve visual consistency and spacing of contact action items by converting chip-like links into pill-shaped, center-aligned buttons that match updated theme tokens.
- Align icon and label sizing for better compactness and readability across responsive layouts.

### Description
- Added horizontal padding to `ModernContactLinks` with `padding: 0 12px 12px` to provide consistent outer spacing.
- Reworked `ModernContactLink` from a column chip to a centered pill by replacing `flex-direction: column` with `align-items: center`, increasing `gap` to `6px`, and changing `padding` to `8px 10px` and `border-radius` to `999px`.
- Switched visual tokens on `ModernContactLink` by replacing `background: var(--matching-chip-bg)` and bordered style with `background: var(--matching-card-bg)` and `border: none`, and updated text and icon colors to `var(--matching-contact-text)` and `var(--matching-accent)` respectively.
- Adjusted typography on `ModernContactLink` to `font-size: 12px`, `font-weight: 900`, and `line-height: 1` for a tighter, bold label presentation.

### Testing
- Ran unit tests via `yarn test` and they completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05746ed30c83269060dada1e107f80)