### PR TITLE
Standardize social/contact field placeholders to 'username'

### DIFF
--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -160,14 +160,14 @@ export const pickerFields = [
   // контакти
   { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail'},
   { name: 'phone', placeholder: '+380 67 123 45 67', svg: 'phone', ukrainianHint:'номер телефону'},
-  { name: 'telegram', placeholder: '@username або t.me/username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
-  { name: 'facebook', placeholder: 'facebook.com/username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
-  { name: 'instagram', placeholder: '@username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
-  { name: 'tiktok', placeholder: '@username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'тікток' },
-  { name: 'twitter', placeholder: '@username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'твітер / x' },
-  { name: 'linkedin', placeholder: 'linkedin.com/in/username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
-  { name: 'youtube', placeholder: 'youtube.com/@channel', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'ютуб' },
-  { name: 'vk', placeholder: '0107655', hint: '0107655', svg: 'vk', ukrainian: '', ukrainianHint:'' },
+  { name: 'telegram', placeholder: 'username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
+  { name: 'facebook', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
+  { name: 'instagram', placeholder: 'username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
+  { name: 'tiktok', placeholder: 'username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'тікток' },
+  { name: 'twitter', placeholder: 'username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'твітер / x' },
+  { name: 'linkedin', placeholder: 'username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
+  { name: 'youtube', placeholder: 'username', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'ютуб' },
+  { name: 'vk', placeholder: 'username', hint: 'username', svg: 'vk', ukrainian: '', ukrainianHint:'' },
 
   // медичне
   { name: 'blood', placeholder: '3+', hint: 'група крові та резус / 3+', svg: 'no', ukrainianHint: 'група крові та резус / 3+'  },
@@ -317,8 +317,8 @@ export const pickerFieldsExtended = [
   // { name: 'email', placeholder: 'Електронна пошта', svg: 'mail', ukrainianHint:'E-mail'},
   // { name: 'phone', placeholder: '380', svg: 'phone', ukrainianHint:'номер телефону в форматі +380'},
   // { name: 'telegram', placeholder: '@username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
-  // { name: 'facebook', placeholder: 'facebook.com/username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
-  // { name: 'instagram', placeholder: '@username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
+  // { name: 'facebook', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
+  // { name: 'instagram', placeholder: 'username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
   
   ...pickerFields,
 


### PR DESCRIPTION
### Motivation
- Simplify and standardize placeholders for social/contact fields in `src/components/formFields.js` so input expectations are clearer and consistent across the UI.

### Description
- Replaced verbose URL/format examples for social fields (`telegram`, `facebook`, `instagram`, `tiktok`, `twitter`, `linkedin`, `youtube`, `vk`) with concise `username` placeholders and adjusted the corresponding commented entries in `pickerFieldsExtended`.

### Testing
- Ran the project test suite and checks including `yarn test`, `yarn lint`, and a development build via `yarn build`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134b1315d48326becb327040afc389)