### PR TITLE
Await signOut before navigation and tighten session check in MyProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1486,8 +1486,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setState({});
       setIsLoggedIn(false);
       setShowInfoModal(false);
-      navigate('/my-profile');
       await signOut(auth);
+      navigate('/my-profile');
     } catch (error) {
       console.error('Error signing out:', error);
     }

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -578,8 +578,8 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setState(initialProfileState);
       setIsLoggedIn(false);
       setShowInfoModal(false);
-      navigate('/my-profile');
       await signOut(auth);
+      navigate('/my-profile');
     } catch (error) {
       console.error('Error signing out:', error);
     }
@@ -873,7 +873,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const [showInfoModal, setShowInfoModal] = useState(false);
-  const isSessionActive = Boolean(isLoggedIn || auth.currentUser || state.userId);
+  const isSessionActive = Boolean(isLoggedIn || auth.currentUser);
 
   useEffect(() => {
     const logged = localStorage.getItem('isLoggedIn');

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -436,8 +436,8 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
       setState({});
       setIsLoggedIn(false);
       setShowInfoModal(false);
-      navigate('/my-profile');
       await signOut(auth);
+      navigate('/my-profile');
     } catch (error) {
       console.error('Error signing out:', error);
     }


### PR DESCRIPTION
### Motivation
- Ensure sign-out completes before redirect to avoid race conditions and stale auth state when exiting a profile. 
- Make session detection in `MyProfile` reflect actual auth state by removing reliance on `state.userId`.

### Description
- Reordered the `handleExit` sequence in `AddNewProfile.jsx`, `ProfileScreen.jsx`, and `MyProfile.jsx` to call `await signOut(auth)` before `navigate('/my-profile')`.
- Updated `isSessionActive` in `MyProfile.jsx` to `Boolean(isLoggedIn || auth.currentUser)` by removing `state.userId` from the condition.

### Testing
- Ran the test suite with `npm test`, which completed successfully.
- Ran lint and build checks with `npm run lint` and `npm run build`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d64679e048326b12115d7cff62990)