### PR TITLE
Keep publish flag boolean on profile publish

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -688,7 +688,7 @@ export const MyProfileNew = () => {
     }
   };
 
-  const saveState = (nextState) => {
+  const saveState = (nextState, { directFields = [] } = {}) => {
     const targetUserId = userId || nextState?.userId || stateRef.current.userId;
     if (!targetUserId) return Promise.resolve();
 
@@ -697,9 +697,15 @@ export const MyProfileNew = () => {
       .then(async () => {
         const { existingData } = await fetchUserData(targetUserId);
         const { password: _password, ...profileData } = nextState;
-        const uploadedInfo = makeUploadedInfo(existingData, {
+        const normalizedProfileData = {
           ...profileData,
           userRole: profileData.userRole || 'ed',
+        };
+        const uploadedInfo = makeUploadedInfo(existingData, normalizedProfileData);
+        directFields.forEach(field => {
+          if (Object.prototype.hasOwnProperty.call(normalizedProfileData, field)) {
+            uploadedInfo[field] = normalizedProfileData[field];
+          }
         });
         delete uploadedInfo.password;
         await persistUserWithFallback(targetUserId, uploadedInfo, 'check');
@@ -727,7 +733,7 @@ export const MyProfileNew = () => {
     setState(nextState);
 
     try {
-      await saveState(nextState);
+      await saveState(nextState, { directFields: ['publish'] });
       localStorage.removeItem('myProfileDraft');
     } catch (error) {
       console.error('publish error', error);


### PR DESCRIPTION
### Motivation
- Prevent `publish` from being stored as a history array (e.g. `[false, true]`) when republishing an existing hidden profile. 

### Description
- Added a `directFields` option to `saveState` so callers can force direct overwrites for specific fields after `makeUploadedInfo` merges history. 
- When publishing, `publishProfile` now calls `saveState(nextState, { directFields: ['publish'] })` to ensure `publish` is written as a boolean. 
- The change is implemented in `src/components/MyProfileNew.jsx` and preserves existing `makeUploadedInfo` behavior for other fields. 

### Testing
- Ran `npx eslint src/components/MyProfileNew.jsx` and it completed without errors. 
- Ran `git diff --check` and no whitespace/format issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217e91f24c832693d8682b7d85585b)