### PR TITLE
Gate reaction snapshot debug counts behind debug flag

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1916,20 +1916,28 @@ const Matching = () => {
       };
 
       const unsubFav = onValue(favRef, snap => {
+        const viewerId = getOwnerId();
+        const isDebugViewer = shouldDebugAdditionalMatching(viewerId);
         favoriteSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
         loadedFavoriteOwnerIds.add(effectiveOwnerId);
-        debugSharedReactionsLog(getOwnerId(), 'loaded favorites snapshot for ownerId', {
+        debugSharedReactionsLog(viewerId, 'loaded favorites snapshot for ownerId', {
           ownerId: effectiveOwnerId,
-          loadedReactionCount: Object.keys(normalizeReactionMap(favoriteSnapshots[effectiveOwnerId])).length,
+          ...(isDebugViewer ? {
+            loadedReactionCount: Object.keys(normalizeReactionMap(favoriteSnapshots[effectiveOwnerId])).length,
+          } : {}),
         });
         applyPrioritizedReactionMaps();
       }, error => markOwnerSnapshotLoaded(favoriteSnapshots, loadedFavoriteOwnerIds, 'favorites', error));
       const unsubDis = onValue(disRef, snap => {
+        const viewerId = getOwnerId();
+        const isDebugViewer = shouldDebugAdditionalMatching(viewerId);
         dislikeSnapshots[effectiveOwnerId] = snap.exists() ? snap.val() : {};
         loadedDislikeOwnerIds.add(effectiveOwnerId);
-        debugSharedReactionsLog(getOwnerId(), 'loaded dislikes snapshot for ownerId', {
+        debugSharedReactionsLog(viewerId, 'loaded dislikes snapshot for ownerId', {
           ownerId: effectiveOwnerId,
-          loadedReactionCount: Object.keys(normalizeReactionMap(dislikeSnapshots[effectiveOwnerId])).length,
+          ...(isDebugViewer ? {
+            loadedReactionCount: Object.keys(normalizeReactionMap(dislikeSnapshots[effectiveOwnerId])).length,
+          } : {}),
         });
         applyPrioritizedReactionMaps();
       }, error => markOwnerSnapshotLoaded(dislikeSnapshots, loadedDislikeOwnerIds, 'dislikes', error));


### PR DESCRIPTION
### Motivation
- Avoid unnecessary O(n) work when favorites/dislikes RTDB snapshots load by preventing `normalizeReactionMap` traversal for non-debug viewers so production users don't pay the cloning/counting cost.

### Description
- In `src/components/Matching.jsx` snapshot callbacks for `multiData/favorites` and `multiData/dislikes` capture `viewerId`, evaluate `shouldDebugAdditionalMatching(viewerId)`, and only include `loadedReactionCount: Object.keys(normalizeReactionMap(...)).length` in the `debugSharedReactionsLog` payload when that debug condition is true, while keeping the original debug log shape for debug viewers.

### Testing
- Changes were committed (`src/components/Matching.jsx`) and a PR was created; no automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c640298e083269ced72f73533e86e)