### PR TITLE
Include cached 'favorite' query IDs when merging favorite users

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3538,6 +3538,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }, {});
 
     const favIds = getFavorites();
+    const favoriteQueryIds = getIdsByQuery('favorite');
+
+    favoriteQueryIds.forEach(id => {
+      if (id) {
+        favIds[id] = true;
+      }
+    });
 
     const normalizedFavs = Object.fromEntries(
       Object.entries(favIds).filter(([, value]) => value),


### PR DESCRIPTION
### Motivation

- Ensure favorite users loaded from a stored query are included when merging favorites fetched from cache/backend so UI and local state remain consistent.

### Description

- When building the favorites map in `fetchAndMergeFavoriteUsers`, retrieve cached query IDs with `getIdsByQuery('favorite')` and merge them into the `favIds` map.
- Guard added to only set truthy IDs into `favIds` during the merge loop using `favoriteQueryIds.forEach(id => { if (id) favIds[id] = true; });`.
- Existing normalization, caching call to `cacheFetchedUsers`, and `setIdsForQuery('favorite', Object.keys(normalizedFavs));` remain and are preserved.

### Testing

- Ran the project linting with `yarn lint` and unit tests with `yarn test`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a173bd231708326b3bf1e0b9731baf2)