### PR TITLE
Exclude internal `cacheVersion` from payload sent to `remoteSave` in `updateCard`

### DIFF
--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -154,7 +154,7 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
   saveCards(cards);
   touchCardInQueries(cardId);
   if (typeof remoteSave === 'function') {
-    const { lastAction, cachedAt, ...toSend } = updatedCard;
+    const { lastAction, cachedAt, cacheVersion, ...toSend } = updatedCard;
     Promise.resolve(remoteSave(toSend)).catch(() => {});
   }
   return updatedCard;


### PR DESCRIPTION
### Motivation
- Prevent sending internal `cacheVersion` to remote storage when calling `remoteSave`, keeping the payload clean and avoiding potential remote errors or leakage of internal metadata.

### Description
- Update `updateCard` to destructure and exclude `cacheVersion` from the object sent to `remoteSave` by changing `const { lastAction, cachedAt, ...toSend }` to `const { lastAction, cachedAt, cacheVersion, ...toSend }`.

### Testing
- Ran unit tests with `yarn test` and the test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c04a2aa448326932d8fa08ee18128)