### PR TITLE
Fix Firebase storage retry configuration import

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata, setMaxDownloadRetryTime, setMaxOperationRetryTime } from 'firebase/storage';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
@@ -66,8 +66,7 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
-setMaxDownloadRetryTime(storage, 120000);
-setMaxOperationRetryTime(storage, 120000);
+storage.maxOperationRetryTime = 120000;
 export const database = getDatabase(app);
 
 const getCurrentAdminUid = () => auth.currentUser?.uid;


### PR DESCRIPTION
### Motivation
- The app errored with an import failure because the installed Firebase SDK does not export `setMaxDownloadRetryTime`/`setMaxOperationRetryTime`, so retry configuration must be applied via the storage instance instead of imported setters.

### Description
- Removed unsupported retry setter imports from `firebase/storage` and configured retry by assigning `storage.maxOperationRetryTime = 120000` on the initialized `storage` instance.

### Testing
- Ran `npm run build` and `npm run lint:js`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48e521c6908326a43c8835d3932399)