### PR TITLE
Load PDF profile photos from Storage avatar folder and render debug page in PDF

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { collection, doc, getDoc as firebaseGetDoc, getDocs as firebaseGetDocs, getFirestore, setDoc, updateDoc, deleteField } from 'firebase/firestore';
-import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes, getMetadata as firebaseGetMetadata } from 'firebase/storage';
+import { getDownloadURL as firebaseGetDownloadURL, getStorage, uploadBytes, ref, deleteObject, listAll as firebaseListAll, getBytes } from 'firebase/storage';
 import {
   getDatabase,
   ref as ref2,
@@ -119,13 +119,6 @@ const getDownloadURL = (...args) => {
     path: args[0],
   });
 };
-
-const getMetadata = (...args) => withAdminDownloadToast(firebaseGetMetadata(...args), {
-  getUid: getCurrentAdminUid,
-  operation: 'Storage object metadata',
-  source: 'config',
-  path: args[0],
-});
 
 export { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 
@@ -2870,8 +2863,6 @@ const collectUserStorageAvatarItems = async userId => {
   return collectStorageItems(folderRef);
 };
 
-const PDF_SUPPORTED_STORAGE_IMAGE_TYPES = new Set(['image/jpeg', 'image/png']);
-
 const getStorageContentTypeFromName = item => {
   const extension = String(item?.name || '').split('.').pop()?.toLowerCase();
   if (extension === 'png') return 'image/png';
@@ -2889,24 +2880,6 @@ const getStorageContentTypeFromBytes = bytes => {
     byteArray[0] === 0x52 && byteArray[1] === 0x49 && byteArray[2] === 0x46 && byteArray[3] === 0x46
     && byteArray[8] === 0x57 && byteArray[9] === 0x45 && byteArray[10] === 0x42 && byteArray[11] === 0x50
   ) return 'image/webp';
-  return null;
-};
-
-const getStorageContentType = async (item, bytes) => {
-  const bytesContentType = getStorageContentTypeFromBytes(bytes);
-  if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(bytesContentType)) return bytesContentType;
-  if (bytesContentType) return null;
-
-  try {
-    const metadata = await getMetadata(item);
-    const metadataContentType = String(metadata?.contentType || '').toLowerCase();
-    if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(metadataContentType)) return metadataContentType;
-  } catch (error) {
-    console.error('Error loading user photo metadata from Storage:', error);
-  }
-
-  const nameContentType = getStorageContentTypeFromName(item);
-  if (PDF_SUPPORTED_STORAGE_IMAGE_TYPES.has(nameContentType)) return nameContentType;
   return null;
 };
 
@@ -2949,36 +2922,71 @@ export const getUserStorageAvatarPhotos = async userId => {
   }
 };
 
-export const getUserStorageAvatarPhotoDataUrls = async (userId, options = {}) => {
-  if (!userId) return [];
+const blobToDataUrl = blob => new Promise((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onloadend = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+  reader.onerror = () => reject(reader.error);
+  reader.readAsDataURL(blob);
+});
 
-  const excludePaths = new Set(Array.isArray(options.excludePaths) ? options.excludePaths.filter(Boolean) : []);
+// Loads every photo from Storage avatar/{userId} (except medication/) as a data URL.
+// Never throws: each file carries its own error text, and a listing failure is
+// returned in `error` — callers surface these in the PDF debug output.
+export const getUserStorageAvatarPhotoFiles = async userId => {
+  if (!userId) return { items: [], error: 'no userId provided' };
 
+  let items;
   try {
-    const items = await collectUserStorageAvatarItems(userId);
-    const settledPhotos = await Promise.allSettled(
-      items
-        .filter(item => !isMedicationStorageItem(item, userId))
-        .filter(item => !excludePaths.has(String(item?.fullPath || '')))
-        .map(async item => {
-          const bytes = await getBytes(item);
-          const contentType = await getStorageContentType(item, bytes);
-          if (!contentType) return '';
-          return `data:${contentType};base64,${bytesToBase64(bytes)}`;
-        })
-    );
-
-    return settledPhotos
-      .flatMap(result => {
-        if (result.status === 'fulfilled') return [result.value];
-        console.error('Error loading user photo bytes from Storage:', result.reason);
-        return [];
-      })
-      .filter(Boolean);
+    items = await collectUserStorageAvatarItems(userId);
   } catch (error) {
     console.error('Error listing user photo bytes from Storage:', error);
-    return [];
+    return { items: [], error: `listAll(avatar/${userId}) failed: ${error?.code || ''} ${error?.message || String(error)}`.trim() };
   }
+
+  const photoItems = items.filter(item => !isMedicationStorageItem(item, userId));
+  const files = await Promise.all(
+    photoItems.map(async item => {
+      const file = {
+        path: String(item?.fullPath || ''),
+        name: String(item?.name || ''),
+        size: 0,
+        contentType: '',
+        dataUrl: '',
+        source: '',
+        error: '',
+      };
+
+      try {
+        const bytes = await getBytes(item);
+        const byteArray = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+        file.size = byteArray.length;
+        file.contentType = getStorageContentTypeFromBytes(byteArray) || getStorageContentTypeFromName(item) || 'image/jpeg';
+        file.dataUrl = `data:${file.contentType};base64,${bytesToBase64(byteArray)}`;
+        file.source = 'getBytes';
+        return file;
+      } catch (bytesError) {
+        const bytesMessage = `getBytes failed: ${bytesError?.code || ''} ${bytesError?.message || String(bytesError)}`.trim();
+        try {
+          const url = await getDownloadURL(item);
+          const response = await fetch(url);
+          if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          const blob = await response.blob();
+          file.size = blob.size;
+          file.contentType = blob.type || getStorageContentTypeFromName(item) || 'image/jpeg';
+          file.dataUrl = await blobToDataUrl(blob);
+          file.source = 'downloadUrl-fetch';
+          file.error = bytesMessage;
+          return file;
+        } catch (fetchError) {
+          file.error = `${bytesMessage}; downloadUrl/fetch failed: ${fetchError?.code || ''} ${fetchError?.message || String(fetchError)}`.trim();
+          console.error('Error loading user photo bytes from Storage:', item?.fullPath, bytesError, fetchError);
+          return file;
+        }
+      }
+    })
+  );
+
+  return { items: files, error: '' };
 };
 
 export const getAllUserPhotos = async (userId, collectionSource = null, { includeStorage = true } = {}) => {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -38,7 +38,7 @@ import { getCurrentValue } from '../getCurrentValue';
 import {
   fetchUserById,
   getAllUserPhotos,
-  getUserStorageAvatarPhotoDataUrls,
+  getUserStorageAvatarPhotoFiles,
   setUserComment as persistUserComment,
   fetchAllCommentsByCardId,
   updateCommentByOwner,
@@ -577,19 +577,6 @@ const getUserProfilePhotoUrls = data => {
   return Array.from(new Set(filterOutMedicationPhotos(photos, data?.userId).filter(Boolean)));
 };
 
-const getFirebaseStorageObjectPath = photoUrl => {
-  const normalizedPhotoUrl = normalizePhotoValue(photoUrl);
-  if (!normalizedPhotoUrl || normalizedPhotoUrl.startsWith('data:')) return '';
-
-  try {
-    const url = new URL(normalizedPhotoUrl);
-    const encodedPath = url.pathname.split('/o/')[1]?.split('/')[0];
-    return encodedPath ? decodeURIComponent(encodedPath) : '';
-  } catch {
-    return '';
-  }
-};
-
 const hasAgentOrIPRole = data =>
   data.userRole === 'ag' || data.userRole === 'ip' || data.role === 'ag' || data.role === 'ip';
 
@@ -1010,6 +997,7 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
   const photoEntries = photos.map(photo => (
     photo && typeof photo === 'object' ? photo : { src: photo, debug: '' }
   )).filter(photo => photo?.src);
+  const debugEntries = Array.isArray(debugLines) ? debugLines.filter(Boolean) : [];
   return (
     <Document title={`${buildName(userData) || 'Profile'} - UKRCOM`}>
       <Page size="A4" style={profilePdfStyles.page}>
@@ -1034,6 +1022,19 @@ const ProfilePdfDocument = ({ userData, photoUrls, debugLines }) => {
           {pdfFooter}
         </Page>
       ))}
+      {debugEntries.length > 0 ? (
+        <Page size="A4" style={profilePdfStyles.debugPage} wrap>
+          <View style={profilePdfStyles.debugContent}>
+            <Text style={profilePdfStyles.debugTitle}>Photo export debug</Text>
+            {debugEntries.map((line, index) => (
+              <Text key={index} style={profilePdfStyles.debugText}>
+                {index + 1}. {line}
+              </Text>
+            ))}
+          </View>
+          {pdfFooter}
+        </Page>
+      ) : null}
     </Document>
   );
 };
@@ -1086,60 +1087,57 @@ const resolvePdfPhotoUrls = async ({ cardData, photoUrls, photosCollection, debu
   pushPdfDebugLine(debugLines, 'PDF photo resolve started', {
     userId: cardData?.userId || null,
     passedPhotosCollection: photosCollection || null,
-    existingPhotos: summarizePdfDebugUrls(existingPhotos),
+    cardPhotos: summarizePdfDebugUrls(existingPhotos),
   });
 
   if (!cardData?.userId) {
-    pushPdfDebugLine(debugLines, 'No userId on cardData; using only existing photos', summarizePdfDebugUrls(existingPhotos));
+    pushPdfDebugLine(debugLines, 'No userId on cardData; using only card photos', summarizePdfDebugUrls(existingPhotos));
     return existingPhotos;
   }
 
-  const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
-  pushPdfDebugLine(debugLines, 'Resolved photo source collection', {
-    sourceCollection: sourceCollection || null,
-    cardSourceCollection: cardData?.__sourceCollection || null,
-    userRole: cardData?.userRole || cardData?.role || null,
+  const { items: storageFiles, error: storageListError } = await getUserStorageAvatarPhotoFiles(cardData.userId);
+  pushPdfDebugLine(debugLines, `Storage listing avatar/${cardData.userId}`, {
+    filesFound: storageFiles.length,
+    listError: storageListError || null,
+  });
+  storageFiles.forEach((file, index) => {
+    pushPdfDebugLine(debugLines, `Storage file ${index + 1}/${storageFiles.length}`, {
+      path: file.path,
+      size: file.size,
+      contentType: file.contentType || null,
+      loaded: Boolean(file.dataUrl),
+      loadedVia: file.source || null,
+      error: file.error || null,
+    });
   });
 
-  const existingStorageAvatarPaths = existingPhotos
-    .map(getFirebaseStorageObjectPath)
-    .filter(path => path.startsWith(`avatar/${cardData.userId}/`) && !path.startsWith(`avatar/${cardData.userId}/medication/`));
-  let storagePhotos = [];
-  let loadedPhotos = [];
+  const storagePhotos = storageFiles.map(file => file.dataUrl).filter(Boolean);
+  if (storagePhotos.length) {
+    pushPdfDebugLine(debugLines, 'Using photos from Storage avatar folder for PDF', { count: storagePhotos.length });
+    return Array.from(new Set(storagePhotos));
+  }
+
+  pushPdfDebugLine(debugLines, 'No photos loaded from Storage; falling back to card/database photos');
+  const sourceCollection = photosCollection || resolveUserPhotoCollection(cardData);
+  let databasePhotos = [];
   try {
-    [storagePhotos, loadedPhotos] = await Promise.all([
-      getUserStorageAvatarPhotoDataUrls(cardData.userId, { excludePaths: existingStorageAvatarPaths }),
-      getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false }),
-    ]);
+    databasePhotos = await getAllUserPhotos(cardData.userId, sourceCollection, { includeStorage: false });
   } catch (error) {
-    pushPdfDebugLine(debugLines, 'Error while loading photo URLs', {
+    pushPdfDebugLine(debugLines, 'Database photo fallback failed', {
       name: error?.name || null,
       message: error?.message || String(error),
     });
-    throw error;
   }
+  pushPdfDebugLine(debugLines, 'Fallback photos from database collections', summarizePdfDebugUrls(databasePhotos));
 
-  pushPdfDebugLine(debugLines, 'Existing Storage avatar paths excluded from Storage data URL load', {
-    count: existingStorageAvatarPaths.length,
-    sample: existingStorageAvatarPaths.slice(0, PDF_DEBUG_URL_SAMPLE_SIZE),
-  });
-  pushPdfDebugLine(debugLines, 'Photos from Storage avatar/{userId} as data URLs', summarizePdfDebugUrls(storagePhotos));
-  pushPdfDebugLine(debugLines, 'Photos from database collections', summarizePdfDebugUrls(loadedPhotos));
-
-  const combinedPhotos = [...existingPhotos, ...storagePhotos, ...loadedPhotos];
-  const filteredPhotos = filterOutMedicationPhotos(combinedPhotos, cardData.userId);
-  const convertedPhotos = filteredPhotos.map(convertDriveLinkToImage).filter(Boolean);
-  const uniquePhotos = Array.from(new Set(convertedPhotos));
-
-  pushPdfDebugLine(debugLines, 'Combined photos before medication filter', summarizePdfDebugUrls(combinedPhotos));
-  pushPdfDebugLine(debugLines, 'Photos after medication filter', summarizePdfDebugUrls(filteredPhotos));
-  pushPdfDebugLine(debugLines, 'Photos after convertDriveLinkToImage/filter(Boolean)', summarizePdfDebugUrls(convertedPhotos));
-  pushPdfDebugLine(debugLines, 'Final unique photo URLs for PDF embedding', summarizePdfDebugUrls(uniquePhotos));
-
+  const combinedPhotos = filterOutMedicationPhotos([...existingPhotos, ...databasePhotos], cardData.userId)
+    .map(convertDriveLinkToImage)
+    .filter(Boolean);
+  const uniquePhotos = Array.from(new Set(combinedPhotos));
+  pushPdfDebugLine(debugLines, 'Final fallback photo URLs for PDF embedding', summarizePdfDebugUrls(uniquePhotos));
   if (!uniquePhotos.length) {
     pushPdfDebugLine(debugLines, 'No photo URLs remained for PDF embedding');
   }
-
   return uniquePhotos;
 };
 


### PR DESCRIPTION
- ProfilePdfDocument accepted debugLines but never rendered them, so failed
  photo loads produced a data-only PDF with no diagnostics; add a debug page
  after the questionnaire and photo pages.
- Replace getUserStorageAvatarPhotoDataUrls with getUserStorageAvatarPhotoFiles:
  per-file results (path, size, content type, load source, error) with a
  getDownloadURL+fetch fallback when getBytes fails, and no silent dropping of
  non-JPEG/PNG files (canvas re-encode normalizes them for @react-pdf).
- Make resolvePdfPhotoUrls Storage-first (avatar/{userId}) and non-throwing;
  card/database photos are only used as a fallback when Storage yields nothing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M9wuVa8Tep8YyoTUY9Kosc