### PR TITLE
Fix searchKeySet rule index matching

### DIFF
--- a/src/utils/__tests__/newUsersFilterSetsIndex.test.js
+++ b/src/utils/__tests__/newUsersFilterSetsIndex.test.js
@@ -77,6 +77,43 @@ describe('getIndexedNewUsersIdsByRules searchKeySets access scope', () => {
     );
   });
 
+  it('matches explicit searchKeySet keys to their rule input index for reaction candidates', async () => {
+    const { getIndexedNewUsersIdsByRules } = loadModule();
+    const viewerId = 'S0VhDLCYjuTFDNLalRa85u7fPcg2';
+    const rules = [
+      'role: ed',
+      'csection: cs0',
+      'userId: id',
+      'reaction: no',
+    ];
+    const existingBuckets = new Map([
+      [`searchKeySets/${viewerId}_3/userId/id`, { ID0001: true }],
+    ]);
+
+    mockFirebaseGet.mockImplementation(path => Promise.resolve(
+      existingBuckets.has(path)
+        ? makeSnapshot(true, existingBuckets.get(path))
+        : makeSnapshot(false)
+    ));
+
+    const result = await getIndexedNewUsersIdsByRules({
+      rawRules: rules,
+      accessUserId: viewerId,
+      searchKeySetKeys: [`${viewerId}_1`, `${viewerId}_2`, `${viewerId}_3`, `${viewerId}_4`],
+      candidateUserIds: ['ID0001'],
+      resultLimit: 1,
+    });
+
+    expect(result.userIds).toEqual(['ID0001']);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_1/role/ed`);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_2/csection/cs0`);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_3/userId/id`);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_4/reaction/no`);
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_1/userId/id`);
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_2/userId/id`);
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, `searchKeySets/${viewerId}_4/userId/id`);
+  });
+
   it('returns empty and does not fallback to global searchKey when setKey buckets are absent', async () => {
     const { getIndexedNewUsersIdsByRules } = loadModule();
 

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -57,6 +57,17 @@ const normalizePathSegment = value => {
 const normalizeSearchKeySetKey = value =>
   normalizePathSegment(String(value || '').trim().replace(/^\/?searchKeySets\//, ''));
 
+const getSearchKeySetInputIndex = (setKey, accessUserId = '') => {
+  const normalizedOwnerId = String(accessUserId || '').trim();
+  const normalizedSetKey = normalizeSearchKeySetKey(setKey);
+  const ownerPrefix = normalizedOwnerId ? `${normalizedOwnerId}${SET_KEY_INDEX_SEPARATOR}` : '';
+  if (!normalizedSetKey || !ownerPrefix || !normalizedSetKey.startsWith(ownerPrefix)) return null;
+
+  const rawIndex = normalizedSetKey.slice(ownerPrefix.length);
+  const numericIndex = Number(rawIndex);
+  return Number.isInteger(numericIndex) && numericIndex > 0 ? numericIndex : null;
+};
+
 export const normalizeSearchKeySetKeys = rawKeys => {
   const collect = value => {
     if (!value) return [];
@@ -1015,9 +1026,13 @@ export const getIndexedNewUsersIdsByRules = async ({
   });
 
   const setEntries = ruleBucketEntries.flatMap(entry => {
-    const setKeys = explicitSetKeys.length ? explicitSetKeys : [entry.defaultSetKey];
+    const setKeys = explicitSetKeys.length
+      ? explicitSetKeys.filter(setKey => getSearchKeySetInputIndex(setKey, normalizedAccessUserId) === entry.inputIndex)
+      : [entry.defaultSetKey];
+
     return [...new Set(setKeys.filter(Boolean))].map(setKey => ({
       setKey,
+      inputIndex: entry.inputIndex,
       indexBuckets: entry.indexBuckets,
       additionalFilterBucketGroups,
     }));


### PR DESCRIPTION
### Motivation
- Виправити помилку, коли явні `searchKeySet` ключі комбінувалися з усіма наборами правил замість прив’язки кожного ключа до відповідного номера правила, через що кандидат `ID0001` фільтрувався неправильно.

### Description
- Додано хелпер `getSearchKeySetInputIndex` для витягання `inputIndex` з імені setKey і валідації префіксу власника в `src/utils/newUsersFilterSetsIndex.js`.
- При побудові `setEntries` тепер при наявності explicit `searchKeySetKeys` кожен `ruleBucketEntry` фільтрує ключі за `inputIndex`, а не комбінує їх з усіма правилами, і `inputIndex` зберігається в записі set.
- Додано регресійний тест, що відтворює випадок viewer з `_1`..`_4` де `ID0001` існує тільки в `_3`, перевіряючи читання правильних путів і результуюче включення `ID0001` в `userIds` в `src/utils/__tests__/newUsersFilterSetsIndex.test.js`.
- Змінені файли: `src/utils/newUsersFilterSetsIndex.js` та `src/utils/__tests__/newUsersFilterSetsIndex.test.js`.

### Testing
- Запущено unit-тести командою `CI=true npm test -- --runTestsByPath src/utils/__tests__/newUsersFilterSetsIndex.test.js --runInBand` і всі тести в цьому файлі пройшли успішно.
- Прогнано `npx eslint src/utils/newUsersFilterSetsIndex.js src/utils/__tests__/newUsersFilterSetsIndex.test.js` без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a423024883268afdd50c9bb97696)