### PR TITLE
Fix PP technical key:value handling

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -94,7 +94,7 @@ import FilterPanel, { getInitialFilters } from './FilterPanel';
 import SearchBar, { detectSearchParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
-import { pickerFieldNames } from './formFields';
+import { newUsersMirrorFieldNames } from './formFields';
 import { PAGE_SIZE, database } from './config';
 import { get as firebaseGet, push, ref } from 'firebase/database';
 import {
@@ -1633,7 +1633,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const ppTechnicalInputFields = pickerFieldNames;
+    const ppTechnicalInputFields = newUsersMirrorFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     const now = Date.now();

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -11,7 +11,7 @@ import {
   auth,
 } from './config';
 import { ProfileForm } from './ProfileForm';
-import { pickerFieldNames } from './formFields';
+import { newUsersMirrorFieldNames } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { renderTopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
@@ -451,7 +451,7 @@ const EditProfile = () => {
     }
 
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const ppTechnicalInputFields = pickerFieldNames;
+    const ppTechnicalInputFields = newUsersMirrorFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
     const isMainProfileField = key => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key);
 
@@ -874,7 +874,7 @@ const EditProfile = () => {
 
   const persistCanonicalByRules = async mergedCard => {
     const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
-    const ppTechnicalInputFields = pickerFieldNames;
+    const ppTechnicalInputFields = newUsersMirrorFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 
     if (mergedCard?.userId?.length > 20) {

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -9,7 +9,7 @@ import { useAutoResize } from '../hooks/useAutoResize';
 import { color, OrangeBtn, uiTokens } from './styles';
 import {
   pickerFieldsExtended as pickerFields,
-  pickerFieldNames,
+  ppTechnicalKeyValueFieldNames,
   getFieldLabel,
   getFieldPlaceholder,
   getOptionLabel,
@@ -242,7 +242,7 @@ const normalizePpTechnicalFieldKey = rawKey =>
   String(rawKey || '').trim().toLowerCase().replace(/\s+/g, '');
 
 const PP_TECHNICAL_FIELD_ALIASES = Object.fromEntries(
-  pickerFieldNames.map(fieldName => [normalizePpTechnicalFieldKey(fieldName), fieldName])
+  ppTechnicalKeyValueFieldNames.map(fieldName => [normalizePpTechnicalFieldKey(fieldName), fieldName])
 );
 
 const normalizePpTechnicalKeyValueField = rawKey => {
@@ -293,6 +293,34 @@ const parsePpTechnicalKeyValueInput = rawInput => {
   finishActiveBlock();
 
   return entries.filter(({ value }) => String(value ?? '').trim());
+};
+
+const PP_TECHNICAL_APPEND_FIELD_NAMES = new Set([
+  'name',
+  'surname',
+  'phone',
+  'email',
+  'telegram',
+  'facebook',
+  'instagram',
+  'ameblo',
+  'tiktok',
+  'linkedin',
+  'youtube',
+  'twitter',
+  'line',
+  'otherLink',
+  'other',
+  'vk',
+]);
+
+const applyPpTechnicalKeyValueEntry = (stateDraft, fieldName, normalizedValue) => {
+  if (PP_TECHNICAL_APPEND_FIELD_NAMES.has(fieldName)) {
+    stateDraft[fieldName] = appendFieldValue(stateDraft[fieldName], normalizedValue);
+    return;
+  }
+
+  stateDraft[fieldName] = normalizedValue;
 };
 
 const normalizePpTechnicalKeyValueEntry = (fieldName, value) => {
@@ -2408,7 +2436,7 @@ ${entries.join('\n')}`;
           const normalizedValue = normalizePpTechnicalKeyValueEntry(fieldName, value);
           if (!normalizedValue) return;
 
-          nextState[fieldName] = appendFieldValue(prevState[fieldName], normalizedValue);
+          applyPpTechnicalKeyValueEntry(nextState, fieldName, normalizedValue);
         });
       } else if (!parsed) {
         const resolvedTechnicalTarget = resolvePpTechnicalInputTarget(rawValue, {

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -265,3 +265,13 @@ export const pickerFieldsExtended = [
 export const pickerFieldNames = [
   ...new Set(pickerFieldsExtended.map(field => field?.name).filter(Boolean)),
 ];
+
+export const nonPickerContactFieldNames = ['ameblo', 'line', 'other'];
+
+export const ppTechnicalKeyValueFieldNames = [
+  ...new Set([...pickerFieldNames, ...nonPickerContactFieldNames]),
+].filter(fieldName => fieldName !== 'userId');
+
+export const newUsersMirrorFieldNames = [
+  ...new Set([...pickerFieldNames, ...nonPickerContactFieldNames]),
+].filter(fieldName => fieldName !== 'publish');


### PR DESCRIPTION
### Motivation
- Keep support for non-picker contact keys (notably `ameblo`) when parsing PP technical key:value input and when mirroring fields into `newUsers`.
- Prevent `userId` from being accepted via the technical key:value parser to avoid accidental writes to the wrong record.
- Ensure repeated key:value entries append against the staged draft state and replace scalar fields where appropriate so numeric/string scalar fields are not converted into arrays.
- Avoid mirroring `publish` into `newUsers` to prevent stale `newUsers.publish` masking later `users.publish` updates.

### Description
- Added `nonPickerContactFieldNames`, `ppTechnicalKeyValueFieldNames`, and `newUsersMirrorFieldNames` exports to `src/components/formFields.js` so non-picker contacts (e.g. `ameblo`) are preserved, `userId` is excluded from the technical-key list, and `publish` is excluded from the `newUsers` mirror list.
- Switched the PP key alias map in `src/components/ProfileForm.jsx` to use `ppTechnicalKeyValueFieldNames` so protected keys are respected when parsing key:value input.
- Introduced `PP_TECHNICAL_APPEND_FIELD_NAMES` and `applyPpTechnicalKeyValueEntry` in `src/components/ProfileForm.jsx` and changed the key:value processing to apply entries against the staged `nextState`, appending only for multi-value/contact fields and replacing for scalar fields.
- Updated long-ID save/mirroring code paths in `src/components/AddNewProfile.jsx` and `src/components/EditProfile.jsx` to use `newUsersMirrorFieldNames` instead of the old `pickerFieldNames`.

### Testing
- Ran ESLint for the changed files with `npm run lint:js -- src/components/ProfileForm.jsx src/components/formFields.js src/components/AddNewProfile.jsx src/components/EditProfile.jsx` which completed without errors.
- Ran a quick repository check with `git diff --check` which reported no whitespace/merge issues.
- Ran the full unit test suite with `npm test -- --watchAll=false`, which reported 30 passing and 8 failing test suites (19 failed tests) in storage/matching/indexing related suites; those failures appear to be pre-existing and unrelated to the PP key:value handling changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d5151cc3c8326858889cf965b03c5)