### PR TITLE
Move PP technical input before birth field

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -2603,7 +2603,7 @@ ${entries.join('\n')}`;
               : state[field.name] || '';
           return (
             <React.Fragment key={index}>
-            {field.name === 'name' && (
+            {field.name === 'birth' && (
               <PickerContainer>
                 <FieldMainRow>
                   <InputDiv>


### PR DESCRIPTION
### Motivation
- Розмістити технічний інпут `ppTechnicalInput` у `ProfileForm` безпосередньо перед полем `birth`, щоб відповідати бажаній порядковості полів у формі.

### Description
- У `src/components/ProfileForm.jsx` змінено умовний рендер: блок з `ppTechnicalInput` тепер рендериться коли `field.name === 'birth'` замість `field.name === 'name'`, без створення нового коду.

### Testing
- Запущено `npm run lint:js -- --quiet` (успішно) та `npm test -- --watchAll=false --runInBand`, причому тести повернули помилки загальною статистикою `8` невдалих тест-сюїтів і `19` невдалих тестів при `30` пройдених сюїтах і `209` пройдених тестах; ці збої стосуються існуючих storage/matching/reactions тестів і не пов’язані з цією UI-правкою.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d519cd754832694364da9c7e2af41)