### PR TITLE
Normalize legacy offline load values and restrict offline reaction filters

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -45,6 +45,9 @@ import {
   AddNewProfileOfflineLoadControls,
   OFFLINE_LOAD_FILTER,
   OFFLINE_LOAD_MODE,
+  OFFLINE_REACTION_FILTER_OPTIONS,
+  normalizeOfflineLoadFilter,
+  normalizeOfflineLoadMode,
   loadMoreUsersOffline as loadMoreUsersOfflineMode,
 } from './AddNewProfileOfflineLoad';
 import { makeUploadedInfo } from './makeUploadedInfo';
@@ -2667,7 +2670,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const buildListQueryKey = (mode, currentFilters = {}) => buildQueryKey(mode, currentFilters, '');
 
   const resolveFilterByLoadSortMode = mode => {
-    switch (mode) {
+    switch (normalizeOfflineLoadMode(mode)) {
       case LOAD_SORT_MODES.LAST_ACTION:
         return 'LAST_ACTION';
       case LOAD_SORT_MODES.LAST_ACTION2:
@@ -2709,7 +2712,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     : enabledSearchKeys;
 
   const handleLoadSortModeChange = useCallback(mode => {
-    setLoadSortMode(mode);
+    setLoadSortMode(normalizeOfflineLoadMode(mode));
   }, []);
 
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
@@ -6186,7 +6189,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setUserNotFound(false);
     }
 
-    setCurrentFilter(snapshot.currentFilter || '');
+    const restoredCurrentFilter = normalizeOfflineLoadFilter(snapshot.currentFilter || '');
+    const restoredLoadSortMode = normalizeOfflineLoadMode(snapshot.loadSortMode || 'GITnew');
+
+    setCurrentFilter(restoredCurrentFilter);
     setCurrentPage(snapshot.currentPage || 1);
     setHasMore(typeof snapshot.hasMore === 'boolean' ? snapshot.hasMore : true);
     setLastKey(snapshot.lastKey ?? null);
@@ -6197,7 +6203,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     if (snapshot.la2State) {
       la2StateRef.current = restoreLA2State(snapshot.la2State);
     }
-    setLoadSortMode(snapshot.loadSortMode || 'GITnew');
+    setLoadSortMode(restoredLoadSortMode);
     setSearch(snapshot.search || '');
     setHasSearched(Boolean(snapshot.hasSearched) || Object.keys(restoredUsers).length > 0);
     logProfileRestoreStep('previous-list:restore-complete-clear-profile-state', {
@@ -6754,6 +6760,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                       onChange={handleFilterChange}
                       storageKey={filterStorageKey}
                       bloodSearchKeyMode={searchIdAndSearchKeyOnlyMode || offlineLoadMode}
+                      reactionFilterOptions={offlineLoadMode ? OFFLINE_REACTION_FILTER_OPTIONS : undefined}
                       allowedFilterNames={(searchIdAndSearchKeyOnlyMode || offlineLoadMode) ? ['bloodGroup', 'rh', 'maritalStatus', 'contact', 'age', 'imt', 'height', 'role', 'userId', 'fields', 'csection', 'reaction', 'getInTouch'] : undefined}
                     />
                   </LoadOptionsPopover>

--- a/src/components/AddNewProfileOfflineLoad.jsx
+++ b/src/components/AddNewProfileOfflineLoad.jsx
@@ -3,6 +3,15 @@ import { loadQueries, normalizeQueryKey } from 'utils/cardIndex';
 
 export const OFFLINE_LOAD_FILTER = 'OFFLINE';
 export const OFFLINE_LOAD_MODE = 'offline';
+export const LEGACY_OFFLINE_LOAD_FILTER = 'OFLINE';
+export const LEGACY_OFFLINE_LOAD_MODE = 'ofline';
+export const OFFLINE_REACTION_FILTER_OPTIONS = [
+  { key: 'pastGetInTouch', label: 'past' },
+  { key: 'like', label: '❤️' },
+  { key: 'dislike', label: '✖' },
+];
+export const normalizeOfflineLoadFilter = filter => (filter === LEGACY_OFFLINE_LOAD_FILTER ? OFFLINE_LOAD_FILTER : filter);
+export const normalizeOfflineLoadMode = mode => (mode === LEGACY_OFFLINE_LOAD_MODE ? OFFLINE_LOAD_MODE : mode);
 export const OFFLINE_LOAD_BACKEND_PAGE_SIZE = 20;
 export const OFFLINE_FILTER_MAIN_OPTIONS = { requireCurrentOrPastGetInTouch: true };
 
@@ -23,12 +32,12 @@ export const AddNewProfileOfflineLoadControls = ({
         type="radio"
         name="load-sort-mode"
         value={OFFLINE_LOAD_MODE}
-        checked={loadSortMode === OFFLINE_LOAD_MODE}
+        checked={normalizeOfflineLoadMode(loadSortMode) === OFFLINE_LOAD_MODE}
         onChange={event => onModeChange(event.target.value)}
       />
       offline
     </SortModeLabel>
-    {loadSortMode === OFFLINE_LOAD_MODE && (
+    {normalizeOfflineLoadMode(loadSortMode) === OFFLINE_LOAD_MODE && (
       <LocalIndexActions>
         <button type="button" onClick={onPickUsersFile}>
           Обрати users.json {hasUsersFile ? '✅' : ''}
@@ -69,7 +78,6 @@ export const getOfflineFilteredIds = ({
     currentFilters,
     favoriteUsersData,
     dislikeUsersData,
-    OFFLINE_FILTER_MAIN_OPTIONS,
   );
 
   return filteredEntries

--- a/src/components/FilterPanel.jsx
+++ b/src/components/FilterPanel.jsx
@@ -129,6 +129,7 @@ const FilterPanel = ({
   nonAdminAllActive = false,
   allowedFilterNames,
   bloodSearchKeyMode = false,
+  reactionFilterOptions,
 }) => {
   const defaultFilters = useMemo(
     () => getDefaultFilters({ mode, nonAdminAllActive }),
@@ -177,6 +178,7 @@ const FilterPanel = ({
       hideCommentLength={hideCommentLength}
       mode={mode}
       bloodSearchKeyMode={bloodSearchKeyMode}
+      reactionFilterOptions={reactionFilterOptions}
       allowedFilterNames={allowedFilterNames}
     />
   );

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -24,10 +24,11 @@ export const SearchFilters = ({
   mode = 'default',
   allowedFilterNames,
   bloodSearchKeyMode = false,
+  reactionFilterOptions,
 }) => {
   let groups = [];
   const contactIconStyle = { display: 'inline-flex', alignItems: 'center' };
-  const reactionOptions = bloodSearchKeyMode
+  const reactionOptions = reactionFilterOptions || (bloodSearchKeyMode
     ? [
         { key: 'pastGetInTouch', label: 'past' },
         { key: 'futureGetInTouch', label: 'future' },
@@ -36,7 +37,7 @@ export const SearchFilters = ({
         { key: 'question', label: '?' },
         { key: 'none', label: 'no' },
       ]
-    : REACTION_FILTER_OPTIONS;
+    : REACTION_FILTER_OPTIONS);
 
   if (mode === 'matching') {
     groups = [


### PR DESCRIPTION
### Motivation
- Restore paths and UI started rejecting older local snapshots because legacy spellings `OFLINE`/`ofline` were no longer recognized, causing the offline radio to be unchecked after restore and breaking offline loads.
- Offline filter UI still exposed reaction options that contradict the offline-only getInTouch constraint, producing empty results when selected.
- Pre-hydration ID filtering applied a strict current/past getInTouch check which could drop stale exported IDs that would be valid after backend hydration.

### Description
- Add legacy constants and normalizers: `LEGACY_OFFLINE_LOAD_FILTER`, `LEGACY_OFFLINE_LOAD_MODE`, `normalizeOfflineLoadFilter`, and `normalizeOfflineLoadMode`, and use them when resolving/restoring load mode and when rendering the offline radio input.
- Define `OFFLINE_REACTION_FILTER_OPTIONS` and pass it into `FilterPanel` only when offline mode is active to limit reaction choices to offline-compatible options.
- Extend `FilterPanel` and `SearchFilters` to accept an optional `reactionFilterOptions` prop and prefer it over the blood-search-key variant when provided.
- Remove the pre-hydration `OFFLINE_FILTER_MAIN_OPTIONS` usage from the local-ID filtering pass so stale local IDs are not rejected before `hydrateOfflineIdsPage` can fetch backend-updated cards.

### Testing
- Ran `npm run lint:js -- --quiet` which completed without lint errors.
- Ran `npm test -- --watchAll=false --runTestsByPath src/components/Matching.sharedReactions.test.js`, which failed with several existing source-string expectation test failures in `Matching.sharedReactions.test.js` that appear unrelated to these offline-load changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37fc46cc288326ad395bf4d3b550dc)