### PR TITLE
Match UK-trigger telegram searchIds by full trigger or handle and add tests

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -871,8 +871,24 @@ export const doesCardMatchSearchParams = (card, params = {}, options = {}) => {
 
     const normalizedFieldValue = normalizeComparableSearchValue(key, fieldValue);
     if (!normalizedFieldValue) return false;
-    if (key === 'telegram' && options.allowTelegramPrefixMatches) {
-      return normalizedFieldValue.startsWith(expected);
+    if (key === 'telegram') {
+      const expectedUkTrigger = parseUkTriggerQuery(String(value || ''));
+      if (expectedUkTrigger?.searchPair?.telegram) {
+        const normalizedUkTrigger = normalizeComparableSearchValue(key, expectedUkTrigger.searchPair.telegram);
+        const normalizedHandle = expectedUkTrigger.handle
+          ? normalizeComparableSearchValue(key, expectedUkTrigger.handle)
+          : '';
+        if (
+          normalizedFieldValue === normalizedUkTrigger ||
+          (normalizedHandle && normalizedFieldValue === normalizedHandle)
+        ) {
+          return true;
+        }
+      }
+
+      if (options.allowTelegramPrefixMatches) {
+        return normalizedFieldValue.startsWith(expected);
+      }
     }
     if (shouldUseExactFieldValidation(key, expected, options)) return normalizedFieldValue === expected;
     return normalizedFieldValue.includes(expected);

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -119,6 +119,25 @@ describe('SearchBar result validation', () => {
     )).toBe(false);
   });
 
+
+  it('validates UK-trigger telegram searchId results by full value or handle', () => {
+    const card = {
+      userId: 'uk-trigger-match',
+      telegram: ['УК СМ Sasha @SashaLjr', 'SashaLjr'],
+    };
+
+    expect(doesCardMatchSearchParams(
+      card,
+      { searchId: 'УК СМ Sasha @SashaLjr' },
+      { searchIdPrefixes: ['telegram'] },
+    )).toBe(true);
+    expect(doesCardMatchSearchParams(
+      { userId: 'handle-only-match', telegram: ['SashaLjr'] },
+      { searchId: 'УК СМ Sasha @SashaLjr' },
+      { searchIdPrefixes: ['telegram'] },
+    )).toBe(true);
+  });
+
   it('keeps partial userId validation as a prefix match', () => {
     expect(doesCardMatchSearchParams(
       { userId: 'Anna123' },


### PR DESCRIPTION
### Motivation

- Allow searches using UK-trigger telegram queries (e.g. `УК СМ ...`) to match cards that store either the full UK-trigger string or just the telegram handle. 

### Description

- Updated `doesCardMatchSearchParams` to parse UK-trigger queries with `parseUkTriggerQuery` and compare the normalized field against the parsed trigger's `searchPair.telegram` or its `handle`. 
- Preserved existing behavior by falling back to `options.allowTelegramPrefixMatches` prefix matching when no UK-trigger is detected. 
- Added a unit test in `SearchBar.partialUserId.test.js` that verifies matching by both full UK-trigger value and handle-only telegram values.

### Testing

- Ran the `SearchBar` unit tests (including `SearchBar.partialUserId.test.js`) which include the new `validates UK-trigger telegram searchId results by full value or handle` case, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36172f27c48326b81722a3ed409f2c)