### PR TITLE
Remove `lastAction` from allowed filter names in Search-ID-only mode

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -4998,7 +4998,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                       onChange={handleFilterChange}
                       storageKey={filterStorageKey}
                       bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode}
-                      allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction', 'lastAction', 'getInTouch'] : undefined}
+                      allowedFilterNames={searchIdAndSearchKeyOnlyMode ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction', 'getInTouch'] : undefined}
                     />
                   </LoadOptionsPopover>
                 )}


### PR DESCRIPTION
### Motivation
- Restrict the available filters when `searchIdAndSearchKeyOnlyMode` is enabled to prevent the `lastAction` filter from being exposed in the limited search mode.

### Description
- Update `src/components/AddNewProfile.jsx` to remove `'lastAction'` from the `allowedFilterNames` array passed to `FilterPanel` when `searchIdAndSearchKeyOnlyMode` is true.

### Testing
- Ran the frontend test suite via `yarn test` and linting via `yarn lint`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199ea26eec8326aea93e6625f6f6b1)