### PR TITLE
Refactor renderTopBlock to accept config object

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -5935,22 +5935,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         {isResolvingEditMode ? null : state.userId ? (
           <>
             <div style={{ ...coloredCard(), marginBottom: '8px' }}>
-              {renderTopBlock(
-                state,
+              {renderTopBlock({
+                userData: state,
                 setUsers,
                 setShowInfoModal,
                 setState,
                 setUserIdToDelete,
-                false,
-                favoriteUsersData,
-                setFavoriteUsersData,
-                dislikeUsersData,
-                setDislikeUsersData,
+                isFromListOfUsers: false,
+                favoriteUsers: favoriteUsersData,
+                setFavoriteUsers: setFavoriteUsersData,
+                dislikeUsers: dislikeUsersData,
+                setDislikeUsers: setDislikeUsersData,
                 currentFilter,
                 isDateInRange,
-                openMedicationsModal,
-                null,
-                {
+                onOpenMedications: openMedicationsModal,
+                topBlueAction: {
                   onClick: handleBackToPreviousList,
                   title: 'Назад до попереднього списку',
                   ariaLabel: 'Назад до попереднього списку',
@@ -5973,10 +5972,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     </svg>
                   ),
                 },
-                null,
-                {},
-                handleTopBlockSubmitHistorySnapshot,
-              )}
+                overlayFieldAdditions: {},
+                onSubmitHistorySnapshot: handleTopBlockSubmitHistorySnapshot,
+              })}
             </div>
             {shouldShowSchedule && state && (
               <div style={{ ...coloredCard(), marginBottom: '8px' }}>

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -846,25 +846,15 @@ const EditProfile = () => {
         <TopBlockSkeleton />
       ) : (
         <div style={{ ...coloredCard(), marginBottom: '8px' }}>
-          {renderTopBlock(
-            state,
-            () => {},
-            () => {},
+          {renderTopBlock({
+            userData: state,
+            setUsers: () => {},
+            setShowInfoModal: () => {},
             setState,
-            () => {},
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            handleOpenMedications,
-            undefined,
-            null,
-            null,
+            setUserIdToDelete: () => {},
+            onOpenMedications: handleOpenMedications,
             overlayFieldAdditions,
-          )}
+          })}
         </div>
       )}
       {shouldShowSchedule && state && (

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -37,13 +37,13 @@ const UserCard = ({
   return (
     <div>
       <div style={{ ...coloredCard(role), marginBottom: '8px' }}>
-        {renderTopBlock(
+        {renderTopBlock({
           userData,
           setUsers,
           setShowInfoModal,
           setState,
           setUserIdToDelete,
-          true,
+          isFromListOfUsers: true,
           favoriteUsers,
           setFavoriteUsers,
           dislikeUsers,
@@ -52,9 +52,8 @@ const UserCard = ({
           isDateInRange,
           onOpenMedications,
           setSearch,
-          null,
-          actions
-        )}
+          additionalActions: actions,
+        })}
       </div>
       {shouldShowSchedule && (
         <div style={{ ...coloredCard(role), marginBottom: '8px' }}>

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1051,7 +1051,7 @@ const TopBlock = ({
   );
 };
 
-export const renderTopBlock = (
+export const renderTopBlock = ({
   userData,
   setUsers,
   setShowInfoModal,
@@ -1069,8 +1069,8 @@ export const renderTopBlock = (
   topBlueAction = null,
   additionalActions = null,
   overlayFieldAdditions = {},
-  onSubmitHistorySnapshot = null
-) => (
+  onSubmitHistorySnapshot = null,
+}) => (
   <TopBlock
     userData={userData}
     setUsers={setUsers}


### PR DESCRIPTION
### Motivation
- Replace the fragile positional argument API of `renderTopBlock` with a single destructured config object to make call sites clearer and less error-prone.
- Allow callers to pass only the named values they need while preserving existing defaults and behavior.
- Keep existing `TopBlock` prop forwarding intact so the refactor is non-invasive to runtime behavior.

### Description
- Changed the export signature in `src/components/smallCard/renderTopBlock.js` to `export const renderTopBlock = ({ userData, setUsers, setShowInfoModal, setState, setUserIdToDelete, isFromListOfUsers, favoriteUsers = {}, setFavoriteUsers, dislikeUsers = {}, setDislikeUsers = () => {}, currentFilter, isDateInRange, onOpenMedications, setSearch = null, topBlueAction = null, additionalActions = null, overlayFieldAdditions = {}, onSubmitHistorySnapshot = null, }) =>` and preserved the same default values.
- Updated call sites to pass a single named-object argument in `src/components/EditProfile.jsx`, `src/components/AddNewProfile.jsx`, and `src/components/UsersList.jsx` so each call constructs the same set of named props as before.
- Left the `<TopBlock ... />` body unchanged and forwarded the destructured values exactly as previously passed positionally.
- Did not introduce extra helper functions; the existing code paths and behaviors were reused.

### Testing
- Ran `npm run lint:js` which completed (warnings about `browserslist` were emitted but lint succeeded).
- Verified there are no remaining positional calls by running `rg -n -U "renderTopBlock\\(\\s*[^\\{]" src` and getting no matches.
- Changes were committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25488cdae88326b3f6a8bdad8943c0)