### PR TITLE
Серіалізувати сабміти видалення в EditProfile

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -298,6 +298,7 @@ const EditProfile = () => {
   }, [userId, currentUid, isAdmin]);
 
   const deletingFieldsRef = useRef(new Set());
+  const submitQueueRef = useRef(Promise.resolve());
 
   const clearDeletingFieldAfterSubmit = useCallback((fieldName, submitPromise) => {
     Promise.resolve(submitPromise)
@@ -528,6 +529,13 @@ const EditProfile = () => {
     }
   };
 
+  const enqueueSubmit = (newState, overwrite, delCondition) => {
+    submitQueueRef.current = submitQueueRef.current
+      .catch(() => {})
+      .then(() => handleSubmit(newState, overwrite, delCondition));
+    return submitQueueRef.current;
+  };
+
   const handleFieldFocus = fieldName => {
     if (!fieldName) return;
     setFocusedField(fieldName);
@@ -596,7 +604,7 @@ const EditProfile = () => {
           ? undefined
           : { [fieldName]: removedValue };
 
-        handleSubmit(newState, 'overwrite', delCondition);
+        enqueueSubmit(newState, 'overwrite', delCondition);
         return newState;
       }
 
@@ -622,7 +630,7 @@ const EditProfile = () => {
         ? undefined
         : { [fieldName]: removedValue };
 
-      const submitPromise = handleSubmit(newState, 'overwrite', delCondition);
+      const submitPromise = enqueueSubmit(newState, 'overwrite', delCondition);
       clearDeletingFieldAfterSubmit(fieldName, submitPromise);
       return newState;
     });
@@ -633,7 +641,7 @@ const EditProfile = () => {
       const newState = { ...prev };
       const deletedValue = newState[fieldName];
       delete newState[fieldName];
-      handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
+      enqueueSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
       return newState;
     });
   };


### PR DESCRIPTION
### Motivation
- Виправити відтворення скаляра після послідовних операцій «масив → скаляр → видалення», коли паралельні виклики `handleSubmit` можуть повторно створити видалене поле.

### Description
- Додано `submitQueueRef` у `src/components/EditProfile.jsx` та реалізовано `enqueueSubmit`, щоб послідовно виконувати всі виклики сабміту для поточної картки.
- Замінено прямі виклики `handleSubmit` на `enqueueSubmit` в шляхах видалення: `handleClear` та `handleDelKeyValue`, збережено `delCondition`/`removeKeys` поведінку.
- Не змінювана логіка canonical/overlay залишена як є, і поведінка видалень все ще передає `key: null` на віддалене оновлення та використовує `removeKeys` у кеші.

### Testing
- Запущено `npm run lint:js -- src/components/EditProfile.jsx`, перевірка пройшла успішно.
- Перевірено `git diff --check`, конфліктів або проблем не виявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196bcfae548326beeb393d76cf41ba)