### PR TITLE
Add SearchBar CSV export and make local index modal scrollable

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -743,6 +743,8 @@ const LocalIndexOverlay = styled.div`
 
 const LocalIndexModal = styled.div`
   width: min(560px, 100%);
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
   background: #fff;
   border-radius: 10px;
   padding: 16px;
@@ -5627,7 +5629,24 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const renderSourceCards = sortedIds
     .map(getRenderCardById)
     .filter(Boolean);
+  const searchBarContactsForExport = searchBarQueryActive ? renderSourceCards : [];
+  const searchBarContactsExportCount = searchBarContactsForExport.length;
   const renderVisibleCards = filterRenderCards(renderSourceCards);
+
+  const saveSearchBarContacts = () => {
+    if (searchBarContactsExportCount === 0) {
+      toast.error('Немає знайдених SearchBar карток для експорту');
+      return;
+    }
+
+    const contactsById = searchBarContactsForExport.reduce((acc, card, index) => {
+      const userId = card?.userId || card?.id || `search-result-${index}`;
+      acc[userId] = { ...card, userId };
+      return acc;
+    }, {});
+
+    saveToContactCsv(contactsById);
+  };
   const renderVisibleIds = renderVisibleCards.map(card => card.userId);
   const loadedPages = Math.ceil(renderVisibleIds.length / PAGE_SIZE) || 1;
   const totalPages = shouldPaginate ? Math.max(loadedPages, hasMore ? currentPage + 1 : currentPage) : 1;
@@ -6640,6 +6659,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 <SaveModalActionButton type="button" onClick={exportFilteredUsersCsv}>
                   <SaveModalActionTitle>CSV з активними фільтрами</SaveModalActionTitle>
                   <SaveModalComment>Ті самі дані, але у CSV для таблиць; також ділиться на файли максимум по 5000 рядків контактів.</SaveModalComment>
+                </SaveModalActionButton>
+                <SaveModalActionButton
+                  type="button"
+                  onClick={saveSearchBarContacts}
+                  disabled={searchBarContactsExportCount === 0}
+                >
+                  <SaveModalActionTitle>saveSearchBar contacts</SaveModalActionTitle>
+                  <SaveModalComment>CSV експорт усіх карток, знайдених останнім SearchBar запитом: {searchBarContactsExportCount}. Використовує повний результат пошуку, а не тільки поточні {PAGE_SIZE} карток на екрані.</SaveModalComment>
                 </SaveModalActionButton>
                 <SaveModalActionButton type="button" onClick={saveAllContacts}>
                   <SaveModalActionTitle>VCF вся колекція</SaveModalActionTitle>


### PR DESCRIPTION
### Motivation
- Allow exporting the full set of cards returned by the last SearchBar query (not just the currently paginated page).
- Prevent Local Index modal content from overflowing the viewport on small screens by making it scrollable.
- Surface the new export option in the existing save/export modal with a disabled state when there are no search results.

### Description
- Added `searchBarContactsForExport` and `searchBarContactsExportCount` to gather and count full SearchBar results when `searchBarQueryActive` is true.
- Implemented `saveSearchBarContacts` which normalizes result objects into an ID-indexed map and calls `saveToContactCsv` to produce CSV output, and shows a toast error when there are no results.
- Added a new `SaveModalActionButton` that calls `saveSearchBarContacts`, shows the result count in the comment, and is disabled when `searchBarContactsExportCount === 0`.
- Updated `LocalIndexModal` styling to include `max-height: calc(100vh - 32px)` and `overflow-y: auto` so the modal scrolls when content is taller than the viewport.

### Testing
- Ran the frontend linting with `yarn lint` and the test suite with `yarn test`, both of which completed successfully.
- Performed a basic export smoke test to verify the new `saveSearchBarContacts` path produces a CSV for SearchBar results and displays a toast when empty.
- Verified the `LocalIndexModal` no longer overflows the viewport and is scrollable on narrow screens.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dabeffc3c8326aa892a58e5a736e8)