### PR TITLE
Fix PDF avatar data URL embedding

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -24,6 +24,7 @@ import {
 import { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 import { filterOutMedicationPhotos } from '../utils/photoFilters';
 import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
+import { isPdfImageDataUrl, loadFirebasePhotoAsDataUrl } from '../utils/pdfImageDataUrl';
 import { getCurrentDate } from './foramtDate';
 import toast from 'react-hot-toast';
 import { getCard, incrementMatchingLoadStat, removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
@@ -2939,20 +2940,6 @@ const getStorageContentType = async (item, bytes, options = {}) => {
   return null;
 };
 
-const bytesToBase64 = bytes => {
-  const byteArray = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-  let binary = '';
-  const chunkSize = 0x8000;
-  for (let index = 0; index < byteArray.length; index += chunkSize) {
-    binary += String.fromCharCode(...byteArray.subarray(index, index + chunkSize));
-  }
-
-  if (typeof btoa === 'function') {
-    return btoa(binary);
-  }
-  return Buffer.from(binary, 'binary').toString('base64');
-};
-
 const isMedicationStorageItem = (item, userId) => String(item?.fullPath || '').startsWith(`avatar/${userId}/medication/`);
 
 export const getUserStorageAvatarPhotos = async userId => {
@@ -2998,62 +2985,35 @@ export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) =>
     });
     const settledPhotos = await Promise.allSettled(
       includedItems
-        .map(async item => {
-          const fullPath = item?.fullPath || null;
-          const bytes = await getBytes(item);
-          const contentType = await getStorageContentType(item, bytes, options);
-          if (!contentType) {
-            const fallbackUrl = await getDownloadURL(item);
-            pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
-              fullPath,
-              reason: 'unsupported-or-unresolved-content-type',
-            });
-            return fallbackUrl;
-          }
-          pushStoragePhotoDebug(options, 'Storage photo prepared as data URL for PDF', {
-            fullPath,
-            contentType,
-            byteLength: bytes?.byteLength || bytes?.length || 0,
-          });
-          return `data:${contentType};base64,${bytesToBase64(bytes)}`;
-        })
+        .map(item => loadFirebasePhotoAsDataUrl(item, {
+          getBytes,
+          getDownloadURL,
+          resolveContentType: (photoRef, bytes) => getStorageContentType(photoRef, bytes, options),
+          onDebug: (message, payload) => pushStoragePhotoDebug(options, message, payload),
+        }))
     );
 
-    const dataUrls = settledPhotos
+    const storageDataUrls = settledPhotos
       .flatMap((result, index) => {
         if (result.status === 'fulfilled') return [result.value];
         const item = includedItems[index];
-        console.error('Error loading user photo bytes from Storage:', result.reason);
-        pushStoragePhotoDebug(options, 'Storage photo bytes load failed; trying download URL fallback for PDF', {
+        console.error('Error loading user photo as data URL from Storage:', result.reason);
+        pushStoragePhotoDebug(options, 'photo skipped: could not convert to data URL', {
           fullPath: item?.fullPath || null,
           message: result.reason?.message || String(result.reason),
         });
-        return [getDownloadURL(item)
-          .then(url => {
-            pushStoragePhotoDebug(options, 'Storage photo added as download URL fallback for PDF', {
-              fullPath: item?.fullPath || null,
-              reason: result.reason?.code || result.reason?.message || String(result.reason),
-            });
-            return url;
-          })
-          .catch(error => {
-            console.error('Error loading user photo download URL from Storage:', error);
-            pushStoragePhotoDebug(options, 'Storage photo download URL fallback failed for PDF', {
-              fullPath: item?.fullPath || null,
-              message: error?.message || String(error),
-            });
-            return '';
-          })];
+        return [];
       })
-      .filter(Boolean);
-    const resolvedDataUrls = (await Promise.all(dataUrls)).filter(Boolean);
+      .filter(isPdfImageDataUrl);
     pushStoragePhotoDebug(options, 'Storage avatar data URL load finished for PDF', {
       requested: includedItems.length,
-      preparedDataUrls: resolvedDataUrls.filter(url => String(url).startsWith('data:image/')).length,
-      fallbackDownloadUrls: resolvedDataUrls.filter(url => /^https?:\/\//i.test(String(url))).length,
-      failedOrUnsupported: includedItems.length - resolvedDataUrls.length,
+      storageDataUrls: storageDataUrls.length,
+      storageDownloadUrlFallbacks: 0,
+      preparedDataUrls: storageDataUrls.length,
+      fallbackDownloadUrls: 0,
+      failedOrUnsupported: includedItems.length - storageDataUrls.length,
     });
-    return resolvedDataUrls;
+    return storageDataUrls;
   } catch (error) {
     console.error('Error listing user photo bytes from Storage:', error);
     pushStoragePhotoDebug(options, 'Storage avatar folder list failed for PDF', {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -49,6 +49,7 @@ import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { filterOutMedicationPhotos } from 'utils/photoFilters';
 import { convertDriveLinkToImage } from 'utils/convertDriveLinkToImage';
+import { isPdfImageDataUrl, blobToDataUrl } from 'utils/pdfImageDataUrl';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
 import { auth } from '../config';
@@ -1106,7 +1107,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
 
   if (!cardData?.userId) {
     pushPdfDebugLine(debugLines, 'No userId on cardData; using only existing photos', summarizePdfDebugUrls(existingPhotos));
-    return existingPhotos;
+    return existingPhotos.filter(isPdfImageDataUrl);
   }
 
   const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
@@ -1141,13 +1142,23 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
     sample: existingStorageAvatarPaths.slice(0, PDF_DEBUG_URL_SAMPLE_SIZE),
     note: 'Storage data URLs are still loaded for all avatar/{userId} files to avoid URL fallback/CORS failures in PDF',
   });
-  pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} as data URLs', summarizePdfDebugUrls(storagePhotos));
+  pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} storageDataUrls', summarizePdfDebugUrls(storagePhotos.filter(isPdfImageDataUrl)));
+  pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} storageDownloadUrlFallbacks', summarizePdfDebugUrls(storagePhotos.filter(url => /^https?:\/\//i.test(String(url)))));
   pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
 
   const combinedPhotos = [...existingPhotos, ...storagePhotos, ...loadedPhotos];
   const filteredPhotos = filterOutMedicationPhotos(combinedPhotos, cardData.userId);
   const convertedPhotos = filteredPhotos.map(convertDriveLinkToImage).filter(Boolean);
-  const uniquePhotos = Array.from(new Set(convertedPhotos));
+  const uniquePhotos = Array.from(new Set(convertedPhotos)).filter(photo => {
+    const printable = isPdfImageDataUrl(photo);
+    if (!printable && photo) {
+      pushPdfDebugLine(debugLines, 'photo skipped: could not convert to data URL', {
+        url: truncatePdfDebugValue(photo),
+        reason: 'final PDF image list accepts only data:image/...;base64 URLs',
+      });
+    }
+    return printable;
+  });
 
   pushPdfDebugLine(debugLines, 'Combined photos before medication filter', summarizePdfDebugUrls(combinedPhotos));
   pushPdfDebugLine(debugLines, 'Photos after medication filter', summarizePdfDebugUrls(filteredPhotos));
@@ -1160,13 +1171,6 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
 
   return uniquePhotos;
 };
-
-const readBlobAsDataUrl = blob => new Promise((resolve, reject) => {
-  const reader = new FileReader();
-  reader.onloadend = () => resolve(typeof reader.result === 'string' ? reader.result : '');
-  reader.onerror = () => reject(reader.error);
-  reader.readAsDataURL(blob);
-});
 
 const loadImageUrlWithXhr = photoUrl => new Promise((resolve, reject) => {
   const request = new XMLHttpRequest();
@@ -1220,7 +1224,7 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
     return { src: '', debug: `Photo ${index + 1}: empty URL` };
   }
 
-  if (String(photoUrl).startsWith('data:image/')) {
+  if (isPdfImageDataUrl(photoUrl)) {
     pushPdfDebugLine(debugLines, 'Embedding photo: using prepared data URL', { index: index + 1 });
     return { src: photoUrl, debug: '' };
   }
@@ -1235,8 +1239,8 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
       type: blob.type || null,
       size: blob.size || 0,
     });
-    const dataUrl = await readBlobAsDataUrl(blob);
-    const isImageDataUrl = dataUrl.startsWith('data:image/');
+    const dataUrl = await blobToDataUrl(blob);
+    const isImageDataUrl = isPdfImageDataUrl(dataUrl);
     pushPdfDebugLine(debugLines, 'Embedding photo: data URL created', {
       url: debugUrl,
       length: dataUrl.length,
@@ -1285,8 +1289,8 @@ const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
       pushPdfDebugLine(debugLines, 'Embedded photo summary', {
         attempted: effectivePhotoUrls.length,
         printable: printablePhotoEntries.length,
-        dataUrls: printablePhotoEntries.filter(entry => String(entry.src).startsWith('data:image/')).length,
-        originalUrlFallbacks: printablePhotoEntries.filter(entry => !String(entry.src).startsWith('data:image/')).length,
+        dataUrls: printablePhotoEntries.filter(entry => isPdfImageDataUrl(entry.src)).length,
+        originalUrlFallbacks: printablePhotoEntries.filter(entry => !isPdfImageDataUrl(entry.src)).length,
         failedWithoutFallback: effectivePhotoUrls.length - printablePhotoEntries.length,
       });
       if (!printablePhotoEntries.length) {

--- a/src/utils/pdfImageDataUrl.js
+++ b/src/utils/pdfImageDataUrl.js
@@ -1,0 +1,106 @@
+export const isPdfImageDataUrl = value => /^data:image\/(?:jpeg|jpg|png);base64,[a-z0-9+/=\s]+$/i.test(String(value || '').trim());
+
+export const blobToDataUrl = blob =>
+  new Promise((resolve, reject) => {
+    if (!blob) {
+      resolve('');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error || new Error('Unable to read blob as data URL'));
+    reader.readAsDataURL(blob);
+  });
+
+const bytesToBlob = (bytes, contentType) => new Blob([bytes], { type: contentType || 'application/octet-stream' });
+
+export const fetchImageUrlAsDataUrl = async url => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Photo request failed with status ${response.status}`);
+  }
+  const blob = await response.blob();
+  if (
+    !String(blob?.type || '')
+      .toLowerCase()
+      .startsWith('image/')
+  ) {
+    throw new Error(`Photo response is not an image blob (${blob?.type || 'unknown type'})`);
+  }
+
+  const dataUrl = await blobToDataUrl(blob);
+  if (!isPdfImageDataUrl(dataUrl)) {
+    throw new Error('Photo blob did not convert to a supported PDF image data URL');
+  }
+  return dataUrl;
+};
+
+export const loadFirebasePhotoAsDataUrl = async (refOrUrl, { getBytes, getDownloadURL, resolveContentType, onDebug } = {}) => {
+  const debug = (message, payload) => {
+    if (typeof onDebug === 'function') onDebug(message, payload);
+  };
+
+  if (isPdfImageDataUrl(refOrUrl)) return refOrUrl;
+
+  if (typeof refOrUrl === 'string') {
+    try {
+      const dataUrl = await fetchImageUrlAsDataUrl(refOrUrl);
+      debug('Storage photo download URL fallback converted to data URL for PDF', { url: refOrUrl });
+      return dataUrl;
+    } catch (error) {
+      debug('photo skipped: could not convert to data URL', {
+        url: refOrUrl,
+        message: error?.message || String(error),
+      });
+      return '';
+    }
+  }
+
+  if (typeof getBytes !== 'function') return '';
+
+  try {
+    const bytes = await getBytes(refOrUrl);
+    const contentType = typeof resolveContentType === 'function' ? await resolveContentType(refOrUrl, bytes) : 'image/jpeg';
+    if (
+      !String(contentType || '')
+        .toLowerCase()
+        .startsWith('image/')
+    ) {
+      throw new Error(`Unsupported image content type (${contentType || 'unknown'})`);
+    }
+    const dataUrl = await blobToDataUrl(bytesToBlob(bytes, contentType));
+    if (!isPdfImageDataUrl(dataUrl)) {
+      throw new Error('Storage bytes did not convert to a supported PDF image data URL');
+    }
+    return dataUrl;
+  } catch (bytesError) {
+    debug('Storage photo bytes load failed; trying download URL fallback for PDF', {
+      fullPath: refOrUrl?.fullPath || null,
+      message: bytesError?.message || String(bytesError),
+      code: bytesError?.code || null,
+    });
+
+    if (typeof getDownloadURL !== 'function') {
+      debug('photo skipped: could not convert to data URL', {
+        fullPath: refOrUrl?.fullPath || null,
+        message: bytesError?.message || String(bytesError),
+      });
+      return '';
+    }
+
+    try {
+      const downloadUrl = await getDownloadURL(refOrUrl);
+      debug('Storage photo using download URL fallback for data URL conversion', {
+        fullPath: refOrUrl?.fullPath || null,
+      });
+      return loadFirebasePhotoAsDataUrl(downloadUrl, { onDebug });
+    } catch (downloadUrlError) {
+      debug('photo skipped: could not convert to data URL', {
+        fullPath: refOrUrl?.fullPath || null,
+        message: downloadUrlError?.message || String(downloadUrlError),
+      });
+      return '';
+    }
+  }
+};

--- a/src/utils/pdfImageDataUrl.test.js
+++ b/src/utils/pdfImageDataUrl.test.js
@@ -1,0 +1,42 @@
+import { fetchImageUrlAsDataUrl, isPdfImageDataUrl, loadFirebasePhotoAsDataUrl } from './pdfImageDataUrl';
+
+describe('PDF image data URL helpers', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('does not treat Firebase download URLs as printable PDF images', () => {
+    expect(isPdfImageDataUrl('https://firebasestorage.googleapis.com/v0/b/demo/o/avatar%2Fu1%2Fphoto.jpg?alt=media')).toBe(false);
+  });
+
+  it('treats JPEG data URLs as printable PDF images', () => {
+    expect(isPdfImageDataUrl('data:image/jpeg;base64,/9j/4AAQSkZJRg==')).toBe(true);
+  });
+
+  it('adds a fallback URL only after converting it to a data URL', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob([new Uint8Array([0xff, 0xd8, 0xff])], { type: 'image/jpeg' }),
+    }));
+
+    const dataUrl = await fetchImageUrlAsDataUrl('https://example.test/photo.jpg');
+
+    expect(dataUrl).toMatch(/^data:image\/jpeg;base64,/);
+    expect(isPdfImageDataUrl(dataUrl)).toBe(true);
+  });
+
+  it('skips fallback URLs that cannot be converted and reports the reason', async () => {
+    const debug = jest.fn();
+    global.fetch = jest.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+
+    const dataUrl = await loadFirebasePhotoAsDataUrl('https://example.test/cors-blocked.jpg', { onDebug: debug });
+
+    expect(dataUrl).toBe('');
+    expect(debug).toHaveBeenCalledWith('photo skipped: could not convert to data URL', expect.objectContaining({ message: 'Failed to fetch' }));
+  });
+});


### PR DESCRIPTION
### Motivation
- PDF export omitted avatar images because Firebase download URLs were passed through instead of printable `data:image/...;base64,...` data URLs, and Storage fallback URLs could be blocked by CORS or be non-image responses.
- The goal is to ensure only valid image data URLs reach `@react-pdf/renderer` <Image /> so profile PDFs reliably include photos and debug output reflects true printable counts.

### Description
- Added `src/utils/pdfImageDataUrl.js` with helpers `isPdfImageDataUrl`, `blobToDataUrl`, `fetchImageUrlAsDataUrl`, and `loadFirebasePhotoAsDataUrl` to validate and convert blobs/URLs to PDF-safe data URLs.
- Reworked `getUserStorageAvatarPhotoDataUrls` to resolve storage entries via `loadFirebasePhotoAsDataUrl`, return only valid `data:image/...;base64,...` values, and emit separate debug counts `storageDataUrls` / `storageDownloadUrlFallbacks` while logging skipped photos with reason `photo skipped: could not convert to data URL`.
- Updated PDF photo resolution and embedding in `renderTopBlock` to use the new helpers, to convert fetched blobs with `blobToDataUrl`, filter the final unique photo list to only printable data URLs, and to adjust debug summary fields so `printable` / `dataUrls` reflect actual embedded data URLs.
- Added unit tests `src/utils/pdfImageDataUrl.test.js` covering: Firebase download URL rejection, JPEG data URL acceptance, successful fallback URL conversion to a data URL, and skipping of non-convertible fallback URLs with debug reported.

### Testing
- Ran unit tests with `npm test -- --watchAll=false src/utils/pdfImageDataUrl.test.js`, and all tests passed.
- Ran linter with `npm run lint:js -- src/utils/pdfImageDataUrl.js src/utils/pdfImageDataUrl.test.js src/components/config.js src/components/smallCard/renderTopBlock.js`, which completed without errors.
- Verified PDF photo resolution flow now produces printable > 0 and dataUrls > 0 when a convertible avatar is present, and that non-convertible download URLs are skipped (logged) rather than included in the final `<Image src={...} />` array.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49032e1c708326ac1154e54aa01a36)