### PR TITLE
Apply deletion conditions to sanitized data and add deep-equality dedupe for array merging

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1394,8 +1394,24 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         const cleanedState = Object.fromEntries(
           Object.entries(syncedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
         );
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            if (key !== 'userId') {
+              delete cleanedState[key];
+            }
+          });
+        }
 
-        const uploadedInfo = makeUploadedInfo(existingData, cleanedState, overwrite);
+        const sanitizedExistingData = { ...(existingData || {}) };
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            if (key !== 'userId') {
+              delete sanitizedExistingData[key];
+            }
+          });
+        }
+
+        const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
         if (delCondition) {
           Object.keys(delCondition).forEach(key => {
             uploadedInfo[key] = null;

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -353,6 +353,13 @@ const EditProfile = () => {
       const cleanedState = Object.fromEntries(
         Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
       );
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          if (key !== 'userId') {
+            delete cleanedState[key];
+          }
+        });
+      }
 
       const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
       if (delCondition) {

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -1,4 +1,43 @@
 export const makeUploadedInfo = (existingData, state, overwrite) => {
+  const isPlainObject = value =>
+    Object.prototype.toString.call(value) === '[object Object]';
+
+  const stableNormalize = value => {
+    if (Array.isArray(value)) {
+      return value.map(item => stableNormalize(item));
+    }
+
+    if (isPlainObject(value)) {
+      return Object.keys(value)
+        .sort()
+        .reduce((acc, key) => {
+          acc[key] = stableNormalize(value[key]);
+          return acc;
+        }, {});
+    }
+
+    return value;
+  };
+
+  const isDeepEqual = (left, right) =>
+    JSON.stringify(stableNormalize(left)) === JSON.stringify(stableNormalize(right));
+
+  const hasValueInArray = (arr, value) =>
+    Array.isArray(arr) && arr.some(item => isDeepEqual(item, value));
+
+  const dedupeArrayDeep = arr => {
+    if (!Array.isArray(arr)) return arr;
+
+    const result = [];
+    arr.forEach(item => {
+      if (!hasValueInArray(result, item)) {
+        result.push(item);
+      }
+    });
+
+    return result;
+  };
+
   let uploadedInfo = { ...existingData };
 
   for (const field in state) {
@@ -27,18 +66,26 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
         if (overwrite && !Array.isArray(state[field])) {
           console.log('Якщо масив має лише одне значення, зберігаємо його як ключ-значення');
           uploadedInfo[field] = state[field];
+        } else if (!Array.isArray(state[field]) && state[field] === '') {
+          const hasEmptyValueInExistingArray = existingData[field].some(item => isDeepEqual(item, ''));
+          if (hasEmptyValueInExistingArray) {
+            console.log('Видалили значення з поля-масиву, залишаємо пустий рядок');
+            uploadedInfo[field] = '';
+          } else {
+            console.log('Порожнє значення для поля-масиву без історичного empty — пропускаємо оновлення');
+          }
         } else if (Array.isArray(state[field])) {
           if (field === 'photos') {
             uploadedInfo[field] = [...state[field]];
           } else {
             console.log('Розпилюємо стейт');
-            uploadedInfo[field] = [...state[field]];
+            uploadedInfo[field] = dedupeArrayDeep([...state[field]]);
           }
         } else {
             console.log('Ключ є, записуємо / перезаписуємо як останній елемент масиву');
-            const updatedField = existingData[field].filter(item => item !== state[field]);
+            const updatedField = existingData[field].filter(item => !isDeepEqual(item, state[field]));
             updatedField.push(state[field]);
-            uploadedInfo[field] = updatedField;
+            uploadedInfo[field] = dedupeArrayDeep(updatedField);
           }
         }else if (overwrite && state[field]===''&& !Array.isArray(existingData[field])){
         console.log('Якщо це не масиви', state[field], existingData[field]);
@@ -54,8 +101,8 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
         uploadedInfo[field] = [existingData[field], state[field]];
       } else {
         console.log('ЕxistingData це не масив, а стейт це масив, дописуємо нові значення в масив', uploadedInfo.name);
-        const updatedField = state[field].filter(item => item !== existingData[field]);
-        uploadedInfo[field] = [existingData[field], ...updatedField]
+        const updatedField = state[field].filter(item => !isDeepEqual(item, existingData[field]));
+        uploadedInfo[field] = dedupeArrayDeep([existingData[field], ...updatedField]);
       }
     } else if (!existingData?.hasOwnProperty(field) && state[field] !== '') {
       if (field === 'postpone') {


### PR DESCRIPTION
### Motivation
- Ensure fields marked for deletion via `delCondition` are removed from both the incoming state and the existing record before computing the upload payload to prevent accidentally restoring deleted values. 
- Avoid duplicate entries and incorrect comparisons for complex array/object fields by performing stable deep-equality checks and deduplication when merging state with existing data.

### Description
- In `AddNewProfile.jsx` and `EditProfile.jsx` apply `delCondition` to `cleanedState` and to `sanitizedExistingData` (skipping `userId` where appropriate) before calling `makeUploadedInfo`.
- Pass the sanitized existing data into `makeUploadedInfo` instead of the raw `existingData` to ensure deletions are respected when building the upload payload.
- Enhance `makeUploadedInfo` with `stableNormalize`, `isDeepEqual`, `hasValueInArray`, and `dedupeArrayDeep` helpers to perform stable deep-equality comparisons and to deduplicate nested arrays when merging values.
- Update merge logic to handle removal of array values represented by empty strings, to dedupe arrays after merges, and to use deep equality rather than simple `===` comparisons when filtering/combining items.

### Testing
- Ran the automated unit test suite with `npm test`, and the tests passed.
- Ran the linter with `npm run lint`, and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1601e23f80832680050859ec8f0009)