### PR TITLE
Виправлення залежностей useCallback у ProfileForm (submitWithNormalization)

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1233,7 +1233,7 @@ export const ProfileForm = ({
       const details = error?.message || String(error);
       toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
     });
-  }, [buildMatchedUserIdsBySetKey, getIndexedMatchedUserIdsByInputIndex, handleSubmit, localSearchKeyPayload, state?.userId]);
+  }, [buildMatchedUserIdsBySetKey, getIndexedMatchedUserIdsByInputIndex, handleSubmit, localSearchKeyPayload, state]);
 
   const handleAddCustomField = () => {
     if (!customField.key) return;


### PR DESCRIPTION
### Motivation
- Виправити попередження `react-hooks/exhaustive-deps`, бо колбек `submitWithNormalization` читає не лише `state.userId`, а й інші поля `state` і повинен відслідковувати весь обʼєкт `state`.

### Description
- Оновлено масив залежностей `useCallback` для `submitWithNormalization` у `src/components/ProfileForm.jsx`, замінивши `state?.userId` на `state` щоб залежності відповідали фактичному використанню всередині колбека.

### Testing
- Жодних автоматизованих тестів не запускалося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c49833ac8326aa5cd58e2b13aa42)