### PR TITLE
Centralize user state updates and refactor TopBlock usage; add userStateUpdate utilities and tests

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -95,7 +95,7 @@ import {
 } from 'utils/stimulationShortcutStorage';
 // import ExcelToJson from './ExcelToJson';
 import { saveToContact, saveToContactCsv } from './ExportContact';
-import { renderTopBlock } from './smallCard/renderTopBlock';
+import { TopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
 import { ReactComponent as BabyIcon } from 'assets/icons/baby.svg';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
@@ -6533,21 +6533,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         {isResolvingEditMode ? null : state.userId ? (
           <>
             <div style={{ ...coloredCard(), marginBottom: '8px' }}>
-              {renderTopBlock({
-                userData: state,
-                setUsers,
-                setShowInfoModal,
-                setState,
-                setUserIdToDelete,
-                isFromListOfUsers: false,
-                favoriteUsers: favoriteUsersData,
-                setFavoriteUsers: setFavoriteUsersData,
-                dislikeUsers: dislikeUsersData,
-                setDislikeUsers: setDislikeUsersData,
-                currentFilter,
-                isDateInRange,
-                onOpenMedications: openMedicationsModal,
-                topBlueAction: {
+              <TopBlock
+                userData={state}
+                setUsers={setUsers}
+                setShowInfoModal={setShowInfoModal}
+                setState={setState}
+                setUserIdToDelete={setUserIdToDelete}
+                isFromListOfUsers={false}
+                favoriteUsers={favoriteUsersData}
+                setFavoriteUsers={setFavoriteUsersData}
+                dislikeUsers={dislikeUsersData}
+                setDislikeUsers={setDislikeUsersData}
+                currentFilter={currentFilter}
+                isDateInRange={isDateInRange}
+                onOpenMedications={openMedicationsModal}
+                topBlueAction={{
                   onClick: handleBackToPreviousList,
                   title: 'Назад до попереднього списку',
                   ariaLabel: 'Назад до попереднього списку',
@@ -6569,16 +6569,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                       />
                     </svg>
                   ),
-                },
-                overlayFieldAdditions: {},
-                onSubmitHistorySnapshot: handleTopBlockSubmitHistorySnapshot,
-                stimulationScheduleToggle: shouldShowSchedule
+                }}
+                overlayFieldAdditions={{}}
+                onSubmitHistorySnapshot={handleTopBlockSubmitHistorySnapshot}
+                stimulationScheduleToggle={shouldShowSchedule
                   ? {
                       visible: isStimulationScheduleVisible,
                       onToggle: () => setIsStimulationScheduleVisible(prev => !prev),
                     }
-                  : null,
-              })}
+                  : null}
+              />
             </div>
             {shouldShowSchedule && isStimulationScheduleVisible && state && (
               <div style={{ ...coloredCard(), marginBottom: '8px' }}>

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -13,7 +13,7 @@ import {
 import { ProfileForm } from './ProfileForm';
 import { newUsersMirrorFieldNames } from './formFields';
 import { makeUploadedInfo } from './makeUploadedInfo';
-import { renderTopBlock } from './smallCard/renderTopBlock';
+import { TopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
 import { coloredCard } from './styles';
 import { updateCachedUser } from '../utils/cache';
@@ -961,21 +961,21 @@ const EditProfile = () => {
         <TopBlockSkeleton />
       ) : (
         <div style={{ ...coloredCard(), marginBottom: '8px' }}>
-          {renderTopBlock({
-            userData: state,
-            setUsers: () => {},
-            setShowInfoModal: () => {},
-            setState,
-            setUserIdToDelete: () => {},
-            onOpenMedications: handleOpenMedications,
-            overlayFieldAdditions,
-            stimulationScheduleToggle: shouldShowSchedule
+          <TopBlock
+            userData={state}
+            setUsers={() => {}}
+            setShowInfoModal={() => {}}
+            setState={setState}
+            setUserIdToDelete={() => {}}
+            onOpenMedications={handleOpenMedications}
+            overlayFieldAdditions={overlayFieldAdditions}
+            stimulationScheduleToggle={shouldShowSchedule
               ? {
                   visible: isStimulationScheduleVisible,
                   onToggle: () => setIsStimulationScheduleVisible(prev => !prev),
                 }
-              : null,
-          })}
+              : null}
+          />
         </div>
       )}
       {shouldShowSchedule && isStimulationScheduleVisible && state && (

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { coloredCard, FadeContainer } from './styles';
 import { makeNewUser } from './config';
-import { renderTopBlock } from './smallCard/renderTopBlock';
+import { TopBlock } from './smallCard/renderTopBlock';
 import { btnCompare } from './smallCard/btnCompare';
 import { btnMore } from './smallCard/btnMore';
 import { renderAllFields } from './ProfileForm';
@@ -53,29 +53,29 @@ const UserCard = ({
   return (
     <div>
       <div style={{ ...coloredCard(role), marginBottom: '8px' }}>
-        {renderTopBlock({
-          userData,
-          setUsers,
-          setShowInfoModal,
-          setState,
-          setUserIdToDelete,
-          isFromListOfUsers: true,
-          favoriteUsers,
-          setFavoriteUsers,
-          dislikeUsers,
-          setDislikeUsers,
-          currentFilter,
-          isDateInRange,
-          onOpenMedications,
-          setSearch,
-          additionalActions: actions,
-          stimulationScheduleToggle: shouldShowSchedule
+        <TopBlock
+          userData={userData}
+          setUsers={setUsers}
+          setShowInfoModal={setShowInfoModal}
+          setState={setState}
+          setUserIdToDelete={setUserIdToDelete}
+          isFromListOfUsers={true}
+          favoriteUsers={favoriteUsers}
+          setFavoriteUsers={setFavoriteUsers}
+          dislikeUsers={dislikeUsers}
+          setDislikeUsers={setDislikeUsers}
+          currentFilter={currentFilter}
+          isDateInRange={isDateInRange}
+          onOpenMedications={onOpenMedications}
+          setSearch={setSearch}
+          additionalActions={actions}
+          stimulationScheduleToggle={shouldShowSchedule
             ? {
                 visible: isStimulationScheduleVisible,
                 onToggle: () => setIsStimulationScheduleVisible(prev => !prev),
               }
-            : null,
-        })}
+            : null}
+        />
       </div>
       {shouldShowSchedule && isStimulationScheduleVisible && (
         <div style={{ ...coloredCard(role), marginBottom: '8px' }}>

--- a/src/components/smallCard/actions.js
+++ b/src/components/smallCard/actions.js
@@ -7,6 +7,7 @@ import {
 import { updateCachedUser } from "utils/cache";
 import { formatDateAndFormula, formatDateToServer } from "components/inputValidations";
 import { makeUploadedInfo } from "components/makeUploadedInfo";
+import { getUserStateShape, markUserPendingRemove, updateUserInState } from "./userStateUpdate";
 
 export const handleChange = (
   setUsers,
@@ -88,41 +89,18 @@ export const handleChange = (
     }
 
     const applyUpdates = prevState => {
-      const keys = prevState && typeof prevState === 'object' && !Array.isArray(prevState)
-        ? Object.keys(prevState)
-        : [];
-
-      const isMultiple =
-        keys.length > 0 &&
-        keys.every(id => prevState[id] && typeof prevState[id] === 'object');
-
-      if (!isMultiple) {
-        const newState = { ...prevState, ...formattedWithAction };
+      return updateUserInState(prevState, userId, currentUser => {
+        const updatedUser = { ...currentUser, ...formattedWithAction };
         removeKeys.forEach(key => {
-          delete newState[key];
+          delete updatedUser[key];
         });
         clickFlag &&
           submitWithHistory(
-            { ...newState, userId: userId || newState.userId },
+            { ...updatedUser, userId: userId || updatedUser.userId },
             removeKeys,
           );
-        return newState;
-      } else {
-        const newState = {
-          ...prevState,
-          [userId]: {
-            ...prevState[userId],
-            ...formattedWithAction,
-          },
-        };
-        removeKeys.forEach(key => {
-          if (newState[userId]) {
-            delete newState[userId][key];
-          }
-        });
-        clickFlag && submitWithHistory({ ...newState[userId], userId }, removeKeys);
-        return newState;
-      }
+        return updatedUser;
+      });
     };
 
     invokeSetUsers(applyUpdates);
@@ -133,16 +111,7 @@ export const handleChange = (
       opts.isDateInRange &&
       !opts.isDateInRange(formatted.getInTouch)
     ) {
-      invokeSetUsers(prev => {
-        if (!prev || typeof prev !== 'object') {
-          return prev;
-        }
-        const copy = { ...prev };
-        if (copy[userId]) {
-          copy[userId]._pendingRemove = true;
-        }
-        return copy;
-      });
+      invokeSetUsers(prev => markUserPendingRemove(prev, userId));
     }
     return;
   }
@@ -175,39 +144,7 @@ export const handleChange = (
 
   if (setState) {
     invokeSetUsers(prevState => {
-      // console.log('prevState!!!!!!!!! :>> ', prevState);
-      // Зроблено в основному для видалення юзера серед масиву карточок, а не з середини
-
-      const keys = prevState && typeof prevState === 'object' && !Array.isArray(prevState)
-        ? Object.keys(prevState)
-        : [];
-
-      const isMultiple =
-        keys.length > 0 &&
-        keys.every(id => prevState[id] && typeof prevState[id] === 'object');
-
-      if (!isMultiple) {
-        const newState = { ...prevState };
-        if ((key === 'lastDelivery' || key === 'getInTouch') && !newValue) {
-          delete newState[key];
-        } else {
-          newState[key] = newValue;
-        }
-        if (click) {
-          newState.lastAction = Date.now();
-        }
-        click &&
-          submitWithHistory(
-            { ...newState, userId: userId || newState.userId },
-            removalKeys,
-          );
-        return newState;
-      } else {
-        const currentUser = prevState?.[userId];
-        if (!currentUser || typeof currentUser !== 'object') {
-          return prevState;
-        }
-
+      return updateUserInState(prevState, userId, currentUser => {
         const updatedUser =
           (key === 'lastDelivery' || key === 'getInTouch') && !newValue
             ? (() => {
@@ -218,51 +155,34 @@ export const handleChange = (
         if (click) {
           updatedUser.lastAction = Date.now();
         }
-
-        const newState = {
-          ...prevState,
-          [userId]: updatedUser,
-        };
         click &&
           submitWithHistory(
-            { ...newState[userId], userId },
+            { ...updatedUser, userId: userId || updatedUser.userId },
             removalKeys,
           );
-        return newState;
-      }
+        return updatedUser;
+      });
     });
   } else {
     invokeSetUsers(prevState => {
-      if (!prevState || typeof prevState !== 'object') {
-        return prevState;
-      }
-
-      const currentUser = prevState[userId];
-      if (!currentUser || typeof currentUser !== 'object') {
-        return prevState;
-      }
-
-      const updatedUser =
-        (key === 'lastDelivery' || key === 'getInTouch') && !newValue
-          ? (() => {
-              const { [key]: _, ...rest } = currentUser;
-              return rest;
-            })()
-          : { ...currentUser, [key]: newValue };
-      if (click) {
-        updatedUser.lastAction = Date.now();
-      }
-
-      const newState = {
-        ...prevState,
-        [userId]: updatedUser,
-      };
-      click &&
-        submitWithHistory(
-          { ...newState[userId], userId },
-          removalKeys,
-        );
-      return newState;
+      return updateUserInState(prevState, userId, currentUser => {
+        const updatedUser =
+          (key === 'lastDelivery' || key === 'getInTouch') && !newValue
+            ? (() => {
+                const { [key]: _, ...rest } = currentUser;
+                return rest;
+              })()
+            : { ...currentUser, [key]: newValue };
+        if (click) {
+          updatedUser.lastAction = Date.now();
+        }
+        click &&
+          submitWithHistory(
+            { ...updatedUser, userId: userId || updatedUser.userId },
+            removalKeys,
+          );
+        return updatedUser;
+      });
     });
   }
 
@@ -276,11 +196,7 @@ export const handleChange = (
       if (!prev || typeof prev !== 'object') {
         return prev;
       }
-      const copy = { ...prev };
-      if (copy[userId]) {
-        copy[userId]._pendingRemove = true;
-      }
-      return copy;
+      return markUserPendingRemove(prev, userId);
     });
   }
 };
@@ -383,37 +299,26 @@ export const removeField = (
   };
 
   setUsers(prev => {
-    const isMultiple =
-      prev &&
-      typeof prev === 'object' &&
-      !Array.isArray(prev) &&
-      Object.keys(prev).every(id => typeof prev[id] === 'object');
-
-    if (isMultiple) {
-      const targetUser = prev[userId];
-      const { changed, value } = removePath(targetUser);
-      if (!changed) {
-        return prev;
+    const shape = getUserStateShape(prev);
+    let submitted = false;
+    const next = updateUserInState(prev, userId, currentUser => {
+      const { changed, value } = removePath(currentUser);
+      if (!changed) return currentUser;
+      const updated = value ?? {};
+      const resolvedUserId = userId || updated.userId;
+      if (resolvedUserId) {
+        submitted = true;
+        triggerHistorySnapshot({ ...updated, userId: resolvedUserId });
+        handleSubmit({ ...updated, userId: resolvedUserId }, 'overwrite', removalList);
       }
-      const updatedUser = value ?? {};
-      const newState = { ...prev, [userId]: updatedUser };
-      triggerHistorySnapshot({ ...updatedUser, userId });
-      handleSubmit({ ...updatedUser, userId }, 'overwrite', removalList);
-      return newState;
+      return updated;
+    });
+
+    if (shape === 'unknown' || submitted || next !== prev) {
+      return next;
     }
 
-    const { changed, value } = removePath(prev);
-    if (!changed) {
-      return prev;
-    }
-    const updated = value ?? {};
-    const resolvedUserId = userId || updated.userId;
-    if (!resolvedUserId) {
-      return updated;
-    }
-    triggerHistorySnapshot({ ...updated, userId: resolvedUserId });
-    handleSubmit({ ...updated, userId: resolvedUserId }, 'overwrite', removalList);
-    return updated;
+    return prev;
   });
 };
 

--- a/src/components/smallCard/fieldDeliveryInfo.js
+++ b/src/components/smallCard/fieldDeliveryInfo.js
@@ -3,7 +3,20 @@ import { utilCalculateMonthsAgo } from './utilCalculateMonthsAgo';
 import { AttentionButton } from 'components/styles';
 import { formatDateToDisplay } from 'components/inputValidations';
 
-export const fieldDeliveryInfo = (setUsers, setState, userData, submitOptions = {}) => {
+export const fieldDeliveryInfo = (args, legacySetState, legacyUserData, legacySubmitOptions = {}) => {
+  const {
+    setUsers,
+    setState,
+    userData,
+    submitOptions = {},
+  } = args && typeof args === 'object' && 'userData' in args
+    ? args
+    : {
+        setUsers: args,
+        setState: legacySetState,
+        userData: legacyUserData,
+        submitOptions: legacySubmitOptions,
+      };
   const { ownKids, lastDelivery, csection } = userData;
   const formattedLastDelivery = formatDateToDisplay(lastDelivery);
 

--- a/src/components/smallCard/fieldGetInTouch.js
+++ b/src/components/smallCard/fieldGetInTouch.js
@@ -1,4 +1,5 @@
 import { handleChange } from './actions';
+import { updateUserInState } from './userStateUpdate';
 import {
   formatDateToDisplay,
   formatDateAndFormula,
@@ -13,14 +14,33 @@ import {
 } from './compactDateRowStyles';
 
 export const fieldGetInTouch = (
-  userData,
-  setUsers,
-  setState,
-  currentFilter,
-  isDateInRange,
-  submitOptions = {},
-  trailingActions = null,
+  args,
+  legacySetUsers,
+  legacySetState,
+  legacyCurrentFilter,
+  legacyIsDateInRange,
+  legacySubmitOptions = {},
+  legacyTrailingActions = null,
 ) => {
+  const {
+    userData,
+    setUsers,
+    setState,
+    currentFilter,
+    isDateInRange,
+    submitOptions = {},
+    trailingActions = null,
+  } = args && typeof args === 'object' && 'userData' in args
+    ? args
+    : {
+        userData: args,
+        setUsers: legacySetUsers,
+        setState: legacySetState,
+        currentFilter: legacyCurrentFilter,
+        isDateInRange: legacyIsDateInRange,
+        submitOptions: legacySubmitOptions,
+        trailingActions: legacyTrailingActions,
+      };
   const handleAddDays = days => {
     const currentDate = new Date();
     currentDate.setDate(currentDate.getDate() + days);
@@ -62,26 +82,10 @@ export const fieldGetInTouch = (
           return prev;
         }
 
-        if (Array.isArray(prev)) {
-          return prev.map(item =>
-            item?.userId === targetId
-              ? { ...item, getInTouch: nextValue }
-              : item,
-          );
-        }
-
-        if (typeof prev === 'object') {
-          const current = prev[targetId];
-          if (!current || typeof current !== 'object') {
-            return prev;
-          }
-          return {
-            ...prev,
-            [targetId]: { ...current, getInTouch: nextValue },
-          };
-        }
-
-        return prev;
+        return updateUserInState(prev, targetId, current => ({
+          ...current,
+          getInTouch: nextValue,
+        }));
       });
     }
   };

--- a/src/components/smallCard/fieldRole.js
+++ b/src/components/smallCard/fieldRole.js
@@ -1,7 +1,20 @@
 import { handleChange } from './actions';
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
-export const fieldRole = (userData, setUsers, setState, submitOptions = {}) => {
+export const fieldRole = (args, legacySetUsers, legacySetState, legacySubmitOptions = {}) => {
+  const {
+    userData,
+    setUsers,
+    setState,
+    submitOptions = {},
+  } = args && typeof args === 'object' && 'userData' in args
+    ? args
+    : {
+        userData: args,
+        setUsers: legacySetUsers,
+        setState: legacySetState,
+        submitOptions: legacySubmitOptions,
+      };
   const handleSetRole = role => {
     handleChange(setUsers, setState, userData.userId, 'role', role, true, submitOptions);
   };

--- a/src/components/smallCard/fieldWritter.js
+++ b/src/components/smallCard/fieldWritter.js
@@ -1,7 +1,20 @@
 import { handleChange } from './actions';
 const { OrangeBtn, UnderlinedInput } = require('components/styles');
 
-export const fieldWriter = (userData, setUsers, setState, submitOptions = {}) => {
+export const fieldWriter = (args, legacySetUsers, legacySetState, legacySubmitOptions = {}) => {
+  const {
+    userData,
+    setUsers,
+    setState,
+    submitOptions = {},
+  } = args && typeof args === 'object' && 'userData' in args
+    ? args
+    : {
+        userData: args,
+        setUsers: legacySetUsers,
+        setState: legacySetState,
+        submitOptions: legacySubmitOptions,
+      };
   const handleCodeClick = code => {
     let currentWriter = userData.writer || '';
     let updatedCodes = currentWriter?.split(', ').filter(item => item !== code); // Видаляємо, якщо є

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -9,6 +9,7 @@ import { fieldWriter } from './fieldWritter';
 import { fieldContacts } from './fieldContacts';
 import { fieldGetInTouch } from './fieldGetInTouch';
 import { handleChange } from './actions';
+import { updateUserInState } from './userStateUpdate';
 import { fieldRole } from './fieldRole';
 import { FieldLastCycle } from './fieldLastCycle';
 import { FieldComment } from './FieldComment';
@@ -518,7 +519,7 @@ const extractMultiDataComments = cardData => {
   return normalized.filter(comment => comment.text);
 };
 
-const TopBlock = ({
+export const TopBlock = ({
   userData,
   setUsers,
   setShowInfoModal,
@@ -646,17 +647,9 @@ const TopBlock = ({
     if (typeof setUsers === 'function') {
       setUsers(prev => {
         if (Array.isArray(prev)) {
-          return prev.map(item => (item?.userId === cardData.userId ? optimisticCard : item));
+          return updateUserInState(prev, cardData.userId, () => optimisticCard);
         }
-        if (prev && typeof prev === 'object') {
-          const current = prev[cardData.userId];
-          if (!current) return prev;
-          return {
-            ...prev,
-            [cardData.userId]: optimisticCard,
-          };
-        }
-        return prev;
+        return updateUserInState(prev, cardData.userId, () => optimisticCard);
       });
     }
     if (typeof setState === 'function' && !isFromListOfUsers) {
@@ -751,13 +744,7 @@ const TopBlock = ({
 
         if (setUsers) {
           setUsers(prev => {
-            if (Array.isArray(prev)) {
-              return prev.map(u => (u.userId === cardData.userId ? backendCard : u));
-            }
-            if (typeof prev === 'object' && prev !== null) {
-              return { ...prev, [cardData.userId]: backendCard };
-            }
-            return prev;
+            return updateUserInState(prev, cardData.userId, () => backendCard);
           });
         }
 
@@ -793,7 +780,20 @@ const TopBlock = ({
   const cardRole = cardData.role || cardData.userRole;
   const displayRole = cardRole || 'role';
   const identityMeta = renderIdentityMeta(cardData);
-  const deliveryInfo = fieldDeliveryInfo(setUsers, setState, cardData, submitOptions);
+  const updateContext = {
+    mode: isFromListOfUsers ? 'list' : 'single',
+    userId: cardData.userId,
+    setCurrentUser: setState,
+    setUserCollection: setUsers,
+  };
+
+  const deliveryInfo = fieldDeliveryInfo({
+    userData: cardData,
+    setUsers,
+    setState,
+    submitOptions,
+    updateContext,
+  });
 
   const handleDetailsRefresh = async event => {
     event.stopPropagation();
@@ -1054,7 +1054,7 @@ const TopBlock = ({
         </div>
         {isRoleEditorOpen && (
           <div style={roleEditorStyle} onClick={event => event.stopPropagation()}>
-            {fieldRole(cardData, setUsers, setState, submitOptions)}
+            {fieldRole({ userData: cardData, setUsers, setState, submitOptions, updateContext })}
           </div>
         )}
         {renderOverlayEntries(['surname', 'name', 'fathersname'])}
@@ -1110,15 +1110,16 @@ const TopBlock = ({
       </div>
       <div style={statusRowStyle}>
         <div style={getInTouchStatusItemStyle}>
-          {fieldGetInTouch(
-            cardData,
+          {fieldGetInTouch({
+            userData: cardData,
             setUsers,
             setState,
             currentFilter,
             isDateInRange,
             submitOptions,
-            getInTouchReactionActions,
-          )}
+            trailingActions: getInTouchReactionActions,
+            updateContext,
+          })}
         </div>
         {!hasHiddenCycleFieldRole && (
           <div style={statusItemStyle}>
@@ -1148,7 +1149,7 @@ const TopBlock = ({
         {renderOverlayEntries(['phone', 'phone2', 'phone3', 'telegram', 'email', 'facebook', 'instagram', 'ameblo', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'vk'])}
       </div>
       <div style={commentsSectionStyle}>
-        {fieldWriter(cardData, setUsers, setState, submitOptions)}
+        {fieldWriter({ userData: cardData, setUsers, setState, submitOptions, updateContext })}
         <FieldComment
           userData={cardData}
           setUsers={setUsers}

--- a/src/components/smallCard/userStateUpdate.js
+++ b/src/components/smallCard/userStateUpdate.js
@@ -1,0 +1,44 @@
+export const getUserStateShape = state => {
+  if (Array.isArray(state)) return 'array';
+  if (!state || typeof state !== 'object') return 'unknown';
+  if (state.userId) return 'single';
+  const values = Object.values(state);
+  if (values.length > 0 && values.every(value => value && typeof value === 'object')) {
+    return 'map';
+  }
+  return 'single';
+};
+
+export const updateUserInState = (state, userId, updater) => {
+  if (!state || typeof updater !== 'function') return state;
+  const shape = getUserStateShape(state);
+
+  if (shape === 'array') {
+    let changed = false;
+    const next = state.map(item => {
+      if (!item || item.userId !== userId) return item;
+      const updated = updater(item);
+      if (updated !== item) changed = true;
+      return updated;
+    });
+    return changed ? next : state;
+  }
+
+  if (shape === 'map') {
+    const current = state[userId];
+    if (!current || typeof current !== 'object') return state;
+    const updated = updater(current);
+    return updated === current ? state : { ...state, [userId]: updated };
+  }
+
+  if (shape === 'single') {
+    if (state.userId && userId && state.userId !== userId) return state;
+    const updated = updater(state);
+    return updated === state ? state : updated;
+  }
+
+  return state;
+};
+
+export const markUserPendingRemove = (state, userId) =>
+  updateUserInState(state, userId, user => ({ ...user, _pendingRemove: true }));

--- a/src/components/smallCard/userStateUpdate.test.js
+++ b/src/components/smallCard/userStateUpdate.test.js
@@ -1,0 +1,43 @@
+import { markUserPendingRemove, updateUserInState } from './userStateUpdate';
+
+describe('userStateUpdate', () => {
+  it('updates one user in an array without changing other cards', () => {
+    const prev = [
+      { userId: 'a', writer: 'old' },
+      { userId: 'b', writer: 'keep' },
+    ];
+
+    expect(updateUserInState(prev, 'a', user => ({ ...user, writer: 'new' }))).toEqual([
+      { userId: 'a', writer: 'new' },
+      { userId: 'b', writer: 'keep' },
+    ]);
+  });
+
+  it('updates one user in an id-keyed map', () => {
+    const prev = {
+      a: { userId: 'a', role: 'ip' },
+      b: { userId: 'b', role: 'pp' },
+    };
+
+    expect(updateUserInState(prev, 'b', user => ({ ...user, role: 'ed' }))).toEqual({
+      a: { userId: 'a', role: 'ip' },
+      b: { userId: 'b', role: 'ed' },
+    });
+  });
+
+  it('updates a single card object', () => {
+    const prev = { userId: 'a', myComment: 'old' };
+
+    expect(updateUserInState(prev, 'a', user => ({ ...user, myComment: 'new' }))).toEqual({
+      userId: 'a',
+      myComment: 'new',
+    });
+  });
+
+  it('marks the matching user as pending removal in arrays', () => {
+    expect(markUserPendingRemove([{ userId: 'a' }, { userId: 'b' }], 'b')).toEqual([
+      { userId: 'a' },
+      { userId: 'b', _pendingRemove: true },
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace ad-hoc in-place state mutation logic across small card components with a single, predictable updater that supports array, map and single-card shapes.
- Convert the legacy `renderTopBlock` call-site API to a `TopBlock` React component and normalize field component argument shapes to simplify integration and props passing.
- Improve maintainability by centralizing pending-remove marking and user updates so UI updates are consistent regardless of how the user collection is represented.

### Description
- Added `src/components/smallCard/userStateUpdate.js` exporting `getUserStateShape`, `updateUserInState`, and `markUserPendingRemove` to standardize updates for array, id-keyed map and single-object states.
- Refactored many callers to use the new `TopBlock` component exported from `src/components/smallCard/renderTopBlock.js` instead of calling the old `renderTopBlock` helper, converting those call sites to JSX usage with normalized prop names.
- Updated `actions.js` to use `updateUserInState` and `markUserPendingRemove` to apply optimistic updates and pending removal flags, and simplified internal update logic accordingly.
- Changed several small-card field modules (`fieldDeliveryInfo`, `fieldGetInTouch`, `fieldRole`, `fieldWritter`) to accept a unified `args` object signature for `userData`, `setUsers`, `setState`, and `submitOptions`, and adjusted `renderTopBlock` to pass the new shapes and `updateContext` where needed.
- Added unit tests `src/components/smallCard/userStateUpdate.test.js` that cover array, map and single-card updates and the `markUserPendingRemove` helper.

### Testing
- Ran the new unit tests in `userStateUpdate.test.js` which exercise `updateUserInState` for array, map and single shapes and `markUserPendingRemove`, and all tests passed.
- Verified that components compile after the refactor by running the project test/build flow locally (unit tests and compilation completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38d9a63cd4832687571eaebb3f88c8)