### PR TITLE
Fix small card side avatar photo handling

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -20,6 +20,7 @@ import { fieldMaritalStatus } from './fieldMaritalStatus';
 import { fieldIMT } from './fieldIMT';
 import { formatDateToDisplay } from 'components/inputValidations';
 import { normalizeRegion } from '../normalizeLocation';
+import { getCurrentValue } from '../getCurrentValue';
 import {
   fetchUserById,
   setUserComment as persistUserComment,
@@ -31,6 +32,7 @@ import { updateCard, clearCardCache } from 'utils/cardsStorage';
 import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { filterOutMedicationPhotos } from 'utils/photoFilters';
+import { convertDriveLinkToImage } from 'utils/convertDriveLinkToImage';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
 import { auth } from '../config';
@@ -423,29 +425,38 @@ const deleteModalTextStyle = {
   lineHeight: 1.35,
 };
 
+const normalizePhotoValue = value => {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+};
+
 const normalizePhotoList = value => {
   if (!value) return [];
   if (Array.isArray(value)) return value.flatMap(normalizePhotoList);
   if (typeof value === 'object') return Object.values(value).flatMap(normalizePhotoList);
-  if (typeof value !== 'string') return [];
-  const photo = value.trim();
+  const photo = normalizePhotoValue(value);
+  return photo ? [photo] : [];
+};
+
+const normalizeCurrentPhoto = value => {
+  const photo = normalizePhotoValue(getCurrentValue(value));
   return photo ? [photo] : [];
 };
 
 const getUserPhotoUrl = data => {
-  const photos = normalizePhotoList([
-    data?.photos,
-    data?.photoUrls,
-    data?.avatarUrls,
-    data?.photoURL,
-    data?.photoUrl,
-    data?.mainPhoto,
-    data?.userPhoto,
-    data?.avatar,
-    data?.photo,
-    data?.image,
-    data?.picture,
-  ]);
+  const photos = [
+    ...normalizePhotoList([data?.photos, data?.photoUrls, data?.avatarUrls]),
+    ...[
+      data?.photoURL,
+      data?.photoUrl,
+      data?.mainPhoto,
+      data?.userPhoto,
+      data?.avatar,
+      data?.photo,
+      data?.image,
+      data?.picture,
+    ].flatMap(normalizeCurrentPhoto),
+  ].map(convertDriveLinkToImage);
   return filterOutMedicationPhotos(photos, data?.userId)[0] || '';
 };
 
@@ -1081,8 +1092,12 @@ export const TopBlock = ({
     },
   ].filter(action => action && action.content);
 
+  const topBlockStyle = userPhotoUrl
+    ? { ...topBlockContainerStyle, paddingRight: '64px' }
+    : topBlockContainerStyle;
+
   return (
-    <div style={topBlockContainerStyle}>
+    <div style={topBlockStyle}>
       {userPhotoUrl && (
         <img
           src={userPhotoUrl}


### PR DESCRIPTION
### Motivation
- Legacy Google Drive sharing links and scalar edit-history photo fields produced broken or stale side avatars in small cards.
- The side avatar is absolutely positioned and could visually overlap header and action content on narrow cards.
- Existing photo normalization utilities (`convertDriveLinkToImage`, current-value selection) should be reused to keep behavior consistent across renderers.

### Description
- Import and reuse `getCurrentValue` and `convertDriveLinkToImage` and add `normalizePhotoValue`/`normalizeCurrentPhoto` helpers to read the current scalar photo value and trim it before use.
- Aggregate photos from list fields and scalar legacy fields, convert Google Drive links with `convertDriveLinkToImage`, and pass the result through `filterOutMedicationPhotos` when selecting the avatar URL.
- Reserve right-side layout space by switching `topBlockContainerStyle` to a `topBlockStyle` with `paddingRight: '64px'` when an avatar is present so content wraps before the absolutely positioned image.
- Keep existing normalization for array/object photo sources while ensuring scalar legacy fields use the current edit-history value.

### Testing
- Ran the unit tests for the converter with `npm test -- --runTestsByPath src/utils/__tests__/convertDriveLinkToImage.test.js --watchAll=false` and they passed.
- Ran linting with `npm run lint:js -- src/components/smallCard/renderTopBlock.js` and no lint errors blocked the change (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42dedab6908326925d9ce5f7e616be)