### PR TITLE
matching: surface UI filter debug summary and per-user failed-filter diagnostics

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -177,6 +177,8 @@ import {
   fetchMatchingIndexedCandidates,
   fetchNewUsersByIdsForMatching as fetchNewUsersByIdsForMatchingData,
   getActiveMatchingFiltersDebug,
+  getMatchingSearchKeyFilterDebugForUser,
+  getMatchingUiFilterDebugSummary,
   isAllowedIdForMatchingCollection,
   isMatchingCardId,
   isSameMatchingCursor,
@@ -921,6 +923,7 @@ const SwipeableCard = ({
   showDebugRejectReasons = false,
   debugFilteredOutReason = '',
   debugUiFilterSummary = '',
+  debugUiFilterFailedFilters = '',
 }) => {
   const resolvedRole = getProfileRole(user) || role;
   const photos = getProfilePhotos(user);
@@ -973,6 +976,9 @@ const SwipeableCard = ({
     : (debugReasons.length > 0 ? 'DEBUG: normally hidden' : '');
   const debugReasonHint = debugReasonText === 'blocked_by_ui_filter'
     ? `Картка прихована активними UI-фільтрами${debugUiFilterSummary ? `: ${debugUiFilterSummary}` : ''}`
+    : '';
+  const debugFailedFiltersHint = debugUiFilterFailedFilters
+    ? `Blocked by: ${debugUiFilterFailedFilters}`
     : '';
   const debugContext = [
     user?.userId ? `userId=${user.userId}` : '',
@@ -1068,6 +1074,7 @@ const SwipeableCard = ({
             {debugReasonLabel && <div>{debugReasonLabel}</div>}
             {debugReasonText && <div style={{ marginTop: 4, fontWeight: 600 }}>Reason: {debugReasonText}</div>}
             {debugReasonHint && <div style={{ marginTop: 4, fontWeight: 500 }}>Hint: {debugReasonHint}</div>}
+            {debugFailedFiltersHint && <div style={{ marginTop: 4, fontWeight: 500 }}>Filters: {debugFailedFiltersHint}</div>}
             {debugContext && <div style={{ marginTop: 4, opacity: 0.9, fontWeight: 500 }}>Context: {debugContext}</div>}
           </div>
         )}
@@ -4418,6 +4425,14 @@ const Matching = () => {
       };
       if (possibleReason === 'excluded_by_userRole_filter') {
         details.failedFilters = ['userRole'];
+      } else if (possibleReason === 'excluded_by_ui_filter') {
+        const searchKeyDebug = getMatchingSearchKeyFilterDebugForUser({
+          user: card,
+          filters,
+          roleIndexSets,
+        });
+        details.failedFilters = searchKeyDebug.failedFilters;
+        details.searchKeyChecks = searchKeyDebug.checks;
       }
       pushFiltered({
         userId,
@@ -4449,7 +4464,7 @@ const Matching = () => {
       filteredOutByReason,
       filteredOutCards,
     };
-  }, [additionalNewUsers, collectionSource, filteredUsers, filters, isAdmin, renderedCards.length, sharedReactionCandidateUsers, users, viewMode, visibleUsers]);
+  }, [additionalNewUsers, collectionSource, filteredUsers, filters, isAdmin, renderedCards.length, roleIndexSets, sharedReactionCandidateUsers, users, viewMode, visibleUsers]);
   const renderedCardsLength = renderedCards.length;
   const debugFilteredOutReasonById = useMemo(() => {
     if (!(debugShowAllIndexedCards && isIndexedDebugTestUser && collectionSource === 'users')) return new Map();
@@ -4457,6 +4472,16 @@ const Matching = () => {
     (debugFilterPipelineDiagnostics.filteredOutCards || []).forEach(item => {
       if (!item?.userId || map.has(item.userId)) return;
       map.set(item.userId, item.reason || 'unknown_final_render_exclusion');
+    });
+    return map;
+  }, [collectionSource, debugFilterPipelineDiagnostics.filteredOutCards, debugShowAllIndexedCards, isIndexedDebugTestUser]);
+  const debugUiFilterFailedFiltersById = useMemo(() => {
+    if (!(debugShowAllIndexedCards && isIndexedDebugTestUser && collectionSource === 'users')) return new Map();
+    const map = new Map();
+    (debugFilterPipelineDiagnostics.filteredOutCards || []).forEach(item => {
+      if (!item?.userId || map.has(item.userId)) return;
+      const failed = Array.isArray(item?.details?.failedFilters) ? item.details.failedFilters.filter(Boolean) : [];
+      if (failed.length > 0) map.set(item.userId, failed.join(', '));
     });
     return map;
   }, [collectionSource, debugFilterPipelineDiagnostics.filteredOutCards, debugShowAllIndexedCards, isIndexedDebugTestUser]);
@@ -5393,21 +5418,8 @@ const Matching = () => {
                       debugRejectReasons={debugShowAllIndexedCards && isIndexedDebugTestUser && !canShowMatchingUser(user, { isAdmin })
                         ? ['blocked_by_ui_filter']
                         : []}
-                      debugUiFilterSummary={Object.entries(filters || {})
-                        .filter(([, value]) => (
-                          Array.isArray(value)
-                            ? value.length > 0
-                            : typeof value === 'boolean'
-                              ? value
-                              : String(value || '').trim() !== ''
-                        ))
-                        .map(([key, value]) => {
-                          if (Array.isArray(value)) return `${key}=${value.join('|')}`;
-                          if (typeof value === 'boolean') return `${key}=true`;
-                          return `${key}=${String(value).trim()}`;
-                        })
-                        .slice(0, 5)
-                        .join(', ')}
+                      debugUiFilterSummary={getMatchingUiFilterDebugSummary(filters)}
+                      debugUiFilterFailedFilters={debugUiFilterFailedFiltersById.get(user?.userId) || ''}
                     />
                   </CardWrapper>
                 </CardContainer>

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -629,6 +629,103 @@ export const applyMatchingSearchKeyFilters = (users, filters, roleIndexSets = nu
   });
 };
 
+const getActiveGroupFilterKeys = group => (
+  Object.entries(group || {})
+    .filter(([, enabled]) => Boolean(enabled))
+    .map(([key]) => key)
+);
+
+export const getMatchingUiFilterDebugSummary = filters => Object.entries(filters || {})
+  .flatMap(([key, value]) => {
+    if (Array.isArray(value)) {
+      const active = value.filter(item => String(item || '').trim() !== '');
+      return active.length > 0 ? [`${key}=[${active.join('|')}]`] : [];
+    }
+
+    if (value && typeof value === 'object') {
+      const active = getActiveGroupFilterKeys(value);
+      return active.length > 0 ? [`${key}=[${active.join('|')}]`] : [];
+    }
+
+    if (typeof value === 'boolean') {
+      return value ? [`${key}=true`] : [];
+    }
+
+    const normalized = String(value || '').trim();
+    return normalized ? [`${key}=${normalized}`] : [];
+  })
+  .slice(0, 10)
+  .join(', ');
+
+export const getMatchingSearchKeyFilterDebugForUser = ({
+  user,
+  filters = {},
+  roleIndexSets = null,
+} = {}) => {
+  const failedFilters = [];
+  const checks = {};
+  const roleFilterMeta = isMatchingFilterGroupActive(filters.userRole)
+    ? buildAllowedRoleIdsFromSearchKey(filters.userRole, roleIndexSets)
+    : null;
+
+  if (isMatchingFilterGroupActive(filters.userRole)) {
+    const active = getActiveGroupFilterKeys(filters.userRole);
+    let category = toRoleCategory(user, roleIndexSets);
+    let pass = Boolean(filters.userRole?.[category]);
+    const details = {
+      active,
+      category,
+      pass,
+      fromIndex: false,
+    };
+    if (roleFilterMeta && user?.userId && roleFilterMeta.allIndexedIds.has(user.userId)) {
+      pass = roleFilterMeta.allowedIds.has(user.userId);
+      details.pass = pass;
+      details.fromIndex = true;
+      details.allowedByIndex = pass;
+    }
+    checks.userRole = details;
+    if (!pass) failedFilters.push('userRole');
+  }
+
+  if (isMatchingFilterGroupActive(filters.maritalStatus)) {
+    const category = toMaritalStatusCategory(user);
+    const active = getActiveGroupFilterKeys(filters.maritalStatus);
+    const pass = Boolean(filters.maritalStatus?.[category]);
+    checks.maritalStatus = { active, category, pass };
+    if (!pass) failedFilters.push('maritalStatus');
+  }
+
+  if (isMatchingFilterGroupActive(filters.bloodGroup)) {
+    const category = toBloodGroupCategory(user);
+    const active = getActiveGroupFilterKeys(filters.bloodGroup);
+    const pass = Boolean(filters.bloodGroup?.[category]);
+    checks.bloodGroup = { active, category, pass };
+    if (!pass) failedFilters.push('bloodGroup');
+  }
+
+  if (isMatchingFilterGroupActive(filters.rh)) {
+    const category = toRhCategory(user);
+    const active = getActiveGroupFilterKeys(filters.rh);
+    const pass = Boolean(filters.rh?.[category]);
+    checks.rh = { active, category, pass };
+    if (!pass) failedFilters.push('rh');
+  }
+
+  if (isMatchingFilterGroupActive(filters.age)) {
+    const category = toAgeCategory(user);
+    const active = getActiveGroupFilterKeys(filters.age);
+    const pass = Boolean(filters.age?.[category]);
+    checks.age = { active, category, pass };
+    if (!pass) failedFilters.push('age');
+  }
+
+  return {
+    failedFilters,
+    checks,
+  };
+};
+
 const passthroughFilterMain = usersData => usersData;
 
 const isReactionViewMode = viewMode => viewMode === 'favorites' || viewMode === 'dislikes';


### PR DESCRIPTION
### Motivation
- Improve diagnostics for why matching profiles are hidden by UI/search-key filters so developers can debug filter interactions and indexed role checks. 
- Provide a compact summary of active UI filters and per-user failed filter names and checks in the indexed-debug view. 

### Description
- Added `getMatchingUiFilterDebugSummary` and `getMatchingSearchKeyFilterDebugForUser` to `src/utils/matchingDataProvider.js` to produce a short summary of active UI filters and detailed per-user search-key filter checks/failed filters. 
- Hooked these helpers into `src/components/Matching.jsx`: compute `debugUiFilterFailedFiltersById`, call `getMatchingSearchKeyFilterDebugForUser` for final render exclusions, and pass `debugUiFilterSummary` and `debugUiFilterFailedFilters` props into `SwipeableCard`. 
- Updated `SwipeableCard` to accept and render `debugUiFilterFailedFilters` in the debug panel and added a small hint string `debugFailedFiltersHint`. 
- Fixed a memo dependency by adding `roleIndexSets` to the `useMemo` dependency list used for the final render diff. 

### Testing
- Ran unit tests with `yarn test` and they succeeded. 
- Ran linter with `yarn lint` and no lint errors were reported. 
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed1475e3883268949cc5bfcd94170)