### PR TITLE
Preserve Storage image MIME for PDF avatars and skip duplicate Storage reloads

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes } from 'firebase/storage';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
@@ -119,6 +119,13 @@ const getDownloadURL = (...args) => {
     path: args[0],
   });
 };
+
+const getMetadata = (...args) => withAdminDownloadToast(firebaseGetMetadata(...args), {
+  getUid: getCurrentAdminUid,
+  operation: 'Storage object metadata',
+  source: 'config',
+  path: args[0],
+});
 
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 
@@ -2863,13 +2870,37 @@ const collectUserStorageAvatarItems = async userId => {
   return collectStorageItems(folderRef);
 };
 
-const getStorageContentType = item => {
+const getStorageContentTypeFromName = item => {
   const extension = String(item?.name || '').split('.').pop()?.toLowerCase();
   if (extension === 'png') return 'image/png';
   if (extension === 'webp') return 'image/webp';
   if (extension === 'gif') return 'image/gif';
   if (extension === 'bmp') return 'image/bmp';
   return 'image/jpeg';
+};
+
+const getStorageContentTypeFromBytes = bytes => {
+  const byteArray = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  if (byteArray[0] === 0xff && byteArray[1] === 0xd8 && byteArray[2] === 0xff) return 'image/jpeg';
+  if (byteArray[0] === 0x89 && byteArray[1] === 0x50 && byteArray[2] === 0x4e && byteArray[3] === 0x47) return 'image/png';
+  if (byteArray[0] === 0x47 && byteArray[1] === 0x49 && byteArray[2] === 0x46) return 'image/gif';
+  if (byteArray[0] === 0x42 && byteArray[1] === 0x4d) return 'image/bmp';
+  if (
+    byteArray[0] === 0x52 && byteArray[1] === 0x49 && byteArray[2] === 0x46 && byteArray[3] === 0x46
+    && byteArray[8] === 0x57 && byteArray[9] === 0x45 && byteArray[10] === 0x42 && byteArray[11] === 0x50
+  ) return 'image/webp';
+  return null;
+};
+
+const getStorageContentType = async (item, bytes) => {
+  try {
+    const metadata = await getMetadata(item);
+    const metadataContentType = String(metadata?.contentType || '').toLowerCase();
+    if (metadataContentType.startsWith('image/')) return metadataContentType;
+  } catch (error) {
+    console.error('Error loading user photo metadata from Storage:', error);
+  }
+  return getStorageContentTypeFromBytes(bytes) || getStorageContentTypeFromName(item);
 };
 
 const bytesToBase64 = bytes => {
@@ -2921,7 +2952,8 @@ export const getUserStorageAvatarPhotoDataUrls = async userId => {
         .filter(item => !isMedicationStorageItem(item, userId))
         .map(async item => {
           const bytes = await getBytes(item);
-          return `data:${getStorageContentType(item)};base64,${bytesToBase64(bytes)}`;
+          const contentType = await getStorageContentType(item, bytes);
+          return `data:${contentType};base64,${bytesToBase64(bytes)}`;
         })
     );
 

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -577,6 +577,25 @@ const getUserProfilePhotoUrls = data => {
   return Array.from(new Set(filterOutMedicationPhotos(photos, data?.userId).filter(Boolean)));
 };
 
+const getFirebaseStorageObjectPath = photoUrl => {
+  const normalizedPhotoUrl = normalizePhotoValue(photoUrl);
+  if (!normalizedPhotoUrl || normalizedPhotoUrl.startsWith('data:')) return '';
+
+  try {
+    const url = new URL(normalizedPhotoUrl);
+    const encodedPath = url.pathname.split('/o/')[1]?.split('/')[0];
+    return encodedPath ? decodeURIComponent(encodedPath) : '';
+  } catch {
+    return '';
+  }
+};
+
+const isUserStorageAvatarPhotoUrl = (photoUrl, userId) => {
+  if (!userId) return false;
+  const storagePath = getFirebaseStorageObjectPath(photoUrl);
+  return storagePath.startsWith(`avatar/${userId}/`) && !storagePath.startsWith(`avatar/${userId}/medication/`);
+};
+
 const hasAgentOrIPRole = data =>
   data.userRole === 'ag' || data.userRole === 'ip' || data.role === 'ag' || data.role === 'ip';
 
@@ -1088,11 +1107,12 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     userRole: cardData?.userRole || cardData?.role || null,
   });
 
+  const existingPhotosIncludeStorageAvatars = existingPhotos.some(photo => isUserStorageAvatarPhotoUrl(photo, cardData.userId));
   let storagePhotos = [];
   let loadedPhotos = [];
   try {
     [storagePhotos, loadedPhotos] = await Promise.all([
-      getUserStorageAvatarPhotoDataUrls(cardData.userId),
+      existingPhotosIncludeStorageAvatars ? Promise.resolve([]) : getUserStorageAvatarPhotoDataUrls(cardData.userId),
       getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false }),
     ]);
   } catch (error) {
@@ -1103,6 +1123,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     throw error;
   }
 
+  pushPdfDebugLine(debugLines, 'Existing photos include Storage avatars', { existingPhotosIncludeStorageAvatars });
   pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} as data URLs', summarizePdfDebugUrls(storagePhotos));
   pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
 


### PR DESCRIPTION
### Motivation
- PDF generation failed when uploaded PNG/WebP/GIF/BMP bytes were wrapped as `image/jpeg` because uploaded files are sometimes stored under a `.jpg` path and MIME was inferred only from the name. 
- Hydrated photo lists already containing Firebase Storage download URLs caused duplicate avatar pages when Storage photos were reloaded as data URLs and could not be deduped.

### Description
- Added a `getMetadata` wrapper around Firebase `getMetadata` and implemented multi-step content-type detection via `getStorageContentType`: consult Storage metadata, then sniff the first bytes (`getStorageContentTypeFromBytes`), and finally fall back to `getStorageContentTypeFromName`.
- Updated `getUserStorageAvatarPhotoDataUrls` to use the new `getStorageContentType(item, bytes)` so produced data URLs use the correct `image/*` MIME type.
- Added `getFirebaseStorageObjectPath` and `isUserStorageAvatarPhotoUrl` helpers and changed `resolvePdfPhotoUrls` to skip reloading Storage data URLs when the passed `photoUrls` already include the same user's Storage avatar URLs, preventing duplicated PDF pages.
- Added extra debug logging to indicate when existing photos include Storage avatars and when Storage data URLs were loaded.

### Testing
- Ran `npm run lint:js -- src/components/config.js src/components/smallCard/renderTopBlock.js` and the lint step completed without errors (only environment warnings were shown). 
- Ran `npm run build` and the project compiled successfully and produced the production build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474f0b117c8326994869c8ceb2e0d9)