### PR TITLE
Add detailed profile-save debug logging and matching debug log download/sync

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -748,6 +748,17 @@ const getProfileRestoreTimestamp = () => {
   return Date.now();
 };
 
+const buildJsonDownloadStamp = () => {
+  const now = new Date();
+  const pad = value => String(value).padStart(2, '0');
+
+  return [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+  ].join('-') + `-${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+};
+
 const summarizeProfileCardForLog = card => {
   if (!card || typeof card !== 'object') {
     return { hasCard: false };
@@ -1210,6 +1221,24 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     document.body.removeChild(anchor);
     URL.revokeObjectURL(url);
   }, []);
+
+  const downloadMatchingDebugLogs = useCallback(() => {
+    if (typeof window === 'undefined') return 0;
+
+    const logs = Array.isArray(window.__MATCHING_DEBUG_LOGS)
+      ? window.__MATCHING_DEBUG_LOGS
+      : [];
+
+    downloadJsonFile(`matching-debug-${buildJsonDownloadStamp()}.json`, {
+      userAgent: window.navigator?.userAgent || '',
+      url: window.location?.href || '',
+      timestamp: new Date().toISOString(),
+      logsCount: logs.length,
+      logs,
+    });
+
+    return logs.length;
+  }, [downloadJsonFile]);
 
   const handleExcelProfilesUpload = useCallback(
     async event => {
@@ -4274,18 +4303,29 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setDownloadSizeToastsEnabled(prev => !prev);
   };
   const handleMatchingDebugLogModeToggle = () => {
-    setMatchingDebugLogMode(prev => {
-      const nextMode = prev === 'file' ? 'console' : 'file';
-      if (typeof window !== 'undefined') {
-        window.__MATCHING_DEBUG_LOG_MODE = nextMode;
-        if (nextMode === 'file') window.__MATCHING_DEBUG_LOGS = [];
-      }
-      if (typeof localStorage !== 'undefined') {
-        localStorage.setItem(MATCHING_DEBUG_LOG_MODE_KEY, nextMode);
-      }
-      toast.success(nextMode === 'file' ? 'Режим file-логів Matching увімкнено.' : 'Режим console-логів Matching увімкнено.');
-      return nextMode;
-    });
+    const nextMode = matchingDebugLogMode === 'file' ? 'console' : 'file';
+    const downloadedLogsCount = matchingDebugLogMode === 'file'
+      ? downloadMatchingDebugLogs()
+      : null;
+
+    if (typeof window !== 'undefined') {
+      window.__MATCHING_DEBUG_LOG_MODE = nextMode;
+      if (nextMode === 'file') window.__MATCHING_DEBUG_LOGS = [];
+      window.dispatchEvent(new CustomEvent('matchingDebugLogModeChange', {
+        detail: { mode: nextMode },
+      }));
+    }
+
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(MATCHING_DEBUG_LOG_MODE_KEY, nextMode);
+    }
+
+    setMatchingDebugLogMode(nextMode);
+    toast.success(
+      nextMode === 'file'
+        ? 'Режим file-логів Matching увімкнено.'
+        : `Режим console-логів Matching увімкнено. Log-файл завантажено (${downloadedLogsCount || 0}).`
+    );
   };
 
   const fieldsToRender = getFieldsToRender(state);

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -104,6 +104,28 @@ const sanitizeOverlayValue = value => {
 const isEmptyOverlayValue = value => sanitizeOverlayValue(value) === '';
 const technicalOverlayFields = new Set(['editor', 'cachedAt', 'lastAction', 'cacheVersion']);
 
+const DEBUG_PROFILE_SAVE = true;
+
+const debugProfileSave = (step, data = {}) => {
+  const isAllowedMode =
+    process.env.NODE_ENV === 'development' ||
+    process.env.NODE_ENV === 'test' ||
+    isAdminUid(auth.currentUser?.uid);
+
+  if (!DEBUG_PROFILE_SAVE || !isAllowedMode) return;
+
+  console.groupCollapsed(
+    `%c[ProfileSaveDebug] ${step}`,
+    'color:#8b5cf6;font-weight:bold;'
+  );
+  console.log({
+    time: new Date().toISOString(),
+    ...data,
+  });
+  console.trace('[ProfileSaveDebug trace]');
+  console.groupEnd();
+};
+
 
 const resolveOverlayIncomingValue = change => {
   if (!change || typeof change !== 'object') return undefined;
@@ -380,6 +402,17 @@ const EditProfile = () => {
         });
       }
 
+      debugProfileSave('remoteUpdate:start', {
+        overwrite,
+        delCondition,
+        cleanedStateWatched: {
+          surname: cleanedState?.surname,
+          name: cleanedState?.name,
+          phone: cleanedState?.phone,
+          email: cleanedState?.email,
+        },
+      });
+
       const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
       if (delCondition) {
         Object.keys(delCondition).forEach(key => {
@@ -389,8 +422,27 @@ const EditProfile = () => {
         });
       }
 
+      debugProfileSave('remoteUpdate:payload-before-backend', {
+        delCondition,
+        uploadedInfoWatched: {
+          surname: uploadedInfo?.surname,
+          name: uploadedInfo?.name,
+          phone: uploadedInfo?.phone,
+          email: uploadedInfo?.email,
+        },
+        uploadedInfoHasSurname: Object.prototype.hasOwnProperty.call(uploadedInfo, 'surname'),
+        fullPayload: uploadedInfo,
+      });
+
       await updateDataInRealtimeDB(updatedState.userId, uploadedInfo, 'update');
       await updateDataInFiresoreDB(updatedState.userId, uploadedInfo, 'check', delCondition);
+
+      debugProfileSave('remoteUpdate:success', {
+        delCondition,
+        uploadedInfoWatched: {
+          surname: uploadedInfo?.surname,
+        },
+      });
 
       const cleanedStateForNewUsers = Object.fromEntries(
         Object.entries(updatedState).filter(([key]) =>
@@ -483,7 +535,22 @@ const EditProfile = () => {
     refreshOverlays();
   }, [userId, refreshOverlays, currentUid, isAdmin, location.key]);
 
-  const handleSubmit = async (newState, overwrite, delCondition) => {
+  const handleSubmit = async (newState, overwrite, delCondition, submitSource) => {
+    const submitState = newState || state || {};
+
+    debugProfileSave('handleSubmit:start', {
+      submitSource,
+      overwrite,
+      delCondition,
+      keys: Object.keys(submitState),
+      watchedValues: {
+        surname: submitState?.surname,
+        name: submitState?.name,
+        phone: submitState?.phone,
+        email: submitState?.email,
+      },
+    });
+
     const now = Date.now();
     const baseState = normalizePhoneState(newState ? { ...newState } : { ...state });
     const updatedState = { ...baseState, lastAction: now };
@@ -553,18 +620,42 @@ const EditProfile = () => {
     await refreshOverlays();
   };
 
-  const handleBlur = async fieldName => {
+  const handleBlur = async name => {
+    const baseFieldName = String(name || '').replace(/-\d+$/, '');
+
+    debugProfileSave('handleBlur:start', {
+      fieldName: baseFieldName,
+      rawNameFromBlur: name,
+      baseFieldName,
+      valueInState: state?.[baseFieldName],
+    });
+
     const normalizedState = normalizePhoneState(state);
     if (normalizedState !== state) {
       setState(normalizedState);
     }
-    await handleSubmit(normalizedState);
-    if (!isAdmin || !fieldName) return;
-    if (focusedField && focusedField !== fieldName) return;
-    await acceptFocusedFieldChanges(fieldName);
+
+    debugProfileSave('handleBlur:submit', {
+      submitSource: 'handleBlur',
+      rawNameFromBlur: name,
+      baseFieldName,
+      submittedValue: normalizedState?.[baseFieldName],
+      fullFieldExists: Object.prototype.hasOwnProperty.call(normalizedState || {}, baseFieldName),
+    });
+
+    await handleSubmit(normalizedState, undefined, undefined, 'handleBlur');
+    if (!isAdmin || !baseFieldName) return;
+    if (focusedField && focusedField !== baseFieldName) return;
+    await acceptFocusedFieldChanges(baseFieldName);
   };
 
   const handleClear = (fieldName, idx) => {
+    debugProfileSave('handleClear:start', {
+      fieldName,
+      idx,
+      prevValue: state?.[fieldName],
+    });
+
     const hasIndex = Number.isInteger(idx);
 
     if (!hasIndex) {
@@ -596,7 +687,23 @@ const EditProfile = () => {
           ? undefined
           : { [fieldName]: removedValue };
 
-        handleSubmit(newState, 'overwrite', delCondition);
+        debugProfileSave('handleClear:computed', {
+          fieldName,
+          idx,
+          newValue: newState?.[fieldName],
+          hasKeyInNewState: Object.prototype.hasOwnProperty.call(newState, fieldName),
+          delCondition,
+        });
+
+        debugProfileSave('handleClear:submit', {
+          fieldName,
+          idx,
+          submitSource: 'handleClear',
+          submittedValue: newState?.[fieldName],
+          delCondition,
+        });
+
+        handleSubmit(newState, 'overwrite', delCondition, 'handleClear');
         return newState;
       }
 
@@ -622,7 +729,23 @@ const EditProfile = () => {
         ? undefined
         : { [fieldName]: removedValue };
 
-      const submitPromise = handleSubmit(newState, 'overwrite', delCondition);
+      debugProfileSave('handleClear:computed', {
+        fieldName,
+        idx,
+        newValue: newState?.[fieldName],
+        hasKeyInNewState: Object.prototype.hasOwnProperty.call(newState, fieldName),
+        delCondition,
+      });
+
+      debugProfileSave('handleClear:submit', {
+        fieldName,
+        idx,
+        submitSource: 'handleClear',
+        submittedValue: newState?.[fieldName],
+        delCondition,
+      });
+
+      const submitPromise = handleSubmit(newState, 'overwrite', delCondition, 'handleClear');
       clearDeletingFieldAfterSubmit(fieldName, submitPromise);
       return newState;
     });

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1305,7 +1305,7 @@ const Matching = () => {
   const ownDislikeUsersRef = useRef(ownDislikeUsers);
   const [viewMode, setViewMode] = useState('default');
   const [activeProfileIndex, setActiveProfileIndex] = useState(0);
-  const [matchingDebugLogMode] = useState(getStoredMatchingDebugLogMode);
+  const [matchingDebugLogMode, setMatchingDebugLogMode] = useState(getStoredMatchingDebugLogMode);
   const [debugShowAllIndexedCards, setDebugShowAllIndexedCards] = useState(getStoredDebugShowAllIndexedCards);
   const [matchingDataSourceMode] = useState(getStoredMatchingDataSourceMode);
   const [themeMode, setThemeMode] = useState(getStoredMatchingTheme);
@@ -5282,6 +5282,28 @@ const Matching = () => {
       localStorage.setItem(MATCHING_DEBUG_LOG_MODE_KEY, matchingDebugLogMode);
     }
   }, [matchingDebugLogMode]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleMatchingDebugLogModeChange = event => {
+      const nextMode = event?.detail?.mode === 'file' ? 'file' : 'console';
+      setMatchingDebugLogMode(nextMode);
+    };
+
+    const handleMatchingDebugLogModeStorage = event => {
+      if (event.key !== MATCHING_DEBUG_LOG_MODE_KEY) return;
+      setMatchingDebugLogMode(event.newValue === 'file' ? 'file' : 'console');
+    };
+
+    window.addEventListener('matchingDebugLogModeChange', handleMatchingDebugLogModeChange);
+    window.addEventListener('storage', handleMatchingDebugLogModeStorage);
+
+    return () => {
+      window.removeEventListener('matchingDebugLogModeChange', handleMatchingDebugLogModeChange);
+      window.removeEventListener('storage', handleMatchingDebugLogModeStorage);
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof localStorage === 'undefined') return;

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1145,7 +1145,7 @@ export const ProfileForm = ({
                 : {},
           });
           toast('searchKeySets очищено: additional access rules видалено.');
-          Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
+          Promise.resolve(handleSubmit(payload, overwrite, delCondition, 'submitWithNormalization')).catch(error => {
             console.error('Failed to submit profile changes', error);
             const details = error?.message || String(error);
             toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
@@ -1159,7 +1159,7 @@ export const ProfileForm = ({
             : await getIndexedMatchedUserIdsByInputIndex(rawRules);
 
         if (!matchedUserIdsByInputIndex) {
-          Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
+          Promise.resolve(handleSubmit(payload, overwrite, delCondition, 'submitWithNormalization')).catch(error => {
             console.error('Failed to submit profile changes', error);
             const details = error?.message || String(error);
             toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
@@ -1267,7 +1267,7 @@ export const ProfileForm = ({
         toast.error(`Не вдалося зберегти індексацію наборів фільтрів.\n${details}`);
       }
     }
-    Promise.resolve(handleSubmit(payload, overwrite, delCondition)).catch(error => {
+    Promise.resolve(handleSubmit(payload, overwrite, delCondition, 'submitWithNormalization')).catch(error => {
       console.error('Failed to submit profile changes', error);
       const details = error?.message || String(error);
       toast.error(`Не вдалося зберегти зміни профілю.\n${details}`);
@@ -2575,7 +2575,14 @@ ${entries.join('\n')}`;
                             [field.name]: prevState[field.name].map((item, i) => (i === idx ? updatedValue : item)),
                           }));
                         }}
-                        onBlur={() => handleBlur(`${field.name}-${idx}`)}
+                        onBlur={() => {
+                          console.log('[ProfileSaveDebug] ProfileForm array input blur', {
+                            fieldName: field.name,
+                            idx,
+                            value: state?.[field.name],
+                          });
+                          handleBlur(`${field.name}-${idx}`);
+                        }}
                       />
                       {canOpenSearchIdBackendShortcut(field.name, value) && (
                         <SearchIdBackendButton
@@ -2593,19 +2600,42 @@ ${entries.join('\n')}`;
                           <ClearButton
                           type="button"
                           onPointerDownCapture={e => {
+                            console.log('[ProfileSaveDebug] ProfileForm clear pointer down', {
+                              eventType: e.type,
+                              fieldName: field.name,
+                              idx,
+                              valueBeforeClear: state?.[field.name],
+                            });
                             e.preventDefault();
                             e.stopPropagation();
                           }}
                           onTouchStartCapture={e => {
+                            console.log('[ProfileSaveDebug] ProfileForm clear pointer down', {
+                              eventType: e.type,
+                              fieldName: field.name,
+                              idx,
+                              valueBeforeClear: state?.[field.name],
+                            });
                             e.preventDefault();
                             e.stopPropagation();
                           }}
                           onMouseDownCapture={e => {
+                            console.log('[ProfileSaveDebug] ProfileForm clear pointer down', {
+                              eventType: e.type,
+                              fieldName: field.name,
+                              idx,
+                              valueBeforeClear: state?.[field.name],
+                            });
                             e.preventDefault();
                             e.stopPropagation();
                           }}
                           onMouseDown={e => e.preventDefault()}
                           onClick={() => {
+                            console.log('[ProfileSaveDebug] ProfileForm clear click', {
+                              fieldName: field.name,
+                              idx,
+                              valueBeforeClear: state?.[field.name],
+                            });
                             if (field.name === ADDITIONAL_ACCESS_FIELD) {
                               handleRemoveAdditionalAccessRuleInput(idx, 'clear');
                               return;
@@ -2731,6 +2761,11 @@ ${entries.join('\n')}`;
                             }));
                           },
                           onBlur: () => {
+                            console.log('[ProfileSaveDebug] ProfileForm scalar input blur', {
+                              fieldName: field.name,
+                              value: state?.[field.name],
+                            });
+
                             if (deletingFieldsRef?.current?.has(field.name)) return;
 
                             if (field.name === 'myComment' && !state.myComment?.trim()) {
@@ -2787,19 +2822,42 @@ ${entries.join('\n')}`;
                     <ClearButton
                       type="button"
                       onPointerDownCapture={e => {
+                        console.log('[ProfileSaveDebug] ProfileForm clear pointer down', {
+                          eventType: e.type,
+                          fieldName: field.name,
+                          idx: undefined,
+                          valueBeforeClear: state?.[field.name],
+                        });
                         e.preventDefault();
                         e.stopPropagation();
                       }}
                       onTouchStartCapture={e => {
+                        console.log('[ProfileSaveDebug] ProfileForm clear pointer down', {
+                          eventType: e.type,
+                          fieldName: field.name,
+                          idx: undefined,
+                          valueBeforeClear: state?.[field.name],
+                        });
                         e.preventDefault();
                         e.stopPropagation();
                       }}
                       onMouseDownCapture={e => {
+                        console.log('[ProfileSaveDebug] ProfileForm clear pointer down', {
+                          eventType: e.type,
+                          fieldName: field.name,
+                          idx: undefined,
+                          valueBeforeClear: state?.[field.name],
+                        });
                         e.preventDefault();
                         e.stopPropagation();
                       }}
                       onMouseDown={e => e.preventDefault()}
                       onClick={() => {
+                        console.log('[ProfileSaveDebug] ProfileForm clear click', {
+                          fieldName: field.name,
+                          idx: undefined,
+                          valueBeforeClear: state?.[field.name],
+                        });
                         if (field.name === ADDITIONAL_ACCESS_FIELD) {
                           handleRemoveAdditionalAccessRuleInput(null, 'clear');
                           return;

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -1,4 +1,20 @@
 export const makeUploadedInfo = (existingData, state, overwrite) => {
+  console.log('[ProfileSaveDebug] makeUploadedInfo:start', {
+    overwrite,
+    existingWatched: {
+      surname: existingData?.surname,
+      name: existingData?.name,
+      phone: existingData?.phone,
+      email: existingData?.email,
+    },
+    stateWatched: {
+      surname: state?.surname,
+      name: state?.name,
+      phone: state?.phone,
+      email: state?.email,
+    },
+  });
+
   const isPlainObject = value =>
     Object.prototype.toString.call(value) === '[object Object]';
 
@@ -105,5 +121,16 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
       // console.log('Такого ключа на сервері не існує, створюємо, записуємо перше значення:', uploadedInfo[field]);
     }
   }
+  console.log('[ProfileSaveDebug] makeUploadedInfo:return', {
+    uploadedWatched: {
+      surname: uploadedInfo?.surname,
+      name: uploadedInfo?.name,
+      phone: uploadedInfo?.phone,
+      email: uploadedInfo?.email,
+    },
+    uploadedHasSurname: Object.prototype.hasOwnProperty.call(uploadedInfo, 'surname'),
+    uploadedInfo,
+  });
+
   return uploadedInfo;
 };


### PR DESCRIPTION
### Motivation
- Improve visibility into profile save/update flows and make Matching debug logs retrievable across sessions for investigation and debugging.
- Provide cross-window synchronization for the Matching debug log mode so UI and background intercepts remain consistent.

### Description
- Added a JSON timestamp helper `buildJsonDownloadStamp` and `downloadMatchingDebugLogs` to `AddNewProfile.jsx`, and updated the matching debug mode toggle to download logs when switching from file to console mode and to dispatch a `matchingDebugLogModeChange` event; localStorage is updated and user-facing `toast` messages are shown.
- Introduced a `matchingDebugLogMode` state setter and a `useEffect` listener in `Matching.jsx` to react to `matchingDebugLogModeChange` events and `storage` events so mode changes propagate across windows/tabs.
- Implemented a lightweight debug helper `debugProfileSave` in `EditProfile.jsx` and instrumented key save-related flows (`handleSubmit`, `handleBlur`, `handleClear`, remote update steps) with structured debug logs to surface payloads, watched fields, and flow steps during development/admin runs.
- Added inline `console.log` debug traces in `ProfileForm.jsx` for input blur/clear events and wired `handleSubmit` calls to include a `submitSource` label such as `submitWithNormalization` or `handleClear` for improved traceability.
- Enhanced `makeUploadedInfo.js` with start/return debug `console.log` statements showing watched input and output fields and whether keys were added to the upload payload.

### Testing
- Ran the project's automated unit test and lint suites after the changes and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19916857088326bdd0aa1b5125744a)