### PR TITLE
Fix PDF photo watermark layering

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -804,7 +804,7 @@ const profilePdfStyles = StyleSheet.create({
   },
   profileImage: {
     position: 'relative',
-    zIndex: 1,
+    zIndex: 0,
     width: 455,
     maxHeight: 620,
     objectFit: 'contain',
@@ -812,7 +812,7 @@ const profilePdfStyles = StyleSheet.create({
   },
   imageWatermark: {
     position: 'absolute',
-    zIndex: 0,
+    zIndex: 1,
     left: -32,
     top: 230,
     width: 520,


### PR DESCRIPTION
### Motivation
- Ensure profile photos are not occluded by the page watermark when exporting PDFs with `@react-pdf` by correcting the render/z-index ordering on the photo pages.

### Description
- Swap the z-index values for `profileImage` and `imageWatermark` in `src/components/smallCard/renderTopBlock.js` so `profileImage` uses `zIndex: 0` and `imageWatermark` uses `zIndex: 1`, adjusting the render order for PDF photo pages.

### Testing
- Ran `npm run lint:js -- --max-warnings=0` and `git diff --check`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a4aab0f508326bed2b2783ab51802)