### PR TITLE
Виправлення поведінки запису RTDB при збереженні профілю в режимі 'check'

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -284,7 +284,7 @@ export const MyProfileNew = () => {
       let shouldWriteFullProfileToNewUsers = false;
 
       try {
-        await updateDataInRealtimeDB(targetUserId, nextUploadedInfo, firestoreCondition === 'set' ? undefined : 'update');
+        await updateDataInRealtimeDB(targetUserId, nextUploadedInfo, firestoreCondition === 'update' ? 'update' : undefined);
       } catch (error) {
         if (!isPermissionDeniedError(error)) {
           throw error;


### PR DESCRIPTION
### Motivation
- Усунути ситуацію, коли режим `check` призводив до часткового злиття (merge) в Realtime DB і залишав застарілі ключі в `users/$uid` після збереження профілю.

### Description
- Змінено умовний аргумент, що передається в `updateDataInRealtimeDB` у `src/components/MyProfileNew.jsx` так, щоб `'update'` передавався лише коли `firestoreCondition === 'update'`, інакше використовувалась поведінка перезапису (`set` via `undefined`).
- Це однорядкове виправлення відновлює попередню поведінку для викликів `persistUserWithFallback(..., 'check')`.

### Testing
- Перевірено відмінності у файлі `src/components/MyProfileNew.jsx` і підтверджено очікувану одну зміну у рядку, що формує виклик `updateDataInRealtimeDB` (успішно).
- Скрипт для застосування зміни виконався і файл оновлено у робочій копії (успішно).
- Викликано `make_pr` для створення опису PR і отримано коректний метаданний результат (успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d2da755083269e19260f17a05b1d)