### PR TITLE
Поліпшення відступів та лейблів у формі профілю

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -71,6 +71,14 @@ const getImtAllowedUserIdsFromSearchKey = (searchKeyPayload, imtValues) => {
   }));
 };
 
+const DYNAMIC_FIELD_LABELS = {
+  additionalAccessRules: 'Додаткові правила',
+  multiDataAccessUserIds: 'Доступ (userId-и)',
+  accessLevel: 'Рівень доступу',
+  searchKey: 'SearchKey',
+  writer: 'Редактор',
+};
+
 export const getFieldsToRender = state => {
   const additionalFields = Object.keys(state).filter(
     key =>
@@ -86,7 +94,7 @@ export const getFieldsToRender = state => {
     ...additionalFields.map(key => ({
       name: key,
       placeholder: key,
-      ukrainianHint: key,
+      ukrainianHint: DYNAMIC_FIELD_LABELS[key] || key,
     })),
   ];
 };
@@ -3155,18 +3163,25 @@ const PickerContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: transparent;
+  background-color: #f0f0f0;
   box-sizing: border-box;
   width: 100%;
-  margin-bottom: 2px;
+  padding: 0 12px;
+  border-bottom: 1px solid #e8e8e8;
+
+  @media (max-width: 768px) {
+    background-color: #f5f5f5;
+    padding: 0 8px;
+  }
 `;
 
 const InputDiv = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  margin: 6px 0;
-  padding: 8px 0;
+  margin-top: 22px;
+  margin-bottom: 4px;
+  padding: 10px 84px 10px 10px;
   background-color: ${({ $isDeletedOverlay, $isOverlaySuggestion }) => {
     if ($isOverlaySuggestion) return uiTokens.colors.cardBg;
     if ($isDeletedOverlay) return uiTokens.colors.mutedBg;
@@ -3176,13 +3191,14 @@ const InputDiv = styled.div`
     if ($isDeletedOverlay) return `1px solid ${uiTokens.colors.danger}`;
     if ($isOverlaySuggestion) return `1px solid ${uiTokens.colors.borderFocus}`;
     if ($isHighlighted) return `1px solid ${uiTokens.colors.borderFocus}`;
-    return `1px solid ${uiTokens.colors.border}`;
+    return `1px solid #ddd`;
   }};
-  border-radius: 0;
+  border-radius: 8px;
   box-sizing: border-box;
   flex: ${({ $isOverlaySuggestion }) => ($isOverlaySuggestion ? '1 1 0' : '1 1 auto')};
   width: ${({ $isOverlaySuggestion }) => ($isOverlaySuggestion ? 'auto' : '100%')};
   min-width: 0;
+  min-height: 44px;
   height: auto;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 
@@ -3301,14 +3317,15 @@ const Placeholder = styled.label`
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: ${uiTokens.typography.fontSizeSm};
+  font-size: 11px;
+  white-space: nowrap;
   ${({ isActive }) =>
     isActive &&
     css`
-      left: 10px;
+      left: 0;
       top: 0;
       transform: translateY(-100%);
-      font-size: ${uiTokens.typography.fontSizeSm};
+      font-size: 11px;
       color: ${uiTokens.colors.accent};
     `}
 `;
@@ -3750,16 +3767,17 @@ const KeyValueRow = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  margin: 6px 0;
-  padding: 8px 0;
+  margin-top: 22px;
+  margin-bottom: 4px;
+  padding: 10px 84px 10px 10px;
   background-color: ${({ $isDeletedOverlay }) =>
     $isDeletedOverlay ? uiTokens.colors.mutedBg : uiTokens.colors.cardBg};
   border-bottom: ${({ $isHighlighted, $isDeletedOverlay }) => {
     if ($isDeletedOverlay) return `1px solid ${uiTokens.colors.danger}`;
     if ($isHighlighted) return `1px solid ${uiTokens.colors.borderFocus}`;
-    return `1px solid ${uiTokens.colors.border}`;
+    return `1px solid #ddd`;
   }};
-  border-radius: 0;
+  border-radius: 8px;
   box-sizing: border-box;
   width: 100%;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
@@ -3793,33 +3811,47 @@ const ButtonGroup = styled.div`
 `;
 
 const Button = styled.button`
-  min-width: 34px;
-  height: 34px;
-  min-height: 34px;
-  padding: 0 8px;
-  border: 1px solid rgba(255, 140, 0, 0.35);
-  background: linear-gradient(135deg, #ffb347 0%, #ff9800 100%);
-  color: #fff;
-  border-radius: 999px;
+  width: 35px;
+  min-width: 35px;
+  height: 35px;
+  min-height: 35px;
+  padding: 3px;
+  border: none;
+  background-color: ${color.accent5};
+  color: white;
+  border-radius: 50%;
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 18px;
+  font-weight: 300;
   line-height: 1;
-  flex: 0 0 auto;
-  transition: filter 0.2s ease, box-shadow 0.2s ease, transform 0.12s ease;
-  margin-right: 0;
-  white-space: nowrap;
+  flex: 0 0 35px;
+  align-self: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
 
   &:hover {
-    filter: brightness(1.04);
-    box-shadow: 0 3px 8px rgba(255, 140, 0, 0.22);
+    background-color: ${color.accent};
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 
   &:active {
-    transform: scale(0.98);
+    transform: scale(0.96);
   }
 `;
 
-const OverlayDebugButton = styled(Button)`
-  margin-top: 12px;
+const OverlayDebugButton = styled.button`
+  margin: 12px 12px 0;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #666;
+  background: #f0f0f0;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover {
+    background: #e4e4e4;
+  }
 `;

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -37,15 +37,17 @@ const Container = styled.div`
 const InnerContainer = styled.div`
   max-width: 450px;
   width: 90%;
-  background-color: #f0f0f0;
-  padding: 20px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
+  background-color: #fafafa;
+  padding: 20px 0;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
 
   @media (max-width: 768px) { // Медіа-запит для пристроїв з шириною екрану до 768px
     background-color: #f5f5f5;
-    box-shadow: 0 4px 8px #f5f5f5;
+    box-shadow: none;
     border-radius: 0;
+    width: 100%;
+    padding: 12px 0 24px;
   }
 `;
 

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -301,13 +301,13 @@ export const pickerFields = [
 export const pickerFieldsExtended = [
   { name: 'userId', placeholder: 'userId', svg: 'user', ukrainianHint: 'Id' },
   { name: 'role', placeholder: 'см/до/смдо/агент', svg: 'user', ukrainianHint: 'СМДО?' },
-  { name: 'myComment', placeholder: 'коментар', svg: 'user', ukrainianHint: 'Коментра' },
+  { name: 'myComment', placeholder: 'коментар', svg: 'user', ukrainianHint: 'Коментар' },
   { name: 'getInTouch', placeholder: '30.01.2025', svg: 'user', ukrainianHint: 'Коли звернутись' },
   { name: 'lastAction', placeholder: '-', svg: 'user', ukrainianHint: 'Останні зміни' },
   { name: 'lastLogin2', placeholder: '-', svg: 'user', ukrainianHint: 'Останній логін' },
   { name: 'publish', placeholder: 'false', svg: 'user', ukrainianHint: 'Анкета опублікована' },
   { name: 'fathersname', placeholder: 'По-батькові', svg: 'user', ukrainianHint: 'По-батькові' },
-  { name: 'otherLink', placeholder: 'www', svg: 'user', ukrainianHint: 'Лінк' },
+  { name: 'otherLink', placeholder: 'www', svg: 'user', ukrainianHint: 'Посилання' },
 
   // { name: 'name', placeholder: 'Ваше ім’я', svg: 'user', ukrainianHint: 'Ім’я' },
   // { name: 'surname', placeholder: 'Ваше призіище', svg: 'user', ukrainianHint: 'Прізвище'},


### PR DESCRIPTION
### Motivation
- Покращити читабельність і візуальну цілісність рядків форми, щоб floating-лейбли не обрізались і поля не «липли» до країв контейнера. 
- Запобігти перекриттю тексту інпутів кнопками очищення/видалення шляхом резервування правого простору. 
- Зробити загальний вигляд картки профілю більш «повітряним» і однорідним на десктопі та мобайлі. 
- Замінити технічні ключі динамічних полів на людські підписи для читабельності. 

### Description
- Оновлено стилі в `src/components/ProfileForm.jsx`: `PickerContainer` отримав горизонтальні відступи і `border-bottom`, `InputDiv` — більший `margin-top`, `padding-right: 84px`, `min-height`, мʼякший бордер і `border-radius: 8px`, а також підлаштовано `KeyValueRow` аналогічно для консистентності. 
- Змінено `Placeholder` (менший шрифт, `white-space: nowrap`) та поведінку лейбла, щоб уникнути переносу і візуального «вилазіння» лейбла за межі поля. 
- Оновлено кнопки: `Button` (плюс) перетворено на круглу і вирівняно по центру рядка, а `OverlayDebugButton` стилізовано як нейтральну кнопку з паддінгом і бордером. 
- Додано мапу читабельних назв `DYNAMIC_FIELD_LABELS` і змінено `getFieldsToRender` у `src/components/ProfileForm.jsx` для відображення дружніших підписів динамічних полів; виправлено підписи в `src/components/formFields.js` (`Коментра` → `Коментар`, `Лінк` → `Посилання`). 
- Оновлено `InnerContainer` у `src/components/ProfileScreen.jsx` для більш «повітряного» вигляду з тоншим шаром тіні, більшим радіусом і зміненими паддінгами для мобільної адаптації. 

### Testing
- Запущено порівняння змін через `git diff -- src/components/ProfileForm.jsx src/components/ProfileScreen.jsx src/components/formFields.js` і перевірено диф — успішно. 
- Файли додано та закомічено через `git commit -m "Refine profile form spacing and field labels"` — коміт успішний. 
- Автоматизовані перегляди файлів/фрагментів виконані командою `nl -ba` з відповідними `sed` фільтрами для верифікації внесених фрагментів — виконано успішно. 
- PR створено через внутрішній скрипт (`make_pr`) і підтверджено метадані PR — виконано успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c46634608326ba59c754df12bdb1)