### PR TITLE
Add parsePartialUserIdPrefix for catalog-key partial userId searches and tests

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -323,6 +323,26 @@ const parseUserId = input => {
   return null;
 };
 
+export const parsePartialUserIdPrefix = input => {
+  const parsedUserId = parseUserId(input);
+  if (parsedUserId) return parsedUserId;
+
+  if (typeof input !== 'string') return null;
+  const candidate = input.trim();
+  if (!candidate) return null;
+
+  // RTDB keys cannot contain these characters, and the partial userId mode
+  // searches by the beginning of the users/newUsers catalog key exactly as typed.
+  if (/[.#$[\]/\s]/.test(candidate)) return null;
+
+  const normalizedPhone = candidate.replace(/[+\s()-]/g, '');
+  if (/^(?:0|380)\d{9}$/.test(normalizedPhone)) return null;
+
+  if (/^[A-Za-z0-9_-]{3,}$/.test(candidate)) return candidate;
+
+  return null;
+};
+
 const detectHttpSocialSearch = input => {
   if (typeof input !== 'string') return null;
 
@@ -1202,11 +1222,11 @@ const SearchBar = ({
   };
 
   const runPartialUserIdSearch = async (rawQuery, isStaleRequest, resultMap = {}) => {
-    const parsedUserId = parseUserId(rawQuery);
-    if (!parsedUserId) return { found: false, results: resultMap };
+    const userIdPrefix = parsePartialUserIdPrefix(rawQuery);
+    if (!userIdPrefix) return { found: false, results: resultMap };
 
     const partialResult = await cachedSearch(
-      { userId: parsedUserId },
+      { userId: userIdPrefix },
       { forcePartialUserIdSearch: true },
     );
     if (isStaleRequest()) return { found: false, results: resultMap };

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -1,0 +1,20 @@
+import { parsePartialUserIdPrefix } from './SearchBar';
+
+describe('parsePartialUserIdPrefix', () => {
+  it('allows exact-case catalog key prefixes for users/newUsers userId search', () => {
+    expect(parsePartialUserIdPrefix('IORgRD')).toBe('IORgRD');
+    expect(parsePartialUserIdPrefix('  AbC_123-XYZ  ')).toBe('AbC_123-XYZ');
+  });
+
+  it('keeps existing known userId prefixes working', () => {
+    expect(parsePartialUserIdPrefix('AA1')).toBe('AA1');
+    expect(parsePartialUserIdPrefix('-ab')).toBe('-ab');
+  });
+
+  it('does not treat phones, emails, urls, or too-short prefixes as catalog prefixes', () => {
+    expect(parsePartialUserIdPrefix('380501234567')).toBeNull();
+    expect(parsePartialUserIdPrefix('test@example.com')).toBeNull();
+    expect(parsePartialUserIdPrefix('https://example.com/id')).toBeNull();
+    expect(parsePartialUserIdPrefix('AB')).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation

- Allow the partial userId search mode to accept general catalog key prefixes (exact beginning-of-key matches) in addition to existing ID patterns while avoiding misclassification of phones, emails, URLs, or RTDB-invalid keys. 

### Description

- Add `parsePartialUserIdPrefix` exported function which validates and normalizes a candidate prefix and returns it when it should be treated as a partial catalog key prefix. 
- The parser rejects RTDB-invalid characters, phone-like numbers, empty/too-short strings, and common non-key inputs, and preserves exact-case prefixes for catalog lookup. 
- Wire `parsePartialUserIdPrefix` into the partial userId search flow by replacing the previous `parseUserId` check in `runPartialUserIdSearch`. 
- Add unit tests in `src/components/SearchBar.partialUserId.test.js` that cover allowed prefixes, legacy known-prefixes, and rejected inputs like phones, emails, URLs, and too-short prefixes. 

### Testing

- Added and ran the new Jest unit tests in `src/components/SearchBar.partialUserId.test.js`, which executed and passed. 
- Existing partial userId search behavior for known ID prefixes remains covered by the new tests and continued to succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25261d84348326805958cc1b16227e)