### PR TITLE
Refactor card action buttons: unify compact styles, add icons and accessibility

### DIFF
--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -9,6 +9,21 @@ import { renderAllFields } from './ProfileForm';
 import StimulationSchedule from './StimulationSchedule';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 
+const cardActionButtonStyle = {
+  width: '30px',
+  height: '30px',
+  minHeight: '30px',
+  flex: '0 0 30px',
+  padding: 0,
+  border: 'none',
+  borderRadius: '9px',
+  color: '#fff',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxShadow: '0 3px 8px rgba(17, 24, 39, 0.25)',
+};
+
 // Компонент для рендерингу картки користувача
 const UserCard = ({
   userData,
@@ -198,8 +213,19 @@ const UsersList = ({
               isDateInRange={isDateInRange}
               actions={
                 <>
-                  {btnCompare(index, users, setUsers, setShowInfoModal, setCompare)}
-                  {btnMore(userData, onOpenMoreActions)}
+                  {btnCompare(
+                    index,
+                    users,
+                    setUsers,
+                    setShowInfoModal,
+                    setCompare,
+                    { ...cardActionButtonStyle, backgroundColor: 'purple' },
+                  )}
+                  {btnMore(
+                    userData,
+                    onOpenMoreActions,
+                    { ...cardActionButtonStyle, backgroundColor: '#1976d2' },
+                  )}
                 </>
               }
             />

--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import { handleSubmitAll } from './actions';
 
+const compareIcon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M7 7h11M7 7l3-3M7 7l3 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M17 17H6M17 17l-3-3M17 17l-3 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
 export const btnCompare = (
   index,
   users,
@@ -8,6 +15,7 @@ export const btnCompare = (
   setShowInfoModal,
   setCompare,
   style = {},
+  content = compareIcon,
 ) => {
   const delKeys = [
     'photos',
@@ -225,10 +233,13 @@ const handleCompareClick = (e, index, users, delKeys, setShowInfoModal, setCompa
 
   return (
     <button
+      type="button"
       style={{ ...styles.removeButton, ...style }}
+      aria-label="Порівняти"
+      title="Порівняти"
       onClick={(e) => handleCompareClick(e, index, users, delKeys, setShowInfoModal, setCompare)}
->
-      comp
+    >
+      {content}
     </button>
   );
 };
@@ -236,12 +247,19 @@ const handleCompareClick = (e, index, users, delKeys, setShowInfoModal, setCompa
 // Стилі
 const styles = {
   removeButton: {
-    padding: '3px 6px',
+    width: '30px',
+    height: '30px',
+    minHeight: '30px',
+    padding: 0,
     backgroundColor: 'purple',
     color: 'white',
     border: 'none',
-    borderRadius: '5px',
+    borderRadius: '9px',
     cursor: 'pointer',
     position: 'static',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxShadow: '0 3px 8px rgba(17, 24, 39, 0.25)',
   },
 };

--- a/src/components/smallCard/btnExport.js
+++ b/src/components/smallCard/btnExport.js
@@ -1,17 +1,33 @@
+import React from 'react';
 import { saveToContact } from 'components/ExportContact';
 import { CardMenuBtn } from 'components/styles';
 
-export const btnExport = userData => (
+const saveIcon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M6 4h9l3 3v13H6V4z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
+    <path d="M9 4v6h6V4" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
+    <path d="M9 17h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+export const btnExport = (userData, style = {}, content = saveIcon) => (
   <CardMenuBtn
+    type="button"
     style={{
       backgroundColor: 'green',
       position: 'static',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      ...style,
     }}
+    aria-label="Зберегти контакт"
+    title="Зберегти контакт"
     onClick={e => {
       e.stopPropagation(); // Запобігаємо активації кліку картки
       saveToContact(userData);
     }}
   >
-    save
+    {content}
   </CardMenuBtn>
 );

--- a/src/components/smallCard/btnMore.js
+++ b/src/components/smallCard/btnMore.js
@@ -1,29 +1,47 @@
 import React from 'react';
 
-export const btnMore = (userData, onOpenMore, style = {}) => {
+const moreIcon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="5" cy="12" r="1.8" fill="currentColor" />
+    <circle cx="12" cy="12" r="1.8" fill="currentColor" />
+    <circle cx="19" cy="12" r="1.8" fill="currentColor" />
+  </svg>
+);
+
+export const btnMore = (userData, onOpenMore, style = {}, content = moreIcon) => {
   if (!userData?.userId || typeof onOpenMore !== 'function') return null;
 
   return (
     <button
+      type="button"
       style={{ ...styles.moreButton, ...style }}
+      aria-label="Більше дій"
+      title="Більше дій"
       onClick={e => {
         e.stopPropagation();
         onOpenMore(userData);
       }}
     >
-      more
+      {content}
     </button>
   );
 };
 
 const styles = {
   moreButton: {
-    padding: '3px 6px',
+    width: '30px',
+    height: '30px',
+    minHeight: '30px',
+    padding: 0,
     backgroundColor: '#1976d2',
     color: 'white',
     border: 'none',
-    borderRadius: '5px',
+    borderRadius: '9px',
     cursor: 'pointer',
     position: 'static',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxShadow: '0 3px 8px rgba(17, 24, 39, 0.25)',
   },
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -72,11 +72,19 @@ const zoneActionButtonStyle = {
 };
 
 const secondaryActionsStyle = {
-  marginLeft: 'auto',
   display: 'flex',
   alignItems: 'center',
   gap: '5px',
   flexShrink: 0,
+};
+
+const compactTopActionButtonStyle = {
+  ...zoneActionButtonStyle,
+  display: 'inline-flex',
+  width: '30px',
+  height: '30px',
+  minHeight: '30px',
+  flex: '0 0 30px',
 };
 
 const addedOverlayEntryStyle = {
@@ -862,7 +870,12 @@ const TopBlock = ({
           </div>
         ))}
         <div style={secondaryActionsStyle}>
-          {showSideActions && btnExport(cardData)}
+          {showSideActions &&
+            btnExport(cardData, {
+              ...compactTopActionButtonStyle,
+              backgroundColor: 'green',
+              color: '#fff',
+            })}
           {additionalActions}
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Standardize the appearance and behavior of compact action buttons on user cards and top-block actions to improve visual consistency and accessibility.

### Description
- Introduced a reusable compact action button style and applied it to compare, more and export buttons in `UsersList.jsx` and `renderTopBlock.js` to enforce a 30x30px layout, rounded corners and box shadow.
- Updated `btnCompare.js`, `btnMore.js` and `btnExport.js` to accept optional `style` and `content` parameters, added SVG icons (`compareIcon`, `moreIcon`, `saveIcon`), and adjusted default styles to use inline-flex centering and consistent sizing.
- Added `type="button"`, `aria-label` and `title` attributes and ensured `onClick` handlers use `stopPropagation` where appropriate to avoid accidental card activation.
- Wired the new styles into `UsersList.jsx` so the comparison and more actions render with the unified compact styling.

### Testing
- Ran the project build with `yarn build` which completed successfully.
- Executed unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and there were no new linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b007d47dc8326bd1b2581909305f6)