### PR TITLE
Виправити порядок навігації MyProfileNew

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -398,15 +398,11 @@ export const MyProfileNew = () => {
     .map(section => ({ ...section, fields: section.fields.filter(name => isDonorRole || visibleNonDonorFields.has(name)) }))
     .filter(section => section.fields.length > 0);
   const firstSectionKey = visibleSections[0]?.key || 'personal';
-  const navSections = useMemo(() => {
-    const [firstSection, ...restSections] = visibleSections;
-    return [
-      ...(firstSection ? [firstSection] : []),
-      { key: 'photo', title: '📷 Фото', fields: ['photos'], isVirtual: true },
-      ...(!isProfileAccessConfirmed ? [{ key: 'auth', title: '🔐 Доступ до анкети', fields: ['email', 'password', 'terms'], isVirtual: true }] : []),
-      ...restSections,
-    ];
-  }, [isProfileAccessConfirmed, visibleSections]);
+  const navSections = useMemo(() => [
+    ...(!isProfileAccessConfirmed ? [{ key: 'auth', title: '🔐 Доступ до анкети', fields: ['email', 'password', 'terms'], isVirtual: true }] : []),
+    { key: 'photo', title: '📷 Фото', fields: ['photos'], isVirtual: true },
+    ...visibleSections,
+  ], [isProfileAccessConfirmed, visibleSections]);
 
   useEffect(() => {
     let isMounted = true;


### PR DESCRIPTION
### Motivation
- Навігаційні кнопки в компоненті `MyProfileNew` повинні відображатися в порядку «Доступ до анкети», «Фото», потім секції анкети, натомість раніше вкладка «Доступ до анкети» показувалась після «Особисті дані». 

### Description
- Змінено формування `navSections` у `src/components/MyProfileNew.jsx` так, щоб масив будувався як `auth` (якщо потрібно), потім `photo`, а потім `...visibleSections`, замінивши попередню логіку з витягуванням `firstSection` і вставкою `photo` посередині. 

### Testing
- Виконано `git diff --check` та `git status --short`, обидві перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21888e7cc88326b4d9029ab2b0a22e)