### PR TITLE
Ensure getInTouch date is current/past in filterMain and enable search-key optimizations

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2027,7 +2027,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return;
     }
 
-    const isSearchKeyMode = loadSortMode === 'SEARCH_ID_KEY_ONLY';
+    const isSearchKeyMode = loadSortMode === 'SearchIdKeyOnly';
     const canInstantlyFilterInSearchKeyMode =
       isSearchKeyMode && currentFilter === 'DATE2.1' && Object.keys(users || {}).length > 0;
 
@@ -2049,6 +2049,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           nextValue,
           favoriteUsersData,
           dislikeUsersData,
+          { requireCurrentOrPastGetInTouch: isSearchKeyMode },
         ).reduce((acc, [, user]) => {
           if (user?.userId) {
             acc[user.userId] = user;
@@ -2607,6 +2608,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           filters,
           favoriteUsersData,
           dislikeUsersData,
+          { requireCurrentOrPastGetInTouch: searchIdAndSearchKeyOnlyMode },
         ).reduce((acc, [, user]) => {
           acc[user.userId] = user;
           return acc;
@@ -2641,6 +2643,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             filters,
             favoriteUsersData,
             dislikeUsersData,
+            { requireCurrentOrPastGetInTouch: true },
           ).reduce((acc, [, user]) => {
             acc[user.userId] = user;
             return acc;
@@ -3349,6 +3352,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         currentFilters,
         fav,
         dislikedUsersMap,
+        { requireCurrentOrPastGetInTouch: true },
       ).length === 0) {
         countLoadFilterDrop(searchKeyDropReasons, 'filterMain');
         return acc;

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -29,7 +29,7 @@ import { incrementMatchingLoadStat, removeCard, setIdsForQuery, normalizeQueryKe
 import { updateCard } from '../utils/cardsStorage';
 import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
 import { getCacheKey } from '../utils/cache';
-import { getReactionCategory } from 'utils/reactionCategory';
+import { getReactionCategory, isGetInTouchDateOnOrBeforeToday } from 'utils/reactionCategory';
 import { buildSearchIndexCandidates, encodeKey } from '../utils/searchIndexCandidates';
 import { getSubmittedSearchIndexKeys } from '../utils/searchIndexSync';
 import {
@@ -5175,7 +5175,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
           filterSettings,
           favoritesMap,
           dislikedMap,
-          { debugLog },
+          { debugLog, requireCurrentOrPastGetInTouch: true },
         );
         filterSummary.filterMainRejected += candidateUsersEntries.length - filteredEntries.length;
         filterSummary.accepted += filteredEntries.length;
@@ -5309,7 +5309,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
         filterSettings,
         favoritesMap,
         dislikedMap,
-        { debugLog },
+        { debugLog, requireCurrentOrPastGetInTouch: true },
       );
       filterSummary.filterMainRejected += candidateUsersEntries.length - filteredEntries.length;
       filterSummary.accepted += filteredEntries.length;
@@ -5786,6 +5786,7 @@ export const filterMain = (
   options = {},
 ) => {
   const debugLog = typeof options?.debugLog === 'function' ? options.debugLog : null;
+  const requireCurrentOrPastGetInTouch = Boolean(options?.requireCurrentOrPastGetInTouch);
   const isPartialFilterActive = group => {
     if (!group || typeof group !== 'object') return false;
     const values = Object.values(group);
@@ -5927,6 +5928,10 @@ export const filterMain = (
 
     if (isFavoriteOnlyFilter) {
       addCheck('favorite', isFavoriteUser(userId, favoriteUsers), isFavoriteUser(userId, favoriteUsers), true);
+    }
+
+    if (requireCurrentOrPastGetInTouch) {
+      addCheck('getInTouch', isGetInTouchDateOnOrBeforeToday(value.getInTouch), value.getInTouch ?? null, '<= today');
     }
 
     if (hasReactionFilter) {

--- a/src/utils/reactionCategory.js
+++ b/src/utils/reactionCategory.js
@@ -107,6 +107,14 @@ const getTodayAtMidnight = () => {
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());
 };
 
+export const isGetInTouchDateOnOrBeforeToday = value => {
+  const normalized = normalizeGetInTouch(value);
+  if (!isValidGetInTouchDate(normalized)) return false;
+
+  const getInTouchDate = parseGetInTouchDate(normalized);
+  return Boolean(getInTouchDate && getInTouchDate <= getTodayAtMidnight());
+};
+
 export const getReactionCategory = (user, favorites = {}, dislikes = {}) => {
   if (!user || typeof user !== 'object') {
     return REACTION_FILTER_KEYS.NONE;


### PR DESCRIPTION
### Motivation
- Prevent users with future `getInTouch` dates from being included in instant/derived search-key filtering and cache-derived flows for the `DATE2.1` filter branch.

### Description
- Add `isGetInTouchDateOnOrBeforeToday` export in `src/utils/reactionCategory.js` to normalize and check `getInTouch` dates against today. 
- Add a `requireCurrentOrPastGetInTouch` option to `filterMain` and use it to add an explicit `getInTouch` check when provided. 
- Update callers that perform search-key or cache-derived filtering to pass `{ requireCurrentOrPastGetInTouch: true }` (notably in `src/components/AddNewProfile.jsx` and `src/components/config.js`).
- Import the new helper in `src/components/config.js` and adjust a `loadSortMode` string literal to `SearchIdKeyOnly` to match the expected mode value.

### Testing
- Ran the repository unit tests with `yarn test` and the test suite completed successfully. 
- Performed a build check with `yarn build` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dea50239c8326bb39c8f129d1a01c)