### PR TITLE
Prefer detected contact params for new profiles and adjust search-label fallback logic

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2983,8 +2983,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         ? detectSearchParams(rawSearch)
         : null;
 
-      const normalizedSearchKeyValuePair =
-        searchKeyValuePair?.searchId && detectedSearchParams?.key && detectedSearchParams?.value
+      const shouldUseDetectedContactParams =
+        CONTACT_SEARCH_KEYS.includes(detectedSearchParams?.key) &&
+        detectedSearchParams?.value;
+      const normalizedSearchKeyValuePair = shouldUseDetectedContactParams
+        ? { [detectedSearchParams.key]: detectedSearchParams.value }
+        : searchKeyValuePair?.searchId && detectedSearchParams?.key && detectedSearchParams?.value
           ? { [detectedSearchParams.key]: detectedSearchParams.value }
           : searchKeyValuePair;
 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -990,14 +990,16 @@ const SearchBar = ({
     const previousKey = resolveSearchLabelKey(lastEmittedSearchLabelRef.current);
     const nextValue = resolveSearchParamValue(params, nextKey);
     const rawSearch = String(search || '').trim();
-    const isWeakEqualToFallbackForContact =
-      meta?.mode === 'equalToAllCards' &&
+    const isWeakFallbackForContact =
       WEAK_FALLBACK_SEARCH_LABEL_KEYS.has(nextKey) &&
       CONTACT_SEARCH_LABEL_KEYS.has(detectedContactParams?.key) &&
-      (previousKey === 'searchId' || previousKey === detectedContactParams.key) &&
-      nextValue === rawSearch;
+      (
+        nextValue === rawSearch ||
+        previousKey === 'searchId' ||
+        previousKey === detectedContactParams.key
+      );
 
-    if (isWeakEqualToFallbackForContact) return;
+    if (isWeakFallbackForContact) return;
 
     lastEmittedSearchLabelRef.current = { params, key: nextKey };
     onSearchKey && onSearchKey(params);


### PR DESCRIPTION
### Motivation
- Ensure when creating a new profile the detected contact search parameter (like phone/email) is preferred over stale `searchKeyValuePair` values so the created profile is initialized with the most relevant contact identifier. 
- Prevent emitting redundant/fallback search labels for contact-style searches by tightening the conditions that skip emitting a label. 

### Description
- In `AddNewProfile.jsx` prefer detected contact parameters when `detectedSearchParams.key` is in `CONTACT_SEARCH_KEYS` by setting `normalizedSearchKeyValuePair` from the detected params before falling back to the existing `searchKeyValuePair` logic. 
- In `SearchBar.jsx` rename the fallback flag to `isWeakFallbackForContact` and change the condition so contact fallback labels are suppressed when `nextKey` is in `WEAK_FALLBACK_SEARCH_LABEL_KEYS`, the detected contact key is a contact label, and either the next value equals the raw search or the previous key was `searchId` or the detected contact key. 
- Remove the `meta?.mode === 'equalToAllCards'` requirement so the fallback suppression applies in the intended contact-search scenarios. 

### Testing
- Ran the test suite with `yarn test` and the unit tests completed successfully. 
- Ran linting with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a247fcbd8d48326aab12d3c36de584b)