### PR TITLE
Enable custom option input for appearance and Yes/No fields in MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -429,7 +429,13 @@ export const MyProfileNew = () => {
     const isTextArea = name === 'moreInfo_main';
     const isAppearanceField = sections.find(section => section.key === 'appearance')?.fields.includes(name);
     const optionValues = Array.isArray(field.options) ? field.options.map(getOptionValue).map(String) : [];
-    const customSelected = isAppearanceField
+    const optionLabels = Array.isArray(field.options) ? field.options.map(getOptionLabel).map(String) : [];
+    const isYesNoField = optionValues.includes('No')
+      && optionValues.includes('Yes')
+      && optionLabels.includes('Ні')
+      && optionLabels.includes('Так');
+    const canUseCustomOption = isAppearanceField || isYesNoField;
+    const customSelected = canUseCustomOption
       && (Boolean(customOptionMode[name]) || (String(val).trim() !== '' && !optionValues.includes(String(val))));
 
     return <Field key={name}>
@@ -455,7 +461,7 @@ export const MyProfileNew = () => {
                 {getOptionLabel(option)}
               </Chip>;
             })}
-            {isAppearanceField ? (
+            {canUseCustomOption ? (
               <Chip
                 key={`${name}-custom-option`}
                 selected={customSelected}
@@ -471,7 +477,7 @@ export const MyProfileNew = () => {
               </Chip>
             ) : null}
           </ChipRow>
-          {isAppearanceField && customSelected ? (
+          {canUseCustomOption && customSelected ? (
             <CustomOptionWrap>
               <Input
                 value={val}


### PR DESCRIPTION
### Motivation

- Allow users to provide a custom value not only for appearance fields but also for Yes/No fields that use localized Ukrainian labels, so the profile form accepts and edits free-form responses in these cases.

### Description

- Compute `optionLabels` from `field.options` and detect `isYesNoField` when `optionValues` include `'No'` and `'Yes'` and `optionLabels` include `'Ні'` and `'Так'`.
- Introduce `canUseCustomOption` which is true for appearance fields or detected Yes/No fields and use it to surface the custom option UI.
- Use `canUseCustomOption` when rendering the "Свій варіант" chip and the custom `Input`, and include it in the `customSelected` logic.
- Keep existing autosave behavior when selecting options or editing the custom input via `triggerAutosave`.

### Testing

- Ran the unit test suite with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` and no issues were reported.
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18336f923883269c7337518ef2da76)