### PR TITLE
Support backend `afterKeys` cursor for DATE2 paging and handle empty DATE2 batches

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2128,6 +2128,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isLoadOptionsOpen, setIsLoadOptionsOpen] = useState(false);
   const [loadRequestId, setLoadRequestId] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
+  const [dateAfterKeys2, setDateAfterKeys2] = useState(null);
   const [dateOffset21, setDateOffset21] = useState(0);
   const [dateOffsetLA, setDateOffsetLA] = useState(0);
   const la2StateRef = useRef(createInitialLA2State());
@@ -2168,6 +2169,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       lastKey,
       lastKey21,
       dateOffset2,
+      dateAfterKeys2,
       dateOffset21,
       dateOffsetLA,
       usersCount: countObjectKeys(users),
@@ -2181,6 +2183,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [
     currentFilter,
     dateOffset2,
+    dateAfterKeys2,
     dateOffset21,
     dateOffsetLA,
     downloadJsonFile,
@@ -2217,6 +2220,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       lastKey: lastKey ?? null,
       lastKey21: lastKey21 ?? null,
       dateOffset2,
+      dateAfterKeys2,
       dateOffset21,
       dateOffsetLA,
       la2State: currentFilter === LAST_ACTION2_FILTER ? serializeLA2State(la2StateRef.current) : undefined,
@@ -2247,6 +2251,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     lastKey,
     lastKey21,
     dateOffset2,
+    dateAfterKeys2,
     dateOffset21,
     dateOffsetLA,
     loadSortMode,
@@ -3029,6 +3034,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setCacheCount(0);
     setBackendCount(0);
     setDateOffsetLA(0);
+    setDateOffset2(0);
+    setDateAfterKeys2(null);
     setDateOffset21(0);
 
     if (!currentFilter) {
@@ -3720,6 +3727,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     appendLoadDebugLog('loadMoreUsersGitSimple:start', {
       queryMode: 'DATE2',
       dateOffset2,
+      hasBackendCursor: Boolean(dateAfterKeys2),
       pageSize: PAGE_SIZE,
       hasMore,
       filters: summarizeLoadFiltersForLog(currentFilters),
@@ -3765,13 +3773,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     appendLoadDebugLog('loadMoreUsersGitSimple:before-fetchFilteredUsersByPage', {
       queryMode: 'DATE2',
       dateOffset2,
+      hasBackendCursor: Boolean(dateAfterKeys2),
       pageSize: PAGE_SIZE,
       filters: summarizeLoadFiltersForLog(currentFilters),
     });
     let res;
     try {
       res = await fetchFilteredUsersByPage(
-        dateOffset2,
+        dateAfterKeys2 ? 0 : dateOffset2,
         undefined,
         id => fetchUserById(id),
         currentFilters,
@@ -3819,6 +3828,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         },
         {
           debugLog: (step, payload) => appendLoadDebugLog(step, payload),
+          afterKeys: dateAfterKeys2,
         },
       );
       appendLoadDebugLog('loadMoreUsersGitSimple:after-fetchFilteredUsersByPage', {
@@ -3866,8 +3876,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
 
     const nextOffset = Number.isFinite(Number(res?.lastKey)) ? Number(res.lastKey) : dateOffset2 + backendIds.length;
+    const nextVisibleOffset = dateAfterKeys2 ? dateOffset2 + backendIds.length : nextOffset;
     const nextHasMore = Boolean(res?.hasMore);
-    setDateOffset2(nextOffset);
+    setDateOffset2(nextVisibleOffset);
+    setDateAfterKeys2(res?.afterKeys || null);
     setHasMore(nextHasMore);
 
     const queryKey = buildListQueryKey('DATE2', currentFilters);
@@ -3880,7 +3892,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       backendCount: backendIds.length,
       loadedIdsCount: loadedIds.length,
       previousOffset: dateOffset2,
-      nextOffset,
+      nextOffset: nextVisibleOffset,
+      backendCursorOffset: nextOffset,
+      hasBackendCursor: Boolean(res?.afterKeys),
       hasMore: nextHasMore,
       targetVisibleCount: PAGE_SIZE,
       stopReason: backendIds.length >= PAGE_SIZE
@@ -4862,6 +4876,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     let more = hasMore;
     let cacheLoaded = 0;
     let backendLoaded = 0;
+    let emptyDate2Batches = 0;
 
     if (currentFilter === 'GITnew') {
       setCurrentPage(page);
@@ -4908,7 +4923,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       loaded += cacheCount + backendCount;
       more = nextMore;
       if (cacheCount + backendCount === 0 && nextMore) {
-        more = false;
+        if (currentFilter === 'DATE2') {
+          emptyDate2Batches += 1;
+          appendLoadDebugLog('handlePageChange:DATE2-empty-batch', {
+            page,
+            needed,
+            emptyDate2Batches,
+            hasMore: nextMore,
+          });
+          if (emptyDate2Batches >= 3) break;
+        } else {
+          more = false;
+        }
+      } else {
+        emptyDate2Batches = 0;
       }
     }
     setCacheCount(cacheLoaded);
@@ -6112,6 +6140,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setCurrentPage(1);
     setLastKey(null);
     setDateOffset2(0);
+    setDateAfterKeys2(null);
     setDateOffset21(0);
     setDateOffsetLA(0);
     resetLA2StateRef(la2StateRef);
@@ -6216,6 +6245,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setLastKey(snapshot.lastKey ?? null);
     setLastKey21(snapshot.lastKey21 ?? null);
     setDateOffset2(snapshot.dateOffset2 || 0);
+    setDateAfterKeys2(snapshot.dateAfterKeys2 || null);
     setDateOffset21(snapshot.dateOffset21 || 0);
     setDateOffsetLA(snapshot.dateOffsetLA || 0);
     if (snapshot.la2State) {

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -210,6 +210,9 @@ export async function fetchFilteredUsersByPage(
   let filtered = [];
   let backendHasMore = false;
   const debugLog = typeof debugOptions?.debugLog === 'function' ? debugOptions.debugLog : null;
+  const initialAfterKeys = debugOptions?.afterKeys && typeof debugOptions.afterKeys === 'object'
+    ? debugOptions.afterKeys
+    : null;
   const emitDebug = (step, payload = {}) => {
     if (!debugLog) return;
     debugLog(step, payload);
@@ -267,7 +270,7 @@ export async function fetchFilteredUsersByPage(
 
   if (hasCustomFetchDateFn) {
     let afterKey = null;
-    let afterKeys = null;
+    let afterKeys = initialAfterKeys;
     let dateHasMore = true;
     while (filtered.length < target && dateHasMore) {
       const fetchLimit = limit - filtered.length;
@@ -296,13 +299,14 @@ export async function fetchFilteredUsersByPage(
       users: customUsers,
       lastKey: customNextOffset,
       hasMore: filtered.length > startOffset + PAGE_SIZE || dateHasMore,
+      afterKeys,
     };
   }
 
   const dayOffset = null;
   const invalidIndex = null;
 
-  let orderedAfterKeys = null;
+  let orderedAfterKeys = initialAfterKeys;
   while (filtered.length < target) {
     emitDebug('fetchFilteredUsersByPage:scan-progress', {
       dateStr: null,
@@ -355,5 +359,5 @@ export async function fetchFilteredUsersByPage(
     stopReason,
   });
 
-  return { users, lastKey: nextOffset, hasMore };
+  return { users, lastKey: nextOffset, hasMore, afterKeys: orderedAfterKeys };
 }

--- a/src/components/dateLoad.test.js
+++ b/src/components/dateLoad.test.js
@@ -155,6 +155,64 @@ describe('fetchFilteredUsersByPage', () => {
     expect(Object.keys(result.users)).toHaveLength(20);
     expect(result.hasMore).toBe(true);
   });
+
+  it('continues GIT scanning from returned backend afterKeys instead of visible offset only', async () => {
+    const database = await import('firebase/database');
+    database.getDatabase.mockReturnValue('db');
+    database.ref.mockImplementation((db, col) => `${db}/${col}`);
+    database.orderByChild.mockImplementation(child => ['orderByChild', child]);
+    database.startAfter.mockImplementation((value, key) => ['startAfter', value, key]);
+    database.limitToFirst.mockImplementation(value => ['limitToFirst', value]);
+    database.query.mockImplementation((...args) => args);
+
+    const makeSnapshot = entries => ({
+      exists: () => entries.length > 0,
+      forEach: callback => {
+        entries.forEach(([id, data]) => callback({ key: id, val: () => data }));
+      },
+    });
+    const firstNewUsersPage = Array.from({ length: 22 }, (_, index) => {
+      const id = `u${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-19', keep: true }];
+    });
+    const secondNewUsersPage = [
+      ['u23', { userId: 'u23', getInTouch: '2026-06-19', keep: true }],
+    ];
+
+    database.get.mockImplementation(async queryArgs => {
+      const path = queryArgs[0];
+      if (path === 'db/users') return makeSnapshot([]);
+      const hasCursor = queryArgs.some(arg => Array.isArray(arg) && arg[0] === 'startAfter');
+      return makeSnapshot(hasCursor ? secondNewUsersPage : firstNewUsersPage);
+    });
+
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const first = await fetchFilteredUsersByPage(
+      0,
+      undefined,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+    );
+    const second = await fetchFilteredUsersByPage(
+      0,
+      undefined,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+      undefined,
+      { afterKeys: first.afterKeys },
+    );
+
+    expect(Object.keys(first.users)).toEqual(firstNewUsersPage.slice(0, 20).map(([id]) => id));
+    expect(first.hasMore).toBe(true);
+    expect(first.afterKeys?.newUsers).toEqual({ value: '2026-06-19', key: 'u22' });
+    expect(Object.keys(second.users)).toEqual(['u23']);
+  });
 });
 
 describe('defaultFetchByDate', () => {


### PR DESCRIPTION
### Motivation
- Ensure DATE2 loads can continue scanning from backend-provided cursor metadata (`afterKeys`) instead of relying only on visible offsets to avoid missing users. 
- Persist and expose the backend cursor through UI state so subsequent loads resume correctly across reloads and restores. 
- Avoid infinite or premature stop conditions when `DATE2` fetches produce empty visible batches by limiting retry attempts.

### Description
- Added component state `dateAfterKeys2` and wired it into logs, snapshot save/restore, reload and manual `handleLoadUsers` resets via `setDateAfterKeys2`.
- Pass `afterKeys: dateAfterKeys2` into `fetchFilteredUsersByPage` call and store returned `afterKeys` from the backend response into `dateAfterKeys2` to continue backend scanning.
- Adjusted visible offset logic so `dateOffset2` reflects the visible offset while preserving the backend cursor offset (exposed as `backendCursorOffset` in logs) when `afterKeys` is present. 
- Implemented a safeguard in `handlePageChange` for `DATE2` that counts consecutive empty batches and stops after 3 empty batches, with debug logging. 
- Updated `fetchFilteredUsersByPage` to accept an initial `afterKeys` debug option, initialize internal cursors from it, and return `afterKeys` in the result for both custom `fetchDateFn` and default ordered fetch paths. 
- Added a unit test in `dateLoad.test.js` that verifies scanning continues from returned backend `afterKeys` and updated mocks for Firebase queries used in that test.

### Testing
- Ran unit tests with `jest`; the test suite including the new `fetchFilteredUsersByPage` test in `dateLoad.test.js` passed. 
- Verified the new test `continues GIT scanning from returned backend afterKeys instead of visible offset only` succeeds and existing date-related tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a396e622450832687758513e4937cb9)