### PR TITLE
Use ukrainianHint for input placeholders and update contact field hints/examples

### DIFF
--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -656,13 +656,13 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
                         setShowInfoModal('pickerOptions');
                       }
                     }}
-                    // placeholder={field.placeholder} // Обов'язково для псевдокласу :placeholder-shown
+                    placeholder={field.ukrainianHint || field.placeholder} // Обов'язково для псевдокласу :placeholder-shown
                     onBlur={() => handleBlur(field.name)}
                   />
                   {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times; {/* HTML-символ для хрестика */}</ClearButton>}
                 </InputFieldContainer>
 
-                <Hint fieldName={field.name} isActive={state[field.name]}>{field.ukrainian || field.placeholder}</Hint>
+                <Hint fieldName={field.name} isActive={state[field.name]}>{field.ukrainian || field.ukrainianHint || field.placeholder}</Hint>
                 <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
               </InputDiv>
               {Array.isArray(field.options) && field.name !== 'education' && field.options.length === 2 && (

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -158,16 +158,16 @@ export const pickerFields = [
   { name: 'city', placeholder: 'буча', hint: 'city', svg: 'no', width: '33%', ukrainian: 'місто', ukrainianHint: 'місто' },
 
   // контакти
-  { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail'},
-  { name: 'phone', placeholder: '+380 67 123 45 67', svg: 'phone', ukrainianHint:'номер телефону'},
-  { name: 'telegram', placeholder: '@username або t.me/username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
-  { name: 'facebook', placeholder: 'facebook.com/username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
-  { name: 'instagram', placeholder: '@username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
-  { name: 'tiktok', placeholder: '@username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'тікток' },
-  { name: 'twitter', placeholder: '@username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'твітер / x' },
-  { name: 'linkedin', placeholder: 'linkedin.com/in/username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
-  { name: 'youtube', placeholder: 'youtube.com/@channel', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'ютуб' },
-  { name: 'vk', placeholder: '0107655', hint: '0107655', svg: 'vk', ukrainian: '', ukrainianHint:'' },
+  { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'name@example.com'},
+  { name: 'phone', placeholder: '+380 67 123 45 67', svg: 'phone', ukrainianHint:'+380 67 123 45 67'},
+  { name: 'telegram', placeholder: 'username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'anna_user' },
+  { name: 'facebook', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'anna.user' },
+  { name: 'instagram', placeholder: 'username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'anna_user' },
+  { name: 'tiktok', placeholder: 'username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'anna_user' },
+  { name: 'twitter', placeholder: 'username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'anna_user' },
+  { name: 'linkedin', placeholder: 'username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'anna-user' },
+  { name: 'youtube', placeholder: 'username', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'@anna_channel' },
+  { name: 'vk', placeholder: 'username', hint: 'username', svg: 'vk', ukrainian: '', ukrainianHint:'id123456789' },
 
   // медичне
   { name: 'blood', placeholder: '3+', hint: 'група крові та резус / 3+', svg: 'no', ukrainianHint: 'група крові та резус / 3+'  },
@@ -317,8 +317,8 @@ export const pickerFieldsExtended = [
   // { name: 'email', placeholder: 'Електронна пошта', svg: 'mail', ukrainianHint:'E-mail'},
   // { name: 'phone', placeholder: '380', svg: 'phone', ukrainianHint:'номер телефону в форматі +380'},
   // { name: 'telegram', placeholder: '@username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
-  // { name: 'facebook', placeholder: 'facebook.com/username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
-  // { name: 'instagram', placeholder: '@username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
+  // { name: 'facebook', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'anna.user' },
+  // { name: 'instagram', placeholder: 'username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'anna_user' },
   
   ...pickerFields,
 


### PR DESCRIPTION
### Motivation
- Make input placeholders use the localized short hint (`ukrainianHint`) so the placeholder-shown CSS and UI show concise Ukrainian hints. 
- Ensure the floating `Hint` falls back to `ukrainianHint` when a full `ukrainian` label isn't present. 
- Improve contact/social field configuration by replacing long example placeholders with concise placeholders and realistic example hints.

### Description
- In `ProfileScreen.jsx` the input `placeholder` now uses `field.ukrainianHint || field.placeholder` so the localized short hint is shown in the placeholder. 
- The visible floating `Hint` text was updated to render `field.ukrainian || field.ukrainianHint || field.placeholder` so `ukrainianHint` is used as a fallback. 
- Updated many entries in `formFields.js` `pickerFields` to use simpler `placeholder` values (e.g. `username`) and provide concrete example values in `ukrainianHint` for contact/social fields and `vk`. 
- Adjusted commented examples in `pickerFieldsExtended` to match the new hint format.

### Testing
- Ran linting with `npm run lint` and it completed successfully. 
- Ran the test suite with `npm test` and all tests passed. 
- Performed a local production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134b1315d48326becb327040afc389)