### PR TITLE
Update profile menu visibility

### DIFF
--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -160,15 +160,15 @@ export const ProfileDotsMenu = ({
   };
 
   const navItems = [
-    { path: '/my-profile-new', label: 'Нова анкета', description: 'Сучасний профіль і редагування', icon: <FaUserEdit /> },
-    { path: '/my-profile', label: 'Мій профіль', description: 'Класичний екран анкети', icon: <FaRegUser /> },
+    { path: '/my-profile-new', label: 'Нова анкета', icon: <FaUserEdit /> },
+    ...(isAdmin ? [{ path: '/my-profile', label: 'Мій профіль', icon: <FaRegUser /> }] : []),
     ...(canSeePrivilegedNav && (isAdmin || resolvedAccess.canAccessAdd)
       ? [{ path: '/add', label: 'Додати анкету', description: 'Адмін-додавання профілів', icon: <MdPersonAddAlt1 /> }]
       : []),
     ...(canSeePrivilegedNav && (isAdmin || resolvedAccess.canAccessMatching)
       ? [{ path: '/matching', label: 'Matching', description: 'Пошук і порівняння анкет', icon: <FaUsers /> }]
       : []),
-    ...(isAdmin ? [{ path: '/flow', label: 'Flow', description: 'Адмін-сценарії комунікацій', icon: <FaProjectDiagram /> }] : []),
+    ...(isAdmin ? [{ path: '/flow', label: 'Flow', icon: <FaProjectDiagram /> }] : []),
   ];
 
   return (
@@ -193,7 +193,7 @@ export const ProfileDotsMenu = ({
               <ItemIcon>{item.icon}</ItemIcon>
               <span>
                 <ItemLabel>{item.label}</ItemLabel>
-                <ItemDescription>{item.description}</ItemDescription>
+                {item.description ? <ItemDescription>{item.description}</ItemDescription> : null}
               </span>
               {active ? <ActivePill>зараз</ActivePill> : null}
             </MenuItem>


### PR DESCRIPTION
### Motivation
- Simplify the profile menu by removing explanatory subtitles for the New profile and Flow entries and restrict the classic My Profile entry to admins only.

### Description
- Remove `description` for `/my-profile-new` and `/flow` and make the `/my-profile` nav item conditional on `isAdmin` in `src/components/ProfileDotsMenu.jsx`.
- Render `ItemDescription` only when `item.description` is present to avoid empty description lines.

### Testing
- Ran `npm run build` which completed successfully, and `npm run lint:js -- src/components/ProfileDotsMenu.jsx` which finished with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29606474b083269727d0fa7733f1f0)