### PR TITLE
Track matching contact detail views

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -79,6 +79,7 @@ import {
   lazyLoadProfilePhotos,
   fetchFavoriteUsers,
   fetchDislikeUsers,
+  addContactViewUser,
   filterMain,
   searchUsersOnly,
   fetchUserComments,
@@ -915,6 +916,7 @@ const SwipeableCard = ({
   const [dir, setDir] = useState(null);
   const favoriteButtonWrapRef = useRef(null);
   const dislikeButtonWrapRef = useRef(null);
+  const contactViewKeysRef = useRef(new Set());
   const touchStart = useRef(null);
   const swipedRef = useRef(false);
 
@@ -1003,6 +1005,17 @@ const SwipeableCard = ({
     `uiFailedFilters=${Array.isArray(diagnostics.uiFailedFilters) && diagnostics.uiFailedFilters.length ? diagnostics.uiFailedFilters.join('|') : '-'}`,
     `searchKeyFailedFilters=${Array.isArray(diagnostics.searchKeyFailedFilters) && diagnostics.searchKeyFailedFilters.length ? diagnostics.searchKeyFailedFilters.join('|') : '-'}`,
   ] : [];
+
+  const handleContactsToggle = e => {
+    e.stopPropagation();
+    const owner = auth.currentUser;
+    if (!e.currentTarget.open || !owner || !user.userId) return;
+    const contactViewKey = `${multiDataOwnerId || owner.uid}:${user.userId}`;
+    if (contactViewKeysRef.current.has(contactViewKey)) return;
+    contactViewKeysRef.current.add(contactViewKey);
+    void addContactViewUser(user.userId, multiDataOwnerId);
+  };
+
   const handleTouchStart = e => {
     if (!e.touches || e.touches.length !== 1) return;
     const touch = e.touches[0];
@@ -1160,7 +1173,7 @@ const SwipeableCard = ({
           ))}
           {sections.filter(section => section.variant === 'contacts').map(section => (
             <ModernSection key={section.title}>
-              <ModernContactDetails onClick={e => e.stopPropagation()} onTouchStart={e => e.stopPropagation()} onTouchEnd={e => e.stopPropagation()}>
+              <ModernContactDetails onToggle={handleContactsToggle} onClick={e => e.stopPropagation()} onTouchStart={e => e.stopPropagation()} onTouchEnd={e => e.stopPropagation()}>
                 <ModernContactSummary>Show contacts</ModernContactSummary>
                 <ProfileContactLinks user={user} role={resolvedRole} />
               </ModernContactDetails>

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -567,6 +567,16 @@ export const addDislikeUser = async (userId, ownerId) => {
   }
 };
 
+export const addContactViewUser = async (userId, ownerId) => {
+  try {
+    const owner = auth.currentUser;
+    if (!owner) return;
+    await set(ref2(database, `multiData/contactViews/${ownerId || owner.uid}/${userId}`), true);
+  } catch (error) {
+    console.error('Error adding contact view user:', error);
+  }
+};
+
 export const removeDislikeUser = async (userId, ownerId) => {
   try {
     const owner = auth.currentUser;


### PR DESCRIPTION
### Motivation
- Record when a viewer opens a profile's contact block so contact views can be tracked per-owner similar to favorites/dislikes.

### Description
- Added `addContactViewUser(userId, ownerId)` helper in `src/components/config.js` that checks `auth.currentUser` and writes `true` to `multiData/contactViews/${ownerId || owner.uid}/${userId}`.
- Imported `addContactViewUser` into `src/components/Matching.jsx` and attached a `handleContactsToggle` handler that runs on `<ModernContactDetails onToggle>` and only records a view when `e.currentTarget.open` is true, `auth.currentUser` and `user.userId` exist, and the view hasn't been recorded yet for this render.
- Added per-card cache `contactViewKeysRef = useRef(new Set())` to avoid duplicate writes during the same render and preserved existing `onClick`/`onTouchStart`/`onTouchEnd` `stopPropagation` handlers to keep swipe/navigation behavior unchanged.
- No RTDB rules file was found in the repo so rules were not modified in code, but the intended RTDB structure is `multiData/contactViews/{ownerId}/{userId}: true` and a suggested rules block was provided for the `multiData` rules set (not applied here).

### Testing
- Ran unit tests `npm test -- --watchAll=false src/components/smallCard/btnFavorite.test.js src/components/smallCard/btnDislike.test.js` and both test suites passed.
- Ran linting with `npm run lint:js` and it completed without errors.
- Built production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bc5839f0c832699e4e56b753cdaba)