### PR TITLE
Improve debugging and metrics for shared reactions in Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1729,10 +1729,12 @@ const Matching = () => {
             localStorage.setItem('accessLevel', accessLevel);
             localStorage.setItem('additionalAccessRules', additionalAccessRules);
             localStorage.setItem('additionalSearchKeySetKeys', searchKeySetKeys.join(','));
-            const accessOwnerIds = parseMultiDataAccessUserIds(profile?.[MULTI_DATA_ACCESS_FIELD]);
+            const rawMultiDataAccessUserIds = profile?.[MULTI_DATA_ACCESS_FIELD];
+            const accessOwnerIds = parseMultiDataAccessUserIds(rawMultiDataAccessUserIds);
             const resolvedOwnerIds = resolveMatchingMultiDataOwnerIds({ viewerId: user.uid, profile });
             debugSharedReactionsLog(user.uid, 'ownerIds read from multiDataAccessUserIds', {
-              multiDataAccessUserIds: accessOwnerIds,
+              rawMultiDataAccessUserIds,
+              sharedOwnerIds: accessOwnerIds,
               ownerIds: resolvedOwnerIds,
               paths: accessOwnerIds.map(sharedOwnerId => ({
                 favorites: `multiData/favorites/${sharedOwnerId}`,
@@ -1830,10 +1832,22 @@ const Matching = () => {
         favorites,
         dislikes,
       });
+      const sharedFavoritesMap = mergeReactionMaps(sharedOwnerIds.map(sharedOwnerId => favoriteSnapshots[sharedOwnerId]));
+      const sharedDislikesMap = mergeReactionMaps(sharedOwnerIds.map(sharedOwnerId => dislikeSnapshots[sharedOwnerId]));
       debugSharedReactionsLog(ownOwnerId, 'priority merge applied for shared reactions', {
         ownerIds,
         availableOwnerIds,
         sharedOwnerIds,
+        loadedReactionCountByOwnerId: sharedOwnerIds.reduce((acc, sharedOwnerId) => {
+          const ownerFavoritesCount = Object.keys(normalizeReactionMap(favoriteSnapshots[sharedOwnerId])).length;
+          const ownerDislikesCount = Object.keys(normalizeReactionMap(dislikeSnapshots[sharedOwnerId])).length;
+          acc[sharedOwnerId] = {
+            favorites: ownerFavoritesCount,
+            dislikes: ownerDislikesCount,
+            total: ownerFavoritesCount + ownerDislikesCount,
+          };
+          return acc;
+        }, {}),
         sharedFavoritesFound: countTruthyReactionEntries(
           sharedOwnerIds.map(sharedOwnerId => favoriteSnapshots[sharedOwnerId])
         ),
@@ -1849,6 +1863,12 @@ const Matching = () => {
         sharedReactionIdsFound: summarizeIdsForDebug(nextSharedReactionIds),
         ownFavoritesFound: Object.keys(ownFavorites).length,
         ownDislikesFound: Object.keys(ownDislikes).length,
+        finalMergedSharedFavoritesCount: Object.keys(sharedFavoritesMap).length,
+        finalMergedSharedDislikesCount: Object.keys(sharedDislikesMap).length,
+        finalMergedSharedReactionCount: new Set([
+          ...Object.keys(sharedFavoritesMap),
+          ...Object.keys(sharedDislikesMap),
+        ]).size,
         appliedFavorites: summarizeIdsForDebug(Object.keys(favorites)),
         appliedDislikes: summarizeIdsForDebug(Object.keys(dislikes)),
         id0001SelfCheck: {
@@ -1894,11 +1914,19 @@ const Matching = () => {
       const unsubFav = onValue(favRef, snap => {
         favoriteSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
         loadedFavoriteOwnerIds.add(effectiveOwnerId);
+        debugSharedReactionsLog(getOwnerId(), 'loaded favorites snapshot for ownerId', {
+          ownerId: effectiveOwnerId,
+          loadedReactionCount: Object.keys(normalizeReactionMap(favoriteSnapshots[effectiveOwnerId])).length,
+        });
         applyPrioritizedReactionMaps();
       }, error => markOwnerSnapshotLoaded(favoriteSnapshots, loadedFavoriteOwnerIds, 'favorites', error));
       const unsubDis = onValue(disRef, snap => {
         dislikeSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
         loadedDislikeOwnerIds.add(effectiveOwnerId);
+        debugSharedReactionsLog(getOwnerId(), 'loaded dislikes snapshot for ownerId', {
+          ownerId: effectiveOwnerId,
+          loadedReactionCount: Object.keys(normalizeReactionMap(dislikeSnapshots[effectiveOwnerId])).length,
+        });
         applyPrioritizedReactionMaps();
       }, error => markOwnerSnapshotLoaded(dislikeSnapshots, loadedDislikeOwnerIds, 'dislikes', error));
 


### PR DESCRIPTION
### Motivation
- Add more visibility into how shared reaction data is loaded and merged so debugging multi-owner reaction behavior is easier.
- Surface counts and merged-map sizes to help diagnose missing or unexpectedly merged favorites/dislikes.

### Description
- Introduced `rawMultiDataAccessUserIds` and passed it through `parseMultiDataAccessUserIds` to clarify the original value vs parsed owner ids used for access checks.
- Merge shared reaction maps into `sharedFavoritesMap` and `sharedDislikesMap` using `mergeReactionMaps` and expose final merged counts (`finalMergedSharedFavoritesCount`, `finalMergedSharedDislikesCount`, `finalMergedSharedReactionCount`) in debug output.
- Add per-owner loaded reaction counts in debug output via `loadedReactionCountByOwnerId` and additional debug entries when each owner's favorites/dislikes snapshot is loaded inside the `onValue` handlers.
- Keep existing prioritized reaction application logic but augment debug context with `sharedFavoritesFound`, `sharedDislikesFound`, `sharedFavoriteIdsFound`, `sharedDislikeIdsFound`, and other summary fields to aid troubleshooting.

### Testing
- Ran the frontend automated test suite via `npm test` and the linter via `npm run lint`, and both completed successfully.
- Verified that the matching component still subscribes/unsubscribes to `multiData/favorites` and `multiData/dislikes` and that debug logs now include the new count and merge fields during snapshot load and merge steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5007bb448326a9ff6c56b6961d8d)