### PR TITLE
Add surrogacy program interest to My Profile

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -297,7 +297,7 @@ const baseSections = [
   { key: 'medical', title: '🏥 Медична інформація', fields: ['height', 'weight', 'blood', 'surgeries', 'chronicDiseases', 'allergy', 'ownKids', 'lastDelivery', 'csection', 'reward'] },
   { key: 'appearance', title: '✨ Зовнішність', fields: ['eyeColor', 'hairColor', 'hairStructure', 'bodyType', 'clothingSize', 'shoeSize', 'breastSize', 'glasses', 'race'] },
   { key: 'social', title: '📱 Соцмережі', fields: ['telegram', 'facebook', 'instagram', 'tiktok', 'twitter', 'linkedin', 'youtube', 'vk'] },
-  { key: 'lifestyle', title: '🌿 Спосіб життя', fields: ['smoking', 'alcohol', 'education', 'profession', 'hobbies', 'twinsInFamily', 'moreInfo_main'] },
+  { key: 'lifestyle', title: '🌿 Спосіб життя', fields: ['smoking', 'alcohol', 'education', 'profession', 'hobbies', 'twinsInFamily', 'moreInfo_main', 'surrogacyProgramInterest'] },
 ];
 
 const visibleNonDonorFields = new Set(['name','surname','email','phone','telegram','facebook','instagram','tiktok','vk','country','region','city','moreInfo_main']);

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -157,6 +157,14 @@ export const educationModalOptions = [
   { placeholder: 'PhD', ukrainian: 'Доктор філософії (PhD)' },
 ];
 
+export const surrogacyProgramInterestOptions = [
+  { placeholder: 'Not considering at all', ukrainian: 'Зовсім не розглядаю' },
+  { placeholder: 'Maybe later', ukrainian: 'Можливо, пізніше' },
+  { placeholder: 'Need more information', ukrainian: 'Потрібно більше інформації' },
+  { placeholder: 'Open to consultation', ukrainian: 'Готова до консультації' },
+  { placeholder: 'Considering', ukrainian: 'Розглядаю' },
+];
+
 export const csectionOptions = [
   { placeholder: '-', ukrainian: 'Ні' },
   { placeholder: '1', ukrainian: '1' },
@@ -236,6 +244,15 @@ export const pickerFields = [
   { name: 'profession', label: 'Професія', ukrainian: 'Професія', placeholder: 'Лікар', svg: 'no', width: '33%' },
   { name: 'twinsInFamily', label: 'Чи були двійнята в родині?', ukrainian: 'Чи були двійнята в родині?', placeholder: 'Так / Ні / Інше', svg: 'no', width: '33%', options: yesNoOptions },
   { name: 'moreInfo_main', label: 'Про себе', ukrainian: 'Про себе', placeholder: 'Коротко розкажіть про себе', ukrainianHint: 'До 300 символів', svg: 'no', width: '100%' },
+  {
+    name: 'surrogacyProgramInterest',
+    label: 'Чи розглядаєте ви потенційну участь у програмі сурогатного материнства?',
+    ukrainian: 'Чи розглядаєте ви потенційну участь у програмі сурогатного материнства?',
+    placeholder: 'Оберіть варіант',
+    svg: 'no',
+    width: '100%',
+    options: surrogacyProgramInterestOptions,
+  },
 
 ];
 


### PR DESCRIPTION
### Motivation
- Collect users' preference about participating in a surrogacy program and save the response via the existing profile autosave/backend flow.  

### Description
- Added a new options array `surrogacyProgramInterestOptions` in `src/components/formFields.js` providing choices including `"Зовсім не розглядаю"`, `"Можливо, пізніше"`, `"Потрібно більше інформації"`, `"Готова до консультації"`, and `"Розглядаю"`.  
- Added a new picker field `surrogacyProgramInterest` to `pickerFields` in `src/components/formFields.js` that uses the new options and is rendered with existing chip/custom-option UI.  
- Appended `surrogacyProgramInterest` to the `lifestyle` section in `src/components/MyProfile.jsx` so the field reuses the existing rendering, validation, autosave, and backend persistence implemented for profile fields.  

### Testing
- Ran `npm test -- --watchAll=false src/components/profileLayoutConfig.test.js src/utils/searchKeyCheckboxFilters.test.js` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa694bdd883268b17ac44529cde32)