### PR TITLE
Виправити handleClear, щоб не видаляти все поле при індексованому видаленні

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -558,7 +558,11 @@ const EditProfile = () => {
           delete newState[fieldName];
         }
 
-        handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
+        const delCondition = Object.prototype.hasOwnProperty.call(newState, fieldName)
+          ? undefined
+          : { [fieldName]: removedValue };
+
+        handleSubmit(newState, 'overwrite', delCondition);
         return newState;
       }
 
@@ -588,7 +592,11 @@ const EditProfile = () => {
         }
       }
 
-      handleSubmit(newState, 'overwrite', { [fieldName]: removedValue });
+      const delCondition = Object.prototype.hasOwnProperty.call(newState, fieldName)
+        ? undefined
+        : { [fieldName]: removedValue };
+
+      handleSubmit(newState, 'overwrite', delCondition);
       return newState;
     });
   };


### PR DESCRIPTION
### Motivation
- Виправлено помилкову поведінку, коли при видаленні елемента за індексом завжди передавався `delCondition`, через що `remoteUpdate` зануляв/видаляв весь ключ в RTDB/Firestore навіть якщо після видалення лишалися інші значення. 

### Description
- В `src/components/EditProfile.jsx` у `handleClear` додано обчислення `delCondition`, яке встановлюється лише якщо поле відсутнє в `newState`, інакше передається `undefined`.
- Логіка застосована до обох гілок видалення (індексований випадок і загальний випадок), щоб часткові видалення масивів або значень зберігалися коректно.
- Зміни внесено через скрипт заміни та закомічено в репозиторії (файл змін: `src/components/EditProfile.jsx`).

### Testing
- Виконано перегляд змін через `git diff -- src/components/EditProfile.jsx`, який показав очікуваний диф і успішно завершився. 
- Файл було закомічено командою `git commit -m "Fix indexed clear to avoid deleting whole profile field"` і коміт пройшов успішно. 
- PR-меседж сформовано через внутрішню утиліту `make_pr` і створення PR пройшло успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171c9867fc83269b07259b7a7a4dbd)