### PR TITLE
Use backend DOB ranges for age filters and expose `collectAgeIdsByFilters`

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -3566,7 +3566,7 @@ const collectIdsFromAgeSnapshot = (snapshot, idSet) => {
   });
 };
 
-const collectAgeIdsByFilters = async (ageFilters, rootPaths = [SEARCH_KEY_INDEX_ROOT]) => {
+export const collectAgeIdsByFilters = async (ageFilters, rootPaths = [SEARCH_KEY_INDEX_ROOT]) => {
   const shouldApplyAge = hasExplicitFilterSelection(ageFilters);
   if (!shouldApplyAge) return null;
 

--- a/src/utils/__tests__/matchingDataProvider.indexCache.test.js
+++ b/src/utils/__tests__/matchingDataProvider.indexCache.test.js
@@ -1,5 +1,6 @@
 const mockFirebaseGet = jest.fn();
 const mockFirebaseRef = jest.fn((database, path) => path);
+const mockCollectAgeIdsByFilters = jest.fn();
 
 jest.mock('firebase/database', () => ({
   get: (...args) => mockFirebaseGet(...args),
@@ -8,6 +9,7 @@ jest.mock('firebase/database', () => ({
 
 jest.mock('components/config', () => ({
   database: { app: 'test-db' },
+  collectAgeIdsByFilters: (...args) => mockCollectAgeIdsByFilters(...args),
 }));
 
 const makeSnapshot = (value = null) => ({
@@ -103,6 +105,11 @@ describe('fetchMatchingIndexedCandidates index-id cache', () => {
       user00000000000000000001: true,
       user00000000000000000002: true,
     }));
+    mockCollectAgeIdsByFilters.mockResolvedValue(new Set([
+      'user00000000000000000001',
+      'user00000000000000000002',
+      'user00000000000000000003',
+    ]));
   });
 
   afterEach(() => {
@@ -158,6 +165,39 @@ describe('fetchMatchingIndexedCandidates index-id cache', () => {
       'user00000000000000000002',
       'user00000000000000000004',
     ]);
+  });
+
+
+  it('uses backend birth-date ranges for matching users age filters instead of frontend bucket nodes', async () => {
+    const { fetchMatchingIndexedCandidates } = loadModule();
+    const hydrateUsersByIds = jest.fn(async ids => Object.fromEntries(ids.map(id => [id, { userId: id }])));
+    const filters = {
+      age: {
+        le25: true,
+        '26_30': true,
+        '31_33': false,
+        '34_36': false,
+        '37_plus': false,
+        other: true,
+      },
+    };
+
+    mockCollectAgeIdsByFilters.mockResolvedValueOnce(new Set([
+      'user00000000000000000003',
+      'user00000000000000000001',
+      'user00000000000000000002',
+    ]));
+
+    const result = await fetchMatchingIndexedCandidates({ filters, limit: 2, hydrateUsersByIds });
+
+    expect(mockCollectAgeIdsByFilters).toHaveBeenCalledWith(filters.age, ['searchKey/users']);
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/age/le21');
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/age/22_25');
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKey/users/age/26_30');
+    expect(result.pageIds).toEqual(['user00000000000000000001', 'user00000000000000000002']);
+    expect(result.hasMore).toBe(true);
+    expect(result.usedAgeDateRangeReader).toBe(true);
+    expect(result.ageDateRangeIdsCount).toBe(3);
   });
 
   it('applies excluded reactions without corrupting the base cached id list', async () => {

--- a/src/utils/__tests__/newUsersFilterSetsIndex.test.js
+++ b/src/utils/__tests__/newUsersFilterSetsIndex.test.js
@@ -2,6 +2,7 @@ const mockFirebaseGet = jest.fn();
 const mockFirebaseRef = jest.fn((database, path) => path);
 const mockPeekCachedSearchKeyPayload = jest.fn();
 const mockGetCachedSearchKeyPayload = jest.fn((path, loader) => loader());
+const mockCollectAgeIdsByFilters = jest.fn();
 
 jest.mock('firebase/database', () => ({
   get: (...args) => mockFirebaseGet(...args),
@@ -16,6 +17,7 @@ jest.mock('firebase/database', () => ({
 }));
 
 jest.mock('components/config', () => ({
+  collectAgeIdsByFilters: (...args) => mockCollectAgeIdsByFilters(...args),
   createAgeSearchKeyIndexInCollection: jest.fn(),
   createContactSearchKeyIndexInCollection: jest.fn(),
   createCsectionSearchKeyIndexInCollection: jest.fn(),
@@ -53,6 +55,7 @@ describe('getIndexedNewUsersIdsByRules searchKeySets access scope', () => {
     mockFirebaseRef.mockImplementation((database, path) => path);
     mockPeekCachedSearchKeyPayload.mockReturnValue(null);
     mockGetCachedSearchKeyPayload.mockImplementation((path, loader) => loader());
+    mockCollectAgeIdsByFilters.mockResolvedValue(new Set());
     jest.spyOn(console, 'info').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
@@ -79,6 +82,40 @@ describe('getIndexedNewUsersIdsByRules searchKeySets access scope', () => {
     expect(result.userIds).toEqual(['U1', 'U2']);
     expect(mockFirebaseRef).toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/age');
     expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, expect.stringContaining('/age/d_'));
+  });
+
+
+  it('reads searchKeySets age matching buckets through backend DOB ranges', async () => {
+    const { getIndexedNewUsersIdsByRules } = loadModule();
+
+    mockFirebaseGet.mockImplementation(path => {
+      const buckets = {
+        'searchKeySets/owner-1_1/role/ed': { U1: true, U2: true, U3: true },
+      };
+      return Promise.resolve(makeSnapshot(Object.prototype.hasOwnProperty.call(buckets, path), buckets[path]));
+    });
+    mockCollectAgeIdsByFilters.mockResolvedValueOnce(new Set(['U1', 'U3']));
+
+    const result = await getIndexedNewUsersIdsByRules({
+      rawRules: 'role: ed',
+      accessUserId: 'owner-1',
+      searchKeySetKeys: ['owner-1_1'],
+      additionalFilterBucketGroups: [{
+        indexName: 'age',
+        values: ['le21', '22_25', '26_30', '?'],
+        selectedValues: ['le25', '26_30', 'other'],
+        allSelected: false,
+        groupActive: true,
+      }],
+    });
+
+    expect(mockCollectAgeIdsByFilters).toHaveBeenCalledWith(
+      { le21: true, '22_25': true, '26_30': true, '?': true },
+      ['searchKeySets/owner-1_1'],
+    );
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/age/le21');
+    expect(mockFirebaseRef).not.toHaveBeenCalledWith({ app: 'test-db' }, 'searchKeySets/owner-1_1/age/26_30');
+    expect(result.userIds).toEqual(['U1', 'U3']);
   });
 
   it('does not read no bucket when point filter sends selected non-no buckets', async () => {

--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -1,5 +1,5 @@
 import { get, ref } from 'firebase/database';
-import { database } from 'components/config';
+import { collectAgeIdsByFilters, database } from 'components/config';
 import { getCard, getIndexIdsByQuery, MATCHING_INDEX_CACHE_VERSION, serializeQueryFilters, setIndexIdsForQuery } from './cardIndex';
 import { collectFilteredMatchingSourceCards } from './matchingSourceBackfill';
 import { getIndexedNewUsersIdsByRules, normalizeSearchKeySetKeys } from './newUsersFilterSetsIndex';
@@ -280,6 +280,18 @@ const readBucketIds = async ({ rootPath, indexName, values }) => {
   return ids;
 };
 
+const readMatchingUsersFilterIds = async ({ group, filters }) => {
+  if (group?.indexName === 'age') {
+    // searchKey/users/age is stored by backend birth-date keys (d_YYYY-MM-DD),
+    // while matching UI/frontend still uses buckets such as le21/22_25/26_30.
+    // Reuse the shared date-range reader so wide age filters page through the
+    // real backend date index instead of looking for non-existent bucket nodes.
+    return collectAgeIdsByFilters(filters?.age, [MATCHING_USERS_INDEX_ROOT]);
+  }
+
+  return readBucketIds({ rootPath: MATCHING_USERS_INDEX_ROOT, ...group });
+};
+
 const intersectIdSets = sets => {
   const usableSets = (sets || []).filter(set => set instanceof Set);
   if (!usableSets.length) return null;
@@ -526,9 +538,12 @@ export const fetchMatchingIndexedCandidates = async ({
   }
 
   const idSets = await Promise.all(
-    filterGroups.map(group => readBucketIds({ rootPath: MATCHING_USERS_INDEX_ROOT, ...group }))
+    filterGroups.map(group => readMatchingUsersFilterIds({ group, filters }))
   );
   const allMatchingIds = intersectIdSets(idSets) || [];
+  const ageDateRangeIdsCount = filterGroups.some(group => group.indexName === 'age')
+    ? (idSets[filterGroups.findIndex(group => group.indexName === 'age')]?.size || 0)
+    : null;
   if (useIndexIdCache) {
     setIndexIdsForQuery(cacheKey, allMatchingIds, {
       complete: true,
@@ -555,6 +570,8 @@ export const fetchMatchingIndexedCandidates = async ({
     nextOffset,
     hasMore,
     filterGroups,
+    usedAgeDateRangeReader: ageDateRangeIdsCount !== null,
+    ageDateRangeIdsCount,
   };
 };
 

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -2,6 +2,7 @@ import { endAt, get as firebaseGet, orderByKey, query, ref, remove, set, startAt
 import { withAdminDownloadToast } from 'utils/backendDownloadToast';
 
 import {
+  collectAgeIdsByFilters,
   createAgeSearchKeyIndexInCollection,
   createContactSearchKeyIndexInCollection,
   createCsectionSearchKeyIndexInCollection,
@@ -72,6 +73,21 @@ const getAgeRangeBounds = values => {
   const dates = [...new Set((Array.isArray(values) ? values : []).map(v => String(v || '').trim()).filter(isAgeBucket))].sort();
   if (!dates.length) return null;
   return { startKey: dates[0], endKey: dates[dates.length - 1] };
+};
+
+
+const AGE_SPECIAL_BUCKETS = new Set(['?', 'other', 'no', 'empty']);
+
+const buildAgeFilterMapFromSearchKeyValues = (values, { specialOnly = false } = {}) => {
+  const filters = (Array.isArray(values) ? values : []).reduce((acc, value) => {
+    const normalized = String(value || '').trim();
+    if (!normalized || isAgeBucket(normalized)) return acc;
+    if (specialOnly && !AGE_SPECIAL_BUCKETS.has(normalized)) return acc;
+    acc[normalized] = true;
+    return acc;
+  }, {});
+
+  return Object.keys(filters).length ? filters : null;
 };
 
 const getSearchKeySetInputIndex = (setKey, accessUserId = '') => {
@@ -1277,55 +1293,78 @@ export const getIndexedNewUsersIdsByRules = async ({
       const normalizedValues = Array.isArray(values) ? values.filter(Boolean) : [];
       const idsForFilter = new Set();
       const ageRange = indexName === 'age' ? getAgeRangeBounds(normalizedValues) : null;
-      if (indexName === 'age' && !ageRange) {
+      const ageFilterMap = indexName === 'age'
+        ? buildAgeFilterMapFromSearchKeyValues(normalizedValues, { specialOnly: Boolean(ageRange) })
+        : null;
+      if (indexName === 'age' && !ageRange && !ageFilterMap) {
         emitDebug('additionalMatching: age filter skipped because inactive', { setKey: entry.setKey });
         continue;
       }
 
-      if (indexName === 'age' && ageRange) {
-        const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/age`;
-        resultPaths.push(`${path}|startAt=${ageRange.startKey}|endAt=${ageRange.endKey}`);
-        emitDebug('additionalMatching: age DOB range lookup', {
-          setKey: entry.setKey,
-          path,
-          startAt: ageRange.startKey,
-          endAt: ageRange.endKey,
-        });
-        // eslint-disable-next-line no-await-in-loop
-        const queryStartAtMs = Date.now();
-        const payload = await readAgeRangePayload({ setKey: entry.setKey, startKey: ageRange.startKey, endKey: ageRange.endKey });
-        const queryDurationMs = Date.now() - queryStartAtMs;
-        const flattenStartAtMs = Date.now();
-        const rangeValue = payload?.exists && payload.value && typeof payload.value === 'object' ? payload.value : {};
-        const dateBuckets = Object.entries(rangeValue);
-        if (payload?.exists) existingBucketsForSet += 1; else missingBucketsForSet += 1;
-        dateBuckets.forEach(([dateKey, bucket]) => {
-          if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
-          if (!setsMap[entry.setKey].age) setsMap[entry.setKey].age = {};
-          setsMap[entry.setKey].age[dateKey] = bucket;
-          Object.keys(bucket || {}).forEach(userId => userId && idsForFilter.add(userId));
-        });
-        const flattenDurationMs = Date.now() - flattenStartAtMs;
-        const idsBeforePreciseFilter = idsForFilter.size;
-        if (idsBeforePreciseFilter > LARGE_AGE_RANGE_IDS_WARNING_THRESHOLD) {
-          console.warn('additionalMatching: unusually large DOB range result', {
+      if (indexName === 'age') {
+        if (ageRange) {
+          const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/age`;
+          resultPaths.push(`${path}|startAt=${ageRange.startKey}|endAt=${ageRange.endKey}`);
+          emitDebug('additionalMatching: age DOB range lookup', {
+            setKey: entry.setKey,
+            path,
+            startAt: ageRange.startKey,
+            endAt: ageRange.endKey,
+          });
+          // eslint-disable-next-line no-await-in-loop
+          const queryStartAtMs = Date.now();
+          const payload = await readAgeRangePayload({ setKey: entry.setKey, startKey: ageRange.startKey, endKey: ageRange.endKey });
+          const queryDurationMs = Date.now() - queryStartAtMs;
+          const flattenStartAtMs = Date.now();
+          const rangeValue = payload?.exists && payload.value && typeof payload.value === 'object' ? payload.value : {};
+          const dateBuckets = Object.entries(rangeValue);
+          if (payload?.exists) existingBucketsForSet += 1; else missingBucketsForSet += 1;
+          dateBuckets.forEach(([dateKey, bucket]) => {
+            if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
+            if (!setsMap[entry.setKey].age) setsMap[entry.setKey].age = {};
+            setsMap[entry.setKey].age[dateKey] = bucket;
+            Object.keys(bucket || {}).forEach(userId => userId && idsForFilter.add(userId));
+          });
+          const flattenDurationMs = Date.now() - flattenStartAtMs;
+          const idsBeforePreciseFilter = idsForFilter.size;
+          if (idsBeforePreciseFilter > LARGE_AGE_RANGE_IDS_WARNING_THRESHOLD) {
+            console.warn('additionalMatching: unusually large DOB range result', {
+              setKey: entry.setKey,
+              startAt: ageRange.startKey,
+              endAt: ageRange.endKey,
+              idsBeforePreciseFilter,
+            });
+          }
+          emitDebug('additionalMatching: age DOB range lookup metrics', {
             setKey: entry.setKey,
             startAt: ageRange.startKey,
             endAt: ageRange.endKey,
+            queryStartAt: queryStartAtMs,
+            queryDurationMs,
+            flattenDurationMs,
+            preciseFilterDurationMs: null,
             idsBeforePreciseFilter,
+            idsAfterPreciseFilter: null,
           });
         }
-        emitDebug('additionalMatching: age DOB range lookup metrics', {
-          setKey: entry.setKey,
-          startAt: ageRange.startKey,
-          endAt: ageRange.endKey,
-          queryStartAt: queryStartAtMs,
-          queryDurationMs,
-          flattenDurationMs,
-          preciseFilterDurationMs: null,
-          idsBeforePreciseFilter,
-          idsAfterPreciseFilter: null,
-        });
+
+        if (ageFilterMap) {
+          const rootPath = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}`;
+          resultPaths.push(`${rootPath}/age|filters=${Object.keys(ageFilterMap).join(',')}`);
+          emitDebug('additionalMatching: age frontend bucket lookup via DOB ranges', {
+            setKey: entry.setKey,
+            rootPath,
+            filters: ageFilterMap,
+          });
+          // eslint-disable-next-line no-await-in-loop
+          const ageIds = await collectAgeIdsByFilters(ageFilterMap, [rootPath]);
+          if (ageIds instanceof Set) {
+            if (ageIds.size > 0) existingBucketsForSet += 1; else emptyBucketsForSet += 1;
+            ageIds.forEach(userId => userId && idsForFilter.add(userId));
+          } else {
+            missingBucketsForSet += 1;
+          }
+        }
       } else if (indexName === FIELD_COUNT_SEARCH_KEY_INDEX_NAME && hasFieldCountRangeBuckets(normalizedValues)) {
         const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}`;
         resultPaths.push(`${path}|fieldCountRanges=${normalizedValues.join(',')}`);


### PR DESCRIPTION
### Motivation

- Frontend age buckets do not map to the backend date-indexed storage (DOB keys), so wide age filters should page through real backend DOB ranges instead of looking for non-existent bucket nodes.
- The shared date-range reader `collectAgeIdsByFilters` must be accessible to other modules to centralize DOB-range lookups.

### Description

- Export `collectAgeIdsByFilters` from `components/config.js` so it can be reused by other modules. 
- In `matchingDataProvider.js` add `readMatchingUsersFilterIds` which uses `collectAgeIdsByFilters` for the `age` index and wire it into the id collection flow, plus surface `usedAgeDateRangeReader` and `ageDateRangeIdsCount` in the result. 
- In `newUsersFilterSetsIndex.js` add `AGE_SPECIAL_BUCKETS` and `buildAgeFilterMapFromSearchKeyValues`, and call `collectAgeIdsByFilters` to resolve frontend age buckets via backend DOB ranges while keeping existing DOB-range lookup logic intact. 
- Update tests to mock the new `collectAgeIdsByFilters` behavior and add assertions that age filters use backend DOB range reader (tests in `matchingDataProvider.indexCache.test.js` and `newUsersFilterSetsIndex.test.js`).

### Testing

- Ran updated Jest unit tests including `matchingDataProvider.indexCache.test.js` and `newUsersFilterSetsIndex.test.js`, and the new/updated tests completed successfully. 
- Verified the new tests assert that `collectAgeIdsByFilters` is called with the expected filter map and root paths and that no frontend age bucket refs are queried when using the DOB reader. 
- Existing matching and field-count related tests continued to pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bfb3fdc608326ad51e8e3b02fb148)