### PR TITLE
Fix reaction-tab filtering and reaction page loading deduplication

### DIFF
--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -588,24 +588,66 @@ export const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = nu
 
 const passthroughFilterMain = usersData => usersData;
 
+const isReactionViewMode = viewMode => viewMode === 'favorites' || viewMode === 'dislikes';
+
+const getFilterMainInputsForMatchingView = ({
+  filters,
+  favoriteUsers = {},
+  dislikeUsers = {},
+  viewMode = 'default',
+} = {}) => {
+  const filterMainFilters = getMatchingFiltersWithoutSearchKeyGroups(filters);
+
+  if (!isReactionViewMode(viewMode)) {
+    return {
+      filterMainFilters,
+      filterMainFavoriteUsers: favoriteUsers,
+      filterMainDislikeUsers: dislikeUsers,
+    };
+  }
+
+  // Reaction tabs already scope the candidate list by the selected reaction map.
+  // Do not let default-deck reaction filters (favorite.favOnly/reaction) or
+  // favorite/dislike maps remove the very cards the active tab is supposed to show.
+  const reactionSafeFilters = { ...filterMainFilters };
+  delete reactionSafeFilters.favorite;
+  delete reactionSafeFilters.reaction;
+  return {
+    filterMainFilters: reactionSafeFilters,
+    filterMainFavoriteUsers: {},
+    filterMainDislikeUsers: {},
+  };
+};
+
 export const applyMatchingUiFiltersToUsers = ({
   users,
   filters,
-  favoriteUsers,
-  dislikeUsers,
+  favoriteUsers = {},
+  dislikeUsers = {},
   excludeReactionUsers = false,
   roleIndexSets,
   collectionSource,
   viewMode = 'default',
   filterMainFn = passthroughFilterMain,
-}) =>
-  applyMatchingSearchKeyFilters(
+}) => {
+  const {
+    filterMainFilters,
+    filterMainFavoriteUsers,
+    filterMainDislikeUsers,
+  } = getFilterMainInputsForMatchingView({
+    filters,
+    favoriteUsers,
+    dislikeUsers,
+    viewMode,
+  });
+
+  return applyMatchingSearchKeyFilters(
     filterMainFn(
       users.map(u => [u.userId, u]),
       null,
-      getMatchingFiltersWithoutSearchKeyGroups(filters),
-      favoriteUsers,
-      dislikeUsers
+      filterMainFilters,
+      filterMainFavoriteUsers,
+      filterMainDislikeUsers
     )
       .map(([, u]) => u)
       .filter(u => (
@@ -615,10 +657,10 @@ export const applyMatchingUiFiltersToUsers = ({
     filters,
     roleIndexSets
   ).filter(u => (
-    viewMode === 'favorites' ||
-    viewMode === 'dislikes' ||
+    isReactionViewMode(viewMode) ||
     isAllowedIdForMatchingCollection(u.userId, collectionSource)
   ));
+};
 
 export const getActiveMatchingFiltersDebug = filters => Object.entries(filters || {}).reduce((acc, [key, value]) => {
   if (value && typeof value === 'object' && !Array.isArray(value)) {

--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -314,13 +314,16 @@ export const loadReactionCardsPageRecords = async ({
       .filter(Boolean)
       .filter(user => user?.userId && !loadedIds.has(user.userId));
 
+    const idsProcessedOnPage = new Set(page.pageIds.filter(Boolean));
+    const idsLoadedBeforeFiltering = new Set(loadedIds);
     const filteredUsers = filterUsers(mappedUsers) || [];
     filteredUsers.forEach(user => {
-      if (collected.length < safeLimit && user?.userId && !loadedIds.has(user.userId)) {
-        loadedIds.add(user.userId);
+      if (collected.length < safeLimit && user?.userId && !idsLoadedBeforeFiltering.has(user.userId)) {
         collected.push(user);
       }
     });
+
+    idsProcessedOnPage.forEach(id => loadedIds.add(id));
 
     if (!page.hasMore) break;
   }


### PR DESCRIPTION
### Motivation
- Ensure favorite/dislike (reaction) view modes show the expected candidate cards by preventing deck-level reaction filters from removing the cards that the reaction tabs are meant to display. 
- Prevent skipping or incorrect deduplication when loading pages of reaction cards by making `loadedIds` handling consistent across page processing.

### Description
- Added `isReactionViewMode` and `getFilterMainInputsForMatchingView` to compute safe filter inputs for reaction tabs, stripping `favorite`/`reaction` filters and clearing reaction maps when `viewMode` is `favorites` or `dislikes`. 
- Updated `applyMatchingUiFiltersToUsers` to use the new helper and to default `favoriteUsers`/`dislikeUsers` to empty maps, then call `applyMatchingSearchKeyFilters` with the adjusted inputs. 
- Modified reaction page loading in `loadReactionCardsPageRecords` to collect `idsProcessedOnPage` and snapshot `idsLoadedBeforeFiltering`, only adding users to `collected` if they weren't present before filtering, and then mark all processed page ids as loaded after filtering to avoid race/skipping. 
- Preserved existing behavior for other view modes and kept final collection filtering aligned with the new `isReactionViewMode` check.

### Testing
- Ran unit tests via `yarn test` and existing test suites related to matching and reactions, and they passed. 
- Ran linter via `yarn lint` with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bfc07a508326a6ff9c5914af8d7e)