### PR TITLE
Combine storage and DB user photos; add photosCollection option for PDF export

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -23,6 +23,7 @@ import {
 } from 'firebase/database';
 import { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 import { filterOutMedicationPhotos } from '../utils/photoFilters';
+import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
 import { getCurrentDate } from './foramtDate';
 import toast from 'react-hot-toast';
 import { getCard, incrementMatchingLoadStat, removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
@@ -2836,12 +2837,38 @@ export const deletePhotos = async (userId, photoUrls = []) => {
   );
 };
 
-export const getAllUserPhotos = async userId => {
+const normalizePhotoValues = value => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.flatMap(normalizePhotoValues);
+  if (typeof value === 'object') return Object.values(value).flatMap(normalizePhotoValues);
+  if (typeof value !== 'string') return [];
+  const photo = value.trim();
+  return photo ? [photo] : [];
+};
+
+const getPhotoSourceCollections = collectionSource => (
+  collectionSource === 'users' || collectionSource === 'newUsers'
+    ? [collectionSource]
+    : ['newUsers', 'users']
+);
+
+export const getAllUserPhotos = async (userId, collectionSource = null) => {
+  if (!userId) return [];
+
   try {
     const folderRef = ref(storage, `avatar/${userId}`);
     const list = await listAll(folderRef);
-    const urls = await Promise.all(list.items.map(item => getDownloadURL(item)));
-    return filterOutMedicationPhotos(urls, userId);
+    const storageUrls = await Promise.all(list.items.map(item => getDownloadURL(item)));
+    const sourceCollections = getPhotoSourceCollections(collectionSource);
+    const snapshots = await Promise.all(
+      sourceCollections.map(source => get(ref2(database, `${source}/${userId}`)).then(snapshot => snapshot.exists() ? snapshot.val() : null))
+    );
+    const databaseUrls = snapshots.flatMap(userData => normalizePhotoValues(userData?.photos));
+    const urls = [...storageUrls, ...databaseUrls]
+      .map(convertDriveLinkToImage)
+      .filter(Boolean);
+
+    return Array.from(new Set(filterOutMedicationPhotos(urls, userId)));
   } catch (error) {
     console.error('Error listing user photos:', error);
     return [];
@@ -6552,7 +6579,7 @@ export const fetchUserById = async userId => {
     // Пошук у newUsers
     const newUserSnapshot = await get(userRefInNewUsers);
     if (newUserSnapshot.exists()) {
-      const photos = await getAllUserPhotos(userId);
+      const photos = await getAllUserPhotos(userId, 'newUsers');
       const userSnapshotInUsers = await get(ref2(db, `users/${userId}`));
       if (userSnapshotInUsers.exists()) {
         return {
@@ -6574,7 +6601,7 @@ export const fetchUserById = async userId => {
     // Пошук у users, якщо не знайдено в newUsers
     const userSnapshot = await get(userRefInUsers);
     if (userSnapshot.exists()) {
-      const photos = await getAllUserPhotos(userId);
+      const photos = await getAllUserPhotos(userId, 'users');
       console.log('Знайдено користувача у users: ', userSnapshot.val());
       return {
         userId,

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -972,11 +972,12 @@ const pdfExportButtonStyle = {
   textDecoration: 'none',
 };
 
-const resolvePdfPhotoUrls = async ({ cardData, photoUrls }) => {
+const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection }) => {
   const existingPhotos = Array.isArray(photoUrls) ? photoUrls : [];
   if (existingPhotos.length > 0 || !cardData?.userId) return existingPhotos;
 
-  const loadedPhotos = await getAllUserPhotos(cardData.userId);
+  const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
+  const loadedPhotos = await getAllUserPhotos(cardData.userId, sourceCollection);
   return Array.from(new Set(
     filterOutMedicationPhotos(loadedPhotos, cardData.userId)
       .map(convertDriveLinkToImage)
@@ -986,7 +987,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls }) => {
 
 const isSurrogateMotherRole = data => String(data?.userRole || data?.role || '').trim().toLowerCase() === 'sm';
 
-const ProfilePdfExportButton = ({ cardData, photoUrls }) => {
+const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
   const [isGenerating, setIsGenerating] = useState(false);
 
   const handleExport = async event => {
@@ -996,7 +997,7 @@ const ProfilePdfExportButton = ({ cardData, photoUrls }) => {
     setIsGenerating(true);
     try {
       const fileName = buildProfilePdfFileName(cardData);
-      const effectivePhotoUrls = await resolvePdfPhotoUrls({ cardData, photoUrls });
+      const effectivePhotoUrls = await resolvePdfPhotoUrls({ cardData, photoUrls, photosCollection });
       const blob = await pdf(<ProfilePdfDocument userData={cardData} photoUrls={effectivePhotoUrls} />).toBlob();
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
@@ -1771,6 +1772,7 @@ export const TopBlock = ({
             <ProfilePdfExportButton
               cardData={cardData}
               photoUrls={userPhotoUrls}
+              photosCollection={photosCollection}
             />
           )}
           {additionalActions}


### PR DESCRIPTION
### Motivation
- Ensure user photos are collected from both Firebase Storage and Realtime Database and normalize various stored formats including Google Drive links.
- Allow PDF export to explicitly choose which collection (`newUsers` vs `users`) to resolve photos from when generating profile PDFs.

### Description
- Added `normalizePhotoValues` and `getPhotoSourceCollections` helpers and updated `getAllUserPhotos` to accept an optional `collectionSource` parameter and merge Storage and Realtime Database photo sources while converting Drive links and deduplicating results using `convertDriveLinkToImage` and `filterOutMedicationPhotos`.
- Updated calls to `getAllUserPhotos` in `fetchUserById` to pass the correct source (`'newUsers'` or `'users'`).
- Updated PDF export flow in `renderTopBlock.js` by adding an optional `photosCollection` parameter to `resolvePdfPhotoUrls` and `ProfilePdfExportButton`, and passing `photosCollection` from `TopBlock` so exports load photos from the intended collection.

### Testing
- Ran the project test suite via `npm test` and linting via `npm run lint`, and both completed successfully.
- Performed automated build checks and the bundle step completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a457b65c0f8832680cf78c2a291feda)