### PR TITLE
Allow visible overflow for compact PhotoItem to prevent clipping

### DIFF
--- a/src/components/Photos.jsx
+++ b/src/components/Photos.jsx
@@ -43,7 +43,7 @@ const PhotoItem = styled.div`
   box-sizing: border-box;
   border: ${({ $compact }) => ($compact ? '2px solid #E8E8E2' : '3px solid #E8E8E2')};
   border-radius: ${({ $compact }) => ($compact ? '50%' : '8px')};
-  overflow: hidden;
+  overflow: ${({ $compact }) => ($compact ? 'visible' : 'hidden')};
   background: #fff;
 `;
 


### PR DESCRIPTION
### Motivation
- Prevent circular images and their controls from being clipped in compact mode by allowing visible overflow when `$compact` is true.

### Description
- Change `PhotoItem` CSS to set `overflow` conditionally: `overflow: ${({ $compact }) => ($compact ? 'visible' : 'hidden')};` so compact (circular) items are not cropped.

### Testing
- Ran `npm test` and all unit tests passed.
- Ran `npm run lint` and the linter reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48130761248326ada9ae6ffbc5cdce)