### PR TITLE
fix: remove unused getFieldHint imports

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -11,7 +11,6 @@ import {
 } from './config';
 import {
   pickerFields,
-  getFieldHint,
   getFieldLabel,
   getOptionLabel,
   getOptionValue,

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -9,7 +9,6 @@ import { useAutoResize } from '../hooks/useAutoResize';
 import { color, OrangeBtn, uiTokens } from './styles';
 import {
   pickerFieldsExtended as pickerFields,
-  getFieldHint,
   getFieldLabel,
   getFieldPlaceholder,
   getOptionLabel,


### PR DESCRIPTION
### Motivation
- Усунути попередження ESLint `no-unused-vars`, спричинене невикористаним імпортом `getFieldHint` у двох компонентах.

### Description
- Вилучено невикористаний імпорт `getFieldHint` з `src/components/MyProfile.jsx` та `src/components/ProfileForm.jsx`.

### Testing
- Автоматизованих тестів не запускали; зміна тривіальна і спрямована на усунення ESLint-попереджень `no-unused-vars`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1363b0b0808326aac41674cd13757f)