### PR TITLE
Extract compact date row styles and apply to smallCard date fields; adjust status layout in top block

### DIFF
--- a/src/components/smallCard/compactDateRowStyles.js
+++ b/src/components/smallCard/compactDateRowStyles.js
@@ -1,0 +1,38 @@
+export const compactDateRowStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  flexWrap: 'wrap',
+  minWidth: 0,
+  width: '100%',
+  overflow: 'visible',
+};
+
+export const compactDateInputStyle = {
+  textAlign: 'left',
+  marginLeft: 0,
+  flex: '1 1 9ch',
+  minWidth: '8ch',
+  maxWidth: '11ch',
+};
+
+export const compactDateButtonStyle = {
+  width: '22px',
+  minWidth: '22px',
+  height: '22px',
+  padding: 0,
+  marginLeft: 0,
+  marginRight: 0,
+  fontSize: '10px',
+  borderRadius: '7px',
+  flex: '0 0 22px',
+};
+
+export const compactDateActionsStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2px',
+  flex: '1 1 132px',
+  flexWrap: 'wrap',
+  minWidth: 0,
+};

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -5,6 +5,12 @@ import {
   formatDateToServer,
 } from 'components/inputValidations';
 import { OrangeBtn, UnderlinedInput } from 'components/styles';
+import {
+  compactDateActionsStyle,
+  compactDateButtonStyle,
+  compactDateInputStyle,
+  compactDateRowStyle,
+} from './compactDateRowStyles';
 
 export const fieldGetInTouch = (
   userData,
@@ -82,33 +88,14 @@ export const fieldGetInTouch = (
   const ActionButton = ({ label, days, onClick }) => (
     <OrangeBtn
       onClick={() => (onClick ? onClick(days) : null)}
-      style={{
-        minWidth: '22px',
-        width: '22px',
-        height: '22px',
-        padding: 0,
-        marginLeft: 0,
-        marginRight: 0,
-        fontSize: '10px',
-        borderRadius: '7px',
-      }}
+      style={compactDateButtonStyle}
     >
       {label}
     </OrangeBtn>
   );
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '3px',
-        flexWrap: 'wrap',
-        minWidth: 0,
-        width: '100%',
-        overflow: 'hidden',
-      }}
-    >
+    <div style={compactDateRowStyle}>
       <UnderlinedInput
         type="text"
         value={formatDateToDisplay(formatDateAndFormula(userData.getInTouch)) || ''}
@@ -185,24 +172,9 @@ export const fieldGetInTouch = (
             { currentFilter, isDateInRange, ...submitOptions },
           );
         }}
-        style={{
-          marginLeft: 0,
-          textAlign: 'left',
-          flex: '1 1 8.5ch',
-          minWidth: '7.5ch',
-          maxWidth: '10.5ch',
-        }}
+        style={compactDateInputStyle}
       />
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '2px',
-          flex: '999 1 112px',
-          flexWrap: 'wrap',
-          minWidth: 0,
-        }}
-      >
+      <div style={compactDateActionsStyle}>
         <ActionButton label="3д" days={3} onClick={handleAddDays} />
         {/* <ActionButton label="7д" days={7} onClick={handleAddDays} /> */}
         <ActionButton label="1м" days={30} onClick={handleAddDays} />

--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -4,6 +4,7 @@ import { formatDateToDisplay, formatDateToServer } from 'components/inputValidat
 import { generateSchedule, serializeSchedule } from '../StimulationSchedule';
 import InfoModal from 'components/InfoModal';
 import { UnderlinedInput, AttentionButton, AttentionDiv, OrangeBtn, color } from 'components/styles';
+import { compactDateButtonStyle, compactDateInputStyle, compactDateRowStyle } from './compactDateRowStyles';
 import { getExpectedDeliveryDate } from 'utils/cycleStatus';
 
 const calculateNextDate = dateString => {
@@ -496,42 +497,18 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
       }
     `}
       </style>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '4px',
-          flexWrap: 'wrap',
-          minWidth: 0,
-          width: '100%',
-          overflow: 'hidden',
-        }}
-      >
+      <div style={compactDateRowStyle}>
         <UnderlinedInput
           type="text"
           value={localValue}
           placeholder="міс"
           onChange={handleLastCycleChange}
           onBlur={handleBlur}
-          style={{
-            textAlign: 'left',
-            color: 'white',
-            marginLeft: 0,
-            flex: '1 1 8.5ch',
-            minWidth: '7.5ch',
-            maxWidth: '10.5ch',
-          }}
+          style={{ ...compactDateInputStyle, color: 'white' }}
         />
         <OrangeBtn
           onClick={handleSetToday}
-          style={{
-            width: '22px',
-            minWidth: '22px',
-            height: '22px',
-            marginLeft: 0,
-            padding: 0,
-            borderRadius: '7px',
-          }}
+          style={compactDateButtonStyle}
         >
           T
         </OrangeBtn>

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -168,11 +168,11 @@ const roleBadgeStyle = role => ({
 });
 
 const statusRowStyle = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 160px), 1fr))',
-  alignItems: 'center',
-  gap: '4px',
-  padding: '5px 6px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+  gap: '6px',
+  padding: '6px',
   borderRadius: '8px',
   background: 'rgba(255,255,255,0.08)',
   border: '1px solid rgba(255,255,255,0.1)',
@@ -187,7 +187,7 @@ const statusItemStyle = {
   alignItems: 'center',
   minWidth: 0,
   width: '100%',
-  overflow: 'hidden',
+  overflow: 'visible',
 };
 
 const getInTouchStatusItemStyle = {


### PR DESCRIPTION
### Motivation
- Consolidate repeated inline styles for compact date inputs and action buttons into a single exported style module for reuse and maintainability.
- Make date input rows behave more predictably with wrapping and overflow handling across small card components.
- Improve the top block status area layout to better support stacked content and avoid clipping by changing overflow behavior.

### Description
- Add a new `src/components/smallCard/compactDateRowStyles.js` file that exports `compactDateRowStyle`, `compactDateInputStyle`, `compactDateButtonStyle`, and `compactDateActionsStyle` for reuse.
- Replace inline styles in `fieldGetInTouch.js` with the new compact date styles and refactor the `ActionButton` to apply `compactDateButtonStyle` instead of an inline object.
- Replace inline styles in `fieldLastCycle.js` with `compactDateRowStyle` and `compactDateInputStyle` (merging color) and apply `compactDateButtonStyle` to the today button.
- Update `renderTopBlock.js` to change `statusRowStyle` from a grid to a column flex layout, tweak padding/gap, and set `statusItemStyle.overflow` to `visible` to prevent clipping.

### Testing
- Ran the project linting with `yarn lint` and fixed style issues introduced by the refactor, with no lint errors remaining.
- Executed the unit test suite with `yarn test` and confirmed all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bcab6783c8326a2e1a4474e917c6e)