### PR TITLE
Приховати поле C-section у Matching

### DIFF
--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -208,7 +208,6 @@ const sectionConfig = {
     ] },
     { title: 'Donation experience', fields: [
       field('experience', 'Previous donation'), field('donationCount', 'Donation count'), field('donationsCount', 'Donations'),
-      field('cSection', 'C-section', user => user?.cSection || user?.csection || user?.c_section || user?.cesareanSection, ['cSection', 'csection', 'c_section', 'cesareanSection']),
     ] },
   ],
   ip: [


### PR DESCRIPTION
### Motivation
- Не відображати значення `C-section` на Matching-картках, тому поле потрібно прибрати з конфігурації секцій профілю для ролі `ed`.

### Description
- Видалено поле `cSection` з секції «Donation experience» для ролі `ed` у файлі `src/components/profileLayoutConfig.js` (raw: https://raw.githubusercontent.com/KnowMe-app/main/refs/heads/main/src/components/profileLayoutConfig.js).

### Testing
- Виконано локальні перевірки коміту та файлу через `git rev-parse --short HEAD`, `git status --short` та вивід частини файлу через `nl -ba ... | sed -n '200,225p'`, всі команди успішні; автоматичних тестів не запускалося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10031fc1f883269e4653b62810d90b)