### PR TITLE
TopBlock: background photo support and medication-photo filtering

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -30,6 +30,7 @@ import {
 import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
+import { filterOutMedicationPhotos } from 'utils/photoFilters';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
 import { auth } from '../config';
@@ -42,6 +43,10 @@ const topBlockContainerStyle = {
   width: '100%',
   minWidth: 0,
   overflow: 'hidden',
+  backgroundSize: 'cover',
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  isolation: 'isolate',
 };
 
 const topButtonsRowStyle = {
@@ -403,6 +408,47 @@ const deleteModalTextStyle = {
   lineHeight: 1.35,
 };
 
+const normalizePhotoList = value => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.flatMap(normalizePhotoList);
+  if (typeof value === 'object') return Object.values(value).flatMap(normalizePhotoList);
+  if (typeof value !== 'string') return [];
+  const photo = value.trim();
+  return photo ? [photo] : [];
+};
+
+const getUserPhotoUrl = data => {
+  const photos = normalizePhotoList([
+    data?.photos,
+    data?.photoUrls,
+    data?.avatarUrls,
+    data?.photoURL,
+    data?.photoUrl,
+    data?.mainPhoto,
+    data?.userPhoto,
+    data?.avatar,
+    data?.photo,
+    data?.image,
+    data?.picture,
+  ]);
+  return filterOutMedicationPhotos(photos, data?.userId)[0] || '';
+};
+
+const getTopBlockBackgroundStyle = photoUrl => {
+  if (!photoUrl) return topBlockContainerStyle;
+
+  return {
+    ...topBlockContainerStyle,
+    color: '#fff',
+    textShadow: '0 1px 3px rgba(0, 0, 0, 0.75)',
+    backgroundColor: '#111827',
+    backgroundImage: [
+      'linear-gradient(135deg, rgba(6, 11, 25, 0.78), rgba(17, 24, 39, 0.58) 48%, rgba(6, 11, 25, 0.82))',
+      `url(${JSON.stringify(photoUrl)})`,
+    ].join(', '),
+  };
+};
+
 const hasAgentOrIPRole = data =>
   data.userRole === 'ag' || data.userRole === 'ip' || data.role === 'ag' || data.role === 'ip';
 
@@ -597,6 +643,8 @@ export const TopBlock = ({
   }, [cardData?.userId]);
 
   if (!cardData) return null;
+
+  const topBlockStyle = getTopBlockBackgroundStyle(getUserPhotoUrl(cardData));
 
   const renderOverlayEntries = fieldNames => {
     const normalizedFieldNames = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
@@ -1034,7 +1082,7 @@ export const TopBlock = ({
   ].filter(action => action && action.content);
 
   return (
-    <div style={topBlockContainerStyle}>
+    <div style={topBlockStyle}>
       <div style={cardHeaderStyle}>
         <div style={cardNameRowStyle}>
           <div style={cardNameStyle}>{buildName(cardData)}</div>


### PR DESCRIPTION
### Motivation
- Render a user's photo as the small card top block background to improve visual context.
- Normalize and aggregate multiple possible photo fields so any available user image can be used as the background.
- Exclude medication-related photos from selection to avoid showing irrelevant or sensitive images as the background.
- Improve contrast and positioning when a background image is present for better readability.

### Description
- Import `filterOutMedicationPhotos` and add `normalizePhotoList` to gather and normalize photo values from fields like `photos`, `photoUrls`, `avatar`, `photoUrl`, `mainPhoto`, and others.
- Add `getUserPhotoUrl` to pick the first valid, non-medication photo and `getTopBlockBackgroundStyle` to return a style with a gradient overlay, adjusted text color, and `backgroundImage` set to the photo URL.
- Extend `topBlockContainerStyle` with background layout properties (`backgroundSize`, `backgroundPosition`, `backgroundRepeat`, `isolation`) and replace the root wrapper's `style` usage to use the computed `topBlockStyle` when a photo is available.
- Keep all existing card behavior unchanged and only apply the visual background when a photo URL is found.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Performed a production build with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42bc430b8c8326bbfe84f60fde8643)