### PR TITLE
Accumulate UK-trigger telegram prefix matches and return as list

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1646,6 +1646,7 @@ const SearchBar = ({
       if (ukTrigger?.searchPair?.telegram) {
         const normalizedTelegram = ukTrigger.searchPair.telegram;
         const searchCandidates = [normalizedTelegram];
+        const ukTriggerResultMap = {};
         if (ukTrigger.handle) {
           searchCandidates.push(ukTrigger.handle);
         }
@@ -1653,10 +1654,6 @@ const SearchBar = ({
         for (const [index, candidate] of searchCandidates.entries()) {
           const telegramValue = candidate?.trim();
           if (!telegramValue) continue;
-
-          const cacheOptions = { allowTelegramPrefixMatches: true };
-          const hasCache = loadCachedResult('telegram', telegramValue, requestId, cacheOptions);
-          const freshCache = hasCache && isCacheFresh('telegram', telegramValue, cacheOptions);
 
           if (index === 0) {
             emitSearchLabel({ telegram: telegramValue }, {
@@ -1666,31 +1663,34 @@ const SearchBar = ({
             });
           }
 
-          if (freshCache) return true;
-
-          if (!hasCache) {
-            applyState({}, requestId);
-            applyUsers({}, requestId);
-          }
+          applyState({}, requestId);
+          applyUsers({}, requestId);
 
           const res = await cachedSearch(
             { telegram: telegramValue },
             { allowTelegramPrefixMatches: true },
           );
           if (res && Object.keys(res).length > 0) {
+            mergeSearchResultMap(ukTriggerResultMap, res, {
+              mode: 'telegram',
+              stage: 'uk-trigger',
+              key: 'telegram',
+              value: telegramValue,
+              candidateIndex: index,
+            });
             notifySearchResult(
               { telegram: telegramValue },
               res,
               { preferredKeys: ['telegram'] },
             );
-            applyUserNotFound(false, requestId);
-            if ('userId' in res) {
-              applyState(res, requestId);
-            } else {
-              applyUsers(res, requestId);
-            }
-            return true;
           }
+        }
+
+        if (Object.keys(ukTriggerResultMap).length > 0) {
+          applyUserNotFound(false, requestId);
+          applyState({}, requestId);
+          applyUsers(ukTriggerResultMap, requestId);
+          return true;
         }
 
         applyUserNotFound(true, requestId);

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -329,6 +329,59 @@ describe('SearchBar cache-first search', () => {
     document.body.removeChild(container);
   });
 
+  it('renders UK-trigger telegram prefix matches as a list even when one match is returned', async () => {
+    const searchFunc = jest.fn().mockResolvedValue({
+      userId: 'oksana',
+      telegram: 'УК СМ Оксана',
+    });
+    const setUsers = jest.fn();
+    const setState = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'УК СМ Оксана',
+        setSearch: jest.fn(),
+        setUsers,
+        setState,
+        setUserNotFound: jest.fn(),
+        enabledSearchKeys: {
+          telegram: true,
+          searchId: false,
+          partialUserId: false,
+          searchKey: false,
+          equalToAllCards: false,
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledWith(
+      { telegram: 'УК СМ Оксана' },
+      expect.objectContaining({
+        allowTelegramPrefixMatches: true,
+      }),
+    );
+    expect(setState).not.toHaveBeenCalledWith(expect.objectContaining({ userId: 'oksana' }));
+    expect(setUsers).toHaveBeenLastCalledWith({
+      oksana: expect.objectContaining({
+        userId: 'oksana',
+        telegram: 'УК СМ Оксана',
+      }),
+    });
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
   it('keeps scoped searchId prefix cache entries isolated for repeated searches', () => {
     updateCard('ig-user', { userId: 'ig-user', name: 'Instagram Match' });
     updateCard('tg-user', { userId: 'tg-user', name: 'Telegram Match' });


### PR DESCRIPTION
### Motivation

- Ensure UK-trigger telegram searches aggregate prefix matches into a unified result set instead of treating a single match as a direct `userId` card, so UI can consistently render matches as a list.

### Description

- Introduced a `ukTriggerResultMap` to accumulate results across telegram search candidates and used `mergeSearchResultMap` to combine candidate responses. 
- Removed early cache-fresh short-circuiting in the UK-trigger path and always perform `cachedSearch` for prefix-matching telegram candidates. 
- Notify per-candidate results via `notifySearchResult` but apply the accumulated map via `applyUsers` when any matches exist, and set `applyUserNotFound` and `applyState` appropriately. 
- Added a unit test `renders UK-trigger telegram prefix matches as a list even when one match is returned` to verify that a single prefix match is returned as a list (`setUsers`) rather than as an individual card (`setState`).

### Testing

- Ran the component unit tests with Jest including the updated `SearchBar.partialUserId.test.js` file and the new test, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d0939b508326848f0ab8eb6c4432)