### PR TITLE
Replace dislike icon and add 'clear contact date' button in TopBlock

### DIFF
--- a/src/components/smallCard/btnDislike.js
+++ b/src/components/smallCard/btnDislike.js
@@ -9,7 +9,7 @@ import { color } from '../styles';
 import { setDislike, cacheDislikedUsers } from 'utils/dislikesStorage';
 import { setFavorite } from 'utils/favoritesStorage';
 import { removeCardFromList } from 'utils/cardsStorage';
-import { FaTimes } from 'react-icons/fa';
+import { FaThumbsDown } from 'react-icons/fa';
 
 export const BtnDislike = ({
   userId,
@@ -151,7 +151,7 @@ export const BtnDislike = ({
         toggleDislike();
       }}
     >
-      <FaTimes size={iconSize} color={isDisliked ? resolvedActiveIconColor : resolvedInactiveIconColor} />
+      <FaThumbsDown size={iconSize} color={isDisliked ? resolvedActiveIconColor : resolvedInactiveIconColor} />
     </button>
   );
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -842,6 +842,34 @@ const TopBlock = ({
 
   const getInTouchReactionActions = (
     <>
+      <button
+        type="button"
+        style={{
+          ...compactReactionButtonStyle,
+          backgroundColor: '#d32f2f',
+          border: 'none',
+          color: '#fff',
+        }}
+        onClick={event => {
+          event.stopPropagation();
+          handleChange(
+            setUsers,
+            setState,
+            cardData.userId,
+            'getInTouch',
+            '',
+            true,
+            { currentFilter, isDateInRange, ...submitOptions },
+          );
+        }}
+        disabled={!cardData?.userId}
+        title="Видалити дату контакту"
+        aria-label="Видалити дату контакту"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+        </svg>
+      </button>
       <BtnDislike
         title="Дизлайк"
         ariaLabel="Дизлайк"


### PR DESCRIPTION
### Motivation
- Replace a non-semantic icon used for the dislike action with a more appropriate thumbs-down icon to improve visual affordance.
- Provide a compact, in-card action to clear the stored contact date (`getInTouch`) directly from the TopBlock controls.

### Description
- Swap the dislike icon in `BtnDislike` from `FaTimes` to `FaThumbsDown` to better represent the dislike action.
- Add a new compact red button to the `getInTouchReactionActions` block in `renderTopBlock.js` which calls `handleChange(..., 'getInTouch', '', ...)` to remove the contact date.
- The new button is disabled when `cardData?.userId` is missing and includes `title` and `aria-label` for accessibility, and it uses an inline SVG `X` icon and compact styling.

### Testing
- Ran unit tests with `npm test` (Jest) and they passed.
- Ran linting with `npm run lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3239b4015483269fb517e84d72e5d3)