### PR TITLE
Support userRole-based matching access and persist userRole in localStorage

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -53,22 +53,26 @@ export const App = () => {
       if (user) {
         localStorage.setItem('ownerId', user.uid);
         let accessLevel = '';
+        let userRole = '';
         try {
           const profile = await fetchUserById(user.uid);
           accessLevel = profile?.accessLevel || '';
+          userRole = profile?.userRole || profile?.role || '';
         } catch (error) {
-          console.error('Failed to load accessLevel for routes', error);
+          console.error('Failed to load access profile for routes', error);
         }
 
-        const access = resolveAccess({ uid: user.uid, accessLevel });
+        const access = resolveAccess({ uid: user.uid, accessLevel, userRole });
         setIsAdmin(access.isAdmin);
         setCanAccessAdd(access.canAccessAdd);
         setCanAccessMatching(access.canAccessMatching);
         localStorage.setItem('accessLevel', accessLevel);
+        localStorage.setItem('userRole', userRole);
         setIsAccessResolved(true);
       } else {
         localStorage.removeItem('ownerId');
         localStorage.removeItem('accessLevel');
+        localStorage.removeItem('userRole');
         setIsAdmin(false);
         setCanAccessAdd(false);
         setCanAccessMatching(false);

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1327,6 +1327,7 @@ const Matching = () => {
   const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
   const [multiDataOwnerIds, setMultiDataOwnerIds] = useState([]);
   const [currentAccessLevel, setCurrentAccessLevel] = useState(() => localStorage.getItem('accessLevel') || '');
+  const [currentUserRole, setCurrentUserRole] = useState(() => localStorage.getItem('userRole') || '');
   const [currentAdditionalAccessRules, setCurrentAdditionalAccessRules] = useState(
     () => localStorage.getItem('additionalAccessRules') || ''
   );
@@ -1338,7 +1339,11 @@ const Matching = () => {
   const [additionalNextOffset, setAdditionalNextOffset] = useState(0);
   const [photoCacheByUserId, setPhotoCacheByUserId] = useState({});
   const [roleIndexSets] = useState(null);
-  const access = resolveAccess({ uid: auth.currentUser?.uid, accessLevel: currentAccessLevel });
+  const access = resolveAccess({
+    uid: auth.currentUser?.uid,
+    accessLevel: currentAccessLevel,
+    userRole: currentUserRole,
+  });
   const isAdmin = access.isAdmin;
   const isIndexedDebugTestUser = String(auth.currentUser?.uid || ownerId || '').trim() === MATCHING_LOG_MODE_TEST_USER_ID;
   const parsedAdditionalAccessRules = useMemo(
@@ -1754,6 +1759,7 @@ const Matching = () => {
 
       const profile = fetchedProfile;
       const accessLevel = profile?.accessLevel || '';
+      const userRole = profile?.userRole || profile?.role || '';
       const additionalAccessRules = profile?.additionalAccessRules || '';
       const searchKeySetsOfExactUser = await resolveAdditionalSearchKeySetKeysForMatching(profile, normalizedAccessUserId);
 
@@ -1804,6 +1810,7 @@ const Matching = () => {
         currentSearchKeySetKeys: searchKeySetsOfExactUser,
       };
       setCurrentAccessLevel(prev => (prev === accessLevel ? prev : accessLevel));
+      setCurrentUserRole(prev => (prev === userRole ? prev : userRole));
       setCurrentAdditionalAccessRules(prev => (prev === additionalAccessRules ? prev : additionalAccessRules));
       setCurrentSearchKeySetKeys(prev => (
         getSearchKeySetsOfExactUserSignature(prev) === getSearchKeySetsOfExactUserSignature(searchKeySetsOfExactUser)
@@ -1811,6 +1818,7 @@ const Matching = () => {
           : searchKeySetsOfExactUser
       ));
       localStorage.setItem('accessLevel', accessLevel);
+      localStorage.setItem('userRole', userRole);
       localStorage.setItem('additionalAccessRules', additionalAccessRules);
       localStorage.setItem('additionalSearchKeySetKeys', searchKeySetsOfExactUser.join(','));
       setMultiDataOwnerIds(resolveMatchingMultiDataOwnerIds({ viewerId: normalizedAccessUserId, profile }));
@@ -1947,15 +1955,18 @@ const Matching = () => {
           try {
             const profile = await fetchUserById(user.uid);
             const accessLevel = profile?.accessLevel || '';
+            const userRole = profile?.userRole || profile?.role || '';
             const additionalAccessRules = profile?.additionalAccessRules || '';
             const searchKeySetKeys = await resolveAdditionalSearchKeySetKeysForMatching(profile, user.uid);
 
             console.info('[Matching][additionalNewUsers] resolvedSearchKeySetKeys', searchKeySetKeys);
 
             setCurrentAccessLevel(accessLevel);
+            setCurrentUserRole(userRole);
             setCurrentAdditionalAccessRules(additionalAccessRules);
             setCurrentSearchKeySetKeys(searchKeySetKeys);
             localStorage.setItem('accessLevel', accessLevel);
+            localStorage.setItem('userRole', userRole);
             localStorage.setItem('additionalAccessRules', additionalAccessRules);
             localStorage.setItem('additionalSearchKeySetKeys', searchKeySetKeys.join(','));
             const rawMultiDataAccessUserIds = profile?.[MULTI_DATA_ACCESS_FIELD];
@@ -1981,6 +1992,7 @@ const Matching = () => {
           } catch (error) {
             console.error('Failed to refresh access profile on Matching', error);
             const cachedAccessLevel = localStorage.getItem('accessLevel') || '';
+            const cachedUserRole = localStorage.getItem('userRole') || '';
             const cachedAdditionalAccessRules = localStorage.getItem('additionalAccessRules') || '';
             const cachedSearchKeySetKeys = normalizeSearchKeySetKeys(localStorage.getItem('additionalSearchKeySetKeys') || '');
             const fallbackSearchKeySetKeys = areSearchKeySetKeysForAccessUserId(cachedSearchKeySetKeys, user.uid)
@@ -1988,6 +2000,7 @@ const Matching = () => {
               : await resolveAdditionalSearchKeySetKeysForMatching(null, user.uid);
             console.info('[Matching][additionalNewUsers] resolvedSearchKeySetsOfExactUser', fallbackSearchKeySetKeys);
             setCurrentAccessLevel(cachedAccessLevel);
+            setCurrentUserRole(cachedUserRole);
             setCurrentAdditionalAccessRules(cachedAdditionalAccessRules);
             setCurrentSearchKeySetKeys(fallbackSearchKeySetKeys);
           }
@@ -1997,6 +2010,7 @@ const Matching = () => {
       } else {
         localStorage.removeItem('ownerId');
         localStorage.removeItem('accessLevel');
+        localStorage.removeItem('userRole');
         localStorage.removeItem('additionalAccessRules');
         localStorage.removeItem('additionalSearchKeySetKeys');
         setOwnerId('');
@@ -2009,6 +2023,7 @@ const Matching = () => {
         setSharedReactionCandidateUsers([]);
         setSharedComments({});
         setCurrentAccessLevel('');
+        setCurrentUserRole('');
         setCurrentAdditionalAccessRules('');
         setCurrentSearchKeySetKeys([]);
         resetAdditionalMatchingState({ resetHasMore: true, resetLoading: true });

--- a/src/utils/accessLevel.js
+++ b/src/utils/accessLevel.js
@@ -9,6 +9,13 @@ const normalize = level =>
     .replace(/_/g, '')
     .replace(/&/g, 'and');
 
+export const normalizeRole = role => String(role || '').trim().toLowerCase();
+
+export const isNonEdRole = role => {
+  const normalizedRole = normalizeRole(role);
+  return Boolean(normalizedRole) && normalizedRole !== 'ed';
+};
+
 const parseAccessLevel = accessLevel => {
   const level = normalize(accessLevel);
   if (!level) {
@@ -26,14 +33,16 @@ export const canAccessMatchingByLevel = accessLevel => {
   return hasMatching;
 };
 
+export const canAccessMatchingByRole = ({ role, userRole } = {}) => isNonEdRole(userRole || role);
+
 export const canAccessAddByLevel = accessLevel => {
   const { hasAdd } = parseAccessLevel(accessLevel);
   return hasAdd;
 };
 
-export const resolveAccess = ({ uid, accessLevel }) => {
+export const resolveAccess = ({ uid, accessLevel, role, userRole } = {}) => {
   const isAdmin = isAdminUid(uid);
-  const canAccessMatching = isAdmin || canAccessMatchingByLevel(accessLevel);
+  const canAccessMatching = isAdmin || canAccessMatchingByLevel(accessLevel) || canAccessMatchingByRole({ role, userRole });
   const canAccessAdd = isAdmin || canAccessAddByLevel(accessLevel);
 
   return {

--- a/src/utils/accessLevel.test.js
+++ b/src/utils/accessLevel.test.js
@@ -1,0 +1,40 @@
+import {
+  ADMIN_UIDS,
+  canAccessMatchingByRole,
+  resolveAccess,
+} from './accessLevel';
+
+describe('accessLevel', () => {
+  it('grants matching access to non-ed roles', () => {
+    expect(canAccessMatchingByRole({ userRole: 'ag' })).toBe(true);
+    expect(canAccessMatchingByRole({ userRole: ' ip ' })).toBe(true);
+    expect(canAccessMatchingByRole({ role: 'sm' })).toBe(true);
+  });
+
+  it('does not grant automatic matching access to ed or empty roles', () => {
+    expect(canAccessMatchingByRole({ userRole: 'ed' })).toBe(false);
+    expect(canAccessMatchingByRole({ userRole: ' ED ' })).toBe(false);
+    expect(canAccessMatchingByRole({ userRole: '' })).toBe(false);
+  });
+
+  it('keeps explicit matching accessLevel access for ed users', () => {
+    expect(resolveAccess({ uid: 'viewer', accessLevel: '', userRole: 'ed' }).canAccessMatching).toBe(false);
+    expect(resolveAccess({ uid: 'viewer', accessLevel: 'matching', userRole: 'ed' }).canAccessMatching).toBe(true);
+  });
+
+  it('keeps admin access independent of role', () => {
+    expect(resolveAccess({ uid: ADMIN_UIDS[0], accessLevel: '', userRole: 'ed' })).toEqual({
+      isAdmin: true,
+      canAccessMatching: true,
+      canAccessAdd: true,
+    });
+  });
+
+  it('does not grant add access from role-only matching access', () => {
+    expect(resolveAccess({ uid: 'viewer', accessLevel: '', userRole: 'ag' })).toEqual({
+      isAdmin: false,
+      canAccessMatching: true,
+      canAccessAdd: false,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Enable additional access control based on a user's `userRole` in addition to `accessLevel` and admin UIDs. 
- Ensure `userRole` is fetched, used to compute access, and persisted across sessions for the matching and add routes. 
- Surface role-based matching rules so non-ED roles can be granted matching access without modifying `accessLevel` strings.

### Description
- Added `userRole` handling across the app: `App.jsx` now reads `userRole` from the fetched profile, passes it into `resolveAccess`, and stores/removes `userRole` in `localStorage` on sign-in/sign-out. 
- `Matching.jsx` now tracks `currentUserRole`, persists it to `localStorage`, updates it when profiles are refetched, and uses it when calling `resolveAccess`. 
- `accessLevel.js` was extended with `normalizeRole`, `isNonEdRole`, and `canAccessMatchingByRole`, and `resolveAccess` now accepts `userRole`/`role` and grants matching when appropriate; `canAccessAdd` remains driven by `accessLevel`. 
- Added unit tests in `src/utils/accessLevel.test.js` covering role-based matching logic, admin overrides, and that `add` access is not granted by role-only matching access.

### Testing
- Ran the new unit tests in `src/utils/accessLevel.test.js` which exercise `canAccessMatchingByRole` and `resolveAccess`, and they passed. 
- Verified no regressions in access resolution logic by running the existing access-level-related tests locally and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e62964cc832690605c0a2ff58967)