### PR TITLE
Add onProgress streaming to fetchUsersBySearchKeyBloodPaged and consume partial results in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3284,6 +3284,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         favoritesMap: fav,
         dislikedMap: dislikedUsersMap,
         debug: (step, payload) => appendLoadDebugLog(step, payload),
+        onProgress: partial => {
+          if (filtersKey !== serializeQueryFilters(filtersRef.current)) return;
+          cacheFetchedUsers(partial, cacheLoad2Users, currentFilters);
+          if (!isEditingRef.current) {
+            setUsers(prev => mergeWithoutOverwrite(prev, partial));
+          }
+        },
       });
 
       const responseUsers = res?.users || {};

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -5008,6 +5008,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
   favoritesMap = {},
   dislikedMap = {},
   debug = null,
+  onProgress = null,
 } = {}) => {
   const debugLog = (step, payload = {}) => {
     if (typeof debug === 'function') {
@@ -5185,6 +5186,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
           if (Object.keys(collectedUsers).length >= targetLimit) return;
           collectedUsers[userId] = { ...user, userId };
         });
+        if (typeof onProgress === 'function') onProgress({ ...collectedUsers });
 
         debugLog('filterMain:after', {
           beforeCount: candidateUsersEntries.length,
@@ -5329,6 +5331,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
         if (!userId || collectedUsers[userId]) return;
         collectedUsers[userId] = { ...user, userId };
       });
+      if (typeof onProgress === 'function') onProgress({ ...collectedUsers });
 
       debugLog('loop:end', {
         batch: batches,


### PR DESCRIPTION
### Motivation
- Improve perceived loading performance by streaming partial user results during paged search operations.
- Allow the caller to cache intermediate results and merge them into UI state without waiting for the full page to complete.
- Avoid overwriting UI while the user is actively editing by gating incremental merges behind an editing flag.

### Description
- Added an `onProgress` optional parameter to `fetchUsersBySearchKeyBloodPaged` and invoke it with the current `collectedUsers` at two points during the fetch/filter loops using `if (typeof onProgress === 'function') onProgress({ ...collectedUsers });`.
- Updated `AddNewProfile` to pass an `onProgress` handler into `fetchUsersBySearchKeyBloodPaged` that validates the current filters, calls `cacheFetchedUsers(partial, cacheLoad2Users, currentFilters)`, and merges partial results into state with `setUsers(prev => mergeWithoutOverwrite(prev, partial))` when not editing.
- The `onProgress` handler also guards against stale progress by comparing `filtersKey` to `serializeQueryFilters(filtersRef.current)` and respects `isEditingRef.current` to avoid unintended overwrites.

### Testing
- Ran the automated unit test suite via `npm test`, and all tests passed.
- Ran the linter via `npm run lint`, and no lint errors were reported.
- Executed component-level smoke tests for `AddNewProfile` to verify incremental updates are applied and no regressions were introduced, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ddc40a60483268c6b4732e578257f)