### PR TITLE
Normalize removed array entries and propagate removed payload in handleClear

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1581,17 +1581,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       if (isArray) {
         const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
         removedValue = prevState[fieldName][idx];
+        const normalizedFilteredArray = filteredArray.filter(
+          value => !(typeof value === 'string' && value.trim() === '')
+        );
 
-        if (filteredArray.length === 0) {
+        if (normalizedFilteredArray.length === 0) {
           delete newState[fieldName];
-        } else if (filteredArray.length === 1) {
-          newState[fieldName] = filteredArray[0];
+          removedPayload = { [fieldName]: prevState[fieldName] };
+        } else if (normalizedFilteredArray.length === 1) {
+          newState[fieldName] = normalizedFilteredArray[0];
+          removedPayload = { [fieldName]: removedValue };
         } else {
-          newState[fieldName] = filteredArray;
+          newState[fieldName] = normalizedFilteredArray;
+          removedPayload = { [fieldName]: removedValue };
         }
-
-        // Для масивів не передаємо removedMap, щоб не тригерити backend-видалення всього ключа.
-        removedPayload = undefined;
       } else {
         removedValue = prevState[fieldName];
         delete newState[fieldName];


### PR DESCRIPTION
### Motivation
- Avoid leaving empty or whitespace-only strings in array fields when clearing items and provide accurate removed payloads so backend deletions and state updates remain consistent.

### Description
- Introduce `normalizedFilteredArray` to filter out empty or whitespace-only string entries from the filtered array before updating state.
- Use `normalizedFilteredArray` for length checks and assign either deletion, single value, or array accordingly.
- Set `removedPayload` for array operations so `handleSubmit` receives the original array when the key is deleted and the removed value when individual items are removed.
- Remove the previous suppression of `removedPayload` for arrays so removals are reported correctly.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and no lint errors were reported.
- Built the application with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c4c4255883268df8bf9718b1845d)