### PR TITLE
Add surrogacyProgramInterest field, pass directFields to autosave, and simplify persistence logic

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -7,7 +7,6 @@ import {
   auth,
   fetchUserData,
   updateDataInFiresoreDB,
-  updateDataInNewUsersRTDB,
   updateDataInRealtimeDB,
 } from './config';
 import { pickerFields, getFieldLabel, getFieldPlaceholder, getOptionLabel, getOptionValue } from './formFields';
@@ -297,7 +296,7 @@ const baseSections = [
   { key: 'medical', title: '🏥 Медична інформація', fields: ['height', 'weight', 'blood', 'surgeries', 'chronicDiseases', 'allergy', 'ownKids', 'lastDelivery', 'csection', 'reward'] },
   { key: 'appearance', title: '✨ Зовнішність', fields: ['eyeColor', 'hairColor', 'hairStructure', 'bodyType', 'clothingSize', 'shoeSize', 'breastSize', 'glasses', 'race'] },
   { key: 'social', title: '📱 Соцмережі', fields: ['telegram', 'facebook', 'instagram', 'tiktok', 'twitter', 'linkedin', 'youtube', 'vk'] },
-  { key: 'lifestyle', title: '🌿 Спосіб життя', fields: ['smoking', 'alcohol', 'education', 'profession', 'hobbies', 'twinsInFamily', 'moreInfo_main'] },
+  { key: 'lifestyle', title: '🌿 Спосіб життя', fields: ['smoking', 'alcohol', 'education', 'profession', 'hobbies', 'twinsInFamily', 'moreInfo_main', 'surrogacyProgramInterest'] },
 ];
 
 const visibleNonDonorFields = new Set(['name','surname','email','phone','telegram','facebook','instagram','tiktok','vk','country','region','city','moreInfo_main']);
@@ -496,7 +495,7 @@ export const MyProfile = () => {
 
     stateRef.current = nextState;
     setState(nextState);
-    triggerAutosave(nextState);
+    triggerAutosave(nextState, { directFields: [name] });
   };
 
   const clearFieldValue = (name, field) => {
@@ -746,37 +745,13 @@ export const MyProfile = () => {
     return emailPattern.test(email);
   };
 
-  const isPermissionDeniedError = error => {
-    const code = String(error?.code || '').toLowerCase();
-    const message = String(error?.message || '').toLowerCase();
-    return code.includes('permission-denied') || code.includes('permission_denied') || message.includes('permission_denied');
-  };
-
-  const persistUserWithFallback = async (targetUserId, nextUploadedInfo, firestoreCondition = 'update') => {
-    let shouldWriteFullProfileToNewUsers = false;
-
-    try {
-      await updateDataInRealtimeDB(targetUserId, nextUploadedInfo, firestoreCondition === 'update' ? 'update' : undefined);
-    } catch (error) {
-      if (!isPermissionDeniedError(error)) {
-        throw error;
-      }
-      shouldWriteFullProfileToNewUsers = true;
-      console.warn('No write access to users/$uid, fallback to newUsers.');
-    }
-
-    try {
-      await updateDataInFiresoreDB(targetUserId, nextUploadedInfo, firestoreCondition);
-    } catch (error) {
-      shouldWriteFullProfileToNewUsers = true;
-      console.warn('Firestore write failed, fallback to newUsers.', error);
-    }
-
-    await updateDataInNewUsersRTDB(
+  const persistUserProfile = async (targetUserId, nextUploadedInfo, firestoreCondition = 'update') => {
+    await updateDataInRealtimeDB(
       targetUserId,
-      shouldWriteFullProfileToNewUsers ? nextUploadedInfo : { lastLogin2: nextUploadedInfo.lastLogin2 },
-      'update'
+      nextUploadedInfo,
+      firestoreCondition === 'update' ? 'update' : undefined
     );
+    await updateDataInFiresoreDB(targetUserId, nextUploadedInfo, firestoreCondition);
   };
 
   const handleAuthConfirm = async () => {
@@ -825,7 +800,7 @@ export const MyProfile = () => {
           userId: userCredential.user.uid,
           userRole: 'ed',
         };
-        await persistUserWithFallback(userCredential.user.uid, uploadedInfo, 'update');
+        await persistUserProfile(userCredential.user.uid, uploadedInfo, 'update');
       } else {
         userCredential = await createUserWithEmailAndPassword(auth, normalizedEmail, password);
         await sendEmailVerification(userCredential.user);
@@ -839,7 +814,7 @@ export const MyProfile = () => {
           userId: userCredential.user.uid,
           userRole: 'ed',
         };
-        await persistUserWithFallback(userCredential.user.uid, uploadedInfo, 'set');
+        await persistUserProfile(userCredential.user.uid, uploadedInfo, 'set');
       }
 
       localStorage.setItem('isLoggedIn', 'true');
@@ -896,14 +871,14 @@ export const MyProfile = () => {
           }
         });
         delete uploadedInfo.password;
-        await persistUserWithFallback(targetUserId, uploadedInfo, 'check');
+        await persistUserProfile(targetUserId, uploadedInfo, 'check');
       });
 
     return saveQueueRef.current;
   };
 
-  const triggerAutosave = (nextState) => {
-    saveState(nextState).catch(error => {
+  const triggerAutosave = (nextState, options) => {
+    saveState(nextState, options).catch(error => {
       console.warn('Autosave failed in MyProfile.', error);
     });
   };
@@ -994,7 +969,7 @@ export const MyProfile = () => {
                   setMissing(prev => ({ ...prev, [name]: false }));
                   stateRef.current = nextState;
                   setState(nextState);
-                  triggerAutosave(nextState);
+                  triggerAutosave(nextState, { directFields: [name] });
                 }}
                 type="button"
               >

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -157,6 +157,14 @@ export const educationModalOptions = [
   { placeholder: 'PhD', ukrainian: 'Доктор філософії (PhD)' },
 ];
 
+export const surrogacyProgramInterestOptions = [
+  { placeholder: 'Not considering at all', ukrainian: 'Зовсім не розглядаю' },
+  { placeholder: 'Maybe later', ukrainian: 'Можливо, пізніше' },
+  { placeholder: 'Need more information', ukrainian: 'Потрібно більше інформації' },
+  { placeholder: 'Open to consultation', ukrainian: 'Готова до консультації' },
+  { placeholder: 'Considering', ukrainian: 'Розглядаю' },
+];
+
 export const csectionOptions = [
   { placeholder: '-', ukrainian: 'Ні' },
   { placeholder: '1', ukrainian: '1' },
@@ -236,6 +244,15 @@ export const pickerFields = [
   { name: 'profession', label: 'Професія', ukrainian: 'Професія', placeholder: 'Лікар', svg: 'no', width: '33%' },
   { name: 'twinsInFamily', label: 'Чи були двійнята в родині?', ukrainian: 'Чи були двійнята в родині?', placeholder: 'Так / Ні / Інше', svg: 'no', width: '33%', options: yesNoOptions },
   { name: 'moreInfo_main', label: 'Про себе', ukrainian: 'Про себе', placeholder: 'Коротко розкажіть про себе', ukrainianHint: 'До 300 символів', svg: 'no', width: '100%' },
+  {
+    name: 'surrogacyProgramInterest',
+    label: 'Чи розглядаєте ви потенційну участь у програмі сурогатного материнства?',
+    ukrainian: 'Чи розглядаєте ви потенційну участь у програмі сурогатного материнства?',
+    placeholder: 'Оберіть варіант',
+    svg: 'no',
+    width: '100%',
+    options: surrogacyProgramInterestOptions,
+  },
 
 ];
 


### PR DESCRIPTION
### Motivation
- Collect user interest in surrogacy programs by adding a new profile field to the lifestyle section. 
- Ensure autosave can indicate which fields were changed to optimize what gets uploaded. 
- Simplify persistence flow by removing the previous fallback path and writing directly to Realtime DB and Firestore.

### Description
- Added `surrogacyProgramInterest` to `baseSections` in `MyProfile.jsx` and introduced the corresponding field and options in `src/components/formFields.js` as `surrogacyProgramInterestOptions` and a `pickerFields` entry. 
- Replaced `persistUserWithFallback` with `persistUserProfile` that calls `updateDataInRealtimeDB` and `updateDataInFiresoreDB` directly, and removed the `updateDataInNewUsersRTDB` import. 
- Updated autosave plumbing so `triggerAutosave` accepts an `options` object and callers (chip click and `saveFieldValue`) pass `directFields: [name]` to `saveState`, which forwards direct field hints into the uploaded payload.

### Testing
- Ran the project's lint and test commands with `npm run lint` and `npm test`, and both completed without failures. 
- Performed a local development build with `npm run build`, which succeeded.»

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa694bdd883268b17ac44529cde32)