### PR TITLE
Local override: reorder MyProfile fields (maritalStatus block)

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -852,6 +852,16 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     'moreInfo_main',
   ]);
   const visiblePickerFields = pickerFields.filter(field => isDonorRole || visibleNonDonorFields.has(field.name));
+  const myProfileCustomOrder = ['maritalStatus', 'ownKids', 'csection', 'lastDelivery', 'deliveryDate', 'experience', 'reward'];
+  const orderedPickerFields = [...visiblePickerFields].sort((a, b) => {
+    const aIndex = myProfileCustomOrder.indexOf(a.name);
+    const bIndex = myProfileCustomOrder.indexOf(b.name);
+
+    if (aIndex === -1 && bIndex === -1) return 0;
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
   // const [state, setState] = useState({ eyeColor: '', hairColor: '' });
 
   const handleOpenModal = fieldName => {
@@ -1023,7 +1033,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         )}
         {state.userId && <Photos state={state} setState={setState} />}
 
-        {visiblePickerFields.map(field => {
+        {orderedPickerFields.map(field => {
           // console.log('field.options:', field.options);
           const isPickerField = Array.isArray(field.options);
           const isCsectionField = field.name === 'csection';


### PR DESCRIPTION
### Motivation
- На сторінці MyProfile потрібно змінити порядок полів локально, не чіпаючи глобального `formFields.js` і не змінюючи структуру даних у Firebase.

### Description
- Додано локальний масив `myProfileCustomOrder` у `src/components/MyProfile.jsx`, що визначає бажаний порядок для блоку полів: `maritalStatus`, `ownKids`, `csection`, `lastDelivery` / `deliveryDate`, `experience`, `reward`.
- Створено `orderedPickerFields` як відсортовану копію `visiblePickerFields` і оновлено рендер з `visiblePickerFields.map(...)` на `orderedPickerFields.map(...)`, щоб дозувати зміни лише для MyProfile.
- Не змінювався `src/components/formFields.js`, не дублювались поля, не змінювались keys/name полів, picker options або структура Firebase, і зміни обмежені тільки `MyProfile.jsx`.

### Testing
- Перевірено в коді, що `myProfileCustomOrder` присутній і що рендер використовує `orderedPickerFields`, шлях файлу: `src/components/MyProfile.jsx` — пройшло успішно.
- Переглянуто файл `src/components/formFields.js` щоб підтвердити відсутність змін у глобальному порядку та опціях — перевірка пройшла успішно.
- Запущено кілька пошуків/виводів файлу (`rg`, `sed`) для підтвердження змін і що інші компоненти (`AddNewProfile`, `EditProfile`) не торкаються цього локального сортування — перевірки успішні.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12dc57bab48326a08e736ef36c4b40)