### PR TITLE
Enable UK trigger prefix matching in searchId mode

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -507,6 +507,12 @@ const resolveSearchIdPrefixStrategy = (input, searchOptions = {}) => {
   };
 };
 
+const getTelegramPrefixMatchOptions = (value, prefix) => {
+  if (prefix !== 'telegram') return {};
+  const parsedUkTrigger = parseUkTriggerQuery(String(value || ''));
+  return parsedUkTrigger?.handle ? { allowTelegramPrefixMatches: true } : {};
+};
+
 const parseSearchIdExact = input => {
   if (typeof input !== 'string') return null;
   const trimmed = input.trim();
@@ -880,7 +886,12 @@ export const doesCardMatchSearchParams = (card, params = {}, options = {}) => {
           : '';
         if (
           normalizedFieldValue === normalizedUkTrigger ||
-          (normalizedHandle && normalizedFieldValue === normalizedHandle)
+          (normalizedHandle && normalizedFieldValue === normalizedHandle) ||
+          (
+            options.allowTelegramPrefixMatches &&
+            normalizedHandle &&
+            normalizedFieldValue.startsWith(normalizedHandle)
+          )
         ) {
           return true;
         }
@@ -1511,6 +1522,7 @@ const SearchBar = ({
             {
               forceEqualToAllCards: false,
               searchIdPrefixes: [prefix],
+              ...getTelegramPrefixMatchOptions(searchIdInput, prefix),
             },
           )
         )
@@ -1745,6 +1757,7 @@ const SearchBar = ({
             cachedSearch(result, {
               forceEqualToAllCards: false,
               searchIdPrefixes: [prefix],
+              ...getTelegramPrefixMatchOptions(id, prefix),
             })
           )
         );

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -138,6 +138,23 @@ describe('SearchBar result validation', () => {
     )).toBe(true);
   });
 
+  it('allows UK-trigger telegram handle prefix matches only when prefix matching is enabled', () => {
+    const card = {
+      userId: 'uk-trigger-prefix-match',
+      telegram: ['Oksana_Koshel'],
+    };
+
+    expect(doesCardMatchSearchParams(
+      card,
+      { telegram: 'УК СМ Оксана Кошель @Oksana' },
+      { allowTelegramPrefixMatches: true },
+    )).toBe(true);
+    expect(doesCardMatchSearchParams(
+      card,
+      { telegram: 'УК СМ Оксана Кошель @Oksana' },
+    )).toBe(false);
+  });
+
   it('keeps partial userId validation as a prefix match', () => {
     expect(doesCardMatchSearchParams(
       { userId: 'Anna123' },
@@ -247,6 +264,63 @@ describe('SearchBar cache-first search', () => {
       }),
     });
     expect(searchFunc).not.toHaveBeenCalled();
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
+
+  it('enables telegram prefix matching for UK-trigger searchId searches', async () => {
+    const searchFunc = jest.fn().mockResolvedValue({
+      oksana: { userId: 'oksana', telegram: ['Oksana_Koshel'] },
+    });
+    const setUsers = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'УК СМ Оксана Кошель @Oksana',
+        setSearch: jest.fn(),
+        setUsers,
+        setState: jest.fn(),
+        setUserNotFound: jest.fn(),
+        enabledSearchKeys: {
+          searchId: true,
+          partialUserId: false,
+          searchKey: false,
+          equalToAllCards: false,
+        },
+        searchOptions: {
+          enabledSearchKeys: {
+            searchId: true,
+            partialUserId: false,
+            searchKey: false,
+            equalToAllCards: false,
+          },
+          searchIdPrefixes: ['telegram'],
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledWith(
+      { searchId: 'УК СМ Оксана Кошель @Oksana' },
+      expect.objectContaining({
+        searchIdPrefixes: ['telegram'],
+        allowTelegramPrefixMatches: true,
+      }),
+    );
+    expect(setUsers).toHaveBeenCalledWith({
+      oksana: expect.objectContaining({ userId: 'oksana' }),
+    });
 
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1849,11 +1849,15 @@ export const searchUserByPartialUserIdUsers = async (userId, users) => {
 };
 
 export const searchUsersOnly = async (searchedValue, options = {}) => {
-  const { searchIdPrefixes } = options;
+  const { searchIdPrefixes, allowTelegramPrefixMatches = false } = options;
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
-    ? { includeVariants: false, includePrefixMatches: false, includeAdaptedPhoneVariant: true }
+    ? {
+      includeVariants: false,
+      includePrefixMatches: allowTelegramPrefixMatches,
+      includeAdaptedPhoneVariant: true,
+    }
     : { includeVariants: searchKey !== 'telegram', includePrefixMatches: searchKey !== 'telegram' };
   const users = {};
   const uniqueUserIds = new Set();
@@ -2431,7 +2435,11 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
-    ? { includeVariants: false, includePrefixMatches: false, includeAdaptedPhoneVariant: true }
+    ? {
+      includeVariants: false,
+      includePrefixMatches: allowTelegramPrefixMatches,
+      includeAdaptedPhoneVariant: true,
+    }
     : {
       includeVariants: searchKey !== 'telegram',
       includePrefixMatches: searchKey !== 'telegram' || allowTelegramPrefixMatches,


### PR DESCRIPTION
## Summary
- Propagate `allowTelegramPrefixMatches` when a UK-trigger query with a Telegram handle is executed through SearchId mode.
- Let backend SearchId exact-mode queries use prefix matches only when that explicit Telegram prefix option is present.
- Add regression coverage for the SearchBar SearchId path so `УК СМ Оксана Кошель @Oksana` can match `Oksana_Koshel`.

## Testing
- `CI=true npm test -- --runTestsByPath src/components/SearchBar.partialUserId.test.js --watchAll=false`
- `npm run lint:js -- src/components/SearchBar.jsx src/components/SearchBar.partialUserId.test.js src/components/config.js`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36dc2293788326890b0b1c0750c2dc)