### PR TITLE
Fix IMT 'other' point-check bucket mapping

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4607,6 +4607,13 @@ const getSelectedFilterKeys = filterMap => {
     .map(([key]) => key);
 };
 
+const getSelectedImtSearchKeyBuckets = imtFilters => {
+  const selectedBuckets = getSelectedFilterKeys(imtFilters);
+  if (!selectedBuckets) return null;
+
+  return selectedBuckets.map(bucket => (bucket === 'other' ? '?' : bucket));
+};
+
 const createPointCheckSearchKeyGroup = ({
   filterSettings,
   filterName,
@@ -4812,7 +4819,7 @@ const buildActiveSearchKeyFilterGroups = (filterSettings = {}, { favoritesMap = 
     groups.push({
       key: 'imt',
       indexName: IMT_SEARCH_KEY_INDEX,
-      buckets: getSelectedFilterKeys(filterSettings.imt) || [],
+      buckets: getSelectedImtSearchKeyBuckets(filterSettings.imt) || [],
       supportsPointCheck: true,
       readIds: () => collectImtIdsByFilters(filterSettings.imt, SEARCH_KEY_INDEXED_ROOT_PATHS),
     });


### PR DESCRIPTION
### Motivation
- Виправити ситуацію, коли при виборі IMT «other» point-check звертався до неіснуючого шляху `/imt/other/<userId>` тоді як індекс зберігає такі значення під `?`, через що фільтрація повертала порожні або неповні результати.

### Description
- Додано хелпер `getSelectedImtSearchKeyBuckets`, який мапить вибраний bucket `other` у фактичний індексований bucket `?` у вигляді `['?', ...]` у файлі `src/components/config.js`.
- Оновлено конфігурацію IMT-групи в `buildActiveSearchKeyFilterGroups`, щоб вона використовувала `getSelectedImtSearchKeyBuckets(...)` для поля `buckets` при збереженні `supportsPointCheck: true` і без зміни існуючої логіки `readIds`.
- Зміни мінімізують втручання в існуючий код і зберігають попередню поведінку читання індексів (`collectImtIdsByFilters`), тільки коригуючи точкові перевірки для IMT «other».

### Testing
- Виконано `npm run lint:js`, яка пройшла успішно з нефатальними попередженнями (Browserslist update warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19fa8bdd04832683156582a9f38526)