### PR TITLE
Parallelize get-in-touch bucket reads and point-membership checks; add lookahead window

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4427,6 +4427,7 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
 };
 
 const SEARCH_KEY_GET_IN_TOUCH_LOOKBACK_DAYS_PER_PAGE = 45;
+const SEARCH_KEY_GET_IN_TOUCH_LOOKAHEAD_DAYS = 7;
 const SEARCH_KEY_GET_IN_TOUCH_MAX_BATCHES_PER_PAGE = 25;
 
 const getTodaySearchKeyDateBucket = () => {
@@ -4510,31 +4511,53 @@ const collectSearchKeyGetInTouchCandidateIds = async ({ cursor, limit = PAGE_SIZ
   let nextCursor = null;
 
   while (ids.length < limit && bucket && lookups < SEARCH_KEY_GET_IN_TOUCH_LOOKBACK_DAYS_PER_PAGE) {
-    lookups += 1;
-    // eslint-disable-next-line no-await-in-loop
-    const bucketResult = await readSearchKeyGetInTouchBucketIds({
-      bucket,
-      afterUserId: userId,
-      limit: limit - ids.length,
-    });
+    const bucketWindow = [];
+    let windowBucket = bucket;
+    let windowUserId = userId;
 
-    bucketResult.ids.forEach(id => {
-      if (!id || seen.has(id)) return;
-      seen.add(id);
-      ids.push(id);
-    });
-
-    if (bucketResult.bucketHasMore && bucketResult.ids.length > 0) {
-      nextCursor = serializeSearchKeyGetInTouchCursor({
-        bucket,
-        userId: bucketResult.ids[bucketResult.ids.length - 1],
-      });
-      break;
+    while (
+      windowBucket &&
+      bucketWindow.length < SEARCH_KEY_GET_IN_TOUCH_LOOKAHEAD_DAYS &&
+      lookups + bucketWindow.length < SEARCH_KEY_GET_IN_TOUCH_LOOKBACK_DAYS_PER_PAGE
+    ) {
+      bucketWindow.push({ bucket: windowBucket, afterUserId: windowUserId });
+      windowBucket = getPreviousSearchKeyDateBucket(windowBucket);
+      windowUserId = '';
     }
 
-    bucket = getPreviousSearchKeyDateBucket(bucket);
-    userId = '';
-    nextCursor = bucket ? serializeSearchKeyGetInTouchCursor({ bucket, userId: '' }) : null;
+    // Читаємо сусідні дні паралельно: це прибирає послідовне очікування Firebase
+    // на кожному порожньому або малому getInTouch bucket-і.
+    // eslint-disable-next-line no-await-in-loop
+    const bucketResults = await Promise.all(
+      bucketWindow.map(({ bucket: bucketKey, afterUserId }) =>
+        readSearchKeyGetInTouchBucketIds({ bucket: bucketKey, afterUserId, limit })
+      )
+    );
+
+    for (let index = 0; index < bucketWindow.length && ids.length < limit; index += 1) {
+      lookups += 1;
+      const currentBucket = bucketWindow[index].bucket;
+      const bucketResult = bucketResults[index];
+      const remaining = limit - ids.length;
+      const pageIds = bucketResult.ids.slice(0, remaining);
+
+      pageIds.forEach(id => {
+        if (!id || seen.has(id)) return;
+        seen.add(id);
+        ids.push(id);
+      });
+
+      if ((bucketResult.bucketHasMore || bucketResult.ids.length > remaining) && pageIds.length > 0) {
+        bucket = currentBucket;
+        userId = pageIds[pageIds.length - 1];
+        nextCursor = serializeSearchKeyGetInTouchCursor({ bucket, userId });
+        break;
+      }
+
+      bucket = getPreviousSearchKeyDateBucket(currentBucket);
+      userId = '';
+      nextCursor = bucket ? serializeSearchKeyGetInTouchCursor({ bucket, userId: '' }) : null;
+    }
   }
 
   if (!bucket) {
@@ -4905,15 +4928,17 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
     return [];
   }
 
-  const matchedIds = [];
-
-  for (const userId of uniqueIds) {
-    // eslint-disable-next-line no-await-in-loop
-    const checks = await Promise.all(
-      pointGroups.map(group => hasSearchKeyPointMembership({ userId, group }))
-    );
-    if (checks.every(Boolean)) matchedIds.push(userId);
-  }
+  // Кожен userId перевіряється незалежно через точні true/false посилання.
+  // Запускаємо ці мережеві перевірки паралельно, а не чекаємо Firebase послідовно для кожного кандидата.
+  const membershipResults = await Promise.all(
+    uniqueIds.map(async userId => {
+      const checks = await Promise.all(
+        pointGroups.map(group => hasSearchKeyPointMembership({ userId, group }))
+      );
+      return checks.every(Boolean) ? userId : null;
+    })
+  );
+  const matchedIds = membershipResults.filter(Boolean);
 
   if (typeof debugLog === 'function') {
     debugLog('pointMembership:filteredCandidateIds', {


### PR DESCRIPTION
### Motivation
- Reduce latency when collecting get-in-touch candidates by avoiding sequential Firebase reads across many per-day buckets. 
- Improve throughput of point-membership filtering by removing per-user sequential awaits. 
- Allow small lookahead across adjacent days to fetch more items per network roundtrip via a configurable window.

### Description
- Added `SEARCH_KEY_GET_IN_TOUCH_LOOKAHEAD_DAYS` constant and updated `collectSearchKeyGetInTouchCandidateIds` to build a per-iteration `bucketWindow` of up to that many days and fetch them in parallel via `Promise.all` against `readSearchKeyGetInTouchBucketIds` while preserving `nextCursor` logic. 
- Reworked the per-bucket processing loop to merge results, respect `limit`, update `lookups`, and compute `nextCursor`/`hasMore` consistently using `serializeSearchKeyGetInTouchCursor`. 
- Replaced sequential per-user membership checks in `filterIdsBySearchKeyPointGroups` with a parallel `Promise.all` over `uniqueIds` that runs `hasSearchKeyPointMembership` checks concurrently and then filters successful ids. 
- Kept existing debug logging and behavior around empty bucket/groups handling unchanged.

### Testing
- Ran the existing test suite with `npm test` and static checks with `npm run lint`, and they completed successfully. 
- Exercised `collectSearchKeyGetInTouchCandidateIds` and `filterIdsBySearchKeyPointGroups` in integration scenarios to validate cursor/hasMore semantics and matching behavior, observing expected results. 
- No new unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4b0f09bc8326955a0d66d0f916b0)