### PR TITLE
Видалено зайву залежність хука у Matching.jsx

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4157,7 +4157,6 @@ const Matching = () => {
     parsedAdditionalAccessRules.length,
     roleIndexSets,
     sharedReactionIds,
-    renderedCardsLength,
     viewMode,
   ]);
 


### PR DESCRIPTION
### Motivation
- Виправити попередження лінтера `react-hooks/exhaustive-deps` і `no-use-before-define`, які виникали через включення `renderedCardsLength` в масив залежностей колбеку перед його оголошенням.

### Description
- Видалено `renderedCardsLength` з масиву залежностей `React.useCallback` відповідного колбеку в `src/components/Matching.jsx`, щоб уникнути зайвого тригера перезапуску колбеку і усунути попередження лінтера.

### Testing
- Перевірено зміни шляхом перегляду фрагмента файлу за допомогою `nl -ba src/components/Matching.jsx | sed -n '4148,4170p'` та стану репозиторія через `git status --short`, обидві команди виконалися успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d721d43a48326ada50d4966ec6624)