### PR TITLE
Preserve search history when clearing cache

### DIFF
--- a/src/utils/__tests__/cache.test.js
+++ b/src/utils/__tests__/cache.test.js
@@ -35,7 +35,7 @@ describe('clearAllCardsCache', () => {
     localStorage.clear();
   });
 
-  it('removes card, query, search key, search history, and legacy matching cache entries', () => {
+  it('removes card, query, search key, and legacy matching cache entries while preserving search history', () => {
     localStorage.setItem('cards', '{}');
     localStorage.setItem('queries', '{}');
     localStorage.setItem('matchingIndexQueries', '{}');
@@ -57,7 +57,7 @@ describe('clearAllCardsCache', () => {
     expect(localStorage.getItem('queries')).toBeNull();
     expect(localStorage.getItem('matchingIndexQueries')).toBeNull();
     expect(localStorage.getItem('searchKey:v2:users/phone/123')).toBeNull();
-    expect(localStorage.getItem('searchHistory:queries')).toBeNull();
+    expect(localStorage.getItem('searchHistory:queries')).toBe('{}');
     expect(localStorage.getItem('cardsCache:load2')).toBeNull();
     expect(localStorage.getItem('additionalNewUsers:filters')).toBeNull();
     expect(localStorage.getItem('matchingIndex:lastAction')).toBeNull();

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -12,7 +12,7 @@ export const MATCHING_CACHE_MAX_CHARS = 4 * 1024 * 1024;
 export const MATCHING_QUERY_MAX_IDS = 2000;
 export const MATCHING_INDEX_CACHE_VERSION = 1;
 const MATCHING_LOCAL_STORAGE_KEYS = new Set([CARDS_KEY, QUERIES_KEY, INDEX_QUERIES_KEY]);
-const MATCHING_LOCAL_STORAGE_PREFIXES = ['searchKey:', 'searchHistory:', 'cardsCache:'];
+const MATCHING_LOCAL_STORAGE_PREFIXES = ['searchKey:', 'cardsCache:'];
 const MATCHING_LOCAL_STORAGE_SUBSTRINGS = [
   'matchingindex',
   'searchkeysets',


### PR DESCRIPTION
### Motivation
- Clearing the matching/cards cache should not erase user search history entries stored under `searchHistory:` prefixes.
- The change prevents accidental removal of search history while keeping legacy matching cache cleanup intact.

### Description
- Removed the `searchHistory:` prefix from `MATCHING_LOCAL_STORAGE_PREFIXES` in `src/utils/cardIndex.js` so `isMatchingLocalStorageCacheKey` no longer treats search history keys as matching cache entries.
- Updated the unit test in `src/utils/__tests__/cache.test.js` to reflect the new behavior and renamed the test to assert that `searchHistory:queries` is preserved.
- Other matching cache keys (cards, queries, `searchKey:` entries, `cardsCache:` entries, and legacy matching substrings) are still removed by `resetMatchingLocalStorageCache`.

### Testing
- Ran `npm test -- --runTestsByPath src/utils/__tests__/cache.test.js --watchAll=false` and the test suite passed.
- Test results: 1 test suite ran, 3 tests passed (all assertions in `cache.test.js` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6be45abc832697e30531104681e1)