### PR TITLE
Виправити відображення інпуту для «Свій варіант» у формі профілю

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -102,6 +102,7 @@ export const MyProfileNew = () => {
   const [state, setState] = useState({});
   const [userId, setUserId] = useState('');
   const [activeTab, setActiveTab] = useState('personal');
+  const [customOptionMode, setCustomOptionMode] = useState({});
   const sectionRefs = useRef({});
   const isManualScrollRef = useRef(false);
   const latestFetchUidRef = useRef('');
@@ -230,7 +231,8 @@ export const MyProfileNew = () => {
     const isTextArea = name === 'moreInfo_main';
     const isAppearanceField = sections.find(section => section.key === 'appearance')?.fields.includes(name);
     const optionValues = Array.isArray(field.options) ? field.options.map(getOptionValue).map(String) : [];
-    const customSelected = isAppearanceField && String(val).trim() !== '' && !optionValues.includes(String(val));
+    const customSelected = isAppearanceField
+      && (Boolean(customOptionMode[name]) || (String(val).trim() !== '' && !optionValues.includes(String(val))));
 
     return <Field key={name}>
       <Label>{getFieldLabel(field)}</Label>
@@ -243,7 +245,10 @@ export const MyProfileNew = () => {
               return <Chip
                 key={`${name}-${optionValue}`}
                 selected={selected}
-                onClick={() => setState(prev => ({ ...prev, [name]: optionValue }))}
+                onClick={() => {
+                  setCustomOptionMode(prev => ({ ...prev, [name]: false }));
+                  setState(prev => ({ ...prev, [name]: optionValue }));
+                }}
                 type="button"
               >
                 {getOptionLabel(option)}
@@ -254,6 +259,7 @@ export const MyProfileNew = () => {
                 key={`${name}-custom-option`}
                 selected={customSelected}
                 onClick={() => {
+                  setCustomOptionMode(prev => ({ ...prev, [name]: true }));
                   if (!customSelected) {
                     setState(prev => ({ ...prev, [name]: '' }));
                   }


### PR DESCRIPTION
### Motivation
- Користувач не бачив поле вводу після вибору кнопки `Свій варіант` у секції «Зовнішність», оскільки логіка показу інпуту залежала лише від значення поля. 

### Description
- Додано локальний стан `customOptionMode` у `MyProfileNew` для явного включення режиму кастомного вводу в полях зовнішності у файлі `src/components/MyProfileNew.jsx`. 
- Оновлено прапорець `customSelected` так, щоб він враховував як наявне кастомне значення, так і `customOptionMode`. 
- При виборі стандартної опції відключається `customOptionMode`, а при натисканні `Свій варіант` він вмикається і поле інпуту залишається видимим для введення. 

### Testing
- Перевірено зміни за допомогою `git diff -- src/components/MyProfileNew.jsx` і підтверджено очікуваний диф; команда виконалася успішно. 
- Змінений файл додано та зафіксовано через `git add`/`git commit` з повідомленням `Fix custom appearance option input in new profile form`, коміт успішний. 
- PR створено через внутрішній інструмент (`make_pr`) і підтверджено зміст тіла PR; операція успішна.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a5c96a8c8326b0b79237c92ba21d)