### PR TITLE
Add concurrency to GitHub Pages workflow and update deploy action to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -36,7 +40,7 @@ jobs:
           npm run build
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: build


### PR DESCRIPTION
### Motivation
- Prevent concurrent GitHub Pages deployments from overlapping and use the maintained `v4` tag of the deploy action for clearer versioning and compatibility.

### Description
- Added a `concurrency` block (`group: github-pages`, `cancel-in-progress: true`) to `.github/workflows/deploy.yml` and updated `JamesIves/github-pages-deploy-action` from `4.1.0` to `v4`, with no other workflow steps modified.

### Testing
- The workflow executes `npm install`, `npm run lint:js`, and `npm run build` as part of CI; these steps are unchanged and will run in GitHub Actions, and no automated test runs were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bfc9a35108326a89eda7f289278ff)