### PR TITLE
Exclude `cacheVersion` from overlays and persisted user payloads

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -103,7 +103,7 @@ const sanitizeOverlayValue = value => {
 };
 
 const isEmptyOverlayValue = value => sanitizeOverlayValue(value) === '';
-const technicalOverlayFields = new Set(['editor', 'cachedAt', 'lastAction']);
+const technicalOverlayFields = new Set(['editor', 'cachedAt', 'lastAction', 'cacheVersion']);
 
 
 const resolveOverlayIncomingValue = change => {
@@ -353,6 +353,7 @@ const EditProfile = () => {
       const cleanedState = Object.fromEntries(
         Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
       );
+      delete cleanedState.cacheVersion;
       if (delCondition) {
         Object.keys(delCondition).forEach(key => {
           if (key !== 'userId') {
@@ -378,6 +379,7 @@ const EditProfile = () => {
           [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
+      delete cleanedStateForNewUsers.cacheVersion;
       if (delCondition) {
         Object.keys(delCondition).forEach(key => {
           if (key !== 'userId') {
@@ -484,6 +486,7 @@ const EditProfile = () => {
       ...updatedState,
       ...(formattedLastDelivery ? { lastDelivery: formattedLastDelivery } : {}),
     };
+    delete syncedState.cacheVersion;
     setIsSyncing(true);
     try {
       const serverData = await remoteUpdate({
@@ -635,6 +638,7 @@ const EditProfile = () => {
       const cleanedState = Object.fromEntries(
         Object.entries(mergedCard).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
       );
+      delete cleanedState.cacheVersion;
       await updateDataInRealtimeDB(mergedCard.userId, cleanedState, 'update');
       await updateDataInFiresoreDB(mergedCard.userId, cleanedState, 'check');
       const cleanedStateForNewUsers = Object.fromEntries(
@@ -642,13 +646,16 @@ const EditProfile = () => {
           [...fieldsForNewUsersOnly, ...ppTechnicalInputFields, 'getInTouch', 'lastDelivery', 'ownKids'].includes(key)
         )
       );
+      delete cleanedStateForNewUsers.cacheVersion;
       await updateDataInNewUsersRTDB(mergedCard.userId, cleanedStateForNewUsers, 'update', true);
       return;
     }
 
     const existingData = await fetchUserById(mergedCard.userId) || {};
     await syncUserSearchIdIndex(mergedCard.userId, existingData, mergedCard);
-    await updateDataInNewUsersRTDB(mergedCard.userId, mergedCard, 'update', true);
+    const sanitizedMergedCard = { ...mergedCard };
+    delete sanitizedMergedCard.cacheVersion;
+    await updateDataInNewUsersRTDB(mergedCard.userId, sanitizedMergedCard, 'update', true);
   };
 
   const effectiveCycleStatus = getEffectiveCycleStatus(state);

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -544,7 +544,7 @@ const sanitizeOverlayValue = value => {
 };
 
 const isEmptyOverlayValue = value => sanitizeOverlayValue(value) === '';
-const technicalOverlayFields = new Set(['editor', 'cachedAt', 'lastAction']);
+const technicalOverlayFields = new Set(['editor', 'cachedAt', 'lastAction', 'cacheVersion']);
 const resolveOverlayIncomingValue = change => {
   if (!change || typeof change !== 'object') return undefined;
 

--- a/src/utils/multiAccountEdits.js
+++ b/src/utils/multiAccountEdits.js
@@ -11,7 +11,7 @@ const get = (...args) =>
   });
 
 const EDITS_ROOT = 'multiData/edits';
-const TECHNICAL_FIELD_NAMES = new Set(['lastAction', 'cachedAt']);
+const TECHNICAL_FIELD_NAMES = new Set(['lastAction', 'cachedAt', 'cacheVersion']);
 
 const isPlainObject = value => value && typeof value === 'object' && !Array.isArray(value);
 


### PR DESCRIPTION
### Motivation
- Treat `cacheVersion` as an internal/technical field that should not be shown as an overlay change.  
- Prevent `cacheVersion` from being written into various user DB payloads to avoid leaking or persisting transient cache metadata.  
- Align multi-account edit logic to ignore `cacheVersion` alongside other technical fields.

### Description
- Added `cacheVersion` to the technical overlay fields set in `EditProfile.jsx` and `ProfileForm.jsx` to prevent it from being displayed or processed as a normal overlay field.  
- Updated multi-account edits util by adding `cacheVersion` to `TECHNICAL_FIELD_NAMES` in `src/utils/multiAccountEdits.js` so it is treated as a technical field when computing overlays.  
- Removed `cacheVersion` from outgoing payloads before persisting or syncing by deleting it from `cleanedState`, `cleanedStateForNewUsers`, `syncedState`, and `sanitizedMergedCard` in `EditProfile.jsx` to ensure it is not written to Realtime DB / Firestore / NewUsers RTDB.

### Testing
- Ran existing unit and integration test suite with `npm test`, and all tests passed.  
- Ran linting via `npm run lint` and fixed no lint errors related to these changes.  
- Manual smoke tested profile update flows locally to verify overlays no longer surface `cacheVersion` and DB writes do not include `cacheVersion`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172c92928c832694620a6ab80293f9)