### PR TITLE
Fix offline load filter restoration

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -45,6 +45,7 @@ import {
   AddNewProfileOfflineLoadControls,
   OFFLINE_LOAD_FILTER,
   OFFLINE_LOAD_MODE,
+  LEGACY_OFFLINE_LOAD_FILTER,
   OFFLINE_REACTION_FILTER_OPTIONS,
   normalizeOfflineLoadFilter,
   normalizeOfflineLoadMode,
@@ -6191,6 +6192,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     const restoredCurrentFilter = normalizeOfflineLoadFilter(snapshot.currentFilter || '');
     const restoredLoadSortMode = normalizeOfflineLoadMode(snapshot.loadSortMode || 'GITnew');
+
+    if (snapshot.currentFilter === LEGACY_OFFLINE_LOAD_FILTER && restoredCurrentFilter === OFFLINE_LOAD_FILTER) {
+      const legacyQueryKey = buildListQueryKey(LEGACY_OFFLINE_LOAD_FILTER, filters);
+      const restoredQueryKey = buildListQueryKey(restoredCurrentFilter, filters);
+      const legacyOfflineIds = getIdsByQuery(legacyQueryKey);
+      if (legacyOfflineIds.length && !getIdsByQuery(restoredQueryKey).length) {
+        setIdsForQuery(restoredQueryKey, legacyOfflineIds);
+        logProfileRestoreStep('previous-list:migrate-legacy-offline-query-ids', {
+          legacyQueryKey,
+          restoredQueryKey,
+          idsCount: legacyOfflineIds.length,
+        });
+      }
+    }
 
     setCurrentFilter(restoredCurrentFilter);
     setCurrentPage(snapshot.currentPage || 1);

--- a/src/components/AddNewProfile.offlineLoad.test.js
+++ b/src/components/AddNewProfile.offlineLoad.test.js
@@ -36,7 +36,7 @@ describe('AddNewProfile offline load mode', () => {
     const hydrateStart = offlineSource.indexOf('export const hydrateOfflineIdsPage');
     const loaderBody = offlineSource.slice(
       hydrateStart,
-      offlineSource.indexOf('};', offlineSource.indexOf('export const loadMoreUsersOffline'))
+      offlineSource.length
     );
 
     expect(offlineSource).toContain('export const OFFLINE_LOAD_BACKEND_PAGE_SIZE = 20');
@@ -44,6 +44,38 @@ describe('AddNewProfile offline load mode', () => {
     expect(loaderBody).toContain('fetchUsersByIds(pageIds)');
     expect(loaderBody).toContain('filterBackendHydratedOfflineUsers');
     expect(offlineSource).toContain('setIdsForQuery(queryKey, nextPassedIds)');
+  });
+
+  it('renders the offline current/future getInTouch reaction bucket', () => {
+    expect(offlineSource).toContain("{ key: 'futureGetInTouch', label: 'today/future' }");
+  });
+
+  it('migrates legacy offline query ids when restoring a previous list snapshot', () => {
+    const restoreBody = addNewProfileSource.slice(
+      addNewProfileSource.indexOf('const handleBackToPreviousList'),
+      addNewProfileSource.indexOf('setCurrentFilter(restoredCurrentFilter)')
+    );
+
+    expect(addNewProfileSource).toContain('LEGACY_OFFLINE_LOAD_FILTER');
+    expect(restoreBody).toContain('snapshot.currentFilter === LEGACY_OFFLINE_LOAD_FILTER');
+    expect(restoreBody).toContain('buildListQueryKey(LEGACY_OFFLINE_LOAD_FILTER, filters)');
+    expect(restoreBody).toContain('setIdsForQuery(restoredQueryKey, legacyOfflineIds)');
+  });
+
+  it('uses backend filter options locally and looks ahead before advertising more offline pages', () => {
+    const getIdsBody = offlineSource.slice(
+      offlineSource.indexOf('export const getOfflineFilteredIds'),
+      offlineSource.indexOf('export const sortOfflineUsersByGetInTouch')
+    );
+    const loaderBody = offlineSource.slice(
+      offlineSource.indexOf('export const loadMoreUsersOffline'),
+      offlineSource.length
+    );
+
+    expect(getIdsBody).toContain('OFFLINE_FILTER_MAIN_OPTIONS');
+    expect(loaderBody).toContain('const lookaheadCount = requestedCount + 1');
+    expect(loaderBody).toContain('Object.keys(hydratedUsers).length < lookaheadCount');
+    expect(loaderBody).toContain('const nextHasMore = hydratedIds.length > requestedCount');
   });
 
   it('removes edited offline cards from the query cache and loads the next card', () => {

--- a/src/components/AddNewProfileOfflineLoad.jsx
+++ b/src/components/AddNewProfileOfflineLoad.jsx
@@ -7,6 +7,7 @@ export const LEGACY_OFFLINE_LOAD_FILTER = 'OFLINE';
 export const LEGACY_OFFLINE_LOAD_MODE = 'ofline';
 export const OFFLINE_REACTION_FILTER_OPTIONS = [
   { key: 'pastGetInTouch', label: 'past' },
+  { key: 'futureGetInTouch', label: 'today/future' },
   { key: 'like', label: '❤️' },
   { key: 'dislike', label: '✖' },
 ];
@@ -78,6 +79,7 @@ export const getOfflineFilteredIds = ({
     currentFilters,
     favoriteUsersData,
     dislikeUsersData,
+    OFFLINE_FILTER_MAIN_OPTIONS,
   );
 
   return filteredEntries
@@ -221,7 +223,9 @@ export const loadMoreUsersOffline = async ({
     filters: summarizeLoadFiltersForLog(currentFilters),
   });
 
-  while (Object.keys(hydratedUsers).length < requestedCount && cursor < localIds.length) {
+  const lookaheadCount = requestedCount + 1;
+
+  while (Object.keys(hydratedUsers).length < lookaheadCount && cursor < localIds.length) {
     const idsToHydrate = localIds.slice(cursor, cursor + OFFLINE_LOAD_BACKEND_PAGE_SIZE);
     cursor += idsToHydrate.length;
     attemptedIds.push(...idsToHydrate);
@@ -256,7 +260,7 @@ export const loadMoreUsersOffline = async ({
   }
 
   const hydratedIds = Object.keys(hydratedUsers);
-  const nextHasMore = nextPassedIds.length < localIds.length;
+  const nextHasMore = hydratedIds.length > requestedCount;
   setDateOffset21(nextPassedIds.length);
   setHasMore(nextHasMore);
 


### PR DESCRIPTION
### Motivation
- Offline mode hid the current/today reaction bucket which made cards due today unfixable when restoring an offline snapshot. 
- Local offline ID filtering did not reapply the backend getInTouch guard, causing rejected local candidates to be advertised as pages. 
- Legacy offline query ids stored under `OFLINE` could be left behind after normalizing to `OFFLINE`, causing rehydration duplicates and incorrect paging.

### Description
- Added a `futureGetInTouch` reaction option to `OFFLINE_REACTION_FILTER_OPTIONS` to expose today/future getInTouch cards in offline mode. (`src/components/AddNewProfileOfflineLoad.jsx`)
- Reused the backend filter options for local offline ID filtering by passing `OFFLINE_FILTER_MAIN_OPTIONS` into `getOfflineFilteredIds`, ensuring local candidates are filtered consistently before hydration. (`src/components/AddNewProfileOfflineLoad.jsx`)
- Changed offline pagination to perform a one-item lookahead (`lookaheadCount = requestedCount + 1`) and derive `hasMore` from the count of accepted/hydrated cards instead of attempted local ids, avoiding advertising pages that contain only rejected ids. (`src/components/AddNewProfileOfflineLoad.jsx`)
- When restoring a previous list snapshot, detect the legacy `OFLINE` filter and migrate stored query ids to the normalized `OFFLINE` query key so pagination continues from the preserved cursor. (`src/components/AddNewProfile.jsx`)
- Extended unit tests to cover the offline current/future bucket, legacy query-id migration, local backend filter usage, and lookahead-based paging. (`src/components/AddNewProfile.offlineLoad.test.js`)

### Testing
- Ran `npm test -- --runTestsByPath src/components/AddNewProfile.offlineLoad.test.js --watchAll=false`, and the test suite passed (all tests in that file passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38436bd2d083268e07d6c8716b6e38)