### PR TITLE
Fix empty profile field saves

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -1077,7 +1077,15 @@ export const MyProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     // placeholder={field.placeholder} // Обов'язково для псевдокласу :placeholder-shown
                     onBlur={() => handleBlur(field.name)}
                   />
-                  {state[field.name] && <ClearButton onClick={() => handleClear(field.name)}>&times; {/* HTML-символ для хрестика */}</ClearButton>}
+                  {state[field.name] && (
+                    <ClearButton
+                      type="button"
+                      onMouseDown={event => event.preventDefault()}
+                      onClick={() => handleClear(field.name)}
+                    >
+                      &times; {/* HTML-символ для хрестика */}
+                    </ClearButton>
+                  )}
                 </InputFieldContainer>
 
                 <Hint fieldName={field.name} isActive={state[field.name]}>{field?.placeholder ?? ''}</Hint>

--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -64,11 +64,48 @@ const FieldGroup = styled.div`padding:0 18px;`;
 const Field = styled.div`padding:14px 0;border-bottom:1px solid var(--border); &:last-child{border-bottom:none;}`;
 const Label = styled.div`font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.6px;color:var(--muted);margin-bottom:6px;`;
 const Input = styled.input`
-  width: 100%; background: var(--bg); border: 1.5px solid var(--border); border-radius: 10px; padding: 10px 14px; outline: none;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 38px 10px 14px;
+  outline: none;
   &:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(232, 121, 26, .12); }
 `;
 const TextArea = styled.textarea`
-  width: 100%; background: var(--bg); border: 1.5px solid var(--border); border-radius: 10px; padding: 10px 14px; outline: none; min-height: 90px;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 38px 10px 14px;
+  outline: none;
+  min-height: 90px;
+`;
+const FieldControl = styled.div`
+  position: relative;
+  width: 100%;
+  min-width: 0;
+`;
+const ClearFieldButton = styled.button`
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
 `;
 const ChipRow = styled.div`display:flex;flex-wrap:wrap;gap:6px;`;
 const Chip = styled.button`
@@ -272,6 +309,10 @@ export const MyProfileNew = () => {
     stateRef.current = nextState;
     setState(nextState);
     triggerAutosave(nextState);
+  };
+
+  const clearFieldValue = (name, field) => {
+    saveFieldValue(name, '', field);
   };
 
   const normalizedRole = String(state.userRole || state.role || '').trim().toLowerCase();
@@ -533,29 +574,65 @@ export const MyProfileNew = () => {
           </ChipRow>
           {canUseCustomOption && customSelected ? (
             <CustomOptionWrap>
-              <Input
-                value={val}
-                placeholder="Введіть свій варіант"
-                onChange={e => updateFieldValue(name, e.target.value, field)}
-                onBlur={e => saveFieldValue(name, e.target.value, field)}
-              />
+              <FieldControl>
+                <Input
+                  value={val}
+                  placeholder="Введіть свій варіант"
+                  onChange={e => updateFieldValue(name, e.target.value, field)}
+                  onBlur={e => saveFieldValue(name, e.target.value, field)}
+                />
+                {val ? (
+                  <ClearFieldButton
+                    type="button"
+                    onMouseDown={event => event.preventDefault()}
+                    onClick={() => clearFieldValue(name, field)}
+                    aria-label="Очистити поле"
+                  >
+                    <FiX size={16} />
+                  </ClearFieldButton>
+                ) : null}
+              </FieldControl>
             </CustomOptionWrap>
           ) : null}
         </>
       ) : isTextArea ? (
-        <TextArea
-          value={val}
-          placeholder={getFieldPlaceholder(field)}
-          onChange={e => updateFieldValue(name, e.target.value, field)}
-          onBlur={e => saveFieldValue(name, e.target.value, field)}
-        />
+        <FieldControl>
+          <TextArea
+            value={val}
+            placeholder={getFieldPlaceholder(field)}
+            onChange={e => updateFieldValue(name, e.target.value, field)}
+            onBlur={e => saveFieldValue(name, e.target.value, field)}
+          />
+          {val ? (
+            <ClearFieldButton
+              type="button"
+              onMouseDown={event => event.preventDefault()}
+              onClick={() => clearFieldValue(name, field)}
+              aria-label="Очистити поле"
+            >
+              <FiX size={16} />
+            </ClearFieldButton>
+          ) : null}
+        </FieldControl>
       ) : (
-        <Input
-          value={val}
-          placeholder={getFieldPlaceholder(field)}
-          onChange={e => updateFieldValue(name, e.target.value, field)}
-          onBlur={e => saveFieldValue(name, e.target.value, field)}
-        />
+        <FieldControl>
+          <Input
+            value={val}
+            placeholder={getFieldPlaceholder(field)}
+            onChange={e => updateFieldValue(name, e.target.value, field)}
+            onBlur={e => saveFieldValue(name, e.target.value, field)}
+          />
+          {val ? (
+            <ClearFieldButton
+              type="button"
+              onMouseDown={event => event.preventDefault()}
+              onClick={() => clearFieldValue(name, field)}
+              aria-label="Очистити поле"
+            >
+              <FiX size={16} />
+            </ClearFieldButton>
+          ) : null}
+        </FieldControl>
       )}
     </Field>;
   };

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -61,7 +61,11 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
       // Дублікати пропускаємо
       existingData[field] !== state[field]
     ) {
-      
+      if (state[field] === '') {
+        uploadedInfo[field] = '';
+        continue;
+      }
+
       if (Array.isArray(existingData[field])) {
         console.log('ExistingData на сервері є масивом');
         if (overwrite && !Array.isArray(state[field])) {


### PR DESCRIPTION
### Motivation
- При очищенні інпуту (вручну або через хрестик) на `my-profile-new` і `my-profile` порожній рядок не надсилався на бекенд, через що старе значення лишалося в історії або в масиві на сервері.
- На `my-profile-new` інпути інколи виходили за ширину екрану на вузьких пристроях і потребували адаптації стилів.

### Description
- У `src/components/makeUploadedInfo.js` додано явну обробку `state[field] === ''`, яка записує `uploadedInfo[field] = ''` і переходить до наступного поля, щоб гарантовано відправляти порожній рядок на бекенд.
- У `src/components/MyProfileNew.jsx` додано `FieldControl` контейнер та `ClearFieldButton`, реалізовано `clearFieldValue(name, field)` що викликає `saveFieldValue(name, '', field)`, а також додано хрестики очищення для звичайних інпутів, `textarea` та кастомних варіантів; клік хрестика захищено `onMouseDown={e => e.preventDefault()}` щоб уникнути race з `onBlur` і не відправляти старе значення.
- У `src/components/MyProfileNew.jsx` змінено стилі `Input` і `TextArea` (`box-sizing: border-box`, `min-width: 0` і додатковий правий паддінг) щоб інпути коректно зменшувалися і не виходили за горизонт екрана.
- У `src/components/MyProfile.jsx` оновлено існуючу кнопку очищення щоб мати `type="button"` і `onMouseDown={event => event.preventDefault()}`, щоб не тригерити `blur`-збереження з попереднім значенням.
- Очищення тепер проходить через існуючий автозберігаючий шлях (`saveFieldValue` / `triggerAutosave`) без дублювання логіки.

### Testing
- Запущено `npm run build` і збірка пройшла успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1851be9fb4832691e4ca6cf045c525)