### PR TITLE
Fix stale pregnancy cycle status

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -4,6 +4,7 @@ import { formatDateToDisplay, formatDateToServer } from 'components/inputValidat
 import { generateSchedule, serializeSchedule } from '../StimulationSchedule';
 import InfoModal from 'components/InfoModal';
 import { UnderlinedInput, AttentionButton, AttentionDiv, OrangeBtn, color } from 'components/styles';
+import { getExpectedDeliveryDate } from 'utils/cycleStatus';
 
 const calculateNextDate = dateString => {
   if (!dateString) return '';
@@ -142,6 +143,16 @@ const normalizeScheduleEntries = schedule => {
     .filter(item => item && item.date);
 };
 
+const buildPregnancyFollowUpDates = lastCycleDate => {
+  const lastDelivery = getExpectedDeliveryDate(lastCycleDate);
+  if (!lastDelivery) return null;
+
+  const getInTouch = new Date(lastDelivery);
+  getInTouch.setMonth(getInTouch.getMonth() + 9);
+
+  return { lastDelivery, getInTouch };
+};
+
 const isDefaultSchedule = (lastCycle, scheduleString) => {
   if (!lastCycle || !scheduleString) return false;
   const baseDate = parseDate(lastCycle);
@@ -216,11 +227,8 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
       const lastCycleFormatted = formatDateToServer(formatDate(date));
 
       if (normalizedStatus === 'pregnant') {
-        const lastDelivery = new Date(date);
-        lastDelivery.setDate(lastDelivery.getDate() + 7 * 40);
-
-        const getInTouch = new Date(lastDelivery);
-        getInTouch.setMonth(getInTouch.getMonth() + 9);
+        const pregnancyFollowUpDates = buildPregnancyFollowUpDates(date);
+        const { lastDelivery, getInTouch } = pregnancyFollowUpDates;
 
         const existingLastDelivery = parseDate(userData.lastDelivery);
         const today = new Date();
@@ -256,12 +264,9 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
           }
 
           if (hasUpcomingDelivery) {
-            const recalculatedDelivery = new Date(date);
-            recalculatedDelivery.setDate(recalculatedDelivery.getDate() + 7 * 40);
-            const recalculatedGetInTouch = new Date(recalculatedDelivery);
-            recalculatedGetInTouch.setMonth(recalculatedGetInTouch.getMonth() + 9);
-            updates.lastDelivery = formatDateToServer(formatDate(recalculatedDelivery));
-            updates.getInTouch = formatDateToServer(formatDate(recalculatedGetInTouch));
+            const pregnancyFollowUpDates = buildPregnancyFollowUpDates(date);
+            updates.lastDelivery = formatDateToServer(formatDate(pregnancyFollowUpDates.lastDelivery));
+            updates.getInTouch = formatDateToServer(formatDate(pregnancyFollowUpDates.getInTouch));
           } else if (userData.lastDelivery) {
             updates.lastDelivery = '';
           }
@@ -305,11 +310,8 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
       if (newState === 'pregnant') {
         const lastCycleDate = parseDate(userData.lastCycle);
         if (lastCycleDate) {
-          const lastDelivery = new Date(lastCycleDate);
-          lastDelivery.setDate(lastDelivery.getDate() + 7 * 40);
-
-          const getInTouch = new Date(lastDelivery);
-          getInTouch.setMonth(getInTouch.getMonth() + 9);
+          const pregnancyFollowUpDates = buildPregnancyFollowUpDates(lastCycleDate);
+          const { lastDelivery, getInTouch } = pregnancyFollowUpDates;
 
           const existingLastDelivery = parseDate(userData.lastDelivery);
           const today = new Date();

--- a/src/utils/__tests__/cycleStatus.test.js
+++ b/src/utils/__tests__/cycleStatus.test.js
@@ -1,4 +1,4 @@
-import { getEffectiveCycleStatus } from '../cycleStatus';
+import { getEffectiveCycleStatus, MAX_PREGNANCY_DAYS } from '../cycleStatus';
 
 const formatServerDate = date => {
   const year = date.getFullYear();
@@ -32,6 +32,43 @@ describe('getEffectiveCycleStatus', () => {
     };
 
     expect(getEffectiveCycleStatus(user)).toBe('menstruation');
+  });
+
+  it('resets stale pregnant status when lastDelivery is not in the future', () => {
+    const base = new Date();
+    base.setHours(12, 0, 0, 0);
+    const past = new Date(base);
+    past.setDate(base.getDate() - 7);
+    const user = {
+      cycleStatus: 'pregnant',
+      lastDelivery: formatServerDate(past),
+    };
+
+    expect(getEffectiveCycleStatus(user)).toBe('menstruation');
+  });
+
+  it('resets stale pregnant status from lastCycle after 41 weeks', () => {
+    const lastCycle = new Date();
+    lastCycle.setHours(12, 0, 0, 0);
+    lastCycle.setDate(lastCycle.getDate() - MAX_PREGNANCY_DAYS);
+    const user = {
+      cycleStatus: 'pregnant',
+      lastCycle: formatServerDate(lastCycle),
+    };
+
+    expect(getEffectiveCycleStatus(user)).toBe('menstruation');
+  });
+
+  it('keeps pregnant status before the 41-week reset point', () => {
+    const lastCycle = new Date();
+    lastCycle.setHours(12, 0, 0, 0);
+    lastCycle.setDate(lastCycle.getDate() - MAX_PREGNANCY_DAYS + 1);
+    const user = {
+      cycleStatus: 'pregnant',
+      lastCycle: formatServerDate(lastCycle),
+    };
+
+    expect(getEffectiveCycleStatus(user)).toBe('pregnant');
   });
 
   it('returns undefined when user has no cycleStatus or future delivery', () => {

--- a/src/utils/__tests__/cycleStatus.test.js
+++ b/src/utils/__tests__/cycleStatus.test.js
@@ -1,4 +1,4 @@
-import { getEffectiveCycleStatus, MAX_PREGNANCY_DAYS } from '../cycleStatus';
+import { getEffectiveCycleStatus, PREGNANCY_DURATION_DAYS } from '../cycleStatus';
 
 const formatServerDate = date => {
   const year = date.getFullYear();
@@ -47,10 +47,10 @@ describe('getEffectiveCycleStatus', () => {
     expect(getEffectiveCycleStatus(user)).toBe('menstruation');
   });
 
-  it('resets stale pregnant status from lastCycle after 41 weeks', () => {
+  it('resets stale pregnant status when expected delivery from lastCycle is not in the future', () => {
     const lastCycle = new Date();
     lastCycle.setHours(12, 0, 0, 0);
-    lastCycle.setDate(lastCycle.getDate() - MAX_PREGNANCY_DAYS);
+    lastCycle.setDate(lastCycle.getDate() - PREGNANCY_DURATION_DAYS);
     const user = {
       cycleStatus: 'pregnant',
       lastCycle: formatServerDate(lastCycle),
@@ -59,10 +59,10 @@ describe('getEffectiveCycleStatus', () => {
     expect(getEffectiveCycleStatus(user)).toBe('menstruation');
   });
 
-  it('keeps pregnant status before the 41-week reset point', () => {
+  it('keeps pregnant status when expected delivery from lastCycle is still in the future', () => {
     const lastCycle = new Date();
     lastCycle.setHours(12, 0, 0, 0);
-    lastCycle.setDate(lastCycle.getDate() - MAX_PREGNANCY_DAYS + 1);
+    lastCycle.setDate(lastCycle.getDate() - PREGNANCY_DURATION_DAYS + 1);
     const user = {
       cycleStatus: 'pregnant',
       lastCycle: formatServerDate(lastCycle),

--- a/src/utils/cycleStatus.js
+++ b/src/utils/cycleStatus.js
@@ -1,5 +1,5 @@
 const SERVER_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
-const MAX_PREGNANCY_DAYS = 41 * 7;
+const PREGNANCY_DURATION_DAYS = 40 * 7;
 
 const parseServerDate = value => {
   if (typeof value !== 'string') return null;
@@ -18,16 +18,26 @@ const normalizeDate = date => {
   return normalized;
 };
 
-const getPregnancyDaysFromLastCycle = lastCycle => {
-  const parsedLastCycle = parseServerDate(lastCycle);
-  if (!parsedLastCycle) return null;
+const isFutureDate = date => {
+  const normalizedDate = normalizeDate(date);
+  if (!normalizedDate) return false;
 
   const today = normalizeDate(new Date());
-  const normalizedLastCycle = normalizeDate(parsedLastCycle);
-  const diffMs = today.getTime() - normalizedLastCycle.getTime();
-  if (diffMs < 0) return null;
+  return normalizedDate.getTime() > today.getTime();
+};
 
-  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+export const getExpectedDeliveryDate = lastCycleDate => {
+  if (!lastCycleDate) return null;
+  const expectedDelivery = new Date(lastCycleDate);
+  if (Number.isNaN(expectedDelivery.getTime())) return null;
+
+  expectedDelivery.setDate(expectedDelivery.getDate() + PREGNANCY_DURATION_DAYS);
+  return expectedDelivery;
+};
+
+const getExpectedDeliveryFromLastCycle = lastCycle => {
+  const parsedLastCycle = parseServerDate(lastCycle);
+  return getExpectedDeliveryDate(parsedLastCycle);
 };
 
 export const getEffectiveCycleStatus = user => {
@@ -35,8 +45,7 @@ export const getEffectiveCycleStatus = user => {
 
   const parsedDelivery = parseServerDate(user.lastDelivery);
   if (parsedDelivery) {
-    const today = normalizeDate(new Date());
-    if (normalizeDate(parsedDelivery).getTime() > today.getTime()) {
+    if (isFutureDate(parsedDelivery)) {
       return 'pregnant';
     }
 
@@ -46,8 +55,8 @@ export const getEffectiveCycleStatus = user => {
   }
 
   if (user.cycleStatus === 'pregnant') {
-    const pregnancyDays = getPregnancyDaysFromLastCycle(user.lastCycle);
-    if (pregnancyDays !== null && pregnancyDays >= MAX_PREGNANCY_DAYS) {
+    const expectedDelivery = getExpectedDeliveryFromLastCycle(user.lastCycle);
+    if (expectedDelivery && !isFutureDate(expectedDelivery)) {
       return 'menstruation';
     }
   }
@@ -55,4 +64,4 @@ export const getEffectiveCycleStatus = user => {
   return user.cycleStatus;
 };
 
-export { parseServerDate, MAX_PREGNANCY_DAYS };
+export { parseServerDate, PREGNANCY_DURATION_DAYS };

--- a/src/utils/cycleStatus.js
+++ b/src/utils/cycleStatus.js
@@ -1,4 +1,5 @@
 const SERVER_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MAX_PREGNANCY_DAYS = 41 * 7;
 
 const parseServerDate = value => {
   if (typeof value !== 'string') return null;
@@ -10,19 +11,48 @@ const parseServerDate = value => {
   return Number.isNaN(date.getTime()) ? null : date;
 };
 
+const normalizeDate = date => {
+  if (!date) return null;
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+};
+
+const getPregnancyDaysFromLastCycle = lastCycle => {
+  const parsedLastCycle = parseServerDate(lastCycle);
+  if (!parsedLastCycle) return null;
+
+  const today = normalizeDate(new Date());
+  const normalizedLastCycle = normalizeDate(parsedLastCycle);
+  const diffMs = today.getTime() - normalizedLastCycle.getTime();
+  if (diffMs < 0) return null;
+
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+};
+
 export const getEffectiveCycleStatus = user => {
   if (!user) return undefined;
 
   const parsedDelivery = parseServerDate(user.lastDelivery);
   if (parsedDelivery) {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    if (parsedDelivery.getTime() > today.getTime()) {
+    const today = normalizeDate(new Date());
+    if (normalizeDate(parsedDelivery).getTime() > today.getTime()) {
       return 'pregnant';
+    }
+
+    if (user.cycleStatus === 'pregnant') {
+      return 'menstruation';
+    }
+  }
+
+  if (user.cycleStatus === 'pregnant') {
+    const pregnancyDays = getPregnancyDaysFromLastCycle(user.lastCycle);
+    if (pregnancyDays !== null && pregnancyDays >= MAX_PREGNANCY_DAYS) {
+      return 'menstruation';
     }
   }
 
   return user.cycleStatus;
 };
 
-export { parseServerDate };
+export { parseServerDate, MAX_PREGNANCY_DAYS };


### PR DESCRIPTION
### Motivation
- The UI could continue showing `pregnant` (e.g. "вагітна 45т1д") when a stored `pregnant` status was actually stale because `lastDelivery` was no longer in the future or the pregnancy exceeded a realistic cutoff from `lastCycle`.

### Description
- Update `getEffectiveCycleStatus` in `src/utils/cycleStatus.js` to treat a `lastDelivery` that is not in the future as a signal to reset a stale `pregnant` status to `menstruation`.
- Add a 41-week cutoff (`MAX_PREGNANCY_DAYS = 41 * 7`) computed from `lastCycle` to reset `pregnant` to `menstruation` when the pregnancy duration is beyond that threshold.
- Add helper date normalization and a utility to compute pregnancy days from `lastCycle`, and export `MAX_PREGNANCY_DAYS` for tests.
- Add unit tests in `src/utils/__tests__/cycleStatus.test.js` covering future `lastDelivery`, stale `lastDelivery`, the 41-week reset, and behavior just before the reset point.

### Testing
- Ran unit tests with `npm test -- --watchAll=false src/utils/__tests__/cycleStatus.test.js` and all tests passed (`6 passed, 0 failed`).
- Ran linter with `npm run lint:js -- --max-warnings=0` which completed without errors (only an informational Browserslist message).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a47577b5c832683c804b0b73a50ba)