### PR TITLE
Exclude package-included items from expense list (except embryo storage) and refine inline edit UI

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -18,6 +18,8 @@ const POPULAR_PACKAGE_BADGE = 'Most popular';
 const BUDGET_EDIT_MODE_STORAGE_KEY = 'budget:edit-mode';
 const GUARANTEED_PACKAGE_IDS = new Set(['4', '5']);
 const FROM_PRICE_ITEM_IDS = new Set(['43', '49', '54', '61', '63', '64', '65']);
+const EMBRYO_STORAGE_MATCHERS = ['embryo', 'ембріон', 'embryon', 'кріо', 'cryo'];
+const STORAGE_MATCHERS = ['storage', 'зберіган', 'зберігання'];
 const CATEGORY_LABELS = {
   coordination: 'Coordination & Documents',
   surrogateMother: 'Surrogate Mother',
@@ -81,6 +83,12 @@ const getCategoryMinimumPrice = items => {
   const amounts = items.map(getItemDisplayAmount).filter(amount => Number.isFinite(amount));
   if (!amounts.length) return '';
   return `from ${formatMoney(Math.min(...amounts), 'EUR')}`;
+};
+
+const isEmbryoStorageItem = item => {
+  const searchableText = `${item?.id || ''} ${item?.name || ''} ${item?.description || ''} ${item?.category || ''}`.toLowerCase();
+  return EMBRYO_STORAGE_MATCHERS.some(matcher => searchableText.includes(matcher))
+    && STORAGE_MATCHERS.some(matcher => searchableText.includes(matcher));
 };
 
 const Page = styled.main`
@@ -441,26 +449,41 @@ const IconButton = styled.button`
   cursor: pointer;
 `;
 
+const EditableGrid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(92px, 132px);
+  gap: 7px;
+  margin-top: 7px;
+
+  @media (max-width: 520px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
 const EditableField = styled.label`
   display: grid;
-  gap: 5px;
-  margin-top: 9px;
+  gap: 3px;
   color: #7b6553;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 900;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
 `;
+
+const EditableDescriptionField = styled(EditableField)`
+  grid-column: 1 / -1;
+`;
+
 
 const EditInput = styled.input`
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #dfcdbc;
-  border-radius: 12px;
+  border-radius: 9px;
   background: rgba(255, 250, 244, 0.92);
   color: #382d24;
-  padding: 10px 11px;
-  font-size: 14px;
+  padding: 7px 9px;
+  font-size: 13px;
   font-weight: 700;
   text-transform: none;
   letter-spacing: normal;
@@ -470,13 +493,13 @@ const EditTextarea = styled.textarea`
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #dfcdbc;
-  border-radius: 12px;
+  border-radius: 9px;
   background: rgba(255, 250, 244, 0.92);
   color: #382d24;
-  min-height: 74px;
-  padding: 10px 11px;
-  font-size: 14px;
-  line-height: 1.45;
+  min-height: 48px;
+  padding: 7px 9px;
+  font-size: 13px;
+  line-height: 1.32;
   resize: vertical;
   text-transform: none;
   letter-spacing: normal;
@@ -589,9 +612,20 @@ const BudgetPage = ({ isAdmin = false }) => {
     return [...catalog.packages].sort((a, b) => Number(a.listedPrice || 0) - Number(b.listedPrice || 0));
   }, [catalog.packages]);
 
+  const includedItemIds = useMemo(() => {
+    return catalog.packages.reduce((ids, program) => {
+      if (Array.isArray(program.children)) {
+        program.children.forEach(id => ids.add(String(id)));
+      }
+      return ids;
+    }, new Set());
+  }, [catalog.packages]);
+
   const groupedExpenses = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return catalog.items.reduce((groups, item) => {
+      const itemId = String(item.id);
+      if (includedItemIds.has(itemId) && !isEmbryoStorageItem(item)) return groups;
       const searchableText = `${item.name || ''} ${item.description || ''} ${isEditMode ? item.internalNote || '' : ''}`.toLowerCase();
       if (normalizedQuery && !searchableText.includes(normalizedQuery)) return groups;
       const category = item.category || 'Other';
@@ -599,7 +633,7 @@ const BudgetPage = ({ isAdmin = false }) => {
       groups[category].push(item);
       return groups;
     }, {});
-  }, [catalog.items, query, isEditMode]);
+  }, [catalog.items, includedItemIds, query, isEditMode]);
 
   useEffect(() => {
     if (isBudgetAdmin) return;
@@ -714,21 +748,13 @@ const BudgetPage = ({ isAdmin = false }) => {
   );
 
   const renderEditableFields = (collection, record, priceField = 'price') => (
-    <>
+    <EditableGrid>
       <EditableField>
         Name
         <EditInput
           value={record.name || ''}
           onChange={event => handleCatalogFieldChange(collection, record.id, 'name', event.target.value)}
           onBlur={event => persistCatalogRecordField(collection, record.id, 'name', event.target.value)}
-        />
-      </EditableField>
-      <EditableField>
-        Description
-        <EditTextarea
-          value={record.description || ''}
-          onChange={event => handleCatalogFieldChange(collection, record.id, 'description', event.target.value)}
-          onBlur={event => persistCatalogRecordField(collection, record.id, 'description', event.target.value)}
         />
       </EditableField>
       <EditableField>
@@ -741,7 +767,15 @@ const BudgetPage = ({ isAdmin = false }) => {
           onBlur={event => persistCatalogRecordField(collection, record.id, priceField, event.target.value)}
         />
       </EditableField>
-    </>
+      <EditableDescriptionField>
+        Description
+        <EditTextarea
+          value={record.description || ''}
+          onChange={event => handleCatalogFieldChange(collection, record.id, 'description', event.target.value)}
+          onBlur={event => persistCatalogRecordField(collection, record.id, 'description', event.target.value)}
+        />
+      </EditableDescriptionField>
+    </EditableGrid>
   );
 
   return (


### PR DESCRIPTION
### Motivation
- Prevent items that are already included in program packages from appearing in the optional expenses list while still showing embryo-related storage items, and improve the inline editing experience for budget admins.

### Description
- Add `EMBRYO_STORAGE_MATCHERS` and `STORAGE_MATCHERS` and implement `isEmbryoStorageItem` to detect embryo storage entries by matching name/description/category text.
- Compute `includedItemIds` from `catalog.packages` and filter out included items in `groupedExpenses` unless `isEmbryoStorageItem` returns true.
- Introduce `EditableGrid` and `EditableDescriptionField`, restructure the editable fields to a two-column responsive grid, and adjust `EditInput`/`EditTextarea` radius, padding, and font sizes for a more compact edit UI.
- Minor refactors and dependency updates to memoization hooks (`includedItemIds` dependency) and small stylistic tweaks across the component.

### Testing
- Ran the project test suite with `npm test`, and all tests passed.
- Ran linting with `npm run lint`, and no lint errors were reported.
- Performed a production build with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b646561a48326a1d0ae120fb11319)