### PR TITLE
Move photo-related right padding from top container to status row

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1092,12 +1092,12 @@ export const TopBlock = ({
     },
   ].filter(action => action && action.content);
 
-  const topBlockStyle = userPhotoUrl
-    ? { ...topBlockContainerStyle, paddingRight: '64px' }
-    : topBlockContainerStyle;
+  const statusRowWithPhotoStyle = userPhotoUrl
+    ? { ...statusRowStyle, paddingRight: '64px' }
+    : statusRowStyle;
 
   return (
-    <div style={topBlockStyle}>
+    <div style={topBlockContainerStyle}>
       {userPhotoUrl && (
         <img
           src={userPhotoUrl}
@@ -1179,7 +1179,7 @@ export const TopBlock = ({
           </button>
         </div>
       </div>
-      <div style={statusRowStyle}>
+      <div style={statusRowWithPhotoStyle}>
         <div style={getInTouchStatusItemStyle}>
           {fieldGetInTouch({
             userData: cardData,


### PR DESCRIPTION
### Motivation
- Prevent layout overlap/spacing issues when a user photo is present by applying the extra right padding to the status row instead of the whole top container.

### Description
- Replace the `topBlockStyle` calculation with `statusRowWithPhotoStyle` that conditionally extends `statusRowStyle` when `userPhotoUrl` is present.
- Always render the outer container with `topBlockContainerStyle` and apply the conditional padding to the status row `<div>` instead of the top container.
- Keep photo rendering and header action behavior unchanged and rename variables for clarity.

### Testing
- Ran unit tests and linting locally with no regressions observed.
- Performed a Storybook/UI smoke check to verify layout with and without a user photo and confirmed the spacing is correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cb74b16c8326b8a7e50f2ad0e013)