### PR TITLE
Respect explicit empty `searchKeyFields` and stop forcing search flags in search-only modes

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2750,8 +2750,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     ? {
         ...enabledSearchKeys,
         searchId: true,
-        equalToAllCards: true,
-        searchKey: true,
+        equalToAllCards: enabledSearchKeys.equalToAllCards,
+        searchKey: enabledSearchKeys.searchKey,
         // Не вимикаємо partialUserId примусово: якщо чекбокс увімкнений,
         // користувач очікує пошук по ключах users/newUsers.
         partialUserId: enabledSearchKeys.partialUserId,

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1449,7 +1449,13 @@ const SearchBar = ({
 
   const runSearchKeyBucketSearch = async (rawQuery, isStaleRequest, resultMap = {}) => {
     const allSearchKeyFields = Object.keys(SEARCH_KEY_BUCKET_SEARCH_PARSERS);
+    const hasExplicitSearchKeyFields = Array.isArray(searchOptions?.searchKeyFields);
     const selectedSearchKeyFields = resolveSelectedSearchKeys(searchOptions, 'searchKeyFields', allSearchKeyFields);
+
+    if (hasExplicitSearchKeyFields && selectedSearchKeyFields.length === 0) {
+      return { found: false, results: resultMap };
+    }
+
     const executionPlan = resolveExecutionPlan({
       allKeys: allSearchKeyFields,
       selectedKeys: selectedSearchKeyFields,

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -410,6 +410,68 @@ describe('SearchBar cache-first search', () => {
     document.body.removeChild(container);
   });
 
+  it('does not search date buckets when searchKeyFields is explicitly empty', async () => {
+    const searchFunc = jest.fn().mockResolvedValue({});
+    const setUsers = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'УК СМ Марія Бекер 02.06.2026',
+        setSearch: jest.fn(),
+        setUsers,
+        setState: jest.fn(),
+        setUserNotFound: jest.fn(),
+        enabledSearchKeys: {
+          telegram: true,
+          searchId: false,
+          partialUserId: false,
+          searchKey: true,
+          equalToAllCards: true,
+        },
+        searchOptions: {
+          enabledSearchKeys: {
+            telegram: true,
+            searchId: false,
+            partialUserId: false,
+            searchKey: true,
+            equalToAllCards: true,
+          },
+          equalToKeys: ['telegram'],
+          searchKeyFields: [],
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledWith(
+      { telegram: 'УК СМ Марія Бекер 02.06.2026' },
+      expect.objectContaining({
+        forceEqualToAllCards: true,
+        equalToKeys: ['telegram'],
+      }),
+    );
+    expect(searchFunc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ lastAction: expect.anything() }),
+      expect.anything(),
+    );
+    expect(searchFunc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ getInTouch: expect.anything() }),
+      expect.anything(),
+    );
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
   it('renders UK-trigger telegram prefix matches as a list even when one match is returned', async () => {
     const searchFunc = jest.fn().mockResolvedValue({
       userId: 'oksana',


### PR DESCRIPTION
### Motivation

- Avoid forcing `equalToAllCards` and `searchKey` to `true` when in search-id/search-key only modes so component respects configured `enabledSearchKeys`.
- Prevent running date-bucket (`searchKey`/date-like) searches when `searchOptions.searchKeyFields` is explicitly provided as an empty array to honor explicit user configuration.

### Description

- Updated `AddNewProfile.jsx` to stop unconditionally setting `equalToAllCards` and `searchKey` to `true` in `effectiveEnabledSearchKeys`, instead preserving the values from `enabledSearchKeys` when in search-id/search-key only modes.  
- Modified `runSearchKeyBucketSearch` in `SearchBar.jsx` to detect an explicit `searchKeyFields` array and return early when it is provided and resolves to an empty set, avoiding unnecessary date-bucket searches.  
- Added a unit test in `SearchBar.partialUserId.test.js` titled `does not search date buckets when searchKeyFields is explicitly empty` that verifies no date-bucket searches are performed when `searchKeyFields: []` is passed.

### Testing

- Ran unit tests including the new `does not search date buckets when searchKeyFields is explicitly empty` test in `SearchBar.partialUserId.test.js`, and the test suite passed.  
- Ran existing search-related tests to ensure no regressions in search behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ede1ea5dc8326ac929c4f4b02497b)