### PR TITLE
Refactor photo component styling and raise PhotoViewer overlay z-index

### DIFF
--- a/src/components/PhotoViewer.jsx
+++ b/src/components/PhotoViewer.jsx
@@ -12,7 +12,7 @@ const Overlay = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 1300;
 `;
 
 const FullImage = styled.img`

--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -39,9 +39,11 @@ const PhotoItem = styled.div`
   height: ${({ $compact }) => ($compact ? '72px' : '100px')};
   position: relative;
   flex-shrink: 0;
-  border: ${({ $compact }) => ($compact ? 'none' : '3px solid')};
-  border-image: ${({ $compact }) => ($compact ? 'none' : 'linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1')};
-  border-radius: ${({ $compact }) => ($compact ? '50%' : '5px')};
+  box-sizing: border-box;
+  border: ${({ $compact }) => ($compact ? '2px solid #E8E8E2' : '3px solid #E8E8E2')};
+  border-radius: ${({ $compact }) => ($compact ? '50%' : '8px')};
+  overflow: hidden;
+  background: #fff;
 `;
 
 const PhotoImage = styled.img`
@@ -49,14 +51,14 @@ const PhotoImage = styled.img`
   width: 100%;
   height: 100%;
   display: block;
-  border-radius: ${({ $compact }) => ($compact ? '50%' : 0)};
+  border-radius: ${({ $compact }) => ($compact ? '50%' : '6px')};
   cursor: pointer;
 `;
 
 const DeleteButton = styled.button`
   position: absolute;
-  top: ${({ $compact }) => ($compact ? '-3px' : '5px')};
-  right: ${({ $compact }) => ($compact ? '-3px' : '5px')};
+  top: ${({ $compact }) => ($compact ? '0' : '5px')};
+  right: ${({ $compact }) => ($compact ? '0' : '5px')};
   background-color: ${({ $compact }) => ($compact ? '#fff' : 'red')};
   color: ${({ $compact }) => ($compact ? '#7A7A72' : 'white')};
   border: ${({ $compact }) => ($compact ? '1px solid #E8E8E2' : 'none')};
@@ -92,11 +94,11 @@ const UploadButtonLabel = styled.label`
   height: ${({ $compact }) => ($compact ? '72px' : 'auto')};
   box-sizing: border-box;
   padding: ${({ $compact }) => ($compact ? 0 : '10px 20px')};
-  background: ${({ $compact }) => ($compact ? 'linear-gradient(145deg, #FFFDF9 0%, #FFF1E2 100%)' : color.accent5)};
-  color: ${({ $compact }) => ($compact ? '#E8791A' : 'white')};
-  border: ${({ $compact }) => ($compact ? '2px dashed #F5A24B' : 'none')};
+  background: ${({ $compact }) => ($compact ? '#fff' : color.accent5)};
+  color: ${({ $compact }) => ($compact ? '#7A7A72' : 'white')};
+  border: ${({ $compact }) => ($compact ? '2px solid #E8E8E2' : 'none')};
   border-radius: ${({ $compact }) => ($compact ? '50%' : '5px')};
-  box-shadow: ${({ $compact }) => ($compact ? '0 4px 12px rgba(232, 121, 26, 0.14), inset 0 0 0 4px #FFF8F0' : 'none')};
+  box-shadow: none;
   cursor: pointer;
   text-align: center;
   font-size: ${({ $compact }) => ($compact ? '32px' : '16px')};
@@ -107,9 +109,9 @@ const UploadButtonLabel = styled.label`
   transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
 
   &:hover {
-    background: ${({ $compact }) => ($compact ? 'linear-gradient(145deg, #FFF8F0 0%, #FFE4C7 100%)' : color.accent)};
-    border-color: ${({ $compact }) => ($compact ? '#E8791A' : 'transparent')};
-    box-shadow: ${({ $compact }) => ($compact ? '0 6px 16px rgba(232, 121, 26, 0.22), inset 0 0 0 4px #FFF8F0' : '0 4px 12px rgba(0, 0, 0, 0.1)')};
+    background: ${({ $compact }) => ($compact ? '#FFF8F0' : color.accent)};
+    border-color: ${({ $compact }) => ($compact ? '#F5A24B' : 'transparent')};
+    box-shadow: ${({ $compact }) => ($compact ? 'none' : '0 4px 12px rgba(0, 0, 0, 0.1)')};
     transform: translateY(-1px);
   }
 


### PR DESCRIPTION
### Motivation
- Improve visual consistency and spacing across compact and regular photo lists and ensure the photo viewer overlay appears above other UI layers.
- Simplify and neutralize compact styling (remove gradients and heavy shadows) for a cleaner, more consistent look.
- Fix clipping/overflow and rounding issues so thumbnails and controls render predictably in different layouts.

### Description
- Increased `Overlay` z-index in `src/components/PhotoViewer.jsx` from `1000` to `1300` so the viewer reliably stacks above other elements.
- Overhauled styling in `src/components/Photos.jsx`: added `box-sizing`, unified border color to `#E8E8E2`, adjusted `border-radius` and `overflow: hidden` on thumbnails, and updated `PhotoImage` rounding to match the container.
- Repositioned and restyled the thumbnail `DeleteButton` for compact mode, and simplified `UploadButtonLabel` by removing gradients/complex shadows, replacing them with solid background/border and simplified hover states.
- Removed rainbow/border-image styling and other decorative effects to standardize appearance across compact and full modes.

### Testing
- Ran unit tests with `yarn test` and code linting with `yarn lint`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a443264defc8326a2bd6d4524a83183)