### PR TITLE
Покращення мікрокопірайту MyProfile (локальні override + лічильник символів)

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -470,6 +470,42 @@ const Button = styled.button`
   }
 `;
 
+const CharCounter = styled.div`
+  width: 100%;
+  text-align: right;
+  margin-top: -6px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: #8a8a8a;
+`;
+
+const myProfileFieldCopyOverrides = {
+  birth: {
+    ukrainianHint: 'Дата народження',
+  },
+  csection: {
+    ukrainianHint: 'Кесарів розтин',
+  },
+  experience: {
+    ukrainianHint: 'Кількість попередніх донацій',
+  },
+  glasses: {
+    ukrainianHint: 'Окуляри або лінзи',
+  },
+  maritalStatus: {
+    ukrainianHint: 'Сімейний стан',
+  },
+  moreInfo_main: {
+    ukrainianHint: 'Про себе',
+    placeholder: 'Коротко розкажіть про себе, досвід, інтереси або важливі деталі',
+  },
+};
+
+const getMyProfileFieldCopy = field => ({
+  ...field,
+  ...(myProfileFieldCopyOverrides[field.name] || {}),
+});
+
 const initialProfileState = pickerFields.reduce(
   (acc, field) => ({ ...acc, [field.name]: '' }),
   { password: '', userId: '', publish: false }
@@ -1034,8 +1070,10 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         {state.userId && <Photos state={state} setState={setState} />}
 
         {orderedPickerFields.map(field => {
+          const displayField = getMyProfileFieldCopy(field);
+          const moreInfoLength = String(state.moreInfo_main || '').length;
           // console.log('field.options:', field.options);
-          const isPickerField = Array.isArray(field.options);
+          const isPickerField = Array.isArray(displayField.options);
           const isCsectionField = field.name === 'csection';
 
           return (
@@ -1046,6 +1084,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     fieldName={field.name}
                     as={field.name === 'moreInfo_main' && 'textarea'}
                     ref={field.name === 'moreInfo_main' ? moreInfoRef : null}
+                    maxLength={field.name === 'moreInfo_main' ? 300 : undefined}
                     inputMode={field.name === 'phone' ? 'numeric' : 'text'}
                     name={field.name}
                     value={state[field.name]}
@@ -1053,7 +1092,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     onChange={e => {
                       const value = e?.target?.value;
                       field.name === 'moreInfo_main' && autoResizeMoreInfo(e.target);
-                      const updatedValue = inputUpdateValue(value, field)
+                      const updatedValue = inputUpdateValue(value, displayField)
                       // if (state[field.name]!=='No' && state[field.name]!=='Yes') {
                       setState(prevState => ({ ...prevState, [field.name]: updatedValue }));
                       // } else {
@@ -1081,9 +1120,10 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times; {/* HTML-символ для хрестика */}</ClearButton>}
                 </InputFieldContainer>
 
-                <Hint fieldName={field.name} isActive={state[field.name]}>{field.ukrainian || field.placeholder}</Hint>
-                <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
+                <Hint fieldName={field.name} isActive={state[field.name]}>{displayField.ukrainian || displayField.placeholder}</Hint>
+                <Placeholder isActive={state[field.name]}>{displayField.ukrainianHint}</Placeholder>
               </InputDiv>
+              {field.name === 'moreInfo_main' && <CharCounter>{moreInfoLength} / 300</CharCounter>}
               {Array.isArray(field.options) && field.options.length === 2 && (
                 <ButtonGroup>
                   <Button


### PR DESCRIPTION
### Motivation
- Зробити labels та placeholders у компоненті MyProfile більш природними та зрозумілими українською без змін глобальних полів або структури даних.

### Description
- Додав локальну мапу `myProfileFieldCopyOverrides` і функцію `getMyProfileFieldCopy(field)` в `src/components/MyProfile.jsx` для локального override мікрокопірайту лише в MyProfile.
- Оновив відображення підписів/placeholder у рендері, використовуючи `displayField` (не змінюючи `formFields.js`), та підключив нові тексти для `birth`, `csection`, `experience`, `glasses`, `maritalStatus` і `moreInfo_main`.
- Додав `maxLength={300}` та простий лічильник символів `0 / 300` для `moreInfo_main` через `CharCounter` без рефакторингу форми або wizard.
- Жодних змін до picker/select options, ключів полів, Firebase-структури або файлів `AddNewProfile`/`EditProfile` не зроблено.

### Testing
- Виконано перевірки diff і статусу: `git diff -- src/components/MyProfile.jsx` та `git status --short`, команди виконалися успішно.
- Збережено та зафіксовано зміни через `git commit` з повідомленням, коміт пройшов успішно.
- PR створено автоматично за допомогою внутрішнього інструменту; жодних автоматичних unit/integration тестів у репозиторії не запускалося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e25795808326924638adf7c0c644)