### PR TITLE
Refine photo upload UI and simplify profile photo copy

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -593,10 +593,7 @@ export const MyProfileNew = () => {
     </StickyHeader>
 
     <PhotoSection>
-      <div>
-        <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 3 }}>Фото профілю</h4>
-        <p style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>Додайте до 5 фото.<br />Перше — головне.</p>
-      </div>
+      <p style={{ margin: 0, fontSize: 12, color: 'var(--muted)', lineHeight: 1.5 }}>Додайте до 5 фото. Перше — головне</p>
       <Photos
         state={{ ...state, userId }}
         setState={setState}

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -92,25 +92,29 @@ const UploadButtonLabel = styled.label`
   height: ${({ $compact }) => ($compact ? '72px' : 'auto')};
   box-sizing: border-box;
   padding: ${({ $compact }) => ($compact ? 0 : '10px 20px')};
-  background-color: ${({ $compact }) => ($compact ? '#FFF0E0' : color.accent5)};
+  background: ${({ $compact }) => ($compact ? 'linear-gradient(145deg, #FFFDF9 0%, #FFF1E2 100%)' : color.accent5)};
   color: ${({ $compact }) => ($compact ? '#E8791A' : 'white')};
-  border: ${({ $compact }) => ($compact ? '1.5px dashed #F5A24B' : 'none')};
+  border: ${({ $compact }) => ($compact ? '2px dashed #F5A24B' : 'none')};
   border-radius: ${({ $compact }) => ($compact ? '50%' : '5px')};
+  box-shadow: ${({ $compact }) => ($compact ? '0 4px 12px rgba(232, 121, 26, 0.14), inset 0 0 0 4px #FFF8F0' : 'none')};
   cursor: pointer;
   text-align: center;
-  font-size: ${({ $compact }) => ($compact ? '30px' : '16px')};
-  font-weight: bold;
+  font-size: ${({ $compact }) => ($compact ? '32px' : '16px')};
+  font-weight: ${({ $compact }) => ($compact ? 500 : 'bold')};
+  line-height: 1;
   flex-shrink: 0;
 
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
 
   &:hover {
-    background-color: ${color.accent}; 
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); 
+    background: ${({ $compact }) => ($compact ? 'linear-gradient(145deg, #FFF8F0 0%, #FFE4C7 100%)' : color.accent)};
+    border-color: ${({ $compact }) => ($compact ? '#E8791A' : 'transparent')};
+    box-shadow: ${({ $compact }) => ($compact ? '0 6px 16px rgba(232, 121, 26, 0.22), inset 0 0 0 4px #FFF8F0' : '0 4px 12px rgba(0, 0, 0, 0.1)')};
+    transform: translateY(-1px);
   }
 
   &:active {
-    transform: scale(0.98); 
+    transform: scale(0.96);
   }
 `;
 


### PR DESCRIPTION
### Motivation

- Simplify the profile photo section copy and layout to make the UI more compact and readable.
- Improve the visual styling and affordance of the compact photo upload button so uploaded photos feel more prominent and interactive.

### Description

- Replaced the two-line heading block in the profile photo section with a single paragraph (`<p>`) containing the simplified copy.
- Overhauled the `UploadButtonLabel` styles in `Photos.jsx` to use a compact gradient background, increased dashed border thickness, added box-shadow, adjusted font-size/weight/line-height, and refined hover and active behaviors including subtle transform and enhanced transitions.
- Adjusted hover state to change background, border color, box-shadow and apply a small translate, and updated the active state scale to `0.96`.
- Kept `compact` behavior and `maxPhotos` logic intact while only changing visual presentation and micro-interactions.

### Testing

- Ran `npm run lint` and the linter completed without errors.
- Ran the test suite with `npm test` and unit/component tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca09029748326ae5e40ccdd34c0f6)