### PR TITLE
Restore MyProfile auth persistence fallback

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -6,8 +6,6 @@ import styled, { css, keyframes } from 'styled-components';
 import {
   auth,
   fetchUserData,
-  updateDataInFiresoreDB,
-  updateDataInRealtimeDB,
 } from './config';
 import { pickerFields, getFieldLabel, getFieldPlaceholder, getOptionLabel, getOptionValue } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -25,6 +23,7 @@ import InfoModal from './InfoModal';
 import { resolveAccess } from 'utils/accessLevel';
 import { getCurrentDate } from './foramtDate';
 import { authNotifications } from './authNotifications';
+import { persistUserWithFallback } from './authProfilePersistence';
 import toast from 'react-hot-toast';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
 
@@ -745,14 +744,7 @@ export const MyProfile = () => {
     return emailPattern.test(email);
   };
 
-  const persistUserProfile = async (targetUserId, nextUploadedInfo, firestoreCondition = 'update') => {
-    await updateDataInRealtimeDB(
-      targetUserId,
-      nextUploadedInfo,
-      firestoreCondition === 'update' ? 'update' : undefined
-    );
-    await updateDataInFiresoreDB(targetUserId, nextUploadedInfo, firestoreCondition);
-  };
+  const persistUserProfile = persistUserWithFallback;
 
   const handleAuthConfirm = async () => {
     const currentState = stateRef.current || {};


### PR DESCRIPTION
### Motivation
- Reinstate the previous auth persistence flow so profile writes fall back to `newUsers` when Realtime DB or Firestore primary writes are denied or fail. 
- Prevent the regression where Firebase Auth can create/sign in a user but their profile data is left unsaved and `newUsers.lastLogin2` remains stale.

### Description
- Replace the inline `persistUserProfile` implementation in `src/components/MyProfile.jsx` with the shared `persistUserWithFallback` from `src/components/authProfilePersistence.js`. 
- Remove direct imports of `updateDataInFiresoreDB` and `updateDataInRealtimeDB` from `MyProfile.jsx` and wire `persistUserProfile` to reuse the existing helper that writes to `newUsers` as a fallback and keeps `lastLogin2` in sync.

### Testing
- Ran `npm run lint:js -- src/components/MyProfile.jsx` and it completed successfully. 
- Ran `git diff --check` and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb2e391388326aab56bdc61a732b7)