### PR TITLE
Persist additional-rule removals and guard searchKeyFile parameter

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1086,7 +1086,10 @@ export const ProfileForm = ({
             rawRules: '',
             accessUserId,
             matchedUserIdsBySetKey: {},
-            searchKeyFile: localSearchKeyPayload,
+            searchKeyFile:
+              localSearchKeyPayload && typeof localSearchKeyPayload === 'object'
+                ? localSearchKeyPayload
+                : {},
           });
           toast('searchKeySets очищено: additional access rules видалено.');
           Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
@@ -1258,7 +1261,36 @@ export const ProfileForm = ({
   };
 
   const removeAdditionalRule = index => {
-    setAdditionalRuleBuilder(prev => prev.filter((_, ruleIndex) => ruleIndex !== index));
+    const nextBuilder = additionalRuleBuilder.filter((_, ruleIndex) => ruleIndex !== index);
+    const nextRulesText = buildAdditionalRulesTextFromBuilder(nextBuilder);
+
+    setAdditionalRuleBuilder(
+      nextBuilder.length > 0
+        ? nextBuilder
+        : [{ key: ADDITIONAL_RULE_ORDER[0], allowedValues: new Set() }]
+    );
+
+    setState(prevState => {
+      const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
+      const updated = { ...prevState };
+
+      if (Array.isArray(currentValue)) {
+        const nextValue = currentValue.map((item, idx) => (idx === activeAdditionalRuleInputIndex ? nextRulesText : item));
+        if (nextValue.every(item => !String(item || '').trim())) {
+          delete updated[ADDITIONAL_ACCESS_FIELD];
+        } else {
+          updated[ADDITIONAL_ACCESS_FIELD] = nextValue;
+        }
+      } else if (nextRulesText.trim()) {
+        updated[ADDITIONAL_ACCESS_FIELD] = nextRulesText;
+      } else {
+        delete updated[ADDITIONAL_ACCESS_FIELD];
+      }
+
+      submitWithNormalization(updated, 'overwrite', nextRulesText.trim() ? undefined : { [ADDITIONAL_ACCESS_FIELD]: currentValue });
+      return updated;
+    });
+
   };
 
   const handleRemoveAdditionalAccessRuleInput = useCallback((removeIndex = null, action = 'clear') => {


### PR DESCRIPTION
### Motivation

- Ensure removing an additional access rule updates the form state and persists the change to the backend instead of only updating the local builder. 
- Prevent non-object `localSearchKeyPayload` from being passed into `buildNewUsersFilterSetIndex` to avoid runtime errors.

### Description

- Guard the `searchKeyFile` argument passed to `buildNewUsersFilterSetIndex` by passing an empty object when `localSearchKeyPayload` is not an object. 
- Replace the simple `removeAdditionalRule` behavior with logic that computes the next builder state, builds the corresponding rules text via `buildAdditionalRulesTextFromBuilder`, and sets a default empty rule when the builder would become empty. 
- Update the component `state` for `ADDITIONAL_ACCESS_FIELD` to reflect the removed rule (handling array and string forms) and delete the field when all entries are empty. 
- Trigger `submitWithNormalization` after removing a rule to persist the change, sending an overwrite and a delete condition when appropriate.

### Testing

- Ran the project's unit test suite via `npm test`, and the tests completed successfully. 
- Ran project linting (`npm run lint`), and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0feb209a188326a106eee94f32dac8)