### PR TITLE
Robust profile photo loading and include existing photos in PDF export

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -6141,7 +6141,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     Promise.all(
       idsToLoad.map(async id => {
-        const photos = await lazyLoadProfilePhotos(id);
+        const photos = await lazyLoadProfilePhotos(id, paginatedUsers[id]?.__sourceCollection);
         return [id, Array.isArray(photos) ? photos : []];
       }),
     )

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1772,7 +1772,7 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
   }
 };
 
-export const lazyLoadProfilePhotos = async userId => getAllUserPhotos(userId);
+export const lazyLoadProfilePhotos = async (userId, collectionSource = null) => getAllUserPhotos(userId, collectionSource);
 
 const addUserFromUsers = async (userId, users) => {
   const userSnap = await get(ref2(database, `users/${userId}`));
@@ -2860,10 +2860,17 @@ export const getAllUserPhotos = async (userId, collectionSource = null) => {
     const list = await listAll(folderRef);
     const storageUrls = await Promise.all(list.items.map(item => getDownloadURL(item)));
     const sourceCollections = getPhotoSourceCollections(collectionSource);
-    const snapshots = await Promise.all(
-      sourceCollections.map(source => get(ref2(database, `${source}/${userId}`)).then(snapshot => snapshot.exists() ? snapshot.val() : null))
+    const snapshots = await Promise.allSettled(
+      sourceCollections.map(source => get(ref2(database, `${source}/${userId}`)))
     );
-    const databaseUrls = snapshots.flatMap(userData => normalizePhotoValues(userData?.photos));
+    const databaseUrls = snapshots.flatMap((result, index) => {
+      if (result.status === 'rejected') {
+        console.error(`Error loading user photos from ${sourceCollections[index]}:`, result.reason);
+        return [];
+      }
+      const snapshot = result.value;
+      return snapshot.exists() ? normalizePhotoValues(snapshot.val()?.photos) : [];
+    });
     const urls = [...storageUrls, ...databaseUrls]
       .map(convertDriveLinkToImage)
       .filter(Boolean);
@@ -6579,8 +6586,11 @@ export const fetchUserById = async userId => {
     // Пошук у newUsers
     const newUserSnapshot = await get(userRefInNewUsers);
     if (newUserSnapshot.exists()) {
-      const photos = await getAllUserPhotos(userId, 'newUsers');
       const userSnapshotInUsers = await get(ref2(db, `users/${userId}`));
+      const photos = await getAllUserPhotos(
+        userId,
+        userSnapshotInUsers.exists() ? null : 'newUsers'
+      );
       if (userSnapshotInUsers.exists()) {
         return {
           userId,

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -974,12 +974,12 @@ const pdfExportButtonStyle = {
 
 const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection }) => {
   const existingPhotos = Array.isArray(photoUrls) ? photoUrls : [];
-  if (existingPhotos.length > 0 || !cardData?.userId) return existingPhotos;
+  if (!cardData?.userId) return existingPhotos;
 
   const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
   const loadedPhotos = await getAllUserPhotos(cardData.userId, sourceCollection);
   return Array.from(new Set(
-    filterOutMedicationPhotos(loadedPhotos, cardData.userId)
+    filterOutMedicationPhotos([...existingPhotos, ...loadedPhotos], cardData.userId)
       .map(convertDriveLinkToImage)
       .filter(Boolean)
   ));


### PR DESCRIPTION
### Motivation
- Ensure profile photos are loaded from the correct database collection (`users` vs `newUsers`) and avoid unnecessary or incorrect fetches when the source is known. 
- Make photo loading more resilient to partial failures when reading database snapshots. 
- Ensure PDF export includes any already-resolved photo URLs and avoid extra work when `userId` is missing.

### Description
- Pass `__sourceCollection` through the list lazy-loader by updating the `AddNewProfile` useEffect to call `lazyLoadProfilePhotos(id, paginatedUsers[id]?.__sourceCollection)`. 
- Change `lazyLoadProfilePhotos` signature to accept an optional `collectionSource` parameter and forward it to `getAllUserPhotos`. 
- Update `getAllUserPhotos` to determine source collections using `getPhotoSourceCollections(collectionSource)`, list storage files as before, and fetch DB snapshots via `Promise.allSettled`; rejected DB reads are logged and skipped. 
- Merge storage and database URLs, convert drive links, filter medication photos, and deduplicate results before returning. 
- Adjust `fetchUserById` to decide which collection to request photos from by checking existence in both `newUsers` and `users`, and call `getAllUserPhotos` with a suitable `collectionSource` hint. 
- Modify PDF resolver `resolvePdfPhotoUrls` to return immediately if `cardData?.userId` is absent and to merge `existingPhotos` with `loadedPhotos` before filtering and deduping, ensuring exported PDFs include previously provided URLs.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a460baf32bc83268493511d409afd78)