### PR TITLE
Preserve cursor ordering by removing parallel bucket lookahead in get-in-touch collection

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4520,39 +4520,24 @@ const collectSearchKeyGetInTouchCandidateIds = async ({ cursor, limit = PAGE_SIZ
       limit: limit - ids.length,
     });
 
-    // Читаємо сусідні дні паралельно: це прибирає послідовне очікування Firebase
-    // на кожному порожньому або малому getInTouch bucket-і.
-    // eslint-disable-next-line no-await-in-loop
-    const bucketResults = await Promise.all(
-      bucketWindow.map(({ bucket: bucketKey, afterUserId }) =>
-        readSearchKeyGetInTouchBucketIds({ bucket: bucketKey, afterUserId, limit })
-      )
-    );
+    const remaining = limit - ids.length;
+    const pageIds = bucketResult.ids.slice(0, remaining);
 
-    for (let index = 0; index < bucketWindow.length && ids.length < limit; index += 1) {
-      lookups += 1;
-      const currentBucket = bucketWindow[index].bucket;
-      const bucketResult = bucketResults[index];
-      const remaining = limit - ids.length;
-      const pageIds = bucketResult.ids.slice(0, remaining);
+    pageIds.forEach(id => {
+      if (!id || seen.has(id)) return;
+      seen.add(id);
+      ids.push(id);
+    });
 
-      pageIds.forEach(id => {
-        if (!id || seen.has(id)) return;
-        seen.add(id);
-        ids.push(id);
-      });
-
-      if ((bucketResult.bucketHasMore || bucketResult.ids.length > remaining) && pageIds.length > 0) {
-        bucket = currentBucket;
-        userId = pageIds[pageIds.length - 1];
-        nextCursor = serializeSearchKeyGetInTouchCursor({ bucket, userId });
-        break;
-      }
-
-      bucket = getPreviousSearchKeyDateBucket(currentBucket);
-      userId = '';
-      nextCursor = bucket ? serializeSearchKeyGetInTouchCursor({ bucket, userId: '' }) : null;
+    if ((bucketResult.bucketHasMore || bucketResult.ids.length > remaining) && pageIds.length > 0) {
+      userId = pageIds[pageIds.length - 1];
+      nextCursor = serializeSearchKeyGetInTouchCursor({ bucket, userId });
+      break;
     }
+
+    bucket = getPreviousSearchKeyDateBucket(bucket);
+    userId = '';
+    nextCursor = bucket ? serializeSearchKeyGetInTouchCursor({ bucket, userId: '' }) : null;
   }
 
   if (!bucket) {


### PR DESCRIPTION
### Motivation

- Fix a bug where parallel lookahead across adjacent date buckets broke the cursor sequencing when collecting get-in-touch candidate IDs.
- Simplify the bucket-reading flow to avoid extra concurrent Firebase reads and reduce complexity.

### Description

- Removed the `Promise.all` parallel reads over `bucketWindow` and the associated multi-bucket loop, and switched to processing a single `bucketResult` per iteration.
- Simplified page id collection and de-duplication by directly slicing `bucketResult.ids` into `pageIds` and adding them to the `ids` array while respecting the `seen` set.
- Revised `nextCursor` computation to serialize using the current `userId` when a page boundary is reached and to advance the `bucket` with `getPreviousSearchKeyDateBucket(bucket)` while resetting `userId` appropriately.

### Testing

- Ran unit tests via `yarn test`, and the test suite passed.
- Ran the linter via `yarn lint`, and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d94b927088326ac2dbb8ac41d7c0d)