### PR TITLE
Виправлення падіння MyProfileNew при валідації/анімаціях

### DIFF
--- a/src/components/MyProfileNew.jsx
+++ b/src/components/MyProfileNew.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { useNavigate } from 'react-router-dom';
 import { FiX } from 'react-icons/fi';
 import { FaEye, FaEyeSlash } from 'react-icons/fa';
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import {
   auth,
   fetchUserData,
@@ -186,7 +186,7 @@ const StatusBadge = styled.button`
 `;
 const HighlightableLabel = styled(Label)`
   display: inline-block;
-  ${({ $active }) => $active && `
+  ${({ $active }) => $active && css`
     color: var(--accent);
     animation: ${hintPulse} .45s ease-in-out;
   `}
@@ -233,7 +233,7 @@ const TermsRow = styled.div`
   gap: 10px;
   padding: 14px 0;
   border-radius: 12px;
-  ${({ $missing, $active }) => ($missing || $active) && `
+  ${({ $missing, $active }) => ($missing || $active) && css`
     margin: 8px 0;
     padding: 14px 12px;
     background: rgba(221, 68, 68, .06);
@@ -267,7 +267,7 @@ const TermsButton = styled.button`
 `;
 const AuthActionButton = styled(SubmitBtn)`
   margin: 4px 0 20px;
-  ${({ $active }) => $active && `
+  ${({ $active }) => $active && css`
     animation: ${hintPulse} .45s ease-in-out;
     box-shadow: 0 0 0 4px rgba(232, 121, 26, .16);
   `}


### PR DESCRIPTION
### Motivation
- Після останніх змін умовні CSS-фрагменти з використанням keyframes іноді викликали runtime crash/білий екран при активації підказок в розділі авторизації (маячок «Логін не відбувся», підсвітка чекбоксу умов, hint-анімація кнопки), тому потрібно повернути стабільну поведінку валідації й запобігти uncaught errors.

### Description
- Додано імпорт `css` з `styled-components` і обгорнуто умовні шаблонні рядки з анімаціями у `css` у файлі `src/components/MyProfileNew.jsx`, щоб keyframe-інтерполяції були коректно оброблені в умовних стилях; зміни торкнулися компонентів підсвітки Label, TermsRow і AuthActionButton.
- Ніякої логіки валідації/submit не змінювалося, тільки виправлено спосіб формування styled-компонентів для запобігання помилок рендерингу.

### Testing
- Виконано `npm run build` для production-білду — збірка пройшла успішно (проект зібрано).
- Виконано `git diff --check` на змінених файлах — проблем не виявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21df2c53908326b68bf62db336e5f4)