### PR TITLE
Restore single backend refresh button and enforce local-first snapshot guards

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1322,7 +1322,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     );
   }, [INDEX_SELECTION_STORAGE_KEY, selectedIndexJobs, selectedSearchKeyIndexes]);
 
-  const [state, setState] = useState(() => {
+  const [state, setRawState] = useState(() => {
     const params = new URLSearchParams(location.search);
     const restoredUserIdFromUrl = params.get('userId') || '';
     const restoredUserIdFromCache = localStorage.getItem(EDIT_PROFILE_USER_ID_KEY) || '';
@@ -1355,6 +1355,46 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     logProfileRestoreStep('init-state:cache-miss-placeholder', { restoredUserId });
     return { userId: restoredUserId };
   });
+  const profileSnapshotVersionRef = useRef(0);
+  const profileSaveRequestRef = useRef(0);
+  const profileFetchRequestRef = useRef(0);
+  const backendInitialLoadUserIdsRef = useRef(new Set());
+  const latestProfileSnapshotRef = useRef(state);
+  const logProfileSnapshotUpdate = useCallback((source, payload = {}) => {
+    const entry = {
+      source,
+      timestamp: new Date().toISOString(),
+      at: getProfileRestoreTimestamp(),
+      version: profileSnapshotVersionRef.current,
+      ...payload,
+    };
+    console.log('[ProfileSnapshotDebug][AddNewProfile]', entry);
+    return entry;
+  }, []);
+  const setState = useCallback((updater, debug = {}) => {
+    setRawState(prevState => {
+      const nextState = typeof updater === 'function' ? updater(prevState) : updater;
+      const prevUserId = String(prevState?.userId || '');
+      const nextUserId = String(nextState?.userId || '');
+      const changed = nextState !== prevState;
+
+      if (changed) {
+        profileSnapshotVersionRef.current += 1;
+        latestProfileSnapshotRef.current = nextState || {};
+      }
+
+      logProfileSnapshotUpdate(debug.source || 'setState', {
+        caller: debug.caller || 'AddNewProfile.setState',
+        applied: changed,
+        reason: changed ? debug.reason || 'local-snapshot-updated' : debug.reason || 'unchanged',
+        prevUserId,
+        nextUserId,
+        keysCount: nextState && typeof nextState === 'object' ? Object.keys(nextState).length : 0,
+      });
+
+      return nextState;
+    });
+  }, [logProfileSnapshotUpdate]);
   const [, setHistoryVersion] = useState(0);
   const editHistoryRef = useRef({
     userId: null,
@@ -1583,6 +1623,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const now = Date.now();
     const baseState = normalizePhoneState(newState ? { ...newState } : { ...state });
     const updatedState = { ...baseState, lastAction: now };
+    const saveRequestId = profileSaveRequestRef.current + 1;
+    profileSaveRequestRef.current = saveRequestId;
 
     const formattedLastDelivery = formatDateToServer(
       formatDateAndFormula(updatedState.lastDelivery)
@@ -1618,7 +1660,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       // Optimistically update the only full-card cache and UI state before syncing with server.
       const removeKeys = delCondition ? Object.keys(delCondition) : [];
       const optimisticCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
-      setState(optimisticCard);
+      const localSaveVersion = profileSnapshotVersionRef.current + 1;
+      setState(optimisticCard, {
+        source: 'userChange',
+        caller: 'handleSubmit:optimistic-update',
+        reason: 'optimistic-local-save-start',
+      });
+      logProfileSnapshotUpdate('saveResponse', {
+        caller: 'handleSubmit:start',
+        requestId: saveRequestId,
+        userId: syncedState.userId,
+        applied: true,
+        reason: 'background-save-started-local-is-source-of-truth',
+      });
       cacheFetchedUsers({ [syncedState.userId]: optimisticCard }, cacheLoad2Users, filters);
       const gitNewCardHidden = hideFutureGitNewCardAndLoadNext(optimisticCard);
       if (!gitNewCardHidden) {
@@ -1746,9 +1800,33 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         }
       }
       console.log('[LS cards before]', getLocalStorageCardsDebugSnapshot());
+      const currentUserId = String((latestProfileSnapshotRef.current || {}).userId || '');
+      const isStaleSaveResponse =
+        profileSaveRequestRef.current !== saveRequestId ||
+        profileSnapshotVersionRef.current !== localSaveVersion ||
+        currentUserId !== String(syncedState.userId || '');
+
+      if (isStaleSaveResponse) {
+        logProfileSnapshotUpdate('saveResponse', {
+          caller: 'handleSubmit:finish',
+          requestId: saveRequestId,
+          userId: syncedState.userId,
+          localSaveVersion,
+          currentVersion: profileSnapshotVersionRef.current,
+          currentUserId,
+          applied: false,
+          reason: 'stale-save-response-local-snapshot-is-newer',
+        });
+        return;
+      }
+
       const savedCachedCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
       cacheFetchedUsers({ [syncedState.userId]: savedCachedCard }, cacheLoad2Users, filters);
-      setState(savedCachedCard);
+      setState(savedCachedCard, {
+        source: 'saveResponse',
+        caller: 'handleSubmit:finish',
+        reason: 'background-save-confirmed-current-snapshot',
+      });
       setUsers(prev => {
         if (!prev || !Object.prototype.hasOwnProperty.call(prev, syncedState.userId)) {
           return prev;
@@ -1943,6 +2021,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   useEffect(() => {
     stateUserIdRef.current = state.userId || '';
     stateRef.current = state;
+    latestProfileSnapshotRef.current = state;
   }, [state]);
 
   const [users, setUsers] = useState({});
@@ -1970,7 +2049,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [profileSource, setProfileSource] = useState('');
   const profileSourceRef = useRef(profileSource);
   const [isResolvingEditMode, setIsResolvingEditMode] = useState(false);
-  const profileFetchRequestRef = useRef(0);
 
   const downloadLoadDebugLogs = useCallback(() => {
     const logs = loadDebugLogsRef.current || [];
@@ -2314,6 +2392,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     const requestId = profileFetchRequestRef.current + 1;
     profileFetchRequestRef.current = requestId;
+    const startedVersion = profileSnapshotVersionRef.current;
     logProfileRestoreStep('profile-data:effect-start', {
       requestId,
       userId: activeUserId,
@@ -2351,18 +2430,57 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       });
       const cachedProfile = { ...cached, userId: cached.userId || activeUserId };
       logRenderSource('cache', cachedProfile);
-      setState(cachedProfile);
+      setState(cachedProfile, {
+        source: 'localStorage',
+        caller: 'profile-data:cache-hit-hydrate-state',
+        reason: 'initial-hydration-from-local-cache',
+      });
       setProfileSource('cache');
     } else {
+      if (backendInitialLoadUserIdsRef.current.has(activeUserId)) {
+        logProfileSnapshotUpdate('backend', {
+          caller: 'profile-data:cache-miss-fetch-backend-start',
+          requestId,
+          userId: activeUserId,
+          applied: false,
+          reason: 'backend-initial-load-already-attempted',
+        });
+        setProfileSource('local');
+        return;
+      }
+      backendInitialLoadUserIdsRef.current.add(activeUserId);
       logProfileRestoreStep('profile-data:cache-miss-fetch-backend-start', {
         requestId,
         userId: activeUserId,
+        startedVersion,
       });
       setProfileSource('loading');
       (async () => {
         try {
           const data = await fetchUserById(activeUserId);
           if (data) {
+            const latestState = latestProfileSnapshotRef.current || {};
+            const latestUserId = String(latestState.userId || '').trim();
+            const isStaleResponse =
+              profileFetchRequestRef.current !== requestId ||
+              latestUserId !== activeUserId ||
+              profileSnapshotVersionRef.current !== startedVersion ||
+              Object.keys(latestState).length > 1;
+
+            if (isStaleResponse) {
+              logProfileSnapshotUpdate('backend', {
+                caller: 'profile-data:backend-hit-update-cache-and-state',
+                requestId,
+                userId: activeUserId,
+                startedVersion,
+                currentVersion: profileSnapshotVersionRef.current,
+                latestUserId,
+                applied: false,
+                reason: 'stale-backend-response-local-snapshot-is-newer',
+              });
+              return;
+            }
+
             logProfileRestoreStep('profile-data:backend-hit-update-cache-and-state', {
               requestId,
               userId: activeUserId,
@@ -2371,7 +2489,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             updateCard(activeUserId, data);
             const backendProfile = { ...data, userId: data.userId || activeUserId };
             logRenderSource('backend', backendProfile);
-            setState(backendProfile);
+            setState(backendProfile, {
+              source: 'backend',
+              caller: 'profile-data:backend-hit-update-cache-and-state',
+              reason: 'initial-hydration-from-backend',
+            });
           } else {
             logProfileRestoreStep('profile-data:backend-empty', {
               requestId,
@@ -2390,13 +2512,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             requestId,
             userId: activeUserId,
           });
-          if (profileFetchRequestRef.current === requestId) {
+          if (profileFetchRequestRef.current === requestId && profileSnapshotVersionRef.current === startedVersion) {
             setProfileSource('backend');
           }
         }
       })();
     }
-  }, [state.userId, setState]);
+  }, [logProfileSnapshotUpdate, state.userId, setState]);
 
   useEffect(() => {
     if (!state.userId) setProfileSource('');
@@ -2652,23 +2774,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const cacheKey = getCacheKey('search', normalizeQueryKey(`userId=${id}`));
       setIdsForQuery(cacheKey, [id]);
 
-      try {
-        const fresh = await fetchUserById(id);
-        if (fresh) {
-          updateCard(id, fresh);
-          setState(fresh);
-          return;
-        }
-      } catch (error) {
-        console.error('Failed to fetch profile for stimulation shortcut', error);
-      }
-
       const fallback =
         (typeof userData === 'object' && userData?.userId ? userData : null) ||
         getCard(id) ||
         { userId: id };
       saveCard(fallback);
-      setState(fallback);
+      setState(fallback, {
+        source: getCard(id) ? 'localStorage' : 'userChange',
+        caller: 'handleOpenScheduleProfile',
+        reason: 'open-profile-local-first',
+      });
     },
     [setSearch, setState],
   );
@@ -4918,7 +5033,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         window.removeEventListener('popstate', handlePopState);
       };
     }
-  }, [isDuplicateView, state.userId]);
+  }, [isDuplicateView, setState, state.userId]);
 
   const searchDuplicates = async () => {
     const { cards: cached } = await getDplCards();

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -833,7 +833,7 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
 
 export const ProfileForm = ({
   state,
-  setState,
+  setState: setExternalState,
   handleBlur,
   handleSubmit,
   handleClear,
@@ -847,6 +847,32 @@ export const ProfileForm = ({
   refreshOverlayForEditor,
   deletingFieldsRef,
 }) => {
+  const latestProfileDraftRef = useRef(state || {});
+  const profileFormVersionRef = useRef(0);
+  useEffect(() => {
+    latestProfileDraftRef.current = state || {};
+  }, [state]);
+  const setState = useCallback((updater, debug = {}) => {
+    setExternalState(prevState => {
+      const nextState = typeof updater === 'function' ? updater(prevState) : updater;
+      const changed = nextState !== prevState;
+      if (changed) {
+        profileFormVersionRef.current += 1;
+        latestProfileDraftRef.current = nextState || {};
+      }
+      console.log('[ProfileSnapshotDebug][ProfileForm]', {
+        source: debug.source || 'userChange',
+        caller: debug.caller || 'ProfileForm.setState',
+        timestamp: new Date().toISOString(),
+        at: getProfileFormRestoreTimestamp(),
+        version: profileFormVersionRef.current,
+        applied: changed,
+        reason: changed ? debug.reason || 'local-draft-updated' : debug.reason || 'unchanged',
+        userId: nextState?.userId || prevState?.userId || '',
+      });
+      return nextState;
+    });
+  }, [setExternalState]);
   const canManageAccessLevel = isAdmin;
   const textareaRef = useRef(null);
   const moreInfoRef = useRef(null);
@@ -2761,20 +2787,23 @@ ${entries.join('\n')}`;
                             }));
                           },
                           onBlur: () => {
+                            const latestDraft = latestProfileDraftRef.current || state || {};
                             console.log('[ProfileSaveDebug] ProfileForm scalar input blur', {
                               fieldName: field.name,
-                              value: state?.[field.name],
+                              value: latestDraft?.[field.name],
+                              source: 'blur',
+                              version: profileFormVersionRef.current,
                             });
 
                             if (deletingFieldsRef?.current?.has(field.name)) return;
 
-                            if (field.name === 'myComment' && !state.myComment?.trim()) {
+                            if (field.name === 'myComment' && !latestDraft.myComment?.trim()) {
                               handleDelKeyValue('myComment');
                               return;
                             }
 
                             if (field.name === 'getInTouch') {
-                              const raw = state.getInTouch;
+                              const raw = latestDraft.getInTouch;
                               const trimmed = typeof raw === 'string' ? raw.trim() : raw;
 
                               if (!trimmed) {
@@ -2784,21 +2813,25 @@ ${entries.join('\n')}`;
                             }
 
                             const needsSocialCleanup = ['facebook', 'instagram', 'twitter'].includes(field.name);
-                            const rawValue = state[field.name];
+                            const rawValue = latestDraft[field.name];
                             const normalizedValue = needsSocialCleanup && rawValue != null
                               ? inputUpdateValue(rawValue, field)
                               : rawValue;
 
                             const nextState =
                               normalizedValue === rawValue
-                                ? state
+                                ? latestDraft
                                 : {
-                                    ...state,
+                                    ...latestDraft,
                                     [field.name]: normalizedValue,
                                   };
 
                             if (normalizedValue !== rawValue) {
-                              setState(nextState);
+                              setState(nextState, {
+                                source: 'blur',
+                                caller: 'ProfileForm.scalarInput.onBlur',
+                                reason: 'normalized-latest-draft',
+                              });
                             }
 
                             submitWithNormalization(nextState, 'overwrite');

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2365,9 +2365,22 @@ const removeUndefined = obj => {
   return obj;
 };
 
-const transientUserDataKeys = ['__sourceCollection', '__photosHydrated'];
+const transientUserDataKeys = [
+  '__sourceCollection',
+  '__photosHydrated',
+  'cachedAt',
+  'cacheVersion',
+  'cashVersion',
+  'cash version',
+  'localVersion',
+  'localUpdatedAt',
+  'source',
+  '__profileSnapshotVersion',
+  '__profileSnapshotSource',
+  '__profileSnapshotUpdatedAt',
+];
 
-const stripTransientUserDataFields = (payload, { markForRealtimeDeletion = false } = {}) => {
+const stripTransientUserDataFields = payload => {
   const cleaned = removeUndefined(payload);
   if (typeof cleaned !== 'object' || cleaned === null || Array.isArray(cleaned)) {
     return cleaned;
@@ -2376,9 +2389,6 @@ const stripTransientUserDataFields = (payload, { markForRealtimeDeletion = false
   const nextPayload = { ...cleaned };
   transientUserDataKeys.forEach(key => {
     delete nextPayload[key];
-    if (markForRealtimeDeletion) {
-      nextPayload[key] = null;
-    }
   });
 
   return nextPayload;

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -52,7 +52,7 @@ export const FieldComment = ({ userData, setUsers, setState, submitOptions = {} 
           resize: 'none',
           overflow: 'hidden',
           padding: '5px',
-          paddingRight: userData.myComment ? '42px' : '26px',
+          paddingRight: userData.myComment ? '32px' : '5px',
         }}
       />
       {userData.myComment && (

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -26,6 +26,7 @@ import {
   deleteCommentByOwner,
 } from '../config';
 import { updateCard, clearCardCache } from 'utils/cardsStorage';
+import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
@@ -627,13 +628,65 @@ const TopBlock = ({
       toast.error('Режим редагування недоступний у цьому контексті');
       return;
     }
-    const authorCard = await fetchUserById(authorId);
-    if (!authorCard) {
-      toast.error('Картку автора не знайдено');
-      return;
-    }
     setSearch(authorId);
-    setState(authorCard);
+    const cachedAuthorCard = getCard(authorId);
+    setState(cachedAuthorCard || { userId: authorId }, {
+      source: cachedAuthorCard ? 'localStorage' : 'userChange',
+      caller: 'renderTopBlock.openAuthorCardForEdit',
+      reason: 'open-author-local-first',
+    });
+  };
+
+  const refreshCardFromBackend = async () => {
+    let fresh = null;
+    let toastFn = toast.error;
+    let toastMsg = 'Не вдалося завантажити дані';
+    try {
+      fresh = await fetchUserById(cardData.userId);
+      if (fresh) {
+        clearCardCache(cardData.userId);
+        updateCard(cardData.userId, fresh);
+        const backendCard = { ...fresh, userId: cardData.userId };
+
+        if (setUsers) {
+          setUsers(prev => {
+            if (Array.isArray(prev)) {
+              return prev.map(u => (u.userId === cardData.userId ? backendCard : u));
+            }
+            if (typeof prev === 'object' && prev !== null) {
+              return { ...prev, [cardData.userId]: backendCard };
+            }
+            return prev;
+          });
+        }
+
+        if (setState && !isFromListOfUsers) {
+          setState(backendCard, {
+            source: 'backend',
+            caller: 'renderTopBlock.detailsRefreshButton',
+            reason: 'manual-backend-refresh',
+          });
+        }
+
+        console.log('[ProfileSnapshotDebug][renderTopBlock]', {
+          source: 'backend',
+          caller: 'details-refresh-button',
+          userId: cardData.userId,
+          fieldsCount: Object.keys(backendCard).length,
+          applied: true,
+          timestamp: new Date().toISOString(),
+        });
+        toastFn = toast.success;
+        toastMsg = `Дані завантажено з бекенду (${Object.keys(backendCard).length} полів)`;
+      } else {
+        toastMsg = 'Свіжі дані відсутні';
+      }
+    } catch (error) {
+      console.error(error);
+      toastMsg = error.message || 'Не вдалося завантажити дані';
+    } finally {
+      toastFn(toastMsg);
+    }
   };
 
   const cardRole = cardData.role || cardData.userRole;
@@ -839,7 +892,12 @@ const TopBlock = ({
       </div>
       <div style={commentsSectionStyle}>
         {fieldWriter(cardData, setUsers, setState, submitOptions)}
-        <FieldComment userData={cardData} setUsers={setUsers} setState={setState} submitOptions={submitOptions} />
+        <FieldComment
+          userData={cardData}
+          setUsers={setUsers}
+          setState={setState}
+          submitOptions={submitOptions}
+        />
         {multiDataComments.map(comment => (
           <div key={comment.commentId || `${comment.authorId}-${comment.text}`} style={multiCommentRowStyle}>
             <button
@@ -968,60 +1026,21 @@ const TopBlock = ({
         onClick={async e => {
           e.stopPropagation();
           const details = document.getElementById(cardData.userId);
-          const toggleDetails = () => {
+          const showDetails = () => {
             if (details) {
-              const isHidden = details.style.display === 'none';
-              details.style.display = isHidden ? 'block' : 'none';
-              details.style.marginTop = isHidden ? '8px' : '0';
-              if (isHidden) {
-                const bg = getParentBackground(details);
-                details.style.color = getContrastColor(bg);
-              }
+              details.style.display = 'block';
+              details.style.marginTop = '8px';
+              const bg = getParentBackground(details);
+              details.style.color = getContrastColor(bg);
             }
           };
 
-          toggleDetails();
-
-          let fresh = null;
-          let toastFn = toast.error;
-          let toastMsg = 'Не вдалося завантажити дані';
-          try {
-            fresh = await fetchUserById(cardData.userId);
-            if (fresh) {
-              clearCardCache(cardData.userId);
-              const updated = updateCard(cardData.userId, fresh);
-
-              if (setUsers) {
-                setUsers(prev => {
-                  if (Array.isArray(prev)) {
-                    return prev.map(u => (u.userId === cardData.userId ? updated : u));
-                  }
-                  if (typeof prev === 'object' && prev !== null) {
-                    return { ...prev, [cardData.userId]: updated };
-                  }
-                  return prev;
-                });
-              }
-
-              if (setState && !isFromListOfUsers) {
-                setState(prev => ({ ...prev, ...updated }));
-              }
-
-              toastFn = toast.success;
-              toastMsg = 'Дані завантажено з бекенду';
-            } else {
-              toastMsg = 'Свіжі дані відсутні';
-            }
-          } catch (error) {
-            console.error(error);
-            toastMsg = error.message || 'Не вдалося завантажити дані';
-          } finally {
-            toastFn(toastMsg);
-          }
+          showDetails();
+          await refreshCardFromBackend();
         }}
         style={detailsToggleStyle}
-        title="Оновити дані з бекенду"
-        aria-label="Оновити дані з бекенду"
+        title="Оновити дані з бекенду та показати всі поля"
+        aria-label="Оновити дані з бекенду та показати всі поля"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <path d="M4 12a8 8 0 0 1 14.93-4H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />


### PR DESCRIPTION
### Motivation
- Ensure there is a single manual backend refresh control (the ↻ on the small-card details) and remove the duplicate ↻ inside `myComment` so manual refresh behavior is unambiguous. 
- Make local state + Local Storage the single source of truth and protect against stale backend/save responses that can overwrite newer local edits. 
- Ensure backend payloads never include cache/debug keys (e.g. `cachedAt`, `cacheVersion`, `cashVersion`) when writing to the server.

### Description
- UI: removed the `↻` refresh button from `FieldComment` and restored the details `↻` in `renderTopBlock` as the single manual backend refresh action which opens the details panel, fetches the full backend snapshot and applies it to UI state while also writing into the cache via `updateCard` (local-first render of backend fields). 
- Staleness guards in `AddNewProfile`: added `profileSnapshotVersionRef`, `profileFetchRequestRef`, `profileSaveRequestRef`, `latestProfileSnapshotRef` and wrapped `setState` to attach debug metadata and increment snapshot version on local updates; backend initial-load and save responses are checked against requestId, active userId and snapshot version before applying to avoid stale overwrites. 
- Profile form robustness: added `latestProfileDraftRef`, form-level `setState` wrapper and a version counter to ensure `onBlur` / normalization use the latest draft (avoid stale closure values) and to consolidate deletions like `myComment` into the same local snapshot/save. 
- Persistence sanitization: expanded `stripTransientUserDataFields` to remove transient/cache/debug keys (`cachedAt`, `cacheVersion`, `cashVersion`, `cash version`, `localVersion`, `localUpdatedAt`, etc.) so cache metadata never goes to backend. 

### Testing
- Ran unit tests: `npm test -- --watchAll=false --runInBand src/components/profileLayoutConfig.test.js` — passed. 
- Ran linter: `npm run lint:js` — passed (no blocking errors). 
- Built production bundle: `npm run build` — succeeded and produced a deployable build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2538822bc48326a7f45606ce26e492)