### PR TITLE
Stop fetching favorite users from backend in AddNewProfile and rely on cached/local favorites

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3539,15 +3539,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     const favIds = getFavorites();
 
-    const favUsers = await fetchFavoriteUsersData(owner);
-    Object.entries(favUsers).forEach(([id, user]) => {
-      favIds[id] = true;
-      if (id && !loaded[id]) {
-        loaded[id] = user;
-        backendCount += 1;
-      }
-    });
-
     const normalizedFavs = Object.fromEntries(
       Object.entries(favIds).filter(([, value]) => value),
     );


### PR DESCRIPTION
### Motivation

- Reduce redundant backend calls when loading favorite users and rely on cached and locally-stored favorites to build the favorites list.

### Description

- Remove the `fetchFavoriteUsersData(owner)` call and the merge of its results into the local `loaded` map in `fetchAndMergeFavoriteUsers` within `AddNewProfile.jsx`.
- Continue to build `normalizedFavs` from the result of `getFavorites()` and use `syncFavorites`, `setFavoriteUsersData`, `setFavoriteIds`, `cacheFetchedUsers`, and `setIdsForQuery` as the single source of truth.
- Preserve the returned structure from `fetchAndMergeFavoriteUsers` (`{ loaded, normalizedFavs, cacheCount, backendCount }`) while no longer incrementing `backendCount` from a backend favorite fetch.

### Testing

- Ran the project's automated test suite with `yarn test` and linters with `yarn lint`, and both completed successfully.
- Verified no test regressions in components depending on `fetchAndMergeFavoriteUsers` through the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172d5f7df08326a447f2d8564ed0ff)