### PR TITLE
Prefer latest Matching array value for display and normalize birth for age calculation

### DIFF
--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -6,8 +6,15 @@ import { CONTACT_FIELDS, getContactValues } from './contactMethods';
 
 const EMPTY_VALUES = new Set(['', '-', '—', 'n/a', 'na', 'null', 'undefined', 'none', 'немає', 'нет']);
 
+const getMatchingCurrentValue = value => {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? getMatchingCurrentValue(value[value.length - 1]) : undefined;
+  }
+  return getCurrentValue(value);
+};
+
 export const normalizeDisplayValue = value => {
-  const current = getCurrentValue(value);
+  const current = getMatchingCurrentValue(value);
   if (Array.isArray(current)) {
     return current.map(normalizeDisplayValue).filter(Boolean).join(', ');
   }
@@ -90,8 +97,9 @@ export const getProfileName = user => {
 };
 
 export const getProfileAge = user => {
-  if (!user?.birth) return '';
-  const age = utilCalculateAge(user.birth);
+  const birth = normalizeDisplayValue(user?.birth);
+  if (!birth) return '';
+  const age = utilCalculateAge(birth);
   return age ? String(age) : '';
 };
 

--- a/src/components/profileLayoutConfig.test.js
+++ b/src/components/profileLayoutConfig.test.js
@@ -1,6 +1,7 @@
 import {
   getHeroFields,
   getProfilePhotos,
+  getProfileAge,
   getProfileRole,
   getProfileSections,
   getQuickFacts,
@@ -127,6 +128,33 @@ describe('profileLayoutConfig', () => {
     expect(getProfileRole({ role: 'egg_donor' })).toBe('ed');
     expect(getProfileRole({ role: 'intended parents' })).toBe('ip');
     expect(getProfileRole({ role: 'sm' })).toBe('other');
+  });
+
+  it('uses the latest array value on Matching and hides fields removed with an empty latest value', () => {
+    const removedBirthUser = {
+      userRole: 'ed',
+      birth: ['25.09.1996', ''],
+      height: ['165', ''],
+      weight: ['94', ''],
+      blood: ['3+', ''],
+      experience: ['0', ''],
+    };
+    const updatedBirthUser = {
+      userRole: 'ed',
+      birth: ['25.09.1996', '26.09.1996'],
+      height: ['160', '165'],
+      weight: ['90', '94'],
+    };
+
+    expect(getProfileAge(removedBirthUser)).toBe('');
+    expect(getHeroFields(removedBirthUser, 'ed')).toEqual([]);
+    expect(shouldRenderField(['25.09.1996', ''])).toBe(false);
+    expect(getProfileAge(updatedBirthUser)).toBe('29');
+    expect(getHeroFields(updatedBirthUser, 'ed').map(field => [field.key, field.value])).toEqual([
+      ['height', '165'],
+      ['weight', '94'],
+      ['bmi', '35'],
+    ]);
   });
 
 });


### PR DESCRIPTION
### Motivation

- Ensure fields coming from Matching (which may be stored as arrays of historical values) use the latest entry for rendering and hide fields when the latest entry is empty.
- Prevent stale/array-wrapped `birth` values from breaking age calculation by normalizing the `birth` value before calling the age util.

### Description

- Added `getMatchingCurrentValue` to pick the last element from array values (falling back to `getCurrentValue`) and wired it into `normalizeDisplayValue` so display normalization uses the latest Matching value.
- Updated `getProfileAge` to normalize `user?.birth` with `normalizeDisplayValue` before calling `utilCalculateAge` so empty/array-wrapped births are handled correctly.
- Adjusted unit tests in `profileLayoutConfig.test.js` to import `getProfileAge` and added a test that verifies latest-array-value behavior and that fields with an empty latest value are hidden.

### Testing

- Ran the updated unit test suite (`profileLayoutConfig.test.js`) which includes the new test for Matching-array behavior, and the tests passed.
- Existing mocks for `utilCalculateAge`, `normalizeCountry`, `normalizeRegion`, and `convertDriveLinkToImage` were used to isolate behavior and validate output shapes; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c6cbb539c83269b64018e8409f8c0)