### PR TITLE
Avoid re-subscribing auth listener by removing `visibleSections` from useEffect deps in MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -249,7 +249,7 @@ export const MyProfileNew = () => {
       isMounted = false;
       unsubscribe();
     };
-  }, [visibleSections]);
+  }, []);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async user => {


### PR DESCRIPTION
### Motivation
- Prevent unnecessary re-attachment of the `onAuthStateChanged` listener whenever `visibleSections` changes, which could trigger repeated fetches and race conditions when retrieving profile data in `src/components/MyProfileNew.jsx`.

### Description
- Updated the `useEffect` that registers the `onAuthStateChanged` listener in `src/components/MyProfileNew.jsx` to use an empty dependency array (`[]`) instead of `[visibleSections]`, ensuring the listener is only registered once on mount and properly cleaned up on unmount.

### Testing
- Ran unit tests with `npm test` and linting with `npm run lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182b4fe67483268b49981507ec6e1a)