### PR TITLE
Drop entries when hydration updates getInTouch to a future date

### DIFF
--- a/src/components/dateLoad.js
+++ b/src/components/dateLoad.js
@@ -247,7 +247,9 @@ export async function fetchFilteredUsersByPage(
     const extras = await Promise.all(ids.map(id => fetchUserByIdFn(id)));
     newEntries.forEach(([id, data], i) => {
       const extra = extras[i];
-      combined.push([id, extra ? { ...data, ...extra } : data]);
+      const mergedUser = extra ? { ...data, ...extra } : data;
+      if (!isCurrentPastOrNonDateGetInTouch(mergedUser?.getInTouch, todayIso)) return;
+      combined.push([id, mergedUser]);
     });
     const rejectReasons = {};
     const collectFilterDebug = (step, payload = {}) => {

--- a/src/components/dateLoad.test.js
+++ b/src/components/dateLoad.test.js
@@ -259,6 +259,50 @@ describe('fetchFilteredUsersByPage', () => {
 
     expect(Object.keys(result.users)).toEqual(['user01', 'user02', 'user03']);
   });
+
+  it('drops a GIT row when longId hydration changes getInTouch to a future date', async () => {
+    const database = await import('firebase/database');
+    database.getDatabase.mockReturnValue('db');
+    database.ref.mockImplementation((db, col) => `${db}/${col}`);
+    database.orderByChild.mockImplementation(child => ['orderByChild', child]);
+    database.limitToFirst.mockImplementation(value => ['limitToFirst', value]);
+    database.query.mockImplementation((...args) => args);
+
+    const makeSnapshot = entries => ({
+      exists: () => entries.length > 0,
+      forEach: callback => {
+        entries.forEach(([id, data]) => callback({ key: id, val: () => data }));
+      },
+    });
+
+    database.get.mockImplementation(async queryArgs => {
+      const path = queryArgs[0];
+      if (path === 'db/newUsers') {
+        return makeSnapshot([
+          ['long-id-future', { userId: 'long-id-future', getInTouch: '2026-06-19', keep: true }],
+          ['long-id-current', { userId: 'long-id-current', getInTouch: '2026-06-19', keep: true }],
+        ]);
+      }
+      return makeSnapshot([]);
+    });
+
+    const { fetchFilteredUsersByPage } = await import('./dateLoad');
+    const result = await fetchFilteredUsersByPage(
+      0,
+      undefined,
+      async id => (
+        id === 'long-id-future'
+          ? { getInTouch: '2026-08-04' }
+          : { getInTouch: '2026-06-19' }
+      ),
+      {},
+      {},
+      {},
+      source => source.filter(([, user]) => user.keep),
+    );
+
+    expect(Object.keys(result.users)).toEqual(['long-id-current']);
+  });
 });
 
 describe('defaultFetchByDate', () => {


### PR DESCRIPTION
### Motivation

- Prevent rows from being included when a user's hydrated `getInTouch` moves from current/past to a future date, avoiding showing stale or incorrect contact rows. 

### Description

- In `appendFetchedEntries` compute `mergedUser` and skip pushing the entry unless `isCurrentPastOrNonDateGetInTouch(mergedUser?.getInTouch, todayIso)` returns true. 
- This change ensures entries whose hydration changes `getInTouch` to a future date are dropped before filtering. 
- Updated `src/components/dateLoad.test.js` to add a test case that verifies a GIT row is dropped when hydration moves `getInTouch` into the future. 
- Modified `src/components/dateLoad.js` to apply the new guard while merging hydrated data. 

### Testing

- Ran the unit tests for `fetchFilteredUsersByPage`, including the new case that asserts a row with a hydrated future `getInTouch` is excluded. 
- All automated tests in `src/components/dateLoad.test.js` passed when run with the test runner (`jest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ade47700c8326adbf4e5b39d4444b)