### PR TITLE
Add matching index cache versioning/meta and fix last-card load trigger handling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4139,6 +4139,7 @@ const Matching = () => {
     } finally {
       finishLoadMoreIfLatest();
       lastCardInFlightTriggerSignatureRef.current = '';
+      lastCardLoadTriggerSignatureRef.current = '';
     }
   }, [
     additionalNewUsers,
@@ -4553,6 +4554,7 @@ const Matching = () => {
   useEffect(() => {
     if (loading) return;
     lastCardInFlightTriggerSignatureRef.current = '';
+    lastCardLoadTriggerSignatureRef.current = '';
   }, [loading]);
 
   useEffect(() => {
@@ -4635,7 +4637,7 @@ const Matching = () => {
       return;
     }
 
-    if (inFlightTriggerSignature && inFlightTriggerSignature === triggerSignature) {
+    if (loadingRefCurrent && inFlightTriggerSignature && inFlightTriggerSignature === triggerSignature) {
       console.log('[Matching][lastCardTrigger] blocked', {
         stopReason: 'blocked-duplicate-trigger-signature',
         previousTriggerSignature,

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -10,6 +10,7 @@ export const MATCHING_INDEX_TTL_MS = MATCHING_PERFORMANCE_CACHE_TTL_MS;
 export const CARDS_CACHE_VERSION = 2;
 export const MATCHING_CACHE_MAX_CHARS = 4 * 1024 * 1024;
 export const MATCHING_QUERY_MAX_IDS = 2000;
+export const MATCHING_INDEX_CACHE_VERSION = 1;
 const MATCHING_LOCAL_STORAGE_KEYS = new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY]);
 const localJsonCache = new Map();
 const pendingSaveTimers = new Map();
@@ -88,7 +89,14 @@ const resetMatchingStorageKey = key => {
 };
 
 export const resetMatchingLocalStorageCache = (reason = 'manual') => {
-  const keysToReset = [CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY];
+  const dynamicKeysToReset = typeof localStorage === 'undefined'
+    ? []
+    : Object.keys(localStorage).filter(key => {
+      const normalized = String(key || '');
+      const lower = normalized.toLowerCase();
+      return lower.includes('matchingindex') || lower.startsWith('searchkey:') || lower.includes('searchkeysets');
+    });
+  const keysToReset = [...new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY, ...dynamicKeysToReset])];
   logMatchingCacheDebug('clearMatchingCache started', { reason, keys: keysToReset });
   const rows = getMatchingLocalStorageCacheStats();
   const cancelledPendingWritesForKeys = [];
@@ -383,7 +391,12 @@ export const setIdsForQuery = (queryKey, ids) => {
   logMatchingCacheDebug('query ids cache save', { key, idsCount: nextIds.length });
 };
 
-export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
+export const getIndexIdsByQuery = (queryKey, options = {}) => {
+  const {
+    ttlMs = MATCHING_INDEX_TTL_MS,
+    requiredComplete = true,
+    expectedMeta = null,
+  } = options || {};
   const key = normalizeQueryKey(queryKey);
   const queries = loadIndexQueries();
   const entry = queries[key];
@@ -398,6 +411,21 @@ export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
     logMatchingCacheDebug('index ids cache miss', { key, reason: 'ttl expired' });
     return null;
   }
+  if (requiredComplete && entry.complete !== true) {
+    logMatchingCacheDebug('index ids cache miss', { key, reason: 'incomplete-cache-entry' });
+    return null;
+  }
+  if (entry.cacheVersion !== MATCHING_INDEX_CACHE_VERSION) {
+    logMatchingCacheDebug('index ids cache miss', { key, reason: 'cache-version-mismatch', cacheVersion: entry.cacheVersion });
+    return null;
+  }
+  if (expectedMeta && typeof expectedMeta === 'object') {
+    const mismatch = Object.keys(expectedMeta).some(metaKey => (entry?.meta?.[metaKey] ?? null) !== (expectedMeta?.[metaKey] ?? null));
+    if (mismatch) {
+      logMatchingCacheDebug('index ids cache miss', { key, reason: 'meta-mismatch' });
+      return null;
+    }
+  }
   const ids = Array.isArray(entry.ids) ? entry.ids.slice() : [];
   if (ids.length > MATCHING_QUERY_MAX_IDS) {
     delete queries[key];
@@ -406,17 +434,18 @@ export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
     return null;
   }
   logMatchingCacheDebug('index ids cache hit', { key, idsCount: ids.length });
-  return ids;
+  return { ids, meta: entry.meta || null, complete: entry.complete === true, cacheVersion: entry.cacheVersion };
 };
 
-export const setIndexIdsForQuery = (queryKey, ids) => {
+export const setIndexIdsForQuery = (queryKey, ids, options = {}) => {
+  const { complete = false, meta = null, cacheVersion = MATCHING_INDEX_CACHE_VERSION } = options || {};
   const key = normalizeQueryKey(queryKey);
   const queries = loadIndexQueries();
   const now = Date.now();
   const nextIds = Array.isArray(ids) ? ids.slice(0, MATCHING_QUERY_MAX_IDS) : [];
-  queries[key] = { ids: nextIds, cachedAt: now, lastAction: now };
+  queries[key] = { ids: nextIds, cachedAt: now, lastAction: now, complete: complete === true, meta: meta && typeof meta === 'object' ? meta : null, cacheVersion };
   saveIndexQueries(queries);
-  logMatchingCacheDebug('index ids cache save', { key, idsCount: nextIds.length });
+  logMatchingCacheDebug('index ids cache save', { key, idsCount: nextIds.length, complete: complete === true });
 };
 
 export const clearMatchingCache = (reason = 'manual') => resetMatchingLocalStorageCache(reason);

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -1,6 +1,6 @@
 import { get, ref } from 'firebase/database';
 import { database } from 'components/config';
-import { getCard, getIndexIdsByQuery, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
+import { getCard, getIndexIdsByQuery, MATCHING_INDEX_CACHE_VERSION, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
 import { collectFilteredMatchingSourceCards } from './matchingSourceBackfill';
 import { getIndexedNewUsersIdsByRules, normalizeSearchKeySetKeys } from './newUsersFilterSetsIndex';
 
@@ -158,6 +158,14 @@ const normalizeSignatureValue = value => {
 
 const buildRawRulesSignature = rawRules => String(rawRules || '').trim();
 
+
+const buildMatchingIndexCacheMeta = ({ filterSignature = '', collectionSource = 'users', ownerId = '', accessUserId = '' } = {}) => ({
+  filterSignature: String(filterSignature || ''),
+  collectionSource: String(collectionSource || 'users'),
+  ownerId: String(ownerId || ''),
+  accessUserId: String(accessUserId || ''),
+});
+
 export const buildMatchingIndexQueryKey = ({
   collectionSource = 'users',
   filters = {},
@@ -274,6 +282,13 @@ export const fetchMatchingIndexedCandidates = async ({
   const excludedSet = new Set((Array.isArray(excludeIds) ? excludeIds : [...(excludeIds || [])]).filter(Boolean));
   const safeOffset = normalizeOffset(offset);
   const safeLimit = normalizeLimit(limit);
+  const filterSignature = serializeQueryFilters(normalizeSignatureValue(filters || {}));
+  const cacheMeta = buildMatchingIndexCacheMeta({
+    filterSignature,
+    collectionSource,
+    ownerId: String(ownerId || '').trim(),
+    accessUserId: String(accessUserId || '').trim(),
+  });
   const cacheKey = buildMatchingIndexQueryKey({
     collectionSource,
     filters,
@@ -287,11 +302,14 @@ export const fetchMatchingIndexedCandidates = async ({
 
   const readCachedPage = () => {
     if (!useIndexIdCache || collectionSource === 'newUsers') return null;
-    const cachedIds = getIndexIdsByQuery(cacheKey);
-    if (!Array.isArray(cachedIds)) return null;
-    const sliced = sliceIndexedBaseIds({ ids: cachedIds, offset: safeOffset, limit: safeLimit, excludedSet });
+    const cached = getIndexIdsByQuery(cacheKey, {
+      requiredComplete: true,
+      expectedMeta: cacheMeta,
+    });
+    if (!cached || !Array.isArray(cached.ids)) return null;
+    const sliced = sliceIndexedBaseIds({ ids: cached.ids, offset: safeOffset, limit: safeLimit, excludedSet });
     return {
-      allIds: cachedIds,
+      allIds: cached.ids,
       ...sliced,
     };
   };
@@ -361,7 +379,13 @@ export const fetchMatchingIndexedCandidates = async ({
     filterGroups.map(group => readBucketIds({ rootPath: MATCHING_USERS_INDEX_ROOT, ...group }))
   );
   const allMatchingIds = intersectIdSets(idSets) || [];
-  if (useIndexIdCache) setIndexIdsForQuery(cacheKey, allMatchingIds);
+  if (useIndexIdCache) {
+    setIndexIdsForQuery(cacheKey, allMatchingIds, {
+      complete: true,
+      cacheVersion: MATCHING_INDEX_CACHE_VERSION,
+      meta: cacheMeta,
+    });
+  }
   const { pageIds, nextOffset, hasMore } = sliceIndexedBaseIds({
     ids: allMatchingIds,
     offset: safeOffset,


### PR DESCRIPTION
### Motivation
- Prevent incorrect or stale matching index cache entries from being used by adding explicit cache versioning and metadata checks.  
- Ensure dynamic matching-related localStorage keys are cleared when resetting the cache.  
- Fix last-card auto-load duplicate triggering and ensure trigger signatures are reset reliably to avoid stuck/blocked loads.  

### Description
- Introduce `MATCHING_INDEX_CACHE_VERSION` and extend index cache entries to include `complete`, `meta`, and `cacheVersion`, and update `setIndexIdsForQuery` and `getIndexIdsByQuery` to accept options and validate TTL, completeness, expected meta, and cache version, returning a structured object instead of a raw id array.  
- Expand `resetMatchingLocalStorageCache` to discover and clear dynamic matching/index keys (keys that include `matchingindex` or start with `searchkey:`) in addition to the static keys.  
- Update `matchingDataProvider` to build `cacheMeta`, pass `requiredComplete` and `expectedMeta` to `getIndexIdsByQuery`, and write index cache entries with `complete`, `meta`, and `cacheVersion` when caching results.  
- Adjust `Matching.jsx` to reset `lastCardLoadTriggerSignatureRef.current` in the `finally` block and `useEffect` handlers, and change the duplicate-trigger guard to only block when `loadingRefCurrent` is true to reduce false-positive duplicate blocking.  

### Testing
- Ran the project's unit test suite with `yarn test`, which passed.  
- Ran lint and build checks with `yarn lint` and `yarn build`, which completed without errors.  
- Exercised matching index cache and last-card auto-load flows via automated integration/smoke checks to validate cache hits/misses and trigger behavior, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db95aed0c8326aa63fda781f148e6)