### PR TITLE
Preserve YouTube channel paths in PP technical input and build correct YouTube links

### DIFF
--- a/src/components/contactMethods.js
+++ b/src/components/contactMethods.js
@@ -57,6 +57,19 @@ export const buildTwitterUrl = value => {
   return `https://x.com/${stripAt(rawValue)}`;
 };
 
+export const buildYoutubeUrl = value => {
+  const rawValue = String(value ?? '').trim();
+  if (!rawValue) return '';
+  if (hasProtocol(rawValue)) return rawValue;
+
+  const normalizedValue = stripAt(rawValue).replace(/^\/+/, '');
+  if (/^(?:channel|c|user)\//i.test(normalizedValue)) {
+    return `https://www.youtube.com/${normalizedValue}`;
+  }
+
+  return `https://www.youtube.com/@${normalizedValue}`;
+};
+
 export const CONTACT_LINK_BUILDERS = {
   phone: value => `tel:${compactPhone(value)}`,
   email: value => `mailto:${String(value || '').trim()}`,
@@ -68,7 +81,7 @@ export const CONTACT_LINK_BUILDERS = {
   tiktok: value => buildPlatformUrl(value, 'www.tiktok.com', '@'),
   vk: value => buildPlatformUrl(value, 'vk.com'),
   linkedin: buildLinkedinUrl,
-  youtube: value => buildPlatformUrl(value, 'www.youtube.com', '@'),
+  youtube: buildYoutubeUrl,
   twitter: buildTwitterUrl,
   website: normalizeExternalUrl,
   otherLink: normalizeExternalUrl,

--- a/src/components/contactMethods.test.js
+++ b/src/components/contactMethods.test.js
@@ -31,6 +31,15 @@ describe('contactMethods', () => {
     ]));
   });
 
+  it('builds YouTube channel links without converting them to handles', () => {
+    expect(getContactEntries({ youtube: 'channel/UC4LwxzuzRqwSpa1A64eziDQ' })).toEqual([
+      expect.objectContaining({
+        key: 'youtube',
+        href: 'https://www.youtube.com/channel/UC4LwxzuzRqwSpa1A64eziDQ',
+      }),
+    ]);
+  });
+
   it('keeps all previously supported social and link contacts', () => {
     const user = {
       facebook: 'fb-page',

--- a/src/components/inputValidations.js
+++ b/src/components/inputValidations.js
@@ -201,16 +201,16 @@ export const formatEmail = email => {
     const lowerFirstSegment = firstSegment.toLowerCase();
 
     if (['channel', 'c', 'user'].includes(lowerFirstSegment) && secondSegment) {
-      return secondSegment.replace(/^@/, '');
+      return `${lowerFirstSegment}/${secondSegment.replace(/^@/, '')}`;
     }
 
-    return firstSegment.replace(/^@/, '');
+    return firstSegment.replace(/^@/, '').toLowerCase();
   };
 
   export const formatYoutube = value => {
     const normalized = String(value ?? '').trim().replace(/\s/g, '');
 
-    return extractYoutubeIdentifier(normalized).toLowerCase();
+    return extractYoutubeIdentifier(normalized);
   };
 
   export const formatOther = value => {

--- a/src/utils/ppTechnicalInputTarget.js
+++ b/src/utils/ppTechnicalInputTarget.js
@@ -47,6 +47,23 @@ const normalizeTwitterStorageValue = value =>
     .replace(/^@/, '')
     .toLowerCase();
 
+const normalizeYoutubeStorageValue = value => {
+  const normalized = stripUrlSuffix(value);
+  if (!normalized) return '';
+
+  const segments = normalized.split('/').filter(Boolean);
+  if (!segments.length) return '';
+
+  const [firstSegment, secondSegment] = segments;
+  const lowerFirstSegment = firstSegment.toLowerCase();
+
+  if (['channel', 'c', 'user'].includes(lowerFirstSegment) && secondSegment) {
+    return `${lowerFirstSegment}/${secondSegment.replace(/^@/, '')}`;
+  }
+
+  return firstSegment.replace(/^@/, '').toLowerCase();
+};
+
 export const resolvePpTechnicalInputSocialTarget = rawValue => {
   const trimmed = String(rawValue || '').trim();
   if (!trimmed) return null;
@@ -56,7 +73,7 @@ export const resolvePpTechnicalInputSocialTarget = rawValue => {
     { fieldName: 'facebook', pattern: /(?:https?:\/\/)?(?:www\.)?(?:facebook\.com|fb\.com)\/([^/?#]+)/i, useRawValue: true },
     { fieldName: 'tiktok', pattern: /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/([^/?#]+)/i },
     { fieldName: 'linkedin', pattern: /(?:https?:\/\/)?(?:www\.)?linkedin\.com\/([^?#]+)/i, normalizeValue: normalizeLinkedinStorageValue },
-    { fieldName: 'youtube', pattern: /(?:https?:\/\/)?(?:m\.|www\.)?(?:(?:youtube\.com)\/(?:@|c\/|channel\/|user\/)?|(?:youtu\.be)\/)([^/?#]+)/i },
+    { fieldName: 'youtube', pattern: /(?:https?:\/\/)?(?:m\.|www\.)?(?:(?:youtube\.com)\/|(?:youtu\.be)\/)(@?[^?#]+|(?:c|channel|user)\/[^?#]+)/i, normalizeValue: normalizeYoutubeStorageValue },
     { fieldName: 'twitter', pattern: /(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/@?([^/?#]+)/i, normalizeValue: normalizeTwitterStorageValue },
     { fieldName: 'telegram', pattern: /(?:https?:\/\/)?(?:www\.)?(?:t\.me|telegram\.me|telegram\.dog)\/([^/?#]+)/i },
   ];

--- a/src/utils/ppTechnicalInputTarget.test.js
+++ b/src/utils/ppTechnicalInputTarget.test.js
@@ -24,10 +24,22 @@ describe('resolvePpTechnicalInputTarget', () => {
       value: 'tgblawyers',
     });
   });
+
+  it('preserves YouTube channel URLs as channel paths with case-sensitive ids', () => {
+    expect(resolvePpTechnicalInputTarget('https://www.youtube.com/channel/UC4LwxzuzRqwSpa1A64eziDQ')).toEqual({
+      fieldName: 'youtube',
+      value: 'channel/UC4LwxzuzRqwSpa1A64eziDQ',
+    });
+  });
 });
 
 describe('inputUpdateValue twitter normalization', () => {
   it('lowercases twitter handles in regular twitter fields too', () => {
     expect(inputUpdateValue('@TGBlawyers', { name: 'twitter' })).toBe('tgblawyers');
+  });
+
+  it('keeps YouTube channel paths and channel id casing in regular youtube fields too', () => {
+    expect(inputUpdateValue('https://www.youtube.com/channel/UC4LwxzuzRqwSpa1A64eziDQ', { name: 'youtube' }))
+      .toBe('channel/UC4LwxzuzRqwSpa1A64eziDQ');
   });
 });


### PR DESCRIPTION
### Motivation
- PP technical input parsed YouTube URLs down to a lowercased id and converted them to handle-style links, which broke case-sensitive channel IDs such as `UC4LwxzuzRqwSpa1A64eziDQ` and turned `/channel/...` routes into `@...` handles. 
- Contact link generation also did not preserve stored `/channel/`, `/c/` or `/user/` route prefixes when building actionable YouTube URLs.

### Description
- Add `normalizeYoutubeStorageValue` and update the YouTube matcher in `resolvePpTechnicalInputSocialTarget` (`src/utils/ppTechnicalInputTarget.js`) to capture and preserve route-prefixed paths like `channel/ID`, `c/...`, or `user/...` and avoid lowercasing channel ids. 
- Update YouTube parsing in `src/components/inputValidations.js` (`extractYoutubeIdentifier` / `formatYoutube`) to return route-prefixed values (e.g. `channel/UC...`) and stop forcing lowercasing of channel ids. 
- Add `buildYoutubeUrl` in `src/components/contactMethods.js` and switch `CONTACT_LINK_BUILDERS.youtube` to use it so stored route-prefixed YouTube values produce `https://www.youtube.com/channel/...` (or `/c/`, `/user/`) while plain handles still produce `https://www.youtube.com/@...`. 
- Add regression tests in `src/utils/ppTechnicalInputTarget.test.js` and `src/components/contactMethods.test.js` to cover the provided `https://www.youtube.com/channel/UC4LwxzuzRqwSpa1A64eziDQ` case and link generation.

### Testing
- Ran `npm test -- --watchAll=false src/utils/ppTechnicalInputTarget.test.js src/components/contactMethods.test.js`, and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08294391788326a386d429d6cf7cb6)