### PR TITLE
refine renderTopBlock visual: glassmorphism, rhythm, chip polish

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -49,7 +49,8 @@ const topButtonsRowStyle = {
   alignItems: 'center',
   gap: '5px',
   flexWrap: 'wrap',
-  marginBottom: '5px',
+  paddingBottom: '5px',
+  borderBottom: '1px solid rgba(255,255,255,0.07)',
   minWidth: 0,
 };
 
@@ -146,9 +147,10 @@ const cardNameRowStyle = {
 };
 
 const cardNameStyle = {
-  fontSize: '15px',
+  fontSize: '16px',
   fontWeight: 700,
   lineHeight: 1.2,
+  letterSpacing: '-0.2px',
   minWidth: 0,
   overflowWrap: 'anywhere',
 };
@@ -167,29 +169,33 @@ const cardIdRowStyle = {
 const roleBadgeStyle = role => ({
   display: 'inline-flex',
   alignItems: 'center',
-  padding: '1px 7px',
+  padding: '2px 8px',
   borderRadius: '10px',
   fontSize: '10px',
   fontWeight: 700,
   letterSpacing: '0.6px',
   textTransform: 'uppercase',
-  background: 'rgba(255,255,255,0.22)',
+  background: 'linear-gradient(135deg, rgba(255,255,255,0.28) 0%, rgba(255,255,255,0.12) 100%)',
+  backdropFilter: 'blur(4px)',
   color: '#fff',
   flexShrink: 0,
-  border: `1px solid rgba(255,255,255,0.3)`,
+  border: '1px solid rgba(255,255,255,0.32)',
   cursor: 'pointer',
   lineHeight: 1.4,
+  transition: 'opacity 0.15s ease',
 });
 
 const statusRowStyle = {
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'stretch',
-  gap: '6px',
-  padding: '6px',
+  gap: '5px',
+  padding: '6px 7px',
   borderRadius: '8px',
-  background: 'rgba(255,255,255,0.08)',
-  border: '1px solid rgba(255,255,255,0.1)',
+  background: 'rgba(255,255,255,0.09)',
+  border: '1px solid rgba(255,255,255,0.13)',
+  boxShadow: '0 1px 6px rgba(0,0,0,0.08)',
+  backdropFilter: 'blur(6px)',
   margin: '5px 0',
   boxSizing: 'border-box',
   width: '100%',
@@ -206,6 +212,8 @@ const statusItemStyle = {
 
 const getInTouchStatusItemStyle = {
   ...statusItemStyle,
+  borderLeft: '2px solid rgba(255,255,255,0.18)',
+  paddingLeft: '4px',
 };
 
 const roleEditorStyle = {
@@ -240,10 +248,11 @@ const factChipStyle = {
   gap: '3px',
   minWidth: 0,
   maxWidth: '100%',
-  padding: '1px 5px',
+  padding: '2px 7px',
   borderRadius: '999px',
-  background: 'rgba(255,255,255,0.08)',
-  border: '1px solid rgba(255,255,255,0.08)',
+  background: 'rgba(255,255,255,0.11)',
+  border: '1px solid rgba(255,255,255,0.15)',
+  fontSize: '11px',
   lineHeight: 1.35,
   overflowWrap: 'anywhere',
 };
@@ -264,7 +273,8 @@ const commentsSectionStyle = {
   marginTop: '5px',
   padding: '4px 6px',
   borderRadius: '7px',
-  background: 'rgba(255,255,255,0.07)',
+  background: 'rgba(255,255,255,0.06)',
+  border: '1px solid rgba(255,255,255,0.08)',
   display: 'flex',
   flexDirection: 'column',
   gap: '3px',
@@ -1183,7 +1193,7 @@ export const TopBlock = ({
                 setIsCommentModalOpen(true);
               }}
             >
-              {`${formatCommentDate(comment.lastAction) || '--.--.----'} - ${comment.text}`}
+              {`${formatCommentDate(comment.lastAction) || '--.--.----'} · ${comment.text}`}
             </div>
             {isAdmin && comment.ownerId && (
               <button


### PR DESCRIPTION
- name: 15px → 16px + letterSpacing -0.2px for sharper heading
- role badge: flat rgba → gradient + backdropFilter blur for glass effect
- button row: marginBottom → borderBottom separator line for section rhythm
- status row: backdropFilter blur(6px) + subtle shadow + tighter border
- getInTouch item: left accent border for visual anchor
- fact chips: larger padding, stronger bg/border, 11px font for legible pills
- comments section: add consistent border to match status row style
- comment date separator: ' - ' → ' · ' for cleaner inline format

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pq6METDrV19rnVYxbh3ui