### PR TITLE
Fix field-count array bucket snapshots

### DIFF
--- a/src/utils/fieldCountBuckets.js
+++ b/src/utils/fieldCountBuckets.js
@@ -40,7 +40,7 @@ export const isFieldCountInSelectedRanges = (countKey, rangeBuckets = []) => {
 
 export const collectFieldCountIdsFromIndexNode = (fieldsIndexNode, rangeBuckets = []) => {
   const ids = new Set();
-  if (!fieldsIndexNode || typeof fieldsIndexNode !== 'object' || Array.isArray(fieldsIndexNode)) return ids;
+  if (!fieldsIndexNode || typeof fieldsIndexNode !== 'object') return ids;
 
   Object.entries(fieldsIndexNode).forEach(([countKey, usersMap]) => {
     if (!isFieldCountInSelectedRanges(countKey, rangeBuckets)) return;

--- a/src/utils/fieldCountBuckets.test.js
+++ b/src/utils/fieldCountBuckets.test.js
@@ -1,0 +1,15 @@
+import { collectFieldCountIdsFromIndexNode } from './fieldCountBuckets';
+
+describe('collectFieldCountIdsFromIndexNode', () => {
+  it('collects ids from dense numeric array snapshots for selected field count ranges', () => {
+    const fieldsIndexNode = [];
+    fieldsIndexNode[4] = { userLe5: true };
+    fieldsIndexNode[7] = { userF6To10: true };
+    fieldsIndexNode[12] = { userF11To20: true };
+
+    expect([...collectFieldCountIdsFromIndexNode(fieldsIndexNode, ['le5', 'f6_10'])].sort()).toEqual([
+      'userF6To10',
+      'userLe5',
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Firebase can materialize dense numeric child maps as arrays, and the previous guard rejected array snapshots causing selected field-count range filters to return no candidates despite `Object.entries()` being able to scan them.

### Description
- Allow array-shaped index snapshots to be scanned by removing the `Array.isArray` short-circuit in `collectFieldCountIdsFromIndexNode` and add a regression test `src/utils/fieldCountBuckets.test.js` that builds a dense numeric array snapshot and verifies collected IDs for selected ranges.

### Testing
- Ran `npm test -- --runTestsByPath src/utils/fieldCountBuckets.test.js --watchAll=false` and `npm run lint:js -- src/utils/fieldCountBuckets.js src/utils/fieldCountBuckets.test.js`, and both the unit test and lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a7f259c108326a1c2df1ddcbde729)