### PR TITLE
Cache-first search: add getFreshCachedSearchResult and use cache in cachedSearch

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -773,6 +773,56 @@ const isSearchPerfDebugEnabled = () => {
   }
 };
 
+
+export const getFreshCachedSearchResult = (key, value) => {
+  if (!key || value === undefined || value === null || String(value).trim() === '') {
+    return { hit: false, cards: [], map: {} };
+  }
+
+  const cacheKey = getCacheKey('search', normalizeQueryKey(`${key}=${value}`));
+  const queries = loadQueries();
+  const entry = queries[cacheKey];
+  if (!entry) return { hit: false, cards: [], map: {} };
+
+  const timestampSource =
+    typeof entry.cachedAt === 'number' && Number.isFinite(entry.cachedAt)
+      ? entry.cachedAt
+      : Number(entry.cachedAt ?? entry.lastAction ?? 0);
+  if (!Number.isFinite(timestampSource) || timestampSource <= 0) {
+    return { hit: false, cards: [], map: {} };
+  }
+  if (Date.now() - timestampSource >= TTL_MS) {
+    return { hit: false, cards: [], map: {} };
+  }
+
+  const ids = getIdsByQuery(cacheKey);
+  if (ids.length === 0) return { hit: false, cards: [], map: {} };
+
+  const cards = ids.map(id => getCard(id)).filter(Boolean);
+  if (cards.length === 0 || cards.length !== ids.length) {
+    return { hit: false, cards: [], map: {} };
+  }
+
+  const map = cards.reduce((acc, card) => {
+    if (card?.userId) acc[card.userId] = card;
+    return acc;
+  }, {});
+
+  return {
+    hit: Object.keys(map).length > 0,
+    cards,
+    map,
+    cacheKey,
+    ids,
+  };
+};
+
+const formatCachedSearchResult = cachedResult => {
+  if (!cachedResult?.hit) return null;
+  if (cachedResult.cards.length === 1) return cachedResult.cards[0];
+  return { ...cachedResult.map };
+};
+
 const SearchBar = ({
   searchFunc,
   setUsers,
@@ -886,42 +936,20 @@ const SearchBar = ({
   };
 
   const loadCachedResult = (key, value, requestId = null) => {
-    const cacheKey = getCacheKey('search', normalizeQueryKey(`${key}=${value}`));
-    const ids = getIdsByQuery(cacheKey);
-    if (ids.length > 0) {
-      const cards = ids.map(id => getCard(id)).filter(Boolean);
-      if (cards.length > 0) {
-        applyUserNotFound(false, requestId);
-        if (key === 'name' || key === 'names' || cards.length > 1) {
-          applyState({}, requestId);
-          const map = {};
-          cards.forEach(c => {
-            map[c.userId] = c;
-          });
-          applyUsers(map, requestId);
-        } else {
-          applyState(cards[0], requestId);
-        }
-        return true;
-      }
+    const cachedResult = getFreshCachedSearchResult(key, value);
+    if (!cachedResult.hit) return false;
+
+    applyUserNotFound(false, requestId);
+    if (key === 'name' || key === 'names' || cachedResult.cards.length > 1) {
+      applyState({}, requestId);
+      applyUsers({ ...cachedResult.map }, requestId);
+    } else {
+      applyState(cachedResult.cards[0], requestId);
     }
-    return false;
+    return true;
   };
 
-  const isCacheFresh = (key, value) => {
-    const cacheKey = getCacheKey('search', normalizeQueryKey(`${key}=${value}`));
-    const queries = loadQueries();
-    const entry = queries[cacheKey];
-    if (!entry) return false;
-    const timestampSource =
-      typeof entry.cachedAt === 'number' && Number.isFinite(entry.cachedAt)
-        ? entry.cachedAt
-        : Number(entry.cachedAt ?? entry.lastAction ?? 0);
-    if (!Number.isFinite(timestampSource) || timestampSource <= 0) {
-      return false;
-    }
-    return Date.now() - timestampSource < TTL_MS;
-  };
+  const isCacheFresh = (key, value) => getFreshCachedSearchResult(key, value).hit;
 
   const addToHistory = value => {
     const trimmedVal = value.trim();
@@ -1257,6 +1285,15 @@ const SearchBar = ({
   };
 
   const cachedSearch = async (params, extraOptions = {}) => {
+    const [key, value] = Object.entries(params)[0] || [];
+    const cachedResult = getFreshCachedSearchResult(key, value);
+    if (cachedResult.hit) {
+      if (perfDebugEnabledRef.current) {
+        console.debug('[SearchPerf][cache-hit]', { params, ids: cachedResult.ids });
+      }
+      return formatCachedSearchResult(cachedResult);
+    }
+
     const perfLabel = `[SearchPerf][searchFunc] ${JSON.stringify(params)}`;
     if (perfDebugEnabledRef.current) console.time(perfLabel);
     const res = await searchFunc(params, {
@@ -1269,7 +1306,6 @@ const SearchBar = ({
       return res;
     }
 
-    const [key, value] = Object.entries(params)[0] || [];
     const arr = Array.isArray(res)
       ? res
       : 'userId' in res

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -1,4 +1,14 @@
-import { parseExplicitSearchKeyCandidate, parsePartialUserIdPrefix, resolveExecutionPlan } from './SearchBar';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import SearchBar, { getFreshCachedSearchResult, parseExplicitSearchKeyCandidate, parsePartialUserIdPrefix, resolveExecutionPlan } from './SearchBar';
+import { getCacheKey } from '../utils/cache';
+import { updateCard } from '../utils/cardsStorage';
+import { resetMatchingLocalStorageCache, setIdsForQuery } from '../utils/cardIndex';
+
+beforeAll(() => {
+  window.IS_REACT_ACT_ENVIRONMENT = true;
+});
 
 describe('parsePartialUserIdPrefix', () => {
   it('allows exact-case catalog key prefixes for users/newUsers userId search', () => {
@@ -53,5 +63,70 @@ describe('resolveExecutionPlan', () => {
       primaryKeys: ['telegram', 'phone', 'email'],
       fallbackKeys: [],
     });
+  });
+});
+
+
+describe('SearchBar cache-first search', () => {
+  beforeEach(() => {
+    resetMatchingLocalStorageCache('SearchBar cache-first test');
+  });
+
+  it('returns cached cards for repeated partial userId searches without calling the backend search function', async () => {
+    updateCard('Anna123', { userId: 'Anna123', name: 'Anna Cached' });
+    setIdsForQuery(getCacheKey('search', 'userId=Anna123'), ['Anna123']);
+
+    const cachedResult = getFreshCachedSearchResult('userId', 'Anna123');
+    expect(cachedResult.hit).toBe(true);
+    expect(cachedResult.cards).toHaveLength(1);
+    expect(cachedResult.cards[0].name).toBe('Anna Cached');
+
+    const searchFunc = jest.fn().mockResolvedValue({});
+    const setUsers = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'Anna123',
+        setSearch: jest.fn(),
+        setUsers,
+        setState: jest.fn(),
+        setUserNotFound: jest.fn(),
+        enabledSearchKeys: {
+          partialUserId: true,
+          searchId: false,
+          searchKey: false,
+          equalToAllCards: false,
+        },
+        searchOptions: {
+          enabledSearchKeys: {
+            partialUserId: true,
+            searchId: false,
+            searchKey: false,
+            equalToAllCards: false,
+          },
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(setUsers).toHaveBeenCalledWith({
+      Anna123: expect.objectContaining({
+        userId: 'Anna123',
+        name: 'Anna Cached',
+      }),
+    });
+    expect(searchFunc).not.toHaveBeenCalled();
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
   });
 });


### PR DESCRIPTION
### Motivation
- Reduce unnecessary backend searches by returning fresh cached search results when available to improve performance.
- Centralize cache validation and result formatting logic to avoid duplicated timestamp and integrity checks.
- Preserve existing behavior for stale or incomplete caches by falling back to live search execution.

### Description
- Introduced `getFreshCachedSearchResult(key, value)` to validate TTL, load ids, resolve cards, and return a structured cache hit object with `hit`, `cards`, `map`, `cacheKey`, and `ids`.
- Added `formatCachedSearchResult` to convert a cache hit into the same shape as live `searchFunc` responses (single card or map of cards).
- Reworked `loadCachedResult` and `isCacheFresh` to use `getFreshCachedSearchResult` and simplified their logic accordingly.
- Updated `cachedSearch` to check the fresh cache first and return cached results (with a `console.debug` perf log on hit) before calling `searchFunc`, and kept previous caching behavior for fresh live results.
- Expanded unit test `SearchBar.partialUserId.test.js` to set up local storage/card index fixtures and added an integration-style test that verifies cache-first behavior for partial userId searches without invoking the backend `searchFunc`.

### Testing
- Ran unit tests with Jest focusing on `SearchBar.partialUserId.test.js`, which includes the new cache-first test; all tests passed.
- Verified the new cache utility function behavior by exercising it via the added test that populates card storage and query ids, and asserting `getFreshCachedSearchResult` returns a hit and that `searchFunc` is not called when cache is fresh.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf00a1144832696bdafa5d7a646ab)