### PR TITLE
Normalize and deduplicate profile name parts in getProfileName

### DIFF
--- a/src/components/Matching.profileLayoutRegression.test.js
+++ b/src/components/Matching.profileLayoutRegression.test.js
@@ -24,9 +24,13 @@ describe('Matching redesigned profile regressions', () => {
     const layoutSource = fs.readFileSync(path.join(__dirname, 'profileLayoutConfig.js'), 'utf8');
 
     expect(getProfileName({ name: 'Anna', surname: 'Smith', nameWife: 'Olena', nameHusband: 'Petro' })).toBe('Anna Smith Olena Petro');
+    expect(getProfileName({ name: 'Anna', surname: 'Smith', nameWife: 'Anna', nameHusband: 'Petro' })).toBe('Anna Smith Petro');
+    expect(getProfileName({ name: 'Anna Smith', surname: '', nameWife: 'Anna Smith', nameHusband: 'Petro' })).toBe('Anna Smith Petro');
+    expect(getProfileName({ name: ['Rajpootgkhan', 'Muhammad'], surname: ['Shafique', 'Hafeez'], nameHusband: 'Muhammad Hafeez' })).toBe('Muhammad Hafeez');
     expect(getProfileName({ email: 'person@example.com', agencyName: 'Agency LLC', companyName: 'Company LLC', agency: 'Hidden Agency' })).toBe('person');
     expect(getProfileName({ agencyName: 'Agency LLC', companyName: 'Company LLC', agency: 'Hidden Agency' })).toBe('');
-    expect(layoutSource).toContain('const name = [user?.name, user?.surname, user?.nameWife, user?.nameHusband]');
+    expect(layoutSource).toContain('const getPrimaryNamePart = user => [user?.name, user?.surname]');
+    expect(layoutSource).toContain('const getUniqueNameParts = user =>');
     expect(layoutSource).toContain('return name || getEmailName(user);');
     expect(layoutSource).not.toContain('agencyName || name');
     expect(layoutSource).not.toContain('companyName');

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -46,11 +46,44 @@ const getEmailName = user => {
   return email.split('@')[0].trim();
 };
 
-export const getProfileName = user => {
-  const name = [user?.name, user?.surname, user?.nameWife, user?.nameHusband]
+const normalizeNameKey = part => part.toLowerCase().replace(/\s+/g, ' ').trim();
+
+const isDuplicateNameKey = (seen, key) => {
+  const keyTokens = key.split(' ');
+
+  return Array.from(seen).some(existingKey => {
+    const existingTokens = existingKey.split(' ');
+    return existingKey === key
+      || keyTokens.every(token => existingTokens.includes(token));
+  });
+};
+
+const appendUniqueNamePart = (parts, seen, part) => {
+  const key = normalizeNameKey(part);
+  if (!key || isDuplicateNameKey(seen, key)) return;
+  seen.add(key);
+  parts.push(part);
+};
+
+const getPrimaryNamePart = user => [user?.name, user?.surname]
+  .map(normalizeDisplayValue)
+  .filter(Boolean)
+  .join(' ');
+
+const getUniqueNameParts = user => {
+  const parts = [];
+  const seen = new Set();
+
+  [getPrimaryNamePart(user), user?.nameWife, user?.nameHusband]
     .map(normalizeDisplayValue)
     .filter(Boolean)
-    .join(' ');
+    .forEach(part => appendUniqueNamePart(parts, seen, part));
+
+  return parts;
+};
+
+export const getProfileName = user => {
+  const name = getUniqueNameParts(user).join(' ');
   return name || getEmailName(user);
 };
 


### PR DESCRIPTION
### Motivation

- Ensure profile display names are constructed only from approved identity fields while avoiding duplicated or overlapping name tokens.
- Preserve previous email fallback behavior when no valid name parts are available.

### Description

- Reworked `getProfileName` to build a unique name by extracting a primary name part and then appending unique spouse/partner name parts via new helpers `getPrimaryNamePart` and `getUniqueNameParts`.
- Added helper functions `normalizeNameKey`, `isDuplicateNameKey`, and `appendUniqueNamePart` to normalize tokens and prevent duplicates when name parts share tokens or are identical.
- Kept the email fallback using `getEmailName` and removed the former flat array of `[user?.name, user?.surname, user?.nameWife, user?.nameHusband]` in favor of the new deduplication flow.
- Updated regression test `Matching.profileLayoutRegression.test.js` to include new expectations for `getProfileName` behavior and to assert the presence of `getPrimaryNamePart` and `getUniqueNameParts` in the layout source.

### Testing

- Ran unit/regression tests and updated `Matching.profileLayoutRegression.test.js` to cover deduplication scenarios; the modified test suite executed successfully.
- Executed the full test command `yarn test` (or `npm test`) and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05751a17b48326959f7068e2d3dccd)