### PR TITLE
Allow 'csection' field to use custom option mode in MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -527,7 +527,7 @@ export const MyProfileNew = () => {
       && optionValues.includes('Yes')
       && optionLabels.includes('Ні')
       && optionLabels.includes('Так');
-    const canUseCustomOption = isAppearanceField || isYesNoField;
+    const canUseCustomOption = isAppearanceField || isYesNoField || name === 'csection';
     const customSelected = canUseCustomOption
       && (Boolean(customOptionMode[name]) || (String(val).trim() !== '' && !optionValues.includes(String(val))));
 


### PR DESCRIPTION
### Motivation
- Treat the `csection` field as eligible for custom option input so users can enter values not present in the predefined options.

### Description
- Update the `canUseCustomOption` check in `MyProfileNew.jsx` to include `name === 'csection'`, enabling custom option mode for that field.

### Testing
- Ran the automated test suite with `yarn test` and linting with `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c975b8fd88326b89605081085d6e5)