### PR TITLE
Fix budget item editing edge cases

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -695,6 +695,7 @@ const BudgetPage = ({ isAdmin = false }) => {
   const [query, setQuery] = useState('');
   const [showStickyContact, setShowStickyContact] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const [categoryDrafts, setCategoryDrafts] = useState({});
   const [newItem, setNewItem] = useState(() => ({ name: '', price: '', description: '', category: 'Other' }));
   const fileInputRef = useRef(null);
   const isBudgetAdmin = Boolean(isAdmin) || isAdminUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
@@ -743,13 +744,13 @@ const BudgetPage = ({ isAdmin = false }) => {
   }, [catalog.packages, isEditMode]);
 
   const includedItemIds = useMemo(() => {
-    return catalog.packages.reduce((ids, program) => {
+    return sortedPackages.reduce((ids, program) => {
       if (Array.isArray(program.children)) {
         program.children.forEach(id => ids.add(String(id)));
       }
       return ids;
     }, new Set());
-  }, [catalog.packages]);
+  }, [sortedPackages]);
 
   const groupedExpenses = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -872,10 +873,16 @@ const BudgetPage = ({ isAdmin = false }) => {
       return;
     }
 
+    const price = Number(newItem.price);
+    if (newItem.price === '' || !Number.isFinite(price)) {
+      toast.error('Enter a valid price for the new budget item.');
+      return;
+    }
+
     const nextRecord = {
       id: getNextBudgetRecordId(catalog.items),
       name,
-      price: Number.isFinite(Number(newItem.price)) && newItem.price !== '' ? Number(newItem.price) : '',
+      price,
       description: newItem.description.trim(),
       category: newItem.category.trim() || 'Other',
     };
@@ -904,10 +911,22 @@ const BudgetPage = ({ isAdmin = false }) => {
     }
 
     const nextRecords = records.filter(item => String(item.id) !== String(recordId));
-    setCatalog(current => ({ ...current, [collection]: nextRecords }));
+    const nextPackages = collection === 'items'
+      ? catalog.packages.map(program => (Array.isArray(program.children)
+        ? { ...program, children: program.children.filter(id => String(id) !== String(recordId)) }
+        : program))
+      : catalog.packages;
+    setCatalog(current => ({
+      ...current,
+      [collection]: nextRecords,
+      ...(collection === 'items' ? { packages: nextPackages } : {}),
+    }));
     setDeleteTarget(null);
     try {
       await set(ref(database, `budget/${collection}`), nextRecords);
+      if (collection === 'items') {
+        await set(ref(database, 'budget/packages'), nextPackages);
+      }
       toast.success('Budget item deleted from backend.');
     } catch (saveError) {
       console.error('Unable to delete budget item', saveError);
@@ -994,9 +1013,20 @@ const BudgetPage = ({ isAdmin = false }) => {
           <EditableField>
             Category
             <EditInput
-              value={record.category || ''}
-              onChange={event => handleCatalogFieldChange(collection, record.id, 'category', event.target.value)}
-              onBlur={event => persistCatalogRecordField(collection, record.id, 'category', event.target.value)}
+              value={categoryDrafts[String(record.id)] ?? record.category ?? ''}
+              onChange={event => setCategoryDrafts(current => ({
+                ...current,
+                [String(record.id)]: event.target.value,
+              }))}
+              onBlur={event => {
+                const nextCategory = event.target.value;
+                setCategoryDrafts(current => {
+                  const nextDrafts = { ...current };
+                  delete nextDrafts[String(record.id)];
+                  return nextDrafts;
+                });
+                persistCatalogRecordField(collection, record.id, 'category', nextCategory);
+              }}
             />
           </EditableField>
         ) : null}


### PR DESCRIPTION
### Motivation
- Prevent stale package references when deleting an `items` record so packages do not keep deleted ids and later reuse of the id cannot resurrect it inside a package.
- Avoid regrouping and unmounting the category input while an admin types a category so edits are not lost when the row moves between accordions.
- Ensure newly created budget items have a valid numeric `price` instead of storing an empty string that renders as `0`.

### Description
- Added a `categoryDrafts` state and changed the category `EditInput` to keep edits in a local draft and only call `persistCatalogRecordField` on `blur` in `src/components/BudgetPage.jsx`.
- Derived `includedItemIds` from the already filtered `sortedPackages` (which hides non-visible packages for clients) to avoid removing items included only by hidden packages.
- In `createBudgetItem` require a numeric `price` (`toast.error` and abort creation if blank/invalid) and store the validated numeric `price` in the new record.
- When deleting an item (`confirmDeleteBudgetRecord`) remove the deleted id from package `children` in the in-memory catalog and persist `budget/packages` to the backend alongside the compacted `items` array.

### Testing
- Ran `npm run build`, which completed successfully with unrelated lint warnings about unused symbols.
- Ran `npm run lint:js -- src/components/BudgetPage.jsx`, which succeeded with existing warnings only.
- Ran the test suite with `CI=true npm test -- --watch=false`, which reported failures in unrelated storage/matching test suites (8 failing suites, 35 passed) and did not indicate any failures caused by the changed `BudgetPage` code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7e23eca883268f4bdbf0c74846f0)