### PR TITLE
Stop applying UI filters to `visibleUsers` in Matching component for normal view

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4366,17 +4366,7 @@ const Matching = () => {
     ? reactionTabUsers
     : (debugShowAllIndexedCards && isIndexedDebugTestUser && collectionSource === 'users')
       ? users
-    : applyMatchingUiFiltersToUsers({
-    users: visibleUsers,
-    filters,
-    filterMainFn: filterMain,
-    favoriteUsers,
-    dislikeUsers,
-    excludeReactionUsers: viewMode === 'default',
-    roleIndexSets,
-    collectionSource,
-    viewMode,
-  });
+      : visibleUsers;
   const renderedCards = filteredUsers;
   const debugFilterPipelineDiagnostics = useMemo(() => {
     const isGroupNeutralOrInactive = value => (


### PR DESCRIPTION
### Motivation
- Prevent unintended removal of candidate cards in the normal view by avoiding the `applyMatchingUiFiltersToUsers` call except for the debug indexed path.

### Description
- Replace the `applyMatchingUiFiltersToUsers({...})` fallback with returning `visibleUsers` directly, preserving the existing debug branch that uses `debugShowAllIndexedCards`, `isIndexedDebugTestUser`, and `collectionSource`.

### Testing
- Ran the automated test suite with `yarn test` and linting with `yarn lint`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3d03f94483269674677cff728c15)