### PR TITLE
Normalize exact `searchId` with prefixes and add Ameblo social normalization

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1651,7 +1651,7 @@ export const searchUserByPartialUserIdUsers = async (userId, users) => {
 
 export const searchUsersOnly = async (searchedValue, options = {}) => {
   const { searchIdPrefixes } = options;
-  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
+  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
     ? { includeVariants: false, includePrefixMatches: true, includeAdaptedPhoneVariant: true }
@@ -2200,7 +2200,7 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     allowTelegramPrefixMatches = false,
   } = options;
   if (isDev) console.log('fetchNewUsersCollectionInRTDB → searchedValue:', searchedValue);
-  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue);
+  const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
     ? { includeVariants: false, includePrefixMatches: true, includeAdaptedPhoneVariant: true }

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -101,6 +101,16 @@ const normalizeYoutubeValue = baseValue => {
   return null;
 };
 
+const normalizeAmebloValue = baseValue => {
+  const urlMatch = baseValue.match(/ameblo\.jp\/([^/?#\s]+)/i);
+  if (urlMatch?.[1]) return stripQueryHashAndSlashSuffix(urlMatch[1].replace(/^@/, ''));
+
+  return normalizeLabeledContactValue(
+    baseValue,
+    /(?:^|[^A-Za-z0-9_])(?:ameblo|амебло)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+  );
+};
+
 const normalizeSocialSearchValue = (searchKey, baseValue) => {
   const parsedTrigger = parseUkTriggerQuery(baseValue);
   if (parsedTrigger?.contactType === searchKey && parsedTrigger?.searchPair?.[searchKey]) {
@@ -113,6 +123,10 @@ const normalizeSocialSearchValue = (searchKey, baseValue) => {
 
   if (searchKey === 'youtube') {
     return normalizeYoutubeValue(baseValue) || baseValue.replace(/\s+/g, ' ');
+  }
+
+  if (searchKey === 'ameblo') {
+    return normalizeAmebloValue(baseValue) || baseValue.replace(/\s+/g, ' ');
   }
 
   return baseValue.replace(/\s+/g, ' ');
@@ -130,6 +144,20 @@ export const normalizeSearchIdInput = (searchKey, rawValue) => {
   }
 
   return baseValue.replace(/\s+/g, ' ');
+};
+
+export const normalizeExactSearchIdInput = (rawValue, searchIdPrefixes) => {
+  const baseValue = String(rawValue || '').trim();
+  if (!baseValue) return '';
+
+  const normalizedPrefixes = getSearchIdPrefixes(searchIdPrefixes);
+  if (normalizedPrefixes.length !== 1) {
+    return baseValue.replace(/\s+/g, ' ');
+  }
+
+  const [onlyPrefix] = normalizedPrefixes;
+  const normalizedValue = normalizeSearchIdInput(onlyPrefix, baseValue);
+  return normalizedValue || baseValue.replace(/\s+/g, ' ');
 };
 
 const normalizePhoneSearchIdValue = rawValue => normalizePhoneValue(rawValue);
@@ -223,9 +251,12 @@ export const buildSearchIdRecordKey = searchedValue => {
   return `${searchKey}_${encodeKey(normalizedSearchValue).toLowerCase()}`;
 };
 
-export const makeSearchKeyValue = searchedValue => {
+export const makeSearchKeyValue = (searchedValue, options = {}) => {
+  const { searchIdPrefixes } = options;
   const [searchKey, searchValue] = Object.entries(searchedValue)[0];
-  const normalizedSearchValue = normalizeSearchIdInput(searchKey, searchValue);
+  const normalizedSearchValue = searchKey === 'searchId'
+    ? normalizeExactSearchIdInput(searchValue, searchIdPrefixes)
+    : normalizeSearchIdInput(searchKey, searchValue);
   const modifiedSearchValue = encodeKey(normalizedSearchValue);
   const searchIdKey = buildSearchIdRecordKey({ [searchKey]: searchValue });
 


### PR DESCRIPTION
### Motivation

- Ensure `searchId` inputs are normalized with awareness of configured `searchIdPrefixes` so exact-id searches behave correctly when a single prefix is expected.
- Add support for normalizing `ameblo.jp` handles/URLs in social search normalization.

### Description

- Updated `makeSearchKeyValue` to accept an `options` argument and to use a new `normalizeExactSearchIdInput` when `searchKey === 'searchId'` to apply prefix-aware normalization.  
- Propagated `searchIdPrefixes` into calls to `makeSearchKeyValue` in `fetchNewUsersCollectionInRTDB` and `searchUsersOnly` so the normalization can consider configured prefixes.  
- Added `normalizeExactSearchIdInput` helper which returns a prefix-aware normalized value only when exactly one `searchIdPrefix` is configured; otherwise falls back to generic normalization.  
- Implemented `normalizeAmebloValue` and wired it into `normalizeSocialSearchValue` to extract and normalize `ameblo.jp` usernames from URLs and labeled inputs.

### Testing

- Ran the project test suite with `npm test` and the linter with `npm run lint`, and both completed successfully.  
- Existing normalization/unit tests that exercise social key parsing and `searchId` behavior were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117fb416ac8326abedacce219705a3)