### PR TITLE
Remove direct Firebase key deletions and add removeKeys-aware merge/cleanup utilities

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -7,7 +7,6 @@ import {
   updateDataInNewUsersRTDB,
   updateDataInRealtimeDB,
   updateDataInFiresoreDB,
-  removeKeyFromFirebase,
   syncUserSearchIdIndex,
   auth,
 } from './config';
@@ -144,19 +143,35 @@ const normalizeEditorOverlayFields = fields => {
   }, {});
 };
 
-const mergeCardStatePreservingKnownFields = (prevState, nextCardState) => {
+const removeKeysFromCardState = (cardState, removeKeys = []) => {
+  if (!cardState || typeof cardState !== 'object') {
+    return cardState;
+  }
+
+  const cleanedState = { ...cardState };
+  removeKeys
+    .map(key => String(key || '').trim())
+    .filter(key => key && key !== 'userId')
+    .forEach(key => {
+      delete cleanedState[key];
+    });
+
+  return cleanedState;
+};
+
+const mergeCardStatePreservingKnownFields = (prevState, nextCardState, removeKeys = []) => {
   if (!nextCardState || typeof nextCardState !== 'object') {
-    return prevState || nextCardState;
+    return removeKeysFromCardState(prevState || nextCardState, removeKeys);
   }
 
   if (!prevState || typeof prevState !== 'object') {
-    return nextCardState;
+    return removeKeysFromCardState(nextCardState, removeKeys);
   }
 
-  return {
+  return removeKeysFromCardState({
     ...prevState,
     ...nextCardState,
-  };
+  }, removeKeys);
 };
 
 const getCanonicalCardFromCache = cardUserId => {
@@ -187,7 +202,7 @@ const EditProfile = () => {
   const [isOverlayResolved, setIsOverlayResolved] = useState(isAdminUid(auth.currentUser?.uid));
 
 
-  const refreshOverlays = useCallback(async () => {
+  const refreshOverlays = useCallback(async (removeKeys = []) => {
     if (!userId) return;
 
     if (!isAdmin && currentUid) {
@@ -254,7 +269,9 @@ const EditProfile = () => {
       lastDelivery: formatDateToDisplay(cardForEditor?.lastDelivery),
     };
 
-    setState(prevState => mergeCardStatePreservingKnownFields(prevState, normalizedIncomingState));
+    setState(prevState =>
+      mergeCardStatePreservingKnownFields(prevState, normalizedIncomingState, removeKeys)
+    );
 
     const visibleOverlays = overlays;
 
@@ -501,12 +518,13 @@ const EditProfile = () => {
           lastAction: serverLast,
           lastDelivery: formatDateToDisplay(serverData.lastDelivery),
         };
-        updateCachedUser(formattedServerData);
-        setState(formattedServerData);
+        const cleanedServerData = removeKeysFromCardState(formattedServerData, removeKeys);
+        updateCachedUser(cleanedServerData, { removeKeys });
+        setState(cleanedServerData);
       }
     } finally {
       setIsSyncing(false);
-      await refreshOverlays();
+      await refreshOverlays(removeKeys);
     }
   };
 
@@ -584,11 +602,7 @@ const EditProfile = () => {
         removedValue = currentValue[idx];
 
         if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
-          const deletedValue = currentValue;
           delete newState[fieldName];
-          if (isAdmin) {
-            removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-          }
         } else if (filtered.length === 1) {
           newState[fieldName] = filtered[0];
         } else {
@@ -596,11 +610,7 @@ const EditProfile = () => {
         }
       } else {
         removedValue = currentValue;
-        const deletedValue = currentValue;
         delete newState[fieldName];
-        if (isAdmin) {
-          removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-        }
       }
 
       const delCondition = Object.prototype.hasOwnProperty.call(newState, fieldName)
@@ -617,9 +627,6 @@ const EditProfile = () => {
       const newState = { ...prev };
       const deletedValue = newState[fieldName];
       delete newState[fieldName];
-      if (isAdmin) {
-        removeKeyFromFirebase(fieldName, deletedValue, prev.userId);
-      }
       handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState;
     });


### PR DESCRIPTION
### Motivation
- Prevent direct deletions in RTDB via `removeKeyFromFirebase` and instead track and clean removed keys at merge/sync time to avoid unsafe immediate removals and improve canonical state hygiene.
- Ensure incoming canonical/server card state can remove specified keys when merging with local state so cached and UI state remain consistent after deletes.

### Description
- Removed the `removeKeyFromFirebase` import and all calls that previously deleted keys immediately from Firebase in UI handlers. 
- Added `removeKeysFromCardState(cardState, removeKeys)` helper to strip specified keys (excluding `userId`) from card state objects. 
- Extended `mergeCardStatePreservingKnownFields` to accept an optional `removeKeys` argument and apply `removeKeysFromCardState` when merging `prevState` and `nextCardState`. 
- Updated `refreshOverlays` to accept a `removeKeys` parameter and pass it into the merge so local state updates honor recent deletions. 
- When applying server-returned data after an update, the code now cleans the server data with `removeKeysFromCardState` and forwards `removeKeys` to `updateCachedUser` and `setState`. 
- Adjusted delete-related handlers to stop calling `removeKeyFromFirebase` and instead rely on the new `removeKeys` flow via `handleSubmit` and downstream sync logic.

### Testing
- Ran the project's automated test suite with `yarn test` and all tests passed. 
- Ran linting with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187f8bec0883268e75eb9add79e9c2)