### PR TITLE
Fix scalar clear blur race

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { onAuthStateChanged } from 'firebase/auth';
 import styled from 'styled-components';
@@ -297,6 +297,25 @@ const EditProfile = () => {
     setIsOverlayResolved(true);
   }, [userId, currentUid, isAdmin]);
 
+  const deletingFieldsRef = useRef(new Set());
+
+  const clearDeletingFieldAfterSubmit = useCallback((fieldName, submitPromise) => {
+    Promise.resolve(submitPromise)
+      .finally(() => {
+        const clearDeletingField = () => {
+          deletingFieldsRef.current.delete(fieldName);
+        };
+
+        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+          window.requestAnimationFrame(() => window.setTimeout(clearDeletingField, 0));
+          return;
+        }
+
+        setTimeout(clearDeletingField, 0);
+      })
+      .catch(() => {});
+  }, []);
+
   const handleOpenMedications = useCallback(
     user => {
       if (!user?.userId) return;
@@ -546,10 +565,15 @@ const EditProfile = () => {
   };
 
   const handleClear = (fieldName, idx) => {
+    const hasIndex = Number.isInteger(idx);
+
+    if (!hasIndex) {
+      deletingFieldsRef.current.add(fieldName);
+    }
+
     setState(prev => {
       const newState = { ...prev };
       let removedValue;
-      const hasIndex = Number.isInteger(idx);
       const currentValue = prev[fieldName];
 
       if (hasIndex) {
@@ -598,7 +622,8 @@ const EditProfile = () => {
         ? undefined
         : { [fieldName]: removedValue };
 
-      handleSubmit(newState, 'overwrite', delCondition);
+      const submitPromise = handleSubmit(newState, 'overwrite', delCondition);
+      clearDeletingFieldAfterSubmit(fieldName, submitPromise);
       return newState;
     });
   };
@@ -760,6 +785,7 @@ const EditProfile = () => {
           refreshOverlayForEditor={refreshOverlays}
           overlayDebugData={pendingOverlays}
           overlayDebugError={overlayReadError}
+          deletingFieldsRef={deletingFieldsRef}
         />
       )}
 

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -845,6 +845,7 @@ export const ProfileForm = ({
   dataSource = '',
   overlayFieldAdditions = {},
   refreshOverlayForEditor,
+  deletingFieldsRef,
 }) => {
   const canManageAccessLevel = isAdmin;
   const textareaRef = useRef(null);
@@ -2591,6 +2592,18 @@ ${entries.join('\n')}`;
                       {(value || value === '') && (
                           <ClearButton
                           type="button"
+                          onPointerDownCapture={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                          }}
+                          onTouchStartCapture={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                          }}
+                          onMouseDownCapture={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                          }}
                           onMouseDown={e => e.preventDefault()}
                           onClick={() => {
                             if (field.name === ADDITIONAL_ACCESS_FIELD) {
@@ -2718,6 +2731,8 @@ ${entries.join('\n')}`;
                             }));
                           },
                           onBlur: () => {
+                            if (deletingFieldsRef?.current?.has(field.name)) return;
+
                             if (field.name === 'myComment' && !state.myComment?.trim()) {
                               handleDelKeyValue('myComment');
                               return;
@@ -2771,6 +2786,18 @@ ${entries.join('\n')}`;
                   {field.name !== 'lastAction' && state[field.name] && (
                     <ClearButton
                       type="button"
+                      onPointerDownCapture={e => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onTouchStartCapture={e => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onMouseDownCapture={e => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
                       onMouseDown={e => e.preventDefault()}
                       onClick={() => {
                         if (field.name === ADDITIONAL_ACCESS_FIELD) {


### PR DESCRIPTION
### Motivation
- Виправити гонку при видаленні scalar-поля через ×, коли `onBlur` відправляє старе значення й потім поле відтворюється у бекенді.
- Зберегти існуючу canonical/overlay логіку та не змінювати поточну поведінку видалення елементів масивів.

### Description
- Додано `deletingFieldsRef` (`useRef(new Set())`) у `EditProfile.jsx` та передано його в `ProfileForm` через проп `deletingFieldsRef`.
- У `handleClear` для scalar-видалення поле додається в `deletingFieldsRef` перед `setState`, submit відправляється з `delCondition`, а очищення з `deletingFieldsRef` виконується лише після завершення submit з невеликою відкладкою (`requestAnimationFrame`/`setTimeout`).
- У `ProfileForm.jsx` додано guard у scalar `onBlur` щоб пропускати submit коли `deletingFieldsRef` містить ім'я поля, і додано mobile-safe capture guards (`onPointerDownCapture`, `onTouchStartCapture`, `onMouseDownCapture`) для кнопок × (scalar і array) щоб запобігти спрацьовуванню blur перед кліком.
- Логіка видалення масивів не змінювалася і `makeUploadedInfo` лишається вторинним захистом для видалених ключів.

### Testing
- Збирання проекту виконано: `npm run build` — успішно.
- Перевірка дифу та синтаксису (`git diff --check`) — без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19660af7308326867a2937acb067ec)