### PR TITLE
Avoid nulling `userId` when applying deletions; propagate deletions to new-users RTDB safely

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1302,6 +1302,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
           )
         );
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            if (key !== 'userId') {
+              cleanedStateForNewUsers[key] = null;
+            }
+          });
+        }
 
         await updateDataInNewUsersRTDB(
           syncedState.userId,

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -355,6 +355,13 @@ const EditProfile = () => {
       );
 
       const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          if (key !== 'userId') {
+            uploadedInfo[key] = null;
+          }
+        });
+      }
 
       await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
       await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
@@ -364,6 +371,13 @@ const EditProfile = () => {
           [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          if (key !== 'userId') {
+            cleanedStateForNewUsers[key] = null;
+          }
+        });
+      }
 
       await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update', true);
     } else if (updatedState?.userId) {


### PR DESCRIPTION
### Motivation
- Prevent accidental clearing of the `userId` field when applying `delCondition` during profile updates and ensure deletions are propagated correctly to the New Users Realtime DB.

### Description
- Added guards so fields listed in `delCondition` are set to `null` for update payloads but skip `userId` when preparing `uploadedInfo` and `cleanedStateForNewUsers` in `EditProfile.jsx`.
- Added the same skip-for-`userId` behavior when preparing `cleanedStateForNewUsers` in `AddNewProfile.jsx` so deletions are applied to the New Users RTDB without removing the identifier.
- Kept existing logic that applies `delCondition` to `uploadedInfo` and `newStateWithDelivery` where appropriate, while preventing `userId` from being nulled in the code paths that persist indexes and new-user records.

### Testing
- Ran the unit test suite and ESLint against the modified files; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0581044ffc8326a10135c698fcb3ab)