### PR TITLE
Embed Firebase Storage avatar images as data-URLs for PDF export and add recursive storage listing

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll } from 'firebase/storage';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
@@ -2852,18 +2852,52 @@ const getPhotoSourceCollections = collectionSource => (
     : ['newUsers', 'users']
 );
 
+const collectUserStorageAvatarItems = async userId => {
+  const folderRef = ref(storage, `avatar/${userId}`);
+  const collectStorageItems = async currentFolderRef => {
+    const list = await listAll(currentFolderRef);
+    const nestedItems = await Promise.all(list.prefixes.map(prefix => collectStorageItems(prefix)));
+    return [...list.items, ...nestedItems.flat()];
+  };
+
+  return collectStorageItems(folderRef);
+};
+
+const getStorageContentType = item => {
+  const extension = String(item?.name || '').split('.').pop()?.toLowerCase();
+  if (extension === 'png') return 'image/png';
+  if (extension === 'webp') return 'image/webp';
+  if (extension === 'gif') return 'image/gif';
+  if (extension === 'bmp') return 'image/bmp';
+  return 'image/jpeg';
+};
+
+const bytesToBase64 = bytes => {
+  const byteArray = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let index = 0; index < byteArray.length; index += chunkSize) {
+    binary += String.fromCharCode(...byteArray.subarray(index, index + chunkSize));
+  }
+
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  return Buffer.from(binary, 'binary').toString('base64');
+};
+
+const isMedicationStorageItem = (item, userId) => String(item?.fullPath || '').startsWith(`avatar/${userId}/medication/`);
+
 export const getUserStorageAvatarPhotos = async userId => {
   if (!userId) return [];
 
   try {
-    const folderRef = ref(storage, `avatar/${userId}`);
-    const collectStorageItems = async currentFolderRef => {
-      const list = await listAll(currentFolderRef);
-      const nestedItems = await Promise.all(list.prefixes.map(prefix => collectStorageItems(prefix)));
-      return [...list.items, ...nestedItems.flat()];
-    };
-    const items = await collectStorageItems(folderRef);
-    const settledUrls = await Promise.allSettled(items.map(item => getDownloadURL(item)));
+    const items = await collectUserStorageAvatarItems(userId);
+    const settledUrls = await Promise.allSettled(
+      items
+        .filter(item => !isMedicationStorageItem(item, userId))
+        .map(item => getDownloadURL(item))
+    );
     return settledUrls
       .flatMap(result => {
         if (result.status === 'fulfilled') return [result.value];
@@ -2873,6 +2907,33 @@ export const getUserStorageAvatarPhotos = async userId => {
       .filter(Boolean);
   } catch (error) {
     console.error('Error listing user photos from Storage:', error);
+    return [];
+  }
+};
+
+export const getUserStorageAvatarPhotoDataUrls = async userId => {
+  if (!userId) return [];
+
+  try {
+    const items = await collectUserStorageAvatarItems(userId);
+    const settledPhotos = await Promise.allSettled(
+      items
+        .filter(item => !isMedicationStorageItem(item, userId))
+        .map(async item => {
+          const bytes = await getBytes(item);
+          return `data:${getStorageContentType(item)};base64,${bytesToBase64(bytes)}`;
+        })
+    );
+
+    return settledPhotos
+      .flatMap(result => {
+        if (result.status === 'fulfilled') return [result.value];
+        console.error('Error loading user photo bytes from Storage:', result.reason);
+        return [];
+      })
+      .filter(Boolean);
+  } catch (error) {
+    console.error('Error listing user photo bytes from Storage:', error);
     return [];
   }
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -38,7 +38,7 @@ import { getCurrentValue } from '../getCurrentValue';
 import {
   fetchUserById,
   getAllUserPhotos,
-  getUserStorageAvatarPhotos,
+  getUserStorageAvatarPhotoDataUrls,
   setUserComment as persistUserComment,
   fetchAllCommentsByCardId,
   updateCommentByOwner,
@@ -997,8 +997,6 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
   const photoEntries = photos.map(photo => (
     photo && typeof photo === 'object' ? photo : { src: photo, debug: '' }
   )).filter(photo => photo?.src);
-  const pdfDebugLines = Array.isArray(debugLines) ? debugLines.filter(Boolean) : [];
-
   return (
     <Document title={`${buildName(userData) || 'Profile'} - UKRCOM`}>
       <Page size="A4" style={profilePdfStyles.page}>
@@ -1012,17 +1010,6 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
               {label}: {value}
             </Text>
           ))}
-        </View>
-        {pdfFooter}
-      </Page>
-      <Page size="A4" style={profilePdfStyles.debugPage}>
-        <View style={profilePdfStyles.debugContent}>
-          <Text style={profilePdfStyles.debugTitle}>PDF photo export debug</Text>
-          {pdfDebugLines.length ? pdfDebugLines.map((line, index) => (
-            <Text key={`pdf-debug-${index}`} style={profilePdfStyles.debugText}>{line}</Text>
-          )) : (
-            <Text style={profilePdfStyles.debugText}>No debug details were collected.</Text>
-          )}
         </View>
         {pdfFooter}
       </Page>
@@ -1105,7 +1092,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
   let loadedPhotos = [];
   try {
     [storagePhotos, loadedPhotos] = await Promise.all([
-      getUserStorageAvatarPhotos(cardData.userId),
+      getUserStorageAvatarPhotoDataUrls(cardData.userId),
       getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false }),
     ]);
   } catch (error) {
@@ -1116,7 +1103,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     throw error;
   }
 
-  pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId}', summarizePdfDebugUrls(storagePhotos));
+  pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} as data URLs', summarizePdfDebugUrls(storagePhotos));
   pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
 
   const combinedPhotos = [...existingPhotos, ...storagePhotos, ...loadedPhotos];
@@ -1147,6 +1134,11 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
   if (!photoUrl) {
     pushPdfDebugLine(debugLines, 'Skipped empty photo URL before embedding');
     return { src: '', debug: `Photo ${index + 1}: empty URL` };
+  }
+
+  if (String(photoUrl).startsWith('data:image/')) {
+    pushPdfDebugLine(debugLines, 'Embedding photo: using prepared data URL', { index: index + 1 });
+    return { src: photoUrl, debug: '' };
   }
 
   const debugUrl = truncatePdfDebugValue(photoUrl);


### PR DESCRIPTION
### Motivation
- Enable embedding avatar images stored in Firebase Storage directly into generated PDFs to avoid extra network fetches and failures when embedding remote URLs. 
- Consolidate and reuse recursive listing logic for `avatar/{userId}` storage folders and exclude medication-related storage items from user photo lists.

### Description
- Added `collectUserStorageAvatarItems`, `getUserStorageAvatarPhotoDataUrls`, `getStorageContentType`, `bytesToBase64`, and `isMedicationStorageItem` helpers and imported `getBytes` from `firebase/storage` to download bytes and build `data:` URLs. 
- Refactored `getUserStorageAvatarPhotos` to reuse the recursive collector and filter out medication storage items. 
- Switched PDF photo resolution to call `getUserStorageAvatarPhotoDataUrls` so storage images are returned as `data:image/...;base64,...` strings, and updated `loadPdfEmbeddedImage` to skip fetching when a `data:` URL is already provided. 
- Updated debug/log messages related to storage photo loading and data-URL handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4740a10bac8326885ac2d419a03943)