### PR TITLE
Improve profile photo upload quality (preserve originals up to 1MB, compress only when larger)

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -271,8 +271,8 @@ const collectUserIdsBySearchIdKeys = async (searchKeys, options = {}) => {
 
 
 export const getUrlofUploadedAvatar = async (photo, userId, options = {}) => {
-  const { disableCompression = false, maxSizeKB = 50 } = options;
-  const file = disableCompression
+  const { disableCompression = false, maxSizeKB = 1024 } = options;
+  const file = disableCompression || photo.size <= maxSizeKB * 1024
     ? photo
     : await getFileBlob(await compressPhoto(photo, maxSizeKB));
 
@@ -309,32 +309,21 @@ const compressPhoto = (file, maxSizeKB) => {
       img.onload = () => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
+        const maxSizeBytes = maxSizeKB * 1024;
 
-        // Задаємо зменшені розміри canvas, зберігаючи пропорції
-        let width = img.width;
-        let height = img.height;
+        canvas.width = img.width;
+        canvas.height = img.height;
 
-        // Якщо зображення більше 1000px по ширині, зменшуємо до 1000px
-        const MAX_WIDTH = 1000;
-        if (width > MAX_WIDTH) {
-          height *= MAX_WIDTH / width;
-          width = MAX_WIDTH;
-        }
+        // Не зменшуємо роздільну здатність: заливаємо оригінальні пікселі,
+        // а для файлів понад ліміт поступово знижуємо лише JPEG-якість.
+        ctx.drawImage(img, 0, 0, img.width, img.height);
 
-        canvas.width = width;
-        canvas.height = height;
-
-        // Малюємо зображення на canvas з новими розмірами
-        ctx.drawImage(img, 0, 0, width, height);
-
-        // Спробуємо спочатку стиснути з якістю 0.6
-        let quality = 0.6;
+        let quality = 0.92;
         let compressedDataUrl = canvas.toDataURL('image/jpeg', quality);
         let compressedFile = dataURLToFile(compressedDataUrl);
 
-        // Перевірка розміру файлу після стиснення і зниження якості поступово
-        while (compressedFile.size > maxSizeKB * 1024 && quality > 0.1) {
-          quality -= 0.1; // Зменшуємо якість
+        while (compressedFile.size > maxSizeBytes && quality > 0.1) {
+          quality = Math.max(quality - 0.07, 0.1);
           compressedDataUrl = canvas.toDataURL('image/jpeg', quality);
           compressedFile = dataURLToFile(compressedDataUrl);
         }


### PR DESCRIPTION
### Motivation
- The profile photo upload flow was aggressively downscaling/compressing images which produced very poor quality avatars and preview photos.
- Keep original image quality where possible while still enforcing a reasonable maximum upload size to avoid excessive bandwidth/storage.

### Description
- Increased default upload threshold from `50KB` to `1024KB` and skip compression when `photo.size <= maxSizeKB * 1024` or `disableCompression` is true in `getUrlofUploadedAvatar` (file: `src/components/config.js`).
- Changed `compressPhoto` to preserve original image dimensions (no downscaling to 1000px) and to compress by reducing JPEG quality only, starting at `0.92` and decreasing by `0.07` steps until the target size is reached.
- Introduced `maxSizeBytes` local variable and adjusted loop condition to compare against that limit, keeping the existing `dataURLToFile` and upload pipeline unchanged.

### Testing
- Ran linter: `npm run lint:js -- src/components/config.js` and it completed successfully.
- Ran full test suite: `npm test -- --watchAll=false --runInBand`, which executed but returned failures unrelated to this change (8 test suites failed, 19 tests failed, 35 passed, 43 suites total); failures appear in existing cache/matching/storage test suites and are not caused by the photo upload logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44d928fbec8326898f762e2245ca47)