### PR TITLE
Batch point-membership checks with limited concurrency

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4427,6 +4427,7 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
 };
 
 const SEARCH_KEY_GET_IN_TOUCH_LOOKBACK_DAYS_PER_PAGE = 45;
+const SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY = 4;
 const SEARCH_KEY_GET_IN_TOUCH_MAX_BATCHES_PER_PAGE = 25;
 
 const getTodaySearchKeyDateBucket = () => {
@@ -4907,12 +4908,20 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
 
   const matchedIds = [];
 
-  for (const userId of uniqueIds) {
+  // Точкові true/false перевірки незалежні, але запускаємо їх малими порціями:
+  // це швидше за повністю послідовний цикл і не перевантажує Firebase великим сплеском запитів.
+  for (let start = 0; start < uniqueIds.length; start += SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY) {
+    const idBatch = uniqueIds.slice(start, start + SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY);
     // eslint-disable-next-line no-await-in-loop
-    const checks = await Promise.all(
-      pointGroups.map(group => hasSearchKeyPointMembership({ userId, group }))
+    const batchMatches = await Promise.all(
+      idBatch.map(async userId => {
+        const checks = await Promise.all(
+          pointGroups.map(group => hasSearchKeyPointMembership({ userId, group }))
+        );
+        return checks.every(Boolean) ? userId : null;
+      })
     );
-    if (checks.every(Boolean)) matchedIds.push(userId);
+    matchedIds.push(...batchMatches.filter(Boolean));
   }
 
   if (typeof debugLog === 'function') {


### PR DESCRIPTION
### Motivation
- Avoid large spikes of Firebase requests when filtering many candidate IDs by point-membership while improving throughput by allowing small concurrent batches.

### Description
- Add `SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY = 4` constant to configure the batch concurrency.
- Replace the single-item sequential loop over `uniqueIds` with batched processing that slices `uniqueIds` into windows of size `SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY` and processes each batch concurrently.
- For each user in a batch, run `hasSearchKeyPointMembership` checks in parallel and include the user only if all group checks pass, then merge matched users into `matchedIds`.
- Preserve existing debug logging and behavior; add an inline comment explaining the batching strategy.

### Testing
- Ran unit tests with `yarn test`, which completed successfully.
- Ran linting with `yarn lint`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4b0f09bc8326955a0d66d0f916b0)