### PR TITLE
Fix deletion markers for short-ID profile updates

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -390,7 +390,15 @@ const EditProfile = () => {
     } else if (updatedState?.userId) {
       const existingData = await fetchUserById(updatedState.userId) || {};
       await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, delCondition);
-      await updateDataInNewUsersRTDB(updatedState.userId, updatedState, 'update', true);
+      const payloadForNewUsers = { ...updatedState };
+      if (delCondition) {
+        Object.keys(delCondition).forEach(key => {
+          if (key !== 'userId') {
+            payloadForNewUsers[key] = null;
+          }
+        });
+      }
+      await updateDataInNewUsersRTDB(updatedState.userId, payloadForNewUsers, 'update', true);
     }
 
     try {


### PR DESCRIPTION
### Motivation
- При видаленні індексованого елемента, якщо залишається лише пустий плейсхолдер, поле видаляється з `newState`, але гілка оновлення для коротких `userId` раніше просто опускала ключ у payload, тож RTDB не отримував маркер видалення і залишав старий масив у записі.

### Description
- В `remoteUpdate` у `src/components/EditProfile.jsx` для гілки з коротким `userId` створюється `payloadForNewUsers`, клонуючий `updatedState` і до якого застосовується `delCondition` шляхом встановлення видалених ключів у `null` (окрім `userId`).
- Виклик `updateDataInNewUsersRTDB` тепер передає цей `payloadForNewUsers`, що узгоджує поведінку видалення з гілкою `userId.length > 20`.
- Зміни мінімальні і торкаються лише підготовки payload перед оновленням нових користувачів у RTDB.

### Testing
- Патч було застосовано та перевірено локальними операціями застосування змін і генерації PR-метаданих, всі кроки виконалися успішно.
- Автоматичних юніт-/інтеграційних тестів не запускалося у цьому патчі.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172a36442c8326b3f24cc3129f9e3c)