### PR TITLE
Add detailed debug hooks to date-based fetch and improve error handling in load flows

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2989,6 +2989,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           setCacheCount(cacheCount);
           setBackendCount(backendCount);
         })
+        .catch(error => {
+          appendLoadDebugLog('reload-effect:DATE2-error', {
+            message: error?.message || String(error),
+            stack: error?.stack || null,
+          });
+          setCacheCount(0);
+          setBackendCount(0);
+        })
         .finally(() => setSearchLoading(false));
       return;
     }
@@ -3681,38 +3689,80 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     const loadedIds = [];
     const loadDropReasons = {};
-    const res = await fetchFilteredUsersByPage(
+    appendLoadDebugLog('loadMoreUsersGitSimple:before-fetchFilteredUsersByPage', {
+      queryMode: 'DATE2',
       dateOffset2,
-      undefined,
-      id => fetchUserById(id),
-      currentFilters,
-      fav,
-      dislikedUsersMap,
-      filterMain,
-      partial => {
-        const normalizedPartial = Object.entries(partial || {}).reduce((acc, [id, user]) => {
-          const userId = user?.userId || id;
-          if (!userId) return acc;
-          acc[userId] = { ...user, userId };
-          return acc;
-        }, {});
-        const partialIds = Object.keys(normalizedPartial);
-        if (!partialIds.length) return;
-        cacheFetchedUsers(normalizedPartial, cacheLoad2Users, currentFilters);
-        if (canApplyLoadResultsToUsers()) {
-          setUsers(prev => mergeWithoutOverwrite(prev, normalizedPartial));
-        }
-        partialIds.forEach(id => {
-          if (!loadedIds.includes(id)) loadedIds.push(id);
-        });
-        appendLoadDebugLog('loadMoreUsersGitSimple:progress', {
-          queryMode: 'DATE2',
-          partialCount: partialIds.length,
-          loadedIdsCount: loadedIds.length,
-          targetVisibleCount: PAGE_SIZE,
-        });
-      }
-    );
+      pageSize: PAGE_SIZE,
+      filters: summarizeLoadFiltersForLog(currentFilters),
+    });
+    let res;
+    try {
+      res = await fetchFilteredUsersByPage(
+        dateOffset2,
+        undefined,
+        id => fetchUserById(id),
+        currentFilters,
+        fav,
+        dislikedUsersMap,
+        filterMain,
+        partial => {
+          const normalizedPartial = Object.entries(partial || {}).reduce((acc, [id, user]) => {
+            const userId = user?.userId || id;
+            if (!userId) return acc;
+            acc[userId] = { ...user, userId };
+            return acc;
+          }, {});
+          const partialIds = Object.keys(normalizedPartial);
+          if (!partialIds.length) {
+            appendLoadDebugLog('loadMoreUsersGitSimple:progress-empty', {
+              queryMode: 'DATE2',
+              reason: 'onProgress received no visible users after filterMain',
+              dateOffset2,
+              targetVisibleCount: PAGE_SIZE,
+            });
+            return;
+          }
+          cacheFetchedUsers(normalizedPartial, cacheLoad2Users, currentFilters);
+          if (canApplyLoadResultsToUsers()) {
+            setUsers(prev => mergeWithoutOverwrite(prev, normalizedPartial));
+          } else {
+            appendLoadDebugLog('loadMoreUsersGitSimple:apply-blocked', {
+              queryMode: 'DATE2',
+              isEditing: isEditingRef.current,
+              searchListIsolated: searchListIsolationRef.current,
+              usersToApply: partialIds.length,
+              source: 'progress',
+            });
+          }
+          partialIds.forEach(id => {
+            if (!loadedIds.includes(id)) loadedIds.push(id);
+          });
+          appendLoadDebugLog('loadMoreUsersGitSimple:progress', {
+            queryMode: 'DATE2',
+            partialCount: partialIds.length,
+            loadedIdsCount: loadedIds.length,
+            targetVisibleCount: PAGE_SIZE,
+          });
+        },
+        {
+          debugLog: (step, payload) => appendLoadDebugLog(step, payload),
+        },
+      );
+      appendLoadDebugLog('loadMoreUsersGitSimple:after-fetchFilteredUsersByPage', {
+        queryMode: 'DATE2',
+        hasResponse: Boolean(res),
+        rawUsersCount: countObjectKeys(res?.users || {}),
+        lastKey: res?.lastKey ?? null,
+        hasMore: Boolean(res?.hasMore),
+      });
+    } catch (error) {
+      appendLoadDebugLog('loadMoreUsersGitSimple:error', {
+        queryMode: 'DATE2',
+        message: error?.message || String(error),
+        stack: error?.stack || null,
+      });
+      throw error;
+    }
 
     const backendEntries = Object.entries(res?.users || {});
     const normalizedUsers = backendEntries.reduce((acc, [id, user]) => {
@@ -3729,6 +3779,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     cacheFetchedUsers(normalizedUsers, cacheLoad2Users, currentFilters);
     if (canApplyLoadResultsToUsers()) {
       setUsers(prev => mergeWithoutOverwrite(prev, normalizedUsers));
+    } else if (backendIds.length) {
+      appendLoadDebugLog('loadMoreUsersGitSimple:apply-blocked', {
+        queryMode: 'DATE2',
+        isEditing: isEditingRef.current,
+        searchListIsolated: searchListIsolationRef.current,
+        usersToApply: backendIds.length,
+        source: 'result',
+      });
     }
     backendIds.forEach(id => {
       if (!loadedIds.includes(id)) loadedIds.push(id);

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -118,7 +118,8 @@ export async function fetchFilteredUsersByPage(
   favoriteUsers = {},
   dislikedUsers = {},
   filterMainFnParam,
-  onProgress
+  onProgress,
+  debugOptions = {}
 ) {
   const today = new Date();
   const target = startOffset + PAGE_SIZE;
@@ -135,6 +136,11 @@ export async function fetchFilteredUsersByPage(
   const seenIds = new Set();
   let filtered = [];
   let backendHasMore = false;
+  const debugLog = typeof debugOptions?.debugLog === 'function' ? debugOptions.debugLog : null;
+  const emitDebug = (step, payload = {}) => {
+    if (!debugLog) return;
+    debugLog(step, payload);
+  };
 
   const emitProgress = () => {
     if (!onProgress) return;
@@ -158,13 +164,30 @@ export async function fetchFilteredUsersByPage(
       const extra = extras[i];
       combined.push([id, extra ? { ...data, ...extra } : data]);
     });
+    const rejectReasons = {};
+    const collectFilterDebug = (step, payload = {}) => {
+      if (step !== 'filterMain:reject') return;
+      Object.entries(payload.reasons || {}).forEach(([reason, check]) => {
+        if (check?.passed) return;
+        rejectReasons[reason] = (rejectReasons[reason] || 0) + 1;
+      });
+    };
     filtered = filterMainFn(
       combined,
       'DATE2',
       filterSettings,
       favoriteUsers,
-      dislikedUsers
+      dislikedUsers,
+      debugLog ? { debugLog: collectFilterDebug } : undefined,
     );
+    emitDebug('fetchFilteredUsersByPage:filter-summary', {
+      entriesLength: entries.length,
+      newEntriesLength: newEntries.length,
+      combinedLength: combined.length,
+      filteredLength: filtered.length,
+      filterRejected: Math.max(0, combined.length - filtered.length),
+      rejectReasons,
+    });
     emitProgress();
   };
 
@@ -175,14 +198,40 @@ export async function fetchFilteredUsersByPage(
 
     while (filtered.length < target && dateHasMore) {
       const fetchLimit = limit - filtered.length;
+      emitDebug('fetchFilteredUsersByPage:scan-date:start', {
+        dateStr,
+        fetchLimit,
+        combinedLength: combined.length,
+        filteredLength: filtered.length,
+        target,
+        afterKey,
+        afterKeys,
+      });
       // eslint-disable-next-line no-await-in-loop
       const batchResult = normalizeDateFetchResult(
         await fetchDateFn(dateStr, fetchLimit, { afterKey, afterKeys })
       );
       const { entries } = batchResult;
+      emitDebug('fetchFilteredUsersByPage:scan-date:entries', {
+        dateStr,
+        entriesLength: entries.length,
+        combinedLength: combined.length,
+        filteredLength: filtered.length,
+        target,
+        batchHasMore: Boolean(batchResult.hasMore),
+        lastKey: batchResult.lastKey ?? null,
+        afterKeys: batchResult.afterKeys ?? null,
+      });
 
       if (entries.length === 0) {
         dateHasMore = false;
+        emitDebug('fetchFilteredUsersByPage:scan-date:stop', {
+          dateStr,
+          reason: 'no-entries-for-date',
+          combinedLength: combined.length,
+          filteredLength: filtered.length,
+          target,
+        });
         break;
       }
 
@@ -191,10 +240,27 @@ export async function fetchFilteredUsersByPage(
       afterKey = batchResult.lastKey ?? entries[entries.length - 1][0];
       afterKeys = batchResult.afterKeys ?? afterKeys;
       dateHasMore = Boolean(batchResult.hasMore && (afterKey || afterKeys));
+      emitDebug('fetchFilteredUsersByPage:scan-date:after-filter', {
+        dateStr,
+        entriesLength: entries.length,
+        combinedLength: combined.length,
+        filteredLength: filtered.length,
+        target,
+        dateHasMore,
+        nextAfterKey: afterKey,
+        nextAfterKeys: afterKeys,
+      });
     }
 
     if (filtered.length >= target && dateHasMore) {
       backendHasMore = true;
+      emitDebug('fetchFilteredUsersByPage:scan-date:stop', {
+        dateStr,
+        reason: 'target-reached-backend-has-more',
+        combinedLength: combined.length,
+        filteredLength: filtered.length,
+        target,
+      });
     }
   };
 
@@ -205,9 +271,29 @@ export async function fetchFilteredUsersByPage(
     const date = new Date(today);
     date.setDate(today.getDate() - dayOffset);
     const dateStr = date.toISOString().split('T')[0];
+    emitDebug('fetchFilteredUsersByPage:scan-progress', {
+      dateStr,
+      dayOffset,
+      invalidIndex: null,
+      entriesLength: null,
+      combinedLength: combined.length,
+      filteredLength: filtered.length,
+      target,
+      maxLoadDays: MAX_LOAD_DAYS,
+    });
     // eslint-disable-next-line no-await-in-loop
     await loadDateUntilEnough(dateStr);
     dayOffset += 1;
+  }
+  if (filtered.length < target && dayOffset >= MAX_LOAD_DAYS) {
+    emitDebug('fetchFilteredUsersByPage:scan-stop', {
+      reason: 'max-lookback-reached',
+      dayOffset,
+      maxLoadDays: MAX_LOAD_DAYS,
+      combinedLength: combined.length,
+      filteredLength: filtered.length,
+      target,
+    });
   }
 
   let invalidIndex = 0;
@@ -215,6 +301,16 @@ export async function fetchFilteredUsersByPage(
     filtered.length < target &&
     invalidIndex < INVALID_DATE_TOKENS.length
   ) {
+    emitDebug('fetchFilteredUsersByPage:scan-progress', {
+      dateStr: INVALID_DATE_TOKENS[invalidIndex],
+      dayOffset,
+      invalidIndex,
+      entriesLength: null,
+      combinedLength: combined.length,
+      filteredLength: filtered.length,
+      target,
+      maxLoadDays: MAX_LOAD_DAYS,
+    });
     // eslint-disable-next-line no-await-in-loop
     await loadDateUntilEnough(INVALID_DATE_TOKENS[invalidIndex]);
     invalidIndex += 1;
@@ -229,6 +325,26 @@ export async function fetchFilteredUsersByPage(
 
   const nextOffset = startOffset + slice.length;
   const hasMore = filtered.length > startOffset + PAGE_SIZE || backendHasMore;
+  const stopReason = slice.length >= PAGE_SIZE
+    ? 'target-reached'
+    : backendHasMore
+      ? 'backend-has-more'
+      : invalidIndex >= INVALID_DATE_TOKENS.length
+        ? 'invalid-tokens-exhausted'
+        : dayOffset >= MAX_LOAD_DAYS
+          ? 'max-lookback-reached'
+          : 'unknown';
+
+  emitDebug('fetchFilteredUsersByPage:result', {
+    usersLength: Object.keys(users).length,
+    combinedLength: combined.length,
+    filteredLength: filtered.length,
+    dayOffset,
+    invalidIndex,
+    lastKey: nextOffset,
+    hasMore,
+    stopReason,
+  });
 
   return { users, lastKey: nextOffset, hasMore };
 }


### PR DESCRIPTION
### Motivation

- Improve observability of date-based user fetching to diagnose why entries are filtered out or loads stop early.
- Harden load flows to surface and log errors during different list-fetch branches so UI state stays consistent.

### Description

- Add a `debugOptions` parameter and `debugLog` hook to `fetchFilteredUsersByPage` in `src/components/dateLoad.js` and emit detailed debug events (`fetchFilteredUsersByPage:*`) at key steps (scan start/entries/after-filter/stop, filter summary, scan progress, result, and stop reasons).
- Collect and report filter rejection reasons during filtering and expose a `stopReason` in the final result debug log to clarify why loading ended.
- Propagate the `debugLog` from the caller in `AddNewProfile.jsx` into `fetchFilteredUsersByPage`, add pre-/post-fetch debug logs around the call, and log when progress yields no visible users or when applying results is blocked by UI state.
- Add explicit error handling: a `.catch` on the `DATE2` branch `loadMoreUsers2()` to log errors and reset counts, and a `try/catch` around `fetchFilteredUsersByPage` to log and rethrow errors.

### Testing

- Ran the project test suite with `npm test` and the test run completed successfully.
- Executed automated smoke tests for search/load flows that exercise the `DATE2` and `GITnew` branches and log hooks, and they completed without uncaught exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378bceb4308326952c17c6630878e2)