### PR TITLE
Add photo cropping UI + sequential crop/upload flow and hydrate TopBlock photos from storage

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -124,14 +124,167 @@ const HiddenFileInput = styled.input`
   display: none; /* Ховаємо справжній input */
 `;
 
+
+const PHOTO_CROP_ASPECT_RATIO = 1;
+const PHOTO_CROP_SIZE = 1200;
+const DEFAULT_CROP_CENTER = { x: 0.5, y: 0.5 };
+
+const CropModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 16px;
+`;
+
+const CropModalCard = styled.div`
+  width: min(92vw, 440px);
+  background: #fff;
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
+`;
+
+const CropModalTitle = styled.h3`
+  margin: 0 0 8px;
+  font-size: 18px;
+`;
+
+const CropModalHint = styled.p`
+  margin: 0 0 12px;
+  color: ${color.gray3};
+  font-size: 14px;
+  line-height: 1.35;
+`;
+
+const CropPreview = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #f3f4f6;
+  cursor: crosshair;
+  user-select: none;
+`;
+
+const CropPreviewImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+`;
+
+const CropCenterMarker = styled.div`
+  position: absolute;
+  left: ${({ $x }) => `${$x * 100}%`};
+  top: ${({ $y }) => `${$y * 100}%`};
+  width: 26px;
+  height: 26px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px ${color.accent5}, 0 2px 8px rgba(0, 0, 0, 0.35);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+`;
+
+const CropActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 14px;
+`;
+
+const CropButton = styled.button`
+  border: none;
+  border-radius: 8px;
+  padding: 9px 14px;
+  cursor: pointer;
+  font-weight: 700;
+  background: ${({ $primary }) => ($primary ? color.accent5 : '#eef2f7')};
+  color: ${({ $primary }) => ($primary ? '#fff' : '#334155')};
+`;
+
+const loadImage = file => new Promise((resolve, reject) => {
+  const url = URL.createObjectURL(file);
+  const image = new window.Image();
+  image.onload = () => {
+    URL.revokeObjectURL(url);
+    resolve(image);
+  };
+  image.onerror = error => {
+    URL.revokeObjectURL(url);
+    reject(error);
+  };
+  image.src = url;
+});
+
+const canvasToBlob = (canvas, type = 'image/jpeg', quality = 0.92) => new Promise(resolve => {
+  canvas.toBlob(resolve, type, quality);
+});
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const cropPhotoToStandardRatio = async (file, center = DEFAULT_CROP_CENTER) => {
+  const image = await loadImage(file);
+  const sourceWidth = image.naturalWidth || image.width;
+  const sourceHeight = image.naturalHeight || image.height;
+  if (!sourceWidth || !sourceHeight) return file;
+
+  let cropWidth = sourceWidth;
+  let cropHeight = cropWidth / PHOTO_CROP_ASPECT_RATIO;
+  if (cropHeight > sourceHeight) {
+    cropHeight = sourceHeight;
+    cropWidth = cropHeight * PHOTO_CROP_ASPECT_RATIO;
+  }
+
+  const normalizedCenter = center || DEFAULT_CROP_CENTER;
+  const sourceX = clamp((normalizedCenter.x * sourceWidth) - cropWidth / 2, 0, sourceWidth - cropWidth);
+  const sourceY = clamp((normalizedCenter.y * sourceHeight) - cropHeight / 2, 0, sourceHeight - cropHeight);
+  const outputSize = Math.min(PHOTO_CROP_SIZE, Math.max(cropWidth, cropHeight));
+  const canvas = document.createElement('canvas');
+  canvas.width = outputSize;
+  canvas.height = outputSize;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(image, sourceX, sourceY, cropWidth, cropHeight, 0, 0, outputSize, outputSize);
+  const blob = await canvasToBlob(canvas);
+  if (!blob) return file;
+  return new File([blob], file.name.replace(/\.[^.]+$/, '.jpg') || 'profile-photo.jpg', {
+    type: 'image/jpeg',
+    lastModified: Date.now(),
+  });
+};
+
 export const Photos = ({ state, setState, collection, hideFirstPhoto = false, uploadInputId = 'file-upload', compact = false, maxPhotos = 9 }) => {
   const [viewerIndex, setViewerIndex] = useState(null);
+  const [pendingCropFiles, setPendingCropFiles] = useState([]);
+  const [croppedPendingFiles, setCroppedPendingFiles] = useState([]);
+  const [cropPreviewUrl, setCropPreviewUrl] = useState('');
+  const [cropCenter, setCropCenter] = useState(DEFAULT_CROP_CENTER);
+  const [hasSelectedCropCenter, setHasSelectedCropCenter] = useState(false);
   const photoKeys = Object.keys(state).filter(
     k => k.toLowerCase().startsWith('photo') && k !== 'photos'
   );
   const arraysEqual = (a = [], b = []) =>
     a.length === b.length && a.every((val, idx) => val === b[idx]);
   const photoValues = photoKeys.map(k => state[k]).join('|');
+  const pendingCropFile = pendingCropFiles[0] || null;
+
+  useEffect(() => {
+    if (!pendingCropFile) {
+      setCropPreviewUrl('');
+      return undefined;
+    }
+
+    const url = URL.createObjectURL(pendingCropFile);
+    setCropPreviewUrl(url);
+    setCropCenter(DEFAULT_CROP_CENTER);
+    setHasSelectedCropCenter(false);
+    return () => URL.revokeObjectURL(url);
+  }, [pendingCropFile]);
 
   const normalizePhotosArray = value => {
     if (!value) {
@@ -262,15 +415,17 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
   };
 
   const handleDeletePhoto = async index => {
-    const photoUrl = state.photos[index];
-    const newPhotos = state.photos.filter((_, i) => i !== index);
+    const currentPhotos = Array.isArray(state.photos) ? state.photos : [];
+    const photoUrl = currentPhotos[index];
+    const newPhotos = currentPhotos.filter((_, i) => i !== index);
+
+    commitPhotosUpdate(newPhotos);
 
     try {
       await deletePhotos(state.userId, [photoUrl]);
-      commitPhotosUpdate(newPhotos);
-
       await savePhotoList(newPhotos);
     } catch (error) {
+      commitPhotosUpdate(currentPhotos);
       console.error('Error deleting photo:', error);
     }
   };
@@ -287,24 +442,66 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
     }
   };
 
-  const addPhoto = async event => {
+  const uploadPreparedPhotos = async files => {
+    const currentPhotos = Array.isArray(state.photos) ? state.photos : [];
+    const previewUrls = files.map(file => URL.createObjectURL(file));
+    commitPhotosUpdate([...currentPhotos, ...previewUrls]);
+
+    try {
+      const newUrls = await Promise.all(
+        files.map(photo => getUrlofUploadedAvatar(photo, state.userId))
+      );
+      const updatedPhotos = [...currentPhotos, ...newUrls];
+      commitPhotosUpdate(updatedPhotos);
+      await savePhotoList(updatedPhotos);
+    } catch (error) {
+      commitPhotosUpdate(currentPhotos);
+      console.error('Error uploading photos:', error);
+    } finally {
+      previewUrls.forEach(url => URL.revokeObjectURL(url));
+    }
+  };
+
+  const addPhoto = event => {
     const currentPhotos = Array.isArray(state.photos) ? state.photos : [];
     const availableSlots = Math.max(maxPhotos - currentPhotos.length, 0);
     const photoArray = Array.from(event.target.files).slice(0, availableSlots);
     event.target.value = '';
     if (photoArray.length === 0) return;
+    setCroppedPendingFiles([]);
+    setPendingCropFiles(photoArray);
+  };
 
-    try {
-      const newUrls = await Promise.all(
-        photoArray.map(photo => getUrlofUploadedAvatar(photo, state.userId))
-      );
-      const updatedPhotos = [...currentPhotos, ...newUrls];
-      commitPhotosUpdate(updatedPhotos);
+  const handleCropPreviewClick = event => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    setCropCenter({
+      x: clamp((event.clientX - rect.left) / rect.width, 0, 1),
+      y: clamp((event.clientY - rect.top) / rect.height, 0, 1),
+    });
+    setHasSelectedCropCenter(true);
+  };
 
-      await savePhotoList(updatedPhotos);
-    } catch (error) {
-      console.error('Error uploading photos:', error);
+  const cancelCrop = () => {
+    setPendingCropFiles([]);
+    setCroppedPendingFiles([]);
+  };
+
+  const confirmCurrentCrop = async () => {
+    if (!pendingCropFile) return;
+    const center = hasSelectedCropCenter ? cropCenter : DEFAULT_CROP_CENTER;
+    const croppedFile = await cropPhotoToStandardRatio(pendingCropFile, center);
+    const remainingFiles = pendingCropFiles.slice(1);
+    const readyFiles = [...croppedPendingFiles, croppedFile];
+
+    if (remainingFiles.length > 0) {
+      setCroppedPendingFiles(readyFiles);
+      setPendingCropFiles(remainingFiles);
+      return;
     }
+
+    setPendingCropFiles([]);
+    setCroppedPendingFiles([]);
+    await uploadPreparedPhotos(readyFiles);
   };
 
   const handlePhotoClick = (url, index) => {
@@ -376,6 +573,24 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
         <NoPhotosText>Додайте свої фото, максимум {maxPhotos} шт</NoPhotosText>
       )}
       {!compact && uploadButton}
+      {pendingCropFile && (
+        <CropModalOverlay onClick={cancelCrop}>
+          <CropModalCard onClick={event => event.stopPropagation()}>
+            <CropModalTitle>Обрізати фото до стандартного розміру</CropModalTitle>
+            <CropModalHint>Клікніть по фото, щоб обрати центр обрізання. Якщо центр не обрано, фото буде обрізано автоматично по центру.</CropModalHint>
+            <CropPreview onClick={handleCropPreviewClick}>
+              {cropPreviewUrl && <CropPreviewImage src={cropPreviewUrl} alt="Попередній перегляд обрізання" />}
+              <CropCenterMarker $x={cropCenter.x} $y={cropCenter.y} />
+            </CropPreview>
+            <CropActions>
+              <CropButton type="button" onClick={cancelCrop}>Скасувати</CropButton>
+              <CropButton type="button" $primary onClick={confirmCurrentCrop}>
+                {pendingCropFiles.length > 1 ? 'Зберегти й наступне' : 'Зберегти'}
+              </CropButton>
+            </CropActions>
+          </CropModalCard>
+        </CropModalOverlay>
+      )}
       {viewerIndex !== null && (
         <PhotoViewer
           photos={state.photos}

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -36,6 +36,7 @@ import { normalizeRegion } from '../normalizeLocation';
 import { getCurrentValue } from '../getCurrentValue';
 import {
   fetchUserById,
+  getAllUserPhotos,
   setUserComment as persistUserComment,
   fetchAllCommentsByCardId,
   updateCommentByOwner,
@@ -1016,6 +1017,8 @@ export const TopBlock = ({
   const region = normalizeRegion(cardData.region);
   const showSideActions = !additionalActions;
   const hasHiddenCycleFieldRole = hasRoleWithoutCycle(cardData);
+  const userPhotoUrls = getUserProfilePhotoUrls(cardData);
+  const userPhotoUrl = userPhotoUrls[0] || '';
 
   React.useEffect(() => {
     if (!cardData?.userId) {
@@ -1038,7 +1041,7 @@ export const TopBlock = ({
     const sourceCollection = resolveUserPhotoCollection(cardData);
     setResolvedPhotosCollection(sourceCollection);
 
-    if (!isPhotosModalOpen || sourceCollection || !cardData?.userId) {
+    if (sourceCollection || !cardData?.userId) {
       return undefined;
     }
 
@@ -1050,7 +1053,7 @@ export const TopBlock = ({
 
         const freshCollection = resolveUserPhotoCollection(fresh);
         if (!freshCollection) {
-          toast.error('Не вдалося визначити джерело фото профілю');
+          if (isPhotosModalOpen) toast.error('Не вдалося визначити джерело фото профілю');
           return;
         }
 
@@ -1083,7 +1086,7 @@ export const TopBlock = ({
       } catch (error) {
         if (isMounted) {
           console.error('Error resolving photo source:', error);
-          toast.error('Не вдалося визначити джерело фото профілю');
+          if (isPhotosModalOpen) toast.error('Не вдалося визначити джерело фото профілю');
         }
       }
     };
@@ -1094,10 +1097,61 @@ export const TopBlock = ({
     };
   }, [cardData, isFromListOfUsers, isPhotosModalOpen, setState, setUsers]);
 
+  React.useEffect(() => {
+    if (!cardData?.userId || userPhotoUrls.length > 0 || !resolvedPhotosCollection) {
+      return undefined;
+    }
+
+    let isMounted = true;
+    const hydrateTopBlockPhotos = async () => {
+      try {
+        const urls = await getAllUserPhotos(cardData.userId, resolvedPhotosCollection);
+        if (!isMounted) return;
+        const filteredUrls = filterOutMedicationPhotos(urls, cardData.userId);
+        if (!filteredUrls.length) return;
+
+        const updatePhotos = currentCard => {
+          const baseCard = currentCard || cardData;
+          if (baseCard?.userId && baseCard.userId !== cardData.userId) return currentCard;
+          const currentUrls = getUserProfilePhotoUrls(baseCard);
+          if (currentUrls.length > 0) return currentCard || baseCard;
+          return {
+            ...baseCard,
+            photos: filteredUrls,
+            __photosHydrated: true,
+          };
+        };
+
+        if (typeof setState === 'function' && !isFromListOfUsers) {
+          setState(prev => updatePhotos(prev), {
+            source: 'userChange',
+            caller: 'renderTopBlock.hydrateTopBlockPhotos',
+            reason: 'photos-hydrated-on-open',
+          });
+        }
+
+        if (typeof setUsers === 'function') {
+          setUsers(prev => (
+            stateContainsUser(prev, cardData.userId)
+              ? updateUserInState(prev, cardData.userId, updatePhotos)
+              : prev
+          ));
+        }
+      } catch (error) {
+        if (isMounted) {
+          console.error('Error hydrating top block photos:', error);
+        }
+      }
+    };
+
+    hydrateTopBlockPhotos();
+    return () => {
+      isMounted = false;
+    };
+  }, [cardData, isFromListOfUsers, resolvedPhotosCollection, setState, setUsers, userPhotoUrls.length]);
+
   if (!cardData) return null;
 
-  const userPhotoUrls = getUserProfilePhotoUrls(cardData);
-  const userPhotoUrl = userPhotoUrls[0] || '';
   const photosCollection = resolvedPhotosCollection;
   const setCardPhotosState = updater => {
     const resolveNextCard = currentCard => {


### PR DESCRIPTION
### Motivation
- Provide a client-side flow to crop uploaded profile photos to a standard square ratio before uploading so photos are consistent. 
- Improve TopBlock photo hydration by fetching all user photos from the resolved collection when the card opens and there are no photos in-state.

### Description
- Added a cropping UI and workflow to `Photos` including modal components, constants (`PHOTO_CROP_ASPECT_RATIO`, `PHOTO_CROP_SIZE`), utilities (`loadImage`, `canvasToBlob`, `cropPhotoToStandardRatio`), and state for `pendingCropFiles` / `croppedPendingFiles` with sequential cropping and upload handling via `uploadPreparedPhotos` and `confirmCurrentCrop`.
- Changed `addPhoto` to stage selected files for cropping instead of uploading immediately and added a preview + click-to-set-center marker that defaults to center when none selected (`handleCropPreviewClick`, `hasSelectedCropCenter`).
- Updated upload and delete flows to show optimistic preview URLs, restore state on error, and revoke preview object URLs after use (`commitPhotosUpdate`, `uploadPreparedPhotos`, `handleDeletePhoto` rollback). 
- In `renderTopBlock.js` moved `userPhotoUrls` computation earlier, imported `getAllUserPhotos`, suppressed error toasts when a photos modal is not open, and added an effect that hydrates `photos` by fetching all user photos from the resolved collection and filtering via `filterOutMedicationPhotos` when no profile photos exist in-state.

### Testing
- Ran the project test suite with `npm test` and static linting with `npm run lint`, and they completed without failures on the modified modules.
- Manual smoke-tested the photo upload flow to verify preview, crop center selection, sequential cropping of multiple files, successful upload, and rollback on upload/delete errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44f9fb3f6483269e75a9357943b125)