### PR TITLE
Add robust source backfill util and stale-guarding for Matching.loadMore

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -162,6 +162,7 @@ import {
   shouldApplySharedReactionCandidateResult,
   uniqueTruthyReactionIds,
 } from 'utils/reactionPriority';
+import { collectFilteredMatchingSourceCards } from 'utils/matchingSourceBackfill';
 
 
 const DEBUG_ADDITIONAL_MATCHING_USER_ID = BACKEND_TRAFFIC_TRACKING_TEST_UID;
@@ -1247,7 +1248,6 @@ const MATCHING_VISIBLE_BUFFER = 2;
 const MATCHING_REFILL_LIMIT = 1;
 const LOAD_MORE = 1;
 const ADDITIONAL_BACKFILL_MAX_PAGES = 3;
-const SOURCE_BACKFILL_MAX_PAGES = 5;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
 const COLLECTION_SOURCE_KEY = 'matchingCollectionSource';
@@ -2430,84 +2430,56 @@ const Matching = () => {
       exclude = new Set(),
       onPart
     ) => {
-      const collected = [];
-      let cursor = lastDate;
-      let hasMore = false;
-      let excludedCount = 0;
-      let prevCursor;
-      let loadedPages = 0;
-
-      while (collected.length < limit && loadedPages < SOURCE_BACKFILL_MAX_PAGES) {
-        loadedPages += 1;
-        if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
-          break;
-        }
-
-        const remaining = limit - collected.length;
-        const sourceRes =
-          collectionSource === 'newUsers'
-            ? await fetchUsersByLastLogin2FromCollection('newUsers', remaining + exclude.size + 1, cursor)
-            : await fetchUsersByLastLogin2(remaining + exclude.size + 1, cursor);
-
-        const activeFilters = filtersRef.current || {};
-        const filtered = isAdmin
-          ? applyMatchingSearchKeyFilters(
-              filterMain(
-                sourceRes.users.map(u => [u.userId, u]),
-                null,
-                getMatchingFiltersWithoutSearchKeyGroups(activeFilters),
-                favoriteUsersRef.current,
-                dislikeUsersRef.current
-              ).map(([, u]) => u),
-              activeFilters,
-              roleIndexSets
-            ).filter(
-              u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
-            )
-          : sourceRes.users.filter(
-              u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
-            );
-
-        excludedCount += sourceRes.users.length - filtered.length;
-        const slice = filtered.slice(0, remaining);
-        const ids = slice.map(user => user.userId);
-        const enrichedMap = await fetchUsersByIds(ids);
-        const validSlice = ids
-          .map(id => enrichedMap[id])
-          .filter(Boolean)
-          .map(user => ({
-            ...user,
-            __sourceCollection: collectionSource === 'newUsers' ? 'newUsers' : 'users',
-          }));
-
-        if (validSlice.length) {
-          collected.push(...validSlice);
-          if (onPart) await onPart(validSlice);
-        }
-
-        hasMore = sourceRes.hasMore;
-        prevCursor = cursor;
-        cursor = sourceRes.lastKey;
-
-        if (!sourceRes.hasMore || !sourceRes.lastKey || isSameCursor(prevCursor, cursor)) {
-          break;
-        }
+      if (collectionSource === 'newUsers' && parsedAdditionalAccessRules.length > 0) {
+        return {
+          users: [],
+          lastKey: lastDate ?? null,
+          hasMore: false,
+          sourceHasMore: false,
+          cursorAdvanced: false,
+          excludedCount: 0,
+          loadedPages: 0,
+        };
       }
 
-      const reachedSafetyCap = Boolean(
-        hasMore &&
-        loadedPages >= SOURCE_BACKFILL_MAX_PAGES &&
-        collected.length < limit
-      );
-
-      return {
-        users: collected,
-        lastKey: cursor,
-        hasMore,
-        sourceHasMore: hasMore,
-        reachedSafetyCap,
-        excludedCount,
-      };
+      return collectFilteredMatchingSourceCards({
+        targetVisibleCount: limit,
+        initialCursor: lastDate,
+        exclude,
+        isSameCursor,
+        getSourceLimit: ({ remaining }) => remaining + exclude.size + 1,
+        fetchSourcePage: ({ limit: sourceLimit, cursor }) => (
+          collectionSource === 'newUsers'
+            ? fetchUsersByLastLogin2FromCollection('newUsers', sourceLimit, cursor)
+            : fetchUsersByLastLogin2(sourceLimit, cursor)
+        ),
+        filterSourceUsers: sourceUsers => {
+          const activeFilters = filtersRef.current || {};
+          return isAdmin
+            ? applyMatchingSearchKeyFilters(
+                filterMain(
+                  sourceUsers.map(u => [u.userId, u]),
+                  null,
+                  getMatchingFiltersWithoutSearchKeyGroups(activeFilters),
+                  favoriteUsersRef.current,
+                  dislikeUsersRef.current
+                ).map(([, u]) => u),
+                activeFilters,
+                roleIndexSets
+              ).filter(
+                u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
+              )
+            : sourceUsers.filter(
+                u => isAllowedIdForCollection(u.userId, collectionSource) && !exclude.has(u.userId)
+              );
+        },
+        hydrateUsersByIds: fetchUsersByIds,
+        decorateUser: user => ({
+          ...user,
+          __sourceCollection: collectionSource === 'newUsers' ? 'newUsers' : 'users',
+        }),
+        onPart,
+      });
     },
     [collectionSource, isAdmin, parsedAdditionalAccessRules.length, roleIndexSets]
   );
@@ -3018,8 +2990,9 @@ const Matching = () => {
       console.log('[loadMore] skip', { hasMore, loading: loadingRef.current, viewMode });
       return;
     }
-    const requestedLimit = Math.max(1, Number(limit) || LOAD_MORE);
-    console.log('[loadMore] start', { lastKey, hasMore, requestedLimit });
+    const visibleDeficit = Math.max(0, Number(targetVisibleCount) - Number(currentVisibleCount));
+    const requestedLimit = Math.max(1, Number(limit) || LOAD_MORE, visibleDeficit);
+    console.log('[loadMore] start', { lastKey, hasMore, requestedLimit, targetVisibleCount, currentVisibleCount });
     loadingRef.current = true;
     setLoading(true);
     const loadMoreVersion = additionalLoadMoreFetchVersionRef.current + 1;
@@ -3043,6 +3016,19 @@ const Matching = () => {
         currentCollectionSource: collectionSource,
       })
     );
+    const finishLoadMoreIfLatest = () => {
+      if (!isLatestLoadMore()) {
+        console.log('[loadMore] stale request finished after a newer request; keeping loading state for active request', {
+          loadMoreVersion,
+          latestLoadMoreVersion: additionalLoadMoreFetchVersionRef.current,
+          applyVersion,
+          latestApplyVersion: additionalMatchingApplyVersionRef.current,
+        });
+        return;
+      }
+      loadingRef.current = false;
+      setLoading(false);
+    };
     try {
       if (isReactionViewMode) {
         const reactionMap = viewMode === 'favorites'
@@ -3101,6 +3087,8 @@ const Matching = () => {
         page.users.forEach(user => {
           updateCard(user.userId, user);
         });
+        await loadCommentsFor(page.users);
+        if (!canApplyLoadMoreResult()) return;
         reactionLoadedIdsRef.current[viewMode] = loadedIds;
         loadedIdsRef.current = new Set(loadedIds);
         setUsers(prev => {
@@ -3109,7 +3097,6 @@ const Matching = () => {
           page.users.forEach(user => map.set(user.userId, user));
           return Array.from(map.values());
         });
-        await loadCommentsFor(page.users);
         const hasPendingSharedCandidates = hasPendingSharedReactionCandidates({
           reactionIds,
           sharedReactionIds,
@@ -3256,16 +3243,18 @@ const Matching = () => {
         if (!isLatestLoadMore()) return;
 
         collected.forEach(user => {
-          loadedIdsRef.current.add(user.userId);
           updateCard(user.userId, user);
+        });
+        await loadCommentsFor(collected);
+        if (!isLatestLoadMore()) return;
+        collected.forEach(user => {
+          loadedIdsRef.current.add(user.userId);
         });
         setAdditionalNewUsers(prev => {
           const map = new Map((shouldResetAdditionalPagination ? [] : prev).map(user => [user.userId, user]));
           collected.forEach(user => map.set(user.userId, user));
           return Array.from(map.values());
         });
-        await loadCommentsFor(collected);
-        if (!isLatestLoadMore()) return;
         setAdditionalNextOffset(nextOffset);
         setHasMore(canLoadMoreAdditional);
         logAdditionalMatchingDebug(ownerId, 'load more additional matching final cards', {
@@ -3292,20 +3281,29 @@ const Matching = () => {
           ...collected.map(u => u.userId).filter(Boolean),
         ]);
         const res = await fetchChunk(remaining, cursor, dynamicExclude);
+        if (!isLatestLoadMore()) {
+          console.log('[loadMore] ignored stale default batch result', {
+            loadMoreVersion,
+            latestLoadMoreVersion: additionalLoadMoreFetchVersionRef.current,
+            applyVersion,
+            latestApplyVersion: additionalMatchingApplyVersionRef.current,
+          });
+          return;
+        }
         console.log('[loadMore] batch', {
           requested: remaining,
           received: res.users.length,
           cursor,
           nextCursor: res.lastKey,
           hasMore: res.hasMore,
-          reachedSafetyCap: res.reachedSafetyCap,
+          sourceHasMore: res.sourceHasMore,
+          loadedPages: res.loadedPages,
         });
 
         const unique = res.users.filter(
           u => u?.userId && !loadedIdsRef.current.has(u.userId)
         );
         if (unique.length) {
-          unique.forEach(u => loadedIdsRef.current.add(u.userId));
           collected.push(...unique);
         }
 
@@ -3315,6 +3313,9 @@ const Matching = () => {
       }
 
       collected.forEach(u => updateCard(u.userId, u));
+      await loadCommentsFor(collected);
+      if (!isLatestLoadMore()) return;
+      collected.forEach(u => loadedIdsRef.current.add(u.userId));
       setUsers(prev => {
         const map = new Map(prev.map(u => [u.userId, u]));
         collected.forEach(u => map.set(u.userId, u));
@@ -3322,11 +3323,10 @@ const Matching = () => {
         setIdsForQuery(defaultListKey, result.map(u => u.userId));
         return result;
       });
-      await loadCommentsFor(collected);
 
-      const stoppedBySafetyCapWithMoreSource = canLoadMore && collected.length === 0;
-      if (stoppedBySafetyCapWithMoreSource) {
-        console.log('[loadMore] source backfill safety cap reached; keeping hasMore true for next cycle');
+      const sourceCanContinueWithoutVisibleCards = canLoadMore && collected.length === 0;
+      if (sourceCanContinueWithoutVisibleCards) {
+        console.log('[loadMore] source cursor advanced with more pages; keeping hasMore true for next cycle');
         setHasMore(true);
       } else if (handleEmptyFetch({ users: collected, lastKey: cursor }, lastKey, setHasMore)) {
         console.log('[loadMore] empty fetch, no more cards');
@@ -3335,8 +3335,7 @@ const Matching = () => {
       }
       setLastKey(cursor);
     } finally {
-      loadingRef.current = false;
-      setLoading(false);
+      finishLoadMoreIfLatest();
     }
   }, [
     additionalNewUsers,

--- a/src/components/Matching.loadMoreStaleGuard.test.js
+++ b/src/components/Matching.loadMoreStaleGuard.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+const loadMoreSource = () => {
+  const source = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
+  const start = source.indexOf('  const loadMore = React.useCallback');
+  const end = source.indexOf('  const filteredUsers = useMemo', start);
+  return source.slice(start, end);
+};
+
+describe('Matching loadMore stale pagination guards', () => {
+  it('guards reaction pagination writes after async comment loading', () => {
+    const source = loadMoreSource();
+
+    expect(source).toContain(`await loadCommentsFor(page.users);
+        if (!canApplyLoadMoreResult()) return;
+        reactionLoadedIdsRef.current[viewMode] = loadedIds;
+        loadedIdsRef.current = new Set(loadedIds);`);
+    expect(source).toContain(`setHasMore(nextHasMore);
+        setLastKey(null);`);
+  });
+
+  it('guards additional newUsers offset, hasMore, lastKey, and loadedIdsRef writes', () => {
+    const source = loadMoreSource();
+
+    expect(source).toContain(`await loadCommentsFor(collected);
+        if (!isLatestLoadMore()) return;
+        collected.forEach(user => {
+          loadedIdsRef.current.add(user.userId);
+        });`);
+    expect(source).toContain(`setAdditionalNextOffset(nextOffset);
+        setHasMore(canLoadMoreAdditional);`);
+    expect(source).toContain(`setLastKey(null);
+        return;`);
+  });
+
+  it('guards default source pagination writes from stale loadMore requests', () => {
+    const source = loadMoreSource();
+    const fetchIndex = source.indexOf('const res = await fetchChunk(remaining, cursor, dynamicExclude);');
+    const staleGuardIndex = source.indexOf("console.log('[loadMore] ignored stale default batch result'", fetchIndex);
+    const uniqueIndex = source.indexOf('const unique = res.users.filter', fetchIndex);
+
+    expect(fetchIndex).toBeGreaterThan(-1);
+    expect(staleGuardIndex).toBeGreaterThan(fetchIndex);
+    expect(staleGuardIndex).toBeLessThan(uniqueIndex);
+    expect(source).toContain(`await loadCommentsFor(collected);
+      if (!isLatestLoadMore()) return;
+      collected.forEach(u => loadedIdsRef.current.add(u.userId));`);
+    expect(source).toContain(`finishLoadMoreIfLatest();`);
+  });
+
+  it('does not clear loading state from stale requests after newer loadMore starts', () => {
+    const source = loadMoreSource();
+    const helperIndex = source.indexOf('const finishLoadMoreIfLatest = () => {');
+    const staleBranchIndex = source.indexOf("[loadMore] stale request finished after a newer request; keeping loading state for active request", helperIndex);
+    const clearRefIndex = source.indexOf('loadingRef.current = false;', helperIndex);
+    const clearStateIndex = source.indexOf('setLoading(false);', helperIndex);
+    const finallyIndex = source.indexOf(`} finally {
+      finishLoadMoreIfLatest();
+    }`, helperIndex);
+
+    expect(helperIndex).toBeGreaterThan(-1);
+    expect(source.slice(helperIndex, clearRefIndex)).toContain('if (!isLatestLoadMore())');
+    expect(staleBranchIndex).toBeGreaterThan(helperIndex);
+    expect(staleBranchIndex).toBeLessThan(clearRefIndex);
+    expect(clearRefIndex).toBeLessThan(clearStateIndex);
+    expect(finallyIndex).toBeGreaterThan(clearStateIndex);
+  });
+});

--- a/src/utils/__tests__/matchingSourceBackfill.test.js
+++ b/src/utils/__tests__/matchingSourceBackfill.test.js
@@ -1,0 +1,73 @@
+import { collectFilteredMatchingSourceCards } from '../matchingSourceBackfill';
+
+const agFilter = users => users.filter(user => user.userRole === 'ag');
+const hydrateUsersByIds = async ids => Object.fromEntries(ids.map(id => [id, { userId: id, userRole: 'ag' }]));
+const isSameCursor = (a, b) => a === b;
+
+describe('collectFilteredMatchingSourceCards', () => {
+  it('keeps source hasMore true when the first source page has no ag cards but later pages can continue', async () => {
+    const pages = [
+      { users: [{ userId: 'ed-1', userRole: 'ed' }], lastKey: 'page-1', hasMore: true },
+      { users: [{ userId: 'ag-1', userRole: 'ag' }], lastKey: 'page-2', hasMore: true },
+    ];
+    const fetchSourcePage = jest.fn(async () => pages.shift());
+
+    const result = await collectFilteredMatchingSourceCards({
+      targetVisibleCount: 1,
+      fetchSourcePage,
+      filterSourceUsers: agFilter,
+      hydrateUsersByIds,
+      isSameCursor,
+    });
+
+    expect(fetchSourcePage).toHaveBeenCalledTimes(2);
+    expect(result.users.map(user => user.userId)).toEqual(['ag-1']);
+    expect(result.hasMore).toBe(true);
+    expect(result.sourceHasMore).toBe(true);
+    expect(result.lastKey).toBe('page-2');
+  });
+
+  it('continues scanning second and third source pages until an ag card appears without refresh', async () => {
+    const pages = [
+      { users: [{ userId: 'ed-1', userRole: 'ed' }], lastKey: 'page-1', hasMore: true },
+      { users: [{ userId: 'ed-2', userRole: 'ed' }], lastKey: 'page-2', hasMore: true },
+      { users: [{ userId: 'ag-2', userRole: 'ag' }], lastKey: 'page-3', hasMore: true },
+    ];
+    const fetchSourcePage = jest.fn(async () => pages.shift());
+
+    const result = await collectFilteredMatchingSourceCards({
+      targetVisibleCount: 1,
+      fetchSourcePage,
+      filterSourceUsers: agFilter,
+      hydrateUsersByIds,
+      isSameCursor,
+    });
+
+    expect(fetchSourcePage).toHaveBeenCalledTimes(3);
+    expect(result.users.map(user => user.userId)).toEqual(['ag-2']);
+    expect(result.hasMore).toBe(true);
+    expect(result.lastKey).toBe('page-3');
+  });
+
+  it('sets hasMore false only after the source is exhausted with no more ag cards', async () => {
+    const pages = [
+      { users: [{ userId: 'ed-1', userRole: 'ed' }], lastKey: 'page-1', hasMore: true },
+      { users: [{ userId: 'ed-2', userRole: 'ed' }], lastKey: 'page-2', hasMore: false },
+    ];
+    const fetchSourcePage = jest.fn(async () => pages.shift());
+
+    const result = await collectFilteredMatchingSourceCards({
+      targetVisibleCount: 1,
+      fetchSourcePage,
+      filterSourceUsers: agFilter,
+      hydrateUsersByIds,
+      isSameCursor,
+    });
+
+    expect(fetchSourcePage).toHaveBeenCalledTimes(2);
+    expect(result.users).toEqual([]);
+    expect(result.hasMore).toBe(false);
+    expect(result.sourceHasMore).toBe(false);
+    expect(result.lastKey).toBe('page-2');
+  });
+});

--- a/src/utils/matchingSourceBackfill.js
+++ b/src/utils/matchingSourceBackfill.js
@@ -1,0 +1,80 @@
+export const collectFilteredMatchingSourceCards = async ({
+  targetVisibleCount,
+  initialCursor,
+  exclude = new Set(),
+  fetchSourcePage,
+  filterSourceUsers = users => users,
+  hydrateUsersByIds,
+  decorateUser = user => user,
+  isSameCursor = (a, b) => a === b,
+  getSourceLimit,
+  onPart,
+}) => {
+  const visibleTarget = Math.max(1, Number(targetVisibleCount) || 1);
+  const collected = [];
+  let cursor = initialCursor;
+  let sourceHasMore = true;
+  let cursorAdvanced = false;
+  let excludedCount = 0;
+  let loadedPages = 0;
+
+  while (collected.length < visibleTarget && sourceHasMore) {
+    loadedPages += 1;
+    const remaining = visibleTarget - collected.length;
+    const sourceLimit = getSourceLimit
+      ? getSourceLimit({ remaining, exclude, collected, loadedPages })
+      : remaining + exclude.size + 1;
+    // eslint-disable-next-line no-await-in-loop
+    const sourceRes = await fetchSourcePage({
+      limit: sourceLimit,
+      cursor,
+      remaining,
+      exclude,
+      collected,
+      loadedPages,
+    });
+
+    const sourceUsers = Array.isArray(sourceRes?.users) ? sourceRes.users : [];
+    const filtered = filterSourceUsers(sourceUsers, { exclude, collected, remaining });
+    excludedCount += sourceUsers.length - filtered.length;
+
+    const slice = filtered.slice(0, remaining);
+    const ids = slice.map(user => user?.userId).filter(Boolean);
+    const hydratedMap = ids.length && hydrateUsersByIds
+      // eslint-disable-next-line no-await-in-loop
+      ? await hydrateUsersByIds(ids)
+      : Object.fromEntries(slice.map(user => [user.userId, user]));
+    const validSlice = ids
+      .map(id => hydratedMap?.[id])
+      .filter(Boolean)
+      .map(decorateUser);
+
+    if (validSlice.length) {
+      collected.push(...validSlice);
+      if (onPart) {
+        // eslint-disable-next-line no-await-in-loop
+        await onPart(validSlice);
+      }
+    }
+
+    const previousCursor = cursor;
+    const nextCursor = sourceRes?.lastKey ?? null;
+    cursorAdvanced = Boolean(nextCursor) && !isSameCursor(previousCursor, nextCursor);
+    sourceHasMore = Boolean(sourceRes?.hasMore) && cursorAdvanced;
+    cursor = nextCursor;
+
+    if (!sourceRes?.hasMore || !nextCursor || !cursorAdvanced) {
+      break;
+    }
+  }
+
+  return {
+    users: collected,
+    lastKey: cursor,
+    hasMore: sourceHasMore,
+    sourceHasMore,
+    cursorAdvanced,
+    excludedCount,
+    loadedPages,
+  };
+};


### PR DESCRIPTION
### Motivation
- Prevent race conditions and stale async writes in the `Matching` component's `loadMore` flow that could clear loading state or apply out-of-date pagination results. 
- Centralize source-page scanning/backfill logic so default source pagination can continue scanning pages until enough visible cards are found without ad-hoc loops in the component. 

### Description
- Add a new utility `collectFilteredMatchingSourceCards` in `src/utils/matchingSourceBackfill.js` and import it into `Matching.jsx` to replace the inlined `fetchChunk` scanning/backfill loop. 
- Change `loadMore` to compute `requestedLimit` using `targetVisibleCount` and `currentVisibleCount`, introduce `finishLoadMoreIfLatest` to avoid clearing loading indicators from stale requests, and add explicit stale-result guards (`isLatestLoadMore`/`canApplyLoadMoreResult`) before applying async responses. 
- Reorder and guard calls that mutate `loadedIdsRef.current`, pagination offsets, and `setHasMore` so updates happen only for the latest request and after comment-loading (`loadCommentsFor`) completes. 
- Remove the old `SOURCE_BACKFILL_MAX_PAGES` safety cap usage and instead let `collectFilteredMatchingSourceCards` control page scanning behavior; add small logging improvements for stale/ignored results. 
- Add unit tests: `src/utils/__tests__/matchingSourceBackfill.test.js` for the new backfill util and `src/components/Matching.loadMoreStaleGuard.test.js` to assert presence of the new stale-guard logic in `Matching.jsx`. 

### Testing
- Ran the new unit tests for the backfill util and stale-guard assertions with the test runner; `matchingSourceBackfill.test.js` and `Matching.loadMoreStaleGuard.test.js` passed. 
- Executed component-level test checks that exercise `loadMore` changes and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07eecc38748326bb52e928044e0c60)