### PR TITLE
Ensure FN contains phone when no personal name and place markers before phone

### DIFF
--- a/src/components/ExportContact.jsx
+++ b/src/components/ExportContact.jsx
@@ -209,11 +209,18 @@ const getContactName = user => {
   const surnames = Array.isArray(user.surname) ? user.surname : [user.surname];
   const fathersNames = Array.isArray(user.fathersname) ? user.fathersname : [user.fathersname];
 
-  const fullNameParts = [
-    ...cleanedNameParts(names),
-    ...getContactNameMarkers(user),
+  const primaryNameParts = cleanedNameParts(names);
+  const secondaryNameParts = [
     ...cleanedNameParts(surnames),
     ...cleanedNameParts(fathersNames),
+  ];
+  const markerParts = getContactNameMarkers(user);
+  const hasPersonalName = primaryNameParts.length || secondaryNameParts.length;
+  const fullNameParts = [
+    ...primaryNameParts,
+    ...markerParts,
+    ...secondaryNameParts,
+    ...(!hasPersonalName && firstPhone ? [String(firstPhone).trim()] : []),
   ];
   const fullName = fullNameParts.join(' ').trim();
 

--- a/src/components/ExportContact.test.js
+++ b/src/components/ExportContact.test.js
@@ -1,4 +1,4 @@
-import { isSingleUserPayload } from './ExportContact';
+import { isSingleUserPayload, makeVCard } from './ExportContact';
 
 describe('isSingleUserPayload', () => {
   it('returns true for a single user object without name', () => {
@@ -12,5 +12,23 @@ describe('isSingleUserPayload', () => {
         u2: { userId: 'u2', phone: '380004445566' },
       }),
     ).toBe(false);
+  });
+});
+
+
+describe('makeVCard contact name', () => {
+  it('keeps structured markers before phone when personal name is missing', () => {
+    const vCard = makeVCard({
+      userId: 'u1',
+      phone: '380971840661',
+      birth: '02.10.1988',
+      blood: '-',
+      csection: '1',
+      height: '160',
+      weight: '90',
+      maritalStatus: 'так',
+    });
+
+    expect(vCard).toMatch(/FN;CHARSET=UTF-8:КМСД \d+ рк- кс1 імт35\.2 заміжня 380971840661/);
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure exported contact `FN` includes the phone number when no personal name is present and keep structured markers visible before the phone. 
- Prevent producing an `FN` that contains only markers with no identifier.

### Description
- Split cleaned name parts into `primaryNameParts` and `secondaryNameParts` and compute `markerParts` separately. 
- Add `hasPersonalName` and append `firstPhone` into `fullNameParts` only when no personal name parts exist. 
- Reorder assembly to `primaryNameParts`, `markerParts`, `secondaryNameParts`, and optional phone so markers appear before the fallback phone. 
- Update tests to import `makeVCard` and add a unit test asserting markers precede the phone in the `FN` field when a personal name is missing.

### Testing
- Ran the unit test suite (`npm test` / `yarn test`) including the existing `isSingleUserPayload` specs and the new `makeVCard contact name` test. All tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8919f91483268d18d95b645e51ec)