### PR TITLE
Fix newUsers indexed pagination exclusions

### DIFF
--- a/src/utils/__tests__/matchingDataProvider.indexCache.test.js
+++ b/src/utils/__tests__/matchingDataProvider.indexCache.test.js
@@ -110,3 +110,74 @@ describe('fetchMatchingIndexedCandidates card hydration cache', () => {
     expect(result.users[0].photos).toBeUndefined();
   });
 });
+
+describe('fetchMatchingIndexedCandidates newUsers pagination', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('keeps newUsers offsets on the unfiltered index cursor when excluding loaded ids', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const baseIds = ['newA', 'newB', 'newC', 'newD', 'newE'];
+    const newUsersIndexReader = jest.fn(async ({ resultOffset = 0, resultLimit = 1, excludedUserIds = [] }) => {
+      const excludedSet = new Set(excludedUserIds);
+      const filteredIds = baseIds.filter(id => !excludedSet.has(id));
+      const userIds = filteredIds.slice(resultOffset, resultOffset + resultLimit);
+      return {
+        userIds,
+        nextOffset: resultOffset + userIds.length,
+        hasMore: resultOffset + userIds.length < filteredIds.length,
+      };
+    });
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));
+
+    const result = await fetchMatchingIndexedCandidates({
+      collectionSource: 'newUsers',
+      rawRules: 'role is ag',
+      accessUserId: 'viewer-1',
+      searchKeySetKeys: ['viewer-1:set-1'],
+      offset: 2,
+      limit: 2,
+      excludeIds: ['newA', 'newB'],
+      hydrateUsersByIds,
+      newUsersIndexReader,
+    });
+
+    expect(newUsersIndexReader).toHaveBeenCalledWith(expect.not.objectContaining({
+      excludedUserIds: expect.anything(),
+    }));
+    expect(result.userIds).toEqual(['newC', 'newD']);
+    expect(result.nextOffset).toBe(4);
+    expect(result.hasMore).toBe(true);
+    expect(hydrateUsersByIds).toHaveBeenCalledWith(['newC', 'newD']);
+  });
+
+  it('filters explicitly excluded newUsers returned from the current cursor page without advancing the cursor twice', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const newUsersIndexReader = jest.fn(async () => ({
+      userIds: ['newA', 'newB'],
+      nextOffset: 2,
+      hasMore: true,
+    }));
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));
+
+    const result = await fetchMatchingIndexedCandidates({
+      collectionSource: 'newUsers',
+      rawRules: 'role is ag',
+      accessUserId: 'viewer-1',
+      searchKeySetKeys: ['viewer-1:set-1'],
+      offset: 0,
+      limit: 2,
+      excludeIds: ['newB'],
+      hydrateUsersByIds,
+      newUsersIndexReader,
+    });
+
+    expect(result.userIds).toEqual(['newA']);
+    expect(result.nextOffset).toBe(2);
+    expect(result.hasMore).toBe(true);
+    expect(hydrateUsersByIds).toHaveBeenCalledWith(['newA']);
+  });
+});

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -321,10 +321,10 @@ export const fetchMatchingIndexedCandidates = async ({
       resultOffset: safeOffset,
       resultLimit: safeLimit,
       additionalFilterBucketGroups: filterGroups,
-      excludedUserIds: [...excludedSet],
     });
-    const userIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
-    const nextOffset = Number.isFinite(Number(indexed?.nextOffset)) ? indexed.nextOffset : safeOffset + userIds.length;
+    const indexedUserIds = Array.isArray(indexed?.userIds) ? indexed.userIds : [];
+    const userIds = indexedUserIds.filter(id => id && !excludedSet.has(id));
+    const nextOffset = Number.isFinite(Number(indexed?.nextOffset)) ? indexed.nextOffset : safeOffset + indexedUserIds.length;
     const hasMore = Boolean(indexed?.hasMore);
     const users = await hydrateOrderedUsers({ ids: userIds, hydrateUsersByIds, collectionSource });
     return {


### PR DESCRIPTION
### Motivation

- A pagination bug caused newUsers profiles to be skipped when `excludeIds` (already-loaded ids) were passed into the indexed reader while also using the stored cursor `offset`, because the reader applied exclusions before paginating the offset. 
- The change preserves the index reader's unfiltered cursor behavior so offsets remain aligned with the underlying index order.

### Description

- Stop passing `excludedUserIds` into the `newUsersIndexReader` call when `collectionSource === 'newUsers'` and instead read the raw indexed page without exclusions. 
- After receiving the indexed page, filter `indexedUserIds` by the local `excludedSet` to produce the returned `userIds`, while computing `nextOffset` from the unfiltered `indexedUserIds` so the index cursor is preserved. 
- Added two regression tests to `src/utils/__tests__/matchingDataProvider.indexCache.test.js` that cover (1) keeping offsets when excluding already-loaded newUsers and (2) filtering excluded IDs returned on the current page without advancing the cursor twice. 
- Included a concise commit and PR description summarizing the fix and added tests.

### Testing

- Ran the focused test file with `npm test -- --runInBand src/utils/__tests__/matchingDataProvider.indexCache.test.js --watchAll=false` and all tests in the suite passed. 
- Ran the linter with `npm run lint:js -- src/utils/matchingDataProvider.js src/utils/__tests__/matchingDataProvider.indexCache.test.js` and it completed without errors relevant to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08941e1c508326b2a884755d8ea213)