### PR TITLE
Add GITnew load mode and paged gitNew loader for searchKey-based GIT merging

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -39,6 +39,7 @@ import {
   buildSearchKeyIndexPayloadFromCollections,
   fetchUsersBySearchKeyBloodPaged,
 } from './config';
+import { fetchUsersBySearchKeyGitNewPaged } from './gitNewLoad';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -907,6 +908,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const LOAD_SORT_MODES = {
     GIT: 'GIT',
+    GIT_NEW: 'GITnew',
     LAST_ACTION: 'LA',
     LAST_ACTION2: LAST_ACTION2_SORT_MODE,
     NO_GIT: 'NoGIT',
@@ -1760,7 +1762,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [hasSearched, setHasSearched] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [currentFilter, setCurrentFilter] = useState('');
-  const [loadSortMode, setLoadSortMode] = useState(LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY);
+  const [loadSortMode, setLoadSortMode] = useState(LOAD_SORT_MODES.GIT_NEW);
   const [isLoadOptionsOpen, setIsLoadOptionsOpen] = useState(false);
   const [loadRequestId, setLoadRequestId] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
@@ -2240,6 +2242,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         return 'LAST_ACTION';
       case LOAD_SORT_MODES.LAST_ACTION2:
         return LAST_ACTION2_FILTER;
+      case LOAD_SORT_MODES.GIT_NEW:
+        return 'GITnew';
       case LOAD_SORT_MODES.NO_GIT:
       case LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY:
         return 'DATE2.1';
@@ -2256,7 +2260,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       ? LAST_ACTION2_FILTER_STORAGE_KEY
       : 'addFilters';
 
-  const searchIdAndSearchKeyOnlyMode = loadSortMode === LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY;
+  const gitNewMode = loadSortMode === LOAD_SORT_MODES.GIT_NEW;
+  const searchIdAndSearchKeyOnlyMode = loadSortMode === LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY || gitNewMode;
 
   const effectiveEnabledSearchKeys = searchIdAndSearchKeyOnlyMode
     ? {
@@ -2586,6 +2591,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       appendLoadDebugLog('reload-effect:branch', { branch: 'DATE2', loader: 'loadMoreUsers2' });
       loadMoreUsers2()
         .then(({ cacheCount, backendCount }) => {
+          setCacheCount(cacheCount);
+          setBackendCount(backendCount);
+        })
+        .finally(() => setSearchLoading(false));
+      return;
+    }
+
+    if (currentFilter === 'GITnew') {
+      appendLoadDebugLog('reload-effect:branch', { branch: 'GITnew', loader: 'loadMoreUsersGitNew' });
+      loadMoreUsersGitNew()
+        .then(({ cacheCount, backendCount, ignored }) => {
+          if (ignored) return;
           setCacheCount(cacheCount);
           setBackendCount(backendCount);
         })
@@ -3206,6 +3223,47 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       useDateByDateBackendFetch: false,
       queryMode: 'DATE2.1',
     });
+  };
+
+  const loadMoreUsersGitNew = async (currentFilters = filters) => {
+    const filtersKey = serializeQueryFilters(currentFilters);
+    const queryKey = buildQueryKey('GITnew', currentFilters, search);
+    const cachedCandidateIds = getIdsByQuery(queryKey);
+    appendLoadDebugLog('loadMoreUsersGitNew:start', {
+      offset: lastKey21 ?? dateOffset21,
+      limit: PAGE_SIZE,
+      cachedCandidateIdsCount: cachedCandidateIds.length,
+      filters: summarizeLoadFiltersForLog(currentFilters),
+    });
+    const res = await fetchUsersBySearchKeyGitNewPaged({
+      filterSettings: currentFilters,
+      offset: lastKey21 ?? dateOffset21,
+      limit: PAGE_SIZE,
+      favoritesMap: favoriteUsersData,
+      dislikedMap: dislikeUsersData,
+      candidateIds: cachedCandidateIds.length > PAGE_SIZE ? cachedCandidateIds : null,
+      debug: (step, payload) => appendLoadDebugLog(step, payload),
+    });
+    if (filtersKey !== serializeQueryFilters(filtersRef.current)) {
+      return { cacheCount: 0, backendCount: 0, hasMore, ignored: true };
+    }
+    const normalizedUsers = res?.users || {};
+    cacheFetchedUsers(normalizedUsers, cacheLoad2Users, currentFilters);
+    if (!isEditingRef.current) setUsers(prev => mergeWithoutOverwrite(prev, normalizedUsers));
+    const candidateIds = Array.isArray(res?.candidateIds) ? res.candidateIds : [];
+    if (candidateIds.length > PAGE_SIZE) setIdsForQuery(queryKey, candidateIds);
+    const backendCount = Object.keys(normalizedUsers).length;
+    setLastKey21(res?.lastKey ?? null);
+    setDateOffset21(res?.lastKey ?? 0);
+    setHasMore(Boolean(res?.hasMore));
+    appendLoadDebugLog('loadMoreUsersGitNew:result', {
+      backendCount,
+      cachedCandidateIdsCount: cachedCandidateIds.length,
+      candidateIdsCount: candidateIds.length,
+      nextLastKey: res?.lastKey ?? null,
+      hasMore: Boolean(res?.hasMore),
+    });
+    return { cacheCount: cachedCandidateIds.length ? backendCount : 0, backendCount: cachedCandidateIds.length ? 0 : backendCount, hasMore: Boolean(res?.hasMore) };
   };
 
   const loadMoreUsersSearchKey = async (currentFilters = filters) => {
@@ -3966,6 +4024,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const { cacheCount, backendCount, hasMore: nextMore, ignored } =
         currentFilter === 'DATE2'
           ? await loadMoreUsers2()
+          : currentFilter === 'GITnew'
+          ? await loadMoreUsersGitNew()
           : currentFilter === 'DATE2.1'
           ? searchIdAndSearchKeyOnlyMode
             ? await loadMoreUsersSearchKey()
@@ -4961,7 +5021,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       missingCachedUserIds,
       currentFilter: snapshot.currentFilter || '',
       currentPage: snapshot.currentPage || 1,
-      loadSortMode: snapshot.loadSortMode || 'SearchIdKeyOnly',
+      loadSortMode: snapshot.loadSortMode || 'GITnew',
       hasSearched: Boolean(snapshot.hasSearched),
     });
 
@@ -4982,7 +5042,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     if (snapshot.la2State) {
       la2StateRef.current = restoreLA2State(snapshot.la2State);
     }
-    setLoadSortMode(snapshot.loadSortMode || 'SearchIdKeyOnly');
+    setLoadSortMode(snapshot.loadSortMode || 'GITnew');
     setSearch(snapshot.search || '');
     setHasSearched(Boolean(snapshot.hasSearched) || Object.keys(restoredUsers).length > 0);
     logProfileRestoreStep('previous-list:restore-complete-clear-profile-state', {
@@ -5467,6 +5527,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                           onChange={event => handleLoadSortModeChange(event.target.value)}
                         />
                         GIT
+                      </SortModeLabel>
+                      <SortModeLabel>
+                        <input
+                          type="radio"
+                          name="load-sort-mode"
+                          value={LOAD_SORT_MODES.GIT_NEW}
+                          checked={loadSortMode === LOAD_SORT_MODES.GIT_NEW}
+                          onChange={event => handleLoadSortModeChange(event.target.value)}
+                        />
+                        GITnew
                       </SortModeLabel>
                       <SortModeLabel>
                         <input

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4749,7 +4749,7 @@ const collectLastActionIdsByFilters = async (lastActionFilters, rootPaths = SEAR
   return lastActionIds;
 };
 
-const buildActiveSearchKeyFilterGroups = (filterSettings = {}, { favoritesMap = {}, dislikedMap = {} } = {}) => {
+export const buildActiveSearchKeyFilterGroups = (filterSettings = {}, { favoritesMap = {}, dislikedMap = {} } = {}) => {
   const groups = [];
   const addGroup = group => {
     if (group) groups.push(group);
@@ -4934,15 +4934,15 @@ const getProfileBloodDebug = profile => {
 
 const toSingleBucketOrList = buckets => buckets.length === 1 ? buckets[0] : buckets;
 
-const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog = null, collectDiagnostics = false }) => {
+export const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog = null, collectDiagnostics = false, collectBloodDiagnostics = true }) => {
   const uniqueIds = [...new Set((ids || []).filter(Boolean).map(String))];
   const pointGroups = (groups || [])
     .filter(group => group?.supportsPointCheck)
-    // Blood перевіряємо першим, щоб summary охоплював кожну картку вхідної сторінки.
-    // Решту фільтрів лишаємо у порядку від найвужчого: вони частіше відсікають картку раніше.
+    // Для старого режиму blood перевіряємо першим, щоб diagnostics охоплював усю вхідну сторінку.
+    // Нові режими можуть вимкнути blood diagnostics і перевіряти групи від найвужчої.
     .sort((a, b) => {
-      if (a?.key === 'blood') return -1;
-      if (b?.key === 'blood') return 1;
+      if (collectBloodDiagnostics && a?.key === 'blood') return -1;
+      if (collectBloodDiagnostics && b?.key === 'blood') return 1;
       return (a?.buckets || []).length - (b?.buckets || []).length;
     });
   if (!pointGroups.length || uniqueIds.length === 0) return uniqueIds;
@@ -4959,7 +4959,7 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
   }
 
   const matchedIds = [];
-  const bloodGroup = pointGroups.find(group => group?.key === 'blood');
+  const bloodGroup = collectBloodDiagnostics ? pointGroups.find(group => group?.key === 'blood') : null;
   const bloodSummary = bloodGroup
     ? {
         inputIdsCount: uniqueIds.length,
@@ -4985,7 +4985,7 @@ const filterIdsBySearchKeyPointGroups = async ({ ids = [], groups = [], debugLog
       idBatch.map(async userId => {
         const checks = [];
         for (const group of pointGroups) {
-          const shouldCollectDiagnostics = collectDiagnostics || group.key === 'blood';
+          const shouldCollectDiagnostics = collectDiagnostics || (collectBloodDiagnostics && group.key === 'blood');
           // eslint-disable-next-line no-await-in-loop
           const result = await hasSearchKeyPointMembership({ userId, group, collectDiagnostics: shouldCollectDiagnostics });
           checks.push({ group, result });
@@ -5095,7 +5095,7 @@ const summarizeSearchKeyFilterSettingsForLog = filterSettings => ({
   raw: filterSettings || {},
 });
 
-export const fetchUsersBySearchKeyBloodPaged = async ({
+export const fetchUsersBySearchKeyPaged = async ({
   filterSettings = {},
   offset = 0,
   limit = PAGE_SIZE,
@@ -5106,7 +5106,7 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
 } = {}) => {
   const debugLog = (step, payload = {}) => {
     if (typeof debug === 'function') {
-      debug(`fetchUsersBySearchKeyBloodPaged:${step}`, payload);
+      debug(`fetchUsersBySearchKeyPaged:${step}`, payload);
     }
   };
 
@@ -5470,6 +5470,12 @@ export const fetchUsersBySearchKeyBloodPaged = async ({
     throw error;
   }
 };
+
+// Старе ім'я зберігаємо як сумісний alias: loader уже обробляє всі searchKey-групи, а не лише blood.
+export const fetchUsersBySearchKeyBloodPaged = options => fetchUsersBySearchKeyPaged(options);
+
+// За відсутності активних searchKey-груп цей самий loader читає default-list у порядку getInTouch.
+export const fetchUsersByDefaultGetInTouchPaged = options => fetchUsersBySearchKeyPaged(options);
 
 // export const updateSearchId = async (searchKey, searchValue, userId, action) => {
 //   console.log('searchKey!!!!!!!!! :>> ', searchKey);
@@ -6056,7 +6062,7 @@ const isValidDate = date => {
 };
 
 // Сортування
-const sortUsers = (
+export const sortUsers = (
   filteredUsers,
   { includeSpecialFutureDates = false, skipGetInTouchFilter = false } = {},
 ) => {

--- a/src/components/gitNewLoad.js
+++ b/src/components/gitNewLoad.js
@@ -1,0 +1,139 @@
+import { get, ref } from 'firebase/database';
+import {
+  buildActiveSearchKeyFilterGroups,
+  database,
+  fetchUsersByDefaultGetInTouchPaged,
+  filterIdsBySearchKeyPointGroups,
+  filterMain,
+  sortUsers,
+} from './config';
+import { PAGE_SIZE } from './constants';
+
+const GITNEW_GET_IN_TOUCH_BATCH_SIZE = 40;
+
+const readGitNewGetInTouchByIds = async ids => {
+  const uniqueIds = [...new Set((ids || []).filter(Boolean))];
+  const entries = [];
+  for (let start = 0; start < uniqueIds.length; start += GITNEW_GET_IN_TOUCH_BATCH_SIZE) {
+    const batchIds = uniqueIds.slice(start, start + GITNEW_GET_IN_TOUCH_BATCH_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const batchEntries = await Promise.all(
+      batchIds.map(async userId => {
+        const [usersSnapshot, newUsersSnapshot] = await Promise.all([
+          get(ref(database, `users/${userId}/getInTouch`)),
+          get(ref(database, `newUsers/${userId}/getInTouch`)),
+        ]);
+        const value = usersSnapshot.exists()
+          ? usersSnapshot.val()
+          : newUsersSnapshot.exists()
+            ? newUsersSnapshot.val()
+            : '';
+        return [userId, value];
+      })
+    );
+    entries.push(...batchEntries);
+  }
+  return Object.fromEntries(entries);
+};
+
+const fetchGitNewUsersByIds = async ids => {
+  const entries = await Promise.all(
+    [...new Set((ids || []).filter(Boolean))].map(async userId => {
+      const [usersSnapshot, newUsersSnapshot] = await Promise.all([
+        get(ref(database, `users/${userId}`)),
+        get(ref(database, `newUsers/${userId}`)),
+      ]);
+      if (!usersSnapshot.exists() && !newUsersSnapshot.exists()) return null;
+      return [
+        userId,
+        {
+          ...(newUsersSnapshot.exists() ? newUsersSnapshot.val() : {}),
+          ...(usersSnapshot.exists() ? usersSnapshot.val() : {}),
+          userId,
+        },
+      ];
+    })
+  );
+  return Object.fromEntries(entries.filter(Boolean));
+};
+
+export const fetchUsersBySearchKeyGitNewPaged = async ({
+  filterSettings = {},
+  offset = 0,
+  limit = PAGE_SIZE,
+  favoritesMap = {},
+  dislikedMap = {},
+  candidateIds = null,
+  debug = null,
+} = {}) => {
+  const debugLog = (step, payload = {}) => {
+    if (typeof debug === 'function') debug(`fetchUsersBySearchKeyGitNewPaged:${step}`, payload);
+  };
+  const targetLimit = Math.max(1, Number(limit) || PAGE_SIZE);
+  const activeGroups = buildActiveSearchKeyFilterGroups(filterSettings, { favoritesMap, dislikedMap });
+  let filteredIds = Array.isArray(candidateIds) && candidateIds.length > PAGE_SIZE
+    ? [...new Set(candidateIds.filter(Boolean))]
+    : null;
+
+  if (!filteredIds) {
+    if (!activeGroups.length) {
+      // Без активного searchKey-фільтра немає стартового bucket-а для GITnew.
+      // Зберігаємо попередню getInTouch-пагінацію як явний default-list fallback.
+      debugLog('defaultGetInTouchFallback', { reason: 'no active searchKey groups' });
+      return fetchUsersByDefaultGetInTouchPaged({ filterSettings, offset, limit, favoritesMap, dislikedMap, debug });
+    }
+    const pointGroups = activeGroups.filter(group => group.supportsPointCheck);
+    const seedGroup = [...(pointGroups.length ? pointGroups : activeGroups)]
+      .sort((left, right) => {
+        const leftPriority = left.key === 'userId' ? 0 : 1;
+        const rightPriority = right.key === 'userId' ? 0 : 1;
+        if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+        return (left.buckets || []).length - (right.buckets || []).length;
+      })[0];
+    filteredIds = [...await seedGroup.readIds({ debugLog })];
+    filteredIds = await filterIdsBySearchKeyPointGroups({ ids: filteredIds, groups: pointGroups, debugLog, collectBloodDiagnostics: false });
+    const deferredGroups = activeGroups.filter(group => !group.supportsPointCheck && group !== seedGroup);
+    for (const group of deferredGroups) {
+      // eslint-disable-next-line no-await-in-loop
+      const groupIds = await group.readIds({ debugLog });
+      filteredIds = filteredIds.filter(userId => groupIds.has(userId));
+    }
+    debugLog('filteredIds', {
+      seedGroup: seedGroup?.key || '',
+      activeGroups: activeGroups.map(group => group.key),
+      count: filteredIds.length,
+    });
+  } else {
+    debugLog('candidateIdsCacheHit', { count: filteredIds.length });
+  }
+
+  const getInTouchById = await readGitNewGetInTouchByIds(filteredIds);
+  const orderedIds = sortUsers(
+    filteredIds.map(userId => [userId, { userId, getInTouch: getInTouchById[userId] }])
+  ).map(([userId]) => userId);
+  const users = {};
+  let cursor = Math.max(0, Number(offset) || 0);
+  while (cursor < orderedIds.length && Object.keys(users).length < targetLimit) {
+    const chunkIds = orderedIds.slice(cursor, cursor + Math.max(targetLimit, PAGE_SIZE));
+    cursor += chunkIds.length;
+    // eslint-disable-next-line no-await-in-loop
+    const chunkUsers = await fetchGitNewUsersByIds(chunkIds);
+    const filteredChunk = filterMain(
+      Object.entries(chunkUsers),
+      'GITnew',
+      filterSettings,
+      favoritesMap,
+      dislikedMap,
+      { requireCurrentOrPastGetInTouch: true },
+    );
+    filteredChunk.forEach(([userId, user]) => {
+      if (Object.keys(users).length < targetLimit) users[userId] = user;
+    });
+  }
+  return {
+    users,
+    lastKey: cursor,
+    hasMore: cursor < orderedIds.length,
+    candidateIds: filteredIds,
+  };
+};


### PR DESCRIPTION
### Motivation

- Introduce a new loading mode that merges results from `users` and `newUsers` sets while honoring active searchKey filters and getInTouch ordering.  
- Provide a dedicated loader optimized for combined GIT/newUsers workflows and to support cached candidate-id paths for faster pagination.  
- Make searchKey-based loaders more generic and configurable (blood diagnostics toggle and aliasing) to reuse existing logic across modes.

### Description

- Added `src/components/gitNewLoad.js` implementing `fetchUsersBySearchKeyGitNewPaged`, which builds seed id lists from active searchKey groups, sorts by `getInTouch`, fetches user chunks from both `users` and `newUsers`, and applies `filterMain`; the loader returns `users`, `lastKey`, `hasMore` and `candidateIds`.  
- Integrated the new mode into the UI and loader flow in `src/components/AddNewProfile.jsx` by importing the new loader, adding `LOAD_SORT_MODES.GIT_NEW` (`'GITnew'`), wiring the radio control, defaulting `loadSortMode` to `GITnew`, adding branch handling for `'GITnew'`, implementing `loadMoreUsersGitNew`, and using it in page change and reload paths.  
- Updated `src/components/config.js` to export `buildActiveSearchKeyFilterGroups`, change `filterIdsBySearchKeyPointGroups` signature to accept `collectBloodDiagnostics`, rename/genericize the searchKey loader to `fetchUsersBySearchKeyPaged` and keep `fetchUsersBySearchKeyBloodPaged` as a compatibility alias, and expose `fetchUsersByDefaultGetInTouchPaged` and `sortUsers` for reuse.  
- Added logging and caching interactions: `loadMoreUsersGitNew` logs debug steps, caches fetched users via `cacheLoad2Users`, updates `lastKey21`/`dateOffset21`, and stores candidate ids for subsequent cache hits.

### Testing

- Ran the project unit test suite with `npm test` and it completed successfully.  
- Executed a development build via `npm run build` to validate exports and bundling and the build succeeded.  
- Performed a quick smoke check of the list-loading UI in development to ensure the new `GITnew` radio mode triggers the new loader without console errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f16dd0cc8832686d738378809bba0)