### PR TITLE
Fix PDF photo watermark layering

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -796,6 +796,12 @@ const profilePdfStyles = StyleSheet.create({
     fontFamily: 'NotoSans',
     backgroundColor: '#fff',
   },
+  profileImageWrap: {
+    position: 'relative',
+    alignSelf: 'center',
+    width: 455,
+    maxHeight: 620,
+  },
   profileImage: {
     position: 'relative',
     zIndex: 1,
@@ -807,8 +813,8 @@ const profilePdfStyles = StyleSheet.create({
   imageWatermark: {
     position: 'absolute',
     zIndex: 0,
-    left: 52,
-    top: 430,
+    left: -32,
+    top: 230,
     width: 520,
     textAlign: 'center',
     fontSize: 86,
@@ -1012,8 +1018,10 @@ const ProfilePdfDocument = ({ userData, photoUrls }) => {
       </Page>
       {photoEntries.map((photo, index) => (
         <Page key={`${photo.src}-${index}`} size="A4" style={profilePdfStyles.imagePage}>
-          <Text style={profilePdfStyles.imageWatermark}>UKRCOM</Text>
-          <Image src={photo.src} style={profilePdfStyles.profileImage} />
+          <View style={profilePdfStyles.profileImageWrap}>
+            <Text style={profilePdfStyles.imageWatermark}>UKRCOM</Text>
+            <Image src={photo.src} style={profilePdfStyles.profileImage} />
+          </View>
           {pdfFooter}
         </Page>
       ))}


### PR DESCRIPTION
## Summary
- Wrap PDF profile photos in a positioned container
- Keep the UKRCOM watermark in the same stacking context as the photo so the image renders above it
- Reuse the existing PDF image and watermark styles with adjusted container-relative positioning

## Checks
- git diff --check

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a41c284ac83268d928947bf9aaaa9)