### PR TITLE
Fix photo collection toggle state races

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1176,7 +1176,7 @@ export const TopBlock = ({
         }
 
         setResolvedPhotosCollection(freshCollection);
-        setSelectedPhotosCollection(freshCollection);
+        setSelectedPhotosCollection(prev => prev || freshCollection);
         if (typeof setState === 'function' && !isFromListOfUsers) {
           setState(prev => {
             const currentCard = prev && typeof prev === 'object' ? prev : cardData;
@@ -1294,6 +1294,23 @@ export const TopBlock = ({
         reason: 'photos-updated',
       });
     }
+  };
+
+  const clearCardPhotosState = () => {
+    setCardPhotosState(currentCard => {
+      if (!currentCard || !Object.prototype.hasOwnProperty.call(currentCard, 'photos')) {
+        return currentCard;
+      }
+
+      const { photos, ...cardWithoutPhotos } = currentCard;
+      return cardWithoutPhotos;
+    });
+  };
+
+  const handlePhotosCollectionSelect = collection => {
+    if (!collection || collection === effectivePhotosCollection) return;
+    setSelectedPhotosCollection(collection);
+    clearCardPhotosState();
   };
 
   const renderOverlayEntries = fieldNames => {
@@ -1967,7 +1984,7 @@ export const TopBlock = ({
                         key={collection}
                         type="button"
                         style={getPhotosCollectionToggleButtonStyle(effectivePhotosCollection === collection)}
-                        onClick={() => setSelectedPhotosCollection(collection)}
+                        onClick={() => handlePhotosCollectionSelect(collection)}
                         aria-pressed={effectivePhotosCollection === collection}
                       >
                         {collection}
@@ -1989,7 +2006,7 @@ export const TopBlock = ({
                 <Photos
                   state={cardData}
                   setState={setCardPhotosState}
-                  collection={selectedPhotosCollection || photosCollection}
+                  collection={effectivePhotosCollection}
                   uploadInputId={`file-upload-${cardData.userId || 'card'}`}
                   cropAspectRatio={2 / 3}
                 />


### PR DESCRIPTION
### Motivation
- Avoid overwriting a user’s explicit photo-collection choice when an async source-resolution completes later. 
- Prevent photo actions (delete/upload) from operating on the wrong collection right after the user toggles the collection. 
- Ensure the `Photos` component always receives the same effective collection that is shown in the modal UI.

### Description
- Initialize resolved selection only when unset by changing the async resolver to `setSelectedPhotosCollection(prev => prev || freshCollection)`.
- Add `clearCardPhotosState` which removes the `photos` field from the current card via `setCardPhotosState` to avoid stale thumbnails/actions being applied after a collection switch.
- Add `handlePhotosCollectionSelect` that calls `clearCardPhotosState()` and updates `selectedPhotosCollection`, and wire the collection toggle buttons to this handler.
- Compute `effectivePhotosCollection = selectedPhotosCollection || photosCollection` and pass that `effectivePhotosCollection` into `<Photos>` so rendered collection and component props stay consistent.

### Testing
- Ran `npm run lint:js` and it completed successfully.
- Ran `npm test -- --watchAll=false --runInBand`; most unit tests passed, but the test run reported failures in existing cache-related suites (not introduced by these changes), including tests under `src/utils/__tests__/favoritesStorage.test.js`, `src/utils/__tests__/getFilteredCardsByList.test.js`, and related `cardIndex` assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4626a6dba08326a5bdf26af44443ce)