### PR TITLE
Reduce profile restore logging churn and remove noisy console output

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -735,7 +735,29 @@ const summarizeProfileCardForLog = card => {
   };
 };
 
+const PROFILE_RESTORE_DEBUG_STEPS = new Set([
+  'init-state:cache-hit',
+  'init-state:cache-miss-placeholder',
+  'url-sync:blocked-no-access',
+  'profile-data:cache-hit-hydrate-state',
+  'profile-data:cache-miss-fetch-backend-start',
+  'profile-data:backend-hit-update-cache-and-state',
+  'profile-data:backend-empty',
+  'profile-data:backend-error',
+  'previous-list:snapshot-save',
+  'previous-list:restore-start',
+  'previous-list:restore-no-snapshot-clear-state',
+  'previous-list:restore-users-from-cache',
+  'previous-list:restore-complete-clear-profile-state',
+  'add-user:start',
+  'add-user:created-profile',
+  'add-user:set-state-open-profile-form',
+  'add-user:finish',
+]);
+
 const logProfileRestoreStep = (step, payload = {}) => {
+  if (!PROFILE_RESTORE_DEBUG_STEPS.has(step)) return;
+
   console.log(PROFILE_RESTORE_LOG_PREFIX, step, {
     at: getProfileRestoreTimestamp(),
     ...payload,
@@ -1112,6 +1134,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const historyNavigationRef = useRef(false);
   const isEditingRef = useRef(false);
   const previousListStateRef = useRef(null);
+  const skipInitialEmptyUrlProfileClearRef = useRef(
+    initialAccess.canAccessAdd &&
+      !new URLSearchParams(location.search).has('userId') &&
+      !new URLSearchParams(location.search).has('search') &&
+      Boolean(localStorage.getItem(EDIT_PROFILE_USER_ID_KEY)),
+  );
 
   const [searchKeyValuePair, setSearchKeyValuePair] = useState(null);
   const [filters, setFilters] = useState({});
@@ -1543,13 +1571,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       // Видаляємо ключ з нового стану
       delete newState[fieldName];
 
-      // console.log('Видалили ключ з локального стану:', fieldName);
-      // console.log('newState:', newState);
 
       // Встановлюємо значення 'del_key' для видалення
       //  newState[fieldName] = 'del_key';
-
-      console.log(`Поле "${fieldName}" позначено для видалення`);
 
       handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState; // Повертаємо оновлений стан
@@ -1584,10 +1608,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     isEditingRef.current = !!state.userId;
   }, [state.userId]);
   const stateUserIdRef = useRef(state.userId || '');
+  const stateRef = useRef(state);
 
   useEffect(() => {
     stateUserIdRef.current = state.userId || '';
-  }, [state.userId]);
+    stateRef.current = state;
+  }, [state]);
 
   const [users, setUsers] = useState({});
   const [hasMore, setHasMore] = useState(true); // Стан для перевірки, чи є ще користувачі
@@ -1610,18 +1636,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [, setCacheCount] = useState(0);
   const [, setBackendCount] = useState(0);
   const [profileSource, setProfileSource] = useState('');
+  const profileSourceRef = useRef(profileSource);
   const [isResolvingEditMode, setIsResolvingEditMode] = useState(false);
-  const restoreLogSeqRef = useRef(0);
   const profileFetchRequestRef = useRef(0);
 
   useEffect(() => {
-    restoreLogSeqRef.current += 1;
-    logProfileRestoreStep('state-change', {
-      seq: restoreLogSeqRef.current,
-      profileSource,
-      state: summarizeProfileCardForLog(state),
-    });
-  }, [profileSource, state]);
+    profileSourceRef.current = profileSource;
+  }, [profileSource]);
 
   useEffect(() => {
     const enteringEditMode = Boolean(state.userId) && !isEditingRef.current;
@@ -1700,22 +1721,23 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setIsResolvingEditMode(false);
         return;
       }
-      logProfileRestoreStep('url-sync:open-edit-mode', {
-        urlUserId,
-        currentStateUserId: stateUserIdRef.current || '',
-        willResolve: !stateUserIdRef.current || stateUserIdRef.current !== urlUserId,
-        locationSearch: location.search,
-      });
-      setIsResolvingEditMode(!stateUserIdRef.current || stateUserIdRef.current !== urlUserId);
-      setProfileSource('');
-      setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
+
+      const shouldResolveUrlUser = !stateUserIdRef.current || stateUserIdRef.current !== urlUserId;
+      setIsResolvingEditMode(shouldResolveUrlUser);
+
+      if (shouldResolveUrlUser) {
+        setProfileSource('');
+        setState(prev => (prev?.userId === urlUserId ? prev : { userId: urlUserId }));
+      }
       return;
     }
     if (!hasSearchParam && stateUserIdRef.current) {
-      logProfileRestoreStep('url-sync:clear-edit-mode', {
-        previousStateUserId: stateUserIdRef.current,
-        locationSearch: location.search,
-      });
+      if (skipInitialEmptyUrlProfileClearRef.current) {
+        skipInitialEmptyUrlProfileClearRef.current = false;
+        setIsResolvingEditMode(false);
+        return;
+      }
+
       setState({});
     }
     setIsResolvingEditMode(false);
@@ -1908,8 +1930,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   ]);
 
   useEffect(() => {
-    if (!state.userId) {
-      logProfileRestoreStep('profile-data:skip-no-user-id', { profileSource });
+    const currentState = stateRef.current || {};
+    const currentProfileSource = profileSourceRef.current || '';
+    const activeUserId = String(currentState.userId || '').trim();
+    if (!activeUserId) {
       return;
     }
 
@@ -1917,79 +1941,81 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     profileFetchRequestRef.current = requestId;
     logProfileRestoreStep('profile-data:effect-start', {
       requestId,
-      userId: state.userId,
-      profileSource,
-      stateKeysCount: Object.keys(state).length,
+      userId: activeUserId,
+      profileSource: currentProfileSource,
+      stateKeysCount: Object.keys(currentState).length,
     });
 
-    if (Object.keys(state).length > 1) {
-      if (!profileSource) {
+    if (Object.keys(currentState).length > 1) {
+      if (!currentProfileSource) {
         logProfileRestoreStep('profile-data:state-already-hydrated-set-cache-source', {
           requestId,
-          userId: state.userId,
-          state: summarizeProfileCardForLog(state),
+          userId: activeUserId,
+          state: summarizeProfileCardForLog(currentState),
         });
         setProfileSource('cache');
       } else {
         logProfileRestoreStep('profile-data:state-already-hydrated-skip', {
           requestId,
-          userId: state.userId,
-          profileSource,
-          state: summarizeProfileCardForLog(state),
+          userId: activeUserId,
+          profileSource: currentProfileSource,
+          state: summarizeProfileCardForLog(currentState),
         });
       }
       return;
     }
 
-    const cached = getCard(state.userId);
+    const cached = getCard(activeUserId);
     if (cached) {
       logProfileRestoreStep('profile-data:cache-hit-hydrate-state', {
         requestId,
-        userId: state.userId,
+        userId: activeUserId,
         cached: summarizeProfileCardForLog(cached),
       });
-      setState({ ...cached, userId: cached.userId || state.userId });
+      setState({ ...cached, userId: cached.userId || activeUserId });
       setProfileSource('cache');
     } else {
       logProfileRestoreStep('profile-data:cache-miss-fetch-backend-start', {
         requestId,
-        userId: state.userId,
+        userId: activeUserId,
       });
       setProfileSource('loading');
       (async () => {
         try {
-          const data = await fetchUserById(state.userId);
+          const data = await fetchUserById(activeUserId);
           if (data) {
             logProfileRestoreStep('profile-data:backend-hit-update-cache-and-state', {
               requestId,
-              userId: state.userId,
+              userId: activeUserId,
               backend: summarizeProfileCardForLog(data),
             });
-            updateCard(state.userId, data);
-            setState({ ...data, userId: data.userId || state.userId });
+            updateCard(activeUserId, data);
+            setState({ ...data, userId: data.userId || activeUserId });
           } else {
             logProfileRestoreStep('profile-data:backend-empty', {
               requestId,
-              userId: state.userId,
+              userId: activeUserId,
             });
           }
         } catch (error) {
           logProfileRestoreStep('profile-data:backend-error', {
             requestId,
-            userId: state.userId,
+            userId: activeUserId,
             message: error?.message || String(error),
           });
           toast.error(error.message);
         } finally {
           logProfileRestoreStep('profile-data:backend-finish-set-source', {
             requestId,
-            userId: state.userId,
+            userId: activeUserId,
           });
-          setProfileSource('backend');
+          if (profileFetchRequestRef.current === requestId) {
+            setProfileSource('backend');
+          }
         }
       })();
     }
-  }, [state, profileSource, setState]);
+  }, [state.userId, setState]);
 
   useEffect(() => {
     if (!state.userId) setProfileSource('');
@@ -2541,7 +2567,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const delConfirm = () => {
-    // console.log('state :>> ', state);
     const handleRemoveUser = async () => {
       try {
         setIsDeleting(true);
@@ -2560,7 +2585,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setState({});
         setShowInfoModal(null);
         setUserIdToDelete(null);
-        console.log(`User ${id} deleted.`);
         navigate('/add');
       } catch (error) {
         console.error('Error deleting user:', error);
@@ -2794,11 +2818,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
 
   const loadMoreUsers = async (filterForload, currentFilters = filters) => {
-    console.log('loadMoreUsers called with', {
-      filterForload,
-      lastKey,
-      currentFilters,
-    });
     const includeSpecialFutureDates = searchBarQueryActive;
     if (isEditingRef.current) return { count: 0, hasMore };
     const param = lastKey;
@@ -2838,18 +2857,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         dislikedUsers: dislikedUsersMap,
       },
     );
-    // console.log('res :>> ', res);
     // Перевіряємо, чи є користувачі у відповіді
     if (res && typeof res.users === 'object' && Object.keys(res.users).length > 0) {
-      // console.log('222 :>> ');
-      // console.log('res.users :>> ', res.users);
 
       // Використовуємо Object.entries для обробки res.users
       const newUsers = Object.entries(res.users)
         .filter(([id]) => !currentFilters.favorite?.favOnly || fav[id])
         .reduce((acc, [userId, user]) => {
         // Перевірка наявності поля userId, щоб уникнути помилок
-        // console.log('3333 :>> ');
         if (user.userId) {
           acc[user.userId] = user; // Додаємо користувача до об'єкта
         } else {
@@ -2869,8 +2884,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setLastKey(res.lastKey); // Оновлюємо lastKey для наступного запиту
       setHasMore(res.hasMore); // Оновлюємо hasMore
       const backendCount = Object.keys(newUsers).length;
-      console.log('loaded users count', backendCount);
-      console.log('next lastKey', res.lastKey);
       return { cacheCount: 0, backendCount, hasMore: res.hasMore };
     } else {
       setHasMore(false); // Якщо немає більше користувачів, оновлюємо hasMore

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -166,17 +166,10 @@ export const Photos = ({ state, setState, collection }) => {
   };
 
   useEffect(() => {
-    console.log('useEffect triggered', {
-      userId: state.userId,
-      photos: state.photos,
-      photoValues,
-    });
     const load = async () => {
       if (state.userId) {
         try {
-          console.log('Fetching photos for user', state.userId);
           const urls = await getAllUserPhotos(state.userId, collection);
-          console.log('Fetched URLs', urls);
           const filteredUrls = filterOutMedicationPhotos(urls, state.userId);
           if (filteredUrls.length > 0) {
             const currentPhotos = normalizePhotosArray(state.photos);
@@ -195,12 +188,10 @@ export const Photos = ({ state, setState, collection }) => {
         const existingPhotos = Array.isArray(state.photos)
           ? state.photos
           : Object.values(state.photos || {});
-        console.log('Existing photos', existingPhotos);
         const converted = existingPhotos
           .map(convertDriveLinkToImage)
           .filter(Boolean);
         const filteredConverted = filterOutMedicationPhotos(converted, state.userId);
-        console.log('Converted photos', converted);
         const changed =
           filteredConverted.length !== existingPhotos.length ||
           filteredConverted.some((url, idx) => url !== existingPhotos[idx]);
@@ -218,7 +209,6 @@ export const Photos = ({ state, setState, collection }) => {
           )
           .map(([, value]) => convertDriveLinkToImage(value))
           .filter(Boolean);
-        console.log('Links from state', links);
 
         if (links.length) {
           commitPhotosUpdate(filterOutMedicationPhotos(links, state.userId));
@@ -316,7 +306,6 @@ export const Photos = ({ state, setState, collection }) => {
                   src={url}
                   alt={`user avatar ${index}`}
                   onClick={() => handlePhotoClick(url, index)}
-                  onLoad={() => console.log('Image loaded', url)}
                   onError={e => {
                     console.error('Image failed to load', url, e);
                     e.target.onerror = null;

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -139,24 +139,17 @@ const getProfileFormRestoreTimestamp = () => {
   return Date.now();
 };
 
-const summarizeProfileFormStateForLog = state => {
-  if (!state || typeof state !== 'object') {
-    return { hasState: false };
-  }
-
-  const keys = Object.keys(state);
-  return {
-    hasState: true,
-    userId: state.userId || '',
-    keysCount: keys.length,
-    keys,
-    cachedAt: state.cachedAt || null,
-    updatedAt: state.updatedAt || state.lastUpdated || null,
-    dataSource: state.__sourceCollection || state.dataSource || null,
-  };
-};
+const PROFILE_FORM_RESTORE_DEBUG_STEPS = new Set([
+  'admin-overlay-additions:load-success',
+  'admin-overlay-additions:load-error',
+  'editor-overlay:auto-apply-start',
+  'editor-overlay:auto-apply-replacements',
+  'editor-overlay:auto-apply-error',
+]);
 
 const logProfileFormRestoreStep = (step, payload = {}) => {
+  if (!PROFILE_FORM_RESTORE_DEBUG_STEPS.has(step)) return;
+
   console.log(PROFILE_FORM_RESTORE_LOG_PREFIX, step, {
     at: getProfileFormRestoreTimestamp(),
     ...payload,
@@ -828,38 +821,6 @@ export const ProfileForm = ({
   const searchKeyFileInputRef = useRef(null);
   const [localSearchKeyPayload, setLocalSearchKeyPayload] = useState(null);
   const autoAppliedOverlayForUserRef = useRef('');
-  const formRestoreRenderSeqRef = useRef(0);
-
-  useEffect(() => {
-    logProfileFormRestoreStep('mount', {
-      dataSource,
-      state: summarizeProfileFormStateForLog(state),
-      isAdmin,
-    });
-
-    return () => {
-      logProfileFormRestoreStep('unmount', {
-        dataSource,
-        userId: state?.userId || '',
-      });
-    };
-    // This intentionally logs only the component lifetime for one opened form.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    formRestoreRenderSeqRef.current += 1;
-    logProfileFormRestoreStep('props-change', {
-      seq: formRestoreRenderSeqRef.current,
-      dataSource,
-      isAdmin,
-      highlightedFieldsCount: highlightedFields.length,
-      deletedOverlayFieldsCount: deletedOverlayFields.length,
-      overlayFieldAdditionsCount: Object.keys(overlayFieldAdditions || {}).length,
-      state: summarizeProfileFormStateForLog(state),
-    });
-  }, [dataSource, deletedOverlayFields, highlightedFields, isAdmin, overlayFieldAdditions, state]);
-
   const addEmptyAdditionalFilter = useCallback(() => {
     const used = new Set(additionalRuleBuilder.map(rule => rule.key));
     const firstAvailable = ADDITIONAL_RULE_ORDER.find(key => !used.has(key)) || ADDITIONAL_RULE_ORDER[0];
@@ -1193,7 +1154,6 @@ export const ProfileForm = ({
         if (Array.isArray(lastSetDebug?.skippedFields) && lastSetDebug.skippedFields.includes('imt')) {
           toast('5/8 Skipped imt field');
         }
-        const filteredFields = Array.isArray(lastSetDebug?.filteredFields) ? lastSetDebug.filteredFields : [];
         toast(
           `Filtered set ready: payloadUsers=${payloadUsersCount}, finalAllowed=${finalAllowedCount}, buckets=${payloadBucketsCount}, records=${payloadRecordsCount}`
         );
@@ -1223,20 +1183,6 @@ export const ProfileForm = ({
         if (!hasSetPayload) {
           toast.error('STOP: payload empty before backend write');
         }
-        console.log('[searchKeySets debug]', {
-          selectedRules: lastSetDebug?.selectedRules,
-          allowedUserIdsCount: Number(lastSetDebug?.allowedUserIdsCount || 0),
-          finalAllowedCount,
-          payloadUsers: payloadUsersCount,
-          allowedSample: Array.isArray(lastSetDebug?.allowedSample) ? lastSetDebug.allowedSample.slice(0, 10) : [],
-          searchKeyFields,
-          skippedFields: Array.isArray(lastSetDebug?.skippedFields) ? lastSetDebug.skippedFields : [],
-          copiedByField,
-          copiedRecords: payloadRecordsCount,
-          copiedBuckets: payloadBucketsCount,
-          filteredFields,
-          backendRequests,
-        });
         if (indexResult && Number(indexResult.writesCount || 0) === 0 && Number(indexResult?.setKeys?.length || 0) === 0) {
           toast('searchKeySets не оновлено: не знайдено валідних правил.');
         }

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -908,11 +908,6 @@ const SearchBar = ({
   useEffect(() => {
     if (search) {
       const { key, value } = detectSearchParams(search);
-      console.log('[SearchBar] Restored persisted search', {
-        raw: search,
-        detectedKey: key,
-        detectedValue: value,
-      });
       loadCachedResult(key, value);
       writeData(search);
     }
@@ -920,11 +915,6 @@ const SearchBar = ({
   }, []);
 
   const emitSearchLabel = (params, meta = {}) => {
-    console.log('[SearchBar] Search label applied', {
-      ...meta,
-      params,
-    });
-
     // Repeated [] search keeps a per-value create context for not-found
     // placeholders, so fallback labels (for example the final name search)
     // must not replace the parent add payload.
@@ -1250,13 +1240,6 @@ const SearchBar = ({
       requestId = null,
     } = options;
 
-    console.log('[SearchBar] Parser evaluation', {
-      platform,
-      raw: inputData,
-      trimmed: trimmedInput,
-      parsed: id,
-    });
-
     if (!id && platform === 'telegram' && allowUkTrigger) {
       const ukTrigger = parseUkTriggerQuery(trimmedInput);
       if (ukTrigger?.searchPair?.telegram) {
@@ -1494,9 +1477,6 @@ const SearchBar = ({
       onSearchExecuted(trimmed);
     }
 
-    if (typeof query === 'string') {
-      console.log('[SearchBar] Incoming query', { raw: rawQuery, trimmed });
-    }
     if (trimmed && !trimmed.startsWith('!') && !suppressHistory) {
       addToHistory(trimmed);
     }
@@ -1505,11 +1485,6 @@ const SearchBar = ({
       const filtersKey = normalizeQueryKey(
         `${filterForload || 'all'}:${serializeQueryFilters(filters)}`,
       );
-      console.log('[SearchBar] Detected bulk command search', {
-        raw: trimmed,
-        command: term,
-        filtersKey,
-      });
       const cacheKey = `allUsers:${filtersKey}`;
       const queries = loadQueries();
       const entry = queries[cacheKey];
@@ -1565,11 +1540,6 @@ const SearchBar = ({
     if (repeatedValues.length > 0) {
       const repeatedPerfLabel = `[SearchPerf][repeat][total] ${trimmed}`;
       if (perfDebugEnabledRef.current) console.time(repeatedPerfLabel);
-      console.log('[SearchBar] Processing repeated search values', {
-        raw: trimmed,
-        values: repeatedValues,
-      });
-
       const collector = {
         requestId,
         results: {},
@@ -1881,11 +1851,6 @@ const SearchBar = ({
     }
 
     const nameTrim = rawQuery.trim();
-    console.log('[SearchBar] Defaulting to name search', {
-      raw: rawQuery,
-      cleaned: nameTrim,
-    });
-
     const hasCache = loadCachedResult('name', nameTrim, requestId);
     const freshCache = hasCache && isCacheFresh('name', nameTrim);
     emitSearchLabel({ name: nameTrim }, { mode: 'name', stage: 'default' });

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -9,9 +9,6 @@ export const layout = {
     height,
   },
 };
-console.log('height :>> ', height);
-console.log('width :>> ', width);
-
 export let resize;
 if (height > 1200) {
   resize = 1.6;
@@ -37,7 +34,6 @@ else {
   resize = 1;
 } // звичайний розмір
 
-console.log('resize :>> ', resize);
 
 export const deviceWidth = width;
 export const deviceHeight = height;

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -482,12 +482,11 @@ const scheduleToast = request => {
 };
 
 const maybeLogConsoleSummary = stats => {
-  if (typeof console === 'undefined' || !console.table) return;
   const runtime = getRuntime();
   const now = Date.now();
   if (now - runtime.lastConsoleSummaryAt < CONSOLE_SUMMARY_DELAY_MS) return;
   runtime.lastConsoleSummaryAt = now;
-  stats.summary();
+  stats.summary({ log: false });
 };
 
 const makeRequestShell = ({ operation = 'get', source = '', path = 'unknown' } = {}) => ({


### PR DESCRIPTION
### Motivation
- Reduce excessive console output during page load and profile restore to make debug logs actionable and avoid repeated mount/unmount churn. 
- Prevent unnecessary state overwrites and effect re-runs when the UI already has the correct `userId` restored from cache or URL. 
- Keep only high-signal debug entries for profile restore and overlay flows. 

### Description
- Whitelist profile-restore debug events and replace noisy `logProfileRestoreStep` spam with a `PROFILE_RESTORE_DEBUG_STEPS` set in `src/components/AddNewProfile.jsx`. 
- Add `skipInitialEmptyUrlProfileClearRef` to avoid clearing a cached restored profile when URL initially lacks `userId`, and only resolve URL-user changes when required. 
- Reduce unnecessary hydration/effect churn in `AddNewProfile.jsx` by using `stateRef` and `profileSourceRef` refs, narrowing the profile-data effect dependencies to `state.userId`, and guarding backend `setProfileSource` with a request id check. 
- Remove various page-load/debug `console.log` calls in `src/components/Photos.jsx`, `src/components/SearchBar.jsx`, and `src/components/styles/index.js` (image load, parser/incoming queries, layout size prints). 
- Limit `ProfileForm` restore logging to key overlay lifecycle events by introducing `PROFILE_FORM_RESTORE_DEBUG_STEPS` and removing mount/unmount/props-change spam. 
- Stop printing `console.table` summaries on every backend summary by changing `maybeLogConsoleSummary` to call `stats.summary({ log: false })` in `src/utils/backendDownloadToast.js`. 
- Remove other small noisy `console.log` lines in `AddNewProfile.jsx` (loadMoreUsers, delete messages, etc.). 

### Testing
- Ran `npm run lint:js` to validate code style and hooks, which completed successfully (no blocking errors). 
- Built the production bundle with `npm run build`, which compiled successfully (build artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07338114ac83268c5d07215c321dc6)