### PR TITLE
Improve search label emission and contact-detection fallback in SearchBar

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -144,7 +144,6 @@ const onValue = wrapAdminOnValue(firebaseOnValue, {
   source: 'AddNewProfile',
 });
 
-
 const getLocalStorageCardsDebugSnapshot = () => {
   if (typeof localStorage === 'undefined') return {};
   try {

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -394,6 +394,50 @@ const SEARCH_ID_PREFIX_KEYS = [...SEARCH_ID_INDEXED_FIELDS];
 
 const SEARCH_ID_SCOPED_PLATFORMS = new Set(SEARCH_ID_PREFIX_KEYS);
 
+const CONTACT_SEARCH_LABEL_KEYS = new Set([
+  'instagram',
+  'ameblo',
+  'facebook',
+  'telegram',
+  'email',
+  'tiktok',
+  'linkedin',
+  'youtube',
+  'twitter',
+  'line',
+  'otherLink',
+  'phone',
+  'vk',
+  'other',
+]);
+
+const WEAK_FALLBACK_SEARCH_LABEL_KEYS = new Set(['name', 'surname']);
+
+const getFirstSearchParamKey = params => {
+  if (!params || typeof params !== 'object') return null;
+  return Object.keys(params).find(key => {
+    const value = params[key];
+    if (Array.isArray(value)) return value.length > 0;
+    return value !== undefined && value !== null && String(value).trim() !== '';
+  }) || null;
+};
+
+const resolveSearchParamValue = (params, key) => {
+  if (!params || !key) return '';
+  const value = params[key];
+  return Array.isArray(value) ? String(value[0] || '').trim() : String(value || '').trim();
+};
+
+const resolveSearchLabelKey = label => label?.key || getFirstSearchParamKey(label?.params);
+
+const resolveDetectedContactParams = rawSearch => {
+  const trimmed = String(rawSearch || '').trim();
+  if (!trimmed) return null;
+
+  const detectedParams = detectSearchParams(trimmed);
+  return CONTACT_SEARCH_LABEL_KEYS.has(detectedParams?.key) ? detectedParams : null;
+};
+
 const resolveSearchIdPrefixStrategy = (input, searchOptions = {}) => {
   const configuredPrefixes = Array.isArray(searchOptions?.searchIdPrefixes)
     ? [...new Set(
@@ -762,6 +806,11 @@ const SearchBar = ({
 
 
   const repeatedSearchCollectorRef = useRef(null);
+  const lastEmittedSearchLabelRef = useRef(null);
+
+  useEffect(() => {
+    lastEmittedSearchLabelRef.current = null;
+  }, [search]);
 
   const collectSearchOutput = (output, requestId = null) => {
     const collector = repeatedSearchCollectorRef.current;
@@ -936,6 +985,21 @@ const SearchBar = ({
     // must not replace the parent add payload.
     if (repeatedSearchCollectorRef.current) return;
 
+    const nextKey = getFirstSearchParamKey(params);
+    const detectedContactParams = resolveDetectedContactParams(search);
+    const previousKey = resolveSearchLabelKey(lastEmittedSearchLabelRef.current);
+    const nextValue = resolveSearchParamValue(params, nextKey);
+    const rawSearch = String(search || '').trim();
+    const isWeakEqualToFallbackForContact =
+      meta?.mode === 'equalToAllCards' &&
+      WEAK_FALLBACK_SEARCH_LABEL_KEYS.has(nextKey) &&
+      CONTACT_SEARCH_LABEL_KEYS.has(detectedContactParams?.key) &&
+      (previousKey === 'searchId' || previousKey === detectedContactParams.key) &&
+      nextValue === rawSearch;
+
+    if (isWeakEqualToFallbackForContact) return;
+
+    lastEmittedSearchLabelRef.current = { params, key: nextKey };
     onSearchKey && onSearchKey(params);
   };
 


### PR DESCRIPTION
### Motivation
- Prevent emitting weak fallback search labels that overwrite meaningful contact-based searches when a fallback (like `name` or `surname`) is equal to the raw contact query.
- Add explicit detection and handling for contact-oriented search inputs so search-label logic can make informed decisions about when to emit labels.

### Description
- Added contact/platform sets `CONTACT_SEARCH_LABEL_KEYS` and `WEAK_FALLBACK_SEARCH_LABEL_KEYS` to classify detected search param types.
- Implemented helper utilities `getFirstSearchParamKey`, `resolveSearchParamValue`, `resolveSearchLabelKey`, and `resolveDetectedContactParams` to derive the active search param key and normalize values.
- Introduced `lastEmittedSearchLabelRef` to track the previously emitted label and updated `emitSearchLabel` to skip emitting when a weak fallback would replace a stronger contact-based label according to the new detection logic.
- Minor whitespace cleanup in `AddNewProfile.jsx`.

### Testing
- Ran the project test suite including unit tests and linting; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2462f7a22c832699b9c3db72e75c89)