### PR TITLE
Auto-scroll active section tab in MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -113,6 +113,8 @@ export const MyProfileNew = () => {
   const [activeTab, setActiveTab] = useState('personal');
   const [customOptionMode, setCustomOptionMode] = useState({});
   const sectionRefs = useRef({});
+  const tabsRef = useRef(null);
+  const tabRefs = useRef({});
   const isManualScrollRef = useRef(false);
   const latestFetchUidRef = useRef('');
 
@@ -223,6 +225,16 @@ export const MyProfileNew = () => {
     return () => observer.disconnect();
   }, []);
 
+
+  useEffect(() => {
+    const tabsEl = tabsRef.current;
+    const activeTabEl = tabRefs.current[activeTab];
+
+    if (!tabsEl || !activeTabEl) return;
+
+    activeTabEl.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+  }, [activeTab]);
+
   const save = async () => {
     if (!userId) return;
     const { existingData } = await fetchUserData(userId);
@@ -319,11 +331,12 @@ export const MyProfileNew = () => {
       </div>
     </ProgressWrap>
 
-      <Tabs>
+      <Tabs ref={tabsRef}>
         {sections.map(s => {
           const info = sectionProgress[s.key] || {};
           return <Tab
             key={s.key}
+            ref={node => { tabRefs.current[s.key] = node; }}
             active={activeTab === s.key}
             complete={Boolean(info.complete)}
             type="button"


### PR DESCRIPTION
### Motivation
- Ensure the active profile section title (horizontal tab) stays visible when the user scrolls the profile vertically so the section name is always readable.

### Description
- In `src/components/MyProfileNew.jsx` added `tabsRef` and `tabRefs`, wired `ref` to the `<Tabs>` container and each `<Tab>`, and added a `useEffect` that calls `scrollIntoView` on the active tab (`inline: 'center'`) whenever `activeTab` changes.

### Testing
- No automated tests were run for this change (per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14ab056b08832683bfcfe455d96030)