### PR TITLE
Matching: cache versioning, lazy photo loading, and load instrumentation

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -67,6 +67,7 @@ import {
   fetchUsersByLastLogin2,
   fetchUserById,
   getAllUserPhotos,
+  lazyLoadProfilePhotos,
   fetchFavoriteUsers,
   fetchDislikeUsers,
   filterMain,
@@ -97,7 +98,7 @@ import PhotoViewer from './PhotoViewer';
 import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { getCacheKey, clearAllCardsCache, setFavoriteIds } from "../utils/cache";
-import { normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard } from '../utils/cardIndex';
+import { incrementMatchingLoadStat, logMatchingLocalStorageCacheStats, normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard } from '../utils/cardIndex';
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
@@ -299,12 +300,14 @@ const debugMissingNewUsersToast = (accessUserId, indexedCount) => {
   logAdditionalMatchingDebug(accessUserId, 'missing fetched newUsers records', { indexedCount });
 };
 
-const get = (...args) =>
-  withAdminDownloadToast(firebaseGet(...args), {
+const get = (...args) => {
+  incrementMatchingLoadStat('rtdbReads');
+  return withAdminDownloadToast(firebaseGet(...args), {
     operation: 'get',
     source: 'Matching',
     path: args[0],
   });
+};
 
 const onValue = wrapAdminOnValue(firebaseOnValue, {
   operation: 'onValue',
@@ -894,8 +897,10 @@ const INITIAL_LOAD = 5;
 const MATCHING_VISIBLE_BUFFER = 2;
 const MATCHING_REFILL_LIMIT = 5;
 const LOAD_MORE = 5;
-const MATCHING_INDEXED_LOAD_MORE_MAX_PAGES = 5;
-const ADDITIONAL_BACKFILL_MAX_PAGES = 3;
+const MATCHING_INDEXED_LOAD_MORE_MAX_PAGES = 2;
+const ADDITIONAL_BACKFILL_MAX_PAGES = 2;
+const MATCHING_AUTO_LOAD_MORE_COOLDOWN_MS = 700;
+const MATCHING_MAX_EMPTY_AUTO_LOAD_MORE_ATTEMPTS = 2;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
 const COLLECTION_SOURCE_KEY = 'matchingCollectionSource';
@@ -1018,6 +1023,7 @@ const Matching = () => {
   const [additionalNewUsers, setAdditionalNewUsers] = useState([]);
   const additionalNewUsersRef = useRef(additionalNewUsers);
   const [additionalNextOffset, setAdditionalNextOffset] = useState(0);
+  const [photoCacheByUserId, setPhotoCacheByUserId] = useState({});
   const [roleIndexSets] = useState(null);
   const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
   const isAdmin = access.isAdmin;
@@ -1039,6 +1045,9 @@ const Matching = () => {
   const additionalMatchingApplyVersionRef = useRef(0);
   const reactionLoadVersionRef = useRef(0);
   const sharedReactionCandidateLoadVersionRef = useRef(0);
+  const autoLoadMoreLastRunRef = useRef(0);
+  const autoLoadMoreSignatureRef = useRef('');
+  const emptyAutoLoadMoreAttemptsRef = useRef(0);
   const matchingProfileStateRef = useRef({
     ownerId: null,
     collectionSource,
@@ -1110,6 +1119,8 @@ const Matching = () => {
     setThemeMode(current => (current === 'light' ? 'dark' : 'light'));
   }, []);
   useEffect(() => {
+    emptyAutoLoadMoreAttemptsRef.current = 0;
+    autoLoadMoreSignatureRef.current = '';
     collectionSourceRef.current = collectionSource;
     localStorage.setItem(COLLECTION_SOURCE_KEY, collectionSource);
   }, [collectionSource]);
@@ -1121,6 +1132,10 @@ const Matching = () => {
       currentSearchKeySetKeys,
     };
   }, [collectionSource, currentAdditionalAccessRules, currentSearchKeySetKeys, ownerId]);
+  useEffect(() => {
+    logMatchingLocalStorageCacheStats('matching mount');
+  }, []);
+
   useEffect(() => {
     window.history.scrollRestoration = 'manual';
     const handleScroll = () => {
@@ -1447,11 +1462,12 @@ const Matching = () => {
     }
   }, []);
 
-  const loadCommentsFor = React.useCallback(async (list, { force = false } = {}) => {
+  const loadCommentsFor = React.useCallback(async (list, { force = false, activeOnly = true } = {}) => {
     const owners = getMatchingMultiDataOwnerIds();
     const ownOwnerId = getOwnerId();
     if (!owners.length || !ownOwnerId) return;
-    const ids = Array.from(new Set((list || []).map(u => u?.userId).filter(Boolean)));
+    const sourceList = activeOnly ? (list || []).slice(0, 1) : (list || []);
+    const ids = Array.from(new Set(sourceList.map(u => u?.userId).filter(Boolean)));
     if (!ids.length) return;
 
     const requestContext = {
@@ -1602,7 +1618,8 @@ const Matching = () => {
             fetchMissingBuckets: true,
             requireSearchKeySetKeys: true,
             resultOffset: 0,
-            resultLimit: Number.POSITIVE_INFINITY,
+            resultLimit: newUserCandidateIds.length,
+            candidateUserIds: newUserCandidateIds,
             debugMatchingFlow: shouldDebugAdditionalMatching(viewerId),
             debugToast: (message, data) => debugAdditionalToast(viewerId, message, data),
           });
@@ -1638,7 +1655,7 @@ const Matching = () => {
     }
 
     if (userCandidateIds.length > 0) {
-      const usersMap = await fetchUsersByIds(userCandidateIds);
+      const usersMap = await fetchUsersByIds(userCandidateIds, { collectionSource: 'users' });
       if (!canApplySharedCandidateResult()) {
         return;
       }
@@ -2137,7 +2154,7 @@ const Matching = () => {
       filterMainFn: filterMain,
       fetchUsersByLastLogin2,
       fetchUsersByLastLogin2FromCollection,
-      hydrateUsersByIds: fetchUsersByIds,
+      hydrateUsersByIds: ids => fetchUsersByIds(ids, { collectionSource }),
       onPart,
     }),
     [collectionSource, isAdmin, parsedAdditionalAccessRules, roleIndexSets]
@@ -2256,7 +2273,7 @@ const Matching = () => {
           offset: 0,
           limit: INITIAL_LOAD,
           excludeIds: [...exclude],
-          hydrateUsersByIds: fetchUsersByIds,
+          hydrateUsersByIds: ids => fetchUsersByIds(ids, { collectionSource }),
         });
         if (viewModeRef.current !== startMode) return;
         const indexedUsers = (indexed.users || []).filter(user => isAllowedIdForCollection(user.userId, collectionSource));
@@ -2306,6 +2323,8 @@ const Matching = () => {
       );
       if (viewModeRef.current !== startMode) return;
       console.log('[loadInitial] initial loaded', res.users.length, 'hasMore', res.hasMore);
+      const stats = typeof window !== 'undefined' ? window.matchingLoadStats : null;
+      if (stats && typeof console.table === 'function') console.table([stats]);
       loadedIdsRef.current = new Set([
         ...loadedIdsRef.current,
         ...res.users.map(u => u.userId),
@@ -2330,6 +2349,8 @@ const Matching = () => {
   }, [collectionSource, defaultListKey, fetchChunk, getMatchingMultiDataOwnerIds, loadCommentsFor, parsedAdditionalAccessRules.length]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
 
   const reloadDefault = React.useCallback(() => {
+    emptyAutoLoadMoreAttemptsRef.current = 0;
+    autoLoadMoreSignatureRef.current = '';
     viewModeRef.current = 'default';
     invalidateReactionAsyncWork();
     resetReactionPaginationState();
@@ -2339,6 +2360,8 @@ const Matching = () => {
 
 
   const handleFiltersChange = React.useCallback(nextFilters => {
+    emptyAutoLoadMoreAttemptsRef.current = 0;
+    autoLoadMoreSignatureRef.current = '';
     filtersRef.current = nextFilters;
     setFilters(nextFilters);
     const currentMode = viewModeRef.current;
@@ -2401,7 +2424,7 @@ const Matching = () => {
     });
 
     const [usersMap, newUsersCards] = await Promise.all([
-      missingUserIds.length ? fetchUsersByIds(missingUserIds) : Promise.resolve({}),
+      missingUserIds.length ? fetchUsersByIds(missingUserIds, { collectionSource: 'users' }) : Promise.resolve({}),
       missingNewUserIds.length ? fetchNewUsersByIdsForMatching(missingNewUserIds) : Promise.resolve([]),
     ]);
 
@@ -2451,7 +2474,8 @@ const Matching = () => {
       fetchMissingBuckets: true,
       requireSearchKeySetKeys: true,
       resultOffset: 0,
-      resultLimit: Number.POSITIVE_INFINITY,
+      resultLimit: newUserReactionIds.length,
+      candidateUserIds: newUserReactionIds,
       debugMatchingFlow: shouldDebugAdditionalMatching(viewerId),
       debugToast: (message, data) => debugAdditionalToast(viewerId, message, data),
     });
@@ -2815,7 +2839,7 @@ const Matching = () => {
         }));
         setHasMore(nextHasMore);
         setLastKey(null);
-        return;
+        return page.users.length;
       }
 
       const baseExclude = new Set([
@@ -2970,7 +2994,7 @@ const Matching = () => {
           finalCardsCount: collected.length,
         });
         setLastKey(null);
-        return;
+        return collected.length;
       }
 
       const activeIndexFilterGroups = buildMatchingIndexFilterGroups({
@@ -2988,7 +3012,7 @@ const Matching = () => {
           viewMode,
           ownerId: getOwnerId(),
           fetchMatchingIndexedCandidates,
-          hydrateUsersByIds: fetchUsersByIds,
+          hydrateUsersByIds: ids => fetchUsersByIds(ids, { collectionSource }),
           isLatestLoadMore,
         });
         if (indexedPage.stale) return;
@@ -2997,6 +3021,7 @@ const Matching = () => {
           console.warn('[Matching][indexedProvider] stopped loadMore because indexed cursor did not move', {
             finalIndexedOffset: indexedPage.finalOffset,
             indexedPageCalls: indexedPage.pageCalls,
+            stopReason: indexedPage.stopReason,
           });
         }
 
@@ -3013,7 +3038,7 @@ const Matching = () => {
         void loadCommentsFor(indexedPage.collected);
         setLastKey(indexedPage.finalOffset);
         setHasMore(Boolean(indexedPage.finalHasMore && !indexedPage.cursorStuck));
-        return;
+        return indexedPage.collected.length;
       }
 
       const collected = [];
@@ -3047,6 +3072,7 @@ const Matching = () => {
           hasMore: res.hasMore,
           sourceHasMore: res.sourceHasMore,
           loadedPages: res.loadedPages,
+          stopReason: res.stopReason,
         });
 
         const unique = res.users.filter(
@@ -3083,6 +3109,7 @@ const Matching = () => {
         setHasMore(canLoadMore);
       }
       setLastKey(cursor);
+      return collected.length;
     } finally {
       finishLoadMoreIfLatest();
     }
@@ -3158,6 +3185,53 @@ const Matching = () => {
   const [activeProfileIndex, setActiveProfileIndex] = useState(0);
   const activeProfile = filteredUsers[activeProfileIndex] || null;
 
+  const withLazyPhotos = React.useCallback(user => {
+    if (!user?.userId) return user;
+    const cachedPhotos = photoCacheByUserId[user.userId];
+    if (!cachedPhotos) return user;
+    return {
+      ...user,
+      photos: cachedPhotos,
+      __photosHydrated: true,
+    };
+  }, [photoCacheByUserId]);
+
+  const activeProfileWithLazyPhotos = withLazyPhotos(activeProfile);
+
+  useEffect(() => {
+    const candidates = [filteredUsers[activeProfileIndex], filteredUsers[activeProfileIndex + 1]]
+      .filter(user => user?.userId && !user.__photosHydrated && !photoCacheByUserId[user.userId]);
+    if (!candidates.length) return undefined;
+
+    let cancelled = false;
+    candidates.forEach(user => {
+      lazyLoadProfilePhotos(user.userId).then(photos => {
+        if (cancelled) return;
+        incrementMatchingLoadStat('photoLazyLoadProfiles');
+        setPhotoCacheByUserId(prev => ({
+          ...prev,
+          [user.userId]: Array.isArray(photos) ? photos : [],
+        }));
+        const stats = typeof window !== 'undefined' ? window.matchingLoadStats : null;
+        if (stats && typeof console.table === 'function') console.table([stats]);
+      }).catch(() => {
+        if (!cancelled) {
+          setPhotoCacheByUserId(prev => ({ ...prev, [user.userId]: [] }));
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProfileIndex, filteredUsers, photoCacheByUserId]);
+
+  useEffect(() => {
+    if (activeProfile?.userId) {
+      void loadCommentsFor([activeProfile], { activeOnly: true });
+    }
+  }, [activeProfile, loadCommentsFor]);
+
   useEffect(() => {
     setActiveProfileIndex(index => {
       if (filteredUsers.length === 0) return 0;
@@ -3220,18 +3294,49 @@ const Matching = () => {
     });
   }, [collectionSource, filteredUsers, filters, ownerId, parsedAdditionalAccessRules.length, visibleUsers]);
 
+  const runAutoLoadMore = React.useCallback((signature, payload) => {
+    if (emptyAutoLoadMoreAttemptsRef.current >= MATCHING_MAX_EMPTY_AUTO_LOAD_MORE_ATTEMPTS) return;
+    if (autoLoadMoreSignatureRef.current === signature) return;
+    const now = Date.now();
+    if (now - autoLoadMoreLastRunRef.current < MATCHING_AUTO_LOAD_MORE_COOLDOWN_MS) return;
+
+    autoLoadMoreSignatureRef.current = signature;
+    autoLoadMoreLastRunRef.current = now;
+    Promise.resolve(loadMore(payload)).then(addedCount => {
+      const visibleAdded = Math.max(0, Number(addedCount) || 0);
+      incrementMatchingLoadStat('visibleCardsAdded', visibleAdded);
+      if (visibleAdded > 0) {
+        emptyAutoLoadMoreAttemptsRef.current = 0;
+      } else {
+        emptyAutoLoadMoreAttemptsRef.current += 1;
+        incrementMatchingLoadStat('emptyLoadMoreAttempts');
+      }
+      const stats = typeof window !== 'undefined' ? window.matchingLoadStats : null;
+      if (stats && typeof console.table === 'function') console.table([stats]);
+    });
+  }, [loadMore]);
+
   useEffect(() => {
     if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;
     if (loadingRef.current || loading) return;
     if (!hasMore) return;
     if (filteredUsers.length >= MATCHING_VISIBLE_BUFFER) return;
 
-    loadMore({
+    const signature = stableAdditionalSignature({
+      type: 'refill',
+      viewMode,
+      collectionSource,
+      length: filteredUsers.length,
+      lastKey,
+      additionalNextOffset,
+      filters,
+    });
+    runAutoLoadMore(signature, {
       currentVisibleCount: filteredUsers.length,
       targetVisibleCount: MATCHING_VISIBLE_BUFFER,
       limit: MATCHING_REFILL_LIMIT,
     });
-  }, [filteredUsers.length, hasMore, loadMore, loading, viewMode]);
+  }, [additionalNextOffset, collectionSource, filteredUsers.length, filters, hasMore, lastKey, loading, runAutoLoadMore, viewMode]);
 
   const lastCardLoadTriggerSignatureRef = useRef('');
   const lastCardVisibilityLogSignatureRef = useRef('');
@@ -3295,7 +3400,7 @@ const Matching = () => {
     if (lastCardLoadTriggerSignatureRef.current === triggerSignature) return;
     lastCardLoadTriggerSignatureRef.current = triggerSignature;
 
-    loadMore({
+    runAutoLoadMore(`last-card:${triggerSignature}`, {
       currentVisibleCount: renderedCardsLength,
       targetVisibleCount: MATCHING_VISIBLE_BUFFER,
       limit: MATCHING_REFILL_LIMIT,
@@ -3306,7 +3411,7 @@ const Matching = () => {
     collectionSource,
     hasMore,
     lastKey,
-    loadMore,
+    runAutoLoadMore,
     loading,
     parsedAdditionalAccessRules.length,
     reactionPaginationByType,
@@ -3475,8 +3580,8 @@ const Matching = () => {
           )}
 
           <Grid>
-            {activeProfile ? (() => {
-              const user = activeProfile;
+            {activeProfileWithLazyPhotos ? (() => {
+              const user = activeProfileWithLazyPhotos;
               const photos = getProfilePhotos(user);
               const photo = photos[0];
               const role = getProfileRole(user);

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -25,7 +25,7 @@ import { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './
 import { filterOutMedicationPhotos } from '../utils/photoFilters';
 import { getCurrentDate } from './foramtDate';
 import toast from 'react-hot-toast';
-import { removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
+import { incrementMatchingLoadStat, removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
 import { updateCard } from '../utils/cardsStorage';
 import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
 import { getCacheKey } from '../utils/cache';
@@ -72,13 +72,15 @@ if (typeof window !== 'undefined') {
   window.__getBackendDownloadToastUid = getCurrentAdminUid;
 }
 
-const get = (...args) =>
-  withAdminDownloadToast(firebaseGet(...args), {
+const get = (...args) => {
+  incrementMatchingLoadStat('rtdbReads');
+  return withAdminDownloadToast(firebaseGet(...args), {
     getUid: getCurrentAdminUid,
     operation: 'get',
     source: 'config',
     path: args[0],
   });
+};
 
 const getDoc = (...args) =>
   withAdminDownloadToast(firebaseGetDoc(...args), {
@@ -96,21 +98,25 @@ const getDocs = (...args) =>
     path: args[0],
   });
 
-const listAll = (...args) =>
-  withAdminDownloadToast(firebaseListAll(...args), {
+const listAll = (...args) => {
+  incrementMatchingLoadStat('storageListAllCalls');
+  return withAdminDownloadToast(firebaseListAll(...args), {
     getUid: getCurrentAdminUid,
     operation: 'listAll',
     source: 'config',
     path: args[0],
   });
+};
 
-const getDownloadURL = (...args) =>
-  withAdminDownloadToast(firebaseGetDownloadURL(...args), {
+const getDownloadURL = (...args) => {
+  incrementMatchingLoadStat('storageDownloadUrlCalls');
+  return withAdminDownloadToast(firebaseGetDownloadURL(...args), {
     getUid: getCurrentAdminUid,
     operation: 'Storage URL metadata',
     source: 'config',
     path: args[0],
   });
+};
 
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 
@@ -1034,6 +1040,7 @@ export const fetchUserComment = async (ownerId, cardId) => {
 
 export const fetchUserComments = async (ownerId, cardIds = []) => {
   try {
+    incrementMatchingLoadStat('commentsReads', Array.isArray(cardIds) ? cardIds.length : 0);
     const commentsRef = ref2(database, `multiData/comments/${ownerId}`);
     const snaps = await Promise.all(
       cardIds.map(cardId =>
@@ -1495,30 +1502,30 @@ export const renameFlowCategory = async ({ ownerId, fromGroupPath, toGroupPath }
   await remove(fromRef);
 };
 
-export const fetchUsersByIds = async ids => {
+export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
   try {
+    const source = collectionSource === 'users' || collectionSource === 'newUsers' ? collectionSource : null;
     const snaps = await Promise.all(
-      ids.map(id =>
-        Promise.all([
-          get(ref2(database, `newUsers/${id}`)),
-          get(ref2(database, `users/${id}`)),
-          getAllUserPhotos(id),
-        ]).then(([newSnap, userSnap, photos]) => {
-          const hasNewUser = newSnap.exists();
-          const hasUser = userSnap.exists();
-          if (!hasNewUser && !hasUser) return null;
-
+      ids.map(id => {
+        const readSources = source
+          ? [source]
+          : (String(id || '').length < 20 ? ['newUsers'] : ['users']);
+        return Promise.all(
+          readSources.map(sourceName => get(ref2(database, `${sourceName}/${id}`)).then(snapshot => [sourceName, snapshot]))
+        ).then(entries => {
+          const foundEntry = entries.find(([, snapshot]) => snapshot.exists());
+          if (!foundEntry) return null;
+          const [sourceName, snapshot] = foundEntry;
           const data = {
             userId: id,
-            ...(hasUser ? userSnap.val() : {}),
-            ...(hasNewUser ? newSnap.val() : {}),
-            photos: Array.isArray(photos) ? photos : [],
-            __photosHydrated: true,
-            __sourceCollection: hasNewUser ? 'newUsers' : 'users',
+            ...(snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {}),
+            photos: [],
+            __photosHydrated: false,
+            __sourceCollection: sourceName,
           };
           return [id, data];
-        })
-      )
+        });
+      })
     );
     const result = {};
     snaps.forEach(entry => {
@@ -1533,6 +1540,8 @@ export const fetchUsersByIds = async ids => {
     return {};
   }
 };
+
+export const lazyLoadProfilePhotos = async userId => getAllUserPhotos(userId);
 
 const addUserFromUsers = async (userId, users) => {
   const userSnap = await get(ref2(database, `users/${userId}`));

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,12 +1,12 @@
 import { getCacheKey } from 'hooks/cardsCache';
 import { updateCard, addCardToList, removeCardFromList } from './cardsStorage';
-import { setIdsForQuery, CARDS_KEY, QUERIES_KEY } from './cardIndex';
+import { setIdsForQuery, resetMatchingLocalStorageCache } from './cardIndex';
 
 export { getCacheKey };
 
 // Clears cached cards and queries from localStorage
 export const clearAllCardsCache = () => {
-  [CARDS_KEY, QUERIES_KEY].forEach(key => localStorage.removeItem(key));
+  resetMatchingLocalStorageCache('clearAllCardsCache');
 };
 
 let favoriteIds = {};

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -7,6 +7,97 @@ export const INDEX_QUERIES_KEY = 'matchingIndexQueries';
 export const TTL_MS = CACHE_TTL_MS;
 export const MATCHING_INDEX_TTL_MS = MATCHING_PERFORMANCE_CACHE_TTL_MS;
 
+export const CARDS_CACHE_VERSION = 2;
+export const MATCHING_CACHE_MAX_CHARS = 4 * 1024 * 1024;
+const MATCHING_LOCAL_STORAGE_KEYS = new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY]);
+const localJsonCache = new Map();
+const pendingSaveTimers = new Map();
+const pendingSaveValues = new Map();
+
+const getMatchingLoadStats = () => {
+  if (typeof window === 'undefined') return null;
+  if (!window.matchingLoadStats || typeof window.matchingLoadStats !== 'object') {
+    window.matchingLoadStats = {};
+  }
+  return window.matchingLoadStats;
+};
+
+export const incrementMatchingLoadStat = (key, amount = 1) => {
+  const stats = getMatchingLoadStats();
+  if (!stats || !key) return;
+  stats[key] = (Number(stats[key]) || 0) + amount;
+};
+
+const estimateMb = value => ((String(value || '').length * 2) / (1024 * 1024));
+
+const shouldGuardMatchingCacheKey = key => MATCHING_LOCAL_STORAGE_KEYS.has(key);
+
+const logMatchingCacheWarning = (message, rows = []) => {
+  console.warn(`[matchingCache] ${message}`, rows);
+  if (typeof console.table === 'function' && rows.length) {
+    console.table(rows);
+  }
+};
+
+export const getMatchingLocalStorageCacheStats = () => {
+  if (typeof localStorage === 'undefined') return [];
+  const keys = [CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY]
+    .concat(Object.keys(localStorage).filter(key => key.toLowerCase().includes('matching')));
+  return [...new Set(keys)].map(key => {
+    const value = localStorage.getItem(key) || '';
+    return {
+      key,
+      stringLength: value.length,
+      approxMb: Number(estimateMb(value).toFixed(3)),
+    };
+  });
+};
+
+export const logMatchingLocalStorageCacheStats = (reason = 'snapshot') => {
+  const rows = getMatchingLocalStorageCacheStats();
+  const stats = getMatchingLoadStats();
+  if (stats) {
+    const cardsRow = rows.find(row => row.key === CARDS_KEY);
+    stats.localStorageCacheSizeMb = cardsRow?.approxMb || 0;
+  }
+  console.info(`[matchingCache] localStorage ${reason}`, rows);
+  if (typeof console.table === 'function') console.table(rows);
+  return rows;
+};
+
+const resetMatchingStorageKey = key => {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore storage reset errors
+  }
+  localJsonCache.delete(key);
+  pendingSaveValues.delete(key);
+  const timer = pendingSaveTimers.get(key);
+  if (timer) clearTimeout(timer);
+  pendingSaveTimers.delete(key);
+};
+
+export const resetMatchingLocalStorageCache = (reason = 'manual') => {
+  const rows = getMatchingLocalStorageCacheStats();
+  [CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY].forEach(resetMatchingStorageKey);
+  logMatchingCacheWarning(`reset ${reason}`, rows);
+  return rows;
+};
+
+const unwrapVersionedCards = value => {
+  if (!value || typeof value !== 'object') return {};
+  if (value.__cacheVersion !== CARDS_CACHE_VERSION) return null;
+  return value.items && typeof value.items === 'object' ? value.items : {};
+};
+
+const wrapVersionedCards = cards => ({
+  __cacheVersion: CARDS_CACHE_VERSION,
+  cachedAt: Date.now(),
+  items: cards && typeof cards === 'object' ? cards : {},
+});
+
+
 const toTimestamp = value => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -23,23 +114,72 @@ const getEntryCacheTimestamp = entry => {
 };
 
 const loadJson = key => {
+  if (localJsonCache.has(key)) return localJsonCache.get(key);
   try {
-    return JSON.parse(localStorage.getItem(key)) || {};
+    incrementMatchingLoadStat('localStorageReads');
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      localJsonCache.set(key, {});
+      return {};
+    }
+    if (shouldGuardMatchingCacheKey(key) && raw.length > MATCHING_CACHE_MAX_CHARS) {
+      logMatchingCacheWarning(`skip oversized key ${key}`, [{ key, stringLength: raw.length, approxMb: Number(estimateMb(raw).toFixed(3)) }]);
+      resetMatchingStorageKey(key);
+      localJsonCache.set(key, {});
+      return {};
+    }
+    const parsed = JSON.parse(raw) || {};
+    localJsonCache.set(key, parsed);
+    return parsed;
   } catch {
+    if (shouldGuardMatchingCacheKey(key)) resetMatchingStorageKey(key);
+    localJsonCache.set(key, {});
     return {};
   }
 };
 
-const saveJson = (key, value) => {
+const flushSaveJson = key => {
+  const value = pendingSaveValues.get(key);
+  pendingSaveValues.delete(key);
+  pendingSaveTimers.delete(key);
   try {
-    localStorage.setItem(key, JSON.stringify(value));
+    const stringified = JSON.stringify(value);
+    if (shouldGuardMatchingCacheKey(key) && stringified.length > MATCHING_CACHE_MAX_CHARS) {
+      logMatchingCacheWarning(`skip writing oversized key ${key}`, [{ key, stringLength: stringified.length, approxMb: Number(estimateMb(stringified).toFixed(3)) }]);
+      resetMatchingStorageKey(key);
+      return;
+    }
+    incrementMatchingLoadStat('localStorageWrites');
+    localStorage.setItem(key, stringified);
   } catch {
     // ignore write errors
   }
 };
 
-export const loadCards = () => loadJson(CARDS_KEY);
-export const saveCards = cards => saveJson(CARDS_KEY, cards);
+const saveJson = (key, value, { debounceMs = 0 } = {}) => {
+  localJsonCache.set(key, value);
+  if (!debounceMs) {
+    pendingSaveValues.set(key, value);
+    flushSaveJson(key);
+    return;
+  }
+  pendingSaveValues.set(key, value);
+  const existingTimer = pendingSaveTimers.get(key);
+  if (existingTimer) clearTimeout(existingTimer);
+  pendingSaveTimers.set(key, setTimeout(() => flushSaveJson(key), debounceMs));
+};
+
+export const loadCards = () => {
+  const parsed = loadJson(CARDS_KEY);
+  const cards = unwrapVersionedCards(parsed);
+  if (cards === null) {
+    logMatchingCacheWarning('reset outdated cards cache', [{ key: CARDS_KEY, cacheVersion: parsed?.__cacheVersion || 'legacy' }]);
+    resetMatchingStorageKey(CARDS_KEY);
+    return {};
+  }
+  return cards;
+};
+export const saveCards = cards => saveJson(CARDS_KEY, wrapVersionedCards(cards), { debounceMs: 800 });
 
 export const loadQueries = () => loadJson(QUERIES_KEY);
 export const saveQueries = queries => saveJson(QUERIES_KEY, queries);
@@ -83,6 +223,27 @@ export const serializeQueryFilters = filters => {
   return JSON.stringify(canonical || {});
 };
 
+
+const HEAVY_CARD_CACHE_KEYS = new Set([
+  'photos',
+  'photoUrls',
+  'avatarUrls',
+  'medicationPhotos',
+  '__photosHydrated',
+  '__fromCardCache',
+  'duplicate',
+]);
+
+export const sanitizeMatchingCardForCache = card => {
+  if (!card || typeof card !== 'object') return card;
+  return Object.entries(card).reduce((acc, [key, value]) => {
+    if (HEAVY_CARD_CACHE_KEYS.has(key)) return acc;
+    if (key.startsWith('__') && key !== '__sourceCollection' && key !== '__matchingAccessAllowed') return acc;
+    acc[key] = value;
+    return acc;
+  }, {});
+};
+
 export const normalizeQueryKey = raw => {
   if (Array.isArray(raw)) {
     return raw.map(s => s.toLowerCase().trim()).sort().join(',');
@@ -111,17 +272,19 @@ export const saveCard = card => {
   const cards = loadCards();
   const existing = cards[card.userId] || {};
   const now = Date.now();
+  const sanitizedCard = sanitizeMatchingCardForCache(card);
   const merged = {
-    ...existing,
-    ...card,
+    ...sanitizeMatchingCardForCache(existing),
+    ...sanitizedCard,
     userId: card.userId,
     cachedAt: now,
+    cacheVersion: CARDS_CACHE_VERSION,
   };
   delete merged.id;
-  if (card.lastAction !== undefined) {
-    const normalized = normalizeLastAction(card.lastAction);
+  if (sanitizedCard.lastAction !== undefined) {
+    const normalized = normalizeLastAction(sanitizedCard.lastAction);
     merged.lastAction =
-      normalized !== undefined ? normalized : card.lastAction;
+      normalized !== undefined ? normalized : sanitizedCard.lastAction;
   }
   cards[card.userId] = merged;
   saveCards(cards);

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -7,6 +7,8 @@ import {
   TTL_MS,
   saveCard as indexSaveCard,
   getQueryEntry,
+  sanitizeMatchingCardForCache,
+  CARDS_CACHE_VERSION,
 } from './cardIndex';
 import { normalizeLastAction } from './normalizeLastAction';
 
@@ -108,7 +110,7 @@ const removeNestedValue = (current, segments, depth = 0) => {
 
 export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
   const cards = loadCards();
-  const existing = cards[cardId] || {};
+  const existing = sanitizeMatchingCardForCache(cards[cardId] || {});
   const explicitRemovals = data && typeof data === 'object'
     ? Object.keys(data).filter(key => data[key] === null)
     : [];
@@ -120,13 +122,14 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
     .filter(key => key && key !== 'userId');
   const sanitizedData =
     data && typeof data === 'object'
-      ? Object.fromEntries(Object.entries(data).filter(([, value]) => value !== null))
+      ? sanitizeMatchingCardForCache(Object.fromEntries(Object.entries(data).filter(([, value]) => value !== null)))
       : data;
   let updatedCard = {
     ...existing,
     ...sanitizedData,
     userId: cardId,
     cachedAt: Date.now(),
+    cacheVersion: CARDS_CACHE_VERSION,
   };
   delete updatedCard.id;
   if (Object.prototype.hasOwnProperty.call(updatedCard, 'duplicate')) {
@@ -207,9 +210,10 @@ export const getCardsByList = async (listKey, remoteFetch) => {
           const { id: _, ...rest } = fresh;
           const now = Date.now();
           const card = {
-            ...rest,
+            ...sanitizeMatchingCardForCache(rest),
             userId: id,
             cachedAt: now,
+            cacheVersion: CARDS_CACHE_VERSION,
           };
           if (rest.lastAction !== undefined) {
             const normalized = normalizeLastAction(rest.lastAction);

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -286,7 +286,7 @@ export const fetchMatchingIndexedCandidates = async ({
   });
 
   const readCachedPage = () => {
-    if (!useIndexIdCache) return null;
+    if (!useIndexIdCache || collectionSource === 'newUsers') return null;
     const cachedIds = getIndexIdsByQuery(cacheKey);
     if (!Array.isArray(cachedIds)) return null;
     const sliced = sliceIndexedBaseIds({ ids: cachedIds, offset: safeOffset, limit: safeLimit, excludedSet });
@@ -318,19 +318,14 @@ export const fetchMatchingIndexedCandidates = async ({
       searchKeySetsOfExactUser: searchKeySetKeys,
       fetchMissingBuckets: true,
       requireSearchKeySetKeys: true,
-      resultOffset: 0,
-      resultLimit: Number.POSITIVE_INFINITY,
+      resultOffset: safeOffset,
+      resultLimit: safeLimit,
       additionalFilterBucketGroups: filterGroups,
-      excludedUserIds: [],
+      excludedUserIds: [...excludedSet],
     });
-    const allUserIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
-    if (useIndexIdCache) setIndexIdsForQuery(cacheKey, allUserIds);
-    const { pageIds: userIds, nextOffset, hasMore } = sliceIndexedBaseIds({
-      ids: allUserIds,
-      offset: safeOffset,
-      limit: safeLimit,
-      excludedSet,
-    });
+    const userIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
+    const nextOffset = Number.isFinite(Number(indexed?.nextOffset)) ? indexed.nextOffset : safeOffset + userIds.length;
+    const hasMore = Boolean(indexed?.hasMore);
     const users = await hydrateOrderedUsers({ ids: userIds, hydrateUsersByIds, collectionSource });
     return {
       usedIndex: true,
@@ -647,8 +642,8 @@ export const fetchNewUsersByIdsForMatching = async ({
   getAllUserPhotos,
 }) => {
   if (!Array.isArray(ids) || ids.length === 0) return [];
-  if (typeof get !== 'function' || typeof ref !== 'function' || !database || typeof getAllUserPhotos !== 'function') {
-    throw new Error('fetchNewUsersByIdsForMatching requires get, ref, database and getAllUserPhotos dependencies');
+  if (typeof get !== 'function' || typeof ref !== 'function' || !database) {
+    throw new Error('fetchNewUsersByIdsForMatching requires get, ref and database dependencies');
   }
 
   const uniqueIds = [...new Set(ids.filter(Boolean))];
@@ -660,16 +655,13 @@ export const fetchNewUsersByIdsForMatching = async ({
     const chunkIds = uniqueIds.slice(offset, offset + safeBatchSize);
     const chunkSnapshots = await Promise.all(
       chunkIds.map(async userId => {
-        const [snapshot, photos] = await Promise.all([
-          get(ref(database, `newUsers/${userId}`)),
-          getAllUserPhotos(userId),
-        ]);
+        const snapshot = await get(ref(database, `newUsers/${userId}`));
         if (!snapshot.exists()) return null;
         return {
           userId,
           ...(snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {}),
-          photos: Array.isArray(photos) ? photos : [],
-          __photosHydrated: true,
+          photos: [],
+          __photosHydrated: false,
           __sourceCollection: 'newUsers',
         };
       })

--- a/src/utils/matchingIndexedLoadMore.js
+++ b/src/utils/matchingIndexedLoadMore.js
@@ -18,9 +18,13 @@ export const collectMatchingIndexedLoadMorePage = async ({
   let finalHasMore = false;
   let cursorStuck = false;
   let pageCalls = 0;
+  let stopReason = '';
 
   while (collected.length < requestedLimit && pageCalls < maxPages) {
     pageCalls += 1;
+    if (typeof window !== 'undefined' && window.matchingLoadStats) {
+      window.matchingLoadStats.backfillPages = (Number(window.matchingLoadStats.backfillPages) || 0) + 1;
+    }
     const collectedUserIds = collected.map(user => user?.userId).filter(Boolean);
     const excludeIds = new Set([
       ...baseExclude,
@@ -62,11 +66,23 @@ export const collectMatchingIndexedLoadMorePage = async ({
     finalOffset = nextOffset;
     finalHasMore = lastHasMore;
 
-    if (!lastHasMore) break;
-    if (cursorStuck) break;
+    if (!indexedUsers.length) {
+      stopReason = indexed.userIds?.length ? 'no_visible_cards_added' : 'empty_index_page';
+      break;
+    }
+    if (!lastHasMore) {
+      stopReason = 'source_exhausted';
+      break;
+    }
+    if (cursorStuck) {
+      stopReason = 'cursor_not_advanced';
+      break;
+    }
 
     offset = nextOffset;
   }
+
+  if (!stopReason && pageCalls >= maxPages && collected.length < requestedLimit) stopReason = 'max_pages_reached';
 
   return {
     collected,
@@ -75,5 +91,6 @@ export const collectMatchingIndexedLoadMorePage = async ({
     cursorStuck,
     pageCalls,
     stale: false,
+    stopReason: stopReason || 'target_reached',
   };
 };

--- a/src/utils/matchingSourceBackfill.js
+++ b/src/utils/matchingSourceBackfill.js
@@ -9,6 +9,7 @@ export const collectFilteredMatchingSourceCards = async ({
   isSameCursor = (a, b) => a === b,
   getSourceLimit,
   onPart,
+  maxPages = 2,
 }) => {
   const visibleTarget = Math.max(1, Number(targetVisibleCount) || 1);
   const collected = [];
@@ -17,9 +18,13 @@ export const collectFilteredMatchingSourceCards = async ({
   let cursorAdvanced = false;
   let excludedCount = 0;
   let loadedPages = 0;
+  let stopReason = '';
 
-  while (collected.length < visibleTarget && sourceHasMore) {
+  while (collected.length < visibleTarget && sourceHasMore && loadedPages < maxPages) {
     loadedPages += 1;
+    if (typeof window !== 'undefined' && window.matchingLoadStats) {
+      window.matchingLoadStats.backfillPages = (Number(window.matchingLoadStats.backfillPages) || 0) + 1;
+    }
     const remaining = visibleTarget - collected.length;
     const sourceLimit = getSourceLimit
       ? getSourceLimit({ remaining, exclude, collected, loadedPages })
@@ -63,10 +68,21 @@ export const collectFilteredMatchingSourceCards = async ({
     sourceHasMore = Boolean(sourceRes?.hasMore) && cursorAdvanced;
     cursor = nextCursor;
 
-    if (!sourceRes?.hasMore || !nextCursor || !cursorAdvanced) {
+    if (!sourceRes?.hasMore) {
+      stopReason = validSlice.length ? 'source_exhausted' : 'no_visible_cards_added';
+      break;
+    }
+    if (!nextCursor || !cursorAdvanced) {
+      stopReason = 'cursor_not_advanced';
+      break;
+    }
+    if (!validSlice.length) {
+      stopReason = 'no_visible_cards_added';
       break;
     }
   }
+
+  if (!stopReason && loadedPages >= maxPages && collected.length < visibleTarget) stopReason = 'max_pages_reached';
 
   return {
     users: collected,
@@ -76,5 +92,6 @@ export const collectFilteredMatchingSourceCards = async ({
     cursorAdvanced,
     excludedCount,
     loadedPages,
+    stopReason: stopReason || (collected.length ? 'target_reached' : 'no_visible_cards_added'),
   };
 };

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -914,9 +914,10 @@ export const getIndexedNewUsersIdsByRules = async ({
   fetchMissingBuckets = false,
   requireSearchKeySetKeys = true,
   resultOffset = 0,
-  resultLimit = Number.POSITIVE_INFINITY,
+  resultLimit = 100,
   additionalFilterBucketGroups = [],
   excludedUserIds = [],
+  candidateUserIds = null,
   debugMatchingFlow = false,
   debugToast,
 }) => {
@@ -1075,7 +1076,7 @@ export const getIndexedNewUsersIdsByRules = async ({
   const numericResultLimit = Number(resultLimit);
   const safeResultLimit = Number.isFinite(numericResultLimit)
     ? Math.max(0, numericResultLimit)
-    : Number.POSITIVE_INFINITY;
+    : 100;
 
   for (const entry of setEntries) {
     const filterSets = [];
@@ -1168,16 +1169,22 @@ export const getIndexedNewUsersIdsByRules = async ({
   }
 
   const excludedUserIdsSet = new Set((Array.isArray(excludedUserIds) ? excludedUserIds : [...(excludedUserIds || [])]).filter(Boolean));
-  const finalUserIds = [...matchedUserIds].filter(userId => !excludedUserIdsSet.has(userId));
+  const candidateUserIdsSet = Array.isArray(candidateUserIds) || candidateUserIds instanceof Set
+    ? new Set((Array.isArray(candidateUserIds) ? candidateUserIds : [...candidateUserIds]).filter(Boolean))
+    : null;
+  const finalUserIds = [...matchedUserIds].filter(userId => (
+    !excludedUserIdsSet.has(userId) && (!candidateUserIdsSet || candidateUserIdsSet.has(userId))
+  ));
   emitDebug('final userIds before pagination', {
     userIds: finalUserIds,
     count: finalUserIds.length,
     excludedCount: excludedUserIdsSet.size,
+    candidateCount: candidateUserIdsSet?.size || 0,
   });
 
   const pageUserIds = finalUserIds.slice(
     safeResultOffset,
-    safeResultLimit === Number.POSITIVE_INFINITY ? undefined : safeResultOffset + safeResultLimit
+    safeResultOffset + safeResultLimit
   );
   const nextOffset = safeResultOffset + pageUserIds.length;
   const hasMore = nextOffset < finalUserIds.length;


### PR DESCRIPTION
### Motivation

- Reduce excessive localStorage usage and crashes by guarding and versioning the matching card cache and making cache writes debounced and observable. 
- Improve visibility into backend/storage usage and load performance with lightweight instrumentation for matching reads, storage calls and cache operations. 
- Defer heavy photo fetches to avoid blocking initial render and reduce unnecessary downloads by lazy-loading profile photos for the active/next profiles. 
- Make indexed/backfill load behavior more conservative and robust to avoid long-running or stuck paginated loads.

### Description

- Added matching load statistics utilities (`incrementMatchingLoadStat`, `logMatchingLocalStorageCacheStats`, `window.matchingLoadStats`) and instrumented key read/write points including wrapped Firebase `get`, `listAll` and `getDownloadURL` calls. 
- Reworked localStorage cache handling in `cardIndex.js` to support cache versioning (`CARDS_CACHE_VERSION`), in-memory JSON cache, oversized-key guards, debounced writes, `resetMatchingLocalStorageCache`, and `sanitizeMatchingCardForCache` to strip heavy fields before storing. 
- Updated card storage flow (`cardsStorage.js`, `config.js`) to persist versioned/sanitized cards, and added `fetchUsersByIds` signature to accept `collectionSource` and return cards with lazy photo hydration; exported `lazyLoadProfilePhotos` from `config`. 
- Implemented lazy photo loading in `Matching.jsx` with `photoCacheByUserId`, `lazyLoadProfilePhotos` usage, a photo-hydration helper, and stats increments for photo lazy loads. 
- Tuned load-more/backfill/indexed logic: reduced indexed/backfill max pages, added explicit `stopReason` fields for diagnostics, added `MATCHING_AUTO_LOAD_MORE_COOLDOWN_MS` and `MATCHING_MAX_EMPTY_AUTO_LOAD_MORE_ATTEMPTS` with an auto-load-more runner that tracks visible cards added and empty attempts. 
- Miscellaneous: adjusted several fetch calls to pass `collectionSource`, updated `fetchNewUsersByIdsForMatching` and related index pagination limits and candidate filtering to support candidate lists and safer defaults.

### Testing

- Ran the test suite with `yarn test` and all unit tests passed. 
- Ran linter with `yarn lint` and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0879ac77a883268c8756f00b21dbad)