### PR TITLE
Scope offline collections by owner

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1167,6 +1167,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [localExportUsersData, setLocalExportUsersData] = useState(null);
   const [localExportNewUsersData, setLocalExportNewUsersData] = useState(null);
   const [isOfflineCollectionsRestoring, setIsOfflineCollectionsRestoring] = useState(true);
+  const offlineCollectionsChangeVersionRef = useRef(0);
   const localUsersFileInputRef = useRef(null);
   const localNewUsersFileInputRef = useRef(null);
   const localExportUsersFileInputRef = useRef(null);
@@ -1936,6 +1937,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setState({});
       setIsLoggedIn(false);
       setShowInfoModal(false);
+      await clearOfflineCollections(auth.currentUser?.uid);
       await signOut(auth);
       navigate('/my-profile');
     } catch (error) {
@@ -5495,10 +5497,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const openLocalIndexModal = useCallback(indexTypes => {
     setPendingLocalIndexTypes(indexTypes);
-    setPendingLocalUsersData(null);
-    setPendingLocalNewUsersData(null);
+    setPendingLocalUsersData(localExportUsersData);
+    setPendingLocalNewUsersData(localExportNewUsersData);
     setShowLocalIndexModal(true);
-  }, []);
+  }, [localExportNewUsersData, localExportUsersData]);
 
   const handleDownloadCollectionsForLocalIndex = useCallback(async () => {
     const toastId = 'download-local-index-collections';
@@ -5535,6 +5537,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const file = event?.target?.files?.[0];
     if (!file) return;
 
+    offlineCollectionsChangeVersionRef.current += 1;
+
     try {
       const parsed = JSON.parse(await file.text());
       if (!parsed || typeof parsed !== 'object') {
@@ -5544,14 +5548,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
       if (collection === 'users') {
         setPendingLocalUsersData(parsed);
+        setLocalExportUsersData(parsed);
       } else {
         setPendingLocalNewUsersData(parsed);
+        setLocalExportNewUsersData(parsed);
       }
+      await saveOfflineCollection(ownerId, collection, parsed);
       toast.success(`Файл ${collection}.json прочитано`);
     } catch (error) {
       toast.error(`Не вдалося прочитати ${collection}.json: ${error?.message || 'невідома помилка'}`);
     }
-  }, []);
+  }, [ownerId]);
 
   const handlePickUsersFileForLocalExport = useCallback(() => {
     if (localExportUsersFileInputRef.current) {
@@ -5569,13 +5576,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   useEffect(() => {
     let isCancelled = false;
+    const restoreChangeVersion = offlineCollectionsChangeVersionRef.current;
 
-    loadOfflineCollections()
+    loadOfflineCollections(ownerId)
       .then(({ users: savedUsers, newUsers: savedNewUsers }) => {
-        if (isCancelled) return;
+        if (isCancelled || restoreChangeVersion !== offlineCollectionsChangeVersionRef.current) return;
 
-        if (savedUsers) setLocalExportUsersData(savedUsers);
-        if (savedNewUsers) setLocalExportNewUsersData(savedNewUsers);
+        if (savedUsers) {
+          setLocalExportUsersData(savedUsers);
+          setPendingLocalUsersData(savedUsers);
+        }
+        if (savedNewUsers) {
+          setLocalExportNewUsersData(savedNewUsers);
+          setPendingLocalNewUsersData(savedNewUsers);
+        }
 
         if (savedUsers || savedNewUsers) {
           toast.success('Offline-файли відновлено зі сховища браузера');
@@ -5591,7 +5605,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     return () => {
       isCancelled = true;
     };
-  }, []);
+  }, [ownerId]);
 
   const handleLocalExportCollectionFileSelected = useCallback(async (event, collection) => {
     const file = event?.target?.files?.[0];
@@ -5604,26 +5618,32 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       }
       if (collection === 'users') {
         setLocalExportUsersData(parsed);
+        setPendingLocalUsersData(parsed);
       } else {
         setLocalExportNewUsersData(parsed);
+        setPendingLocalNewUsersData(parsed);
       }
-      await saveOfflineCollection(collection, parsed);
+      offlineCollectionsChangeVersionRef.current += 1;
+      await saveOfflineCollection(ownerId, collection, parsed);
       toast.success(`Локальний файл для експорту ${collection}.json прочитано`);
     } catch (error) {
       toast.error(`Не вдалося прочитати ${collection}.json: ${error?.message || 'невідома помилка'}`);
     }
-  }, []);
+  }, [ownerId]);
 
   const handleClearSavedOfflineCollections = useCallback(async () => {
     try {
-      await clearOfflineCollections();
+      offlineCollectionsChangeVersionRef.current += 1;
+      await clearOfflineCollections(ownerId);
       setLocalExportUsersData(null);
       setLocalExportNewUsersData(null);
+      setPendingLocalUsersData(null);
+      setPendingLocalNewUsersData(null);
       toast.success('Збережені offline-файли очищено');
     } catch (error) {
       toast.error(`Не вдалося очистити offline-файли: ${error?.message || 'невідома помилка'}`);
     }
-  }, []);
+  }, [ownerId]);
 
   const handleApplyLocalIndexing = useCallback(async () => {
     if (!pendingLocalUsersData || !pendingLocalNewUsersData) {

--- a/src/utils/offlineCollectionsStorage.js
+++ b/src/utils/offlineCollectionsStorage.js
@@ -3,6 +3,14 @@ const DB_VERSION = 1;
 const STORE_NAME = 'collections';
 const COLLECTION_KEYS = ['users', 'newUsers'];
 
+const getScopedCollectionKey = (ownerId, collection) => {
+  if (!ownerId) {
+    throw new Error('Owner ID is required for offline collections');
+  }
+
+  return `${ownerId}:${collection}`;
+};
+
 const openOfflineCollectionsDb = () =>
   new Promise((resolve, reject) => {
     if (typeof indexedDB === 'undefined') {
@@ -45,36 +53,53 @@ const runCollectionStoreRequest = async (mode, requestFactory) => {
   });
 };
 
-export const saveOfflineCollection = (collection, data) => {
+export const saveOfflineCollection = (ownerId, collection, data) => {
   if (!COLLECTION_KEYS.includes(collection)) {
     return Promise.reject(new Error(`Unsupported offline collection: ${collection}`));
   }
 
+  let scopedCollection;
+  try {
+    scopedCollection = getScopedCollectionKey(ownerId, collection);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+
   return runCollectionStoreRequest('readwrite', store =>
     store.put({
-      collection,
+      collection: scopedCollection,
+      ownerId,
+      collectionName: collection,
       data,
       savedAt: new Date().toISOString(),
     }),
   );
 };
 
-export const loadOfflineCollection = async collection => {
-  if (!COLLECTION_KEYS.includes(collection)) return null;
+export const loadOfflineCollection = async (ownerId, collection) => {
+  if (!COLLECTION_KEYS.includes(collection) || !ownerId) return null;
 
-  const record = await runCollectionStoreRequest('readonly', store => store.get(collection));
+  const record = await runCollectionStoreRequest('readonly', store => store.get(getScopedCollectionKey(ownerId, collection)));
   return record?.data || null;
 };
 
-export const loadOfflineCollections = async () => {
+export const loadOfflineCollections = async ownerId => {
+  if (!ownerId) return { users: null, newUsers: null };
+
   const [users, newUsers] = await Promise.all([
-    loadOfflineCollection('users'),
-    loadOfflineCollection('newUsers'),
+    loadOfflineCollection(ownerId, 'users'),
+    loadOfflineCollection(ownerId, 'newUsers'),
   ]);
 
   return { users, newUsers };
 };
 
-export const clearOfflineCollections = async () => {
-  await runCollectionStoreRequest('readwrite', store => store.clear());
+export const clearOfflineCollections = async ownerId => {
+  if (!ownerId) return;
+
+  await Promise.all(
+    COLLECTION_KEYS.map(collection =>
+      runCollectionStoreRequest('readwrite', store => store.delete(getScopedCollectionKey(ownerId, collection))),
+    ),
+  );
 };


### PR DESCRIPTION
### Motivation
- Prevent persisted `users`/`newUsers` JSON from being shared across different signed-in accounts on the same origin by scoping stored records to the owner/UID. 
- Avoid race conditions where async IndexedDB restores overwrite newly selected files in the UI. 
- Reuse restored offline collections for the local indexing flow and ensure saved owner-scoped offline files are cleared on sign-out.

### Description
- IndexedDB storage now uses an owner-scoped key and exposes owner-aware helpers: `saveOfflineCollection(ownerId, collection, data)`, `loadOfflineCollection(ownerId, collection)`, `loadOfflineCollections(ownerId)` and `clearOfflineCollections(ownerId)` (changes in `src/utils/offlineCollectionsStorage.js`).
- `AddNewProfile.jsx` was updated to pass `ownerId` to load/save/clear calls, clear the current owner’s saved offline collections on sign-out, and seed the local-index modal with restored collections (changes in `src/components/AddNewProfile.jsx`).
- Added a change-version ref (`offlineCollectionsChangeVersionRef`) to the component to ignore stale async restore completions after the user manually selects/clears files, and increment the version on manual changes; restored collections are now applied to both `localExport*` and `pendingLocal*` state to unify export and local-index flows.
- Persisted files selected via both export and local-index file pickers into the owner-scoped IndexedDB entries and cleared pending/local states when saved data is cleared.

### Testing
- Ran `npm run lint:js -- --max-warnings=0` and the linter completed without errors. (success)
- Built a production bundle with `npm run build` and the build completed successfully. (success)
- Ran basic diff/check (`git diff --check`) to ensure no trivial whitespace/errors. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37f38be2288326ba6ff44c3b06a2f2)