### PR TITLE
Center avatar within status rows

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1093,19 +1093,11 @@ export const TopBlock = ({
   ].filter(action => action && action.content);
 
   const statusRowWithPhotoStyle = userPhotoUrl
-    ? { ...statusRowStyle, paddingRight: '64px' }
+    ? { ...statusRowStyle, position: 'relative', paddingRight: '64px' }
     : statusRowStyle;
 
   return (
     <div style={topBlockContainerStyle}>
-      {userPhotoUrl && (
-        <img
-          src={userPhotoUrl}
-          alt={buildName(cardData) || 'Фото користувача'}
-          style={topBlockPhotoStyle}
-          loading="lazy"
-        />
-      )}
       <div style={cardHeaderStyle}>
         <div style={cardNameRowStyle}>
           <div style={cardNameStyle}>{buildName(cardData)}</div>
@@ -1180,6 +1172,14 @@ export const TopBlock = ({
         </div>
       </div>
       <div style={statusRowWithPhotoStyle}>
+        {userPhotoUrl && (
+          <img
+            src={userPhotoUrl}
+            alt={buildName(cardData) || 'Фото користувача'}
+            style={topBlockPhotoStyle}
+            loading="lazy"
+          />
+        )}
         <div style={getInTouchStatusItemStyle}>
           {fieldGetInTouch({
             userData: cardData,


### PR DESCRIPTION
## Summary
- Move the avatar into the status row so it is positioned on the right and vertically centered within the get-in-touch/cycle block.
- Reuse the existing avatar absolute positioning and reserve right-side padding on the status row only when a user photo is present.

## Testing
- `npx eslint src/components/smallCard/renderTopBlock.js`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4417ec2f508326a08087230baa7d00)