### PR TITLE
Skip redundant filterMain for searchKey results and add diagnostic-aware point-membership checks

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -3345,19 +3345,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         countLoadFilterDrop(searchKeyDropReasons, 'invalidUser');
         return acc;
       }
-      const normalizedUser = { ...user, userId: targetId };
-      if (filterMain(
-        [[targetId, normalizedUser]],
-        'DATE2.1',
-        currentFilters,
-        fav,
-        dislikedUsersMap,
-        { requireCurrentOrPastGetInTouch: true },
-      ).length === 0) {
-        countLoadFilterDrop(searchKeyDropReasons, 'filterMain');
-        return acc;
-      }
-      acc[targetId] = normalizedUser;
+      // fetchUsersBySearchKeyBloodPaged вже повертає картки після filterMain.
+      // Не запускаємо повторно ту саму перевірку для кожної картки у UI.
+      acc[targetId] = { ...user, userId: targetId };
       return acc;
     }, {});
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4427,7 +4427,7 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
 };
 
 const SEARCH_KEY_GET_IN_TOUCH_LOOKBACK_DAYS_PER_PAGE = 45;
-const SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY = 4;
+const SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY = 12;
 const SEARCH_KEY_GET_IN_TOUCH_MAX_BATCHES_PER_PAGE = 25;
 
 const getTodaySearchKeyDateBucket = () => {
@@ -4903,6 +4903,7 @@ const hasSearchKeyPointMembership = async ({
   userId,
   group,
   rootPaths = SEARCH_KEY_INDEXED_ROOT_PATHS,
+  collectDiagnostics = false,
 }) => {
   const allowedBuckets = [...new Set((group?.buckets || []).map(String).filter(Boolean))];
   const matchedBuckets = await readSearchKeyPointMembershipBuckets({ userId, group, buckets: allowedBuckets, rootPaths });
@@ -4910,12 +4911,16 @@ const hasSearchKeyPointMembership = async ({
     return { passed: true, matchedBuckets, userBuckets: matchedBuckets };
   }
 
+  if (!collectDiagnostics) {
+    return { passed: false, matchedBuckets: [], userBuckets: [] };
+  }
+
   const diagnosticBuckets = [...new Set([...(group?.allBuckets || []), ...allowedBuckets])];
   const userBuckets = await readSearchKeyPointMembershipBuckets({ userId, group, buckets: diagnosticBuckets, rootPaths });
   return { passed: false, matchedBuckets: [], userBuckets };
 };
 
-const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog = null }) => {
+const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog = null, collectDiagnostics = false }) => {
   const uniqueIds = [...new Set((ids || []).filter(Boolean).map(String))];
   const pointGroups = (groups || []).filter(group => group?.supportsPointCheck);
   if (!pointGroups.length || uniqueIds.length === 0) return uniqueIds;
@@ -4940,12 +4945,15 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
     // eslint-disable-next-line no-await-in-loop
     const batchMatches = await Promise.all(
       idBatch.map(async userId => {
-        const checks = await Promise.all(
-          pointGroups.map(async group => ({
-            group,
-            result: await hasSearchKeyPointMembership({ userId, group }),
-          }))
-        );
+        const checks = [];
+        for (const group of pointGroups) {
+          // У звичайному режимі припиняємо точкові Firebase-запити після першого false.
+          // Повний перелік причин потрібен лише для явно ввімкненої діагностики.
+          // eslint-disable-next-line no-await-in-loop
+          const result = await hasSearchKeyPointMembership({ userId, group, collectDiagnostics });
+          checks.push({ group, result });
+          if (!result.passed && !collectDiagnostics) break;
+        }
         const rejectedChecks = checks.filter(check => !check.result.passed);
         if (typeof debugLog === 'function') {
           if (rejectedChecks.length > 0) {
@@ -5128,6 +5136,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
           ids: pageIds,
           groups: pointCheckGroups,
           debugLog,
+          collectDiagnostics: typeof debug === 'function',
         });
         filterSummary.pointMembershipRejected += pageIds.length - candidateIds.length;
         debugLog('indexedGetInTouch:candidatePage', {


### PR DESCRIPTION
### Motivation
- Avoid re-running the same `filterMain` checks in the UI for user cards that were already filtered by backend searchKey logic to reduce wasted CPU and duplicate work.
- Reduce Firebase request storm and improve throughput of point-membership checks by increasing concurrency.
- Add optional diagnostics to collect full failure reasons for point-membership checks when debugging.

### Description
- Stop calling `filterMain` per-card in `AddNewProfile.jsx` and directly use the backend-provided cards by assigning `acc[targetId] = { ...user, userId: targetId }`.
- Increase `SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY` from `4` to `12` to allow larger parallel batches for point-membership checks.
- Add a `collectDiagnostics` flag to `hasSearchKeyPointMembership` that controls whether full diagnostic buckets are read, and return early when diagnostics are not requested.
- Add `collectDiagnostics` to `filterIdsBySearchKeyPointGroups` and change per-user group checks to run sequentially with an early `break` on the first failed check when diagnostics are not enabled, while still collecting full reasons when diagnostics are requested; pass `collectDiagnostics: typeof debug === 'function'` from the caller in `fetchUsersBySearchKeyBloodPaged`.

### Testing
- Ran the project's automated test suite via `npm test` and the linter via `npm run lint`, and both completed successfully.
- Executed automated tests covering searchKey fetching and point-membership filtering, which passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df1fb088083269e2a289bf49f3c60)