### PR TITLE
Add per-card debug diagnostics and surface UI-filter diagnostics in Matching cards

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -924,6 +924,7 @@ const SwipeableCard = ({
   debugFilteredOutReason = '',
   debugUiFilterSummary = '',
   debugUiFilterFailedFilters = '',
+  debugCardDiagnostics = null,
 }) => {
   const resolvedRole = getProfileRole(user) || role;
   const photos = getProfilePhotos(user);
@@ -985,6 +986,17 @@ const SwipeableCard = ({
     user?.__sourceCollection ? `source=${user.__sourceCollection}` : '',
     typeof user?.__matchingAccessAllowed === 'boolean' ? `matchingAccess=${user.__matchingAccessAllowed ? 'allowed' : 'blocked'}` : '',
   ].filter(Boolean).join(' · ');
+  const diagnostics = debugCardDiagnostics && typeof debugCardDiagnostics === 'object' ? debugCardDiagnostics : null;
+  const debugDiagnosticsRows = diagnostics ? [
+    `role=${diagnostics.role || '-'}`,
+    `userRole=${diagnostics.userRole || '-'}`,
+    `cardSource=${diagnostics.__sourceCollection || '-'}`,
+    `deckSource=${diagnostics.collectionSource || '-'}`,
+    `inVisible=${diagnostics.inVisibleCardIds ? 'yes' : 'no'}`,
+    `inFiltered=${diagnostics.inFilteredUsers ? 'yes' : 'no'}`,
+    `hiddenByUiFilter=${diagnostics.hiddenByUiFilter ? 'yes' : 'no'}`,
+    `failedFilters=${Array.isArray(diagnostics.failedFilters) && diagnostics.failedFilters.length ? diagnostics.failedFilters.join('|') : '-'}`,
+  ] : [];
   const handleTouchStart = e => {
     if (!e.touches || e.touches.length !== 1) return;
     const touch = e.touches[0];
@@ -1076,6 +1088,9 @@ const SwipeableCard = ({
             {debugReasonHint && <div style={{ marginTop: 4, fontWeight: 500 }}>Hint: {debugReasonHint}</div>}
             {debugFailedFiltersHint && <div style={{ marginTop: 4, fontWeight: 500 }}>Filters: {debugFailedFiltersHint}</div>}
             {debugContext && <div style={{ marginTop: 4, opacity: 0.9, fontWeight: 500 }}>Context: {debugContext}</div>}
+            {debugDiagnosticsRows.map(row => (
+              <div key={row} style={{ marginTop: 2, opacity: 0.92, fontWeight: 500 }}>Diag: {row}</div>
+            ))}
           </div>
         )}
         {shouldShowHeroContent && (
@@ -4517,6 +4532,43 @@ const Matching = () => {
       });
     });
 
+    const hiddenByUiFilterSet = new Set(
+      Array.from(new Set([...loadedIds, ...renderedIds, ...visibleCardIds]))
+        .filter(Boolean)
+        .filter(userId => renderedIdsSet.has(userId) && !visibleCardIdsSet.has(userId))
+    );
+    const failedFiltersByUserId = new Map();
+    filteredOutCards
+      .filter(item => item?.reason === 'excluded_by_ui_filter' && item?.userId)
+      .forEach(item => {
+        if (failedFiltersByUserId.has(item.userId)) return;
+        failedFiltersByUserId.set(item.userId, item?.details?.failedFilters || []);
+      });
+
+    const allDebugIds = Array.from(new Set([
+      ...loadedIds,
+      ...renderedIds,
+      ...visibleCardIds,
+      ...Array.from(cardById.keys()),
+    ].filter(Boolean)));
+
+    const cardsDebug = allDebugIds.map(userId => {
+      const card = cardById.get(userId) || null;
+      const cardRole = card ? getProfileRole(card) : null;
+      return {
+        userId,
+        role: cardRole,
+        userRole: card?.userRole || null,
+        __sourceCollection: card?.__sourceCollection || null,
+        collectionSource,
+        inFilteredUsers: renderedIdsSet.has(userId),
+        inRenderedUsers: renderedIdsSet.has(userId),
+        inVisibleCardIds: visibleCardIdsSet.has(userId),
+        hiddenByUiFilter: hiddenByUiFilterSet.has(userId),
+        failedFilters: failedFiltersByUserId.get(userId) || [],
+      };
+    });
+
     return {
       batchId,
       loadedIdsCount: loadedIds.length,
@@ -4527,6 +4579,7 @@ const Matching = () => {
       renderedIdsCount: renderedIds.length,
       missingFromRenderedCount: missingFromRendered.length,
       missingFromRendered,
+      cardsDebug,
       filteredOutByReason,
       filteredOutCards,
     };
@@ -4565,6 +4618,15 @@ const Matching = () => {
     });
     return map;
   }, [collectionSource, debugFilterPipelineDiagnostics.filteredOutCards, debugShowAllIndexedCards, isIndexedDebugTestUser]);
+  const debugCardDiagnosticsById = useMemo(() => {
+    if (!(debugShowAllIndexedCards && isIndexedDebugTestUser && collectionSource === 'users')) return new Map();
+    const map = new Map();
+    (debugFilterPipelineDiagnostics.cardsDebug || []).forEach(item => {
+      if (!item?.userId || map.has(item.userId)) return;
+      map.set(item.userId, item);
+    });
+    return map;
+  }, [collectionSource, debugFilterPipelineDiagnostics.cardsDebug, debugShowAllIndexedCards, isIndexedDebugTestUser]);
   const debugHiddenStats = useMemo(() => {
     if (!(debugShowAllIndexedCards && isIndexedDebugTestUser)) return null;
     const visibleSet = new Set(applyMatchingUiFiltersToUsers({
@@ -5495,11 +5557,12 @@ const Matching = () => {
                       }}
                       showDebugRejectReasons={debugShowAllIndexedCards && isIndexedDebugTestUser}
                       debugFilteredOutReason={debugFilteredOutReasonById.get(user?.userId) || ''}
-                      debugRejectReasons={debugShowAllIndexedCards && isIndexedDebugTestUser && !canShowMatchingUser(user, { isAdmin })
+                      debugRejectReasons={debugShowAllIndexedCards && isIndexedDebugTestUser && debugFilteredOutReasonById.get(user?.userId) === 'excluded_by_ui_filter'
                         ? ['blocked_by_ui_filter']
                         : []}
                       debugUiFilterSummary={getMatchingUiFilterDebugSummary(filters)}
                       debugUiFilterFailedFilters={debugUiFilterFailedFiltersById.get(user?.userId) || ''}
+                      debugCardDiagnostics={debugCardDiagnosticsById.get(user?.userId) || null}
                     />
                   </CardWrapper>
                 </CardContainer>


### PR DESCRIPTION
### Motivation
- Improve visibility into why individual matching cards are hidden or filtered by exposing per-card diagnostics in the UI and debug pipeline output.
- Make it easier for indexed-debug users and admins to inspect card-level filter and source metadata when troubleshooting matching issues.

### Description
- Added a new `debugCardDiagnostics` prop to `SwipeableCard` and render diagnostic rows inside the debug panel when provided.
- Computed `cardsDebug` in the matching debug pipeline by collecting card-level metadata (role, source collections, visibility, hidden-by-UI-filter and failed filters) and added it to the debug payload.
- Added `debugCardDiagnosticsById` memo that maps cards from `debugFilterPipelineDiagnostics.cardsDebug` and passed the per-user diagnostics into `SwipeableCard` as `debugCardDiagnostics`.
- Adjusted the `debugRejectReasons` logic to surface a `blocked_by_ui_filter` indicator when the final reason is `excluded_by_ui_filter`.

### Testing
- Ran unit tests with `yarn test` and the frontend test suite completed successfully.
- Ran linting with `yarn lint` and there were no lint errors.
- Executed a local production build with `yarn build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1d4a90b08326b71422f8e9a3572d)