### PR TITLE
Improve budget page visuals and add PDF export

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -3,60 +3,30 @@ import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, remove, set, update } from 'firebase/database';
 import { FaCheck, FaChevronDown, FaChevronUp, FaExternalLinkAlt, FaFilePdf, FaPen, FaPlus, FaTimes, FaTrash, FaUpload } from 'react-icons/fa';
+import { saveAs } from 'file-saver';
 import { auth, database } from './config';
 import { isAdminUid } from 'utils/accessLevel';
+import {
+  formatEuroAmount,
+  formatMoney,
+  getCategoryLabel,
+  getCategoryMinimumPrice,
+  getClientNoteGroupLabel,
+  getExpensePriceLabel,
+  normalizeCatalog,
+  KNOWN_CLIENT_NOTE_GROUPS,
+} from './budgetCatalogUtils';
 
-const USD_ITEM_IDS = new Set([
-  'sm-program-compensation',
-  'surrogate-mother-compensation',
-  'sm-compensation',
-]);
-const USD_TO_EUR_RATE = 0.92;
 const INCLUDED_PREVIEW_LIMIT = 6;
 const POPULAR_PACKAGE_ID = '3';
 const POPULAR_PACKAGE_BADGE = 'Most popular';
 const BUDGET_EDIT_MODE_STORAGE_KEY = 'budget:edit-mode';
 const GUARANTEED_PACKAGE_IDS = new Set(['4', '5']);
-const FROM_PRICE_ITEM_IDS = new Set(['43', '49', '54', '61', '63', '64', '65']);
 const FALLBACK_FIREBASE_PROJECT_ID = 'webringitapp';
 const BUDGET_COLLECTION_LABELS = {
   packages: 'program',
   items: 'expense',
 };
-const CATEGORY_LABELS = {
-  coordination: 'Coordination & Documents',
-  surrogateMother: 'Surrogate Mother',
-  eggDonor: 'Egg Donor',
-  ivf: 'IVF & Embryology',
-  pregnancyAndDiagnostics: 'Pregnancy & Diagnostics',
-  deliveryAndNewborn: 'Delivery & Newborn',
-  legalAndRegistration: 'Legal & Registration',
-  insurance: 'Insurance',
-};
-
-const formatMoney = (value, currency = 'EUR') => {
-  const amount = Number(value);
-  if (!Number.isFinite(amount)) return `— ${currency || 'EUR'}`;
-  return `${new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(amount)} ${currency || 'EUR'}`;
-};
-
-const formatEuroAmount = value => {
-  const amount = Number(value);
-  if (!Number.isFinite(amount)) return '€—';
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'EUR',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
-};
-
-const normalizeCatalog = catalog => ({
-  packages: Array.isArray(catalog?.packages) ? catalog.packages : [],
-  items: Array.isArray(catalog?.items) ? catalog.items : [],
-  clientNotes: Array.isArray(catalog?.clientNotes) ? catalog.clientNotes : [],
-  technical: catalog?.technical && typeof catalog.technical === 'object' ? catalog.technical : {},
-});
 
 const getFirebaseConsoleProjectId = () =>
   process.env.REACT_APP_PROJECT_ID || FALLBACK_FIREBASE_PROJECT_ID;
@@ -95,40 +65,6 @@ const validateCatalog = catalog => {
   if (!Array.isArray(catalog.packages)) return 'Budget JSON must include packages[].';
   if (!Array.isArray(catalog.items)) return 'Budget JSON must include items[].';
   return '';
-};
-
-const getItemDisplayAmount = item => {
-  const basePrice = Number(item?.price);
-  if (!Number.isFinite(basePrice)) return null;
-  const isUsd = USD_ITEM_IDS.has(String(item?.id || '').trim());
-  return isUsd ? basePrice * USD_TO_EUR_RATE : basePrice;
-};
-
-const getItemDisplayPrice = item => {
-  const amount = getItemDisplayAmount(item);
-  return amount === null ? formatMoney(item?.price, 'EUR') : formatMoney(amount, 'EUR');
-};
-
-const getExpensePriceLabel = item => {
-  const prefix = FROM_PRICE_ITEM_IDS.has(String(item?.id)) ? 'from ' : '';
-  return `${prefix}${getItemDisplayPrice(item)}`;
-};
-
-const getCategoryLabel = category => {
-  const key = String(category || 'Other');
-  if (CATEGORY_LABELS[key]) return CATEGORY_LABELS[key];
-  return key
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/[-_]+/g, ' ')
-    .trim()
-    .replace(/\s+/g, ' ')
-    .replace(/\b\w/g, char => char.toUpperCase()) || 'Other';
-};
-
-const getCategoryMinimumPrice = items => {
-  const amounts = items.map(getItemDisplayAmount).filter(amount => Number.isFinite(amount));
-  if (!amounts.length) return '';
-  return `from ${formatMoney(Math.min(...amounts), 'EUR')}`;
 };
 
 const Page = styled.main`
@@ -218,26 +154,47 @@ const DangerButton = styled(SoftButton)`
   color: #8d4a36;
 `;
 
+const MiniButton = styled.button`
+  border: 1px solid #dfcdbc;
+  background: #fffaf4;
+  color: #5c4939;
+  border-radius: 8px;
+  min-height: 30px;
+  padding: 4px 10px;
+  font-size: 11.5px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+`;
+
+const MiniDangerButton = styled(MiniButton)`
+  border-color: #d9b0a2;
+  color: #8d4a36;
+`;
+
 const InlineActionRow = styled.div`
-  grid-column: 1 / -1;
+  flex: 1 1 100%;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
 `;
 
 const BackendIdButton = styled.button`
   border: 1px solid #dfcdbc;
-  border-radius: 9px;
+  border-radius: 8px;
   background: rgba(255, 250, 244, 0.92);
   color: #67462f;
-  min-height: 34px;
-  padding: 7px 9px;
+  min-height: 30px;
+  padding: 4px 8px;
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  font-size: 13px;
+  gap: 6px;
+  font-size: 12px;
   font-weight: 900;
   text-align: left;
   cursor: pointer;
@@ -247,12 +204,11 @@ const HiddenBadge = styled.span`
   display: inline-flex;
   align-items: center;
   width: fit-content;
-  margin-top: 7px;
   border-radius: 999px;
   background: #f3ded8;
   color: #8d4a36;
-  padding: 5px 8px;
-  font-size: 11px;
+  padding: 4px 7px;
+  font-size: 10px;
   font-weight: 900;
   text-transform: uppercase;
 `;
@@ -445,16 +401,28 @@ const PaymentScheduleAmount = styled.span`
   white-space: nowrap;
 `;
 
-const PaymentScheduleEditor = styled.div`
+const PaymentScheduleTotalRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid rgba(140, 101, 70, 0.28);
   margin-top: 10px;
+  padding-top: 8px;
+  color: #4d392b;
+  font-size: 13px;
+  font-weight: 900;
+`;
+
+const PaymentScheduleEditor = styled.div`
+  margin-top: 8px;
   display: grid;
-  gap: 10px;
+  gap: 7px;
 `;
 
 const PaymentEditorRow = styled.div`
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(92px, 126px) auto;
-  gap: 7px;
+  grid-template-columns: minmax(0, 1fr) minmax(76px, 96px) auto;
+  gap: 6px;
   align-items: end;
 
   @media (max-width: 560px) {
@@ -464,7 +432,7 @@ const PaymentEditorRow = styled.div`
 
 const PaymentEditorActions = styled.div`
   display: flex;
-  gap: 7px;
+  gap: 6px;
   flex-wrap: wrap;
 `;
 
@@ -629,27 +597,39 @@ const Muted = styled.p`
 `;
 
 const InternalNote = styled.div`
-  margin-top: 8px;
+  margin-top: 6px;
   border: 1px solid rgba(185, 28, 28, 0.28);
-  border-radius: 12px;
+  border-radius: 10px;
   background: rgba(254, 226, 226, 0.64);
   color: #991b1b;
   display: grid;
-  grid-template-columns: 1fr 44px;
-  gap: 8px;
+  grid-template-columns: 1fr 32px;
+  gap: 6px;
   align-items: center;
-  padding: 8px 0 8px 10px;
-  font-size: 12px;
+  padding: 5px 0 5px 8px;
+  font-size: 11.5px;
   font-weight: 800;
   line-height: 1.35;
+`;
+
+const InternalNoteInput = styled.textarea`
+  width: 100%;
+  box-sizing: border-box;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  min-height: 28px;
+  padding: 2px 0;
+  resize: vertical;
 `;
 
 const IconButton = styled.button`
   border: 0;
   background: transparent;
   color: inherit;
-  min-height: 44px;
-  min-width: 44px;
+  min-height: 30px;
+  min-width: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -657,14 +637,11 @@ const IconButton = styled.button`
 `;
 
 const EditableGrid = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(92px, 132px);
-  gap: 7px;
-  margin-top: 7px;
-
-  @media (max-width: 520px) {
-    grid-template-columns: 1fr;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: flex-end;
+  margin-top: 8px;
 `;
 
 const AddRecordGrid = styled(EditableGrid)`
@@ -673,16 +650,26 @@ const AddRecordGrid = styled(EditableGrid)`
 
 const EditableField = styled.label`
   display: grid;
-  gap: 3px;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 150px;
   color: #7b6553;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 900;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 `;
 
+const EditableIdField = styled(EditableField)`
+  flex: 0 0 64px;
+`;
+
+const EditablePriceField = styled(EditableField)`
+  flex: 0 1 92px;
+`;
+
 const EditableDescriptionField = styled(EditableField)`
-  grid-column: 1 / -1;
+  flex: 1 1 100%;
 `;
 
 
@@ -690,11 +677,12 @@ const EditInput = styled.input`
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #dfcdbc;
-  border-radius: 9px;
+  border-radius: 8px;
   background: rgba(255, 250, 244, 0.92);
   color: #382d24;
-  padding: 7px 9px;
-  font-size: 13px;
+  min-height: 30px;
+  padding: 5px 8px;
+  font-size: 12.5px;
   font-weight: 700;
   text-transform: none;
   letter-spacing: normal;
@@ -704,12 +692,12 @@ const EditTextarea = styled.textarea`
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #dfcdbc;
-  border-radius: 9px;
+  border-radius: 8px;
   background: rgba(255, 250, 244, 0.92);
   color: #382d24;
-  min-height: 48px;
-  padding: 7px 9px;
-  font-size: 13px;
+  min-height: 38px;
+  padding: 5px 8px;
+  font-size: 12.5px;
   line-height: 1.32;
   resize: vertical;
   text-transform: none;
@@ -728,13 +716,51 @@ const SearchInput = styled.input`
   margin-bottom: 14px;
 `;
 
-const NoteList = styled.ul`
-  margin: 12px 0 0;
-  padding: 18px 20px 18px 34px;
+const NotesGrid = styled.div`
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+
+  @media (max-width: 420px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const NoteCard = styled.div`
+  border: 1px solid rgba(140, 101, 70, 0.14);
   border-radius: 22px;
-  background: rgba(255, 250, 244, 0.72);
+  background: rgba(255, 250, 244, 0.78);
+  padding: 18px 20px;
+`;
+
+const NoteCardTitle = styled.h3`
+  margin: 0 0 10px;
+  font-size: 16px;
+  letter-spacing: -0.02em;
+  color: #4d392b;
+`;
+
+const NoteList = styled.ul`
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 7px;
   color: #66594f;
+  font-size: 14px;
   line-height: 1.55;
+`;
+
+const NotesEditorGroup = styled.div`
+  display: grid;
+  gap: 6px;
+`;
+
+const NoteEditorRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 32px;
+  gap: 6px;
+  align-items: start;
+  color: #8d4a36;
 `;
 
 const StateCard = styled.div`
@@ -780,6 +806,7 @@ const BudgetPage = ({ isAdmin = false }) => {
   const [query, setQuery] = useState('');
   const [showStickyContact, setShowStickyContact] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const [isExporting, setIsExporting] = useState(false);
   const [categoryDrafts, setCategoryDrafts] = useState({});
   const [newItem, setNewItem] = useState(() => ({ name: '', price: '', description: '', category: 'Other' }));
   const fileInputRef = useRef(null);
@@ -859,12 +886,44 @@ const BudgetPage = ({ isAdmin = false }) => {
     }, {});
   }, [catalog.items, includedItemIds, query, isEditMode]);
 
+  const noteGroupKeys = useMemo(() => {
+    const keys = [...KNOWN_CLIENT_NOTE_GROUPS];
+    Object.keys(catalog.clientNotes || {}).forEach(key => {
+      if (!keys.includes(key)) keys.push(key);
+    });
+    return keys;
+  }, [catalog.clientNotes]);
+
+  const visibleNoteGroups = useMemo(() => noteGroupKeys
+    .map(key => [key, (catalog.clientNotes?.[key] || []).filter(note => String(note).trim())])
+    .filter(([, notes]) => notes.length), [noteGroupKeys, catalog.clientNotes]);
+
   useEffect(() => {
     if (isBudgetAdmin) return;
     setIsEditMode(false);
   }, [isBudgetAdmin]);
 
   const handleUploadClick = () => fileInputRef.current?.click();
+
+  const handleExportPdf = async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      // Load the PDF renderer lazily so it stays out of the main bundle.
+      const [{ pdf }, { default: BudgetPdfDocument }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('./BudgetPdfDocument'),
+      ]);
+      const blob = await pdf(React.createElement(BudgetPdfDocument, { catalog })).toBlob();
+      saveAs(blob, `program-budget-${new Date().toISOString().slice(0, 10)}.pdf`);
+      toast.success('Budget PDF exported.');
+    } catch (exportError) {
+      console.error('Unable to export budget PDF', exportError);
+      toast.error('Unable to export budget PDF.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   const toggleEditMode = () => {
     if (!isBudgetAdmin) return;
@@ -1166,6 +1225,7 @@ const BudgetPage = ({ isAdmin = false }) => {
   const renderPaymentSchedule = schedule => {
     const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
     if (!payments.length) return null;
+    const total = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
 
     return (
       <PaymentScheduleCard aria-label="Payment schedule">
@@ -1173,11 +1233,15 @@ const BudgetPage = ({ isAdmin = false }) => {
         <PaymentScheduleList>
           {payments.map((payment, index) => (
             <PaymentScheduleRow key={`${schedule.id || 'payment'}-${index}`}>
-              <PaymentScheduleLabel>{payment.title}</PaymentScheduleLabel>
+              <PaymentScheduleLabel>{`${index + 1}. ${payment.title || ''}`}</PaymentScheduleLabel>
               <PaymentScheduleAmount>{formatEuroAmount(payment.amount)}</PaymentScheduleAmount>
             </PaymentScheduleRow>
           ))}
         </PaymentScheduleList>
+        <PaymentScheduleTotalRow>
+          <span>Total</span>
+          <span>{formatEuroAmount(total)}</span>
+        </PaymentScheduleTotalRow>
       </PaymentScheduleCard>
     );
   };
@@ -1188,9 +1252,9 @@ const BudgetPage = ({ isAdmin = false }) => {
       return (
         <PaymentScheduleCard>
           <PaymentScheduleTitle>Payment schedule</PaymentScheduleTitle>
-          <SoftButton type="button" onClick={() => createProgramPaymentSchedule(program)}>
+          <MiniButton type="button" onClick={() => createProgramPaymentSchedule(program)}>
             <FaPlus /> Create payment schedule
-          </SoftButton>
+          </MiniButton>
         </PaymentScheduleCard>
       );
     }
@@ -1227,22 +1291,22 @@ const BudgetPage = ({ isAdmin = false }) => {
                 />
               </EditableField>
               <PaymentEditorActions>
-                <SoftButton type="button" onClick={() => addPayment(schedule.id, index)}>
-                  <FaPlus /> After
-                </SoftButton>
-                <DangerButton type="button" onClick={() => deletePayment(schedule.id, index)}>
+                <MiniButton type="button" title="Insert payment after this one" onClick={() => addPayment(schedule.id, index)}>
+                  <FaPlus />
+                </MiniButton>
+                <MiniDangerButton type="button" title="Delete payment" onClick={() => deletePayment(schedule.id, index)}>
                   <FaTrash />
-                </DangerButton>
+                </MiniDangerButton>
               </PaymentEditorActions>
             </PaymentEditorRow>
           ))}
           <PaymentEditorActions>
-            <SoftButton type="button" onClick={() => addPayment(schedule.id, payments.length - 1)}>
+            <MiniButton type="button" onClick={() => addPayment(schedule.id, payments.length - 1)}>
               <FaPlus /> {payments.length ? 'Add payment' : 'Add first payment'}
-            </SoftButton>
-            <DangerButton type="button" onClick={() => deleteProgramPaymentSchedule(program)}>
+            </MiniButton>
+            <MiniDangerButton type="button" onClick={() => deleteProgramPaymentSchedule(program)}>
               <FaTrash /> Delete schedule
-            </DangerButton>
+            </MiniDangerButton>
           </PaymentEditorActions>
         </PaymentScheduleEditor>
       </PaymentScheduleCard>
@@ -1263,6 +1327,44 @@ const BudgetPage = ({ isAdmin = false }) => {
     }
   };
 
+  const persistClientNotes = async (nextNotes, successMessage = 'Client notes updated.') => {
+    setCatalog(current => ({ ...current, clientNotes: nextNotes }));
+    try {
+      await set(ref(database, 'budget/clientNotes'), nextNotes);
+      toast.success(successMessage);
+    } catch (saveError) {
+      console.error('Unable to update client notes', saveError);
+      toast.error('Unable to update client notes.');
+      loadBudget();
+    }
+  };
+
+  const updateClientNote = (groupKey, noteIndex, value) => {
+    const groups = catalog.clientNotes || {};
+    const notes = Array.isArray(groups[groupKey]) ? [...groups[groupKey]] : [];
+    if (String(notes[noteIndex] ?? '') === value) return;
+    notes[noteIndex] = value;
+    persistClientNotes({ ...groups, [groupKey]: notes });
+  };
+
+  const addClientNote = groupKey => {
+    const groups = catalog.clientNotes || {};
+    const notes = Array.isArray(groups[groupKey]) ? [...groups[groupKey], ''] : [''];
+    persistClientNotes({ ...groups, [groupKey]: notes }, 'Note added.');
+  };
+
+  const deleteClientNote = (groupKey, noteIndex) => {
+    const groups = catalog.clientNotes || {};
+    const notes = (Array.isArray(groups[groupKey]) ? groups[groupKey] : []).filter((note, index) => index !== noteIndex);
+    const nextGroups = { ...groups };
+    if (notes.length) {
+      nextGroups[groupKey] = notes;
+    } else {
+      delete nextGroups[groupKey];
+    }
+    persistClientNotes(nextGroups, 'Note deleted.');
+  };
+
   const scrollToContact = () => {
     const target = document.getElementById('contact') || document.querySelector('[data-contact-section]');
     if (target) {
@@ -1275,7 +1377,14 @@ const BudgetPage = ({ isAdmin = false }) => {
   const renderInternalNote = (collection, record) => (
     record.internalNote ? (
       <InternalNote>
-        <span>{record.internalNote}</span>
+        <InternalNoteInput
+          defaultValue={record.internalNote}
+          aria-label="Internal note"
+          onBlur={event => {
+            if (event.target.value === record.internalNote) return;
+            persistCatalogRecordField(collection, record.id, 'internalNote', event.target.value);
+          }}
+        />
         <IconButton
           type="button"
           aria-label="Remove internal note"
@@ -1293,7 +1402,7 @@ const BudgetPage = ({ isAdmin = false }) => {
 
     return (
       <EditableGrid>
-        <EditableField>
+        <EditableIdField>
           ID
           <BackendIdButton
             type="button"
@@ -1304,7 +1413,7 @@ const BudgetPage = ({ isAdmin = false }) => {
             <span>{record.id}</span>
             <FaExternalLinkAlt size={12} />
           </BackendIdButton>
-        </EditableField>
+        </EditableIdField>
         <EditableField>
           Name
           <EditInput
@@ -1313,7 +1422,7 @@ const BudgetPage = ({ isAdmin = false }) => {
             onBlur={event => persistCatalogRecordField(collection, record.id, 'name', event.target.value)}
           />
         </EditableField>
-        <EditableField>
+        <EditablePriceField>
           Price
           <EditInput
             type="number"
@@ -1322,7 +1431,7 @@ const BudgetPage = ({ isAdmin = false }) => {
             onChange={event => handleCatalogFieldChange(collection, record.id, priceField, event.target.value)}
             onBlur={event => persistCatalogRecordField(collection, record.id, priceField, event.target.value)}
           />
-        </EditableField>
+        </EditablePriceField>
         {collection === 'items' ? (
           <EditableField>
             Category
@@ -1353,20 +1462,20 @@ const BudgetPage = ({ isAdmin = false }) => {
           />
         </EditableDescriptionField>
         <InlineActionRow>
-          <SoftButton
+          <MiniButton
             type="button"
             onClick={() => persistCatalogRecordHidden(collection, record.id, !record.hidden)}
           >
             {record.hidden ? `Show ${collectionLabel}` : `Hide ${collectionLabel}`}
-          </SoftButton>
-          <DangerButton
+          </MiniButton>
+          <MiniDangerButton
             type="button"
             onClick={() => setDeleteTarget({ collection, recordId: record.id, name: record.name || record.id })}
           >
-            <FaTrash /> Delete from backend
-          </DangerButton>
+            <FaTrash /> Delete
+          </MiniDangerButton>
+          {record.hidden ? <HiddenBadge>Hidden from clients</HiddenBadge> : null}
         </InlineActionRow>
-        {record.hidden ? <HiddenBadge>Hidden from clients</HiddenBadge> : null}
       </EditableGrid>
     );
   };
@@ -1383,8 +1492,13 @@ const BudgetPage = ({ isAdmin = false }) => {
             </Subtitle>
           </div>
           <HeaderActions>
-            <SoftButton type="button" disabled title="PDF export will be added in the next step">
-              <FaFilePdf /> Export as PDF
+            <SoftButton
+              type="button"
+              onClick={handleExportPdf}
+              disabled={loading || Boolean(error) || isExporting}
+              title="Download the client budget as a PDF"
+            >
+              <FaFilePdf /> {isExporting ? 'Preparing PDF…' : 'Export as PDF'}
             </SoftButton>
             {isBudgetAdmin ? (
               <SoftButton
@@ -1542,10 +1656,10 @@ const BudgetPage = ({ isAdmin = false }) => {
                   <H2 id="budget-create-item-title">Create new expense</H2>
                   <SectionNote>New records are saved to the backend with the next id after the last budget item.</SectionNote>
                   <AddRecordGrid>
-                    <EditableField>
+                    <EditableIdField>
                       ID
                       <EditInput value={getNextBudgetRecordId(catalog.items)} readOnly />
-                    </EditableField>
+                    </EditableIdField>
                     <EditableField>
                       Name
                       <EditInput
@@ -1554,7 +1668,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                         placeholder="New service name"
                       />
                     </EditableField>
-                    <EditableField>
+                    <EditablePriceField>
                       Price
                       <EditInput
                         type="number"
@@ -1563,7 +1677,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                         onChange={event => handleNewItemChange('price', event.target.value)}
                         placeholder="0"
                       />
-                    </EditableField>
+                    </EditablePriceField>
                     <EditableField>
                       Category
                       <EditInput
@@ -1581,21 +1695,69 @@ const BudgetPage = ({ isAdmin = false }) => {
                       />
                     </EditableDescriptionField>
                     <InlineActionRow>
-                      <SoftButton type="button" onClick={createBudgetItem}>
+                      <MiniButton type="button" onClick={createBudgetItem}>
                         <FaPlus /> Create and save to backend
-                      </SoftButton>
+                      </MiniButton>
                     </InlineActionRow>
                   </AddRecordGrid>
                 </EditPanel>
               </Section>
             ) : null}
 
-            {catalog.clientNotes.length ? (
+            {visibleNoteGroups.length || isEditMode ? (
               <Section aria-labelledby="budget-notes-title">
-                <H2 id="budget-notes-title">Client notes</H2>
-                <NoteList>
-                  {catalog.clientNotes.map((note, index) => <li key={`${note}-${index}`}>{note}</li>)}
-                </NoteList>
+                <SectionHeading>
+                  <div>
+                    <H2 id="budget-notes-title">Good to know</H2>
+                    <SectionNote>Key milestones and notes for intended parents.</SectionNote>
+                  </div>
+                </SectionHeading>
+                {isEditMode ? (
+                  <NotesGrid>
+                    {noteGroupKeys.map(groupKey => {
+                      const notes = Array.isArray(catalog.clientNotes?.[groupKey]) ? catalog.clientNotes[groupKey] : [];
+                      return (
+                        <NoteCard key={groupKey}>
+                          <NoteCardTitle>{getClientNoteGroupLabel(groupKey)}</NoteCardTitle>
+                          <NotesEditorGroup>
+                            {notes.map((note, index) => (
+                              <NoteEditorRow key={`${groupKey}-${index}-${note}`}>
+                                <EditTextarea
+                                  defaultValue={note}
+                                  aria-label={`${getClientNoteGroupLabel(groupKey)} note ${index + 1}`}
+                                  onBlur={event => updateClientNote(groupKey, index, event.target.value)}
+                                />
+                                <IconButton
+                                  type="button"
+                                  aria-label="Delete note"
+                                  onClick={() => deleteClientNote(groupKey, index)}
+                                >
+                                  <FaTrash />
+                                </IconButton>
+                              </NoteEditorRow>
+                            ))}
+                            <div>
+                              <MiniButton type="button" onClick={() => addClientNote(groupKey)}>
+                                <FaPlus /> Add note
+                              </MiniButton>
+                            </div>
+                          </NotesEditorGroup>
+                        </NoteCard>
+                      );
+                    })}
+                  </NotesGrid>
+                ) : (
+                  <NotesGrid>
+                    {visibleNoteGroups.map(([groupKey, notes]) => (
+                      <NoteCard key={groupKey}>
+                        <NoteCardTitle>{getClientNoteGroupLabel(groupKey)}</NoteCardTitle>
+                        <NoteList>
+                          {notes.map((note, index) => <li key={`${note}-${index}`}>{note}</li>)}
+                        </NoteList>
+                      </NoteCard>
+                    ))}
+                  </NotesGrid>
+                )}
               </Section>
             ) : null}
           </>

--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -1,0 +1,543 @@
+import React from 'react';
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import {
+  formatMoney,
+  getCategoryLabel,
+  getCategoryMinimumPrice,
+  getClientNoteGroupLabel,
+  getExpensePriceLabel,
+  getVisibleSortedPackages,
+  normalizeClientNotes,
+  resolveProgramPaymentSchedule,
+  KNOWN_CLIENT_NOTE_GROUPS,
+} from './budgetCatalogUtils';
+
+const INK = '#33291f';
+const MUTED = '#6f6359';
+const ACCENT = '#7a4c2f';
+const SOFT = '#9a6b48';
+const LINE = '#e6d7c4';
+const HEAD_BG = '#f3e6d2';
+const ROW_ALT = '#faf3e8';
+const CARD_BG = '#fdf8f0';
+
+const PROGRAM_COL_WIDTH = 52;
+
+// The built-in Helvetica font only covers WinAnsi glyphs, so swap the few
+// characters from the catalog data that would otherwise render blank.
+const sanitizePdfText = value => String(value ?? '')
+  .replace(/№/g, 'No.')
+  .replace(/[’‘]/g, "'")
+  .replace(/[“”]/g, '"')
+  .replace(/[–—]/g, '-')
+  .replace(/[✓✔]/g, 'x')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const formatAmount = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '-';
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(amount);
+};
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 40,
+    paddingBottom: 62,
+    paddingHorizontal: 44,
+    fontFamily: 'Helvetica',
+    fontSize: 9,
+    color: INK,
+    backgroundColor: '#ffffff',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+  eyebrow: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 7.5,
+    letterSpacing: 1.8,
+    color: SOFT,
+    textTransform: 'uppercase',
+    marginBottom: 5,
+  },
+  title: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 24,
+    letterSpacing: -0.5,
+    color: INK,
+  },
+  headerDate: {
+    fontSize: 9,
+    color: MUTED,
+    marginBottom: 3,
+  },
+  subtitle: {
+    fontSize: 9.5,
+    lineHeight: 1.5,
+    color: MUTED,
+    marginTop: 7,
+    maxWidth: 420,
+  },
+  section: {
+    marginTop: 22,
+  },
+  sectionTitle: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 12.5,
+    letterSpacing: -0.2,
+    marginBottom: 3,
+    color: INK,
+  },
+  sectionNote: {
+    fontSize: 8.5,
+    color: MUTED,
+    marginBottom: 9,
+  },
+  programRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    borderTopWidth: 1,
+    borderTopColor: LINE,
+    borderTopStyle: 'solid',
+    paddingVertical: 8,
+  },
+  programIndexCell: {
+    width: 28,
+  },
+  programIndexText: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 9,
+    color: SOFT,
+  },
+  programBody: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  programName: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 10.5,
+    marginBottom: 2,
+  },
+  programDescription: {
+    fontSize: 8.5,
+    color: MUTED,
+    lineHeight: 1.45,
+  },
+  programPrice: {
+    width: 88,
+    textAlign: 'right',
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 11,
+    color: ACCENT,
+  },
+  table: {
+    borderWidth: 1,
+    borderColor: LINE,
+    borderStyle: 'solid',
+    borderRadius: 6,
+  },
+  tableHeadRow: {
+    flexDirection: 'row',
+    backgroundColor: HEAD_BG,
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: LINE,
+    borderTopStyle: 'solid',
+  },
+  tableRowAlt: {
+    backgroundColor: ROW_ALT,
+  },
+  labelCell: {
+    flex: 1,
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+  },
+  labelCellHeadText: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 8.5,
+    color: '#4d392b',
+  },
+  labelCellText: {
+    fontSize: 8.5,
+    lineHeight: 1.4,
+  },
+  programCell: {
+    width: PROGRAM_COL_WIDTH,
+    paddingVertical: 5,
+    paddingHorizontal: 4,
+    borderLeftWidth: 1,
+    borderLeftColor: LINE,
+    borderLeftStyle: 'solid',
+    justifyContent: 'center',
+  },
+  programCellHead: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 8.5,
+    textAlign: 'center',
+    color: '#4d392b',
+  },
+  programCellHeadPrice: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 7.5,
+    textAlign: 'center',
+    color: ACCENT,
+    marginTop: 2,
+  },
+  amountCellText: {
+    fontSize: 8.5,
+    textAlign: 'center',
+  },
+  markCellText: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 8.5,
+    textAlign: 'center',
+    color: ACCENT,
+  },
+  totalRow: {
+    borderTopColor: '#d8c3a8',
+    backgroundColor: HEAD_BG,
+  },
+  categoryBlock: {
+    marginBottom: 12,
+  },
+  categoryHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    backgroundColor: HEAD_BG,
+    borderRadius: 6,
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    marginBottom: 2,
+  },
+  categoryTitle: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 9.5,
+    color: '#4d392b',
+  },
+  categoryMeta: {
+    fontSize: 8,
+    color: SOFT,
+  },
+  expenseRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    borderBottomWidth: 1,
+    borderBottomColor: '#efe3d1',
+    borderBottomStyle: 'solid',
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  expenseBody: {
+    flex: 1,
+    paddingRight: 10,
+  },
+  expenseName: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 8.8,
+    marginBottom: 1.5,
+  },
+  expenseDescription: {
+    fontSize: 8,
+    color: MUTED,
+    lineHeight: 1.4,
+  },
+  expensePrice: {
+    width: 80,
+    textAlign: 'right',
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 8.8,
+    color: ACCENT,
+  },
+  noteCard: {
+    backgroundColor: CARD_BG,
+    borderWidth: 1,
+    borderColor: LINE,
+    borderStyle: 'solid',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+  },
+  noteGroupTitle: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 9.5,
+    marginBottom: 6,
+    color: '#4d392b',
+  },
+  noteRow: {
+    flexDirection: 'row',
+    marginBottom: 4,
+  },
+  noteBullet: {
+    width: 12,
+    fontSize: 8.5,
+    color: ACCENT,
+  },
+  noteText: {
+    flex: 1,
+    fontSize: 8.5,
+    lineHeight: 1.45,
+    color: '#5a4d42',
+  },
+  footer: {
+    position: 'absolute',
+    left: 44,
+    right: 44,
+    bottom: 24,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    borderTopWidth: 1,
+    borderTopColor: LINE,
+    borderTopStyle: 'solid',
+    paddingTop: 8,
+  },
+  footerText: {
+    fontSize: 7.5,
+    color: MUTED,
+  },
+});
+
+const BudgetPdfDocument = ({ catalog }) => {
+  const items = Array.isArray(catalog?.items) ? catalog.items : [];
+  const visibleItems = items.filter(item => !item.hidden);
+  const itemsById = new Map(visibleItems.map(item => [String(item.id), item]));
+  const packages = getVisibleSortedPackages(catalog);
+
+  const programSchedules = packages.map(program => resolveProgramPaymentSchedule(catalog, program));
+  const scheduleRowCount = programSchedules.reduce(
+    (count, schedule) => Math.max(count, Array.isArray(schedule?.payments) ? schedule.payments.length : 0),
+    0,
+  );
+  const scheduleRows = Array.from({ length: scheduleRowCount }, (_, index) => {
+    const titleSource = programSchedules.find(schedule => schedule?.payments?.[index]?.title);
+    return {
+      title: titleSource?.payments[index].title || `Payment ${index + 1}`,
+      amounts: programSchedules.map(schedule => schedule?.payments?.[index]?.amount),
+    };
+  });
+  const scheduleTotals = programSchedules.map(schedule => (Array.isArray(schedule?.payments)
+    ? schedule.payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0)
+    : null));
+
+  const includedIds = [];
+  packages.forEach(program => {
+    (Array.isArray(program.children) ? program.children : []).forEach(id => {
+      const key = String(id);
+      if (!includedIds.includes(key)) includedIds.push(key);
+    });
+  });
+  const includedIdSet = new Set(includedIds);
+  const includedRows = includedIds
+    .map(id => itemsById.get(id))
+    .filter(Boolean)
+    .sort((a, b) => Number(a.id) - Number(b.id));
+
+  const groupedExpenses = visibleItems.reduce((groups, item) => {
+    if (includedIdSet.has(String(item.id))) return groups;
+    const category = item.category || 'Other';
+    if (!groups[category]) groups[category] = [];
+    groups[category].push(item);
+    return groups;
+  }, {});
+
+  const clientNotes = normalizeClientNotes(catalog?.clientNotes);
+  const noteGroups = [
+    ...KNOWN_CLIENT_NOTE_GROUPS,
+    ...Object.keys(clientNotes).filter(key => !KNOWN_CLIENT_NOTE_GROUPS.includes(key)),
+  ]
+    .map(key => [key, clientNotes[key] || []])
+    .filter(([, notes]) => notes.length);
+
+  const dateLabel = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+
+  const renderProgramColumnsHead = () => (
+    <View style={styles.tableHeadRow} wrap={false}>
+      <View style={styles.labelCell}>
+        <Text style={styles.labelCellHeadText}>Provided service</Text>
+      </View>
+      {packages.map((program, index) => (
+        <View key={program.id} style={styles.programCell}>
+          <Text style={styles.programCellHead}>{`#${index + 1}`}</Text>
+          <Text style={styles.programCellHeadPrice}>{formatAmount(program.listedPrice)}</Text>
+        </View>
+      ))}
+    </View>
+  );
+
+  return (
+    <Document title="Program Budget" subject="Surrogacy program budget" creator="KnowMe">
+      <Page size="A4" style={styles.page} wrap>
+        <View style={styles.headerRow}>
+          <View>
+            <Text style={styles.eyebrow}>Private client budget</Text>
+            <Text style={styles.title}>Program Budget</Text>
+          </View>
+          <Text style={styles.headerDate}>{dateLabel}</Text>
+        </View>
+        <Text style={styles.subtitle}>
+          A clear overview of surrogacy program packages and optional expenses, prepared for international
+          intended parents with transparent inclusions. All prices are in EUR unless stated otherwise.
+        </Text>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Programs</Text>
+          <Text style={styles.sectionNote}>Core program packages, ordered from essential to premium.</Text>
+          {packages.map((program, index) => (
+            <View key={program.id} style={styles.programRow} wrap={false}>
+              <View style={styles.programIndexCell}>
+                <Text style={styles.programIndexText}>{`#${index + 1}`}</Text>
+              </View>
+              <View style={styles.programBody}>
+                <Text style={styles.programName}>{sanitizePdfText(program.name)}</Text>
+                {program.description ? (
+                  <Text style={styles.programDescription}>{sanitizePdfText(program.description)}</Text>
+                ) : null}
+              </View>
+              <Text style={styles.programPrice}>{formatMoney(program.listedPrice, program.currency || 'EUR')}</Text>
+            </View>
+          ))}
+        </View>
+
+        {scheduleRowCount > 0 ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Payment schedule</Text>
+            <Text style={styles.sectionNote}>Amounts in EUR, payable at each program milestone.</Text>
+            <View style={styles.table}>
+              <View style={styles.tableHeadRow} wrap={false}>
+                <View style={styles.labelCell}>
+                  <Text style={styles.labelCellHeadText}>Milestone</Text>
+                </View>
+                {packages.map((program, index) => (
+                  <View key={program.id} style={styles.programCell}>
+                    <Text style={styles.programCellHead}>{`#${index + 1}`}</Text>
+                    <Text style={styles.programCellHeadPrice}>{formatAmount(program.listedPrice)}</Text>
+                  </View>
+                ))}
+              </View>
+              {scheduleRows.map((row, rowIndex) => (
+                <View
+                  key={`schedule-row-${rowIndex}`}
+                  style={rowIndex % 2 ? [styles.tableRow, styles.tableRowAlt] : styles.tableRow}
+                  wrap={false}
+                >
+                  <View style={styles.labelCell}>
+                    <Text style={styles.labelCellText}>{`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}</Text>
+                  </View>
+                  {row.amounts.map((amount, columnIndex) => (
+                    <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={styles.programCell}>
+                      <Text style={styles.amountCellText}>{amount == null ? '-' : formatAmount(amount)}</Text>
+                    </View>
+                  ))}
+                </View>
+              ))}
+              <View style={[styles.tableRow, styles.totalRow]} wrap={false}>
+                <View style={styles.labelCell}>
+                  <Text style={styles.labelCellHeadText}>Total</Text>
+                </View>
+                {scheduleTotals.map((total, columnIndex) => (
+                  <View key={`schedule-total-${columnIndex}`} style={styles.programCell}>
+                    <Text style={styles.programCellHead}>{total == null ? '-' : formatAmount(total)}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          </View>
+        ) : null}
+
+        {includedRows.length ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Included services by program</Text>
+            <Text style={styles.sectionNote}>An “x” marks the services included in each program package.</Text>
+            <View style={styles.table}>
+              {renderProgramColumnsHead()}
+              {includedRows.map((item, rowIndex) => (
+                <View
+                  key={item.id}
+                  style={rowIndex % 2 ? [styles.tableRow, styles.tableRowAlt] : styles.tableRow}
+                  wrap={false}
+                >
+                  <View style={styles.labelCell}>
+                    <Text style={styles.labelCellText}>{sanitizePdfText(item.name)}</Text>
+                  </View>
+                  {packages.map(program => {
+                    const included = Array.isArray(program.children)
+                      && program.children.some(id => String(id) === String(item.id));
+                    return (
+                      <View key={`${item.id}-${program.id}`} style={styles.programCell}>
+                        <Text style={styles.markCellText}>{included ? 'x' : ''}</Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {Object.keys(groupedExpenses).length ? (
+          <View style={styles.section} break>
+            <Text style={styles.sectionTitle}>Other expenses</Text>
+            <Text style={styles.sectionNote}>
+              Optional and situational services, grouped by category. “From” prices are lower bounds of a range.
+            </Text>
+            {Object.entries(groupedExpenses).map(([category, categoryItems]) => (
+              <View key={category} style={styles.categoryBlock}>
+                <View style={styles.categoryHeader} wrap={false} minPresenceAhead={40}>
+                  <Text style={styles.categoryTitle}>{sanitizePdfText(getCategoryLabel(category))}</Text>
+                  <Text style={styles.categoryMeta}>
+                    {`${categoryItems.length} services${getCategoryMinimumPrice(categoryItems) ? ` · ${getCategoryMinimumPrice(categoryItems)}` : ''}`}
+                  </Text>
+                </View>
+                {categoryItems.map(item => (
+                  <View key={item.id} style={styles.expenseRow} wrap={false}>
+                    <View style={styles.expenseBody}>
+                      <Text style={styles.expenseName}>{sanitizePdfText(item.name)}</Text>
+                      {item.description ? (
+                        <Text style={styles.expenseDescription}>{sanitizePdfText(item.description)}</Text>
+                      ) : null}
+                    </View>
+                    <Text style={styles.expensePrice}>{getExpensePriceLabel(item)}</Text>
+                  </View>
+                ))}
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        {noteGroups.length ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Good to know</Text>
+            <Text style={styles.sectionNote}>Key milestones and notes for intended parents.</Text>
+            {noteGroups.map(([groupKey, notes]) => (
+              <View key={groupKey} style={styles.noteCard} wrap={false}>
+                <Text style={styles.noteGroupTitle}>{sanitizePdfText(getClientNoteGroupLabel(groupKey))}</Text>
+                {notes.map((note, index) => (
+                  <View key={`${groupKey}-${index}`} style={styles.noteRow}>
+                    <Text style={styles.noteBullet}>•</Text>
+                    <Text style={styles.noteText}>{sanitizePdfText(note)}</Text>
+                  </View>
+                ))}
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <View style={styles.footer} fixed>
+          <Text style={styles.footerText}>{`Program Budget · generated ${dateLabel}`}</Text>
+          <Text
+            style={styles.footerText}
+            render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}
+          />
+        </View>
+      </Page>
+    </Document>
+  );
+};
+
+export default BudgetPdfDocument;

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -1,0 +1,126 @@
+// Shared helpers for the budget catalog: used by BudgetPage (screen) and BudgetPdfDocument (export).
+
+export const USD_ITEM_IDS = new Set([
+  '22',
+  'sm-program-compensation',
+  'surrogate-mother-compensation',
+  'sm-compensation',
+]);
+export const USD_TO_EUR_RATE = 0.92;
+// Items whose catalog price is the lower bound of a range (or a base price with add-ons).
+export const FROM_PRICE_ITEM_IDS = new Set(['32', '43', '49', '54', '61', '63', '64', '65']);
+export const KNOWN_CLIENT_NOTE_GROUPS = ['programMilestones', 'surrogateMotherExpenses'];
+
+const CATEGORY_LABELS = {
+  coordination: 'Coordination & Documents',
+  surrogateMother: 'Surrogate Mother',
+  eggDonor: 'Egg Donor',
+  ivf: 'IVF & Embryology',
+  pregnancyAndDiagnostics: 'Pregnancy & Diagnostics',
+  deliveryAndNewborn: 'Delivery & Newborn',
+  legalAndRegistration: 'Legal & Registration',
+  insurance: 'Insurance',
+};
+
+const CLIENT_NOTE_GROUP_LABELS = {
+  programMilestones: 'Milestones for the intended parents',
+  surrogateMotherExpenses: "Surrogate mother's expenses",
+  general: 'Client notes',
+};
+
+const prettifyKey = key => String(key || '')
+  .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+  .replace(/[-_]+/g, ' ')
+  .trim()
+  .replace(/\s+/g, ' ')
+  .replace(/\b\w/g, char => char.toUpperCase());
+
+export const formatMoney = (value, currency = 'EUR') => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return `— ${currency || 'EUR'}`;
+  return `${new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(amount)} ${currency || 'EUR'}`;
+};
+
+export const formatEuroAmount = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '€—';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+};
+
+export const normalizeClientNotes = value => {
+  if (Array.isArray(value)) {
+    const notes = value.filter(note => typeof note === 'string' && note.trim());
+    return notes.length ? { general: notes } : {};
+  }
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce((groups, [key, notes]) => {
+      if (Array.isArray(notes)) {
+        const list = notes.filter(note => typeof note === 'string' && note.trim());
+        if (list.length) groups[key] = list;
+      }
+      return groups;
+    }, {});
+  }
+  return {};
+};
+
+export const normalizeCatalog = catalog => ({
+  packages: Array.isArray(catalog?.packages) ? catalog.packages : [],
+  items: Array.isArray(catalog?.items) ? catalog.items : [],
+  clientNotes: normalizeClientNotes(catalog?.clientNotes),
+  technical: catalog?.technical && typeof catalog.technical === 'object' ? catalog.technical : {},
+});
+
+export const getClientNoteGroupLabel = key =>
+  CLIENT_NOTE_GROUP_LABELS[key] || prettifyKey(key) || 'Client notes';
+
+export const getItemDisplayAmount = item => {
+  const basePrice = Number(item?.price);
+  if (!Number.isFinite(basePrice)) return null;
+  const isUsd = USD_ITEM_IDS.has(String(item?.id || '').trim());
+  return isUsd ? basePrice * USD_TO_EUR_RATE : basePrice;
+};
+
+export const getItemDisplayPrice = item => {
+  const amount = getItemDisplayAmount(item);
+  return amount === null ? formatMoney(item?.price, 'EUR') : formatMoney(amount, 'EUR');
+};
+
+export const getExpensePriceLabel = item => {
+  const prefix = FROM_PRICE_ITEM_IDS.has(String(item?.id)) ? 'from ' : '';
+  return `${prefix}${getItemDisplayPrice(item)}`;
+};
+
+export const getCategoryLabel = category => {
+  const key = String(category || 'Other');
+  if (CATEGORY_LABELS[key]) return CATEGORY_LABELS[key];
+  return prettifyKey(key) || 'Other';
+};
+
+export const getCategoryMinimumPrice = items => {
+  const amounts = items.map(getItemDisplayAmount).filter(amount => Number.isFinite(amount));
+  if (!amounts.length) return '';
+  return `from ${formatMoney(Math.min(...amounts), 'EUR')}`;
+};
+
+export const getVisibleSortedPackages = catalog =>
+  (Array.isArray(catalog?.packages) ? catalog.packages : [])
+    .filter(program => !program.hidden)
+    .sort((a, b) => Number(a.listedPrice || 0) - Number(b.listedPrice || 0));
+
+export const resolveProgramPaymentSchedule = (catalog, program) => {
+  const schedules = Array.isArray(catalog?.technical?.paymentSchedules)
+    ? catalog.technical.paymentSchedules
+    : [];
+  if (program?.paymentScheduleId) {
+    return schedules.find(schedule => String(schedule.id) === String(program.paymentScheduleId)) || null;
+  }
+  return program?.paymentSchedule && typeof program.paymentSchedule === 'object'
+    ? program.paymentSchedule
+    : null;
+};

--- a/src/components/budgetCatalogUtils.test.js
+++ b/src/components/budgetCatalogUtils.test.js
@@ -1,0 +1,58 @@
+import {
+  formatMoney,
+  getExpensePriceLabel,
+  getItemDisplayAmount,
+  normalizeCatalog,
+  normalizeClientNotes,
+  USD_TO_EUR_RATE,
+} from './budgetCatalogUtils';
+
+describe('budgetCatalogUtils', () => {
+  it('converts USD-based items to EUR for display', () => {
+    const item = { id: 22, price: 23000 };
+    expect(getItemDisplayAmount(item)).toBeCloseTo(23000 * USD_TO_EUR_RATE);
+  });
+
+  it('keeps EUR items unchanged', () => {
+    expect(getItemDisplayAmount({ id: 1, price: 5000 })).toBe(5000);
+  });
+
+  it('prefixes range-based items with "from"', () => {
+    expect(getExpensePriceLabel({ id: 32, price: 100 })).toBe('from 100 EUR');
+    expect(getExpensePriceLabel({ id: 1, price: 5000 })).toBe('5,000 EUR');
+  });
+
+  it('formats money with thousands separators', () => {
+    expect(formatMoney(40000)).toBe('40,000 EUR');
+    expect(formatMoney('not-a-number')).toBe('— EUR');
+  });
+
+  it('normalizes grouped client notes objects', () => {
+    const notes = normalizeClientNotes({
+      programMilestones: ['First note', ''],
+      surrogateMotherExpenses: ['Second note'],
+      broken: 'not-an-array',
+    });
+    expect(notes).toEqual({
+      programMilestones: ['First note'],
+      surrogateMotherExpenses: ['Second note'],
+    });
+  });
+
+  it('normalizes legacy array client notes into the general group', () => {
+    expect(normalizeClientNotes(['A note'])).toEqual({ general: ['A note'] });
+    expect(normalizeClientNotes(null)).toEqual({});
+  });
+
+  it('normalizes a full catalog with grouped client notes', () => {
+    const catalog = normalizeCatalog({
+      packages: [{ id: 1 }],
+      items: [{ id: 1 }],
+      clientNotes: { programMilestones: ['Note'] },
+      technical: { wireTransferSurchargeRate: 0.14 },
+    });
+    expect(catalog.packages).toHaveLength(1);
+    expect(catalog.clientNotes.programMilestones).toEqual(['Note']);
+    expect(catalog.technical.wireTransferSurchargeRate).toBe(0.14);
+  });
+});


### PR DESCRIPTION
- Extract shared budget catalog helpers into budgetCatalogUtils.js
- Fix client notes never rendering (data is a grouped object, not an array)
- Fix USD conversion never applying to SM program compensation (item 22)
- Mark couple examinations (item 32) as a from-price range item
- Render client notes as two note cards; editable and deletable in edit mode
- Make edit mode compact: smaller inputs, inline flex field rows, mini buttons
- Make internal notes editable in place
- Number payment schedule rows and show a total per program
- Enable Export as PDF with a styled multi-page @react-pdf/renderer document
  (programs, payment schedule matrix, included services matrix, other
  expenses by category, client notes, page footer)
- Add unit tests for the shared budget helpers

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BqChPFX9pCx2utMveQhDPP