### PR TITLE
Separate storage avatar fetch and dedupe photo sources for PDF export

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2852,34 +2852,47 @@ const getPhotoSourceCollections = collectionSource => (
     : ['newUsers', 'users']
 );
 
-export const getAllUserPhotos = async (userId, collectionSource = null) => {
+export const getUserStorageAvatarPhotos = async userId => {
   if (!userId) return [];
 
   try {
     const folderRef = ref(storage, `avatar/${userId}`);
     const list = await listAll(folderRef);
-    const storageUrls = await Promise.all(list.items.map(item => getDownloadURL(item)));
-    const sourceCollections = getPhotoSourceCollections(collectionSource);
-    const snapshots = await Promise.allSettled(
-      sourceCollections.map(source => get(ref2(database, `${source}/${userId}`)))
-    );
-    const databaseUrls = snapshots.flatMap((result, index) => {
-      if (result.status === 'rejected') {
-        console.error(`Error loading user photos from ${sourceCollections[index]}:`, result.reason);
+    const settledUrls = await Promise.allSettled(list.items.map(item => getDownloadURL(item)));
+    return settledUrls
+      .flatMap(result => {
+        if (result.status === 'fulfilled') return [result.value];
+        console.error('Error loading user photo from Storage:', result.reason);
         return [];
-      }
-      const snapshot = result.value;
-      return snapshot.exists() ? normalizePhotoValues(snapshot.val()?.photos) : [];
-    });
-    const urls = [...storageUrls, ...databaseUrls]
-      .map(convertDriveLinkToImage)
+      })
       .filter(Boolean);
-
-    return Array.from(new Set(filterOutMedicationPhotos(urls, userId)));
   } catch (error) {
-    console.error('Error listing user photos:', error);
+    console.error('Error listing user photos from Storage:', error);
     return [];
   }
+};
+
+export const getAllUserPhotos = async (userId, collectionSource = null, { includeStorage = true } = {}) => {
+  if (!userId) return [];
+
+  const storageUrls = includeStorage ? await getUserStorageAvatarPhotos(userId) : [];
+  const sourceCollections = getPhotoSourceCollections(collectionSource);
+  const snapshots = await Promise.allSettled(
+    sourceCollections.map(source => get(ref2(database, `${source}/${userId}`)))
+  );
+  const databaseUrls = snapshots.flatMap((result, index) => {
+    if (result.status === 'rejected') {
+      console.error(`Error loading user photos from ${sourceCollections[index]}:`, result.reason);
+      return [];
+    }
+    const snapshot = result.value;
+    return snapshot.exists() ? normalizePhotoValues(snapshot.val()?.photos) : [];
+  });
+  const urls = [...storageUrls, ...databaseUrls]
+    .map(convertDriveLinkToImage)
+    .filter(Boolean);
+
+  return Array.from(new Set(filterOutMedicationPhotos(urls, userId)));
 };
 
 export const getMedicationPhotos = async userId => {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -38,6 +38,7 @@ import { getCurrentValue } from '../getCurrentValue';
 import {
   fetchUserById,
   getAllUserPhotos,
+  getUserStorageAvatarPhotos,
   setUserComment as persistUserComment,
   fetchAllCommentsByCardId,
   updateCommentByOwner,
@@ -977,9 +978,12 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection }) =>
   if (!cardData?.userId) return existingPhotos;
 
   const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
-  const loadedPhotos = await getAllUserPhotos(cardData.userId, sourceCollection);
+  const [storagePhotos, loadedPhotos] = await Promise.all([
+    getUserStorageAvatarPhotos(cardData.userId),
+    getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false }),
+  ]);
   return Array.from(new Set(
-    filterOutMedicationPhotos([...existingPhotos, ...loadedPhotos], cardData.userId)
+    filterOutMedicationPhotos([...existingPhotos, ...storagePhotos, ...loadedPhotos], cardData.userId)
       .map(convertDriveLinkToImage)
       .filter(Boolean)
   ));


### PR DESCRIPTION
### Motivation
- Prevent duplicate photo URLs and improve error handling when aggregating user photos from Firebase Storage and the Realtime Database for profile exports. 
- Make storage-only avatar loading reusable and allow toggling storage inclusion when composing the full photo list.

### Description
- Added `getUserStorageAvatarPhotos(userId)` to list `avatar/<userId>` in Storage and return download URLs using `Promise.allSettled` with per-item error logging. 
- Reworked `getAllUserPhotos(userId, collectionSource, { includeStorage = true })` to optionally include storage URLs, fetch database photo fields from `users`/`newUsers`, normalize values, convert Drive links and deduplicate and filter out medication photos. 
- Updated `resolvePdfPhotoUrls` in `src/components/smallCard/renderTopBlock.js` to concurrently fetch storage avatars via `getUserStorageAvatarPhotos` and database photos via `getAllUserPhotos(..., { includeStorage: false })`, then merge, normalize and filter the final photo set. 
- Adjusted imports and improved error messages when listing photos from Storage.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a462174797c83268abb587e84c42604)