### PR TITLE
Add explicit labels and normalize placeholders for picker fields

### DIFF
--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -177,21 +177,21 @@ export const pickerFields = [
   { name: 'city', label: 'Місто', placeholder: 'буча', svg: 'no', width: '33%' },
 
   // контакти
-  { name: 'email', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail'},
+  { name: 'email', label: 'E-mail', placeholder: 'name@example.com', svg: 'mail', ukrainianHint:'e-mail'},
   { name: 'phone', label: 'Телефон', placeholder: '+380 67 123 45 67', hint: 'Номер у міжнародному форматі', svg: 'phone'},
   { name: 'telegram', label: 'телеграм', placeholder: '@username', svg: 'telegram-plane' },
-  { name: 'facebook', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
+  { name: 'facebook', label: 'фейсбук', placeholder: 'username', svg: 'facebook-f', ukrainian: 'фейсбук', ukrainianHint:'фейсбук' },
   { name: 'instagram', label: 'інстаграм', placeholder: '@username', svg: 'instagram' },
   { name: 'tiktok', label: 'тікток', placeholder: '@username', svg: 'tiktok' },
   { name: 'twitter', label: 'твітер / x', placeholder: '@username', svg: 'no' },
-  { name: 'linkedin', placeholder: 'username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
+  { name: 'linkedin', label: 'лінкедін', placeholder: 'username', svg: 'no', ukrainian: 'лінкедін', ukrainianHint:'лінкедін' },
   { name: 'youtube', label: 'ютуб', placeholder: '@channel', svg: 'no' },
-  { name: 'vk', placeholder: 'username', hint: 'username', svg: 'vk', ukrainian: '', ukrainianHint:'' },
+  { name: 'vk', label: 'вконтакті', placeholder: 'username', hint: 'username', svg: 'vk', ukrainian: '', ukrainianHint:'' },
 
   // медичне
   { name: 'blood', label: 'Група крові та резус', placeholder: '3+', svg: 'no'  },
   { name: 'ownKids', label: 'Кількість пологів', placeholder: '1', svg: 'no' },
-  { name: 'lastDelivery', placeholder: 'дд.мм.рррр', hint: 'last delivery', svg: 'no', width: '33%', ukrainianHint: 'останні пологи були (дд.мм.рррр)' },
+  { name: 'lastDelivery', label: 'Останні пологи', placeholder: 'дд.мм.рррр', hint: 'last delivery', svg: 'no', width: '33%', ukrainianHint: 'останні пологи були (дд.мм.рррр)' },
   {
     name: 'csection',
     placeholder: 'Оберіть: Ні / 1 / 2',
@@ -202,9 +202,10 @@ export const pickerFields = [
     label: 'Кесарів розтин',
   },
   { name: 'experience', label: 'Кількість попередніх донацій', placeholder: '2', svg: 'no', width: '33%' },
-  { name: 'allergy', placeholder: 'пеніцилін', hint: 'Allergy', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'алергії' },
+  { name: 'allergy', label: 'Алергії', placeholder: 'пеніцилін', hint: 'Allergy', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'алергії' },
   {
     name: 'surgeries',
+    label: 'Перенесені операції',
     placeholder: 'апендицит у 2021',
     hint: 'surgeries',
     svg: 'no',
@@ -213,18 +214,19 @@ export const pickerFields = [
     ukrainian: 'перенесені операції',
     ukrainianHint: 'перенесені операції',
   },
-  { name: 'chronicDiseases', placeholder: '-', hint: 'Chronic diseases', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хронічні захворювання' },
+  { name: 'chronicDiseases', label: 'Хронічні захворювання', placeholder: '-', hint: 'Chronic diseases', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хронічні захворювання' },
 
   // фізичні
   { name: 'height', label: 'зріст в см', placeholder: '168', hint: 'У сантиметрах', svg: 'no' },
   { name: 'weight', label: 'вага в кг', placeholder: '58', hint: 'У кілограмах', svg: 'no' },
-  { name: 'clothingSize', placeholder: '38-40', hint: 'clothing size', svg: 'no', width: '33%', ukrainian: 'розмір одягу', ukrainianHint: 'розмір одягу' },
-  { name: 'shoeSize', placeholder: '38', hint: 'shoe size', svg: 'no', width: '33%', ukrainian: 'розмір взуття', ukrainianHint: 'розмір взуття' },
-  { name: 'breastSize', placeholder: '75b', hint: 'breast size', svg: 'no', width: '33%', ukrainian: 'розмір грудей', ukrainianHint: 'розмір грудей' },
-  { name: 'reward', placeholder: '500', hint: '$ reward', svg: 'no', ukrainianHint: 'бажана винагорода в $' },
-  { name: 'eyeColor', placeholder: 'голубі', hint: 'eyes', svg: 'no', width: '33%', options: eyeColorOptions, ukrainian: 'колір очей', ukrainianHint: 'колір очей' },
+  { name: 'clothingSize', label: 'Розмір одягу', placeholder: '38-40', hint: 'clothing size', svg: 'no', width: '33%', ukrainian: 'розмір одягу', ukrainianHint: 'розмір одягу' },
+  { name: 'shoeSize', label: 'Розмір взуття', placeholder: '38', hint: 'shoe size', svg: 'no', width: '33%', ukrainian: 'розмір взуття', ukrainianHint: 'розмір взуття' },
+  { name: 'breastSize', label: 'Розмір грудей', placeholder: '75B', hint: 'breast size', svg: 'no', width: '33%', ukrainian: 'розмір грудей', ukrainianHint: 'розмір грудей' },
+  { name: 'reward', label: 'Бажана винагорода в $', placeholder: '500', hint: '$ reward', svg: 'no', ukrainianHint: 'бажана винагорода в $' },
+  { name: 'eyeColor', label: 'Колір очей', placeholder: 'Голубі', hint: 'eyes', svg: 'no', width: '33%', options: eyeColorOptions, ukrainian: 'колір очей', ukrainianHint: 'колір очей' },
   {
     name: 'hairColor',
+    label: 'Колір волосся',
     placeholder: 'блонд',
     hint: 'hair',
     svg: 'no',
@@ -233,10 +235,11 @@ export const pickerFields = [
     ukrainian: 'колір волосся',
     ukrainianHint: 'колір волосся',
   },
-  { name: 'glasses', placeholder: '-2.5', hint: 'glasses', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'окуляри?' },
+  { name: 'glasses', label: 'Окуляри', placeholder: '-2.5', hint: 'glasses', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'окуляри?' },
  
   {
     name: 'hairStructure',
+    label: 'Структура волосся',
     placeholder: 'Хвилясте',
     hint: 'hair structure',
     svg: 'no',
@@ -247,6 +250,7 @@ export const pickerFields = [
   },
   {
     name: 'race',
+    label: 'Етнічна група',
     placeholder: 'Азіатська',
     hint: 'human race',
     svg: 'no',
@@ -257,6 +261,7 @@ export const pickerFields = [
   },
   {
     name: 'bodyType',
+    label: 'Фігура',
     placeholder: 'Трикутник',
     hint: 'body type',
     svg: 'no',
@@ -265,16 +270,16 @@ export const pickerFields = [
     ukrainian: 'фігура',
     ukrainianHint: 'фігура',
   },
-  { name: 'faceShape', placeholder: 'Овальне', hint: 'face shape', svg: 'no', width: '33%', options: faceShapeOptions, ukrainian: 'форма обличчя', ukrainianHint: 'форма обличчя'},
-  { name: 'noseShape', placeholder: 'Прямий', hint: 'nose shape', svg: 'no', width: '33%', options: noseShapeOptions, ukrainian: 'форма носа', ukrainianHint: 'форма носа' },
-  { name: 'lipsShape', placeholder: 'Повні', hint: 'lips shape', svg: 'no', width: '33%', options: lipsShapeOptions, ukrainian: 'форма губ', ukrainianHint: 'форма губ' },
-  { name: 'chin', placeholder: 'Pointed', hint: 'сhin', svg: 'no', width: '33%', options: chinShapeOptions, ukrainian: 'підборіддя', ukrainianHint: 'підборіддя' },
+  { name: 'faceShape', label: 'Форма обличчя', placeholder: 'Овальне', hint: 'face shape', svg: 'no', width: '33%', options: faceShapeOptions, ukrainian: 'форма обличчя', ukrainianHint: 'форма обличчя'},
+  { name: 'noseShape', label: 'Форма носа', placeholder: 'Прямий', hint: 'nose shape', svg: 'no', width: '33%', options: noseShapeOptions, ukrainian: 'форма носа', ukrainianHint: 'форма носа' },
+  { name: 'lipsShape', label: 'Форма губ', placeholder: 'Повні', hint: 'lips shape', svg: 'no', width: '33%', options: lipsShapeOptions, ukrainian: 'форма губ', ukrainianHint: 'форма губ' },
+  { name: 'chin', label: 'Підборіддя', placeholder: 'Гостре', hint: 'сhin', svg: 'no', width: '33%', options: chinShapeOptions, ukrainian: 'підборіддя', ukrainianHint: 'підборіддя' },
 
   // спосіб життя
-  { name: 'smoking', placeholder: '-', hint: 'Smoking', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'куріння' },
-  { name: 'alcohol', placeholder: '-', hint: 'Alcohol', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'вживання алкоголю' },
-  { name: 'sport', placeholder: 'Волейбол', hint: 'Sport', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'спорт' },
-  { name: 'hobbies', placeholder: 'Читання', hint: 'Hobbies', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хоббі'  },
+  { name: 'smoking', label: 'Куріння', placeholder: '-', hint: 'Smoking', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'куріння' },
+  { name: 'alcohol', label: 'Вживання алкоголю', placeholder: '-', hint: 'Alcohol', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'вживання алкоголю' },
+  { name: 'sport', label: 'Спорт', placeholder: 'Волейбол', hint: 'Sport', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'спорт' },
+  { name: 'hobbies', label: 'Хобі', placeholder: 'Читання', hint: 'Hobbies', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'хоббі'  },
 
   // додатково
   {
@@ -294,6 +299,7 @@ export const pickerFields = [
     width: '33%',
     options: educationOptions,
     modalOptions: educationModalOptions,
+    label: 'Освіта',
     ukrainian: 'освіта',
     ukrainianHint: 'освіта',
   },
@@ -303,10 +309,11 @@ export const pickerFields = [
     hint: '',
     svg: 'no',
     width: '33%',
+    label: 'Професія',
     ukrainian: 'професія',
     ukrainianHint: 'професія',
   },
-  { name: 'twinsInFamily', placeholder: '-', hint: 'Twins in the family?', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'чи були двійнята в родині?'  },
+  { name: 'twinsInFamily', label: 'Чи були двійнята в родині?', placeholder: '-', hint: 'Twins in the family?', svg: 'no', width: '33%', options: yesNoOptions, ukrainianHint: 'чи були двійнята в родині?'  },
   {
     name: 'moreInfo_main',
     label: 'Про себе',


### PR DESCRIPTION
### Motivation
- Ensure picker fields expose explicit `label` values for consistent UI rendering and localization.
- Normalize placeholders and capitalization across fields to improve readability and data consistency.
- Improve Ukrainian localization support by making labels explicit and keeping existing `ukrainian`/`ukrainianHint` values intact.

### Description
- Added `label` properties to many entries in `pickerFields` (including contact, medical, physical, facial, lifestyle, and misc fields) to provide explicit UI labels for each field.
- Updated placeholders and casing for several fields (for example `breastSize` to `75B`, capitalized `eyeColor` and other placeholders) and adjusted some social field labels (`email`, `facebook`, `linkedin`, `vk`) for clarity.
- Kept existing options, widths and `ukrainian`/`ukrainianHint` keys unchanged; no change to data structures or options arrays.

### Testing
- Ran linting and the automated test suite via `yarn lint` and `yarn test`, and both completed successfully.
- No failing tests were observed and type checks in the test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13688a381483268ac95a6f6d453811)