### PR TITLE
Support dynamic crop aspect ratio in CropPreview

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -168,7 +168,7 @@ const CropModalHint = styled.p`
 const CropPreview = styled.div`
   position: relative;
   width: 100%;
-  aspect-ratio: 1 / 1;
+  aspect-ratio: ${({ $aspectRatio }) => $aspectRatio || DEFAULT_CROP_ASPECT_RATIO};
   overflow: hidden;
   border-radius: 12px;
   background: #f3f4f6;
@@ -741,6 +741,7 @@ export const Photos = ({ state, setState, collection, hideFirstPhoto = false, up
         <CropModalTitle>Обрізати фото до стандартного розміру</CropModalTitle>
         <CropModalHint>Перетягніть фото всередині рамки та змініть масштаб, щоб обрати найвдалішу частину для картки.</CropModalHint>
         <CropPreview
+          $aspectRatio={safeCropAspectRatio}
           onPointerDown={handleCropPreviewPointerDown}
           onPointerMove={handleCropPreviewPointerMove}
           onPointerUp={handleCropPreviewPointerUp}


### PR DESCRIPTION
### Motivation

- Allow the crop preview area to use dynamic aspect ratios instead of a fixed 1:1 ratio so cropping matches different card/photo shapes.

### Description

- Change the `CropPreview` styled component to set `aspect-ratio` from the `$aspectRatio` prop falling back to `DEFAULT_CROP_ASPECT_RATIO`.
- Pass `safeCropAspectRatio` into the `CropPreview` instance via the `$aspectRatio` prop so the preview, focus frame, and grid align.
- No other layout or interaction logic was modified; images and offsets continue to use the existing display and bounding logic.

### Testing

- Ran the test suite with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a457b044af08326abe9b3f12487623c)