### PR TITLE
Fix profile form field deletion via X and del buttons

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1284,8 +1284,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         );
 
         const uploadedInfo = makeUploadedInfo(existingData, cleanedState, overwrite);
-        if (delCondition) {
-          Object.keys(delCondition).forEach(key => {
+        // Only set null for fields that were completely removed, not for partial array updates
+        const completelyDeletedCondition = delCondition
+          ? Object.fromEntries(Object.entries(delCondition).filter(([key]) => !(key in cleanedState)))
+          : null;
+        if (completelyDeletedCondition) {
+          Object.keys(completelyDeletedCondition).forEach(key => {
             uploadedInfo[key] = null;
           });
         }
@@ -1293,15 +1297,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         if (!makeIndex) {
           await Promise.all([
             updateDataInRealtimeDB(syncedState.userId, uploadedInfo, 'update'),
-            updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', delCondition),
+            updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', completelyDeletedCondition),
           ]);
         }
 
+        const newUsersWhitelist = new Set([...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids']);
         const cleanedStateForNewUsers = Object.fromEntries(
-          Object.entries(syncedState).filter(([key]) =>
-            [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
-          )
+          Object.entries(syncedState).filter(([key]) => newUsersWhitelist.has(key))
         );
+        if (completelyDeletedCondition) {
+          Object.keys(completelyDeletedCondition).forEach(key => {
+            if (newUsersWhitelist.has(key)) {
+              cleanedStateForNewUsers[key] = null;
+            }
+          });
+        }
 
         await updateDataInNewUsersRTDB(
           syncedState.userId,
@@ -1319,7 +1329,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           }
           if (delCondition) {
             Object.keys(delCondition).forEach(key => {
-              newStateWithDelivery[key] = null;
+              // Only null-out fields that were completely removed, not partially-updated arrays
+              if (!(key in newStateWithDelivery)) {
+                newStateWithDelivery[key] = null;
+              }
             });
           }
           await updateDataInNewUsersRTDB(

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -343,9 +343,14 @@ const EditProfile = () => {
 
       await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, delCondition);
 
+      // Only treat fields as deleted if they were completely removed (not partial array updates)
+      const completelyDeletedCondition = delCondition
+        ? Object.fromEntries(Object.entries(delCondition).filter(([key]) => !(key in updatedState)))
+        : null;
+
       const sanitizedExistingData = { ...existingData };
-      if (delCondition) {
-        Object.keys(delCondition).forEach(key => {
+      if (completelyDeletedCondition) {
+        Object.keys(completelyDeletedCondition).forEach(key => {
           delete sanitizedExistingData[key];
         });
       }
@@ -357,19 +362,33 @@ const EditProfile = () => {
       const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
 
       await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
-      await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
+      await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', completelyDeletedCondition);
 
+      const newUsersWhitelist = new Set([...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids']);
       const cleanedStateForNewUsers = Object.fromEntries(
-        Object.entries(updatedState).filter(([key]) =>
-          [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
-        )
+        Object.entries(updatedState).filter(([key]) => newUsersWhitelist.has(key))
       );
+      if (completelyDeletedCondition) {
+        Object.keys(completelyDeletedCondition).forEach(key => {
+          if (newUsersWhitelist.has(key)) {
+            cleanedStateForNewUsers[key] = null;
+          }
+        });
+      }
 
       await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update', true);
     } else if (updatedState?.userId) {
       const existingData = await fetchUserById(updatedState.userId) || {};
       await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, delCondition);
-      await updateDataInNewUsersRTDB(updatedState.userId, updatedState, 'update', true);
+      const dataToUpdate = { ...updatedState };
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          if (!(key in updatedState)) {
+            dataToUpdate[key] = null;
+          }
+        });
+      }
+      await updateDataInNewUsersRTDB(updatedState.userId, dataToUpdate, 'update', true);
     }
 
     try {


### PR DESCRIPTION
When removing a single element from a multi-value array field, the
delCondition key was being set to null in all backend payloads, wiping
the entire field instead of just the removed element.

Introduced completelyDeletedCondition that only includes fields absent
from the new state (fully deleted), so partial array updates are sent
as the updated array rather than null.

Also fixed newUsers RTDB not receiving null markers for deleted
whitelist fields on userId.length > 20 profiles, and fixed the
userId <= 20 path in EditProfile.remoteUpdate where the deleted field
was silently absent from the update payload instead of being
explicitly nulled.

https://claude.ai/code/session_01QwPjiF3YnFzKPg291DZvmY