### PR TITLE
Exclude cesarean-related fields from profile hero/summary in Matching component

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -925,7 +925,22 @@ const SwipeableCard = ({
   const title = [name, age].filter(Boolean).join(', ');
   const shouldShowRoleBadge = !isGenericProfileRole;
   const locationInfo = getProfileLocation(user);
-  const identityAndLocationKeys = ['name', 'surname', 'agencyName', 'companyName', 'agency', 'country', 'region', 'city', 'role', 'userRole'];
+  const identityAndLocationKeys = [
+    'name',
+    'surname',
+    'agencyName',
+    'companyName',
+    'agency',
+    'country',
+    'region',
+    'city',
+    'role',
+    'userRole',
+    'cSection',
+    'csection',
+    'c_section',
+    'cesareanSection',
+  ];
   const heroFields = getHeroFields(user, resolvedRole, { excludeKeys: identityAndLocationKeys });
   const usedSummaryFieldKeys = collectProfileFieldKeys(heroFields);
   const bodyHeroFields = getQuickFacts(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys] });


### PR DESCRIPTION
### Motivation
- Prevent cesarean-related fields from appearing in the profile hero/summary by treating several common key variants as identity/location keys so they are excluded from prominent UI areas.

### Description
- In `src/components/Matching.jsx` the `identityAndLocationKeys` array was extended with `'cSection'`, `'csection'`, `'c_section'`, and `'cesareanSection'` so those fields are excluded from `heroFields`, `bodyHeroFields`, and profile `sections`.

### Testing
- Ran unit tests with `yarn test` and linting with `yarn lint`, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100bbf41808326a59d28d9e5226c5e)