### PR TITLE
Remove 'del' key-value button from ProfileForm inputs

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2783,20 +2783,6 @@ ${entries.join('\n')}`;
                       &times;
                     </ClearButton>
                   )}
-                  {field.name !== 'lastAction' && state[field.name] && (
-                    <DelKeyValueBTN
-                      onMouseDown={e => e.preventDefault()}
-                      onClick={() => {
-                        if (field.name === ADDITIONAL_ACCESS_FIELD) {
-                          handleRemoveAdditionalAccessRuleInput(null, 'del');
-                          return;
-                        }
-                        handleDelKeyValue(field.name);
-                      }}
-                    >
-                      del
-                    </DelKeyValueBTN>
-                  )}
                 </InputFieldContainer>
 
                 {field.name !== 'accessLevel' && (
@@ -3766,27 +3752,6 @@ const SearchKeySourceActions = styled.div`
         background: rgba(255, 255, 255, 0.1);
       }
     }
-  }
-`;
-
-const DelKeyValueBTN = styled.button`
-  position: absolute;
-  right: 45px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: ${uiTokens.colors.danger};
-  font-size: 14px;
-  font-weight: 500;
-  width: 34px;
-  height: 32px;
-  border-radius: 999px;
-  &:hover {
-    color: ${uiTokens.colors.textPrimary};
-    background: rgba(229, 57, 53, 0.12);
   }
 `;
 


### PR DESCRIPTION
### Motivation

- Remove the inline "del" action button from key-value input rows to simplify the input controls and avoid redundant delete affordances next to the existing clear/open buttons.

### Description

- Deleted the render block that injected the `DelKeyValueBTN` button next to inputs that called `handleDelKeyValue` or `handleRemoveAdditionalAccessRuleInput(..., 'del')`.
- Removed the `DelKeyValueBTN` styled component definition and related styling for the deleted button.
- Kept existing clear/open buttons and handlers intact so key-value deletion remains possible through other UI flows or programmatic calls to `handleDelKeyValue` and `handleRemoveAdditionalAccessRuleInput`.

### Testing

- Ran the project test suite with `yarn test` and all tests passed.  
- Ran linting with `yarn lint` and a local build with `yarn build`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1737c785308326b8658e31f31ea75b)