### PR TITLE
Defer broad search-key point-check groups when selected buckets are too many

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -4447,6 +4447,8 @@ export const buildSearchKeyIndexPayloadFromCollections = (collectionsMap, indexT
 const SEARCH_KEY_GET_IN_TOUCH_LOOKBACK_DAYS_PER_PAGE = 45;
 const SEARCH_KEY_POINT_MEMBERSHIP_CONCURRENCY = 12;
 const SEARCH_KEY_GET_IN_TOUCH_MAX_BATCHES_PER_PAGE = 25;
+const SEARCH_KEY_BROAD_POINT_CHECK_MIN_BUCKETS = 3;
+const SEARCH_KEY_BROAD_POINT_CHECK_RATIO = 0.65;
 
 const getTodaySearchKeyDateBucket = () => {
   const today = new Date();
@@ -4891,6 +4893,16 @@ export const buildActiveSearchKeyFilterGroups = (filterSettings = {}, { favorite
   return groups;
 };
 
+const isBroadSearchKeyPointGroup = group => {
+  const allowedCount = (group?.buckets || []).length;
+  const allCount = (group?.allBuckets || []).length;
+
+  if (!group?.supportsPointCheck || allCount < SEARCH_KEY_BROAD_POINT_CHECK_MIN_BUCKETS) return false;
+  if (allowedCount <= 1 || allowedCount >= allCount) return false;
+
+  return allowedCount / allCount >= SEARCH_KEY_BROAD_POINT_CHECK_RATIO;
+};
+
 const readSearchKeyPointMembershipBuckets = async ({
   userId,
   group,
@@ -5168,20 +5180,31 @@ export const fetchUsersBySearchKeyPaged = async ({
     });
 
     if (activeSearchKeyGroups.length > 0) {
-      const pointCheckGroups = activeSearchKeyGroups.filter(group => group.supportsPointCheck);
-      const deferredGroups = activeSearchKeyGroups.filter(group => !group.supportsPointCheck);
+      const broadPointCheckGroups = activeSearchKeyGroups
+        .filter(group => group.supportsPointCheck && isBroadSearchKeyPointGroup(group));
+      const pointCheckGroups = activeSearchKeyGroups
+        .filter(group => group.supportsPointCheck && !isBroadSearchKeyPointGroup(group));
+      const deferredGroups = activeSearchKeyGroups
+        .filter(group => !group.supportsPointCheck || isBroadSearchKeyPointGroup(group));
 
       debugLog('indexedSearchKeyGroups', {
         count: activeSearchKeyGroups.length,
         pointCheckCount: pointCheckGroups.length,
+        broadDeferredPointCheckCount: broadPointCheckGroups.length,
         deferredCount: deferredGroups.length,
         source: 'indexedGetInTouchPointMembership',
+        broadDeferRule: {
+          minBuckets: SEARCH_KEY_BROAD_POINT_CHECK_MIN_BUCKETS,
+          ratio: SEARCH_KEY_BROAD_POINT_CHECK_RATIO,
+        },
         groups: activeSearchKeyGroups.map(group => ({
           key: group.key,
           indexName: group.indexName,
           bucketsCount: (group.buckets || []).length,
+          allBucketsCount: (group.allBuckets || []).length,
           bucketsSample: (group.buckets || []).slice(0, 20),
           supportsPointCheck: Boolean(group.supportsPointCheck),
+          deferredBecauseBroad: broadPointCheckGroups.includes(group),
         })),
       });
 


### PR DESCRIPTION
### Motivation

- Reduce expensive per-user point-membership checks for search-key groups that are too broad (many allowed buckets relative to known indexed buckets). 

### Description

- Add constants `SEARCH_KEY_BROAD_POINT_CHECK_MIN_BUCKETS` and `SEARCH_KEY_BROAD_POINT_CHECK_RATIO` to control broad-group detection. 
- Introduce helper `isBroadSearchKeyPointGroup` to detect groups that should be deferred from point-checks based on bucket counts and ratio. 
- Update `fetchUsersBySearchKeyPaged` grouping logic to classify groups into `broadPointCheckGroups`, `pointCheckGroups`, and `deferredGroups` and to defer broad groups from immediate point-membership checking. 
- Extend diagnostics output to include `broadDeferredPointCheckCount`, `broadDeferRule`, `allBucketsCount`, and a `deferredBecauseBroad` flag per group for easier debugging. 

### Testing

- Ran the project's unit test suite with `yarn test` and the linter with `yarn lint`, and they completed successfully. 
- Verified that search-key diagnostics logs include the new fields when running the indexed search-key path in development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fce209b648326bab7ff26a574b5ae)