### PR TITLE
Short-circuit point-membership checks and prioritize narrow filters to reduce Firebase load

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4922,7 +4922,10 @@ const hasSearchKeyPointMembership = async ({
 
 const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog = null, collectDiagnostics = false }) => {
   const uniqueIds = [...new Set((ids || []).filter(Boolean).map(String))];
-  const pointGroups = (groups || []).filter(group => group?.supportsPointCheck);
+  const pointGroups = (groups || [])
+    .filter(group => group?.supportsPointCheck)
+    // Спочатку перевіряємо найвужчі фільтри: вони частіше відсікають картку раніше.
+    .sort((a, b) => (a?.buckets || []).length - (b?.buckets || []).length);
   if (!pointGroups.length || uniqueIds.length === 0) return uniqueIds;
 
   if (pointGroups.some(group => !(group?.buckets || []).length)) {
@@ -4938,22 +4941,20 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
 
   const matchedIds = [];
 
-  // Точкові true/false перевірки незалежні, але запускаємо їх малими порціями:
-  // це швидше за повністю послідовний цикл і не перевантажує Firebase великим сплеском запитів.
+  // Різні userId перевіряємо паралельно малими порціями, але фільтри однієї картки — послідовно.
+  // Після першого false не запускаємо зайві Firebase-запити для решти груп цієї картки.
   for (let start = 0; start < uniqueIds.length; start += SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY) {
     const idBatch = uniqueIds.slice(start, start + SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY);
     // eslint-disable-next-line no-await-in-loop
     const batchMatches = await Promise.all(
       idBatch.map(async userId => {
-        // Всі групи перевіряємо паралельно: час відповіді = max(груп) замість sum(груп).
-        const results = await Promise.all(
-          pointGroups.map(group => hasSearchKeyPointMembership({ userId, group, collectDiagnostics }))
-        );
-        const checks = pointGroups.map((group, i) => ({ group, result: results[i] }));
-        const rejectedChecks = checks.filter(check => !check.result.passed);
-        if (typeof debugLog === 'function') {
-          if (rejectedChecks.length > 0) {
-            rejectedChecks.forEach(({ group, result }) => {
+        const checks = [];
+        for (const group of pointGroups) {
+          // eslint-disable-next-line no-await-in-loop
+          const result = await hasSearchKeyPointMembership({ userId, group, collectDiagnostics });
+          checks.push({ group, result });
+          if (!result.passed) {
+            if (typeof debugLog === 'function') {
               debugLog('pointMembership:reject', {
                 userId,
                 group: group.key,
@@ -4962,19 +4963,22 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
                 allowedBuckets: group.buckets || [],
                 reason: result.userBuckets.length > 0 ? 'bucket mismatch' : 'user bucket not found in searchKey index',
               });
-            });
-          } else {
-            debugLog('pointMembership:accept', {
-              userId,
-              matchedGroups: checks.map(({ group, result }) => ({
-                group: group.key,
-                indexName: group.indexName,
-                userBucket: result.matchedBuckets.length === 1 ? result.matchedBuckets[0] : result.matchedBuckets,
-              })),
-            });
+            }
+            return null;
           }
         }
-        return rejectedChecks.length === 0 ? userId : null;
+
+        if (typeof debugLog === 'function') {
+          debugLog('pointMembership:accept', {
+            userId,
+            matchedGroups: checks.map(({ group, result }) => ({
+              group: group.key,
+              indexName: group.indexName,
+              userBucket: result.matchedBuckets.length === 1 ? result.matchedBuckets[0] : result.matchedBuckets,
+            })),
+          });
+        }
+        return userId;
       })
     );
     matchedIds.push(...batchMatches.filter(Boolean));
@@ -5132,7 +5136,8 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
           ids: pageIds,
           groups: pointCheckGroups,
           debugLog,
-          collectDiagnostics: typeof debug === 'function',
+          // Детальні повторні читання bucket-ів лишаємо вимкненими у звичайній видачі.
+          collectDiagnostics: false,
         });
         filterSummary.pointMembershipRejected += pageIds.length - candidateIds.length;
         debugLog('indexedGetInTouch:candidatePage', {
@@ -5180,7 +5185,8 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
           filterSettings,
           favoritesMap,
           dislikedMap,
-          { debugLog, requireCurrentOrPastGetInTouch: true },
+          // Без per-card debug filterMain завершується одразу після першого false.
+          { requireCurrentOrPastGetInTouch: true },
         );
         filterSummary.filterMainRejected += candidateUsersEntries.length - filteredEntries.length;
         filterSummary.accepted += filteredEntries.length;
@@ -5314,7 +5320,8 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
         filterSettings,
         favoritesMap,
         dislikedMap,
-        { debugLog, requireCurrentOrPastGetInTouch: true },
+        // Без per-card debug filterMain завершується одразу після першого false.
+        { requireCurrentOrPastGetInTouch: true },
       );
       filterSummary.filterMainRejected += candidateUsersEntries.length - filteredEntries.length;
       filterSummary.accepted += filteredEntries.length;


### PR DESCRIPTION
### Motivation
- Reduce Firebase request volume and latency when filtering candidate userIds by search-key point membership. 
- Avoid unnecessary per-card diagnostic reads and per-card debug overhead during normal indexed get-in-touch flows.

### Description
- Sort `pointGroups` in `filterIdsBySearchKeyPointGroups` by increasing bucket count so narrower filters run earlier using `Array.prototype.sort` to prioritize early rejections. 
- Change per-user check logic in `filterIdsBySearchKeyPointGroups` to run group checks sequentially and short-circuit on the first failing `hasSearchKeyPointMembership` result to skip further Firebase requests for that user. 
- Adjust debug logging to emit a reject immediately on first failed check and emit accept only after all groups pass. 
- Disable diagnostic bucket re-reads for the indexed get-in-touch path by passing `collectDiagnostics: false` into `filterIdsBySearchKeyPointGroups`. 
- Stop forwarding `debugLog` into `filterMain` calls for per-card evaluation to avoid forcing per-card debug runs and let `filterMain` exit early when appropriate.

### Testing
- Ran the project test suite with `yarn test`, and all tests passed. 
- Ran the linter with `yarn lint`, and no new lint errors were reported. 
- Executed a local smoke test of the indexed get-in-touch flow, and the flow completed with expected candidate filtering behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e274bf0408326bc672188e74f3a33)