### PR TITLE
Prefer newUsers over users when merging RTDB collections and update related tests

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -4555,8 +4555,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         userId,
         {
           userId,
-          ...newUserRaw,
           ...(usersData[userId] || {}),
+          ...newUserRaw,
         },
       ];
     });

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -1,32 +1,69 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('fetchUsersByIds merging', () => {
-  it('keeps newUsers fields and source marker ahead of users records', () => {
-    const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+describe('newUsers merge priority', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+  const addNewProfileSource = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
+
+  it('fetchUsersByIds reads both collections by default and lets newUsers override users fields', () => {
     const fetchUsersByIdsBody = source.slice(
       source.indexOf('export const fetchUsersByIds'),
       source.indexOf('const addUserFromUsers')
     );
 
-    expect(fetchUsersByIdsBody.indexOf('...(hasUser ? userSnap.val() : {})'))
-      .toBeLessThan(fetchUsersByIdsBody.indexOf('...(hasNewUser ? newSnap.val() : {})'));
+    expect(fetchUsersByIdsBody).toContain("const readSources = source ? [source] : ['users', 'newUsers'];");
+    expect(fetchUsersByIdsBody.indexOf('...(hasUser ? dataBySource.users : {})'))
+      .toBeLessThan(fetchUsersByIdsBody.indexOf('...(hasNewUser ? dataBySource.newUsers : {})'));
     expect(fetchUsersByIdsBody).toContain("__sourceCollection: hasNewUser ? 'newUsers' : 'users'");
   });
 
-  it('marks fetchUserById records with their backing collection', () => {
-    const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+  it('addUserFromUsers lets newUsers override users fields in search results', () => {
+    const addUserFromUsersBody = source.slice(
+      source.indexOf('const addUserFromUsers'),
+      source.indexOf('const searchBySearchIdUsers')
+    );
 
+    expect(addUserFromUsersBody.indexOf('...userData'))
+      .toBeLessThan(addUserFromUsersBody.indexOf('...newUserData'));
+  });
+
+  it('bulk merged RTDB exports let newUsers override users fields', () => {
+    const fetchAllFilteredUsersBody = source.slice(
+      source.indexOf('export const fetchAllFilteredUsers'),
+      source.indexOf('export const fetchAllUsersFromRTDB')
+    );
+    const fetchAllUsersFromRTDBBody = source.slice(
+      source.indexOf('export const fetchAllUsersFromRTDB'),
+      source.indexOf('export const getAllUsersWithGetInTouch')
+    );
+
+    expect(fetchAllFilteredUsersBody.indexOf('...(usersData[userId] || {})'))
+      .toBeLessThan(fetchAllFilteredUsersBody.indexOf('...newUserRaw'));
+    expect(fetchAllUsersFromRTDBBody.indexOf('...(usersData[userId] || {})'))
+      .toBeLessThan(fetchAllUsersFromRTDBBody.indexOf('...newUserRaw'));
+  });
+
+
+  it('local export collection merge lets newUsers override users fields', () => {
+    const localExportMergeBody = addNewProfileSource.slice(
+      addNewProfileSource.indexOf('const getMergedUsersFromLocalExportCollections'),
+      addNewProfileSource.indexOf('const hasPhoneStartingWith38')
+    );
+
+    expect(localExportMergeBody.indexOf('...(usersData[userId] || {})'))
+      .toBeLessThan(localExportMergeBody.indexOf('...newUserRaw'));
+  });
+
+  it('marks fetchUserById records with their backing collection', () => {
     expect(source).toContain("__sourceCollection: 'newUsers'");
     expect(source).toContain("__sourceCollection: 'users'");
   });
 
   it('strips client-only source markers before database writes', () => {
-    const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
-
-    expect(source).toContain("const transientUserDataKeys = ['__sourceCollection', '__photosHydrated']");
+    expect(source).toContain('const transientUserDataKeys = [');
+    expect(source).toContain("'__sourceCollection'");
+    expect(source).toContain("'__photosHydrated'");
     expect(source).toContain('const cleanedUploadedInfo = stripTransientUserDataFields(uploadedInfo);');
     expect(source.match(/markForRealtimeDeletion: condition === 'update'/g)).toHaveLength(2);
   });
-
 });

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1511,7 +1511,9 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
 
     uniqueIds.forEach(id => {
       const cached = getCard(id);
-      if (cached && (!source || cached.__sourceCollection === source)) {
+      if (cached && source && cached.__sourceCollection === source) {
+        result[id] = cached;
+      } else if (cached && !source && cached.__sourceCollection === 'newUsers') {
         result[id] = cached;
       } else {
         missingIds.push(id);
@@ -1520,21 +1522,28 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
 
     const snaps = await Promise.all(
       missingIds.map(id => {
-        const readSources = source
-          ? [source]
-          : (String(id || '').length < 20 ? ['newUsers'] : ['users']);
+        const readSources = source ? [source] : ['users', 'newUsers'];
         return Promise.all(
           readSources.map(sourceName => get(ref2(database, `${sourceName}/${id}`)).then(snapshot => [sourceName, snapshot]))
         ).then(entries => {
-          const foundEntry = entries.find(([, snapshot]) => snapshot.exists());
-          if (!foundEntry) return null;
-          const [sourceName, snapshot] = foundEntry;
+          const dataBySource = Object.fromEntries(
+            entries
+              .filter(([, snapshot]) => snapshot.exists())
+              .map(([sourceName, snapshot]) => [
+                sourceName,
+                snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {},
+              ])
+          );
+          const hasUser = Object.prototype.hasOwnProperty.call(dataBySource, 'users');
+          const hasNewUser = Object.prototype.hasOwnProperty.call(dataBySource, 'newUsers');
+          if (!hasUser && !hasNewUser) return null;
           const data = {
             userId: id,
-            ...(snapshot.val() && typeof snapshot.val() === 'object' ? snapshot.val() : {}),
+            ...(hasUser ? dataBySource.users : {}),
+            ...(hasNewUser ? dataBySource.newUsers : {}),
             photos: [],
             __photosHydrated: false,
-            __sourceCollection: sourceName,
+            __sourceCollection: hasNewUser ? 'newUsers' : 'users',
           };
           return [id, updateCard(id, data)];
         });
@@ -1565,8 +1574,8 @@ const addUserFromUsers = async (userId, users) => {
   if (userSnap.exists() || newUserSnap.exists()) {
     users[userId] = {
       userId,
-      ...newUserData,
       ...userData,
+      ...newUserData,
     };
   }
 };
@@ -6917,8 +6926,8 @@ export const fetchAllFilteredUsers = async (
         userId,
         {
           userId,
-          ...newUserRaw,
           ...(usersData[userId] || {}),
+          ...newUserRaw,
         },
       ];
     });
@@ -6958,8 +6967,8 @@ export const fetchAllUsersFromRTDB = async () => {
         userId,
         {
           userId,
-          ...newUserRaw,
           ...(usersData[userId] || {}),
+          ...newUserRaw,
         },
       ];
     });


### PR DESCRIPTION
### Motivation
- Ensure the "newUsers" collection consistently takes precedence over "users" when reading or merging records from the realtime database and local export collections.
- Unify read/merge behavior to avoid surprising field ordering and to correctly mark the backing collection on loaded records.

### Description
- Update `fetchUsersByIds` to always read both `users` and `newUsers` (unless a specific collection is requested), merge `users` then `newUsers` so `newUsers` fields override, and set `__sourceCollection` to `'newUsers'` when present; also normalize snapshot values into `dataBySource` and adjust cache handling for explicit `collectionSource`.
- Change `addUserFromUsers`, `fetchAllFilteredUsers`, and `fetchAllUsersFromRTDB` merges to apply `users` first and then `newUsers` so `newUsers` wins on field conflicts.
- Fix `getMergedUsersFromLocalExportCollections` in `AddNewProfile.jsx` to merge local export `users` and `newUsers` with the same override order (newUsers overriding users).
- Update unit tests in `config.fetchUsersByIds.test.js` to reflect the new read/merge order, add tests covering bulk RTDB exports and local export merge behavior, and relax/adjust assertions around transient keys.

### Testing
- Ran the updated unit tests in `src/components/config.fetchUsersByIds.test.js` under the Jest test suite and they completed successfully.
- Executed the repository test suite (`yarn test` / `npm test`) and observed no failing tests after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25486dd7708326a13ee7812d2a1a7f)