### PR TITLE
Fix advanced search field scoping, date normalization, and UK-trigger telegram parsing

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -458,14 +458,39 @@ const resolveDetectedContactParams = rawSearch => {
   return CONTACT_SEARCH_LABEL_KEYS.has(detectedParams?.key) ? detectedParams : null;
 };
 
+const normalizeConfiguredSearchKeys = (keys, allKeys) => {
+  if (!Array.isArray(keys)) return [];
+  return [...new Set(
+    keys
+      .map(key => (typeof key === 'string' ? key.trim() : ''))
+      .filter(key => allKeys.includes(key)),
+  )];
+};
+
+const getEnabledFieldKeys = (enabledKeys, allKeys) => {
+  if (!enabledKeys || typeof enabledKeys !== 'object') return null;
+  const configuredFieldKeys = allKeys.filter(key => Object.prototype.hasOwnProperty.call(enabledKeys, key));
+  if (configuredFieldKeys.length === 0) return null;
+  return configuredFieldKeys.filter(key => Boolean(enabledKeys[key]));
+};
+
+const resolveSelectedSearchKeys = (searchOptions = {}, optionKey, allKeys) => {
+  if (Array.isArray(searchOptions?.[optionKey])) {
+    return normalizeConfiguredSearchKeys(searchOptions[optionKey], allKeys);
+  }
+
+  return getEnabledFieldKeys(searchOptions?.enabledSearchKeys, allKeys) || [];
+};
+
+const hasExplicitEmptySearchKeyList = (searchOptions = {}, optionKey) =>
+  Array.isArray(searchOptions?.[optionKey]) && searchOptions[optionKey].length === 0;
+
 const resolveSearchIdPrefixStrategy = (input, searchOptions = {}) => {
-  const configuredPrefixes = Array.isArray(searchOptions?.searchIdPrefixes)
-    ? [...new Set(
-      searchOptions.searchIdPrefixes
-        .map(prefix => (typeof prefix === 'string' ? prefix.trim() : ''))
-        .filter(prefix => SEARCH_ID_PREFIX_KEYS.includes(prefix)),
-    )]
-    : [];
+  const configuredPrefixes = resolveSelectedSearchKeys(
+    searchOptions,
+    'searchIdPrefixes',
+    SEARCH_ID_PREFIX_KEYS,
+  );
 
   const executionPlan = resolveExecutionPlan({
     allKeys: SEARCH_ID_PREFIX_KEYS,
@@ -545,6 +570,9 @@ const parseGroupedSearchValues = input => {
 };
 
 export const parseTelegramSearchValue = input => {
+  const parsedUkTrigger = parseUkTriggerQuery(input);
+  if (parsedUkTrigger?.searchPair?.telegram) return null;
+
   if (typeof input !== 'string') return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -775,6 +803,13 @@ const EXACT_SEARCH_ID_VALIDATION_FIELDS = new Set(
   [...SEARCH_ID_INDEXED_FIELDS].filter(key => key !== 'name' && key !== 'surname' && key !== 'phone'),
 );
 
+const formatLocalIsoDate = date => {
+  const year = String(date.getFullYear()).padStart(4, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 const normalizeDateComparableValue = value => {
   const raw = String(value ?? '').trim();
   if (!raw) return '';
@@ -796,11 +831,11 @@ const normalizeDateComparableValue = value => {
   if (Number.isFinite(timestamp) && timestamp > 0) {
     const millis = timestamp < 10000000000 ? timestamp * 1000 : timestamp;
     const date = new Date(millis);
-    if (!Number.isNaN(date.getTime())) return date.toISOString().slice(0, 10);
+    if (!Number.isNaN(date.getTime())) return formatLocalIsoDate(date);
   }
 
   const date = new Date(raw);
-  if (!Number.isNaN(date.getTime())) return date.toISOString().slice(0, 10);
+  if (!Number.isNaN(date.getTime())) return formatLocalIsoDate(date);
 
   return raw.replace(/\s+/g, ' ').toLowerCase();
 };
@@ -892,12 +927,26 @@ export const getSelectedAdvancedSearchModes = (searchOptions = {}, isSearchEnabl
   const enabledKeys = searchOptions?.enabledSearchKeys;
   const isExplicitlyEnabled = key =>
     enabledKeys && typeof enabledKeys === 'object' && Boolean(enabledKeys[key]);
+  const hasSelectableFields = (optionKey, allKeys) => {
+    if (Array.isArray(searchOptions?.[optionKey])) return searchOptions[optionKey].length > 0;
+    const enabledFieldKeys = getEnabledFieldKeys(enabledKeys, allKeys);
+    return enabledFieldKeys === null || enabledFieldKeys.length > 0;
+  };
 
   return [
     (searchOptions?.enablePartialUserIdSearch || isExplicitlyEnabled('partialUserId')) ? 'partialUserId' : null,
-    (isExplicitlyEnabled('searchId') || (Array.isArray(searchOptions?.searchIdPrefixes) && searchOptions.searchIdPrefixes.length > 0)) ? 'searchId' : null,
-    (isExplicitlyEnabled('searchKey') || (Array.isArray(searchOptions?.searchKeyFields) && searchOptions.searchKeyFields.length > 0)) ? 'searchKey' : null,
-    (isExplicitlyEnabled('equalToAllCards') || (Array.isArray(searchOptions?.equalToKeys) && searchOptions.equalToKeys.length > 0)) ? 'equalToAllCards' : null,
+    (
+      (isExplicitlyEnabled('searchId') && !hasExplicitEmptySearchKeyList(searchOptions, 'searchIdPrefixes') && hasSelectableFields('searchIdPrefixes', SEARCH_ID_PREFIX_KEYS)) ||
+      (Array.isArray(searchOptions?.searchIdPrefixes) && searchOptions.searchIdPrefixes.length > 0)
+    ) ? 'searchId' : null,
+    (
+      (isExplicitlyEnabled('searchKey') && !hasExplicitEmptySearchKeyList(searchOptions, 'searchKeyFields') && hasSelectableFields('searchKeyFields', Object.keys(SEARCH_KEY_BUCKET_SEARCH_PARSERS))) ||
+      (Array.isArray(searchOptions?.searchKeyFields) && searchOptions.searchKeyFields.length > 0)
+    ) ? 'searchKey' : null,
+    (
+      (isExplicitlyEnabled('equalToAllCards') && !hasExplicitEmptySearchKeyList(searchOptions, 'equalToKeys') && hasSelectableFields('equalToKeys', Object.keys(EQUAL_TO_SEARCH_PARSERS))) ||
+      (Array.isArray(searchOptions?.equalToKeys) && searchOptions.equalToKeys.length > 0)
+    ) ? 'equalToAllCards' : null,
   ].filter(key => key && isSearchEnabled(key));
 };
 
@@ -1289,9 +1338,7 @@ const SearchBar = ({
 
     if (isSearchEnabled('equalToAllCards')) {
       const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);
-      const selectedEqualToKeys = Array.isArray(searchOptions?.equalToKeys)
-        ? searchOptions.equalToKeys.filter(key => allEqualToKeys.includes(key))
-        : [];
+      const selectedEqualToKeys = resolveSelectedSearchKeys(searchOptions, 'equalToKeys', allEqualToKeys);
       const equalToExecutionPlan = resolveEqualToExecutionKeys({
         allKeys: allEqualToKeys,
         selectedKeys: selectedEqualToKeys,
@@ -1361,10 +1408,8 @@ const SearchBar = ({
   ) => {
     const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);
     const selectedEqualToKeys = Array.isArray(forcedEqualToKeys)
-      ? forcedEqualToKeys.filter(key => allEqualToKeys.includes(key))
-      : Array.isArray(searchOptions?.equalToKeys)
-        ? searchOptions.equalToKeys.filter(key => allEqualToKeys.includes(key))
-        : [];
+      ? normalizeConfiguredSearchKeys(forcedEqualToKeys, allEqualToKeys)
+      : resolveSelectedSearchKeys(searchOptions, 'equalToKeys', allEqualToKeys);
     const equalToExecutionPlan = resolveEqualToExecutionKeys({
       allKeys: allEqualToKeys,
       selectedKeys: selectedEqualToKeys,
@@ -1393,9 +1438,7 @@ const SearchBar = ({
 
   const runSearchKeyBucketSearch = async (rawQuery, isStaleRequest, resultMap = {}) => {
     const allSearchKeyFields = Object.keys(SEARCH_KEY_BUCKET_SEARCH_PARSERS);
-    const selectedSearchKeyFields = Array.isArray(searchOptions?.searchKeyFields)
-      ? searchOptions.searchKeyFields.filter(key => allSearchKeyFields.includes(key))
-      : [];
+    const selectedSearchKeyFields = resolveSelectedSearchKeys(searchOptions, 'searchKeyFields', allSearchKeyFields);
     const executionPlan = resolveExecutionPlan({
       allKeys: allSearchKeyFields,
       selectedKeys: selectedSearchKeyFields,

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -42,6 +42,7 @@ describe('parseExplicitSearchKeyCandidate', () => {
   it('normalizes UK trigger telegram queries through the shared telegram parser', () => {
     expect(parseTelegramSearchValue('УК СМ ALIA 09.10.2025')).toBeNull();
     expect(parseTelegramSearchValue('УК СМ Надія @nadia_agent')).toBeNull();
+    expect(parseTelegramSearchValue('УК СМ tg: nadia_agent')).toBeNull();
     expect(parseTelegramSearchValue('@plain_handle')).toBe('plain_handle');
     expect(parseTelegramSearchValue('https://t.me/plain_handle')).toBe('plain_handle');
   });
@@ -82,6 +83,10 @@ describe('resolveExecutionPlan', () => {
     expect(getSelectedAdvancedSearchModes({ searchIdPrefixes: ['telegram'], equalToKeys: ['telegram'] }, key => key === 'searchId')).toEqual(['searchId']);
     expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { partialUserId: true } }, enabled)).toEqual(['partialUserId']);
     expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { searchId: true, searchKey: true, equalToAllCards: true } }, enabled)).toEqual(['searchId', 'searchKey', 'equalToAllCards']);
+    expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { searchId: true, telegram: false } }, enabled)).toEqual([]);
+    expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { equalToAllCards: true, telegram: false } }, enabled)).toEqual([]);
+    expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { searchId: true, telegram: true } }, enabled)).toEqual(['searchId']);
+    expect(getSelectedAdvancedSearchModes({ enabledSearchKeys: { searchId: true }, searchIdPrefixes: [] }, enabled)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent advanced search modes (`searchId`, `searchKey`, `equalToAllCards`) from being enabled when per-field toggles in `enabledSearchKeys` disable those fields or when an explicit empty field list is provided.
- Avoid dropping valid timestamp-backed cards due to UTC conversion when comparing date-bucket fields.
- Ensure UK-trigger labeled telegram queries are handled by the dedicated UK-trigger code path instead of the generic telegram parser so fallback lookup uses the full normalized value.

### Description
- Added helper utilities `normalizeConfiguredSearchKeys`, `getEnabledFieldKeys`, `resolveSelectedSearchKeys`, and `hasExplicitEmptySearchKeyList` to unify selection/normalization of configured field lists. (new functions in `src/components/SearchBar.jsx`).
- Updated `getSelectedAdvancedSearchModes` to respect per-field `enabledSearchKeys` and to treat an explicit empty array as disabling the mode.
- Switched `resolveSearchIdPrefixStrategy`, `runEqualToAllCardsSearch`, `runSearchKeyBucketSearch`, and repeated/combined search code to use the new key-selection helpers so only intentionally-selected fields are tried.
- Restored a UK-trigger guard in `parseTelegramSearchValue` so `parseUkTriggerQuery` labeled telegram inputs return `null` to allow the UK-trigger path to run with the full normalized label.
- Replaced UTC `toISOString().slice(0,10)` usage with a `formatLocalIsoDate` helper and used `getFullYear`/`getMonth`/`getDate` to preserve local-day boundaries when normalizing timestamps and date strings in `normalizeDateComparableValue`.
- Added/updated unit test assertions in `src/components/SearchBar.partialUserId.test.js` covering disabled advanced fields, explicit-empty-list behavior, and labeled UK-trigger telegram inputs.

### Testing
- Ran the focused test suite with `npm test -- --watchAll=false src/components/SearchBar.partialUserId.test.js` and it passed (`1` test suite, `16` tests all passing).
- Ran linter with `npm run lint:js -- src/components/SearchBar.jsx src/components/SearchBar.partialUserId.test.js` and it completed without errors relevant to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6b4dfc3c8326b964ee922c78e0f4)