### PR TITLE
Fix card cache merge ordering, immediate localStorage saves, and add debug logging in AddNewProfile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -145,6 +145,24 @@ const onValue = wrapAdminOnValue(firebaseOnValue, {
   source: 'AddNewProfile',
 });
 
+
+const getLocalStorageCardsDebugSnapshot = () => {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem('cards') || '[]');
+  } catch (error) {
+    return {
+      parseError: error?.message || String(error),
+      raw: localStorage.getItem('cards'),
+    };
+  }
+};
+
+const logRenderSource = (source, card) => {
+  if (!card?.userId) return;
+  console.log('[RENDER SOURCE]', source, card.userId, card.getInTouch);
+};
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -1574,6 +1592,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       }
 
+      console.log('[SAVE] userId:', syncedState.userId);
+
       if (syncedState?.userId?.length > 20) {
 
         const cleanedState = Object.fromEntries(
@@ -1604,6 +1624,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
 
         if (!makeIndex) {
+          console.log('[SAVE] payload to firebase:', uploadedInfo);
           await Promise.all([
             updateDataInRealtimeDB(syncedState.userId, uploadedInfo, 'update'),
             updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', delCondition),
@@ -1623,6 +1644,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           });
         }
 
+        console.log('[SAVE] payload to firebase:', cleanedStateForNewUsers);
         await updateDataInNewUsersRTDB(
           syncedState.userId,
           cleanedStateForNewUsers,
@@ -1630,7 +1652,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         );
       } else {
         if (newState) {
-          const newStateWithDelivery = { ...newState };
+          const newStateWithDelivery = { ...syncedState };
 
           if (formattedLastDelivery) {
             newStateWithDelivery.lastDelivery = formattedLastDelivery;
@@ -1642,39 +1664,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               newStateWithDelivery[key] = null;
             });
           }
+          console.log('[SAVE] payload to firebase:', newStateWithDelivery);
           await updateDataInNewUsersRTDB(
             syncedState.userId,
             newStateWithDelivery,
             'update'
           );
         } else {
+          console.log('[SAVE] payload to firebase:', syncedState);
           await updateDataInNewUsersRTDB(syncedState.userId, syncedState, 'update');
         }
       }
-      try {
-        const serverData = await fetchUserById(syncedState.userId);
-        const serverLast = normalizeLastAction(serverData?.lastAction);
-        if (serverLast && serverLast > syncedState.lastAction) {
-          const formattedServer = {
-            ...serverData,
-            lastAction: serverLast,
-            lastDelivery: formatDateToDisplay(serverData.lastDelivery),
-          };
-          updateCachedUser(formattedServer);
-          cacheFetchedUsers(
-            { [formattedServer.userId]: formattedServer },
-            cacheLoad2Users,
-            filters,
-          );
-          const serverGitNewCardHidden = hideFutureGitNewCardAndLoadNext(formattedServer);
-          if (!serverGitNewCardHidden) {
-            setUsers(prev => ({ ...prev, [formattedServer.userId]: formattedServer }));
-          }
-          setState(formattedServer);
-        }
-      } catch {
-        // ignore fetch errors
-      }
+      console.log('[LS cards before]', getLocalStorageCardsDebugSnapshot());
+      updateCachedUser(syncedState, { removeKeys });
+      cacheFetchedUsers({ [syncedState.userId]: syncedState }, cacheLoad2Users, filters);
+      console.log('[LS cards after]', getLocalStorageCardsDebugSnapshot());
     } catch (submitError) {
       const details = submitError?.message || String(submitError);
       console.error('Submit failed', submitError);
@@ -2247,6 +2251,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           userId: activeUserId,
           state: summarizeProfileCardForLog(currentState),
         });
+        logRenderSource('state', currentState);
         setProfileSource('cache');
       } else {
         logProfileRestoreStep('profile-data:state-already-hydrated-skip', {
@@ -2255,6 +2260,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           profileSource: currentProfileSource,
           state: summarizeProfileCardForLog(currentState),
         });
+        logRenderSource(currentProfileSource || 'state', currentState);
       }
       return;
     }
@@ -2266,7 +2272,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         userId: activeUserId,
         cached: summarizeProfileCardForLog(cached),
       });
-      setState({ ...cached, userId: cached.userId || activeUserId });
+      const cachedProfile = { ...cached, userId: cached.userId || activeUserId };
+      logRenderSource('cache', cachedProfile);
+      setState(cachedProfile);
       setProfileSource('cache');
     } else {
       logProfileRestoreStep('profile-data:cache-miss-fetch-backend-start', {
@@ -2284,7 +2292,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               backend: summarizeProfileCardForLog(data),
             });
             updateCard(activeUserId, data);
-            setState({ ...data, userId: data.userId || activeUserId });
+            const backendProfile = { ...data, userId: data.userId || activeUserId };
+            logRenderSource('backend', backendProfile);
+            setState(backendProfile);
           } else {
             logProfileRestoreStep('profile-data:backend-empty', {
               requestId,

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -190,14 +190,18 @@ const flushSaveJson = key => {
 
 const saveJson = (key, value, { debounceMs = 0 } = {}) => {
   localJsonCache.set(key, value);
+  const existingTimer = pendingSaveTimers.get(key);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
+    pendingSaveTimers.delete(key);
+  }
+
+  pendingSaveValues.set(key, value);
   if (!debounceMs) {
-    pendingSaveValues.set(key, value);
     flushSaveJson(key);
     return;
   }
-  pendingSaveValues.set(key, value);
-  const existingTimer = pendingSaveTimers.get(key);
-  if (existingTimer) clearTimeout(existingTimer);
+
   pendingSaveTimers.set(key, setTimeout(() => flushSaveJson(key), debounceMs));
 };
 
@@ -211,7 +215,8 @@ export const loadCards = () => {
   }
   return cards;
 };
-export const saveCards = cards => saveJson(CARDS_KEY, wrapVersionedCards(cards), { debounceMs: 800 });
+export const saveCards = (cards, { immediate = false } = {}) =>
+  saveJson(CARDS_KEY, wrapVersionedCards(cards), { debounceMs: immediate ? 0 : 800 });
 
 export const loadQueries = () => loadJson(QUERIES_KEY);
 export const loadIndexQueries = () => loadJson(INDEX_QUERIES_KEY);

--- a/src/utils/cardsStorage.js
+++ b/src/utils/cardsStorage.js
@@ -151,7 +151,7 @@ export const updateCard = (cardId, data, remoteSave, removeKeys = []) => {
   });
 
   cards[cardId] = updatedCard;
-  saveCards(cards);
+  saveCards(cards, { immediate: true });
   touchCardInQueries(cardId);
   if (typeof remoteSave === 'function') {
     const { lastAction, cachedAt, cacheVersion, ...toSend } = updatedCard;

--- a/src/utils/dislikesStorage.js
+++ b/src/utils/dislikesStorage.js
@@ -47,7 +47,7 @@ export const syncDislikes = remoteDislikes => {
 export const cacheDislikedUsers = usersObj => {
   const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    const merged = existing[id] ? { ...existing[id], ...data } : data;
     updateCard(id, merged);
     addCardToList(id, DISLIKE_LIST_KEY);
   });

--- a/src/utils/dplStorage.js
+++ b/src/utils/dplStorage.js
@@ -6,7 +6,7 @@ const DPL_LIST_KEY = 'dpl';
 export const cacheDplUsers = usersObj => {
   const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    const merged = existing[id] ? { ...existing[id], ...data } : data;
     updateCard(id, merged);
     addCardToList(id, DPL_LIST_KEY);
   });

--- a/src/utils/favoritesStorage.js
+++ b/src/utils/favoritesStorage.js
@@ -41,7 +41,7 @@ export const syncFavorites = remoteFavs => {
 export const cacheFavoriteUsers = usersObj => {
   const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    const merged = existing[id] ? { ...existing[id], ...data } : data;
     updateCard(id, merged);
     addCardToList(id, FAVORITE_LIST_KEY);
   });

--- a/src/utils/load2Storage.js
+++ b/src/utils/load2Storage.js
@@ -8,7 +8,7 @@ export const cacheLoad2Users = (usersObj, filters = {}) => {
   const listKey = buildLoad2Key(filters);
   const existing = loadCards();
   Object.entries(usersObj).forEach(([id, data]) => {
-    const merged = existing[id] ? { ...data, ...existing[id] } : data;
+    const merged = existing[id] ? { ...existing[id], ...data } : data;
     updateCard(id, merged);
     addCardToList(id, listKey);
   });


### PR DESCRIPTION
### Motivation

- Ensure incoming user/card data correctly overrides cached data and make card writes to localStorage more reliable and observable for debugging intermittent cache issues.
- Improve debounced save semantics to avoid lost writes and provide an option for immediate persistence when updating a single card.
- Add render/source and localStorage snapshot logging in the profile editor to help diagnose where card state is coming from.

### Description

- Added `getLocalStorageCardsDebugSnapshot` and `logRenderSource` helpers and inserted `console.log` calls around save flows and profile-hydration paths in `AddNewProfile.jsx`, and replaced a buggy `newStateWithDelivery` assignment to use `syncedState` when creating payloads for new users. 
- Replaced the server re-fetch/merge block with direct `updateCachedUser`/`cacheFetchedUsers` usage and surrounding localStorage snapshots in `AddNewProfile.jsx` to make cache updates and their effects observable.
- Improved `saveJson` in `src/utils/cardIndex.js` to clear existing debounce timers before scheduling a new one and store pending values earlier, and added an `immediate` option to `saveCards` to allow synchronous writes. 
- Made `updateCard` call `saveCards(cards, { immediate: true })` so individual card updates persist immediately. 
- Fixed merge ordering in cache helpers (`dislikesStorage`, `dplStorage`, `favoritesStorage`, `load2Storage`) to merge as `{ ...existing[id], ...data }` so incoming data overwrites existing cached fields.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23d6b35ba883269eeb5f01dbdb39a5)