### PR TITLE
Fix SearchBar fallback and validation regressions

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -545,11 +545,6 @@ const parseGroupedSearchValues = input => {
 };
 
 export const parseTelegramSearchValue = input => {
-  const parsedUkTrigger = parseUkTriggerQuery(input);
-  if (parsedUkTrigger?.searchPair?.telegram) {
-    return parsedUkTrigger.searchPair.telegram;
-  }
-
   if (typeof input !== 'string') return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -740,11 +735,6 @@ const resolveEqualToExecutionKeys = ({ allKeys, selectedKeys, rawQuery }) => {
 
 
 export const detectSearchParamsByQueryContent = query => {
-  const parsedUkTrigger = parseUkTriggerQuery(query);
-  if (parsedUkTrigger?.searchPair?.telegram) {
-    return { key: 'telegram', value: parsedUkTrigger.searchPair.telegram };
-  }
-
   const trimmed = query.trim();
   const parsers = [
     ['facebook', parseFacebookId],
@@ -779,6 +769,50 @@ const normalizeComparableSearchValue = (key, value) => {
     return normalizeSearchIdInput(key, raw).toLowerCase();
   }
   return raw.replace(/\s+/g, ' ').toLowerCase();
+};
+
+const EXACT_SEARCH_ID_VALIDATION_FIELDS = new Set(
+  [...SEARCH_ID_INDEXED_FIELDS].filter(key => key !== 'name' && key !== 'surname' && key !== 'phone'),
+);
+
+const normalizeDateComparableValue = value => {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+
+  const numericDate = raw.match(/^(\d{1,2})[./-](\d{1,2})[./-](\d{2,4})$/);
+  if (numericDate) {
+    const [, day, month, year] = numericDate;
+    const fullYear = year.length === 2 ? `20${year}` : year;
+    return `${fullYear.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+  }
+
+  const isoDate = raw.match(/^(\d{4})[./-](\d{1,2})[./-](\d{1,2})/);
+  if (isoDate) {
+    const [, year, month, day] = isoDate;
+    return `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+  }
+
+  const timestamp = Number(raw);
+  if (Number.isFinite(timestamp) && timestamp > 0) {
+    const millis = timestamp < 10000000000 ? timestamp * 1000 : timestamp;
+    const date = new Date(millis);
+    if (!Number.isNaN(date.getTime())) return date.toISOString().slice(0, 10);
+  }
+
+  const date = new Date(raw);
+  if (!Number.isNaN(date.getTime())) return date.toISOString().slice(0, 10);
+
+  return raw.replace(/\s+/g, ' ').toLowerCase();
+};
+
+const isDateSearchValidationKey = key =>
+  DATE_LIKE_EQUAL_TO_KEYS.has(key) || SEARCH_KEY_BUCKET_SEARCH_PARSERS[key];
+
+const shouldUseExactFieldValidation = (key, expected, options = {}) => {
+  if (options.forceEqualToAllCards) return true;
+  if (isDateSearchValidationKey(key)) return true;
+  if (key === 'phone') return String(expected || '').replace(/\D/g, '').length >= 10;
+  return EXACT_SEARCH_ID_VALIDATION_FIELDS.has(key);
 };
 
 const getCardFieldValues = (card, key) => {
@@ -830,9 +864,18 @@ export const doesCardMatchSearchParams = (card, params = {}, options = {}) => {
   if (fieldValues.length === 0) return false;
 
   return fieldValues.some(fieldValue => {
+    if (isDateSearchValidationKey(key)) {
+      const normalizedDateFieldValue = normalizeDateComparableValue(fieldValue);
+      const normalizedDateExpected = normalizeDateComparableValue(value);
+      return Boolean(normalizedDateFieldValue && normalizedDateExpected && normalizedDateFieldValue === normalizedDateExpected);
+    }
+
     const normalizedFieldValue = normalizeComparableSearchValue(key, fieldValue);
     if (!normalizedFieldValue) return false;
-    if (SEARCH_ID_INDEXED_FIELDS.has(key)) return normalizedFieldValue === expected;
+    if (key === 'telegram' && options.allowTelegramPrefixMatches) {
+      return normalizedFieldValue.startsWith(expected);
+    }
+    if (shouldUseExactFieldValidation(key, expected, options)) return normalizedFieldValue === expected;
     return normalizedFieldValue.includes(expected);
   });
 };
@@ -845,12 +888,18 @@ export const filterSearchResultByParams = (result, params = {}, options = {}) =>
   return cardsToResultShape(filteredCards, result);
 };
 
-export const getSelectedAdvancedSearchModes = (searchOptions = {}, isSearchEnabled = () => true) => [
-  searchOptions?.enablePartialUserIdSearch ? 'partialUserId' : null,
-  Array.isArray(searchOptions?.searchIdPrefixes) && searchOptions.searchIdPrefixes.length > 0 ? 'searchId' : null,
-  Array.isArray(searchOptions?.searchKeyFields) && searchOptions.searchKeyFields.length > 0 ? 'searchKey' : null,
-  Array.isArray(searchOptions?.equalToKeys) && searchOptions.equalToKeys.length > 0 ? 'equalToAllCards' : null,
-].filter(key => key && isSearchEnabled(key));
+export const getSelectedAdvancedSearchModes = (searchOptions = {}, isSearchEnabled = () => true) => {
+  const enabledKeys = searchOptions?.enabledSearchKeys;
+  const isExplicitlyEnabled = key =>
+    enabledKeys && typeof enabledKeys === 'object' && Boolean(enabledKeys[key]);
+
+  return [
+    (searchOptions?.enablePartialUserIdSearch || isExplicitlyEnabled('partialUserId')) ? 'partialUserId' : null,
+    (isExplicitlyEnabled('searchId') || (Array.isArray(searchOptions?.searchIdPrefixes) && searchOptions.searchIdPrefixes.length > 0)) ? 'searchId' : null,
+    (isExplicitlyEnabled('searchKey') || (Array.isArray(searchOptions?.searchKeyFields) && searchOptions.searchKeyFields.length > 0)) ? 'searchKey' : null,
+    (isExplicitlyEnabled('equalToAllCards') || (Array.isArray(searchOptions?.equalToKeys) && searchOptions.equalToKeys.length > 0)) ? 'equalToAllCards' : null,
+  ].filter(key => key && isSearchEnabled(key));
+};
 
 const isSearchPerfDebugEnabled = () => {
   if (typeof window === 'undefined') return false;

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -40,8 +40,8 @@ describe('parseExplicitSearchKeyCandidate', () => {
 
 
   it('normalizes UK trigger telegram queries through the shared telegram parser', () => {
-    expect(parseTelegramSearchValue('УК СМ ALIA 09.10.2025')).toBe('УК СМ ALIA 09.10.2025');
-    expect(parseTelegramSearchValue('УК СМ Надія @nadia_agent')).toBe('УК СМ Надія @nadia_agent');
+    expect(parseTelegramSearchValue('УК СМ ALIA 09.10.2025')).toBeNull();
+    expect(parseTelegramSearchValue('УК СМ Надія @nadia_agent')).toBeNull();
     expect(parseTelegramSearchValue('@plain_handle')).toBe('plain_handle');
     expect(parseTelegramSearchValue('https://t.me/plain_handle')).toBe('plain_handle');
   });
@@ -80,6 +80,8 @@ describe('resolveExecutionPlan', () => {
     expect(getSelectedAdvancedSearchModes({ searchIdPrefixes: ['telegram'] }, enabled)).toEqual(['searchId']);
     expect(getSelectedAdvancedSearchModes({ equalToKeys: ['telegram'] }, enabled)).toEqual(['equalToAllCards']);
     expect(getSelectedAdvancedSearchModes({ searchIdPrefixes: ['telegram'], equalToKeys: ['telegram'] }, key => key === 'searchId')).toEqual(['searchId']);
+    expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { partialUserId: true } }, enabled)).toEqual(['partialUserId']);
+    expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { searchId: true, searchKey: true, equalToAllCards: true } }, enabled)).toEqual(['searchId', 'searchKey', 'equalToAllCards']);
   });
 });
 
@@ -117,6 +119,35 @@ describe('SearchBar result validation', () => {
       { userId: 'Anna123' },
       { userId: 'Anna' },
       { forcePartialUserIdSearch: true },
+    )).toBe(true);
+  });
+
+  it('keeps default name and short phone searches as substring matches', () => {
+    expect(doesCardMatchSearchParams(
+      { userId: 'name-match', name: 'Anna' },
+      { name: 'Ann' },
+    )).toBe(true);
+    expect(doesCardMatchSearchParams(
+      { userId: 'phone-match', phone: '380501234567' },
+      { phone: '1234' },
+    )).toBe(true);
+  });
+
+  it('uses exact validation for equalTo fields and normalized date bucket values', () => {
+    expect(doesCardMatchSearchParams(
+      { userId: 'comment-miss', myComment: 'abcd' },
+      { myComment: 'abc' },
+      { forceEqualToAllCards: true },
+    )).toBe(false);
+    expect(doesCardMatchSearchParams(
+      { userId: 'date-match', getInTouch: '2025-01-30' },
+      { getInTouch: '30.01.2025' },
+      { forceSearchKeyBucket: true },
+    )).toBe(true);
+    expect(doesCardMatchSearchParams(
+      { userId: 'timestamp-match', lastAction: new Date('2025-01-30T15:00:00Z').getTime() },
+      { lastAction: '30.01.2025' },
+      { forceSearchKeyBucket: true },
     )).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- UK-trigger telegram inputs were being consumed by the generic telegram parser which prevented the specialized `allowUkTrigger` fallback branch from running.  
- Default name searches and short-phone fragments were being forced into exact-match validation because `SEARCH_ID_INDEXED_FIELDS` was used too broadly.  
- Date-bucket searches lost matches when raw string validators compared non-normalized query formats (e.g. `30.01.2025`) against ISO or timestamp-backed values.  
- Advanced search modes could be disabled unintentionally when callers passed `enabledSearchKeys` without populating the related field arrays.

### Description
- Prevented UK-trigger strings from being claimed by the generic telegram parser by removing the `parseUkTriggerQuery` early handling from `parseTelegramSearchValue` and `detectSearchParamsByQueryContent`.  
- Introduced `EXACT_SEARCH_ID_VALIDATION_FIELDS`, `normalizeDateComparableValue`, `isDateSearchValidationKey`, and `shouldUseExactFieldValidation` helpers and used them in `doesCardMatchSearchParams` to limit exact-equality checks to exact-only contexts and date/equalTo modes.  
- Added date normalization (supporting dd.mm.yyyy, ISO, numeric timestamps and `Date` parsing) so date-bucket/equalTo validations match backend-normalized date values.  
- Kept name/surname and short-phone fragment searches as substring matches while preserving exact equality for truly exact fields and for `forceEqualToAllCards` contexts, and added special-case `allowTelegramPrefixMatches` to allow prefix matches for telegram fallback candidates.  
- Updated `getSelectedAdvancedSearchModes` to honor an `enabledSearchKeys` object so explicitly enabled advanced modes run even if their per-field arrays are empty.  
- Added/updated unit tests in `src/components/SearchBar.partialUserId.test.js` to cover UK-trigger handling, enabled advanced modes behavior, substring name/phone matching, exact equalTo validation, and normalized date matching.

### Testing
- Ran the unit test file with `npm test -- --runInBand src/components/SearchBar.partialUserId.test.js` and all tests passed (`1 suite, 16 tests` reported).  
- Ran linter with `npm run lint:js -- --quiet` and no lint errors were produced.  
- The changes touch `src/components/SearchBar.jsx` and its test `src/components/SearchBar.partialUserId.test.js` and the updated tests exercise the new behaviors described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6704f21c83269ddbbeb3760ec324)