### PR TITLE
Photos: allow reconciliation with shorter remote photo lists

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -472,7 +472,7 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
           if (filteredUrls.length > 0) {
             const currentPhotos = normalizePhotosArray(state.photos);
             const hasLocalPreviewPhotos = currentPhotos.some(url => typeof url === 'string' && url.startsWith('blob:'));
-            if (isUploadingPhotos || hasLocalPreviewPhotos || currentPhotos.length > filteredUrls.length) {
+            if (isUploadingPhotos || hasLocalPreviewPhotos) {
               return;
             }
             const sanitizedCurrent = filterOutMedicationPhotos(currentPhotos, state.userId);


### PR DESCRIPTION
### Motivation
- The component could start with a stale `state.photos` array longer than the current Storage listing and an early-return based on list length prevented `commitPhotosUpdate(filteredUrls)` from removing deleted remote photos, leaving stale entries visible and persisted.

### Description
- Remove the `currentPhotos.length > filteredUrls.length` early-return in the `useEffect` that loads remote photos so shorter remote lists can reconcile stale `state.photos`, while preserving the existing guards for `isUploadingPhotos` and local blob-preview URLs.

### Testing
- Ran `npm run lint:js -- src/components/Photos.jsx` which completed (lint warnings only); ran `npm test -- --watchAll=false` which executed the test suite but reported unrelated failures in several storage/matching tests (8 failed, 35 passed, 43 total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a457a30929083269998e7baa31206db)