### PR TITLE
Normalize offline load mode (rename 'ofline' → 'offline') and add offline filter options

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -45,7 +45,7 @@ import {
   AddNewProfileOfflineLoadControls,
   OFFLINE_LOAD_FILTER,
   OFFLINE_LOAD_MODE,
-  loadMoreUsersOfline as loadMoreUsersOflineMode,
+  loadMoreUsersOffline as loadMoreUsersOfflineMode,
 } from './AddNewProfileOfflineLoad';
 import { makeUploadedInfo } from './makeUploadedInfo';
 import { onAuthStateChanged, signOut } from 'firebase/auth';
@@ -1089,7 +1089,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     LAST_ACTION2: LAST_ACTION2_SORT_MODE,
     NO_GIT: 'NoGIT',
     SEARCH_ID_KEY_ONLY: 'SearchIdKeyOnly',
-    OFLINE: OFFLINE_LOAD_MODE,
+    OFFLINE: OFFLINE_LOAD_MODE,
   };
   const SEARCH_KEY_INDEX_OPTIONS = [
     { key: 'blood', label: 'blood' },
@@ -1654,7 +1654,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     return true;
   };
 
-  const hideOflineCardAndLoadNext = submittedState => {
+  const hideOfflineCardAndLoadNext = submittedState => {
     const userId = submittedState?.userId;
     if (currentFilter !== OFFLINE_LOAD_FILTER || !userId) {
       return false;
@@ -1668,17 +1668,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       return restUsers;
     });
 
-    appendLoadDebugLog('handleSubmit:ofline-remove-from-query-and-refill', {
+    appendLoadDebugLog('handleSubmit:offline-remove-from-query-and-refill', {
       queryKey,
       userId,
       currentPage,
     });
 
-    loadMoreUsersOfline(filters, {
+    loadMoreUsersOffline(filters, {
       targetLoadedCount: PAGE_SIZE,
       forceVisibleUpdate: true,
     }).catch(error => {
-      appendLoadDebugLog('handleSubmit:ofline-load-next-error', {
+      appendLoadDebugLog('handleSubmit:offline-load-next-error', {
         queryKey,
         userId,
         message: error?.message || String(error),
@@ -1777,8 +1777,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       });
       cacheFetchedUsers({ [syncedState.userId]: optimisticCard }, cacheLoad2Users, filters);
       const gitNewCardHidden = hideFutureGitNewCardAndLoadNext(optimisticCard);
-      const oflineCardHidden = hideOflineCardAndLoadNext(optimisticCard);
-      if (!gitNewCardHidden && !oflineCardHidden) {
+      const offlineCardHidden = hideOfflineCardAndLoadNext(optimisticCard);
+      if (!gitNewCardHidden && !offlineCardHidden) {
         setUsers(prev => ({ ...prev, [syncedState.userId]: optimisticCard }));
       }
 
@@ -2675,7 +2675,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       case LOAD_SORT_MODES.NO_GIT:
       case LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY:
         return 'DATE2.1';
-      case LOAD_SORT_MODES.OFLINE:
+      case LOAD_SORT_MODES.OFFLINE:
         return OFFLINE_LOAD_FILTER;
       case LOAD_SORT_MODES.GIT:
       default:
@@ -2691,7 +2691,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       : 'addFilters';
 
   const gitNewMode = loadSortMode === LOAD_SORT_MODES.GIT_NEW;
-  const offlineLoadMode = loadSortMode === LOAD_SORT_MODES.OFLINE;
+  const offlineLoadMode = loadSortMode === LOAD_SORT_MODES.OFFLINE;
   const searchIdAndSearchKeyOnlyMode = loadSortMode === LOAD_SORT_MODES.SEARCH_ID_KEY_ONLY || gitNewMode;
 
   const effectiveEnabledSearchKeys = searchIdAndSearchKeyOnlyMode
@@ -3054,8 +3054,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
 
     if (currentFilter === OFFLINE_LOAD_FILTER) {
-      appendLoadDebugLog('reload-effect:branch', { branch: OFFLINE_LOAD_FILTER, loader: 'loadMoreUsersOfline' });
-      loadMoreUsersOfline(filters, { reset: true })
+      appendLoadDebugLog('reload-effect:branch', { branch: OFFLINE_LOAD_FILTER, loader: 'loadMoreUsersOffline' });
+      loadMoreUsersOffline(filters, { reset: true })
         .then(({ cacheCount, backendCount, ignored }) => {
           if (ignored) return;
           setCacheCount(cacheCount);
@@ -4559,7 +4559,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     return { cacheCount, backendCount, hasMore: more };
   };
 
-  const loadMoreUsersOfline = async (currentFilters = filters, options = {}) => loadMoreUsersOflineMode({
+  const loadMoreUsersOffline = async (currentFilters = filters, options = {}) => loadMoreUsersOfflineMode({
     currentFilters,
     ...options,
     pageSize: PAGE_SIZE,
@@ -4887,7 +4887,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             ? await loadMoreUsersSearchKey()
             : await loadMoreUsers21()
           : currentFilter === OFFLINE_LOAD_FILTER
-          ? await loadMoreUsersOfline()
+          ? await loadMoreUsersOffline()
           : currentFilter === 'LAST_ACTION'
           ? await loadMoreUsersLastAction()
           : currentFilter === LAST_ACTION2_FILTER

--- a/src/components/AddNewProfile.offlineLoad.test.js
+++ b/src/components/AddNewProfile.offlineLoad.test.js
@@ -1,20 +1,20 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('AddNewProfile ofline load mode', () => {
+describe('AddNewProfile offline load mode', () => {
   const addNewProfileSource = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
   const offlineSource = fs.readFileSync(path.join(__dirname, 'AddNewProfileOfflineLoad.jsx'), 'utf8');
 
-  it('keeps ofline as a separate AddNewProfileOfflineLoad module and component', () => {
+  it('keeps offline as a separate AddNewProfileOfflineLoad module and component', () => {
     expect(addNewProfileSource).toContain("} from './AddNewProfileOfflineLoad';");
     expect(offlineSource).toContain('export const AddNewProfileOfflineLoadControls');
-    expect(offlineSource).toContain("export const OFFLINE_LOAD_MODE = 'ofline';");
+    expect(offlineSource).toContain("export const OFFLINE_LOAD_MODE = 'offline';");
     expect(addNewProfileSource).toContain('<AddNewProfileOfflineLoadControls');
   });
 
-  it('registers ofline as a load sort mode and routes it to a dedicated filter', () => {
-    expect(addNewProfileSource).toContain('OFLINE: OFFLINE_LOAD_MODE');
-    expect(addNewProfileSource).toContain('case LOAD_SORT_MODES.OFLINE:');
+  it('registers offline as a load sort mode and routes it to a dedicated filter', () => {
+    expect(addNewProfileSource).toContain('OFFLINE: OFFLINE_LOAD_MODE');
+    expect(addNewProfileSource).toContain('case LOAD_SORT_MODES.OFFLINE:');
     expect(addNewProfileSource).toContain('return OFFLINE_LOAD_FILTER;');
   });
 
@@ -27,6 +27,8 @@ describe('AddNewProfile ofline load mode', () => {
     expect(getIdsBody).toContain('getMergedUsersFromLocalExportCollections()');
     expect(getIdsBody).toContain('filterMain(');
     expect(getIdsBody).toContain('OFFLINE_LOAD_FILTER');
+    expect(getIdsBody).toContain('OFFLINE_FILTER_MAIN_OPTIONS');
+    expect(offlineSource).toContain('requireCurrentOrPastGetInTouch: true');
     expect(getIdsBody).toContain('left.getInTouch.localeCompare(right.getInTouch)');
   });
 
@@ -34,24 +36,25 @@ describe('AddNewProfile ofline load mode', () => {
     const hydrateStart = offlineSource.indexOf('export const hydrateOfflineIdsPage');
     const loaderBody = offlineSource.slice(
       hydrateStart,
-      offlineSource.indexOf('};', offlineSource.indexOf('export const loadMoreUsersOfline'))
+      offlineSource.indexOf('};', offlineSource.indexOf('export const loadMoreUsersOffline'))
     );
 
     expect(offlineSource).toContain('export const OFFLINE_LOAD_BACKEND_PAGE_SIZE = 20');
     expect(loaderBody).toContain('slice(0, OFFLINE_LOAD_BACKEND_PAGE_SIZE)');
     expect(loaderBody).toContain('fetchUsersByIds(pageIds)');
+    expect(loaderBody).toContain('filterBackendHydratedOfflineUsers');
     expect(offlineSource).toContain('setIdsForQuery(queryKey, nextPassedIds)');
   });
 
-  it('removes edited ofline cards from the query cache and loads the next card', () => {
+  it('removes edited offline cards from the query cache and loads the next card', () => {
     const invalidationBody = addNewProfileSource.slice(
-      addNewProfileSource.indexOf('const hideOflineCardAndLoadNext'),
+      addNewProfileSource.indexOf('const hideOfflineCardAndLoadNext'),
       addNewProfileSource.indexOf('const refillGitAfterGetInTouchChange')
     );
 
     expect(invalidationBody).toContain('currentFilter !== OFFLINE_LOAD_FILTER');
     expect(invalidationBody).toContain('removeUserIdFromQuery(queryKey, userId)');
-    expect(invalidationBody).toContain('loadMoreUsersOfline(filters, {');
+    expect(invalidationBody).toContain('loadMoreUsersOffline(filters, {');
     expect(invalidationBody).toContain('forceVisibleUpdate: true');
   });
 });

--- a/src/components/AddNewProfileOfflineLoad.jsx
+++ b/src/components/AddNewProfileOfflineLoad.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { loadQueries, normalizeQueryKey } from 'utils/cardIndex';
 
-export const OFFLINE_LOAD_FILTER = 'OFLINE';
-export const OFFLINE_LOAD_MODE = 'ofline';
+export const OFFLINE_LOAD_FILTER = 'OFFLINE';
+export const OFFLINE_LOAD_MODE = 'offline';
 export const OFFLINE_LOAD_BACKEND_PAGE_SIZE = 20;
+export const OFFLINE_FILTER_MAIN_OPTIONS = { requireCurrentOrPastGetInTouch: true };
 
 export const AddNewProfileOfflineLoadControls = ({
   SortModeLabel,
@@ -25,7 +26,7 @@ export const AddNewProfileOfflineLoadControls = ({
         checked={loadSortMode === OFFLINE_LOAD_MODE}
         onChange={event => onModeChange(event.target.value)}
       />
-      ofline
+      offline
     </SortModeLabel>
     {loadSortMode === OFFLINE_LOAD_MODE && (
       <LocalIndexActions>
@@ -68,6 +69,7 @@ export const getOfflineFilteredIds = ({
     currentFilters,
     favoriteUsersData,
     dislikeUsersData,
+    OFFLINE_FILTER_MAIN_OPTIONS,
   );
 
   return filteredEntries
@@ -106,6 +108,7 @@ export const filterBackendHydratedOfflineUsers = ({
         currentFilters,
         favoriteUsersData,
         dislikeUsersData,
+        OFFLINE_FILTER_MAIN_OPTIONS,
       ),
     ),
   );
@@ -144,7 +147,7 @@ export const hydrateOfflineIdsPage = async ({
   return filteredUsers;
 };
 
-export const loadMoreUsersOfline = async ({
+export const loadMoreUsersOffline = async ({
   currentFilters,
   reset = false,
   targetLoadedCount,
@@ -184,8 +187,8 @@ export const loadMoreUsersOfline = async ({
   });
 
   if (!localIds) {
-    toast.error('Оберіть локальні users.json та newUsers.json для ofline load');
-    appendLoadDebugLog('loadMoreUsersOfline:missing-local-files', { queryKey });
+    toast.error('Оберіть локальні users.json та newUsers.json для offline load');
+    appendLoadDebugLog('loadMoreUsersOffline:missing-local-files', { queryKey });
     setHasMore(false);
     return { cacheCount: 0, backendCount: 0, hasMore: false };
   }
@@ -201,7 +204,7 @@ export const loadMoreUsersOfline = async ({
   let hydratedUsers = {};
   const attemptedIds = [];
 
-  appendLoadDebugLog('loadMoreUsersOfline:start', {
+  appendLoadDebugLog('loadMoreUsersOffline:start', {
     queryKey,
     localIdsCount: localIds.length,
     previousPassedIdsCount: previousPassedIds.length,
@@ -249,7 +252,7 @@ export const loadMoreUsersOfline = async ({
   setDateOffset21(nextPassedIds.length);
   setHasMore(nextHasMore);
 
-  appendLoadDebugLog('loadMoreUsersOfline:result', {
+  appendLoadDebugLog('loadMoreUsersOffline:result', {
     queryKey,
     hydratedIdsCount: hydratedIds.length,
     attemptedIdsCount: attemptedIds.length,


### PR DESCRIPTION
### Motivation
- Standardize naming for the offline load mode and fix multiple misspellings of `ofline` to `offline` to avoid inconsistent symbols and improve readability.
- Ensure the offline load path applies a stricter filter for `getInTouch` dates when hydrating and filtering local/exported users.
- Update tests and references so the code and tests remain consistent after the rename.

### Description
- Renamed constants, modes and UI label: `OFFLINE_LOAD_FILTER` is now `'OFFLINE'`, `OFFLINE_LOAD_MODE` is `'offline'`, and the UI label text changed from `ofline` to `offline` in `AddNewProfileOfflineLoad.jsx`.
- Renamed functions and wrappers from `loadMoreUsersOfline` / `hideOflineCardAndLoadNext` to `loadMoreUsersOffline` / `hideOfflineCardAndLoadNext` and updated all callers in `AddNewProfile.jsx` to match.
- Added `OFFLINE_FILTER_MAIN_OPTIONS = { requireCurrentOrPastGetInTouch: true }` and passed it into `filterMain` calls and backend-filtering helpers (`getOfflineFilteredIds` and `filterBackendHydratedOfflineUsers`) so offline filtering respects current/past `getInTouch` semantics.
- Normalized debug log keys and error messages from `ofline` to `offline` and adjusted related helper names (`hydrateOfflineIdsPage`, `loadMoreUsersOffline`, etc.).
- Renamed the test file `AddNewProfile.oflineLoad.test.js` to `AddNewProfile.offlineLoad.test.js` and updated expectations to assert the new `offline` symbols and new helper names.

### Testing
- Ran the unit test file `src/components/AddNewProfile.offlineLoad.test.js` and its assertions for symbol renames and behavior checks, and the test passed.
- Executed the project test suite (`npm test`) after the change and observed no failing tests related to the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37f389db248326b5250bf04c2fe6fc)