### PR TITLE
Preserve YouTube route prefixes and scheme-less URLs for search and contact links

### DIFF
--- a/src/components/contactMethods.js
+++ b/src/components/contactMethods.js
@@ -63,6 +63,10 @@ export const buildYoutubeUrl = value => {
   if (hasProtocol(rawValue)) return rawValue;
 
   const normalizedValue = stripAt(rawValue).replace(/^\/+/, '');
+  if (/^(?:(?:m\.|www\.)?youtube\.com|youtu\.be)\//i.test(normalizedValue)) {
+    return normalizeExternalUrl(normalizedValue);
+  }
+
   if (/^(?:channel|c|user)\//i.test(normalizedValue)) {
     return `https://www.youtube.com/${normalizedValue}`;
   }

--- a/src/components/contactMethods.test.js
+++ b/src/components/contactMethods.test.js
@@ -40,6 +40,15 @@ describe('contactMethods', () => {
     ]);
   });
 
+  it('preserves scheme-less YouTube URLs instead of treating the domain as a handle', () => {
+    expect(getContactEntries({ youtube: 'www.youtube.com/channel/UC4LwxzuzRqwSpa1A64eziDQ' })).toEqual([
+      expect.objectContaining({
+        key: 'youtube',
+        href: 'https://www.youtube.com/channel/UC4LwxzuzRqwSpa1A64eziDQ',
+      }),
+    ]);
+  });
+
   it('keeps all previously supported social and link contacts', () => {
     const user = {
       facebook: 'fb-page',

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -71,14 +71,32 @@ const normalizeLinkedInValue = baseValue => {
   );
 };
 
-const normalizeYoutubeValue = baseValue => {
-  const urlMatch = baseValue.match(/(?:youtube\.com\/(?:@|c\/|channel\/|user\/)?|youtu\.be\/)([^/?#]+)/i);
-  if (urlMatch?.[1]) return stripQueryHashAndSlashSuffix(urlMatch[1].replace(/^@/, ''));
+const normalizeYoutubePath = (rawPath, preserveRoutePrefixes = true) => {
+  const [pathBeforeQuery] = String(rawPath || '').split(/[?#]/);
+  const pathSegments = pathBeforeQuery.split('/').filter(Boolean);
 
-  return normalizeLabeledContactValue(
-    baseValue,
-    /(?:^|[^A-Za-z0-9_])(?:youtube|youtu\.?be|yt|ютуб)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+  if (!pathSegments.length) return '';
+
+  const [firstSegment, secondSegment] = pathSegments;
+  const lowerFirstSegment = firstSegment.toLowerCase();
+
+  if (preserveRoutePrefixes && ['channel', 'c', 'user'].includes(lowerFirstSegment) && secondSegment) {
+    return `${lowerFirstSegment}/${secondSegment.replace(/^@/, '')}`;
+  }
+
+  return firstSegment.replace(/^@/, '');
+};
+
+const normalizeYoutubeValue = baseValue => {
+  const urlMatch = baseValue.match(/(?:https?:\/\/)?(?:m\.|www\.)?(?:(youtube\.com)\/|(?:youtu\.be)\/)([^\s]+)/i);
+  if (urlMatch?.[2]) return normalizeYoutubePath(urlMatch[2], Boolean(urlMatch[1]));
+
+  const labelMatch = baseValue.match(
+    /(?:^|[^A-Za-z0-9_])(?:youtube|youtu\.?be|yt|ютуб)\s*:?\s*@?([A-Za-z0-9._-]+(?:\/(?:[A-Za-z0-9._-]+))?)/i,
   );
+  if (labelMatch?.[1]) return normalizeYoutubePath(labelMatch[1]);
+
+  return null;
 };
 
 const normalizeSocialSearchValue = (searchKey, baseValue) => {

--- a/src/utils/searchKeyUtils.test.js
+++ b/src/utils/searchKeyUtils.test.js
@@ -1,0 +1,28 @@
+import {
+  buildSearchIdRecordKey,
+  normalizeSearchIdInput,
+} from './searchKeyUtils';
+
+const youtubeChannelId = 'UC4LwxzuzRqwSpa1A64eziDQ';
+
+describe('searchKeyUtils YouTube normalization', () => {
+  it('keeps YouTube route-prefixed URL searches aligned with stored channel paths', () => {
+    expect(normalizeSearchIdInput('youtube', `https://www.youtube.com/channel/${youtubeChannelId}`))
+      .toBe(`channel/${youtubeChannelId}`);
+    expect(buildSearchIdRecordKey({ youtube: `https://www.youtube.com/channel/${youtubeChannelId}` }))
+      .toBe(`youtube_channel_slash_${youtubeChannelId.toLowerCase()}`);
+    expect(buildSearchIdRecordKey({ youtube: `channel/${youtubeChannelId}` }))
+      .toBe(`youtube_channel_slash_${youtubeChannelId.toLowerCase()}`);
+  });
+
+  it('keeps YouTube c and user route prefixes while still normalizing handles', () => {
+    expect(normalizeSearchIdInput('youtube', 'https://youtube.com/c/KnowMeOfficial?view=videos'))
+      .toBe('c/KnowMeOfficial');
+    expect(normalizeSearchIdInput('youtube', 'https://m.youtube.com/user/KnowMeOfficial#about'))
+      .toBe('user/KnowMeOfficial');
+    expect(normalizeSearchIdInput('youtube', 'https://www.youtube.com/@KnowMeOfficial'))
+      .toBe('KnowMeOfficial');
+    expect(normalizeSearchIdInput('youtube', 'youtube: channel/UC4LwxzuzRqwSpa1A64eziDQ'))
+      .toBe('channel/UC4LwxzuzRqwSpa1A64eziDQ');
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix mismatch between indexed YouTube search IDs (which can include `channel/`, `c/`, `user/` prefixes) and search-side normalization so URL searches find stored route-prefixed values. 
- Avoid treating scheme-less full YouTube domains like `www.youtube.com/channel/...` as a handle when building contact links. 

### Description
- Added `normalizeYoutubePath` and updated `normalizeYoutubeValue` in `src/utils/searchKeyUtils.js` to parse full YouTube URLs (including `https`, `m.`, `www.`, and `youtu.be`) and preserve `channel/`, `c/`, and `user/` route prefixes when present. 
- Changed labeled-value parsing for YouTube to forward label matches through the new path normalizer so inputs like `youtube: channel/UC...` are handled consistently. 
- Updated `buildYoutubeUrl` in `src/components/contactMethods.js` to detect scheme-less YouTube domains (e.g. `www.youtube.com/...` or `youtu.be/...`) and normalize them to `https://...` instead of converting the domain into a handle. 
- Added unit tests in `src/utils/searchKeyUtils.test.js` and expanded `src/components/contactMethods.test.js` to cover route-prefixed URL normalization, `c`/`user` prefixes, handle normalization, and scheme-less domain preservation. 

### Testing
- Ran `npm test -- --runTestsByPath src/utils/searchKeyUtils.test.js src/components/contactMethods.test.js --watchAll=false` and both test suites passed. 
- Ran `npm run lint:js` for the modified files and linter completed without errors (browserslist warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0838e195b48326b9c4364fe4f57d41)