### PR TITLE
Fix partial array removals triggering key deletion

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1590,10 +1590,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           removedPayload = { [fieldName]: prevState[fieldName] };
         } else if (normalizedFilteredArray.length === 1) {
           newState[fieldName] = normalizedFilteredArray[0];
-          removedPayload = { [fieldName]: removedValue };
         } else {
           newState[fieldName] = normalizedFilteredArray;
-          removedPayload = { [fieldName]: removedValue };
         }
       } else {
         removedValue = prevState[fieldName];


### PR DESCRIPTION
### Motivation
- При частковому видаленні елемента з масиву `handleClear` у `src/components/AddNewProfile.jsx` встановлювався `removedPayload`, через що `handleSubmit` трактував поле як видалене і видаляв увесь ключ у БД замість збереження залишкових значень.

### Description
- Прибрано встановлення `removedPayload` для випадків, коли після фільтрації масив залишається непорожнім (для `length === 1` та `> 1`), залишивши поведінку видалення ключа без змін для повного видалення.

### Testing
- Автоматизованих тестів не було запущено; зміна невелика і не порушує існуючу логіку видалення ключа.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151c3587788326a30655b06b701679)