### PR TITLE
Fix PDF avatar storage export handling (enumerate storage avatars & restrict to JPEG/PNG)

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2870,13 +2870,13 @@ const collectUserStorageAvatarItems = async userId => {
   return collectStorageItems(folderRef);
 };
 
+const PDF_SUPPORTED_STORAGE_IMAGE_TYPES = new Set(['image/jpeg', 'image/png']);
+
 const getStorageContentTypeFromName = item => {
   const extension = String(item?.name || '').split('.').pop()?.toLowerCase();
   if (extension === 'png') return 'image/png';
-  if (extension === 'webp') return 'image/webp';
-  if (extension === 'gif') return 'image/gif';
-  if (extension === 'bmp') return 'image/bmp';
-  return 'image/jpeg';
+  if (extension === 'jpg' || extension === 'jpeg') return 'image/jpeg';
+  return null;
 };
 
 const getStorageContentTypeFromBytes = bytes => {
@@ -2893,14 +2893,21 @@ const getStorageContentTypeFromBytes = bytes => {
 };
 
 const getStorageContentType = async (item, bytes) => {
+  const bytesContentType = getStorageContentTypeFromBytes(bytes);
+  if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(bytesContentType)) return bytesContentType;
+  if (bytesContentType) return null;
+
   try {
     const metadata = await getMetadata(item);
     const metadataContentType = String(metadata?.contentType || '').toLowerCase();
-    if (metadataContentType.startsWith('image/')) return metadataContentType;
+    if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(metadataContentType)) return metadataContentType;
   } catch (error) {
     console.error('Error loading user photo metadata from Storage:', error);
   }
-  return getStorageContentTypeFromBytes(bytes) || getStorageContentTypeFromName(item);
+
+  const nameContentType = getStorageContentTypeFromName(item);
+  if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(nameContentType)) return nameContentType;
+  return null;
 };
 
 const bytesToBase64 = bytes => {
@@ -2942,17 +2949,21 @@ export const getUserStorageAvatarPhotos = async userId => {
   }
 };
 
-export const getUserStorageAvatarPhotoDataUrls = async userId => {
+export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) => {
   if (!userId) return [];
+
+  const excludePaths = new Set(Array.isArray(options.excludePaths) ? options.excludePaths.filter(Boolean) : []);
 
   try {
     const items = await collectUserStorageAvatarItems(userId);
     const settledPhotos = await Promise.allSettled(
       items
         .filter(item => !isMedicationStorageItem(item, userId))
+        .filter(item => !excludePaths.has(String(item?.fullPath || '')))
         .map(async item => {
           const bytes = await getBytes(item);
           const contentType = await getStorageContentType(item, bytes);
+          if (!contentType) return '';
           return `data:${contentType};base64,${bytesToBase64(bytes)}`;
         })
     );

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -590,12 +590,6 @@ const getFirebaseStorageObjectPath = photoUrl => {
   }
 };
 
-const isUserStorageAvatarPhotoUrl = (photoUrl, userId) => {
-  if (!userId) return false;
-  const storagePath = getFirebaseStorageObjectPath(photoUrl);
-  return storagePath.startsWith(`avatar/${userId}/`) && !storagePath.startsWith(`avatar/${userId}/medication/`);
-};
-
 const hasAgentOrIPRole = data =>
   data.userRole === 'ag' || data.userRole === 'ip' || data.role === 'ag' || data.role === 'ip';
 
@@ -1107,12 +1101,14 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     userRole: cardData?.userRole || cardData?.role || null,
   });
 
-  const existingPhotosIncludeStorageAvatars = existingPhotos.some(photo => isUserStorageAvatarPhotoUrl(photo, cardData.userId));
+  const existingStorageAvatarPaths = existingPhotos
+    .map(getFirebaseStorageObjectPath)
+    .filter(path => path.startsWith(`avatar/${cardData.userId}/`) && !path.startsWith(`avatar/${cardData.userId}/medication/`));
   let storagePhotos = [];
   let loadedPhotos = [];
   try {
     [storagePhotos, loadedPhotos] = await Promise.all([
-      existingPhotosIncludeStorageAvatars ? Promise.resolve([]) : getUserStorageAvatarPhotoDataUrls(cardData.userId),
+      getUserStorageAvatarPhotoDataUrls(cardData.userId, { excludePaths: existingStorageAvatarPaths }),
       getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false }),
     ]);
   } catch (error) {
@@ -1123,7 +1119,10 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     throw error;
   }
 
-  pushPdfDebugLine(debugLines, 'Existing photos include Storage avatars', { existingPhotosIncludeStorageAvatars });
+  pushPdfDebugLine(debugLines, 'Existing Storage avatar paths excluded from Storage data URL load', {
+    count: existingStorageAvatarPaths.length,
+    sample: existingStorageAvatarPaths.slice(0, PDF_DEBUG_URL_SAMPLE_SIZE),
+  });
   pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} as data URLs', summarizePdfDebugUrls(storagePhotos));
   pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
 


### PR DESCRIPTION
### Motivation
- Prevent skipping all Firebase Storage avatar files when a single Storage avatar URL is already present in `photoUrls`, so exported PDFs include all current avatar files instead of omitting them. 
- Avoid generating data URLs for Storage images that the React PDF resolver cannot handle (non-JPEG/PNG), which caused PDF generation to fail. 

### Description
- De-duplicate by Storage object path: compute `existingStorageAvatarPaths` from incoming URLs and pass them as `excludePaths` to `getUserStorageAvatarPhotoDataUrls` so only those specific objects are skipped while the rest of `avatar/{userId}` is still enumerated. 
- Add `options.excludePaths` to `getUserStorageAvatarPhotoDataUrls` and filter out matching `item.fullPath` entries before loading bytes. 
- Restrict prepared Storage data URLs to PDF-supported image MIME types by adding `PDF_SUPPORTED_STORAGE_IMAGE_TYPES` and updating `getStorageContentType` to return only `image/jpeg` or `image/png`; unsupported types are ignored so they are not emitted as data URLs. 
- Improve PDF debug output to report how many Storage paths were excluded and include a sample of excluded paths. 

### Testing
- Ran `git diff --check` with no issues. 
- Ran linter via `npx eslint src/components/config.js src/components/smallCard/renderTopBlock.js` which passed. 
- Ran unit tests with `npm test -- --watchAll=false --runInBand`; test run completed with many existing unrelated failures (Test Suites: 8 failed, 35 passed, 43 total; Tests: 20 failed, 252 passed, 272 total) that appear to be pre-existing and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47535c4cc48326b79b5fc52759eb66)