### PR TITLE
Remove noisy card load debug logs

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1533,10 +1533,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   // }, [state]);
 
   useEffect(() => {
-    console.log('state2!!!!!!!!!! :>> ', state);
-  }, [state]);
-
-  useEffect(() => {
     isEditingRef.current = !!state.userId;
   }, [state.userId]);
   const stateUserIdRef = useRef(state.userId || '');

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -166,17 +166,10 @@ export const Photos = ({ state, setState, collection }) => {
   };
 
   useEffect(() => {
-    console.log('useEffect triggered', {
-      userId: state.userId,
-      photos: state.photos,
-      photoValues,
-    });
     const load = async () => {
       if (state.userId) {
         try {
-          console.log('Fetching photos for user', state.userId);
           const urls = await getAllUserPhotos(state.userId, collection);
-          console.log('Fetched URLs', urls);
           const filteredUrls = filterOutMedicationPhotos(urls, state.userId);
           if (filteredUrls.length > 0) {
             const currentPhotos = normalizePhotosArray(state.photos);
@@ -195,12 +188,10 @@ export const Photos = ({ state, setState, collection }) => {
         const existingPhotos = Array.isArray(state.photos)
           ? state.photos
           : Object.values(state.photos || {});
-        console.log('Existing photos', existingPhotos);
         const converted = existingPhotos
           .map(convertDriveLinkToImage)
           .filter(Boolean);
         const filteredConverted = filterOutMedicationPhotos(converted, state.userId);
-        console.log('Converted photos', converted);
         const changed =
           filteredConverted.length !== existingPhotos.length ||
           filteredConverted.some((url, idx) => url !== existingPhotos[idx]);
@@ -218,7 +209,6 @@ export const Photos = ({ state, setState, collection }) => {
           )
           .map(([, value]) => convertDriveLinkToImage(value))
           .filter(Boolean);
-        console.log('Links from state', links);
 
         if (links.length) {
           commitPhotosUpdate(filterOutMedicationPhotos(links, state.userId));

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -908,11 +908,6 @@ const SearchBar = ({
   useEffect(() => {
     if (search) {
       const { key, value } = detectSearchParams(search);
-      console.log('[SearchBar] Restored persisted search', {
-        raw: search,
-        detectedKey: key,
-        detectedValue: value,
-      });
       loadCachedResult(key, value);
       writeData(search);
     }
@@ -920,11 +915,6 @@ const SearchBar = ({
   }, []);
 
   const emitSearchLabel = (params, meta = {}) => {
-    console.log('[SearchBar] Search label applied', {
-      ...meta,
-      params,
-    });
-
     // Repeated [] search keeps a per-value create context for not-found
     // placeholders, so fallback labels (for example the final name search)
     // must not replace the parent add payload.
@@ -1250,13 +1240,6 @@ const SearchBar = ({
       requestId = null,
     } = options;
 
-    console.log('[SearchBar] Parser evaluation', {
-      platform,
-      raw: inputData,
-      trimmed: trimmedInput,
-      parsed: id,
-    });
-
     if (!id && platform === 'telegram' && allowUkTrigger) {
       const ukTrigger = parseUkTriggerQuery(trimmedInput);
       if (ukTrigger?.searchPair?.telegram) {
@@ -1494,9 +1477,6 @@ const SearchBar = ({
       onSearchExecuted(trimmed);
     }
 
-    if (typeof query === 'string') {
-      console.log('[SearchBar] Incoming query', { raw: rawQuery, trimmed });
-    }
     if (trimmed && !trimmed.startsWith('!') && !suppressHistory) {
       addToHistory(trimmed);
     }

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -9,9 +9,6 @@ export const layout = {
     height,
   },
 };
-console.log('height :>> ', height);
-console.log('width :>> ', width);
-
 export let resize;
 if (height > 1200) {
   resize = 1.6;
@@ -37,7 +34,6 @@ else {
   resize = 1;
 } // звичайний розмір
 
-console.log('resize :>> ', resize);
 
 export const deviceWidth = width;
 export const deviceHeight = height;


### PR DESCRIPTION
### Motivation
- Reduce noisy console output emitted during page and card load so developer console focuses on actionable errors and important events.
- Keep error logging and explicit bulk-command diagnostics while removing per-render and import-time debug prints that clutter telemetry.

### Description
- Removed import-time layout debug `console.log` for device `height`, `width`, and `resize` from `src/components/styles/index.js`.
- Removed transient photo-load debug logs from `src/components/Photos.jsx` while preserving `console.error` for failures.
- Removed SearchBar debug logs for persisted restore, parser evaluation, incoming query and search-label emission in `src/components/SearchBar.jsx` while keeping bulk-command detection logging.
- Removed a noisy `useEffect` that dumped whole `state` on every change from `src/components/AddNewProfile.jsx`.

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runTestsByPath src/utils/__tests__/backendDownloadToast.test.js` and the suite passed (6 tests, 1 file).
- Ran linter with `npm run lint:js -- --quiet` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070125e8948326ae24c75a1c9543af)