### PR TITLE
Add budget price formulas, category picker and compact edit mode

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -4,15 +4,22 @@ import toast from 'react-hot-toast';
 import { get, ref, remove, set, update } from 'firebase/database';
 import { FaCheck, FaChevronDown, FaChevronUp, FaExternalLinkAlt, FaFilePdf, FaPen, FaPlus, FaTimes, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
-import { auth, database } from './config';
+import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
 import { isAdminUid } from 'utils/accessLevel';
 import {
+  collectFormulaReferencedItemIds,
+  computePackageChildrenTotal,
+  describeBudgetPriceFormula,
   formatEuroAmount,
   formatMoney,
   getCategoryLabel,
   getClientNoteGroupLabel,
   getExpensePriceLabel,
+  normalizeBudgetPriceInput,
   normalizeCatalog,
+  parseBudgetPriceValue,
+  resolveBudgetPriceAmount,
+  KNOWN_CATEGORY_KEYS,
   KNOWN_CLIENT_NOTE_GROUPS,
 } from './budgetCatalogUtils';
 
@@ -26,6 +33,10 @@ const BUDGET_COLLECTION_LABELS = {
   packages: 'program',
   items: 'expense',
 };
+const UKRCOM_MARKER = 'REPRODUCTIVE AGENCY "UKRCOM"';
+const CUSTOM_CATEGORY_OPTION = '__custom__';
+
+const getTodayYmd = () => new Date().toISOString().slice(0, 10);
 
 const getFirebaseConsoleProjectId = () =>
   process.env.REACT_APP_PROJECT_ID || FALLBACK_FIREBASE_PROJECT_ID;
@@ -107,14 +118,6 @@ const Title = styled.h1`
   letter-spacing: -0.055em;
 `;
 
-const Subtitle = styled.p`
-  max-width: 720px;
-  margin: 12px 0 0;
-  color: #6f6359;
-  font-size: 16px;
-  line-height: 1.62;
-`;
-
 const HeaderActions = styled.div`
   display: flex;
   gap: 10px;
@@ -183,20 +186,24 @@ const InlineActionRow = styled.div`
 `;
 
 const BackendIdButton = styled.button`
-  border: 1px solid #dfcdbc;
-  border-radius: 8px;
-  background: rgba(255, 250, 244, 0.92);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
   color: #67462f;
-  min-height: 30px;
-  padding: 4px 8px;
+  min-height: 20px;
+  padding: 1px 2px;
   display: inline-flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 6px;
   font-size: 12px;
   font-weight: 900;
   text-align: left;
   cursor: pointer;
+
+  &:hover {
+    background: rgba(223, 205, 188, 0.35);
+  }
 `;
 
 const HiddenBadge = styled.span`
@@ -638,9 +645,9 @@ const IconButton = styled.button`
 const EditableGrid = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 3px 8px;
   align-items: flex-end;
-  margin-top: 8px;
+  margin-top: 5px;
 `;
 
 const AddRecordGrid = styled(EditableGrid)`
@@ -672,35 +679,111 @@ const EditableDescriptionField = styled(EditableField)`
 `;
 
 
+// Edit-mode inputs stay inputs, but render as plain text to keep edit mode compact.
 const EditInput = styled.input`
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid #dfcdbc;
-  border-radius: 8px;
-  background: rgba(255, 250, 244, 0.92);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
   color: #382d24;
-  min-height: 30px;
-  padding: 5px 8px;
+  min-height: 20px;
+  padding: 1px 2px;
   font-size: 12.5px;
   font-weight: 700;
   text-transform: none;
   letter-spacing: normal;
+
+  &:hover {
+    background: rgba(223, 205, 188, 0.28);
+  }
+
+  &:focus {
+    outline: none;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: inset 0 0 0 1px #dfcdbc;
+  }
 `;
 
 const EditTextarea = styled.textarea`
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid #dfcdbc;
-  border-radius: 8px;
-  background: rgba(255, 250, 244, 0.92);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
   color: #382d24;
-  min-height: 38px;
-  padding: 5px 8px;
+  min-height: 20px;
+  padding: 1px 2px;
   font-size: 12.5px;
   line-height: 1.32;
   resize: vertical;
   text-transform: none;
   letter-spacing: normal;
+
+  &:hover {
+    background: rgba(223, 205, 188, 0.28);
+  }
+
+  &:focus {
+    outline: none;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: inset 0 0 0 1px #dfcdbc;
+  }
+`;
+
+const EditSelect = styled.select`
+  width: 100%;
+  box-sizing: border-box;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #382d24;
+  min-height: 20px;
+  padding: 1px 2px;
+  font-size: 12.5px;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: normal;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(223, 205, 188, 0.28);
+  }
+
+  &:focus {
+    outline: none;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: inset 0 0 0 1px #dfcdbc;
+  }
+`;
+
+const PriceComputedBadge = styled.span`
+  margin-left: 6px;
+  color: ${({ $over }) => ($over ? '#b91c1c' : '#15803d')};
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: nowrap;
+`;
+
+const ScheduleDiffBadge = styled.span`
+  margin-left: 8px;
+  color: ${({ $over }) => ($over ? '#b91c1c' : '#15803d')};
+  font-size: 12px;
+  font-weight: 900;
+  white-space: nowrap;
+`;
+
+const FormulaDebugNote = styled.div`
+  flex: 1 1 100%;
+  color: #8a7563;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: normal;
+  text-transform: none;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
 `;
 
 const SearchInput = styled.input`
@@ -807,7 +890,15 @@ const BudgetPage = ({ isAdmin = false }) => {
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [isExporting, setIsExporting] = useState(false);
   const [categoryDrafts, setCategoryDrafts] = useState({});
-  const [newItem, setNewItem] = useState(() => ({ name: '', price: '', description: '', category: 'Other' }));
+  const [exchangeRates, setExchangeRates] = useState(null);
+  const [focusedPriceKey, setFocusedPriceKey] = useState('');
+  const [newItem, setNewItem] = useState(() => ({
+    name: '',
+    price: '',
+    description: '',
+    category: 'Other',
+    customCategory: '',
+  }));
   const fileInputRef = useRef(null);
   const isBudgetAdmin = Boolean(isAdmin) || isAdminUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
     && new URLSearchParams(window.location.search).get('admin') === '1');
@@ -836,6 +927,22 @@ const BudgetPage = ({ isAdmin = false }) => {
   }, [loadBudget]);
 
   useEffect(() => {
+    let cancelled = false;
+    // The official NBU rate powers "=" price formulas: when the rate changes,
+    // resolved prices change with it.
+    fetchNbuUahExchangeRatesByDate(getTodayYmd())
+      .then(rates => {
+        if (!cancelled && rates) setExchangeRates(rates);
+      })
+      .catch(ratesError => {
+        console.error('Unable to load NBU exchange rates for budget formulas', ratesError);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     const handleScroll = () => {
       setShowStickyContact(window.scrollY > window.innerHeight);
     };
@@ -848,6 +955,26 @@ const BudgetPage = ({ isAdmin = false }) => {
     return new Map(catalog.items.map(item => [String(item.id), item]));
   }, [catalog.items]);
 
+  const priceContext = useMemo(
+    () => ({ itemsById, rates: exchangeRates }),
+    [itemsById, exchangeRates],
+  );
+
+  const formulaReferencedItemIds = useMemo(
+    () => collectFormulaReferencedItemIds(catalog),
+    [catalog],
+  );
+
+  const categoryOptions = useMemo(() => {
+    const keys = [...KNOWN_CATEGORY_KEYS];
+    catalog.items.forEach(item => {
+      const category = String(item?.category || '').trim();
+      if (category && !keys.includes(category)) keys.push(category);
+    });
+    if (!keys.includes('Other')) keys.push('Other');
+    return keys;
+  }, [catalog.items]);
+
   const paymentScheduleById = useMemo(() => {
     const schedules = Array.isArray(catalog.technical?.paymentSchedules)
       ? catalog.technical.paymentSchedules
@@ -858,8 +985,9 @@ const BudgetPage = ({ isAdmin = false }) => {
   const sortedPackages = useMemo(() => {
     return catalog.packages
       .filter(program => isEditMode || !program.hidden)
-      .sort((a, b) => Number(a.listedPrice || 0) - Number(b.listedPrice || 0));
-  }, [catalog.packages, isEditMode]);
+      .sort((a, b) => (resolveBudgetPriceAmount(a.listedPrice, priceContext) || 0)
+        - (resolveBudgetPriceAmount(b.listedPrice, priceContext) || 0));
+  }, [catalog.packages, isEditMode, priceContext]);
 
   const includedItemIds = useMemo(() => {
     return sortedPackages.reduce((ids, program) => {
@@ -876,6 +1004,9 @@ const BudgetPage = ({ isAdmin = false }) => {
       if (!isEditMode && item.hidden) return groups;
       const itemId = String(item.id);
       if (includedItemIds.has(itemId)) return groups;
+      // Sub-services referenced from price formulas are already part of another
+      // service/package price, so clients never see them as separate rows.
+      if (!isEditMode && formulaReferencedItemIds.has(itemId)) return groups;
       const searchableText = `${item.name || ''} ${item.description || ''} ${isEditMode ? item.internalNote || '' : ''}`.toLowerCase();
       if (normalizedQuery && !searchableText.includes(normalizedQuery)) return groups;
       const category = item.category || 'Other';
@@ -883,7 +1014,7 @@ const BudgetPage = ({ isAdmin = false }) => {
       groups[category].push(item);
       return groups;
     }, {});
-  }, [catalog.items, includedItemIds, query, isEditMode]);
+  }, [catalog.items, includedItemIds, formulaReferencedItemIds, query, isEditMode]);
 
   const noteGroupKeys = useMemo(() => {
     const keys = [...KNOWN_CLIENT_NOTE_GROUPS];
@@ -913,7 +1044,7 @@ const BudgetPage = ({ isAdmin = false }) => {
         import('@react-pdf/renderer'),
         import('./BudgetPdfDocument'),
       ]);
-      const blob = await pdf(React.createElement(BudgetPdfDocument, { catalog })).toBlob();
+      const blob = await pdf(React.createElement(BudgetPdfDocument, { catalog, rates: exchangeRates })).toBlob();
       saveAs(blob, `program-budget-${new Date().toISOString().slice(0, 10)}.pdf`);
       toast.success('Budget PDF exported.');
     } catch (exportError) {
@@ -975,7 +1106,8 @@ const BudgetPage = ({ isAdmin = false }) => {
     const index = catalog[collection].findIndex(record => String(record.id) === String(recordId));
     if (index === -1) return;
     const numericFields = new Set(['price', 'listedPrice', 'extraUnitPrice']);
-    const nextValue = numericFields.has(field) && value !== '' ? Number(value) : value;
+    // Price fields accept "=" formulas and "from ..." values, stored as strings.
+    const nextValue = numericFields.has(field) ? normalizeBudgetPriceInput(value) : value;
     updateCatalogRecord(collection, recordId, { [field]: nextValue });
     try {
       await update(ref(database, `budget/${collection}/${index}`), { [field]: nextValue });
@@ -1023,24 +1155,33 @@ const BudgetPage = ({ isAdmin = false }) => {
       return;
     }
 
-    const price = Number(newItem.price);
-    if (newItem.price === '' || !Number.isFinite(price)) {
+    const price = normalizeBudgetPriceInput(newItem.price);
+    const parsedPrice = parseBudgetPriceValue(price);
+    if (parsedPrice.isEmpty) {
+      toast.error('Enter a price, "from" price or "=" formula for the new budget item.');
+      return;
+    }
+    if (!parsedPrice.isFormula && !Number.isFinite(Number(parsedPrice.expression.replace(',', '.')))) {
       toast.error('Enter a valid price for the new budget item.');
       return;
     }
+
+    const category = newItem.category === CUSTOM_CATEGORY_OPTION
+      ? newItem.customCategory.trim() || 'Other'
+      : newItem.category.trim() || 'Other';
 
     const nextRecord = {
       id: getNextBudgetRecordId(catalog.items),
       name,
       price,
       description: newItem.description.trim(),
-      category: newItem.category.trim() || 'Other',
+      category,
     };
     const nextItems = [...catalog.items, nextRecord];
     setCatalog(current => ({ ...current, items: nextItems }));
     try {
       await set(ref(database, `budget/items/${nextItems.length - 1}`), nextRecord);
-      setNewItem({ name: '', price: '', description: '', category: 'Other' });
+      setNewItem({ name: '', price: '', description: '', category: 'Other', customCategory: '' });
       setOpenCategories(current => ({ ...current, [nextRecord.category]: true }));
       toast.success('Budget item created.');
     } catch (saveError) {
@@ -1259,10 +1400,22 @@ const BudgetPage = ({ isAdmin = false }) => {
     }
 
     const payments = Array.isArray(schedule.payments) ? schedule.payments : [];
+    const scheduleTotal = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
+    const packagePrice = resolveBudgetPriceAmount(program.listedPrice, priceContext);
 
     return (
       <PaymentScheduleCard>
-        <PaymentScheduleTitle>Payment schedule editor</PaymentScheduleTitle>
+        <PaymentScheduleTitle>
+          Payment schedule editor
+          {packagePrice != null ? (
+            <ScheduleDiffBadge
+              $over={packagePrice > scheduleTotal}
+              title="Package price vs payment schedule total"
+            >
+              {formatEuroAmount(packagePrice)} vs {formatEuroAmount(scheduleTotal)}
+            </ScheduleDiffBadge>
+          ) : null}
+        </PaymentScheduleTitle>
         <PaymentScheduleEditor>
           <EditableField>
             Schedule ID
@@ -1395,9 +1548,27 @@ const BudgetPage = ({ isAdmin = false }) => {
     ) : null
   );
 
+  // Focused price inputs show the raw stored value (e.g. "=23000/EUR"),
+  // blurred ones show the resolved amount.
+  const getPriceInputDisplayValue = rawValue => {
+    const parsed = parseBudgetPriceValue(rawValue);
+    if (!parsed.isFormula) return rawValue ?? '';
+    const amount = resolveBudgetPriceAmount(rawValue, priceContext);
+    if (amount == null) return String(rawValue);
+    return `${parsed.isFrom ? 'from ' : ''}${Math.round(amount * 100) / 100}`;
+  };
+
   const renderEditableFields = (collection, record, priceField = 'price') => {
     const recordIndex = catalog[collection].findIndex(item => String(item.id) === String(record.id));
     const collectionLabel = BUDGET_COLLECTION_LABELS[collection] || 'item';
+    const priceKey = `${collection}:${record.id}`;
+    const rawPrice = record[priceField] ?? '';
+    const isPriceFocused = focusedPriceKey === priceKey;
+    const formulaDebug = describeBudgetPriceFormula(rawPrice, priceContext);
+    const resolvedRecordPrice = resolveBudgetPriceAmount(rawPrice, priceContext);
+    const childrenTotal = collection === 'packages'
+      ? computePackageChildrenTotal(record, priceContext)
+      : null;
 
     return (
       <EditableGrid>
@@ -1422,15 +1593,29 @@ const BudgetPage = ({ isAdmin = false }) => {
           />
         </EditableField>
         <EditablePriceField>
-          Price
+          <span>
+            Price
+            {childrenTotal && childrenTotal.count ? (
+              <PriceComputedBadge
+                $over={resolvedRecordPrice != null && childrenTotal.total > resolvedRecordPrice}
+                title="Real cost of the included services"
+              >
+                Σ {formatEuroAmount(childrenTotal.total)}
+              </PriceComputedBadge>
+            ) : null}
+          </span>
           <EditInput
-            type="number"
-            inputMode="decimal"
-            value={record[priceField] ?? ''}
+            type="text"
+            value={isPriceFocused ? String(rawPrice) : getPriceInputDisplayValue(rawPrice)}
+            onFocus={() => setFocusedPriceKey(priceKey)}
             onChange={event => handleCatalogFieldChange(collection, record.id, priceField, event.target.value)}
-            onBlur={event => persistCatalogRecordField(collection, record.id, priceField, event.target.value)}
+            onBlur={event => {
+              setFocusedPriceKey('');
+              persistCatalogRecordField(collection, record.id, priceField, event.target.value);
+            }}
           />
         </EditablePriceField>
+        {formulaDebug ? <FormulaDebugNote title="Price formula">{formulaDebug}</FormulaDebugNote> : null}
         {collection === 'items' ? (
           <EditableField>
             Category
@@ -1484,11 +1669,8 @@ const BudgetPage = ({ isAdmin = false }) => {
       <Shell>
         <Header>
           <div>
-            <Eyebrow>Private client budget</Eyebrow>
+            <Eyebrow>{UKRCOM_MARKER}</Eyebrow>
             <Title>Program Budget</Title>
-            <Subtitle>
-              A clear overview of surrogacy program packages and optional expenses, prepared for international intended parents with transparent inclusions and calm, private presentation.
-            </Subtitle>
           </div>
           <HeaderActions>
             <SoftButton
@@ -1530,7 +1712,6 @@ const BudgetPage = ({ isAdmin = false }) => {
               <SectionHeading>
                 <div>
                   <H2 id="budget-programs-title">Programs</H2>
-                  <SectionNote>Core program packages are ordered from essential to premium.</SectionNote>
                 </div>
               </SectionHeading>
               <ProgramsGrid>
@@ -1552,7 +1733,12 @@ const BudgetPage = ({ isAdmin = false }) => {
                       {isPopular ? <Badge>{POPULAR_PACKAGE_BADGE}</Badge> : null}
                       {isGuaranteed ? <ProgramMeta>Guaranteed program</ProgramMeta> : null}
                       <ProgramName>{program.name}</ProgramName>
-                      <Price $compact={!isEditMode}>{formatMoney(program.listedPrice, program.currency || 'EUR')}</Price>
+                      <Price $compact={!isEditMode}>
+                        {formatMoney(
+                          resolveBudgetPriceAmount(program.listedPrice, priceContext) ?? program.listedPrice,
+                          program.currency || 'EUR',
+                        )}
+                      </Price>
                       {program.description ? <Description $compact={!isEditMode}>{program.description}</Description> : null}
                       {isEditMode ? renderInternalNote('packages', program) : null}
                       {isEditMode ? renderEditableFields('packages', program, 'listedPrice') : null}
@@ -1605,7 +1791,6 @@ const BudgetPage = ({ isAdmin = false }) => {
               <SectionHeading>
                 <div>
                   <H2 id="budget-expenses-title">Other expenses</H2>
-                  <SectionNote>Additional expenses are grouped by service category and collapsed for a softer first view.</SectionNote>
                 </div>
               </SectionHeading>
               <SearchInput
@@ -1630,7 +1815,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                             <ExpenseRow key={item.id} $compact={!isEditMode}>
                               <ExpenseTop>
                                 <ExpenseName>{item.name}</ExpenseName>
-                                <ExpensePrice>{getExpensePriceLabel(item)}</ExpensePrice>
+                                <ExpensePrice>{getExpensePriceLabel(item, priceContext)}</ExpensePrice>
                               </ExpenseTop>
                               {item.description ? <Muted $compact={!isEditMode}>{item.description}</Muted> : null}
                               {item.extraUnit && item.extraUnitPrice ? (
@@ -1669,21 +1854,44 @@ const BudgetPage = ({ isAdmin = false }) => {
                     <EditablePriceField>
                       Price
                       <EditInput
-                        type="number"
-                        inputMode="decimal"
-                        value={newItem.price}
+                        type="text"
+                        value={focusedPriceKey === 'new-item'
+                          ? newItem.price
+                          : getPriceInputDisplayValue(newItem.price)}
+                        onFocus={() => setFocusedPriceKey('new-item')}
                         onChange={event => handleNewItemChange('price', event.target.value)}
-                        placeholder="0"
+                        onBlur={() => setFocusedPriceKey('')}
+                        placeholder="0, from 0 or =0/EUR"
                       />
                     </EditablePriceField>
+                    {describeBudgetPriceFormula(newItem.price, priceContext) ? (
+                      <FormulaDebugNote title="Price formula">
+                        {describeBudgetPriceFormula(newItem.price, priceContext)}
+                      </FormulaDebugNote>
+                    ) : null}
                     <EditableField>
                       Category
-                      <EditInput
+                      <EditSelect
                         value={newItem.category}
                         onChange={event => handleNewItemChange('category', event.target.value)}
-                        placeholder="Other"
-                      />
+                        aria-label="Category for the new budget item"
+                      >
+                        {categoryOptions.map(key => (
+                          <option key={key} value={key}>{getCategoryLabel(key)}</option>
+                        ))}
+                        <option value={CUSTOM_CATEGORY_OPTION}>Custom category…</option>
+                      </EditSelect>
                     </EditableField>
+                    {newItem.category === CUSTOM_CATEGORY_OPTION ? (
+                      <EditableField>
+                        Custom category
+                        <EditInput
+                          value={newItem.customCategory}
+                          onChange={event => handleNewItemChange('customCategory', event.target.value)}
+                          placeholder="New category name"
+                        />
+                      </EditableField>
+                    ) : null}
                     <EditableDescriptionField>
                       Description
                       <EditTextarea
@@ -1707,7 +1915,6 @@ const BudgetPage = ({ isAdmin = false }) => {
                 <SectionHeading>
                   <div>
                     <H2 id="budget-notes-title">Good to know</H2>
-                    <SectionNote>Key milestones and notes for intended parents.</SectionNote>
                   </div>
                 </SectionHeading>
                 {isEditMode ? (

--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import {
+  collectFormulaReferencedItemIds,
   formatMoney,
   getCategoryLabel,
   getClientNoteGroupLabel,
   getExpensePriceLabel,
   getVisibleSortedPackages,
   normalizeClientNotes,
+  resolveBudgetPriceAmount,
   resolveProgramPaymentSchedule,
   KNOWN_CLIENT_NOTE_GROUPS,
 } from './budgetCatalogUtils';
+
+const UKRCOM_MARKER = 'REPRODUCTIVE AGENCY "UKRCOM"';
 
 const INK = '#33291f';
 const MUTED = '#6f6359';
@@ -302,11 +306,15 @@ const styles = StyleSheet.create({
   },
 });
 
-const BudgetPdfDocument = ({ catalog }) => {
+const BudgetPdfDocument = ({ catalog, rates = null }) => {
   const items = Array.isArray(catalog?.items) ? catalog.items : [];
   const visibleItems = items.filter(item => !item.hidden);
   const itemsById = new Map(visibleItems.map(item => [String(item.id), item]));
-  const packages = getVisibleSortedPackages(catalog);
+  const priceContext = { itemsById: new Map(items.map(item => [String(item.id), item])), rates };
+  const packages = getVisibleSortedPackages(catalog, priceContext);
+  const formulaReferencedIds = collectFormulaReferencedItemIds(catalog);
+  const resolveListedPrice = program =>
+    resolveBudgetPriceAmount(program?.listedPrice, priceContext) ?? program?.listedPrice;
 
   const programSchedules = packages.map(program => resolveProgramPaymentSchedule(catalog, program));
   const scheduleRowCount = programSchedules.reduce(
@@ -339,6 +347,9 @@ const BudgetPdfDocument = ({ catalog }) => {
 
   const groupedExpenses = visibleItems.reduce((groups, item) => {
     if (includedIdSet.has(String(item.id))) return groups;
+    // Sub-services referenced from price formulas are already included in
+    // another service/package price, so they are not listed separately.
+    if (formulaReferencedIds.has(String(item.id))) return groups;
     const category = item.category || 'Other';
     if (!groups[category]) groups[category] = [];
     groups[category].push(item);
@@ -363,30 +374,25 @@ const BudgetPdfDocument = ({ catalog }) => {
       {packages.map((program, index) => (
         <View key={program.id} style={styles.programCell}>
           <Text style={styles.programCellHead}>{`#${index + 1}`}</Text>
-          <Text style={styles.programCellHeadPrice}>{formatAmount(program.listedPrice)}</Text>
+          <Text style={styles.programCellHeadPrice}>{formatAmount(resolveListedPrice(program))}</Text>
         </View>
       ))}
     </View>
   );
 
   return (
-    <Document title="Program Budget" subject="Surrogacy program budget" creator="KnowMe">
+    <Document title="UKRCOM - Program Budget" subject="Surrogacy program budget" creator="UKRCOM">
       <Page size="A4" style={styles.page} wrap>
         <View style={styles.headerRow}>
           <View>
-            <Text style={styles.eyebrow}>Private client budget</Text>
+            <Text style={styles.eyebrow}>{UKRCOM_MARKER}</Text>
             <Text style={styles.title}>Program Budget</Text>
           </View>
           <Text style={styles.headerDate}>{dateLabel}</Text>
         </View>
-        <Text style={styles.subtitle}>
-          A clear overview of surrogacy program packages and optional expenses, prepared for international
-          intended parents with transparent inclusions. All prices are in EUR unless stated otherwise.
-        </Text>
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Programs</Text>
-          <Text style={styles.sectionNote}>Core program packages, ordered from essential to premium.</Text>
           {packages.map((program, index) => (
             <View key={program.id} style={styles.programRow} wrap={false}>
               <View style={styles.programIndexCell}>
@@ -398,7 +404,7 @@ const BudgetPdfDocument = ({ catalog }) => {
                   <Text style={styles.programDescription}>{sanitizePdfText(program.description)}</Text>
                 ) : null}
               </View>
-              <Text style={styles.programPrice}>{formatMoney(program.listedPrice, program.currency || 'EUR')}</Text>
+              <Text style={styles.programPrice}>{formatMoney(resolveListedPrice(program), program.currency || 'EUR')}</Text>
             </View>
           ))}
         </View>
@@ -406,7 +412,6 @@ const BudgetPdfDocument = ({ catalog }) => {
         {scheduleRowCount > 0 ? (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Payment schedule</Text>
-            <Text style={styles.sectionNote}>Amounts in EUR, payable at each program milestone.</Text>
             <View style={styles.table}>
               <View style={styles.tableHeadRow} wrap={false}>
                 <View style={styles.labelCell}>
@@ -415,7 +420,7 @@ const BudgetPdfDocument = ({ catalog }) => {
                 {packages.map((program, index) => (
                   <View key={program.id} style={styles.programCell}>
                     <Text style={styles.programCellHead}>{`#${index + 1}`}</Text>
-                    <Text style={styles.programCellHeadPrice}>{formatAmount(program.listedPrice)}</Text>
+                    <Text style={styles.programCellHeadPrice}>{formatAmount(resolveListedPrice(program))}</Text>
                   </View>
                 ))}
               </View>
@@ -482,9 +487,7 @@ const BudgetPdfDocument = ({ catalog }) => {
         {Object.keys(groupedExpenses).length ? (
           <View style={styles.section} break>
             <Text style={styles.sectionTitle}>Other expenses</Text>
-            <Text style={styles.sectionNote}>
-              Optional and situational services, grouped by category. “From” prices are lower bounds of a range.
-            </Text>
+            <Text style={styles.sectionNote}>“From” prices are lower bounds of a range.</Text>
             {Object.entries(groupedExpenses).map(([category, categoryItems]) => (
               <View key={category} style={styles.categoryBlock}>
                 <View style={styles.categoryHeader} wrap={false} minPresenceAhead={40}>
@@ -501,7 +504,7 @@ const BudgetPdfDocument = ({ catalog }) => {
                         <Text style={styles.expenseDescription}>{sanitizePdfText(item.description)}</Text>
                       ) : null}
                     </View>
-                    <Text style={styles.expensePrice}>{getExpensePriceLabel(item)}</Text>
+                    <Text style={styles.expensePrice}>{getExpensePriceLabel(item, priceContext)}</Text>
                   </View>
                 ))}
               </View>
@@ -512,7 +515,6 @@ const BudgetPdfDocument = ({ catalog }) => {
         {noteGroups.length ? (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Good to know</Text>
-            <Text style={styles.sectionNote}>Key milestones and notes for intended parents.</Text>
             {noteGroups.map(([groupKey, notes]) => (
               <View key={groupKey} style={styles.noteCard} wrap={false}>
                 <Text style={styles.noteGroupTitle}>{sanitizePdfText(getClientNoteGroupLabel(groupKey))}</Text>
@@ -528,7 +530,7 @@ const BudgetPdfDocument = ({ catalog }) => {
         ) : null}
 
         <View style={styles.footer} fixed>
-          <Text style={styles.footerText}>{`Program Budget · generated ${dateLabel}`}</Text>
+          <Text style={styles.footerText}>{sanitizePdfText(`${UKRCOM_MARKER} · Program Budget · generated ${dateLabel}`)}</Text>
           <Text
             style={styles.footerText}
             render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -1,5 +1,12 @@
 // Shared helpers for the budget catalog: used by BudgetPage (screen) and BudgetPdfDocument (export).
 
+import {
+  evaluateBudgetPriceFormula,
+  extractBudgetFormulaItemIds,
+  isBudgetPriceFormula,
+  stripBudgetFormulaPrefix,
+} from 'utils/budgetPriceFormula';
+
 export const USD_ITEM_IDS = new Set([
   '22',
   'sm-program-compensation',
@@ -22,11 +29,16 @@ const CATEGORY_LABELS = {
   insurance: 'Insurance',
 };
 
+export const KNOWN_CATEGORY_KEYS = Object.keys(CATEGORY_LABELS);
+
 const CLIENT_NOTE_GROUP_LABELS = {
   programMilestones: 'Milestones for the intended parents',
   surrogateMotherExpenses: "Surrogate mother's expenses",
   general: 'Client notes',
 };
+
+const FROM_PREFIX_REGEX = /^from\s*/i;
+const PLAIN_NUMBER_REGEX = /^[-+]?\d+(?:[.,]\d+)?$/;
 
 const prettifyKey = key => String(key || '')
   .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
@@ -50,6 +62,99 @@ export const formatEuroAmount = value => {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(amount);
+};
+
+// Splits a stored price into its "from" flag and the remaining expression
+// (a plain number, or a "=..." formula).
+export const parseBudgetPriceValue = raw => {
+  if (typeof raw === 'number') {
+    return { isFrom: false, expression: String(raw), isFormula: false, isEmpty: !Number.isFinite(raw) };
+  }
+  const text = String(raw ?? '').trim();
+  if (!text) return { isFrom: false, expression: '', isFormula: false, isEmpty: true };
+  const isFrom = FROM_PREFIX_REGEX.test(text);
+  const expression = text.replace(FROM_PREFIX_REGEX, '').trim();
+  return { isFrom, expression, isFormula: isBudgetPriceFormula(expression), isEmpty: !expression };
+};
+
+// Keeps plain numbers numeric on the backend; formulas and "from ..." strings stay as-is.
+export const normalizeBudgetPriceInput = raw => {
+  const text = String(raw ?? '').trim();
+  if (text === '') return '';
+  if (PLAIN_NUMBER_REGEX.test(text)) {
+    const numeric = Number(text.replace(',', '.'));
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return text;
+};
+
+// Resolves a stored price to a EUR number: plain numbers pass through, formulas
+// are evaluated with the NBU rates and idNN references to other items.
+export const resolveBudgetPriceAmount = (raw, context = {}, seenIds = new Set()) => {
+  const parsed = parseBudgetPriceValue(raw);
+  if (parsed.isEmpty) return null;
+  if (!parsed.isFormula) {
+    const numeric = Number(parsed.expression.replace(',', '.'));
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  const { itemsById, rates } = context;
+  try {
+    return evaluateBudgetPriceFormula(parsed.expression, name => {
+      const lower = String(name).toLowerCase();
+      if (lower === 'eur') return rates?.eur;
+      if (lower === 'usd') return rates?.usd;
+      const idMatch = /^id(\d+)$/.exec(lower);
+      if (!idMatch) return NaN;
+      const itemId = idMatch[1];
+      if (seenIds.has(itemId)) return NaN;
+      const item = itemsById?.get?.(itemId);
+      if (!item) return NaN;
+      const nextSeen = new Set(seenIds);
+      nextSeen.add(itemId);
+      const amount = resolveBudgetPriceAmount(item.price, context, nextSeen);
+      return amount == null ? NaN : amount;
+    });
+  } catch (error) {
+    return null;
+  }
+};
+
+const formatShortAmount = value => {
+  if (!Number.isFinite(value)) return '?';
+  return String(Math.round(value * 100) / 100);
+};
+
+// Debug line for edit mode: the formula with idNN replaced by service names
+// (with their resolved amounts) plus the computed total.
+export const describeBudgetPriceFormula = (raw, context = {}) => {
+  const parsed = parseBudgetPriceValue(raw);
+  if (!parsed.isFormula) return '';
+  const { itemsById, rates } = context;
+  const readable = stripBudgetFormulaPrefix(parsed.expression)
+    .replace(/\bid(\d+)\b/gi, (match, itemId) => {
+      const item = itemsById?.get?.(String(itemId));
+      if (!item) return `id${itemId}?`;
+      const amount = resolveBudgetPriceAmount(item.price, context);
+      return `${item.name || `id${itemId}`} [${formatShortAmount(amount == null ? NaN : amount)}]`;
+    })
+    .replace(/\bEUR\b/g, `EUR ${formatShortAmount(Number(rates?.eur))}`)
+    .replace(/\bUSD\b/g, `USD ${formatShortAmount(Number(rates?.usd))}`);
+  const total = resolveBudgetPriceAmount(raw, context);
+  return `${readable} = ${formatShortAmount(total == null ? NaN : total)}`;
+};
+
+// IDs of items referenced from price formulas (sub-services). They are already
+// part of another service/package price, so clients should not see them twice.
+export const collectFormulaReferencedItemIds = catalog => {
+  const ids = new Set();
+  const scan = value => {
+    const parsed = parseBudgetPriceValue(value);
+    if (!parsed.isFormula) return;
+    extractBudgetFormulaItemIds(parsed.expression).forEach(id => ids.add(String(id)));
+  };
+  (Array.isArray(catalog?.items) ? catalog.items : []).forEach(item => scan(item?.price));
+  (Array.isArray(catalog?.packages) ? catalog.packages : []).forEach(program => scan(program?.listedPrice));
+  return ids;
 };
 
 export const normalizeClientNotes = value => {
@@ -79,21 +184,41 @@ export const normalizeCatalog = catalog => ({
 export const getClientNoteGroupLabel = key =>
   CLIENT_NOTE_GROUP_LABELS[key] || prettifyKey(key) || 'Client notes';
 
-export const getItemDisplayAmount = item => {
-  const basePrice = Number(item?.price);
-  if (!Number.isFinite(basePrice)) return null;
+export const getItemDisplayAmount = (item, context = {}) => {
+  const basePrice = resolveBudgetPriceAmount(item?.price, context);
+  if (basePrice == null) return null;
   const isUsd = USD_ITEM_IDS.has(String(item?.id || '').trim());
   return isUsd ? basePrice * USD_TO_EUR_RATE : basePrice;
 };
 
-export const getItemDisplayPrice = item => {
-  const amount = getItemDisplayAmount(item);
+export const getItemDisplayPrice = (item, context = {}) => {
+  const amount = getItemDisplayAmount(item, context);
   return amount === null ? formatMoney(item?.price, 'EUR') : formatMoney(amount, 'EUR');
 };
 
-export const getExpensePriceLabel = item => {
-  const prefix = FROM_PRICE_ITEM_IDS.has(String(item?.id)) ? 'from ' : '';
-  return `${prefix}${getItemDisplayPrice(item)}`;
+export const isFromPricedItem = item =>
+  parseBudgetPriceValue(item?.price).isFrom || FROM_PRICE_ITEM_IDS.has(String(item?.id));
+
+export const getExpensePriceLabel = (item, context = {}) => {
+  const prefix = isFromPricedItem(item) ? 'from ' : '';
+  return `${prefix}${getItemDisplayPrice(item, context)}`;
+};
+
+// Real cost of a package: the sum of its included services (sub-service
+// formulas resolved). Used as the margin marker next to the package price.
+export const computePackageChildrenTotal = (program, context = {}) => {
+  const children = Array.isArray(program?.children) ? program.children : [];
+  let total = 0;
+  let resolvedCount = 0;
+  children.forEach(id => {
+    const item = context.itemsById?.get?.(String(id));
+    const amount = item ? getItemDisplayAmount(item, context) : null;
+    if (amount != null) {
+      total += amount;
+      resolvedCount += 1;
+    }
+  });
+  return { total, count: children.length, resolvedCount };
 };
 
 export const getCategoryLabel = category => {
@@ -102,10 +227,11 @@ export const getCategoryLabel = category => {
   return prettifyKey(key) || 'Other';
 };
 
-export const getVisibleSortedPackages = catalog =>
+export const getVisibleSortedPackages = (catalog, context = {}) =>
   (Array.isArray(catalog?.packages) ? catalog.packages : [])
     .filter(program => !program.hidden)
-    .sort((a, b) => Number(a.listedPrice || 0) - Number(b.listedPrice || 0));
+    .sort((a, b) => (resolveBudgetPriceAmount(a.listedPrice, context) || 0)
+      - (resolveBudgetPriceAmount(b.listedPrice, context) || 0));
 
 export const resolveProgramPaymentSchedule = (catalog, program) => {
   const schedules = Array.isArray(catalog?.technical?.paymentSchedules)

--- a/src/components/budgetCatalogUtils.test.js
+++ b/src/components/budgetCatalogUtils.test.js
@@ -1,9 +1,14 @@
 import {
+  collectFormulaReferencedItemIds,
+  computePackageChildrenTotal,
+  describeBudgetPriceFormula,
   formatMoney,
   getExpensePriceLabel,
   getItemDisplayAmount,
+  normalizeBudgetPriceInput,
   normalizeCatalog,
   normalizeClientNotes,
+  resolveBudgetPriceAmount,
   USD_TO_EUR_RATE,
 } from './budgetCatalogUtils';
 
@@ -42,6 +47,82 @@ describe('budgetCatalogUtils', () => {
   it('normalizes legacy array client notes into the general group', () => {
     expect(normalizeClientNotes(['A note'])).toEqual({ general: ['A note'] });
     expect(normalizeClientNotes(null)).toEqual({});
+  });
+
+  it('resolves "=" price formulas with the EUR rate', () => {
+    const context = { rates: { eur: 46, usd: 42 } };
+    expect(resolveBudgetPriceAmount('=23000/EUR', context)).toBeCloseTo(500);
+    expect(resolveBudgetPriceAmount('=23000/EUR', {})).toBeNull();
+    expect(resolveBudgetPriceAmount(5000)).toBe(5000);
+    expect(resolveBudgetPriceAmount('from 250')).toBe(250);
+  });
+
+  it('resolves item references (sub-services) inside formulas', () => {
+    const itemsById = new Map([
+      ['14', { id: 14, name: 'Medication', price: 100 }],
+      ['15', { id: 15, name: 'Screening', price: '=60/EUR' }],
+    ]);
+    const context = { itemsById, rates: { eur: 2 } };
+    expect(resolveBudgetPriceAmount('=(id14+id15*3)/EUR', context)).toBeCloseTo(95);
+  });
+
+  it('returns null for circular item references', () => {
+    const itemsById = new Map([
+      ['1', { id: 1, price: '=id2' }],
+      ['2', { id: 2, price: '=id1' }],
+    ]);
+    expect(resolveBudgetPriceAmount('=id1', { itemsById, rates: {} })).toBeNull();
+  });
+
+  it('prefixes items with "from" stored in the price', () => {
+    expect(getExpensePriceLabel({ id: 1, price: 'from 250' })).toBe('from 250 EUR');
+    expect(getItemDisplayAmount({ id: 1, price: 'from 250' })).toBe(250);
+  });
+
+  it('keeps plain numbers numeric and formulas as strings on save', () => {
+    expect(normalizeBudgetPriceInput('250')).toBe(250);
+    expect(normalizeBudgetPriceInput(' 250,5 ')).toBe(250.5);
+    expect(normalizeBudgetPriceInput('=23000/EUR')).toBe('=23000/EUR');
+    expect(normalizeBudgetPriceInput('from 250')).toBe('from 250');
+    expect(normalizeBudgetPriceInput('')).toBe('');
+  });
+
+  it('collects sub-service ids referenced from price formulas', () => {
+    const catalog = {
+      items: [
+        { id: 1, price: '=(id14+id15*3)/EUR' },
+        { id: 14, price: 100 },
+        { id: 15, price: 30 },
+      ],
+      packages: [{ id: 'p1', listedPrice: '=id16*2' }],
+    };
+    expect([...collectFormulaReferencedItemIds(catalog)].sort()).toEqual(['14', '15', '16']);
+  });
+
+  it('describes formulas with service names and the computed total', () => {
+    const itemsById = new Map([
+      ['14', { id: 14, name: 'Medication', price: 100 }],
+      ['15', { id: 15, name: 'Screening', price: 30 }],
+    ]);
+    const context = { itemsById, rates: { eur: 2 } };
+    const description = describeBudgetPriceFormula('=(id14+id15*3)/EUR', context);
+    expect(description).toContain('Medication [100]');
+    expect(description).toContain('Screening [30]');
+    expect(description).toContain('EUR 2');
+    expect(description).toContain('= 95');
+    expect(describeBudgetPriceFormula(500, context)).toBe('');
+  });
+
+  it('sums resolved prices of package children', () => {
+    const itemsById = new Map([
+      ['1', { id: 1, price: 100 }],
+      ['2', { id: 2, price: '=40/EUR' }],
+    ]);
+    const context = { itemsById, rates: { eur: 2 } };
+    const summary = computePackageChildrenTotal({ children: [1, 2, 99] }, context);
+    expect(summary.total).toBeCloseTo(120);
+    expect(summary.count).toBe(3);
+    expect(summary.resolvedCount).toBe(2);
   });
 
   it('normalizes a full catalog with grouped client notes', () => {

--- a/src/utils/budgetPriceFormula.js
+++ b/src/utils/budgetPriceFormula.js
@@ -1,0 +1,182 @@
+// Formula support for budget prices, mirroring the Flow amount formulas.
+// A price starting with "=" is a formula: numbers, + - * / ( ) and identifiers.
+// Identifiers: EUR / USD resolve to the NBU UAH rate, idNN resolves to the
+// price of budget item NN (so a service can be composed of sub-services).
+
+export const BUDGET_FORMULA_PREFIX = '=';
+
+const ITEM_REFERENCE_REGEX = /\bid(\d+)\b/gi;
+
+const normalizeFormulaOperator = char => {
+  if (char === '×' || char === 'x' || char === 'X' || char === 'х' || char === 'Х') return '*';
+  if (char === '÷' || char === ':') return '/';
+  if (char === '−' || char === '–' || char === '—') return '-';
+  return char;
+};
+
+export const isBudgetPriceFormula = value =>
+  typeof value === 'string' && value.trim().startsWith(BUDGET_FORMULA_PREFIX);
+
+export const stripBudgetFormulaPrefix = value => {
+  const text = String(value || '').trim();
+  return text.startsWith(BUDGET_FORMULA_PREFIX) ? text.slice(BUDGET_FORMULA_PREFIX.length) : text;
+};
+
+export const extractBudgetFormulaItemIds = value => {
+  const ids = [];
+  for (const match of String(value || '').matchAll(ITEM_REFERENCE_REGEX)) {
+    if (!ids.includes(match[1])) ids.push(match[1]);
+  }
+  return ids;
+};
+
+const tokenizeBudgetFormula = rawExpression => {
+  const expression = String(rawExpression || '');
+  const tokens = [];
+  let index = 0;
+
+  while (index < expression.length) {
+    const rawChar = expression[index];
+    const char = normalizeFormulaOperator(rawChar);
+
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (/\d/.test(char) || char === '.' || char === ',') {
+      let numberText = '';
+      let decimalSeen = false;
+
+      while (index < expression.length) {
+        const nextChar = expression[index];
+        if (/\d/.test(nextChar)) {
+          numberText += nextChar;
+          index += 1;
+          continue;
+        }
+        if (nextChar === '.' || nextChar === ',') {
+          if (decimalSeen) break;
+          decimalSeen = true;
+          numberText += '.';
+          index += 1;
+          continue;
+        }
+        break;
+      }
+
+      if (!/\d/.test(numberText)) {
+        throw new Error('Formula number is invalid');
+      }
+      tokens.push({ type: 'number', value: Number(numberText) });
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(rawChar) && !/[xXхХ]/.test(rawChar)) {
+      let name = '';
+      while (index < expression.length && /[A-Za-z0-9_]/.test(expression[index])) {
+        name += expression[index];
+        index += 1;
+      }
+      tokens.push({ type: 'identifier', name });
+      continue;
+    }
+
+    if (/[xXхХ]/.test(rawChar)) {
+      tokens.push({ type: '*' });
+      index += 1;
+      continue;
+    }
+
+    if ('+-*/()%'.includes(char)) {
+      tokens.push({ type: char });
+      index += 1;
+      continue;
+    }
+
+    throw new Error('Formula contains unsupported characters');
+  }
+
+  return tokens;
+};
+
+export const evaluateBudgetPriceFormula = (rawFormula, resolveIdentifier) => {
+  const tokens = tokenizeBudgetFormula(stripBudgetFormulaPrefix(rawFormula));
+  let position = 0;
+
+  const peek = () => tokens[position];
+  const consume = type => {
+    if (peek()?.type !== type) return false;
+    position += 1;
+    return true;
+  };
+
+  const parseExpression = () => {
+    let value = parseTerm();
+    while (peek()?.type === '+' || peek()?.type === '-') {
+      const operator = peek().type;
+      position += 1;
+      const right = parseTerm();
+      value = operator === '+' ? value + right : value - right;
+    }
+    return value;
+  };
+
+  const parseTerm = () => {
+    let value = parseFactor();
+    while (peek()?.type === '*' || peek()?.type === '/') {
+      const operator = peek().type;
+      position += 1;
+      const right = parseFactor();
+      if (operator === '/' && right === 0) {
+        throw new Error('Formula division by zero');
+      }
+      value = operator === '*' ? value * right : value / right;
+    }
+    return value;
+  };
+
+  const parseFactor = () => {
+    let value;
+    if (consume('+')) {
+      value = parseFactor();
+    } else if (consume('-')) {
+      value = -parseFactor();
+    } else if (consume('(')) {
+      value = parseExpression();
+      if (!consume(')')) {
+        throw new Error('Formula closing parenthesis is missing');
+      }
+    } else if (peek()?.type === 'number') {
+      value = peek().value;
+      position += 1;
+    } else if (peek()?.type === 'identifier') {
+      const resolved = Number(resolveIdentifier?.(peek().name));
+      if (!Number.isFinite(resolved)) {
+        throw new Error(`Formula identifier "${peek().name}" is unresolved`);
+      }
+      value = resolved;
+      position += 1;
+    } else {
+      throw new Error('Formula value is missing');
+    }
+
+    while (consume('%')) {
+      value /= 100;
+    }
+    return value;
+  };
+
+  if (tokens.length === 0) {
+    throw new Error('Formula is empty');
+  }
+
+  const result = parseExpression();
+  if (position !== tokens.length) {
+    throw new Error('Formula has an unexpected token');
+  }
+  if (!Number.isFinite(result)) {
+    throw new Error('Formula result is invalid');
+  }
+  return result;
+};

--- a/src/utils/budgetPriceFormula.test.js
+++ b/src/utils/budgetPriceFormula.test.js
@@ -1,0 +1,50 @@
+import {
+  evaluateBudgetPriceFormula,
+  extractBudgetFormulaItemIds,
+  isBudgetPriceFormula,
+  stripBudgetFormulaPrefix,
+} from './budgetPriceFormula';
+
+describe('budgetPriceFormula', () => {
+  it('detects formulas by the "=" prefix', () => {
+    expect(isBudgetPriceFormula('=23000/EUR')).toBe(true);
+    expect(isBudgetPriceFormula('  =1+2')).toBe(true);
+    expect(isBudgetPriceFormula('23000')).toBe(false);
+    expect(isBudgetPriceFormula(23000)).toBe(false);
+  });
+
+  it('strips the formula prefix', () => {
+    expect(stripBudgetFormulaPrefix('=1+2')).toBe('1+2');
+    expect(stripBudgetFormulaPrefix('1+2')).toBe('1+2');
+  });
+
+  it('evaluates arithmetic with +, -, *, / and parentheses', () => {
+    expect(evaluateBudgetPriceFormula('=2+3*4')).toBe(14);
+    expect(evaluateBudgetPriceFormula('=(2+3)*4')).toBe(20);
+    expect(evaluateBudgetPriceFormula('=10-4/2')).toBe(8);
+    expect(evaluateBudgetPriceFormula('=-5+10')).toBe(5);
+  });
+
+  it('resolves currency identifiers through the resolver', () => {
+    const resolve = name => (name.toLowerCase() === 'eur' ? 46 : NaN);
+    expect(evaluateBudgetPriceFormula('=23000/EUR', resolve)).toBeCloseTo(500);
+  });
+
+  it('resolves item references through the resolver', () => {
+    const values = { id14: 100, id15: 30, eur: 2 };
+    const resolve = name => values[name.toLowerCase()] ?? values[name] ?? NaN;
+    expect(evaluateBudgetPriceFormula('=(id14+id15*3)/EUR', resolve)).toBeCloseTo(95);
+  });
+
+  it('throws for unresolved identifiers, bad syntax and division by zero', () => {
+    expect(() => evaluateBudgetPriceFormula('=1/EUR')).toThrow();
+    expect(() => evaluateBudgetPriceFormula('=1+')).toThrow();
+    expect(() => evaluateBudgetPriceFormula('=1/0')).toThrow();
+    expect(() => evaluateBudgetPriceFormula('=')).toThrow();
+  });
+
+  it('extracts referenced item ids from a formula', () => {
+    expect(extractBudgetFormulaItemIds('=(id14+id15*3)/EUR')).toEqual(['14', '15']);
+    expect(extractBudgetFormulaItemIds('=100/EUR')).toEqual([]);
+  });
+});


### PR DESCRIPTION
- Price fields accept "=" formulas (+,-,*,/,()) with EUR/USD resolved via
  the official NBU rate fetched daily: focused inputs show the raw formula,
  blurred inputs show the computed EUR amount, and amounts follow rate changes.
- Formulas can reference other services as idNN (e.g. =(id14+id15*3)/EUR) to
  compose a service from sub-services; referenced sub-services are stored on
  the backend as part of the formula and hidden from the client view and PDF.
  A small debug line under the price shows the formula with service names and
  the computed total.
- New expenses pick a category from the existing ones or a custom option.
- Prices support a "from" prefix stored as-is on the backend and rendered as
  "from X EUR".
- Package price inputs show the real cost of included services (red when the
  cost exceeds the listed price); the payment schedule editor shows the
  package price vs schedule total in green/red.
- Add UKRCOM markers to the budget page header and the exported PDF.
- Remove marketing noise copy from the page and the PDF.
- Edit-mode inputs render as plain text (borders appear only on hover/focus)
  for a more compact editing layout.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016scuXFPrWAkjbciduwaZTB