### PR TITLE
Виправити fallback для міток полів та відновити підказки у профілі

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -1080,7 +1080,7 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 </InputFieldContainer>
 
                 <Hint fieldName={field.name} isActive={state[field.name]}>{getFieldLabel(field)}</Hint>
-                <Placeholder isActive={state[field.name]}>{getFieldLabel(field)}</Placeholder>
+                <Placeholder isActive={state[field.name]}>{field.hint || field.ukrainianHint || getFieldLabel(field)}</Placeholder>
               </InputDiv>
               {Array.isArray(field.options) && field.options.length === 2 && (
                 <ButtonGroup>

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -92,7 +92,7 @@ export const getFieldsToRender = state => {
     ...additionalFields.map(key => ({
       name: key,
       placeholder: key,
-      ukrainianHint: key,
+      ukrainianHint: PROFILE_FORM_LABELS[key] || key,
     })),
   ];
 };
@@ -109,7 +109,8 @@ const PROFILE_FORM_LABELS = {
 
 const getFieldDisplayLabel = field => {
   const fieldName = resolveFieldNameBase(field?.name);
-  return getFieldLabel(field) || PROFILE_FORM_LABELS[fieldName] || getFieldPlaceholder(field) || fieldName;
+
+  return PROFILE_FORM_LABELS[fieldName] || getFieldLabel(field) || getFieldPlaceholder(field) || fieldName;
 };
 
 

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -663,7 +663,7 @@ export const ProfileScreen = ({ isLoggedIn, setIsLoggedIn }) => {
                 </InputFieldContainer>
 
                 <Hint fieldName={field.name} isActive={state[field.name]}>{field.ukrainian || field.placeholder}</Hint>
-                <Placeholder isActive={state[field.name]}>{field.ukrainianHint}</Placeholder>
+                <Placeholder isActive={state[field.name]}>{field.ukrainianHint || field.label || field.ukrainian || field.placeholder}</Placeholder>
               </InputDiv>
               {Array.isArray(field.options) && field.name !== 'education' && field.options.length === 2 && (
                 <ButtonGroup>

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -7,8 +7,14 @@ export const inputFields = [
   
 ];
 
-export const getFieldLabel = field =>
-  field?.label ?? field?.ukrainianHint ?? field?.ukrainian ?? field?.hint ?? field?.name ?? '';
+const hasDisplayText = value => typeof value === 'string' ? value.trim() !== '' : value != null;
+
+export const getFieldLabel = field => {
+  const candidates = [field?.label, field?.ukrainianHint, field?.ukrainian, field?.hint, field?.name];
+  const firstValue = candidates.find(hasDisplayText);
+
+  return firstValue ?? '';
+};
 
 export const getFieldPlaceholder = field => field?.placeholder ?? '';
 


### PR DESCRIPTION
### Motivation
- Усунути регресії, коли канонічна мапа міток (`PROFILE_FORM_LABELS`) пропускалась для динамічно згенерованих полів і показувались сирі ключі.
- Зробити так, щоб порожні локалізовані рядки (наприклад `''` в `ukrainian`) не блокували fallback і не приводили до пустих лейблів.
- Відновити відображення спеціальних підказок/форматів у формі профілю замість дублювання одного й того самого label.
- Забезпечити сумісний fallback для полів, що були мігровані з `ukrainianHint` → `label`, щоб підписи в `ProfileScreen` не зникали.

### Description
- Змінено `getFieldLabel` у `src/components/formFields.js`, щоб вважати порожні рядки за відсутні значення і пробувати наступні fallback-значення у порядку `label, ukrainianHint, ukrainian, hint, name`.
- У `src/components/ProfileForm.jsx` змінено `getFieldDisplayLabel` щоб спочатку перевіряти `PROFILE_FORM_LABELS[fieldName]`, потім `getFieldLabel(field)` та інші fallback-джерела, для збереження канонічних міток.
- У `src/components/ProfileForm.jsx` модифіковано `getFieldsToRender` щоб для динамічних ключів виставляти `ukrainianHint: PROFILE_FORM_LABELS[key] || key`, тобто матеріалізовані поля отримують локалізований підпис коли він існує.
- В `src/components/MyProfile.jsx` відновлено окремий текст плаваючої підказки (`Placeholder`) — тепер використовується `field.hint || field.ukrainianHint || getFieldLabel(field)` щоб не дублювати display label і не втратити guidance-тексти.
- В `src/components/ProfileScreen.jsx` додано більш надійний fallback для `Placeholder`: `field.ukrainianHint || field.label || field.ukrainian || field.placeholder`, щоб підписи не зникали після міграції метаданих.

### Testing
- Запущені перевірки змінів у коді за допомогою `git diff -- src/components/formFields.js src/components/ProfileForm.jsx src/components/MyProfile.jsx src/components/ProfileScreen.jsx`, які успішно показали очікувані дельти.
- Виконано `git status --short` і коміт змін через `git commit` — операції пройшли успішно.
- Переглянуто файли з `nl -ba` для перевірки вставлених рядків; ці перевірки виконані локально та завершилися успішно.
- Жодних автоматизованих unit/integration тестів у цьому наборі змін не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136466ff8083268456c7b622261bf0)