### PR TITLE
Normalize ameblo.jp URLs for `searchId` (extract profile slug)

### DIFF
--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -101,6 +101,16 @@ const normalizeYoutubeValue = baseValue => {
   return null;
 };
 
+const normalizeAmebloValue = baseValue => {
+  const urlMatch = baseValue.match(/ameblo\.jp\/([^/?#\s]+)/i);
+  if (urlMatch?.[1]) return stripQueryHashAndSlashSuffix(urlMatch[1]);
+
+  return normalizeLabeledContactValue(
+    baseValue,
+    /(?:^|[^A-Za-z0-9_])(?:ameblo|амебло)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+  );
+};
+
 const normalizeSocialSearchValue = (searchKey, baseValue) => {
   const parsedTrigger = parseUkTriggerQuery(baseValue);
   if (parsedTrigger?.contactType === searchKey && parsedTrigger?.searchPair?.[searchKey]) {
@@ -113,6 +123,10 @@ const normalizeSocialSearchValue = (searchKey, baseValue) => {
 
   if (searchKey === 'youtube') {
     return normalizeYoutubeValue(baseValue) || baseValue.replace(/\s+/g, ' ');
+  }
+
+  if (searchKey === 'ameblo') {
+    return normalizeAmebloValue(baseValue) || baseValue.replace(/\s+/g, ' ');
   }
 
   return baseValue.replace(/\s+/g, ' ');


### PR DESCRIPTION
### Motivation
- Виправити невірну нормалізацію для `ameblo` в режимі `searchId`, коли повний URL виду `https://ameblo.jp/sonoda911` не перетворювався на індексований ні́к `sonoda911`, тому картка не знаходилася.

### Description
- Додано `normalizeAmebloValue` в `src/utils/searchKeyUtils.js`, який витягує slug з `ameblo.jp/<slug>` або парсить підписаний формат, і підключено його в `normalizeSocialSearchValue` для ключа `ameblo`, повторно використавши `stripQueryHashAndSlashSuffix` та `normalizeLabeledContactValue`.

### Testing
- Запущені автоматичні кроки: `git commit` для фіксації змін та перегляд файлу через `nl -ba src/utils/searchKeyUtils.js | sed -n '80,170p'`, всі кроки виконалися успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117fb416ac8326abedacce219705a3)