### PR TITLE
Fix indexed clear to delete field when only blank item remains

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -552,7 +552,7 @@ const EditProfile = () => {
 
         if (filtered.length > 1) {
           newState[fieldName] = filtered;
-        } else if (filtered.length === 1) {
+        } else if (filtered.length === 1 && filtered[0] !== '') {
           newState[fieldName] = filtered[0];
         } else {
           delete newState[fieldName];


### PR DESCRIPTION
### Motivation
- Виправити випадок, коли при очищенні індексованого елемента масиву (наприклад `["telegram", ""]`) після видалення останнього не-порожнього елемента поле лишалося як порожній рядок і зберігалося в БД замість повного видалення.

### Description
- У `src/components/EditProfile.jsx` змінено умову в гілці `handleClear` для indexed-видалення: якщо після фільтрації залишається єдиний елемент `''`, поле видаляється з `newState`, що дозволяє передати коректний `delCondition` і видалити ключ на бекенді.

### Testing
- Автоматичних тестів не виконувалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17203f56b88326b4182abfc93c3164)