### PR TITLE
Ignore transient `device*` fields when preparing uploads and comparisons

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -5661,7 +5661,6 @@ export const mergeDuplicateUsers = async () => {
       'bodyType',
       'lastAction',
       'clothingSize',
-      'deviceHeight',
       'education',
       'experience',
       'eyeColor',

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -41,14 +41,15 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
   let uploadedInfo = { ...existingData };
 
   for (const field in state) {
+    if (field.startsWith('device')) {
+      continue;
+    }
+
     if (
       field === 'lastAction' ||
       field === 'loadingCounter' ||
       field === 'lastLogin' ||
       field === 'lastLogin2' ||
-      field === 'deviceResize' ||
-      field === 'deviceHeight' ||
-      field === 'deviceWidth' ||
       field === 'modifiedUser'||
       field === 'saved_age' || field === 'saved_height' || field === 'saved_weight' || field === 'saved_reward'|| field === 'saved_eyeColor' || field === 'saved_blood' || field === 'saved_country'
     ) {

--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -18,7 +18,6 @@ export const btnCompare = (
     'bodyType',
     'lastAction',
     'clothingSize',
-    'deviceHeight',
     'education',
     'experience',
     'eyeColor',


### PR DESCRIPTION
### Motivation
- Transient device-related fields (like screen width/height/resize) should not be treated as user data when merging, uploading, or comparing profiles.
- Prevent accidental overwrites or inclusion of ephemeral `device*` keys in persisted user information.

### Description
- Added an early skip in `src/components/makeUploadedInfo.js` to ignore any state fields starting with `device` by returning early from the loop with `if (field.startsWith('device')) { continue; }`.
- Removed explicit device keys (`deviceResize`, `deviceHeight`, `deviceWidth`) from the list of fields forcibly overwritten when preparing upload so they are no longer treated as persistent fields.
- Removed `deviceHeight` from the `delKeys` arrays in `src/components/config.js` and `src/components/smallCard/btnCompare.js` so device-specific keys are no longer considered for deletion/merge.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174b5ae8208326b60b57bfcfa1e1ca)