### PR TITLE
Improve matching performance and owner-scoped comments cache; add index id caching and stale-load guards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -889,10 +889,10 @@ const SwipeableCard = ({
   );
 };
 
-const INITIAL_LOAD = 2;
+const INITIAL_LOAD = 5;
 const MATCHING_VISIBLE_BUFFER = 2;
-const MATCHING_REFILL_LIMIT = 1;
-const LOAD_MORE = 1;
+const MATCHING_REFILL_LIMIT = 5;
+const LOAD_MORE = 5;
 const ADDITIONAL_BACKFILL_MAX_PAGES = 3;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
@@ -1189,7 +1189,7 @@ const Matching = () => {
     setSharedReactionCandidateUsers([]);
     viewModeRef.current = 'search';
     setViewMode('search');
-    await loadCommentsFor(filtered);
+    void loadCommentsFor(filtered);
   };
 
   useEffect(() => {
@@ -1222,7 +1222,8 @@ const Matching = () => {
       ...users.map(u => u.userId),
       ...sharedReactionCandidateUsers.map(u => u.userId),
     ];
-    pruneComments(ids);
+    const ownOwnerId = getOwnerId();
+    if (ownOwnerId) pruneComments(ownOwnerId, ids);
     setComments(prev => {
       const map = {};
       ids.forEach(id => {
@@ -1444,38 +1445,71 @@ const Matching = () => {
     }
   }, []);
 
-  const loadCommentsFor = React.useCallback(async list => {
+  const loadCommentsFor = React.useCallback(async (list, { force = false } = {}) => {
     const owners = getMatchingMultiDataOwnerIds();
     const ownOwnerId = getOwnerId();
     if (!owners.length || !ownOwnerId) return;
-    const ids = Array.from(
-      new Set([...usersRef.current.map(u => u.userId), ...list.map(u => u.userId)])
+    const ids = Array.from(new Set((list || []).map(u => u?.userId).filter(Boolean)));
+    if (!ids.length) return;
+
+    const requestContext = {
+      viewMode: viewModeRef.current,
+      collectionSource: collectionSourceRef.current,
+      filtersSignature: stableAdditionalSignature(filtersRef.current || {}),
+      ownerId: ownOwnerId,
+      ownersSignature: stableAdditionalSignature(owners),
+    };
+    const canApplyCommentsResult = () => (
+      requestContext.viewMode === viewModeRef.current &&
+      requestContext.collectionSource === collectionSourceRef.current &&
+      requestContext.filtersSignature === stableAdditionalSignature(filtersRef.current || {}) &&
+      requestContext.ownerId === getOwnerId() &&
+      requestContext.ownersSignature === stableAdditionalSignature(getMatchingMultiDataOwnerIds())
     );
+
     const cache = loadComments();
     const fetchedEntries = await Promise.all(
-      owners.map(async owner => ({ owner, comments: await fetchUserComments(owner, ids) }))
+      owners.map(async owner => {
+        const ownerCache = cache[owner] || {};
+        const missingIds = force ? ids : ids.filter(id => !ownerCache[id]);
+        if (!missingIds.length) return { owner, comments: {}, requestedIds: [] };
+        return { owner, comments: await fetchUserComments(owner, missingIds), requestedIds: missingIds };
+      })
     );
-    const newStore = {};
+
+    const latestStore = loadComments();
+    const nextStore = { ...latestStore };
+    fetchedEntries.forEach(({ owner, comments: ownerComments = {}, requestedIds = [] }) => {
+      nextStore[owner] = { ...(nextStore[owner] || {}) };
+      requestedIds.forEach(id => {
+        const serverComments = ownerComments?.[id] || [];
+        const newestServer = [...serverComments].sort((a, b) => (b.lastAction || 0) - (a.lastAction || 0))[0];
+        const local = nextStore[owner][id];
+        if (shouldUseServerComment(newestServer, local)) {
+          nextStore[owner][id] = {
+            ...newestServer,
+            text: String(newestServer.text || ''),
+            lastAction: newestServer.lastAction || Date.now(),
+            cachedAt: Date.now(),
+          };
+        } else if (local) {
+          nextStore[owner][id] = { ...local, cachedAt: local.cachedAt || Date.now() };
+        } else {
+          nextStore[owner][id] = { text: '', lastAction: Date.now(), cachedAt: Date.now(), empty: true };
+        }
+      });
+    });
+
     const commentsMap = {};
     const sharedCommentsMap = {};
     ids.forEach(id => {
-      const ownEntry = fetchedEntries.find(entry => entry.owner === ownOwnerId);
-      const ownComments = ownEntry?.comments?.[id] || [];
-      const ownServer = [...ownComments].sort((a, b) => (b.lastAction || 0) - (a.lastAction || 0))[0];
-      const local = cache[id];
-      if (shouldUseServerComment(ownServer, local)) {
-        newStore[id] = ownServer;
-        commentsMap[id] = ownServer.text;
-      } else if (local) {
-        newStore[id] = local;
-        commentsMap[id] = local.text;
-      } else {
-        commentsMap[id] = '';
-      }
+      const ownEntry = nextStore?.[ownOwnerId]?.[id];
+      if (ownEntry && !ownEntry.empty) commentsMap[id] = ownEntry.text || '';
 
-      sharedCommentsMap[id] = fetchedEntries
-        .filter(entry => entry.owner !== ownOwnerId)
-        .flatMap(entry => entry.comments?.[id] || [])
+      sharedCommentsMap[id] = owners
+        .filter(owner => owner !== ownOwnerId)
+        .map(owner => nextStore?.[owner]?.[id])
+        .filter(entry => entry && !entry.empty)
         .sort((a, b) => (b.lastAction || 0) - (a.lastAction || 0))
         .map(comment => String(comment.text || '').trim())
         .filter(Boolean);
@@ -1494,15 +1528,16 @@ const Matching = () => {
           .map(([cardId]) => cardId)
       ),
     });
-    saveComments(newStore);
-    setComments(commentsMap);
-    setSharedComments(sharedCommentsMap);
+    saveComments(nextStore);
+    if (!canApplyCommentsResult()) return;
+    setComments(prev => ({ ...prev, ...commentsMap }));
+    setSharedComments(prev => ({ ...prev, ...sharedCommentsMap }));
   }, [getMatchingMultiDataOwnerIds]);
 
   useEffect(() => {
-    if (!users.length || !multiDataOwnerIds.length) return;
-    loadCommentsFor(users);
-  }, [loadCommentsFor, multiDataOwnerIds, users]);
+    if (!usersRef.current.length || !multiDataOwnerIds.length) return;
+    loadCommentsFor(usersRef.current);
+  }, [loadCommentsFor, multiDataOwnerIds]);
 
   const loadSharedReactionCandidates = React.useCallback(async () => {
     const viewerId = ownerId || getOwnerId();
@@ -1633,7 +1668,7 @@ const Matching = () => {
       loadedUsers,
       candidateIds,
     }));
-    await loadCommentsFor(loadedUsers);
+    void loadCommentsFor(loadedUsers);
 
     if (!canApplySharedCandidateResult()) {
       return;
@@ -2041,8 +2076,8 @@ const Matching = () => {
             loadedPages,
             visibleCount,
           });
-          collected.forEach(user => updateCard(user.userId, user));
-          await loadCommentsFor(collected);
+          collected.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
+          void loadCommentsFor(collected);
           const toastSignature = `${currentAdditionalAccessRules}::${nextOffset}${sourceHasMore ? '+' : ''}`;
           if (additionalRulesToastRef.current !== toastSignature) {
             toast(
@@ -2214,6 +2249,8 @@ const Matching = () => {
         const indexed = await fetchMatchingIndexedCandidates({
           collectionSource: 'users',
           filters: filtersRef.current || {},
+          viewMode: viewModeRef.current,
+          ownerId: getOwnerId(),
           offset: 0,
           limit: INITIAL_LOAD,
           excludeIds: [...exclude],
@@ -2224,11 +2261,11 @@ const Matching = () => {
         if (indexedUsers.length === 0 && !indexed.hasMore) {
           console.warn('[Matching][indexedProvider] empty users index result; falling back to source pagination');
         } else {
-          indexedUsers.forEach(user => updateCard(user.userId, user));
+          indexedUsers.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
           loadedIdsRef.current = new Set(indexedUsers.map(user => user.userId).filter(Boolean));
           setUsers(indexedUsers);
           setIdsForQuery(defaultListKey, indexedUsers.map(user => user.userId));
-          await loadCommentsFor(indexedUsers);
+          void loadCommentsFor(indexedUsers);
           if (viewModeRef.current !== startMode) return;
           setLastKey(indexed.nextOffset);
           setHasMore(Boolean(indexed.hasMore));
@@ -2246,7 +2283,7 @@ const Matching = () => {
         loadedIdsRef.current = new Set(filteredCached.map(u => u.userId));
         setUsers(filteredCached);
         setIdsForQuery(defaultListKey, filteredCached.map(u => u.userId));
-        await loadCommentsFor(filteredCached);
+        void loadCommentsFor(filteredCached);
         if (viewModeRef.current !== startMode) return;
         setViewMode('default');
         // continue to fetch latest data to refresh cache
@@ -2261,7 +2298,7 @@ const Matching = () => {
           if (unique.length) {
             unique.forEach(u => loadedIdsRef.current.add(u.userId));
             setUsers(prev => [...prev, ...unique]);
-            await loadCommentsFor(unique);
+            void loadCommentsFor(unique);
           }
         }
       );
@@ -2271,7 +2308,7 @@ const Matching = () => {
         ...loadedIdsRef.current,
         ...res.users.map(u => u.userId),
       ]);
-      res.users.forEach(u => updateCard(u.userId, u));
+      res.users.forEach(u => { if (!u.__fromCardCache) updateCard(u.userId, u); });
       setUsers(prev => {
         const map = new Map(prev.map(u => [u.userId, u]));
         res.users.forEach(u => map.set(u.userId, u));
@@ -2279,7 +2316,7 @@ const Matching = () => {
         setIdsForQuery(defaultListKey, result.map(u => u.userId));
         return result;
       });
-      await loadCommentsFor(res.users);
+      void loadCommentsFor(res.users);
       if (viewModeRef.current !== startMode) return;
       setLastKey(res.lastKey);
       setHasMore(res.hasMore);
@@ -2341,9 +2378,7 @@ const Matching = () => {
 
     uniqueIds.forEach(id => {
       const cached = getCard(id);
-      const cachedPhotos = Array.isArray(cached?.photos) ? cached.photos : [];
-      const hasHydratedPhotoState = cachedPhotos.length > 0 || cached?.__photosHydrated === true;
-      const canUseCachedCard = cached && hasHydratedPhotoState && (
+      const canUseCachedCard = cached && (
         cached.__sourceCollection ||
         cached.publish === true ||
         !isShortId(id)
@@ -2354,6 +2389,7 @@ const Matching = () => {
           ...cached,
           userId: id,
           __sourceCollection: cached.__sourceCollection || (isShortId(id) ? 'newUsers' : 'users'),
+          __fromCardCache: true,
         });
       } else if (isShortId(id)) {
         missingNewUserIds.push(id);
@@ -2568,7 +2604,7 @@ const Matching = () => {
       });
       if (!canApplyReactionLoad()) return;
 
-      page.users.forEach(user => updateCard(user.userId, user));
+      page.users.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
       if (isFavoritesMode) {
         cacheFavoriteUsers(Object.fromEntries(page.users.map(user => [user.userId, user])));
       } else {
@@ -2577,7 +2613,7 @@ const Matching = () => {
       reactionLoadedIdsRef.current[reactionType] = loadedIds;
       loadedIdsRef.current = new Set(page.users.map(user => user.userId));
       setUsers(page.users);
-      await loadCommentsFor(page.users);
+      void loadCommentsFor(page.users);
       if (!canApplyReactionLoad()) return;
       const hasPendingSharedCandidates = hasPendingSharedReactionCandidates({
         reactionIds,
@@ -2748,10 +2784,7 @@ const Matching = () => {
 
         if (!canApplyLoadMoreResult()) return;
 
-        page.users.forEach(user => {
-          updateCard(user.userId, user);
-        });
-        await loadCommentsFor(page.users);
+        page.users.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
         if (!canApplyLoadMoreResult()) return;
         reactionLoadedIdsRef.current[viewMode] = loadedIds;
         loadedIdsRef.current = new Set(loadedIds);
@@ -2761,6 +2794,7 @@ const Matching = () => {
           page.users.forEach(user => map.set(user.userId, user));
           return Array.from(map.values());
         });
+        void loadCommentsFor(page.users);
         const hasPendingSharedCandidates = hasPendingSharedReactionCandidates({
           reactionIds,
           sharedReactionIds,
@@ -2914,10 +2948,7 @@ const Matching = () => {
 
         if (!isLatestLoadMore()) return;
 
-        collected.forEach(user => {
-          updateCard(user.userId, user);
-        });
-        await loadCommentsFor(collected);
+        collected.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
         if (!isLatestLoadMore()) return;
         collected.forEach(user => {
           loadedIdsRef.current.add(user.userId);
@@ -2927,6 +2958,7 @@ const Matching = () => {
           collected.forEach(user => map.set(user.userId, user));
           return Array.from(map.values());
         });
+        void loadCommentsFor(collected);
         setAdditionalNextOffset(nextOffset);
         setHasMore(canLoadMoreAdditional);
         logAdditionalMatchingDebug(ownerId, 'load more additional matching final cards', {
@@ -2947,6 +2979,8 @@ const Matching = () => {
         const indexed = await fetchMatchingIndexedCandidates({
           collectionSource: 'users',
           filters: filtersRef.current || {},
+          viewMode,
+          ownerId: getOwnerId(),
           offset: Number.isFinite(Number(lastKey)) ? Number(lastKey) : 0,
           limit: requestedLimit,
           excludeIds: [...baseExclude],
@@ -2959,8 +2993,7 @@ const Matching = () => {
         if (indexedUsers.length === 0 && !indexed.hasMore) {
           console.warn('[Matching][indexedProvider] empty users index result; falling back to source pagination');
         } else {
-          indexedUsers.forEach(user => updateCard(user.userId, user));
-          await loadCommentsFor(indexedUsers);
+          indexedUsers.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
           if (!isLatestLoadMore()) return;
           indexedUsers.forEach(user => loadedIdsRef.current.add(user.userId));
           setUsers(prev => {
@@ -2970,6 +3003,7 @@ const Matching = () => {
             setIdsForQuery(defaultListKey, result.map(user => user.userId));
             return result;
           });
+          void loadCommentsFor(indexedUsers);
           setLastKey(indexed.nextOffset);
           setHasMore(Boolean(indexed.hasMore));
           return;
@@ -3021,8 +3055,7 @@ const Matching = () => {
         canLoadMore = res.hasMore && !stuck;
       }
 
-      collected.forEach(u => updateCard(u.userId, u));
-      await loadCommentsFor(collected);
+      collected.forEach(u => { if (!u.__fromCardCache) updateCard(u.userId, u); });
       if (!isLatestLoadMore()) return;
       collected.forEach(u => loadedIdsRef.current.add(u.userId));
       setUsers(prev => {
@@ -3032,6 +3065,7 @@ const Matching = () => {
         setIdsForQuery(defaultListKey, result.map(u => u.userId));
         return result;
       });
+      void loadCommentsFor(collected);
 
       const sourceCanContinueWithoutVisibleCards = canLoadMore && collected.length === 0;
       if (sourceCanContinueWithoutVisibleCards) {
@@ -3489,7 +3523,7 @@ const Matching = () => {
                         if (auth.currentUser) {
                           const text = comments[user.userId] || '';
                           const res = await setUserComment(user.userId, text, ownerId);
-                          setLocalComment(user.userId, text, res?.lastAction);
+                          setLocalComment(ownerId, user.userId, text, res?.lastAction);
                         }
                       }}
                       onAdminEdit={() => {

--- a/src/components/Matching.loadMoreStaleGuard.test.js
+++ b/src/components/Matching.loadMoreStaleGuard.test.js
@@ -9,13 +9,16 @@ const loadMoreSource = () => {
 };
 
 describe('Matching loadMore stale pagination guards', () => {
-  it('guards reaction pagination writes after async comment loading', () => {
+  it('updates reaction cards before async comment loading while preserving stale guards', () => {
     const source = loadMoreSource();
 
-    expect(source).toContain(`await loadCommentsFor(page.users);
-        if (!canApplyLoadMoreResult()) return;
+    expect(source).toContain(`if (!canApplyLoadMoreResult()) return;
         reactionLoadedIdsRef.current[viewMode] = loadedIds;
         loadedIdsRef.current = new Set(loadedIds);`);
+    const setUsersIndex = source.indexOf('setUsers(prev => {\n          if (didAccessSnapshotChange) return page.users;');
+    const commentsIndex = source.indexOf('void loadCommentsFor(page.users);', setUsersIndex);
+    expect(setUsersIndex).toBeGreaterThan(-1);
+    expect(commentsIndex).toBeGreaterThan(setUsersIndex);
     expect(source).toContain(`setHasMore(nextHasMore);
         setLastKey(null);`);
   });
@@ -23,11 +26,14 @@ describe('Matching loadMore stale pagination guards', () => {
   it('guards additional newUsers offset, hasMore, lastKey, and loadedIdsRef writes', () => {
     const source = loadMoreSource();
 
-    expect(source).toContain(`await loadCommentsFor(collected);
-        if (!isLatestLoadMore()) return;
+    expect(source).toContain(`if (!isLatestLoadMore()) return;
         collected.forEach(user => {
           loadedIdsRef.current.add(user.userId);
         });`);
+    const setAdditionalIndex = source.indexOf('setAdditionalNewUsers(prev => {');
+    const commentsIndex = source.indexOf('void loadCommentsFor(collected);', setAdditionalIndex);
+    expect(setAdditionalIndex).toBeGreaterThan(-1);
+    expect(commentsIndex).toBeGreaterThan(setAdditionalIndex);
     expect(source).toContain(`setAdditionalNextOffset(nextOffset);
         setHasMore(canLoadMoreAdditional);`);
     expect(source).toContain(`setLastKey(null);
@@ -43,9 +49,12 @@ describe('Matching loadMore stale pagination guards', () => {
     expect(fetchIndex).toBeGreaterThan(-1);
     expect(staleGuardIndex).toBeGreaterThan(fetchIndex);
     expect(staleGuardIndex).toBeLessThan(uniqueIndex);
-    expect(source).toContain(`await loadCommentsFor(collected);
-      if (!isLatestLoadMore()) return;
+    expect(source).toContain(`if (!isLatestLoadMore()) return;
       collected.forEach(u => loadedIdsRef.current.add(u.userId));`);
+    const defaultSetUsersIndex = source.lastIndexOf('setUsers(prev => {');
+    const commentsIndex = source.indexOf('void loadCommentsFor(collected);', defaultSetUsersIndex);
+    expect(defaultSetUsersIndex).toBeGreaterThan(-1);
+    expect(commentsIndex).toBeGreaterThan(defaultSetUsersIndex);
     expect(source).toContain(`finishLoadMoreIfLatest();`);
   });
 

--- a/src/components/Matching.sharedReactions.test.js
+++ b/src/components/Matching.sharedReactions.test.js
@@ -24,8 +24,8 @@ describe('Matching shared reaction card UI', () => {
     const matchingSource = fs.readFileSync(path.join(__dirname, 'Matching.jsx'), 'utf8');
     const configSource = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
 
-    expect(matchingSource).toContain('getAllUserPhotos(userId)');
-    expect(matchingSource).toContain('photos: Array.isArray(photos) ? photos : []');
+    expect(matchingSource).toContain('missingUserIds.length ? fetchUsersByIds(missingUserIds)');
+    expect(matchingSource).toContain('missingNewUserIds.length ? fetchNewUsersByIdsForMatching(missingNewUserIds)');
     expect(configSource).toContain('getAllUserPhotos(id)');
     expect(configSource).toContain('photos: Array.isArray(photos) ? photos : []');
   });
@@ -37,7 +37,9 @@ describe('Matching shared reaction card UI', () => {
     expect(source).toContain("(collectionSource === 'newUsers' || hasAccessScopedNewUserReactionIds)");
     expect(source).toContain('currentPagination.accessSnapshotKey !== reactionAccessSnapshotKey');
     expect(source).toContain('if (didAccessSnapshotChange) return page.users;');
-    expect(source).toContain('const hasHydratedPhotoState = cachedPhotos.length > 0 || cached?.__photosHydrated === true;');
+    expect(source).toContain('const canUseCachedCard = cached && (');
+    expect(source).toContain('__fromCardCache: true');
+    expect(source).not.toContain('const hasHydratedPhotoState = cachedPhotos.length > 0 || cached?.__photosHydrated === true;');
   });
 
   it('guards stale default shared-candidate requests while allowing reaction tabs across collections', () => {

--- a/src/utils/__tests__/commentsStorage.test.js
+++ b/src/utils/__tests__/commentsStorage.test.js
@@ -1,4 +1,51 @@
-import { shouldUseServerComment } from '../commentsStorage';
+import {
+  COMMENTS_TTL_MS,
+  getCachedComment,
+  loadComments,
+  saveComments,
+  setLocalComment,
+  shouldUseServerComment,
+} from '../commentsStorage';
+
+describe('commentsStorage owner-scoped cache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(Date, 'now').mockReturnValue(10_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps comments separated by owner', () => {
+    setLocalComment('owner-a', 'card-1', 'own text', 100);
+    setLocalComment('owner-b', 'card-1', 'shared text', 200);
+
+    expect(getCachedComment('owner-a', 'card-1').text).toBe('own text');
+    expect(getCachedComment('owner-b', 'card-1').text).toBe('shared text');
+  });
+
+  it('caches empty comments per owner', () => {
+    setLocalComment('owner-a', 'card-1', '', 100);
+
+    expect(getCachedComment('owner-a', 'card-1')).toMatchObject({
+      text: '',
+      empty: true,
+    });
+  });
+
+  it('expires entries after the matching comments TTL', () => {
+    saveComments({
+      'owner-a': {
+        'card-1': { text: 'fresh enough', lastAction: 1, cachedAt: 10_000 },
+        'card-2': { text: 'stale', lastAction: 1, cachedAt: 10_000 - COMMENTS_TTL_MS - 1 },
+      },
+    });
+
+    expect(loadComments()['owner-a']).toHaveProperty('card-1');
+    expect(loadComments()['owner-a']).not.toHaveProperty('card-2');
+  });
+});
 
 describe('shouldUseServerComment', () => {
   it('keeps a newer local comment instead of replacing it with stale server data', () => {
@@ -19,5 +66,12 @@ describe('shouldUseServerComment', () => {
     const server = { text: 'server text', lastAction: 1000 };
 
     expect(shouldUseServerComment(server, undefined)).toBe(true);
+  });
+
+  it('does not overwrite a newer empty local edit with older server data', () => {
+    const local = { text: '', lastAction: 2000, empty: true };
+    const server = { text: 'old server text', lastAction: 1000 };
+
+    expect(shouldUseServerComment(server, local)).toBe(false);
   });
 });

--- a/src/utils/__tests__/matchingDataProvider.indexCache.test.js
+++ b/src/utils/__tests__/matchingDataProvider.indexCache.test.js
@@ -1,0 +1,112 @@
+const mockFirebaseGet = jest.fn();
+const mockFirebaseRef = jest.fn((database, path) => path);
+
+jest.mock('firebase/database', () => ({
+  get: (...args) => mockFirebaseGet(...args),
+  ref: (...args) => mockFirebaseRef(...args),
+}));
+
+jest.mock('components/config', () => ({
+  database: { app: 'test-db' },
+}));
+
+const makeSnapshot = (value = null) => ({
+  exists: () => value !== null,
+  val: () => value,
+});
+
+const loadModule = () => require('../matchingDataProvider');
+
+describe('fetchMatchingIndexedCandidates index-id cache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    localStorage.clear();
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    mockFirebaseRef.mockImplementation((database, path) => path);
+    mockFirebaseGet.mockResolvedValue(makeSnapshot({
+      user00000000000000000003: true,
+      user00000000000000000001: true,
+      user00000000000000000002: true,
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reads role/ag bucket once and reuses cached ordered ids for next page', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id, role: 'ag' }])));
+    const filters = { userRole: { ag: true, ed: false, ip: false, other: false } };
+
+    const first = await fetchMatchingIndexedCandidates({ filters, limit: 2, hydrateUsersByIds });
+    const second = await fetchMatchingIndexedCandidates({ filters, offset: 2, limit: 2, hydrateUsersByIds });
+
+    expect(mockFirebaseGet).toHaveBeenCalledTimes(1);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/role/ag');
+    expect(first.userIds).toEqual(['user00000000000000000001', 'user00000000000000000002']);
+    expect(second.userIds).toEqual(['user00000000000000000003']);
+  });
+
+  it('rereads bucket after matching index TTL expires', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));
+    const filters = { userRole: { ag: true, ed: false } };
+
+    await fetchMatchingIndexedCandidates({ filters, limit: 1, hydrateUsersByIds });
+    Date.now.mockReturnValue(1_000_000 + (10 * 60 * 1000) + 1);
+    await fetchMatchingIndexedCandidates({ filters, offset: 1, limit: 1, hydrateUsersByIds });
+
+    expect(mockFirebaseGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies excluded reactions without corrupting the base cached id list', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));
+    const filters = { userRole: { ag: true, ed: false } };
+
+    const excluded = await fetchMatchingIndexedCandidates({ filters, limit: 5, excludeIds: ['user00000000000000000001'], hydrateUsersByIds });
+    const base = await fetchMatchingIndexedCandidates({ filters, limit: 5, hydrateUsersByIds });
+
+    expect(mockFirebaseGet).toHaveBeenCalledTimes(1);
+    expect(excluded.userIds).toEqual(['user00000000000000000002', 'user00000000000000000003']);
+    expect(base.userIds).toEqual(['user00000000000000000001', 'user00000000000000000002', 'user00000000000000000003']);
+  });
+});
+
+describe('fetchMatchingIndexedCandidates card hydration cache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    localStorage.clear();
+    jest.spyOn(Date, 'now').mockReturnValue(2_000_000);
+    mockFirebaseGet.mockResolvedValue(makeSnapshot({
+      user00000000000000000001: true,
+      user00000000000000000002: true,
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reuses cached basic cards and hydrates only missing ids', async () => {
+    const { updateCard } = require('../cardsStorage');
+    updateCard('user00000000000000000001', {
+      userId: 'user00000000000000000001',
+      name: 'Cached basic',
+      __sourceCollection: 'users',
+    });
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id, name: 'Hydrated', photos: ['p'], __photosHydrated: true }])));
+    const filters = { userRole: { ag: true, ed: false } };
+
+    const result = await fetchMatchingIndexedCandidates({ filters, limit: 2, hydrateUsersByIds });
+
+    expect(hydrateUsersByIds).toHaveBeenCalledWith(['user00000000000000000002']);
+    expect(result.users.map(user => user.name)).toEqual(['Cached basic', 'Hydrated']);
+    expect(result.users[0].__fromCardCache).toBe(true);
+    expect(result.users[0].photos).toBeUndefined();
+  });
+});

--- a/src/utils/cacheConstants.js
+++ b/src/utils/cacheConstants.js
@@ -1,1 +1,2 @@
 export const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+export const MATCHING_PERFORMANCE_CACHE_TTL_MS = 10 * 60 * 1000;

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -1,9 +1,11 @@
-import { CACHE_TTL_MS } from './cacheConstants';
+import { CACHE_TTL_MS, MATCHING_PERFORMANCE_CACHE_TTL_MS } from './cacheConstants';
 import { normalizeLastAction } from './normalizeLastAction';
 
 export const CARDS_KEY = 'cards';
 export const QUERIES_KEY = 'queries';
+export const INDEX_QUERIES_KEY = 'matchingIndexQueries';
 export const TTL_MS = CACHE_TTL_MS;
+export const MATCHING_INDEX_TTL_MS = MATCHING_PERFORMANCE_CACHE_TTL_MS;
 
 const toTimestamp = value => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -41,6 +43,8 @@ export const saveCards = cards => saveJson(CARDS_KEY, cards);
 
 export const loadQueries = () => loadJson(QUERIES_KEY);
 export const saveQueries = queries => saveJson(QUERIES_KEY, queries);
+export const loadIndexQueries = () => loadJson(INDEX_QUERIES_KEY);
+export const saveIndexQueries = queries => saveJson(INDEX_QUERIES_KEY, queries);
 
 const canonicalizeQueryValue = value => {
   if (value === undefined) {
@@ -179,6 +183,28 @@ export const setIdsForQuery = (queryKey, ids) => {
   const now = Date.now();
   queries[key] = { ids: ids.slice(), cachedAt: now, lastAction: now };
   saveQueries(queries);
+};
+
+export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
+  const key = normalizeQueryKey(queryKey);
+  const queries = loadIndexQueries();
+  const entry = queries[key];
+  const cachedAt = getEntryCacheTimestamp(entry);
+  if (!entry || !cachedAt) return null;
+  if (Date.now() - cachedAt > ttlMs) {
+    delete queries[key];
+    saveIndexQueries(queries);
+    return null;
+  }
+  return Array.isArray(entry.ids) ? entry.ids.slice() : [];
+};
+
+export const setIndexIdsForQuery = (queryKey, ids) => {
+  const key = normalizeQueryKey(queryKey);
+  const queries = loadIndexQueries();
+  const now = Date.now();
+  queries[key] = { ids: Array.isArray(ids) ? ids.slice() : [], cachedAt: now, lastAction: now };
+  saveIndexQueries(queries);
 };
 
 export const touchCardInQueries = cardId => {

--- a/src/utils/commentsStorage.js
+++ b/src/utils/commentsStorage.js
@@ -1,18 +1,59 @@
-import { CACHE_TTL_MS } from './cacheConstants';
+import { MATCHING_PERFORMANCE_CACHE_TTL_MS } from './cacheConstants';
 
 const COMMENTS_KEY = 'commentsCache';
-const TTL_MS = CACHE_TTL_MS;
+export const COMMENTS_TTL_MS = MATCHING_PERFORMANCE_CACHE_TTL_MS;
+
+const now = () => Date.now();
+
+const isFresh = entry => {
+  if (!entry) return false;
+  const cachedAt = Number(entry.cachedAt || entry.lastAction || 0);
+  return Boolean(cachedAt) && now() - cachedAt <= COMMENTS_TTL_MS;
+};
+
+const normalizeEntry = entry => {
+  if (!entry || typeof entry !== 'object') return null;
+  const cachedAt = Number(entry.cachedAt || entry.lastAction || now());
+  return {
+    ...entry,
+    text: String(entry.text || ''),
+    lastAction: Number(entry.lastAction || cachedAt),
+    cachedAt,
+    ...(entry.empty ? { empty: true } : {}),
+  };
+};
+
+const isOwnerScopedCache = parsed =>
+  parsed && typeof parsed === 'object' && Object.values(parsed).some(ownerValue => (
+    ownerValue &&
+    typeof ownerValue === 'object' &&
+    Object.values(ownerValue).some(entry => entry && typeof entry === 'object' && ('cachedAt' in entry || 'text' in entry || 'empty' in entry))
+  ));
+
+const migrateFlatCache = parsed => {
+  const ownerId = localStorage.getItem('ownerId') || '__local__';
+  const scoped = { [ownerId]: {} };
+  Object.entries(parsed || {}).forEach(([cardId, entry]) => {
+    const normalized = normalizeEntry(entry);
+    if (normalized && isFresh(normalized)) scoped[ownerId][cardId] = normalized;
+  });
+  return scoped;
+};
 
 export const loadComments = () => {
   try {
     const raw = localStorage.getItem(COMMENTS_KEY);
     if (!raw) return {};
     const parsed = JSON.parse(raw);
+    const scoped = isOwnerScopedCache(parsed) ? parsed : migrateFlatCache(parsed);
     const result = {};
-    Object.entries(parsed).forEach(([id, entry]) => {
-      if (entry && (!entry.lastAction || Date.now() - entry.lastAction <= TTL_MS)) {
-        result[id] = entry;
-      }
+    Object.entries(scoped || {}).forEach(([ownerId, ownerComments]) => {
+      const freshOwnerComments = {};
+      Object.entries(ownerComments || {}).forEach(([cardId, entry]) => {
+        const normalized = normalizeEntry(entry);
+        if (normalized && isFresh(normalized)) freshOwnerComments[cardId] = normalized;
+      });
+      if (Object.keys(freshOwnerComments).length) result[ownerId] = freshOwnerComments;
     });
     return result;
   } catch {
@@ -22,15 +63,30 @@ export const loadComments = () => {
 
 export const saveComments = comments => {
   try {
-    localStorage.setItem(COMMENTS_KEY, JSON.stringify(comments));
+    localStorage.setItem(COMMENTS_KEY, JSON.stringify(comments || {}));
   } catch {
     // ignore write errors
   }
 };
 
-export const setLocalComment = (id, text, lastAction = Date.now()) => {
+export const getOwnerComments = ownerId => loadComments()[ownerId] || {};
+
+export const getCachedComment = (ownerId, cardId) => {
+  const entry = loadComments()?.[ownerId]?.[cardId];
+  return isFresh(entry) ? entry : null;
+};
+
+export const setLocalComment = (...args) => {
+  const [ownerIdOrCardId, cardIdOrText, textOrLastAction, maybeLastAction] = args;
+  const hasOwner = args.length >= 3;
+  const ownerId = hasOwner ? ownerIdOrCardId : (localStorage.getItem('ownerId') || '__local__');
+  const cardId = hasOwner ? cardIdOrText : ownerIdOrCardId;
+  const text = hasOwner ? textOrLastAction : cardIdOrText;
+  const lastAction = hasOwner ? (maybeLastAction || now()) : (textOrLastAction || now());
+  if (!ownerId || !cardId) return;
   const comments = loadComments();
-  comments[id] = { text, lastAction };
+  comments[ownerId] = comments[ownerId] || {};
+  comments[ownerId][cardId] = { text: String(text || ''), lastAction, cachedAt: now(), empty: !String(text || '').trim() };
   saveComments(comments);
 };
 
@@ -40,17 +96,32 @@ export const shouldUseServerComment = (server, local) => {
   return (server.lastAction || 0) > (local.lastAction || 0);
 };
 
-export const pruneComments = ids => {
+export const pruneComments = (ownerIdOrIds, maybeIds) => {
+  const ownerScoped = Array.isArray(maybeIds);
+  const ownerId = ownerScoped ? ownerIdOrIds : null;
+  const ids = ownerScoped ? maybeIds : ownerIdOrIds;
+  const keep = new Set((ids || []).filter(Boolean));
   const existing = loadComments();
   const pruned = {};
-  ids.forEach(id => {
-    if (existing[id]) pruned[id] = existing[id];
+  Object.entries(existing).forEach(([currentOwnerId, ownerComments]) => {
+    if (ownerId && currentOwnerId !== ownerId) {
+      pruned[currentOwnerId] = ownerComments;
+      return;
+    }
+    const nextOwnerComments = {};
+    keep.forEach(id => {
+      if (ownerComments?.[id]) nextOwnerComments[id] = ownerComments[id];
+    });
+    if (Object.keys(nextOwnerComments).length) pruned[currentOwnerId] = nextOwnerComments;
   });
   saveComments(pruned);
 };
 
-export const getLocalComment = id => {
-  const comments = loadComments();
-  return comments[id]?.text || '';
+export const getLocalComment = (ownerIdOrCardId, maybeCardId) => {
+  const ownerId = maybeCardId ? ownerIdOrCardId : (localStorage.getItem('ownerId') || '__local__');
+  const cardId = maybeCardId || ownerIdOrCardId;
+  const entry = getCachedComment(ownerId, cardId);
+  return entry?.text || '';
 };
 
+export const isCommentCacheEntryFresh = isFresh;

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -1,5 +1,6 @@
 import { get, ref } from 'firebase/database';
 import { database } from 'components/config';
+import { getCard, getIndexIdsByQuery, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
 import { collectFilteredMatchingSourceCards } from './matchingSourceBackfill';
 import { getIndexedNewUsersIdsByRules, normalizeSearchKeySetKeys } from './newUsersFilterSetsIndex';
 
@@ -144,12 +145,77 @@ const intersectIdSets = sets => {
     .sort((a, b) => a.localeCompare(b));
 };
 
+const normalizeSignatureValue = value => {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(normalizeSignatureValue).sort();
+  return Object.keys(value).sort().reduce((acc, key) => {
+    const normalized = normalizeSignatureValue(value[key]);
+    if (normalized !== undefined) acc[key] = normalized;
+    return acc;
+  }, {});
+};
+
+const buildRawRulesSignature = rawRules => String(rawRules || '').trim();
+
+export const buildMatchingIndexQueryKey = ({
+  collectionSource = 'users',
+  filters = {},
+  viewMode = 'default',
+  ownerId = '',
+  accessUserId = '',
+  rawRules = '',
+  searchKeySetKeys = [],
+  searchKeySetsOfExactUser = searchKeySetKeys,
+} = {}) => {
+  const relevantViewMode = viewMode === 'favorites' || viewMode === 'dislikes' ? viewMode : 'default';
+  return `matchingIndex:${serializeQueryFilters(normalizeSignatureValue({
+    collectionSource,
+    filters: normalizeSignatureValue(filters || {}),
+    viewMode: relevantViewMode,
+    ownerId: String(ownerId || accessUserId || '').trim(),
+    accessUserId: String(accessUserId || ownerId || '').trim(),
+    accessSnapshot: collectionSource === 'newUsers'
+      ? {
+          rawRulesSignature: buildRawRulesSignature(rawRules),
+          searchKeySetKeys: normalizeSearchKeySetKeys(searchKeySetKeys),
+          searchKeySetsOfExactUser: normalizeSearchKeySetKeys(searchKeySetsOfExactUser),
+        }
+      : null,
+  }))}`;
+};
+
+const isCachedCardCompatible = (card, collectionSource) => {
+  if (!card?.userId) return false;
+  const cachedSource = card.__sourceCollection || (card.userId.length < 20 ? 'newUsers' : 'users');
+  if (collectionSource === 'users') return cachedSource === 'users' || cachedSource === undefined;
+  if (collectionSource === 'newUsers') return cachedSource === 'newUsers';
+  return true;
+};
+
 const hydrateOrderedUsers = async ({ ids, hydrateUsersByIds, collectionSource }) => {
   if (!ids.length || typeof hydrateUsersByIds !== 'function') return [];
-  const hydrated = await hydrateUsersByIds(ids);
+  const cachedById = new Map();
+  const missingIds = [];
+  ids.forEach(id => {
+    const cached = getCard(id);
+    if (cached && isCachedCardCompatible(cached, collectionSource)) {
+      cachedById.set(id, {
+        ...cached,
+        userId: id,
+        __sourceCollection: cached.__sourceCollection || collectionSource,
+        __fromCardCache: true,
+      });
+    } else {
+      missingIds.push(id);
+    }
+  });
+
+  const hydrated = missingIds.length ? await hydrateUsersByIds(missingIds) : [];
   const map = Array.isArray(hydrated)
     ? new Map(hydrated.map(user => [user?.userId, user]).filter(([id]) => Boolean(id)))
     : new Map(Object.entries(hydrated || {}));
+  cachedById.forEach((user, id) => map.set(id, user));
 
   return ids
     .map(id => map.get(id))
@@ -159,6 +225,35 @@ const hydrateOrderedUsers = async ({ ids, hydrateUsersByIds, collectionSource })
 
 const normalizeOffset = value => Math.max(0, Number(value) || 0);
 const normalizeLimit = value => Math.max(1, Number(value) || 1);
+
+const sliceIndexedBaseIds = ({ ids = [], offset = 0, limit = 1, excludedSet = new Set() } = {}) => {
+  const safeOffset = normalizeOffset(offset);
+  const safeLimit = normalizeLimit(limit);
+  const pageIds = [];
+  let cursor = safeOffset;
+
+  while (cursor < ids.length && pageIds.length < safeLimit) {
+    const id = ids[cursor];
+    cursor += 1;
+    if (!id || excludedSet.has(id)) continue;
+    pageIds.push(id);
+  }
+
+  let hasMore = false;
+  for (let index = cursor; index < ids.length; index += 1) {
+    const id = ids[index];
+    if (id && !excludedSet.has(id)) {
+      hasMore = true;
+      break;
+    }
+  }
+
+  return {
+    pageIds,
+    nextOffset: cursor,
+    hasMore,
+  };
+};
 
 export const fetchMatchingIndexedCandidates = async ({
   collectionSource = 'users',
@@ -171,11 +266,50 @@ export const fetchMatchingIndexedCandidates = async ({
   excludeIds = [],
   hydrateUsersByIds,
   newUsersIndexReader = getIndexedNewUsersIdsByRules,
+  viewMode = 'default',
+  ownerId = '',
+  useIndexIdCache = true,
 } = {}) => {
   const filterGroups = buildMatchingIndexFilterGroups({ filters, collectionSource });
   const excludedSet = new Set((Array.isArray(excludeIds) ? excludeIds : [...(excludeIds || [])]).filter(Boolean));
   const safeOffset = normalizeOffset(offset);
   const safeLimit = normalizeLimit(limit);
+  const cacheKey = buildMatchingIndexQueryKey({
+    collectionSource,
+    filters,
+    viewMode,
+    ownerId,
+    accessUserId,
+    rawRules,
+    searchKeySetKeys,
+    searchKeySetsOfExactUser: searchKeySetKeys,
+  });
+
+  const readCachedPage = () => {
+    if (!useIndexIdCache) return null;
+    const cachedIds = getIndexIdsByQuery(cacheKey);
+    if (!Array.isArray(cachedIds)) return null;
+    const sliced = sliceIndexedBaseIds({ ids: cachedIds, offset: safeOffset, limit: safeLimit, excludedSet });
+    return {
+      allIds: cachedIds,
+      ...sliced,
+    };
+  };
+
+  const cachedPage = readCachedPage();
+  if (cachedPage) {
+    const users = await hydrateOrderedUsers({ ids: cachedPage.pageIds, hydrateUsersByIds, collectionSource });
+    return {
+      usedIndex: true,
+      usedIndexIdCache: true,
+      cacheKey,
+      userIds: cachedPage.pageIds,
+      users,
+      nextOffset: cachedPage.nextOffset,
+      hasMore: cachedPage.hasMore,
+      filterGroups,
+    };
+  }
 
   if (collectionSource === 'newUsers') {
     const indexed = await newUsersIndexReader({
@@ -184,19 +318,28 @@ export const fetchMatchingIndexedCandidates = async ({
       searchKeySetsOfExactUser: searchKeySetKeys,
       fetchMissingBuckets: true,
       requireSearchKeySetKeys: true,
-      resultOffset: safeOffset,
-      resultLimit: safeLimit,
+      resultOffset: 0,
+      resultLimit: Number.POSITIVE_INFINITY,
       additionalFilterBucketGroups: filterGroups,
-      excludedUserIds: [...excludedSet],
+      excludedUserIds: [],
     });
-    const userIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
+    const allUserIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
+    if (useIndexIdCache) setIndexIdsForQuery(cacheKey, allUserIds);
+    const { pageIds: userIds, nextOffset, hasMore } = sliceIndexedBaseIds({
+      ids: allUserIds,
+      offset: safeOffset,
+      limit: safeLimit,
+      excludedSet,
+    });
     const users = await hydrateOrderedUsers({ ids: userIds, hydrateUsersByIds, collectionSource });
     return {
       usedIndex: true,
+      usedIndexIdCache: false,
+      cacheKey,
       userIds,
       users,
-      nextOffset: Number.isFinite(Number(indexed?.nextOffset)) ? indexed.nextOffset : safeOffset + userIds.length,
-      hasMore: Boolean(indexed?.hasMore),
+      nextOffset,
+      hasMore,
       filterGroups,
       reason: indexed?.reason,
     };
@@ -209,17 +352,24 @@ export const fetchMatchingIndexedCandidates = async ({
   const idSets = await Promise.all(
     filterGroups.map(group => readBucketIds({ rootPath: MATCHING_USERS_INDEX_ROOT, ...group }))
   );
-  const allMatchingIds = (intersectIdSets(idSets) || []).filter(id => !excludedSet.has(id));
-  const pageIds = allMatchingIds.slice(safeOffset, safeOffset + safeLimit);
+  const allMatchingIds = intersectIdSets(idSets) || [];
+  if (useIndexIdCache) setIndexIdsForQuery(cacheKey, allMatchingIds);
+  const { pageIds, nextOffset, hasMore } = sliceIndexedBaseIds({
+    ids: allMatchingIds,
+    offset: safeOffset,
+    limit: safeLimit,
+    excludedSet,
+  });
   const users = await hydrateOrderedUsers({ ids: pageIds, hydrateUsersByIds, collectionSource: 'users' });
-  const nextOffset = safeOffset + pageIds.length;
 
   return {
     usedIndex: true,
+    usedIndexIdCache: false,
+    cacheKey,
     userIds: pageIds,
     users,
     nextOffset,
-    hasMore: nextOffset < allMatchingIds.length,
+    hasMore,
     filterGroups,
   };
 };
@@ -589,6 +739,7 @@ export const fetchAdditionalNewUsersBySearchIndex = async ({
     filters,
     rawRules,
     accessUserId: normalizedAccessUserId,
+    ownerId: normalizedAccessUserId,
     searchKeySetKeys,
     offset,
     limit,


### PR DESCRIPTION
### Motivation
- Reduce perceived latency and increase throughput for the matching UI by increasing initial and refill batch sizes and reusing cached index/id lists.
- Avoid UI jank by not blocking rendering on comment fetches and by preserving stale-result guards for async loads.
- Make comment caching owner-scoped with TTL so different viewers keep separate comment drafts and to expire stale entries reliably.
- Reuse basic cached card data to avoid redundant hydration network calls for matching pages.

### Description
- Bumped batch sizes by updating `INITIAL_LOAD`, `MATCHING_REFILL_LIMIT` and `LOAD_MORE` to `5` to reduce round trips and improve fill behavior.
- Refactored comment loading: changed `loadCommentsFor` signature to accept `{ force }`, made it owner-aware, added request-context validation to avoid applying stale results, and switched many callers in `Matching.jsx` to call `void loadCommentsFor(...)` so card updates are applied before comment fetches complete.
- Made comment cache owner-scoped in `src/utils/commentsStorage.js` with `COMMENTS_TTL_MS`, migration from flat cache, new helpers `getCachedComment`, `getOwnerComments`, `isCommentCacheEntryFresh`, changed `setLocalComment` and `getLocalComment` signatures to accept owner scoping, and updated `pruneComments` to accept owner + ids.
- Prevented blocking UI by updating cards before awaiting comment fetches and by avoiding overwriting cards that were loaded from card cache via `__fromCardCache` marker; `Matching.jsx` now calls `updateCard(...)` only when appropriate and marks cached cards accordingly.
- Added index id caching to `src/utils/cardIndex.js` (`INDEX_QUERIES_KEY`, `MATCHING_INDEX_TTL_MS`, `getIndexIdsByQuery`, `setIndexIdsForQuery`) and performance TTL in `cacheConstants.js` (`MATCHING_PERFORMANCE_CACHE_TTL_MS`).
- Extended `src/utils/matchingDataProvider.js` to build a stable cache key via `buildMatchingIndexQueryKey`, slice cached id lists with `sliceIndexedBaseIds`, reuse cached index ids when available, and hydrate only missing ids while marking reused cards with `__fromCardCache`.
- Updated call-sites in `Matching.jsx` to pass owner id when storing local comments (`setLocalComment(ownerId, userId, text, lastAction)`) and to prune comments with owner context, and added additional concurrency/stale-result guards across load-more and shared-candidate flows.
- Tests added and adjusted to cover the changes: new `matchingDataProvider.indexCache.test.js`, extended `commentsStorage.test.js`, and updated `Matching.*` tests to reflect new ordering and cache flags.

### Testing
- Ran unit tests with the component/test-suite that include updated assertions in `Matching.loadMoreStaleGuard.test.js` and `Matching.sharedReactions.test.js`, and the added `matchingDataProvider.indexCache.test.js`, all of which passed.
- Updated comment storage tests in `src/utils/__tests__/commentsStorage.test.js` to validate owner-scoped caching, TTL behavior, and `shouldUseServerComment`, and these tests passed.
- Overall test suite was executed (`npm test`/`yarn test`) and completed without failures for the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084e68ba5083268ab3b2660792dd11)