### PR TITLE
Normalize and accept alias search index types; dedupe index types

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4234,6 +4234,17 @@ export const createGetInTouchSearchKeyIndexInCollection = async (collection, onP
   );
 };
 
+const SEARCH_KEY_INDEX_TYPE_ALIASES = {
+  imtHeightWeight: SEARCH_KEY_INDEX_TYPES.imtHeightWeight,
+  fieldCount: SEARCH_KEY_INDEX_TYPES.fieldCount,
+};
+
+const normalizeSearchKeyIndexType = indexType =>
+  SEARCH_KEY_INDEX_TYPE_ALIASES[indexType] || indexType;
+
+const normalizeSearchKeyIndexTypes = indexTypes =>
+  [...new Set((indexTypes || []).map(normalizeSearchKeyIndexType))];
+
 const SEARCH_KEY_INDEX_BUILDERS = {
   [SEARCH_KEY_INDEX_TYPES.blood]: createSearchKeyIndexInCollection,
   [SEARCH_KEY_INDEX_TYPES.maritalStatus]: createMaritalStatusSearchKeyIndexInCollection,
@@ -4252,7 +4263,7 @@ const SEARCH_KEY_INDEX_BUILDERS = {
 export const createSelectedSearchKeyIndexesInCollection = async (collection, indexTypes = [], onProgress, options = {}) => {
   if (!collection || !Array.isArray(indexTypes) || indexTypes.length === 0) return;
 
-  const uniqueIndexTypes = [...new Set(indexTypes)].filter(indexType => SEARCH_KEY_INDEX_BUILDERS[indexType]);
+  const uniqueIndexTypes = normalizeSearchKeyIndexTypes(indexTypes).filter(indexType => SEARCH_KEY_INDEX_BUILDERS[indexType]);
   if (!uniqueIndexTypes.length) return;
 
   const usersData = await loadCollectionWithIndexCache(collection, {
@@ -4374,7 +4385,7 @@ const resolveSearchKeyValuesByIndexType = (indexType, userId, userData) => {
 };
 
 export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexTypes = []) => {
-  const uniqueIndexTypes = [...new Set(indexTypes)].filter(indexType => Boolean(SEARCH_KEY_INDEX_BUILDERS[indexType]));
+  const uniqueIndexTypes = normalizeSearchKeyIndexTypes(indexTypes).filter(indexType => Boolean(SEARCH_KEY_INDEX_BUILDERS[indexType]));
   if (!uniqueIndexTypes.length) return {};
 
   const payload = {};


### PR DESCRIPTION
### Motivation

- Allow callers to pass legacy or alternate index type names and ensure they map to canonical index types before building indexes.
- Prevent missing builder lookups and duplicate work by normalizing and deduplicating requested index types.

### Description

- Added `SEARCH_KEY_INDEX_TYPE_ALIASES` to map alias names to canonical `SEARCH_KEY_INDEX_TYPES` values.
- Implemented `normalizeSearchKeyIndexType` and `normalizeSearchKeyIndexTypes` helpers to map aliases and dedupe the list of index types.
- Updated `createSelectedSearchKeyIndexesInCollection` and `buildSearchKeyIndexPayloadFromCollections` to use the normalization helpers before filtering by `SEARCH_KEY_INDEX_BUILDERS`.

### Testing

- Ran the unit test suite with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` and no issues were reported.
- Built the project with `yarn build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19aed9df5c8326b0e8ecaba08a50f3)