### PR TITLE
Fix DATE2 cursor advancement

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2128,7 +2128,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [isLoadOptionsOpen, setIsLoadOptionsOpen] = useState(false);
   const [loadRequestId, setLoadRequestId] = useState(0);
   const [dateOffset2, setDateOffset2] = useState(0);
+  const dateOffset2Ref = useRef(0);
   const [dateAfterKeys2, setDateAfterKeys2] = useState(null);
+  const dateAfterKeys2Ref = useRef(null);
   const [dateOffset21, setDateOffset21] = useState(0);
   const [dateOffsetLA, setDateOffsetLA] = useState(0);
   const la2StateRef = useRef(createInitialLA2State());
@@ -2153,6 +2155,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
   const canApplyLoadResultsToUsers = () =>
     !isEditingRef.current && !searchListIsolationRef.current;
+
+  const updateDateOffset2 = value => {
+    dateOffset2Ref.current = value;
+    setDateOffset2(value);
+  };
+
+  const updateDateAfterKeys2 = value => {
+    dateAfterKeys2Ref.current = value;
+    setDateAfterKeys2(value);
+  };
 
   const downloadLoadDebugLogs = useCallback(() => {
     const logs = loadDebugLogsRef.current || [];
@@ -3034,8 +3046,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setCacheCount(0);
     setBackendCount(0);
     setDateOffsetLA(0);
-    setDateOffset2(0);
-    setDateAfterKeys2(null);
+    updateDateOffset2(0);
+    updateDateAfterKeys2(null);
     setDateOffset21(0);
 
     if (!currentFilter) {
@@ -3724,10 +3736,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   };
 
   const loadMoreUsersGitSimple = async (currentFilters = filters) => {
+    const activeDateAfterKeys2 = dateAfterKeys2Ref.current;
+    const activeDateOffset2 = dateOffset2Ref.current;
     appendLoadDebugLog('loadMoreUsersGitSimple:start', {
       queryMode: 'DATE2',
-      dateOffset2,
-      hasBackendCursor: Boolean(dateAfterKeys2),
+      dateOffset2: activeDateOffset2,
+      hasBackendCursor: Boolean(activeDateAfterKeys2),
       pageSize: PAGE_SIZE,
       hasMore,
       filters: summarizeLoadFiltersForLog(currentFilters),
@@ -3772,15 +3786,15 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     const loadDropReasons = {};
     appendLoadDebugLog('loadMoreUsersGitSimple:before-fetchFilteredUsersByPage', {
       queryMode: 'DATE2',
-      dateOffset2,
-      hasBackendCursor: Boolean(dateAfterKeys2),
+      dateOffset2: activeDateOffset2,
+      hasBackendCursor: Boolean(activeDateAfterKeys2),
       pageSize: PAGE_SIZE,
       filters: summarizeLoadFiltersForLog(currentFilters),
     });
     let res;
     try {
       res = await fetchFilteredUsersByPage(
-        dateAfterKeys2 ? 0 : dateOffset2,
+        activeDateAfterKeys2 ? 0 : activeDateOffset2,
         undefined,
         id => fetchUserById(id),
         currentFilters,
@@ -3799,7 +3813,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             appendLoadDebugLog('loadMoreUsersGitSimple:progress-empty', {
               queryMode: 'DATE2',
               reason: 'onProgress received no visible users after filterMain',
-              dateOffset2,
+              dateOffset2: activeDateOffset2,
               targetVisibleCount: PAGE_SIZE,
             });
             return;
@@ -3828,7 +3842,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         },
         {
           debugLog: (step, payload) => appendLoadDebugLog(step, payload),
-          afterKeys: dateAfterKeys2,
+          afterKeys: activeDateAfterKeys2,
         },
       );
       appendLoadDebugLog('loadMoreUsersGitSimple:after-fetchFilteredUsersByPage', {
@@ -3875,11 +3889,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       if (!loadedIds.includes(id)) loadedIds.push(id);
     });
 
-    const nextOffset = Number.isFinite(Number(res?.lastKey)) ? Number(res.lastKey) : dateOffset2 + backendIds.length;
-    const nextVisibleOffset = dateAfterKeys2 ? dateOffset2 + backendIds.length : nextOffset;
+    const nextOffset = Number.isFinite(Number(res?.lastKey)) ? Number(res.lastKey) : activeDateOffset2 + backendIds.length;
+    const nextVisibleOffset = activeDateAfterKeys2 ? activeDateOffset2 + backendIds.length : nextOffset;
     const nextHasMore = Boolean(res?.hasMore);
-    setDateOffset2(nextVisibleOffset);
-    setDateAfterKeys2(res?.afterKeys || null);
+    updateDateOffset2(nextVisibleOffset);
+    updateDateAfterKeys2(res?.afterKeys || null);
     setHasMore(nextHasMore);
 
     const queryKey = buildListQueryKey('DATE2', currentFilters);
@@ -3891,7 +3905,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       rawUsersCount: backendEntries.length,
       backendCount: backendIds.length,
       loadedIdsCount: loadedIds.length,
-      previousOffset: dateOffset2,
+      previousOffset: activeDateOffset2,
       nextOffset: nextVisibleOffset,
       backendCursorOffset: nextOffset,
       hasBackendCursor: Boolean(res?.afterKeys),
@@ -4560,7 +4574,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
 
     if (useDateByDateBackendFetch) {
-      setDateOffset2(offset);
+      updateDateOffset2(offset);
     } else {
       setDateOffset21(offset);
     }
@@ -6139,8 +6153,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setHasMore(true);
     setCurrentPage(1);
     setLastKey(null);
-    setDateOffset2(0);
-    setDateAfterKeys2(null);
+    updateDateOffset2(0);
+    updateDateAfterKeys2(null);
     setDateOffset21(0);
     setDateOffsetLA(0);
     resetLA2StateRef(la2StateRef);
@@ -6244,8 +6258,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setHasMore(typeof snapshot.hasMore === 'boolean' ? snapshot.hasMore : true);
     setLastKey(snapshot.lastKey ?? null);
     setLastKey21(snapshot.lastKey21 ?? null);
-    setDateOffset2(snapshot.dateOffset2 || 0);
-    setDateAfterKeys2(snapshot.dateAfterKeys2 || null);
+    updateDateOffset2(snapshot.dateOffset2 || 0);
+    updateDateAfterKeys2(snapshot.dateAfterKeys2 || null);
     setDateOffset21(snapshot.dateOffset21 || 0);
     setDateOffsetLA(snapshot.dateOffsetLA || 0);
     if (snapshot.la2State) {

--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -32,10 +32,12 @@ async function defaultFetchGetInTouchOrdered(limit, options = {}) {
   const collections = ['newUsers', 'users'];
   const combined = {};
   const orderedEntries = [];
-  const nextCursors = {};
+  const { afterKeys = null, cursorLimit = null } = options || {};
+  const nextCursors = { ...(afterKeys || {}) };
   let hasMore = false;
-  const fetchLimit = Math.max(1, Number(limit) || PAGE_SIZE) + 1;
-  const { afterKeys = null } = options || {};
+  const requestedLimit = Math.max(1, Number(limit) || PAGE_SIZE);
+  const cursorEntryLimit = Math.max(1, Number(cursorLimit) || requestedLimit);
+  const fetchLimit = requestedLimit + 1;
 
   for (const col of collections) {
     const collectionRef = ref2(db, col);
@@ -62,19 +64,17 @@ async function defaultFetchGetInTouchOrdered(limit, options = {}) {
           const id = childSnap.key;
           const data = childSnap.val();
           collectionCount += 1;
-          nextCursors[col] = { value: data?.getInTouch ?? '', key: id };
           if (!combined[id]) {
             combined[id] = data;
-            orderedEntries.push([id, data]);
+            orderedEntries.push([id, data, col]);
           }
         });
       } else {
         Object.entries(snap.val()).forEach(([id, data]) => {
           collectionCount += 1;
-          nextCursors[col] = { value: data?.getInTouch ?? '', key: id };
           if (!combined[id]) {
             combined[id] = data;
-            orderedEntries.push([id, data]);
+            orderedEntries.push([id, data, col]);
           }
         });
       }
@@ -83,10 +83,12 @@ async function defaultFetchGetInTouchOrdered(limit, options = {}) {
   }
 
   orderedEntries.sort(([, a], [, b]) => String(a?.getInTouch || '').localeCompare(String(b?.getInTouch || '')));
-  // Return every row that advanced a collection cursor. Slicing the merged list
-  // after advancing per-collection cursors skips unreturned rows from the other
-  // collection on the next request.
-  return { entries: orderedEntries, hasMore, afterKeys: nextCursors };
+  const limitedEntries = orderedEntries.slice(0, cursorEntryLimit);
+  limitedEntries.forEach(([id, data, col]) => {
+    nextCursors[col] = { value: data?.getInTouch ?? '', key: id };
+  });
+  hasMore = hasMore || orderedEntries.length > limitedEntries.length;
+  return { entries: orderedEntries.map(([id, data]) => [id, data]), hasMore, afterKeys: nextCursors };
 }
 
 const normalizeDateFetchResult = result => {
@@ -113,12 +115,14 @@ export async function defaultFetchByDate(dateStr, limit, options = {}) {
   const collections = ['newUsers', 'users'];
   const combined = {};
   const orderedEntries = [];
-  const nextCursors = {};
   let hasMore = false;
   let lastKey = null;
-  const { afterKey = null, afterKeys = null } = options || {};
+  const { afterKey = null, afterKeys = null, cursorLimit = null } = options || {};
+  const nextCursors = { ...(afterKeys || {}) };
   const hasCollectionCursors = afterKeys && typeof afterKeys === 'object';
-  const fetchLimit = Math.max(1, Number(limit) || PAGE_SIZE) + 1;
+  const requestedLimit = Math.max(1, Number(limit) || PAGE_SIZE);
+  const cursorEntryLimit = Math.max(1, Number(cursorLimit) || requestedLimit);
+  const fetchLimit = requestedLimit + 1;
 
   // Iterate through both collections and gather matching records.
   // Keep reading one extra row so DATE2 can know whether the same date still
@@ -147,18 +151,16 @@ export async function defaultFetchByDate(dateStr, limit, options = {}) {
         snap.forEach(childSnap => {
           const id = childSnap.key;
           const data = childSnap.val();
-          nextCursors[col] = id;
           if (!combined[id]) {
             combined[id] = data;
-            orderedEntries.push([id, data]);
+            orderedEntries.push([id, data, col]);
           }
         });
       } else {
         Object.entries(snap.val()).forEach(([id, data]) => {
-          nextCursors[col] = id;
           if (!combined[id]) {
             combined[id] = data;
-            orderedEntries.push([id, data]);
+            orderedEntries.push([id, data, col]);
           }
         });
       }
@@ -171,11 +173,19 @@ export async function defaultFetchByDate(dateStr, limit, options = {}) {
   }
 
   const entries = orderedEntries.slice(0, fetchLimit);
-  const limitedEntries = entries.slice(0, Math.max(1, Number(limit) || PAGE_SIZE));
+  const limitedEntries = entries.slice(0, cursorEntryLimit);
+  limitedEntries.forEach(([id, , col]) => {
+    nextCursors[col] = id;
+  });
   hasMore = hasMore || entries.length > limitedEntries.length;
   lastKey = limitedEntries.length > 0 ? limitedEntries[limitedEntries.length - 1][0] : null;
 
-  return { entries: limitedEntries, hasMore, lastKey, afterKeys: nextCursors };
+  return {
+    entries: entries.map(([id, data]) => [id, data]),
+    hasMore,
+    lastKey,
+    afterKeys: nextCursors,
+  };
 }
 
 
@@ -275,7 +285,11 @@ export async function fetchFilteredUsersByPage(
     while (filtered.length < target && dateHasMore) {
       const fetchLimit = limit - filtered.length;
       const batchResult = normalizeDateFetchResult(
-        await fetchDateFn(todayIso, fetchLimit, { afterKey, afterKeys })
+        await fetchDateFn(todayIso, fetchLimit, {
+          afterKey,
+          afterKeys,
+          cursorLimit: target - filtered.length,
+        })
       );
       const { entries } = batchResult;
       if (entries.length === 0) {
@@ -321,7 +335,10 @@ export async function fetchFilteredUsersByPage(
     });
     // eslint-disable-next-line no-await-in-loop
     const batchResult = normalizeDateFetchResult(
-      await defaultFetchGetInTouchOrdered(limit - filtered.length, { afterKeys: orderedAfterKeys })
+      await defaultFetchGetInTouchOrdered(limit - filtered.length, {
+        afterKeys: orderedAfterKeys,
+        cursorLimit: target - filtered.length,
+      })
     );
     orderedAfterKeys = batchResult.afterKeys ?? null;
     const rawEntries = batchResult.entries || [];

--- a/src/components/dateLoad.test.js
+++ b/src/components/dateLoad.test.js
@@ -210,7 +210,7 @@ describe('fetchFilteredUsersByPage', () => {
 
     expect(Object.keys(first.users)).toEqual(firstNewUsersPage.slice(0, 20).map(([id]) => id));
     expect(first.hasMore).toBe(true);
-    expect(first.afterKeys?.newUsers).toEqual({ value: '2026-06-19', key: 'u22' });
+    expect(first.afterKeys?.newUsers).toEqual({ value: '2026-06-19', key: 'u20' });
     expect(Object.keys(second.users)).toEqual(['u23']);
   });
 


### PR DESCRIPTION
### Motivation
- Prevent DATE2 pagination from skipping rows by ensuring backend cursors are advanced only past rows that were actually exposed to the UI, and avoid restarting exhausted collections. 
- Ensure cursor/reset semantics are synchronous for reloads and retries so subsequent calls don’t use stale React state and miss matching rows. 
- Preserve existing per-collection cursors when a collection returns zero rows so previously-exhausted collections are not re-scanned from the beginning.

### Description
- In `src/components/dateLoad.js` added `cursorLimit` handling and changed ordered fetches to initialize `nextCursors` from incoming `afterKeys`, carry collection tags with merged entries, and only advance per-collection cursors up to a cursor-safe window so the backend cursor aligns with the visible page while still returning extra rows for filtering. 
- In `src/components/defaultFetchByDate` updated the same-day fetch to honor `cursorLimit`, track per-collection cursors, and only advance those cursors for entries included in the cursor window. 
- In `src/components/AddNewProfile.jsx` introduced `dateOffset2Ref` and `dateAfterKeys2Ref` plus `updateDateOffset2`/`updateDateAfterKeys2` helpers and switched DATE2 logic to read/update these refs so reloads and empty-batch retries use the latest cursor/offset synchronously. 
- Updated the DATE2 pagination test expectation in `src/components/dateLoad.test.js` to match the corrected cursor advancement behavior.

### Testing
- Ran `npm test -- --watchAll=false src/components/dateLoad.test.js` and the suite passed (all `dateLoad` tests succeeded). 
- Ran `npm run lint:js -- src/components/dateLoad.js src/components/AddNewProfile.jsx src/components/dateLoad.test.js` and lint completed with no new errors. 
- Ran the full test run `npm test -- --watchAll=false` and observed unrelated pre-existing failures in other suites (some snapshot / localStorage-backed storage tests), confirming the changes did not break `dateLoad` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a397dfdf6788326b4dc6534154ea582)