### PR TITLE
Preserve search history when clearing cache

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -92,7 +92,6 @@ import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { btnMerge } from './smallCard/btnMerge';
 import FilterPanel, { getInitialFilters } from './FilterPanel';
 import SearchBar, { detectSearchParams } from './SearchBar';
-import { clearCacheByPrefix } from 'hooks/cardsCache';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import { newUsersMirrorFieldNames } from './formFields';
@@ -5139,7 +5138,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const handleClearCache = () => {
     clearAllCardsCache();
-    clearCacheByPrefix('searchHistory');
     localStorage.removeItem(SEARCH_KEY);
     setSearch('');
     setUsers({});


### PR DESCRIPTION
### Motivation
- When the user triggers cache clearing from the AddNewProfile UI, we must not erase the SearchBar history cache so recent searches remain available.

### Description
- Removed the `clearCacheByPrefix('searchHistory')` call from `handleClearCache` in `src/components/AddNewProfile.jsx` so search history is preserved.
- Removed the now-unused import `clearCacheByPrefix` from `hooks/cardsCache` in `src/components/AddNewProfile.jsx`.
- Kept existing behavior that still calls `clearAllCardsCache()` and removes the current search key via `localStorage.removeItem(SEARCH_KEY)`.

### Testing
- Ran `npm test -- --runTestsByPath src/utils/__tests__/cache.test.js --watchAll=false` and the suite passed.
- Test summary: 1 test suite passed, 3 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcded64848326a7fc65c8377d78c5)