### PR TITLE
Додати опцію «Свій варіант» для так/ні полів у MyProfileNew

### DIFF
--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -1,6 +1,7 @@
 export const yesNoOptions = [
   { placeholder: 'No', ukrainian: 'Ні' },
   { placeholder: 'Yes', ukrainian: 'Так' },
+  { placeholder: 'Custom', ukrainian: 'Свій варіант', value: 'Свій варіант' },
 ];
 
 export const inputFields = [


### PR DESCRIPTION
### Motivation
- Додати можливість вказати власний варіант відповіді для полів у формі `/my-profile-new`, які зараз використовують набір опцій "Так / Ні / Інше".

### Description
- Розширено масив `yesNoOptions` у файлі `src/components/formFields.js`, додавши `{ placeholder: 'Custom', ukrainian: 'Свій варіант', value: 'Свій варіант' }`; змінений файл доступний за адресою `https://raw.githubusercontent.com/KnowMe-app/main/refs/heads/main/src/components/formFields.js`.

### Testing
- Автоматичних тестів не запускали.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182c8143e88326af8be3e91fe6fcfe)