### PR TITLE
Add paginated date fetch and resilient DATE2 pagination; add tests

### DIFF
--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -1,4 +1,14 @@
-import { getDatabase, ref as ref2, query, orderByChild, equalTo, limitToFirst, get as firebaseGet } from 'firebase/database';
+import {
+  getDatabase,
+  ref as ref2,
+  query,
+  orderByChild,
+  equalTo,
+  limitToFirst,
+  startAfter,
+  endAt,
+  get as firebaseGet,
+} from 'firebase/database';
 import { withAdminDownloadToast } from 'utils/backendDownloadToast';
 
 import { PAGE_SIZE, INVALID_DATE_TOKENS, MAX_LOOKBACK_DAYS } from './constants';
@@ -10,16 +20,52 @@ const get = (...args) =>
     path: args[0],
   });
 
-export async function defaultFetchByDate(dateStr, limit) {
+const normalizeDateFetchResult = result => {
+  if (Array.isArray(result)) {
+    return {
+      entries: result,
+      hasMore: false,
+      lastKey: result.length > 0 ? result[result.length - 1][0] : null,
+    };
+  }
+
+  const entries = Array.isArray(result?.entries) ? result.entries : [];
+  return {
+    entries,
+    hasMore: Boolean(result?.hasMore),
+    lastKey: result?.lastKey ?? (entries.length > 0 ? entries[entries.length - 1][0] : null),
+  };
+};
+
+export async function defaultFetchByDate(dateStr, limit, options = {}) {
   const db = getDatabase();
 
   const collections = ['newUsers', 'users'];
   const combined = {};
+  let hasMore = false;
+  let lastKey = null;
+  const { afterKey = null } = options || {};
+  const fetchLimit = Math.max(1, Number(limit) || PAGE_SIZE) + 1;
 
-  // Iterate through both collections and gather matching records
+  // Iterate through both collections and gather matching records.
+  // Keep reading one extra row so DATE2 can know whether the same date still
+  // has candidates after filters remove the first batch.
   for (const col of collections) {
-    // eslint-disable-next-line no-await-in-loop
-    const q = query(ref2(db, col), orderByChild('getInTouch'), equalTo(dateStr), limitToFirst(limit));
+    const collectionRef = ref2(db, col);
+    const q = afterKey
+      ? query(
+          collectionRef,
+          orderByChild('getInTouch'),
+          startAfter(dateStr, afterKey),
+          endAt(dateStr),
+          limitToFirst(fetchLimit),
+        )
+      : query(
+          collectionRef,
+          orderByChild('getInTouch'),
+          equalTo(dateStr),
+          limitToFirst(fetchLimit),
+        );
     // eslint-disable-next-line no-await-in-loop
     const snap = await get(q);
     if (snap.exists()) {
@@ -28,10 +74,18 @@ export async function defaultFetchByDate(dateStr, limit) {
       });
     }
 
-    if (Object.keys(combined).length >= limit) break;
+    if (Object.keys(combined).length >= fetchLimit) {
+      hasMore = true;
+      break;
+    }
   }
 
-  return Object.entries(combined).slice(0, limit);
+  const entries = Object.entries(combined).slice(0, fetchLimit);
+  const limitedEntries = entries.slice(0, Math.max(1, Number(limit) || PAGE_SIZE));
+  hasMore = hasMore || entries.length > limitedEntries.length;
+  lastKey = limitedEntries.length > 0 ? limitedEntries[limitedEntries.length - 1][0] : null;
+
+  return { entries: limitedEntries, hasMore, lastKey };
 }
 
 
@@ -58,84 +112,87 @@ export async function fetchFilteredUsersByPage(
 
   const combined = [];
   let filtered = [];
+  let backendHasMore = false;
+
+  const emitProgress = () => {
+    if (!onProgress) return;
+    const partial = filtered.slice(
+      startOffset,
+      Math.min(filtered.length, startOffset + PAGE_SIZE)
+    );
+    const partUsers = {};
+    partial.forEach(([pid, pdata]) => {
+      partUsers[pid] = pdata;
+    });
+    onProgress(partUsers);
+  };
+
+  const appendFetchedEntries = async entries => {
+    const ids = entries.map(([id]) => id);
+    const extras = await Promise.all(ids.map(id => fetchUserByIdFn(id)));
+    entries.forEach(([id, data], i) => {
+      const extra = extras[i];
+      combined.push([id, extra ? { ...data, ...extra } : data]);
+    });
+    filtered = filterMainFn(
+      combined,
+      'DATE2',
+      filterSettings,
+      favoriteUsers,
+      dislikedUsers
+    );
+    emitProgress();
+  };
+
+  const loadDateUntilEnough = async dateStr => {
+    let afterKey = null;
+    let dateHasMore = true;
+
+    while (filtered.length < target && dateHasMore) {
+      const fetchLimit = limit - filtered.length;
+      // eslint-disable-next-line no-await-in-loop
+      const batchResult = normalizeDateFetchResult(
+        await fetchDateFn(dateStr, fetchLimit, { afterKey })
+      );
+      const { entries } = batchResult;
+
+      if (entries.length === 0) {
+        dateHasMore = false;
+        backendHasMore = backendHasMore || batchResult.hasMore;
+        break;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await appendFetchedEntries(entries);
+      afterKey = batchResult.lastKey ?? entries[entries.length - 1][0];
+      dateHasMore = Boolean(batchResult.hasMore && afterKey);
+      backendHasMore = backendHasMore || dateHasMore;
+    }
+  };
 
   const MAX_LOAD_DAYS = MAX_LOOKBACK_DAYS; // safety cap
   let dayOffset = 0;
-  let invalidIndex = 0;
 
   while (filtered.length < target && dayOffset < MAX_LOAD_DAYS) {
-    const fetchLimit = limit - filtered.length;
     const date = new Date(today);
     date.setDate(today.getDate() - dayOffset);
     const dateStr = date.toISOString().split('T')[0];
     // eslint-disable-next-line no-await-in-loop
-    const chunk = await fetchDateFn(dateStr, fetchLimit);
-    if (chunk.length === 0) {
-      while (
-        filtered.length < target &&
-        invalidIndex < INVALID_DATE_TOKENS.length
-      ) {
-        // eslint-disable-next-line no-await-in-loop
-        const extra = await fetchDateFn(
-          INVALID_DATE_TOKENS[invalidIndex],
-          limit - filtered.length
-        );
-        invalidIndex += 1;
-        const extraIds = extra.map(([eid]) => eid);
-        const extraUsers = await Promise.all(
-          extraIds.map(id => fetchUserByIdFn(id))
-        );
-        extra.forEach(([eid, edata], idx) => {
-          const extraUser = extraUsers[idx];
-          combined.push([eid, extraUser ? { ...edata, ...extraUser } : edata]);
-        });
-        filtered = filterMainFn(
-          combined,
-          'DATE2',
-          filterSettings,
-          favoriteUsers,
-          dislikedUsers
-        );
-        if (onProgress) {
-          const partial = filtered.slice(
-            startOffset,
-            Math.min(filtered.length, startOffset + PAGE_SIZE)
-          );
-          const partUsers = {};
-          partial.forEach(([pid, pdata]) => {
-            partUsers[pid] = pdata;
-          });
-          onProgress(partUsers);
-        }
-      }
-    } else {
-      const ids = chunk.map(([id]) => id);
-      const extras = await Promise.all(ids.map(id => fetchUserByIdFn(id)));
-      chunk.forEach(([id, data], i) => {
-        const extra = extras[i];
-        combined.push([id, extra ? { ...data, ...extra } : data]);
-      });
-      filtered = filterMainFn(
-        combined,
-        'DATE2',
-        filterSettings,
-        favoriteUsers,
-        dislikedUsers
-      );
-      if (onProgress) {
-        const partial = filtered.slice(
-          startOffset,
-          Math.min(filtered.length, startOffset + PAGE_SIZE)
-        );
-        const partUsers = {};
-        partial.forEach(([pid, pdata]) => {
-          partUsers[pid] = pdata;
-        });
-        onProgress(partUsers);
-      }
-    }
+    await loadDateUntilEnough(dateStr);
     dayOffset += 1;
   }
+
+  let invalidIndex = 0;
+  while (
+    filtered.length < target &&
+    invalidIndex < INVALID_DATE_TOKENS.length
+  ) {
+    // eslint-disable-next-line no-await-in-loop
+    await loadDateUntilEnough(INVALID_DATE_TOKENS[invalidIndex]);
+    invalidIndex += 1;
+  }
+
+  backendHasMore = backendHasMore || dayOffset < MAX_LOAD_DAYS || invalidIndex < INVALID_DATE_TOKENS.length;
 
   const slice = filtered.slice(startOffset, startOffset + PAGE_SIZE);
 
@@ -145,7 +202,7 @@ export async function fetchFilteredUsersByPage(
   });
 
   const nextOffset = startOffset + slice.length;
-  const hasMore = filtered.length > startOffset + PAGE_SIZE;
+  const hasMore = filtered.length > startOffset + PAGE_SIZE || backendHasMore;
 
   return { users, lastKey: nextOffset, hasMore };
 }

--- a/src/components/dateLoad.test.js
+++ b/src/components/dateLoad.test.js
@@ -1,0 +1,122 @@
+jest.mock('firebase/database', () => ({
+  getDatabase: jest.fn(),
+  ref: jest.fn(),
+  query: jest.fn(),
+  orderByChild: jest.fn(),
+  equalTo: jest.fn(),
+  limitToFirst: jest.fn(),
+  startAfter: jest.fn(),
+  endAt: jest.fn(),
+  get: jest.fn(),
+}));
+
+jest.mock('utils/backendDownloadToast', () => ({
+  withAdminDownloadToast: promise => promise,
+}));
+
+describe('fetchFilteredUsersByPage', () => {
+  const RealDate = Date;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.Date = class extends RealDate {
+      constructor(...args) {
+        if (args.length === 0) return new RealDate('2026-06-19T12:00:00.000Z');
+        return new RealDate(...args);
+      }
+
+      static now() {
+        return new RealDate('2026-06-19T12:00:00.000Z').getTime();
+      }
+
+      static parse(value) {
+        return RealDate.parse(value);
+      }
+
+      static UTC(...args) {
+        return RealDate.UTC(...args);
+      }
+    };
+  });
+
+  afterEach(() => {
+    global.Date = RealDate;
+  });
+
+  it('continues reading the same date when the first batch is mostly filtered out', async () => {
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const entries = Array.from({ length: 30 }, (_, index) => {
+      const id = `u${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-19', keep: index === 0 || index >= 20 }];
+    });
+    const fetchDateFn = jest.fn(async (dateStr, limit, { afterKey } = {}) => {
+      if (dateStr !== '2026-06-19') return { entries: [], hasMore: false, lastKey: null };
+      const startIndex = afterKey ? entries.findIndex(([id]) => id === afterKey) + 1 : 0;
+      const batch = entries.slice(startIndex, startIndex + limit);
+      return {
+        entries: batch,
+        hasMore: startIndex + limit < entries.length,
+        lastKey: batch.length ? batch[batch.length - 1][0] : null,
+      };
+    });
+    const fetchUserByIdFn = jest.fn(async id => ({ hydrated: id }));
+    const filterMainFn = jest.fn(source => source.filter(([, user]) => user.keep));
+
+    const result = await fetchFilteredUsersByPage(
+      0,
+      fetchDateFn,
+      fetchUserByIdFn,
+      {},
+      {},
+      {},
+      filterMainFn,
+    );
+
+    expect(fetchDateFn).toHaveBeenNthCalledWith(2, '2026-06-19', expect.any(Number), { afterKey: 'u21' });
+    expect(Object.keys(result.users)).toEqual([
+      'u01',
+      'u21',
+      'u22',
+      'u23',
+      'u24',
+      'u25',
+      'u26',
+      'u27',
+      'u28',
+      'u29',
+      'u30',
+    ]);
+  });
+
+  it('keeps hasMore true when a short visible page still has unread same-date backend records', async () => {
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const entries = Array.from({ length: 40 }, (_, index) => {
+      const id = `u${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-19', keep: index === 0 }];
+    });
+    const fetchDateFn = jest.fn(async (dateStr, limit, { afterKey } = {}) => {
+      if (dateStr !== '2026-06-19') return { entries: [], hasMore: false, lastKey: null };
+      const startIndex = afterKey ? entries.findIndex(([id]) => id === afterKey) + 1 : 0;
+      const batch = entries.slice(startIndex, startIndex + limit);
+      return {
+        entries: batch,
+        hasMore: startIndex + limit < entries.length,
+        lastKey: batch.length ? batch[batch.length - 1][0] : null,
+      };
+    });
+    const filterMainFn = jest.fn(source => source.filter(([, user]) => user.keep));
+
+    const result = await fetchFilteredUsersByPage(
+      0,
+      fetchDateFn,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      filterMainFn,
+    );
+
+    expect(Object.keys(result.users)).toEqual(['u01']);
+    expect(result.hasMore).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve date-based loading to support pagination across multiple backend pages and ensure DATE2 continues reading the same date when many candidates are filtered out.

### Description
- Add `normalizeDateFetchResult` and extend `defaultFetchByDate` to support `afterKey` pagination using `startAfter`/`endAt` and to return `{ entries, hasMore, lastKey }` instead of a raw list.
- Refactor `fetchFilteredUsersByPage` to stream-progress via `onProgress`, to iteratively `appendFetchedEntries`, and to use `loadDateUntilEnough` to repeatedly fetch the same `dateStr` until enough visible items are produced or the backend is exhausted.
- Track backend-side availability with `backendHasMore` and compute the final `hasMore` by combining UI-visible results with backend pagination hints, and include support for exhausting `INVALID_DATE_TOKENS` as before.
- Add unit tests in `src/components/dateLoad.test.js` that mock `fetchDateFn` to validate same-date continuation and preserve `hasMore` semantics when many items are filtered out.

### Testing
- Added Jest unit tests in `src/components/dateLoad.test.js` and ran `jest src/components/dateLoad.test.js` which succeeded.
- Existing test suite involving the modified module was executed and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a358a61baa48326ac171fa0e6969b36)