### PR TITLE
MyProfileNew: display main profile photo and integrate Photos component

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -4,6 +4,7 @@ import { auth, fetchUserData, updateDataInFiresoreDB, updateDataInRealtimeDB } f
 import { pickerFields, getFieldLabel, getFieldPlaceholder, getOptionLabel, getOptionValue } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged } from 'firebase/auth';
+import Photos from './Photos';
 
 const Page = styled.div`
   --accent: #E8791A;
@@ -80,9 +81,18 @@ const PhotoSection = styled.div`
 `;
 const AvatarRing = styled.div`position:relative;flex-shrink:0;`;
 const AvatarImg = styled.div`
-  width:72px;height:72px;border-radius:50%;
-  background: linear-gradient(135deg, #FFE0B2, #FFCC80);
-  display:flex;align-items:center;justify-content:center;font-size:28px;
+  width:72px;
+  height:72px;
+  border-radius:50%;
+  background: ${({ $photo }) =>
+    $photo
+      ? `center / cover no-repeat url(${$photo})`
+      : 'linear-gradient(135deg, #FFE0B2, #FFCC80)'};
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:28px;
+  overflow:hidden;
 `;
 const AvatarBadge = styled.div`
   position:absolute;bottom:0;right:0;width:22px;height:22px;border-radius:50%;
@@ -92,7 +102,6 @@ const PhotoBtn = styled.button`
   margin-left:auto;padding:8px 16px;background:var(--accent-light);color:var(--accent);
   border-radius:8px;font-size:13px;font-weight:600;border:none;
 `;
-
 const SubmitBtn = styled.button`width:100%;padding:16px;background:linear-gradient(135deg,#E8791A 0%,#F5A24B 100%);color:#fff;border:none;border-radius:var(--radius);font-size:16px;font-weight:700;`;
 const CustomOptionWrap = styled.div`margin-top:10px;`;
 
@@ -189,6 +198,8 @@ export const MyProfileNew = () => {
     await updateDataInRealtimeDB(userId, uploadedInfo);
     await updateDataInFiresoreDB(userId, uploadedInfo, 'check', { password: true });
   };
+
+  const mainProfilePhoto = Array.isArray(state.photos) && state.photos.length > 0 ? state.photos[0] : '';
 
   const renderField = (name) => {
     const field = fieldsMap.get(name);
@@ -289,15 +300,17 @@ export const MyProfileNew = () => {
 
     <PhotoSection>
       <AvatarRing>
-        <AvatarImg>🧑</AvatarImg>
+        <AvatarImg $photo={mainProfilePhoto}>{mainProfilePhoto ? '' : '🧑'}</AvatarImg>
         <AvatarBadge>+</AvatarBadge>
       </AvatarRing>
       <div>
         <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 3 }}>Фото профілю</h4>
         <p style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>Додайте до 5 фото.<br />Перше — головне.</p>
       </div>
-      <PhotoBtn type="button">Додати</PhotoBtn>
+      <PhotoBtn type="button">{mainProfilePhoto ? 'Змінити' : 'Додати'}</PhotoBtn>
     </PhotoSection>
+
+    <Photos state={{ ...state, userId }} setState={setState} />
 
     {sections.map(section => (
       <Card key={section.key} ref={node => { sectionRefs.current[section.key] = node; }}>


### PR DESCRIPTION
### Motivation
- Show the user's main profile photo in the avatar and provide a clearer photo management UI by integrating the photo picker component.
- Make the avatar styling support an image background while preserving the emoji placeholder when no photo exists.

### Description
- Imported the `Photos` component and rendered it as `<Photos state={{ ...state, userId }} setState={setState} />` below the photo section.
- Added `mainProfilePhoto` derived from `state.photos` to use the first photo as the primary avatar image.
- Updated `AvatarImg` styled component to accept a `$photo` prop and use it as a CSS `background` (`center / cover no-repeat url(...)`) and applied `overflow: hidden` to contain images.
- Made the avatar contents conditional so the emoji placeholder is shown only when no photo is present, and changed the `PhotoBtn` label to toggle between `Додати` and `Змінити` based on `mainProfilePhoto`.

### Testing
- Started the development build and verified the avatar shows the first photo from `state.photos` when present and falls back to the emoji placeholder when absent; the `Photos` component renders and the photo button label toggles accordingly (manual dev verification).
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149d9d1b308326877a0b2dee887e45)