### PR TITLE
Remove debug download helper and make matching debug/data-source settings read-only

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -190,7 +190,6 @@ import {
 
 const DEBUG_ADDITIONAL_MATCHING_USER_ID = BACKEND_TRAFFIC_TRACKING_TEST_UID;
 const MATCHING_LOG_MODE_TEST_USER_ID = 'S0VhDLCYjuTFDNLalRa85u7fPcg2';
-const MATCHING_DATA_SOURCE_TEST_USER_ID = 'S0VhDLCYjuTFDNLalRa85u7fPcg2';
 const MATCHING_DATA_SOURCE_MODE_KEY = 'matchingDataSourceMode';
 const MATCHING_DEBUG_LOG_MODE_KEY = 'matchingDebugLogMode';
 const MATCHING_DEBUG_SHOW_ALL_INDEXED_CARDS_KEY = 'matchingDebugShowAllIndexedCards';
@@ -234,37 +233,6 @@ const getMatchingDebugLogsStore = () => {
     window.__MATCHING_DEBUG_LOGS = [];
   }
   return window.__MATCHING_DEBUG_LOGS;
-};
-
-const downloadMatchingDebugLogs = ({ reason = 'manual' } = {}) => {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
-  const logs = getMatchingDebugLogsStore() || [];
-  const now = new Date();
-  const pad = value => String(value).padStart(2, '0');
-  const fileStamp = [
-    now.getFullYear(),
-    pad(now.getMonth() + 1),
-    pad(now.getDate()),
-  ].join('-') + `-${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
-  const body = {
-    matchingDebugVersion: MATCHING_DEBUG_VERSION,
-    userAgent: window.navigator?.userAgent || '',
-    url: window.location?.href || '',
-    timestamp: now.toISOString(),
-    testUserId: MATCHING_LOG_MODE_TEST_USER_ID,
-    logMode: window.__MATCHING_DEBUG_LOG_MODE || 'console',
-    reason,
-    logs,
-  };
-  const blob = new Blob([JSON.stringify(body, null, 2)], { type: 'application/json' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = `matching-debug-${fileStamp}.json`;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(link.href);
-  return true;
 };
 
 const writeMatchingDebugLog = (stage, data = {}, errors = null) => {
@@ -1322,9 +1290,9 @@ const Matching = () => {
   const ownDislikeUsersRef = useRef(ownDislikeUsers);
   const [viewMode, setViewMode] = useState('default');
   const [activeProfileIndex, setActiveProfileIndex] = useState(0);
-  const [matchingDebugLogMode, setMatchingDebugLogMode] = useState(getStoredMatchingDebugLogMode);
+  const [matchingDebugLogMode] = useState(getStoredMatchingDebugLogMode);
   const [debugShowAllIndexedCards, setDebugShowAllIndexedCards] = useState(getStoredDebugShowAllIndexedCards);
-  const [matchingDataSourceMode, setMatchingDataSourceMode] = useState(getStoredMatchingDataSourceMode);
+  const [matchingDataSourceMode] = useState(getStoredMatchingDataSourceMode);
   const [themeMode, setThemeMode] = useState(getStoredMatchingTheme);
   const viewModeRef = useRef(viewMode);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
### Motivation
- Simplify the matching debug flow by removing an unused download helper and reduce mutable debug state to avoid accidental updates.
- Prevent UI code from exposing setters for debug modes that should be derived from persistent storage only.

### Description
- Removed the `downloadMatchingDebugLogs` helper which created and downloaded a JSON blob of matching debug logs.
- Deleted the `MATCHING_DATA_SOURCE_TEST_USER_ID` constant which was no longer used.
- Changed `matchingDebugLogMode` and `matchingDataSourceMode` hooks to be read-only by removing their setters and keeping only the initialized values from `getStoredMatchingDebugLogMode` and `getStoredMatchingDataSourceMode`.
- Kept existing debug log storage and `writeMatchingDebugLog` behavior intact while preventing the client-side manual download path.

### Testing
- Ran the unit test suite with `yarn test` and all tests passed.
- Ran lint checks with `yarn lint` and no lint errors were reported.
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fdfd93324832691df8ebc01e2d176)