### PR TITLE
Normalize `user.publish` values and surface debug info in matching-user guard

### DIFF
--- a/src/utils/reactionPriority.js
+++ b/src/utils/reactionPriority.js
@@ -3,6 +3,24 @@ const isTruthyReactionValue = value => {
   return Boolean(value);
 };
 
+export const normalizePublish = value => {
+  if (value === true) return true;
+  if (value === false) return false;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value == null || value === '') return false;
+
+  if (Array.isArray(value)) {
+    return value.some(item => item === true || item === 'true');
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value).some(item => item === true || item === 'true');
+  }
+
+  return Boolean(value);
+};
+
 export const normalizeReactionMap = map => {
   if (!map || typeof map !== 'object') return {};
   return Object.fromEntries(
@@ -83,6 +101,8 @@ export const resolvePrioritizedReactionMaps = ({
 
 export const getCanShowMatchingUserDebug = (user, { isAdmin = false } = {}) => {
   const userId = String(user?.userId || '').trim();
+  const rawPublish = user?.publish;
+  const normalizedPublish = normalizePublish(rawPublish);
   if (!userId) {
     return {
       canShow: false,
@@ -138,24 +158,28 @@ export const getCanShowMatchingUserDebug = (user, { isAdmin = false } = {}) => {
     };
   }
 
-  if (user?.publish !== true) {
+  if (!normalizedPublish && !isAdmin) {
     return {
       canShow: false,
       excludedFunction: 'canShowMatchingUser',
-      excludedCondition: 'user.publish === false && !isAdmin',
-      exactReason: `users_publish_false_for_non_admin:publish=${user?.publish},isAdmin=${isAdmin},userId=${userId}`,
+      excludedCondition: '!normalizedPublish && !isAdmin',
+      exactReason: `users_publish_false_for_non_admin: rawPublish=${JSON.stringify(rawPublish)}, normalizedPublish=${normalizedPublish}, isAdmin=${isAdmin}, userId=${userId}`,
       excludedAtStage: 'final render guard',
       reasonCode: 'users_publish_false_for_non_admin',
+      rawPublish,
+      normalizedPublish,
     };
   }
 
   return {
     canShow: true,
     excludedFunction: 'canShowMatchingUser',
-    excludedCondition: 'user.publish === true',
-    exactReason: `users_publish_true:userId=${userId},publish=${user?.publish}`,
+    excludedCondition: 'publish check passed',
+    exactReason: `publish check passed: rawPublish=${JSON.stringify(rawPublish)}, normalizedPublish=${normalizedPublish}, userId=${userId}`,
     excludedAtStage: 'final render guard',
     reasonCode: 'allowed_users_publish_true',
+    rawPublish,
+    normalizedPublish,
   };
 };
 


### PR DESCRIPTION
### Motivation

- Improve robustness of the final render guard by treating various `user.publish` representations (strings, arrays, objects, null/empty) consistently instead of only accepting the boolean `true`.
- Surface the raw and normalized publish values in debug responses to make it easier to diagnose why a user was excluded or allowed.

### Description

- Add and export `normalizePublish` which normalizes `publish` values from booleans, string booleans, arrays, and objects into a single truthy/falsey boolean result.
- Use `normalizePublish` inside `getCanShowMatchingUserDebug` and replace the previous `user?.publish !== true` check with `!normalizedPublish && !isAdmin` to allow more flexible publish inputs while preserving admin behavior.
- Include `rawPublish` and `normalizedPublish` in the debug return payloads and update `excludedCondition` and `exactReason` messages to reference the normalized check.

### Testing

- Ran unit tests for the utils package with `yarn test` and the test suite completed successfully.
- Ran targeted tests for `src/utils/reactionPriority` with `yarn test src/utils/reactionPriority.test.js` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f613bb71c832688b06bdaa111fe65)