### PR TITLE
Preserve profile state when resolving photo source and guard user-map updates

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -765,10 +765,15 @@ export const TopBlock = ({
         }
 
         setResolvedPhotosCollection(freshCollection);
-        const withCollection = { ...cardData, __sourceCollection: freshCollection };
-
         if (typeof setState === 'function' && !isFromListOfUsers) {
-          setState(withCollection, {
+          setState(prev => {
+            const currentCard = prev && typeof prev === 'object' ? prev : cardData;
+            if (currentCard?.userId && currentCard.userId !== cardData.userId) return prev;
+            return {
+              ...currentCard,
+              __sourceCollection: freshCollection,
+            };
+          }, {
             source: 'userChange',
             caller: 'renderTopBlock.resolvePhotosCollection',
             reason: 'photos-source-resolved',
@@ -777,7 +782,7 @@ export const TopBlock = ({
 
         if (typeof setUsers === 'function') {
           setUsers(prev => (
-            isFromListOfUsers || stateContainsUser(prev, cardData.userId)
+            stateContainsUser(prev, cardData.userId)
               ? updateUserInState(prev, cardData.userId, currentCard => ({
                 ...currentCard,
                 __sourceCollection: freshCollection,
@@ -811,7 +816,7 @@ export const TopBlock = ({
 
     if (typeof setUsers === 'function' && cardData.userId) {
       setUsers(prev => (
-        isFromListOfUsers || stateContainsUser(prev, cardData.userId)
+        stateContainsUser(prev, cardData.userId)
           ? updateUserInState(prev, cardData.userId, currentCard => resolveNextCard(currentCard))
           : prev
       ));


### PR DESCRIPTION
### Motivation
- Prevent an async photo-source resolution from overwriting a newer single-profile state by replacing it with a stale `cardData` snapshot.
- Avoid corrupting the users backing state when updating photo collection or photos modal for a card while the users map is empty or does not contain the target user.

### Description
- Replace the direct `setState(withCollection, ...)` call with a functional `setState(prev => ...)` that merges only `__sourceCollection` into the latest single-profile state and verifies the current card still matches the target `userId` before applying the change.
- Restrict `setUsers` updates to only run when `stateContainsUser(prev, cardData.userId)` is true so empty maps are not treated as single-card objects; apply the same guard in `setCardPhotosState`.
- Remove the intermediate stale `withCollection` snapshot and keep `setResolvedPhotosCollection(freshCollection)` as before.
- Changes are localized to `src/components/smallCard/renderTopBlock.js` and reuse existing helpers `stateContainsUser` and `updateUserInState`.

### Testing
- Ran `npm test -- --runTestsByPath src/components/smallCard/userStateUpdate.test.js --watchAll=false` and the test suite passed.
- Ran `npm run lint:js -- src/components/smallCard/renderTopBlock.js` and the lint task completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a442c75d3408326a111605d2b1596a1)