### PR TITLE
Add UI section metadata and section headers to MyProfile form

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -104,6 +104,32 @@ const PickerContainer = styled.div`
   }
 `;
 
+const ProfileSectionHeader = styled.div`
+  margin: ${({ $isFirst }) => ($isFirst ? '8px 0 14px' : '30px 0 14px')};
+  padding: 0 2px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: rgba(255, 143, 0, 0.22);
+  }
+`;
+
+const ProfileSectionTitle = styled.div`
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 143, 0, 0.1);
+  color: #d67800;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+`;
+
 const InputDiv = styled.div`
   display: flex;
   align-items: center;
@@ -854,6 +880,10 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     'moreInfo_main',
   ]);
   const visiblePickerFields = pickerFields.filter(field => isDonorRole || visibleNonDonorFields.has(field.name));
+  const fieldsWithSections = visiblePickerFields.map((field, index, arr) => ({
+    ...field,
+    showSectionTitle: field.section && field.section !== arr[index - 1]?.section,
+  }));
   // const [state, setState] = useState({ eyeColor: '', hairColor: '' });
 
   const handleOpenModal = fieldName => {
@@ -1025,13 +1055,19 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         )}
         {state.userId && <Photos state={state} setState={setState} />}
 
-        {visiblePickerFields.map(field => {
+        {fieldsWithSections.map((field, index) => {
           // console.log('field.options:', field.options);
           const isPickerField = Array.isArray(field.options);
           const isCsectionField = field.name === 'csection';
 
           return (
-            <PickerContainer>
+            <React.Fragment key={field.name}>
+              {field.showSectionTitle && (
+                <ProfileSectionHeader $isFirst={index === 0}>
+                  <ProfileSectionTitle>{field.section}</ProfileSectionTitle>
+                </ProfileSectionHeader>
+              )}
+              <PickerContainer>
               <InputDiv key={field.name}>
                 <InputFieldContainer fieldName={field.name} value={state[field.name]}>
                   <InputField
@@ -1121,6 +1157,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 </ButtonGroup>
               )}
             </PickerContainer>
+            </React.Fragment>
           );
         })}
         {!state.publish && (

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -150,29 +150,29 @@ export const csectionOptions = [
 
 export const pickerFields = [
   // базове
-  { name: 'name', placeholder: 'Ваше ім’я', svg: 'user', ukrainianHint: 'ім’я' },
-  { name: 'surname', placeholder: 'Ваше прізвище', svg: 'user', ukrainianHint: 'прізвище'},
-  { name: 'birth', placeholder: 'дд.мм.рррр', hint: 'DOB', svg: 'no', width: '33%', ukrainianHint: 'дата народження (дд.мм.рррр)' },
-  { name: 'country', placeholder: 'україна', hint: 'country', svg: 'no', width: '33%', ukrainian: 'країна', ukrainianHint: 'країна проживання' },
-  { name: 'region', placeholder: 'київська', hint: 'region', svg: 'no', width: '33%', ukrainian: 'область', ukrainianHint: 'область' },
-  { name: 'city', placeholder: 'буча', hint: 'city', svg: 'no', width: '33%', ukrainian: 'місто', ukrainianHint: 'місто' },
+  { name: 'name', placeholder: 'Ваше ім’я', svg: 'user', ukrainianHint: 'ім’я', section: 'Основна інформація' },
+  { name: 'surname', placeholder: 'Ваше прізвище', svg: 'user', ukrainianHint: 'прізвище', section: 'Основна інформація' },
+  { name: 'birth', placeholder: 'дд.мм.рррр', hint: 'DOB', svg: 'no', width: '33%', ukrainianHint: 'дата народження (дд.мм.рррр)', section: 'Основна інформація' },
+  { name: 'country', placeholder: 'україна', hint: 'country', svg: 'no', width: '33%', ukrainian: 'країна', ukrainianHint: 'країна проживання', section: 'Основна інформація' },
+  { name: 'region', placeholder: 'київська', hint: 'region', svg: 'no', width: '33%', ukrainian: 'область', ukrainianHint: 'область', section: 'Основна інформація' },
+  { name: 'city', placeholder: 'буча', hint: 'city', svg: 'no', width: '33%', ukrainian: 'місто', ukrainianHint: 'місто', section: 'Основна інформація' },
 
   // контакти
-  { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail'},
-  { name: 'phone', placeholder: '+380 67 123 45 67', svg: 'phone', ukrainianHint:'номер телефону'},
-  { name: 'telegram', placeholder: '@username або t.me/username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
-  { name: 'facebook', placeholder: 'facebook.com/username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
-  { name: 'instagram', placeholder: '@username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
-  { name: 'tiktok', placeholder: '@username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'тікток' },
-  { name: 'twitter', placeholder: '@username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'твітер / x' },
-  { name: 'linkedin', placeholder: 'linkedin.com/in/username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
-  { name: 'youtube', placeholder: 'youtube.com/@channel', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'ютуб' },
-  { name: 'vk', placeholder: '0107655', hint: '0107655', svg: 'vk', ukrainian: '', ukrainianHint:'' },
+  { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail', section: 'Контакти' },
+  { name: 'phone', placeholder: '+380 67 123 45 67', svg: 'phone', ukrainianHint:'номер телефону', section: 'Контакти' },
+  { name: 'telegram', placeholder: '@username або t.me/username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм', section: 'Контакти' },
+  { name: 'facebook', placeholder: 'facebook.com/username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук', section: 'Контакти' },
+  { name: 'instagram', placeholder: '@username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм', section: 'Контакти' },
+  { name: 'tiktok', placeholder: '@username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'тікток', section: 'Контакти' },
+  { name: 'twitter', placeholder: '@username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'твітер / x', section: 'Контакти' },
+  { name: 'linkedin', placeholder: 'linkedin.com/in/username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін', section: 'Контакти' },
+  { name: 'youtube', placeholder: 'youtube.com/@channel', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'ютуб', section: 'Контакти' },
+  { name: 'vk', placeholder: '0107655', hint: '0107655', svg: 'vk', ukrainian: '', ukrainianHint:'', section: 'Контакти' },
 
   // медичне
-  { name: 'blood', placeholder: '3+', hint: 'група крові та резус / 3+', svg: 'no', ukrainianHint: 'група крові та резус / 3+'  },
-  { name: 'ownKids', placeholder: '1', hint: 'own kids', svg: 'no', ukrainian: 'кількість пологів', ukrainianHint: 'кількість пологів' },
-  { name: 'lastDelivery', placeholder: 'дд.мм.рррр', hint: 'last delivery', svg: 'no', width: '33%', ukrainianHint: 'останні пологи були (дд.мм.рррр)' },
+  { name: 'blood', placeholder: '3+', hint: 'група крові та резус / 3+', svg: 'no', ukrainianHint: 'група крові та резус / 3+', section: 'Медична інформація та досвід'  },
+  { name: 'ownKids', placeholder: '1', hint: 'own kids', svg: 'no', ukrainian: 'кількість пологів', ukrainianHint: 'кількість пологів', section: 'Медична інформація та досвід' },
+  { name: 'lastDelivery', placeholder: 'дд.мм.рррр', hint: 'last delivery', svg: 'no', width: '33%', ukrainianHint: 'останні пологи були (дд.мм.рррр)', section: 'Медична інформація та досвід' },
   {
     name: 'csection',
     placeholder: 'Оберіть: Ні / 1 / 2',
@@ -181,9 +181,10 @@ export const pickerFields = [
     width: '33%',
     options: csectionOptions,
     ukrainianHint: 'кесарів розтин',
+    section: 'Медична інформація та досвід',
   },
-  { name: 'experience', placeholder: '2', hint: 'donatin exp?', svg: 'no', width: '33%', ukrainianHint: 'кількість попередніх донацій' },
-  { name: 'allergy', placeholder: 'пеніцилін', hint: 'Allergy', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'алергії' },
+  { name: 'experience', placeholder: '2', hint: 'donatin exp?', svg: 'no', width: '33%', ukrainianHint: 'кількість попередніх донацій', section: 'Медична інформація та досвід' },
+  { name: 'allergy', placeholder: 'пеніцилін', hint: 'Allergy', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'алергії', section: 'Медична інформація та досвід' },
   {
     name: 'surgeries',
     placeholder: 'апендицит у 2021',
@@ -193,17 +194,18 @@ export const pickerFields = [
     options: yesNoOptions,
     ukrainian: 'перенесені операції',
     ukrainianHint: 'перенесені операції',
+    section: 'Медична інформація та досвід',
   },
-  { name: 'chronicDiseases', placeholder: '-', hint: 'Chronic diseases', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хронічні захворювання' },
+  { name: 'chronicDiseases', placeholder: '-', hint: 'Chronic diseases', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хронічні захворювання', section: 'Медична інформація та досвід' },
 
   // фізичні
-  { name: 'height', placeholder: '168', hint: 'cm', svg: 'no',  ukrainian: 'зріст', ukrainianHint: 'зріст в см' },
-  { name: 'weight', placeholder: '58', hint: 'kg', svg: 'no', ukrainian: 'вага', ukrainianHint: 'вага в кг' },
-  { name: 'clothingSize', placeholder: '38-40', hint: 'clothing size', svg: 'no', width: '33%', ukrainian: 'розмір одягу', ukrainianHint: 'розмір одягу' },
-  { name: 'shoeSize', placeholder: '38', hint: 'shoe size', svg: 'no', width: '33%', ukrainian: 'розмір взуття', ukrainianHint: 'розмір взуття' },
-  { name: 'breastSize', placeholder: '75b', hint: 'breast size', svg: 'no', width: '33%', ukrainian: 'розмір грудей', ukrainianHint: 'розмір грудей' },
-  { name: 'reward', placeholder: '500', hint: '$ reward', svg: 'no', ukrainianHint: 'бажана винагорода в $' },
-  { name: 'eyeColor', placeholder: 'голубі', hint: 'eyes', svg: 'no', width: '33%', options: eyeColorOptions, ukrainian: 'колір очей', ukrainianHint: 'колір очей' },
+  { name: 'height', placeholder: '168', hint: 'cm', svg: 'no',  ukrainian: 'зріст', ukrainianHint: 'зріст в см', section: 'Параметри та зовнішність' },
+  { name: 'weight', placeholder: '58', hint: 'kg', svg: 'no', ukrainian: 'вага', ukrainianHint: 'вага в кг', section: 'Параметри та зовнішність' },
+  { name: 'clothingSize', placeholder: '38-40', hint: 'clothing size', svg: 'no', width: '33%', ukrainian: 'розмір одягу', ukrainianHint: 'розмір одягу', section: 'Параметри та зовнішність' },
+  { name: 'shoeSize', placeholder: '38', hint: 'shoe size', svg: 'no', width: '33%', ukrainian: 'розмір взуття', ukrainianHint: 'розмір взуття', section: 'Параметри та зовнішність' },
+  { name: 'breastSize', placeholder: '75b', hint: 'breast size', svg: 'no', width: '33%', ukrainian: 'розмір грудей', ukrainianHint: 'розмір грудей', section: 'Параметри та зовнішність' },
+  { name: 'reward', placeholder: '500', hint: '$ reward', svg: 'no', ukrainianHint: 'бажана винагорода в $', section: 'Параметри та зовнішність' },
+  { name: 'eyeColor', placeholder: 'голубі', hint: 'eyes', svg: 'no', width: '33%', options: eyeColorOptions, ukrainian: 'колір очей', ukrainianHint: 'колір очей', section: 'Параметри та зовнішність' },
   {
     name: 'hairColor',
     placeholder: 'блонд',
@@ -213,8 +215,9 @@ export const pickerFields = [
     options: hairColorOptions,
     ukrainian: 'колір волосся',
     ukrainianHint: 'колір волосся',
+    section: 'Параметри та зовнішність',
   },
-  { name: 'glasses', placeholder: '-2.5', hint: 'glasses', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'окуляри?' },
+  { name: 'glasses', placeholder: '-2.5', hint: 'glasses', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'окуляри?', section: 'Параметри та зовнішність' },
  
   {
     name: 'hairStructure',
@@ -225,6 +228,7 @@ export const pickerFields = [
     options: hairStructureOptions,
     ukrainian: 'структура волосся',
     ukrainianHint: 'структура волосся',
+    section: 'Параметри та зовнішність',
   },
   {
     name: 'race',
@@ -235,6 +239,7 @@ export const pickerFields = [
     options: raceOptions,
     ukrainian: 'етнічна група',
     ukrainianHint: 'етнічна група',
+    section: 'Параметри та зовнішність',
   },
   {
     name: 'bodyType',
@@ -245,17 +250,18 @@ export const pickerFields = [
     options: bodyTypeOptions,
     ukrainian: 'фігура',
     ukrainianHint: 'фігура',
+    section: 'Параметри та зовнішність',
   },
-  { name: 'faceShape', placeholder: 'Овальне', hint: 'face shape', svg: 'no', width: '33%', options: faceShapeOptions, ukrainian: 'форма обличчя', ukrainianHint: 'форма обличчя'},
-  { name: 'noseShape', placeholder: 'Прямий', hint: 'nose shape', svg: 'no', width: '33%', options: noseShapeOptions, ukrainian: 'форма носа', ukrainianHint: 'форма носа' },
-  { name: 'lipsShape', placeholder: 'Повні', hint: 'lips shape', svg: 'no', width: '33%', options: lipsShapeOptions, ukrainian: 'форма губ', ukrainianHint: 'форма губ' },
-  { name: 'chin', placeholder: 'Pointed', hint: 'сhin', svg: 'no', width: '33%', options: chinShapeOptions, ukrainian: 'підборіддя', ukrainianHint: 'підборіддя' },
+  { name: 'faceShape', placeholder: 'Овальне', hint: 'face shape', svg: 'no', width: '33%', options: faceShapeOptions, ukrainian: 'форма обличчя', ukrainianHint: 'форма обличчя', section: 'Параметри та зовнішність'},
+  { name: 'noseShape', placeholder: 'Прямий', hint: 'nose shape', svg: 'no', width: '33%', options: noseShapeOptions, ukrainian: 'форма носа', ukrainianHint: 'форма носа', section: 'Параметри та зовнішність' },
+  { name: 'lipsShape', placeholder: 'Повні', hint: 'lips shape', svg: 'no', width: '33%', options: lipsShapeOptions, ukrainian: 'форма губ', ukrainianHint: 'форма губ', section: 'Параметри та зовнішність' },
+  { name: 'chin', placeholder: 'Pointed', hint: 'сhin', svg: 'no', width: '33%', options: chinShapeOptions, ukrainian: 'підборіддя', ukrainianHint: 'підборіддя', section: 'Параметри та зовнішність' },
 
   // спосіб життя
-  { name: 'smoking', placeholder: '-', hint: 'Smoking', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'куріння' },
-  { name: 'alcohol', placeholder: '-', hint: 'Alcohol', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'вживання алкоголю' },
-  { name: 'sport', placeholder: 'Волейбол', hint: 'Sport', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'спорт' },
-  { name: 'hobbies', placeholder: 'Читання', hint: 'Hobbies', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хоббі'  },
+  { name: 'smoking', placeholder: '-', hint: 'Smoking', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'куріння', section: 'Спосіб життя' },
+  { name: 'alcohol', placeholder: '-', hint: 'Alcohol', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'вживання алкоголю', section: 'Спосіб життя' },
+  { name: 'sport', placeholder: 'Волейбол', hint: 'Sport', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'спорт', section: 'Спосіб життя' },
+  { name: 'hobbies', placeholder: 'Читання', hint: 'Hobbies', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хоббі', section: 'Спосіб життя'  },
 
   // додатково
   {
@@ -267,6 +273,7 @@ export const pickerFields = [
     options: yesNoOptions,
     ukrainian: 'сімейний стан',
     ukrainianHint: 'сімейний стан',
+    section: 'Освіта, сім’я та додатково',
   },
   {
     name: 'education',
@@ -278,6 +285,7 @@ export const pickerFields = [
     modalOptions: educationModalOptions,
     ukrainian: 'освіта',
     ukrainianHint: 'освіта',
+    section: 'Освіта, сім’я та додатково',
   },
   {
     name: 'profession',
@@ -287,8 +295,9 @@ export const pickerFields = [
     width: '33%',
     ukrainian: 'професія',
     ukrainianHint: 'професія',
+    section: 'Освіта, сім’я та додатково',
   },
-  { name: 'twinsInFamily', placeholder: '-', hint: 'Twins in the family?', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'чи були двійнята в родині?'  },
+  { name: 'twinsInFamily', placeholder: '-', hint: 'Twins in the family?', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'чи були двійнята в родині?', section: 'Освіта, сім’я та додатково'  },
   {
     name: 'moreInfo_main',
     placeholder: 'Більше про себе... (макс 300 символів)',
@@ -297,6 +306,7 @@ export const pickerFields = [
     width: '100%',
     ukrainian: 'Більше про себе... (макс 300 символів)',
     ukrainianHint: 'додаткова інформація',
+    section: 'Освіта, сім’я та додатково',
   },
 
 ];


### PR DESCRIPTION
### Motivation
- Розбити довгу форму на сторінці `MyProfile` на візуальні секції для кращого сприйняття без зміни логіки збереження чи структури даних.
- Секції мають бути тільки UI-метаданими і не впливати на `Firebase` або інші компоненти, що використовують `pickerFields`.

### Description
- Додано опціональне UI-метаполе `section` до записів в `pickerFields` в `src/components/formFields.js` з рекомендованими назвами секцій (наприклад `Основна інформація`, `Контакти`, `Медична інформація та досвід`, `Параметри та зовнішність`, `Спосіб життя`, `Освіта, сім’я та додатково`).
- У `src/components/MyProfile.jsx` обчислюються `fieldsWithSections` на основі `visiblePickerFields` і для полів встановлюється прапорець `showSectionTitle` коли починається нова секція (рішення реалізовано згідно рекомендації з `map(...)`).
- Додано відображення заголовків секцій у місці рендеру полів: перед першим полем кожної секції показується `ProfileSectionHeader` з `ProfileSectionTitle`, а заголовок не дублюється для наступних полів тієї ж секції.
- Додано стилізовані `styled-components` у `MyProfile.jsx`: `ProfileSectionHeader` та `ProfileSectionTitle` з адаптивними відступами (менший верхній відступ для першої секції) і мобільно-дружнім візуальним стилем.

### Testing
- Виконано автоматизовані перевірки вмісту файлів за допомогою `rg`/`sed`/`nl` для підтвердження наявності доданих полів `section` у `src/components/formFields.js` та нових компонентів/рендер-логіки в `src/components/MyProfile.jsx`, всі перевірки пройшли успішно.
- Переглянуто `diff` файлів щоб переконатися, що `name`, `placeholder`, `ukrainian`, `ukrainianHint`, `options` і порядок полів не змінились; перевірка пройшла успішно.
- Не виконувались інтеграційні або юніт-тести; зміни обмежені UI і не торкаються збереження/структури даних, отже функціональні автотести не були необхідні для цього PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133b661e988326878aa9af96c81aa4)