### PR TITLE
Allow deselecting appearance option chips by toggling selected value

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -258,7 +258,10 @@ export const MyProfileNew = () => {
                 selected={selected}
                 onClick={() => {
                   setCustomOptionMode(prev => ({ ...prev, [name]: false }));
-                  setState(prev => ({ ...prev, [name]: optionValue }));
+                  setState(prev => {
+                    const isSelected = String(prev[name] || '') === String(optionValue);
+                    return { ...prev, [name]: isSelected ? '' : optionValue };
+                  });
                 }}
                 type="button"
               >


### PR DESCRIPTION
### Motivation
- Make appearance option chips in `MyProfileNew.jsx` toggleable so a user can clear an already-selected option by clicking it again instead of always overwriting it.

### Description
- Change the `Chip` click handler to compute `isSelected` and update `setState` to set the field to `''` when the clicked option was already selected, otherwise set it to the option value, while keeping `setCustomOptionMode` behavior intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a64895c48326b1848f7ebf6113cb)