### PR TITLE
Introduce uiTokens theme and migrate components to use design tokens

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -48,7 +48,7 @@ import { buildOverlayFromDraft, getCanonicalCard, saveOverlayForUserCard } from 
 import InfoModal from './InfoModal';
 import { VerifyEmail } from './VerifyEmail';
 
-import { color, coloredCard } from './styles';
+import { color, coloredCard, uiTokens } from './styles';
 //import { formatPhoneNumber } from './inputValidations';
 import { UsersList } from './UsersList';
 import {
@@ -150,13 +150,13 @@ const Container = styled.div`
   justify-content: center;
   align-items: center;
   padding: 5px;
-  background-color: #f5f5f5;
+  background-color: ${uiTokens.colors.pageBg};
 
   @media (max-width: 768px) {
     // Медіа-запит для пристроїв з шириною екрану до 768px
     padding: 10px;
   }
-  /* max-width: 450px; */
+  /* max-width: 560px; */
 
   /* maxWidth:  */
   /* height: 100vh; */
@@ -284,17 +284,17 @@ const MatchingMiniMeta = styled.div`
 `;
 
 const InnerContainer = styled.div`
-  max-width: 450px;
+  max-width: 560px;
   width: 100%;
   box-sizing: border-box;
   background-color: #f0f0f0;
-  padding: 20px;
+  padding: 16px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
 
   @media (max-width: 768px) {
     // Медіа-запит для пристроїв з шириною екрану до 768px
-    background-color: #f5f5f5;
+    background-color: ${uiTokens.colors.pageBg};
     box-shadow: 0 4px 8px #f5f5f5;
     border-radius: 0;
     padding: 0;

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -15,7 +15,7 @@ import { makeUploadedInfo } from './makeUploadedInfo';
 import { ProfileForm } from './ProfileForm';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
-import { coloredCard } from './styles';
+import { coloredCard, uiTokens } from './styles';
 import { updateCachedUser } from '../utils/cache';
 import { getCard } from '../utils/cardIndex';
 import {
@@ -42,9 +42,9 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 20px;
+  padding: 16px;
   box-sizing: border-box;
-  max-width: 450px;
+  max-width: 560px;
   width: 100%;
   margin: 0 auto;
 `;

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -6,7 +6,7 @@ import { withAdminDownloadToast } from 'utils/backendDownloadToast';
 import Photos from './Photos';
 import { inputUpdateValue } from './inputUpdatedValue';
 import { useAutoResize } from '../hooks/useAutoResize';
-import { color, OrangeBtn } from './styles';
+import { color, OrangeBtn, uiTokens } from './styles';
 import { pickerFieldsExtended as pickerFields } from './formFields';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import {
@@ -2406,7 +2406,8 @@ ${entries.join('\n')}`;
   };
 
   return (
-    <>
+    <FormPage>
+      <FormCard>
       {state.userId && (
         <div
           id={state.userId}
@@ -3054,6 +3055,8 @@ ${entries.join('\n')}`;
         </AdditionalRulesOverlay>
       )}
 
+      </FormCard>
+
       {showInfoModal && (
         <InfoModal
           onClose={handleCloseModal}
@@ -3065,31 +3068,64 @@ ${entries.join('\n')}`;
           text={showInfoModal}
         />
       )}
-    </>
+    </FormPage>
   );
 };
 
+
+const FormPage = styled.div`
+  background: ${uiTokens.colors.pageBg};
+  padding: 16px;
+  border-radius: ${uiTokens.radius.lg};
+  width: 100%;
+
+  @media (max-width: 768px) {
+    padding: 12px;
+  }
+`;
+
+const FormCard = styled.div`
+  background: ${uiTokens.colors.cardBg};
+  border: 1px solid ${uiTokens.colors.border};
+  border-radius: ${uiTokens.radius.xl};
+  box-shadow: ${uiTokens.shadow.card};
+  padding: ${uiTokens.spacing.md};
+  display: flex;
+  flex-direction: column;
+  gap: ${uiTokens.spacing.sm};
+`;
+
+
 const PhotosBlock = styled.div`
   position: relative;
-  max-width: 400px;
+  max-width: 420px;
   margin: 0 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
 `;
 
 const CollectionToggle = styled.select`
-  position: absolute;
-  top: 0;
-  right: 0;
+  align-self: flex-end;
+  border: 1px solid ${uiTokens.colors.border};
+  border-radius: 999px;
+  padding: 6px 28px 6px 10px;
+  font-size: ${uiTokens.typography.fontSizeSm};
+  background: ${uiTokens.colors.cardBg};
+  color: ${uiTokens.colors.textPrimary};
 `;
 
 const PickerContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #f0f0f0;
+  background-color: ${uiTokens.colors.pageBg};
   box-sizing: border-box;
   width: 100%;
   @media (max-width: 768px) {
-    background-color: #f5f5f5;
+    background-color: ${uiTokens.colors.pageBg};
   }
 `;
 
@@ -3100,17 +3136,17 @@ const InputDiv = styled.div`
   margin: 10px 0;
   padding: 10px;
   background-color: ${({ $isDeletedOverlay, $isOverlaySuggestion }) => {
-    if ($isOverlaySuggestion) return '#fff';
-    if ($isDeletedOverlay) return '#f7f7f7';
-    return '#fff';
+    if ($isOverlaySuggestion) return uiTokens.colors.cardBg;
+    if ($isDeletedOverlay) return uiTokens.colors.mutedBg;
+    return uiTokens.colors.cardBg;
   }};
   border: ${({ $isHighlighted, $isDeletedOverlay, $isOverlaySuggestion }) => {
-    if ($isDeletedOverlay) return '2px solid #e53935';
-    if ($isOverlaySuggestion) return '1px solid #2f6df6';
-    if ($isHighlighted) return '2px solid #2f6df6';
-    return '1px solid #ccc';
+    if ($isDeletedOverlay) return `1px solid ${uiTokens.colors.danger}`;
+    if ($isOverlaySuggestion) return `1px solid ${uiTokens.colors.borderFocus}`;
+    if ($isHighlighted) return `1px solid ${uiTokens.colors.borderFocus}`;
+    return `1px solid ${uiTokens.colors.border}`;
   }};
-  border-radius: 5px;
+  border-radius: ${uiTokens.radius.md};
   box-sizing: border-box;
   flex: ${({ $isOverlaySuggestion }) => ($isOverlaySuggestion ? '1 1 0' : '1 1 auto')};
   width: ${({ $isOverlaySuggestion }) => ($isOverlaySuggestion ? 'auto' : '100%')};
@@ -3149,7 +3185,7 @@ const InputField = styled.input`
   max-width: 100%;
   min-width: 0;
   pointer-events: auto;
-  color: ${({ $isDeletedOverlay }) => ($isDeletedOverlay ? '#8f8f8f' : '#000')};
+  color: ${({ $isDeletedOverlay }) => ($isDeletedOverlay ? uiTokens.colors.textSecondary : uiTokens.colors.textPrimary)};
   height: 100%;
   resize: vertical;
   &::placeholder {
@@ -3171,7 +3207,7 @@ const AccessLevelSelect = styled.select`
   background: transparent;
   min-height: 100%;
   height: 100%;
-  color: ${({ value }) => (value ? '#000' : 'gray')};
+  color: ${({ value }) => (value ? uiTokens.colors.textPrimary : uiTokens.colors.textSecondary)};
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
@@ -3182,7 +3218,7 @@ const AccessLevelSelect = styled.select`
   background-size: 10px 6px;
 
   option[value=''] {
-    color: gray;
+    color: ${uiTokens.colors.textSecondary};
   }
 `;
 
@@ -3197,7 +3233,7 @@ const Hint = styled.label`
   display: flex;
   align-items: center;
   transition: all 0.3s ease;
-  color: gray;
+  color: ${uiTokens.colors.textSecondary};
   pointer-events: none;
   display: flex;
   align-items: center;
@@ -3215,7 +3251,7 @@ const Placeholder = styled.label`
   top: 0;
   transform: translateY(-100%);
   transition: all 0.3s ease;
-  color: gray;
+  color: ${uiTokens.colors.textSecondary};
   pointer-events: none;
   display: flex;
   align-items: center;
@@ -3228,7 +3264,7 @@ const Placeholder = styled.label`
       top: 0;
       transform: translateY(-100%);
       font-size: 12px;
-      color: orange;
+      color: ${uiTokens.colors.accent};
     `}
 `;
 
@@ -3254,7 +3290,7 @@ const InputFieldContainer = styled.div`
     left: 10px;
     display: flex;
     align-items: center;
-    color: ${({ value }) => (value ? '#000' : 'gray')};
+    color: ${({ value }) => (value ? uiTokens.colors.textPrimary : uiTokens.colors.textSecondary)};
     font-size: 16px;
     text-align: center;
   }
@@ -3292,12 +3328,12 @@ const ClearButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: gray;
+  color: ${uiTokens.colors.textSecondary};
   font-size: 18px;
   width: 35px;
   height: 35px;
   &:hover {
-    color: black;
+    color: ${uiTokens.colors.textPrimary};
   }
 `;
 
@@ -3651,12 +3687,12 @@ const DelKeyValueBTN = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: red;
+  color: ${uiTokens.colors.danger};
   font-size: 18px;
   width: 35px;
   height: 35px;
   &:hover {
-    color: black;
+    color: ${uiTokens.colors.textPrimary};
   }
 `;
 
@@ -3668,11 +3704,11 @@ const KeyValueRow = styled.div`
   padding: 10px;
   background-color: ${({ $isDeletedOverlay }) => ($isDeletedOverlay ? '#f7f7f7' : '#fff')};
   border: ${({ $isHighlighted, $isDeletedOverlay }) => {
-    if ($isDeletedOverlay) return '2px solid #e53935';
-    if ($isHighlighted) return '2px solid #2f6df6';
-    return '1px solid #ccc';
+    if ($isDeletedOverlay) return `1px solid ${uiTokens.colors.danger}`;
+    if ($isHighlighted) return `1px solid ${uiTokens.colors.borderFocus}`;
+    return `1px solid ${uiTokens.colors.border}`;
   }};
-  border-radius: 5px;
+  border-radius: ${uiTokens.radius.md};
   box-sizing: border-box;
   width: 100%;
 `;
@@ -3699,15 +3735,15 @@ const ButtonGroup = styled.div`
 `;
 
 const Button = styled.button`
-  width: 35px;
-  min-width: 35px;
-  height: 35px;
-  min-height: 35px;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  min-height: 36px;
   padding: 3px;
   border: none;
-  background-color: ${color.accent5};
+  background-color: ${uiTokens.colors.accent};
   color: white;
-  border-radius: 50px;
+  border-radius: ${uiTokens.radius.md};
   cursor: pointer;
   font-size: 12px;
   flex: 0 0 35px;

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -369,3 +369,40 @@ export const UnderlinedInput = styled.input`
   width: 9.5ch; // Точний розмір для дати формату 01.01.2022
   text-align: center; // Вирівнювання тексту
 `;
+
+
+export const uiTokens = {
+  colors: {
+    pageBg: '#f4f6fb',
+    cardBg: '#ffffff',
+    textPrimary: '#1f2937',
+    textSecondary: '#6b7280',
+    border: '#d7deea',
+    borderFocus: '#2f6df6',
+    accent: '#2f6df6',
+    danger: '#e53935',
+    mutedBg: '#eef2f8',
+  },
+  radius: {
+    sm: '8px',
+    md: '12px',
+    lg: '14px',
+    xl: '18px',
+  },
+  spacing: {
+    xs: '6px',
+    sm: '10px',
+    md: '14px',
+    lg: '18px',
+    xl: '24px',
+  },
+  shadow: {
+    card: '0 12px 30px rgba(15, 23, 42, 0.08)',
+    focus: '0 0 0 3px rgba(47, 109, 246, 0.16)',
+  },
+  typography: {
+    fontSizeSm: '12px',
+    fontSizeMd: '14px',
+    fontSizeLg: '16px',
+  },
+};


### PR DESCRIPTION
### Motivation

- Replace scattered hard-coded colors, spacing and radii with a centralized design token set to improve consistency and make future theming easier. 
- Align component paddings and max widths for a more consistent layout across profile creation and editing views.

### Description

- Add `uiTokens` export in `src/components/styles/index.js` containing color, radius, spacing, shadow and typography tokens. 
- Migrate multiple components (`AddNewProfile.jsx`, `EditProfile.jsx`, `ProfileForm.jsx`) to consume `uiTokens` and replace hard-coded colors, borders, radii, paddings and sizes with token values. 
- Introduce new layout wrappers `FormPage` and `FormCard` in `ProfileForm.jsx` and adjust other style props (max-widths increased to 560px, paddings reduced to 16px, PhotosBlock sizing and layout tweaks). 
- Update several individual styled elements to use token-based values (inputs, hints, placeholders, buttons, overlays, borders and danger/accent colors) and small UX polish (button sizes, border focus colors, muted text colors).

### Testing

- Ran the project build with `yarn build` and the build completed successfully. 
- Ran the unit test suite with `yarn test` and all tests passed. 
- Ran linter checks with `yarn lint` and no style/lint errors remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10797cc2d083269695d992d6dcf46f)