### PR TITLE
Persist offline users/newUsers JSON to IndexedDB and add UI restore/clear controls

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -114,6 +114,11 @@ import {
   setBackendDownloadToastsEnabled,
   withAdminDownloadToast,
 } from 'utils/backendDownloadToast';
+import {
+  clearOfflineCollections,
+  loadOfflineCollections,
+  saveOfflineCollection,
+} from 'utils/offlineCollectionsStorage';
 // import JsonToExcelButton from './topBtns/btnJsonToExcel';
 // import { aiHandler } from './aiHandler';
 import {
@@ -1161,6 +1166,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [localExportUsersData, setLocalExportUsersData] = useState(null);
   const [localExportNewUsersData, setLocalExportNewUsersData] = useState(null);
+  const [isOfflineCollectionsRestoring, setIsOfflineCollectionsRestoring] = useState(true);
   const localUsersFileInputRef = useRef(null);
   const localNewUsersFileInputRef = useRef(null);
   const localExportUsersFileInputRef = useRef(null);
@@ -5561,6 +5567,32 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   }, []);
 
+  useEffect(() => {
+    let isCancelled = false;
+
+    loadOfflineCollections()
+      .then(({ users: savedUsers, newUsers: savedNewUsers }) => {
+        if (isCancelled) return;
+
+        if (savedUsers) setLocalExportUsersData(savedUsers);
+        if (savedNewUsers) setLocalExportNewUsersData(savedNewUsers);
+
+        if (savedUsers || savedNewUsers) {
+          toast.success('Offline-файли відновлено зі сховища браузера');
+        }
+      })
+      .catch(error => {
+        console.warn('[AddNewProfile] Failed to restore offline collections from IndexedDB', error);
+      })
+      .finally(() => {
+        if (!isCancelled) setIsOfflineCollectionsRestoring(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
   const handleLocalExportCollectionFileSelected = useCallback(async (event, collection) => {
     const file = event?.target?.files?.[0];
     if (!file) return;
@@ -5575,9 +5607,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       } else {
         setLocalExportNewUsersData(parsed);
       }
+      await saveOfflineCollection(collection, parsed);
       toast.success(`Локальний файл для експорту ${collection}.json прочитано`);
     } catch (error) {
       toast.error(`Не вдалося прочитати ${collection}.json: ${error?.message || 'невідома помилка'}`);
+    }
+  }, []);
+
+  const handleClearSavedOfflineCollections = useCallback(async () => {
+    try {
+      await clearOfflineCollections();
+      setLocalExportUsersData(null);
+      setLocalExportNewUsersData(null);
+      toast.success('Збережені offline-файли очищено');
+    } catch (error) {
+      toast.error(`Не вдалося очистити offline-файли: ${error?.message || 'невідома помилка'}`);
     }
   }, []);
 
@@ -6680,6 +6724,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                         onModeChange={handleLoadSortModeChange}
                         onPickUsersFile={handlePickUsersFileForLocalExport}
                         onPickNewUsersFile={handlePickNewUsersFileForLocalExport}
+                        onClearSavedFiles={handleClearSavedOfflineCollections}
                         hasUsersFile={Boolean(localExportUsersData)}
                         hasNewUsersFile={Boolean(localExportNewUsersData)}
                       />
@@ -6933,6 +6978,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   <button type="button" onClick={handlePickNewUsersFileForLocalExport}>
                     Обрати newUsers.json {localExportNewUsersData ? '✅' : ''}
                   </button>
+                  {(localExportUsersData || localExportNewUsersData) && (
+                    <button type="button" onClick={handleClearSavedOfflineCollections}>
+                      Очистити збережені offline-файли
+                    </button>
+                  )}
+                  {isOfflineCollectionsRestoring && (
+                    <SaveModalComment>Перевіряємо збережені offline-файли...</SaveModalComment>
+                  )}
                 </LocalIndexActions>
               )}
             </SaveModalSection>

--- a/src/components/AddNewProfileOfflineLoad.jsx
+++ b/src/components/AddNewProfileOfflineLoad.jsx
@@ -12,6 +12,7 @@ export const AddNewProfileOfflineLoadControls = ({
   onModeChange,
   onPickUsersFile,
   onPickNewUsersFile,
+  onClearSavedFiles,
   hasUsersFile,
   hasNewUsersFile,
 }) => (
@@ -34,6 +35,11 @@ export const AddNewProfileOfflineLoadControls = ({
         <button type="button" onClick={onPickNewUsersFile}>
           Обрати newUsers.json {hasNewUsersFile ? '✅' : ''}
         </button>
+        {(hasUsersFile || hasNewUsersFile) && onClearSavedFiles && (
+          <button type="button" onClick={onClearSavedFiles}>
+            Очистити збережені offline-файли
+          </button>
+        )}
       </LocalIndexActions>
     )}
   </>

--- a/src/utils/offlineCollectionsStorage.js
+++ b/src/utils/offlineCollectionsStorage.js
@@ -1,0 +1,80 @@
+const DB_NAME = 'offlineCollections';
+const DB_VERSION = 1;
+const STORE_NAME = 'collections';
+const COLLECTION_KEYS = ['users', 'newUsers'];
+
+const openOfflineCollectionsDb = () =>
+  new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is unavailable'));
+      return;
+    }
+
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'collection' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('Failed to open IndexedDB'));
+  });
+
+const runCollectionStoreRequest = async (mode, requestFactory) => {
+  const db = await openOfflineCollectionsDb();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const request = requestFactory(store);
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || transaction.error || new Error('IndexedDB request failed'));
+    transaction.oncomplete = () => db.close();
+    transaction.onerror = () => {
+      db.close();
+      reject(transaction.error || new Error('IndexedDB transaction failed'));
+    };
+    transaction.onabort = () => {
+      db.close();
+      reject(transaction.error || new Error('IndexedDB transaction aborted'));
+    };
+  });
+};
+
+export const saveOfflineCollection = (collection, data) => {
+  if (!COLLECTION_KEYS.includes(collection)) {
+    return Promise.reject(new Error(`Unsupported offline collection: ${collection}`));
+  }
+
+  return runCollectionStoreRequest('readwrite', store =>
+    store.put({
+      collection,
+      data,
+      savedAt: new Date().toISOString(),
+    }),
+  );
+};
+
+export const loadOfflineCollection = async collection => {
+  if (!COLLECTION_KEYS.includes(collection)) return null;
+
+  const record = await runCollectionStoreRequest('readonly', store => store.get(collection));
+  return record?.data || null;
+};
+
+export const loadOfflineCollections = async () => {
+  const [users, newUsers] = await Promise.all([
+    loadOfflineCollection('users'),
+    loadOfflineCollection('newUsers'),
+  ]);
+
+  return { users, newUsers };
+};
+
+export const clearOfflineCollections = async () => {
+  await runCollectionStoreRequest('readwrite', store => store.clear());
+};


### PR DESCRIPTION
### Motivation

- Allow users to persist locally selected `users.json` and `newUsers.json` between sessions so offline exports and indexing workflows can be resumed without reselecting files.

### Description

- Add `utils/offlineCollectionsStorage.js` which implements IndexedDB helpers `saveOfflineCollection`, `loadOfflineCollection`, `loadOfflineCollections`, and `clearOfflineCollections` for `users` and `newUsers` collections.
- Integrate offline storage into `AddNewProfile` by importing the new helpers, adding `isOfflineCollectionsRestoring` state, loading saved collections on mount with `loadOfflineCollections`, and saving selected files with `saveOfflineCollection` when a local file is chosen.
- Add a `handleClearSavedOfflineCollections` handler and surface a clear button in the UI and in `AddNewProfileOfflineLoad` by passing `onClearSavedFiles` and conditionally rendering the button when saved files exist.

### Testing

- No new automated tests were added for IndexedDB persistence in this change. 
- Existing test suite and static checks (`unit tests`/`lint`) were executed against the codebase and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37e8fa551c832695f72b8c07a12dcd)