### PR TITLE
Add download-URL fallbacks and improve PDF photo embedding debug

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2998,11 +2998,19 @@ export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) =>
     const settledPhotos = await Promise.allSettled(
       includedItems
         .map(async item => {
+          const fullPath = item?.fullPath || null;
           const bytes = await getBytes(item);
           const contentType = await getStorageContentType(item, bytes, options);
-          if (!contentType) return '';
+          if (!contentType) {
+            const fallbackUrl = await getDownloadURL(item);
+            pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
+              fullPath,
+              reason: 'unsupported-or-unresolved-content-type',
+            });
+            return fallbackUrl;
+          }
           pushStoragePhotoDebug(options, 'Storage photo prepared as data URL for PDF', {
-            fullPath: item?.fullPath || null,
+            fullPath,
             contentType,
             byteLength: bytes?.byteLength || bytes?.length || 0,
           });
@@ -3011,21 +3019,40 @@ export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) =>
     );
 
     const dataUrls = settledPhotos
-      .flatMap(result => {
+      .flatMap((result, index) => {
         if (result.status === 'fulfilled') return [result.value];
+        const item = includedItems[index];
         console.error('Error loading user photo bytes from Storage:', result.reason);
-        pushStoragePhotoDebug(options, 'Storage photo bytes load failed', {
+        pushStoragePhotoDebug(options, 'Storage photo bytes load failed; trying download URL fallback for PDF', {
+          fullPath: item?.fullPath || null,
           message: result.reason?.message || String(result.reason),
         });
-        return [];
+        return [getDownloadURL(item)
+          .then(url => {
+            pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
+              fullPath: item?.fullPath || null,
+              reason: result.reason?.code || result.reason?.message || String(result.reason),
+            });
+            return url;
+          })
+          .catch(error => {
+            console.error('Error loading user photo download URL from Storage:', error);
+            pushStoragePhotoDebug(options, 'Storage photo download URL fallback failed for PDF', {
+              fullPath: item?.fullPath || null,
+              message: error?.message || String(error),
+            });
+            return '';
+          })];
       })
       .filter(Boolean);
+    const resolvedDataUrls = (await Promise.all(dataUrls)).filter(Boolean);
     pushStoragePhotoDebug(options, 'Storage avatar data URL load finished for PDF', {
       requested: includedItems.length,
-      preparedDataUrls: dataUrls.length,
-      failedOrUnsupported: includedItems.length - dataUrls.length,
+      preparedDataUrls: resolvedDataUrls.filter(url => String(url).startsWith('data:image/')).length,
+      fallbackDownloadUrls: resolvedDataUrls.filter(url => /^https?:\/\//i.test(String(url))).length,
+      failedOrUnsupported: includedItems.length - resolvedDataUrls.length,
     });
-    return dataUrls;
+    return resolvedDataUrls;
   } catch (error) {
     console.error('Error listing user photo bytes from Storage:', error);
     pushStoragePhotoDebug(options, 'Storage avatar folder list failed for PDF', {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1214,11 +1214,17 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
     return { src: dataUrl, debug: `Photo ${index + 1}: embedded as data URL (${blob.type || 'unknown type'}, ${blob.size || 0} bytes)` };
   } catch (error) {
     console.error('Unable to load PDF photo', photoUrl, error);
-    pushPdfDebugLine(debugLines, 'Embedding photo failed; skipped original URL fallback for PDF reliability', {
+    const canUseOriginalUrlFallback = /^https?:\/\//i.test(String(photoUrl || ''));
+    pushPdfDebugLine(debugLines, canUseOriginalUrlFallback
+      ? 'Embedding photo fetch failed; using original URL fallback for PDF'
+      : 'Embedding photo failed; no original URL fallback available for PDF', {
       url: debugUrl,
       name: error?.name || null,
       message: error?.message || String(error),
     });
+    if (canUseOriginalUrlFallback) {
+      return { src: photoUrl, debug: `Photo ${index + 1}: embedded from original URL fallback after fetch error (${error?.message || String(error)})` };
+    }
     return { src: '', debug: `Photo ${index + 1}: skipped after fetch error (${error?.message || String(error)})` };
   }
 };


### PR DESCRIPTION
### Motivation
- Improve robustness when reading avatar images from Storage for PDF export by falling back to downloadable URLs if content type detection or bytes loading fails.
- Provide clearer debug diagnostics for why images are embedded, skipped, or returned as fallback URLs to aid troubleshooting.

### Description
- In `getUserStorageAvatarPhotoDataUrls` add a `fullPath` capture and return a `getDownloadURL` fallback when `getStorageContentType` is unavailable, and attempt download-URL fallback for items that fail to load, resolving all fallback promises before returning results.
- Update `getUserStorageAvatarPhotoDataUrls` to report `preparedDataUrls`, `fallbackDownloadUrls`, and `failedOrUnsupported` in debug output and return `resolvedDataUrls` instead of raw settled results.
- In `loadPdfEmbeddedImage` change error handling to detect if the original `photoUrl` is an HTTP(S) URL and use it as a fallback `src` after fetch errors, while adding more explicit debug lines about availability of the fallback.

### Testing
- Ran the project's automated test suite with `npm test` and linting checks, and the tests completed without failures.
- Existing PDF export flows were exercised in development to confirm that image content-type failures and fetch errors now yield fallback download URLs or original URL fallbacks as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48140b6940832680d88bb959afa0c5)