### PR TITLE
Improve GitHub Pages workflow: Node 20, split build/deploy, and Pages actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,19 @@ name: Build and deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: github-pages
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -18,7 +24,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
+          cache: npm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Create .env file
         run: |
@@ -33,14 +43,27 @@ jobs:
           echo "REACT_APP_OPENAI_API_KEY=${{ secrets.REACT_APP_OPENAI_API_KEY }}" >> .env
           echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> .env
 
-      - name: Install, lint, build 🔧
-        run: |
-          npm install
-          npm run lint:js
-          npm run build
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Lint JavaScript
+        run: npm run lint:js
+
+      - name: Build 🔧
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages
-          folder: build
+          path: build
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
### Motivation
- Modernize and harden the GitHub Pages CI by using the newer Pages actions and explicit permissions. 
- Use a current Node runtime and npm caching to ensure reproducible and faster builds. 
- Separate build and deploy steps to upload artifacts then deploy, matching the newer `actions/*-pages` workflow pattern.

### Description
- Added `workflow_dispatch` trigger and explicit `permissions` for `contents`, `pages`, and `id-token` in `.github/workflows/deploy.yml`. 
- Bumped Node from `16` to `20`, enabled npm cache, and replaced `npm install` with `npm ci`. 
- Introduced `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v5`, and split the job into a `build` job and a `deploy` job. 
- Kept environment `.env` creation and lint/build steps but rearranged into `Install dependencies`, `Lint JavaScript`, and `Build` steps, and changed artifact upload to use `path: build`.

### Testing
- No automated tests were executed as part of this change; CI will run the updated workflow on pushes to `main` or via `workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46c260b2088326a7258e46f696014e)