### PR TITLE
Support structured PP technical input and centralize picker field names

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -94,6 +94,7 @@ import FilterPanel, { getInitialFilters } from './FilterPanel';
 import SearchBar, { detectSearchParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
+import { pickerFieldNames } from './formFields';
 import { PAGE_SIZE, database } from './config';
 import { get as firebaseGet, push, ref } from 'firebase/database';
 import {
@@ -1632,8 +1633,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'ameblo', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
-    const ppTechnicalInputFields = ['name', 'surname', ...contacts];
+    const ppTechnicalInputFields = pickerFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     const now = Date.now();

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -11,6 +11,7 @@ import {
   auth,
 } from './config';
 import { ProfileForm } from './ProfileForm';
+import { pickerFieldNames } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
@@ -450,8 +451,7 @@ const EditProfile = () => {
     }
 
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
-    const ppTechnicalInputFields = ['name', 'surname', ...contacts];
+    const ppTechnicalInputFields = pickerFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
     const isMainProfileField = key => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key);
 
@@ -874,8 +874,7 @@ const EditProfile = () => {
 
   const persistCanonicalByRules = async mergedCard => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const contacts = ['instagram', 'facebook', 'email', 'phone', 'telegram', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other', 'vk', 'userId'];
-    const ppTechnicalInputFields = ['name', 'surname', ...contacts];
+    const ppTechnicalInputFields = pickerFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (mergedCard?.userId?.length > 20) {

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -9,6 +9,7 @@ import { useAutoResize } from '../hooks/useAutoResize';
 import { color, OrangeBtn, uiTokens } from './styles';
 import {
   pickerFieldsExtended as pickerFields,
+  pickerFieldNames,
   getFieldLabel,
   getFieldPlaceholder,
   getOptionLabel,
@@ -235,6 +236,71 @@ const normalizePpTechnicalTargetValue = (fieldName, value) => {
   }
 
   return inputUpdateValue(rawValue, { name: fieldName });
+};
+
+const normalizePpTechnicalFieldKey = rawKey =>
+  String(rawKey || '').trim().toLowerCase().replace(/\s+/g, '');
+
+const PP_TECHNICAL_FIELD_ALIASES = Object.fromEntries(
+  pickerFieldNames.map(fieldName => [normalizePpTechnicalFieldKey(fieldName), fieldName])
+);
+
+const normalizePpTechnicalKeyValueField = rawKey => {
+  const normalized = normalizePpTechnicalFieldKey(rawKey);
+  return PP_TECHNICAL_FIELD_ALIASES[normalized] || '';
+};
+
+const parsePpTechnicalKeyValueInput = rawInput => {
+  const lines = String(rawInput || '').replace(/\r\n/g, '\n').split('\n');
+  const entries = [];
+  let activeBlock = null;
+
+  const finishActiveBlock = () => {
+    if (!activeBlock) return;
+    entries.push({
+      fieldName: activeBlock.fieldName,
+      value: activeBlock.lines.join('\n').trim(),
+    });
+    activeBlock = null;
+  };
+
+  for (const line of lines) {
+    const keyValueMatch = line.match(/^([A-Za-z][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+
+    if (keyValueMatch) {
+      const fieldName = normalizePpTechnicalKeyValueField(keyValueMatch[1]);
+      if (!fieldName) {
+        if (activeBlock) activeBlock.lines.push(line.replace(/^\s{2}/, ''));
+        continue;
+      }
+
+      finishActiveBlock();
+
+      const rawValue = keyValueMatch[2] ?? '';
+      if (rawValue.trim() === '|') {
+        activeBlock = { fieldName, lines: [] };
+      } else {
+        entries.push({ fieldName, value: rawValue.trim() });
+      }
+      continue;
+    }
+
+    if (activeBlock) {
+      activeBlock.lines.push(line.replace(/^\s{2}/, ''));
+    }
+  }
+
+  finishActiveBlock();
+
+  return entries.filter(({ value }) => String(value ?? '').trim());
+};
+
+const normalizePpTechnicalKeyValueEntry = (fieldName, value) => {
+  if (fieldName === 'myComment') {
+    return String(value ?? '').trim();
+  }
+
+  return normalizePpTechnicalTargetValue(fieldName, value);
 };
 
 const REPRODUCTIVE_FIELDS = [
@@ -2332,12 +2398,20 @@ ${entries.join('\n')}`;
     const rawValue = String(ppTechnicalInput || '').trim();
     if (!rawValue) return;
 
+    const keyValueEntries = parsePpTechnicalKeyValueInput(rawValue);
     const parsed = parseUkTriggerQuery(rawValue);
 
     setState(prevState => {
       const nextState = { ...prevState };
 
-      if (!parsed) {
+      if (keyValueEntries.length > 0) {
+        keyValueEntries.forEach(({ fieldName, value }) => {
+          const normalizedValue = normalizePpTechnicalKeyValueEntry(fieldName, value);
+          if (!normalizedValue) return;
+
+          nextState[fieldName] = appendFieldValue(prevState[fieldName], normalizedValue);
+        });
+      } else if (!parsed) {
         const resolvedTechnicalTarget = resolvePpTechnicalInputTarget(rawValue, {
           normalizePhone: normalizePhoneValue,
         });
@@ -2538,6 +2612,7 @@ ${entries.join('\n')}`;
                       <InputField
                         fieldName="ppTechnicalInput"
                         name="ppTechnicalInput"
+                        as="textarea"
                         value={ppTechnicalInput}
                         onChange={e => setPpTechnicalInput(e?.target?.value || '')}
                         onBlur={handlePpTechnicalInputSubmit}
@@ -3399,6 +3474,12 @@ const InputField = styled.input`
       return css`
         min-height: 28px;
         max-height: 84px;
+        resize: vertical;
+      `;
+    }
+    if (as === 'textarea' && baseFieldName === 'ppTechnicalInput') {
+      return css`
+        min-height: 64px;
         resize: vertical;
       `;
     }

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -261,3 +261,7 @@ export const pickerFieldsExtended = [
   ...pickerFields,
 
  ]
+
+export const pickerFieldNames = [
+  ...new Set(pickerFieldsExtended.map(field => field?.name).filter(Boolean)),
+];


### PR DESCRIPTION
### Motivation
- Centralize picker field names to avoid duplicated hard-coded lists and keep form field metadata consistent across components.
- Allow PP users to submit multi-line, key:value technical input that can map to existing profile fields and multi-line values.

### Description
- Added `pickerFieldNames` export in `src/components/formFields.js` to derive a canonical list of field names from `pickerFieldsExtended`.
- Replaced several hard-coded `ppTechnicalInput`/contact field arrays with the centralized `pickerFieldNames` in `AddNewProfile.jsx` and `EditProfile.jsx` to keep allowed technical fields consistent.
- Implemented parsing and normalization for PP technical key:value input in `ProfileForm.jsx`, including `normalizePpTechnicalFieldKey`, `PP_TECHNICAL_FIELD_ALIASES`, `parsePpTechnicalKeyValueInput`, and helpers to normalize values before appending to state.
- Integrated parsed key:value handling into `handlePpTechnicalInputSubmit` to support single-line `key: value` entries and multi-line block values using `|` as a block indicator, and kept existing legacy parsing fallback (`parseUkTriggerQuery`) and contact resolution logic.
- Updated the PP technical input UI to use a textarea (`as="textarea"`) and adjusted styling to provide a larger, resizable input for multi-line entries.

### Testing
- Ran linter with `npm run lint` and the lint checks passed.
- Ran unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d46b0dcbc8326a0892719c24ef74b)