### PR TITLE
Preserve gh-pages deployment path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: github-pages
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -26,9 +24,6 @@ jobs:
         with:
           node-version: '20'
           cache: npm
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
 
       - name: Create .env file
         run: |
@@ -52,18 +47,8 @@ jobs:
       - name: Build 🔧
         run: npm run build
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: build
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages 🚀
-        id: deployment
-        uses: actions/deploy-pages@v5
+          branch: gh-pages
+          folder: build

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The repository deploys to GitHub Pages from the `main` branch using `.github/wor
 The workflow:
 
 1. checks out the repository;
-2. installs Node.js 16;
+2. installs Node.js 20;
 3. creates `.env` from GitHub Actions secrets;
 4. installs dependencies;
 5. runs `npm run lint:js` and `npm run build`;


### PR DESCRIPTION
### Motivation
- Keep the repository publishing behavior consistent with the documented branch-based Pages source by restoring a `gh-pages` branch deploy instead of switching to the Actions Pages artifact flow.
- Ensure the workflow has the correct token scope required for branch pushes rather than the artifact-based `actions/deploy-pages` flow.
- Update documentation to reflect the upgraded Node.js runtime used by the workflow.

### Description
- Replaced the artifact-based Pages flow with a branch push using `JamesIves/github-pages-deploy-action@v4` to publish the `build/` folder to the `gh-pages` branch in `.github/workflows/deploy.yml`.
- Simplified `permissions` to `contents: write` so the workflow can push to `gh-pages` rather than using Pages artifact scopes and `id-token`.
- Removed the `actions/configure-pages@v5` and `actions/upload-pages-artifact@v3` / `actions/deploy-pages@v5` steps and the separate `deploy` job, consolidating into a single `build-and-deploy` job.
- Updated `README.md` deployment section to indicate Node.js `20` to match the workflow change.

### Testing
- Ran `git diff --check` with no issues reported (success).
- Ran `npm run lint:js` which completed (warnings only) (success).
- Ran `npm run build` which completed and produced the `build/` output (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46c846736883268737ab4ea3555a2c)