### PR TITLE
Add detailed debug metadata for matching search-key filters and surface exact UI filter failure reason

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4433,6 +4433,9 @@ const Matching = () => {
         });
         details.failedFilters = searchKeyDebug.failedFilters;
         details.searchKeyChecks = searchKeyDebug.checks;
+        details.exactReason = searchKeyDebug.failedFilters.length > 0
+          ? `ui_filter_failed:${searchKeyDebug.failedFilters.join('|')}`
+          : 'ui_filter_failed:unknown_group';
       }
       pushFiltered({
         userId,

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -38,12 +38,30 @@ const selectedFilterKeys = group => {
     .map(([key]) => key);
 };
 
+const getFilterGroupDebugState = (groupName, group) => {
+  const normalizedGroup = group && typeof group === 'object' ? group : {};
+  const entries = Object.entries(normalizedGroup);
+  const selectedValues = entries.filter(([, enabled]) => Boolean(enabled)).map(([key]) => key);
+  const allSelected = entries.length > 0 && entries.every(([, enabled]) => Boolean(enabled));
+  const groupActive = hasActiveFilterGroup(normalizedGroup);
+  return {
+    groupName,
+    selectedValues,
+    allSelected,
+    groupActive,
+  };
+};
+
 const unique = values => [...new Set((values || []).filter(Boolean))];
 
-const addGroup = (groups, indexName, values) => {
+const addGroup = (groups, indexName, values, debug = {}) => {
   const normalizedValues = unique(values.map(value => String(value || '').trim()).filter(Boolean));
   if (!indexName || normalizedValues.length === 0) return;
-  groups.push({ indexName, values: normalizedValues });
+  groups.push({
+    indexName,
+    values: normalizedValues,
+    ...debug,
+  });
 };
 
 const buildRoleBuckets = (filters, collectionSource) => {
@@ -112,10 +130,45 @@ const buildAgeBuckets = filters => {
 
 export const buildMatchingIndexFilterGroups = ({ filters = {}, collectionSource = 'users' } = {}) => {
   const groups = [];
-  addGroup(groups, 'role', buildRoleBuckets(filters, collectionSource));
-  addGroup(groups, 'maritalStatus', buildMaritalStatusBuckets(filters));
-  addGroup(groups, 'blood', buildBloodBuckets(filters));
-  addGroup(groups, 'age', buildAgeBuckets(filters));
+  addGroup(
+    groups,
+    'role',
+    buildRoleBuckets(filters, collectionSource),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('userRole', filters?.userRole || filters?.role),
+    }
+  );
+  addGroup(
+    groups,
+    'maritalStatus',
+    buildMaritalStatusBuckets(filters),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('maritalStatus', filters?.maritalStatus),
+    }
+  );
+  addGroup(
+    groups,
+    'blood',
+    buildBloodBuckets(filters),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('bloodGroup+rh', {
+        ...(filters?.bloodGroup || {}),
+        ...(filters?.rh ? Object.fromEntries(Object.entries(filters.rh).map(([key, value]) => [`rh:${key}`, value])) : {}),
+      }),
+    }
+  );
+  addGroup(
+    groups,
+    'age',
+    buildAgeBuckets(filters),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('age', filters?.age),
+    }
+  );
   return groups;
 };
 
@@ -684,7 +737,14 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
       details.fromIndex = true;
       details.allowedByIndex = pass;
     }
-    checks.userRole = details;
+    checks.userRole = {
+      ...details,
+      groupName: 'userRole',
+      selectedValues: active,
+      allSelected: false,
+      groupActive: true,
+      source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('userRole');
   }
 
@@ -692,7 +752,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toMaritalStatusCategory(user);
     const active = getActiveGroupFilterKeys(filters.maritalStatus);
     const pass = Boolean(filters.maritalStatus?.[category]);
-    checks.maritalStatus = { active, category, pass };
+    checks.maritalStatus = {
+      active, category, pass, groupName: 'maritalStatus', selectedValues: active, allSelected: false, groupActive: true, source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('maritalStatus');
   }
 
@@ -700,7 +762,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toBloodGroupCategory(user);
     const active = getActiveGroupFilterKeys(filters.bloodGroup);
     const pass = Boolean(filters.bloodGroup?.[category]);
-    checks.bloodGroup = { active, category, pass };
+    checks.bloodGroup = {
+      active, category, pass, groupName: 'bloodGroup', selectedValues: active, allSelected: false, groupActive: true, source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('bloodGroup');
   }
 
@@ -708,7 +772,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toRhCategory(user);
     const active = getActiveGroupFilterKeys(filters.rh);
     const pass = Boolean(filters.rh?.[category]);
-    checks.rh = { active, category, pass };
+    checks.rh = {
+      active, category, pass, groupName: 'rh', selectedValues: active, allSelected: false, groupActive: true, source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('rh');
   }
 
@@ -716,7 +782,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toAgeCategory(user);
     const active = getActiveGroupFilterKeys(filters.age);
     const pass = Boolean(filters.age?.[category]);
-    checks.age = { active, category, pass };
+    checks.age = {
+      active, category, pass, groupName: 'age', selectedValues: active, allSelected: false, groupActive: true, source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('age');
   }
 

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1238,11 +1238,31 @@ export const getIndexedNewUsersIdsByRules = async ({
       ...Object.entries(entry.indexBuckets).map(([indexName, values]) => ({ indexName, values })),
       ...(Array.isArray(entry.additionalFilterBucketGroups) ? entry.additionalFilterBucketGroups : []),
     ].filter(group => {
+      if (group && typeof group === 'object' && Object.prototype.hasOwnProperty.call(group, 'groupActive')) {
+        if (!group.groupActive || group.allSelected) {
+          emitDebug('additionalMatching: indexed filter skipped because neutral/inactive', {
+            setKey: entry.setKey,
+            indexName: group?.indexName,
+            groupName: group?.groupName || group?.indexName || '',
+            selectedValues: Array.isArray(group?.selectedValues) ? group.selectedValues : [],
+            allSelected: Boolean(group?.allSelected),
+            groupActive: Boolean(group?.groupActive),
+            source: group?.source || 'searchKeySets/keySet',
+            reason: 'all options selected or group inactive',
+          });
+          return false;
+        }
+      }
       const normalizedValues = Array.isArray(group?.values) ? group.values.filter(Boolean) : [];
       if (normalizedValues.length > 0) return true;
       emitDebug('additionalMatching: indexed filter skipped because inactive', {
         setKey: entry.setKey,
         indexName: group?.indexName,
+        groupName: group?.groupName || group?.indexName || '',
+        selectedValues: Array.isArray(group?.selectedValues) ? group.selectedValues : [],
+        allSelected: Boolean(group?.allSelected),
+        groupActive: Boolean(group?.groupActive),
+        source: group?.source || 'searchKeySets/keySet',
         stage: 'before_bucket_generation',
       });
       return false;


### PR DESCRIPTION
### Motivation

- Improve observability of why users are excluded by matching search-key (indexed) filter groups and surface a deterministic `exactReason` for UI-side filter exclusions.
- Make indexed filter group state explicit so the matching pipeline can skip neutral/inactive groups and emit richer debug information.

### Description

- Add `getFilterGroupDebugState` to compute normalized debug metadata (`selectedValues`, `allSelected`, `groupActive`, `groupName`) for a filter group.  
- Extend `addGroup` to accept and propagate a `debug` object so `buildMatchingIndexFilterGroups` now attaches `source` and group debug state for `role`, `maritalStatus`, `blood`, and `age` groups.  
- Enhance `getMatchingSearchKeyFilterDebugForUser` to include group-level debug fields (`groupName`, `selectedValues`, `allSelected`, `groupActive`, `source`) in each `checks` entry returned for user-level search-key checks.  
- Produce a more specific UI exclusion `exactReason` in `Matching.jsx` using `searchKeyDebug.failedFilters` or a fallback `unknown_group`.  
- Update `newUsersFilterSetsIndex.js` to ignore indexed bucket groups when they are neutral or inactive (`groupActive === false` or `allSelected === true`) and emit richer debug events with group metadata when skipping groups.

### Testing

- Ran the unit test suite with `yarn test` and the test run completed successfully.  
- Ran the linter with `yarn lint` and static checks passed.  
- Built the project with `yarn build` to validate bundling and compilation, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee6d16c308326ac9f5d07071eba94)