### PR TITLE
Hide removed matching contact fields

### DIFF
--- a/src/components/contactMethods.js
+++ b/src/components/contactMethods.js
@@ -98,14 +98,14 @@ export const CONTACT_LINK_BUILDERS = {
 
 export const isHiddenTelegramValue = value => String(value ?? '').trim().startsWith('УК СМ');
 
-const valueList = value => {
-  const current = getCurrentValue(value);
+const valueList = (value, currentValueGetter = getCurrentValue) => {
+  const current = currentValueGetter(value);
   if (Array.isArray(current)) return current;
   return current ? [current] : [];
 };
 
-export const getContactValues = (data, key) => {
-  const values = valueList(data?.[key])
+export const getContactValues = (data, key, currentValueGetter) => {
+  const values = valueList(data?.[key], currentValueGetter)
     .map(value => (typeof value === 'string' ? value.trim() : value))
     .filter(value => value !== null && value !== undefined && String(value).trim() !== '');
 

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -292,7 +292,7 @@ const contactFields = CONTACT_FIELDS.map(key =>
   field(
     key,
     key === 'otherLink' ? 'Other link' : key.charAt(0).toUpperCase() + key.slice(1),
-    user => getContactValues(user, key).join(', ')
+    user => getContactValues(user, key, getMatchingCurrentValue).join(', ')
   )
 );
 

--- a/src/components/profileLayoutConfig.test.js
+++ b/src/components/profileLayoutConfig.test.js
@@ -138,6 +138,8 @@ describe('profileLayoutConfig', () => {
       weight: ['94', ''],
       blood: ['3+', ''],
       experience: ['0', ''],
+      telegram: ['@old', ''],
+      website: ['old.example', 'new.example'],
     };
     const updatedBirthUser = {
       userRole: 'ed',
@@ -148,6 +150,9 @@ describe('profileLayoutConfig', () => {
 
     expect(getProfileAge(removedBirthUser)).toBe('');
     expect(getHeroFields(removedBirthUser, 'ed')).toEqual([]);
+    expect(getProfileSections(removedBirthUser, 'ed')
+      .find(section => section.title === 'Contacts')?.fields
+      .map(field => [field.key, field.value])).toEqual([['website', 'new.example']]);
     expect(shouldRenderField(['25.09.1996', ''])).toBe(false);
     expect(getProfileAge(updatedBirthUser)).toBe('29');
     expect(getHeroFields(updatedBirthUser, 'ed').map(field => [field.key, field.value])).toEqual([


### PR DESCRIPTION
### Motivation
- Contacts in the Matching profile still rendered stale values when a contact history array had an empty latest element (e.g. `telegram: ['@old', '']`), because contact extraction used the old `getCurrentValue` path while other fields used the new latest-value resolution.
- The goal is to make contact field normalization follow the same latest-value semantics as the rest of the profile layout so that fields intentionally removed by an empty latest entry are hidden.

### Description
- `valueList` in `src/components/contactMethods.js` was generalized to accept an optional `currentValueGetter` parameter with a default of `getCurrentValue` to preserve existing behavior.
- `getContactValues` was updated to accept a `currentValueGetter` argument and forward it into `valueList` so callers can control how the current value is resolved.
- `src/components/profileLayoutConfig.js` now calls `getContactValues(user, key, getMatchingCurrentValue)` for Contacts so contact arrays use the same latest-value resolution as other display normalization.
- Tests were extended in `profileLayoutConfig.test.js` to cover a removed contact history (`telegram`) and a changed website history to ensure the Contacts section reflects the latest-value logic.

### Testing
- Ran `npm test -- --watchAll=false src/components/profileLayoutConfig.test.js src/components/contactMethods.test.js` and both test suites passed (`2 passed`, `11 passed` tests total).
- Ran `npm run lint:js -- src/components/contactMethods.js src/components/profileLayoutConfig.js src/components/profileLayoutConfig.test.js` and lint completed with no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c71e5b0dc8326a8e2c0fc5380e233)