### PR TITLE
Clear broader localStorage caches and reset SearchBar on cache clear

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -92,6 +92,7 @@ import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { btnMerge } from './smallCard/btnMerge';
 import FilterPanel, { getInitialFilters } from './FilterPanel';
 import SearchBar, { detectSearchParams } from './SearchBar';
+import { clearCacheByPrefix } from 'hooks/cardsCache';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { newUsersMirrorFieldNames } from './formFields';
@@ -1125,6 +1126,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   });
   const [searchBarQueryActive, setSearchBarQueryActive] = useState(false);
   const [lastSearchBarQuery, setLastSearchBarQuery] = useState('');
+  const [searchBarResetVersion, setSearchBarResetVersion] = useState(0);
   const searchListIsolationRef = useRef(Boolean((search || '').trim()));
   const [isExcelImporting, setIsExcelImporting] = useState(false);
   const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
@@ -5135,6 +5137,29 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleClearCache = () => {
     clearAllCardsCache();
+    clearCacheByPrefix('searchHistory');
+    localStorage.removeItem(SEARCH_KEY);
+    setSearch('');
+    setUsers({});
+    setFavoriteUsersData({});
+    setDislikeUsersData({});
+    setSearchKeyValuePair(null);
+    setSearchLoading(false);
+    setHasSearched(false);
+    setUserNotFound(false);
+    setHasMore(true);
+    setCurrentPage(1);
+    setLastKey(null);
+    setLastKey21(null);
+    setSearchBarQueryActive(false);
+    setLastSearchBarQuery('');
+    setCacheCount(0);
+    setBackendCount(0);
+    setDuplicates('');
+    setIsDuplicateView(false);
+    searchListIsolationRef.current = false;
+    renderCacheHydrationIdsRef.current = new Set();
+    setSearchBarResetVersion(version => version + 1);
     toast.success('Cache cleared');
   };
 
@@ -5986,6 +6011,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
         <SearchBarRow>
           <SearchBar
+            key={`add-search-${searchBarResetVersion}`}
             searchFunc={fetchNewUsersCollectionInRTDB}
             search={search}
             setSearch={value => {

--- a/src/hooks/cardsCache.js
+++ b/src/hooks/cardsCache.js
@@ -6,6 +6,15 @@ const TTL_MS = CACHE_TTL_MS;
 export const getCacheKey = (mode, term) =>
   `cards:${mode}${term ? `:${term}` : ''}`;
 
+
+export const clearCacheByPrefix = prefix => {
+  if (!prefix || typeof localStorage === 'undefined') return 0;
+  const cachePrefix = `${prefix}:`;
+  const keys = Object.keys(localStorage).filter(key => key.startsWith(cachePrefix));
+  keys.forEach(key => localStorage.removeItem(key));
+  return keys.length;
+};
+
 export const createCache = (prefix, ttl = TTL_MS) => {
   const CACHE_PREFIX = `${prefix}:`;
 

--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -35,17 +35,37 @@ describe('clearAllCardsCache', () => {
     localStorage.clear();
   });
 
-  it('removes only cards and queries entries', () => {
+  it('removes card, query, search key, search history, and legacy matching cache entries', () => {
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
+    localStorage.setItem('matchingIndexQueries', '{}');
+    localStorage.setItem('searchKey:v2:users/phone/123', '{}');
+    localStorage.setItem('searchHistory:queries', '{}');
+    localStorage.setItem('cardsCache:load2', '{}');
+    localStorage.setItem('additionalNewUsers:filters', '{}');
+    localStorage.setItem('matchingIndex:lastAction', '{}');
+    localStorage.setItem('searchKeySets:owner', '{}');
     localStorage.setItem('isLoggedIn', 'true');
+    localStorage.setItem('ownerId', 'owner-1');
+    localStorage.setItem('accessLevel', 'admin');
+    localStorage.setItem('userRole', 'admin');
     localStorage.setItem('other', 'value');
 
     clearAllCardsCache();
 
     expect(localStorage.getItem('cards')).toBeNull();
     expect(localStorage.getItem('queries')).toBeNull();
+    expect(localStorage.getItem('matchingIndexQueries')).toBeNull();
+    expect(localStorage.getItem('searchKey:v2:users/phone/123')).toBeNull();
+    expect(localStorage.getItem('searchHistory:queries')).toBeNull();
+    expect(localStorage.getItem('cardsCache:load2')).toBeNull();
+    expect(localStorage.getItem('additionalNewUsers:filters')).toBeNull();
+    expect(localStorage.getItem('matchingIndex:lastAction')).toBeNull();
+    expect(localStorage.getItem('searchKeySets:owner')).toBeNull();
     expect(localStorage.getItem('other')).toBe('value');
     expect(localStorage.getItem('isLoggedIn')).toBe('true');
+    expect(localStorage.getItem('ownerId')).toBe('owner-1');
+    expect(localStorage.getItem('accessLevel')).toBe('admin');
+    expect(localStorage.getItem('userRole')).toBe('admin');
   });
 });

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -12,6 +12,22 @@ export const MATCHING_CACHE_MAX_CHARS = 4 * 1024 * 1024;
 export const MATCHING_QUERY_MAX_IDS = 2000;
 export const MATCHING_INDEX_CACHE_VERSION = 1;
 const MATCHING_LOCAL_STORAGE_KEYS = new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY]);
+const MATCHING_LOCAL_STORAGE_PREFIXES = ['searchKey:', 'searchHistory:', 'cardsCache:'];
+const MATCHING_LOCAL_STORAGE_SUBSTRINGS = [
+  'matchingindex',
+  'searchkeysets',
+  'additionalnewusers',
+];
+
+export const isMatchingLocalStorageCacheKey = key => {
+  const normalized = String(key || '');
+  const lower = normalized.toLowerCase();
+  return (
+    MATCHING_LOCAL_STORAGE_KEYS.has(normalized) ||
+    MATCHING_LOCAL_STORAGE_PREFIXES.some(prefix => normalized.startsWith(prefix)) ||
+    MATCHING_LOCAL_STORAGE_SUBSTRINGS.some(fragment => lower.includes(fragment))
+  );
+};
 const localJsonCache = new Map();
 const pendingSaveTimers = new Map();
 const pendingSaveValues = new Map();
@@ -91,11 +107,7 @@ const resetMatchingStorageKey = key => {
 export const resetMatchingLocalStorageCache = (reason = 'manual') => {
   const dynamicKeysToReset = typeof localStorage === 'undefined'
     ? []
-    : Object.keys(localStorage).filter(key => {
-      const normalized = String(key || '');
-      const lower = normalized.toLowerCase();
-      return lower.includes('matchingindex') || lower.startsWith('searchkey:') || lower.includes('searchkeysets');
-    });
+    : Object.keys(localStorage).filter(isMatchingLocalStorageCacheKey);
   const keysToReset = [...new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY, ...dynamicKeysToReset])];
   logMatchingCacheDebug('clearMatchingCache started', { reason, keys: keysToReset });
   const rows = getMatchingLocalStorageCacheStats();


### PR DESCRIPTION
### Motivation

- Ensure `clearAllCardsCache` and matching cache reset remove all legacy and derived cache entries (search keys, search history, cards cache prefixes and related matching artifacts). 
- Add a utility to clear localStorage entries by prefix to simplify cache invalidation. 
- Force remounting of the `SearchBar` after a full cache clear to avoid stale UI state and ensure a clean search state.

### Description

- Added `clearCacheByPrefix` utility in `src/hooks/cardsCache.js` that removes localStorage keys with a given prefix and returns the number removed. 
- Updated `AddNewProfile.jsx` to import and call `clearCacheByPrefix('searchHistory')`, clear many search- and matching-related localStorage keys, reset multiple search-related React states, and bump a new `searchBarResetVersion` state to force `SearchBar` remount by passing `key={`add-search-${searchBarResetVersion}`}`. 
- Extended matching cache detection in `src/utils/cardIndex.js` by adding `MATCHING_LOCAL_STORAGE_PREFIXES`, `MATCHING_LOCAL_STORAGE_SUBSTRINGS`, and `isMatchingLocalStorageCacheKey()` and using it in `resetMatchingLocalStorageCache` to identify more cache keys to purge. 
- Updated `src/utils/__tests__/cache.test.js` to reflect the broader set of keys removed by `clearAllCardsCache` and matching reset.

### Testing

- Ran unit tests including `utils/__tests__/cache.test.js` with the test suite and updated expectations for additional keys, and the tests passed. 
- Executed the primary automated test command `yarn test` (or `npm test`) to validate updated cache behavior and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6696ef0c8326b9bc2152d87aacbd)