### PR TITLE
Перенести кнопки лайк/дизлайк після кнопки `1р` у `renderTopBlock`

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -29,6 +29,8 @@ export const BtnDislike = ({
   inactiveIconColor = '#fff',
   activeIconColor = color.reactionIdleIcon,
   iconSize = 18,
+  activeBorderWidth = 4,
+  activeBoxShadowWidth = 2,
   title = 'Дизлайк',
   ariaLabel = 'Дизлайк',
   multiDataOwnerId,
@@ -126,11 +128,11 @@ export const BtnDislike = ({
           ? activeColor
           : customBackground || customBackgroundColor || color.accent5,
         border: isDisliked
-          ? `4px solid ${activeBorderColor}`
+          ? `${activeBorderWidth}px solid ${activeBorderColor}`
           : customBorder || `2px solid ${color.reactionIdleBorder}`,
         color: isDisliked ? resolvedActiveIconColor : resolvedInactiveIconColor,
         boxShadow: isDisliked
-          ? `0 0 0 2px ${activeColor}`
+          ? `0 0 0 ${activeBoxShadowWidth}px ${activeColor}`
           : customBoxShadow || 'none',
         opacity: 1,
         zIndex: 1,

--- a/src/components/smallCard/btnFavorite.js
+++ b/src/components/smallCard/btnFavorite.js
@@ -28,6 +28,8 @@ export const BtnFavorite = ({
   inactiveIconColor = '#fff',
   activeIconColor = color.reactionIdleIcon,
   iconSize = 18,
+  activeBorderWidth = 4,
+  activeBoxShadowWidth = 2,
   title = 'В обране',
   ariaLabel = 'В обране',
   multiDataOwnerId,
@@ -122,11 +124,11 @@ export const BtnFavorite = ({
           ? activeColor
           : customBackground || customBackgroundColor || color.accent5,
         border: isFavorite
-          ? `4px solid ${activeBorderColor}`
+          ? `${activeBorderWidth}px solid ${activeBorderColor}`
           : customBorder || `2px solid ${color.reactionIdleBorder}`,
         color: isFavorite ? resolvedActiveIconColor : resolvedInactiveIconColor,
         boxShadow: isFavorite
-          ? `0 0 0 2px ${activeColor}`
+          ? `0 0 0 ${activeBoxShadowWidth}px ${activeColor}`
           : customBoxShadow || 'none',
         opacity: 1,
         zIndex: 1,

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -19,6 +19,7 @@ export const fieldGetInTouch = (
   currentFilter,
   isDateInRange,
   submitOptions = {},
+  trailingActions = null,
 ) => {
   const handleAddDays = days => {
     const currentDate = new Date();
@@ -181,6 +182,7 @@ export const fieldGetInTouch = (
         <ActionButton label="3м" days={90} onClick={handleAddDays} />
         <ActionButton label="6м" days={180} onClick={handleAddDays} />
         <ActionButton label="1р" days={365} onClick={handleAddDays} />
+        {trailingActions}
       </div>
     </div>
   );

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -12,6 +12,7 @@ import { handleChange } from './actions';
 import { fieldRole } from './fieldRole';
 import { FieldLastCycle } from './fieldLastCycle';
 import { FieldComment } from './FieldComment';
+import { compactDateButtonStyle } from './compactDateRowStyles';
 import { fieldBirth } from './fieldBirth';
 import { fieldBlood } from './fieldBlood';
 import { fieldMaritalStatus } from './fieldMaritalStatus';
@@ -97,6 +98,18 @@ const compactTopActionButtonStyle = {
   height: '30px',
   minHeight: '30px',
   flex: '0 0 30px',
+};
+
+const compactReactionButtonStyle = {
+  ...compactDateButtonStyle,
+  position: 'static',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: compactDateButtonStyle.height,
+  padding: 0,
+  margin: 0,
+  boxShadow: '0 2px 5px rgba(17, 24, 39, 0.18)',
 };
 
 const addedOverlayEntryStyle = {
@@ -824,6 +837,84 @@ const TopBlock = ({
     )
   );
 
+  const getInTouchReactionActions = (
+    <>
+      <BtnDislike
+        title="Дизлайк"
+        ariaLabel="Дизлайк"
+        userId={cardData.userId}
+        userData={cardData}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        onDislikeAdded={() =>
+          handleChange(
+            setUsers,
+            setState,
+            cardData.userId,
+            'getInTouch',
+            '2099-99-99',
+            true,
+            { currentFilter, isDateInRange, ...submitOptions },
+          )
+        }
+        onDislikeRemoved={() =>
+          handleChange(
+            setUsers,
+            setState,
+            cardData.userId,
+            'getInTouch',
+            '',
+            true,
+            { currentFilter, isDateInRange, ...submitOptions },
+          )
+        }
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        customStyle={{
+          ...compactReactionButtonStyle,
+          backgroundColor: '#ef6c00',
+          border: 'none',
+        }}
+        inactiveIconColor="#fff"
+        activeIconColor="#1f2937"
+        iconSize={11}
+        activeBorderWidth={2}
+        activeBoxShadowWidth={1}
+      />
+      <BtnFavorite
+        title="В обране"
+        ariaLabel="В обране"
+        userId={cardData.userId}
+        userData={cardData}
+        favoriteUsers={favoriteUsers}
+        setFavoriteUsers={setFavoriteUsers}
+        dislikeUsers={dislikeUsers}
+        setDislikeUsers={setDislikeUsers}
+        onDislikeRemoved={() =>
+          handleChange(
+            setUsers,
+            setState,
+            cardData.userId,
+            'getInTouch',
+            '',
+            true,
+            { currentFilter, isDateInRange, ...submitOptions },
+          )
+        }
+        customStyle={{
+          ...compactReactionButtonStyle,
+          backgroundColor: '#f9a825',
+          border: 'none',
+        }}
+        inactiveIconColor="#fff"
+        activeIconColor="#1f2937"
+        iconSize={11}
+        activeBorderWidth={2}
+        activeBoxShadowWidth={1}
+      />
+    </>
+  );
+
   const topActions = [
     {
       key: 'delete',
@@ -840,87 +931,6 @@ const TopBlock = ({
           <path d="M10 11v5M14 11v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
         </svg>,
         { ...zoneActionButtonStyle, backgroundColor: '#d32f2f', color: '#fff' }
-      ),
-    },
-    {
-      key: 'dislike',
-      color: '#ef6c00',
-      content: (
-        <BtnDislike
-          title="Дизлайк"
-          ariaLabel="Дизлайк"
-          userId={cardData.userId}
-          userData={cardData}
-          dislikeUsers={dislikeUsers}
-          setDislikeUsers={setDislikeUsers}
-          onDislikeAdded={() =>
-            handleChange(
-              setUsers,
-              setState,
-              cardData.userId,
-              'getInTouch',
-              '2099-99-99',
-              true,
-              { currentFilter, isDateInRange, ...submitOptions },
-            )
-          }
-          onDislikeRemoved={() =>
-            handleChange(
-              setUsers,
-              setState,
-              cardData.userId,
-              'getInTouch',
-              '',
-              true,
-              { currentFilter, isDateInRange, ...submitOptions },
-            )
-          }
-          favoriteUsers={favoriteUsers}
-          setFavoriteUsers={setFavoriteUsers}
-          customStyle={{
-            ...zoneActionButtonStyle,
-            backgroundColor: '#ef6c00',
-            border: 'none',
-          }}
-          inactiveIconColor="#fff"
-          activeIconColor="#1f2937"
-          iconSize={15}
-        />
-      ),
-    },
-    {
-      key: 'favorite',
-      color: '#f9a825',
-      content: (
-        <BtnFavorite
-          title="В обране"
-          ariaLabel="В обране"
-          userId={cardData.userId}
-          userData={cardData}
-          favoriteUsers={favoriteUsers}
-          setFavoriteUsers={setFavoriteUsers}
-          dislikeUsers={dislikeUsers}
-          setDislikeUsers={setDislikeUsers}
-          onDislikeRemoved={() =>
-            handleChange(
-              setUsers,
-              setState,
-              cardData.userId,
-              'getInTouch',
-              '',
-              true,
-              { currentFilter, isDateInRange, ...submitOptions },
-            )
-          }
-          customStyle={{
-            ...zoneActionButtonStyle,
-            backgroundColor: '#f9a825',
-            border: 'none',
-          }}
-          inactiveIconColor="#fff"
-          activeIconColor="#1f2937"
-          iconSize={15}
-        />
       ),
     },
     typeof onOpenMedications === 'function' && {
@@ -1028,7 +1038,15 @@ const TopBlock = ({
       </div>
       <div style={statusRowStyle}>
         <div style={getInTouchStatusItemStyle}>
-          {fieldGetInTouch(cardData, setUsers, setState, currentFilter, isDateInRange, submitOptions)}
+          {fieldGetInTouch(
+            cardData,
+            setUsers,
+            setState,
+            currentFilter,
+            isDateInRange,
+            submitOptions,
+            getInTouchReactionActions,
+          )}
         </div>
         {!hasHiddenCycleFieldRole && (
           <div style={statusItemStyle}>


### PR DESCRIPTION
### Motivation
- Перемістити кнопки реакцій (лайк/дизлайк) з верхнього ряду дій у блок дати `getInTouch`, щоб вони відображалися після кнопки `1р` і були ближчі до логіки відмічання контакту. 
- Зберегти існуючу кольорову гаму та візуальну мову реакцій. 
- Максимально перевикористати наявні стилі та компоненти, щоб форма і розмір відповідали кнопці `1р`.

### Description
- Додав параметр `trailingActions` до `fieldGetInTouch` і передаю в нього новий JSX `getInTouchReactionActions`, щоб вбудувати кнопки після `1р` (`src/components/smallCard/fieldGetInTouch.js`, `src/components/smallCard/renderTopBlock.js`).
- Створив компактний стиль `compactReactionButtonStyle` на базі `compactDateButtonStyle` і використав його для кнопок, щоб зберегти форму/розмір як у `1р` (`src/components/smallCard/renderTopBlock.js`).
- Виніс дизлайк/лайк з масиву `topActions` і додав їх як `getInTouchReactionActions`, які передаються до `fieldGetInTouch` (логіка видалена з верхнього ряду і додана в блок `getInTouch`) (`src/components/smallCard/renderTopBlock.js`).
- Додав конфігурувані пропси `activeBorderWidth` та `activeBoxShadowWidth` у `BtnFavorite` і `BtnDislike` щоб дозволити тонку настройку товщини бордера/тіні для компактного варіанту без порушення стандартного вигляду (`src/components/smallCard/btnFavorite.js`, `src/components/smallCard/btnDislike.js`).

### Testing
- Запущено unit-тести: `npm test -- --watchAll=false src/components/smallCard/btnFavorite.test.js src/components/smallCard/btnDislike.test.js` — всі тести пройшли (2 suites, 3 tests passed). 
- Зібрано production-бандл: `npm run build` — збірка успішна. 
- Спроба зробити скриншот UI через Playwright завершилась невдало через помилку скачування браузера (`403 Domain forbidden`), тому візуальну перевірку в headless браузері не вдалося завершити.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bee7cfa6c8326a78e9794815ff3df)