### PR TITLE
Add negative-cache handling for search results to skip redundant backend calls

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -972,31 +972,40 @@ export const getSearchCacheKeyForParams = (key, value, options = {}) => {
 
 export const getFreshCachedSearchResult = (key, value, options = {}) => {
   if (!key || value === undefined || value === null || String(value).trim() === '') {
-    return { hit: false, cards: [], map: {} };
+    return { hit: false, negativeHit: false, cards: [], map: {} };
   }
 
   const cacheKey = getSearchCacheKeyForParams(key, value, options);
   const queries = loadQueries();
   const entry = queries[cacheKey];
-  if (!entry) return { hit: false, cards: [], map: {} };
+  if (!entry) return { hit: false, negativeHit: false, cards: [], map: {} };
 
   const timestampSource =
     typeof entry.cachedAt === 'number' && Number.isFinite(entry.cachedAt)
       ? entry.cachedAt
       : Number(entry.cachedAt ?? entry.lastAction ?? 0);
   if (!Number.isFinite(timestampSource) || timestampSource <= 0) {
-    return { hit: false, cards: [], map: {} };
+    return { hit: false, negativeHit: false, cards: [], map: {} };
   }
   if (Date.now() - timestampSource >= TTL_MS) {
-    return { hit: false, cards: [], map: {} };
+    return { hit: false, negativeHit: false, cards: [], map: {} };
   }
 
   const ids = getIdsByQuery(cacheKey);
-  if (ids.length === 0) return { hit: false, cards: [], map: {} };
+  if (ids.length === 0) {
+    return {
+      hit: false,
+      negativeHit: true,
+      cards: [],
+      map: {},
+      cacheKey,
+      ids: [],
+    };
+  }
 
   const cards = ids.map(id => getCard(id)).filter(Boolean);
   if (cards.length === 0 || cards.length !== ids.length) {
-    return { hit: false, cards: [], map: {} };
+    return { hit: false, negativeHit: false, cards: [], map: {} };
   }
 
   const map = cards.reduce((acc, card) => {
@@ -1006,6 +1015,7 @@ export const getFreshCachedSearchResult = (key, value, options = {}) => {
 
   return {
     hit: Object.keys(map).length > 0,
+    negativeHit: false,
     cards,
     map,
     cacheKey,
@@ -1518,6 +1528,12 @@ const SearchBar = ({
   const cachedSearch = async (params, extraOptions = {}) => {
     const [key, value] = Object.entries(params)[0] || [];
     const cachedResult = getFreshCachedSearchResult(key, value, extraOptions);
+    if (cachedResult.negativeHit) {
+      if (perfDebugEnabledRef.current) {
+        console.debug('[SearchPerf][cache-negative-hit]', { params, options: extraOptions });
+      }
+      return {};
+    }
     if (cachedResult.hit) {
       if (perfDebugEnabledRef.current) {
         console.debug('[SearchPerf][cache-hit]', { params, options: extraOptions, ids: cachedResult.ids });
@@ -1525,6 +1541,7 @@ const SearchBar = ({
       const filteredCachedMap = filterSearchResultByParams(cachedResult.map, params, extraOptions);
       if (Object.keys(filteredCachedMap || {}).length === 0) {
         if (cachedResult.cacheKey) setIdsForQuery(cachedResult.cacheKey, []);
+        return {};
       } else {
         const filteredCards = Object.values(filteredCachedMap);
         if (filteredCards.length !== cachedResult.cards.length && cachedResult.cacheKey) {
@@ -1543,11 +1560,19 @@ const SearchBar = ({
     });
     if (perfDebugEnabledRef.current) console.timeEnd(perfLabel);
     if (!res || Object.keys(res).length === 0) {
+      if (key && value) {
+        const cacheKey = getSearchCacheKeyForParams(key, value, extraOptions);
+        setIdsForQuery(cacheKey, []);
+      }
       return res;
     }
 
     const filteredRes = filterSearchResultByParams(res, params, extraOptions);
     if (!filteredRes || Object.keys(filteredRes).length === 0) {
+      if (key && value) {
+        const cacheKey = getSearchCacheKeyForParams(key, value, extraOptions);
+        setIdsForQuery(cacheKey, []);
+      }
       return Array.isArray(res) ? [] : {};
     }
 

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -262,4 +262,84 @@ describe('SearchBar cache-first search', () => {
     expect(telegramResult.ids).toEqual(['tg-user']);
     expect(getFreshCachedSearchResult('searchId', 'shared-id').hit).toBe(false);
   });
+
+  it('caches negative search results so repeated identical searches skip backend calls', async () => {
+    const searchFunc = jest.fn().mockResolvedValue({});
+    const setUserNotFound = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'https://www.instagram.com/_sky.lol_?igsh=MTd4Y2swbGJmc3Vsbw==',
+        setSearch: jest.fn(),
+        setUsers: jest.fn(),
+        setState: jest.fn(),
+        setUserNotFound,
+        enabledSearchKeys: {
+          userId: false,
+          facebook: false,
+          instagram: true,
+          ameblo: false,
+          telegram: false,
+          email: false,
+          tiktok: false,
+          phone: false,
+          vk: false,
+          other: false,
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledTimes(1);
+    const cachedResult = getFreshCachedSearchResult('instagram', '_sky.lol_', {
+      searchIdPrefixes: ['instagram'],
+    });
+    expect(cachedResult.negativeHit).toBe(true);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+
+    const secondRoot = createRoot(container);
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      secondRoot.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'https://www.instagram.com/_sky.lol_?igsh=MTd4Y2swbGJmc3Vsbw==',
+        setSearch: jest.fn(),
+        setUsers: jest.fn(),
+        setState: jest.fn(),
+        setUserNotFound,
+        enabledSearchKeys: {
+          userId: false,
+          facebook: false,
+          instagram: true,
+          ameblo: false,
+          telegram: false,
+          email: false,
+          tiktok: false,
+          phone: false,
+          vk: false,
+          other: false,
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledTimes(1);
+    expect(setUserNotFound).toHaveBeenLastCalledWith(true);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      secondRoot.unmount();
+    });
+    document.body.removeChild(container);
+  });
 });


### PR DESCRIPTION
### Motivation

- Reduce unnecessary backend searches by marking queries that previously returned no results as negative hits in the local cache. 
- Ensure cached negative results are respected across component mounts so repeated identical searches skip remote calls. 

### Description

- Add a `negativeHit` flag to `getFreshCachedSearchResult` return values and set it when a cached query has zero `ids`, while preserving `cacheKey` and `ids`. 
- Propagate `negativeHit` handling into `cachedSearch` to early-return when a negative cache is found and log with `perfDebugEnabledRef` using the label `[SearchPerf][cache-negative-hit]`. 
- Ensure `cachedSearch` writes empty id lists to the cache via `setIdsForQuery` whenever remote `searchFunc` returns empty results or filtered results are empty, using `getSearchCacheKeyForParams` to compute the cache key. 
- Keep existing positive-cache behavior and result formatting via `formatCachedSearchResult` while ensuring `negativeHit` is explicitly false for valid positive hits. 
- Add an integration unit test `caches negative search results so repeated identical searches skip backend calls` in `SearchBar.partialUserId.test.js` that mounts the `SearchBar`, asserts the backend `searchFunc` is only called once, verifies the cached negative hit, remounts, and verifies no additional backend call and that `setUserNotFound` is invoked. 

### Testing

- Ran unit tests including the new `SearchBar.partialUserId.test.js` spec and the suite passed successfully. 
- Verified the new test asserts `searchFunc` is called once across remounts and that `getFreshCachedSearchResult` records `negativeHit: true` for empty query results. 
- Confirmed logs for negative cache hits are printed when `perfDebugEnabledRef` is enabled (manual observation via test mocks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3450ce22dc8326bd80fe5d57becf2c)