### PR TITLE
Видалити невикористаний імпорт `uiTokens` у src/components/EditProfile.jsx

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -15,7 +15,7 @@ import { makeUploadedInfo } from './makeUploadedInfo';
 import { ProfileForm } from './ProfileForm';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
-import { coloredCard, uiTokens } from './styles';
+import { coloredCard } from './styles';
 import { updateCachedUser } from '../utils/cache';
 import { getCard } from '../utils/cardIndex';
 import {


### PR DESCRIPTION
### Motivation
- Усунути ESLint-попередження `no-unused-vars`, яке виникало через визначений, але невикористаний імпорт `uiTokens`.

### Description
- Видалено невикористаний імпорт `uiTokens` з `src/components/EditProfile.jsx`, залишивши лише потрібний імпорт `coloredCard` з `./styles`.

### Testing
- Ніяких автоматичних тестів не запускалося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10849653cc8326861f14752a1f181e)