### PR TITLE
Add fallback persistence to newUsers RTDB when RealtimeDB/Firestore writes fail

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { auth, fetchUserData, updateDataInFiresoreDB, updateDataInRealtimeDB } from './config';
+import {
+  auth,
+  fetchUserData,
+  updateDataInFiresoreDB,
+  updateDataInNewUsersRTDB,
+  updateDataInRealtimeDB,
+} from './config';
 import { pickerFields, getFieldLabel, getFieldPlaceholder, getOptionLabel, getOptionValue } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged } from 'firebase/auth';
@@ -267,8 +273,41 @@ export const MyProfileNew = () => {
     const { password: _password, ...profileData } = state;
     const uploadedInfo = makeUploadedInfo(existingData, profileData);
     delete uploadedInfo.password;
-    await updateDataInRealtimeDB(userId, uploadedInfo);
-    await updateDataInFiresoreDB(userId, uploadedInfo, 'check', { password: true });
+
+    const isPermissionDeniedError = error => {
+      const code = String(error?.code || '').toLowerCase();
+      const message = String(error?.message || '').toLowerCase();
+      return code.includes('permission-denied') || code.includes('permission_denied') || message.includes('permission_denied');
+    };
+
+    const persistUserWithFallback = async (targetUserId, nextUploadedInfo, firestoreCondition = 'update') => {
+      let shouldWriteFullProfileToNewUsers = false;
+
+      try {
+        await updateDataInRealtimeDB(targetUserId, nextUploadedInfo, firestoreCondition === 'set' ? undefined : 'update');
+      } catch (error) {
+        if (!isPermissionDeniedError(error)) {
+          throw error;
+        }
+        shouldWriteFullProfileToNewUsers = true;
+        console.warn('No write access to users/$uid, fallback to newUsers.');
+      }
+
+      try {
+        await updateDataInFiresoreDB(targetUserId, nextUploadedInfo, firestoreCondition);
+      } catch (error) {
+        shouldWriteFullProfileToNewUsers = true;
+        console.warn('Firestore write failed, fallback to newUsers.', error);
+      }
+
+      await updateDataInNewUsersRTDB(
+        targetUserId,
+        shouldWriteFullProfileToNewUsers ? nextUploadedInfo : { lastLogin2: nextUploadedInfo.lastLogin2 },
+        'update'
+      );
+    };
+
+    await persistUserWithFallback(userId, uploadedInfo, 'check');
   };
 
   const mainProfilePhoto = Array.isArray(state.photos) && state.photos.length > 0 ? state.photos[0] : '';


### PR DESCRIPTION
### Motivation

- Ensure profile saves succeed even when write access to `users/$uid` in RealtimeDB or Firestore is restricted by falling back to a `newUsers` RTDB path. 

### Description

- Add import of `updateDataInNewUsersRTDB` and replace the direct `updateDataInRealtimeDB`/`updateDataInFiresoreDB` calls with a `persistUserWithFallback` helper that coordinates writes. 
- Introduce `isPermissionDeniedError` to detect permission-denied errors from DB write attempts and trigger fallback behavior. 
- Attempt RealtimeDB write first and fall back to writing full profile into `newUsers` when permission is denied, then always attempt Firestore write and mark fallback when it fails. 
- Always write to `newUsers` RTDB with either the full profile (on fallback) or a minimal `lastLogin2` update when primary writes succeed. 

### Testing

- Ran linter via `yarn lint` with no new issues reported. 
- Ran unit test suite via `yarn test` and the tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a153265ccec83269c4f70a31c52a3eb)