### PR TITLE
Respect explicit empty equalTo key selections and keep legacy fallback when unset

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1407,17 +1407,22 @@ const SearchBar = ({
     forcedEqualToKeys = null,
   ) => {
     const allEqualToKeys = Object.keys(EQUAL_TO_SEARCH_PARSERS);
+    const hasExplicitEqualToKeys = Array.isArray(forcedEqualToKeys) || Array.isArray(searchOptions?.equalToKeys);
     const selectedEqualToKeys = Array.isArray(forcedEqualToKeys)
       ? normalizeConfiguredSearchKeys(forcedEqualToKeys, allEqualToKeys)
       : resolveSelectedSearchKeys(searchOptions, 'equalToKeys', allEqualToKeys);
+    let found = false;
+
+    if (hasExplicitEqualToKeys && selectedEqualToKeys.length === 0) {
+      return { found, results: resultMap };
+    }
+
     const equalToExecutionPlan = resolveEqualToExecutionKeys({
       allKeys: allEqualToKeys,
       selectedKeys: selectedEqualToKeys,
       rawQuery,
     });
     const keysToTry = equalToExecutionPlan.primaryKeys || [];
-
-    let found = false;
     for (const equalToKey of keysToTry) {
       const candidates = getParsedCandidatesForKey(equalToKey, rawQuery);
       for (const parsedValue of candidates) {

--- a/src/utils/searchKeyCheckboxFilters.js
+++ b/src/utils/searchKeyCheckboxFilters.js
@@ -46,20 +46,19 @@ export const getSearchIdPrefixes = searchIdPrefixes => {
 };
 
 export const resolveEqualToSearchKeys = equalToKeys => {
-  const normalizedSelected = Array.isArray(equalToKeys)
-    ? equalToKeys
-      .map(key => (typeof key === 'string' ? key.trim() : ''))
-      .filter(Boolean)
-    : [];
+  if (!Array.isArray(equalToKeys)) {
+    return [...EQUAL_TO_INDEX_KEYS];
+  }
+
+  const normalizedSelected = equalToKeys
+    .map(key => (typeof key === 'string' ? key.trim() : ''))
+    .filter(Boolean);
 
   const allowedSelected = EQUAL_TO_INDEX_KEYS.filter(key =>
     normalizedSelected.includes(key)
   );
 
-  if (
-    allowedSelected.length === 0 ||
-    allowedSelected.length === EQUAL_TO_INDEX_KEYS.length
-  ) {
+  if (allowedSelected.length === EQUAL_TO_INDEX_KEYS.length) {
     return [...EQUAL_TO_INDEX_KEYS];
   }
 

--- a/src/utils/searchKeyCheckboxFilters.test.js
+++ b/src/utils/searchKeyCheckboxFilters.test.js
@@ -1,0 +1,16 @@
+import { resolveEqualToSearchKeys } from './searchKeyCheckboxFilters';
+
+describe('resolveEqualToSearchKeys', () => {
+  it('keeps equalTo searches scoped to explicitly selected keys', () => {
+    expect(resolveEqualToSearchKeys(['createdAt'])).toEqual(['createdAt']);
+  });
+
+  it('does not fall back to every equalTo key for an explicit empty selection', () => {
+    expect(resolveEqualToSearchKeys([])).toEqual([]);
+    expect(resolveEqualToSearchKeys(['unknownKey'])).toEqual([]);
+  });
+
+  it('keeps the legacy all-keys fallback only when no explicit key list is provided', () => {
+    expect(resolveEqualToSearchKeys()).toEqual(expect.arrayContaining(['createdAt', 'getInTouch']));
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent running broad "equalTo" searches when an explicit empty key list was provided, which caused unintended wide queries.
- Preserve the legacy behavior of falling back to all equalTo keys only when no explicit key list is supplied.
- Add tests to lock down the intended behavior for explicit empty selections, unknown keys, and the unset case.

### Description

- In `SearchBar.jsx` `runEqualToAllCardsSearch` now detects whether `equalToKeys` were explicitly provided and returns early with no results when an explicit selection resolves to an empty list. 
- Adjusted the `found` variable placement and short-circuited the search when an explicit empty selection is detected to avoid unnecessary work.
- In `src/utils/searchKeyCheckboxFilters.js` `resolveEqualToSearchKeys` now returns the full `EQUAL_TO_INDEX_KEYS` only when `equalToKeys` is not an array (unset), and otherwise normalizes and filters the provided keys and only falls back to all keys when the allowed selection equals the full key set. 
- Added unit tests in `src/utils/searchKeyCheckboxFilters.test.js` that validate explicit selections, explicit empty/unknown selections, and the legacy fallback behavior.

### Testing

- Ran the unit test file `src/utils/searchKeyCheckboxFilters.test.js`, and all tests passed. 
- Ran the repository test suite with `yarn test` and no regressions were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dacad705c8326b28a6ec6c581774b)