### PR TITLE
Приховати графік стимуляції за замовчуванням

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -5975,10 +5975,10 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
   const scheduleUserData = state;
   const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveCycleStatus);
-  const [isStimulationScheduleVisible, setIsStimulationScheduleVisible] = useState(true);
+  const [isStimulationScheduleVisible, setIsStimulationScheduleVisible] = useState(false);
 
   useEffect(() => {
-    setIsStimulationScheduleVisible(true);
+    setIsStimulationScheduleVisible(false);
   }, [state?.userId, shouldShowSchedule]);
 
 

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -907,10 +907,10 @@ const EditProfile = () => {
   const effectiveCycleStatus = getEffectiveCycleStatus(state);
   const scheduleUserData = state;
   const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveCycleStatus);
-  const [isStimulationScheduleVisible, setIsStimulationScheduleVisible] = useState(true);
+  const [isStimulationScheduleVisible, setIsStimulationScheduleVisible] = useState(false);
 
   useEffect(() => {
-    setIsStimulationScheduleVisible(true);
+    setIsStimulationScheduleVisible(false);
   }, [state?.userId, shouldShowSchedule]);
 
   const overlayFieldAdditions = useMemo(() => {

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -47,7 +47,7 @@ const UserCard = ({
     cycleStatus: effectiveStatus ?? userData?.cycleStatus,
   };
   const shouldShowSchedule = ['stimulation', 'pregnant'].includes(effectiveStatus);
-  const [isStimulationScheduleVisible, setIsStimulationScheduleVisible] = React.useState(true);
+  const [isStimulationScheduleVisible, setIsStimulationScheduleVisible] = React.useState(false);
   const role = userData?.role || userData?.userRole;
 
   return (


### PR DESCRIPTION
### Motivation
- Зменшити візуальний шум у картках та профілі, роблячи графік стимуляції прихованим за замовчуванням у всіх місцях рендерингу, де він показується.
- Зберегти існуючу кнопку-перемикач у `TopBlock`, щоб користувачі могли вручну показати графік при потребі.

### Description
- Змінено початковий стан `isStimulationScheduleVisible` на `false` у `src/components/UsersList.jsx` для карток списку.
- Змінено початковий стан `isStimulationScheduleVisible` на `false` у `src/components/EditProfile.jsx` і відповідний `useEffect` скидання видимості при зміні профілю/статусу.
- Змінено початковий стан `isStimulationScheduleVisible` на `false` у `src/components/AddNewProfile.jsx` і відповідний `useEffect` скидання видимості при зміні профілю/статусу.
- Ніяких змін до логіки `TopBlock` або кнопки перемикання не зроблено, тільки стартовий стан видимості.

### Testing
- Запущено `npm test -- --watchAll=false --runInBand src/components/StimulationSchedule.test.jsx` і всі тести пройшли успішно (1 suite, 12 тестів).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a451c18741c83268ba21824b0b6a95f)