### PR TITLE
Fix additional-rule delete condition when clearing one builder group

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1273,11 +1273,15 @@ export const ProfileForm = ({
     setState(prevState => {
       const currentValue = prevState?.[ADDITIONAL_ACCESS_FIELD];
       const updated = { ...prevState };
+      let shouldDeleteAdditionalAccessField = false;
 
       if (Array.isArray(currentValue)) {
-        const nextValue = currentValue.map((item, idx) => (idx === activeAdditionalRuleInputIndex ? nextRulesText : item));
+        const nextValue = currentValue.map((item, idx) =>
+          idx === activeAdditionalRuleInputIndex ? nextRulesText : item
+        );
         if (nextValue.every(item => !String(item || '').trim())) {
           delete updated[ADDITIONAL_ACCESS_FIELD];
+          shouldDeleteAdditionalAccessField = true;
         } else {
           updated[ADDITIONAL_ACCESS_FIELD] = nextValue;
         }
@@ -1285,9 +1289,13 @@ export const ProfileForm = ({
         updated[ADDITIONAL_ACCESS_FIELD] = nextRulesText;
       } else {
         delete updated[ADDITIONAL_ACCESS_FIELD];
+        shouldDeleteAdditionalAccessField = true;
       }
 
-      submitWithNormalization(updated, 'overwrite', nextRulesText.trim() ? undefined : { [ADDITIONAL_ACCESS_FIELD]: currentValue });
+      const delCondition = shouldDeleteAdditionalAccessField
+        ? { [ADDITIONAL_ACCESS_FIELD]: currentValue }
+        : undefined;
+      submitWithNormalization(updated, 'overwrite', delCondition);
       return updated;
     });
 


### PR DESCRIPTION
### Motivation

- Prevent accidental full-field deletion of `ADDITIONAL_ACCESS_FIELD` when clearing the last rule in one additional-rule builder input, since `delCondition` was causing backend full-field nulling even if sibling entries remained populated.

### Description

- Add a `shouldDeleteAdditionalAccessField` flag and compute `delCondition` only when the field is actually removed in `removeAdditionalRule` in `src/components/ProfileForm.jsx`.
- Update only the active array entry when present so non-empty sibling entries are preserved instead of triggering a full-field delete.
- Call `submitWithNormalization(updated, 'overwrite', delCondition)` with `delCondition` set only when all entries are empty to avoid unintended backend nulling.

### Testing

- Ran unit tests with `npm test -- --watch=false`, which completed and reported "No tests found related to files changed since last commit".
- Attempted to run lint via `npm run lint`, but the repository does not define a `lint` script so linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a98f61288326b0650169f0f5d984)