### PR TITLE
Separate placeholder text from display label in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -110,7 +110,13 @@ const PROFILE_FORM_LABELS = {
 const getFieldDisplayLabel = field => {
   const fieldName = resolveFieldNameBase(field?.name);
 
-  return PROFILE_FORM_LABELS[fieldName] || getFieldLabel(field) || getFieldPlaceholder(field) || fieldName;
+  return PROFILE_FORM_LABELS[fieldName] || getFieldLabel(field) || fieldName;
+};
+
+const getFieldPlaceholderText = field => {
+  const fieldName = resolveFieldNameBase(field?.name);
+
+  return getFieldPlaceholder(field) || PROFILE_FORM_LABELS[fieldName] || getFieldLabel(field) || fieldName;
 };
 
 
@@ -2596,7 +2602,7 @@ ${entries.join('\n')}`;
                         <Hint fieldName={field.name} isActive={value}>
                           {getFieldDisplayLabel(field)}
                         </Hint>
-                        <Placeholder isActive={value}>{getFieldDisplayLabel(field)}</Placeholder>
+                        <Placeholder isActive={value}>{getFieldPlaceholderText(field)}</Placeholder>
                       </>
                     )}
                   </InputDiv>
@@ -2790,7 +2796,7 @@ ${entries.join('\n')}`;
                     <Hint fieldName={field.name} isActive={state[field.name]}>
                       {getFieldDisplayLabel(field)}
                     </Hint>
-                    <Placeholder isActive={state[field.name]}>{getFieldDisplayLabel(field)}</Placeholder>
+                    <Placeholder isActive={state[field.name]}>{getFieldPlaceholderText(field)}</Placeholder>
                   </>
                 )}
               </InputDiv>


### PR DESCRIPTION
### Motivation
- Ensure placeholders and visible field labels are chosen separately so the input placeholder shows the intended placeholder text while the hint/display label uses the configured label mapping or explicit field label.

### Description
- Introduced `getFieldPlaceholderText` to centralize placeholder selection logic and prefer explicit placeholder values before falling back to labels or the field name.
- Adjusted `getFieldDisplayLabel` to stop falling back to the placeholder and to prefer `PROFILE_FORM_LABELS` and `getFieldLabel` only.
- Updated JSX in `ProfileForm.jsx` to use `getFieldPlaceholderText` for `Placeholder` components in both single and multi-input branches.

### Testing
- Ran unit tests with `yarn test` and linting with `yarn lint`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1365aa660c8326bd3a016038b8d3ae)