### PR TITLE
Increase top block card avatar size

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -68,6 +68,7 @@ const topBlockContainerStyle = {
 };
 
 const topBlockAvatarRadius = '10px';
+const topBlockHeaderAvatarSize = '72px';
 
 const topBlockPhotoStyle = {
   width: '100%',
@@ -120,7 +121,9 @@ const topBlockHeaderAvatarButtonStyle = {
   right: 'auto',
   top: 'auto',
   transform: 'none',
-  flex: '0 0 48px',
+  width: topBlockHeaderAvatarSize,
+  height: topBlockHeaderAvatarSize,
+  flex: `0 0 ${topBlockHeaderAvatarSize}`,
   zIndex: 1,
 };
 


### PR DESCRIPTION
## Summary
- Increased the top-block header avatar from 48px to 72px so it fills the height of roughly three rows.
- Kept width and height tied to one shared size constant to preserve proportions.

## Testing
- git diff --check

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8244f21483269106ed02f6420fa8)