### PR TITLE
Refine matching index filters: exclude implicit 'no' buckets, add point-bucket groups and tests

### DIFF
--- a/src/utils/__tests__/matchingDataProvider.indexCache.test.js
+++ b/src/utils/__tests__/matchingDataProvider.indexCache.test.js
@@ -17,6 +17,80 @@ const makeSnapshot = (value = null) => ({
 
 const loadModule = () => require('../matchingDataProvider');
 
+
+describe('buildMatchingIndexFilterGroups bucket selection', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('uses selected non-no point buckets when no is unchecked', () => {
+    const { buildMatchingIndexFilterGroups } = loadModule();
+
+    const groups = buildMatchingIndexFilterGroups({
+      filters: {
+        csection: {
+          cs2plus: true,
+          cs1: true,
+          cs0: true,
+          other: true,
+          no: false,
+        },
+      },
+      collectionSource: 'newUsers',
+    });
+
+    expect(groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        indexName: 'csection',
+        values: ['cs2plus', 'cs1', 'cs0', 'other'],
+        selectedValues: ['cs2plus', 'cs1', 'cs0', 'other'],
+        allSelected: false,
+        groupActive: true,
+      }),
+    ]));
+    expect(groups.find(group => group.indexName === 'csection')?.values).not.toContain('no');
+  });
+
+
+  it('does not include implicit no from other-like buckets when explicit no is unchecked', () => {
+    const { buildMatchingIndexFilterGroups } = loadModule();
+
+    const groups = buildMatchingIndexFilterGroups({
+      filters: {
+        role: { ed: true, sm: true, ag: true, ip: true, pp: true, cl: true, other: true, empty: false },
+        maritalStatus: { married: true, unmarried: true, other: true, empty: false },
+        bloodGroup: { 1: true, 2: true, 3: true, 4: true, other: true, empty: false },
+        rh: { '+': true, '-': true, other: true, empty: false },
+      },
+      collectionSource: 'newUsers',
+    });
+
+    expect(groups.find(group => group.indexName === 'role')?.values).not.toContain('no');
+    expect(groups.find(group => group.indexName === 'maritalStatus')?.values).not.toContain('no');
+    expect(groups.find(group => group.indexName === 'blood')?.values).not.toContain('no');
+  });
+
+  it('keeps derived imt filters out of additional newUsers searchKeySets', () => {
+    const { buildMatchingIndexFilterGroups } = loadModule();
+
+    const groups = buildMatchingIndexFilterGroups({
+      filters: {
+        imt: {
+          le28: true,
+          '29_31': true,
+          '32_35': true,
+          '36_plus': true,
+          other: true,
+          no: false,
+        },
+      },
+      collectionSource: 'newUsers',
+    });
+
+    expect(groups.some(group => group.indexName === 'imt')).toBe(false);
+  });
+});
+
 describe('fetchMatchingIndexedCandidates index-id cache', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -45,8 +119,8 @@ describe('fetchMatchingIndexedCandidates index-id cache', () => {
 
     expect(mockFirebaseGet).toHaveBeenCalledTimes(1);
     expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/role/ag');
-    expect(first.userIds).toEqual(['user00000000000000000001', 'user00000000000000000002']);
-    expect(second.userIds).toEqual(['user00000000000000000003']);
+    expect(first.pageIds).toEqual(['user00000000000000000001', 'user00000000000000000002']);
+    expect(second.pageIds).toEqual(['user00000000000000000003']);
   });
 
   it('rereads bucket after matching index TTL expires', async () => {
@@ -70,8 +144,8 @@ describe('fetchMatchingIndexedCandidates index-id cache', () => {
     const base = await fetchMatchingIndexedCandidates({ filters, limit: 5, hydrateUsersByIds });
 
     expect(mockFirebaseGet).toHaveBeenCalledTimes(1);
-    expect(excluded.userIds).toEqual(['user00000000000000000002', 'user00000000000000000003']);
-    expect(base.userIds).toEqual(['user00000000000000000001', 'user00000000000000000002', 'user00000000000000000003']);
+    expect(excluded.pageIds).toEqual(['user00000000000000000002', 'user00000000000000000003']);
+    expect(base.pageIds).toEqual(['user00000000000000000001', 'user00000000000000000002', 'user00000000000000000003']);
   });
 });
 

--- a/src/utils/__tests__/newUsersFilterSetsIndex.test.js
+++ b/src/utils/__tests__/newUsersFilterSetsIndex.test.js
@@ -80,4 +80,38 @@ describe('getIndexedNewUsersIdsByRules searchKeySets access scope', () => {
     expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/age');
     expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, expect.stringContaining('/age/d_'));
   });
+
+  it('does not read no bucket when point filter sends selected non-no buckets', async () => {
+    const { getIndexedNewUsersIdsByRules } = loadModule();
+
+    mockFirebaseGet.mockImplementation(path => {
+      const buckets = {
+        'searchKeySets/owner-1_1/role/ed': { U1: true, U2: true, U3: true, U4: true, U5: true },
+        'searchKeySets/owner-1_1/csection/cs2plus': { U1: true },
+        'searchKeySets/owner-1_1/csection/cs1': { U2: true },
+        'searchKeySets/owner-1_1/csection/cs0': { U3: true },
+        'searchKeySets/owner-1_1/csection/other': { U4: true },
+        'searchKeySets/owner-1_1/csection/no': { U5: true },
+      };
+      return Promise.resolve(makeSnapshot(Object.prototype.hasOwnProperty.call(buckets, path), buckets[path]));
+    });
+
+    const result = await getIndexedNewUsersIdsByRules({
+      rawRules: 'role: ed',
+      accessUserId: 'owner-1',
+      searchKeySetKeys: ['owner-1_1'],
+      additionalFilterBucketGroups: [{
+        indexName: 'csection',
+        values: ['cs2plus', 'cs1', 'cs0', 'other'],
+        selectedValues: ['cs2plus', 'cs1', 'cs0', 'other'],
+        allSelected: false,
+        groupActive: true,
+      }],
+    });
+
+    expect(result.userIds).toEqual(['U1', 'U2', 'U3', 'U4']);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/csection/cs2plus');
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/csection/no');
+  });
+
 });

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -9,6 +9,11 @@ export const MATCHING_USERS_INDEX_ROOT = `${MATCHING_INDEX_ROOT}/users`;
 
 const BLOOD_BUCKETS = ['1+', '1-', '1', '2+', '2-', '2', '3+', '3-', '3', '4+', '4-', '4', '?', 'no'];
 const ROLE_BUCKETS = ['ed', 'sm', 'ag', 'ip', 'pp', 'cl', '?', 'no'];
+const CSECTION_BUCKETS = ['cs2plus', 'cs1', 'cs0', 'other', 'no'];
+const IMT_BUCKETS = ['le28', '29_31', '32_35', '36_plus', '?', 'no'];
+const CONTACT_BUCKETS = ['vk', 'instagram', 'ameblo', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email', 'twitter', 'line', 'otherLink'];
+const USER_ID_BUCKETS = ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'];
+const FIELD_COUNT_BUCKETS = ['le5', 'f6_10', 'f11_20', 'f20_plus'];
 const AGE_BUCKETS_BY_MATCHING_KEY = {
   le21: ['le21'],
   le25: ['le21', '22_25'],
@@ -38,6 +43,12 @@ const selectedFilterKeys = group => {
     .map(([key]) => key);
 };
 
+const hasFilterOption = (group, option) =>
+  Boolean(group && typeof group === 'object' && Object.prototype.hasOwnProperty.call(group, option));
+
+const shouldIncludeNoBucket = (group, noOption = 'empty') =>
+  !hasFilterOption(group, noOption) || Boolean(group?.[noOption]);
+
 const getFilterGroupDebugState = (groupName, group) => {
   const normalizedGroup = group && typeof group === 'object' ? group : {};
   const entries = Object.entries(normalizedGroup);
@@ -53,6 +64,9 @@ const getFilterGroupDebugState = (groupName, group) => {
 };
 
 const unique = values => [...new Set((values || []).filter(Boolean))];
+
+const mapSelectedFilterBuckets = (group, bucketMap = {}) =>
+  selectedFilterKeys(group).map(key => bucketMap[key] || key);
 
 const addGroup = (groups, indexName, values, debug = {}) => {
   const normalizedValues = unique(values.map(value => String(value || '').trim()).filter(Boolean));
@@ -77,7 +91,8 @@ const buildRoleBuckets = (filters, collectionSource) => {
   if (selected.includes('cl')) buckets.push('cl');
   if (selected.includes('empty')) buckets.push('no');
   if (selected.includes('other')) {
-    buckets.push('?', 'no');
+    buckets.push('?');
+    if (shouldIncludeNoBucket(filters?.userRole || filters?.role, 'empty')) buckets.push('no');
     ROLE_BUCKETS.forEach(bucket => {
       if (!['ed', 'ag', 'ip', 'no'].includes(bucket)) buckets.push(bucket);
     });
@@ -85,7 +100,11 @@ const buildRoleBuckets = (filters, collectionSource) => {
 
   // Matching treats additional newUsers without a role as donor profiles, so keep
   // the indexed provider aligned with the existing post-filter fallback.
-  if (collectionSource === 'newUsers' && selected.includes('ed')) buckets.push('no');
+  if (
+    collectionSource === 'newUsers' &&
+    selected.includes('ed') &&
+    shouldIncludeNoBucket(filters?.userRole || filters?.role, 'empty')
+  ) buckets.push('no');
 
   return buckets;
 };
@@ -103,6 +122,12 @@ const buildBloodBuckets = filters => {
   if (!bloodGroupActive && !rhActive) return [];
 
   return BLOOD_BUCKETS.filter(bucket => {
+    if (bucket === 'no') {
+      const bloodNoAllowed = bloodGroupActive ? shouldIncludeNoBucket(filters?.bloodGroup, 'empty') : true;
+      const rhNoAllowed = rhActive ? shouldIncludeNoBucket(filters?.rh, 'empty') : true;
+      return bloodNoAllowed && rhNoAllowed;
+    }
+
     const meta = getBloodMeta(bucket);
     const bloodAllowed = bloodGroupActive ? Boolean(filters?.bloodGroup?.[meta.bloodGroup]) : true;
     const rhAllowed = rhActive ? Boolean(filters?.rh?.[meta.rh]) : true;
@@ -117,7 +142,10 @@ const buildMaritalStatusBuckets = filters => {
   const buckets = [];
   if (selected.includes('married')) buckets.push('+');
   if (selected.includes('unmarried')) buckets.push('-');
-  if (selected.includes('other')) buckets.push('?', 'no');
+  if (selected.includes('other')) {
+    buckets.push('?');
+    if (shouldIncludeNoBucket(filters?.maritalStatus, 'empty')) buckets.push('no');
+  }
   if (selected.includes('empty')) buckets.push('no');
   return buckets;
 };
@@ -127,6 +155,9 @@ const buildAgeBuckets = filters => {
   if (!selected.length) return [];
   return selected.flatMap(key => AGE_BUCKETS_BY_MATCHING_KEY[key] || []);
 };
+
+const buildPointBuckets = (filters, filterName, bucketMap = {}) =>
+  mapSelectedFilterBuckets(filters?.[filterName], bucketMap);
 
 export const buildMatchingIndexFilterGroups = ({ filters = {}, collectionSource = 'users' } = {}) => {
   const groups = [];
@@ -169,6 +200,55 @@ export const buildMatchingIndexFilterGroups = ({ filters = {}, collectionSource 
       ...getFilterGroupDebugState('age', filters?.age),
     }
   );
+  addGroup(
+    groups,
+    'csection',
+    CSECTION_BUCKETS.filter(bucket => buildPointBuckets(filters, 'csection').includes(bucket)),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('csection', filters?.csection),
+    }
+  );
+  addGroup(
+    groups,
+    'contact',
+    CONTACT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'contact').includes(bucket)),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('contact', filters?.contact),
+    }
+  );
+  addGroup(
+    groups,
+    'userId',
+    USER_ID_BUCKETS.filter(bucket => buildPointBuckets(filters, 'userId').includes(bucket)),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('userId', filters?.userId),
+    }
+  );
+  addGroup(
+    groups,
+    'fields',
+    FIELD_COUNT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'fields').includes(bucket)),
+    {
+      source: 'searchKey/users',
+      ...getFilterGroupDebugState('fields', filters?.fields),
+    }
+  );
+
+  if (collectionSource !== 'newUsers') {
+    addGroup(
+      groups,
+      'imt',
+      IMT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'imt', { other: '?' }).includes(bucket)),
+      {
+        source: 'searchKey/users',
+        ...getFilterGroupDebugState('imt', filters?.imt),
+      }
+    );
+  }
+
   return groups;
 };
 


### PR DESCRIPTION
### Motivation

- Prevent implicit inclusion of the `no` bucket when a filter group explicitly leaves the 'empty'/'no' option unchecked and align newUsers behavior with existing post-filter fallback. 
- Add support for several point-style bucket groups and ensure `imt` derived filters are not used for additional `newUsers` searchKeySets.
- Improve test coverage for the above behaviors and update existing cache tests to reflect API surface changes.

### Description

- Added helper functions `hasFilterOption`, `shouldIncludeNoBucket`, and `mapSelectedFilterBuckets` to control when the `no` bucket is allowed and to map selected point filters to bucket names. 
- Tightened logic in `buildRoleBuckets`, `buildBloodBuckets`, and `buildMaritalStatusBuckets` to only include the `no` bucket when the corresponding `empty`/`no` option is present or allowed. 
- Introduced new bucket sets `CSECTION_BUCKETS`, `IMT_BUCKETS`, `CONTACT_BUCKETS`, `USER_ID_BUCKETS`, and `FIELD_COUNT_BUCKETS`, and added groups for `csection`, `contact`, `userId`, and `fields` via `buildPointBuckets`. 
- Excluded the `imt` group from additional `newUsers` searchKeySets by skipping it when `collectionSource === 'newUsers'`. 
- Updated tests: added unit tests for `buildMatchingIndexFilterGroups` behavior (including csection/no handling and `imt` exclusion) and a test in `newUsersFilterSetsIndex.test.js` to assert that `no` buckets are not read when not selected, and adjusted expectations in cache tests to use `pageIds` instead of `userIds`.

### Testing

- Ran the unit tests for `matchingDataProvider` and `newUsersFilterSetsIndex` (`jest`), which exercise the new bucket selection and exclusion logic, and they passed. 
- Ran the updated index-cache tests that assert cache reuse and exclusion behavior, and they passed. 
- Executed the full Jest suite to verify no regressions in related modules, and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a4c99e8bc8326b4f89d3736831626)