### PR TITLE
Improve profile loading/save: prevent races, normalize arrays, and forward save options

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -109,6 +109,7 @@ export const MyProfileNew = () => {
   const [userId, setUserId] = useState('');
   const [activeTab, setActiveTab] = useState('personal');
   const sectionRefs = useRef({});
+  const latestFetchUidRef = useRef('');
 
   const normalizeProfileData = (data = {}) => Object.entries(data).reduce((acc, [key, value]) => {
     if (key === 'password') {
@@ -120,20 +121,36 @@ export const MyProfileNew = () => {
       return acc;
     }
 
-    acc[key] = Array.isArray(value) ? value[value.length - 1] : value;
+    if (Array.isArray(value)) {
+      acc[key] = value.length > 0 ? value[value.length - 1] : '';
+      return acc;
+    }
+
+    acc[key] = value;
     return acc;
   }, {});
 
   useEffect(() => {
+    let isMounted = true;
+
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       const uid = user?.uid || localStorage.getItem('ownerId') || '';
       if (!uid) return;
+      latestFetchUidRef.current = uid;
       setUserId(uid);
       const { existingData } = await fetchUserData(uid);
+
+      if (!isMounted || latestFetchUidRef.current !== uid) {
+        return;
+      }
+
       setState(normalizeProfileData(existingData || {}));
     });
 
-    return () => unsubscribe();
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
   }, []);
 
   const fieldsMap = useMemo(() => new Map(pickerFields.map(field => [field.name, field])), []);
@@ -170,7 +187,7 @@ export const MyProfileNew = () => {
     const uploadedInfo = makeUploadedInfo(existingData, profileData);
     delete uploadedInfo.password;
     await updateDataInRealtimeDB(userId, uploadedInfo);
-    await updateDataInFiresoreDB(userId, uploadedInfo, 'check');
+    await updateDataInFiresoreDB(userId, uploadedInfo, 'check', { password: true });
   };
 
   const renderField = (name) => {


### PR DESCRIPTION
### Motivation
- Prevent stale or duplicate profile state updates when auth changes or async fetches overlap.
- Ensure array fields normalize to an empty string when empty to avoid rendering unexpected values.
- Pass explicit save options when writing to Firestore so downstream logic can handle password-related fields.

### Description
- Added `latestFetchUidRef` and an `isMounted` guard in the `onAuthStateChanged` effect to avoid race conditions and ignore out-of-date fetches before setting state.  
- Updated `normalizeProfileData` to treat empty arrays as an empty string and to handle arrays defensively when extracting the last value.  
- Enhanced cleanup of the auth listener by toggling `isMounted` and calling `unsubscribe`.  
- Changed the `save` call to `updateDataInFiresoreDB(userId, uploadedInfo, 'check', { password: true })` to forward password handling options.

### Testing
- Ran the frontend unit test suite with `npm test` and all tests passed.  
- Ran linter with `npm run lint` and no issues were reported.  
- Ran component-level integration tests covering profile load/save flows and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14735ef968832688f3758bba09bdb2)