### PR TITLE
Update additional-rule removal to update form state, submit changes, and reindex

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1258,7 +1258,39 @@ export const ProfileForm = ({
   };
 
   const removeAdditionalRule = index => {
-    setAdditionalRuleBuilder(prev => prev.filter((_, ruleIndex) => ruleIndex !== index));
+    const nextBuilder = additionalRuleBuilder.filter((_, ruleIndex) => ruleIndex !== index);
+    const nextRulesText = buildAdditionalRulesTextFromBuilder(nextBuilder);
+
+    setAdditionalRuleBuilder(
+      nextBuilder.length > 0
+        ? nextBuilder
+        : [{ key: ADDITIONAL_RULE_ORDER[0], allowedValues: new Set() }]
+    );
+
+    setState(prevState => {
+      const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
+      const updated = { ...prevState };
+
+      if (Array.isArray(currentValue)) {
+        const nextValue = currentValue.map((item, idx) => (idx === activeAdditionalRuleInputIndex ? nextRulesText : item));
+        if (nextValue.every(item => !String(item || '').trim())) {
+          delete updated[ADDITIONAL_ACCESS_FIELD];
+        } else {
+          updated[ADDITIONAL_ACCESS_FIELD] = nextValue;
+        }
+      } else if (nextRulesText.trim()) {
+        updated[ADDITIONAL_ACCESS_FIELD] = nextRulesText;
+      } else {
+        delete updated[ADDITIONAL_ACCESS_FIELD];
+      }
+
+      submitWithNormalization(updated, 'overwrite', nextRulesText.trim() ? undefined : { [ADDITIONAL_ACCESS_FIELD]: currentValue });
+      return updated;
+    });
+
+    Promise.resolve(indexAdditionalRulesForUser(nextRulesText)).catch(error => {
+      console.error('Failed to reindex additional access rules after removing filter', error);
+    });
   };
 
   const handleRemoveAdditionalAccessRuleInput = useCallback((removeIndex = null, action = 'clear') => {


### PR DESCRIPTION
### Motivation

- Ensure removing an additional access rule not only updates the builder UI but also updates the underlying form state and persisted rule text.
- Trigger backend reindexing and submit normalized state on removal and avoid leaving the builder empty by restoring a default rule entry.

### Description

- Compute `nextBuilder` and `nextRulesText` after removal and set the builder to `nextBuilder` or a default single rule when empty.
- Update the form `state` for `ADDITIONAL_ACCESS_FIELD` to handle array and string representations and remove the field when resulting values are blank.
- Call `submitWithNormalization` with an `overwrite` mode and appropriate fallback to persist the updated field state immediately.
- Invoke `indexAdditionalRulesForUser(nextRulesText)` asynchronously and log errors if reindexing fails.

### Testing

- Ran the test suite with `npm test` and all unit tests passed.
- Ran linter with `npm run lint` and static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0feb209a188326a106eee94f32dac8)