### PR TITLE
Drop category from-prices and rework PDF page breaks

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -10,7 +10,6 @@ import {
   formatEuroAmount,
   formatMoney,
   getCategoryLabel,
-  getCategoryMinimumPrice,
   getClientNoteGroupLabel,
   getExpensePriceLabel,
   normalizeCatalog,
@@ -1619,11 +1618,10 @@ const BudgetPage = ({ isAdmin = false }) => {
               <AccordionList>
                 {Object.entries(groupedExpenses).map(([category, items]) => {
                   const isOpen = Boolean(openCategories[category]);
-                  const minimumPrice = getCategoryMinimumPrice(items);
                   return (
                     <Accordion key={category}>
                       <AccordionHeader type="button" onClick={() => toggleCategory(category)} aria-expanded={isOpen} $compact={!isEditMode}>
-                        <span>{getCategoryLabel(category)} {minimumPrice ? <Count>{minimumPrice}</Count> : null}</span>
+                        <span>{getCategoryLabel(category)} <Count>{items.length} {items.length === 1 ? 'service' : 'services'}</Count></span>
                         {isOpen ? <FaChevronUp /> : <FaChevronDown />}
                       </AccordionHeader>
                       {isOpen ? (

--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -3,7 +3,6 @@ import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import {
   formatMoney,
   getCategoryLabel,
-  getCategoryMinimumPrice,
   getClientNoteGroupLabel,
   getExpensePriceLabel,
   getVisibleSortedPackages,
@@ -451,7 +450,7 @@ const BudgetPdfDocument = ({ catalog }) => {
         ) : null}
 
         {includedRows.length ? (
-          <View style={styles.section}>
+          <View style={styles.section} break>
             <Text style={styles.sectionTitle}>Included services by program</Text>
             <Text style={styles.sectionNote}>An “x” marks the services included in each program package.</Text>
             <View style={styles.table}>
@@ -491,7 +490,7 @@ const BudgetPdfDocument = ({ catalog }) => {
                 <View style={styles.categoryHeader} wrap={false} minPresenceAhead={40}>
                   <Text style={styles.categoryTitle}>{sanitizePdfText(getCategoryLabel(category))}</Text>
                   <Text style={styles.categoryMeta}>
-                    {`${categoryItems.length} services${getCategoryMinimumPrice(categoryItems) ? ` · ${getCategoryMinimumPrice(categoryItems)}` : ''}`}
+                    {`${categoryItems.length} ${categoryItems.length === 1 ? 'service' : 'services'}`}
                   </Text>
                 </View>
                 {categoryItems.map(item => (

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -102,12 +102,6 @@ export const getCategoryLabel = category => {
   return prettifyKey(key) || 'Other';
 };
 
-export const getCategoryMinimumPrice = items => {
-  const amounts = items.map(getItemDisplayAmount).filter(amount => Number.isFinite(amount));
-  if (!amounts.length) return '';
-  return `from ${formatMoney(Math.min(...amounts), 'EUR')}`;
-};
-
 export const getVisibleSortedPackages = catalog =>
   (Array.isArray(catalog?.packages) ? catalog.packages : [])
     .filter(program => !program.hidden)


### PR DESCRIPTION
Follow-up to #2697 — this commit was pushed after that PR was merged, so it needs its own PR.

- Replace the meaningless "from X EUR" category badge with a service count in both the app accordion headers and the PDF category headers
- Remove the now-unused `getCategoryMinimumPrice` helper
- Start the included-services matrix on its own PDF page, so page 1 holds the programs and the full payment schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqChPFX9pCx2utMveQhDPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqChPFX9pCx2utMveQhDPP)_