### PR TITLE
Show reaction tab cards (favorites/dislikes) with proper access and de-duplication

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -440,6 +440,16 @@ const getPreferredReactionSources = id => (
   isLikelyNewUsersUserId(id) ? ['newUsers', 'users'] : ['users', 'newUsers']
 );
 
+const canShowReactionTabCard = (card, { isAdmin = false } = {}) => {
+  if (!card?.userId) return false;
+  const source = card.__sourceCollection || (isShortId(card.userId) ? 'newUsers' : 'users');
+  if (source === 'newUsers') {
+    return card.__matchingAccessAllowed !== false;
+  }
+  if (isAdmin) return true;
+  return card.publish !== false;
+};
+
 const FETCH_USERS_BY_IDS_BATCH_SIZE = 100;
 const fetchNewUsersByIdsForMatching = (ids, batchSize = FETCH_USERS_BY_IDS_BATCH_SIZE) =>
   fetchNewUsersByIdsForMatchingData({
@@ -2900,7 +2910,7 @@ const Matching = () => {
         const scopedCandidates = candidates
           .filter(user => activeReactionMap[user.userId])
           .filter(user => isMatchingCardId(user.userId))
-          .filter(user => canShowMatchingUser(user, { isAdmin }))
+          .filter(user => canShowReactionTabCard(user, { isAdmin }))
           .filter(user => !loadedIds.has(user.userId));
 
         debugReactionFlowLog('loadReactionCardsPage:scopedCandidates-before-ui-filters', {
@@ -3748,7 +3758,46 @@ const Matching = () => {
     collectionSource,
   ]);
 
-  const filteredUsers = applyMatchingUiFiltersToUsers({
+  const reactionTabUsers = useMemo(() => {
+    if (viewMode !== 'favorites' && viewMode !== 'dislikes') return [];
+
+    const reactionMap = viewMode === 'favorites' ? favoriteUsers : dislikeUsers;
+    const reactionIds = Object.keys(normalizeReactionMap(reactionMap));
+    if (!reactionIds.length) return [];
+
+    const candidateUsersById = new Map();
+    [
+      ...users,
+      ...additionalNewUsers,
+      ...sharedReactionCandidateUsers,
+    ].forEach(user => {
+      if (!user?.userId || candidateUsersById.has(user.userId)) return;
+      candidateUsersById.set(user.userId, user);
+    });
+
+    const uniqueIds = new Set();
+    return reactionIds
+      .map(id => candidateUsersById.get(id))
+      .filter(card => Boolean(card))
+      .filter(card => {
+        if (!card?.userId || uniqueIds.has(card.userId)) return false;
+        if (!canShowReactionTabCard(card, { isAdmin })) return false;
+        uniqueIds.add(card.userId);
+        return true;
+      });
+  }, [
+    additionalNewUsers,
+    dislikeUsers,
+    favoriteUsers,
+    isAdmin,
+    sharedReactionCandidateUsers,
+    users,
+    viewMode,
+  ]);
+
+  const filteredUsers = (viewMode === 'favorites' || viewMode === 'dislikes')
+    ? reactionTabUsers
+    : applyMatchingUiFiltersToUsers({
     users: visibleUsers,
     filters,
     filterMainFn: filterMain,
@@ -3771,9 +3820,11 @@ const Matching = () => {
       loadingRef: loadingRef.current,
       hasMore,
       collectionSource,
+      reactionIds: summarizeIdsForDebug(Object.keys(normalizeReactionMap(viewMode === 'favorites' ? favoriteUsers : dislikeUsers))),
       users: summarizeUsersForReactionDebug(users),
       additionalNewUsers: summarizeUsersForReactionDebug(additionalNewUsers),
       sharedReactionCandidateUsers: summarizeUsersForReactionDebug(sharedReactionCandidateUsers),
+      reactionTabUsers: summarizeUsersForReactionDebug(reactionTabUsers),
       visibleUsers: summarizeUsersForReactionDebug(visibleUsers),
       filteredUsers: summarizeUsersForReactionDebug(filteredUsers),
       renderedCards: summarizeUsersForReactionDebug(renderedCards),
@@ -3788,6 +3839,7 @@ const Matching = () => {
     dislikeUsers,
     favoriteUsers,
     filteredUsers,
+    reactionTabUsers,
     filters,
     hasMore,
     loading,


### PR DESCRIPTION
### Motivation
- Ensure reaction tab views (`favorites` and `dislikes`) render the correct user cards by handling newUsers vs users sources, access/publish rules, and avoiding duplicates. 
- Replace the previous generic visibility check with a targeted check for reaction-tab flows so unpublished or blocked cards are hidden unless allowed. 
- Improve debug visibility for reaction-tab loading and rendering to help diagnose reaction pagination and filtering issues.

### Description
- Added a new helper `canShowReactionTabCard(card, { isAdmin })` that determines visibility based on `card.__sourceCollection`, `card.__matchingAccessAllowed`, `card.publish`, and admin status. 
- Switched `loadReactionCardsPageRecords` filtering from `canShowMatchingUser` to `canShowReactionTabCard` for reaction flows. 
- Introduced `reactionTabUsers` computed via `useMemo` to assemble a de-duplicated list of candidate users for the `favorites` and `dislikes` views by merging `users`, `additionalNewUsers`, and `sharedReactionCandidateUsers`, and applying `canShowReactionTabCard`. 
- Made `filteredUsers` use `reactionTabUsers` when `viewMode` is `favorites` or `dislikes`, and added extra debug fields (`reactionIds` and `reactionTabUsers`) to the reaction render log. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c3b2be2408326a1889fd834113f57)