### PR TITLE
Introduce field/option accessor helpers and migrate form fields/components to use them

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -9,7 +9,13 @@ import {
   updateDataInRealtimeDB,
   updateDataInNewUsersRTDB,
 } from './config';
-import { pickerFields } from './formFields';
+import {
+  pickerFields,
+  getFieldHint,
+  getFieldLabel,
+  getOptionLabel,
+  getOptionValue,
+} from './formFields';
 import {
   onAuthStateChanged,
   signOut,
@@ -899,7 +905,8 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleSelectOption = option => {
     if (selectedField) {
-      const newValue = option.placeholder === 'Clear' ? '' : option.placeholder;
+      const optionValue = getOptionValue(option);
+      const newValue = optionValue === 'Clear' ? '' : optionValue;
       setState(prevState => {
         const newState = { ...prevState, [selectedField]: newValue };
         handleSubmit(newState);
@@ -1073,8 +1080,8 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times; {/* HTML-символ для хрестика */}</ClearButton>}
                 </InputFieldContainer>
 
-                <Hint fieldName={field.name} isActive={state[field.name]}>{field.ukrainian || field.placeholder}</Hint>
-                <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
+                <Hint fieldName={field.name} isActive={state[field.name]}>{getFieldLabel(field)}</Hint>
+                <Placeholder isActive={state[field.name]}>{getFieldLabel(field)}</Placeholder>
               </InputDiv>
               {Array.isArray(field.options) && field.options.length === 2 && (
                 <ButtonGroup>
@@ -1108,14 +1115,14 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 <ButtonGroup>
                   {field.options.map(option => (
                     <Button
-                      key={`${field.name}-${option.placeholder}`}
+                      key={`${field.name}-${getOptionValue(option)}`}
                       type="button"
                       onClick={() => {
-                        setState(prevState => ({ ...prevState, [field.name]: option.placeholder }));
+                        setState(prevState => ({ ...prevState, [field.name]: getOptionValue(option) }));
                         handleBlur(field.name);
                       }}
                     >
-                      {option.ukrainian || option.placeholder}
+                      {getOptionLabel(option)}
                     </Button>
                   ))}
                 </ButtonGroup>

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -7,7 +7,14 @@ import Photos from './Photos';
 import { inputUpdateValue } from './inputUpdatedValue';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { color, OrangeBtn, uiTokens } from './styles';
-import { pickerFieldsExtended as pickerFields } from './formFields';
+import {
+  pickerFieldsExtended as pickerFields,
+  getFieldHint,
+  getFieldLabel,
+  getFieldPlaceholder,
+  getOptionLabel,
+  getOptionValue,
+} from './formFields';
 import { utilCalculateAge } from './smallCard/utilCalculateAge';
 import {
   formatDateToDisplay,
@@ -103,7 +110,7 @@ const PROFILE_FORM_LABELS = {
 
 const getFieldDisplayLabel = field => {
   const fieldName = resolveFieldNameBase(field?.name);
-  return field?.ukrainian || PROFILE_FORM_LABELS[fieldName] || field?.ukrainianHint || field?.placeholder || fieldName;
+  return getFieldLabel(field) || PROFILE_FORM_LABELS[fieldName] || getFieldPlaceholder(field) || fieldName;
 };
 
 
@@ -2358,7 +2365,8 @@ ${entries.join('\n')}`;
       return;
     }
 
-    const newValue = option.placeholder === 'Clear' ? '' : option.placeholder;
+    const optionValue = getOptionValue(option);
+    const newValue = optionValue === 'Clear' ? '' : optionValue;
     setState(prevState => {
       const newState = { ...prevState, [selectedField]: newValue };
       submitWithNormalization(newState, 'overwrite');
@@ -2588,7 +2596,7 @@ ${entries.join('\n')}`;
                         <Hint fieldName={field.name} isActive={value}>
                           {getFieldDisplayLabel(field)}
                         </Hint>
-                        <Placeholder isActive={value}>{field.ukrainianHint}</Placeholder>
+                        <Placeholder isActive={value}>{getFieldDisplayLabel(field)}</Placeholder>
                       </>
                     )}
                   </InputDiv>
@@ -2782,7 +2790,7 @@ ${entries.join('\n')}`;
                     <Hint fieldName={field.name} isActive={state[field.name]}>
                       {getFieldDisplayLabel(field)}
                     </Hint>
-                    <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
+                    <Placeholder isActive={state[field.name]}>{getFieldDisplayLabel(field)}</Placeholder>
                   </>
                 )}
               </InputDiv>
@@ -2887,7 +2895,7 @@ ${entries.join('\n')}`;
                 <ButtonGroup>
                   {field.options.map(option => (
                     <Button
-                      key={`${field.name}-${option.placeholder}`}
+                      key={`${field.name}-${getOptionValue(option)}`}
                       type="button"
                       onClick={() => {
                         if (!state.myComment?.trim()) {
@@ -2896,17 +2904,17 @@ ${entries.join('\n')}`;
                         setState(prevState => {
                           const newState = {
                             ...prevState,
-                            [field.name]: option.placeholder,
+                            [field.name]: getOptionValue(option),
                           };
                           submitWithNormalization(newState, 'overwrite');
-                          if (option.placeholder === 'Other') {
+                          if (getOptionValue(option) === 'Other') {
                             handleBlur(field.name);
                           }
                           return newState;
                         });
                       }}
                     >
-                      {option.ukrainian || option.placeholder}
+                      {getOptionLabel(option)}
                     </Button>
                   ))}
                 </ButtonGroup>
@@ -2938,7 +2946,7 @@ ${entries.join('\n')}`;
                   <Hint fieldName={field.name} isActive={entry.value}>
                     {getFieldDisplayLabel(field)}
                   </Hint>
-                  <Placeholder isActive={entry.value}>{field.ukrainianHint}</Placeholder>
+                  <Placeholder isActive={entry.value}>{getFieldDisplayLabel(field)}</Placeholder>
                 </InputDiv>
                 <Button type="button" onClick={() => handleOverlayApply(field.name, entry)}>
                   ОК

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -7,6 +7,19 @@ export const inputFields = [
   
 ];
 
+export const getFieldLabel = field =>
+  field?.label ?? field?.ukrainianHint ?? field?.ukrainian ?? field?.hint ?? field?.name ?? '';
+
+export const getFieldPlaceholder = field => field?.placeholder ?? '';
+
+export const getFieldHint = field => field?.hint ?? '';
+
+export const getOptionLabel = option =>
+  option?.label ?? option?.ukrainian ?? option?.placeholder ?? option?.value ?? '';
+
+export const getOptionValue = option =>
+  option?.value ?? option?.placeholder ?? option?.label ?? '';
+
 
 export const inputFieldsEdRowOpu = [
   { name: 'opuDate', placeholder: '30.03.2022', hint: 'date of OPU', svg: 'no', width: '33%', ukrainianHint: 'дата пункції' },
@@ -150,28 +163,28 @@ export const csectionOptions = [
 
 export const pickerFields = [
   // базове
-  { name: 'name', placeholder: 'Ваше ім’я', svg: 'user', ukrainianHint: 'ім’я' },
-  { name: 'surname', placeholder: 'Ваше прізвище', svg: 'user', ukrainianHint: 'прізвище'},
-  { name: 'birth', placeholder: 'дд.мм.рррр', hint: 'DOB', svg: 'no', width: '33%', ukrainianHint: 'дата народження (дд.мм.рррр)' },
-  { name: 'country', placeholder: 'україна', hint: 'country', svg: 'no', width: '33%', ukrainian: 'країна', ukrainianHint: 'країна проживання' },
-  { name: 'region', placeholder: 'київська', hint: 'region', svg: 'no', width: '33%', ukrainian: 'область', ukrainianHint: 'область' },
-  { name: 'city', placeholder: 'буча', hint: 'city', svg: 'no', width: '33%', ukrainian: 'місто', ukrainianHint: 'місто' },
+  { name: 'name', label: 'Ім’я', placeholder: 'Ваше ім’я', svg: 'user' },
+  { name: 'surname', label: 'Прізвище', placeholder: 'Ваше прізвище', svg: 'user' },
+  { name: 'birth', label: 'Дата народження', placeholder: 'дд.мм.рррр', hint: 'Формат: дд.мм.рррр', svg: 'no', width: '33%' },
+  { name: 'country', label: 'Країна проживання', placeholder: 'україна', svg: 'no', width: '33%' },
+  { name: 'region', label: 'Область', placeholder: 'київська', svg: 'no', width: '33%' },
+  { name: 'city', label: 'Місто', placeholder: 'буча', svg: 'no', width: '33%' },
 
   // контакти
   { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail'},
-  { name: 'phone', placeholder: '+380 67 123 45 67', svg: 'phone', ukrainianHint:'номер телефону'},
-  { name: 'telegram', placeholder: 'username', svg: 'telegram-plane', ukrainian: 'телеграм', ukrainianHint:'телеграм' },
+  { name: 'phone', label: 'Телефон', placeholder: '+380 67 123 45 67', hint: 'Номер у міжнародному форматі', svg: 'phone'},
+  { name: 'telegram', label: 'телеграм', placeholder: '@username', svg: 'telegram-plane' },
   { name: 'facebook', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
-  { name: 'instagram', placeholder: 'username', svg: 'instagram', ukrainian: 'інстаграм', ukrainianHint:'інстаграм' },
-  { name: 'tiktok', placeholder: 'username', svg: 'tiktok', ukrainian: 'тікток', ukrainianHint:'тікток' },
-  { name: 'twitter', placeholder: 'username', svg: 'no', ukrainian: 'твітер / x', ukrainianHint:'твітер / x' },
+  { name: 'instagram', label: 'інстаграм', placeholder: '@username', svg: 'instagram' },
+  { name: 'tiktok', label: 'тікток', placeholder: '@username', svg: 'tiktok' },
+  { name: 'twitter', label: 'твітер / x', placeholder: '@username', svg: 'no' },
   { name: 'linkedin', placeholder: 'username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
-  { name: 'youtube', placeholder: 'username', svg: 'no', ukrainian: 'ютуб', ukrainianHint:'ютуб' },
+  { name: 'youtube', label: 'ютуб', placeholder: '@channel', svg: 'no' },
   { name: 'vk', placeholder: 'username', hint: 'username', svg: 'vk', ukrainian: '', ukrainianHint:'' },
 
   // медичне
-  { name: 'blood', placeholder: '3+', hint: 'група крові та резус / 3+', svg: 'no', ukrainianHint: 'група крові та резус / 3+'  },
-  { name: 'ownKids', placeholder: '1', hint: 'own kids', svg: 'no', ukrainian: 'кількість пологів', ukrainianHint: 'кількість пологів' },
+  { name: 'blood', label: 'Група крові та резус', placeholder: '3+', svg: 'no'  },
+  { name: 'ownKids', label: 'Кількість пологів', placeholder: '1', svg: 'no' },
   { name: 'lastDelivery', placeholder: 'дд.мм.рррр', hint: 'last delivery', svg: 'no', width: '33%', ukrainianHint: 'останні пологи були (дд.мм.рррр)' },
   {
     name: 'csection',
@@ -180,9 +193,9 @@ export const pickerFields = [
     svg: 'no',
     width: '33%',
     options: csectionOptions,
-    ukrainianHint: 'кесарів розтин',
+    label: 'Кесарів розтин',
   },
-  { name: 'experience', placeholder: '2', hint: 'donatin exp?', svg: 'no', width: '33%', ukrainianHint: 'кількість попередніх донацій' },
+  { name: 'experience', label: 'Кількість попередніх донацій', placeholder: '2', svg: 'no', width: '33%' },
   { name: 'allergy', placeholder: 'пеніцилін', hint: 'Allergy', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'алергії' },
   {
     name: 'surgeries',
@@ -197,8 +210,8 @@ export const pickerFields = [
   { name: 'chronicDiseases', placeholder: '-', hint: 'Chronic diseases', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хронічні захворювання' },
 
   // фізичні
-  { name: 'height', placeholder: '168', hint: 'cm', svg: 'no',  ukrainian: 'зріст', ukrainianHint: 'зріст в см' },
-  { name: 'weight', placeholder: '58', hint: 'kg', svg: 'no', ukrainian: 'вага', ukrainianHint: 'вага в кг' },
+  { name: 'height', label: 'зріст в см', placeholder: '168', hint: 'У сантиметрах', svg: 'no' },
+  { name: 'weight', label: 'вага в кг', placeholder: '58', hint: 'У кілограмах', svg: 'no' },
   { name: 'clothingSize', placeholder: '38-40', hint: 'clothing size', svg: 'no', width: '33%', ukrainian: 'розмір одягу', ukrainianHint: 'розмір одягу' },
   { name: 'shoeSize', placeholder: '38', hint: 'shoe size', svg: 'no', width: '33%', ukrainian: 'розмір взуття', ukrainianHint: 'розмір взуття' },
   { name: 'breastSize', placeholder: '75b', hint: 'breast size', svg: 'no', width: '33%', ukrainian: 'розмір грудей', ukrainianHint: 'розмір грудей' },
@@ -265,13 +278,12 @@ export const pickerFields = [
     svg: 'no',
     width: '33%',
     options: yesNoOptions,
-    ukrainian: 'сімейний стан',
-    ukrainianHint: 'сімейний стан',
+    label: 'Сімейний стан',
   },
   {
     name: 'education',
     placeholder: 'Вища освіта',
-    hint: 'education',
+    hint: '',
     svg: 'no',
     width: '33%',
     options: educationOptions,
@@ -282,7 +294,7 @@ export const pickerFields = [
   {
     name: 'profession',
     placeholder: 'Лікар',
-    hint: 'profession',
+    hint: '',
     svg: 'no',
     width: '33%',
     ukrainian: 'професія',
@@ -291,12 +303,11 @@ export const pickerFields = [
   { name: 'twinsInFamily', placeholder: '-', hint: 'Twins in the family?', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'чи були двійнята в родині?'  },
   {
     name: 'moreInfo_main',
-    placeholder: 'Більше про себе... (макс 300 символів)',
-    hint: 'extra info',
+    label: 'Про себе',
+    placeholder: 'Коротко розкажіть про себе',
+    hint: 'До 300 символів',
     svg: 'no',
     width: '100%',
-    ukrainian: 'Більше про себе... (макс 300 символів)',
-    ukrainianHint: 'додаткова інформація',
   },
 
 ];


### PR DESCRIPTION
### Motivation
- Standardize how field labels, placeholders, hints and option values/labels are read across the profile form to reduce coupling to legacy property names.
- Prepare form metadata for more explicit and consistent internationalization and UI rendering by introducing canonical `label`, `placeholder`, and `hint` accessors.

### Description
- Added accessor helpers in `src/components/formFields.js`: `getFieldLabel`, `getFieldPlaceholder`, `getFieldHint`, `getOptionLabel`, and `getOptionValue` to normalize reading metadata from field and option objects.
- Updated `pickerFields` entries to include `label`, `placeholder`, and `hint` fields and removed/standardized older `ukrainian`/`ukrainianHint` usage in several entries.
- Migrated usage in `MyProfile.jsx` and `ProfileForm.jsx` to import and use the new accessors for rendering hints/placeholders and for option selection and key generation, including replacing direct `option.placeholder`/`field.ukrainianHint` lookups with `getOptionValue`, `getOptionLabel`, and `getFieldLabel`.
- Ensured option keys and selected values use the canonical value via `getOptionValue` to avoid inconsistencies when option objects use different property names.

### Testing
- Ran linting with `npm run lint` and fixed issues introduced by the changes; lint passed.
- Executed the unit test suite with `npm test` and all tests passed.
- Built the frontend with `npm run build` to validate the changes in a production bundle and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135c1f3870832690ba1818a7bf75fa)