### PR TITLE
Unify top refresh button styling

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -276,10 +276,13 @@ const commentsSectionStyle = {
 
 const detailsToggleStyle = {
   ...compactTopActionButtonStyle,
+  alignItems: 'center',
+  justifyContent: 'center',
   cursor: 'pointer',
-  color: '#ebe0c2',
-  background: 'rgba(255,255,255,0.12)',
-  opacity: 0.85,
+  backgroundColor: '#1976d2',
+  color: '#fff',
+  border: 'none',
+  boxShadow: '0 3px 8px rgba(17, 24, 39, 0.25)',
   lineHeight: 1,
 };
 
@@ -1029,9 +1032,9 @@ const TopBlock = ({
             title="Оновити дані з бекенду та показати всі поля"
             aria-label="Оновити дані з бекенду та показати всі поля"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M4 12a8 8 0 0 1 14.93-4H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M20 12a8 8 0 0 1-14.93 4H9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M4 12a8 8 0 0 1 14.93-4H15" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M20 12a8 8 0 0 1-14.93 4H9" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </button>
         </div>


### PR DESCRIPTION
### Motivation
- Make the top refresh/details button visually consistent with other action buttons in the top bar by reusing existing styles and matching color/border/shadow approach. 
- Ensure the refresh icon size and stroke weight match neighboring action icons for balanced visual weight. 
- Preserve the button behavior and layout so the control remains `30px x 30px`, centered, and still calls `handleDetailsRefresh` on click. 

### Description
- Updated `detailsToggleStyle` in `src/components/smallCard/renderTopBlock.js` to extend `...compactTopActionButtonStyle` and added `alignItems: 'center'`, `justifyContent: 'center'`, `backgroundColor: '#1976d2'`, `color: '#fff'`, `border: 'none'`, and `boxShadow: '0 3px 8px rgba(17, 24, 39, 0.25)'` to match other top action buttons. 
- Replaced the local refresh SVG `width=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf2ea71f08326be3ec014f7d4395e)