### PR TITLE
Normalize social handles and make `searchId` normalization prefix-aware

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1651,7 +1651,7 @@ export const searchUserByPartialUserIdUsers = async (userId, users) => {
 
 export const searchUsersOnly = async (searchedValue, options = {}) => {
   const { searchIdPrefixes } = options;
-  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
+  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
     ? { includeVariants: false, includePrefixMatches: true, includeAdaptedPhoneVariant: true }
@@ -2200,7 +2200,7 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     allowTelegramPrefixMatches = false,
   } = options;
   if (isDev) console.log('fetchNewUsersCollectionInRTDB → searchedValue:', searchedValue);
-  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
+  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
     ? { includeVariants: false, includePrefixMatches: true, includeAdaptedPhoneVariant: true }

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -63,6 +63,12 @@ const normalizeLabeledContactValue = (baseValue, labelPattern) => {
   return stripQueryHashAndSlashSuffix(labelMatch[1].replace(/^@/, ''));
 };
 
+const normalizeSocialHandleFromUrlOrLabel = ({ baseValue, domainPattern, labelPattern }) => {
+  const urlMatch = baseValue.match(domainPattern);
+  if (urlMatch?.[1]) return stripQueryHashAndSlashSuffix(urlMatch[1].replace(/^@/, ''));
+  return normalizeLabeledContactValue(baseValue, labelPattern);
+};
+
 const normalizeLinkedInValue = baseValue => {
   const urlMatch = baseValue.match(/linkedin\.com\/(?:in|company)\/([^/?#]+)/i);
   if (urlMatch?.[1]) return stripQueryHashAndSlashSuffix(urlMatch[1]);
@@ -101,6 +107,24 @@ const normalizeYoutubeValue = baseValue => {
   return null;
 };
 
+const normalizeInstagramValue = baseValue => normalizeSocialHandleFromUrlOrLabel({
+  baseValue,
+  domainPattern: /instagram\.com\/([^/?#\s]+)/i,
+  labelPattern: /(?:^|[^A-Za-z0-9_])(?:instagram|insta|інста|інстаграм)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+});
+
+const normalizeFacebookValue = baseValue => normalizeSocialHandleFromUrlOrLabel({
+  baseValue,
+  domainPattern: /(?:facebook|fb)\.com\/([^/?#\s]+)/i,
+  labelPattern: /(?:^|[^A-Za-z0-9_])(?:facebook|fb|фейсбук|фб)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+});
+
+const normalizeAmebloValue = baseValue => normalizeSocialHandleFromUrlOrLabel({
+  baseValue,
+  domainPattern: /ameblo\.jp\/([^/?#\s]+)/i,
+  labelPattern: /(?:^|[^A-Za-z0-9_])(?:ameblo|амебло)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+});
+
 const normalizeSocialSearchValue = (searchKey, baseValue) => {
   const parsedTrigger = parseUkTriggerQuery(baseValue);
   if (parsedTrigger?.contactType === searchKey && parsedTrigger?.searchPair?.[searchKey]) {
@@ -113,6 +137,18 @@ const normalizeSocialSearchValue = (searchKey, baseValue) => {
 
   if (searchKey === 'youtube') {
     return normalizeYoutubeValue(baseValue) || baseValue.replace(/\s+/g, ' ');
+  }
+
+  if (searchKey === 'instagram') {
+    return normalizeInstagramValue(baseValue) || baseValue.replace(/\s+/g, ' ');
+  }
+
+  if (searchKey === 'facebook') {
+    return normalizeFacebookValue(baseValue) || baseValue.replace(/\s+/g, ' ');
+  }
+
+  if (searchKey === 'ameblo') {
+    return normalizeAmebloValue(baseValue) || baseValue.replace(/\s+/g, ' ');
   }
 
   return baseValue.replace(/\s+/g, ' ');
@@ -130,6 +166,20 @@ export const normalizeSearchIdInput = (searchKey, rawValue) => {
   }
 
   return baseValue.replace(/\s+/g, ' ');
+};
+
+export const normalizeExactSearchIdInput = (rawValue, searchIdPrefixes) => {
+  const baseValue = String(rawValue || '').trim();
+  if (!baseValue) return '';
+
+  const normalizedPrefixes = getSearchIdPrefixes(searchIdPrefixes);
+  if (normalizedPrefixes.length !== 1) {
+    return baseValue.replace(/\s+/g, ' ');
+  }
+
+  const [onlyPrefix] = normalizedPrefixes;
+  const normalizedValue = normalizeSearchIdInput(onlyPrefix, baseValue);
+  return normalizedValue || baseValue.replace(/\s+/g, ' ');
 };
 
 const normalizePhoneSearchIdValue = rawValue => normalizePhoneValue(rawValue);
@@ -223,9 +273,12 @@ export const buildSearchIdRecordKey = searchedValue => {
   return `${searchKey}_${encodeKey(normalizedSearchValue).toLowerCase()}`;
 };
 
-export const makeSearchKeyValue = searchedValue => {
+export const makeSearchKeyValue = (searchedValue, options = {}) => {
+  const { searchIdPrefixes } = options;
   const [searchKey, searchValue] = Object.entries(searchedValue)[0];
-  const normalizedSearchValue = normalizeSearchIdInput(searchKey, searchValue);
+  const normalizedSearchValue = searchKey === 'searchId'
+    ? normalizeExactSearchIdInput(searchValue, searchIdPrefixes)
+    : normalizeSearchIdInput(searchKey, searchValue);
   const modifiedSearchValue = encodeKey(normalizedSearchValue);
   const searchIdKey = buildSearchIdRecordKey({ [searchKey]: searchValue });
 


### PR DESCRIPTION
### Motivation
- Improve parsing of social handles supplied as URLs or labeled text (Instagram, Facebook, Ameblo) to produce consistent search tokens. 
- Ensure exact `searchId` searches respect provided `searchIdPrefixes` so single-prefix modes normalize values correctly and avoid broad fallbacks. 

### Description
- Added a helper `normalizeSocialHandleFromUrlOrLabel` and new normalization functions `normalizeInstagramValue`, `normalizeFacebookValue`, and `normalizeAmebloValue` to extract handles from URLs or labeled strings. 
- Updated `normalizeSocialSearchValue` to use the new social normalization functions for `instagram`, `facebook`, and `ameblo`. 
- Introduced `normalizeExactSearchIdInput` that uses `getSearchIdPrefixes` to normalize `searchId` values when exactly one prefix is configured. 
- Changed `makeSearchKeyValue` to accept an `options` object (including `searchIdPrefixes`) and to call `normalizeExactSearchIdInput` for `searchId` keys. 
- Propagated the `searchIdPrefixes` option into callers in `src/components/config.js` (`searchUsersOnly` and `fetchNewUsersCollectionInRTDB`).

### Testing
- Ran unit tests with `yarn test`, and the test suite completed successfully. 
- Ran linters with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117fb416ac8326abedacce219705a3)