### PR TITLE
Show cycle day in menstruation label

### DIFF
--- a/src/components/smallCard/fieldLastCycle.js
+++ b/src/components/smallCard/fieldLastCycle.js
@@ -188,6 +188,21 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
 
   const nextCycle = React.useMemo(() => calculateNextDate(userData.lastCycle), [userData.lastCycle]);
 
+  const cycleDay = React.useMemo(() => {
+    const lastCycleDate = normalizeDate(parseDate(userData.lastCycle));
+    if (!lastCycleDate) {
+      return null;
+    }
+
+    const today = normalizeDate(new Date());
+    const diffMs = today.getTime() - lastCycleDate.getTime();
+    if (diffMs < 0) {
+      return 1;
+    }
+
+    return Math.floor(diffMs / (24 * 60 * 60 * 1000)) + 1;
+  }, [userData.lastCycle]);
+
   const pregnancyDuration = React.useMemo(() => {
     const lastCycleDate = parseDate(userData.lastCycle);
     if (!lastCycleDate) {
@@ -556,7 +571,7 @@ export const FieldLastCycle = ({ userData, setUsers, setState, submitOptions = {
               color: 'white',
             }}
           >
-            місячні
+            {cycleDay ? `${cycleDay}д місячні` : 'місячні'}
           </span>
         )}
         {status !== 'pregnant' && nextCycle && (


### PR DESCRIPTION
### Motivation
- Показати в топ-блоці поруч із лейблом "місячні" який сьогодні день циклу у форматі `5д`, щоб швидко бачити номер дня без переходу у графік.

### Description
- Додано обчислення `cycleDay` із нормалізацією дат у `src/components/smallCard/fieldLastCycle.js` і fallback для майбутньої дати як `1`.
- Замінено статичний лейбл `місячні` на условний вираз `{cycleDay ? `${cycleDay}д місячні` : 'місячні'}` у тому ж файлі.

### Testing
- Запущено тести: `npm test -- --watchAll=false --runTestsByPath src/components/smallCard/userStateUpdate.test.js src/components/smallCard/btnFavorite.test.js src/components/smallCard/btnDislike.test.js`, всі заявлені тести пройшли (3/3 passed).
- Виконано збірку: `npm run build`, збірка пройшла успішно (compiled successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1ff57a78832681a1b77ecdc685a7)