### PR TITLE
Handle errors and avoid duplicate remote deletes for scalar profile fields in EditProfile

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -599,7 +599,11 @@ const EditProfile = () => {
         const deletedValue = currentValue;
         delete newState[fieldName];
         if (isAdmin) {
-          removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
+          removeKeyFromFirebase(fieldName, deletedValue, prev.userId).catch(error => {
+            console.error('Scalar field delete failed', error);
+            toast.error('Не вдалося видалити поле');
+          });
+          return newState;
         }
       }
 
@@ -617,6 +621,13 @@ const EditProfile = () => {
       const newState = { ...prev };
       const deletedValue = newState[fieldName];
       delete newState[fieldName];
+      if (isAdmin && !Array.isArray(deletedValue)) {
+        removeKeyFromFirebase(fieldName, deletedValue, prev.userId).catch(error => {
+          console.error('Scalar field delete failed', error);
+          toast.error('Не вдалося видалити поле');
+        });
+        return newState;
+      }
       if (isAdmin) {
         removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
       }


### PR DESCRIPTION
### Motivation
- Ensure remote deletions for scalar profile fields are handled gracefully, avoid duplicate remote delete calls for admin actions, and surface failures to the user. 

### Description
- Add `.catch` handlers around `removeKeyFromFirebase` for scalar deletes to log errors and show a toast (`Не вдалося видалити поле`), add early `return newState` after initiating the remote delete for scalar fields, and adjust `handleDelKeyValue` to only call `removeKeyFromFirebase` once depending on whether the deleted value is an array.

### Testing
- Ran the test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187f8bec0883268e75eb9add79e9c2)