### PR TITLE
Improve spacing and styling for array items in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2484,7 +2484,12 @@ ${entries.join('\n')}`;
               {Array.isArray(state[field.name]) ? (
               <div style={{ width: '100%', display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
                 {state[field.name].map((value, idx) => (
-                  <InputDiv key={`${field.name}-${idx}`} $isHighlighted={highlightedFields.includes(field.name)} $isDeletedOverlay={deletedOverlayFields.includes(field.name)}>
+                  <InputDiv
+                    key={`${field.name}-${idx}`}
+                    $isHighlighted={highlightedFields.includes(field.name)}
+                    $isDeletedOverlay={deletedOverlayFields.includes(field.name)}
+                    $isArrayItem
+                  >
                     <InputFieldContainer fieldName={`${field.name}-${idx}`} value={value}>
                       <InputField
                         fieldName={`${field.name}-${idx}`}
@@ -3167,8 +3172,9 @@ const InputDiv = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  margin: 6px 0;
-  padding: 6px 0;
+  margin: ${({ $isArrayItem }) => ($isArrayItem ? '10px 0' : '6px 0')};
+  padding: ${({ $isArrayItem }) => ($isArrayItem ? '10px 0 8px' : '6px 0')};
+  min-height: ${({ $isArrayItem }) => ($isArrayItem ? '44px' : 'auto')};
   background-color: ${({ $isDeletedOverlay, $isOverlaySuggestion }) => {
     if ($isOverlaySuggestion) return uiTokens.colors.cardBg;
     if ($isDeletedOverlay) return uiTokens.colors.mutedBg;


### PR DESCRIPTION
### Motivation
- Array-type fields rendered in `ProfileForm` needed different spacing and minimum height to avoid cramped layout and improve touch/click targets.
- The JSX for array item inputs was reformatted for readability and to pass the new styling flag into the styled component.

### Description
- Pass `$isArrayItem` to `InputDiv` when rendering items of array fields so the styled component can adjust appearance.  
- Update the `InputDiv` styled component to conditionally apply `margin`, `padding`, and `min-height` based on `$isArrayItem` and keep existing focus/overlay/border logic intact.  
- Reformat multi-prop JSX for the array inputs to multiple lines for clarity; no functional input handling logic was changed.

### Testing
- Ran the test suite with `yarn test` and all tests passed.  
- Ran the linter with `yarn lint` and there were no new linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e90a58b483269464511d93c7caea)