### PR TITLE
Очищення myProfileDraft та скидання стану MyProfile при виході

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1482,6 +1482,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     try {
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('userEmail');
+      localStorage.removeItem('myProfileDraft');
       localStorage.removeItem('ownerId');
       setState({});
       setIsLoggedIn(false);

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -811,6 +811,8 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         setIsLoggedIn(false);
         localStorage.removeItem('isLoggedIn');
         localStorage.removeItem('ownerId');
+        localStorage.removeItem('myProfileDraft');
+        setState(initialProfileState);
         console.log('No user is logged in.');
       }
     });


### PR DESCRIPTION
### Motivation
- Після виходу зі сторінки додавання профілю у компоненті зберігалися старі значення в інпутах і ховався блок email/password при наступному вході через залишений draft у localStorage.

### Description
- При виході з `AddNewProfile` тепер видаляється ключ `myProfileDraft` з `localStorage`, а в `MyProfile` при відсутності авторизованого користувача також очищається `myProfileDraft` і локальний стан скидається до `initialProfileState`.

### Testing
- Автоматичних тестів не запускалося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f938a080832684939a68bb741421)