### PR TITLE
Handle clearing of profile fields robustly and preserve RTDB overlay keys

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -530,16 +530,41 @@ const EditProfile = () => {
 
   const handleClear = (fieldName, idx) => {
     setState(prev => {
-      const isArray = Array.isArray(prev[fieldName]);
       const newState = { ...prev };
       let removedValue;
+      const hasIndex = Number.isInteger(idx);
+      const currentValue = prev[fieldName];
+
+      if (hasIndex) {
+        const sourceArray = Array.isArray(currentValue)
+          ? currentValue
+          : (currentValue !== undefined && currentValue !== null ? [currentValue] : []);
+
+        const filtered = sourceArray.filter((_, i) => i !== idx);
+        removedValue = sourceArray[idx];
+
+        if (filtered.length > 1) {
+          newState[fieldName] = filtered;
+        } else if (filtered.length === 1) {
+          newState[fieldName] = filtered[0];
+        } else {
+          // Для видалення конкретного елемента через "хрестик" не видаляємо весь ключ,
+          // щоб уникнути втрати поля в RTDB/overlay потоці.
+          newState[fieldName] = '';
+        }
+
+        handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
+        return newState;
+      }
+
+      const isArray = Array.isArray(currentValue);
 
       if (isArray) {
-        const filtered = prev[fieldName].filter((_, i) => i !== idx);
-        removedValue = prev[fieldName][idx];
+        const filtered = currentValue.filter((_, i) => i !== idx);
+        removedValue = currentValue[idx];
 
         if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
-          const deletedValue = prev[fieldName];
+          const deletedValue = currentValue;
           delete newState[fieldName];
           if (isAdmin) {
             removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
@@ -550,8 +575,8 @@ const EditProfile = () => {
           newState[fieldName] = filtered;
         }
       } else {
-        removedValue = prev[fieldName];
-        const deletedValue = prev[fieldName];
+        removedValue = currentValue;
+        const deletedValue = currentValue;
         delete newState[fieldName];
         if (isAdmin) {
           removeKeyFromFirebase(fieldName, deletedValue, prev.userId);


### PR DESCRIPTION
### Motivation
- Fix incorrect behavior when clearing field values so indexed removals and single-value fields are handled consistently and do not inadvertently remove keys from the RTDB/overlay stream.

### Description
- Refactor `handleClear` to use `Number.isInteger(idx)` and a normalized `currentValue` to support removing an indexed element from both arrays and single-value fields.
- When removing a specific element, convert single values to a one-item array and, if removal results in no items, set the field to an empty string instead of deleting the key to avoid losing the RTDB/overlay key.
- Ensure `removedValue` and `deletedValue` are computed from the normalized `currentValue`, and call `handleSubmit` with overwrite metadata; preserve existing admin `removeKeyFromFirebase` behavior when a key is deleted.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and build with `yarn build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14ae6d83648326b725cc87d41aeec8)