### PR TITLE
Remove Matching debug-log and data-source toggles and associated helpers

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5366,44 +5366,7 @@ const Matching = () => {
     setDownloadSizeToastsEnabled(prev => !prev);
   };
 
-  const buildCardsDebugSnapshot = () => ({
-    ownerId,
-    viewMode: viewModeRef.current,
-    collectionSource: collectionSourceRef.current,
-    currentlyRenderedCards: Array.isArray(usersRef.current) ? usersRef.current.length : 0,
-    currentlyLoadedIds: loadedIdsRef.current?.size || 0,
-    hasMore,
-    lastKey,
-    lastBatchStats: matchingLastCardsDebugStatsRef.current,
-  });
-
-  const handleMatchingDebugLogModeToggle = () => {
-    setMatchingDebugLogMode(prev => {
-      const nextMode = prev === 'file' ? 'console' : 'file';
-      if (nextMode === 'file') {
-        if (typeof window !== 'undefined') {
-          window.__MATCHING_DEBUG_LOG_MODE = 'file';
-        }
-        writeMatchingDebugLog('logMode:enabled-file', buildCardsDebugSnapshot());
-        toast.success('Логи Matching пишуться у файл. Натисни ще раз, щоб завантажити файл.');
-      } else {
-        writeMatchingDebugLog('cards:snapshot-before-download', buildCardsDebugSnapshot());
-        writeMatchingDebugLog('logMode:disabled-file', buildCardsDebugSnapshot());
-        downloadMatchingDebugLogs({ reason: 'toggle-to-console' });
-        if (typeof window !== 'undefined') window.__MATCHING_DEBUG_LOG_MODE = 'console';
-        toast.success('Файл логів Matching завантажено. Консольні логи увімкнено.');
-      }
-      return nextMode;
-    });
-  };
-
-  const handleMatchingDataSourceModeToggle = () => {
-    setMatchingDataSourceMode(prev => (prev === 'backend' ? 'localFirst' : 'backend'));
-  };
-
   const showBackendTrafficToggle = ownerId === BACKEND_TRAFFIC_TRACKING_TEST_UID;
-  const showMatchingDebugLogModeToggle = isAdmin || ownerId === MATCHING_LOG_MODE_TEST_USER_ID;
-  const showMatchingDataSourceModeToggle = ownerId === MATCHING_DATA_SOURCE_TEST_USER_ID;
 
   const dotsMenu = () => (
     <>
@@ -5532,42 +5495,6 @@ const Matching = () => {
                 >
                   📦
                   <BackendTrafficToggleStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</BackendTrafficToggleStatus>
-                </BackendTrafficToggleButton>
-              )}
-              {showMatchingDebugLogModeToggle && (
-                <BackendTrafficToggleButton
-                  type="button"
-                  $active={matchingDebugLogMode === 'file'}
-                  aria-pressed={matchingDebugLogMode === 'file'}
-                  title={
-                    matchingDebugLogMode === 'file'
-                      ? 'Завантажити файл логів Matching і повернути логи в консоль'
-                      : 'Писати логи Matching у файл замість консолі'
-                  }
-                  aria-label={
-                    matchingDebugLogMode === 'file'
-                      ? 'Завантажити файл логів Matching і повернути логи в консоль'
-                      : 'Писати логи Matching у файл замість консолі'
-                  }
-                  onClick={handleMatchingDebugLogModeToggle}
-                >
-                  🧾
-                  <BackendTrafficToggleStatus>{matchingDebugLogMode === 'file' ? 'FILE' : 'LOG'}</BackendTrafficToggleStatus>
-                </BackendTrafficToggleButton>
-              )}
-              {showMatchingDataSourceModeToggle && (
-                <BackendTrafficToggleButton
-                  type="button"
-                  $active={matchingDataSourceMode === 'backend'}
-                  aria-pressed={matchingDataSourceMode === 'backend'}
-                  title={matchingDataSourceMode === 'backend' ? 'Backend only' : 'Local first'}
-                  aria-label={matchingDataSourceMode === 'backend' ? 'Backend only' : 'Local first'}
-                  onClick={handleMatchingDataSourceModeToggle}
-                >
-                  🧪
-                  <BackendTrafficToggleStatus>
-                    {matchingDataSourceMode === 'backend' ? 'Backend only' : 'Local first'}
-                  </BackendTrafficToggleStatus>
                 </BackendTrafficToggleButton>
               )}
               {isIndexedDebugTestUser && (


### PR DESCRIPTION
### Motivation
- Simplify the Matching UI by removing rarely used developer toggles and their runtime behaviors to reduce maintenance surface and potential side-effects.
- Remove file-based debug logging and data-source mode switching features that were gated behind test user flags.

### Description
- Remove `buildCardsDebugSnapshot`, `handleMatchingDebugLogModeToggle`, and `handleMatchingDataSourceModeToggle` helper functions from `Matching.jsx`.
- Remove rendering of the Matching debug log mode toggle (file/console) and the Matching data source mode toggle (backend/localFirst) from the top actions UI.
- Remove the `showMatchingDebugLogModeToggle` and `showMatchingDataSourceModeToggle` flags that controlled visibility of those toggles and all related `window.__MATCHING_DEBUG_LOG_MODE` usage and log download calls.
- Keep other debug controls (backend traffic size toasts and indexed debug toggle) intact.

### Testing
- Ran unit tests with `yarn test`, and the test suite passed.
- Ran linter with `yarn lint`, and there were no linting errors.
- Built the app with `yarn build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f688ca7308326ba03b746a841863b)