### PR TITLE
FilterPanel: extract init/storage helpers, avoid duplicate onChange calls, and use saved filters in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -89,7 +89,7 @@ import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { btnExportUsers } from './topBtns/btnExportUsers';
 import { btnExportUsersCsv } from './topBtns/btnExportUsersCsv';
 import { btnMerge } from './smallCard/btnMerge';
-import FilterPanel from './FilterPanel';
+import FilterPanel, { getInitialFilters } from './FilterPanel';
 import SearchBar, { detectSearchParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
@@ -1213,7 +1213,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   );
 
   const [searchKeyValuePair, setSearchKeyValuePair] = useState(null);
-  const [filters, setFilters] = useState({});
+  const [filters, setFilters] = useState(() => getInitialFilters({ storageKey: 'addFilters' }));
   const filtersRef = useRef(filters);
   const skipNextReloadRef = useRef(false);
   const searchKeyCoverageRef = useRef({});

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { SearchFilters } from './SearchFilters';
 import { REACTION_FILTER_DEFAULTS } from 'utils/reactionCategory';
 
@@ -90,6 +90,35 @@ const normalizeFilterGroup = (value, defaults) => {
   }, {});
 };
 
+export const getDefaultFilters = ({ mode = 'default', nonAdminAllActive = false } = {}) => {
+  if (mode !== 'matching') return defaultsAdd;
+  if (!nonAdminAllActive) return defaultsMatching;
+  return {
+    ...defaultsMatching,
+    userRole: { ed: true, ag: true, ip: true, other: true },
+  };
+};
+
+export const getFilterStorageKey = ({ mode = 'default', storageKey } = {}) =>
+  storageKey || (mode === 'matching' ? 'matchingFilters' : 'userFilters');
+
+export const getInitialFilters = ({ mode = 'default', storageKey, nonAdminAllActive = false } = {}) => {
+  const defaultFilters = getDefaultFilters({ mode, nonAdminAllActive });
+  const stored = localStorage.getItem(getFilterStorageKey({ mode, storageKey }));
+  if (!stored) return { ...defaultFilters };
+  try {
+    const parsed = JSON.parse(stored);
+    const result = {};
+    for (const key of Object.keys(defaultFilters)) {
+      const savedKey = parsed[key] !== undefined ? key : key === 'userRole' ? 'role' : key;
+      result[key] = normalizeFilterGroup(parsed[savedKey], defaultFilters[key]);
+    }
+    return result;
+  } catch {
+    return { ...defaultFilters };
+  }
+};
+
 const FilterPanel = ({
   onChange,
   hideUserId = false,
@@ -101,44 +130,38 @@ const FilterPanel = ({
   allowedFilterNames,
   bloodSearchKeyMode = false,
 }) => {
-  const defaultFilters = useMemo(() => {
-    if (mode !== 'matching') return defaultsAdd;
-    if (!nonAdminAllActive) return defaultsMatching;
-    return {
-      ...defaultsMatching,
-      userRole: { ed: true, ag: true, ip: true, other: true },
-    };
-  }, [mode, nonAdminAllActive]);
-  const storageKey = customKey || (mode === 'matching' ? 'matchingFilters' : 'userFilters');
+  const defaultFilters = useMemo(
+    () => getDefaultFilters({ mode, nonAdminAllActive }),
+    [mode, nonAdminAllActive],
+  );
+  const storageKey = getFilterStorageKey({ mode, storageKey: customKey });
 
-  const getInitialFilters = () => {
-    const stored = localStorage.getItem(storageKey);
-    if (!stored) return { ...defaultFilters };
-    try {
-      const parsed = JSON.parse(stored);
-      const result = {};
-      for (const key of Object.keys(defaultFilters)) {
-        const savedKey = parsed[key] !== undefined ? key : key === 'userRole' ? 'role' : key;
-        result[key] = normalizeFilterGroup(parsed[savedKey], defaultFilters[key]);
-      }
-      return result;
-    } catch {
-      return { ...defaultFilters };
-    }
-  };
-
-  const [filters, setFilters] = useState(getInitialFilters);
+  const [filters, setFilters] = useState(() =>
+    getInitialFilters({ mode, storageKey, nonAdminAllActive }),
+  );
   const onChangeRef = useRef(onChange);
+  const lastNotifiedFiltersRef = useRef();
   const prevResetTokenRef = useRef(resetToken);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
 
+  const notifyFiltersChange = useCallback(nextFilters => {
+    if (lastNotifiedFiltersRef.current === nextFilters) return;
+    lastNotifiedFiltersRef.current = nextFilters;
+    if (onChangeRef.current) onChangeRef.current(nextFilters);
+  }, []);
+
+  const handleFiltersChange = useCallback(nextFilters => {
+    setFilters(nextFilters);
+    notifyFiltersChange(nextFilters);
+  }, [notifyFiltersChange]);
+
   useEffect(() => {
     localStorage.setItem(storageKey, JSON.stringify(filters));
-    if (onChangeRef.current) onChangeRef.current(filters);
-  }, [filters, storageKey]);
+    notifyFiltersChange(filters);
+  }, [filters, notifyFiltersChange, storageKey]);
 
   useEffect(() => {
     if (prevResetTokenRef.current === resetToken) return;
@@ -149,7 +172,7 @@ const FilterPanel = ({
   return (
     <SearchFilters
       filters={filters}
-      onChange={setFilters}
+      onChange={handleFiltersChange}
       hideUserId={hideUserId}
       hideCommentLength={hideCommentLength}
       mode={mode}


### PR DESCRIPTION
### Motivation

- Persist and reuse saved filter state across sessions and components while supporting different filter modes and storage keys.  
- Consolidate filter initialization logic into reusable helpers to avoid duplicated code and inconsistent defaults.  
- Prevent redundant `onChange` notifications from `FilterPanel` to improve performance and avoid repeated parent updates.

### Description

- Exported `getDefaultFilters`, `getFilterStorageKey`, and `getInitialFilters` from `FilterPanel.jsx` and moved initialization/normalization logic into these helpers.  
- Refactored `FilterPanel` to compute `defaultFilters` with `useMemo`, derive `storageKey` via `getFilterStorageKey`, initialize state with `getInitialFilters`, and persist filters to `localStorage`.  
- Added `notifyFiltersChange`/`handleFiltersChange` with `useCallback` and `lastNotifiedFiltersRef` to avoid sending duplicate `onChange` notifications, and stabilized `onChange` usage via `onChangeRef`.  
- Updated `AddNewProfile.jsx` to import and use `getInitialFilters` to initialize its `filters` state from the saved `addFilters` key instead of an empty object.

### Testing

- Ran the automated unit test suite with `npm test`, and the tests completed successfully.  
- Ran the linter with `npm run lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db7147b4883269f75fc9dc0a792c6)