### PR TITLE
Log matching search queries to Realtime DB from Matching UI

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -81,6 +81,7 @@ import {
   fetchFavoriteUsers,
   fetchDislikeUsers,
   addContactViewUser,
+  addMatchingSearchQuery,
   filterMain,
   searchUsersOnly,
   fetchUserComments,
@@ -3712,6 +3713,10 @@ const Matching = () => {
     loadFavoriteCards();
   };
 
+  const handleMatchingSearchExecuted = React.useCallback(value => {
+    addMatchingSearchQuery(value, ownerId);
+  }, [ownerId]);
+
   const searchUsers = async params => {
     const [key, value] = Object.entries(params)[0] || [];
     const term = key && value ? `${key}=${value}` : undefined;
@@ -5598,6 +5603,7 @@ const Matching = () => {
                 wrapperStyle={{ width: '100%', marginBottom: 0 }}
                 leftIcon="🔍"
                 storageKey={SEARCH_KEY}
+                onSearchExecuted={handleMatchingSearchExecuted}
                 onClear={reloadDefault}
               />
             </FilterDrawerSection>

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -577,6 +577,21 @@ export const addContactViewUser = async (userId, ownerId) => {
   }
 };
 
+export const addMatchingSearchQuery = async (searchQuery, ownerId) => {
+  try {
+    const owner = auth.currentUser;
+    if (!owner) return;
+
+    const normalizedQuery = String(searchQuery || '').trim();
+    if (!normalizedQuery) return;
+
+    const queryRef = push(ref2(database, `multiData/searchQueries/${ownerId || owner.uid}`));
+    await set(queryRef, normalizedQuery);
+  } catch (error) {
+    console.error('Error adding matching search query:', error);
+  }
+};
+
 export const removeDislikeUser = async (userId, ownerId) => {
   try {
     const owner = auth.currentUser;


### PR DESCRIPTION
### Motivation
- Persist admin search activity for matching to enable later analysis or debugging of search queries.

### Description
- Added `addMatchingSearchQuery` to `src/components/config.js` to push normalized non-empty search strings to `multiData/searchQueries/<ownerId>` in the Realtime Database.
- Hooked the new API into the matching UI by importing `addMatchingSearchQuery` in `src/components/Matching.jsx`, creating `handleMatchingSearchExecuted`, and passing it as the `onSearchExecuted` prop to `SearchBar` in the filter drawer.
- The new helper guards against unauthenticated owners and empty queries before writing to the database and logs errors to the console.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c71ad0a1483269c03df1b9079f6fb)