### PR TITLE
Авто-ресайз для полів `additionalAccessRules` та `multiDataAccessUserIds`

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -803,6 +803,8 @@ export const ProfileForm = ({
   const canManageAccessLevel = isAdmin;
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
+  const additionalAccessRulesRef = useRef(null);
+  const multiDataAccessUserIdsRef = useRef(null);
   const [customField, setCustomField] = useState({ key: '', value: '' });
   const [collection, setCollection] = useState('newUsers');
   const [selectedField, setSelectedField] = useState(null);
@@ -1691,6 +1693,8 @@ export const ProfileForm = ({
 
   const autoResizeMyComment = useAutoResize(textareaRef, state.myComment);
   const autoResizeMoreInfo = useAutoResize(moreInfoRef, state.moreInfo_main);
+  const autoResizeAdditionalAccessRules = useAutoResize(additionalAccessRulesRef, state[ADDITIONAL_ACCESS_FIELD]);
+  const autoResizeMultiDataAccessUserIds = useAutoResize(multiDataAccessUserIdsRef, state[MULTI_DATA_ACCESS_FIELD]);
 
   const priorityOrder = [
     'birth',
@@ -2469,8 +2473,8 @@ ${entries.join('\n')}`;
                     <InputFieldContainer fieldName={`${field.name}-${idx}`} value={value}>
                       <InputField
                         fieldName={`${field.name}-${idx}`}
-                        as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
-                        ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
+                        as={(field.name === 'moreInfo_main' || field.name === 'myComment' || field.name === ADDITIONAL_ACCESS_FIELD || field.name === MULTI_DATA_ACCESS_FIELD) && 'textarea'}
+                        ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : field.name === ADDITIONAL_ACCESS_FIELD ? additionalAccessRulesRef : field.name === MULTI_DATA_ACCESS_FIELD ? multiDataAccessUserIdsRef : null}
                         inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                         name={`${field.name}-${idx}`}
                         value={value || ''}
@@ -2489,6 +2493,12 @@ ${entries.join('\n')}`;
                           }
                           if (field.name === 'moreInfo_main') {
                             autoResizeMoreInfo(e.target);
+                          }
+                          if (field.name === ADDITIONAL_ACCESS_FIELD) {
+                            autoResizeAdditionalAccessRules(e.target);
+                          }
+                          if (field.name === MULTI_DATA_ACCESS_FIELD) {
+                            autoResizeMultiDataAccessUserIds(e.target);
                           }
                           const updatedValue =
                             field.name === 'telegram'
@@ -2565,6 +2575,8 @@ ${entries.join('\n')}`;
                     <>
                       <InputField
                         fieldName={field.name}
+                        as="textarea"
+                        ref={additionalAccessRulesRef}
                         name={field.name}
                         value={displayValue}
                         placeholder={ADDITIONAL_ACCESS_TEMPLATE}
@@ -2579,8 +2591,8 @@ ${entries.join('\n')}`;
                   ) : (
                   <InputField
                     fieldName={field.name}
-                    as={(field.name === 'moreInfo_main' || field.name === 'myComment') && 'textarea'}
-                    ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : null}
+                    as={(field.name === 'moreInfo_main' || field.name === 'myComment' || field.name === ADDITIONAL_ACCESS_FIELD || field.name === MULTI_DATA_ACCESS_FIELD) && 'textarea'}
+                    ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : field.name === ADDITIONAL_ACCESS_FIELD ? additionalAccessRulesRef : field.name === MULTI_DATA_ACCESS_FIELD ? multiDataAccessUserIdsRef : null}
                     inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                     name={field.name}
                     value={displayValue}
@@ -2621,6 +2633,12 @@ ${entries.join('\n')}`;
                             }
                             if (field.name === 'moreInfo_main') {
                               autoResizeMoreInfo(e.target);
+                            }
+                            if (field.name === ADDITIONAL_ACCESS_FIELD) {
+                              autoResizeAdditionalAccessRules(e.target);
+                            }
+                            if (field.name === MULTI_DATA_ACCESS_FIELD) {
+                              autoResizeMultiDataAccessUserIds(e.target);
                             }
                             let value = e?.target?.value;
                             if (field.name === 'publish') {


### PR DESCRIPTION
### Motivation
- Підлаштувати висоту полів `additionalAccessRules` та `multiDataAccessUserIds` під кількість тексту так само, як це зроблено для `myComment`, щоб покращити зручність редагування довгих правил та списків користувачів.

### Description
- Додано реф-и `additionalAccessRulesRef` та `multiDataAccessUserIdsRef` і прив'язки `useAutoResize` для обох полів у `src/components/ProfileForm.jsx`.
- Оновлено умови рендерингу, щоб `additionalAccessRules` і `multiDataAccessUserIds` рендерились як `textarea` там, де потрібно, та отримували відповідні `ref` для авто-ресайзу.
- Додано виклики обробників авто-ресайзу (`autoResizeAdditionalAccessRules` та `autoResizeMultiDataAccessUserIds`) у `onChange`, щоб висота змінювалась динамічно під час вводу.
- Зміни обмежені файлом `src/components/ProfileForm.jsx` і не змінюють існуючу логіку збереження або режимів лише для читання.

### Testing
- Автоматичних тестів не запускалося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bc5c4bf883269dabd871f3cf09d8)