### PR TITLE
Add matching mode label and improve toolbar controls (wide button, toggle handlers, accessibility)

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -71,6 +71,7 @@ import {
   ModernSectionTitle,
   BackendTrafficToggleButton,
   BackendTrafficToggleStatus,
+  MatchingModeLabel,
 } from './Matching.styled';
 import {
   fetchUsersByLastLogin2,
@@ -116,7 +117,7 @@ import {
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
-import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaDownload, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight, FaMapMarkerAlt } from 'react-icons/fa';
+import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight, FaMapMarkerAlt } from 'react-icons/fa';
 import { FaPhoneVolume, FaXTwitter } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
@@ -3680,6 +3681,37 @@ const Matching = () => {
 
   const loadDislikeCards = () => switchMatchingMode('dislikes');
 
+  const matchingModeLabel = {
+    default: 'Загальний список',
+    favorites: 'Обране',
+    dislikes: 'Дизлайки',
+    search: 'Пошук',
+  }[viewMode] || 'Matching';
+
+  const handleDislikeModeClick = () => {
+    if (viewMode === 'dislikes') {
+      reloadDefault();
+      return;
+    }
+
+    loadDislikeCards();
+  };
+
+  const handleDefaultModeClick = () => {
+    if (viewMode !== 'default') {
+      reloadDefault();
+    }
+  };
+
+  const handleFavoriteModeClick = () => {
+    if (viewMode === 'favorites') {
+      reloadDefault();
+      return;
+    }
+
+    loadFavoriteCards();
+  };
+
   const searchUsers = async params => {
     const [key, value] = Object.entries(params)[0] || [];
     const term = key && value ? `${key}=${value}` : undefined;
@@ -5614,7 +5646,7 @@ const Matching = () => {
         <InnerContainer>
           <HeaderContainer>
             <TopActions>
-              <TopActionGroup aria-label="Основні дії matching">
+              <TopActionGroup aria-label="Фільтри matching">
                 <ActionButton
                   type="button"
                   onClick={() => setShowFilters(s => !s)}
@@ -5625,27 +5657,41 @@ const Matching = () => {
                   <FaFilter />
                   {activeFilterGroupCount > 0 && <ActionBadge>{activeFilterGroupCount}</ActionBadge>}
                 </ActionButton>
+              </TopActionGroup>
+              <TopActionGroup aria-label="Навігація matching">
                 <ActionButton
                   type="button"
-                  onClick={loadDislikeCards}
-                  disabled={viewMode === 'dislikes' || !ownerId}
+                  onClick={handleDislikeModeClick}
+                  disabled={!ownerId}
                   $active={viewMode === 'dislikes'}
-                  aria-label="Показати дизлайки"
-                  title="Показати дизлайки"
+                  aria-label={viewMode === 'dislikes' ? 'Повернутись до загального списку' : 'Показати дизлайки'}
+                  title={viewMode === 'dislikes' ? 'Повернутись до загального списку' : 'Показати дизлайки'}
                 >
                   <FaTimes />
                 </ActionButton>
                 <ActionButton
                   type="button"
-                  onClick={loadFavoriteCards}
-                  disabled={viewMode === 'favorites' || !ownerId}
+                  onClick={handleDefaultModeClick}
+                  disabled={!ownerId}
+                  $active={viewMode === 'default'}
+                  $wide
+                  aria-label="До загального списку"
+                  title="До загального списку"
+                >
+                  Всі
+                </ActionButton>
+                <ActionButton
+                  type="button"
+                  onClick={handleFavoriteModeClick}
+                  disabled={!ownerId}
                   $active={viewMode === 'favorites'}
-                  aria-label="Показати обране"
-                  title="Показати обране"
+                  aria-label={viewMode === 'favorites' ? 'Повернутись до загального списку' : 'Показати обране'}
+                  title={viewMode === 'favorites' ? 'Повернутись до загального списку' : 'Показати обране'}
                 >
                   <FaHeart />
                 </ActionButton>
               </TopActionGroup>
+              <MatchingModeLabel aria-live="polite">{matchingModeLabel}</MatchingModeLabel>
               <TopActionGroup aria-label="Налаштування matching">
                 <ThemeToggleButton
                   type="button"
@@ -5672,16 +5718,6 @@ const Matching = () => {
                     <ThemeToggleScene $themeMode={themeMode} />
                   </ThemeToggleKnob>
                 </ThemeToggleButton>
-                {viewMode !== 'default' && (
-                  <ActionButton
-                    type="button"
-                    onClick={reloadDefault}
-                    aria-label="Повернутись до основного списку"
-                    title="Повернутись до основного списку"
-                  >
-                    <FaDownload />
-                  </ActionButton>
-                )}
               </TopActionGroup>
               <TopActionGroup aria-label="Адміністративні дії matching">
                 {showBackendTrafficToggle && (

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -361,9 +361,10 @@ export const TopActionGroup = styled.div`
 
 export const ActionButton = styled.button`
   position: relative;
-  width: 35px;
+  width: ${({ $wide }) => ($wide ? 'auto' : '35px')};
+  min-width: ${({ $wide }) => ($wide ? '44px' : '35px')};
   height: 35px;
-  padding: 3px;
+  padding: ${({ $wide }) => ($wide ? '3px 10px' : '3px')};
   border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'transparent')};
   background: ${({ $active }) => ($active ? 'rgba(255, 149, 0, 0.14)' : 'var(--matching-action-bg, ' + color.accent5 + ')')};
   color: ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-action-color, white)')};
@@ -371,7 +372,9 @@ export const ActionButton = styled.button`
   transition: transform 240ms cubic-bezier(0.4, 0, 0.2, 1), background 240ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 240ms cubic-bezier(0.4, 0, 0.2, 1), border-color 240ms cubic-bezier(0.4, 0, 0.2, 1), color 240ms cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 50px;
   cursor: pointer;
-  font-size: 18px;
+  font-size: ${({ $wide }) => ($wide ? '13px' : '18px')};
+  font-weight: ${({ $wide }) => ($wide ? '800' : 'inherit')};
+  letter-spacing: ${({ $wide }) => ($wide ? '0.01em' : 'normal')};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -417,6 +420,23 @@ export const ActionBadge = styled.span`
   font-weight: 800;
   line-height: 1;
   box-sizing: border-box;
+`;
+
+export const MatchingModeLabel = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 31px;
+  padding: 3px 10px;
+  border: 1px solid var(--matching-section-border, rgba(255, 255, 255, 0.14));
+  border-radius: 999px;
+  background: var(--matching-section-bg, rgba(255, 255, 255, 0.82));
+  color: var(--matching-muted-text, #6B7280);
+  box-shadow: var(--matching-section-shadow, 0 8px 18px rgba(22, 22, 22, 0.08));
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
+  flex: 0 0 auto;
 `;
 
 


### PR DESCRIPTION
### Motivation

- Surface the current matching view mode to users and make toolbar actions more discoverable and accessible.
- Provide idempotent toggle behavior for favorites/dislikes/default so clicking an active mode returns to the main list.
- Make the central action button support a wider, labeled variant for a clearer "All" action.

### Description

- Added a new `MatchingModeLabel` styled component and rendered it in the toolbar to display the current mode label. 
- Introduced `matchingModeLabel` mapping and handlers `handleDislikeModeClick`, `handleDefaultModeClick`, and `handleFavoriteModeClick` to manage toggling between `default`, `favorites`, and `dislikes` modes. 
- Updated toolbar markup and ARIA labels to improve accessibility and changed `TopActionGroup` aria text for clarity. 
- Extended `ActionButton` with a `$wide` prop and adjusted styles (`width`, `min-width`, `padding`, `font-size`, `font-weight`) to support a labeled "Всі" button; removed the previous download/action button in favor of the new layout. 
- Minor import cleanup (removed unused `FaDownload` from the icon import list).

### Testing

- Ran unit tests with `yarn test` and they completed successfully. 
- Ran linter with `yarn lint` and there were no linting errors. 
- Executed a local smoke test of the matching toolbar to verify mode switching and label updates, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c6db0b4688326a3efa6b69901dcfc)