### PR TITLE
Support exclude-buckets strategy, limit source card scans, and handle negative cache entries

### DIFF
--- a/src/utils/matchingDataProvider.js
+++ b/src/utils/matchingDataProvider.js
@@ -93,6 +93,21 @@ const addGroup = (groups, indexName, values, debug = {}) => {
   });
 };
 
+const buildExcludeBucketMeta = ({ group, allBuckets = [], bucketMap = {}, allowedBuckets = [] } = {}) => {
+  if (!hasActiveFilterGroup(group)) return {};
+  const normalizedAllowed = new Set((allowedBuckets || []).map(String));
+  const excludedValues = (allBuckets || [])
+    .map(String)
+    .filter(bucket => !normalizedAllowed.has(bucket) && group?.[normalizeBucketFilterKey(bucket, bucketMap)] === false);
+
+  if (!excludedValues.length || !normalizedAllowed.size) return {};
+
+  return {
+    excludedValues,
+    indexStrategy: excludedValues.length < normalizedAllowed.size ? 'exclude-buckets' : 'include-buckets',
+  };
+};
+
 const buildRoleBuckets = (filters, collectionSource) => {
   const roleFilters = filters?.userRole || filters?.role;
   const buckets = buildAllowedBucketsFromFilterGroup(roleFilters, ROLE_BUCKETS, { no: 'empty', '?': 'other' });
@@ -135,10 +150,12 @@ const buildBloodBuckets = filters => {
   });
 };
 
+const MARITAL_STATUS_BUCKETS = ['+', '-', '?', 'no'];
+const MARITAL_STATUS_BUCKET_MAP = { '+': 'married', '-': 'unmarried', '?': 'other', no: 'empty' };
 const buildMaritalStatusBuckets = filters => buildAllowedBucketsFromFilterGroup(
   filters?.maritalStatus,
-  ['+', '-', '?', 'no'],
-  { '+': 'married', '-': 'unmarried', '?': 'other', no: 'empty' }
+  MARITAL_STATUS_BUCKETS,
+  MARITAL_STATUS_BUCKET_MAP
 );
 
 const buildAgeBuckets = filters => {
@@ -152,34 +169,42 @@ const buildPointBuckets = (filters, filterName, bucketMap = {}) =>
 
 export const buildMatchingIndexFilterGroups = ({ filters = {}, collectionSource = 'users' } = {}) => {
   const groups = [];
+  const roleBuckets = buildRoleBuckets(filters, collectionSource);
+  const roleFilters = filters?.userRole || filters?.role;
   addGroup(
     groups,
     'role',
-    buildRoleBuckets(filters, collectionSource),
+    roleBuckets,
     {
       source: 'searchKey/users',
-      ...getFilterGroupDebugState('userRole', filters?.userRole || filters?.role),
+      ...getFilterGroupDebugState('userRole', roleFilters),
+      ...buildExcludeBucketMeta({ group: roleFilters, allBuckets: ROLE_BUCKETS, bucketMap: { no: 'empty', '?': 'other' }, allowedBuckets: roleBuckets }),
     }
   );
+  const maritalStatusBuckets = buildMaritalStatusBuckets(filters);
   addGroup(
     groups,
     'maritalStatus',
-    buildMaritalStatusBuckets(filters),
+    maritalStatusBuckets,
     {
       source: 'searchKey/users',
       ...getFilterGroupDebugState('maritalStatus', filters?.maritalStatus),
+      ...buildExcludeBucketMeta({ group: filters?.maritalStatus, allBuckets: MARITAL_STATUS_BUCKETS, bucketMap: MARITAL_STATUS_BUCKET_MAP, allowedBuckets: maritalStatusBuckets }),
     }
   );
+  const bloodBuckets = buildBloodBuckets(filters);
   addGroup(
     groups,
     'blood',
-    buildBloodBuckets(filters),
+    bloodBuckets,
     {
       source: 'searchKey/users',
       ...getFilterGroupDebugState('bloodGroup+rh', {
         ...(filters?.bloodGroup || {}),
         ...(filters?.rh ? Object.fromEntries(Object.entries(filters.rh).map(([key, value]) => [`rh:${key}`, value])) : {}),
       }),
+      excludedValues: BLOOD_BUCKETS.filter(bucket => !bloodBuckets.includes(bucket)),
+      indexStrategy: BLOOD_BUCKETS.filter(bucket => !bloodBuckets.includes(bucket)).length < bloodBuckets.length ? 'exclude-buckets' : 'include-buckets',
     }
   );
   addGroup(
@@ -191,51 +216,61 @@ export const buildMatchingIndexFilterGroups = ({ filters = {}, collectionSource 
       ...getFilterGroupDebugState('age', filters?.age),
     }
   );
+  const csectionBuckets = CSECTION_BUCKETS.filter(bucket => buildPointBuckets(filters, 'csection').includes(bucket));
   addGroup(
     groups,
     'csection',
-    CSECTION_BUCKETS.filter(bucket => buildPointBuckets(filters, 'csection').includes(bucket)),
+    csectionBuckets,
     {
       source: 'searchKey/users',
       ...getFilterGroupDebugState('csection', filters?.csection),
+      ...buildExcludeBucketMeta({ group: filters?.csection, allBuckets: CSECTION_BUCKETS, allowedBuckets: csectionBuckets }),
     }
   );
+  const contactBuckets = CONTACT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'contact').includes(bucket));
   addGroup(
     groups,
     'contact',
-    CONTACT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'contact').includes(bucket)),
+    contactBuckets,
     {
       source: 'searchKey/users',
       ...getFilterGroupDebugState('contact', filters?.contact),
+      ...buildExcludeBucketMeta({ group: filters?.contact, allBuckets: CONTACT_BUCKETS, allowedBuckets: contactBuckets }),
     }
   );
+  const userIdBuckets = USER_ID_BUCKETS.filter(bucket => buildPointBuckets(filters, 'userId').includes(bucket));
   addGroup(
     groups,
     'userId',
-    USER_ID_BUCKETS.filter(bucket => buildPointBuckets(filters, 'userId').includes(bucket)),
+    userIdBuckets,
     {
       source: 'searchKey/users',
       ...getFilterGroupDebugState('userId', filters?.userId),
+      ...buildExcludeBucketMeta({ group: filters?.userId, allBuckets: USER_ID_BUCKETS, allowedBuckets: userIdBuckets }),
     }
   );
+  const fieldBuckets = FIELD_COUNT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'fields').includes(bucket));
   addGroup(
     groups,
     'fields',
-    FIELD_COUNT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'fields').includes(bucket)),
+    fieldBuckets,
     {
       source: 'searchKey/users',
       ...getFilterGroupDebugState('fields', filters?.fields),
+      ...buildExcludeBucketMeta({ group: filters?.fields, allBuckets: FIELD_COUNT_BUCKETS, allowedBuckets: fieldBuckets }),
     }
   );
 
   if (collectionSource !== 'newUsers') {
+    const imtBuckets = IMT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'imt', { other: '?' }).includes(bucket));
     addGroup(
       groups,
       'imt',
-      IMT_BUCKETS.filter(bucket => buildPointBuckets(filters, 'imt', { other: '?' }).includes(bucket)),
+      imtBuckets,
       {
         source: 'searchKey/users',
         ...getFilterGroupDebugState('imt', filters?.imt),
+        ...buildExcludeBucketMeta({ group: filters?.imt, allBuckets: IMT_BUCKETS, bucketMap: { other: '?' }, allowedBuckets: imtBuckets }),
       }
     );
   }
@@ -1195,6 +1230,8 @@ export const fetchFilteredMatchingSourceChunk = ({
     exclude,
     isSameCursor: isSameMatchingCursor,
     getSourceLimit: ({ remaining }) => remaining + exclude.size + 1,
+    maxSourceCards: 500,
+    debugLabel: `matchingSourceBackfill:${collectionSource}`,
     fetchSourcePage: ({ limit: sourceLimit, cursor }) => (
       collectionSource === 'newUsers'
         ? fetchUsersByLastLogin2FromCollection('newUsers', sourceLimit, cursor)

--- a/src/utils/matchingSourceBackfill.js
+++ b/src/utils/matchingSourceBackfill.js
@@ -10,6 +10,8 @@ export const collectFilteredMatchingSourceCards = async ({
   getSourceLimit,
   onPart,
   maxPages = 2,
+  maxSourceCards = 500,
+  debugLabel = 'matchingSourceBackfill',
 }) => {
   const visibleTarget = Math.max(1, Number(targetVisibleCount) || 1);
   const collected = [];
@@ -22,8 +24,9 @@ export const collectFilteredMatchingSourceCards = async ({
   let sourceCardsCount = 0;
   let filteredCardsCount = 0;
   let emittedCardsCount = 0;
+  const safeMaxSourceCards = Math.max(1, Number(maxSourceCards) || 500);
 
-  while (collected.length < visibleTarget && sourceHasMore && loadedPages < maxPages) {
+  while (collected.length < visibleTarget && sourceHasMore && loadedPages < maxPages && sourceCardsCount < safeMaxSourceCards) {
     loadedPages += 1;
     if (typeof window !== 'undefined' && window.matchingLoadStats) {
       window.matchingLoadStats.backfillPages = (Number(window.matchingLoadStats.backfillPages) || 0) + 1;
@@ -74,6 +77,10 @@ export const collectFilteredMatchingSourceCards = async ({
     sourceHasMore = Boolean(sourceRes?.hasMore) && cursorAdvanced;
     cursor = nextCursor;
 
+    if (sourceCardsCount >= safeMaxSourceCards) {
+      stopReason = 'max_source_cards_reached';
+      break;
+    }
     if (!sourceRes?.hasMore) {
       stopReason = validSlice.length ? 'source_exhausted' : 'no_visible_cards_added';
       break;
@@ -89,6 +96,20 @@ export const collectFilteredMatchingSourceCards = async ({
   }
 
   if (!stopReason && loadedPages >= maxPages && collected.length < visibleTarget) stopReason = 'max_pages_reached';
+  if (!stopReason && sourceCardsCount >= safeMaxSourceCards && collected.length < visibleTarget) stopReason = 'max_source_cards_reached';
+
+  const finalStopReason = stopReason || (collected.length ? 'target_reached' : 'no_visible_cards_added');
+  if (typeof console !== 'undefined' && finalStopReason !== 'target_reached') {
+    console.info(`[${debugLabel}] stopped`, {
+      stopReason: finalStopReason,
+      loadedPages,
+      sourceCardsCount,
+      filteredCardsCount,
+      emittedCardsCount,
+      cursorAdvanced,
+      sourceHasMore,
+    });
+  }
 
   return {
     users: collected,
@@ -101,6 +122,6 @@ export const collectFilteredMatchingSourceCards = async ({
     filteredCardsCount,
     emittedCardsCount,
     loadedPages,
-    stopReason: stopReason || (collected.length ? 'target_reached' : 'no_visible_cards_added'),
+    stopReason: finalStopReason,
   };
 };

--- a/src/utils/newUsersFilterSetsIndex.js
+++ b/src/utils/newUsersFilterSetsIndex.js
@@ -1289,7 +1289,8 @@ export const getIndexedNewUsersIdsByRules = async ({
       return false;
     });
 
-    for (const { indexName, values } of bucketGroups) {
+    for (const group of bucketGroups) {
+      const { indexName, values } = group;
       const normalizedValues = Array.isArray(values) ? values.filter(Boolean) : [];
       const idsForFilter = new Set();
       const ageRange = indexName === 'age' ? getAgeRangeBounds(normalizedValues) : null;
@@ -1390,30 +1391,67 @@ export const getIndexedNewUsersIdsByRules = async ({
 
         if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
         setsMap[entry.setKey][indexName] = fieldsIndexValue;
-      } else for (const value of normalizedValues) {
-        const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`;
-        resultPaths.push(path);
-        emitDebug('reading Firebase path', { path, setKey: entry.setKey, indexName, value });
+      } else {
+        const excludedValues = Array.isArray(group?.excludedValues)
+          ? [...new Set(group.excludedValues.filter(Boolean).map(String))]
+          : [];
+        const useExcludeStrategy = group?.indexStrategy === 'exclude-buckets'
+          && excludedValues.length > 0
+          && filterSets.length > 0;
+        const valuesToRead = useExcludeStrategy ? excludedValues : normalizedValues;
 
-        // eslint-disable-next-line no-await-in-loop
-        const payload = await readBucketPayload(path);
-        const bucketValue = payload?.exists && payload.value && typeof payload.value === 'object'
-          ? payload.value
-          : {};
-        const bucketIdsCount = Object.keys(bucketValue).filter(Boolean).length;
+        emitDebug('additionalMatching: bucket read strategy', {
+          setKey: entry.setKey,
+          indexName,
+          strategy: useExcludeStrategy ? 'exclude-buckets' : 'include-buckets',
+          valuesCount: normalizedValues.length,
+          excludedValuesCount: excludedValues.length,
+          baseFilterSetsCount: filterSets.length,
+        });
 
-        if (payload?.exists) {
-          existingBucketsForSet += 1;
-          if (bucketIdsCount === 0) emptyBucketsForSet += 1;
-        } else {
-          missingBucketsForSet += 1;
+        const bucketReads = await Promise.all(valuesToRead.map(async value => {
+          const path = `${SEARCH_KEY_SETS_ROOT}/${entry.setKey}/${indexName}/${value}`;
+          resultPaths.push(path);
+          emitDebug('reading Firebase path', { path, setKey: entry.setKey, indexName, value });
+
+          const payload = await readBucketPayload(path);
+          const bucketValue = payload?.exists && payload.value && typeof payload.value === 'object'
+            ? payload.value
+            : {};
+          return { value, payload, bucketValue };
+        }));
+
+        const excludedIds = new Set();
+        for (const { value, payload, bucketValue } of bucketReads) {
+          const bucketIds = Object.keys(bucketValue).filter(Boolean);
+
+          if (payload?.exists) {
+            existingBucketsForSet += 1;
+            if (bucketIds.length === 0) emptyBucketsForSet += 1;
+          } else {
+            missingBucketsForSet += 1;
+          }
+
+          if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
+          if (!setsMap[entry.setKey][indexName]) setsMap[entry.setKey][indexName] = {};
+          setsMap[entry.setKey][indexName][value] = bucketValue;
+
+          bucketIds.sort((a, b) => a.localeCompare(b)).forEach(userId => {
+            if (!userId) return;
+            if (useExcludeStrategy) excludedIds.add(userId);
+            else idsForFilter.add(userId);
+          });
         }
 
-        if (!setsMap[entry.setKey]) setsMap[entry.setKey] = {};
-        if (!setsMap[entry.setKey][indexName]) setsMap[entry.setKey][indexName] = {};
-        setsMap[entry.setKey][indexName][value] = bucketValue;
-
-        Object.keys(bucketValue).sort((a, b) => a.localeCompare(b)).forEach(userId => { if (userId) idsForFilter.add(userId); });
+        if (useExcludeStrategy) {
+          const [firstSet, ...restSets] = [...filterSets].sort((a, b) => a.size - b.size);
+          [...firstSet]
+            .sort((a, b) => a.localeCompare(b))
+            .forEach(userId => {
+              if (excludedIds.has(userId)) return;
+              if (restSets.every(set => set.has(userId))) idsForFilter.add(userId);
+            });
+        }
       }
 
       // OR between bucket values for the same indexName, AND between different indexName fields.

--- a/src/utils/searchKeyCache.js
+++ b/src/utils/searchKeyCache.js
@@ -5,6 +5,7 @@ export const MAX_LOCAL_CACHE_ITEM_BYTES = 3 * 1024 * 1024;
 
 const SEARCH_KEY_PREFIX = 'searchKey:';
 const TTL_MS = CACHE_TTL_MS;
+const NEGATIVE_CACHE_TTL_MS = 10 * 60 * 1000;
 
 const normalizePath = path =>
   String(path || '')
@@ -24,13 +25,18 @@ export const isEmptyCachedValue = value => {
 const isValidPayloadForCache = payload => {
   if (!payload || typeof payload !== 'object') return false;
   if (payload.version && payload.version !== MATCHING_CACHE_VERSION) return false;
+  if (payload.exists === false) return true;
   if (payload.exists !== true) return false;
-  return !isEmptyCachedValue(payload.value);
+  return true;
 };
 
+const isNegativePayload = payload => (
+  !payload || payload.exists === false || isEmptyCachedValue(payload.value)
+);
+
 const normalizePayloadForCache = payload => ({
-  exists: true,
-  value: payload.value,
+  exists: payload?.exists === false ? false : true,
+  value: payload?.exists === false ? null : (payload?.value ?? {}),
   version: MATCHING_CACHE_VERSION,
 });
 
@@ -88,12 +94,13 @@ const readStorageRecord = storageKey => {
 
   try {
     const parsed = JSON.parse(raw);
-    if (TTL_MS && parsed?.timestamp && Date.now() - parsed.timestamp > TTL_MS) {
+    const data = getStoredData(parsed);
+    const ttl = isNegativePayload(data) ? NEGATIVE_CACHE_TTL_MS : TTL_MS;
+    if (ttl && parsed?.timestamp && Date.now() - parsed.timestamp > ttl) {
       safeRemoveItem(storageKey);
       return null;
     }
 
-    const data = getStoredData(parsed);
     if (!isValidPayloadForCache(data)) {
       safeRemoveItem(storageKey);
       return null;
@@ -185,7 +192,7 @@ export const cleanupMatchingLocalStorageCache = ({ debug = false } = {}) => {
         return;
       }
       if (isNegativeOrEmptyRecord(key, parsed)) {
-        remove('negative');
+        stats.negative += 1;
       }
     } catch {
       remove('corrupted');


### PR DESCRIPTION
### Motivation
- Reduce expensive bucket reads by supporting an "exclude-buckets" index strategy for search-key sets and provide metadata for filter groups to drive that behavior.
- Prevent unbounded source scans when backfilling by capping scanned source cards and surface diagnostics when stopping early.
- Improve local cache behavior by treating negative/non-existent payloads specially and applying a shorter TTL to them instead of evicting them immediately.

### Description
- Added `buildExcludeBucketMeta` and threaded `excludedValues` and `indexStrategy` into matching index filter groups for role, maritalStatus, blood, csection, contact, userId, fields and imt groups. Also extracted marital status buckets/map constants (`MARITAL_STATUS_BUCKETS`, `MARITAL_STATUS_BUCKET_MAP`).
- Implemented exclude-buckets read strategy in `getIndexedNewUsersIdsByRules` by optionally reading excluded bucket values, collecting excluded ids, and deriving the final ids-by-filter via set-difference + intersection when `indexStrategy === 'exclude-buckets'`.
- Added `maxSourceCards` limit and `debugLabel` to `collectFilteredMatchingSourceCards` and passed `maxSourceCards: 500` / debug label from caller, and stop scanning once `sourceCardsCount` exceeds the cap; emit a console info with a stop reason and stats when stopping early.
- Made `collectFilteredMatchingSourceCards` return a normalized `stopReason` (`finalStopReason`) and included counters (`sourceCardsCount`, `filteredCardsCount`, `emittedCardsCount`) in the returned payload.
- Enhanced `searchKeyCache` to support negative cache entries: introduced `NEGATIVE_CACHE_TTL_MS`, treat `payload.exists === false` as a valid cached value, preserve `exists` in cache records, use a shorter TTL for negative entries in `readStorageRecord`, and stop removing negative records in `cleanupMatchingLocalStorageCache` (they are now counted instead).

### Testing
- Ran unit tests with `npm test`, which completed successfully.
- Ran linting with `npm run lint`, which completed successfully.
- Executed matching backfill smoke flow locally to verify stop conditions and console diagnostics, and observed expected `max_source_cards_reached` behavior when limits were hit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31843161108326ac828f2db30723c8)