### PR TITLE
Enable Telegram UK-trigger prefix matching for partial search pairs

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -510,7 +510,7 @@ const resolveSearchIdPrefixStrategy = (input, searchOptions = {}) => {
 const getTelegramPrefixMatchOptions = (value, prefix) => {
   if (prefix !== 'telegram') return {};
   const parsedUkTrigger = parseUkTriggerQuery(String(value || ''));
-  return parsedUkTrigger?.handle ? { allowTelegramPrefixMatches: true } : {};
+  return parsedUkTrigger?.searchPair?.telegram ? { allowTelegramPrefixMatches: true } : {};
 };
 
 const parseSearchIdExact = input => {
@@ -886,6 +886,10 @@ export const doesCardMatchSearchParams = (card, params = {}, options = {}) => {
           : '';
         if (
           normalizedFieldValue === normalizedUkTrigger ||
+          (
+            options.allowTelegramPrefixMatches &&
+            normalizedFieldValue.startsWith(normalizedUkTrigger)
+          ) ||
           (normalizedHandle && normalizedFieldValue === normalizedHandle) ||
           (
             options.allowTelegramPrefixMatches &&

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -155,6 +155,29 @@ describe('SearchBar result validation', () => {
     )).toBe(false);
   });
 
+  it('allows partial UK-trigger telegram value prefix matches only when prefix matching is enabled', () => {
+    const result = {
+      exact: { userId: 'exact', telegram: 'УК СМ Оксана' },
+      longer: { userId: 'longer', telegram: 'УК СМ Оксана Кошель @Oksana_Koshel' },
+      other: { userId: 'other', telegram: 'УК СМ Інша' },
+    };
+
+    expect(filterSearchResultByParams(
+      result,
+      { telegram: 'УК СМ Оксана' },
+      { allowTelegramPrefixMatches: true },
+    )).toEqual({
+      exact: result.exact,
+      longer: result.longer,
+    });
+    expect(filterSearchResultByParams(
+      result,
+      { telegram: 'УК СМ Оксана' },
+    )).toEqual({
+      exact: result.exact,
+    });
+  });
+
   it('keeps partial userId validation as a prefix match', () => {
     expect(doesCardMatchSearchParams(
       { userId: 'Anna123' },
@@ -320,6 +343,64 @@ describe('SearchBar cache-first search', () => {
     );
     expect(setUsers).toHaveBeenCalledWith({
       oksana: expect.objectContaining({ userId: 'oksana' }),
+    });
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
+  it('enables telegram prefix matching for partial UK-trigger searchId searches without handles', async () => {
+    const searchFunc = jest.fn().mockResolvedValue({
+      exact: { userId: 'exact', telegram: 'УК СМ Оксана' },
+      longer: { userId: 'longer', telegram: 'УК СМ Оксана Кошель @Oksana_Koshel' },
+    });
+    const setUsers = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'УК СМ Оксана',
+        setSearch: jest.fn(),
+        setUsers,
+        setState: jest.fn(),
+        setUserNotFound: jest.fn(),
+        enabledSearchKeys: {
+          searchId: true,
+          partialUserId: false,
+          searchKey: false,
+          equalToAllCards: false,
+        },
+        searchOptions: {
+          enabledSearchKeys: {
+            searchId: true,
+            partialUserId: false,
+            searchKey: false,
+            equalToAllCards: false,
+          },
+          searchIdPrefixes: ['telegram'],
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledWith(
+      { searchId: 'УК СМ Оксана' },
+      expect.objectContaining({
+        searchIdPrefixes: ['telegram'],
+        allowTelegramPrefixMatches: true,
+      }),
+    );
+    expect(setUsers).toHaveBeenCalledWith({
+      exact: expect.objectContaining({ userId: 'exact' }),
+      longer: expect.objectContaining({ userId: 'longer' }),
     });
 
     // eslint-disable-next-line testing-library/no-unnecessary-act


### PR DESCRIPTION
### Motivation

- Allow searches that include a UK-trigger telegram search pair without an explicit handle to match telegram values by prefix so partial queries like `УК СМ Оксана` can find longer telegram entries. 
- Ensure the search options passed to the search function enable prefix matching when the parsed UK-trigger contains a `searchPair.telegram` even if there is no `handle`.

### Description

- Update `getTelegramPrefixMatchOptions` in `src/components/SearchBar.jsx` to check `parsedUkTrigger?.searchPair?.telegram` instead of `parsedUkTrigger?.handle` when deciding to enable `allowTelegramPrefixMatches`.
- Extend `doesCardMatchSearchParams` in `src/components/SearchBar.jsx` to allow prefix matches of the normalized `searchPair.telegram` value when `options.allowTelegramPrefixMatches` is true by accepting `normalizedFieldValue.startsWith(normalizedUkTrigger)`.
- Add tests in `src/components/SearchBar.partialUserId.test.js` that verify partial UK-trigger telegram prefix matching behavior and that the `SearchBar` passes `allowTelegramPrefixMatches: true` to `searchFunc` for partial `searchId` queries without handles.

### Testing

- Ran the unit tests in `SearchBar.partialUserId.test.js` (via the repository test suite) which include new assertions for partial UK-trigger prefix matching and they passed.
- Executed the component-level tests exercising `SearchBar` render and calls to `searchFunc` (using `act`) and those tests also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37e851756c8326958718a84f37e52a)