### PR TITLE
Prefer detected contact search params when raw search contains contact URLs

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -144,6 +144,53 @@ const onValue = wrapAdminOnValue(firebaseOnValue, {
   source: 'AddNewProfile',
 });
 
+const DETECTED_CONTACT_SEARCH_KEYS = new Set([
+  'instagram',
+  'ameblo',
+  'facebook',
+  'telegram',
+  'email',
+  'tiktok',
+  'linkedin',
+  'youtube',
+  'twitter',
+  'line',
+  'otherLink',
+  'phone',
+  'vk',
+  'other',
+]);
+
+const CONTACT_URL_HOST_PATTERN = new RegExp(
+  '\\b(?:instagram\\.com|ameblo\\.jp|facebook\\.com|fb\\.com|t\\.me|' +
+    'telegram\\.me|tiktok\\.com|linkedin\\.com|youtube\\.com|youtu\\.be|' +
+    'twitter\\.com|x\\.com|vk\\.com|vkontakte\\.ru)\\b',
+  'i',
+);
+
+const getSingleSearchPairKey = searchPair => {
+  if (!searchPair || typeof searchPair !== 'object') return null;
+  return Object.keys(searchPair).find(key => {
+    const value = searchPair[key];
+    if (Array.isArray(value)) return value.length > 0;
+    return value !== undefined && value !== null && String(value).trim() !== '';
+  }) || null;
+};
+
+const shouldPreferDetectedContactPair = (rawSearch, detectedSearchParams, searchKeyValuePair) => {
+  if (!detectedSearchParams?.key || !detectedSearchParams?.value) return false;
+  if (!DETECTED_CONTACT_SEARCH_KEYS.has(detectedSearchParams.key)) return false;
+
+  const trimmedRawSearch = String(rawSearch || '').trim();
+  if (!trimmedRawSearch) return false;
+
+  const hasStrongContactSignal =
+    /^https?:\/\//i.test(trimmedRawSearch) || CONTACT_URL_HOST_PATTERN.test(trimmedRawSearch);
+  if (!hasStrongContactSignal) return false;
+
+  const currentKey = getSingleSearchPairKey(searchKeyValuePair);
+  return !currentKey || currentKey === 'searchId' || currentKey !== detectedSearchParams.key;
+};
 
 const getLocalStorageCardsDebugSnapshot = () => {
   if (typeof localStorage === 'undefined') return {};
@@ -2985,7 +3032,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         : null;
 
       const normalizedSearchKeyValuePair =
-        searchKeyValuePair?.searchId && detectedSearchParams?.key && detectedSearchParams?.value
+        shouldPreferDetectedContactPair(rawSearch, detectedSearchParams, searchKeyValuePair) ||
+        (searchKeyValuePair?.searchId && detectedSearchParams?.key && detectedSearchParams?.value)
           ? { [detectedSearchParams.key]: detectedSearchParams.value }
           : searchKeyValuePair;
 


### PR DESCRIPTION
### Motivation
- Improve how a new profile is created from freeform search input by preferring detected contact-type parameters when the raw search looks like a contact URL or host.
- Avoid losing explicit contact links parsed from the search string when a weaker `searchKeyValuePair` (like `searchId`) is present.

### Description
- Added `DETECTED_CONTACT_SEARCH_KEYS` to enumerate contact-related search keys and `CONTACT_URL_HOST_PATTERN` to detect contact URL/host text.
- Implemented `getSingleSearchPairKey` to safely inspect an existing search key/value pair and `shouldPreferDetectedContactPair` to decide when to prefer detected params based on the raw search and current pair.
- Updated profile creation flow to use `shouldPreferDetectedContactPair` when computing `normalizedSearchKeyValuePair` passed to `makeNewUser`, so detected contact params are used when appropriate.

### Testing
- Ran unit tests with `yarn test` and all tests passed.  
- Ran linter with `yarn lint` with no errors.  
- Built the app with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2462f7a22c832699b9c3db72e75c89)