### PR TITLE
Remove redesign suggestion banner from MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -21,12 +21,6 @@ const Page = styled.div`
   color: var(--text);
   min-height: 100vh;
 `;
-const CompareBanner = styled.div`
-  background: linear-gradient(135deg, #1A1A1A 0%, #2D2D2D 100%);
-  color: #fff;
-  text-align: center;
-  padding: 20px;
-`;
 const Topbar = styled.div`
   background: var(--card);
   border-bottom: 1px solid var(--border);
@@ -250,11 +244,6 @@ export const MyProfileNew = () => {
   };
 
   return <Page>
-    <CompareBanner>
-      <h2 style={{ fontFamily: 'Playfair Display, serif', fontSize: 22, marginBottom: 6 }}>Редизайн <span style={{ color: '#F5A24B', fontStyle: 'italic' }}>анкети</span></h2>
-      <p style={{ color: '#aaa', fontSize: 12 }}>Пропозиції покращення UI/UX</p>
-    </CompareBanner>
-
     <StickyHeader>
       <Topbar>
         <div style={{ fontFamily: 'Playfair Display, serif', fontSize: 18 }}>Know<span style={{ color: '#E8791A', fontStyle: 'italic' }}>Me</span></div>


### PR DESCRIPTION
### Motivation
- Прибрати тимчасовий/пропозиційний банер «Редизайн анкети / Пропозиції покращення UI/UX» зі сторінки профілю, щоб позбутись зайвого елементу інтерфейсу.

### Description
- Видалено JSX-блок `CompareBanner` та відповідну styled-компоненту `CompareBanner` у файлі `src/components/MyProfileNew.jsx`.

### Testing
- Виконано автоматичні перевірки: `rg -n "Редизайн анкети|Пропозиції покращення UI/UX|UI/UX" src`, `git diff -- src/components/MyProfileNew.jsx`, `git status --short` та `git show --stat --oneline -1`, усі пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e04409c8326a3dfaae676e77e37)