### PR TITLE
Add detailed cardsDebug diagnostics to Matching memoized result

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4517,6 +4517,42 @@ const Matching = () => {
       });
     });
 
+    const hiddenByUiFilterSet = new Set(
+      missingFromRendered
+        .filter(item => item?.possibleReason === 'excluded_by_ui_filter')
+        .map(item => item.userId)
+        .filter(Boolean)
+    );
+    const failedFiltersByUserId = new Map(
+      filteredOutCards
+        .filter(item => item?.reason === 'excluded_by_ui_filter' && item?.userId)
+        .map(item => [item.userId, item?.details?.failedFilters || []])
+    );
+
+    const allDebugIds = Array.from(new Set([
+      ...loadedIds,
+      ...renderedIds,
+      ...visibleCardIds,
+      ...Array.from(cardById.keys()),
+    ].filter(Boolean)));
+
+    const cardsDebug = allDebugIds.map(userId => {
+      const card = cardById.get(userId) || null;
+      const cardRole = card ? getProfileRole(card) : null;
+      return {
+        userId,
+        role: cardRole,
+        userRole: card?.userRole || null,
+        __sourceCollection: card?.__sourceCollection || null,
+        collectionSource,
+        inFilteredUsers: renderedIdsSet.has(userId),
+        inRenderedUsers: renderedIdsSet.has(userId),
+        inVisibleCardIds: visibleCardIdsSet.has(userId),
+        hiddenByUiFilter: hiddenByUiFilterSet.has(userId),
+        failedFilters: failedFiltersByUserId.get(userId) || [],
+      };
+    });
+
     return {
       batchId,
       loadedIdsCount: loadedIds.length,
@@ -4527,6 +4563,7 @@ const Matching = () => {
       renderedIdsCount: renderedIds.length,
       missingFromRenderedCount: missingFromRendered.length,
       missingFromRendered,
+      cardsDebug,
       filteredOutByReason,
       filteredOutCards,
     };


### PR DESCRIPTION
### Motivation
- Provide richer diagnostics for why users/cards are missing from the final render, particularly to surface UI-filter exclusions and failed filters per user.

### Description
- Add `hiddenByUiFilterSet` to collect userIds from `missingFromRendered` that were labeled `excluded_by_ui_filter`.
- Build `failedFiltersByUserId` map from `filteredOutCards` to expose per-user `failedFilters` details.
- Compute `allDebugIds` as the union of `loadedIds`, `renderedIds`, `visibleCardIds`, and `cardById.keys()` and construct `cardsDebug` with per-user debug fields including `role`, `userRole`, `inVisibleCardIds`, `hiddenByUiFilter`, and `failedFilters`.
- Return `cardsDebug` as part of the memoized diagnostics object so debug UIs can surface the additional info.

### Testing
- Ran the JavaScript/React unit test suite and component snapshot tests; all tests passed. 
- Ran linting and a local build; no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1d4a90b08326b71422f8e9a3572d)