### PR TITLE
Remove matching card count display

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -7,7 +7,6 @@ import {
   AdminToggle,
   AnimatedCard,
   CardContainer,
-  CardCount,
   CardWrapper,
   ClickableId,
   CollectionSourceLabel,
@@ -3517,7 +3516,6 @@ const Matching = () => {
       <Container $themeMode={themeMode}>
         <InnerContainer>
           <HeaderContainer>
-            <CardCount $themeMode={themeMode}>{filteredUsers.length ? `${activeProfileIndex + 1} / ${filteredUsers.length}` : '0'} карточок</CardCount>
             <TopActions>
               <ThemeToggleButton
                 type="button"

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -330,7 +330,6 @@ export const SkeletonLine = styled.div`
 
 export const TopActions = styled.div`
   position: static;
-  grid-column: 3;
   display: flex;
   justify-content: flex-end;
   gap: 8px;
@@ -538,20 +537,11 @@ export const BackendTrafficToggleStatus = styled.span`
 
 export const HeaderContainer = styled.div`
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(64px, 1fr) auto minmax(64px, 1fr);
+  display: flex;
+  justify-content: flex-end;
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-`;
-
-export const CardCount = styled.p`
-  grid-column: 2;
-  margin: 0;
-  text-align: center;
-  color: var(--matching-header-text, #fff8ec);
-  font-weight: 700;
-  text-shadow: ${({ $themeMode }) => ($themeMode === 'light' ? '0 1px 0 rgba(255,255,255,0.72)' : '0 1px 12px rgba(0, 0, 0, 0.28)')};
 `;
 
 export const LoadMoreButton = styled.button`


### PR DESCRIPTION
### Motivation
- Убрав віджет лічильника карток у хедері Matching (`1 / 25 карточок`), оскільки він не дає корисної інформації та підвантажує систему/бекенд зайвими обчисленнями.

### Description
- Видалено використання і імпорт `CardCount` у `src/components/Matching.jsx` і прибрано рендер лічильника з хедера. 
- У `src/components/Matching.styled.jsx` видалено стилізований компонент `CardCount`, змінено `HeaderContainer` з grid-розмітки на `flex` для вирівнювання action-кнопок праворуч, та прибрано `grid-column` з `TopActions` для спрощення layout.

### Testing
- Запущено `npm test -- --watchAll=false --runTestsByPath src/components/Matching.sharedReactions.test.js` — тестова суїта пройшла успішно (`9 passed`).
- Виконано `npm run build` — збірка завершилася успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a058243ccb4832686599e226473f94e)