### PR TITLE
Fix profile PDF photo embedding

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata } from 'firebase/storage';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata, setMaxDownloadRetryTime, setMaxOperationRetryTime } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
@@ -66,6 +66,8 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
+setMaxDownloadRetryTime(storage, 120000);
+setMaxOperationRetryTime(storage, 120000);
 export const database = getDatabase(app);
 
 const getCurrentAdminUid = () => auth.currentUser?.uid;

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1027,6 +1027,14 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
         </View>
         {pdfFooter}
       </Page>
+      {photoEntries.map((photo, index) => (
+        <Page key={`${photo.src}-${index}`} size="A4" style={profilePdfStyles.imagePage}>
+          <Image src={photo.src} style={profilePdfStyles.profileImage} />
+          {photo.debug ? <Text style={profilePdfStyles.photoCaption}>{photo.debug}</Text> : null}
+          <Text style={profilePdfStyles.imageWatermark}>UKRCOM</Text>
+          {pdfFooter}
+        </Page>
+      ))}
       <Page size="A4" style={profilePdfStyles.debugPage}>
         <Text style={profilePdfStyles.watermark}>UKRCOM</Text>
         <Text style={profilePdfStyles.debugTitle}>PDF photo debug</Text>
@@ -1041,14 +1049,6 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
         </View>
         {pdfFooter}
       </Page>
-      {photoEntries.map((photo, index) => (
-        <Page key={`${photo.src}-${index}`} size="A4" style={profilePdfStyles.imagePage}>
-          <Image src={photo.src} style={profilePdfStyles.profileImage} />
-          {photo.debug ? <Text style={profilePdfStyles.photoCaption}>{photo.debug}</Text> : null}
-          <Text style={profilePdfStyles.imageWatermark}>UKRCOM</Text>
-          {pdfFooter}
-        </Page>
-      ))}
     </Document>
   );
 };
@@ -1168,6 +1168,52 @@ const readBlobAsDataUrl = blob => new Promise((resolve, reject) => {
   reader.readAsDataURL(blob);
 });
 
+const loadImageUrlWithXhr = photoUrl => new Promise((resolve, reject) => {
+  const request = new XMLHttpRequest();
+  request.open('GET', photoUrl, true);
+  request.responseType = 'blob';
+  request.onload = () => {
+    if (request.status >= 200 && request.status < 300 && request.response) {
+      resolve(request.response);
+      return;
+    }
+    reject(new Error(`Photo XHR request failed with status ${request.status}`));
+  };
+  request.onerror = () => reject(new Error('Photo XHR request failed'));
+  request.ontimeout = () => reject(new Error('Photo XHR request timed out'));
+  request.timeout = 60000;
+  request.send();
+});
+
+const fetchImageUrlAsDataUrl = async (photoUrl, debugLines, debugUrl) => {
+  try {
+    const response = await fetch(photoUrl);
+    pushPdfDebugLine(debugLines, 'Embedding photo: fetch response', {
+      url: debugUrl,
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      contentType: response.headers?.get?.('content-type') || null,
+    });
+    if (!response.ok) {
+      throw new Error(`Photo request failed with status ${response.status}`);
+    }
+    return response.blob();
+  } catch (fetchError) {
+    pushPdfDebugLine(debugLines, 'Embedding photo: fetch failed; trying XHR blob fallback', {
+      url: debugUrl,
+      message: fetchError?.message || String(fetchError),
+    });
+    const blob = await loadImageUrlWithXhr(photoUrl);
+    pushPdfDebugLine(debugLines, 'Embedding photo: XHR blob fallback loaded', {
+      url: debugUrl,
+      type: blob.type || null,
+      size: blob.size || 0,
+    });
+    return blob;
+  }
+};
+
 const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
   if (!photoUrl) {
     pushPdfDebugLine(debugLines, 'Skipped empty photo URL before embedding');
@@ -1183,18 +1229,7 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
   pushPdfDebugLine(debugLines, 'Embedding photo: fetch started', debugUrl);
 
   try {
-    const response = await fetch(photoUrl);
-    pushPdfDebugLine(debugLines, 'Embedding photo: fetch response', {
-      url: debugUrl,
-      ok: response.ok,
-      status: response.status,
-      statusText: response.statusText,
-      contentType: response.headers?.get?.('content-type') || null,
-    });
-    if (!response.ok) {
-      throw new Error(`Photo request failed with status ${response.status}`);
-    }
-    const blob = await response.blob();
+    const blob = await fetchImageUrlAsDataUrl(photoUrl, debugLines, debugUrl);
     pushPdfDebugLine(debugLines, 'Embedding photo: blob loaded', {
       url: debugUrl,
       type: blob.type || null,
@@ -1214,17 +1249,11 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
     return { src: dataUrl, debug: `Photo ${index + 1}: embedded as data URL (${blob.type || 'unknown type'}, ${blob.size || 0} bytes)` };
   } catch (error) {
     console.error('Unable to load PDF photo', photoUrl, error);
-    const canUseOriginalUrlFallback = /^https?:\/\//i.test(String(photoUrl || ''));
-    pushPdfDebugLine(debugLines, canUseOriginalUrlFallback
-      ? 'Embedding photo fetch failed; using original URL fallback for PDF'
-      : 'Embedding photo failed; no original URL fallback available for PDF', {
+    pushPdfDebugLine(debugLines, 'Embedding photo failed; PDF image requires a data URL', {
       url: debugUrl,
       name: error?.name || null,
       message: error?.message || String(error),
     });
-    if (canUseOriginalUrlFallback) {
-      return { src: photoUrl, debug: `Photo ${index + 1}: embedded from original URL fallback after fetch error (${error?.message || String(error)})` };
-    }
     return { src: '', debug: `Photo ${index + 1}: skipped after fetch error (${error?.message || String(error)})` };
   }
 };


### PR DESCRIPTION
## Summary
- place profile photos immediately after the questionnaire in exported PDFs
- add XHR blob fallback when converting HTTP photo URLs to data URLs for PDF embedding
- extend Firebase Storage download/operation retry windows to better support avatar photo reads from `avatar/{userId}`
- avoid rendering unusable original URL fallbacks that produced blank photo pages

## Testing
- `npm run lint:js -- --max-warnings=0`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48df053d54832692c1babf0b97a1e0)