### PR TITLE
Remove photosCollection dependency from profile PDF export and simplify photo resolution

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -971,11 +971,11 @@ const pdfExportButtonStyle = {
   textDecoration: 'none',
 };
 
-const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection }) => {
+const resolvePdfPhotoUrls = async ({ cardData, photoUrls }) => {
   const existingPhotos = Array.isArray(photoUrls) ? photoUrls : [];
-  if (existingPhotos.length > 0 || !cardData?.userId || !photosCollection) return existingPhotos;
+  if (existingPhotos.length > 0 || !cardData?.userId) return existingPhotos;
 
-  const loadedPhotos = await getAllUserPhotos(cardData.userId, photosCollection);
+  const loadedPhotos = await getAllUserPhotos(cardData.userId);
   return Array.from(new Set(
     filterOutMedicationPhotos(loadedPhotos, cardData.userId)
       .map(convertDriveLinkToImage)
@@ -985,7 +985,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection }) =>
 
 const isSurrogateMotherRole = data => String(data?.userRole || data?.role || '').trim().toLowerCase() === 'sm';
 
-const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
+const ProfilePdfExportButton = ({ cardData, photoUrls }) => {
   const [isGenerating, setIsGenerating] = useState(false);
 
   const handleExport = async event => {
@@ -995,7 +995,7 @@ const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
     setIsGenerating(true);
     try {
       const fileName = buildProfilePdfFileName(cardData);
-      const effectivePhotoUrls = await resolvePdfPhotoUrls({ cardData, photoUrls, photosCollection });
+      const effectivePhotoUrls = await resolvePdfPhotoUrls({ cardData, photoUrls });
       const blob = await pdf(<ProfilePdfDocument userData={cardData} photoUrls={effectivePhotoUrls} />).toBlob();
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
@@ -1770,7 +1770,6 @@ export const TopBlock = ({
             <ProfilePdfExportButton
               cardData={cardData}
               photoUrls={userPhotoUrls}
-              photosCollection={photosCollection}
             />
           )}
           {additionalActions}


### PR DESCRIPTION
### Motivation
- Simplify PDF photo resolution by removing the external `photosCollection` dependency and rely solely on the user ID and existing `photoUrls` when generating profile PDFs.
- Reduce prop drilling and make `ProfilePdfExportButton` interface cleaner and easier to use in places where a `photosCollection` is not available.

### Description
- Changed `resolvePdfPhotoUrls` signature to accept only `{ cardData, photoUrls }` and exit early when `photoUrls` exist or `cardData?.userId` is missing.
- Updated `resolvePdfPhotoUrls` to call `getAllUserPhotos(cardData.userId)` with a single `userId` argument instead of passing `photosCollection` through.
- Updated `ProfilePdfExportButton` component to remove the `photosCollection` prop and adjusted its call site to stop passing `photosCollection`.
- Kept existing filtering/normalization logic by deduplicating, filtering medication photos, and converting drive links to image URLs before returning results.

### Testing
- Ran unit tests with `yarn test`, and the test suite completed successfully with no failures.
- Ran linter with `yarn lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452028efec8326a108e38c5f006fd4)