### PR TITLE
Додати точну умову виключення картки в діагностику Matching

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1000,6 +1000,7 @@ const SwipeableCard = ({
     `excludedAtStage=${diagnostics.excludedAtStage || '-'}`,
     `excludedReason=${diagnostics.excludedReason || '-'}`,
     `excludedFunction=${diagnostics.excludedFunction || '-'}`,
+    `excludedCondition=${diagnostics.excludedCondition || '-'}`,
     `exactReason=${diagnostics.exactReason || '-'}`,
     `uiFailedFilters=${Array.isArray(diagnostics.uiFailedFilters) && diagnostics.uiFailedFilters.length ? diagnostics.uiFailedFilters.join('|') : '-'}`,
     `searchKeyFailedFilters=${Array.isArray(diagnostics.searchKeyFailedFilters) && diagnostics.searchKeyFailedFilters.length ? diagnostics.searchKeyFailedFilters.join('|') : '-'}`,
@@ -4497,10 +4498,12 @@ const Matching = () => {
         activeUserRoleFilters,
         excludedBy: null,
         excludedFunction: null,
+        excludedCondition: null,
       };
       if (possibleReason === 'excluded_by_userRole_filter') {
         details.excludedBy = 'userRole';
         details.excludedFunction = 'getProfileRole + activeUserRoleFilters.includes';
+        details.excludedCondition = `hasUserRoleFilter && cardRole && !activeUserRoleFilters.includes(cardRole) [cardRole=${cardRole || '-'}; active=${activeUserRoleFilters.join('|') || '-'}]`;
         details.failedFilters = ['userRole'];
         details.exactReason = 'ui_filter_failed:userRole';
       } else if (possibleReason === 'excluded_by_ui_filter') {
@@ -4527,17 +4530,27 @@ const Matching = () => {
         details.excludedFunction = details.uiFailedFilters.length > 0
           ? 'applyMatchingUiFiltersToUsers'
           : (details.searchKeyFailedFilters.length > 0 ? 'getMatchingSearchKeyFilterDebugForUser' : 'unknown');
+        const firstFailedFilter = details.failedFilters[0] || null;
+        const firstFailedSearchKeyCheck = firstFailedFilter && searchKeyDebug.checks?.[firstFailedFilter]
+          ? searchKeyDebug.checks[firstFailedFilter]
+          : null;
+        details.excludedCondition = firstFailedFilter
+          ? `${firstFailedFilter}: selected=${(firstFailedSearchKeyCheck?.active || []).join('|') || '-'}; cardCategory=${firstFailedSearchKeyCheck?.category || '-'}; pass=${firstFailedSearchKeyCheck?.pass ? 'yes' : 'no'}; source=${firstFailedSearchKeyCheck?.source || '-'}; predicate=Boolean(filters.${firstFailedFilter}?.[category])`
+          : 'No specific failed filter resolved';
         details.exactReason = details.failedFilters.length > 0
           ? `ui_filter_failed:${details.failedFilters.join('|')}`
           : 'ui_filter_failed:unknown_group';
       } else if (possibleReason === 'hidden') {
         details.excludedFunction = 'canShowMatchingUser';
+        details.excludedCondition = 'canShowMatchingUser(card, { isAdmin }) === false';
         details.exactReason = 'visibility_guard:hidden';
       } else if (possibleReason === 'publish_false') {
         details.excludedFunction = 'publish_flag_check';
+        details.excludedCondition = '!card.publish && card.__sourceCollection !== newUsers';
         details.exactReason = 'publish_false';
       } else if (possibleReason === 'unknown_final_render_exclusion') {
         details.excludedFunction = 'final_render_diff';
+        details.excludedCondition = 'Card id exists in loadedIdsRef, but absent in final renderedIds';
         details.exactReason = 'unknown_final_render_exclusion';
       }
       pushFiltered({
@@ -4599,6 +4612,7 @@ const Matching = () => {
         excludedAtStage: filteredOutDetailsByUserId.get(userId)?.stage || null,
         excludedReason: filteredOutDetailsByUserId.get(userId)?.reason || null,
         excludedFunction: filteredOutDetailsByUserId.get(userId)?.details?.excludedFunction || null,
+        excludedCondition: filteredOutDetailsByUserId.get(userId)?.details?.excludedCondition || null,
         exactReason: filteredOutDetailsByUserId.get(userId)?.details?.exactReason || null,
         uiFailedFilters: filteredOutDetailsByUserId.get(userId)?.details?.uiFailedFilters || [],
         searchKeyFailedFilters: filteredOutDetailsByUserId.get(userId)?.details?.searchKeyFailedFilters || [],


### PR DESCRIPTION
### Motivation
- Потрібно показувати точну функцію та предикат, які відсікають картку в механізмі підбору, щоб швидко знаходити і виправляти помилки фільтрації.
- Існуючі поля (`excludedFunction`, `exactReason`) не давали достатньо контексту для відтворення конкретної умови, особливо для UI- та searchKey-фільтрів.

### Description
- Додав поле `excludedCondition` до об'єкта `details` у `src/components/Matching.jsx` для усіх ключових сценаріїв: `excluded_by_userRole_filter`, `excluded_by_ui_filter`, `hidden`, `publish_false` та `unknown_final_render_exclusion`.
- Для `excluded_by_ui_filter` збирання `excludedCondition` тепер включає інформацію про перший провалений фільтр: вибрані значення, категорію картки, прапорець `pass`, джерело перевірки та предикат (через `getMatchingSearchKeyFilterDebugForUser` і `detectUiFailedFiltersForCard`).
- Пропрокинув `excludedCondition` у `cardsDebug` і додав рядок з `excludedCondition` у `debugDiagnosticsRows`, тож debug-плашка показує і функцію (`excludedFunction`), і конкретну умову (`excludedCondition`).

### Testing
- Застосовано патч до `src/components/Matching.jsx` і перевірено оновлені ділянки файлу за допомогою `nl -ba src/components/Matching.jsx | sed -n '968,1012p'` та `nl -ba src/components/Matching.jsx | sed -n '4488,4565p'`, що успішно показало внесені зміни.
- Переглянуто блоки `cardsDebug` та `debugDiagnosticsRows` у файлі, і присутність `excludedCondition` підтверджена шляхом інспекції коду, успішно.
- Створено PR через `make_pr`, генерація PR пройшла успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f5202467083269fd936df40d45eab)