### PR TITLE
Adjust spacing and vertical alignment in ProfileForm inputs

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -3165,8 +3165,8 @@ const InputDiv = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  margin: 6px 0;
-  padding: 8px 0;
+  margin: 8px 0;
+  padding: 12px 0 10px;
   background-color: ${({ $isDeletedOverlay, $isOverlaySuggestion }) => {
     if ($isOverlaySuggestion) return uiTokens.colors.cardBg;
     if ($isDeletedOverlay) return uiTokens.colors.mutedBg;
@@ -3196,7 +3196,7 @@ const FieldMainRow = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-  gap: 8px;
+  gap: 10px;
   flex-wrap: nowrap;
 `;
 
@@ -3229,7 +3229,7 @@ const InputField = styled.input`
   background: transparent;
   font-size: ${uiTokens.typography.fontSizeMd};
   font-weight: 500;
-  line-height: 1.35;
+  line-height: 1.45;
   &::placeholder {
     color: transparent;
   }
@@ -3275,6 +3275,7 @@ const Hint = styled.label`
   }};
   display: flex;
   align-items: center;
+  top: 12px;
   transition: all 0.2s ease;
   color: ${uiTokens.colors.textSecondary};
   pointer-events: none;
@@ -3282,7 +3283,7 @@ const Hint = styled.label`
   align-items: center;
   gap: 6px;
   font-size: ${uiTokens.typography.fontSizeMd};
-  line-height: 1.25;
+  line-height: 1.35;
   ${({ isActive }) =>
     isActive &&
     css`
@@ -3293,8 +3294,8 @@ const Hint = styled.label`
 const Placeholder = styled.label`
   position: absolute;
   padding-left: 10px;
-  top: 0;
-  transform: translateY(-100%);
+  top: 7px;
+  transform: none;
   transition: all 0.2s ease;
   color: ${uiTokens.colors.textSecondary};
   pointer-events: none;
@@ -3302,12 +3303,13 @@ const Placeholder = styled.label`
   align-items: center;
   gap: 8px;
   font-size: ${uiTokens.typography.fontSizeSm};
+  line-height: 1.2;
   ${({ isActive }) =>
     isActive &&
     css`
       left: 10px;
-      top: 0;
-      transform: translateY(-100%);
+      top: 7px;
+      transform: none;
       font-size: ${uiTokens.typography.fontSizeSm};
       color: ${uiTokens.colors.accent};
     `}
@@ -3333,6 +3335,8 @@ const InputFieldContainer = styled.div`
     }};
     position: absolute;
     left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
     display: flex;
     align-items: center;
     color: ${({ value }) => (value ? uiTokens.colors.textPrimary : uiTokens.colors.textSecondary)};


### PR DESCRIPTION
### Motivation
- Improve vertical alignment of placeholders, hints, and prefix icons in profile form input rows for more consistent visual spacing.
- Adjust padding and line-height to avoid clipping and ensure consistent appearance across different contact/social field types.

### Description
- Increase `InputDiv` margin and padding and bump `FieldMainRow` gap to refine overall spacing within form rows.
- Increase `InputField` `line-height` and update `Hint` and `Placeholder` `top` and `line-height` values so labels and hints are vertically centered and hints hide when active.
- Vertically center the input prefix pseudo-element by setting `top: 50%` with `transform: translateY(-50%)` in `InputFieldContainer`.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c828d2588326bdb0d9dbba75575e)