### PR TITLE
Add paged indexed-load helper for matching loadMore and integrate into Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -107,6 +107,7 @@ import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getContactEntries, CONTACT_LINK_BUILDERS } from './contactMethods';
 import { handleEmptyFetch } from './loadMoreUtils';
+import { collectMatchingIndexedLoadMorePage } from 'utils/matchingIndexedLoadMore';
 import {
   getHeroFields,
   getQuickFacts,
@@ -893,6 +894,7 @@ const INITIAL_LOAD = 5;
 const MATCHING_VISIBLE_BUFFER = 2;
 const MATCHING_REFILL_LIMIT = 5;
 const LOAD_MORE = 5;
+const MATCHING_INDEXED_LOAD_MORE_MAX_PAGES = 5;
 const ADDITIONAL_BACKFILL_MAX_PAGES = 3;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
@@ -2976,38 +2978,42 @@ const Matching = () => {
         collectionSource,
       });
       if (collectionSource === 'users' && activeIndexFilterGroups.length > 0) {
-        const indexed = await fetchMatchingIndexedCandidates({
-          collectionSource: 'users',
+        const indexedPage = await collectMatchingIndexedLoadMorePage({
+          requestedLimit,
+          initialOffset: Number(lastKey) || 0,
+          maxPages: MATCHING_INDEXED_LOAD_MORE_MAX_PAGES,
+          baseExclude,
+          loadedIds: loadedIdsRef.current,
           filters: filtersRef.current || {},
           viewMode,
           ownerId: getOwnerId(),
-          offset: Number.isFinite(Number(lastKey)) ? Number(lastKey) : 0,
-          limit: requestedLimit,
-          excludeIds: [...baseExclude],
+          fetchMatchingIndexedCandidates,
           hydrateUsersByIds: fetchUsersByIds,
+          isLatestLoadMore,
         });
-        if (!isLatestLoadMore()) return;
-        const indexedUsers = (indexed.users || []).filter(
-          user => user?.userId && !loadedIdsRef.current.has(user.userId)
-        );
-        if (indexedUsers.length === 0 && !indexed.hasMore) {
-          console.warn('[Matching][indexedProvider] empty users index result; falling back to source pagination');
-        } else {
-          indexedUsers.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
-          if (!isLatestLoadMore()) return;
-          indexedUsers.forEach(user => loadedIdsRef.current.add(user.userId));
-          setUsers(prev => {
-            const map = new Map(prev.map(user => [user.userId, user]));
-            indexedUsers.forEach(user => map.set(user.userId, user));
-            const result = Array.from(map.values());
-            setIdsForQuery(defaultListKey, result.map(user => user.userId));
-            return result;
+        if (indexedPage.stale) return;
+
+        if (indexedPage.cursorStuck) {
+          console.warn('[Matching][indexedProvider] stopped loadMore because indexed cursor did not move', {
+            finalIndexedOffset: indexedPage.finalOffset,
+            indexedPageCalls: indexedPage.pageCalls,
           });
-          void loadCommentsFor(indexedUsers);
-          setLastKey(indexed.nextOffset);
-          setHasMore(Boolean(indexed.hasMore));
-          return;
         }
+
+        indexedPage.collected.forEach(user => { if (!user.__fromCardCache) updateCard(user.userId, user); });
+        if (!isLatestLoadMore()) return;
+        indexedPage.collected.forEach(user => loadedIdsRef.current.add(user.userId));
+        setUsers(prev => {
+          const map = new Map(prev.map(user => [user.userId, user]));
+          indexedPage.collected.forEach(user => map.set(user.userId, user));
+          const result = Array.from(map.values());
+          setIdsForQuery(defaultListKey, result.map(user => user.userId));
+          return result;
+        });
+        void loadCommentsFor(indexedPage.collected);
+        setLastKey(indexedPage.finalOffset);
+        setHasMore(Boolean(indexedPage.finalHasMore && !indexedPage.cursorStuck));
+        return;
       }
 
       const collected = [];

--- a/src/components/Matching.loadMoreStaleGuard.test.js
+++ b/src/components/Matching.loadMoreStaleGuard.test.js
@@ -58,6 +58,22 @@ describe('Matching loadMore stale pagination guards', () => {
     expect(source).toContain(`finishLoadMoreIfLatest();`);
   });
 
+
+  it('keeps active users indexed filters from falling through to source pagination', () => {
+    const source = loadMoreSource();
+    const indexedBranchIndex = source.indexOf("if (collectionSource === 'users' && activeIndexFilterGroups.length > 0)");
+    const sourcePaginationIndex = source.indexOf('const collected = [];', indexedBranchIndex);
+    const indexedBranch = source.slice(indexedBranchIndex, sourcePaginationIndex);
+    const indexedReturnIndex = indexedBranch.lastIndexOf('return;');
+
+    expect(indexedBranchIndex).toBeGreaterThan(-1);
+    expect(sourcePaginationIndex).toBeGreaterThan(indexedBranchIndex);
+    expect(indexedBranch).toContain('collectMatchingIndexedLoadMorePage({');
+    expect(indexedBranch).toContain('setLastKey(indexedPage.finalOffset);');
+    expect(indexedBranch).toContain('setHasMore(Boolean(indexedPage.finalHasMore && !indexedPage.cursorStuck));');
+    expect(indexedReturnIndex).toBeGreaterThan(indexedBranch.indexOf('setHasMore(Boolean(indexedPage.finalHasMore'));
+  });
+
   it('does not clear loading state from stale requests after newer loadMore starts', () => {
     const source = loadMoreSource();
     const helperIndex = source.indexOf('const finishLoadMoreIfLatest = () => {');

--- a/src/utils/matchingIndexedLoadMore.js
+++ b/src/utils/matchingIndexedLoadMore.js
@@ -1,0 +1,79 @@
+export const collectMatchingIndexedLoadMorePage = async ({
+  requestedLimit = 1,
+  initialOffset = 0,
+  maxPages = 5,
+  baseExclude = [],
+  loadedIds = new Set(),
+  filters = {},
+  viewMode = 'default',
+  ownerId = '',
+  fetchMatchingIndexedCandidates,
+  hydrateUsersByIds,
+  isLatestLoadMore = () => true,
+} = {}) => {
+  const collected = [];
+  const collectedIds = new Set();
+  let offset = Number(initialOffset) || 0;
+  let finalOffset = offset;
+  let finalHasMore = false;
+  let cursorStuck = false;
+  let pageCalls = 0;
+
+  while (collected.length < requestedLimit && pageCalls < maxPages) {
+    pageCalls += 1;
+    const collectedUserIds = collected.map(user => user?.userId).filter(Boolean);
+    const excludeIds = new Set([
+      ...baseExclude,
+      ...loadedIds,
+      ...collectedUserIds,
+    ]);
+    const indexed = await fetchMatchingIndexedCandidates({
+      collectionSource: 'users',
+      filters,
+      viewMode,
+      ownerId,
+      offset,
+      limit: requestedLimit - collected.length,
+      excludeIds: [...excludeIds],
+      hydrateUsersByIds,
+    });
+    if (!isLatestLoadMore()) {
+      return {
+        collected,
+        finalOffset,
+        finalHasMore,
+        cursorStuck,
+        pageCalls,
+        stale: true,
+      };
+    }
+
+    const indexedUsers = (indexed.users || []).filter(
+      user => user?.userId && !loadedIds.has(user.userId) && !collectedIds.has(user.userId)
+    );
+    indexedUsers.forEach(user => {
+      collected.push(user);
+      collectedIds.add(user.userId);
+    });
+
+    const nextOffset = Number(indexed.nextOffset) || 0;
+    const lastHasMore = Boolean(indexed.hasMore);
+    cursorStuck = nextOffset === offset;
+    finalOffset = nextOffset;
+    finalHasMore = lastHasMore;
+
+    if (!lastHasMore) break;
+    if (cursorStuck) break;
+
+    offset = nextOffset;
+  }
+
+  return {
+    collected,
+    finalOffset,
+    finalHasMore,
+    cursorStuck,
+    pageCalls,
+    stale: false,
+  };
+};

--- a/src/utils/matchingIndexedLoadMore.test.js
+++ b/src/utils/matchingIndexedLoadMore.test.js
@@ -1,0 +1,60 @@
+import { collectMatchingIndexedLoadMorePage } from './matchingIndexedLoadMore';
+
+describe('collectMatchingIndexedLoadMorePage', () => {
+  it('добирає другу indexed page після stale/already loaded role/ag IDs без source pagination', async () => {
+    const alreadyLoadedId = 'loaded-ag-user-0000000001';
+    const staleId = 'stale-ag-user-00000000001';
+    const validId = 'valid-ag-user-00000000001';
+    const loadedIds = new Set([alreadyLoadedId]);
+    const fetchChunk = jest.fn();
+    const fetchMatchingIndexedCandidates = jest
+      .fn()
+      .mockResolvedValueOnce({
+        users: [],
+        userIds: [staleId, alreadyLoadedId],
+        nextOffset: 2,
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        users: [{ userId: validId, role: 'ag' }],
+        userIds: [validId],
+        nextOffset: 3,
+        hasMore: false,
+      });
+
+    const result = await collectMatchingIndexedLoadMorePage({
+      requestedLimit: 1,
+      initialOffset: 0,
+      maxPages: 5,
+      baseExclude: ['favorite-ag-user-0000001'],
+      loadedIds,
+      filters: { userRole: { ag: true, ed: false } },
+      viewMode: 'default',
+      ownerId: 'owner-id',
+      fetchMatchingIndexedCandidates,
+      hydrateUsersByIds: jest.fn(),
+      isLatestLoadMore: () => true,
+    });
+
+    expect(result.collected).toEqual([{ userId: validId, role: 'ag' }]);
+    expect(result.finalOffset).toBe(3);
+    expect(result.finalHasMore).toBe(false);
+    expect(result.cursorStuck).toBe(false);
+    expect(fetchMatchingIndexedCandidates).toHaveBeenCalledTimes(2);
+    expect(fetchMatchingIndexedCandidates).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        offset: 0,
+        excludeIds: expect.arrayContaining(['favorite-ag-user-0000001', alreadyLoadedId]),
+      })
+    );
+    expect(fetchMatchingIndexedCandidates).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        offset: 2,
+        excludeIds: expect.arrayContaining(['favorite-ag-user-0000001', alreadyLoadedId]),
+      })
+    );
+    expect(fetchChunk).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent indexed-filtered loads from falling through to the default source pagination when indexed results are available by paging through indexed results until requested items are collected.  
- Avoid infinite or stuck pagination when an indexed cursor does not advance and skip already-loaded or excluded IDs across pages.  
- Centralize and simplify the indexed-load loop so the `Matching` component can handle cursor/stale conditions cleanly.

### Description
- Added `collectMatchingIndexedLoadMorePage` utility in `src/utils/matchingIndexedLoadMore.js` that pages up to `maxPages`, collects indexed candidates while honoring `baseExclude` and `loadedIds`, detects `cursorStuck`, and returns `collected`, `finalOffset`, `finalHasMore`, `cursorStuck`, and `pageCalls`.  
- Integrated the helper into `src/components/Matching.jsx`, introduced `MATCHING_INDEXED_LOAD_MORE_MAX_PAGES`, and updated the indexed-branch to call `collectMatchingIndexedLoadMorePage` and handle its results (including stale requests and cursor-stuck logging) instead of a single indexed fetch.  
- Added unit tests in `src/utils/matchingIndexedLoadMore.test.js` and updated `src/components/Matching.loadMoreStaleGuard.test.js` to assert the new indexed-load behavior and ensure the indexed branch does not fall through to source pagination.

### Testing
- Ran the new unit test `matchingIndexedLoadMore.test.js` which validates paging, excludes, offsets, and collected users and it passed.  
- Ran the updated `Matching.loadMoreStaleGuard.test.js` which checks the stale-guard and indexed-branch behavior and it passed.  
- Tests were executed via the project test runner (`yarn test`) and no regressions were observed in the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0859add68083269b60d0fed599ab97)