### PR TITLE
Normalize filter groups and remove deprecated 'empty' flags in matching defaults

### DIFF
--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -61,9 +61,9 @@ const defaultsAdd = {
 
 const defaultsMatching = {
   userRole: { ed: true, ag: false, ip: false, other: false },
-  maritalStatus: { married: true, unmarried: true, other: true, empty: true },
-  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: true },
-  rh: { '+': true, '-': true, other: true, empty: true },
+  maritalStatus: { married: true, unmarried: true, other: true },
+  bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true },
+  rh: { '+': true, '-': true, other: true },
   age: {
     le25: true,
     '26_30': true,
@@ -83,7 +83,11 @@ const defaultsMatching = {
 };
 
 const normalizeFilterGroup = (value, defaults) => {
-  return typeof value === 'object' && value !== null ? { ...defaults, ...value } : { ...defaults };
+  if (!value || typeof value !== 'object') return { ...defaults };
+  return Object.keys(defaults).reduce((acc, key) => {
+    acc[key] = value[key] !== undefined ? value[key] : defaults[key];
+    return acc;
+  }, {});
 };
 
 const FilterPanel = ({


### PR DESCRIPTION
### Motivation

- Remove deprecated `empty` flags from matching filter defaults to simplify the set of available options.
- Prevent persisted filter objects from carrying unknown or legacy keys that can produce incorrect UI state.
- Ensure normalization is robust for non-object inputs and preserves explicit `false` selections.

### Description

- Removed `empty` keys from `defaultsMatching` for `maritalStatus`, `bloodGroup`, and `rh`.
- Rewrote `normalizeFilterGroup` to return `...defaults` for non-object inputs and to construct the result by iterating `Object.keys(defaults)` so only known keys are included. 
- The new normalization logic uses `value[key] !== undefined ? value[key] : defaults[key]` to preserve explicit `false` values while falling back to defaults for missing entries.

### Testing

- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0edccb20f08326b515ee7ef123c9a1)