### PR TITLE
Add PDF photo debug output and make storage/photo embedding more robust (skip unreliable fallbacks)

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2892,21 +2892,49 @@ const getStorageContentTypeFromBytes = bytes => {
   return null;
 };
 
-const getStorageContentType = async (item, bytes) => {
+const pushStoragePhotoDebug = (options, message, payload) => {
+  if (typeof options?.onDebug !== 'function') return;
+  options.onDebug(message, payload);
+};
+
+const getStorageContentType = async (item, bytes, options = {}) => {
   const bytesContentType = getStorageContentTypeFromBytes(bytes);
   if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(bytesContentType)) return bytesContentType;
-  if (bytesContentType) return null;
+  if (bytesContentType) {
+    pushStoragePhotoDebug(options, 'Storage photo skipped: unsupported image type detected from bytes', {
+      fullPath: item?.fullPath || null,
+      contentType: bytesContentType,
+      supportedTypes: Array.from(PDF_SUPPORTED_STORAGE_IMAGE_TYPES),
+    });
+    return null;
+  }
 
   try {
     const metadata = await getMetadata(item);
     const metadataContentType = String(metadata?.contentType || '').toLowerCase();
     if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(metadataContentType)) return metadataContentType;
+    if (metadataContentType) {
+      pushStoragePhotoDebug(options, 'Storage photo skipped: unsupported metadata content type', {
+        fullPath: item?.fullPath || null,
+        contentType: metadataContentType,
+        supportedTypes: Array.from(PDF_SUPPORTED_STORAGE_IMAGE_TYPES),
+      });
+    }
   } catch (error) {
     console.error('Error loading user photo metadata from Storage:', error);
+    pushStoragePhotoDebug(options, 'Storage photo metadata load failed', {
+      fullPath: item?.fullPath || null,
+      message: error?.message || String(error),
+    });
   }
 
   const nameContentType = getStorageContentTypeFromName(item);
   if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(nameContentType)) return nameContentType;
+  pushStoragePhotoDebug(options, 'Storage photo skipped: unable to resolve supported image type', {
+    fullPath: item?.fullPath || null,
+    detectedFromName: nameContentType || null,
+    supportedTypes: Array.from(PDF_SUPPORTED_STORAGE_IMAGE_TYPES),
+  });
   return null;
 };
 
@@ -2956,27 +2984,55 @@ export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) =>
 
   try {
     const items = await collectUserStorageAvatarItems(userId);
+    const avatarItems = items.filter(item => !isMedicationStorageItem(item, userId));
+    const includedItems = avatarItems.filter(item => !excludePaths.has(String(item?.fullPath || '')));
+    pushStoragePhotoDebug(options, 'Storage avatar folder listed for PDF', {
+      userId,
+      folder: `avatar/${userId}`,
+      totalItems: items.length,
+      medicationItemsSkipped: items.length - avatarItems.length,
+      excludedExistingItems: avatarItems.length - includedItems.length,
+      itemsToRead: includedItems.length,
+      sample: includedItems.slice(0, 3).map(item => item?.fullPath || item?.name || ''),
+    });
     const settledPhotos = await Promise.allSettled(
-      items
-        .filter(item => !isMedicationStorageItem(item, userId))
-        .filter(item => !excludePaths.has(String(item?.fullPath || '')))
+      includedItems
         .map(async item => {
           const bytes = await getBytes(item);
-          const contentType = await getStorageContentType(item, bytes);
+          const contentType = await getStorageContentType(item, bytes, options);
           if (!contentType) return '';
+          pushStoragePhotoDebug(options, 'Storage photo prepared as data URL for PDF', {
+            fullPath: item?.fullPath || null,
+            contentType,
+            byteLength: bytes?.byteLength || bytes?.length || 0,
+          });
           return `data:${contentType};base64,${bytesToBase64(bytes)}`;
         })
     );
 
-    return settledPhotos
+    const dataUrls = settledPhotos
       .flatMap(result => {
         if (result.status === 'fulfilled') return [result.value];
         console.error('Error loading user photo bytes from Storage:', result.reason);
+        pushStoragePhotoDebug(options, 'Storage photo bytes load failed', {
+          message: result.reason?.message || String(result.reason),
+        });
         return [];
       })
       .filter(Boolean);
+    pushStoragePhotoDebug(options, 'Storage avatar data URL load finished for PDF', {
+      requested: includedItems.length,
+      preparedDataUrls: dataUrls.length,
+      failedOrUnsupported: includedItems.length - dataUrls.length,
+    });
+    return dataUrls;
   } catch (error) {
     console.error('Error listing user photo bytes from Storage:', error);
+    pushStoragePhotoDebug(options, 'Storage avatar folder list failed for PDF', {
+      userId,
+      folder: `avatar/${userId}`,
+      message: error?.message || String(error),
+    });
     return [];
   }
 };

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1007,6 +1007,7 @@ const buildProfilePdfFileName = data => {
 const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
   const rows = buildProfilePdfRows(userData);
   const photos = Array.isArray(photoUrls) ? photoUrls : [];
+  const debugEntries = Array.isArray(debugLines) ? debugLines.filter(Boolean) : [];
   const photoEntries = photos.map(photo => (
     photo && typeof photo === 'object' ? photo : { src: photo, debug: '' }
   )).filter(photo => photo?.src);
@@ -1023,6 +1024,20 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
               {label}: {value}
             </Text>
           ))}
+        </View>
+        {pdfFooter}
+      </Page>
+      <Page size="A4" style={profilePdfStyles.debugPage}>
+        <Text style={profilePdfStyles.watermark}>UKRCOM</Text>
+        <Text style={profilePdfStyles.debugTitle}>PDF photo debug</Text>
+        <View style={profilePdfStyles.debugContent}>
+          {debugEntries.length > 0 ? debugEntries.map((line, index) => (
+            <Text key={`${line}-${index}`} style={profilePdfStyles.debugText}>
+              {index + 1}. {line}
+            </Text>
+          )) : (
+            <Text style={profilePdfStyles.debugText}>No debug entries were collected.</Text>
+          )}
         </View>
         {pdfFooter}
       </Page>
@@ -1108,7 +1123,9 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
   let loadedPhotos = [];
   try {
     [storagePhotos, loadedPhotos] = await Promise.all([
-      getUserStorageAvatarPhotoDataUrls(cardData.userId, { excludePaths: existingStorageAvatarPaths }),
+      getUserStorageAvatarPhotoDataUrls(cardData.userId, {
+        onDebug: (message, payload) => pushPdfDebugLine(debugLines, message, payload),
+      }),
       getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false }),
     ]);
   } catch (error) {
@@ -1119,9 +1136,10 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     throw error;
   }
 
-  pushPdfDebugLine(debugLines, 'Existing Storage avatar paths excluded from Storage data URL load', {
+  pushPdfDebugLine(debugLines, 'Existing Storage avatar paths already present in card data', {
     count: existingStorageAvatarPaths.length,
     sample: existingStorageAvatarPaths.slice(0, PDF_DEBUG_URL_SAMPLE_SIZE),
+    note: 'Storage data URLs are still loaded for all avatar/{userId} files to avoid URL fallback/CORS failures in PDF',
   });
   pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} as data URLs', summarizePdfDebugUrls(storagePhotos));
   pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
@@ -1190,18 +1208,18 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
       isImageDataUrl,
     });
     if (!isImageDataUrl) {
-      pushPdfDebugLine(debugLines, 'Embedding photo: data URL is not an image, using original URL fallback', debugUrl);
-      return { src: photoUrl, debug: `Photo ${index + 1}: original URL fallback; fetched blob was not image data` };
+      pushPdfDebugLine(debugLines, 'Embedding photo skipped: fetched data URL is not an image', debugUrl);
+      return { src: '', debug: `Photo ${index + 1}: skipped because fetched blob was not image data` };
     }
     return { src: dataUrl, debug: `Photo ${index + 1}: embedded as data URL (${blob.type || 'unknown type'}, ${blob.size || 0} bytes)` };
   } catch (error) {
     console.error('Unable to load PDF photo', photoUrl, error);
-    pushPdfDebugLine(debugLines, 'Embedding photo failed; using original URL fallback', {
+    pushPdfDebugLine(debugLines, 'Embedding photo failed; skipped original URL fallback for PDF reliability', {
       url: debugUrl,
       name: error?.name || null,
       message: error?.message || String(error),
     });
-    return { src: photoUrl, debug: `Photo ${index + 1}: original URL fallback after fetch error (${error?.message || String(error)})` };
+    return { src: '', debug: `Photo ${index + 1}: skipped after fetch error (${error?.message || String(error)})` };
   }
 };
 


### PR DESCRIPTION
### Motivation

- Improve visibility into why Storage images are skipped or fail to embed when generating profile PDFs. 
- Avoid embedding non-image blobs or falling back to potentially broken original URLs which cause CORS/format issues in generated PDFs. 
- Provide a debug page inside the generated PDF to surface collected photo processing diagnostics for troubleshooting.

### Description

- Introduced `pushStoragePhotoDebug(options, message, payload)` and extended `getStorageContentType` to emit detailed debug messages when bytes/metadata/name resolution yields unsupported or error states. 
- Enhanced `getUserStorageAvatarPhotoDataUrls` to accept `options.onDebug`, log folder listing details, exclusion counts, per-photo preparations, and final load stats, and to pass these debug events to callers. 
- Updated PDF generation flow to pass storage debug events into the global PDF debug lines and added a debug page in `ProfilePdfDocument` that prints collected `debugLines`. 
- Changed embedding behavior in `loadPdfEmbeddedImage` to skip photos whose fetched blob is not image data or failed to fetch instead of falling back to the original URL, and to attach clearer debug captions for skipped/embedded photos.

### Testing

- Ran unit tests with `npm test`, and they completed successfully. 
- Ran linting with `npm run lint`, and no new lint errors were introduced. 
- Performed a production build with `npm run build`, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475be24b788326adda28e7fe3123b7)