### PR TITLE
Виправити MyProfileNew: чекати на auth, нормалізувати масиви та не зберігати пароль

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { auth, fetchUserData, updateDataInFiresoreDB, updateDataInRealtimeDB } from './config';
 import { pickerFields, getFieldLabel, getFieldPlaceholder, getOptionLabel, getOptionValue } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
+import { onAuthStateChanged } from 'firebase/auth';
 
 const Page = styled.div`
   --accent: #E8791A;
@@ -102,11 +103,30 @@ export const MyProfileNew = () => {
   const [userId, setUserId] = useState('');
   const [activeTab, setActiveTab] = useState('personal');
 
+  const normalizeProfileData = (data = {}) => Object.entries(data).reduce((acc, [key, value]) => {
+    if (key === 'password') {
+      return acc;
+    }
+
+    if (key === 'photos' && Array.isArray(value)) {
+      acc[key] = value;
+      return acc;
+    }
+
+    acc[key] = Array.isArray(value) ? value[value.length - 1] : value;
+    return acc;
+  }, {});
+
   useEffect(() => {
-    const uid = auth.currentUser?.uid || localStorage.getItem('ownerId') || '';
-    if (!uid) return;
-    setUserId(uid);
-    fetchUserData(uid).then(({ existingData }) => setState(existingData || {}));
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      const uid = user?.uid || localStorage.getItem('ownerId') || '';
+      if (!uid) return;
+      setUserId(uid);
+      const { existingData } = await fetchUserData(uid);
+      setState(normalizeProfileData(existingData || {}));
+    });
+
+    return () => unsubscribe();
   }, []);
 
   const fieldsMap = useMemo(() => new Map(pickerFields.map(field => [field.name, field])), []);
@@ -119,7 +139,9 @@ export const MyProfileNew = () => {
   const save = async () => {
     if (!userId) return;
     const { existingData } = await fetchUserData(userId);
-    const uploadedInfo = makeUploadedInfo(existingData, state);
+    const { password: _password, ...profileData } = state;
+    const uploadedInfo = makeUploadedInfo(existingData, profileData);
+    delete uploadedInfo.password;
     await updateDataInRealtimeDB(userId, uploadedInfo);
     await updateDataInFiresoreDB(userId, uploadedInfo, 'check');
   };


### PR DESCRIPTION
### Motivation
- Уникнути повторного збереження чутливого поля `password`, яке може існувати в legacy-документах та випадково переписуватись при збереженні профілю.
- Виправити некоректне відображення полів, які історично зберігаються як масиви, щоб інпути й чіпи отримували скалярні значення (остання версія).
- Усунути race condition при старті компонента, коли `auth.currentUser` ще не відновлений і профіль лишається пустим.

### Description
- Замінив одноразову перевірку `auth.currentUser` на підписку через `onAuthStateChanged` для повторної спроби завантаження даних після відновлення сесії.
- Додав функцію `normalizeProfileData` яка: відкидає ключ `password`, зберігає `photos` як масив, а для інших полів-масивів бере останній елемент; ця нормалізація застосовується перед встановленням `state`.
- У `save` виключаю `password` зі `state` перед викликом `makeUploadedInfo` і додатково видаляю `uploadedInfo.password` перед записом у Realtime DB та Firestore.
- Додав імпорт `onAuthStateChanged` з `firebase/auth` і мінімальні зміни викликів `fetchUserData`/оновлення стану у `src/components/MyProfileNew.jsx`.

### Testing
- Виконано локальні перевірки репозиторію: `git commit` і `git show --stat --oneline HEAD`, обидві операції пройшли успішно.
- Автоматичних юніт-/інтеграційних тестів у цьому патчі не запускалось (жодних CI тестів не було доступно під час правки).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a146ac18cfc8326a224695dbd6676a2)