### PR TITLE
Спрощення текстів на екрані входу

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -72,14 +72,6 @@ const WelcomeAccent = styled.span`
   color: var(--accent);
 `;
 
-const IntroText = styled.p`
-  margin: 8px auto 0;
-  max-width: 320px;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.45;
-`;
-
 const InputDiv = styled.div`
   display: flex;
   align-items: center;
@@ -244,12 +236,6 @@ const RoleName = styled.span`
   color: var(--text);
   font-size: 14px;
   font-weight: 800;
-`;
-
-const RoleHint = styled.span`
-  color: var(--muted);
-  font-size: 11px;
-  line-height: 1.35;
 `;
 
 const TermsButton = styled.button`
@@ -492,7 +478,6 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
         <LoginCard>
           <BrandBlock>
             <WelcomeText>KnowMe<WelcomeAccent>.</WelcomeAccent></WelcomeText>
-            <IntroText>Загальний вхід для донорів, агентств і команди. Оберіть роль — ми відкриємо відповідний формат анкети.</IntroText>
           </BrandBlock>
 
           <InputDiv $active={focused === 'email' || Boolean(state.email)}>
@@ -532,14 +517,12 @@ export const LoginScreen = ({ isLoggedIn, setIsLoggedIn }) => {
                 <RoleRadio type="radio" name="userRole" value="ed" checked={selectedRole === 'ed'} onChange={e => setSelectedRole(e.target.value)} />
                 <RoleText>
                   <RoleName>Я донор яйцеклітин</RoleName>
-                  <RoleHint>Перейти до нової анкети з полегшеним сценарієм заповнення.</RoleHint>
                 </RoleText>
               </RoleOption>
               <RoleOption $selected={selectedRole === 'ag'}>
                 <RoleRadio type="radio" name="userRole" value="ag" checked={selectedRole === 'ag'} onChange={e => setSelectedRole(e.target.value)} />
                 <RoleText>
                   <RoleName>Ми агентство і шукаємо ДО</RoleName>
-                  <RoleHint>Зберегти роль агентства та працювати з доступним набором полів.</RoleHint>
                 </RoleText>
               </RoleOption>
             </RoleGrid>


### PR DESCRIPTION
### Motivation
- Прибрати зайві пояснення з екрану входу щоб зробити інтерфейс компактнішим і підготувати загальний вхід для донорів, агентств і команди.

### Description
- Видалено компонент стилів `IntroText` та його рендер у блоці бренду, залишивши тільки назву KnowMe.
- Видалено компонент стилів `RoleHint` та текстові підказки під варіантами ролей донор/агентство, зберігши саму UI-логіку вибору ролі.
- Очистка коду для цих компонентів, без зміни поведінки аутентифікації чи навігації.

### Testing
- Запущено `npm run lint:js` і перевірка ESLint пройшла успішно.
- Зібрано проект командою `npm run build`, збірка пройшла успішно.
- Спроба запустити тести Jest для `LoginScreen` через `npm test -- --watchAll=false --runTestsByPath src/components/LoginScreen.jsx` повернула `No tests found`, оскільки для цього файлу немає unit-тестів.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a294cc074608326986e5b24dfa9d6f9)