### PR TITLE
Fix DATE2 pagination cursors

### DIFF
--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -34,6 +34,7 @@ const normalizeDateFetchResult = result => {
     entries,
     hasMore: Boolean(result?.hasMore),
     lastKey: result?.lastKey ?? (entries.length > 0 ? entries[entries.length - 1][0] : null),
+    afterKeys: result?.afterKeys ?? null,
   };
 };
 
@@ -42,9 +43,12 @@ export async function defaultFetchByDate(dateStr, limit, options = {}) {
 
   const collections = ['newUsers', 'users'];
   const combined = {};
+  const orderedEntries = [];
+  const nextCursors = {};
   let hasMore = false;
   let lastKey = null;
-  const { afterKey = null } = options || {};
+  const { afterKey = null, afterKeys = null } = options || {};
+  const hasCollectionCursors = afterKeys && typeof afterKeys === 'object';
   const fetchLimit = Math.max(1, Number(limit) || PAGE_SIZE) + 1;
 
   // Iterate through both collections and gather matching records.
@@ -52,11 +56,12 @@ export async function defaultFetchByDate(dateStr, limit, options = {}) {
   // has candidates after filters remove the first batch.
   for (const col of collections) {
     const collectionRef = ref2(db, col);
-    const q = afterKey
+    const collectionAfterKey = hasCollectionCursors ? afterKeys[col] : afterKey;
+    const q = collectionAfterKey
       ? query(
           collectionRef,
           orderByChild('getInTouch'),
-          startAfter(dateStr, afterKey),
+          startAfter(dateStr, collectionAfterKey),
           endAt(dateStr),
           limitToFirst(fetchLimit),
         )
@@ -69,23 +74,39 @@ export async function defaultFetchByDate(dateStr, limit, options = {}) {
     // eslint-disable-next-line no-await-in-loop
     const snap = await get(q);
     if (snap.exists()) {
-      Object.entries(snap.val()).forEach(([id, data]) => {
-        if (!combined[id]) combined[id] = data;
-      });
+      if (typeof snap.forEach === 'function') {
+        snap.forEach(childSnap => {
+          const id = childSnap.key;
+          const data = childSnap.val();
+          nextCursors[col] = id;
+          if (!combined[id]) {
+            combined[id] = data;
+            orderedEntries.push([id, data]);
+          }
+        });
+      } else {
+        Object.entries(snap.val()).forEach(([id, data]) => {
+          nextCursors[col] = id;
+          if (!combined[id]) {
+            combined[id] = data;
+            orderedEntries.push([id, data]);
+          }
+        });
+      }
     }
 
-    if (Object.keys(combined).length >= fetchLimit) {
+    if (orderedEntries.length >= fetchLimit) {
       hasMore = true;
       break;
     }
   }
 
-  const entries = Object.entries(combined).slice(0, fetchLimit);
+  const entries = orderedEntries.slice(0, fetchLimit);
   const limitedEntries = entries.slice(0, Math.max(1, Number(limit) || PAGE_SIZE));
   hasMore = hasMore || entries.length > limitedEntries.length;
   lastKey = limitedEntries.length > 0 ? limitedEntries[limitedEntries.length - 1][0] : null;
 
-  return { entries: limitedEntries, hasMore, lastKey };
+  return { entries: limitedEntries, hasMore, lastKey, afterKeys: nextCursors };
 }
 
 
@@ -111,6 +132,7 @@ export async function fetchFilteredUsersByPage(
   }
 
   const combined = [];
+  const seenIds = new Set();
   let filtered = [];
   let backendHasMore = false;
 
@@ -128,9 +150,11 @@ export async function fetchFilteredUsersByPage(
   };
 
   const appendFetchedEntries = async entries => {
-    const ids = entries.map(([id]) => id);
+    const newEntries = entries.filter(([id]) => !seenIds.has(id));
+    newEntries.forEach(([id]) => seenIds.add(id));
+    const ids = newEntries.map(([id]) => id);
     const extras = await Promise.all(ids.map(id => fetchUserByIdFn(id)));
-    entries.forEach(([id, data], i) => {
+    newEntries.forEach(([id, data], i) => {
       const extra = extras[i];
       combined.push([id, extra ? { ...data, ...extra } : data]);
     });
@@ -146,27 +170,31 @@ export async function fetchFilteredUsersByPage(
 
   const loadDateUntilEnough = async dateStr => {
     let afterKey = null;
+    let afterKeys = null;
     let dateHasMore = true;
 
     while (filtered.length < target && dateHasMore) {
       const fetchLimit = limit - filtered.length;
       // eslint-disable-next-line no-await-in-loop
       const batchResult = normalizeDateFetchResult(
-        await fetchDateFn(dateStr, fetchLimit, { afterKey })
+        await fetchDateFn(dateStr, fetchLimit, { afterKey, afterKeys })
       );
       const { entries } = batchResult;
 
       if (entries.length === 0) {
         dateHasMore = false;
-        backendHasMore = backendHasMore || batchResult.hasMore;
         break;
       }
 
       // eslint-disable-next-line no-await-in-loop
       await appendFetchedEntries(entries);
       afterKey = batchResult.lastKey ?? entries[entries.length - 1][0];
-      dateHasMore = Boolean(batchResult.hasMore && afterKey);
-      backendHasMore = backendHasMore || dateHasMore;
+      afterKeys = batchResult.afterKeys ?? afterKeys;
+      dateHasMore = Boolean(batchResult.hasMore && (afterKey || afterKeys));
+    }
+
+    if (filtered.length >= target && dateHasMore) {
+      backendHasMore = true;
     }
   };
 
@@ -191,8 +219,6 @@ export async function fetchFilteredUsersByPage(
     await loadDateUntilEnough(INVALID_DATE_TOKENS[invalidIndex]);
     invalidIndex += 1;
   }
-
-  backendHasMore = backendHasMore || dayOffset < MAX_LOAD_DAYS || invalidIndex < INVALID_DATE_TOKENS.length;
 
   const slice = filtered.slice(startOffset, startOffset + PAGE_SIZE);
 

--- a/src/components/dateLoad.test.js
+++ b/src/components/dateLoad.test.js
@@ -72,7 +72,12 @@ describe('fetchFilteredUsersByPage', () => {
       filterMainFn,
     );
 
-    expect(fetchDateFn).toHaveBeenNthCalledWith(2, '2026-06-19', expect.any(Number), { afterKey: 'u21' });
+    expect(fetchDateFn).toHaveBeenNthCalledWith(
+      2,
+      '2026-06-19',
+      expect.any(Number),
+      expect.objectContaining({ afterKey: 'u21' }),
+    );
     expect(Object.keys(result.users)).toEqual([
       'u01',
       'u21',
@@ -88,7 +93,7 @@ describe('fetchFilteredUsersByPage', () => {
     ]);
   });
 
-  it('keeps hasMore true when a short visible page still has unread same-date backend records', async () => {
+  it('clears hasMore after sparse filters exhaust same-date backend records', async () => {
     const { fetchFilteredUsersByPage } = await import('./dateLoad');
     const entries = Array.from({ length: 40 }, (_, index) => {
       const id = `u${String(index + 1).padStart(2, '0')}`;
@@ -117,6 +122,88 @@ describe('fetchFilteredUsersByPage', () => {
     );
 
     expect(Object.keys(result.users)).toEqual(['u01']);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('keeps hasMore true when enough visible records stop before unread same-date backend records', async () => {
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const entries = Array.from({ length: 50 }, (_, index) => {
+      const id = `u${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-19', keep: true }];
+    });
+    const fetchDateFn = jest.fn(async (dateStr, limit, { afterKey } = {}) => {
+      if (dateStr !== '2026-06-19') return { entries: [], hasMore: false, lastKey: null };
+      const startIndex = afterKey ? entries.findIndex(([id]) => id === afterKey) + 1 : 0;
+      const batch = entries.slice(startIndex, startIndex + limit);
+      return {
+        entries: batch,
+        hasMore: startIndex + limit < entries.length,
+        lastKey: batch.length ? batch[batch.length - 1][0] : null,
+      };
+    });
+
+    const result = await fetchFilteredUsersByPage(
+      0,
+      fetchDateFn,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+    );
+
+    expect(Object.keys(result.users)).toHaveLength(20);
     expect(result.hasMore).toBe(true);
+  });
+});
+
+describe('defaultFetchByDate', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('builds entries and cursors from Firebase snapshot iteration order', async () => {
+    const database = await import('firebase/database');
+    database.getDatabase.mockReturnValue('db');
+    database.ref.mockImplementation((db, col) => `${db}/${col}`);
+    database.orderByChild.mockImplementation(child => ['orderByChild', child]);
+    database.equalTo.mockImplementation(value => ['equalTo', value]);
+    database.limitToFirst.mockImplementation(value => ['limitToFirst', value]);
+    database.query.mockImplementation((...args) => args);
+    database.get.mockResolvedValueOnce({
+      exists: () => true,
+      val: () => ({ z: { userId: 'z' }, a: { userId: 'a' } }),
+      forEach: callback => {
+        callback({ key: 'a', val: () => ({ userId: 'a' }) });
+        callback({ key: 'z', val: () => ({ userId: 'z' }) });
+      },
+    }).mockResolvedValueOnce({
+      exists: () => false,
+    });
+
+    const { defaultFetchByDate } = await import('./dateLoad');
+    const result = await defaultFetchByDate('2026-06-19', 20);
+
+    expect(result.entries.map(([id]) => id)).toEqual(['a', 'z']);
+    expect(result.lastKey).toBe('z');
+    expect(result.afterKeys).toEqual({ newUsers: 'z' });
+  });
+
+  it('uses collection-specific cursors instead of applying a merged key to every collection', async () => {
+    const database = await import('firebase/database');
+    database.getDatabase.mockReturnValue('db');
+    database.ref.mockImplementation((db, col) => `${db}/${col}`);
+    database.orderByChild.mockImplementation(child => ['orderByChild', child]);
+    database.startAfter.mockImplementation((date, key) => ['startAfter', date, key]);
+    database.endAt.mockImplementation(date => ['endAt', date]);
+    database.limitToFirst.mockImplementation(value => ['limitToFirst', value]);
+    database.query.mockImplementation((...args) => args);
+    database.get.mockResolvedValue({ exists: () => false });
+
+    const { defaultFetchByDate } = await import('./dateLoad');
+    await defaultFetchByDate('2026-06-19', 20, { afterKey: 'merged', afterKeys: { newUsers: 'new-cursor' } });
+
+    expect(database.startAfter).toHaveBeenCalledWith('2026-06-19', 'new-cursor');
+    expect(database.startAfter).not.toHaveBeenCalledWith('2026-06-19', 'merged');
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent DATE2 from re-reading or skipping records when a single-date query spans multiple collections by avoiding a single merged `afterKey` applied to every collection.  
- Ensure cursor selection follows Firebase query order instead of relying on `snap.val()` object ordering which is not guaranteed.  
- Avoid stale `hasMore` signals caused by intermediate batches that do not reflect the final stop condition.  

### Description
- Track per-collection pagination cursors by adding an `afterKeys` option and returning `afterKeys` from `defaultFetchByDate`, and use those per-collection cursors when building queries.  
- Preserve Firebase query ordering by iterating `DataSnapshot` with `snap.forEach` (falling back to `Object.entries` when needed) and build `orderedEntries` from that iteration order.  
- Dedupe appended DATE2 results by maintaining a `seenIds` set in `fetchFilteredUsersByPage` so repeated fetches do not re-append the same user.  
- Only set `backendHasMore` when the load stops with an active backend cursor (final stop condition), instead of latching it on any intermediate batch.  
- Add and update unit tests in `src/components/dateLoad.test.js` covering sparse-filter exhaustion, active-backend overflow, snapshot iteration order, and collection-specific cursors.  
- Files changed: `src/components/dateLoad.js`, `src/components/dateLoad.test.js`.

### Testing
- Ran unit tests with `npm test -- --runTestsByPath src/components/dateLoad.test.js --watchAll=false`, all tests passed (`5 passed`).  
- Ran linter with `npm run lint:js -- --max-warnings=0`, no lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a359cf37c608326bb7709e08512d11e)