### PR TITLE
Use cached card storage for rendering and fix optimistic cache updates

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -71,6 +71,8 @@ import {
   setIdsForQuery,
   getIdsByQuery,
   getCard,
+  getCardsByIds,
+  loadCards,
   normalizeQueryKey,
   serializeQueryFilters,
 } from 'utils/cardIndex';
@@ -147,9 +149,9 @@ const onValue = wrapAdminOnValue(firebaseOnValue, {
 
 
 const getLocalStorageCardsDebugSnapshot = () => {
-  if (typeof localStorage === 'undefined') return [];
+  if (typeof localStorage === 'undefined') return {};
   try {
-    return JSON.parse(localStorage.getItem('cards') || '[]');
+    return loadCards();
   } catch (error) {
     return {
       parseError: error?.message || String(error),
@@ -1545,14 +1547,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         return;
       }
 
-      // Optimistically update local cache and UI state before syncing with server
-      setState(syncedState);
+      // Optimistically update the only full-card cache and UI state before syncing with server.
       const removeKeys = delCondition ? Object.keys(delCondition) : [];
-      updateCachedUser(syncedState, { removeKeys });
-      cacheFetchedUsers({ [syncedState.userId]: syncedState }, cacheLoad2Users, filters);
-      const gitNewCardHidden = hideFutureGitNewCardAndLoadNext(syncedState);
+      const optimisticCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
+      setState(optimisticCard);
+      cacheFetchedUsers({ [syncedState.userId]: optimisticCard }, cacheLoad2Users, filters);
+      const gitNewCardHidden = hideFutureGitNewCardAndLoadNext(optimisticCard);
       if (!gitNewCardHidden) {
-        setUsers(prev => ({ ...prev, [syncedState.userId]: syncedState }));
+        setUsers(prev => ({ ...prev, [syncedState.userId]: optimisticCard }));
       }
 
       let existingData = null;
@@ -1676,8 +1678,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       }
       console.log('[LS cards before]', getLocalStorageCardsDebugSnapshot());
-      updateCachedUser(syncedState, { removeKeys });
-      cacheFetchedUsers({ [syncedState.userId]: syncedState }, cacheLoad2Users, filters);
+      const savedCachedCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
+      cacheFetchedUsers({ [syncedState.userId]: savedCachedCard }, cacheLoad2Users, filters);
+      setState(savedCachedCard);
+      setUsers(prev => {
+        if (!prev || !Object.prototype.hasOwnProperty.call(prev, syncedState.userId)) {
+          return prev;
+        }
+        return { ...prev, [syncedState.userId]: savedCachedCard };
+      });
       console.log('[LS cards after]', getLocalStorageCardsDebugSnapshot());
     } catch (submitError) {
       const details = submitError?.message || String(submitError);
@@ -2402,8 +2411,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
   const isDateInRange = dateStr => {
-    const dates = Object.values(users)
-      .map(u => u.getInTouch)
+    const currentCardsById = loadCards();
+    const dates = Object.keys(users || {})
+      .map(id => (currentCardsById[id] || users[id])?.getInTouch)
       .filter(d => dateRegex.test(d));
     if (dates.length === 0) return true;
     dates.sort();
@@ -5185,6 +5195,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     : currentFilter !== 'FAVORITE' && currentFilter !== 'CYCLE_FAVORITE';
   const getSortedIds = () => {
     const ids = Object.keys(users);
+    const currentCardsById = loadCards();
+    const getVisibleCard = id => currentCardsById[id] || users[id] || {};
     if (isDuplicateView || currentFilter === 'CYCLE_FAVORITE') {
       return ids;
     }
@@ -5196,8 +5208,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     if (currentFilter === 'LAST_ACTION') {
       return ids.sort((a, b) => {
-        const left = normalizeLastAction(users[a]?.lastAction) || 0;
-        const right = normalizeLastAction(users[b]?.lastAction) || 0;
+        const left = normalizeLastAction(getVisibleCard(a)?.lastAction) || 0;
+        const right = normalizeLastAction(getVisibleCard(b)?.lastAction) || 0;
         return right - left;
       });
     }
@@ -5205,27 +5217,56 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const reactionSortDirection = getSearchKeyReactionSortDirection(filters?.reaction);
     if (reactionSortDirection) {
       return ids.sort((a, b) => {
-        const left = users[a]?.getInTouch || '';
-        const right = users[b]?.getInTouch || '';
+        const left = getVisibleCard(a)?.getInTouch || '';
+        const right = getVisibleCard(b)?.getInTouch || '';
         return reactionSortDirection === 'desc'
           ? right.localeCompare(left)
           : left.localeCompare(right);
       });
     }
 
-    return ids.sort((a, b) => compareUsersByGetInTouch(users[a] || {}, users[b] || {}));
+    return ids.sort((a, b) => compareUsersByGetInTouch(getVisibleCard(a), getVisibleCard(b)));
   };
 
   const sortedIds = getSortedIds();
-  const loadedPages = Math.ceil(sortedIds.length / PAGE_SIZE) || 1;
+  const {
+    cardsById: renderCardsById,
+    queryIds: sortedQueryIds,
+    visibleCards: sortedCardsFromCache,
+  } = getCardsByIds(sortedIds);
+  const filterRenderCards = cards => {
+    if (isDuplicateView) return cards;
+
+    return filterMain(
+      cards.map(card => [card.userId, card]),
+      currentFilter,
+      filters,
+      favoriteUsersData,
+      dislikeUsersData,
+      { requireCurrentOrPastGetInTouch: searchIdAndSearchKeyOnlyMode && currentFilter === 'DATE2.1' },
+    ).map(([, card]) => card);
+  };
+  const renderVisibleCards = filterRenderCards(sortedCardsFromCache);
+  const renderVisibleIds = renderVisibleCards.map(card => card.userId);
+  const loadedPages = Math.ceil(renderVisibleIds.length / PAGE_SIZE) || 1;
   const totalPages = shouldPaginate ? Math.max(loadedPages, hasMore ? currentPage + 1 : currentPage) : 1;
   const displayedUserIds = shouldPaginate
-    ? sortedIds.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
-    : sortedIds;
-  const paginatedUsers = displayedUserIds.reduce((acc, id) => {
-    acc[id] = users[id];
+    ? renderVisibleIds.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+    : renderVisibleIds;
+  const { visibleCards: paginatedVisibleCards } = getCardsByIds(displayedUserIds);
+  const paginatedUsers = paginatedVisibleCards.reduce((acc, card) => {
+    acc[card.userId] = card;
     return acc;
   }, {});
+
+  console.log('[CACHE] cards source:', renderCardsById);
+  console.log('[QUERIES] ids:', sortedQueryIds);
+  console.log('[RENDER] visible cards:', paginatedVisibleCards.map(c => ({
+    userId: c.userId,
+    getInTouch: c.getInTouch,
+    lastAction: c.lastAction,
+    cachedAt: c.cachedAt,
+  })));
 
   const handleLoadUsers = () => {
     setUsers({});

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -23,7 +23,7 @@ export const updateCachedUser = (
   user,
   { removeFavorite = false, removeKeys = [] } = {},
 ) => {
-  updateCard(user.userId, user, undefined, removeKeys);
+  const updatedCard = updateCard(user.userId, user, undefined, removeKeys);
   addCardToList(user.userId, 'load2');
   const shouldFav = isFavorite(user.userId);
 
@@ -32,4 +32,6 @@ export const updateCachedUser = (
   } else if (shouldFav) {
     addCardToList(user.userId, 'favorite');
   }
+
+  return updatedCard;
 };

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -288,8 +288,7 @@ export const normalizeQueryKey = raw => {
   return String(raw || '').toLowerCase().trim();
 };
 
-export const getCard = id => {
-  const cards = loadCards();
+const normalizeCachedCard = (cards, id) => {
   const card = cards[id];
   if (!card) return null;
   const cachedAt = toTimestamp(card.cachedAt);
@@ -298,11 +297,40 @@ export const getCard = id => {
   if (!cachedAt && lastAction) {
     const updated = { ...card, cachedAt: lastAction };
     cards[id] = updated;
-    saveCards(cards);
     return updated;
   }
   return card;
 };
+
+export const getCard = id => {
+  const cards = loadCards();
+  const card = normalizeCachedCard(cards, id);
+  if (card && card !== cards[id]) {
+    saveCards(cards);
+  }
+  return card;
+};
+
+export const getCardsByIds = ids => {
+  const cards = loadCards();
+  let changed = false;
+  const queryIds = Array.isArray(ids) ? ids.filter(Boolean).map(String) : [];
+  const visibleCards = queryIds
+    .map(id => {
+      const before = cards[id];
+      const card = normalizeCachedCard(cards, id);
+      if (card && card !== before) changed = true;
+      return card;
+    })
+    .filter(Boolean);
+
+  if (changed) {
+    saveCards(cards);
+  }
+
+  return { cardsById: cards, queryIds, visibleCards };
+};
+
 
 export const saveCard = card => {
   if (!card || !card.userId) return;
@@ -324,7 +352,8 @@ export const saveCard = card => {
       normalized !== undefined ? normalized : sanitizedCard.lastAction;
   }
   cards[card.userId] = merged;
-  saveCards(cards);
+  saveCards(cards, { immediate: true });
+  return merged;
 };
 
 export const getQueryEntry = queryKey => {


### PR DESCRIPTION
### Motivation
- Improve rendering consistency and performance by reading card data from the local matching cache instead of parsing raw localStorage snapshots. 
- Make optimistic saves update and re-use the sanitized cached card so UI and cache remain in sync after edits. 
- Add utilities to fetch multiple cached cards and normalize cached timestamps to avoid stale data being used.

### Description
- Switched debug/local snapshot reads in `AddNewProfile.jsx` to use `loadCards()` instead of parsing `localStorage` directly by changing `getLocalStorageCardsDebugSnapshot` to return `loadCards()` output. 
- Changed optimistic save flow in `AddNewProfile.jsx` to use the return value from `updateCachedUser` (now returned as `optimisticCard`) for `setState`, `cacheFetchedUsers`, `hideFutureGitNewCardAndLoadNext`, `setUsers` and final post-save cache updates. 
- Adjusted multiple render and sorting helpers in `AddNewProfile.jsx` to consult the cached cards first (`loadCards()`), introduced `getCardsByIds` usage to batch-resolve cards for rendering and pagination, and added logging for cache/query/render sources. 
- Modified `updateCachedUser` in `src/utils/cache.js` to return the sanitized/updated card from `updateCard` so callers can use the canonical cached object. 
- Added `normalizeCachedCard`, enhanced `getCard` to persist normalized timestamps when necessary, and implemented `getCardsByIds` in `src/utils/cardIndex.js` to return `{ cardsById, queryIds, visibleCards }` while saving cards when timestamps are normalized. 
- Updated `saveCard` to call `saveCards(cards, { immediate: true })` and return the merged sanitized card.

### Testing
- Ran unit tests with `yarn test` against the modified modules and they completed successfully. 
- Ran linters via `yarn lint` with no new lint errors reported. 
- Executed the app-level manual smoke check for load/save/render flows locally and observed expected behavior for optimistic saves and cached rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23f3083bd08326ae36c4ebe6e8858d)