### PR TITLE
Fix Ameblo label parsing edge cases (require separator, disallow bare-domain misparse)

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -161,7 +161,7 @@ const parseAmebloId = input => {
   const amebloMatch = trimmed.match(amebloRegex);
   if (amebloMatch?.[1]) return amebloMatch[1];
 
-  const labeledRegex = /(?:^|[^A-Za-z0-9Ѐ-ӿ_])(ameblo|амебло)[:\s]+([A-Za-z0-9._-]+)/i;
+  const labeledRegex = /(?:^|[^A-Za-z0-9Ѐ-ӿ_])(ameblo|амебло)(?:\s*:\s*|\s+)([A-Za-z0-9][A-Za-z0-9._-]*)/i;
   const labeledMatch = trimmed.match(labeledRegex);
   if (labeledMatch?.[2]) return labeledMatch[2];
 

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -107,7 +107,7 @@ const normalizeAmebloValue = baseValue => {
 
   return normalizeLabeledContactValue(
     baseValue,
-    /(?:^|[^A-Za-z0-9_])(?:ameblo|амебло)\s*:?\s*@?([A-Za-z0-9._-]+)/i,
+    /(?:^|[^A-Za-z0-9_])(?:ameblo|амебло)(?:\s*:\s*|\s+)@?([A-Za-z0-9][A-Za-z0-9._-]*)/i,
   );
 };
 


### PR DESCRIPTION
### Motivation
- Усунути регресію, коли мітка `ameblo|амебло` трактувалась як префікс навіть без явного роздільника, через що `ameblo123` нормалізувався в `123` і викликав помилкові `searchId` пошуки.
- Забезпечити, що bare-домени на кшталт `ameblo.jp` не парсяться як мітка `ameblo` з handle `.jp`, що могло будувати некоректні ключі в exact `searchId` режимі.

### Description
- Затягнуто регулярні вирази для label-формату `ameblo|амебло` у двох місцях так, щоб після мітки вимагався явний роздільник (`:` або пробіл) і щоб parsed handle починався з алфанумерного символу: зміни в `src/components/SearchBar.jsx` і `src/utils/searchKeyUtils.js`.
- Збережено існуючий парсинг URL-формату `ameblo.jp/<handle>` без змін.
- Змінені файли (raw посилання для правок): https://raw.githubusercontent.com/KnowMe-app/main/refs/heads/main/src/components/SearchBar.jsx, https://raw.githubusercontent.com/KnowMe-app/main/refs/heads/main/src/utils/searchKeyUtils.js

### Testing
- Запущено базові автоматизовані VCS-чекери: `git diff -- src/components/SearchBar.jsx src/utils/searchKeyUtils.js` пройшов; зміни зафіксовано командою `git commit` без помилок.
- Жодного автоматизованого unit/integration тест-рану для цього патчу не виконано.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11caa7536483269dcd07ff4184befb)