### PR TITLE
Normalize phone spaces in contact exports

### DIFF
--- a/src/components/ExportContact.jsx
+++ b/src/components/ExportContact.jsx
@@ -6,6 +6,9 @@ const hasEmoji = value => /[\p{Extended_Pictographic}]/u.test(value);
 const hasNonAscii = value => /[^\x20-\x7E]/.test(value);
 const hasWhitespace = value => /\s/.test(value);
 
+export const normalizeContactPhoneForExport = value =>
+  String(value ?? '').replace(/\s+/g, '');
+
 const normalizeTelegramHandle = value => {
   if (!value) return '';
   const trimmed = String(value).trim();
@@ -159,7 +162,8 @@ const getContactNameMarkers = user => [
 
 const getContactName = user => {
   const prefix = getPrefix(user);
-  const phones = Array.isArray(user.phone) ? user.phone : [user.phone];
+  const phones = (Array.isArray(user.phone) ? user.phone : [user.phone])
+    .map(normalizeContactPhoneForExport);
   const firstPhone = phones.find(phone => phone);
 
   const names = Array.isArray(user.name) ? user.name : [user.name];
@@ -328,7 +332,8 @@ export const makeVCard = user => {
   safeAddLine(lines, 'VERSION:3.0');
 
   const finalName = getContactName(user);
-  const phones = Array.isArray(user.phone) ? user.phone : [user.phone];
+  const phones = (Array.isArray(user.phone) ? user.phone : [user.phone])
+    .map(normalizeContactPhoneForExport);
 
   safeAddLine(lines, `FN;CHARSET=UTF-8:${escapeTextValue(finalName)}`);
   safeAddLine(lines, `N;CHARSET=UTF-8:${escapeTextValue(finalName)};;;;`);
@@ -336,7 +341,7 @@ export const makeVCard = user => {
   // Обробка телефонів
   phones.forEach(phone => {
     if (phone) {
-      safeAddLine(lines, `TEL;TYPE=CELL:+${String(phone).trim()}`);
+      safeAddLine(lines, `TEL;TYPE=CELL:+${phone}`);
     }
   });
 
@@ -478,7 +483,8 @@ const stringifyList = list =>
     .join('; ');
 
 export const makeCsvRow = user => {
-  const phones = Array.isArray(user.phone) ? user.phone : [user.phone];
+  const phones = (Array.isArray(user.phone) ? user.phone : [user.phone])
+    .map(normalizeContactPhoneForExport);
   const emails = Array.isArray(user.email) ? user.email : [user.email];
   const addresses = Array.isArray(user.address) ? user.address : [user.address];
   const roles = Array.isArray(user.userRole) ? user.userRole : [user.userRole];

--- a/src/components/topBtns/btnJsonToExcel.js
+++ b/src/components/topBtns/btnJsonToExcel.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
+import { normalizeContactPhoneForExport } from "components/ExportContact";
 
 const JsonToExcelButton = () => {
   const [jsonData, setJsonData] = useState([]);
@@ -85,9 +86,11 @@ const JsonToExcelButton = () => {
       allKeys.forEach((key) => {
         const [field, index] = key.match(/(\D+)(\d*)/).slice(1, 3); // Розбиваємо ключ на основну частину та індекс
         if (Array.isArray(item[field])) {
-          row[key] = item[field][index - 1] || ""; // Дістаємо відповідний елемент масиву
+          const value = item[field][index - 1] || ""; // Дістаємо відповідний елемент масиву
+          row[key] = field === "phone" ? normalizeContactPhoneForExport(value) : value;
         } else {
-          row[key] = index === "1" ? item[field] || "" : ""; // Якщо є індекс > 1, залишаємо пустим
+          const value = index === "1" ? item[field] || "" : ""; // Якщо є індекс > 1, залишаємо пустим
+          row[key] = field === "phone" ? normalizeContactPhoneForExport(value) : value;
         }
       });
       return row;


### PR DESCRIPTION
### Motivation
- Забезпечити консистентність телефонних номерів при експорті в VCF/CSV/XLSX шляхом видалення пробілів перед формуванням файлів.

### Description
- Додано експортовану функцію `normalizeContactPhoneForExport` в `src/components/ExportContact.jsx`, яка прибирає всі пробільні символи з номера телефону.
- Застосовано нормалізацію телефонів у формуванні імені контакту (`getContactName`), у генерації `TEL`-рядків для vCard (`makeVCard`) та при формуванні CSV-колонки `Phone` (`makeCsvRow`) в `src/components/ExportContact.jsx`.
- Перевикористано цю функцію в XLSX JSON-експорті в `src/components/topBtns/btnJsonToExcel.js` для полів `phone` перед записом в Excel.
- Змінено лише мінімальні місця виклику для повторного використання існуючої логіки без створення нових залежностей.

### Testing
- Запущено тестовий набір для `ExportContact` за допомогою `npm test -- --watchAll=false ExportContact`, всі тести пройшли успішно.
- Запущено лінтинг `npm run lint:js -- --quiet` без критичних помилок (warnings не перешкодили виконанню).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24237c62e083268614a35da7c5ef70)