### PR TITLE
Normalize and sanitize reaction cards; improve fetch/cache logic in Matching.jsx

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -491,6 +491,53 @@ const getPreferredReactionSources = id => (
   isLikelyNewUsersUserId(id) ? ['newUsers', 'users'] : ['users', 'newUsers']
 );
 
+const sanitizeCardForBackend = card => {
+  if (!card || typeof card !== 'object') return card;
+  const blockedPrefixes = ['__', '_cache', '_debug', '_local'];
+  return Object.fromEntries(
+    Object.entries(card).filter(([key]) => {
+      if (key === 'collectionSource') return false;
+      return !blockedPrefixes.some(prefix => key.startsWith(prefix));
+    })
+  );
+};
+
+
+const hasRenderableMatchingProfilePayload = card => {
+  if (!card || typeof card !== 'object') return false;
+  const hasName = Boolean(String(card.name || card.displayName || '').trim());
+  const hasPhoto = Boolean(card.photoURL || card.photo || card.avatar || card.mainPhoto);
+  const hasPhotosArray = Array.isArray(card.photos) && card.photos.length > 0;
+  const hasAbout = Boolean(String(card.about || card.bio || '').trim());
+  return hasName || hasPhoto || hasPhotosArray || hasAbout;
+};
+
+const getReactionCardSource = (card, fallbackId = '') => {
+  const source = card?.__sourceCollection || card?.collectionSource;
+  if (source === 'users' || source === 'newUsers') return source;
+  return isShortId(card?.userId || card?.id || fallbackId) ? 'newUsers' : 'users';
+};
+
+const normalizeReactionCard = (card, id, sourceHint) => {
+  if (!card || typeof card !== 'object') return null;
+  const normalizedId = String(card.userId || card.id || id || '').trim();
+  if (!normalizedId) return null;
+  const source = sourceHint || getReactionCardSource(card, normalizedId);
+  return {
+    ...card,
+    userId: normalizedId,
+    id: card.id || normalizedId,
+    __sourceCollection: source,
+  };
+};
+
+const isValidCachedReactionCard = (card, id, sourceHint) => {
+  const normalized = normalizeReactionCard(card, id, sourceHint);
+  if (!normalized) return false;
+  const source = normalized.__sourceCollection;
+  if (source !== 'users' && source !== 'newUsers') return false;
+  return hasRenderableMatchingProfilePayload(normalized);
+};
 const canShowReactionTabCard = (card, { isAdmin = false } = {}) => {
   if (!card?.userId) return false;
   const source = card.__sourceCollection || (isShortId(card.userId) ? 'newUsers' : 'users');
@@ -1412,8 +1459,9 @@ const Matching = () => {
       )
     );
     try {
-      await updateDataInRealtimeDB(user.userId, { publish: newValue }, 'update');
-      await updateDataInFiresoreDB(user.userId, { publish: newValue }, 'update');
+      const backendPayload = sanitizeCardForBackend({ publish: newValue });
+      await updateDataInRealtimeDB(user.userId, backendPayload, 'update');
+      await updateDataInFiresoreDB(user.userId, backendPayload, 'update');
     } catch (err) {
       console.error('Failed to toggle publish', err);
     }
@@ -1866,7 +1914,7 @@ const Matching = () => {
       }
 
       const { todayDash } = getCurrentDate();
-      updateDataInNewUsersRTDB(user.uid, { lastLogin2: todayDash }, 'update');
+      updateDataInNewUsersRTDB(user.uid, sanitizeCardForBackend({ lastLogin2: todayDash }), 'update');
 
     });
 
@@ -2479,7 +2527,7 @@ const Matching = () => {
         setLoading(false);
       }
     }
-  }, [collectionSource, defaultListKey, fetchChunk, getMatchingMultiDataOwnerIds, loadCommentsFor, parsedAdditionalAccessRules.length]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
+  }, [collectionSource, defaultListKey, fetchChunk, getMatchingMultiDataOwnerIds, hasMore, lastKey, loadCommentsFor, parsedAdditionalAccessRules.length]); // include fetchChunk to satisfy react-hooks/exhaustive-deps
 
   const reloadDefault = React.useCallback(() => {
     emptyAutoLoadMoreAttemptsRef.current = 0;
@@ -2662,6 +2710,7 @@ const Matching = () => {
     const uniqueIds = [...new Set((ids || []).map(id => String(id || '').trim()).filter(Boolean))];
     const sourceById = reactionSourceByIdRef.current || {};
     const cachedEntries = new Map();
+    const invalidCacheHitIds = [];
     const missingBySource = {
       users: [],
       newUsers: [],
@@ -2684,24 +2733,29 @@ const Matching = () => {
       let source = sourceById[id];
       if (!source && (cached?.__sourceCollection === 'users' || cached?.__sourceCollection === 'newUsers')) {
         source = cached.__sourceCollection;
-        reactionSourceByIdRef.current = {
-          ...reactionSourceByIdRef.current,
-          [id]: source,
-        };
       }
-      const canUseCachedCard = cached && (!source || !cached.__sourceCollection || cached.__sourceCollection === source);
+      const normalizedCached = normalizeReactionCard(cached, id, source || undefined);
+      const canUseCachedCard = isValidCachedReactionCard(normalizedCached, id, source || undefined)
+        && (!source || normalizedCached.__sourceCollection === source);
 
       if (canUseCachedCard) {
+        const resolvedSource = normalizedCached.__sourceCollection;
+        reactionSourceByIdRef.current = {
+          ...reactionSourceByIdRef.current,
+          [id]: resolvedSource,
+        };
         cachedEntries.set(id, {
-          ...cached,
-          userId: id,
-          __sourceCollection: cached.__sourceCollection || source || getPreferredReactionSources(id)[0],
+          ...normalizedCached,
           __fromCardCache: true,
         });
-      } else if (source === 'users' || source === 'newUsers') {
-        missingBySource[source].push(id);
       } else {
-        unknownSourceIds.push(id);
+        if (cached) invalidCacheHitIds.push(id);
+        const fallbackSource = source || getPreferredReactionSources(id)[0];
+        if (fallbackSource === 'users' || fallbackSource === 'newUsers') {
+          missingBySource[fallbackSource].push(id);
+        } else {
+          unknownSourceIds.push(id);
+        }
       }
     });
 
@@ -2725,7 +2779,12 @@ const Matching = () => {
 
     debugReactionFlowLog('fetchReactionCardsByIds:request-backend', {
       requestedIds: summarizeIdsForDebug(uniqueIds),
-      cacheHitIds: summarizeIdsForDebug(Array.from(cachedEntries.keys())),
+      requestedIdsCount: uniqueIds.length,
+      validCacheHitIds: summarizeIdsForDebug(Array.from(cachedEntries.keys())),
+      validCacheHitIdsCount: cachedEntries.size,
+      invalidCacheHitIds: summarizeIdsForDebug(invalidCacheHitIds),
+      invalidCacheHitIdsCount: invalidCacheHitIds.length,
+      backendFetchIdsCount: missingUserIds.length + missingNewUserIds.length,
       missingUserIds: summarizeIdsForDebug(missingUserIds),
       missingNewUserIds: summarizeIdsForDebug(missingNewUserIds),
     });
@@ -2742,21 +2801,29 @@ const Matching = () => {
       missingNewUsersIds: summarizeIdsForDebug(missingNewUserIds.filter(id => !(newUsersCards || []).some(card => card.userId === id))),
     });
 
+    const fetchedNewUsersMap = Object.fromEntries((newUsersCards || []).map(card => [String(card?.userId || '').trim(), card]).filter(([id]) => Boolean(id)));
     const result = {};
     uniqueIds.forEach(id => {
-      const source = reactionSourceByIdRef.current?.[id];
+      const source = reactionSourceByIdRef.current?.[id] || sourceById[id] || getPreferredReactionSources(id)[0];
       const cached = cachedEntries.get(id);
       const fetchedUser = usersMap?.[id];
-      const fetchedNewUser = (newUsersCards || []).find(card => card.userId === id);
-      const user = cached || (source === 'newUsers' ? fetchedNewUser : fetchedUser);
+      const fetchedNewUser = fetchedNewUsersMap[id];
+      const selectedUser = cached || (source === 'newUsers' ? fetchedNewUser : fetchedUser) || fetchedUser || fetchedNewUser;
+      const normalizedUser = normalizeReactionCard(selectedUser, id, source);
 
-      if (user && (source === 'users' || source === 'newUsers')) {
-        result[id] = { ...user, userId: id, __sourceCollection: source };
+      if (normalizedUser && isValidCachedReactionCard(normalizedUser, id, source)) {
+        reactionSourceByIdRef.current = {
+          ...reactionSourceByIdRef.current,
+          [id]: normalizedUser.__sourceCollection,
+        };
+        result[id] = normalizedUser;
       }
     });
 
     debugReactionFlowLog('fetchReactionCardsByIds:result', {
       requestedIds: summarizeIdsForDebug(uniqueIds),
+      finalReturnedCardsCount: Object.keys(result).length,
+      finalReturnedIds: summarizeIdsForDebug(Object.keys(result)),
       returnedIds: summarizeIdsForDebug(Object.keys(result)),
       missingResultIds: summarizeIdsForDebug(uniqueIds.filter(id => !result[id])),
       users: summarizeUsersForReactionDebug(Object.values(result)),
@@ -4350,12 +4417,12 @@ const Matching = () => {
       targetVisibleCount: MATCHING_VISIBLE_BUFFER,
       limit: MATCHING_REFILL_LIMIT,
     });
-  }, [additionalNextOffset, collectionSource, filteredUsers.length, filters, hasMore, lastKey, loading, runAutoLoadMore, viewMode]);
+  }, [additionalNextOffset, collectionSource, filteredUsers.length, filters, hasMore, lastKey, loading, ownerId, runAutoLoadMore, viewMode]);
 
   const lastCardLoadTriggerSignatureRef = useRef('');
   useEffect(() => {
     writeMatchingDebugLog('lastCardObserver:mounted', { ownerId, viewMode: viewModeRef.current, collectionSource: collectionSourceRef.current });
-  }, []);
+  }, [ownerId]);
   const lastCardVisibilityLogSignatureRef = useRef('');
   useEffect(() => {
     if (viewMode !== 'default' && viewMode !== 'favorites' && viewMode !== 'dislikes') return;
@@ -4465,7 +4532,7 @@ const Matching = () => {
       matchingDebugVersion: MATCHING_DEBUG_VERSION,
       initialLogMode: matchingDebugLogMode,
     });
-  }, []);
+  }, [matchingDebugLogMode, ownerId]);
 
   useEffect(() => {
     writeMatchingDebugLog('loadMore:function-ready', {


### PR DESCRIPTION
### Motivation
- Prevent unsafe or internal fields from being sent to the backend and ensure reaction cards from cache or backend are normalized and renderable.
- Reduce incorrect cache hits and improve source classification for reaction cards to avoid inconsistent UI or missing profiles.
- Tighten effect dependencies to keep debug/logging and refill behaviors in sync with relevant state such as `ownerId`, `hasMore`, and `lastKey`.

### Description
- Added `sanitizeCardForBackend` to strip internal keys (prefixes like `__`, `_cache`, `_debug`, `_local`) and block `collectionSource` before updating backend stores, and used it in `togglePublish` and login last-login updates.
- Introduced normalization utilities: `normalizeReactionCard`, `getReactionCardSource`, `hasRenderableMatchingProfilePayload`, and `isValidCachedReactionCard` to standardize `userId`, `id`, and `__sourceCollection` and to validate cards for rendering.
- Reworked `fetchReactionCardsByIds` to normalize cached entries, detect invalid cache hits, classify unknown sources, batch backend requests, map fetched new-user cards efficiently, and populate `reactionSourceByIdRef` consistently; added expanded debug logging to reflect valid/invalid cache hits and final result counts.
- Adjusted several React `useEffect`/`useCallback` dependency arrays to include `hasMore`, `lastKey`, `ownerId`, and `matchingDebugLogMode` where relevant to avoid stale closures and improve refill/observer behavior.

### Testing
- Ran linting with `yarn lint` and code formatting checks, which passed without errors.
- Executed the test suite with `yarn test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbc3150e083269591a0597b2e4048)