### PR TITLE
Search: add search debug metadata, advanced-mode selector, telegram UK-trigger parsing, and strict prefix handling

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -544,7 +544,12 @@ const parseGroupedSearchValues = input => {
     .filter(Boolean);
 };
 
-const parseTelegramId = input => {
+export const parseTelegramSearchValue = input => {
+  const parsedUkTrigger = parseUkTriggerQuery(input);
+  if (parsedUkTrigger?.searchPair?.telegram) {
+    return parsedUkTrigger.searchPair.telegram;
+  }
+
   if (typeof input !== 'string') return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -560,6 +565,8 @@ const parseTelegramId = input => {
   if (textMatch && textMatch[1]) return textMatch[1];
   return null;
 };
+
+const parseTelegramId = parseTelegramSearchValue;
 
 const parseOtherContact = input => {
   if (typeof input !== 'string') return null;
@@ -762,6 +769,14 @@ export const detectSearchParamsByQueryContent = query => {
 };
 
 export const detectSearchParams = query => detectSearchParamsByQueryContent(query);
+
+
+export const getSelectedAdvancedSearchModes = (searchOptions = {}, isSearchEnabled = () => true) => [
+  searchOptions?.enablePartialUserIdSearch ? 'partialUserId' : null,
+  Array.isArray(searchOptions?.searchIdPrefixes) && searchOptions.searchIdPrefixes.length > 0 ? 'searchId' : null,
+  Array.isArray(searchOptions?.searchKeyFields) && searchOptions.searchKeyFields.length > 0 ? 'searchKey' : null,
+  Array.isArray(searchOptions?.equalToKeys) && searchOptions.equalToKeys.length > 0 ? 'equalToAllCards' : null,
+].filter(key => key && isSearchEnabled(key));
 
 const isSearchPerfDebugEnabled = () => {
   if (typeof window === 'undefined') return false;
@@ -1066,21 +1081,39 @@ const SearchBar = ({
 
   const notifySearchResult = () => {};
 
-  const mergeSearchResultMap = (acc, res) => {
+  const isSearchDebugEnabled = () => {
+    try {
+      return window.localStorage.getItem('searchDebug') === '1';
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const attachSearchDebugMeta = (card, meta) => {
+    if (!card || !meta || !isSearchDebugEnabled()) return card;
+    return {
+      ...card,
+      __searchDebug: meta,
+    };
+  };
+
+  const mergeSearchResultMap = (acc, res, meta = null) => {
     if (!res || Object.keys(res).length === 0) return;
     if (Array.isArray(res)) {
       res.forEach(card => {
         if (card?.userId) {
-          acc[card.userId] = card;
+          acc[card.userId] = attachSearchDebugMeta(card, meta);
         }
       });
       return;
     }
     if ('userId' in res) {
-      acc[res.userId] = res;
+      acc[res.userId] = attachSearchDebugMeta(res, meta);
       return;
     }
-    Object.assign(acc, res);
+    Object.entries(res).forEach(([userId, card]) => {
+      acc[userId] = attachSearchDebugMeta(card, meta);
+    });
   };
 
   const buildRepeatedSearchContext = value => {
@@ -1214,7 +1247,7 @@ const SearchBar = ({
         if (isStaleRequest()) return { found, results: resultMap };
         if (!res || Object.keys(res).length === 0) continue;
         found = true;
-        mergeSearchResultMap(resultMap, res);
+        mergeSearchResultMap(resultMap, res, { mode: 'equalToAllCards', key: equalToKey, value: parsedValue });
       }
     }
 
@@ -1247,7 +1280,7 @@ const SearchBar = ({
         if (isStaleRequest()) return { found, results: resultMap };
         if (!res || Object.keys(res).length === 0) continue;
         found = true;
-        mergeSearchResultMap(resultMap, res);
+        mergeSearchResultMap(resultMap, res, { mode: 'searchKey', key: searchKeyField, value: parsedValue });
       }
     }
 
@@ -1267,7 +1300,7 @@ const SearchBar = ({
       return { found: false, results: resultMap };
     }
 
-    mergeSearchResultMap(resultMap, partialResult);
+    mergeSearchResultMap(resultMap, partialResult, { mode: 'partialUserId', key: 'userId', value: userIdPrefix });
     return { found: true, results: resultMap };
   };
 
@@ -1309,10 +1342,10 @@ const SearchBar = ({
       );
       if (isStaleRequest()) return { found: false, results: resultMap };
 
-      searchIdResults.forEach(searchIdResult => {
+      searchIdResults.forEach((searchIdResult, index) => {
         if (!searchIdResult || Object.keys(searchIdResult).length === 0) return;
         foundCombinedResults = true;
-        mergeSearchResultMap(resultMap, searchIdResult);
+        mergeSearchResultMap(resultMap, searchIdResult, { mode: 'searchId', key: prefixesToIterate[index], value: searchIdInput });
       });
     }
 
@@ -1488,21 +1521,8 @@ const SearchBar = ({
         platform !== 'searchId' && SEARCH_ID_SCOPED_PLATFORMS.has(platform)
           ? [platform]
           : undefined;
-      const mergeSearchResult = (acc, res) => {
-        if (!res || Object.keys(res).length === 0) return;
-        if (Array.isArray(res)) {
-          res.forEach(card => {
-            if (card?.userId) {
-              acc[card.userId] = card;
-            }
-          });
-          return;
-        }
-        if ('userId' in res) {
-          acc[res.userId] = res;
-          return;
-        }
-        Object.assign(acc, res);
+      const mergeSearchResult = (acc, res, meta = null) => {
+        mergeSearchResultMap(acc, res, meta);
       };
 
       let finalRes = null;
@@ -1519,8 +1539,8 @@ const SearchBar = ({
           )
         );
 
-        prefixResults.forEach(partialRes => {
-          mergeSearchResult(aggregatedResults, partialRes);
+        prefixResults.forEach((partialRes, index) => {
+          mergeSearchResult(aggregatedResults, partialRes, { mode: 'searchId', key: prefixesToIterate[index], value: id });
         });
 
         if (Object.keys(aggregatedResults).length > 0) {
@@ -1680,12 +1700,7 @@ const SearchBar = ({
       }
       return;
     }
-    const selectedAdvancedSearchModes = [
-      'partialUserId',
-      'searchId',
-      'searchKey',
-      'equalToAllCards',
-    ].filter(key => isSearchEnabled(key));
+    const selectedAdvancedSearchModes = getSelectedAdvancedSearchModes(searchOptions, isSearchEnabled);
     const shouldUseSelectedAdvancedSearchModes = selectedAdvancedSearchModes.length > 0;
 
     const repeatedValues = parseGroupedSearchValues(trimmed);

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createRoot } from 'react-dom/client';
-import SearchBar, { getFreshCachedSearchResult, getSearchCacheKeyForParams, parseExplicitSearchKeyCandidate, parsePartialUserIdPrefix, resolveExecutionPlan } from './SearchBar';
+import SearchBar, { getFreshCachedSearchResult, getSearchCacheKeyForParams, getSelectedAdvancedSearchModes, parseExplicitSearchKeyCandidate, parsePartialUserIdPrefix, parseTelegramSearchValue, resolveExecutionPlan } from './SearchBar';
 import { updateCard } from '../utils/cardsStorage';
 import { resetMatchingLocalStorageCache, setIdsForQuery } from '../utils/cardIndex';
 
@@ -37,6 +37,14 @@ describe('parseExplicitSearchKeyCandidate', () => {
   it('keeps labeled telegram parsing working before falling back to raw key normalization', () => {
     expect(parseExplicitSearchKeyCandidate('telegram', 'telegram: Anna_Smile0808')).toBe('Anna_Smile0808');
   });
+
+
+  it('normalizes UK trigger telegram queries through the shared telegram parser', () => {
+    expect(parseTelegramSearchValue('УК СМ ALIA 09.10.2025')).toBe('УК СМ ALIA 09.10.2025');
+    expect(parseTelegramSearchValue('УК СМ Надія @nadia_agent')).toBe('УК СМ Надія @nadia_agent');
+    expect(parseTelegramSearchValue('@plain_handle')).toBe('plain_handle');
+    expect(parseTelegramSearchValue('https://t.me/plain_handle')).toBe('plain_handle');
+  });
 });
 
 describe('resolveExecutionPlan', () => {
@@ -62,6 +70,16 @@ describe('resolveExecutionPlan', () => {
       primaryKeys: ['telegram', 'phone', 'email'],
       fallbackKeys: [],
     });
+  });
+
+
+  it('only treats explicitly configured advanced scopes as selected', () => {
+    const enabled = key => ({ searchId: true, searchKey: true, equalToAllCards: true, partialUserId: true }[key]);
+
+    expect(getSelectedAdvancedSearchModes({}, enabled)).toEqual([]);
+    expect(getSelectedAdvancedSearchModes({ searchIdPrefixes: ['telegram'] }, enabled)).toEqual(['searchId']);
+    expect(getSelectedAdvancedSearchModes({ equalToKeys: ['telegram'] }, enabled)).toEqual(['equalToAllCards']);
+    expect(getSelectedAdvancedSearchModes({ searchIdPrefixes: ['telegram'], equalToKeys: ['telegram'] }, key => key === 'searchId')).toEqual(['searchId']);
   });
 });
 
@@ -108,6 +126,7 @@ describe('SearchBar cache-first search', () => {
           equalToAllCards: false,
         },
         searchOptions: {
+          enablePartialUserIdSearch: true,
           enabledSearchKeys: {
             partialUserId: true,
             searchId: false,

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1852,7 +1852,7 @@ export const searchUsersOnly = async (searchedValue, options = {}) => {
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
-    ? { includeVariants: false, includePrefixMatches: true, includeAdaptedPhoneVariant: true }
+    ? { includeVariants: false, includePrefixMatches: false, includeAdaptedPhoneVariant: true }
     : { includeVariants: searchKey !== 'telegram', includePrefixMatches: searchKey !== 'telegram' };
   const users = {};
   const uniqueUserIds = new Set();
@@ -2401,7 +2401,7 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
-    ? { includeVariants: false, includePrefixMatches: true, includeAdaptedPhoneVariant: true }
+    ? { includeVariants: false, includePrefixMatches: false, includeAdaptedPhoneVariant: true }
     : {
       includeVariants: searchKey !== 'telegram',
       includePrefixMatches: searchKey !== 'telegram' || allowTelegramPrefixMatches,

--- a/src/utils/searchKeyUtils.test.js
+++ b/src/utils/searchKeyUtils.test.js
@@ -1,6 +1,7 @@
 import {
   buildSearchIdRecordKey,
   normalizeSearchIdInput,
+  buildSearchIdCandidateKeys,
 } from './searchKeyUtils';
 
 const youtubeChannelId = 'UC4LwxzuzRqwSpa1A64eziDQ';
@@ -24,5 +25,17 @@ describe('searchKeyUtils YouTube normalization', () => {
       .toBe('KnowMeOfficial');
     expect(normalizeSearchIdInput('youtube', 'youtube: channel/UC4LwxzuzRqwSpa1A64eziDQ'))
       .toBe('channel/UC4LwxzuzRqwSpa1A64eziDQ');
+  });
+});
+
+
+describe('searchKeyUtils exact searchId behavior', () => {
+  it('builds only the exact selected telegram key when variants are disabled', () => {
+    const normalized = normalizeSearchIdInput('telegram', 'УК СМ ALIA 09.10.2025');
+
+    expect(buildSearchIdCandidateKeys(normalized, 'УК СМ ALIA 09.10.2025', ['telegram'], {
+      includeVariants: false,
+      includePrefixMatches: false,
+    })).toEqual(['telegram_ук см alia 09.10.2025']);
   });
 });


### PR DESCRIPTION
### Motivation
- Improve search observability by attaching debug metadata to cards returned by searches when enabled. 
- Expose and centralize selection of advanced search modes so configuration-driven searches honor explicit options. 
- Make telegram parsing reuse the shared parser to support UK-trigger queries and preserve existing labeled parsing. 
- Tighten prefix-match behavior for exact searchId flows to avoid unintended prefix matches in certain fast-paths.

### Description
- Exported `parseTelegramSearchValue` and aliased `parseTelegramId` to it, and wired in `parseUkTriggerQuery` handling so UK-trigger telegram queries return a normalized telegram value. 
- Added `getSelectedAdvancedSearchModes(searchOptions, isSearchEnabled)` and replaced the inline selection of advanced modes with this helper. 
- Introduced `isSearchDebugEnabled` and `attachSearchDebugMeta` and extended `mergeSearchResultMap` to accept an optional `meta` argument and attach `__searchDebug` to cards when debug is enabled; updated all call sites to pass mode/key/value metadata. 
- Replaced the local `mergeSearchResult` implementation inside `cachedSearch` with the centralized `mergeSearchResultMap` behavior. 
- Changed search backend options to disable `includePrefixMatches` when `shouldSkipBroadFallback` is true in both `searchUsersOnly` and `fetchNewUsersCollectionInRTDB`. 
- Updated unit tests to import/export the new symbols and added tests for `parseTelegramSearchValue` UK-trigger normalization, `getSelectedAdvancedSearchModes` behavior, and exact `searchId` candidate key building for telegram.

### Testing
- Ran the `parsePartialUserIdPrefix` and `parseExplicitSearchKeyCandidate` unit tests and they passed. 
- Ran the `resolveExecutionPlan` suite and the new `getSelectedAdvancedSearchModes` assertions and they passed. 
- Ran the `SearchBar cache-first search` integration test (updated to enable `enablePartialUserIdSearch`) and it passed. 
- Ran the `searchKeyUtils` exact `searchId` behavior test and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d587bad8c83269f52dcbd7543e684)