### PR TITLE
Strip '__photosHydrated' transient field before database writes

### DIFF
--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -24,7 +24,7 @@ describe('fetchUsersByIds merging', () => {
   it('strips client-only source markers before database writes', () => {
     const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
 
-    expect(source).toContain("const transientUserDataKeys = ['__sourceCollection']");
+    expect(source).toContain("const transientUserDataKeys = ['__sourceCollection', '__photosHydrated']");
     expect(source).toContain('const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo);');
     expect(source.match(/markForRealtimeDeletion: condition === 'update'/g)).toHaveLength(2);
   });

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2344,7 +2344,7 @@ const removeUndefined = obj => {
   return obj;
 };
 
-const transientUserDataKeys = ['__sourceCollection'];
+const transientUserDataKeys = ['__sourceCollection', '__photosHydrated'];
 
 const stripTransientUserDataFields = (payload, { markForRealtimeDeletion = false } = {}) => {
   const cleaned = removeUndefined(payload);


### PR DESCRIPTION
### Motivation
- Ensure the client-only marker for hydrated photos is not written to the database by treating `__photosHydrated` as a transient user data key.

### Description
- Add `__photosHydrated` to the `transientUserDataKeys` array in `src/components/config.js` so it is stripped by `stripTransientUserDataFields` before writes, and update `src/components/config.fetchUsersByIds.test.js` to expect the new transient key.

### Testing
- Updated unit test `src/components/config.fetchUsersByIds.test.js` and ran the test suite (`npm test` / `jest`); all affected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057b8ee08483269eef68d91a9e574d)