### PR TITLE
Fix PDF photo resolution fallbacks

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -49,7 +49,7 @@ import { getCard } from 'utils/cardIndex';
 import { normalizeLastAction } from 'utils/normalizeLastAction';
 import { filterOutMedicationPhotos } from 'utils/photoFilters';
 import { convertDriveLinkToImage } from 'utils/convertDriveLinkToImage';
-import { isPdfImageDataUrl, isHttpImageUrl } from 'utils/pdfImageDataUrl';
+import { isPdfImageDataUrl, isHttpImageUrl, fetchImageUrlAsDataUrl } from 'utils/pdfImageDataUrl';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
 import { auth } from '../config';
@@ -1154,17 +1154,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
   }
 
   const existingPhotoCandidates = preparePdfPhotoCandidates(existingPhotos, cardData.userId, debugLines);
-  const existingLimitedPhotos = existingPhotoCandidates.uniquePhotos.slice(0, PDF_MAX_PROFILE_PHOTOS);
-  if (existingLimitedPhotos.length) {
-    pushPdfDebugLine(debugLines, 'Using existing card photo URLs for PDF', summarizePdfEmbeddingCandidates(existingLimitedPhotos));
-    if (existingPhotoCandidates.uniquePhotos.length > existingLimitedPhotos.length) {
-      pushPdfDebugLine(debugLines, 'PDF photo list limited for mobile export stability', {
-        limit: PDF_MAX_PROFILE_PHOTOS,
-        skippedByLimit: existingPhotoCandidates.uniquePhotos.length - existingLimitedPhotos.length,
-      });
-    }
-    return existingLimitedPhotos;
-  }
+  pushPdfDebugLine(debugLines, 'Prepared existing card photo URLs for PDF', summarizePdfEmbeddingCandidates(existingPhotoCandidates.uniquePhotos));
 
   const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
   pushPdfDebugLine(debugLines, 'Resolved photo source collection', {
@@ -1203,7 +1193,7 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
   pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} storageDownloadUrlFallbacks', summarizePdfDebugUrls(storagePhotos.filter(url => /^https?:\/\//i.test(String(url)))));
   pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
 
-  const combinedPhotos = [...storagePhotos, ...loadedPhotos];
+  const combinedPhotos = [...existingPhotoCandidates.uniquePhotos, ...storagePhotos, ...loadedPhotos];
   const { filteredPhotos, convertedPhotos, uniquePhotos } = preparePdfPhotoCandidates(combinedPhotos, cardData.userId, debugLines);
   const limitedPhotos = uniquePhotos.slice(0, PDF_MAX_PROFILE_PHOTOS);
 
@@ -1244,8 +1234,22 @@ const loadPdfEmbeddedImage = async (photoUrl, debugLines, index = 0) => {
     return { src: '', debug: `Photo ${index + 1}: skipped because URL is unsupported` };
   }
 
-  pushPdfDebugLine(debugLines, 'Embedding photo: using existing remote URL', debugUrl);
-  return { src: photoUrl, debug: `Photo ${index + 1}: embedded as existing URL` };
+  try {
+    const dataUrl = await withPdfTimeout(
+      fetchImageUrlAsDataUrl(photoUrl),
+      15000,
+      `Photo ${index + 1} remote validation timed out`,
+    );
+    pushPdfDebugLine(debugLines, 'Embedding photo: converted remote URL to data URL', { index: index + 1, url: debugUrl });
+    return { src: dataUrl, debug: '' };
+  } catch (error) {
+    pushPdfDebugLine(debugLines, 'Embedding photo skipped: could not validate remote URL', {
+      index: index + 1,
+      url: debugUrl,
+      message: error?.message || String(error),
+    });
+    return { src: '', debug: `Photo ${index + 1}: skipped because remote URL could not be validated` };
+  }
 };
 
 const isSurrogateMotherRole = data => String(data?.userRole || data?.role || '').trim().toLowerCase() === 'sm';


### PR DESCRIPTION
### Motivation
- Ensure PDF exports do not short-circuit when a card contains one cached/remote URL so Storage/database images are still loaded to produce PDF-safe data URLs and avoid CORS/fallback blank images. 
- Prevent marking unvalidated remote image URLs as printable to avoid blank photo pages in `@react-pdf/renderer` when responses are HTML, permission-gated, or otherwise not an image blob.

### Description
- Updated `src/components/smallCard/renderTopBlock.js` to import `fetchImageUrlAsDataUrl` from `utils/pdfImageDataUrl` for shared remote-to-data-URL conversion. 
- Removed the early return that skipped loading Storage/database candidates when `photoUrls` contained existing remote URLs and instead added a debug line with prepared existing candidates. 
- Included existing card candidates in the `combinedPhotos` array before de-duplication and limiting so existing, Storage, and database photos are considered together. 
- Reworked `loadPdfEmbeddedImage` to validate and convert remote `http(s)` URLs to PDF-safe data URLs via `fetchImageUrlAsDataUrl` with a `withPdfTimeout` wrapper, and skip/emit debug info for failed remote validations.

### Testing
- Ran unit tests: `npm test -- --watchAll=false src/utils/pdfImageDataUrl.test.js`, all tests passed. 
- Ran linter: `npm run lint:js -- src/components/smallCard/renderTopBlock.js`, lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49424bb2448326bfbf8296d6720eb7)