### PR TITLE
Remove custom option from yes/no form options

### DIFF
--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -1,7 +1,6 @@
 export const yesNoOptions = [
   { placeholder: 'No', ukrainian: 'Ні' },
   { placeholder: 'Yes', ukrainian: 'Так' },
-  { placeholder: 'Custom', ukrainian: 'Свій варіант', value: 'Свій варіант' },
 ];
 
 export const inputFields = [


### PR DESCRIPTION
### Motivation
- Remove the free-text/custom entry from the yes/no options to enforce a strict binary choice and avoid presenting an extra irrelevant option to users.

### Description
- Deleted the `Custom` option from the `yesNoOptions` array in `src/components/formFields.js` so the list now contains only `No` and `Yes` entries.

### Testing
- Ran the automated test suite with `npm test` and the linter with `npm run lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c970209b48326a08ead5983adfb52)