### PR TITLE
Matching: index cache versioning/meta, empty-index handling, and load-trigger fixes

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4139,6 +4139,7 @@ const Matching = () => {
     } finally {
       finishLoadMoreIfLatest();
       lastCardInFlightTriggerSignatureRef.current = '';
+      lastCardLoadTriggerSignatureRef.current = '';
     }
   }, [
     additionalNewUsers,
@@ -4553,6 +4554,7 @@ const Matching = () => {
   useEffect(() => {
     if (loading) return;
     lastCardInFlightTriggerSignatureRef.current = '';
+    lastCardLoadTriggerSignatureRef.current = '';
   }, [loading]);
 
   useEffect(() => {
@@ -4635,7 +4637,7 @@ const Matching = () => {
       return;
     }
 
-    if (inFlightTriggerSignature && inFlightTriggerSignature === triggerSignature) {
+    if (loadingRefCurrent && inFlightTriggerSignature && inFlightTriggerSignature === triggerSignature) {
       console.log('[Matching][lastCardTrigger] blocked', {
         stopReason: 'blocked-duplicate-trigger-signature',
         previousTriggerSignature,

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -10,6 +10,7 @@ export const MATCHING_INDEX_TTL_MS = MATCHING_PERFORMANCE_CACHE_TTL_MS;
 export const CARDS_CACHE_VERSION = 2;
 export const MATCHING_CACHE_MAX_CHARS = 4 * 1024 * 1024;
 export const MATCHING_QUERY_MAX_IDS = 2000;
+export const MATCHING_INDEX_CACHE_VERSION = 1;
 const MATCHING_LOCAL_STORAGE_KEYS = new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY]);
 const localJsonCache = new Map();
 const pendingSaveTimers = new Map();
@@ -88,7 +89,14 @@ const resetMatchingStorageKey = key => {
 };
 
 export const resetMatchingLocalStorageCache = (reason = 'manual') => {
-  const keysToReset = [CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY];
+  const dynamicKeysToReset = typeof localStorage === 'undefined'
+    ? []
+    : Object.keys(localStorage).filter(key => {
+      const normalized = String(key || '');
+      const lower = normalized.toLowerCase();
+      return lower.includes('matchingindex') || lower.startsWith('searchkey:') || lower.includes('searchkeysets');
+    });
+  const keysToReset = [...new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY, ...dynamicKeysToReset])];
   logMatchingCacheDebug('clearMatchingCache started', { reason, keys: keysToReset });
   const rows = getMatchingLocalStorageCacheStats();
   const cancelledPendingWritesForKeys = [];
@@ -383,7 +391,12 @@ export const setIdsForQuery = (queryKey, ids) => {
   logMatchingCacheDebug('query ids cache save', { key, idsCount: nextIds.length });
 };
 
-export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
+export const getIndexIdsByQuery = (queryKey, options = {}) => {
+  const {
+    ttlMs = MATCHING_INDEX_TTL_MS,
+    requiredComplete = true,
+    expectedMeta = null,
+  } = options || {};
   const key = normalizeQueryKey(queryKey);
   const queries = loadIndexQueries();
   const entry = queries[key];
@@ -398,6 +411,21 @@ export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
     logMatchingCacheDebug('index ids cache miss', { key, reason: 'ttl expired' });
     return null;
   }
+  if (requiredComplete && entry.complete !== true) {
+    logMatchingCacheDebug('index ids cache miss', { key, reason: 'incomplete-cache-entry' });
+    return null;
+  }
+  if (entry.cacheVersion !== MATCHING_INDEX_CACHE_VERSION) {
+    logMatchingCacheDebug('index ids cache miss', { key, reason: 'cache-version-mismatch', cacheVersion: entry.cacheVersion });
+    return null;
+  }
+  if (expectedMeta && typeof expectedMeta === 'object') {
+    const mismatch = Object.keys(expectedMeta).some(metaKey => (entry?.meta?.[metaKey] ?? null) !== (expectedMeta?.[metaKey] ?? null));
+    if (mismatch) {
+      logMatchingCacheDebug('index ids cache miss', { key, reason: 'meta-mismatch' });
+      return null;
+    }
+  }
   const ids = Array.isArray(entry.ids) ? entry.ids.slice() : [];
   if (ids.length > MATCHING_QUERY_MAX_IDS) {
     delete queries[key];
@@ -406,17 +434,18 @@ export const getIndexIdsByQuery = (queryKey, ttlMs = MATCHING_INDEX_TTL_MS) => {
     return null;
   }
   logMatchingCacheDebug('index ids cache hit', { key, idsCount: ids.length });
-  return ids;
+  return { ids, meta: entry.meta || null, complete: entry.complete === true, cacheVersion: entry.cacheVersion };
 };
 
-export const setIndexIdsForQuery = (queryKey, ids) => {
+export const setIndexIdsForQuery = (queryKey, ids, options = {}) => {
+  const { complete = false, meta = null, cacheVersion = MATCHING_INDEX_CACHE_VERSION } = options || {};
   const key = normalizeQueryKey(queryKey);
   const queries = loadIndexQueries();
   const now = Date.now();
   const nextIds = Array.isArray(ids) ? ids.slice(0, MATCHING_QUERY_MAX_IDS) : [];
-  queries[key] = { ids: nextIds, cachedAt: now, lastAction: now };
+  queries[key] = { ids: nextIds, cachedAt: now, lastAction: now, complete: complete === true, meta: meta && typeof meta === 'object' ? meta : null, cacheVersion };
   saveIndexQueries(queries);
-  logMatchingCacheDebug('index ids cache save', { key, idsCount: nextIds.length });
+  logMatchingCacheDebug('index ids cache save', { key, idsCount: nextIds.length, complete: complete === true });
 };
 
 export const clearMatchingCache = (reason = 'manual') => resetMatchingLocalStorageCache(reason);

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -1,6 +1,6 @@
 import { get, ref } from 'firebase/database';
 import { database } from 'components/config';
-import { getCard, getIndexIdsByQuery, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
+import { getCard, getIndexIdsByQuery, MATCHING_INDEX_CACHE_VERSION, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
 import { collectFilteredMatchingSourceCards } from './matchingSourceBackfill';
 import { getIndexedNewUsersIdsByRules, normalizeSearchKeySetKeys } from './newUsersFilterSetsIndex';
 
@@ -158,6 +158,14 @@ const normalizeSignatureValue = value => {
 
 const buildRawRulesSignature = rawRules => String(rawRules || '').trim();
 
+
+const buildMatchingIndexCacheMeta = ({ filterSignature = '', collectionSource = 'users', ownerId = '', accessUserId = '' } = {}) => ({
+  filterSignature: String(filterSignature || ''),
+  collectionSource: String(collectionSource || 'users'),
+  ownerId: String(ownerId || ''),
+  accessUserId: String(accessUserId || ''),
+});
+
 export const buildMatchingIndexQueryKey = ({
   collectionSource = 'users',
   filters = {},
@@ -274,6 +282,13 @@ export const fetchMatchingIndexedCandidates = async ({
   const excludedSet = new Set((Array.isArray(excludeIds) ? excludeIds : [...(excludeIds || [])]).filter(Boolean));
   const safeOffset = normalizeOffset(offset);
   const safeLimit = normalizeLimit(limit);
+  const filterSignature = serializeQueryFilters(normalizeSignatureValue(filters || {}));
+  const cacheMeta = buildMatchingIndexCacheMeta({
+    filterSignature,
+    collectionSource,
+    ownerId: String(ownerId || '').trim(),
+    accessUserId: String(accessUserId || '').trim(),
+  });
   const cacheKey = buildMatchingIndexQueryKey({
     collectionSource,
     filters,
@@ -287,11 +302,14 @@ export const fetchMatchingIndexedCandidates = async ({
 
   const readCachedPage = () => {
     if (!useIndexIdCache || collectionSource === 'newUsers') return null;
-    const cachedIds = getIndexIdsByQuery(cacheKey);
-    if (!Array.isArray(cachedIds)) return null;
-    const sliced = sliceIndexedBaseIds({ ids: cachedIds, offset: safeOffset, limit: safeLimit, excludedSet });
+    const cached = getIndexIdsByQuery(cacheKey, {
+      requiredComplete: true,
+      expectedMeta: cacheMeta,
+    });
+    if (!cached || !Array.isArray(cached.ids)) return null;
+    const sliced = sliceIndexedBaseIds({ ids: cached.ids, offset: safeOffset, limit: safeLimit, excludedSet });
     return {
-      allIds: cachedIds,
+      allIds: cached.ids,
       ...sliced,
     };
   };
@@ -361,7 +379,13 @@ export const fetchMatchingIndexedCandidates = async ({
     filterGroups.map(group => readBucketIds({ rootPath: MATCHING_USERS_INDEX_ROOT, ...group }))
   );
   const allMatchingIds = intersectIdSets(idSets) || [];
-  if (useIndexIdCache) setIndexIdsForQuery(cacheKey, allMatchingIds);
+  if (useIndexIdCache) {
+    setIndexIdsForQuery(cacheKey, allMatchingIds, {
+      complete: true,
+      cacheVersion: MATCHING_INDEX_CACHE_VERSION,
+      meta: cacheMeta,
+    });
+  }
   const { pageIds, nextOffset, hasMore } = sliceIndexedBaseIds({
     ids: allMatchingIds,
     offset: safeOffset,

--- a/src/utils/matchingIndexedLoadMore.js
+++ b/src/utils/matchingIndexedLoadMore.js
@@ -78,10 +78,6 @@ export const collectMatchingIndexedLoadMorePage = async ({
     finalOffset = nextOffset;
     finalHasMore = lastHasMore;
 
-    if (!indexedUsers.length) {
-      stopReason = indexed.userIds?.length ? 'no_visible_cards_added' : 'empty_index_page';
-      break;
-    }
     if (!lastHasMore) {
       stopReason = 'source_exhausted';
       break;
@@ -89,6 +85,12 @@ export const collectMatchingIndexedLoadMorePage = async ({
     if (cursorStuck) {
       stopReason = 'cursor_not_advanced';
       break;
+    }
+
+    if (!indexedUsers.length) {
+      stopReason = indexed.userIds?.length ? 'no_visible_cards_added_continue' : 'empty_index_page_continue';
+      offset = nextOffset;
+      continue;
     }
 
     offset = nextOffset;


### PR DESCRIPTION
### Motivation
- Ensure matching index cache correctness by introducing cache versioning and metadata so cached index pages are validated against expected query context.
- Avoid prematurely stopping indexed load-more when an index page contains no visible cards by continuing to next offset instead of breaking.
- Prevent duplicate/inconsistent load-more triggers and ensure trigger refs are cleared at the right times.

### Description
- Add `MATCHING_INDEX_CACHE_VERSION` and schema fields (`complete`, `meta`, `cacheVersion`) to index query cache handling in `src/utils/cardIndex.js` and return richer results from `getIndexIdsByQuery` and accept options in `setIndexIdsForQuery`.
- Make `resetMatchingLocalStorageCache` clear dynamic matching index/searchkey-related localStorage keys in addition to the fixed keys to avoid stale data.
- Update `src/utils/matchingDataProvider.js` to build `cacheMeta`, pass `expectedMeta` and `requiredComplete` when reading index caches, and store `meta` and `cacheVersion` when writing index ids to cache.
- Change `src/utils/matchingIndexedLoadMore.js` logic to continue to the next offset when an indexed page contains no visible users instead of stopping, and adjust stop reasons accordingly.
- Fix load-more trigger state in `src/components/Matching.jsx` by clearing `lastCardLoadTriggerSignatureRef` in more places and tightening the duplicate-trigger block to check `loadingRefCurrent` before rejecting a trigger.

### Testing
- Ran unit tests via `yarn test` (including matching-related utility tests) and they passed.
- Ran static checks via `yarn lint` and a production build via `yarn build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db95aed0c8326aa63fda781f148e6)