### PR TITLE
Photo manager modal: mounted with open state and conditional first-photo hiding

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -125,11 +125,14 @@ const PhotoManagerModal = styled.div`
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.45);
-  z-index: 1200;
+  z-index: 900;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 20px;
+  opacity: ${({ $open }) => ($open ? 1 : 0)};
+  visibility: ${({ $open }) => ($open ? 'visible' : 'hidden')};
+  pointer-events: ${({ $open }) => ($open ? 'auto' : 'none')};
 `;
 const PhotoManagerCard = styled.div`
   width: min(640px, 100%);
@@ -478,8 +481,10 @@ export const MyProfileNew = () => {
       </Card>
     ))}
 
-    {isPhotoManagerOpen ? (
-      <PhotoManagerModal onClick={e => { if (e.target === e.currentTarget) setIsPhotoManagerOpen(false); }}>
+    <PhotoManagerModal
+      $open={isPhotoManagerOpen}
+      onClick={e => { if (e.target === e.currentTarget) setIsPhotoManagerOpen(false); }}
+    >
         <PhotoManagerCard>
           <PhotoManagerHeader>
             <div>Керування фотографіями</div>
@@ -488,11 +493,15 @@ export const MyProfileNew = () => {
             </IconPlainBtn>
           </PhotoManagerHeader>
           <div style={{ padding: '12px 8px 18px' }}>
-            <Photos state={{ ...state, userId }} setState={setState} hideFirstPhoto uploadInputId={uploadInputId} />
+            <Photos
+              state={{ ...state, userId }}
+              setState={setState}
+              hideFirstPhoto={Array.isArray(state.photos) && state.photos.length > 1}
+              uploadInputId={uploadInputId}
+            />
           </div>
         </PhotoManagerCard>
       </PhotoManagerModal>
-    ) : null}
 
     <SubmitWrap>
       <SubmitBtn type="button" onClick={save}>Опублікувати анкету</SubmitBtn>


### PR DESCRIPTION
### Motivation
- Ensure the photo manager modal stays mounted to allow CSS-driven show/hide transitions and avoid remounting side-effects. 
- Only hide the first profile photo in the manager when there is more than one uploaded photo to avoid hiding the only photo.

### Description
- Added a `$open` prop to `PhotoManagerModal` and switched from conditional rendering to always mounting the modal while controlling `opacity`, `visibility`, and `pointer-events` via styled props. 
- Lowered modal `z-index` from `1200` to `900` in `PhotoManagerModal`. 
- Changed the `Photos` component call to compute `hideFirstPhoto` as `Array.isArray(state.photos) && state.photos.length > 1` instead of always passing a truthy prop. 
- Minor JSX formatting for the modal and `Photos` props to improve readability and maintain the click-to-close handler.

### Testing
- Ran the frontend test suite with `yarn test` and all tests passed. 
- Ran the linter (`yarn lint`) with no new warnings or errors. 
- Manually verified that opening/closing the photo manager toggles visibility without remounting and that the first photo is only hidden when multiple photos exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ed58e5fc832696d69af6680a77aa)