### PR TITLE
Add visibleSections to hook/memo dependency arrays to fix stale section state

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -242,7 +242,7 @@ export const MyProfileNew = () => {
       isMounted = false;
       unsubscribe();
     };
-  }, []);
+  }, [visibleSections]);
 
 
 
@@ -287,7 +287,7 @@ export const MyProfileNew = () => {
     const keys = visibleSections.flatMap(s => s.fields);
     const filled = keys.filter(name => String(state[name] || '').trim() !== '').length;
     return Math.round((filled / keys.length) * 100);
-  }, [state]);
+  }, [state, visibleSections]);
 
 
   const sectionProgress = useMemo(() => visibleSections.reduce((acc, section) => {
@@ -349,7 +349,7 @@ export const MyProfileNew = () => {
     entries.forEach(item => observer.observe(item.node));
 
     return () => observer.disconnect();
-  }, []);
+  }, [visibleSections]);
 
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent stale reads of `visibleSections` inside effects and memos so UI (active tab, progress, and fetched profile) updates when section visibility changes.
- Address missing dependency warnings for the hooks and memos referencing `visibleSections` to keep behavior consistent with linter expectations.

### Description
- Added `visibleSections` to the dependency array of the initial `useEffect` that fetches and sets profile data via `onAuthStateChanged` so fetch result application respects current visible fields. 
- Added `visibleSections` to the dependency array of `useMemo` computing `filledPct` so filled percentage recomputes when visible fields change. 
- Added `visibleSections` to the dependency array of the `IntersectionObserver` `useEffect` so section intersection tracking reacts to changes in visible sections. 

### Testing
- Ran the project test suite with `yarn test`, which completed successfully. 
- Built the app with `yarn build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17510196d883268863ad5df786d306)