### PR TITLE
Fix photo collection hydration race

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1220,15 +1220,18 @@ export const TopBlock = ({
     };
   }, [cardData, isFromListOfUsers, isPhotosModalOpen, setState, setUsers]);
 
+  const photosCollection = resolvedPhotosCollection;
+  const effectivePhotosCollection = selectedPhotosCollection || photosCollection;
+
   React.useEffect(() => {
-    if (!cardData?.userId || userPhotoUrls.length > 0 || !resolvedPhotosCollection) {
+    if (!cardData?.userId || userPhotoUrls.length > 0 || !effectivePhotosCollection) {
       return undefined;
     }
 
     let isMounted = true;
     const hydrateTopBlockPhotos = async () => {
       try {
-        const urls = await getAllUserPhotos(cardData.userId, resolvedPhotosCollection);
+        const urls = await getAllUserPhotos(cardData.userId, effectivePhotosCollection);
         if (!isMounted) return;
         const filteredUrls = filterOutMedicationPhotos(urls, cardData.userId);
         if (!filteredUrls.length) return;
@@ -1271,12 +1274,10 @@ export const TopBlock = ({
     return () => {
       isMounted = false;
     };
-  }, [cardData, isFromListOfUsers, resolvedPhotosCollection, setState, setUsers, userPhotoUrls.length]);
+  }, [cardData, effectivePhotosCollection, isFromListOfUsers, setState, setUsers, userPhotoUrls.length]);
 
   if (!cardData) return null;
 
-  const photosCollection = resolvedPhotosCollection;
-  const effectivePhotosCollection = selectedPhotosCollection || photosCollection;
   const setCardPhotosState = updater => {
     const resolveNextCard = currentCard => {
       const baseCard = currentCard || cardData;


### PR DESCRIPTION
### Motivation
- Prevent stale photos from being written back into a card when the user switches the photos collection by making the hydration effect use the currently selected collection and allowing React to cancel in-flight fetches.

### Description
- Compute `effectivePhotosCollection` earlier as `selectedPhotosCollection || resolvedPhotosCollection`, use it when calling `getAllUserPhotos`, and add it to the hydration effect dependency array so switching the collection triggers cleanup and fresh fetches.

### Testing
- Ran `npm run lint:js -- src/components/smallCard/renderTopBlock.js` and the linter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4654cfbed48326bdbae5a17c7f9935)