### PR TITLE
Виправлення імпорту AccessContext у MyProfileNew — використати `resolveAccess`

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -15,7 +15,7 @@ import { onAuthStateChanged, signOut } from 'firebase/auth';
 import Photos from './Photos';
 import { VerifyEmail } from './VerifyEmail';
 import InfoModal from './InfoModal';
-import { useAccess } from './AccessContext';
+import { resolveAccess } from 'utils/accessLevel';
 import { ExitButton, SubmitButton } from './MyProfile';
 
 const Page = styled.div`
@@ -187,7 +187,8 @@ const visibleNonDonorFields = new Set(['name','surname','email','phone','telegra
 export const MyProfileNew = () => {
   const [state, setState] = useState({});
   const navigate = useNavigate();
-  const access = useAccess();
+  const currentUid = auth.currentUser?.uid || localStorage.getItem('ownerId') || '';
+  const access = resolveAccess({ uid: currentUid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') });
   const isAdmin = access.isAdmin;
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [isEmailVerified, setIsEmailVerified] = useState(false);


### PR DESCRIPTION
### Motivation
- Виправити помилку збірки `Module not found: Can't resolve './AccessContext'`, що виникала через відсутній файл `src/components/AccessContext` при імпорті `useAccess` у `MyProfileNew.jsx`.
- Перевикористати існуючу допоміжну функцію доступу щоб зберегти узгодженість логіки доступу в профільних компонентах і уникнути додаткового контексту.

### Description
- У файлі `src/components/MyProfileNew.jsx` замінено імпорт `import { useAccess } from './AccessContext';` на `import { resolveAccess } from 'utils/accessLevel';`.
- Ініціалізацію доступу змінено на використання `resolveAccess({ uid: currentUid, accessLevel: state.accessLevel || localStorage.getItem('accessLevel') })`, де `currentUid` отримується з `auth.currentUser?.uid` з fallback на `localStorage`.

### Testing
- Виконано `git diff -- src/components/MyProfileNew.jsx` і перевірено зміни, команда успішна.
- Виконано `git commit -m "Fix missing AccessContext import in MyProfileNew"` і коміт створено успішно.
- Переглянуто частини файлу через `nl -ba src/components/MyProfileNew.jsx | sed -n '1,30p;182,205p'` щоб підтвердити внесені правки, команда успішна.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d097cd34832695b07454a70f154a)