### PR TITLE
Fix AddNewProfile hook dependency warning

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2664,11 +2664,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     [filters]
   );
 
-  const buildQueryKey = (mode, currentFilters = {}, term = '') =>
+  const buildQueryKey = useCallback((mode, currentFilters = {}, term = '') =>
     normalizeQueryKey(
       `${mode || 'all'}:${term || ''}:${serializeQueryFilters(currentFilters)}`,
-    );
-  const buildListQueryKey = (mode, currentFilters = {}) => buildQueryKey(mode, currentFilters, '');
+    ), []);
+  const buildListQueryKey = useCallback(
+    (mode, currentFilters = {}) => buildQueryKey(mode, currentFilters, ''),
+    [buildQueryKey],
+  );
 
   const resolveFilterByLoadSortMode = mode => {
     switch (normalizeOfflineLoadMode(mode)) {
@@ -6226,7 +6229,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       restoredUsersCount: Object.keys(restoredUsers).length,
     });
     setState({});
-  }, [location.pathname, location.search, navigate, setSearch, setState, state?.userId]);
+  }, [buildListQueryKey, filters, location.pathname, location.search, navigate, setSearch, setState, state?.userId]);
 
   useEffect(() => {
     if (!state?.userId) {


### PR DESCRIPTION
### Motivation
- Remove a React Hook lint warning caused by using unstable helpers inside a hook dependency array so effects behave predictably.

### Description
- Memoized the query-key builder `buildQueryKey` with `useCallback` to make it stable across renders.
- Wrapped `buildListQueryKey` in `useCallback` and made it depend on the memoized `buildQueryKey`.
- Added the missing `buildListQueryKey` and `filters` entries to the dependency array of the previous-list restore callback `useEffect` in `src/components/AddNewProfile.jsx`.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx` and it completed without new lint errors related to the change.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38479c3c0c8326a4db2594fd419ef0)