### PR TITLE
Support backend afterKeys cursor for DATE2 loads and handle empty DATE2 batches

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2128,6 +2128,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isLoadOptionsOpen, setIsLoadOptionsOpen] = useState(false);
   const [loadRequestId, setLoadRequestId] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
+  const [dateAfterKeys2, setDateAfterKeys2] = useState(null);
   const [dateOffset21, setDateOffset21] = useState(0);
   const [dateOffsetLA, setDateOffsetLA] = useState(0);
   const la2StateRef = useRef(createInitialLA2State());
@@ -2168,6 +2169,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       lastKey,
       lastKey21,
       dateOffset2,
+      dateAfterKeys2,
       dateOffset21,
       dateOffsetLA,
       usersCount: countObjectKeys(users),
@@ -2181,6 +2183,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [
     currentFilter,
     dateOffset2,
+    dateAfterKeys2,
     dateOffset21,
     dateOffsetLA,
     downloadJsonFile,
@@ -2217,6 +2220,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       lastKey: lastKey ?? null,
       lastKey21: lastKey21 ?? null,
       dateOffset2,
+      dateAfterKeys2,
       dateOffset21,
       dateOffsetLA,
       la2State: currentFilter === LAST_ACTION2_FILTER ? serializeLA2State(la2StateRef.current) : undefined,
@@ -2247,6 +2251,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     lastKey,
     lastKey21,
     dateOffset2,
+    dateAfterKeys2,
     dateOffset21,
     dateOffsetLA,
     loadSortMode,
@@ -3029,6 +3034,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setCacheCount(0);
     setBackendCount(0);
     setDateOffsetLA(0);
+    setDateOffset2(0);
+    setDateAfterKeys2(null);
     setDateOffset21(0);
 
     if (!currentFilter) {
@@ -3720,6 +3727,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     appendLoadDebugLog('loadMoreUsersGitSimple:start', {
       queryMode: 'DATE2',
       dateOffset2,
+      hasBackendCursor: Boolean(dateAfterKeys2),
       pageSize: PAGE_SIZE,
       hasMore,
       filters: summarizeLoadFiltersForLog(currentFilters),
@@ -3765,13 +3773,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     appendLoadDebugLog('loadMoreUsersGitSimple:before-fetchFilteredUsersByPage', {
       queryMode: 'DATE2',
       dateOffset2,
+      hasBackendCursor: Boolean(dateAfterKeys2),
       pageSize: PAGE_SIZE,
       filters: summarizeLoadFiltersForLog(currentFilters),
     });
     let res;
     try {
       res = await fetchFilteredUsersByPage(
-        dateOffset2,
+        dateAfterKeys2 ? 0 : dateOffset2,
         undefined,
         id => fetchUserById(id),
         currentFilters,
@@ -3819,6 +3828,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         },
         {
           debugLog: (step, payload) => appendLoadDebugLog(step, payload),
+          afterKeys: dateAfterKeys2,
         },
       );
       appendLoadDebugLog('loadMoreUsersGitSimple:after-fetchFilteredUsersByPage', {
@@ -3866,8 +3876,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
 
     const nextOffset = Number.isFinite(Number(res?.lastKey)) ? Number(res.lastKey) : dateOffset2 + backendIds.length;
+    const nextVisibleOffset = dateAfterKeys2 ? dateOffset2 + backendIds.length : nextOffset;
     const nextHasMore = Boolean(res?.hasMore);
-    setDateOffset2(nextOffset);
+    setDateOffset2(nextVisibleOffset);
+    setDateAfterKeys2(res?.afterKeys || null);
     setHasMore(nextHasMore);
 
     const queryKey = buildListQueryKey('DATE2', currentFilters);
@@ -3880,7 +3892,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       backendCount: backendIds.length,
       loadedIdsCount: loadedIds.length,
       previousOffset: dateOffset2,
-      nextOffset,
+      nextOffset: nextVisibleOffset,
+      backendCursorOffset: nextOffset,
+      hasBackendCursor: Boolean(res?.afterKeys),
       hasMore: nextHasMore,
       targetVisibleCount: PAGE_SIZE,
       stopReason: backendIds.length >= PAGE_SIZE
@@ -4862,6 +4876,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     let more = hasMore;
     let cacheLoaded = 0;
     let backendLoaded = 0;
+    let emptyDate2Batches = 0;
 
     if (currentFilter === 'GITnew') {
       setCurrentPage(page);
@@ -4908,7 +4923,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       loaded += cacheCount + backendCount;
       more = nextMore;
       if (cacheCount + backendCount === 0 && nextMore) {
-        more = false;
+        if (currentFilter === 'DATE2') {
+          emptyDate2Batches += 1;
+          appendLoadDebugLog('handlePageChange:DATE2-empty-batch', {
+            page,
+            needed,
+            emptyDate2Batches,
+            hasMore: nextMore,
+          });
+          if (emptyDate2Batches >= 3) break;
+        } else {
+          more = false;
+        }
+      } else {
+        emptyDate2Batches = 0;
       }
     }
     setCacheCount(cacheLoaded);
@@ -6112,6 +6140,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setCurrentPage(1);
     setLastKey(null);
     setDateOffset2(0);
+    setDateAfterKeys2(null);
     setDateOffset21(0);
     setDateOffsetLA(0);
     resetLA2StateRef(la2StateRef);
@@ -6216,6 +6245,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setLastKey(snapshot.lastKey ?? null);
     setLastKey21(snapshot.lastKey21 ?? null);
     setDateOffset2(snapshot.dateOffset2 || 0);
+    setDateAfterKeys2(snapshot.dateAfterKeys2 || null);
     setDateOffset21(snapshot.dateOffset21 || 0);
     setDateOffsetLA(snapshot.dateOffsetLA || 0);
     if (snapshot.la2State) {

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -83,11 +83,10 @@ async function defaultFetchGetInTouchOrdered(limit, options = {}) {
   }
 
   orderedEntries.sort(([, a], [, b]) => String(a?.getInTouch || '').localeCompare(String(b?.getInTouch || '')));
-  const entries = orderedEntries.slice(0, fetchLimit);
-  const limitedEntries = entries.slice(0, Math.max(1, Number(limit) || PAGE_SIZE));
-  hasMore = hasMore || entries.length > limitedEntries.length;
-
-  return { entries: limitedEntries, hasMore, afterKeys: nextCursors };
+  // Return every row that advanced a collection cursor. Slicing the merged list
+  // after advancing per-collection cursors skips unreturned rows from the other
+  // collection on the next request.
+  return { entries: orderedEntries, hasMore, afterKeys: nextCursors };
 }
 
 const normalizeDateFetchResult = result => {
@@ -210,6 +209,9 @@ export async function fetchFilteredUsersByPage(
   let filtered = [];
   let backendHasMore = false;
   const debugLog = typeof debugOptions?.debugLog === 'function' ? debugOptions.debugLog : null;
+  const initialAfterKeys = debugOptions?.afterKeys && typeof debugOptions.afterKeys === 'object'
+    ? debugOptions.afterKeys
+    : null;
   const emitDebug = (step, payload = {}) => {
     if (!debugLog) return;
     debugLog(step, payload);
@@ -262,12 +264,13 @@ export async function fetchFilteredUsersByPage(
       rejectReasons,
     });
     emitProgress();
+    return newEntries.length;
   };
 
 
   if (hasCustomFetchDateFn) {
     let afterKey = null;
-    let afterKeys = null;
+    let afterKeys = initialAfterKeys;
     let dateHasMore = true;
     while (filtered.length < target && dateHasMore) {
       const fetchLimit = limit - filtered.length;
@@ -280,10 +283,11 @@ export async function fetchFilteredUsersByPage(
         break;
       }
       // eslint-disable-next-line no-await-in-loop
-      await appendFetchedEntries(entries);
+      const appendedCount = await appendFetchedEntries(entries);
       afterKey = batchResult.lastKey ?? entries[entries.length - 1][0];
       afterKeys = batchResult.afterKeys ?? afterKeys;
       dateHasMore = Boolean(batchResult.hasMore && (afterKey || afterKeys));
+      if (appendedCount === 0) break;
     }
 
     const customSlice = filtered.slice(startOffset, startOffset + PAGE_SIZE);
@@ -296,13 +300,14 @@ export async function fetchFilteredUsersByPage(
       users: customUsers,
       lastKey: customNextOffset,
       hasMore: filtered.length > startOffset + PAGE_SIZE || dateHasMore,
+      afterKeys,
     };
   }
 
   const dayOffset = null;
   const invalidIndex = null;
 
-  let orderedAfterKeys = null;
+  let orderedAfterKeys = initialAfterKeys;
   while (filtered.length < target) {
     emitDebug('fetchFilteredUsersByPage:scan-progress', {
       dateStr: null,
@@ -324,9 +329,9 @@ export async function fetchFilteredUsersByPage(
       isCurrentPastOrNonDateGetInTouch(user?.getInTouch, todayIso)
     ));
     // eslint-disable-next-line no-await-in-loop
-    await appendFetchedEntries(entries);
+    const appendedCount = await appendFetchedEntries(entries);
     backendHasMore = Boolean(batchResult.hasMore);
-    if (!batchResult.hasMore || rawEntries.length === 0) break;
+    if (!batchResult.hasMore || rawEntries.length === 0 || appendedCount === 0) break;
   }
 
   const slice = filtered.slice(startOffset, startOffset + PAGE_SIZE);
@@ -355,5 +360,5 @@ export async function fetchFilteredUsersByPage(
     stopReason,
   });
 
-  return { users, lastKey: nextOffset, hasMore };
+  return { users, lastKey: nextOffset, hasMore, afterKeys: orderedAfterKeys };
 }

--- a/src/components/dateLoad.test.js
+++ b/src/components/dateLoad.test.js
@@ -155,6 +155,110 @@ describe('fetchFilteredUsersByPage', () => {
     expect(Object.keys(result.users)).toHaveLength(20);
     expect(result.hasMore).toBe(true);
   });
+
+  it('continues GIT scanning from returned backend afterKeys instead of visible offset only', async () => {
+    const database = await import('firebase/database');
+    database.getDatabase.mockReturnValue('db');
+    database.ref.mockImplementation((db, col) => `${db}/${col}`);
+    database.orderByChild.mockImplementation(child => ['orderByChild', child]);
+    database.startAfter.mockImplementation((value, key) => ['startAfter', value, key]);
+    database.limitToFirst.mockImplementation(value => ['limitToFirst', value]);
+    database.query.mockImplementation((...args) => args);
+
+    const makeSnapshot = entries => ({
+      exists: () => entries.length > 0,
+      forEach: callback => {
+        entries.forEach(([id, data]) => callback({ key: id, val: () => data }));
+      },
+    });
+    const firstNewUsersPage = Array.from({ length: 22 }, (_, index) => {
+      const id = `u${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-19', keep: true }];
+    });
+    const secondNewUsersPage = [
+      ['u23', { userId: 'u23', getInTouch: '2026-06-19', keep: true }],
+    ];
+
+    database.get.mockImplementation(async queryArgs => {
+      const path = queryArgs[0];
+      if (path === 'db/users') return makeSnapshot([]);
+      const hasCursor = queryArgs.some(arg => Array.isArray(arg) && arg[0] === 'startAfter');
+      return makeSnapshot(hasCursor ? secondNewUsersPage : firstNewUsersPage);
+    });
+
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const first = await fetchFilteredUsersByPage(
+      0,
+      undefined,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+    );
+    const second = await fetchFilteredUsersByPage(
+      0,
+      undefined,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+      undefined,
+      { afterKeys: first.afterKeys },
+    );
+
+    expect(Object.keys(first.users)).toEqual(firstNewUsersPage.slice(0, 20).map(([id]) => id));
+    expect(first.hasMore).toBe(true);
+    expect(first.afterKeys?.newUsers).toEqual({ value: '2026-06-19', key: 'u22' });
+    expect(Object.keys(second.users)).toEqual(['u23']);
+  });
+
+  it('does not skip users rows when merged newUsers rows fill the first ordered batch', async () => {
+    const database = await import('firebase/database');
+    database.getDatabase.mockReturnValue('db');
+    database.ref.mockImplementation((db, col) => `${db}/${col}`);
+    database.orderByChild.mockImplementation(child => ['orderByChild', child]);
+    database.limitToFirst.mockImplementation(value => ['limitToFirst', value]);
+    database.query.mockImplementation((...args) => args);
+
+    const makeSnapshot = entries => ({
+      exists: () => entries.length > 0,
+      forEach: callback => {
+        entries.forEach(([id, data]) => callback({ key: id, val: () => data }));
+      },
+    });
+    const newUsersPage = Array.from({ length: 22 }, (_, index) => {
+      const id = `new${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-01', keep: false }];
+    });
+    const usersPage = Array.from({ length: 3 }, (_, index) => {
+      const id = `user${String(index + 1).padStart(2, '0')}`;
+      return [id, { userId: id, getInTouch: '2026-06-19', keep: true }];
+    });
+
+    database.get.mockImplementation(async queryArgs => {
+      const path = queryArgs[0];
+      const hasCursor = queryArgs.some(arg => Array.isArray(arg) && arg[0] === 'startAfter');
+      if (hasCursor) return makeSnapshot([]);
+      if (path === 'db/newUsers') return makeSnapshot(newUsersPage);
+      if (path === 'db/users') return makeSnapshot(usersPage);
+      return makeSnapshot([]);
+    });
+
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const result = await fetchFilteredUsersByPage(
+      0,
+      undefined,
+      async id => ({ hydrated: id }),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+    );
+
+    expect(Object.keys(result.users)).toEqual(['user01', 'user02', 'user03']);
+  });
 });
 
 describe('defaultFetchByDate', () => {


### PR DESCRIPTION
### Motivation

- Ensure date-based (GIT / `DATE2`) pagination resumes from backend-provided per-collection cursors (`afterKeys`) instead of only using the visible offset to avoid skipping rows.
- Persist and propagate the backend cursor through UI state so manual reloads and profile-restore restore the correct scan cursor.
- Avoid premature stop or infinite loops when `DATE2` batches return zero visible rows by allowing a small number of empty backend batches to be retried.

### Description

- Added `dateAfterKeys2` state in `AddNewProfile.jsx` and threaded it into debug logs, reload/restore logic, and manual load handlers via `setDateAfterKeys2` and snapshot persistence. 
- Updated `loadMoreUsersGitSimple` to use `dateAfterKeys2` when provided (passing `afterKeys` to `fetchFilteredUsersByPage`), compute a `nextVisibleOffset` vs backend cursor offset, and store `res.afterKeys` on result to continue backend scanning.
- Introduced empty-batch handling in `handlePageChange` for `DATE2` by tracking `emptyDate2Batches` and allowing up to 3 empty backend batches before breaking the load loop.
- Reworked date fetching in `dateLoad.js` so `defaultFetchGetInTouchOrdered` returns the full merged ordered entries and `fetchFilteredUsersByPage` accepts and forwards an initial `afterKeys` cursor, preserves and returns `afterKeys`, stops when appended rows are zero, and returns `afterKeys` with the response.
- Added tests in `dateLoad.test.js` to validate continuing scans using returned `afterKeys` and to ensure merged rows from `newUsers`/`users` don't cause skipped rows.

### Testing

- Ran unit tests in `src/components/dateLoad.test.js` (Jest) including the two new test cases for `afterKeys` resume and merged-row behavior, and they passed.
- Ran the project unit test suite (`jest`) for the date load module and the changed tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a396e622450832687758513e4937cb9)