### PR TITLE
Clean up debug logs, fix AddNewProfile race/fetch logic, add backend console-summary flag and test

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1495,13 +1495,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       // Видаляємо ключ з нового стану
       delete newState[fieldName];
 
-      // console.log('Видалили ключ з локального стану:', fieldName);
-      // console.log('newState:', newState);
 
       // Встановлюємо значення 'del_key' для видалення
       //  newState[fieldName] = 'del_key';
 
-      console.log(`Поле "${fieldName}" позначено для видалення`);
 
       handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState; // Повертаємо оновлений стан
@@ -1528,13 +1525,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   // useEffect(() => {
   //   // Рендеринг картки при зміні стану state
   //   if (state && state.userId) {
-  //     console.log('state updated:', state); // Перевірка оновленого стану
   //   }
   // }, [state]);
-
-  useEffect(() => {
-    console.log('state2!!!!!!!!!! :>> ', state);
-  }, [state]);
 
   useEffect(() => {
     isEditingRef.current = !!state.userId;
@@ -1624,7 +1616,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setSearch(prev => (prev === urlSearchValue ? prev : urlSearchValue));
     } else if (urlUserId && canAccessAdd) {
       setSearch(prev => (prev ? prev : urlUserId));
-    } else if (!urlUserId) {
+    } else if (!urlUserId && !stateUserIdRef.current) {
       setSearch(prev => (prev ? '' : prev));
     }
 
@@ -1633,14 +1625,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setIsResolvingEditMode(false);
         return;
       }
-      setIsResolvingEditMode(!stateUserIdRef.current || stateUserIdRef.current !== urlUserId);
-      setProfileSource('');
-      setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
+
+      const currentStateUserId = stateUserIdRef.current;
+      const shouldResolveUserId = !currentStateUserId || currentStateUserId !== urlUserId;
+      setIsResolvingEditMode(shouldResolveUserId);
+
+      if (shouldResolveUserId) {
+        setProfileSource('');
+        setState({ userId: urlUserId });
+      }
       return;
     }
-    if (!hasSearchParam && stateUserIdRef.current) {
-      setState({});
-    }
+
     setIsResolvingEditMode(false);
   }, [canAccessAdd, location.search, setSearch, setState]);
 
@@ -1831,26 +1827,46 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return;
     }
 
-    const cached = getCard(state.userId);
+    const targetUserId = state.userId;
+    const cached = getCard(targetUserId);
     if (cached) {
-      setState({ ...cached, userId: cached.userId || state.userId });
+      setState(prev => {
+        if (prev?.userId !== targetUserId) return prev;
+        if (Object.keys(prev || {}).length > 1) return prev;
+        return { ...cached, userId: cached.userId || targetUserId };
+      });
       setProfileSource('cache');
-    } else {
-      setProfileSource('loading');
-      (async () => {
-        try {
-          const data = await fetchUserById(state.userId);
-          if (data) {
-            updateCard(state.userId, data);
-            setState({ ...data, userId: data.userId || state.userId });
-          }
-        } catch (error) {
+      return;
+    }
+
+    let cancelled = false;
+    setProfileSource('loading');
+
+    (async () => {
+      try {
+        const data = await fetchUserById(targetUserId);
+        if (cancelled || !data) return;
+
+        updateCard(targetUserId, data);
+        setState(prev => {
+          if (prev?.userId !== targetUserId) return prev;
+          if (Object.keys(prev || {}).length > 1) return prev;
+          return { ...data, userId: data.userId || targetUserId };
+        });
+      } catch (error) {
+        if (!cancelled) {
           toast.error(error.message);
-        } finally {
+        }
+      } finally {
+        if (!cancelled) {
           setProfileSource('backend');
         }
-      })();
-    }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [state, profileSource, setState]);
 
   useEffect(() => {
@@ -2390,7 +2406,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const delConfirm = () => {
-    // console.log('state :>> ', state);
     const handleRemoveUser = async () => {
       try {
         setIsDeleting(true);
@@ -2409,7 +2424,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setState({});
         setShowInfoModal(null);
         setUserIdToDelete(null);
-        console.log(`User ${id} deleted.`);
         navigate('/add');
       } catch (error) {
         console.error('Error deleting user:', error);
@@ -2643,11 +2657,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
 
   const loadMoreUsers = async (filterForload, currentFilters = filters) => {
-    console.log('loadMoreUsers called with', {
-      filterForload,
-      lastKey,
-      currentFilters,
-    });
     const includeSpecialFutureDates = searchBarQueryActive;
     if (isEditingRef.current) return { count: 0, hasMore };
     const param = lastKey;
@@ -2687,18 +2696,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         dislikedUsers: dislikedUsersMap,
       },
     );
-    // console.log('res :>> ', res);
     // Перевіряємо, чи є користувачі у відповіді
     if (res && typeof res.users === 'object' && Object.keys(res.users).length > 0) {
-      // console.log('222 :>> ');
-      // console.log('res.users :>> ', res.users);
 
       // Використовуємо Object.entries для обробки res.users
       const newUsers = Object.entries(res.users)
         .filter(([id]) => !currentFilters.favorite?.favOnly || fav[id])
         .reduce((acc, [userId, user]) => {
         // Перевірка наявності поля userId, щоб уникнути помилок
-        // console.log('3333 :>> ');
         if (user.userId) {
           acc[user.userId] = user; // Додаємо користувача до об'єкта
         } else {
@@ -2718,8 +2723,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setLastKey(res.lastKey); // Оновлюємо lastKey для наступного запиту
       setHasMore(res.hasMore); // Оновлюємо hasMore
       const backendCount = Object.keys(newUsers).length;
-      console.log('loaded users count', backendCount);
-      console.log('next lastKey', res.lastKey);
       return { cacheCount: 0, backendCount, hasMore: res.hasMore };
     } else {
       setHasMore(false); // Якщо немає більше користувачів, оновлюємо hasMore

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -20,7 +20,6 @@ export const App = () => {
   const [canAccessAdd, setCanAccessAdd] = useState(false);
   const [canAccessMatching, setCanAccessMatching] = useState(false);
   const [isAccessResolved, setIsAccessResolved] = useState(false);
-  // console.log('isLoggedIn :>> ', isLoggedIn);
 
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/components/ExportContact.jsx
+++ b/src/components/ExportContact.jsx
@@ -372,7 +372,6 @@ export const saveToContact = data => {
     link.download = fileName;
     link.click();
 
-    console.log('Generated vCard:', contactVCard);
 
     window.URL.revokeObjectURL(url);
   }
@@ -472,7 +471,6 @@ export const saveToContactCsv = data => {
     link.download = fileName;
     link.click();
 
-    console.log('Generated CSV:', csvContent);
 
     window.URL.revokeObjectURL(url);
   }

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -339,7 +339,6 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       if (userCredential.user.uid !== process.env.REACT_APP_USER1) {
         navigate('/my-profile');
       }
-      console.log('User signed in:', userCredential.user);
     } catch (error) {
       if (error.code === 'auth/wrong-password') {
         authNotifications.wrongPassword();
@@ -354,7 +353,6 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleRegistration = async email => {
     try {
       const userCredential = await createUserWithEmailAndPassword(auth, email, state.password);
-      console.log('User registered in:', userCredential.user);
 
       const uploadedInfo = {
         email,

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2509,7 +2509,6 @@ const Matching = () => {
   );
 
   const loadInitial = React.useCallback(async () => {
-    console.log('[loadInitial] start');
     loadingRef.current = true;
     const startMode = viewModeRef.current;
     setLoading(true);
@@ -2610,7 +2609,6 @@ const Matching = () => {
 
       const { cards: cached } = await getCardsByList(defaultListKey);
       if (cached.length && viewModeRef.current === startMode) {
-        console.log('[loadInitial] using cache', cached.length);
         const filteredCached = cached.filter(
           u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
         );
@@ -2637,7 +2635,6 @@ const Matching = () => {
         }
       );
       if (viewModeRef.current !== startMode) return;
-      console.log('[loadInitial] initial loaded', res.users.length, 'hasMore', res.hasMore);
       loadedIdsRef.current = new Set([
         ...loadedIdsRef.current,
         ...res.users.map(u => u.userId),
@@ -3011,11 +3008,9 @@ const Matching = () => {
   const loadMore = React.useCallback(async ({ targetVisibleCount = 0, currentVisibleCount = 0, limit = LOAD_MORE } = {}) => {
     const isReactionViewMode = viewMode === 'favorites' || viewMode === 'dislikes';
     if (!hasMore || loadingRef.current || (viewMode !== 'default' && !isReactionViewMode)) {
-      console.log('[loadMore] skip', { hasMore, loading: loadingRef.current, viewMode });
       return;
     }
     const requestedLimit = Math.max(1, Number(limit) || LOAD_MORE);
-    console.log('[loadMore] start', { lastKey, hasMore, requestedLimit });
     loadingRef.current = true;
     setLoading(true);
     const loadMoreVersion = additionalLoadMoreFetchVersionRef.current + 1;
@@ -3288,14 +3283,6 @@ const Matching = () => {
           ...collected.map(u => u.userId).filter(Boolean),
         ]);
         const res = await fetchChunk(remaining, cursor, dynamicExclude);
-        console.log('[loadMore] batch', {
-          requested: remaining,
-          received: res.users.length,
-          cursor,
-          nextCursor: res.lastKey,
-          hasMore: res.hasMore,
-          reachedSafetyCap: res.reachedSafetyCap,
-        });
 
         const unique = res.users.filter(
           u => u?.userId && !loadedIdsRef.current.has(u.userId)
@@ -3322,10 +3309,8 @@ const Matching = () => {
 
       const stoppedBySafetyCapWithMoreSource = canLoadMore && collected.length === 0;
       if (stoppedBySafetyCapWithMoreSource) {
-        console.log('[loadMore] source backfill safety cap reached; keeping hasMore true for next cycle');
         setHasMore(true);
       } else if (handleEmptyFetch({ users: collected, lastKey: cursor }, lastKey, setHasMore)) {
-        console.log('[loadMore] empty fetch, no more cards');
       } else {
         setHasMore(canLoadMore);
       }
@@ -3359,7 +3344,6 @@ const Matching = () => {
   ]);
 
   useEffect(() => {
-    console.log('[useEffect] calling loadInitial');
     reloadDefault();
   }, [reloadDefault]);
 
@@ -3522,17 +3506,6 @@ const Matching = () => {
 
     if (penultimateVisibilityLogSignatureRef.current !== visibilityLogSignature) {
       penultimateVisibilityLogSignatureRef.current = visibilityLogSignature;
-      console.log('[Matching][penultimateCardVisible]', {
-        renderedLength: renderedCardsLength,
-        triggerIndex,
-        triggerUserId: penultimateRenderedCardUserId,
-        hasMore: sourceHasMore,
-        loadingRefCurrent,
-        sourceNextOffset,
-        lastKey,
-        sourceCursor,
-        sourceCursorSignature,
-      });
     }
 
     if (!sourceHasMore || loadingRefCurrent || loading) return;

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -481,7 +481,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [missing, setMissing] = useState({});
   const [showPassword, setShowPassword] = useState(false);
   const [hasAgreed, setHasAgreed] = useState(false);
-  console.log('focused :>> ', focused);
   const navigate = useNavigate();
   const currentUid = auth.currentUser?.uid;
   const access = resolveAccess({ uid: currentUid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
@@ -521,7 +520,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           // Успішний результат
           const latitude = position.coords.latitude;
           const longitude = position.coords.longitude;
-          console.log(`Latitude: ${latitude}, Longitude: ${longitude}`);
 
           fetch(`https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json`)
             .then(response => response.json())
@@ -531,7 +529,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               const city = address.city || address.town || address.village || '';
               const state = address.state || '';
               const country = address.country || '';
-              console.log(`Street: ${street}, City: ${city}, State: ${state}, Country: ${country}`);
               setState(prevState => ({ ...prevState, city, street, state, country }));
             })
             .catch(error => console.error('Error:', error));
@@ -542,7 +539,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       );
     } else {
-      console.log('Geolocation is not supported by this browser.');
     }
   }, []); // Порожній масив залежностей
 
@@ -741,9 +737,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   // зберігаємо дані при завантаженні сторінки
   const fetchData = async user => {
-    // console.log('fetchData :>> ');
     // const user = auth.currentUser;
-    // console.log('user :>> ', user.uid);
     if (user && user.uid) {
       const data = await fetchUserData(user.uid);
       const existingData = data.existingData || {};
@@ -789,7 +783,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         );
       }
 
-      console.log('processedData :>> ', processedData);
       setState(prevState => ({
         ...prevState, // Зберегти попередні значення
         ...processedData,
@@ -805,13 +798,11 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setIsLoggedIn(true);
         localStorage.setItem('isLoggedIn', 'true');
         localStorage.setItem('ownerId', user.uid);
-        console.log('User is logged in: ', user.uid);
         fetchData(user);
       } else {
         setIsLoggedIn(false);
         localStorage.removeItem('isLoggedIn');
         localStorage.removeItem('ownerId');
-        console.log('No user is logged in.');
       }
     });
 
@@ -827,7 +818,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   // Цей екран доступний і без авторизації
 
   useEffect(() => {
-    // console.log('state.photos :>> ', state.photos);
     handleSubmit();
     // eslint-disable-next-line
   }, [state.publish, state.photos]);
@@ -1024,7 +1014,6 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         {state.userId && <Photos state={state} setState={setState} />}
 
         {visiblePickerFields.map(field => {
-          // console.log('field.options:', field.options);
           const isPickerField = Array.isArray(field.options);
           const isCsectionField = field.name === 'csection';
 

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -166,17 +166,10 @@ export const Photos = ({ state, setState, collection }) => {
   };
 
   useEffect(() => {
-    console.log('useEffect triggered', {
-      userId: state.userId,
-      photos: state.photos,
-      photoValues,
-    });
     const load = async () => {
       if (state.userId) {
         try {
-          console.log('Fetching photos for user', state.userId);
           const urls = await getAllUserPhotos(state.userId, collection);
-          console.log('Fetched URLs', urls);
           const filteredUrls = filterOutMedicationPhotos(urls, state.userId);
           if (filteredUrls.length > 0) {
             const currentPhotos = normalizePhotosArray(state.photos);
@@ -195,12 +188,10 @@ export const Photos = ({ state, setState, collection }) => {
         const existingPhotos = Array.isArray(state.photos)
           ? state.photos
           : Object.values(state.photos || {});
-        console.log('Existing photos', existingPhotos);
         const converted = existingPhotos
           .map(convertDriveLinkToImage)
           .filter(Boolean);
         const filteredConverted = filterOutMedicationPhotos(converted, state.userId);
-        console.log('Converted photos', converted);
         const changed =
           filteredConverted.length !== existingPhotos.length ||
           filteredConverted.some((url, idx) => url !== existingPhotos[idx]);
@@ -218,7 +209,6 @@ export const Photos = ({ state, setState, collection }) => {
           )
           .map(([, value]) => convertDriveLinkToImage(value))
           .filter(Boolean);
-        console.log('Links from state', links);
 
         if (links.length) {
           commitPhotosUpdate(filterOutMedicationPhotos(links, state.userId));
@@ -316,7 +306,6 @@ export const Photos = ({ state, setState, collection }) => {
                   src={url}
                   alt={`user avatar ${index}`}
                   onClick={() => handlePhotoClick(url, index)}
-                  onLoad={() => console.log('Image loaded', url)}
                   onError={e => {
                     console.error('Image failed to load', url, e);
                     e.target.onerror = null;

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1157,20 +1157,6 @@ export const ProfileForm = ({
         if (!hasSetPayload) {
           toast.error('STOP: payload empty before backend write');
         }
-        console.log('[searchKeySets debug]', {
-          selectedRules: lastSetDebug?.selectedRules,
-          allowedUserIdsCount: Number(lastSetDebug?.allowedUserIdsCount || 0),
-          finalAllowedCount,
-          payloadUsers: payloadUsersCount,
-          allowedSample: Array.isArray(lastSetDebug?.allowedSample) ? lastSetDebug.allowedSample.slice(0, 10) : [],
-          searchKeyFields,
-          skippedFields: Array.isArray(lastSetDebug?.skippedFields) ? lastSetDebug.skippedFields : [],
-          copiedByField,
-          copiedRecords: payloadRecordsCount,
-          copiedBuckets: payloadBucketsCount,
-          filteredFields,
-          backendRequests,
-        });
         if (indexResult && Number(indexResult.writesCount || 0) === 0 && Number(indexResult?.setKeys?.length || 0) === 0) {
           toast('searchKeySets не оновлено: не знайдено валідних правил.');
         }

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -364,7 +364,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
     publish: false,
   });
   const [focused, setFocused] = useState(null);
-  console.log('focused :>> ', focused);
   const navigate = useNavigate();
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
   const isAdmin = access.isAdmin;
@@ -382,7 +381,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
           // Успішний результат
           const latitude = position.coords.latitude;
           const longitude = position.coords.longitude;
-          console.log(`Latitude: ${latitude}, Longitude: ${longitude}`);
 
           fetch(`https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json`)
             .then(response => response.json())
@@ -392,7 +390,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
               const city = address.city || address.town || address.village || '';
               const state = address.state || '';
               const country = address.country || '';
-              console.log(`Street: ${street}, City: ${city}, State: ${state}, Country: ${country}`);
               setState(prevState => ({ ...prevState, city, street, state, country }));
             })
             .catch(error => console.error('Error:', error));
@@ -403,7 +400,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       );
     } else {
-      console.log('Geolocation is not supported by this browser.');
     }
   }, []); // Порожній масив залежностей
 
@@ -455,9 +451,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
 
   // зберігаємо дані при завантаженні сторінки
   const fetchData = async user => {
-    // console.log('fetchData :>> ');
     // const user = auth.currentUser;
-    // console.log('user :>> ', user.uid);
     if (user && user.uid) {
       const data = await fetchUserData(user.uid);
       const existingData = data.existingData || {};
@@ -473,7 +467,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
         return acc;
       }, {});
 
-      console.log('processedData :>> ', processedData);
       setState(prevState => ({
         ...prevState, // Зберегти попередні значення
         ...processedData,
@@ -487,11 +480,9 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
     const unsubscribe = onAuthStateChanged(auth, user => {
       if (user) {
         localStorage.setItem('ownerId', user.uid);
-        console.log('User is logged in: ', user.uid);
         fetchData(user);
       } else {
         localStorage.removeItem('ownerId');
-        console.log('No user is logged in.');
       }
     });
 
@@ -516,7 +507,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
   }, []);
 
   useEffect(() => {
-    // console.log('state.photos :>> ', state.photos);
     handleSubmit();
     // eslint-disable-next-line
   }, [state.publish, state.photos]);
@@ -620,7 +610,6 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
         <Photos state={state} setState={setState} />
 
         {pickerFields.map(field => {
-          // console.log('field.options:', field.options);
 
           return (
             <PickerContainer>
@@ -645,11 +634,8 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
                     }}
                     onFocus={() => {
                       if (field.options === undefined) {
-                        console.log('field.options === undefined :>> ');
                         handleFocus(field.name);
                       } else if (state[field.name] !== '' && state[field.name] !== undefined) {
-                        console.log('state[field.name] :>> ', state[field.name]);
-                        console.log('field.options !== ');
                         handleFocus(field.name);
                       } else {
                         handleOpenModal(field.name);

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -908,11 +908,6 @@ const SearchBar = ({
   useEffect(() => {
     if (search) {
       const { key, value } = detectSearchParams(search);
-      console.log('[SearchBar] Restored persisted search', {
-        raw: search,
-        detectedKey: key,
-        detectedValue: value,
-      });
       loadCachedResult(key, value);
       writeData(search);
     }
@@ -920,11 +915,6 @@ const SearchBar = ({
   }, []);
 
   const emitSearchLabel = (params, meta = {}) => {
-    console.log('[SearchBar] Search label applied', {
-      ...meta,
-      params,
-    });
-
     // Repeated [] search keeps a per-value create context for not-found
     // placeholders, so fallback labels (for example the final name search)
     // must not replace the parent add payload.
@@ -1250,13 +1240,6 @@ const SearchBar = ({
       requestId = null,
     } = options;
 
-    console.log('[SearchBar] Parser evaluation', {
-      platform,
-      raw: inputData,
-      trimmed: trimmedInput,
-      parsed: id,
-    });
-
     if (!id && platform === 'telegram' && allowUkTrigger) {
       const ukTrigger = parseUkTriggerQuery(trimmedInput);
       if (ukTrigger?.searchPair?.telegram) {
@@ -1494,9 +1477,6 @@ const SearchBar = ({
       onSearchExecuted(trimmed);
     }
 
-    if (typeof query === 'string') {
-      console.log('[SearchBar] Incoming query', { raw: rawQuery, trimmed });
-    }
     if (trimmed && !trimmed.startsWith('!') && !suppressHistory) {
       addToHistory(trimmed);
     }
@@ -1505,11 +1485,6 @@ const SearchBar = ({
       const filtersKey = normalizeQueryKey(
         `${filterForload || 'all'}:${serializeQueryFilters(filters)}`,
       );
-      console.log('[SearchBar] Detected bulk command search', {
-        raw: trimmed,
-        command: term,
-        filtersKey,
-      });
       const cacheKey = `allUsers:${filtersKey}`;
       const queries = loadQueries();
       const entry = queries[cacheKey];
@@ -1565,10 +1540,6 @@ const SearchBar = ({
     if (repeatedValues.length > 0) {
       const repeatedPerfLabel = `[SearchPerf][repeat][total] ${trimmed}`;
       if (perfDebugEnabledRef.current) console.time(repeatedPerfLabel);
-      console.log('[SearchBar] Processing repeated search values', {
-        raw: trimmed,
-        values: repeatedValues,
-      });
 
       const collector = {
         requestId,
@@ -1881,10 +1852,6 @@ const SearchBar = ({
     }
 
     const nameTrim = rawQuery.trim();
-    console.log('[SearchBar] Defaulting to name search', {
-      raw: rawQuery,
-      cleaned: nameTrim,
-    });
 
     const hasCache = loadCachedResult('name', nameTrim, requestId);
     const freshCache = hasCache && isCacheFresh('name', nameTrim);

--- a/src/components/VerifyEmail.jsx
+++ b/src/components/VerifyEmail.jsx
@@ -29,13 +29,10 @@ margin-bottom: 20px;
                 localStorage.setItem('ownerId', user.uid);
                 try {
                   await sendEmailVerification(user);
-                  console.log('sendEmailVerification(user) :>> ',);
                   setIsCounting(true);
                 } catch (error) {
                   if (error.code === 'auth/too-many-requests') {
-                      console.log('Забагато запитів');
                   } else {
-                      console.log('Помилка надсилання підтвердження');
                   }
                 }
               } else {
@@ -46,7 +43,6 @@ margin-bottom: 20px;
               unsubscribe();
             };
           } catch (error) {
-            console.log('Error in UserRoleScreen :>> ', error);
           }
         };
       

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -367,7 +367,6 @@ export const fetchUsersCollection = async () => {
   const usersCollection = collection(db, 'users');
   const querySnapshot = await getDocs(usersCollection);
   const database = querySnapshot.docs.map(doc => doc.data());
-  // console.log('userDataArray!!!!!!! :>> ', userDataArray);
   return database;
 };
 
@@ -1888,10 +1887,8 @@ const getDayTimestampRange = isoDate => {
 };
 
 const searchByDate = async (searchValue, uniqueUserIds, users) => {
-  if (isDev) console.log('searchByDate → input:', searchValue);
   const dateFormats = getDateFormats(searchValue);
   const isoDateVariants = getIsoDateVariants(dateFormats);
-  if (isDev) console.log('searchByDate → formats:', dateFormats);
   if (dateFormats.length === 0) return false;
 
   const collections = ['newUsers', 'users'];
@@ -1900,7 +1897,6 @@ const searchByDate = async (searchValue, uniqueUserIds, users) => {
   for (const date of dateFormats) {
     for (const collection of collections) {
       for (const field of fields) {
-        if (isDev) console.log(`searchByDate → querying ${collection}.${field} for`, date);
         const refToCollection = ref2(database, collection);
         const queries =
           field === 'lastAction'
@@ -1915,12 +1911,10 @@ const searchByDate = async (searchValue, uniqueUserIds, users) => {
         try {
           for (const currentQuery of queries) {
             const snapshot = await get(currentQuery);
-            if (isDev) console.log('snapshot.exists():', snapshot.exists());
             if (snapshot.exists()) {
               const promises = [];
               snapshot.forEach(userSnapshot => {
                 const userId = userSnapshot.key;
-                if (isDev) console.log(`Found ${userId} in ${collection}.${field}`);
                 if (!uniqueUserIds.has(userId)) {
                   uniqueUserIds.add(userId);
                   promises.push(addUserToResults(userId, users));
@@ -2094,10 +2088,8 @@ const searchByPrefixes = async (searchValue, uniqueUserIds, users) => {
     return false;
   };
 
-  // console.log('🔍 searchValue :>> ', searchValue);
 
   for (const prefix of keysToCheck) {
-    // console.log('🛠 Searching by prefix:', prefix);
 
     let formattedSearchValue = searchValue.trim();
 
@@ -2139,10 +2131,8 @@ const searchByPrefixes = async (searchValue, uniqueUserIds, users) => {
           const snapshotByPrefix = await get(
             query(ref2(database, collection), orderByChild(prefix), startAt(queryPrefix), endAt(`${queryPrefix}\uf8ff`))
           );
-          // console.log(`📡 Firebase Query Executed for '${collection}.${prefix}'`);
 
           if (!snapshotByPrefix.exists()) continue;
-          // console.log(`✅ Found results for '${collection}.${prefix}'`);
 
           snapshotByPrefix.forEach(userSnapshot => {
             const userId = userSnapshot.key;
@@ -2150,14 +2140,9 @@ const searchByPrefixes = async (searchValue, uniqueUserIds, users) => {
 
             const fieldValue = userData[prefix];
 
-            // console.log('📌 Checking user:', userId);
-            // console.log(`🧐 userData['${prefix}']:`, fieldValue);
-            // console.log('📏 Type of fieldValue:', typeof fieldValue);
-            // console.log(
             //   '🔍 Includes searchValue?',
             //   fieldValue.toLowerCase().includes(formattedSearchValue.toLowerCase())
             // );
-            // console.log('🛑 Already in uniqueUserIds?', uniqueUserIds.has(userId));
 
             if (
               fieldMatchesSearch(fieldValue, formattedSearchValue.toLowerCase()) &&
@@ -2168,7 +2153,6 @@ const searchByPrefixes = async (searchValue, uniqueUserIds, users) => {
                 userId,
                 ...userData,
               };
-              // console.log(`✅ Added user '${userId}' to results`);
             }
           });
         }
@@ -2190,7 +2174,6 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     forcePartialUserIdSearch = false,
     allowTelegramPrefixMatches = false,
   } = options;
-  if (isDev) console.log('fetchNewUsersCollectionInRTDB → searchedValue:', searchedValue);
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
@@ -2199,11 +2182,6 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
       includeVariants: searchKey !== 'telegram',
       includePrefixMatches: searchKey !== 'telegram' || allowTelegramPrefixMatches,
     };
-  if (isDev)
-    console.log('fetchNewUsersCollectionInRTDB → params:', {
-      searchValue,
-      modifiedSearchValue,
-    });
   const users = {};
   const uniqueUserIds = new Set();
 
@@ -2222,7 +2200,6 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     const isDateSearch = shouldRunBroadDateSearch
       ? await searchByDate(searchValue, uniqueUserIds, users)
       : false;
-    if (isDev) console.log('fetchNewUsersCollectionInRTDB → isDateSearch:', isDateSearch);
     if (!isDateSearch) {
       if (forcePartialUserIdSearch) {
         await searchUserByPartialUserId(searchValue, users);
@@ -2267,16 +2244,13 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
 
     if (Object.keys(users).length === 1) {
       const singleUserId = Object.keys(users)[0];
-      if (isDev) console.log('Знайдено одного користувача:', users[singleUserId]);
       return users[singleUserId];
     }
 
     if (Object.keys(users).length > 1) {
-      if (isDev) console.log('Знайдено кілька користувачів:', users);
       return users;
     }
 
-    if (isDev) console.log('Користувача не знайдено.');
     return {};
   } catch (error) {
     console.error('Error fetching data:', error);
@@ -2421,7 +2395,6 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
         const shouldRemoveKey = uploadedInfo[key] === '' || uploadedInfo[key] === null;
 
         if (shouldRemoveKey) {
-          console.log(`${key} має пусте або null значення. Видаляємо.`);
           if (currentUserData[key] !== undefined && currentUserData[key] !== null) {
             await updateSearchId(key, currentUserData[key], userId, 'remove');
           }
@@ -2430,7 +2403,6 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
         }
 
         if (uploadedInfo[key] !== undefined) {
-          // console.log(`${key} uploadedInfo[key] :>> `, uploadedInfo[key]);
 
           // Формуємо currentValues
           const currentValues = Array.isArray(currentUserData?.[key])
@@ -2450,8 +2422,6 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
                 ? [uploadedInfo[key]].filter(Boolean)
                 : [];
 
-          // console.log(`${key} currentValues :>> `, currentValues);
-          // console.log(`${key} newValues :>> `, newValues);
 
           // Видаляємо значення, яких більше немає у новому масиві
           for (const value of currentValues) {
@@ -2476,12 +2446,9 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
               cleanedValue = normalizePhoneForStorage(value);
             }
 
-            // console.log('cleanedValue :>> ', cleanedValue);
 
             // Додаємо новий ID, якщо його ще немає в currentValues
             if (!currentValues.includes(cleanedValue)) {
-              console.log('currentValues :>> ', currentValues);
-              console.log('cleanedValue :>> ', cleanedValue);
               await updateSearchId(key, cleanedValue.toLowerCase(), userId, 'add'); // Додаємо новий ID
             }
           }
@@ -2491,8 +2458,6 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
 
     // Оновлення користувача в базі
 
-    console.log('uploadedInfo :>> ', uploadedInfo);
-    console.log('currentUserData :>> ', currentUserData);
 
     // if (condition === 'update' && !(Object.keys(uploadedInfo).length < Object.keys(currentUserData).length)) {
     const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo, {
@@ -2500,10 +2465,8 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
     });
 
     if (condition === 'update') {
-      console.log('update :>> ');
       await update(userRefRTDB, { ...cleanedUploadedInfo });
     } else {
-      console.log('set :>> ');
       await set(userRefRTDB, { ...cleanedUploadedInfo });
     }
 
@@ -2579,9 +2542,6 @@ export const getMedicationPhotos = async userId => {
 // Функція для оновлення або видалення пар у searchId
 export const updateSearchId = async (searchKey, searchValue, userId, action) => {
   if (isDev) {
-    console.log('searchKey!!!!!!!!! :>> ', searchKey);
-    console.log('searchValue!!!!!!!!! :>> ', searchValue);
-    console.log('action!!!!!!!!!!! :>> ', action);
   }
   try {
     if (!searchValue || !searchKey || !userId) {
@@ -2590,14 +2550,12 @@ export const updateSearchId = async (searchKey, searchValue, userId, action) => 
     }
 
     if (!SEARCH_ID_INDEXED_FIELDS.has(searchKey)) {
-      if (isDev) console.log('Пропускаємо не-searchId ключ :>> ', searchKey);
       return;
     }
 
     const normalizedValue = normalizeSearchIdInput(searchKey, searchValue).toLowerCase();
     const searchIdKey = `${searchKey}_${encodeKey(normalizedValue)}`;
     const searchIdRef = ref2(database, `searchId/${searchIdKey}`);
-    if (isDev) console.log('searchIdKey in updateSearchId :>> ', searchIdKey);
 
     if (action === 'add') {
       const searchIdSnapshot = await get(searchIdRef);
@@ -2609,20 +2567,15 @@ export const updateSearchId = async (searchKey, searchValue, userId, action) => 
           if (!existingValue.includes(userId)) {
             const updatedValue = [...existingValue, userId];
             await update(ref2(database, 'searchId'), { [searchIdKey]: updatedValue });
-            if (isDev) console.log(`Додано userId до масиву: ${searchIdKey}:`, updatedValue);
           } else {
-            if (isDev) console.log(`userId вже існує в масиві для ключа: ${searchIdKey}`);
           }
         } else if (existingValue !== userId) {
           const updatedValue = [existingValue, userId];
           await update(ref2(database, 'searchId'), { [searchIdKey]: updatedValue });
-          if (isDev) console.log(`Перетворено значення на масив і додано userId: ${searchIdKey}:`, updatedValue);
         } else {
-          if (isDev) console.log(`Ключ вже містить userId: ${searchIdKey}`);
         }
       } else {
         await update(ref2(database, 'searchId'), { [searchIdKey]: userId });
-        if (isDev) console.log(`Додано нову пару в searchId: ${searchIdKey}: ${userId}`);
       }
     } else if (action === 'remove') {
       const searchIdSnapshot = await get(searchIdRef);
@@ -2635,22 +2588,16 @@ export const updateSearchId = async (searchKey, searchValue, userId, action) => 
 
           if (updatedValue.length === 1) {
             await update(ref2(database, 'searchId'), { [searchIdKey]: updatedValue[0] });
-            if (isDev) console.log(`Оновлено значення ключа до одиничного значення: ${searchIdKey}:`, updatedValue[0]);
           } else if (updatedValue.length === 0) {
             await remove(searchIdRef);
-            if (isDev) console.log(`Видалено ключ: ${searchIdKey}`);
           } else {
             await update(ref2(database, 'searchId'), { [searchIdKey]: updatedValue });
-            if (isDev) console.log(`Оновлено масив ключа: ${searchIdKey}:`, updatedValue);
           }
         } else if (existingValue === userId) {
           await remove(searchIdRef);
-          if (isDev) console.log(`Видалено ключ, що мав одиничне значення: ${searchIdKey}`);
         } else {
-          if (isDev) console.log(`userId не знайдено для видалення: ${searchIdKey}`);
         }
       } else {
-        if (isDev) console.log(`Ключ не знайдено для видалення: ${searchIdKey}`);
       }
     } else {
       console.error('Unknown action provided:', action);
@@ -4556,9 +4503,6 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
 };
 
 // export const updateSearchId = async (searchKey, searchValue, userId, action) => {
-//   console.log('searchKey!!!!!!!!! :>> ', searchKey);
-//   console.log('searchValue!!!!!!!!! :>> ', searchValue);
-//   console.log('action!!!!!!!!!!! :>> ', action);
 
 //   if (!searchValue || !searchKey || !userId) {
 //     console.error('Invalid parameters provided:', { searchKey, searchValue, userId });
@@ -4567,7 +4511,6 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
 
 //   const searchIdKey = `${searchKey}_${encodeKey(searchValue)}`;
 //   const searchIdRef = ref2(database, `searchId/${searchIdKey}`);
-//   console.log('searchIdKey in updateSearchId :>> ', searchIdKey);
 
 //   try {
 //     await runTransaction(searchIdRef, currentData => {
@@ -4616,7 +4559,6 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
 //       applyLocally: false // Якщо не потрібне локальне застосування
 //     });
 
-//     console.log(`Операція '${action}' успішно виконана для ключа ${searchIdKey}.`);
 //   } catch (error) {
 //     console.error('Error in updateSearchId with transaction:', error);
 //   }
@@ -4627,7 +4569,6 @@ export const createSearchIdsInCollection = async (collection, onProgress) => {
   if (!usersData) return;
 
   const userIds = Object.keys(usersData);
-  if (isDev) console.log('userIds :>> ', userIds);
 
   const totalUsers = userIds.length;
   for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
@@ -4640,7 +4581,6 @@ export const createSearchIdsInCollection = async (collection, onProgress) => {
           let value = user[key];
 
           if (Array.isArray(value)) {
-            if (isDev) console.log('Array.isArray(value) :>> ', value);
             value.forEach(item => {
               if (item && typeof item === 'string') {
                 let cleanedValue = item.toString().trim();
@@ -4695,14 +4635,12 @@ export const removeSearchId = async userId => {
     // Видаляємо пари, що відповідають userId
     for (const key of keysToRemove) {
       await remove(ref2(db, `searchId/${key}`));
-      console.log(`Видалено пару в searchId: ${key}`);
     }
   }
 
   // Видалення картки в newUsers
   const userRef = ref2(db, `newUsers/${userId}`);
   await remove(userRef);
-  console.log(`Видалено картку користувача з newUsers: ${userId}`);
 };
 
 // Функція для видалення пар у searchId
@@ -4712,21 +4650,16 @@ export const removeSpecificSearchId = async (userId, searchedValue) => {
   const [searchKey, searchValue] = Object.entries(searchedValue)[0];
   const searchIdKey = buildSearchIdRecordKey({ [searchKey]: searchValue }); // Формуємо ключ для пошуку у searchId
   if (!searchIdKey) return;
-  console.log(`searchIdKey`, searchIdKey);
   // Отримуємо всі пари в searchId
   const searchIdSnapshot = await get(ref2(db, `searchId`));
-  console.log(`5555555555`);
   if (searchIdSnapshot.exists()) {
     const searchIdData = searchIdSnapshot.val();
-    console.log(`searchIdData`, searchIdData);
 
     // Перебираємо всі ключі у searchId
     const keysToRemove = Object.keys(searchIdData).filter(key => key === searchIdKey && searchIdData[key] === userId);
-    console.log(`keysToRemove`, keysToRemove);
     // Видаляємо пари, що відповідають userId
     for (const key of keysToRemove) {
       await remove(ref2(db, `searchId/${key}`));
-      console.log(`Видалено пару в searchId: ${key}`);
     }
   }
 };
@@ -5246,7 +5179,6 @@ export const fetchListOfUsers = async () => {
 export const fetchUserById = async userId => {
   const db = getDatabase();
 
-  // console.log('userId в fetchUserById: ', userId);
 
   // Референси для пошуку в newUsers і users
   const userRefInNewUsers = ref2(db, `newUsers/${userId}`);
@@ -5279,7 +5211,6 @@ export const fetchUserById = async userId => {
     const userSnapshot = await get(userRefInUsers);
     if (userSnapshot.exists()) {
       const photos = await getAllUserPhotos(userId);
-      console.log('Знайдено користувача у users: ', userSnapshot.val());
       return {
         userId,
         ...userSnapshot.val(),
@@ -5289,7 +5220,6 @@ export const fetchUserById = async userId => {
     }
 
     // Якщо користувача не знайдено в жодній колекції
-    console.log('Користувача не знайдено в жодній колекції.1.');
     return null;
   } catch (error) {
     console.error('Помилка під час пошуку користувача: ', error);
@@ -5317,26 +5247,21 @@ export const removeKeyFromFirebase = async (field, value, userId) => {
     }
     // Видалення з newUsers у Realtime Database
     await remove(newUsersRefRealtime);
-    console.log(`Ключ "${field}" видалено з Realtime Database: newUsers/${userId}`);
-    // console.log(`Значення "${value}" видалено з Realtime Database: newUsers/${userId}`);
     await updateSearchId(field, value, userId, 'remove');
 
     // Видалення з users у Realtime Database
     await remove(usersRefRealtime);
-    console.log(`Ключ "${field}" видалено з Realtime Database: users/${userId}`);
 
     // Видалення з newUsers у Firestore
     // const newUsersDocSnap = await getDoc(newUsersDocFirestore);
     // if (newUsersDocSnap.exists()) {
     //   await updateDoc(newUsersDocFirestore, { [field]: deleteField() });
-    //   console.log(`Ключ "${field}" видалено з Firestore: newUsers/${userId}`);
     // }
 
     // Видалення з users у Firestore
     const usersDocSnap = await getDoc(usersDocFirestore);
     if (usersDocSnap.exists()) {
       await updateDoc(usersDocFirestore, { [field]: deleteField() });
-      console.log(`Ключ "${field}" видалено з Firestore: users/${userId}`);
     }
   } catch (error) {
     console.error('Помилка видалення ключа з Firebase:', error);
@@ -5361,18 +5286,15 @@ export const removeKeyFromFirebase = async (field, value, userId) => {
 //         }
 
 //         if (Array.isArray(userIdOrArray)) {
-//           console.log('Duplicate found in searchId:', { searchKey, userIdOrArray });
 
 //           // Якщо ключ - масив, додаємо всі userId до списку дублікатів
 //           duplicates.push(...userIdOrArray);
 //         }
 //       }
 
-//       console.log('All duplicates (with repeats):', duplicates);
 
 //       // Отримуємо перші 20 userId, включаючи повтори
 //       const first20Duplicates = duplicates.slice(0, 20);
-//       console.log('First 20 duplicates (with repeats):', first20Duplicates);
 
 //       // Отримуємо дані по кожному userId
 // // Отримуємо дані по кожному userId
@@ -5408,12 +5330,10 @@ export const removeKeyFromFirebase = async (field, value, userId) => {
 //         }
 //       }
 
-//       console.log('Duplicate users:', mergedUsers);
 
 //       // Повертаємо перші 20 користувачів
 //       return mergedUsers;
 //     } else {
-//       console.log('No duplicates found in searchId.');
 //       return {};
 //     }
 //   } catch (error) {
@@ -5426,7 +5346,6 @@ export const loadDuplicateUsers = async () => {
     const searchIdData = await loadCollectionWithIndexCache('searchId');
 
     if (!searchIdData) {
-      console.log('No duplicates found in searchId.');
       return {};
     }
 
@@ -5443,19 +5362,16 @@ export const loadDuplicateUsers = async () => {
       }
 
       if (Array.isArray(userIdOrArray)) {
-        console.log('Duplicate found in searchId:', { searchKey, userIdOrArray });
         // Зберігаємо пару в масив pairs
         // Припускаємо, що це завжди пара (2 значення), якщо буває більше — можна додати перевірку.
         pairs.push(userIdOrArray);
       }
     }
 
-    console.log('All pairs of duplicates:', pairs);
 
     // Отримаємо перші 10 пар
     const first10Pairs = pairs.slice(0, 300);
     const totalDuplicates = pairs.length;
-    // console.log('totalDuplicates :>> ', totalDuplicates);
 
     const mergedUsers = {};
     for (const pair of first10Pairs) {
@@ -5534,7 +5450,6 @@ export const loadDuplicateUsers = async () => {
       // Перевіряємо першого користувача
       const keysFirst = Object.keys(mergedDataFirst);
       if (keysFirst.length <= 1) {
-        console.log(`Ignoring pair [${firstUserId}, ${secondUserId}] because first user is empty`);
         continue;
       }
 
@@ -5542,7 +5457,6 @@ export const loadDuplicateUsers = async () => {
       const keysSecond = Object.keys(mergedDataSecond);
       if (keysSecond.length <= 1) {
         // Другий користувач не має даних окрім userId, ігноруємо цю пару
-        console.log(`Ignoring pair [${firstUserId}, ${secondUserId}] because second user is empty`);
         continue;
       }
 
@@ -5551,7 +5465,6 @@ export const loadDuplicateUsers = async () => {
       mergedUsers[secondUserId] = mergedDataSecond;
     }
 
-    console.log('Duplicate users after filtering empty second user:', mergedUsers);
 
     return { mergedUsers, totalDuplicates };
   } catch (error) {
@@ -5565,7 +5478,6 @@ export const mergeDuplicateUsers = async () => {
     const searchIdData = await loadCollectionWithIndexCache('searchId');
 
     if (!searchIdData) {
-      console.log('No duplicates found in searchId.');
       return {};
     }
 
@@ -5582,12 +5494,10 @@ export const mergeDuplicateUsers = async () => {
       }
 
       if (Array.isArray(userIdOrArray)) {
-        console.log('Duplicate found in searchId:', { searchKey, userIdOrArray });
         pairs.push(userIdOrArray);
       }
     }
 
-    console.log('All pairs of duplicates:', pairs);
 
     const first10Pairs = pairs;
     // .slice(0, 300);
@@ -5682,13 +5592,11 @@ export const mergeDuplicateUsers = async () => {
       const user2 = await getUserData(secondUserId);
 
       if (Object.keys(user1).length <= 1 || Object.keys(user2).length <= 1) {
-        console.log(`Ignoring pair [${firstUserId}, ${secondUserId}] because one user is empty`);
         continue;
       }
 
       // Перевіряємо чи userId містить тільки `VK` або `AA`
       if (!/^VK|AA\d+$/.test(user1.userId) || !/^VK|AA\d+$/.test(user2.userId)) {
-        console.log(`Skipping pair [${firstUserId}, ${secondUserId}] because userId is not VK or AA`);
         continue;
       }
 
@@ -5704,7 +5612,6 @@ export const mergeDuplicateUsers = async () => {
         primaryUser = secondUserId;
       }
 
-      console.log(`Primary user: ${primaryUser}, Donor user: ${donorUser}`);
 
       for (const key of Object.keys(user2)) {
         if (!delKeys.includes(key) && key !== 'userId') {
@@ -5717,16 +5624,13 @@ export const mergeDuplicateUsers = async () => {
 
       mergedUsers[primaryUser] = user1; // Використовуємо `primaryUser`, бо він завжди правильний
 
-      console.log(`Merged user saved as ${primaryUser}:`, mergedUsers[primaryUser]);
 
       await updateDataInNewUsersRTDB(mergedUsers[primaryUser].userId, mergedUsers[primaryUser], 'update');
 
       const db = getDatabase();
       await remove(ref2(db, `newUsers/${donorUser}`));
-      console.log(`Deleted donor user: ${donorUser}`);
     }
 
-    console.log('Final merged users:', mergedUsers);
 
     return { mergedUsers, totalDuplicates };
   } catch (error) {
@@ -5747,7 +5651,6 @@ export const removeCardAndSearchId = async userId => {
     }
 
     const userData = userSnapshot.val();
-    console.log(`Дані користувача:`, userData);
 
     // Зберігаємо видалені значення для відображення в toast
     const deletedFields = [];
@@ -5760,7 +5663,6 @@ export const removeCardAndSearchId = async userId => {
 
       // Якщо значення — рядок
       if (typeof valueToCheck === 'string' || typeof valueToCheck === 'number') {
-        console.log(`Видалення рядкового значення: ${key} -> ${valueToCheck}`);
         const candidates = buildSearchIndexCandidates(key, valueToCheck);
         for (const candidate of candidates) {
           // eslint-disable-next-line no-await-in-loop
@@ -5771,7 +5673,6 @@ export const removeCardAndSearchId = async userId => {
 
       // Якщо значення — масив
       if (Array.isArray(valueToCheck)) {
-        console.log(`Видалення масиву значень для ключа: ${key} -> ${valueToCheck}`);
         for (const item of valueToCheck) {
           if (typeof item === 'string' || typeof item === 'number') {
             const candidates = buildSearchIndexCandidates(key, item);
@@ -5791,7 +5692,6 @@ export const removeCardAndSearchId = async userId => {
     // console.warn(`Видаляємо картку користувача з newUsers: ${userId}`);
     // Видаляємо картку користувача з newUsers
     await remove(ref2(db, `newUsers/${userId}`));
-    console.log(`Картка користувача видалена з newUsers: ${userId}`);
 
     removeCard(userId);
 
@@ -5944,7 +5844,6 @@ export const fetchAllUsersFromRTDB = async () => {
     // Перетворюємо назад в об’єкт
     const limitedUsers = Object.fromEntries(limitedUsersArray);
 
-    console.log('Отримано перших 3 користувачів:', limitedUsers);
     return limitedUsers;
   } catch (error) {
     console.error('Помилка при отриманні даних:', error);

--- a/src/components/foramtDate.js
+++ b/src/components/foramtDate.js
@@ -20,7 +20,6 @@ export const getCurrentDate = () => {
 };
 
 export const formatToLongDate = date => {
-  // console.log('date :>> ', date);
   // Перевіряємо, чи date не є undefined або null
   if (date === undefined || date === null || date === '') {
     return ''; // Повертаємо пустий рядок у випадку, якщо date === undefined або date === null

--- a/src/components/inputValidations.js
+++ b/src/components/inputValidations.js
@@ -311,7 +311,6 @@ export const normalizePhoneState = currentState => {
       const [fullMatch, countryCode, areaCode, firstPart, secondPart, thirdPart] = match;
       formattedNumber = '';
   
-      console.log('fullMatch :>> ', fullMatch);
       // if (countryCode && countryCode.charAt(0) === '0') {
       formattedNumber += countryCode;
       // } else if (countryCode) {
@@ -375,7 +374,7 @@ export const normalizePhoneState = currentState => {
               if (age && (age > 90 || age < 15)) {
                 !option && alert(`Перевірте правильність введення дати, Вам ${age}?`);
                 formattedDate = '';
-              } else console.log('Формат дати вірний');
+              }
             }
           }
         }
@@ -482,7 +481,6 @@ export const normalizePhoneState = currentState => {
         try {
           const cleanFormula = formula.slice(0, -1);
   
-          console.log('Формула для обчислення:', cleanFormula);
   
           if (!cleanFormula) {
             throw new Error('Порожня формула');
@@ -495,7 +493,6 @@ export const normalizePhoneState = currentState => {
           }
   
           today.setDate(today.getDate() + result);
-          console.log('Нова дата:', today.toISOString().split('T')[0]); // Логування у форматі YYYY-MM-DD
           return today.toISOString().split('T')[0]; // Повертаємо у форматі YYYY-MM-DD
         } catch (error) {
           console.error('Помилка в обчисленні формули:', error.message);
@@ -575,7 +572,6 @@ export const formatDateToServer = (dateString) => {
     const isOperator = (token) => ['+', '-', '*', '/'].includes(token);
   
     const tokens = expression.match(/(\d+|\+|-|\*|\/)/g);
-    console.log('Токени формули:', tokens);
   
     if (!tokens) {
       throw new Error('Невірний вираз: порожній або некоректний ввід');
@@ -588,7 +584,6 @@ export const formatDateToServer = (dateString) => {
       const b = values.pop();
       const a = values.pop();
       const op = ops.pop();
-      console.log('Застосовуємо оператор:', op, '| Операнди:', a, b);
       if (a === undefined || b === undefined || !operators[op]) {
         throw new Error('Неповний вираз');
       }
@@ -596,16 +591,13 @@ export const formatDateToServer = (dateString) => {
     };
   
     tokens.forEach((token) => {
-      console.log('Обробка токена:', token);
       if (!isNaN(token)) {
         values.push(parseFloat(token));
-        console.log('Додавання числа в стек:', values);
       } else if (isOperator(token)) {
         while (ops.length && precedence[ops[ops.length - 1]] >= precedence[token]) {
           applyOperator();
         }
         ops.push(token);
-        console.log('Додавання оператора в стек:', ops);
       } else {
         throw new Error('Невірний токен');
       }
@@ -619,7 +611,6 @@ export const formatDateToServer = (dateString) => {
       throw new Error('Помилка обчислення: некоректний стек після обчислення');
     }
   
-    console.log('Результат обчислення:', values[0]);
     return values[0];
   };
   

--- a/src/components/lastLoginLoad.js
+++ b/src/components/lastLoginLoad.js
@@ -45,7 +45,6 @@ export async function fetchUsersByLastLoginPaged(
   const target = startOffset + limit;
   const totalLimit = target + 1;
 
-  console.log('[fetchUsersByLastLoginPaged] startOffset', startOffset, 'limit', limit);
 
   const combined = [];
   const MAX_LOAD_DAYS = MAX_LOOKBACK_DAYS; // safety cap
@@ -60,7 +59,6 @@ export async function fetchUsersByLastLoginPaged(
     const dateStr = `${dd}.${mm}.${yy}`;
     // eslint-disable-next-line no-await-in-loop
     const chunk = await fetchDateFn(dateStr, totalLimit - combined.length);
-    console.log('[fetchUsersByLastLoginPaged] fetched', dateStr, 'count', chunk.length);
 
     if (chunk.length > 0) {
       const parse = str => {

--- a/src/components/loadMoreUtils.js
+++ b/src/components/loadMoreUtils.js
@@ -1,7 +1,6 @@
 export const handleEmptyFetch = (res, prevLastKey, setHasMore) => {
   const shouldStop = res.users.length === 0 && res.lastKey === prevLastKey;
   if (shouldStop) {
-    console.log('[handleEmptyFetch] stopping further loads');
     setHasMore(false);
   }
   return shouldStop;

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -13,7 +13,6 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
       field === 'modifiedUser'||
       field === 'saved_age' || field === 'saved_height' || field === 'saved_weight' || field === 'saved_reward'|| field === 'saved_eyeColor' || field === 'saved_blood' || field === 'saved_country'
     ) {
-      // console.log('Перезатираємо поле яке відправляємо');
       uploadedInfo[field] = state[field];
     }
     /////////////////////////////////////////////////////
@@ -23,47 +22,36 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
     ) {
       
       if (Array.isArray(existingData[field])) {
-        console.log('ExistingData на сервері є масивом');
         if (overwrite && [state[field]].length === 1) {
-          console.log('Якщо масив має лише одне значення, зберігаємо його як ключ-значення');
           uploadedInfo[field] = state[field];
         } else if (Array.isArray(state[field])) {
           if (field === 'photos') {
             uploadedInfo[field] = [...state[field]];
           } else {
-            console.log('Розпилюємо стейт');
             uploadedInfo[field] = [...state[field]];
           }
         } else {
-            console.log('Ключ є, записуємо / перезаписуємо як останній елемент масиву');
             const updatedField = existingData[field].filter(item => item !== state[field]);
             updatedField.push(state[field]);
             uploadedInfo[field] = updatedField;
           }
         }else if (overwrite && state[field]===''&& !Array.isArray(existingData[field])){
-        console.log('Якщо це не масиви', state[field], existingData[field]);
         uploadedInfo[field] = '';
       } else if (overwrite && !Array.isArray(state[field]==='') && !Array.isArray(existingData[field])){
-        console.log('Якщо ЕxistingData не масив та state не масив і його треба перезаписати', state[field], existingData[field]);
         uploadedInfo[field] = state[field];
       } else if (existingData[field]===''){
-        console.log('Якщо це не масиви', state[field], existingData[field]);
         uploadedInfo[field] = state[field];
       } else if (!Array.isArray(state[field])){
-        console.log('Якщо ЕxistingData не масив та state не масив, то створюємо масив', state[field], existingData[field]);
         uploadedInfo[field] = [existingData[field], state[field]];
       } else {
-        console.log('ЕxistingData це не масив, а стейт це масив, дописуємо нові значення в масив', uploadedInfo.name);
         const updatedField = state[field].filter(item => item !== existingData[field]);
         uploadedInfo[field] = [existingData[field], ...updatedField]
       }
     } else if (!existingData?.hasOwnProperty(field) && state[field] !== '') {
       if (field === 'postpone') {
         uploadedInfo[field] = [state[field]];
-        // console.log('postpone на сервері не існує, створюємо, записуємо як перший елемент масиву', uploadedInfo[field]);
       }
       uploadedInfo[field] = state[field];
-      // console.log('Такого ключа на сервері не існує, створюємо, записуємо перше значення:', uploadedInfo[field]);
     }
   }
   return uploadedInfo;

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -3,7 +3,6 @@ import { useRef } from 'react';
 import { useAutoResize } from '../../hooks/useAutoResize';
 
 export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} }) => {
-  // console.log('userData in RenderCommentInput :>> ', userData);
   const textareaRef = useRef(null);
   const autoResize = useAutoResize(textareaRef, userData.myComment);
 

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -175,7 +175,6 @@ export const handleChange = (
 
   if (setState) {
     invokeSetUsers(prevState => {
-      // console.log('prevState!!!!!!!!! :>> ', prevState);
       // Зроблено в основному для видалення юзера серед масиву карточок, а не з середини
 
       const keys = prevState && typeof prevState === 'object' && !Array.isArray(prevState)

--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -84,7 +84,6 @@ export const btnCompare = (
       currentVal = decodeURIComponent(currentVal);
     }
     const targetUserId = currentVal ? userIdNext : userIdCur;
-    console.log('Target User ID:', targetUserId);
   
     if (users[targetUserId]) {
       const updatedUsers = { ...users };
@@ -112,7 +111,6 @@ export const btnCompare = (
       setUsers(updatedUsers);
       handleSubmitAll(updatedTargetUser, 'overwrite');
   
-      console.log('Updated user data:', updatedTargetUser);
     } else {
       console.error(`User with ID ${targetUserId} not found`);
     }

--- a/src/components/smallCard/btnEdit.js
+++ b/src/components/smallCard/btnEdit.js
@@ -14,7 +14,6 @@ export const btnEdit = (userData, setSearch, setState, style = {}, content = 'ed
       saveCard(userData);
       setIdsForQuery(cacheKey, [userData.userId]);
     } else {
-      console.log('Користувача не знайдено.');
     }
   };
 

--- a/src/components/smallCard/btnMerge.js
+++ b/src/components/smallCard/btnMerge.js
@@ -6,7 +6,6 @@ export const btnMerge = async (users, setUsers, setDuplicates) => {
   const { mergedUsers, 
     // totalDuplicates 
   } = await mergeDuplicateUsers();
-  console.log('mergedUsers :>> ', mergedUsers);
 
   // setDuplicates(totalDuplicates);
 
@@ -78,13 +77,11 @@ export const btnMerge = async (users, setUsers, setDuplicates) => {
   //   usersToDelete.add(donorUser);
   // });
 
-  // console.log('usersToDelete:', usersToDelete);
 
   // // Видаляємо лише юзерів, які йдуть другим у кожній парі
   // usersToDelete.forEach(userId => {
   //   // delete updatedUsers[userId];
   // });
 
-  // console.log('Оновлений список користувачів:', updatedUsers);
   // setUsers(updatedUsers);
 };

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -9,9 +9,6 @@ export const layout = {
     height,
   },
 };
-console.log('height :>> ', height);
-console.log('width :>> ', width);
-
 export let resize;
 if (height > 1200) {
   resize = 1.6;
@@ -37,7 +34,6 @@ else {
   resize = 1;
 } // звичайний розмір
 
-console.log('resize :>> ', resize);
 
 export const deviceWidth = width;
 export const deviceHeight = height;

--- a/src/components/topBtns/btnJsonToExcel.js
+++ b/src/components/topBtns/btnJsonToExcel.js
@@ -17,7 +17,6 @@ const JsonToExcelButton = () => {
       try {
         const content = e.target.result;
         const data = JSON.parse(content);
-        console.log("JSON успішно завантажено:", data);
 
         // Перетворення структури JSON
         const transformedData = Object.keys(data).map((key) => ({
@@ -77,7 +76,6 @@ const JsonToExcelButton = () => {
   
     // Отримання всіх ключів у групованому порядку
     const allKeys = groupKeys(jsonData);
-    console.log("Унікальні ключі (колонки):", allKeys);
   
     // Формування таблиці з усіма ключами
     const excelData = jsonData.map((item) => {
@@ -93,7 +91,6 @@ const JsonToExcelButton = () => {
       return row;
     });
   
-    console.log("Підготовлені дані для Excel:", excelData);
   
     // Створення робочої книги
     try {
@@ -105,7 +102,6 @@ const JsonToExcelButton = () => {
       const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
       const blob = new Blob([excelBuffer], { type: "application/octet-stream" });
       saveAs(blob, "data.xlsx");
-      console.log("Файл Excel успішно збережено!");
     } catch (error) {
       console.error("Помилка під час створення Excel:", error.message);
     }

--- a/src/components/topBtns/uploadJSON.js
+++ b/src/components/topBtns/uploadJSON.js
@@ -219,7 +219,6 @@ export const UploadJson = () => {
       finalResult.myComments = myComments.join("; ");
     }
   
-    console.log("finalResult :>> ", finalResult);
     return finalResult;
   };
   

--- a/src/components/topBtns/uploadNewJSON.js
+++ b/src/components/topBtns/uploadNewJSON.js
@@ -104,20 +104,17 @@ export const UploadJson = () => {
         cleanedPhone = "38" + cleanedPhone;
       }
       if (!/\d/.test(cleanedPhone)) {
-        // console.log(`Невалідний номер (немає цифр): ${singlePhone}`);
         return null;
       }
 
        // Перевіряємо на довжину, якщо номер починається з 380 і має менше 11 символів
     if (cleanedPhone.startsWith("380") && cleanedPhone.length < 11) {
-      // console.log(`Невалідний номер: ${singlePhone}`); // Логування невалідного номера
       return null; // Повертаємо null, щоб видалити невалідний номер
     }
 
         // Фільтруємо номери, які є 101, 102, 103
         const invalidNumbers = ["101", "102", "103"];
         if (invalidNumbers.includes(cleanedPhone)) {
-          // console.log(`Невалідний номер (спеціальний): ${singlePhone}`);
           return null;
         }
 
@@ -131,23 +128,18 @@ export const UploadJson = () => {
               matches.forEach((match) => {
                 // Перевіряємо кожен знайдений номер
                 if (!repeatedDigitsPattern.test(match)) {
-                  // console.log(`Оригінальний номер: ${cleanedPhone}`);
-                  // console.log(`Оновлений номер: ${match}`);
                   // Зберігаємо або повертаємо оновлений номер
                   return match; // Зберігаємо перший валідний номер
                 } else {
-                  // console.log(`Невалідний витягнутий номер (5 і більше однакових цифр): ${match}`);
                 }
               });
             } else {
-              // console.log(`Невалідний номер (немає коректної послідовності "380"): ${cleanedPhone}`);
             }
             return null; // Якщо всі номери невалідні, повертаємо null
           }
 
            // Перевіряємо на довжину, якщо номер починається з 380 і має менше 11 символів
            if (cleanedPhone.length < 10) {
-            // console.log(`Невалідний короткий номер: ${singlePhone}`); // Логування невалідного номера
             return null; // Повертаємо null, щоб видалити невалідний номер
           }
 

--- a/src/utils/__tests__/backendDownloadToast.test.js
+++ b/src/utils/__tests__/backendDownloadToast.test.js
@@ -71,6 +71,18 @@ describe('backendDownloadToast admin traffic tracker', () => {
     expect(toast.success).toHaveBeenCalled();
   });
 
+  it('does not print automatic console table summaries during tracking', () => {
+    const { tracker } = loadTracker();
+    window.__getBackendDownloadToastUid = () => ADMIN_UID;
+
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ name: 'Admin payload' }) },
+      { operation: 'get', source: 'config', path: 'newUsers/user-id' },
+    );
+
+    expect(console.table).not.toHaveBeenCalled();
+  });
+
   it('collects stats while silent mode suppresses toast output', () => {
     const { tracker, toast } = loadTracker();
     window.__getBackendDownloadToastUid = () => ADMIN_UID;

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -3,6 +3,7 @@ import { isAdminUid } from './accessLevel';
 
 export const ENABLE_BACKEND_TRAFFIC_TOAST = true;
 export const BACKEND_TRAFFIC_SILENT_MODE = false;
+export const BACKEND_TRAFFIC_AUTO_CONSOLE_SUMMARY = false;
 export const BACKEND_DOWNLOAD_TOASTS_STORAGE_KEY = 'backendDownloadSizeToastsEnabled';
 export const BACKEND_TRAFFIC_TRACKING_TEST_UID = 'vtDxkDMjCwYuTDqTUnZsO29bpQr1';
 const BACKEND_TRAFFIC_EXTRA_TRACKED_UIDS = [BACKEND_TRAFFIC_TRACKING_TEST_UID];
@@ -482,6 +483,7 @@ const scheduleToast = request => {
 };
 
 const maybeLogConsoleSummary = stats => {
+  if (!BACKEND_TRAFFIC_AUTO_CONSOLE_SUMMARY) return;
   if (typeof console === 'undefined' || !console.table) return;
   const runtime = getRuntime();
   const now = Date.now();

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -804,17 +804,6 @@ export const buildNewUsersFilterSetIndex = async ({
       },
     });
 
-    console.log('[searchKeySets][debug] build result', {
-      setKey,
-      legacyRuleBucketWritesPaths: Object.keys(ruleBucketWrites),
-      payloadBucketsCount: debugBucketsCount,
-      filteredFields: debugFilteredFields,
-      bucketsCount: debugBucketsCount,
-      recordsCount: debugRecordsCount,
-      payloadUsers: payloadUserIds.size,
-      finalAllowedCount,
-      source: 'searchKeyFile+finalAllowedUserIds',
-    });
 
     if (payloadUserIds.size === 0 || debugRecordsCount === 0) {
       console.error('[searchKeySets] EMPTY PAYLOAD', {
@@ -847,13 +836,6 @@ export const buildNewUsersFilterSetIndex = async ({
       throw error;
     }
 
-    console.log('WRITE PAYLOAD:', {
-      setId: setKey,
-      hasPayload: !!filteredSearchKeySet,
-      fields: Object.keys(filteredSearchKeySet),
-      payloadUsers: payloadUserIds.size,
-      totalRecords: debugRecordsCount,
-    });
 
     debug.backendRequests.push({
       type: 'set',
@@ -870,7 +852,6 @@ export const buildNewUsersFilterSetIndex = async ({
       backendRequests: debug.backendRequests,
       setKey,
     };
-    console.log('backendRequests:', debug.backendRequests);
 
     const writesCountForSet = debugBucketsCount;
     bucketWritesCount += writesCountForSet;


### PR DESCRIPTION
### Motivation
- Remove noisy debug logging across the codebase and harden profile loading to avoid race conditions when resolving `userId` from the URL.
- Make backend traffic console summaries opt-in and add a test to prevent unexpected `console.table` output during tracking.

### Description
- Stripped many `console.log`/debug statements across components including `AddNewProfile`, `Matching`, `MyProfile`, `ProfileScreen`, `Photos`, `SearchBar`, `config.js`, utilities and top buttons to reduce console noise.
- Fixed `AddNewProfile` URL handling and profile fetch flow by using a `stateUserIdRef`, only resolving edit mode when necessary, starting a cancellable async fetch for `fetchUserById`, guarding `setState` updates to the intended `userId`, and setting `profileSource` consistently (`loading` → backend/cancelation handling).
- Converted several cache/state updates to safer functional updates to avoid overwriting concurrent state (e.g. when applying cached cards and fetched data).
- Added `BACKEND_TRAFFIC_AUTO_CONSOLE_SUMMARY` flag to `backendDownloadToast.js` and gated `maybeLogConsoleSummary` behind it to suppress automatic console summaries by default.
- Added/updated a unit test in `utils/__tests__/backendDownloadToast.test.js` to assert that automatic `console.table` summaries are not printed during tracking.

### Testing
- Ran the Jest unit test `utils/__tests__/backendDownloadToast.test.js` which includes the new assertion preventing console summary output; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070125e8948326ae24c75a1c9543af)