### PR TITLE
Use Storage blob/bytes fallbacks for PDF image data URLs and improve debug logs

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata } from 'firebase/storage';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getBlob, getMetadata as firebaseGetMetadata } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
@@ -2952,6 +2952,34 @@ const bytesToBase64 = bytes => {
   return Buffer.from(binary, 'binary').toString('base64');
 };
 
+const getStoragePhotoBlobDataUrl = async (item, options = {}) => {
+  const blob = await getBlob(item);
+  const bytes = await blob.arrayBuffer();
+  const contentType = PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(String(blob.type || '').toLowerCase())
+    ? String(blob.type).toLowerCase()
+    : await getStorageContentType(item, bytes, options);
+  if (!contentType) return '';
+  pushStoragePhotoDebug(options, 'Storage photo prepared as blob data URL for PDF', {
+    fullPath: item?.fullPath || null,
+    contentType,
+    byteLength: bytes?.byteLength || bytes?.length || 0,
+  });
+  return `data:${contentType};base64,${bytesToBase64(bytes)}`;
+};
+
+const getStoragePhotoBytesDataUrl = async (item, options = {}) => {
+  const fullPath = item?.fullPath || null;
+  const bytes = await getBytes(item);
+  const contentType = await getStorageContentType(item, bytes, options);
+  if (!contentType) return '';
+  pushStoragePhotoDebug(options, 'Storage photo prepared as data URL for PDF', {
+    fullPath,
+    contentType,
+    byteLength: bytes?.byteLength || bytes?.length || 0,
+  });
+  return `data:${contentType};base64,${bytesToBase64(bytes)}`;
+};
+
 const isMedicationStorageItem = (item, userId) => String(item?.fullPath || '').startsWith(`avatar/${userId}/medication/`);
 
 export const getUserStorageAvatarPhotos = async userId => {
@@ -2998,34 +3026,81 @@ export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) =>
     const settledPhotos = await Promise.allSettled(
       includedItems
         .map(async item => {
-          const bytes = await getBytes(item);
-          const contentType = await getStorageContentType(item, bytes, options);
-          if (!contentType) return '';
-          pushStoragePhotoDebug(options, 'Storage photo prepared as data URL for PDF', {
-            fullPath: item?.fullPath || null,
-            contentType,
-            byteLength: bytes?.byteLength || bytes?.length || 0,
+          const fullPath = item?.fullPath || null;
+          try {
+            const blobDataUrl = await getStoragePhotoBlobDataUrl(item, options);
+            if (blobDataUrl) return blobDataUrl;
+          } catch (error) {
+            console.error('Error loading user photo blob from Storage:', error);
+            pushStoragePhotoDebug(options, 'Storage photo blob load failed; trying bytes fallback for PDF', {
+              fullPath,
+              message: error?.message || String(error),
+            });
+          }
+          const bytesDataUrl = await getStoragePhotoBytesDataUrl(item, options);
+          if (bytesDataUrl) return bytesDataUrl;
+          const fallbackUrl = await getDownloadURL(item);
+          pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
+            fullPath,
+            reason: 'unsupported-or-unresolved-content-type',
           });
-          return `data:${contentType};base64,${bytesToBase64(bytes)}`;
+          return fallbackUrl;
         })
     );
 
     const dataUrls = settledPhotos
-      .flatMap(result => {
+      .flatMap((result, index) => {
         if (result.status === 'fulfilled') return [result.value];
+        const item = includedItems[index];
         console.error('Error loading user photo bytes from Storage:', result.reason);
-        pushStoragePhotoDebug(options, 'Storage photo bytes load failed', {
+        pushStoragePhotoDebug(options, 'Storage photo bytes load failed; trying download URL fallback for PDF', {
+          fullPath: item?.fullPath || null,
           message: result.reason?.message || String(result.reason),
         });
-        return [];
+        return [getStoragePhotoBlobDataUrl(item, options)
+          .then(dataUrl => {
+            if (dataUrl) return dataUrl;
+            return getDownloadURL(item).then(url => {
+              pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
+                fullPath: item?.fullPath || null,
+                reason: result.reason?.code || result.reason?.message || String(result.reason),
+              });
+              return url;
+            });
+          })
+          .catch(blobError => {
+            console.error('Error loading user photo blob from Storage:', blobError);
+            pushStoragePhotoDebug(options, 'Storage photo blob fallback failed; trying download URL fallback for PDF', {
+              fullPath: item?.fullPath || null,
+              message: blobError?.message || String(blobError),
+            });
+            return getDownloadURL(item)
+              .then(url => {
+                pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
+                  fullPath: item?.fullPath || null,
+                  reason: result.reason?.code || result.reason?.message || String(result.reason),
+                });
+                return url;
+              });
+          })
+          .catch(error => {
+            console.error('Error loading user photo download URL from Storage:', error);
+            pushStoragePhotoDebug(options, 'Storage photo download URL fallback failed for PDF', {
+              fullPath: item?.fullPath || null,
+              message: error?.message || String(error),
+            });
+            return '';
+          })];
       })
       .filter(Boolean);
+    const resolvedDataUrls = (await Promise.all(dataUrls)).filter(Boolean);
     pushStoragePhotoDebug(options, 'Storage avatar data URL load finished for PDF', {
       requested: includedItems.length,
-      preparedDataUrls: dataUrls.length,
-      failedOrUnsupported: includedItems.length - dataUrls.length,
+      preparedDataUrls: resolvedDataUrls.filter(url => String(url).startsWith('data:image/')).length,
+      fallbackDownloadUrls: resolvedDataUrls.filter(url => /^https?:\/\//i.test(String(url))).length,
+      failedOrUnsupported: includedItems.length - resolvedDataUrls.length,
     });
-    return dataUrls;
+    return resolvedDataUrls;
   } catch (error) {
     console.error('Error listing user photo bytes from Storage:', error);
     pushStoragePhotoDebug(options, 'Storage avatar folder list failed for PDF', {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1214,7 +1214,7 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
     return { src: dataUrl, debug: `Photo ${index + 1}: embedded as data URL (${blob.type || 'unknown type'}, ${blob.size || 0} bytes)` };
   } catch (error) {
     console.error('Unable to load PDF photo', photoUrl, error);
-    pushPdfDebugLine(debugLines, 'Embedding photo failed; skipped original URL fallback for PDF reliability', {
+    pushPdfDebugLine(debugLines, 'Embedding photo failed; skipped because PDF requires a readable image data URL', {
       url: debugUrl,
       name: error?.name || null,
       message: error?.message || String(error),


### PR DESCRIPTION
### Motivation
- Ensure avatar photos from Firebase Storage can be embedded into PDFs by using the Storage `getBlob` API and a bytes fallback when content-type detection fails. 
- Improve robustness by falling back to download URLs and enriching debug traces for troubleshooting. 
- Clarify PDF embedding failure messaging for easier diagnosis.

### Description
- Import `getBlob` from `firebase/storage` and add `getStoragePhotoBlobDataUrl` and `getStoragePhotoBytesDataUrl` helpers to produce base64 data URLs from blobs or bytes. 
- Update `getUserStorageAvatarPhotoDataUrls` to attempt a blob-based data URL first, then a bytes-based data URL, and finally fall back to `getDownloadURL`, with detailed `pushStoragePhotoDebug` calls and error handling for each step. 
- Resolve and filter all fallback promises to return a final list of data URLs or download URLs and report counts of prepared data URLs, fallback download URLs, and failures. 
- Update PDF embedding debug text in `renderTopBlock.js` to a clearer message when fetched blob data cannot be used for PDF embedding.

### Testing
- Ran the project test suite and linting (`yarn test` / `yarn lint`); both completed without failures. 
- No new automated tests were added for the Storage fallback logic in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48140b6940832680d88bb959afa0c5)