### PR TITLE
Refactor editable fields layout and exclude packaged items from expense groups

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -441,26 +441,41 @@ const IconButton = styled.button`
   cursor: pointer;
 `;
 
+const EditableGrid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(92px, 132px);
+  gap: 7px;
+  margin-top: 7px;
+
+  @media (max-width: 520px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
 const EditableField = styled.label`
   display: grid;
-  gap: 5px;
-  margin-top: 9px;
+  gap: 3px;
   color: #7b6553;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 900;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
 `;
+
+const EditableDescriptionField = styled(EditableField)`
+  grid-column: 1 / -1;
+`;
+
 
 const EditInput = styled.input`
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #dfcdbc;
-  border-radius: 12px;
+  border-radius: 9px;
   background: rgba(255, 250, 244, 0.92);
   color: #382d24;
-  padding: 10px 11px;
-  font-size: 14px;
+  padding: 7px 9px;
+  font-size: 13px;
   font-weight: 700;
   text-transform: none;
   letter-spacing: normal;
@@ -470,13 +485,13 @@ const EditTextarea = styled.textarea`
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #dfcdbc;
-  border-radius: 12px;
+  border-radius: 9px;
   background: rgba(255, 250, 244, 0.92);
   color: #382d24;
-  min-height: 74px;
-  padding: 10px 11px;
-  font-size: 14px;
-  line-height: 1.45;
+  min-height: 48px;
+  padding: 7px 9px;
+  font-size: 13px;
+  line-height: 1.32;
   resize: vertical;
   text-transform: none;
   letter-spacing: normal;
@@ -589,9 +604,20 @@ const BudgetPage = ({ isAdmin = false }) => {
     return [...catalog.packages].sort((a, b) => Number(a.listedPrice || 0) - Number(b.listedPrice || 0));
   }, [catalog.packages]);
 
+  const includedItemIds = useMemo(() => {
+    return catalog.packages.reduce((ids, program) => {
+      if (Array.isArray(program.children)) {
+        program.children.forEach(id => ids.add(String(id)));
+      }
+      return ids;
+    }, new Set());
+  }, [catalog.packages]);
+
   const groupedExpenses = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return catalog.items.reduce((groups, item) => {
+      const itemId = String(item.id);
+      if (includedItemIds.has(itemId)) return groups;
       const searchableText = `${item.name || ''} ${item.description || ''} ${isEditMode ? item.internalNote || '' : ''}`.toLowerCase();
       if (normalizedQuery && !searchableText.includes(normalizedQuery)) return groups;
       const category = item.category || 'Other';
@@ -599,7 +625,7 @@ const BudgetPage = ({ isAdmin = false }) => {
       groups[category].push(item);
       return groups;
     }, {});
-  }, [catalog.items, query, isEditMode]);
+  }, [catalog.items, includedItemIds, query, isEditMode]);
 
   useEffect(() => {
     if (isBudgetAdmin) return;
@@ -714,21 +740,13 @@ const BudgetPage = ({ isAdmin = false }) => {
   );
 
   const renderEditableFields = (collection, record, priceField = 'price') => (
-    <>
+    <EditableGrid>
       <EditableField>
         Name
         <EditInput
           value={record.name || ''}
           onChange={event => handleCatalogFieldChange(collection, record.id, 'name', event.target.value)}
           onBlur={event => persistCatalogRecordField(collection, record.id, 'name', event.target.value)}
-        />
-      </EditableField>
-      <EditableField>
-        Description
-        <EditTextarea
-          value={record.description || ''}
-          onChange={event => handleCatalogFieldChange(collection, record.id, 'description', event.target.value)}
-          onBlur={event => persistCatalogRecordField(collection, record.id, 'description', event.target.value)}
         />
       </EditableField>
       <EditableField>
@@ -741,7 +759,15 @@ const BudgetPage = ({ isAdmin = false }) => {
           onBlur={event => persistCatalogRecordField(collection, record.id, priceField, event.target.value)}
         />
       </EditableField>
-    </>
+      <EditableDescriptionField>
+        Description
+        <EditTextarea
+          value={record.description || ''}
+          onChange={event => handleCatalogFieldChange(collection, record.id, 'description', event.target.value)}
+          onBlur={event => persistCatalogRecordField(collection, record.id, 'description', event.target.value)}
+        />
+      </EditableDescriptionField>
+    </EditableGrid>
   );
 
   return (


### PR DESCRIPTION
### Motivation

- Clean up the inline edit UI to be more compact and responsive while keeping description full-width for clarity.
- Prevent duplicate listing of items that are already included as children of packaged programs in the expense grouping.
- Improve styling consistency for edit inputs and textareas to better match the visual design and mobile layout.

### Description

- Added `EditableGrid` and `EditableDescriptionField` layout components and reworked `renderEditableFields` to place name and price side-by-side with description spanning full width. 
- Adjusted visual styles: reduced gaps, font sizes, padding, and border-radius in `EditableField`, `EditInput`, and `EditTextarea`, and added a responsive media query for the grid. 
- Introduced `includedItemIds` `useMemo` to collect children ids from `catalog.packages` and updated `groupedExpenses` to skip items that are included in those packages by checking `includedItemIds` and adding it to the hook dependencies.

### Testing

- Ran linting with `npm run lint` and the linter passed without errors. 
- Executed unit tests with `npm test` and all tests passed. 
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b646561a48326a1d0ae120fb11319)