### PR TITLE
Scope SearchBar cache entries by search options

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -774,12 +774,58 @@ const isSearchPerfDebugEnabled = () => {
 };
 
 
-export const getFreshCachedSearchResult = (key, value) => {
+const SEARCH_CACHE_SCOPE_OPTION_KEYS = [
+  'searchIdPrefixes',
+  'searchKeyFields',
+  'equalToKeys',
+  'forceEqualToAllCards',
+  'forceSearchKeyBucket',
+  'forcePartialUserIdSearch',
+  'allowTelegramPrefixMatches',
+];
+
+const normalizeSearchCacheScopeValue = value => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeSearchCacheScopeValue).sort();
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value).sort().reduce((acc, scopeKey) => {
+      const normalizedValue = normalizeSearchCacheScopeValue(value[scopeKey]);
+      if (normalizedValue !== undefined) acc[scopeKey] = normalizedValue;
+      return acc;
+    }, {});
+  }
+  if (value === undefined || value === null || value === false) return undefined;
+  return value;
+};
+
+const buildSearchCacheScope = options => {
+  if (!options || typeof options !== 'object') return null;
+
+  const scope = SEARCH_CACHE_SCOPE_OPTION_KEYS.reduce((acc, scopeKey) => {
+    const normalizedValue = normalizeSearchCacheScopeValue(options[scopeKey]);
+    if (normalizedValue !== undefined) acc[scopeKey] = normalizedValue;
+    return acc;
+  }, {});
+
+  return Object.keys(scope).length > 0 ? scope : null;
+};
+
+export const getSearchCacheKeyForParams = (key, value, options = {}) => {
+  const baseQueryKey = `${key}=${value}`;
+  const scope = buildSearchCacheScope(options);
+  const scopedQueryKey = scope
+    ? `${baseQueryKey}|scope=${JSON.stringify(scope)}`
+    : baseQueryKey;
+  return getCacheKey('search', normalizeQueryKey(scopedQueryKey));
+};
+
+export const getFreshCachedSearchResult = (key, value, options = {}) => {
   if (!key || value === undefined || value === null || String(value).trim() === '') {
     return { hit: false, cards: [], map: {} };
   }
 
-  const cacheKey = getCacheKey('search', normalizeQueryKey(`${key}=${value}`));
+  const cacheKey = getSearchCacheKeyForParams(key, value, options);
   const queries = loadQueries();
   const entry = queries[cacheKey];
   if (!entry) return { hit: false, cards: [], map: {} };
@@ -1286,10 +1332,10 @@ const SearchBar = ({
 
   const cachedSearch = async (params, extraOptions = {}) => {
     const [key, value] = Object.entries(params)[0] || [];
-    const cachedResult = getFreshCachedSearchResult(key, value);
+    const cachedResult = getFreshCachedSearchResult(key, value, extraOptions);
     if (cachedResult.hit) {
       if (perfDebugEnabledRef.current) {
-        console.debug('[SearchPerf][cache-hit]', { params, ids: cachedResult.ids });
+        console.debug('[SearchPerf][cache-hit]', { params, options: extraOptions, ids: cachedResult.ids });
       }
       return formatCachedSearchResult(cachedResult);
     }
@@ -1314,10 +1360,7 @@ const SearchBar = ({
     const updatedArr = arr.map(u => updateCard(u.userId, u));
 
     if (key && value) {
-      const cacheKey = getCacheKey(
-        'search',
-        normalizeQueryKey(`${key}=${value}`),
-      );
+      const cacheKey = getSearchCacheKeyForParams(key, value, extraOptions);
       setIdsForQuery(cacheKey, updatedArr.map(u => u.userId));
     }
 

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createRoot } from 'react-dom/client';
-import SearchBar, { getFreshCachedSearchResult, parseExplicitSearchKeyCandidate, parsePartialUserIdPrefix, resolveExecutionPlan } from './SearchBar';
-import { getCacheKey } from '../utils/cache';
+import SearchBar, { getFreshCachedSearchResult, getSearchCacheKeyForParams, parseExplicitSearchKeyCandidate, parsePartialUserIdPrefix, resolveExecutionPlan } from './SearchBar';
 import { updateCard } from '../utils/cardsStorage';
 import { resetMatchingLocalStorageCache, setIdsForQuery } from '../utils/cardIndex';
 
@@ -74,9 +73,14 @@ describe('SearchBar cache-first search', () => {
 
   it('returns cached cards for repeated partial userId searches without calling the backend search function', async () => {
     updateCard('Anna123', { userId: 'Anna123', name: 'Anna Cached' });
-    setIdsForQuery(getCacheKey('search', 'userId=Anna123'), ['Anna123']);
+    setIdsForQuery(
+      getSearchCacheKeyForParams('userId', 'Anna123', { forcePartialUserIdSearch: true }),
+      ['Anna123'],
+    );
 
-    const cachedResult = getFreshCachedSearchResult('userId', 'Anna123');
+    const cachedResult = getFreshCachedSearchResult('userId', 'Anna123', {
+      forcePartialUserIdSearch: true,
+    });
     expect(cachedResult.hit).toBe(true);
     expect(cachedResult.cards).toHaveLength(1);
     expect(cachedResult.cards[0].name).toBe('Anna Cached');
@@ -128,5 +132,32 @@ describe('SearchBar cache-first search', () => {
       root.unmount();
     });
     document.body.removeChild(container);
+  });
+
+  it('keeps scoped searchId prefix cache entries isolated for repeated searches', () => {
+    updateCard('ig-user', { userId: 'ig-user', name: 'Instagram Match' });
+    updateCard('tg-user', { userId: 'tg-user', name: 'Telegram Match' });
+
+    setIdsForQuery(
+      getSearchCacheKeyForParams('searchId', 'shared-id', { searchIdPrefixes: ['instagram'] }),
+      ['ig-user'],
+    );
+    setIdsForQuery(
+      getSearchCacheKeyForParams('searchId', 'shared-id', { searchIdPrefixes: ['telegram'] }),
+      ['tg-user'],
+    );
+
+    const instagramResult = getFreshCachedSearchResult('searchId', 'shared-id', {
+      searchIdPrefixes: ['instagram'],
+    });
+    const telegramResult = getFreshCachedSearchResult('searchId', 'shared-id', {
+      searchIdPrefixes: ['telegram'],
+    });
+
+    expect(instagramResult.hit).toBe(true);
+    expect(instagramResult.ids).toEqual(['ig-user']);
+    expect(telegramResult.hit).toBe(true);
+    expect(telegramResult.ids).toEqual(['tg-user']);
+    expect(getFreshCachedSearchResult('searchId', 'shared-id').hit).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- The search cache keyed only on `key=value` caused collisions when the same query was executed with different search option scopes (for example different `searchIdPrefixes`), which made prefix-specific searches return other-prefix results and omit valid matches.

### Description
- Added a scoped cache-key builder `getSearchCacheKeyForParams` that appends a normalized options `scope` to the `key=value` query key and reuses `normalizeQueryKey` for stability.
- Implemented `buildSearchCacheScope` and `normalizeSearchCacheScopeValue` to extract and normalize relevant option keys (`searchIdPrefixes`, `searchKeyFields`, `equalToKeys`, force flags, etc.) into a deterministic scope value.
- Updated `getFreshCachedSearchResult` to accept an `options` argument and use the scoped cache key, and updated `cachedSearch` to pass `extraOptions` into reads and writes so reads and writes use the same scoped key and debug logs include the options.
- Updated tests in `src/components/SearchBar.partialUserId.test.js` to use `getSearchCacheKeyForParams` and added a regression test that verifies `searchId` cache entries remain isolated per prefix.

### Testing
- Ran the focused test suite with `CI=true npm test -- --runTestsByPath src/components/SearchBar.partialUserId.test.js --watchAll=false`, and the tests passed (`9 passed, 0 failed`).
- Ran linting with `npm run lint:js -- src/components/SearchBar.jsx src/components/SearchBar.partialUserId.test.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bfd92aa4c8326aeb4c1d1fef5e2db)