### PR TITLE
Merge paginated user cards with current React state

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -5516,8 +5516,22 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     ? renderVisibleIds.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
     : renderVisibleIds;
   const { visibleCards: paginatedVisibleCards } = getCardsByIds(displayedUserIds);
-  const paginatedUsers = paginatedVisibleCards.reduce((acc, card) => {
+  const cachedPaginatedUsers = paginatedVisibleCards.reduce((acc, card) => {
     acc[card.userId] = card;
+    return acc;
+  }, {});
+  const paginatedUsers = displayedUserIds.reduce((acc, id) => {
+    const cachedCard = cachedPaginatedUsers[id];
+    const currentUser = users[id];
+    const mergedCard = currentUser
+      ? {
+        ...(cachedCard || {}),
+        ...currentUser,
+        userId: currentUser.userId || cachedCard?.userId || id,
+      }
+      : cachedCard;
+
+    if (mergedCard) acc[id] = mergedCard;
     return acc;
   }, {});
 


### PR DESCRIPTION
### Motivation
- Ensure UI components (e.g. `FieldComment`) receive immediate updates from the React `users` state (like `myComment`) without requiring backend submit or duplicating logic in the component.

### Description
- Replace previous `paginatedUsers` construction to first build a `cachedPaginatedUsers` map from `getCardsByIds(displayedUserIds)` and then iterate `displayedUserIds` to produce `paginatedUsers` by merging `cachedCard` with `users[id]` where present so the live `users` state takes precedence.
- Preserve cached card fields as the base and ensure `userId` fallback is respected (`userId: currentUser.userId || cachedCard?.userId || id`).
- Change implemented in `src/components/AddNewProfile.jsx` around the `getCardsByIds(displayedUserIds)` usage.

### Testing
- Ran `npm run lint:js -- src/components/AddNewProfile.jsx` and the linter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a256bbd36fc8326916f94f98ab523d9)