### PR TITLE
Replace photo manager modal with compact Photos integration and add compact/maxPhotos support

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FiEdit2, FiX } from 'react-icons/fi';
+import { FiX } from 'react-icons/fi';
 import styled from 'styled-components';
 import {
   auth,
@@ -115,100 +115,22 @@ const Chip = styled.button`
 const SubmitWrap = styled.div`padding:20px;`;
 const PhotoSection = styled.div`
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
+  gap: 12px;
   margin: 0 20px 20px;
   padding: 18px;
   background: var(--card);
   border-radius: var(--radius);
   border: 1.5px dashed var(--border);
   box-shadow: var(--shadow);
-`;
-const AvatarRing = styled.div`position:relative;flex-shrink:0;`;
-const AvatarImg = styled.div`
-  width:72px;
-  height:72px;
-  border-radius:50%;
-  background: ${({ $photo }) =>
-    $photo
-      ? `center / cover no-repeat url(${$photo})`
-      : 'linear-gradient(135deg, #FFE0B2, #FFCC80)'};
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:28px;
-  overflow:hidden;
-`;
-const AvatarActionBtn = styled.button`
-  position:absolute;
-  border:none;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  color:#fff;
-  cursor:pointer;
-`;
-const AvatarAddBtn = styled(AvatarActionBtn)`
-  bottom:0;
-  right:0;
-  width:22px;
-  height:22px;
-  border-radius:50%;
-  background: var(--accent);
-  border:2px solid #fff;
-  font-size:11px;
-`;
-const PhotoBtn = styled.button`
-  margin-left:auto;padding:8px 16px;background:var(--accent-light);color:var(--accent);
-  border-radius:8px;font-size:13px;font-weight:600;border:none;
+  min-width: 0;
 `;
 const SubmitBtn = styled.button`width:100%;padding:16px;background:linear-gradient(135deg,#E8791A 0%,#F5A24B 100%);color:#fff;border:none;border-radius:var(--radius);font-size:16px;font-weight:700;`;
 const CustomOptionWrap = styled.div`margin-top:10px;`;
-const PhotoManagerModal = styled.div`
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  z-index: 900;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-  opacity: ${({ $open }) => ($open ? 1 : 0)};
-  visibility: ${({ $open }) => ($open ? 'visible' : 'hidden')};
-  pointer-events: ${({ $open }) => ($open ? 'auto' : 'none')};
-`;
-const PhotoManagerCard = styled.div`
-  width: min(640px, 100%);
-  max-height: 88vh;
-  overflow: auto;
-  background: var(--card);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  border: 1px solid var(--border);
-`;
-const PhotoManagerHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
-`;
-
 const DotsButton = styled.button`
   display:flex;align-items:center;justify-content:center;
   width:34px;height:34px;border-radius:8px;border:1px solid var(--border);
   background:var(--card);cursor:pointer;font-size:22px;line-height:1;color:var(--muted);
-`;
-
-const IconPlainBtn = styled.button`
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 `;
 
 const sections = [
@@ -233,7 +155,6 @@ export const MyProfileNew = () => {
   const [userId, setUserId] = useState('');
   const [activeTab, setActiveTab] = useState('personal');
   const [customOptionMode, setCustomOptionMode] = useState({});
-  const [isPhotoManagerOpen, setIsPhotoManagerOpen] = useState(false);
   const sectionRefs = useRef({});
   const tabsRef = useRef(null);
   const tabRefs = useRef({});
@@ -512,9 +433,6 @@ export const MyProfileNew = () => {
     await saveState(state);
   };
 
-  const mainProfilePhoto = Array.isArray(state.photos) && state.photos.length > 0 ? state.photos[0] : '';
-  const uploadInputId = 'my-profile-new-photo-upload';
-
   const renderField = (name) => {
     const field = fieldsMap.get(name);
     if (!field) return null;
@@ -675,21 +593,17 @@ export const MyProfileNew = () => {
     </StickyHeader>
 
     <PhotoSection>
-      <AvatarRing>
-        <AvatarImg $photo={mainProfilePhoto}>{mainProfilePhoto ? '' : '🧑'}</AvatarImg>
-        <AvatarAddBtn
-          type="button"
-          onClick={() => setIsPhotoManagerOpen(true)}
-          aria-label={mainProfilePhoto ? 'Редагувати фото профілю' : 'Додати фото профілю'}
-        >
-          {mainProfilePhoto ? <FiEdit2 size={12} /> : '+'}
-        </AvatarAddBtn>
-      </AvatarRing>
       <div>
         <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 3 }}>Фото профілю</h4>
         <p style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>Додайте до 5 фото.<br />Перше — головне.</p>
       </div>
-      <PhotoBtn type="button" onClick={() => setIsPhotoManagerOpen(true)}>{mainProfilePhoto ? 'Редагувати фото' : 'Додати фото'}</PhotoBtn>
+      <Photos
+        state={{ ...state, userId }}
+        setState={setState}
+        uploadInputId="my-profile-new-photo-upload"
+        compact
+        maxPhotos={5}
+      />
     </PhotoSection>
 
 
@@ -706,27 +620,7 @@ export const MyProfileNew = () => {
       </Card>
     ))}
 
-    <PhotoManagerModal
-      $open={isPhotoManagerOpen}
-      onClick={e => { if (e.target === e.currentTarget) setIsPhotoManagerOpen(false); }}
-    >
-        <PhotoManagerCard>
-          <PhotoManagerHeader>
-            <div>Керування фотографіями</div>
-            <IconPlainBtn type="button" onClick={() => setIsPhotoManagerOpen(false)} aria-label="Закрити">
-              <FiX size={18} />
-            </IconPlainBtn>
-          </PhotoManagerHeader>
-          <div style={{ padding: '12px 8px 18px' }}>
-            <Photos
-              state={{ ...state, userId }}
-              setState={setState}
-              hideFirstPhoto={Array.isArray(state.photos) && state.photos.length > 1}
-              uploadInputId={uploadInputId}
-            />
-          </div>
-        </PhotoManagerCard>
-      </PhotoManagerModal>
+
 
     {showInfoModal && (
       <InfoModal

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -14,33 +14,34 @@ import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
 import { filterOutMedicationPhotos } from '../utils/photoFilters';
 
 const Container = styled.div`
-  padding-bottom: 10px;
-  max-width: 400px;
-
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
-  padding-bottom: 10px;
-  max-width: 400px;
+  align-items: ${({ $compact }) => ($compact ? 'stretch' : 'center')};
+  padding-bottom: ${({ $compact }) => ($compact ? 0 : '10px')};
+  max-width: ${({ $compact }) => ($compact ? '100%' : '400px')};
   width: 100%; /* Це забезпечує адаптивну ширину */
   margin: 0 auto; /* Центрує контейнер по горизонталі */
+  min-width: 0;
 `;
 
 const PhotosWrapper = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center; /* Вирівнювання фото по центру */
-  gap: 10px; /* Відстань між фото */
+  flex-wrap: ${({ $compact }) => ($compact ? 'nowrap' : 'wrap')};
+  justify-content: ${({ $compact }) => ($compact ? 'flex-start' : 'center')};
+  gap: ${({ $compact }) => ($compact ? '12px' : '10px')};
+  overflow-x: ${({ $compact }) => ($compact ? 'auto' : 'visible')};
+  padding: ${({ $compact }) => ($compact ? '4px 4px 8px' : 0)};
 `;
 
 const PhotoItem = styled.div`
-  width: 100px;
-  height: 100px;
+  width: ${({ $compact }) => ($compact ? '72px' : '100px')};
+  height: ${({ $compact }) => ($compact ? '72px' : '100px')};
   position: relative;
-  border: 3px solid;
-  border-image: linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1;
-  border-radius: 5px;
+  flex-shrink: 0;
+  border: ${({ $compact }) => ($compact ? 'none' : '3px solid')};
+  border-image: ${({ $compact }) => ($compact ? 'none' : 'linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1')};
+  border-radius: ${({ $compact }) => ($compact ? '50%' : '5px')};
 `;
 
 const PhotoImage = styled.img`
@@ -48,22 +49,27 @@ const PhotoImage = styled.img`
   width: 100%;
   height: 100%;
   display: block;
+  border-radius: ${({ $compact }) => ($compact ? '50%' : 0)};
+  cursor: pointer;
 `;
 
 const DeleteButton = styled.button`
   position: absolute;
-  top: 5px;
-  right: 5px;
-  background-color: red;
-  color: white;
-  border: none;
+  top: ${({ $compact }) => ($compact ? '-3px' : '5px')};
+  right: ${({ $compact }) => ($compact ? '-3px' : '5px')};
+  background-color: ${({ $compact }) => ($compact ? '#fff' : 'red')};
+  color: ${({ $compact }) => ($compact ? '#7A7A72' : 'white')};
+  border: ${({ $compact }) => ($compact ? '1px solid #E8E8E2' : 'none')};
   border-radius: 50%;
   width: 20px;
   height: 20px;
+  padding: 0;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 16px;
+  line-height: 1;
 `;
 
 const NoPhotosText = styled.p`
@@ -74,19 +80,27 @@ const NoPhotosText = styled.p`
 const UploadButtonWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: 20px;
+  margin-top: ${({ $compact }) => ($compact ? 0 : '20px')};
+  flex-shrink: 0;
 `;
 
 const UploadButtonLabel = styled.label`
-  display: inline-block;
-  padding: 10px 20px;
-  background-color: ${color.accent5};
-  color: white;
-  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${({ $compact }) => ($compact ? '72px' : 'auto')};
+  height: ${({ $compact }) => ($compact ? '72px' : 'auto')};
+  box-sizing: border-box;
+  padding: ${({ $compact }) => ($compact ? 0 : '10px 20px')};
+  background-color: ${({ $compact }) => ($compact ? '#FFF0E0' : color.accent5)};
+  color: ${({ $compact }) => ($compact ? '#E8791A' : 'white')};
+  border: ${({ $compact }) => ($compact ? '1.5px dashed #F5A24B' : 'none')};
+  border-radius: ${({ $compact }) => ($compact ? '50%' : '5px')};
   cursor: pointer;
   text-align: center;
-  font-size: 16px;
+  font-size: ${({ $compact }) => ($compact ? '30px' : '16px')};
   font-weight: bold;
+  flex-shrink: 0;
 
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
 
@@ -104,7 +118,7 @@ const HiddenFileInput = styled.input`
   display: none; /* Ховаємо справжній input */
 `;
 
-export const Photos = ({ state, setState, collection, hideFirstPhoto = false, uploadInputId = 'file-upload' }) => {
+export const Photos = ({ state, setState, collection, hideFirstPhoto = false, uploadInputId = 'file-upload', compact = false, maxPhotos = 9 }) => {
   const [viewerIndex, setViewerIndex] = useState(null);
   const photoKeys = Object.keys(state).filter(
     k => k.toLowerCase().startsWith('photo') && k !== 'photos'
@@ -268,12 +282,17 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
   };
 
   const addPhoto = async event => {
-    const photoArray = Array.from(event.target.files);
+    const currentPhotos = Array.isArray(state.photos) ? state.photos : [];
+    const availableSlots = Math.max(maxPhotos - currentPhotos.length, 0);
+    const photoArray = Array.from(event.target.files).slice(0, availableSlots);
+    event.target.value = '';
+    if (photoArray.length === 0) return;
+
     try {
       const newUrls = await Promise.all(
         photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId))
       );
-      const updatedPhotos = [...(state.photos || []), ...newUrls];
+      const updatedPhotos = [...currentPhotos, ...newUrls];
       commitPhotosUpdate(updatedPhotos);
 
       await savePhotoList(updatedPhotos);
@@ -297,46 +316,60 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
 
   const allPhotos = Array.isArray(state.photos) ? state.photos : [];
   const displayedPhotos = hideFirstPhoto ? allPhotos.slice(1) : allPhotos;
-  const canUploadMore = allPhotos.length < 9;
+  const canUploadMore = allPhotos.length < maxPhotos;
+
+  const uploadButton = canUploadMore && (
+    <UploadButtonWrapper $compact={compact}>
+      <UploadButtonLabel
+        $compact={compact}
+        htmlFor={uploadInputId}
+        aria-label="Додати фото"
+      >
+        {compact ? '+' : 'Додати фото'}
+        <HiddenFileInput
+          id={uploadInputId}
+          type="file"
+          multiple
+          accept="image/*"
+          onChange={addPhoto}
+        />
+      </UploadButtonLabel>
+    </UploadButtonWrapper>
+  );
 
   return (
-    <Container>
-      <PhotosWrapper>
-        {displayedPhotos.length > 0 ? (
-          <PhotosWrapper>
-            {displayedPhotos.map((url, index) => {
-              const actualIndex = hideFirstPhoto ? index + 1 : index;
-              return <PhotoItem key={`${url}-${actualIndex}`}>
-                <PhotoImage
-                  src={url}
-                  alt={`user avatar ${actualIndex}`}
-                  onClick={() => handlePhotoClick(url, actualIndex)}
-                  onError={e => {
-                    console.error('Image failed to load', url, e);
-                    e.target.onerror = null;
-                    e.target.src = '/logo192.png';
-                  }}
-                />
-                <DeleteButton onClick={() => handleDeletePhoto(actualIndex)}>×</DeleteButton>
-              </PhotoItem>
-            })}
-          </PhotosWrapper>
-        ) : (
-          <NoPhotosText>Додайте свої фото, максимум 9 шт</NoPhotosText>
-        )}
+    <Container $compact={compact}>
+      <PhotosWrapper $compact={compact}>
+        {displayedPhotos.map((url, index) => {
+          const actualIndex = hideFirstPhoto ? index + 1 : index;
+          return <PhotoItem $compact={compact} key={`${url}-${actualIndex}`}>
+            <PhotoImage
+              $compact={compact}
+              src={url}
+              alt={`Фото профілю ${actualIndex + 1}`}
+              onClick={() => handlePhotoClick(url, actualIndex)}
+              onError={e => {
+                console.error('Image failed to load', url, e);
+                e.target.onerror = null;
+                e.target.src = '/logo192.png';
+              }}
+            />
+            <DeleteButton
+              $compact={compact}
+              type="button"
+              onClick={() => handleDeletePhoto(actualIndex)}
+              aria-label={`Видалити фото ${actualIndex + 1}`}
+            >
+              ×
+            </DeleteButton>
+          </PhotoItem>;
+        })}
+        {compact && uploadButton}
       </PhotosWrapper>
-      {canUploadMore && <UploadButtonWrapper>
-        <UploadButtonLabel htmlFor={uploadInputId}>
-          Додати фото
-          <HiddenFileInput
-            id={uploadInputId}
-            type="file"
-            multiple
-            accept="image/*"
-            onChange={addPhoto}
-          />
-        </UploadButtonLabel>
-      </UploadButtonWrapper>}
+      {!compact && displayedPhotos.length === 0 && (
+        <NoPhotosText>Додайте свої фото, максимум {maxPhotos} шт</NoPhotosText>
+      )}
+      {!compact && uploadButton}
       {viewerIndex !== null && (
         <PhotoViewer
           photos={state.photos}


### PR DESCRIPTION
### Motivation
- Simplify the profile photo UX by removing the separate photo manager modal and embedding photo controls directly in the profile page.  
- Provide a compact, responsive photos UI for use in tighter layouts and limit the number of uploaded photos.  

### Description
- Removed modal-driven photo manager and avatar-specific styled components from `MyProfileNew.jsx` and replaced them with an inline `Photos` component instance using `compact` mode and `uploadInputId`.  
- Adjusted `PhotoSection` layout to a vertical column and removed `mainProfilePhoto`, `isPhotoManagerOpen`, and modal handling.  
- Extended `Photos.jsx` to accept `compact` and `maxPhotos` props, changed styling to support compact horizontal scrolling, circular thumbnails, and compact upload button, and added ARIA labels for delete and upload controls.  
- Added client-side upload slot limiting and file-slice handling in `addPhoto` to prevent uploading more than `maxPhotos`, and cleared the file input after selection.  

### Testing
- Ran the project build with `npm run build` and it completed successfully.  
- Executed the existing test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c98f0e7d08326b9ac1c46dff865b9)