### PR TITLE
Improve Matching filters UI, accessibility, and chip styling

### DIFF
--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 const GroupWrapper = styled.div`
-  margin-bottom: 10px;
+  margin-bottom: 12px;
 `;
 
 const GroupLabel = styled.span`
@@ -12,18 +12,19 @@ const GroupLabel = styled.span`
   color: var(--matching-chip-label, #aaa);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 5px;
+  margin-bottom: 7px;
   line-height: 1;
 `;
 
 const ChipsRow = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
 `;
 
 const Chip = styled.button`
-  padding: 3px 9px;
+  min-height: 36px;
+  padding: 7px 12px;
   border-radius: 20px;
   border: 1.5px solid ${({ $active }) => ($active ? '#FF8C00' : 'var(--matching-chip-border, #e0e0e0)')};
   background: ${({ $active }) => ($active ? 'rgba(255, 243, 224, 0.92)' : 'var(--matching-chip-bg, #fafafa)')};
@@ -32,13 +33,20 @@ const Chip = styled.button`
   font-weight: ${({ $active }) => ($active ? '600' : '400')};
   cursor: pointer;
   line-height: 1.5;
-  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 
   &:hover {
     border-color: #FF8C00;
     color: #CC5500;
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(247, 147, 30, 0.38);
+    outline-offset: 2px;
   }
 `;
 
@@ -57,16 +65,24 @@ export const CheckboxGroup = ({ label, filterName, options, filters, onChange })
     <GroupWrapper>
       {label && <GroupLabel>{label}</GroupLabel>}
       <ChipsRow>
-        {options.map(({ val, label: optionLabel }) => (
-          <Chip
-            key={val}
-            $active={filters[filterName][val]}
-            onClick={() => handleToggle(val)}
-            type="button"
-          >
-            {optionLabel}
-          </Chip>
-        ))}
+        {options.map(({ val, label: optionLabel }) => {
+          const isActive = Boolean(filters[filterName][val]);
+          const readableLabel = typeof optionLabel === 'string' ? optionLabel : val;
+          const groupLabel = label || filterName;
+
+          return (
+            <Chip
+              key={val}
+              $active={isActive}
+              aria-pressed={isActive}
+              aria-label={`${groupLabel}: ${readableLabel}`}
+              onClick={() => handleToggle(val)}
+              type="button"
+            >
+              {optionLabel}
+            </Chip>
+          );
+        })}
       </ChipsRow>
     </GroupWrapper>
   );

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { resolveAccess } from 'utils/accessLevel';
 import {
+  ActionBadge,
   ActionButton,
   AdminToggle,
   AnimatedCard,
@@ -10,12 +11,21 @@ import {
   CardWrapper,
   ClickableId,
   CollectionSourceLabel,
+  CollectionSourceOptions,
   CollectionSourceTitle,
   CollectionSourceWrap,
   CommentBox,
   CommentInput,
   Container,
   FilterContainer,
+  FilterDrawerBody,
+  FilterDrawerClose,
+  FilterDrawerFooter,
+  FilterDrawerHeader,
+  FilterDrawerHeading,
+  FilterDrawerSection,
+  FilterDrawerSubtitle,
+  FilterDrawerTitle,
   FilterOverlay,
   FilterResetButton,
   Grid,
@@ -31,6 +41,7 @@ import {
   ThemeToggleKnob,
   ThemeToggleScene,
   ThemeToggleTrackIcon,
+  TopActionGroup,
   TopActions,
   ModernActionRail,
   ModernBioText,
@@ -93,7 +104,7 @@ import { BtnFavorite } from './smallCard/btnFavorite';
 import { BtnDislike } from './smallCard/btnDislike';
 import SearchBar from './SearchBar';
 import PhotoViewer from './PhotoViewer';
-import FilterPanel from './FilterPanel';
+import FilterPanel, { getDefaultFilters } from './FilterPanel';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { getCacheKey, clearAllCardsCache, setFavoriteIds } from "../utils/cache";
 import { incrementMatchingLoadStat, logMatchingLocalStorageCacheStats, normalizeQueryKey, getIdsByQuery, setIdsForQuery, getCard, clearMatchingCache } from '../utils/cardIndex';
@@ -1277,6 +1288,19 @@ const fetchUsersByLastLogin2FromCollection = async (collection = 'users', limit 
   };
 };
 
+const countChangedMatchingFilterGroups = (currentFilters, defaultFilters) => {
+  if (!currentFilters || !defaultFilters) return 0;
+
+  return Object.keys(defaultFilters).reduce((count, groupName) => {
+    const defaultGroup = defaultFilters[groupName] || {};
+    const currentGroup = currentFilters[groupName] || {};
+    const changed = Object.keys(defaultGroup).some(optionName =>
+      Boolean(currentGroup[optionName]) !== Boolean(defaultGroup[optionName])
+    );
+    return changed ? count + 1 : count;
+  }, 0);
+};
+
 const Matching = () => {
   const navigate = useNavigate();
   const [users, setUsers] = useState([]);
@@ -1343,6 +1367,17 @@ const Matching = () => {
     accessLevel: currentAccessLevel,
     userRole: currentUserRole,
   });
+  const matchingDefaultFilters = useMemo(
+    () => getDefaultFilters({ mode: 'matching', nonAdminAllActive: !access.isAdmin }),
+    [access.isAdmin],
+  );
+  const activeFilterGroupCount = useMemo(
+    () => countChangedMatchingFilterGroups(filters, matchingDefaultFilters),
+    [filters, matchingDefaultFilters],
+  );
+  const filterDrawerSubtitle = activeFilterGroupCount > 0
+    ? `Активно змінено груп: ${activeFilterGroupCount}`
+    : 'Всі профілі показані за поточними правилами доступу';
   const isAdmin = access.isAdmin;
   const isIndexedDebugTestUser = String(auth.currentUser?.uid || ownerId || '').trim() === MATCHING_LOG_MODE_TEST_USER_ID;
   const parsedAdditionalAccessRules = useMemo(
@@ -5423,100 +5458,158 @@ const Matching = () => {
   return (
     <>
       {showFilters && <FilterOverlay show={showFilters} onClick={() => setShowFilters(false)} />}
-      <FilterContainer show={showFilters} $themeMode={themeMode} onClick={e => e.stopPropagation()}>
-        {isAdmin && (
-          <SearchBar
-            searchFunc={searchUsers}
-            setUsers={applySearchResults}
-            setUserNotFound={() => {}}
-            wrapperStyle={{ width: '100%', marginBottom: '10px' }}
-            leftIcon="🔍"
-            storageKey={SEARCH_KEY}
-            onClear={reloadDefault}
+      <FilterContainer
+        show={showFilters}
+        $themeMode={themeMode}
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="matching-filter-title"
+      >
+        <FilterDrawerHeader>
+          <FilterDrawerTitle>
+            <FilterDrawerHeading id="matching-filter-title">Фільтри matching</FilterDrawerHeading>
+            <FilterDrawerSubtitle>{filterDrawerSubtitle}</FilterDrawerSubtitle>
+          </FilterDrawerTitle>
+          <FilterDrawerClose
+            type="button"
+            aria-label="Закрити фільтри"
+            title="Закрити фільтри"
+            onClick={() => setShowFilters(false)}
+          >
+            <FaTimes />
+          </FilterDrawerClose>
+        </FilterDrawerHeader>
+        <FilterDrawerBody>
+          {isAdmin && (
+            <FilterDrawerSection aria-label="Пошук профілів">
+              <SearchBar
+                searchFunc={searchUsers}
+                setUsers={applySearchResults}
+                setUserNotFound={() => {}}
+                wrapperStyle={{ width: '100%', marginBottom: 0 }}
+                leftIcon="🔍"
+                storageKey={SEARCH_KEY}
+                onClear={reloadDefault}
+              />
+            </FilterDrawerSection>
+          )}
+          <CollectionSourceWrap>
+            <CollectionSourceTitle>Колекція профілів</CollectionSourceTitle>
+            <CollectionSourceOptions>
+              <CollectionSourceLabel $active={collectionSource === 'users'}>
+                <input
+                  type="radio"
+                  name="matchingCollectionSource"
+                  value="users"
+                  checked={collectionSource === 'users'}
+                  onChange={e => switchCollectionSource(e.target.value)}
+                />
+                Основний список
+              </CollectionSourceLabel>
+              <CollectionSourceLabel $active={collectionSource === 'newUsers'}>
+                <input
+                  type="radio"
+                  name="matchingCollectionSource"
+                  value="newUsers"
+                  checked={collectionSource === 'newUsers'}
+                  onChange={e => switchCollectionSource(e.target.value)}
+                />
+                Додатковий список
+              </CollectionSourceLabel>
+            </CollectionSourceOptions>
+          </CollectionSourceWrap>
+          <FilterPanel
+            mode="matching"
+            hideUserId
+            hideCommentLength
+            onChange={handleFiltersChange}
+            resetToken={filterResetToken}
+            nonAdminAllActive={!isAdmin}
           />
-        )}
-        <FilterResetButton onClick={resetFiltersAndCache}>
-          Скинути фільтри та кеш
-        </FilterResetButton>
-        <CollectionSourceWrap>
-          <CollectionSourceTitle>Колекція профілів:</CollectionSourceTitle>
-          <CollectionSourceLabel>
-            <input
-              type="radio"
-              name="matchingCollectionSource"
-              value="users"
-              checked={collectionSource === 'users'}
-              onChange={e => switchCollectionSource(e.target.value)}
-            />
-            Основний список
-          </CollectionSourceLabel>
-          <CollectionSourceLabel>
-            <input
-              type="radio"
-              name="matchingCollectionSource"
-              value="newUsers"
-              checked={collectionSource === 'newUsers'}
-              onChange={e => switchCollectionSource(e.target.value)}
-            />
-            Додатковий список
-          </CollectionSourceLabel>
-        </CollectionSourceWrap>
-        <FilterPanel
-          mode="matching"
-          hideUserId
-          hideCommentLength
-          onChange={handleFiltersChange}
-          resetToken={filterResetToken}
-          nonAdminAllActive={!isAdmin}
-        />
+        </FilterDrawerBody>
+        <FilterDrawerFooter>
+          <FilterResetButton type="button" onClick={resetFiltersAndCache}>
+            Скинути фільтри й оновити кеш
+          </FilterResetButton>
+        </FilterDrawerFooter>
       </FilterContainer>
       <Container $themeMode={themeMode}>
         <InnerContainer>
           <HeaderContainer>
             <TopActions>
-              <ThemeToggleButton
-                type="button"
-                $themeMode={themeMode}
-                aria-pressed={themeMode === 'light'}
-                aria-label={themeMode === 'light' ? 'Switch Matching to dark theme' : 'Switch Matching to light theme'}
-                title={themeMode === 'light' ? 'Dark theme' : 'Light theme'}
-                onClick={handleThemeToggle}
-              >
-                <ThemeToggleTrackIcon $side="left" $active={themeMode === 'dark'} aria-hidden="true">
-                  <svg viewBox="0 0 24 24" role="img">
-                    <path fill="currentColor" d="M15.4 2.8a7.4 7.4 0 1 0 5.8 10.8 6.2 6.2 0 1 1-5.8-10.8Z" />
-                    <circle cx="6" cy="6" r="1.4" fill="#ffd45c" />
-                    <circle cx="19" cy="5.5" r="1.1" fill="#ffd45c" />
-                  </svg>
-                </ThemeToggleTrackIcon>
-                <ThemeToggleTrackIcon $side="right" $active={themeMode === 'light'} aria-hidden="true">
-                  <svg viewBox="0 0 24 24" role="img">
-                    <circle cx="9" cy="9" r="4" fill="#ffd45c" />
-                    <path fill="currentColor" d="M8 17.5h8.8a3.8 3.8 0 0 0 .4-7.6 5.3 5.3 0 0 0-10.1 1.7A3 3 0 0 0 8 17.5Z" />
-                  </svg>
-                </ThemeToggleTrackIcon>
-                <ThemeToggleKnob $themeMode={themeMode} aria-hidden="true">
-                  <ThemeToggleScene $themeMode={themeMode} />
-                </ThemeToggleKnob>
-              </ThemeToggleButton>
-              {viewMode !== 'default' && (
-                <ActionButton onClick={reloadDefault}><FaDownload /></ActionButton>
-              )}
-              <ActionButton onClick={() => setShowFilters(s => !s)}><FaFilter /></ActionButton>
-              <ActionButton
-                onClick={loadDislikeCards}
-                disabled={viewMode === 'dislikes' || !ownerId}
-              >
-                <FaTimes />
-              </ActionButton>
-              <ActionButton
-                onClick={loadFavoriteCards}
-                disabled={viewMode === 'favorites' || !ownerId}
-              >
-                <FaHeart />
-              </ActionButton>
-              {showBackendTrafficToggle && (
-                <BackendTrafficToggleButton
+              <TopActionGroup aria-label="Основні дії matching">
+                <ActionButton
+                  type="button"
+                  onClick={() => setShowFilters(s => !s)}
+                  $active={showFilters || activeFilterGroupCount > 0}
+                  aria-label={showFilters ? 'Закрити фільтри' : 'Відкрити фільтри'}
+                  title={showFilters ? 'Закрити фільтри' : 'Відкрити фільтри'}
+                >
+                  <FaFilter />
+                  {activeFilterGroupCount > 0 && <ActionBadge>{activeFilterGroupCount}</ActionBadge>}
+                </ActionButton>
+                <ActionButton
+                  type="button"
+                  onClick={loadDislikeCards}
+                  disabled={viewMode === 'dislikes' || !ownerId}
+                  $active={viewMode === 'dislikes'}
+                  aria-label="Показати дизлайки"
+                  title="Показати дизлайки"
+                >
+                  <FaTimes />
+                </ActionButton>
+                <ActionButton
+                  type="button"
+                  onClick={loadFavoriteCards}
+                  disabled={viewMode === 'favorites' || !ownerId}
+                  $active={viewMode === 'favorites'}
+                  aria-label="Показати обране"
+                  title="Показати обране"
+                >
+                  <FaHeart />
+                </ActionButton>
+              </TopActionGroup>
+              <TopActionGroup aria-label="Налаштування matching">
+                <ThemeToggleButton
+                  type="button"
+                  $themeMode={themeMode}
+                  aria-pressed={themeMode === 'light'}
+                  aria-label={themeMode === 'light' ? 'Перемкнути Matching на темну тему' : 'Перемкнути Matching на світлу тему'}
+                  title={themeMode === 'light' ? 'Темна тема' : 'Світла тема'}
+                  onClick={handleThemeToggle}
+                >
+                  <ThemeToggleTrackIcon $side="left" $active={themeMode === 'dark'} aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img">
+                      <path fill="currentColor" d="M15.4 2.8a7.4 7.4 0 1 0 5.8 10.8 6.2 6.2 0 1 1-5.8-10.8Z" />
+                      <circle cx="6" cy="6" r="1.4" fill="#ffd45c" />
+                      <circle cx="19" cy="5.5" r="1.1" fill="#ffd45c" />
+                    </svg>
+                  </ThemeToggleTrackIcon>
+                  <ThemeToggleTrackIcon $side="right" $active={themeMode === 'light'} aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img">
+                      <circle cx="9" cy="9" r="4" fill="#ffd45c" />
+                      <path fill="currentColor" d="M8 17.5h8.8a3.8 3.8 0 0 0 .4-7.6 5.3 5.3 0 0 0-10.1 1.7A3 3 0 0 0 8 17.5Z" />
+                    </svg>
+                  </ThemeToggleTrackIcon>
+                  <ThemeToggleKnob $themeMode={themeMode} aria-hidden="true">
+                    <ThemeToggleScene $themeMode={themeMode} />
+                  </ThemeToggleKnob>
+                </ThemeToggleButton>
+                {viewMode !== 'default' && (
+                  <ActionButton
+                    type="button"
+                    onClick={reloadDefault}
+                    aria-label="Повернутись до основного списку"
+                    title="Повернутись до основного списку"
+                  >
+                    <FaDownload />
+                  </ActionButton>
+                )}
+              </TopActionGroup>
+              <TopActionGroup aria-label="Адміністративні дії matching">
+                {showBackendTrafficToggle && (
+                  <BackendTrafficToggleButton
                   type="button"
                   $active={downloadSizeToastsEnabled}
                   aria-pressed={downloadSizeToastsEnabled}
@@ -5554,7 +5647,15 @@ const Matching = () => {
                   <BackendTrafficToggleStatus>{debugShowAllIndexedCards ? 'ALL' : 'NORMAL'}</BackendTrafficToggleStatus>
                 </BackendTrafficToggleButton>
               )}
-              <ActionButton aria-label="Відкрити меню профілю" onClick={() => setShowInfoModal('dotsMenu')}><FaEllipsisV /></ActionButton>
+                <ActionButton
+                  type="button"
+                  aria-label="Відкрити меню профілю"
+                  title="Відкрити меню профілю"
+                  onClick={() => setShowInfoModal('dotsMenu')}
+                >
+                  <FaEllipsisV />
+                </ActionButton>
+              </TopActionGroup>
             </TopActions>
           </HeaderContainer>
           {!ownerId && (
@@ -5578,7 +5679,7 @@ const Matching = () => {
                       $side="left"
                       onClick={e => { e.stopPropagation(); navigateActiveProfile(-1); }}
                       disabled={activeProfileIndex === 0}
-                      aria-label="Previous profile"
+                      aria-label="Previous profile" title="Попередній профіль"
                     >
                       <FaChevronLeft />
                     </ModernDesktopNavButton>
@@ -5587,7 +5688,7 @@ const Matching = () => {
                       $side="right"
                       onClick={e => { e.stopPropagation(); navigateActiveProfile(1); }}
                       disabled={activeProfileIndex >= filteredUsers.length - 1}
-                      aria-label="Next profile"
+                      aria-label="Next profile" title="Наступний профіль"
                     >
                       <FaChevronRight />
                     </ModernDesktopNavButton>

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -332,39 +332,93 @@ export const TopActions = styled.div`
   position: static;
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   gap: 8px;
   z-index: 10;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 2px;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const TopActionGroup = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 4px;
+  border: 1px solid var(--matching-section-border, rgba(255, 255, 255, 0.14));
+  border-radius: 999px;
+  background: var(--matching-section-bg, rgba(255, 255, 255, 0.82));
+  box-shadow: var(--matching-section-shadow, 0 8px 18px rgba(22, 22, 22, 0.08));
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 `;
 
 export const ActionButton = styled.button`
+  position: relative;
   width: 35px;
   height: 35px;
   padding: 3px;
-  border: none;
-  background: var(--matching-action-bg, ${color.accent5});
-  color: var(--matching-action-color, white);
+  border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'transparent')};
+  background: ${({ $active }) => ($active ? 'rgba(255, 149, 0, 0.14)' : 'var(--matching-action-bg, ' + color.accent5 + ')')};
+  color: ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-action-color, white)')};
   box-shadow: var(--matching-action-shadow, none);
-  transition: transform 240ms cubic-bezier(0.4, 0, 0.2, 1), background 240ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 240ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 240ms cubic-bezier(0.4, 0, 0.2, 1), background 240ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 240ms cubic-bezier(0.4, 0, 0.2, 1), border-color 240ms cubic-bezier(0.4, 0, 0.2, 1), color 240ms cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 50px;
   cursor: pointer;
   font-size: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 auto;
+
   &:hover:not(:disabled) {
     transform: translateY(-1px) scale(1.03);
+    border-color: var(--matching-accent, #FF9500);
   }
 
   &:active:not(:disabled) {
     transform: scale(0.96);
   }
 
+  &:focus-visible {
+    outline: 3px solid rgba(247, 147, 30, 0.42);
+    outline-offset: 2px;
+  }
+
   &:disabled {
     background-color: ${color.gray3};
     color: ${color.gray4};
+    box-shadow: none;
     cursor: default;
   }
 `;
+
+export const ActionBadge = styled.span`
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+  border: 2px solid var(--matching-panel-bg, #fff);
+  border-radius: 999px;
+  background: var(--matching-accent, #FF9500);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  box-sizing: border-box;
+`;
+
 
 
 
@@ -536,12 +590,22 @@ export const BackendTrafficToggleStatus = styled.span`
 `;
 
 export const HeaderContainer = styled.div`
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 12;
   display: flex;
   justify-content: flex-end;
   align-items: center;
   gap: 8px;
-  padding: 10px 12px;
+  padding: max(10px, env(safe-area-inset-top)) 12px 10px;
+  background: var(--matching-panel-bg, rgba(246, 247, 249, 0.94));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+
+  @media (max-width: 768px) {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
 `;
 
 export const LoadMoreButton = styled.button`
@@ -616,26 +680,29 @@ export const FilterOverlay = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.42);
   z-index: 15;
   display: ${props => (props.show ? 'block' : 'none')};
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
 `;
 
-export const FilterContainer = styled.div`
+export const FilterContainer = styled.aside`
   position: fixed;
   top: 0;
   right: 0;
   height: 100%;
-  width: 320px;
-  max-width: 80%;
+  width: min(390px, 92vw);
   ${matchingThemeVars}
   background: var(--matching-panel-bg);
   color: var(--matching-panel-text);
   z-index: 20;
   transform: translateX(${props => (props.show ? '0' : '100%')});
-  transition: transform 0.3s ease-in-out;
-  padding: 10px;
+  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  box-shadow: ${props => (props.show ? '-24px 0 48px rgba(0, 0, 0, 0.24)' : 'none')};
 
   input,
   textarea,
@@ -646,49 +713,175 @@ export const FilterContainer = styled.div`
   }
 
   button {
-    transition: background 220ms cubic-bezier(0.4, 0, 0.2, 1), color 220ms cubic-bezier(0.4, 0, 0.2, 1), border-color 220ms cubic-bezier(0.4, 0, 0.2, 1);
+    transition: background 220ms cubic-bezier(0.4, 0, 0.2, 1), color 220ms cubic-bezier(0.4, 0, 0.2, 1), border-color 220ms cubic-bezier(0.4, 0, 0.2, 1), transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 `;
 
-export const FilterResetButton = styled.button`
-  width: 100%;
-  padding: 10px;
-  margin: 0 0 10px;
-  border: 1px solid ${color.gray3};
-  border-radius: 8px;
-  background: ${color.accent5};
-  color: #fff;
-  font-weight: 600;
-  cursor: pointer;
+export const FilterDrawerHeader = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  padding: max(16px, env(safe-area-inset-top)) 16px 12px;
+  border-bottom: 1px solid var(--matching-section-border, #eee);
+  background: var(--matching-panel-bg, #fff);
 `;
 
+export const FilterDrawerTitle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const FilterDrawerHeading = styled.h2`
+  margin: 0;
+  color: var(--matching-header-text, #161616);
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1.2;
+`;
+
+export const FilterDrawerSubtitle = styled.p`
+  margin: 0;
+  color: var(--matching-muted-text, #6B7280);
+  font-size: 12px;
+  line-height: 1.35;
+`;
+
+export const FilterDrawerClose = styled.button`
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--matching-section-border, #E8E2D8);
+  border-radius: 999px;
+  background: var(--matching-action-bg, #fff);
+  color: var(--matching-action-color, #FF9500);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex: 0 0 auto;
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--matching-accent, #FF9500);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(247, 147, 30, 0.38);
+    outline-offset: 2px;
+  }
+`;
+
+export const FilterDrawerBody = styled.div`
+  flex: 1 1 auto;
+  padding: 12px 14px 96px;
+`;
+
+export const FilterDrawerSection = styled.section`
+  margin: 0 0 12px;
+`;
+
+export const FilterDrawerFooter = styled.div`
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  padding: 12px 14px max(14px, env(safe-area-inset-bottom));
+  border-top: 1px solid var(--matching-section-border, #eee);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), var(--matching-panel-bg, #fff) 18%);
+`;
+
+
+export const FilterResetButton = styled.button`
+  width: 100%;
+  padding: 12px 14px;
+  margin: 0;
+  border: 1px solid rgba(220, 38, 38, 0.28);
+  border-radius: 14px;
+  background: rgba(220, 38, 38, 0.06);
+  color: #b42318;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(220, 38, 38, 0.1);
+    border-color: rgba(220, 38, 38, 0.42);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(220, 38, 38, 0.22);
+    outline-offset: 2px;
+  }
+`;
+
+
 export const CollectionSourceWrap = styled.div`
-  margin: 0 0 10px;
-  border: 1px solid ${color.gray3};
-  border-radius: 8px;
+  margin: 0 0 12px;
+  border: 1px solid var(--matching-section-border, ${color.gray3});
+  border-radius: 16px;
   padding: 10px;
   background: var(--matching-section-bg, #fff);
   color: var(--matching-panel-text, #2c2d38);
+  box-shadow: var(--matching-section-shadow, 0 8px 18px rgba(22, 22, 22, 0.06));
 `;
 
 export const CollectionSourceTitle = styled.p`
   margin: 0 0 8px;
-  font-weight: 600;
-  color: #2c2d38;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--matching-chip-label, #6B7280);
+`;
+
+export const CollectionSourceOptions = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
 `;
 
 export const CollectionSourceLabel = styled.label`
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 0 0 6px;
+  justify-content: center;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-chip-border, #E5E0D8)')};
+  border-radius: 12px;
+  background: ${({ $active }) => ($active ? 'rgba(255, 149, 0, 0.14)' : 'var(--matching-chip-bg, #fff)')};
+  color: ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-chip-text, #2c2d38)')};
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
   cursor: pointer;
-  color: #2c2d38;
 
   input {
-    accent-color: ${color.accent5};
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  &:hover {
+    border-color: var(--matching-accent, #FF9500);
+  }
+
+  &:has(input:focus-visible) {
+    outline: 3px solid rgba(247, 147, 30, 0.38);
+    outline-offset: 2px;
   }
 `;
+
 
 export const Title = styled.span`
   color: ${props => getRoleColors(props.$role).text};
@@ -1373,31 +1566,49 @@ export const ModernContactLink = styled.a`
 
 export const ModernDesktopNavButton = styled.button`
   position: absolute;
-  top: 50%;
-  ${({ $side }) => ($side === 'left' ? 'left: 8px;' : 'right: 8px;')}
-  transform: translateY(-50%);
+  top: 0;
+  bottom: 0;
+  ${({ $side }) => ($side === 'left' ? 'left: 0;' : 'right: 0;')}
   z-index: 9;
-  width: 26px;
-  height: 40px;
-  border: 1px solid rgba(255, 255, 255, 0.26);
-  border-radius: 999px;
-  background: rgba(21, 18, 15, 0.26);
-  color: rgba(255, 255, 255, 0.84);
+  width: 56px;
+  border: 0;
+  border-radius: ${({ $side }) => ($side === 'left' ? `${STACK_CARD_RADIUS} 0 0 ${STACK_CARD_RADIUS}` : `0 ${STACK_CARD_RADIUS} ${STACK_CARD_RADIUS} 0`)};
+  background: ${({ $side }) => ($side === 'left'
+    ? 'linear-gradient(90deg, rgba(12, 10, 8, 0.38) 0%, rgba(12, 10, 8, 0.10) 62%, transparent 100%)'
+    : 'linear-gradient(270deg, rgba(12, 10, 8, 0.38) 0%, rgba(12, 10, 8, 0.10) 62%, transparent 100%)')};
+  color: rgba(255, 255, 255, 0.88);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  backdrop-filter: blur(8px);
-  transition: opacity 0.2s ease, background 0.2s ease;
+  opacity: 0.72;
+  transition: opacity 0.2s ease, background 0.2s ease, color 0.2s ease;
+
+  svg {
+    width: 26px;
+    height: 44px;
+    padding: 0 5px;
+    border: 1px solid rgba(255, 255, 255, 0.26);
+    border-radius: 999px;
+    background: rgba(21, 18, 15, 0.34);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-sizing: border-box;
+  }
 
   &:hover:not(:disabled),
   &:focus-visible:not(:disabled) {
-    background: rgba(21, 18, 15, 0.68);
+    opacity: 1;
     color: #fff;
   }
 
+  &:focus-visible {
+    outline: 3px solid rgba(247, 147, 30, 0.42);
+    outline-offset: -4px;
+  }
+
   &:disabled {
-    opacity: 0.24;
+    opacity: 0.18;
     cursor: default;
   }
 
@@ -1405,6 +1616,7 @@ export const ModernDesktopNavButton = styled.button`
     display: none;
   }
 `;
+
 
 export const ModernActionRail = styled.div`
   position: absolute;

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -42,7 +42,7 @@ export const SearchFilters = ({
     groups = [
       {
         filterName: 'userRole',
-        label: '',
+        label: 'Тип профілю',
         options: [
           { val: 'ed', label: 'ДО' },
           { val: 'ag', label: 'Агентства' },
@@ -52,7 +52,7 @@ export const SearchFilters = ({
       },
       {
         filterName: 'maritalStatus',
-        label: '',
+        label: 'Статус',
         options: [
           { val: 'married', label: 'Married' },
           { val: 'unmarried', label: 'Single' },
@@ -73,7 +73,7 @@ export const SearchFilters = ({
       },
       {
         filterName: 'rh',
-        label: '',
+        label: 'Rh',
         options: [
           { val: '+', label: 'Rh+' },
           { val: '-', label: 'Rh-' },
@@ -107,7 +107,7 @@ export const SearchFilters = ({
       },
       {
         filterName: 'country',
-        label: '',
+        label: 'Країна',
         options: [
           { val: 'ua', label: 'Ukraine' },
           { val: 'other', label: 'Other country' },


### PR DESCRIPTION
### Motivation
- Improve accessibility and keyboard interaction for filter chips and the matching filters drawer.
- Make the filter panel a proper accessible drawer with header, body and footer and surface the number of changed filter groups.
- Polish visuals and spacing across matching controls and chips for better responsiveness and touch interaction.

### Description
- Updated `CheckboxGroup.jsx` to increase chip padding/min-height, adjust spacing, add `aria-pressed` and descriptive `aria-label`, fallback readable label, hover transform and `:focus-visible` outline for keyboard focus.
- Introduced `countChangedMatchingFilterGroups` and integrated `getDefaultFilters` in `Matching.jsx` to compute `activeFilterGroupCount`, derive a localized drawer subtitle, and show a badge on the filters action when groups are changed.
- Reworked the matching filters UI in `Matching.jsx` to render an accessible drawer (`role="dialog"`, `aria-modal`) with `FilterDrawerHeader`, `FilterDrawerBody`, and `FilterDrawerFooter`, moved collection source controls into the drawer, and added ARIA attributes and `title`s on action buttons.
- Added new styled components and style refinements in `Matching.styled.jsx` (e.g. `TopActionGroup`, `ActionBadge`, sticky `HeaderContainer`, improved `FilterContainer` as a drawer, overlay/backdrop changes, focus outlines and responsive adjustments) and adapted button states/transitions.
- Localized and clarified several filter group labels in `SearchFilters.jsx` for `mode="matching"` (for example `userRole` -> `Тип профілю`, `maritalStatus` -> `Статус`, `country` -> `Країна`).

### Testing
- Ran unit tests with `npm test`; all tests passed.
- Ran linter with `npm run lint`; no lint errors reported.
- Performed production build with `npm run build`; build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b20687bf8832687450345c24fbd02)