### PR TITLE
Fix field-count range matching index lookups

### DIFF
--- a/src/utils/__tests__/matchingDataProvider.indexCache.test.js
+++ b/src/utils/__tests__/matchingDataProvider.indexCache.test.js
@@ -135,6 +135,31 @@ describe('fetchMatchingIndexedCandidates index-id cache', () => {
     expect(mockFirebaseGet).toHaveBeenCalledTimes(2);
   });
 
+  it('scans numeric field-count buckets for selected Fields ranges', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));
+    const filters = { fields: { le5: true, f6_10: false, f11_20: false, f20_plus: true } };
+
+    mockFirebaseGet.mockResolvedValueOnce(makeSnapshot({
+      0: { user00000000000000000001: true },
+      5: { user00000000000000000002: true },
+      6: { user00000000000000000003: true },
+      21: { user00000000000000000004: true },
+      le5: { user00000000000000000099: true },
+    }));
+
+    const result = await fetchMatchingIndexedCandidates({ filters, limit: 10, hydrateUsersByIds });
+
+    expect(mockFirebaseGet).toHaveBeenCalledTimes(1);
+    expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/fields');
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/fields/le5');
+    expect(result.pageIds).toEqual([
+      'user00000000000000000001',
+      'user00000000000000000002',
+      'user00000000000000000004',
+    ]);
+  });
+
   it('applies excluded reactions without corrupting the base cached id list', async () => {
     const { fetchMatchingIndexedCandidates } = loadModule();
     const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));

--- a/src/utils/fieldCountBuckets.js
+++ b/src/utils/fieldCountBuckets.js
@@ -1,0 +1,53 @@
+export const FIELD_COUNT_RANGE_BUCKETS = ['le5', 'f6_10', 'f11_20', 'f20_plus'];
+
+export const FIELD_COUNT_SEARCH_KEY_INDEX_NAME = 'fields';
+
+const normalizeBucketValues = values => {
+  if (!values) return [];
+  if (Array.isArray(values)) return values;
+  if (values instanceof Set) return [...values];
+  return [values];
+};
+
+export const hasFieldCountRangeBuckets = values =>
+  normalizeBucketValues(values).some(value => FIELD_COUNT_RANGE_BUCKETS.includes(String(value || '').trim()));
+
+export const isFieldCountInRangeBucket = (countKey, rangeBucket) => {
+  const parsedCount = Number.parseInt(String(countKey), 10);
+  if (!Number.isInteger(parsedCount) || parsedCount < 0) return false;
+
+  switch (rangeBucket) {
+    case 'le5':
+      return parsedCount <= 5;
+    case 'f6_10':
+      return parsedCount >= 6 && parsedCount <= 10;
+    case 'f11_20':
+      return parsedCount >= 11 && parsedCount <= 20;
+    case 'f20_plus':
+      return parsedCount > 20;
+    default:
+      return false;
+  }
+};
+
+export const isFieldCountInSelectedRanges = (countKey, rangeBuckets = []) => {
+  const selectedRangeBuckets = normalizeBucketValues(rangeBuckets)
+    .map(value => String(value || '').trim())
+    .filter(value => FIELD_COUNT_RANGE_BUCKETS.includes(value));
+
+  return selectedRangeBuckets.some(rangeBucket => isFieldCountInRangeBucket(countKey, rangeBucket));
+};
+
+export const collectFieldCountIdsFromIndexNode = (fieldsIndexNode, rangeBuckets = []) => {
+  const ids = new Set();
+  if (!fieldsIndexNode || typeof fieldsIndexNode !== 'object' || Array.isArray(fieldsIndexNode)) return ids;
+
+  Object.entries(fieldsIndexNode).forEach(([countKey, usersMap]) => {
+    if (!isFieldCountInSelectedRanges(countKey, rangeBuckets)) return;
+    Object.keys(usersMap || {}).forEach(userId => {
+      if (userId) ids.add(userId);
+    });
+  });
+
+  return ids;
+};

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -3,6 +3,12 @@ import { database } from 'components/config';
 import { getCard, getIndexIdsByQuery, MATCHING_INDEX_CACHE_VERSION, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
 import { collectFilteredMatchingSourceCards } from './matchingSourceBackfill';
 import { getIndexedNewUsersIdsByRules, normalizeSearchKeySetKeys } from './newUsersFilterSetsIndex';
+import {
+  FIELD_COUNT_RANGE_BUCKETS,
+  FIELD_COUNT_SEARCH_KEY_INDEX_NAME,
+  collectFieldCountIdsFromIndexNode,
+  hasFieldCountRangeBuckets,
+} from './fieldCountBuckets';
 
 export const MATCHING_INDEX_ROOT = 'searchKey';
 export const MATCHING_USERS_INDEX_ROOT = `${MATCHING_INDEX_ROOT}/users`;
@@ -13,7 +19,7 @@ const CSECTION_BUCKETS = ['cs2plus', 'cs1', 'cs0', 'other', 'no'];
 const IMT_BUCKETS = ['le28', '29_31', '32_35', '36_plus', '?', 'no'];
 const CONTACT_BUCKETS = ['vk', 'instagram', 'ameblo', 'facebook', 'phone', 'telegram', 'telegram2', 'tiktok', 'linkedin', 'youtube', 'email', 'twitter', 'line', 'otherLink'];
 const USER_ID_BUCKETS = ['vk', 'aa', 'ab', 'id', 'long', 'mid', 'other'];
-const FIELD_COUNT_BUCKETS = ['le5', 'f6_10', 'f11_20', 'f20_plus'];
+const FIELD_COUNT_BUCKETS = FIELD_COUNT_RANGE_BUCKETS;
 const AGE_BUCKETS_BY_MATCHING_KEY = {
   le21: ['le21'],
   le25: ['le21', '22_25'],
@@ -258,6 +264,13 @@ const collectIdsFromValue = value => {
 };
 
 const readBucketIds = async ({ rootPath, indexName, values }) => {
+  if (indexName === FIELD_COUNT_SEARCH_KEY_INDEX_NAME && hasFieldCountRangeBuckets(values)) {
+    const snapshot = await get(ref(database, `${rootPath}/${indexName}`));
+    return snapshot.exists()
+      ? collectFieldCountIdsFromIndexNode(snapshot.val(), values)
+      : new Set();
+  }
+
   const ids = new Set();
   await Promise.all(values.map(async value => {
     const snapshot = await get(ref(database, `${rootPath}/${indexName}/${value}`));

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -20,6 +20,11 @@ import {
   resolveAdditionalAccessSearchKeyBuckets,
 } from './additionalAccessRules';
 import {
+  FIELD_COUNT_SEARCH_KEY_INDEX_NAME,
+  collectFieldCountIdsFromIndexNode,
+  hasFieldCountRangeBuckets,
+} from './fieldCountBuckets';
+import {
   getCachedSearchKeyPayload,
   peekCachedSearchKeyPayload,
   saveCachedAdditionalRulesSetIndex,
@@ -1321,6 +1326,31 @@ export const getIndexedNewUsersIdsByRules = async ({
           idsBeforePreciseFilter,
           idsAfterPreciseFilter: null,
         });
+      } else if (indexName === FIELD_COUNT_SEARCH_KEY_INDEX_NAME && hasFieldCountRangeBuckets(normalizedValues)) {
+        const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}`;
+        resultPaths.push(`${path}|fieldCountRanges=${normalizedValues.join(',')}`);
+        emitDebug('additionalMatching: field-count range lookup', {
+          setKey: entry.setKey,
+          path,
+          ranges: normalizedValues,
+        });
+        // eslint-disable-next-line no-await-in-loop
+        const payload = await readBucketPayload(path);
+        const fieldsIndexValue = payload?.exists && payload.value && typeof payload.value === 'object'
+          ? payload.value
+          : {};
+        const fieldCountIds = collectFieldCountIdsFromIndexNode(fieldsIndexValue, normalizedValues);
+        fieldCountIds.forEach(userId => idsForFilter.add(userId));
+
+        if (payload?.exists) {
+          existingBucketsForSet += 1;
+          if (fieldCountIds.size === 0) emptyBucketsForSet += 1;
+        } else {
+          missingBucketsForSet += 1;
+        }
+
+        if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
+        setsMap[entry.setKey][indexName] = fieldsIndexValue;
       } else for (const value of normalizedValues) {
         const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`;
         resultPaths.push(path);


### PR DESCRIPTION
### Motivation
- The `fields` filter currently emits range labels like `le5`/`f6_10` while the search-key index stores raw numeric count buckets, causing the indexed provider to read non-existent paths such as `searchKey/users/fields/le5` and return no candidates for range selections.
- The goal is to align the indexed reads with how the index is written (numeric count buckets) so range badges are resolved by scanning numeric buckets instead of treating them as top-level bucket paths.

### Description
- Added `src/utils/fieldCountBuckets.js` with shared helpers (`FIELD_COUNT_RANGE_BUCKETS`, `FIELD_COUNT_SEARCH_KEY_INDEX_NAME`, `collectFieldCountIdsFromIndexNode`, `hasFieldCountRangeBuckets`, etc.) to map range badges to numeric count buckets and collect matching ids.
- Updated `src/utils/matchingDataProvider.js` to import the helpers and special-case reads in `readBucketIds` so that when the `fields` index is queried with range buckets the code reads the parent `searchKey/.../fields` node and scans numeric buckets instead of requesting `fields/<range>` paths.
- Updated `src/utils/newUsersFilterSetsIndex.js` to apply the same numeric-bucket scan for `searchKeySets/<set>/fields` when additional filter bucket groups include `fields` range badges, and to populate `setsMap` with the numeric index snapshot.
- Added a unit test in `src/utils/__tests__/matchingDataProvider.indexCache.test.js` verifying that selected `fields` range filters cause a single read of `searchKey/users/fields`, do not read `searchKey/users/fields/le5`, and return ids collected from numeric buckets.

### Testing
- Ran the focused test suite with `npm test -- --runTestsByPath src/utils/__tests__/matchingDataProvider.indexCache.test.js --watchAll=false`, and all tests passed.
- Ran `npx eslint` against the changed files (`src/utils/matchingDataProvider.js`, `src/utils/newUsersFilterSetsIndex.js`, `src/utils/fieldCountBuckets.js`, and the test file`) with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a6ec847d08326a213a70df39620a3)