### PR TITLE
Fix EditProfile payload filtering and search index sync

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -160,6 +160,11 @@ const applyDeletedKeysToSnapshot = (snapshot, deletedKeys = []) => {
   return nextSnapshot;
 };
 
+const filterObjectByAllowedKeys = (source, isAllowedKey) =>
+  Object.fromEntries(
+    Object.entries(source || {}).filter(([key]) => isAllowedKey(key))
+  );
+
 const prepareSyncedSnapshot = (snapshot, deletedKeys = []) => {
   const cleaned = applyDeletedKeysToSnapshot(snapshot, deletedKeys);
   delete cleaned.cacheVersion;
@@ -448,15 +453,13 @@ const EditProfile = () => {
     const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
     const ppTechnicalInputFields = ['name', 'surname', ...contacts];
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
+    const isMainProfileField = key => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key);
 
     if (updatedState?.userId?.length > 20) {
-      const existingData = await fetchUserById(updatedState.userId) || {};
+      const fetchedExistingData = await fetchUserById(updatedState.userId);
+      const existingData = fetchedExistingData || lastSyncedSnapshotRef.current || {};
 
-      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, deletedKeys);
-
-      const cleanedState = Object.fromEntries(
-        Object.entries(updatedState).filter(([key]) => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key))
-      );
+      const cleanedState = filterObjectByAllowedKeys(updatedState, isMainProfileField);
       delete cleanedState.cacheVersion;
       if (delCondition) {
         Object.keys(delCondition).forEach(key => {
@@ -477,11 +480,14 @@ const EditProfile = () => {
         },
       });
 
-      const sanitizedExistingData = applyDeletedKeysToSnapshot(existingData, deletedKeys);
+      const mainProfileExistingData = filterObjectByAllowedKeys(existingData, isMainProfileField);
+      const sanitizedExistingData = applyDeletedKeysToSnapshot(mainProfileExistingData, deletedKeys);
       const uploadedInfo = applyDeletedKeysToPayload(
         makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite),
         deletedKeys
       );
+
+      await syncUserSearchIdIndex(updatedState.userId, existingData, uploadedInfo, deletedKeys);
 
       debugProfileSave('remoteUpdate:payload-before-backend', {
         delCondition,
@@ -515,9 +521,10 @@ const EditProfile = () => {
 
       await updateDataInNewUsersRTDB(updatedState.userId, cleanedStateForNewUsers, 'update', true);
     } else if (updatedState?.userId) {
-      const existingData = await fetchUserById(updatedState.userId) || {};
-      await syncUserSearchIdIndex(updatedState.userId, existingData, updatedState, deletedKeys);
+      const fetchedExistingData = await fetchUserById(updatedState.userId);
+      const existingData = fetchedExistingData || lastSyncedSnapshotRef.current || {};
       const payloadForNewUsers = applyDeletedKeysToPayload({ ...updatedState }, deletedKeys);
+      await syncUserSearchIdIndex(updatedState.userId, existingData, payloadForNewUsers, deletedKeys);
       await updateDataInNewUsersRTDB(updatedState.userId, payloadForNewUsers, 'update', true);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent `newUsers`-only fields (e.g. `role`, `lastCycle`, `myComment`, `writer`) from being accidentally reintroduced into main `users` payloads during long-ID admin saves. 
- Ensure search index updates compare the correct baseline and final payload so preserved/merged values are handled consistently. 
- Avoid treating a transient `fetchUserById` read failure as an empty baseline which can leave stale index entries. 

### Description
- Added a small helper `filterObjectByAllowedKeys` and used it to restrict objects to the main-profile field set before merging. 
- When saving long-ID profiles, filter `existingData` to the main-profile fields before calling `makeUploadedInfo`, and pass that sanitized snapshot to the merge logic so `newUsers`-only keys are not reintroduced. 
- Call `syncUserSearchIdIndex` against the final `uploadedInfo` payload (the actual data saved) for long-ID saves, and also use `lastSyncedSnapshotRef.current` as a fallback baseline when `fetchUserById` returns null. 
- Applied the same `fetchUserById` fallback and index-sync-against-final-payload behavior to the short-ID/newUsers save path. 

### Testing
- Ran `npx eslint src/components/EditProfile.jsx` which completed without fatal lint errors. 
- Ran `npm run build` which produced a successful production build. 
- Ran the test suite with `npm test -- --watchAll=false --runInBand`, which returned `37` total suites with `28` passing and `9` failing; the failing suites are unrelated (matching/cache/storage areas) and the `EditProfile.jsx` changes did not introduce new test failures in the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a44dffaa48326b57be7e747fc7b0c)