### PR TITLE
Fix useCallback dependencies in Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4276,7 +4276,7 @@ const Matching = () => {
       const stats = typeof window !== 'undefined' ? window.matchingLoadStats : null;
       if (stats && typeof console.table === 'function') console.table([stats]);
     });
-  }, [loadMore]);
+  }, [hasMore, loadMore, loading]);
 
   useEffect(() => {
     if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;


### PR DESCRIPTION
### Motivation
- Виправити попередження ESLint `react-hooks/exhaustive-deps` у компоненті `Matching` шляхом приведення масиву залежностей до фактично використовуваних змінних.

### Description
- Додано `hasMore` та `loading` до масиву залежностей `React.useCallback` для `runAutoLoadMore` у `src/components/Matching.jsx` (рядок близько 4279), щоб уникнути некоректних або непередбачуваних викликів хука.

### Testing
- Запущено `npx eslint src/components/Matching.jsx` і перевірка пройшла успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca07e4b808326b5cf5e2966247c93)