### PR TITLE
Виправлення попередження залежностей React Hook у Matching через використання refs

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1212,6 +1212,16 @@ const Matching = () => {
     [currentAdditionalAccessRules]
   );
   const loadingRef = useRef(false);
+  const hasMoreRef = useRef(hasMore);
+  const loadingStateRef = useRef(loading);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  useEffect(() => {
+    loadingStateRef.current = loading;
+  }, [loading]);
   const loadedIdsRef = useRef(new Set());
   const reactionLoadedIdsRef = useRef({
     favorites: new Set(),
@@ -3412,7 +3422,7 @@ const Matching = () => {
       });
     };
     writeMatchingDebugLog('loadMore:start', buildLoadMoreDebugPayload(commonDebug));
-    if (!hasMore) {
+    if (!hasMoreRef.current) {
       markBlockedLoadMore('blocked-no-hasMore', { guard: 'hasMore === false' });
       writeMatchingDebugLog('loadMore:blocked:noHasMore', buildLoadMoreDebugPayload(commonDebug));
       return;
@@ -4236,8 +4246,8 @@ const Matching = () => {
     const commonDebug = {
       signature,
       payload,
-      hasMore,
-      loading,
+      hasMore: hasMoreRef.current,
+      loading: loadingStateRef.current,
       loadingRefCurrent: loadingRef.current,
       emptyAttempts: emptyAutoLoadMoreAttemptsRef.current,
       maxEmptyAttempts: MATCHING_MAX_EMPTY_AUTO_LOAD_MORE_ATTEMPTS,
@@ -4276,11 +4286,11 @@ const Matching = () => {
       const stats = typeof window !== 'undefined' ? window.matchingLoadStats : null;
       if (stats && typeof console.table === 'function') console.table([stats]);
     });
-  }, [hasMore, loadMore, loading]);
+  }, [loadMore]);
 
   useEffect(() => {
     if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;
-    if (loadingRef.current || loading) {
+    if (loadingRef.current || loadingStateRef.current) {
       console.log('[Matching][refillEffect] blocked', { stopReason: 'blocked-loading', loadingRefCurrent: loadingRef.current, loading });
       return;
     }


### PR DESCRIPTION
### Motivation
- При виклику `useCallback` для `runAutoLoadMore` виникало попередження `react-hooks/exhaustive-deps` через захоплення змінних `hasMore` і `loading`. 
- Потрібно зберегти поточні значення цих станів всередині меморизованих колбеків без додавання зайвих залежностей, щоб уникнути частих перегенерацій функцій.

### Description
- Додано `hasMoreRef` і `loadingStateRef` з ініціалізацією через `useRef` і синхронізацією через `useEffect`, щоб зберігати актуальні значення `hasMore` і `loading` в рефах. (файл: `src/components/Matching.jsx`)
- Змінено перевірки в `loadMore` з прямого звернення до `hasMore` на використання `hasMoreRef.current` для уникнення захоплення застарілого значення. (файл: `src/components/Matching.jsx`)
- Оновлено `runAutoLoadMore` так, щоб воно читало `hasMore` і `loading` через рефи і зменшено масив залежностей до `[loadMore]`, що прибирає помилку `exhaustive-deps` при збереженні попередньої поведінки. (файл: `src/components/Matching.jsx`)
- Оновлено одну перевірку в ефекті-повторному доповненні (`refillEffect`) на використання `loadingStateRef.current`. (файл: `src/components/Matching.jsx`)

### Testing
- Запуск `npx eslint src/components/Matching.jsx` пройшов успішно і не показав попереджень щодо залежностей хукiв.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca58dc674832694530bd06704e20b)