### PR TITLE
Add spacing for array-valued inputs in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2484,7 +2484,13 @@ ${entries.join('\n')}`;
               {Array.isArray(state[field.name]) ? (
               <div style={{ width: '100%', display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
                 {state[field.name].map((value, idx) => (
-                  <InputDiv key={`${field.name}-${idx}`} $isHighlighted={highlightedFields.includes(field.name)} $isDeletedOverlay={deletedOverlayFields.includes(field.name)}>
+                  <InputDiv
+                    key={`${field.name}-${idx}`}
+                    $isHighlighted={highlightedFields.includes(field.name)}
+                    $isDeletedOverlay={deletedOverlayFields.includes(field.name)}
+                    $isArrayValueItem
+                    $isFirstArrayValueItem={idx === 0}
+                  >
                     <InputFieldContainer fieldName={`${field.name}-${idx}`} value={value}>
                       <InputField
                         fieldName={`${field.name}-${idx}`}
@@ -3187,6 +3193,8 @@ const InputDiv = styled.div`
   min-width: 0;
   height: auto;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  margin-top: ${({ $isArrayValueItem, $isFirstArrayValueItem }) =>
+    $isArrayValueItem && !$isFirstArrayValueItem ? '16px' : '6px'};
 
   &:focus-within {
     border-bottom-color: ${uiTokens.colors.borderFocus};


### PR DESCRIPTION
### Motivation
- Improve visual spacing and readability for fields that render as array values by adding extra top margin for non-first items.

### Description
- Pass `$isArrayValueItem` and `$isFirstArrayValueItem` props to `InputDiv` when rendering array fields and conditionally set `margin-top` in the `InputDiv` styled component so non-first array items get `16px` while others remain `6px`.
- Reformat the array item JSX for clarity when rendering multiple input items.

### Testing
- Ran unit tests with `npm test`, and the test suite completed successfully.
- Ran linter with `npm run lint` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f3eb1f5c832692129923990b3dc7)