### PR TITLE
Add admin-facing Matching debug log mode toggle and collect backfill stats

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -710,6 +710,7 @@ const LocalIndexActions = styled.div`
 
 
 const PROFILE_RESTORE_LOG_PREFIX = '[ProfileRestore]';
+const MATCHING_DEBUG_LOG_MODE_KEY = 'matchingDebugLogMode';
 
 const getProfileRestoreTimestamp = () => {
   if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
@@ -907,6 +908,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [lastSearchBarQuery, setLastSearchBarQuery] = useState('');
   const [isExcelImporting, setIsExcelImporting] = useState(false);
   const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
+  const [matchingDebugLogMode, setMatchingDebugLogMode] = useState(() => (
+    typeof localStorage !== 'undefined' && localStorage.getItem(MATCHING_DEBUG_LOG_MODE_KEY) === 'file'
+      ? 'file'
+      : 'console'
+  ));
   const excelImportInputRef = useRef(null);
   const [showSearchKeyIndexPanel, setShowSearchKeyIndexPanel] = useState(false);
   const [showLocalIndexModal, setShowLocalIndexModal] = useState(false);
@@ -4073,6 +4079,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleDownloadSizeToastsToggle = () => {
     setDownloadSizeToastsEnabled(prev => !prev);
   };
+  const handleMatchingDebugLogModeToggle = () => {
+    setMatchingDebugLogMode(prev => {
+      const nextMode = prev === 'file' ? 'console' : 'file';
+      if (typeof window !== 'undefined') {
+        window.__MATCHING_DEBUG_LOG_MODE = nextMode;
+        if (nextMode === 'file') window.__MATCHING_DEBUG_LOGS = [];
+      }
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(MATCHING_DEBUG_LOG_MODE_KEY, nextMode);
+      }
+      toast.success(nextMode === 'file' ? 'Режим file-логів Matching увімкнено.' : 'Режим console-логів Matching увімкнено.');
+      return nextMode;
+    });
+  };
 
   const fieldsToRender = getFieldsToRender(state);
 
@@ -4382,6 +4402,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               📦
               <DownloadSizeToastStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</DownloadSizeToastStatus>
             </DownloadSizeToastToggleButton>
+            {isAdmin && (
+              <DownloadSizeToastToggleButton
+                type="button"
+                $active={matchingDebugLogMode === 'file'}
+                aria-pressed={matchingDebugLogMode === 'file'}
+                title={matchingDebugLogMode === 'file' ? 'Перемкнути логи Matching у консоль' : 'Перемкнути логи Matching у файл'}
+                aria-label={matchingDebugLogMode === 'file' ? 'Перемкнути логи Matching у консоль' : 'Перемкнути логи Matching у файл'}
+                onClick={handleMatchingDebugLogModeToggle}
+              >
+                🧾
+                <DownloadSizeToastStatus>{matchingDebugLogMode === 'file' ? 'FILE' : 'LOG'}</DownloadSizeToastStatus>
+              </DownloadSizeToastToggleButton>
+            )}
             <DotsButton
               onClick={() => {
                 setShowInfoModal('dotsMenu');

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -2343,6 +2343,18 @@ const Matching = () => {
       );
       if (!canApplyInitialLoad()) return;
       console.log('[loadInitial] initial loaded', res.users.length, 'hasMore', res.hasMore);
+      writeMatchingDebugLog('cards:loadInitial-summary', {
+        requestedVisible: INITIAL_LOAD,
+        sourceCardsCount: Number(res.sourceCardsCount || 0),
+        filteredCardsCount: Number(res.filteredCardsCount || 0),
+        emittedCardsCount: Number(res.emittedCardsCount || 0),
+        filteredOutCount: Math.max(0, Number(res.sourceCardsCount || 0) - Number(res.filteredCardsCount || 0)),
+        visibleReturnedCount: Number(res.users?.length || 0),
+        excludedCount: Number(res.excludedCount || 0),
+        loadedPages: Number(res.loadedPages || 0),
+        stopReason: res.stopReason || '',
+        hasMore: Boolean(res.hasMore),
+      });
       const stats = typeof window !== 'undefined' ? window.matchingLoadStats : null;
       if (stats && typeof console.table === 'function') console.table([stats]);
       loadedIdsRef.current = new Set([
@@ -3685,6 +3697,19 @@ const Matching = () => {
           loadedPages: res.loadedPages,
           stopReason: res.stopReason,
         });
+        writeMatchingDebugLog('cards:loadMore-batch-summary', {
+          requestedVisible: remaining,
+          sourceCardsCount: Number(res.sourceCardsCount || 0),
+          filteredCardsCount: Number(res.filteredCardsCount || 0),
+          emittedCardsCount: Number(res.emittedCardsCount || 0),
+          filteredOutCount: Math.max(0, Number(res.sourceCardsCount || 0) - Number(res.filteredCardsCount || 0)),
+          visibleReturnedCount: Number(res.users?.length || 0),
+          excludedCount: Number(res.excludedCount || 0),
+          loadedPages: Number(res.loadedPages || 0),
+          stopReason: res.stopReason || '',
+          hasMore: Boolean(res.hasMore),
+          sourceHasMore: Boolean(res.sourceHasMore),
+        });
 
         const unique = res.users.filter(
           u => u?.userId && !loadedIdsRef.current.has(u.userId)
@@ -4172,7 +4197,7 @@ const Matching = () => {
   };
 
   const showBackendTrafficToggle = ownerId === BACKEND_TRAFFIC_TRACKING_TEST_UID;
-  const showMatchingDebugLogModeToggle = ownerId === MATCHING_LOG_MODE_TEST_USER_ID;
+  const showMatchingDebugLogModeToggle = isAdmin || ownerId === MATCHING_LOG_MODE_TEST_USER_ID;
 
   const dotsMenu = () => (
     <>

--- a/src/utils/matchingSourceBackfill.js
+++ b/src/utils/matchingSourceBackfill.js
@@ -19,6 +19,9 @@ export const collectFilteredMatchingSourceCards = async ({
   let excludedCount = 0;
   let loadedPages = 0;
   let stopReason = '';
+  let sourceCardsCount = 0;
+  let filteredCardsCount = 0;
+  let emittedCardsCount = 0;
 
   while (collected.length < visibleTarget && sourceHasMore && loadedPages < maxPages) {
     loadedPages += 1;
@@ -41,6 +44,8 @@ export const collectFilteredMatchingSourceCards = async ({
 
     const sourceUsers = Array.isArray(sourceRes?.users) ? sourceRes.users : [];
     const filtered = filterSourceUsers(sourceUsers, { exclude, collected, remaining });
+    sourceCardsCount += sourceUsers.length;
+    filteredCardsCount += filtered.length;
     excludedCount += sourceUsers.length - filtered.length;
 
     const slice = filtered.slice(0, remaining);
@@ -55,6 +60,7 @@ export const collectFilteredMatchingSourceCards = async ({
       .map(decorateUser);
 
     if (validSlice.length) {
+      emittedCardsCount += validSlice.length;
       collected.push(...validSlice);
       if (onPart) {
         // eslint-disable-next-line no-await-in-loop
@@ -91,6 +97,9 @@ export const collectFilteredMatchingSourceCards = async ({
     sourceHasMore,
     cursorAdvanced,
     excludedCount,
+    sourceCardsCount,
+    filteredCardsCount,
+    emittedCardsCount,
     loadedPages,
     stopReason: stopReason || (collected.length ? 'target_reached' : 'no_visible_cards_added'),
   };


### PR DESCRIPTION
### Motivation
- Enable easier debugging of Matching by allowing admins to toggle between console and file log modes and persist that preference.
- Surface summary statistics from source backfill operations to help reason about filtering/emission during matching.
- Provide lightweight in-app controls and telemetry to diagnose matching load/scan behavior without changing core fetching logic.

### Description
- Add a persistent `matchingDebugLogMode` key and state in `AddNewProfile.jsx`, expose an admin-only toggle button that flips between `file` and `console`, updates `localStorage`, sets `window.__MATCHING_DEBUG_LOG_MODE`/`window.__MATCHING_DEBUG_LOGS`, and shows toast notifications via `handleMatchingDebugLogModeToggle`.
- In `Matching.jsx` emit structured debug summaries by calling `writeMatchingDebugLog(...)` during `loadInitial` and `loadMore` flows and make the debug-mode toggle visible to admins as well as the test user, while handling toggle behavior to collect/download logs.
- In `matchingSourceBackfill.js` track and return additional counters (`sourceCardsCount`, `filteredCardsCount`, `emittedCardsCount`) alongside existing backfill metadata so callers can report aggregated stats.

### Testing
- Ran linting with `npm run lint` and static checks which completed successfully.
- Ran unit tests with `npm test` and the test suite passed without failures.
- Ran automated build `npm run build` to ensure the bundle compiles and the new exports/types are accepted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7f48d00483268027183640eb71d7)