### PR TITLE
Remove unused embryo storage helper from BudgetPage

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -18,8 +18,6 @@ const POPULAR_PACKAGE_BADGE = 'Most popular';
 const BUDGET_EDIT_MODE_STORAGE_KEY = 'budget:edit-mode';
 const GUARANTEED_PACKAGE_IDS = new Set(['4', '5']);
 const FROM_PRICE_ITEM_IDS = new Set(['43', '49', '54', '61', '63', '64', '65']);
-const EMBRYO_STORAGE_MATCHERS = ['embryo', 'ембріон', 'embryon', 'кріо', 'cryo'];
-const STORAGE_MATCHERS = ['storage', 'зберіган', 'зберігання'];
 const CATEGORY_LABELS = {
   coordination: 'Coordination & Documents',
   surrogateMother: 'Surrogate Mother',
@@ -83,12 +81,6 @@ const getCategoryMinimumPrice = items => {
   const amounts = items.map(getItemDisplayAmount).filter(amount => Number.isFinite(amount));
   if (!amounts.length) return '';
   return `from ${formatMoney(Math.min(...amounts), 'EUR')}`;
-};
-
-const isEmbryoStorageItem = item => {
-  const searchableText = `${item?.id || ''} ${item?.name || ''} ${item?.description || ''} ${item?.category || ''}`.toLowerCase();
-  return EMBRYO_STORAGE_MATCHERS.some(matcher => searchableText.includes(matcher))
-    && STORAGE_MATCHERS.some(matcher => searchableText.includes(matcher));
 };
 
 const Page = styled.main`


### PR DESCRIPTION
### Motivation
- Remove unused embryo storage matcher constants and the `isEmbryoStorageItem` helper to address a `no-unused-vars` ESLint warning and reduce dead code in the budget page helpers.

### Description
- Deleted `EMBRYO_STORAGE_MATCHERS`, `STORAGE_MATCHERS`, and the `isEmbryoStorageItem` helper from `src/components/BudgetPage.jsx` while preserving the rest of the budget utilities and UI code.

### Testing
- Ran `npm run lint:js -- src/components/BudgetPage.jsx` which completed and no longer reported the previous `no-unused-vars` warning.
- Ran `git diff --check` which reported no diff/whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b784dfd148326a6c5d882c5aa99b4)