### PR TITLE
Improve UI filter diagnostics and merge/dedupe failed filter lists in Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4483,8 +4483,19 @@ const Matching = () => {
           roleIndexSets,
         });
         const uiFailedFilters = detectUiFailedFiltersForCard(card);
-        details.failedFilters = uiFailedFilters.length > 0 ? uiFailedFilters : searchKeyDebug.failedFilters;
+        const resolvedFailedFilters = Array.from(new Set([
+          ...(Array.isArray(uiFailedFilters) ? uiFailedFilters : []),
+          ...(Array.isArray(searchKeyDebug.failedFilters) ? searchKeyDebug.failedFilters : []),
+        ].filter(Boolean)));
+        details.failedFilters = resolvedFailedFilters;
         details.searchKeyChecks = searchKeyDebug.checks;
+        details.searchKeyFailedFilters = Array.isArray(searchKeyDebug.failedFilters) ? searchKeyDebug.failedFilters : [];
+        details.uiFailedFilters = Array.isArray(uiFailedFilters) ? uiFailedFilters : [];
+        details.failedFilterGroupsBySource = {
+          ui: details.uiFailedFilters,
+          searchKey: details.searchKeyFailedFilters,
+          merged: details.failedFilters,
+        };
         details.exactReason = details.failedFilters.length > 0
           ? `ui_filter_failed:${details.failedFilters.join('|')}`
           : 'ui_filter_failed:unknown_group';


### PR DESCRIPTION
### Motivation

- Make exclusion diagnostics more actionable by preserving per-source failed filter lists and by merging/deduplicating them for a clear single view of why a card was excluded.
- Handle cases where `detectUiFailedFiltersForCard` or `searchKeyDebug.failedFilters` may not return arrays to avoid runtime errors and noisy output.

### Description

- Merge UI and search-key failed filter lists into a deduplicated `details.failedFilters` using a `Set` and guard inputs with `Array.isArray` to avoid non-array values. 
- Preserve original arrays on `details.searchKeyFailedFilters` and `details.uiFailedFilters` so callers can inspect source-specific failures. 
- Add `details.failedFilterGroupsBySource` that contains `ui`, `searchKey`, and `merged` groups for clearer diagnostics. 
- Keep existing `details.searchKeyChecks` and compute `details.exactReason` from the merged `details.failedFilters` as before.

### Testing

- Ran unit tests with `yarn test` (Jest) and all tests completed successfully. 
- Performed a production build with `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eff451eb48326afac10eaafbaf321)