### PR TITLE
List nested Storage avatar files and embed images for PDF export

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2857,8 +2857,13 @@ export const getUserStorageAvatarPhotos = async userId => {
 
   try {
     const folderRef = ref(storage, `avatar/${userId}`);
-    const list = await listAll(folderRef);
-    const settledUrls = await Promise.allSettled(list.items.map(item => getDownloadURL(item)));
+    const collectStorageItems = async currentFolderRef => {
+      const list = await listAll(currentFolderRef);
+      const nestedItems = await Promise.all(list.prefixes.map(prefix => collectStorageItems(prefix)));
+      return [...list.items, ...nestedItems.flat()];
+    };
+    const items = await collectStorageItems(folderRef);
+    const settledUrls = await Promise.allSettled(items.map(item => getDownloadURL(item)));
     return settledUrls
       .flatMap(result => {
         if (result.status === 'fulfilled') return [result.value];

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1013,6 +1013,29 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection }) =>
   ));
 };
 
+const readBlobAsDataUrl = blob => new Promise((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onloadend = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+  reader.onerror = () => reject(reader.error);
+  reader.readAsDataURL(blob);
+});
+
+const loadPdfEmbeddedImage = async photoUrl => {
+  if (!photoUrl) return '';
+
+  try {
+    const response = await fetch(photoUrl);
+    if (!response.ok) {
+      throw new Error(`Photo request failed with status ${response.status}`);
+    }
+    const blob = await response.blob();
+    return readBlobAsDataUrl(blob);
+  } catch (error) {
+    console.error('Unable to load PDF photo', photoUrl, error);
+    return '';
+  }
+};
+
 const isSurrogateMotherRole = data => String(data?.userRole || data?.role || '').trim().toLowerCase() === 'sm';
 
 const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
@@ -1026,7 +1049,10 @@ const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
     try {
       const fileName = buildProfilePdfFileName(cardData);
       const effectivePhotoUrls = await resolvePdfPhotoUrls({ cardData, photoUrls, photosCollection });
-      const blob = await pdf(<ProfilePdfDocument userData={cardData} photoUrls={effectivePhotoUrls} />).toBlob();
+      const embeddedPhotoUrls = await Promise.all(effectivePhotoUrls.map(loadPdfEmbeddedImage));
+      const blob = await pdf(
+        <ProfilePdfDocument userData={cardData} photoUrls={embeddedPhotoUrls.filter(Boolean)} />
+      ).toBlob();
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;


### PR DESCRIPTION
### Motivation
- Ensure avatar pictures stored in nested Storage folders are discovered when collecting user photos. 
- Prevent broken or CORS-blocked remote images in generated profile PDFs by embedding image data before PDF rendering.

### Description
- Update `getUserStorageAvatarPhotos` to recursively collect items from all `prefixes` using a new `collectStorageItems` helper so nested folders are included. 
- Add `readBlobAsDataUrl` and `loadPdfEmbeddedImage` helpers to fetch image URLs and convert them to data URLs for embedding. 
- Modify `ProfilePdfExportButton` to load and filter embedded image data URLs before passing `photoUrls` into the PDF generator, so the PDF contains inline image data rather than external links.

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a466ae274788326a0c40cf14b6f5bce)