### PR TITLE
Remove admin-only Firebase key deletion calls from EditProfile

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -7,7 +7,6 @@ import {
   updateDataInNewUsersRTDB,
   updateDataInRealtimeDB,
   updateDataInFiresoreDB,
-  removeKeyFromFirebase,
   syncUserSearchIdIndex,
   auth,
 } from './config';
@@ -584,11 +583,7 @@ const EditProfile = () => {
         removedValue = currentValue[idx];
 
         if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
-          const deletedValue = currentValue;
           delete newState[fieldName];
-          if (isAdmin) {
-            removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-          }
         } else if (filtered.length === 1) {
           newState[fieldName] = filtered[0];
         } else {
@@ -596,11 +591,7 @@ const EditProfile = () => {
         }
       } else {
         removedValue = currentValue;
-        const deletedValue = currentValue;
         delete newState[fieldName];
-        if (isAdmin) {
-          removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-        }
       }
 
       const delCondition = Object.prototype.hasOwnProperty.call(newState, fieldName)
@@ -617,9 +608,6 @@ const EditProfile = () => {
       const newState = { ...prev };
       const deletedValue = newState[fieldName];
       delete newState[fieldName];
-      if (isAdmin) {
-        removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-      }
       handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState;
     });


### PR DESCRIPTION
### Motivation
- Avoid performing direct Firebase key removals from the UI code path when an admin deletes values, likely because the `removeKeyFromFirebase` side-effect is deprecated or causes unsafe deletions.
- Simplify deletion logic in `EditProfile` so that removals are handled via the existing `handleSubmit`/persistence flows rather than ad-hoc remote calls.

### Description
- Removed the import of `removeKeyFromFirebase` from `src/components/EditProfile.jsx`.
- Deleted admin-only calls to `removeKeyFromFirebase` in all deletion code paths inside `EditProfile`, including array-item removal, non-array field removal, and `handleDelKeyValue`.
- Kept the existing `delCondition` construction and calls to `handleSubmit`/persistence so deletions still propagate through the normal update flow.

### Testing
- Ran the project test suite with `npm test` and all tests passed.
- Ran linting with `npm run lint` and the codebase reported no new lint errors.
- Performed a production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187f8bec0883268e75eb9add79e9c2)