### PR TITLE
Hide VK contact on Matching cards and add regression test

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -474,6 +474,7 @@ const isValidId = isValidMatchingUserId;
 const isShortId = isShortMatchingUserId;
 const isAllowedIdForCollection = isAllowedIdForMatchingCollection;
 const NEW_USERS_USER_ID_PREFIXES = ['-O', 'AA', 'AB', 'VK', 'ID'];
+const MATCHING_HIDDEN_CONTACT_KEYS = ['vk'];
 const isLikelyNewUsersUserId = id => {
   const value = String(id || '').trim();
   return Boolean(value) && (
@@ -763,7 +764,7 @@ const getContactLabel = key => ({
 }[key] || key.charAt(0).toUpperCase() + key.slice(1));
 
 const ProfileContactLinks = ({ user, role }) => {
-  const entries = getContactEntries(user);
+  const entries = getContactEntries(user).filter(entry => !MATCHING_HIDDEN_CONTACT_KEYS.includes(entry.key));
   if (!entries.length) return null;
 
   return (
@@ -955,7 +956,7 @@ const SwipeableCard = ({
   const usedSummaryFieldKeys = collectProfileFieldKeys(heroFields);
   const bodyHeroFields = getQuickFacts(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys] });
   const usedBodyFieldKeys = collectProfileFieldKeys(bodyHeroFields);
-  const sections = getProfileSections(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys, ...usedBodyFieldKeys] });
+  const sections = getProfileSections(user, resolvedRole, { excludeKeys: [...identityAndLocationKeys, ...usedSummaryFieldKeys, ...usedBodyFieldKeys, ...MATCHING_HIDDEN_CONTACT_KEYS] });
   const bio = getProfileBio(user);
   const initials = name
     .split(/\s+/)

--- a/src/components/Matching.profileLayoutRegression.test.js
+++ b/src/components/Matching.profileLayoutRegression.test.js
@@ -18,6 +18,13 @@ describe('Matching redesigned profile regressions', () => {
     expect(matchingSource).toContain('CONTACT_LINK_BUILDERS.whatsappFromPhone');
   });
 
+  it('hides VK contacts from matching cards for every viewer, including admins', () => {
+    const matchingSource = source();
+
+    expect(matchingSource).toContain("const MATCHING_HIDDEN_CONTACT_KEYS = ['vk'];");
+    expect(matchingSource).toContain('getContactEntries(user).filter(entry => !MATCHING_HIDDEN_CONTACT_KEYS.includes(entry.key))');
+    expect(matchingSource).toContain('...MATCHING_HIDDEN_CONTACT_KEYS');
+  });
 
   it('builds matching profile names only from approved identity fields', () => {
     const matchingSource = source();


### PR DESCRIPTION
### Motivation

- Prevent VK (`vk`) contact entries from being rendered on matching profile cards for any viewer, including admins, to avoid exposing that channel in the action links UI.
- Ensure VK is also excluded from profile sections so it doesn't appear in other parts of the redesigned profile layout.

### Description

- Introduce `MATCHING_HIDDEN_CONTACT_KEYS = ['vk']` constant to list contact keys that should be hidden on matching cards.
- Filter contact entries in `ProfileContactLinks` with `.filter(entry => !MATCHING_HIDDEN_CONTACT_KEYS.includes(entry.key))` to remove `vk` before building actionable links.
- Add `...MATCHING_HIDDEN_CONTACT_KEYS` to the `excludeKeys` passed to `getProfileSections` so `vk` is omitted from profile sections.
- Add a regression test in `Matching.profileLayoutRegression.test.js` that asserts the `MATCHING_HIDDEN_CONTACT_KEYS` constant and the filtering/exclusion code are present in `Matching.jsx`.

### Testing

- Ran the updated unit test file `Matching.profileLayoutRegression.test.js`, and the new regression test passed.
- Ran the project's test suite (`yarn test`) and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba0bd7080832681e54d0ebf4eb33f)