### PR TITLE
Remove unused budget matcher constants

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -18,8 +18,6 @@ const POPULAR_PACKAGE_BADGE = 'Most popular';
 const BUDGET_EDIT_MODE_STORAGE_KEY = 'budget:edit-mode';
 const GUARANTEED_PACKAGE_IDS = new Set(['4', '5']);
 const FROM_PRICE_ITEM_IDS = new Set(['43', '49', '54', '61', '63', '64', '65']);
-const EMBRYO_STORAGE_MATCHERS = ['embryo', 'ембріон', 'embryon', 'кріо', 'cryo'];
-const STORAGE_MATCHERS = ['storage', 'зберіган', 'зберігання'];
 const FALLBACK_FIREBASE_PROJECT_ID = 'webringitapp';
 const BUDGET_COLLECTION_LABELS = {
   packages: 'program',


### PR DESCRIPTION
### Motivation
- Eliminate ESLint `no-unused-vars` warnings by removing unused budget matcher constants from the component.

### Description
- Deleted `EMBRYO_STORAGE_MATCHERS` and `STORAGE_MATCHERS` from `src/components/BudgetPage.jsx` since they were declared but never referenced.

### Testing
- Ran `npm run lint:js -- src/components/BudgetPage.jsx` and the lint run completed without the previous `no-unused-vars` warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7db95d5c8326a407024085581a24)