### PR TITLE
Fix Matching localStorage cache pollution

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -99,6 +99,11 @@ import FilterPanel from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { getCacheKey, clearAllCardsCache, setFavoriteIds } from "../utils/cache";
 import { incrementMatchingLoadStat, logMatchingLocalStorageCacheStats, normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard } from '../utils/cardIndex';
+import {
+  cleanupMatchingLocalStorageCache,
+  clearMatchingLocalStorageCache,
+  logMatchingLocalStorageDebugStats,
+} from '../utils/searchKeyCache';
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
@@ -1151,8 +1156,15 @@ const Matching = () => {
     };
   }, [collectionSource, currentAdditionalAccessRules, currentSearchKeySetKeys, ownerId]);
   useEffect(() => {
-    logMatchingLocalStorageCacheStats('matching mount');
-  }, []);
+    const debugMatchingCache = isAdmin || shouldDebugAdditionalMatching(ownerId);
+    const cleanupStats = cleanupMatchingLocalStorageCache({ debug: debugMatchingCache });
+
+    if (debugMatchingCache) {
+      logMatchingLocalStorageCacheStats('matching mount');
+      logMatchingLocalStorageDebugStats('matching mount');
+      console.info('[Matching cache] cleanup summary:', cleanupStats);
+    }
+  }, [isAdmin, ownerId]);
 
   useEffect(() => {
     window.history.scrollRestoration = 'manual';
@@ -2403,13 +2415,47 @@ const Matching = () => {
   }, [invalidateReactionAsyncWork, resetReactionPaginationState]);
 
   const resetFiltersAndCache = React.useCallback(() => {
+    const debugMatchingCache = isAdmin || shouldDebugAdditionalMatching(ownerId);
+    const removedLocalStorageKeys = clearMatchingLocalStorageCache({ debug: debugMatchingCache });
     localStorage.removeItem('matchingFilters');
     localStorage.removeItem(SEARCH_KEY);
     clearAllCardsCache();
+
+    emptyAutoLoadMoreAttemptsRef.current = 0;
+    autoLoadMoreSignatureRef.current = '';
+    loadingRef.current = false;
+    loadedIdsRef.current = new Set();
+    additionalRulesToastRef.current = '';
+    additionalProfileCacheRef.current = null;
+    additionalProfileRequestVersionRef.current += 1;
+    additionalMatchingFetchVersionRef.current += 1;
+    additionalLoadMoreFetchVersionRef.current += 1;
+    additionalMatchingApplyVersionRef.current += 1;
+    invalidateReactionAsyncWork();
+    resetReactionPaginationState();
+    filtersRef.current = {};
+    viewModeRef.current = 'default';
+    setFilters({});
+    setUsers([]);
+    setAdditionalNewUsers([]);
+    setAdditionalNextOffset(0);
+    setSharedReactionIds([]);
+    setSharedReactionCandidateUsers([]);
+    setPhotoCacheByUserId({});
+    setLastKey(null);
+    setHasMore(true);
+    setLoading(false);
+    setViewMode('default');
     setFilterResetToken(prev => prev + 1);
-    reloadDefault();
+
+    if (debugMatchingCache) {
+      console.info('[Matching cache] reset removed keys:', removedLocalStorageKeys);
+      logMatchingLocalStorageDebugStats('after reset');
+    }
+
+    loadInitial();
     toast.success('Фільтри та кеш скинуто');
-  }, [reloadDefault]);
+  }, [invalidateReactionAsyncWork, isAdmin, loadInitial, ownerId, resetReactionPaginationState]);
 
   const fetchReactionCardsByIds = React.useCallback(async ids => {
     const uniqueIds = [...new Set((ids || []).filter(Boolean))];

--- a/src/utils/searchKeyCache.js
+++ b/src/utils/searchKeyCache.js
@@ -1,39 +1,249 @@
-import { createCache } from 'hooks/cardsCache';
+import { CACHE_TTL_MS } from './cacheConstants';
 
-const { loadCache, saveCache } = createCache('searchKey');
+export const MATCHING_CACHE_VERSION = 'v2';
+export const MAX_LOCAL_CACHE_ITEM_BYTES = 3 * 1024 * 1024;
+
+const SEARCH_KEY_PREFIX = 'searchKey:';
+const TTL_MS = CACHE_TTL_MS;
 
 const normalizePath = path =>
   String(path || '')
     .trim()
     .replace(/^\/+/, '');
 
+const buildStorageKey = normalizedPath => `${SEARCH_KEY_PREFIX}${MATCHING_CACHE_VERSION}:${normalizedPath}`;
+const buildLegacyStorageKey = normalizedPath => `${SEARCH_KEY_PREFIX}${normalizedPath}`;
+
+export const isEmptyCachedValue = value => {
+  if (value == null) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+};
+
+const isValidPayloadForCache = payload => {
+  if (!payload || typeof payload !== 'object') return false;
+  if (payload.version && payload.version !== MATCHING_CACHE_VERSION) return false;
+  if (payload.exists !== true) return false;
+  return !isEmptyCachedValue(payload.value);
+};
+
+const normalizePayloadForCache = payload => ({
+  exists: true,
+  value: payload.value,
+  version: MATCHING_CACHE_VERSION,
+});
+
+const shouldTreatKeyAsMatchingCache = key => {
+  const normalized = String(key || '');
+  const lower = normalized.toLowerCase();
+  return (
+    normalized.startsWith(SEARCH_KEY_PREFIX) ||
+    normalized.includes('searchKeySets') ||
+    lower.includes('matching') ||
+    normalized.includes('additionalNewUsers') ||
+    normalized.includes('cardsCache') ||
+    normalized === 'cards' ||
+    normalized === 'queries' ||
+    normalized === 'matchingIndexQueries'
+  );
+};
+
+const isDailyBucketKey = key => /\/(age|lastAction)\/d_[^/]+/i.test(String(key || ''));
+
+const getStoredData = parsed => {
+  if (!parsed || typeof parsed !== 'object') return parsed;
+  if (Object.prototype.hasOwnProperty.call(parsed, 'data')) return parsed.data;
+  return parsed;
+};
+
+const isNegativeOrEmptyRecord = (key, parsed) => {
+  const data = getStoredData(parsed);
+  if (!data || typeof data !== 'object') return isDailyBucketKey(key) && isEmptyCachedValue(data);
+  if (data.exists === false) return true;
+  if (Object.prototype.hasOwnProperty.call(data, 'value') && isEmptyCachedValue(data.value)) return true;
+  if (isDailyBucketKey(key) && isEmptyCachedValue(data.value ?? data)) return true;
+  return false;
+};
+
+const safeRemoveItem = key => {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // localStorage cleanup is best-effort.
+  }
+};
+
+const readStorageRecord = storageKey => {
+  if (typeof localStorage === 'undefined') return null;
+
+  const raw = localStorage.getItem(storageKey);
+  if (!raw) return null;
+
+  if (raw.length > MAX_LOCAL_CACHE_ITEM_BYTES) {
+    console.warn('[Matching cache] cache item too large, removing:', storageKey, raw.length);
+    safeRemoveItem(storageKey);
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (TTL_MS && parsed?.timestamp && Date.now() - parsed.timestamp > TTL_MS) {
+      safeRemoveItem(storageKey);
+      return null;
+    }
+
+    const data = getStoredData(parsed);
+    if (!isValidPayloadForCache(data)) {
+      safeRemoveItem(storageKey);
+      return null;
+    }
+
+    return normalizePayloadForCache(data);
+  } catch {
+    safeRemoveItem(storageKey);
+    return null;
+  }
+};
+
+const writeStorageRecord = (storageKey, payload) => {
+  if (typeof localStorage === 'undefined') return;
+  if (!isValidPayloadForCache(payload)) return;
+
+  try {
+    const record = {
+      version: MATCHING_CACHE_VERSION,
+      data: normalizePayloadForCache(payload),
+      timestamp: Date.now(),
+    };
+    const stringified = JSON.stringify(record);
+    if (stringified.length > MAX_LOCAL_CACHE_ITEM_BYTES) {
+      console.warn('[Matching cache] cache item too large, not writing:', storageKey, stringified.length);
+      return;
+    }
+    localStorage.setItem(storageKey, stringified);
+  } catch {
+    // ignore write errors/quota limits
+  }
+};
 
 export const peekCachedSearchKeyPayload = path => {
   const normalizedPath = normalizePath(path);
   if (!normalizedPath) return null;
 
-  const cached = loadCache(normalizedPath);
-  if (cached && typeof cached.exists === 'boolean') {
-    return cached;
-  }
+  const legacyKey = buildLegacyStorageKey(normalizedPath);
+  const currentKey = buildStorageKey(normalizedPath);
+  if (legacyKey !== currentKey) safeRemoveItem(legacyKey);
 
-  return null;
+  return readStorageRecord(currentKey);
 };
 
 export const getCachedSearchKeyPayload = async (path, loader) => {
   const normalizedPath = normalizePath(path);
   if (!normalizedPath || typeof loader !== 'function') return null;
 
-  const cached = loadCache(normalizedPath);
-  if (cached && typeof cached.exists === 'boolean') {
-    return cached;
-  }
+  const storageKey = buildStorageKey(normalizedPath);
+  const cached = peekCachedSearchKeyPayload(normalizedPath);
+  if (cached) return cached;
 
   const loaded = await loader();
-  if (!loaded || typeof loaded.exists !== 'boolean') return null;
+  if (!isValidPayloadForCache(loaded)) return null;
 
-  saveCache(normalizedPath, loaded);
-  return loaded;
+  const normalizedPayload = normalizePayloadForCache(loaded);
+  writeStorageRecord(storageKey, normalizedPayload);
+  return normalizedPayload;
+};
+
+export const cleanupMatchingLocalStorageCache = ({ debug = false } = {}) => {
+  if (typeof localStorage === 'undefined') {
+    return { removed: 0, negative: 0, corrupted: 0, oversized: 0, outdated: 0 };
+  }
+
+  const keys = Object.keys(localStorage).filter(key => key.startsWith(SEARCH_KEY_PREFIX));
+  const stats = { removed: 0, negative: 0, corrupted: 0, oversized: 0, outdated: 0 };
+
+  keys.forEach(key => {
+    const raw = localStorage.getItem(key);
+    if (!raw) return;
+
+    const remove = reason => {
+      safeRemoveItem(key);
+      stats.removed += 1;
+      stats[reason] += 1;
+    };
+
+    if (raw.length > MAX_LOCAL_CACHE_ITEM_BYTES) {
+      remove('oversized');
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      const isCurrentVersion = parsed?.version === MATCHING_CACHE_VERSION || parsed?.data?.version === MATCHING_CACHE_VERSION;
+      if (!isCurrentVersion) {
+        remove('outdated');
+        return;
+      }
+      if (isNegativeOrEmptyRecord(key, parsed)) {
+        remove('negative');
+      }
+    } catch {
+      remove('corrupted');
+    }
+  });
+
+  if (debug) {
+    console.info('[Matching cache] cleanup localStorage keys:', stats);
+  }
+
+  return stats;
+};
+
+export const getMatchingLocalStorageDebugStats = () => {
+  if (typeof localStorage === 'undefined') {
+    return { keyCount: 0, totalMb: 0, largestKeys: [] };
+  }
+
+  const rows = Object.keys(localStorage)
+    .filter(shouldTreatKeyAsMatchingCache)
+    .map(key => {
+      const raw = localStorage.getItem(key) || '';
+      return {
+        key,
+        bytes: raw.length,
+        mb: Number((raw.length / (1024 * 1024)).toFixed(3)),
+      };
+    })
+    .sort((a, b) => b.bytes - a.bytes);
+
+  const totalBytes = rows.reduce((sum, row) => sum + row.bytes, 0);
+  return {
+    keyCount: rows.length,
+    totalMb: Number((totalBytes / (1024 * 1024)).toFixed(3)),
+    largestKeys: rows.slice(0, 10),
+  };
+};
+
+export const logMatchingLocalStorageDebugStats = (reason = 'snapshot') => {
+  const stats = getMatchingLocalStorageDebugStats();
+  console.info(`[Matching cache] ${reason}`, stats);
+  if (typeof console.table === 'function' && stats.largestKeys.length) {
+    console.table(stats.largestKeys);
+  }
+  return stats;
+};
+
+export const clearMatchingLocalStorageCache = ({ debug = true } = {}) => {
+  if (typeof localStorage === 'undefined') return 0;
+
+  const keysToRemove = Object.keys(localStorage).filter(shouldTreatKeyAsMatchingCache);
+  keysToRemove.forEach(safeRemoveItem);
+
+  if (debug) {
+    console.warn('[Matching cache] cleared localStorage keys:', keysToRemove.length);
+  }
+
+  return keysToRemove.length;
 };
 
 const normalizeRulesText = rawRules =>
@@ -51,11 +261,11 @@ export const buildAdditionalRulesCacheKey = ({ rawRules, accessUserId }) => {
 export const getCachedAdditionalRulesPreview = ({ rawRules, accessUserId }) => {
   const cacheKey = buildAdditionalRulesCacheKey({ rawRules, accessUserId });
   if (!cacheKey) return null;
-  const cached = loadCache(cacheKey);
-  if (!cached || typeof cached !== 'object') return null;
+  const cached = readStorageRecord(buildStorageKey(cacheKey));
+  if (!cached || typeof cached.value !== 'object') return null;
 
-  const userIds = Array.isArray(cached.userIds) ? cached.userIds.filter(Boolean) : [];
-  const count = Number.isFinite(cached.count) ? cached.count : userIds.length;
+  const userIds = Array.isArray(cached.value.userIds) ? cached.value.userIds.filter(Boolean) : [];
+  const count = Number.isFinite(cached.value.count) ? cached.value.count : userIds.length;
   return {
     count,
     userIds,
@@ -69,9 +279,13 @@ export const saveCachedAdditionalRulesPreview = ({ rawRules, accessUserId, count
   const normalizedIds = Array.isArray(userIds) ? [...new Set(userIds.filter(Boolean))] : [];
   const normalizedCount = Number.isFinite(count) ? count : normalizedIds.length;
 
-  saveCache(cacheKey, {
-    count: normalizedCount,
-    userIds: normalizedIds,
+  if (!normalizedIds.length && normalizedCount === 0) return;
+  writeStorageRecord(buildStorageKey(cacheKey), {
+    exists: true,
+    value: {
+      count: normalizedCount,
+      userIds: normalizedIds,
+    },
   });
 };
 
@@ -86,9 +300,9 @@ export const getCachedAdditionalRulesSetIndex = ({ rawRules, accessUserId }) => 
   const cacheKey = buildAdditionalRulesSetIndexCacheKey({ rawRules, accessUserId });
   if (!cacheKey) return null;
 
-  const cached = loadCache(cacheKey);
-  if (!cached || typeof cached !== 'object') return null;
-  return cached;
+  const cached = readStorageRecord(buildStorageKey(cacheKey));
+  if (!cached || !cached.value || typeof cached.value !== 'object') return null;
+  return cached.value;
 };
 
 export const saveCachedAdditionalRulesSetIndex = ({ rawRules, accessUserId, setsMap }) => {
@@ -97,5 +311,5 @@ export const saveCachedAdditionalRulesSetIndex = ({ rawRules, accessUserId, sets
 
   if (!setsMap || typeof setsMap !== 'object' || Array.isArray(setsMap)) return;
   if (Object.keys(setsMap).length === 0) return;
-  saveCache(cacheKey, setsMap);
+  writeStorageRecord(buildStorageKey(cacheKey), { exists: true, value: setsMap });
 };


### PR DESCRIPTION
### Motivation

- Індексаційна логіка Matching записувала у `localStorage` негативні/порожні Firebase snapshots (особливо щоденні вікіт-ба́кети `age/d_*` та `lastAction/d_*`), що створювало тисячі марних ключів і уповільнювало старт.
- Потрібно уникнути кешування пустих/negative записів, інвалідувати старі версії кешу та захиститися від надто великих елементів у `localStorage`.
- Кнопка «Reset filters and cache» не видаляла ці `searchKey`/`searchKeySets` ключі і не скидала повністю in-memory стан Matching, що потребувало розширення її поведінки.

### Description

- Додано новий/переписаний модуль кешу `src/utils/searchKeyCache.js` з версіонуванням (`MATCHING_CACHE_VERSION = 'v2'`), лімітом розміру запису (`MAX_LOCAL_CACHE_ITEM_BYTES`) та TTL-логікою; лише заповнені payload-и з `exists: true` кешуються; порожні, `null`, або negative результати більше не записуються.
- Реалізовано безпечну перевірку перед `JSON.parse` та видалення/ігнорування занадто великих або пошкоджених записів, а також інвалідацію старих кеш-версій і перехід від legacy-ключів.
- Додано `cleanupMatchingLocalStorageCache` і `clearMatchingLocalStorageCache` для прибирання негативних/порожніх/корумпованих/oversized/старих записів та функції для отримання debug-статистики (`logMatchingLocalStorageDebugStats`).
- Оновлено `src/components/Matching.jsx`: при монтуванні запускається прибирання кешу в адмін/debug режимі, а обробник `resetFiltersAndCache` тепер очищує всі Matching-related localStorage ключі, додає скидання in-memory стану (завантажені id, offsets, hasMore, loading refs, фільтри тощо) та ініціює свіжий початковий завантажувальний запит.

Файли змінені: `src/utils/searchKeyCache.js`, `src/components/Matching.jsx`.

### Testing

- Запущені unit-тести: `npm test -- --watchAll=false --runTestsByPath src/utils/__tests__/newUsersFilterSetsIndex.test.js` — пройшли (PASS).
- Запущені додаткові тести кешу: `npm test -- --watchAll=false --runTestsByPath src/utils/__tests__/matchingDataProvider.indexCache.test.js src/utils/__tests__/cache.test.js` — пройшли (PASS).
- Прогін лінтера: `npm run lint:js` — пройшов без фатальних помилок.
- Побудова продакшн-бандлу: `npm run build` — успішно зібрано.

Усі автоматизовані перевірки, виконані під час розробки цього ПР, пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0987dbc7b483268392e781bdc03cf1)