### PR TITLE
Allow searchId miss to not block other explicitly selected search sources

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1645,9 +1645,17 @@ const SearchBar = ({
       })
     ) return;
 
+    const shouldContinueAfterSearchIdMiss =
+      isSearchEnabled('equalToAllCards') || isSearchEnabled('searchKey');
+
     if (
       isSearchEnabled('searchId') &&
-      await processUserSearch('searchId', parseSearchIdExact, rawQuery, { requestId })
+      await processUserSearch('searchId', parseSearchIdExact, rawQuery, {
+        // Якщо користувач випадково лишив searchId увімкненим, miss не має
+        // блокувати інші явно вибрані джерела пошуку, зокрема equalTo lastAction.
+        continueOnMiss: shouldContinueAfterSearchIdMiss,
+        requestId,
+      })
     ) return;
 
     if (isSearchEnabled('searchKey')) {


### PR DESCRIPTION
### Motivation
- Ensure that if `searchId` is enabled but yields no result, it does not prevent other explicitly selected search sources (for example `equalToAllCards` or `searchKey`) from running.

### Description
- Compute `shouldContinueAfterSearchIdMiss` from `isSearchEnabled('equalToAllCards')` or `isSearchEnabled('searchKey')` and pass it as `continueOnMiss` to `processUserSearch('searchId', ...)`, preserving existing behavior when appropriate and allowing other searches to proceed on a miss.

### Testing
- Ran the test suite with `yarn test` and linting with `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23f8bcb9cc8326ae3b700d6befec2b)