### PR TITLE
Improve matching filter debug diagnostics and skip neutral filter groups in indexed queries

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4364,6 +4364,57 @@ const Matching = () => {
   });
   const renderedCards = filteredUsers;
   const debugFilterPipelineDiagnostics = useMemo(() => {
+    const isGroupNeutralOrInactive = value => (
+      !value ||
+      typeof value !== 'object' ||
+      Array.isArray(value) ||
+      !Object.values(value).some(flag => flag === false)
+    );
+    const buildNeutralGroup = value => (
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? Object.keys(value).reduce((acc, key) => ({ ...acc, [key]: true }), {})
+        : value
+    );
+    const detectUiFailedFiltersForCard = card => {
+      if (!card?.userId) return [];
+      const baseCandidate = [card];
+      const baselineVisible = applyMatchingUiFiltersToUsers({
+        users: baseCandidate,
+        filters,
+        filterMainFn: filterMain,
+        favoriteUsers,
+        dislikeUsers,
+        excludeReactionUsers: viewMode === 'default',
+        roleIndexSets,
+        collectionSource,
+        viewMode,
+      }).length > 0;
+      if (baselineVisible) return [];
+
+      const groupKeys = Object.entries(filters || {})
+        .filter(([, value]) => value && typeof value === 'object' && !Array.isArray(value))
+        .filter(([, value]) => !isGroupNeutralOrInactive(value))
+        .map(([key]) => key);
+
+      return groupKeys.filter(groupKey => {
+        const relaxedFilters = {
+          ...(filters || {}),
+          [groupKey]: buildNeutralGroup(filters?.[groupKey]),
+        };
+        return applyMatchingUiFiltersToUsers({
+          users: baseCandidate,
+          filters: relaxedFilters,
+          filterMainFn: filterMain,
+          favoriteUsers,
+          dislikeUsers,
+          excludeReactionUsers: viewMode === 'default',
+          roleIndexSets,
+          collectionSource,
+          viewMode,
+        }).length > 0;
+      });
+    };
+
     const batchId = `${viewMode}:${collectionSource}:${Date.now()}`;
     const loadedIds = Array.from(loadedIdsRef.current || []).filter(Boolean);
     const renderedIds = filteredUsers.map(card => card?.userId).filter(Boolean);
@@ -4431,8 +4482,12 @@ const Matching = () => {
           filters,
           roleIndexSets,
         });
-        details.failedFilters = searchKeyDebug.failedFilters;
+        const uiFailedFilters = detectUiFailedFiltersForCard(card);
+        details.failedFilters = uiFailedFilters.length > 0 ? uiFailedFilters : searchKeyDebug.failedFilters;
         details.searchKeyChecks = searchKeyDebug.checks;
+        details.exactReason = details.failedFilters.length > 0
+          ? `ui_filter_failed:${details.failedFilters.join('|')}`
+          : 'ui_filter_failed:unknown_group';
       }
       pushFiltered({
         userId,
@@ -4464,7 +4519,21 @@ const Matching = () => {
       filteredOutByReason,
       filteredOutCards,
     };
-  }, [additionalNewUsers, collectionSource, filteredUsers, filters, isAdmin, renderedCards.length, roleIndexSets, sharedReactionCandidateUsers, users, viewMode, visibleUsers]);
+  }, [
+    additionalNewUsers,
+    collectionSource,
+    dislikeUsers,
+    favoriteUsers,
+    filteredUsers,
+    filters,
+    isAdmin,
+    renderedCards.length,
+    roleIndexSets,
+    sharedReactionCandidateUsers,
+    users,
+    viewMode,
+    visibleUsers,
+  ]);
   const renderedCardsLength = renderedCards.length;
   const debugFilteredOutReasonById = useMemo(() => {
     if (!(debugShowAllIndexedCards && isIndexedDebugTestUser && collectionSource === 'users')) return new Map();

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -38,12 +38,30 @@ const selectedFilterKeys = group => {
     .map(([key]) => key);
 };
 
+const getFilterGroupDebugState = (groupName, group) => {
+  const normalizedGroup = group && typeof group === 'object' ? group : {};
+  const entries = Object.entries(normalizedGroup);
+  const selectedValues = entries.filter(([, enabled]) => Boolean(enabled)).map(([key]) => key);
+  const allSelected = entries.length > 0 && entries.every(([, enabled]) => Boolean(enabled));
+  const groupActive = hasActiveFilterGroup(normalizedGroup);
+  return {
+    groupName,
+    selectedValues,
+    allSelected,
+    groupActive,
+  };
+};
+
 const unique = values => [...new Set((values || []).filter(Boolean))];
 
-const addGroup = (groups, indexName, values) => {
+const addGroup = (groups, indexName, values, debug = {}) => {
   const normalizedValues = unique(values.map(value => String(value || '').trim()).filter(Boolean));
   if (!indexName || normalizedValues.length === 0) return;
-  groups.push({ indexName, values: normalizedValues });
+  groups.push({
+    indexName,
+    values: normalizedValues,
+    ...debug,
+  });
 };
 
 const buildRoleBuckets = (filters, collectionSource) => {
@@ -112,10 +130,45 @@ const buildAgeBuckets = filters => {
 
 export const buildMatchingIndexFilterGroups = ({ filters = {}, collectionSource = 'users' } = {}) => {
   const groups = [];
-  addGroup(groups, 'role', buildRoleBuckets(filters, collectionSource));
-  addGroup(groups, 'maritalStatus', buildMaritalStatusBuckets(filters));
-  addGroup(groups, 'blood', buildBloodBuckets(filters));
-  addGroup(groups, 'age', buildAgeBuckets(filters));
+  addGroup(
+    groups,
+    'role',
+    buildRoleBuckets(filters, collectionSource),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('userRole', filters?.userRole || filters?.role),
+    }
+  );
+  addGroup(
+    groups,
+    'maritalStatus',
+    buildMaritalStatusBuckets(filters),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('maritalStatus', filters?.maritalStatus),
+    }
+  );
+  addGroup(
+    groups,
+    'blood',
+    buildBloodBuckets(filters),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('bloodGroup+rh', {
+        ...(filters?.bloodGroup || {}),
+        ...(filters?.rh ? Object.fromEntries(Object.entries(filters.rh).map(([key, value]) => [`rh:${key}`, value])) : {}),
+      }),
+    }
+  );
+  addGroup(
+    groups,
+    'age',
+    buildAgeBuckets(filters),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('age', filters?.age),
+    }
+  );
   return groups;
 };
 
@@ -643,6 +696,7 @@ export const getMatchingUiFilterDebugSummary = filters => Object.entries(filters
     }
 
     if (value && typeof value === 'object') {
+      if (!isMatchingFilterGroupActive(value)) return [];
       const active = getActiveGroupFilterKeys(value);
       return active.length > 0 ? [`${key}=[${active.join('|')}]`] : [];
     }
@@ -684,7 +738,12 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
       details.fromIndex = true;
       details.allowedByIndex = pass;
     }
-    checks.userRole = details;
+    const groupState = getFilterGroupDebugState('userRole', filters.userRole);
+    checks.userRole = {
+      ...details,
+      ...groupState,
+      source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('userRole');
   }
 
@@ -692,7 +751,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toMaritalStatusCategory(user);
     const active = getActiveGroupFilterKeys(filters.maritalStatus);
     const pass = Boolean(filters.maritalStatus?.[category]);
-    checks.maritalStatus = { active, category, pass };
+    checks.maritalStatus = {
+      active, category, pass, ...getFilterGroupDebugState('maritalStatus', filters.maritalStatus), source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('maritalStatus');
   }
 
@@ -700,7 +761,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toBloodGroupCategory(user);
     const active = getActiveGroupFilterKeys(filters.bloodGroup);
     const pass = Boolean(filters.bloodGroup?.[category]);
-    checks.bloodGroup = { active, category, pass };
+    checks.bloodGroup = {
+      active, category, pass, ...getFilterGroupDebugState('bloodGroup', filters.bloodGroup), source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('bloodGroup');
   }
 
@@ -708,7 +771,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toRhCategory(user);
     const active = getActiveGroupFilterKeys(filters.rh);
     const pass = Boolean(filters.rh?.[category]);
-    checks.rh = { active, category, pass };
+    checks.rh = {
+      active, category, pass, ...getFilterGroupDebugState('rh', filters.rh), source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('rh');
   }
 
@@ -716,7 +781,9 @@ export const getMatchingSearchKeyFilterDebugForUser = ({
     const category = toAgeCategory(user);
     const active = getActiveGroupFilterKeys(filters.age);
     const pass = Boolean(filters.age?.[category]);
-    checks.age = { active, category, pass };
+    checks.age = {
+      active, category, pass, ...getFilterGroupDebugState('age', filters.age), source: 'searchKey/users',
+    };
     if (!pass) failedFilters.push('age');
   }
 

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1238,11 +1238,31 @@ export const getIndexedNewUsersIdsByRules = async ({
       ...Object.entries(entry.indexBuckets).map(([indexName, values]) => ({ indexName, values })),
       ...(Array.isArray(entry.additionalFilterBucketGroups) ? entry.additionalFilterBucketGroups : []),
     ].filter(group => {
+      if (group && typeof group === 'object' && Object.prototype.hasOwnProperty.call(group, 'groupActive')) {
+        if (!group.groupActive || group.allSelected) {
+          emitDebug('additionalMatching: indexed filter skipped because neutral/inactive', {
+            setKey: entry.setKey,
+            indexName: group?.indexName,
+            groupName: group?.groupName || group?.indexName || '',
+            selectedValues: Array.isArray(group?.selectedValues) ? group.selectedValues : [],
+            allSelected: Boolean(group?.allSelected),
+            groupActive: Boolean(group?.groupActive),
+            source: group?.source || 'searchKeySets/keySet',
+            reason: 'all options selected or group inactive',
+          });
+          return false;
+        }
+      }
       const normalizedValues = Array.isArray(group?.values) ? group.values.filter(Boolean) : [];
       if (normalizedValues.length > 0) return true;
       emitDebug('additionalMatching: indexed filter skipped because inactive', {
         setKey: entry.setKey,
         indexName: group?.indexName,
+        groupName: group?.groupName || group?.indexName || '',
+        selectedValues: Array.isArray(group?.selectedValues) ? group.selectedValues : [],
+        allSelected: Boolean(group?.allSelected),
+        groupActive: Boolean(group?.groupActive),
+        source: group?.source || 'searchKeySets/keySet',
         stage: 'before_bucket_generation',
       });
       return false;


### PR DESCRIPTION
### Motivation
- Provide clearer diagnostics for why candidate cards are excluded by UI filters so debugging of mismatches between indexed searchKey results and UI rendering is easier. 
- Surface per-filter-group debug metadata from the searchKey/index layer into UI diagnostics to correlate index decisions with UI exclusions. 
- Avoid running indexed lookups for filter groups that are neutral or effectively inactive to reduce unnecessary queries and false negatives. 

### Description
- Added `detectUiFailedFiltersForCard`, `isGroupNeutralOrInactive` and `buildNeutralGroup` to `Matching.jsx` and used them to populate `debugFilterPipelineDiagnostics` so UI filter failures are reported per-group and an `exactReason` is captured.  
- Broadened the `useMemo` dependency list in `Matching.jsx` to include `dislikeUsers` and `favoriteUsers` so diagnostics update when reaction sets change.  
- Introduced `getFilterGroupDebugState` and extended `addGroup` to accept debug metadata in `src/utils/matchingDataProvider.js`, and wired group-level debug fields into `buildMatchingIndexFilterGroups` and `getMatchingSearchKeyFilterDebugForUser` so checks include `selectedValues`, `allSelected`, `groupActive` and `source`.  
- Updated `src/utils/newUsersFilterSetsIndex.js` to skip generation of indexed bucket groups when a group is neutral or all options are selected and to emit richer debug events (`emitDebug`) with group metadata for skipped/active decisions.  

### Testing
- Ran unit and lint checks with `yarn test` and `yarn lint`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee6d16c308326ac9f5d07071eba94)