### PR TITLE
Виправити висоту і накладання поля additionalAccessRules у ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2488,8 +2488,8 @@ ${entries.join('\n')}`;
                     <InputFieldContainer fieldName={`${field.name}-${idx}`} value={value}>
                       <InputField
                         fieldName={`${field.name}-${idx}`}
-                        as={(field.name === 'moreInfo_main' || field.name === 'myComment' || field.name === ADDITIONAL_ACCESS_FIELD || field.name === MULTI_DATA_ACCESS_FIELD) && 'textarea'}
-                        ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : field.name === ADDITIONAL_ACCESS_FIELD ? additionalAccessRulesRef : field.name === MULTI_DATA_ACCESS_FIELD ? multiDataAccessUserIdsRef : null}
+                        as={(field.name === 'moreInfo_main' || field.name === 'myComment' || field.name === MULTI_DATA_ACCESS_FIELD) && 'textarea'}
+                        ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : field.name === MULTI_DATA_ACCESS_FIELD ? multiDataAccessUserIdsRef : null}
                         inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                         name={`${field.name}-${idx}`}
                         value={value || ''}
@@ -2590,7 +2590,6 @@ ${entries.join('\n')}`;
                     <>
                       <InputField
                         fieldName={field.name}
-                        as="textarea"
                         ref={additionalAccessRulesRef}
                         name={field.name}
                         value={displayValue}
@@ -2606,8 +2605,8 @@ ${entries.join('\n')}`;
                   ) : (
                   <InputField
                     fieldName={field.name}
-                    as={(field.name === 'moreInfo_main' || field.name === 'myComment' || field.name === ADDITIONAL_ACCESS_FIELD || field.name === MULTI_DATA_ACCESS_FIELD) && 'textarea'}
-                    ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : field.name === ADDITIONAL_ACCESS_FIELD ? additionalAccessRulesRef : field.name === MULTI_DATA_ACCESS_FIELD ? multiDataAccessUserIdsRef : null}
+                    as={(field.name === 'moreInfo_main' || field.name === 'myComment' || field.name === MULTI_DATA_ACCESS_FIELD) && 'textarea'}
+                    ref={field.name === 'myComment' ? textareaRef : field.name === 'moreInfo_main' ? moreInfoRef : field.name === MULTI_DATA_ACCESS_FIELD ? multiDataAccessUserIdsRef : null}
                     inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                     name={field.name}
                     value={displayValue}


### PR DESCRIPTION
### Motivation
- Поле `additionalAccessRules` рендерилося як `textarea`, через що одно-рядкові значення мали зайву висоту і візуально наповзали одне на одне; мета — зробити його візуально таким же, як інші однорядкові інпути.
- Потрібно зберегти поведінку `multiDataAccessUserIds` як `textarea` та не ламати інші поля або модальні механіки, що відкриваються при кліку.

### Description
- Прибрано рендеринг `additionalAccessRules` як `textarea` у загальних гілках рендеру, щоб воно поводилось як однорядковий `input` (файл `src/components/ProfileForm.jsx`, зміни в логіці `as`-пропа для інпутів). 
- Видалено використання `additionalAccessRulesRef` у загальному рендері полів і залишено `additionalAccessRulesRef` тільки в спеціалізованій гілці для цього поля, збережено `readOnly` і обробник `onClick`, що відкриває модальне вікно правил.
- Залишено без змін поведінку `multiDataAccessUserIds` як `textarea` та всі пов'язані автозмінювачі розміру (`autoResizeMultiDataAccessUserIds`).
- Файли для правки/перевірки: https://raw.githubusercontent.com/KnowMe-app/main/refs/heads/main/src/components/ProfileForm.jsx; ключові символи: `ADDITIONAL_ACCESS_FIELD`, `additionalAccessRulesRef`, `multiDataAccessUserIds`.

### Testing
- Автоматичних тестів (CI/unit) під час цього виправлення не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e101c0c483269e273a35d2c01352)