### PR TITLE
Remove MatchingModeLabel component and its usage

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -71,7 +71,6 @@ import {
   ModernSectionTitle,
   BackendTrafficToggleButton,
   BackendTrafficToggleStatus,
-  MatchingModeLabel,
   MatchingSearchStatusMessage,
 } from './Matching.styled';
 import {
@@ -3713,13 +3712,6 @@ const Matching = () => {
 
   const loadDislikeCards = () => switchMatchingMode('dislikes');
 
-  const matchingModeLabel = {
-    default: 'Загальний список',
-    favorites: 'Обране',
-    dislikes: 'Дизлайки',
-    search: 'Пошук',
-  }[viewMode] || 'Matching';
-
   const handleDislikeModeClick = () => {
     if (viewMode === 'dislikes') {
       reloadDefault();
@@ -5785,7 +5777,6 @@ const Matching = () => {
                   <FaHeart />
                 </ActionButton>
               </TopActionGroup>
-              <MatchingModeLabel aria-live="polite">{matchingModeLabel}</MatchingModeLabel>
               <TopActionGroup aria-label="Налаштування matching">
                 <ThemeToggleButton
                   type="button"

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -420,26 +420,6 @@ export const ActionBadge = styled.span`
   box-sizing: border-box;
 `;
 
-export const MatchingModeLabel = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 31px;
-  padding: 3px 10px;
-  border: 1px solid var(--matching-section-border, rgba(255, 255, 255, 0.14));
-  border-radius: 999px;
-  background: var(--matching-section-bg, rgba(255, 255, 255, 0.82));
-  color: var(--matching-muted-text, #6B7280);
-  box-shadow: var(--matching-section-shadow, 0 8px 18px rgba(22, 22, 22, 0.08));
-  font-size: 11px;
-  font-weight: 800;
-  white-space: nowrap;
-  flex: 0 0 auto;
-`;
-
-
-
-
 export const ThemeToggleButton = styled.button`
   position: relative;
   flex: 0 0 auto;


### PR DESCRIPTION
### Motivation
- Simplify the matching header UI by removing the static matching mode label element which was no longer required.

### Description
- Deleted the `MatchingModeLabel` styled component from `Matching.styled.jsx` and removed its import and JSX usage from `Matching.jsx`, along with the `matchingModeLabel` helper variable.

### Testing
- Ran the component build and automated checks via `yarn build`, `yarn test`, and `yarn lint`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a461051b5f48326913ef58da761a18e)