### PR TITLE
Make ClearButton remove last item for array fields and remove redundant DelKeyValue button

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2777,25 +2777,19 @@ ${entries.join('\n')}`;
                           handleRemoveAdditionalAccessRuleInput(null, 'clear');
                           return;
                         }
+                        const fieldValue = state[field.name];
+                        if (Array.isArray(fieldValue)) {
+                          const removeIndex = fieldValue.length - 1;
+                          if (removeIndex >= 0) {
+                            handleClear(field.name, removeIndex);
+                          }
+                          return;
+                        }
                         handleClear(field.name);
                       }}
                     >
                       &times;
                     </ClearButton>
-                  )}
-                  {field.name !== 'lastAction' && state[field.name] && (
-                    <DelKeyValueBTN
-                      onMouseDown={e => e.preventDefault()}
-                      onClick={() => {
-                        if (field.name === ADDITIONAL_ACCESS_FIELD) {
-                          handleRemoveAdditionalAccessRuleInput(null, 'del');
-                          return;
-                        }
-                        handleDelKeyValue(field.name);
-                      }}
-                    >
-                      del
-                    </DelKeyValueBTN>
                   )}
                 </InputFieldContainer>
 
@@ -3766,27 +3760,6 @@ const SearchKeySourceActions = styled.div`
         background: rgba(255, 255, 255, 0.1);
       }
     }
-  }
-`;
-
-const DelKeyValueBTN = styled.button`
-  position: absolute;
-  right: 45px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: ${uiTokens.colors.danger};
-  font-size: 14px;
-  font-weight: 500;
-  width: 34px;
-  height: 32px;
-  border-radius: 999px;
-  &:hover {
-    color: ${uiTokens.colors.textPrimary};
-    background: rgba(229, 57, 53, 0.12);
   }
 `;
 


### PR DESCRIPTION
### Motivation
- Simplify the input controls and avoid a redundant "del" control by consolidating deletion behavior into the existing clear action.
- Ensure array-backed fields can remove their last element when the clear control is used to match user expectations for multi-value inputs.

### Description
- Updated the ClearButton click handler to detect array values and call `handleClear(field.name, removeIndex)` to remove the last element when `state[field.name]` is an array.
- Preserved the existing special-case behavior for `ADDITIONAL_ACCESS_FIELD` which still calls `handleRemoveAdditionalAccessRuleInput(null, 'clear')`.
- Removed the `DelKeyValueBTN` component and its usage from the input row markup and the styled-component definition.

### Testing
- Ran the unit test suite with `yarn test`, and all tests passed.
- Ran the linter with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1737c785308326b8658e31f31ea75b)