### PR TITLE
Виправити JSX-помилку парсингу в MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -185,43 +185,45 @@ export const MyProfileNew = () => {
     return <Field key={name}>
       <Label>{getFieldLabel(field)}</Label>
       {Array.isArray(field.options) && field.options.length > 0 ? (
-        <ChipRow>
-          {field.options.map(option => {
-            const optionValue = getOptionValue(option);
-            const selected = String(val) === String(optionValue);
-            return <Chip
-              key={`${name}-${optionValue}`}
-              selected={selected}
-              onClick={() => setState(prev => ({ ...prev, [name]: optionValue }))}
-              type="button"
-            >
-              {getOptionLabel(option)}
-            </Chip>;
-          })}
-          {isAppearanceField ? (
-            <Chip
-              key={`${name}-custom-option`}
-              selected={customSelected}
-              onClick={() => {
-                if (!customSelected) {
-                  setState(prev => ({ ...prev, [name]: '' }));
-                }
-              }}
-              type="button"
-            >
-              Свій варіант
-            </Chip>
-          ) : null}
-        </ChipRow>
-        {isAppearanceField && customSelected ? (
-          <CustomOptionWrap>
+        <>
+          <ChipRow>
+            {field.options.map(option => {
+              const optionValue = getOptionValue(option);
+              const selected = String(val) === String(optionValue);
+              return <Chip
+                key={`${name}-${optionValue}`}
+                selected={selected}
+                onClick={() => setState(prev => ({ ...prev, [name]: optionValue }))}
+                type="button"
+              >
+                {getOptionLabel(option)}
+              </Chip>;
+            })}
+            {isAppearanceField ? (
+              <Chip
+                key={`${name}-custom-option`}
+                selected={customSelected}
+                onClick={() => {
+                  if (!customSelected) {
+                    setState(prev => ({ ...prev, [name]: '' }));
+                  }
+                }}
+                type="button"
+              >
+                Свій варіант
+              </Chip>
+            ) : null}
+          </ChipRow>
+          {isAppearanceField && customSelected ? (
+            <CustomOptionWrap>
               <Input
-              value={val}
-              placeholder="Введіть свій варіант"
-              onChange={e => setState(prev => ({ ...prev, [name]: e.target.value }))}
-            />
-          </CustomOptionWrap>
-        ) : null}
+                value={val}
+                placeholder="Введіть свій варіант"
+                onChange={e => setState(prev => ({ ...prev, [name]: e.target.value }))}
+              />
+            </CustomOptionWrap>
+          ) : null}
+        </>
       ) : isTextArea ? (
         <TextArea value={val} placeholder={getFieldPlaceholder(field)} onChange={e => setState(prev => ({ ...prev, [name]: e.target.value }))} />
       ) : (


### PR DESCRIPTION
### Motivation
- Виправити синтаксичну помилку JSX у `src/components/MyProfileNew.jsx`, де тернарний вираз повертав два сусідні елементи без спільного wrapper-а, що спричиняло падіння парсера.

### Description
- Обгорнуто `ChipRow` та умовний блок вводу кастомної опції у React fragment `<>...</>` в `src/components/MyProfileNew.jsx`, зберігаючи існуючу логіку і відображення.

### Testing
- Запущено `npx eslint src/components/MyProfileNew.jsx`, парсингова помилка усунута і лінт пройшов успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148802b0c8832693d170762c338e18)