### PR TITLE
Normalize additional access rules comparison and adjust reindex trigger

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -486,6 +486,14 @@ const additionalRulesTextToInputs = raw => {
   return text.split(/\r?\n\s*\r?\n+/);
 };
 
+const normalizeAdditionalRulesValueForCompare = raw => {
+  const inputs = additionalRulesTextToInputs(raw)
+    .map(item => String(item || '').trim())
+    .filter(Boolean);
+
+  return inputs.join('\n\n');
+};
+
 
 const sanitizeOverlayValue = value => {
   if (Array.isArray(value)) {
@@ -1073,8 +1081,12 @@ export const ProfileForm = ({
         : nextState;
     try {
       const rawRules = payload?.[ADDITIONAL_ACCESS_FIELD];
+      const previousRulesValue = state?.[ADDITIONAL_ACCESS_FIELD];
+      const nextRulesSignature = normalizeAdditionalRulesValueForCompare(rawRules);
+      const previousRulesSignature = normalizeAdditionalRulesValueForCompare(previousRulesValue);
+      const additionalRulesRemovedExplicitly = Boolean(delCondition?.[ADDITIONAL_ACCESS_FIELD] !== undefined);
       const shouldReindexAfterAdditionalRulesChange =
-        rawRules !== undefined || Boolean(delCondition?.[ADDITIONAL_ACCESS_FIELD] !== undefined);
+        additionalRulesRemovedExplicitly || nextRulesSignature !== previousRulesSignature;
       if (shouldReindexAfterAdditionalRulesChange) {
         const accessUserId = String(payload?.userId || state?.userId || '').trim();
         const hasAnyAdditionalRules =


### PR DESCRIPTION
### Motivation
- Prevent unnecessary reindexing when additional access rules are semantically unchanged but formatted differently.  
- Ensure deletions of additional rules are detected explicitly and still trigger the appropriate index rebuild.

### Description
- Added `normalizeAdditionalRulesValueForCompare` which normalizes raw additional-rules input by converting it to inputs via `additionalRulesTextToInputs`, trimming, removing empty items, and joining with double newlines.  
- In `submitWithNormalization` compute `previousRulesSignature` and `nextRulesSignature` from the normalized values and detect explicit removals via `delCondition`.  
- Change reindex trigger logic to use the normalized signatures or explicit deletion flag (`additionalRulesRemovedExplicitly`) instead of raw value inequality.  
- Preserve existing behavior for clearing all rules by calling `buildNewUsersFilterSetIndex` with an empty `rawRules` and continuing submission handling and user toasts.

### Testing
- Ran the existing automated test suite with `yarn test`, and the tests completed successfully.  
- Performed a build with `yarn build` which completed without errors; no new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bc84a5508326ab0c666df91ba09f)