### PR TITLE
Simplify Hint padding in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -3283,13 +3283,7 @@ const AccessLevelSelect = styled.select`
 
 const Hint = styled.label`
   position: absolute;
-  padding-left: ${({ fieldName }) => {
-    const baseFieldName = resolveFieldNameBase(fieldName);
-    if (baseFieldName === 'phone') return '20px';
-    if (baseFieldName === 'telegram' || baseFieldName === 'facebook' || baseFieldName === 'instagram' || baseFieldName === 'tiktok' || baseFieldName === 'twitter') return '25px';
-    if (baseFieldName === 'vk') return '23px';
-    return '10px';
-  }};
+  padding-left: 10px;
   display: flex;
   align-items: center;
   top: 0;


### PR DESCRIPTION
### Motivation
- Normalize hint label spacing by removing per-field padding adjustments and using a single, consistent left padding.

### Description
- Replace the dynamic `padding-left` computation in the `Hint` styled component with a fixed `padding-left: 10px`, removing the field-specific branches.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11d53874a4832681200b0d8d020789)