### PR TITLE
Fix matching comment input dark tint

### DIFF
--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -202,6 +202,14 @@ export const CommentInput = styled.textarea`
   border: ${props => (props.plain ? 'none' : `1px solid ${color.gray3}`)};
   border-radius: ${props => (props.plain ? '0' : '8px')};
   outline: ${props => (props.plain ? 'none' : 'auto')};
+  background: ${props => (props.plain ? 'transparent' : 'var(--matching-chip-bg, #fff)')};
+  color: var(--matching-chip-text, #161616);
+  caret-color: var(--matching-accent, ${color.accent5});
+  transition: background 220ms cubic-bezier(0.4, 0, 0.2, 1), color 220ms cubic-bezier(0.4, 0, 0.2, 1);
+
+  &::placeholder {
+    color: var(--matching-muted-text, ${color.gray1});
+  }
 `;
 
 export const CommentBox = styled.div`


### PR DESCRIPTION
### Motivation
- The matching comment textarea picked up a browser dark-tinted background in dark mode because it did not define its own background or theme-aware colors, causing poor contrast on dark themes.

### Description
- Update `CommentInput` in `src/components/Matching.styled.jsx` to set a transparent background for `plain` mode and add theme-aware `background`, `color`, `caret-color`, placeholder color, and transitions so the textarea respects the matching theme variables.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057de25dd88326a1464a60a4444cf9)