### PR TITLE
Fix search negative cache scoping

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -91,7 +91,7 @@ import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 // import { UploadJson } from './topBtns/uploadNewJSON';
 import { btnMerge } from './smallCard/btnMerge';
 import FilterPanel, { getInitialFilters } from './FilterPanel';
-import SearchBar, { detectSearchParams } from './SearchBar';
+import SearchBar, { detectSearchParams, getSearchCacheKeyForParams } from './SearchBar';
 import { Pagination } from './Pagination';
 import { ProfileForm, getFieldsToRender } from './ProfileForm';
 import {
@@ -3180,6 +3180,19 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         normalizedSearchKeyValuePair,
       });
       updateCachedUser(newProfile);
+      if (normalizedSearchKeyValuePair && newProfile?.userId) {
+        const [cacheKeyName, cacheValue] = Object.entries(normalizedSearchKeyValuePair)[0] || [];
+        if (cacheKeyName && cacheValue) {
+          const profileSearchCacheKey = getSearchCacheKeyForParams(cacheKeyName, cacheValue, {
+            searchIdPrefixes: selectedSearchIdPrefixes,
+            equalToKeys: selectedEqualToKeys,
+            searchKeyFields: selectedSearchKeyFields,
+            enabledSearchKeys: effectiveEnabledSearchKeys,
+            cacheScope: { collections: ['newUsers', 'users'] },
+          });
+          setIdsForQuery(profileSearchCacheKey, [newProfile.userId]);
+        }
+      }
       cacheFetchedUsers(
         { [newProfile.userId]: newProfile },
         cacheLoad2Users,
@@ -6041,6 +6054,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               searchKeyFields: selectedSearchKeyFields,
               autoOtherFallback: shouldAutoRunOtherFallback,
               enabledSearchKeys: effectiveEnabledSearchKeys,
+              cacheScope: { collections: ['newUsers', 'users'] },
             }}
             searchHistoryLimit={15}
             suppressInitialSearchExecution={Boolean(

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5686,6 +5686,7 @@ const Matching = () => {
                 searchOptions={{
                   searchIdPrefixes: MATCHING_SEARCH_ID_PREFIXES,
                   enabledSearchKeys: MATCHING_SEARCH_BAR_ENABLED_KEYS,
+                  cacheScope: { collections: ['users'] },
                 }}
               />
               {matchingSearchStatus && (

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -6,6 +6,7 @@ import { getCacheKey } from '../utils/cache';
 import {
   normalizeQueryKey,
   getIdsByQuery,
+  getQueryEntry,
   getCard,
   setIdsForQuery,
   loadQueries,
@@ -932,6 +933,7 @@ const SEARCH_CACHE_SCOPE_OPTION_KEYS = [
   'forceSearchKeyBucket',
   'forcePartialUserIdSearch',
   'allowTelegramPrefixMatches',
+  'cacheScope',
 ];
 
 const normalizeSearchCacheScopeValue = value => {
@@ -991,8 +993,8 @@ export const getFreshCachedSearchResult = (key, value, options = {}) => {
     return { hit: false, negativeHit: false, cards: [], map: {} };
   }
 
-  const ids = getIdsByQuery(cacheKey);
-  if (ids.length === 0) {
+  const { ids, isNegativeHit } = getQueryEntry(cacheKey);
+  if (ids.length === 0 && isNegativeHit) {
     return {
       hit: false,
       negativeHit: true,
@@ -1559,10 +1561,14 @@ const SearchBar = ({
       ...extraOptions,
     });
     if (perfDebugEnabledRef.current) console.timeEnd(perfLabel);
-    if (!res || Object.keys(res).length === 0) {
+    if (!res) {
+      return res;
+    }
+
+    if (Object.keys(res).length === 0) {
       if (key && value) {
         const cacheKey = getSearchCacheKeyForParams(key, value, extraOptions);
-        setIdsForQuery(cacheKey, []);
+        setIdsForQuery(cacheKey, [], { isNegativeHit: true });
       }
       return res;
     }
@@ -1571,7 +1577,7 @@ const SearchBar = ({
     if (!filteredRes || Object.keys(filteredRes).length === 0) {
       if (key && value) {
         const cacheKey = getSearchCacheKeyForParams(key, value, extraOptions);
-        setIdsForQuery(cacheKey, []);
+        setIdsForQuery(cacheKey, [], { isNegativeHit: true });
       }
       return Array.isArray(res) ? [] : {};
     }

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -263,6 +263,31 @@ describe('SearchBar cache-first search', () => {
     expect(getFreshCachedSearchResult('searchId', 'shared-id').hit).toBe(false);
   });
 
+
+
+  it('does not treat pruned positive cache entries as negative hits', () => {
+    const cacheKey = getSearchCacheKeyForParams('instagram', 'missing-card');
+    setIdsForQuery(cacheKey, ['missing-user']);
+
+    const cachedResult = getFreshCachedSearchResult('instagram', 'missing-card');
+
+    expect(cachedResult.hit).toBe(false);
+    expect(cachedResult.negativeHit).toBe(false);
+  });
+
+  it('keeps negative cache entries isolated by collection scope', () => {
+    const usersScope = { cacheScope: { collections: ['users'] } };
+    const allCollectionsScope = { cacheScope: { collections: ['newUsers', 'users'] } };
+    setIdsForQuery(
+      getSearchCacheKeyForParams('instagram', 'collection-only', usersScope),
+      [],
+      { isNegativeHit: true }
+    );
+
+    expect(getFreshCachedSearchResult('instagram', 'collection-only', usersScope).negativeHit).toBe(true);
+    expect(getFreshCachedSearchResult('instagram', 'collection-only', allCollectionsScope).negativeHit).toBe(false);
+  });
+
   it('caches negative search results so repeated identical searches skip backend calls', async () => {
     const searchFunc = jest.fn().mockResolvedValue({});
     const setUserNotFound = jest.fn();

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -402,6 +402,7 @@ export const getQueryEntry = queryKey => {
   return {
     ids,
     cachedAt,
+    isNegativeHit: Boolean(updatedEntry?.isNegativeHit),
   };
 };
 
@@ -427,14 +428,20 @@ export const getIdsByQuery = queryKey => {
   return ids;
 };
 
-export const setIdsForQuery = (queryKey, ids) => {
+export const setIdsForQuery = (queryKey, ids, options = {}) => {
   const key = normalizeQueryKey(queryKey);
   const queries = loadQueries();
   const now = Date.now();
   const nextIds = Array.isArray(ids) ? ids.slice(0, MATCHING_QUERY_MAX_IDS) : [];
-  queries[key] = { ids: nextIds, cachedAt: now, lastAction: now };
+  const isNegativeHit = Boolean(options?.isNegativeHit && nextIds.length === 0);
+  queries[key] = {
+    ids: nextIds,
+    cachedAt: now,
+    lastAction: now,
+    ...(isNegativeHit ? { isNegativeHit: true } : {}),
+  };
   saveQueries(queries);
-  logMatchingCacheDebug('query ids cache save', { key, idsCount: nextIds.length });
+  logMatchingCacheDebug('query ids cache save', { key, idsCount: nextIds.length, isNegativeHit });
 };
 
 export const getIndexIdsByQuery = (queryKey, options = {}) => {


### PR DESCRIPTION
### Motivation
- Avoid treating transient backend failures (null/undefined) or pruned id lists as deliberate "not found" results that get negative-cached. 
- Prevent negative cache entries created for one backend/collection from suppressing searches that query a different collection. 
- Ensure newly-created profiles immediately replace any prior negative cache entry for the same search.

### Description
- Add an explicit `isNegativeHit` marker to query entries and extend `setIdsForQuery` to accept `options.isNegativeHit` so only deliberate empty results are recorded as negatives (changes in `src/utils/cardIndex.js`).
- Update `getFreshCachedSearchResult` and `cachedSearch` in `SearchBar` to treat `null`/`undefined` backend responses as non-cacheable failures and to only return `negativeHit` when the explicit marker is present (changes in `src/components/SearchBar.jsx`).
- Add `cacheScope` into search cache key construction so cache entries can be scoped by search options/collection and avoid cross-backend pollution (changes in `src/components/SearchBar.jsx`).
- Pass collection-scoped `searchOptions.cacheScope` when instantiating SearchBar in Matching (`users` scope) and AddNewProfile (`newUsers + users` scope) so the same query in different collections remains isolated (changes in `src/components/Matching.jsx` and `src/components/AddNewProfile.jsx`).
- When creating a profile in AddNewProfile, write the new profile id into the corresponding scoped search cache key to replace any prior negative entry (changes in `src/components/AddNewProfile.jsx`).
- Add regression tests covering pruned positive cache entries and collection-scoped negative-cache isolation (changes in `src/components/SearchBar.partialUserId.test.js`).

### Testing
- Ran the focused test suite: `npm test -- --runInBand src/components/SearchBar.partialUserId.test.js` and all tests passed (19/19).
- Ran linting: `npx eslint src/components/SearchBar.jsx src/components/AddNewProfile.jsx src/components/Matching.jsx src/utils/cardIndex.js src/components/SearchBar.partialUserId.test.js` with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355be6a08c8326939304a47cc45fd4)