### PR TITLE
Extract date normalization util and apply to search filtering and equal-to matching

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -15,7 +15,7 @@ import {
 } from '../utils/cardIndex';
 import { updateCard, searchCachedCards } from '../utils/cardsStorage';
 import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
-import { SEARCH_ID_INDEXED_FIELDS, normalizeSearchIdInput } from '../utils/searchKeyUtils';
+import { SEARCH_ID_INDEXED_FIELDS, normalizeSearchIdInput, normalizeSearchDateComparableValue } from '../utils/searchKeyUtils';
 
 const SearchIcon = (
   <svg
@@ -803,43 +803,6 @@ const EXACT_SEARCH_ID_VALIDATION_FIELDS = new Set(
   [...SEARCH_ID_INDEXED_FIELDS].filter(key => key !== 'name' && key !== 'surname' && key !== 'phone'),
 );
 
-const formatLocalIsoDate = date => {
-  const year = String(date.getFullYear()).padStart(4, '0');
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
-const normalizeDateComparableValue = value => {
-  const raw = String(value ?? '').trim();
-  if (!raw) return '';
-
-  const numericDate = raw.match(/^(\d{1,2})[./-](\d{1,2})[./-](\d{2,4})$/);
-  if (numericDate) {
-    const [, day, month, year] = numericDate;
-    const fullYear = year.length === 2 ? `20${year}` : year;
-    return `${fullYear.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
-  }
-
-  const isoDate = raw.match(/^(\d{4})[./-](\d{1,2})[./-](\d{1,2})/);
-  if (isoDate) {
-    const [, year, month, day] = isoDate;
-    return `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
-  }
-
-  const timestamp = Number(raw);
-  if (Number.isFinite(timestamp) && timestamp > 0) {
-    const millis = timestamp < 10000000000 ? timestamp * 1000 : timestamp;
-    const date = new Date(millis);
-    if (!Number.isNaN(date.getTime())) return formatLocalIsoDate(date);
-  }
-
-  const date = new Date(raw);
-  if (!Number.isNaN(date.getTime())) return formatLocalIsoDate(date);
-
-  return raw.replace(/\s+/g, ' ').toLowerCase();
-};
-
 const isDateSearchValidationKey = key =>
   DATE_LIKE_EQUAL_TO_KEYS.has(key) || SEARCH_KEY_BUCKET_SEARCH_PARSERS[key];
 
@@ -900,8 +863,8 @@ export const doesCardMatchSearchParams = (card, params = {}, options = {}) => {
 
   return fieldValues.some(fieldValue => {
     if (isDateSearchValidationKey(key)) {
-      const normalizedDateFieldValue = normalizeDateComparableValue(fieldValue);
-      const normalizedDateExpected = normalizeDateComparableValue(value);
+      const normalizedDateFieldValue = normalizeSearchDateComparableValue(fieldValue);
+      const normalizedDateExpected = normalizeSearchDateComparableValue(value);
       return Boolean(normalizedDateFieldValue && normalizedDateExpected && normalizedDateFieldValue === normalizedDateExpected);
     }
 

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -154,6 +154,16 @@ describe('SearchBar result validation', () => {
       { lastAction: '30.01.2025' },
       { forceSearchKeyBucket: true },
     )).toBe(true);
+    expect(filterSearchResultByParams(
+      {
+        wrongDateField: { userId: 'wrongDateField', getInTouch: '13.06.2026', createdAt: '14.05.2026' },
+        createdAtMatch: { userId: 'createdAtMatch', getInTouch: '14.05.2026', createdAt: '13.06.2026' },
+      },
+      { createdAt: '13.06.2026' },
+      { forceEqualToAllCards: true, equalToKeys: ['createdAt'] },
+    )).toEqual({
+      createdAtMatch: { userId: 'createdAtMatch', getInTouch: '14.05.2026', createdAt: '13.06.2026' },
+    });
   });
 });
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -39,6 +39,7 @@ import {
   getEqualToCandidates,
   makeSearchKeyValue,
   normalizeSearchIdInput,
+  normalizeSearchDateComparableValue,
   shouldSkipBroadFallbackForExactSearchId,
 } from '../utils/searchKeyUtils';
 import { resolveEqualToSearchKeys } from '../utils/searchKeyCheckboxFilters';
@@ -2211,6 +2212,33 @@ const executeSearchBySearchKeyBucket = async (searchKeys, rawSearchValue, unique
   }
 };
 
+
+const DATE_LIKE_EQUAL_TO_FIELDS = new Set([
+  'getInTouch',
+  'lastAction',
+  'lastLogin2',
+  'createdAt',
+  'lastCycle',
+  'lastLogin',
+]);
+
+const isEqualToFieldMatch = (userData, key, expectedValue) => {
+  if (!userData || !key) return false;
+  const fieldValue = key === 'userId' ? userData.userId : userData[key];
+  const values = Array.isArray(fieldValue) ? fieldValue : [fieldValue];
+
+  if (DATE_LIKE_EQUAL_TO_FIELDS.has(key)) {
+    const expectedDate = normalizeSearchDateComparableValue(expectedValue);
+    return Boolean(expectedDate && values.some(value =>
+      normalizeSearchDateComparableValue(value) === expectedDate
+    ));
+  }
+
+  const expected = String(expectedValue ?? '').trim().replace(/\s+/g, ' ').toLowerCase();
+  if (!expected) return false;
+  return values.some(value => String(value ?? '').trim().replace(/\s+/g, ' ').toLowerCase() === expected);
+};
+
 const buildEqualToQueriesForField = (collectionRef, key, candidate) => {
   if (key === 'lastAction') {
     const ranges = getIsoDateVariantsForSearch(candidate)
@@ -2264,7 +2292,9 @@ const executeSearchByEqualToFields = async (searchKeys, rawSearchValue, uniqueUs
             if (snapshot.exists()) {
               snapshot.forEach(userSnapshot => {
                 const userId = userSnapshot.key;
+                const userData = userSnapshot.val();
                 if (uniqueUserIds.has(userId)) return;
+                if (!isEqualToFieldMatch({ userId, ...userData }, key, candidate)) return;
 
                 uniqueUserIds.add(userId);
                 promises.push(addUserToResults(userId, users));

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -160,6 +160,44 @@ export const normalizeExactSearchIdInput = (rawValue, searchIdPrefixes) => {
   return normalizedValue || baseValue.replace(/\s+/g, ' ');
 };
 
+
+export const formatLocalIsoDate = date => {
+  const year = String(date.getFullYear()).padStart(4, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const normalizeSearchDateComparableValue = value => {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+
+  const numericDate = raw.match(/^(\d{1,2})[./-](\d{1,2})[./-](\d{2,4})$/);
+  if (numericDate) {
+    const [, day, month, year] = numericDate;
+    const fullYear = year.length === 2 ? `20${year}` : year;
+    return `${fullYear.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+  }
+
+  const isoDate = raw.match(/^(\d{4})[./-](\d{1,2})[./-](\d{1,2})/);
+  if (isoDate) {
+    const [, year, month, day] = isoDate;
+    return `${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+  }
+
+  const timestamp = Number(raw);
+  if (Number.isFinite(timestamp) && timestamp > 0) {
+    const millis = timestamp < 10000000000 ? timestamp * 1000 : timestamp;
+    const date = new Date(millis);
+    if (!Number.isNaN(date.getTime())) return formatLocalIsoDate(date);
+  }
+
+  const date = new Date(raw);
+  if (!Number.isNaN(date.getTime())) return formatLocalIsoDate(date);
+
+  return raw.replace(/\s+/g, ' ').toLowerCase();
+};
+
 const normalizePhoneSearchIdValue = rawValue => normalizePhoneValue(rawValue);
 
 export const buildSearchIdCandidateKeys = (


### PR DESCRIPTION
### Motivation

- Provide a single canonical date normalization routine for search comparisons to avoid duplicated logic and inconsistent date matching.
- Ensure equal-to queries and result filtering compare date-like fields in a normalized ISO-local date form so timestamp/string/date variants match correctly.

### Description

- Extracted date normalization logic into `normalizeSearchDateComparableValue` and `formatLocalIsoDate` in `src/utils/searchKeyUtils.js`. 
- Replaced the inline `normalizeDateComparableValue` in `src/components/SearchBar.jsx` with the new `normalizeSearchDateComparableValue` import and usage. 
- Added `DATE_LIKE_EQUAL_TO_FIELDS` set and `isEqualToFieldMatch` helper in `src/components/config.js` and applied the date-normalization check when processing `equalTo` query results. 
- Updated imports in `SearchBar.jsx` and `config.js` to include the new utility and removed the duplicate date normalization implementation from `SearchBar.jsx`. 
- Extended `SearchBar.partialUserId.test.js` with a test asserting that `filterSearchResultByParams` respects normalized `createdAt` equality matching when `forceEqualToAllCards` and `equalToKeys` are used. 

### Testing

- Ran unit tests including `SearchBar.partialUserId.test.js` with the new case, and the test suite passed. 
- Verified existing search-related tests still pass after replacing the inline date normalization with the shared utility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcf27bf30832681e96e45ad658468)