### PR TITLE
Use deep equality and stable deduplication when merging uploaded info

### DIFF
--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -1,4 +1,43 @@
 export const makeUploadedInfo = (existingData, state, overwrite) => {
+  const isPlainObject = value =>
+    Object.prototype.toString.call(value) === '[object Object]';
+
+  const stableNormalize = value => {
+    if (Array.isArray(value)) {
+      return value.map(item => stableNormalize(item));
+    }
+
+    if (isPlainObject(value)) {
+      return Object.keys(value)
+        .sort()
+        .reduce((acc, key) => {
+          acc[key] = stableNormalize(value[key]);
+          return acc;
+        }, {});
+    }
+
+    return value;
+  };
+
+  const isDeepEqual = (left, right) =>
+    JSON.stringify(stableNormalize(left)) === JSON.stringify(stableNormalize(right));
+
+  const hasValueInArray = (arr, value) =>
+    Array.isArray(arr) && arr.some(item => isDeepEqual(item, value));
+
+  const dedupeArrayDeep = arr => {
+    if (!Array.isArray(arr)) return arr;
+
+    const result = [];
+    arr.forEach(item => {
+      if (!hasValueInArray(result, item)) {
+        result.push(item);
+      }
+    });
+
+    return result;
+  };
+
   let uploadedInfo = { ...existingData };
 
   for (const field in state) {
@@ -32,13 +71,13 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
             uploadedInfo[field] = [...state[field]];
           } else {
             console.log('Розпилюємо стейт');
-            uploadedInfo[field] = [...state[field]];
+            uploadedInfo[field] = dedupeArrayDeep([...state[field]]);
           }
         } else {
             console.log('Ключ є, записуємо / перезаписуємо як останній елемент масиву');
-            const updatedField = existingData[field].filter(item => item !== state[field]);
+            const updatedField = existingData[field].filter(item => !isDeepEqual(item, state[field]));
             updatedField.push(state[field]);
-            uploadedInfo[field] = updatedField;
+            uploadedInfo[field] = dedupeArrayDeep(updatedField);
           }
         }else if (overwrite && state[field]===''&& !Array.isArray(existingData[field])){
         console.log('Якщо це не масиви', state[field], existingData[field]);
@@ -54,8 +93,8 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
         uploadedInfo[field] = [existingData[field], state[field]];
       } else {
         console.log('ЕxistingData це не масив, а стейт це масив, дописуємо нові значення в масив', uploadedInfo.name);
-        const updatedField = state[field].filter(item => item !== existingData[field]);
-        uploadedInfo[field] = [existingData[field], ...updatedField]
+        const updatedField = state[field].filter(item => !isDeepEqual(item, existingData[field]));
+        uploadedInfo[field] = dedupeArrayDeep([existingData[field], ...updatedField]);
       }
     } else if (!existingData?.hasOwnProperty(field) && state[field] !== '') {
       if (field === 'postpone') {


### PR DESCRIPTION
### Motivation
- Prevent incorrect duplicate entries and incorrect comparisons when merging state into `existingData` by using deep equality instead of shallow `!==` checks for arrays/objects.
- Ensure deterministic ordering when comparing nested structures so that logically equal objects are treated as equal.

### Description
- Added `isPlainObject`, `stableNormalize`, and `isDeepEqual` helpers to perform stable deep-equality comparisons between values.
- Implemented `hasValueInArray` and `dedupeArrayDeep` to remove deep-equal duplicates from arrays before assigning them to `uploadedInfo`.
- Replaced shallow `!==` comparisons and simple `filter(item => item !== ...)` logic with `isDeepEqual` checks and deduplication when merging or pushing array/object values, preserving existing special-case for `photos`.
- Minor reorganization of array merge branches to call `dedupeArrayDeep` on merged results.

### Testing
- Ran the project test suite with `npm test` and all tests passed.
- Ran the linter with `npm run lint` and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1601e23f80832680050859ec8f0009)