### PR TITLE
Unify component styles under shared KnowMe design system

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,12 +4,18 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon2.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#E8791A" />
     <meta
       name="description"
       content="KnowMe: Egg Donor mobile application. User Agreement and Privacy Policy"
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&family=Playfair+Display:ital,wght@0,500;0,600;1,500&display=swap"
+      rel="stylesheet"
+    />
     <title>KnowMe: Egg Donor</title>
 
     <!-- Start Single Page Apps for GitHub Pages -->

--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -58,7 +58,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { resolveAccess } from 'utils/accessLevel';
 import { normalizePhoneState } from './inputValidations';
 import { buildOverlayFromDraft, getCanonicalCard, saveOverlayForUserCard } from 'utils/multiAccountEdits';
-import InfoModal from './InfoModal';
+import InfoModal, { ModalTitle, ModalText, ModalActionRow, ModalDangerButton, ModalGhostButton } from './InfoModal';
 
 import { color, coloredCard, uiTokens } from './styles';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
@@ -3435,9 +3435,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           <span className="spinner" />
         ) : (
           <>
-            <p>Видалити профіль?</p>
-            <SubmitButton onClick={handleRemoveUser}>Видалити</SubmitButton>
-            <SubmitButton onClick={handleCloseModal}>Відмінити</SubmitButton>
+            <ModalTitle>Видалити профіль?</ModalTitle>
+            <ModalText>Цю дію не можна скасувати.</ModalText>
+            <ModalActionRow>
+              <ModalGhostButton type="button" onClick={handleCloseModal}>Відмінити</ModalGhostButton>
+              <ModalDangerButton type="button" onClick={handleRemoveUser}>Видалити</ModalDangerButton>
+            </ModalActionRow>
           </>
         )}
       </>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -14,6 +14,7 @@ import BudgetPage from './BudgetPage';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth, fetchUserById } from './config';
 import { resolveAccess } from 'utils/accessLevel';
+import { applyStoredAppSettings } from 'hooks/useAppSettings';
 
 export const App = () => {
 
@@ -28,6 +29,7 @@ export const App = () => {
   const location = useLocation();
 
   useEffect(() => {
+    applyStoredAppSettings();
     const stored = localStorage.getItem('isLoggedIn');
     if (stored === 'true') {
       setIsLoggedIn(true);

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -79,10 +79,10 @@ const validateCatalog = catalog => {
 
 const Page = styled.main`
   min-height: 100vh;
-  background: linear-gradient(180deg, #fbf4eb 0%, #f7efe4 44%, #fffaf4 100%);
-  color: #2f2923;
+  background: var(--km-bg);
+  color: var(--km-text);
   padding: 22px 14px 96px;
-  font-family: 'DM Sans', 'Inter', Arial, sans-serif;
+  font-family: var(--km-font);
 `;
 
 const Shell = styled.div`
@@ -103,7 +103,7 @@ const Header = styled.header`
 `;
 
 const Eyebrow = styled.div`
-  color: #9a6b48;
+  color: var(--km-accent);
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.16em;
@@ -131,9 +131,9 @@ const HeaderActions = styled.div`
 `;
 
 const SoftButton = styled.button`
-  border: 1px solid ${({ $danger }) => ($danger ? '#d9b0a2' : '#dfcdbc')};
-  background: ${({ disabled }) => (disabled ? 'rgba(255,255,255,0.5)' : '#fffaf4')};
-  color: ${({ $danger }) => ($danger ? '#8d4a36' : '#5c4939')};
+  border: 1px solid ${({ $danger }) => ($danger ? 'var(--km-danger-border)' : 'var(--km-border)')};
+  background: ${({ disabled }) => (disabled ? 'rgba(255, 255, 255, 0.55)' : 'var(--km-card)')};
+  color: ${({ $danger }) => ($danger ? 'var(--km-danger)' : 'var(--km-text)')};
   border-radius: 999px;
   padding: 11px 16px;
   font-size: 13px;
@@ -152,14 +152,14 @@ const SoftButton = styled.button`
 
 
 const DangerButton = styled(SoftButton)`
-  border-color: #d9b0a2;
-  color: #8d4a36;
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
 `;
 
 const MiniButton = styled.button`
-  border: 1px solid #dfcdbc;
-  background: #fffaf4;
-  color: #5c4939;
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
   border-radius: 8px;
   min-height: 30px;
   padding: 4px 10px;
@@ -173,8 +173,8 @@ const MiniButton = styled.button`
 `;
 
 const MiniDangerButton = styled(MiniButton)`
-  border-color: #d9b0a2;
-  color: #8d4a36;
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
 `;
 
 const InlineActionRow = styled.div`
@@ -189,7 +189,7 @@ const BackendIdButton = styled.button`
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: #67462f;
+  color: var(--km-accent);
   min-height: 20px;
   padding: 1px 2px;
   display: inline-flex;
@@ -202,7 +202,7 @@ const BackendIdButton = styled.button`
   cursor: pointer;
 
   &:hover {
-    background: rgba(223, 205, 188, 0.35);
+    background: var(--km-accent-light);
   }
 `;
 
@@ -211,8 +211,8 @@ const HiddenBadge = styled.span`
   align-items: center;
   width: fit-content;
   border-radius: 999px;
-  background: #f3ded8;
-  color: #8d4a36;
+  background: var(--km-danger-bg);
+  color: var(--km-danger);
   padding: 4px 7px;
   font-size: 10px;
   font-weight: 900;
@@ -221,9 +221,9 @@ const HiddenBadge = styled.span`
 
 const EditPanel = styled.div`
   margin-top: 16px;
-  border: 1px solid rgba(140, 101, 70, 0.16);
+  border: 1px solid var(--km-border);
   border-radius: 22px;
-  background: rgba(255, 250, 244, 0.78);
+  background: var(--km-card);
   padding: 16px;
 `;
 
@@ -231,7 +231,7 @@ const ModalBackdrop = styled.div`
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: rgba(42, 32, 25, 0.46);
+  background: rgba(20, 16, 12, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -241,10 +241,10 @@ const ModalBackdrop = styled.div`
 const ConfirmModal = styled.div`
   width: min(100%, 440px);
   border-radius: 24px;
-  background: #fffaf4;
-  box-shadow: 0 24px 70px rgba(42, 32, 25, 0.24);
+  background: var(--km-card);
+  box-shadow: 0 24px 70px rgba(20, 16, 12, 0.24);
   padding: 22px;
-  color: #382d24;
+  color: var(--km-text);
 `;
 
 const ModalTitle = styled.h3`
@@ -254,7 +254,7 @@ const ModalTitle = styled.h3`
 
 const ModalText = styled.p`
   margin: 0 0 16px;
-  color: #6f6359;
+  color: var(--km-muted);
   line-height: 1.5;
 `;
 
@@ -285,7 +285,7 @@ const H2 = styled.h2`
 
 const SectionNote = styled.p`
   margin: 4px 0 0;
-  color: #76685d;
+  color: var(--km-muted);
   font-size: 14px;
   line-height: 1.5;
 `;
@@ -302,10 +302,10 @@ const ProgramsGrid = styled.div`
 
 const ProgramCard = styled.article`
   position: relative;
-  border: 1px solid ${({ $guaranteed }) => ($guaranteed ? 'rgba(175, 126, 51, 0.46)' : 'rgba(140, 101, 70, 0.16)')};
+  border: 1px solid ${({ $guaranteed }) => ($guaranteed ? 'rgba(232, 121, 26, 0.45)' : 'var(--km-border)')};
   border-radius: 28px;
-  background: ${({ $guaranteed }) => ($guaranteed ? 'rgba(255, 248, 235, 0.96)' : 'rgba(255, 250, 244, 0.92)')};
-  box-shadow: 0 24px 70px rgba(89, 63, 40, 0.09);
+  background: ${({ $guaranteed }) => ($guaranteed ? '#FFF8EF' : 'var(--km-card)')};
+  box-shadow: 0 24px 70px rgba(26, 26, 26, 0.07);
   padding: ${({ $compact }) => ($compact ? '17px' : '22px')};
 `;
 
@@ -314,8 +314,8 @@ const Badge = styled.span`
   top: 18px;
   right: 18px;
   border-radius: 999px;
-  background: #efe0ca;
-  color: #6c472f;
+  background: var(--km-accent-light);
+  color: var(--km-accent);
   font-size: 11px;
   font-weight: 900;
   letter-spacing: 0.04em;
@@ -324,7 +324,7 @@ const Badge = styled.span`
 `;
 
 const ProgramMeta = styled.div`
-  color: #9b6b2e;
+  color: var(--km-accent);
   font-size: 12px;
   font-weight: 900;
   letter-spacing: 0.1em;
@@ -341,7 +341,7 @@ const ProgramName = styled.h3`
 
 const Price = styled.div`
   margin: 0 0 ${({ $compact }) => ($compact ? '8px' : '12px')};
-  color: #7a4c2f;
+  color: var(--km-accent);
   font-size: ${({ $compact }) => ($compact ? 'clamp(27px, 7vw, 38px)' : 'clamp(32px, 8vw, 46px)')};
   font-weight: 900;
   letter-spacing: -0.06em;
@@ -349,14 +349,14 @@ const Price = styled.div`
 
 const Description = styled.p`
   margin: 0;
-  color: #6d6259;
+  color: var(--km-muted);
   font-size: ${({ $compact }) => ($compact ? '14px' : '15px')};
   line-height: ${({ $compact }) => ($compact ? 1.42 : 1.56)};
 `;
 
 const PaymentScheduleCard = styled.section`
   margin-top: 14px;
-  border: 1px solid rgba(140, 101, 70, 0.16);
+  border: 1px solid var(--km-border);
   border-radius: 18px;
   background: rgba(250, 241, 229, 0.72);
   padding: 13px;
@@ -364,7 +364,7 @@ const PaymentScheduleCard = styled.section`
 
 const PaymentScheduleTitle = styled.h4`
   margin: 0 0 10px;
-  color: #4d392b;
+  color: var(--km-text);
   font-size: 14px;
   font-weight: 900;
   letter-spacing: -0.01em;
@@ -380,7 +380,7 @@ const PaymentScheduleRow = styled.div`
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-items: start;
-  border-top: 1px solid rgba(140, 101, 70, 0.12);
+  border-top: 1px solid var(--km-border);
   padding-top: 8px;
 
   &:first-child {
@@ -391,7 +391,7 @@ const PaymentScheduleRow = styled.div`
 
 const PaymentScheduleLabel = styled.span`
   min-width: 0;
-  color: #5f5148;
+  color: var(--km-muted);
   font-size: 13px;
   font-weight: 750;
   line-height: 1.35;
@@ -399,7 +399,7 @@ const PaymentScheduleLabel = styled.span`
 `;
 
 const PaymentScheduleAmount = styled.span`
-  color: #65432d;
+  color: var(--km-accent);
   font-size: 13px;
   font-weight: 900;
   line-height: 1.35;
@@ -411,10 +411,10 @@ const PaymentScheduleTotalRow = styled.div`
   display: flex;
   justify-content: space-between;
   gap: 12px;
-  border-top: 1px solid rgba(140, 101, 70, 0.28);
+  border-top: 1px solid #D8D8CE;
   margin-top: 10px;
   padding-top: 8px;
-  color: #4d392b;
+  color: var(--km-text);
   font-size: 13px;
   font-weight: 900;
 `;
@@ -445,8 +445,8 @@ const PaymentEditorActions = styled.div`
 const Toggle = styled.button`
   width: 100%;
   border: 0;
-  background: #f1e4d6;
-  color: #553c2b;
+  background: var(--km-accent-light);
+  color: var(--km-text);
   border-radius: 16px;
   margin: 18px 0 0;
   padding: 12px 14px;
@@ -467,7 +467,7 @@ const IncludedItem = styled.div`
   display: grid;
   grid-template-columns: 22px 1fr;
   gap: 10px;
-  color: #4b4139;
+  color: var(--km-text);
   font-size: 14px;
   line-height: 1.45;
 
@@ -480,8 +480,8 @@ const CheckIcon = styled.span`
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: #dcc4a8;
-  color: #4d3320;
+  background: var(--km-accent-light);
+  color: var(--km-accent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -492,7 +492,7 @@ const CheckIcon = styled.span`
 const DetailButton = styled.button`
   border: 0;
   background: transparent;
-  color: #8a5c3f;
+  color: var(--km-accent);
   display: inline-flex;
   align-items: center;
   min-height: 44px;
@@ -505,14 +505,24 @@ const DetailButton = styled.button`
 const CTA = styled.button`
   width: 100%;
   border: 0;
-  border-radius: 18px;
-  background: #3f2f26;
-  color: #fff8ef;
+  border-radius: var(--km-radius);
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+  color: #fff;
   margin-top: 18px;
   padding: 14px 16px;
   font-size: 15px;
   font-weight: 900;
   cursor: pointer;
+  transition: box-shadow 0.18s ease, transform 0.18s ease, filter 0.18s ease;
+
+  &:hover {
+    filter: brightness(1.05);
+    box-shadow: 0 8px 22px rgba(232, 121, 26, 0.28);
+  }
+
+  &:active {
+    transform: scale(0.99);
+  }
 `;
 
 const AccordionList = styled.div`
@@ -522,16 +532,16 @@ const AccordionList = styled.div`
 
 const Accordion = styled.div`
   overflow: hidden;
-  border: 1px solid rgba(140, 101, 70, 0.16);
+  border: 1px solid var(--km-border);
   border-radius: 22px;
-  background: rgba(255, 250, 244, 0.78);
+  background: var(--km-card);
 `;
 
 const AccordionHeader = styled.button`
   width: 100%;
   border: 0;
   background: transparent;
-  color: #33291f;
+  color: var(--km-text);
   padding: ${({ $compact }) => ($compact ? '13px 16px' : '17px 18px')};
   display: flex;
   align-items: center;
@@ -544,16 +554,16 @@ const AccordionHeader = styled.button`
 `;
 
 const Count = styled.span`
-  color: #9a836f;
+  color: var(--km-muted);
   font-size: 12px;
   font-weight: 800;
 `;
 
 const ShowMoreButton = styled.button`
-  border: 1px solid rgba(140, 101, 70, 0.18);
+  border: 1px solid var(--km-border);
   border-radius: 14px;
-  background: rgba(255, 250, 244, 0.72);
-  color: #67462f;
+  background: var(--km-card);
+  color: var(--km-accent);
   min-height: 44px;
   padding: 10px 12px;
   font-size: 13px;
@@ -562,13 +572,13 @@ const ShowMoreButton = styled.button`
 `;
 
 const ExpenseRows = styled.div`
-  border-top: 1px solid rgba(140, 101, 70, 0.13);
+  border-top: 1px solid var(--km-border);
   padding: 2px 18px 10px;
 `;
 
 const ExpenseRow = styled.div`
   padding: ${({ $compact }) => ($compact ? '9px 0' : '13px 0')};
-  border-bottom: 1px solid rgba(140, 101, 70, 0.1);
+  border-bottom: 1px solid var(--km-border);
 
   &:last-child {
     border-bottom: 0;
@@ -589,7 +599,7 @@ const ExpenseName = styled.div`
 `;
 
 const ExpensePrice = styled.div`
-  color: #69462f;
+  color: var(--km-accent);
   font-size: 15px;
   font-weight: 900;
   white-space: nowrap;
@@ -597,7 +607,7 @@ const ExpensePrice = styled.div`
 
 const Muted = styled.p`
   margin: ${({ $compact }) => ($compact ? '3px 0 0' : '5px 0 0')};
-  color: #7e7369;
+  color: var(--km-muted);
   font-size: ${({ $compact }) => ($compact ? '12px' : '13px')};
   line-height: ${({ $compact }) => ($compact ? 1.35 : 1.45)};
 `;
@@ -659,7 +669,7 @@ const EditableField = styled.label`
   gap: 2px;
   min-width: 0;
   flex: 1 1 150px;
-  color: #7b6553;
+  color: var(--km-muted);
   font-size: 9px;
   font-weight: 900;
   letter-spacing: 0.05em;
@@ -686,7 +696,7 @@ const EditInput = styled.input`
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: #382d24;
+  color: var(--km-text);
   min-height: 20px;
   padding: 1px 2px;
   font-size: 12.5px;
@@ -695,13 +705,13 @@ const EditInput = styled.input`
   letter-spacing: normal;
 
   &:hover {
-    background: rgba(223, 205, 188, 0.28);
+    background: var(--km-accent-light);
   }
 
   &:focus {
     outline: none;
     background: rgba(255, 255, 255, 0.85);
-    box-shadow: inset 0 0 0 1px #dfcdbc;
+    box-shadow: inset 0 0 0 1px var(--km-border);
   }
 `;
 
@@ -711,7 +721,7 @@ const EditTextarea = styled.textarea`
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: #382d24;
+  color: var(--km-text);
   min-height: 20px;
   padding: 1px 2px;
   font-size: 12.5px;
@@ -721,13 +731,13 @@ const EditTextarea = styled.textarea`
   letter-spacing: normal;
 
   &:hover {
-    background: rgba(223, 205, 188, 0.28);
+    background: var(--km-accent-light);
   }
 
   &:focus {
     outline: none;
     background: rgba(255, 255, 255, 0.85);
-    box-shadow: inset 0 0 0 1px #dfcdbc;
+    box-shadow: inset 0 0 0 1px var(--km-border);
   }
 `;
 
@@ -737,7 +747,7 @@ const EditSelect = styled.select`
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: #382d24;
+  color: var(--km-text);
   min-height: 20px;
   padding: 1px 2px;
   font-size: 12.5px;
@@ -747,13 +757,13 @@ const EditSelect = styled.select`
   cursor: pointer;
 
   &:hover {
-    background: rgba(223, 205, 188, 0.28);
+    background: var(--km-accent-light);
   }
 
   &:focus {
     outline: none;
     background: rgba(255, 255, 255, 0.85);
-    box-shadow: inset 0 0 0 1px #dfcdbc;
+    box-shadow: inset 0 0 0 1px var(--km-border);
   }
 `;
 
@@ -777,7 +787,7 @@ const ScheduleDiffBadge = styled.span`
 
 const FormulaDebugNote = styled.div`
   flex: 1 1 100%;
-  color: #8a7563;
+  color: var(--km-muted);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: normal;
@@ -789,10 +799,10 @@ const FormulaDebugNote = styled.div`
 const SearchInput = styled.input`
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid #dfcdbc;
+  border: 1px solid var(--km-border);
   border-radius: 18px;
-  background: #fffaf4;
-  color: #382d24;
+  background: var(--km-card);
+  color: var(--km-text);
   padding: 13px 15px;
   font-size: 15px;
   margin-bottom: 14px;
@@ -809,9 +819,9 @@ const NotesGrid = styled.div`
 `;
 
 const NoteCard = styled.div`
-  border: 1px solid rgba(140, 101, 70, 0.14);
+  border: 1px solid var(--km-border);
   border-radius: 22px;
-  background: rgba(255, 250, 244, 0.78);
+  background: var(--km-card);
   padding: 18px 20px;
 `;
 
@@ -819,7 +829,7 @@ const NoteCardTitle = styled.h3`
   margin: 0 0 10px;
   font-size: 16px;
   letter-spacing: -0.02em;
-  color: #4d392b;
+  color: var(--km-text);
 `;
 
 const NoteList = styled.ul`
@@ -827,7 +837,7 @@ const NoteList = styled.ul`
   padding-left: 18px;
   display: grid;
   gap: 7px;
-  color: #66594f;
+  color: var(--km-muted);
   font-size: 14px;
   line-height: 1.55;
 `;
@@ -842,14 +852,14 @@ const NoteEditorRow = styled.div`
   grid-template-columns: minmax(0, 1fr) 32px;
   gap: 6px;
   align-items: start;
-  color: #8d4a36;
+  color: var(--km-danger);
 `;
 
 const StateCard = styled.div`
   padding: 28px;
   border-radius: 24px;
-  background: rgba(255, 250, 244, 0.82);
-  color: #6d6259;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--km-muted);
 `;
 
 const StickyContact = styled.div`
@@ -861,8 +871,8 @@ const StickyContact = styled.div`
   min-height: 64px;
   padding: 8px 14px calc(8px + env(safe-area-inset-bottom));
   box-sizing: border-box;
-  background: rgba(255, 250, 244, 0.82);
-  border-top: 1px solid rgba(140, 101, 70, 0.16);
+  background: rgba(255, 255, 255, 0.86);
+  border-top: 1px solid var(--km-border);
   backdrop-filter: blur(12px);
 `;
 

--- a/src/components/CheckboxGroup.jsx
+++ b/src/components/CheckboxGroup.jsx
@@ -9,7 +9,7 @@ const GroupLabel = styled.span`
   display: block;
   font-size: 10px;
   font-weight: 700;
-  color: var(--matching-chip-label, #aaa);
+  color: var(--matching-chip-label, var(--km-muted));
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 7px;
@@ -26,9 +26,10 @@ const Chip = styled.button`
   min-height: 36px;
   padding: 7px 12px;
   border-radius: 20px;
-  border: 1.5px solid ${({ $active }) => ($active ? '#FF8C00' : 'var(--matching-chip-border, #e0e0e0)')};
-  background: ${({ $active }) => ($active ? 'rgba(255, 243, 224, 0.92)' : 'var(--matching-chip-bg, #fafafa)')};
-  color: ${({ $active }) => ($active ? '#CC5500' : 'var(--matching-chip-text, #666)')};
+  border: 1.5px solid ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--matching-chip-border, var(--km-border))')};
+  background: ${({ $active }) => ($active ? 'var(--km-accent-light)' : 'var(--matching-chip-bg, var(--km-card))')};
+  color: ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--matching-chip-text, var(--km-muted))')};
+  font-family: var(--km-font);
   font-size: 12px;
   font-weight: ${({ $active }) => ($active ? '600' : '400')};
   cursor: pointer;
@@ -39,13 +40,13 @@ const Chip = styled.button`
   justify-content: center;
 
   &:hover {
-    border-color: #FF8C00;
-    color: #CC5500;
+    border-color: var(--km-accent);
+    color: var(--km-accent);
     transform: translateY(-1px);
   }
 
   &:focus-visible {
-    outline: 3px solid rgba(247, 147, 30, 0.38);
+    outline: 3px solid var(--km-accent-ring);
     outline-offset: 2px;
   }
 `;

--- a/src/components/InfoModal.jsx
+++ b/src/components/InfoModal.jsx
@@ -7,59 +7,65 @@ const ModalOverlay = styled.div`
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(20, 16, 12, 0.55);
+  backdrop-filter: blur(2px);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1000;
+  padding: 16px;
+  box-sizing: border-box;
 `;
 
 const OptionsList = styled.ul`
   list-style: none;
   padding: 0;
   margin: 0;
-  text-align: left; 
+  text-align: left;
 `;
 
 const OptionItem = styled.li`
   cursor: pointer;
-  padding: 10px;
-  color: black;
-  font-size: 16px;
+  padding: 12px 10px;
+  color: var(--km-text);
+  font-size: 15px;
   line-height: 1.5;
-  transition: background-color 0.3s ease;
-  border-bottom: 1px solid #ddd; /* Лінія між елементами */
+  border-radius: 10px;
+  transition: background-color 0.18s ease, color 0.18s ease;
 
-  &:last-child {
-    /* border-bottom: none; Прибирає лінію у останнього елемента */
+  & + & {
+    border-top: 1px solid var(--km-border);
   }
 
   &:hover {
-    background-color: #f5f5f5; /* Легкий фон при наведенні */
+    background-color: var(--km-accent-light);
+    color: var(--km-accent);
   }
 `;
 
 const CustomInput = styled.input`
-  padding: 10px;
+  padding: 12px;
   padding-right: 40px;
-  /* padding-bottom: 0; */
-  /* margin-top: 10px; */
   width: 100%;
   box-sizing: border-box;
-  border: none;
+  border: 1.5px solid var(--km-border);
+  border-radius: 10px;
+  background: var(--km-bg);
   outline: none;
-  font-size: 16px;
-  color: black; /* Темно оранжевий колір */
+  font-family: var(--km-font);
+  font-size: 15px;
+  color: var(--km-text);
   line-height: 1.5;
+  margin-top: 10px;
 
   &::placeholder {
-    color: darkorange; /* Темно оранжевий колір плейсхолдера */
-    font-size: 16px;
-    font-style: italic; /* Курсив для плейсхолдера */
-    font-weight: bold; /* Жирний текст для плейсхолдера */
+    color: var(--km-muted);
+    font-size: 14px;
   }
-  &:hover {
-    background-color: #f5f5f5; /* Легкий фон при наведенні */
+
+  &:focus {
+    border-color: var(--km-accent);
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
   }
 `;
 
@@ -75,25 +81,24 @@ const InlineDeleteButton = styled.button`
   align-items: center;
   width: 32px;
   height: 32px;
-  margin: -7px;
   padding: 0;
-  top: 50%;
+  top: calc(50% + 5px);
   transform: translateY(-50%);
   background: none;
   border: none;
   border-radius: 50%;
   cursor: pointer;
-  color: gray;
+  color: var(--km-muted);
   font-size: 18px;
   touch-action: manipulation;
 
   &:hover {
-    color: black;
-    background-color: rgba(0, 0, 0, 0.04);
+    color: var(--km-text);
+    background-color: var(--km-accent-light);
   }
 
   &:focus-visible {
-    outline: 2px solid #f57c00;
+    outline: 2px solid var(--km-accent);
     outline-offset: 1px;
   }
 `;
@@ -101,24 +106,26 @@ const InlineDeleteButton = styled.button`
 const ActionRow = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: 10px;
+  gap: 10px;
+  margin-top: 14px;
 `;
 
 const OkButton = styled.button`
-  width: 35px;
-  height: 35px;
-  padding: 3px;
+  min-height: 40px;
+  padding: 8px 24px;
   border: none;
-  background-color: #ff7043;
-  color: white;
-  border-radius: 50px;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+  color: #fff;
+  border-radius: 99px;
   cursor: pointer;
-  font-size: 12px;
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  font-family: var(--km-font);
+  font-size: 14px;
+  font-weight: 700;
+  transition: box-shadow 0.18s ease, transform 0.18s ease, filter 0.18s ease;
 
   &:hover {
-    background-color: #ff5722;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    filter: brightness(1.05);
+    box-shadow: 0 8px 22px rgba(232, 121, 26, 0.28);
   }
 
   &:active {
@@ -126,20 +133,24 @@ const OkButton = styled.button`
   }
 
   &:disabled {
-    opacity: 0.6;
+    opacity: 0.55;
     cursor: not-allowed;
     box-shadow: none;
   }
 `;
 
 const ModalContent = styled.div`
-  background-color: white;
+  background-color: var(--km-card);
+  color: var(--km-text);
+  font-family: var(--km-font);
   padding: 20px;
-  border-radius: 5px;
-  width: 300px;
+  border-radius: var(--km-radius-lg);
+  border: 1px solid var(--km-border);
+  box-shadow: var(--km-shadow-pop);
+  width: min(92vw, 320px);
   text-align: center;
-  color: black;
   position: relative;
+  box-sizing: border-box;
 `;
 
 const LargeModalContent = styled(ModalContent)`
@@ -152,12 +163,64 @@ const MenuModalContent = styled(ModalContent)`
   width: min(92vw, 380px);
   padding: 14px;
   border-radius: 22px;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.22);
-  border: 1px solid rgba(232, 232, 226, 0.9);
+  max-height: 90vh;
+  overflow: auto;
 `;
 
 const OrangeStrong = styled.strong`
-  color: orange;
+  color: var(--km-accent);
+`;
+
+// Спільні елементи для модалок підтвердження (використовуються і в інших екранах).
+export const ModalTitle = styled.h3`
+  margin: 0 0 6px;
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--km-text);
+`;
+
+export const ModalText = styled.p`
+  margin: 0 0 4px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--km-muted);
+`;
+
+export const ModalActionRow = styled(ActionRow)``;
+
+export const ModalPrimaryButton = styled(OkButton)``;
+
+export const ModalDangerButton = styled(OkButton)`
+  background: var(--km-danger);
+
+  &:hover {
+    box-shadow: 0 8px 22px rgba(180, 35, 24, 0.25);
+  }
+`;
+
+export const ModalGhostButton = styled.button`
+  min-height: 40px;
+  padding: 8px 24px;
+  border: 1.5px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
+  border-radius: 99px;
+  cursor: pointer;
+  font-family: var(--km-font);
+  font-size: 14px;
+  font-weight: 600;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
+
+  &:hover {
+    background: var(--km-accent-light);
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
 `;
 
 export const InfoModal = ({
@@ -177,21 +240,23 @@ export const InfoModal = ({
 
   const delProfile = (
     <>
-      <p>Щоб видалити анкету, відправте запит на пошту</p>
-      <a href="mailto:KnowMeEggDonor@gmail.com?subject=Видаліть мою анкету" style={{ color: 'black', textDecoration: 'none' }}>
-        <strong>KnowMeEggDonor@gmail.com</strong>
+      <ModalTitle>Видалення анкети</ModalTitle>
+      <ModalText>Щоб видалити анкету, відправте запит на пошту</ModalText>
+      <a href="mailto:KnowMeEggDonor@gmail.com?subject=Видаліть мою анкету" style={{ color: 'inherit', textDecoration: 'none' }}>
+        <OrangeStrong>KnowMeEggDonor@gmail.com</OrangeStrong>
       </a>
-      <p>з темою листа "Видаліть мою анкету".</p>
+      <ModalText style={{ marginTop: 4 }}>з темою листа «Видаліть мою анкету».</ModalText>
     </>
   );
 
   const viewProfile = (
     <>
-      <p>Щоб переглянути анкету, встановіть застосунок</p>
-      <a href="https://play.google.com/store/apps/details?id=com.xanderkiev.MyApp" style={{ color: 'black', textDecoration: 'none' }}>
+      <ModalTitle>Перегляд анкети</ModalTitle>
+      <ModalText>Щоб переглянути анкету, встановіть застосунок</ModalText>
+      <a href="https://play.google.com/store/apps/details?id=com.xanderkiev.MyApp" style={{ color: 'inherit', textDecoration: 'none' }}>
         <OrangeStrong>KnowMe: Egg donor</OrangeStrong>
       </a>
-      <p>в Google Play</p>
+      <ModalText style={{ marginTop: 4 }}>в Google Play</ModalText>
     </>
   );
 

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -37,10 +37,6 @@ import {
   SkeletonInfo,
   SkeletonLine,
   SkeletonPhoto,
-  ThemeToggleButton,
-  ThemeToggleKnob,
-  ThemeToggleScene,
-  ThemeToggleTrackIcon,
   TopActionGroup,
   TopActions,
   ModernActionRail,
@@ -124,6 +120,7 @@ import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getContactEntries, CONTACT_LINK_BUILDERS } from './contactMethods';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
+import { useAppSettings } from 'hooks/useAppSettings';
 import { handleEmptyFetch } from './loadMoreUtils';
 import { collectMatchingIndexedLoadMorePage } from 'utils/matchingIndexedLoadMore';
 import {
@@ -1261,16 +1258,6 @@ const MATCHING_MAX_EMPTY_AUTO_LOAD_MORE_ATTEMPTS = 2;
 const SCROLL_Y_KEY = 'matchingScrollY';
 const SEARCH_KEY = 'matchingSearchQuery';
 const COLLECTION_SOURCE_KEY = 'matchingCollectionSource';
-const MATCHING_THEME_KEY = 'matchingThemeMode';
-
-const getStoredMatchingTheme = () => {
-  try {
-    const storedTheme = localStorage.getItem(MATCHING_THEME_KEY) || sessionStorage.getItem(MATCHING_THEME_KEY);
-    return storedTheme === 'light' ? 'light' : 'dark';
-  } catch (error) {
-    return 'dark';
-  }
-};
 
 const fetchUsersByLastLogin2FromCollection = async (collection = 'users', limit = 9, lastDate) => {
   const usersRef = refDb(database, collection);
@@ -1375,7 +1362,8 @@ const Matching = () => {
   const [matchingDebugLogMode, setMatchingDebugLogMode] = useState(getStoredMatchingDebugLogMode);
   const [debugShowAllIndexedCards, setDebugShowAllIndexedCards] = useState(getStoredDebugShowAllIndexedCards);
   const [matchingDataSourceMode] = useState(getStoredMatchingDataSourceMode);
-  const [themeMode, setThemeMode] = useState(getStoredMatchingTheme);
+  // Тема тепер глобальна: перемикається в меню трьох крапок (ProfileDotsMenu).
+  const { themeMode } = useAppSettings();
   const viewModeRef = useRef(viewMode);
   const [loading, setLoading] = useState(true);
   const [filters, setFilters] = useState({});
@@ -1542,18 +1530,6 @@ const Matching = () => {
   useEffect(() => {
     viewModeRef.current = viewMode;
   }, [viewMode]);
-  useEffect(() => {
-    try {
-      localStorage.setItem(MATCHING_THEME_KEY, themeMode);
-      sessionStorage.setItem(MATCHING_THEME_KEY, themeMode);
-    } catch (error) {
-      // Theme persistence is non-critical; keep the in-memory theme if storage is unavailable.
-    }
-    document.documentElement.dataset.matchingTheme = themeMode;
-  }, [themeMode]);
-  const handleThemeToggle = React.useCallback(() => {
-    setThemeMode(current => (current === 'light' ? 'dark' : 'light'));
-  }, []);
   useEffect(() => {
     emptyAutoLoadMoreAttemptsRef.current = 0;
     autoLoadMoreSignatureRef.current = '';
@@ -5776,33 +5752,6 @@ const Matching = () => {
                 >
                   <FaHeart />
                 </ActionButton>
-              </TopActionGroup>
-              <TopActionGroup aria-label="Налаштування matching">
-                <ThemeToggleButton
-                  type="button"
-                  $themeMode={themeMode}
-                  aria-pressed={themeMode === 'light'}
-                  aria-label={themeMode === 'light' ? 'Перемкнути Matching на темну тему' : 'Перемкнути Matching на світлу тему'}
-                  title={themeMode === 'light' ? 'Темна тема' : 'Світла тема'}
-                  onClick={handleThemeToggle}
-                >
-                  <ThemeToggleTrackIcon $side="left" $active={themeMode === 'dark'} aria-hidden="true">
-                    <svg viewBox="0 0 24 24" role="img">
-                      <path fill="currentColor" d="M15.4 2.8a7.4 7.4 0 1 0 5.8 10.8 6.2 6.2 0 1 1-5.8-10.8Z" />
-                      <circle cx="6" cy="6" r="1.4" fill="#ffd45c" />
-                      <circle cx="19" cy="5.5" r="1.1" fill="#ffd45c" />
-                    </svg>
-                  </ThemeToggleTrackIcon>
-                  <ThemeToggleTrackIcon $side="right" $active={themeMode === 'light'} aria-hidden="true">
-                    <svg viewBox="0 0 24 24" role="img">
-                      <circle cx="9" cy="9" r="4" fill="#ffd45c" />
-                      <path fill="currentColor" d="M8 17.5h8.8a3.8 3.8 0 0 0 .4-7.6 5.3 5.3 0 0 0-10.1 1.7A3 3 0 0 0 8 17.5Z" />
-                    </svg>
-                  </ThemeToggleTrackIcon>
-                  <ThemeToggleKnob $themeMode={themeMode} aria-hidden="true">
-                    <ThemeToggleScene $themeMode={themeMode} />
-                  </ThemeToggleKnob>
-                </ThemeToggleButton>
               </TopActionGroup>
               <TopActionGroup aria-label="Адміністративні дії matching">
                 {showBackendTrafficToggle && (

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -5,43 +5,44 @@ const STACK_CARD_RADIUS = '18px';
 
 const matchingThemeVars = css`
   --matching-page-bg: ${({ $themeMode }) => ($themeMode === 'light'
-    ? '#F6F7F9'
-    : 'radial-gradient(circle at 50% 0%, rgba(247, 147, 30, 0.11), transparent 32%), linear-gradient(180deg, #17120e 0%, #0c0a09 100%)')};
+    ? '#FAFAF8'
+    : 'radial-gradient(circle at 50% 0%, rgba(232, 121, 26, 0.11), transparent 32%), linear-gradient(180deg, #17120e 0%, #0c0a09 100%)')};
   --matching-shell-bg: ${({ $themeMode }) => ($themeMode === 'light'
-    ? '#F6F7F9'
-    : 'radial-gradient(circle at 18% 0%, rgba(247, 147, 30, 0.16), transparent 28%), linear-gradient(180deg, #17120e 0%, #0c0a09 100%)')};
+    ? '#FAFAF8'
+    : 'radial-gradient(circle at 18% 0%, rgba(232, 121, 26, 0.16), transparent 28%), linear-gradient(180deg, #17120e 0%, #0c0a09 100%)')};
   --matching-card-bg: ${({ $themeMode }) => ($themeMode === 'light' ? '#FFFFFF' : '#17120e')};
-  --matching-card-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8E2D8' : 'rgba(255, 214, 148, 0.14)')};
+  --matching-card-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8E8E2' : 'rgba(255, 214, 148, 0.14)')};
   --matching-card-shadow: ${({ $themeMode }) => ($themeMode === 'light'
     ? '0 16px 34px rgba(22, 22, 22, 0.08)'
-    : '0 18px 40px rgba(0, 0, 0, 0.3), 0 0 22px rgba(247, 147, 30, 0.05)')};
-  --matching-header-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#161616' : '#fff8ec')};
-  --matching-muted-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#6B7280' : 'rgba(255, 248, 236, 0.88)')};
+    : '0 18px 40px rgba(0, 0, 0, 0.3), 0 0 22px rgba(232, 121, 26, 0.05)')};
+  --matching-header-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#1A1A1A' : '#fff8ec')};
+  --matching-muted-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#7A7A72' : 'rgba(255, 248, 236, 0.88)')};
   --matching-panel-bg: ${({ $themeMode }) => ($themeMode === 'light' ? '#FFFFFF' : '#15120f')};
-  --matching-panel-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#161616' : '#fff8ec')};
+  --matching-panel-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#1A1A1A' : '#fff8ec')};
   --matching-section-bg: ${({ $themeMode }) => ($themeMode === 'light' ? '#FFFFFF' : 'rgba(26, 23, 20, 0.82)')};
-  --matching-section-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8E2D8' : 'rgba(255, 214, 148, 0.11)')};
+  --matching-section-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8E8E2' : 'rgba(255, 214, 148, 0.11)')};
   --matching-section-shadow: ${({ $themeMode }) => ($themeMode === 'light' ? '0 10px 24px rgba(22, 22, 22, 0.06)' : '0 12px 28px rgba(0, 0, 0, 0.18)')};
-  --matching-section-title: ${({ $themeMode }) => ($themeMode === 'light' ? '#161616' : '#ffd18a')};
+  --matching-section-title: ${({ $themeMode }) => ($themeMode === 'light' ? '#1A1A1A' : '#ffd18a')};
   --matching-chip-bg: ${({ $themeMode }) => ($themeMode === 'light' ? '#FFFFFF' : 'rgba(255, 255, 255, 0.045)')};
-  --matching-chip-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E5E0D8' : 'rgba(255, 214, 148, 0.12)')};
-  --matching-chip-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#161616' : '#fff8ec')};
-  --matching-chip-label: ${({ $themeMode }) => ($themeMode === 'light' ? '#6B7280' : 'rgba(247, 185, 95, 0.76)')};
-  --matching-accent: ${({ $themeMode }) => ($themeMode === 'light' ? '#FF9500' : '#f7931e')};
+  --matching-chip-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8E8E2' : 'rgba(255, 214, 148, 0.12)')};
+  --matching-chip-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#1A1A1A' : '#fff8ec')};
+  --matching-chip-label: ${({ $themeMode }) => ($themeMode === 'light' ? '#7A7A72' : 'rgba(247, 185, 95, 0.76)')};
+  --matching-accent: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8791A' : '#F08A2C')};
   --matching-contact-text: ${({ $themeMode }) => ($themeMode === 'light' ? '#2A2A2A' : '#ffd899')};
-  --matching-contact-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E5E0D8' : 'rgba(255, 214, 148, 0.12)')};
+  --matching-contact-border: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8E8E2' : 'rgba(255, 214, 148, 0.12)')};
   --matching-hero-fallback: ${({ $themeMode }) => ($themeMode === 'light'
-    ? 'linear-gradient(145deg, #e8edf4 0%, #d7dee8 100%)'
-    : 'radial-gradient(circle at 26% 16%, rgba(247, 147, 30, 0.54), transparent 30%), radial-gradient(circle at 78% 18%, rgba(255, 218, 145, 0.16), transparent 24%), linear-gradient(145deg, #3a281b 0%, #15110f 56%, #070605 100%)')};
+    ? 'linear-gradient(145deg, #f4ede4 0%, #e9ded1 100%)'
+    : 'radial-gradient(circle at 26% 16%, rgba(232, 121, 26, 0.54), transparent 30%), radial-gradient(circle at 78% 18%, rgba(255, 218, 145, 0.16), transparent 24%), linear-gradient(145deg, #3a281b 0%, #15110f 56%, #070605 100%)')};
   --matching-hero-bottom: ${({ $themeMode }) => ($themeMode === 'light'
     ? 'linear-gradient(180deg, rgba(22, 22, 22, 0) 0%, rgba(22, 22, 22, 0.22) 100%)'
     : 'linear-gradient(180deg, transparent 0%, rgba(9, 7, 5, 0.36) 46%, rgba(9, 7, 5, 0.66) 100%)')};
   --matching-rail-bg: transparent;
   --matching-rail-border: transparent;
   --matching-action-bg: ${({ $themeMode }) => ($themeMode === 'light' ? '#FFFFFF' : '#211b16')};
-  --matching-action-color: ${({ $themeMode }) => ($themeMode === 'light' ? '#FF9500' : '#fff8ec')};
+  --matching-action-color: ${({ $themeMode }) => ($themeMode === 'light' ? '#E8791A' : '#fff8ec')};
   --matching-action-shadow: ${({ $themeMode }) => ($themeMode === 'light' ? '0 8px 18px rgba(22, 22, 22, 0.10)' : '0 8px 18px rgba(0, 0, 0, 0.22)')};
   color-scheme: ${({ $themeMode }) => ($themeMode === 'light' ? 'light' : 'dark')};
+  font-family: var(--km-font);
   transition: background 280ms cubic-bezier(0.4, 0, 0.2, 1), color 280ms cubic-bezier(0.4, 0, 0.2, 1);
 `;
 
@@ -55,8 +56,8 @@ export const ROLE_COLORS = {
 
 export const getRoleColors = role => ROLE_COLORS[role] || {
   accent: color.accent5,
-  light: 'rgba(247,147,30,0.08)',
-  border: 'rgba(247,147,30,0.25)',
+  light: 'rgba(232,121,26,0.08)',
+  border: 'rgba(232,121,26,0.25)',
   text: color.accent3,
   tag: 'rgba(255,243,224,0.9)',
 };
@@ -363,9 +364,9 @@ export const ActionButton = styled.button`
   min-width: ${({ $wide }) => ($wide ? '44px' : '35px')};
   height: 35px;
   padding: ${({ $wide }) => ($wide ? '3px 10px' : '3px')};
-  border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'transparent')};
-  background: ${({ $active }) => ($active ? 'rgba(255, 149, 0, 0.14)' : 'var(--matching-action-bg, ' + color.accent5 + ')')};
-  color: ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-action-color, white)')};
+  border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #E8791A)' : 'transparent')};
+  background: ${({ $active }) => ($active ? 'rgba(232, 121, 26, 0.14)' : 'var(--matching-action-bg, ' + color.accent5 + ')')};
+  color: ${({ $active }) => ($active ? 'var(--matching-accent, #E8791A)' : 'var(--matching-action-color, white)')};
   box-shadow: var(--matching-action-shadow, none);
   transition: transform 240ms cubic-bezier(0.4, 0, 0.2, 1), background 240ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 240ms cubic-bezier(0.4, 0, 0.2, 1), border-color 240ms cubic-bezier(0.4, 0, 0.2, 1), color 240ms cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: 50px;
@@ -380,7 +381,7 @@ export const ActionButton = styled.button`
 
   &:hover:not(:disabled) {
     transform: translateY(-1px) scale(1.03);
-    border-color: var(--matching-accent, #FF9500);
+    border-color: var(--matching-accent, #E8791A);
   }
 
   &:active:not(:disabled) {
@@ -388,7 +389,7 @@ export const ActionButton = styled.button`
   }
 
   &:focus-visible {
-    outline: 3px solid rgba(247, 147, 30, 0.42);
+    outline: 3px solid rgba(232, 121, 26, 0.42);
     outline-offset: 2px;
   }
 
@@ -409,7 +410,7 @@ export const ActionBadge = styled.span`
   padding: 0 4px;
   border: 2px solid var(--matching-panel-bg, #fff);
   border-radius: 999px;
-  background: var(--matching-accent, #FF9500);
+  background: var(--matching-accent, #E8791A);
   color: #fff;
   display: inline-flex;
   align-items: center;
@@ -418,150 +419,6 @@ export const ActionBadge = styled.span`
   font-weight: 800;
   line-height: 1;
   box-sizing: border-box;
-`;
-
-export const ThemeToggleButton = styled.button`
-  position: relative;
-  flex: 0 0 auto;
-  width: 64px;
-  height: 34px;
-  padding: 3px;
-  border: 0;
-  border-radius: 9999px;
-  background: ${({ $themeMode }) => ($themeMode === 'light' ? '#f5f5f7' : '#24242a')};
-  box-shadow:
-    inset 0 2px 6px rgba(0, 0, 0, 0.06),
-    ${({ $themeMode }) => ($themeMode === 'light'
-      ? '0 6px 14px rgba(83, 61, 35, 0.12)'
-      : '0 6px 16px rgba(0, 0, 0, 0.34)')};
-  cursor: pointer;
-  overflow: hidden;
-  -webkit-tap-highlight-color: transparent;
-  transition:
-    transform 260ms cubic-bezier(0.4, 0, 0.2, 1),
-    background 260ms cubic-bezier(0.4, 0, 0.2, 1),
-    box-shadow 260ms cubic-bezier(0.4, 0, 0.2, 1),
-    opacity 180ms ease;
-
-  &:hover {
-    transform: scale(1.03);
-    box-shadow:
-      inset 0 2px 7px rgba(0, 0, 0, 0.07),
-      ${({ $themeMode }) => ($themeMode === 'light'
-        ? '0 8px 18px rgba(83, 61, 35, 0.16)'
-        : '0 8px 20px rgba(0, 0, 0, 0.42)')};
-  }
-
-  &:active {
-    transform: scale(0.97);
-    opacity: 0.92;
-  }
-
-  &:focus-visible {
-    outline: 3px solid rgba(247, 147, 30, 0.48);
-    outline-offset: 3px;
-  }
-`;
-
-export const ThemeToggleTrackIcon = styled.span`
-  position: absolute;
-  top: 50%;
-  width: 17px;
-  height: 17px;
-  transform: translateY(-50%);
-  color: ${({ $active }) => ($active ? 'rgba(247, 147, 30, 0.78)' : 'rgba(120, 112, 104, 0.42)')};
-  opacity: ${({ $active }) => ($active ? 0.95 : 0.5)};
-  transition: opacity 260ms cubic-bezier(0.4, 0, 0.2, 1), color 260ms cubic-bezier(0.4, 0, 0.2, 1);
-
-  ${({ $side }) => ($side === 'left' ? 'left: 9px;' : 'right: 9px;')}
-
-  svg {
-    width: 100%;
-    height: 100%;
-    display: block;
-  }
-`;
-
-export const ThemeToggleKnob = styled.span`
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 26px;
-  height: 26px;
-  border-radius: 9999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  transform: translateX(${({ $themeMode }) => ($themeMode === 'light' ? '30px' : '0')});
-  background: ${({ $themeMode }) => ($themeMode === 'light'
-    ? 'linear-gradient(145deg, #dff2ff 0%, #9ed7ff 100%)'
-    : 'linear-gradient(145deg, #162950 0%, #071327 100%)')};
-  box-shadow:
-    0 5px 12px rgba(0, 0, 0, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.42);
-  transition:
-    transform 280ms cubic-bezier(0.4, 0, 0.2, 1),
-    background 280ms cubic-bezier(0.4, 0, 0.2, 1),
-    box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1);
-`;
-
-export const ThemeToggleScene = styled.span`
-  position: relative;
-  width: 100%;
-  height: 100%;
-  display: block;
-
-  &::before {
-    content: '';
-    position: absolute;
-    border-radius: 999px;
-    transition: all 280ms cubic-bezier(0.4, 0, 0.2, 1);
-    ${({ $themeMode }) => ($themeMode === 'light'
-      ? `
-        width: 13px;
-        height: 13px;
-        left: 6px;
-        top: 5px;
-        z-index: 2;
-        background: #ffd45c;
-        box-shadow: 0 0 0 3px rgba(255, 212, 92, 0.24);
-      `
-      : `
-        width: 15px;
-        height: 15px;
-        left: 8px;
-        top: 7px;
-        background: #fffaf0;
-        box-shadow: inset -5px -1px 0 #cbd7ef;
-      `)}
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    transition: all 280ms cubic-bezier(0.4, 0, 0.2, 1);
-    ${({ $themeMode }) => ($themeMode === 'light'
-      ? `
-        width: 14px;
-        height: 7px;
-        right: 4px;
-        bottom: 5px;
-        z-index: 1;
-        border-radius: 999px;
-        background: rgba(255, 255, 255, 0.94);
-        box-shadow: -5px 0 0 -2px rgba(255, 255, 255, 0.92);
-      `
-      : `
-        width: 3px;
-        height: 3px;
-        right: 8px;
-        top: 8px;
-        border-radius: 50%;
-        background: #ffd45c;
-        box-shadow: -8px 7px 0 #ffd45c, 2px 13px 0 rgba(255, 212, 92, 0.82);
-      `)}
-  }
 `;
 
 export const BackendTrafficToggleButton = styled(ActionButton)`
@@ -753,7 +610,7 @@ export const FilterDrawerClose = styled.button`
   border: 1px solid var(--matching-section-border, #E8E2D8);
   border-radius: 999px;
   background: var(--matching-action-bg, #fff);
-  color: var(--matching-action-color, #FF9500);
+  color: var(--matching-action-color, #E8791A);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -762,12 +619,12 @@ export const FilterDrawerClose = styled.button`
 
   &:hover,
   &:focus-visible {
-    border-color: var(--matching-accent, #FF9500);
+    border-color: var(--matching-accent, #E8791A);
     transform: translateY(-1px);
   }
 
   &:focus-visible {
-    outline: 3px solid rgba(247, 147, 30, 0.38);
+    outline: 3px solid rgba(232, 121, 26, 0.38);
     outline-offset: 2px;
   }
 `;
@@ -785,7 +642,7 @@ export const MatchingSearchStatusMessage = styled.p`
   margin: 6px 0 0;
   padding: 8px 10px;
   border-radius: 10px;
-  background: rgba(247, 147, 30, 0.1);
+  background: rgba(232, 121, 26, 0.1);
   color: var(--matching-text, #2d2d2d);
   font-size: 13px;
   font-weight: 700;
@@ -857,10 +714,10 @@ export const CollectionSourceLabel = styled.label`
   justify-content: center;
   min-height: 38px;
   padding: 8px 10px;
-  border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-chip-border, #E5E0D8)')};
+  border: 1px solid ${({ $active }) => ($active ? 'var(--matching-accent, #E8791A)' : 'var(--matching-chip-border, #E5E0D8)')};
   border-radius: 12px;
-  background: ${({ $active }) => ($active ? 'rgba(255, 149, 0, 0.14)' : 'var(--matching-chip-bg, #fff)')};
-  color: ${({ $active }) => ($active ? 'var(--matching-accent, #FF9500)' : 'var(--matching-chip-text, #2c2d38)')};
+  background: ${({ $active }) => ($active ? 'rgba(232, 121, 26, 0.14)' : 'var(--matching-chip-bg, #fff)')};
+  color: ${({ $active }) => ($active ? 'var(--matching-accent, #E8791A)' : 'var(--matching-chip-text, #2c2d38)')};
   font-size: 12px;
   font-weight: 700;
   text-align: center;
@@ -879,11 +736,11 @@ export const CollectionSourceLabel = styled.label`
   }
 
   &:hover {
-    border-color: var(--matching-accent, #FF9500);
+    border-color: var(--matching-accent, #E8791A);
   }
 
   &:has(input:focus-visible) {
-    outline: 3px solid rgba(247, 147, 30, 0.38);
+    outline: 3px solid rgba(232, 121, 26, 0.38);
     outline-offset: 2px;
   }
 `;
@@ -992,7 +849,7 @@ export const Table = styled.div`
 export const MoreInfo = styled.div`
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(0, 0, 0, 0.06);
-  border-left: 4px solid ${props => (props.$isAdmin ? '#ff6b6b' : '#f7931e')};
+  border-left: 4px solid ${props => (props.$isAdmin ? '#ff6b6b' : '#E8791A')};
   border-radius: 12px;
   padding: 10px 12px;
   margin-bottom: 10px;
@@ -1023,8 +880,8 @@ export const Icons = styled.div`
     width: 30px !important;
     height: 30px !important;
     border-radius: 8px;
-    background: rgba(247, 147, 30, 0.1);
-    border: 1px solid rgba(247, 147, 30, 0.22) !important;
+    background: rgba(232, 121, 26, 0.1);
+    border: 1px solid rgba(232, 121, 26, 0.22) !important;
     transition: all 0.15s ease;
   }
 
@@ -1228,7 +1085,7 @@ export const ModernHero = styled.div`
   }
 
   &:focus-visible {
-    outline: 3px solid rgba(255, 149, 0, 0.75);
+    outline: 3px solid rgba(232, 121, 26, 0.75);
     outline-offset: -5px;
   }
 `;
@@ -1257,7 +1114,7 @@ export const ModernHeroFallbackMark = styled.div`
   font-size: 38px;
   font-weight: 900;
   letter-spacing: 1px;
-  background: linear-gradient(145deg, rgba(255,255,255,0.16), rgba(255,149,0,0.16));
+  background: linear-gradient(145deg, rgba(255,255,255,0.16), rgba(232,121,26,0.16));
   border: 1px solid rgba(255, 255, 255, 0.28);
   box-shadow: 0 24px 70px rgba(0, 0, 0, 0.18);
   backdrop-filter: blur(14px);
@@ -1288,7 +1145,7 @@ export const ModernRoleBadge = styled.span`
   border-radius: 999px;
   color: #FFFFFF;
   background: var(--matching-accent);
-  box-shadow: 0 8px 18px rgba(255, 149, 0, 0.18);
+  box-shadow: 0 8px 18px rgba(232, 121, 26, 0.18);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.7px;
@@ -1609,7 +1466,7 @@ export const ModernDesktopNavButton = styled.button`
   }
 
   &:focus-visible {
-    outline: 3px solid rgba(247, 147, 30, 0.42);
+    outline: 3px solid rgba(232, 121, 26, 0.42);
     outline-offset: -4px;
   }
 

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -26,19 +26,21 @@ import { authNotifications } from './authNotifications';
 import { persistUserWithFallback } from './authProfilePersistence';
 import toast from 'react-hot-toast';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
+import { KnowMeBrand } from './styles/knowme';
 
 const Page = styled.div`
-  --accent: #E8791A;
-  --accent-light: #FFF0E0;
-  --accent-mid: #F5A24B;
-  --bg: #FAFAF8;
-  --card: #FFFFFF;
-  --text: #1A1A1A;
-  --muted: #7A7A72;
-  --border: #E8E8E2;
-  --radius: 14px;
-  --shadow: 0 2px 16px rgba(0, 0, 0, 0.06);
-  font-family: 'DM Sans', sans-serif;
+  /* Локальні псевдоніми з глобальних KnowMe-токенів: сторінка автоматично підтримує світлу/темну тему. */
+  --accent: var(--km-accent);
+  --accent-light: var(--km-accent-light);
+  --accent-mid: var(--km-accent-mid);
+  --bg: var(--km-bg);
+  --card: var(--km-card);
+  --text: var(--km-text);
+  --muted: var(--km-muted);
+  --border: var(--km-border);
+  --radius: var(--km-radius);
+  --shadow: var(--km-shadow);
+  font-family: var(--km-font);
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
@@ -590,6 +592,7 @@ export const MyProfile = () => {
       access={access}
       isEmailVerified={isEmailVerified}
       showVerifyEmail
+      isSessionActive={isProfileAccessConfirmed}
       onExit={handleExit}
       onSelect={() => setShowInfoModal(false)}
     />
@@ -1055,14 +1058,12 @@ export const MyProfile = () => {
   return <Page style={{ '--sticky-header-offset': `${stickyHeaderOffset}px` }}>
     <StickyHeader ref={stickyHeaderRef}>
       <Topbar>
-        <div style={{ fontFamily: 'Playfair Display, serif', fontSize: 18 }}>Know<span style={{ color: '#E8791A', fontStyle: 'italic' }}>Me</span></div>
+        <KnowMeBrand />
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <StatusBadge type="button" $clickable={!isProfileAccessConfirmed} onClick={handleAuthBadgeClick}>
             ● {isProfileAccessConfirmed ? 'Прихована' : 'Логін не відбувся'}
           </StatusBadge>
-          {isProfileAccessConfirmed && (
-            <DotsButton type='button' aria-label='Відкрити меню профілю' onClick={() => setShowInfoModal('dotsMenu')}>⋮</DotsButton>
-          )}
+          <DotsButton type='button' aria-label='Відкрити меню профілю' onClick={() => setShowInfoModal('dotsMenu')}>⋮</DotsButton>
         </div>
       </Topbar>
 

--- a/src/components/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy.jsx
@@ -1,52 +1,136 @@
 import React, { useState } from 'react';
-import { Button, Container } from './App.styled';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import { termsAndConditions } from './termsAndConditions';
+import { useAppSettings } from 'hooks/useAppSettings';
+import { KmPage, KmTopbar, KmIconButton, KnowMeBrand } from './styles/knowme';
+import InfoModal from './InfoModal';
+import { ProfileDotsMenu } from './ProfileDotsMenu';
+import { resolveAccess } from 'utils/accessLevel';
+
+const ContentWrap = styled.main`
+  width: min(100%, 760px);
+  margin: 0 auto;
+  padding: 24px 20px 64px;
+  box-sizing: border-box;
+`;
+
+const TermsCard = styled.section`
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  border-radius: var(--km-radius-lg);
+  box-shadow: var(--km-shadow);
+  padding: 28px 24px 36px;
+
+  @media (max-width: 480px) {
+    padding: 22px 16px 28px;
+  }
+`;
+
+const Paragraph = styled.p`
+  margin: 0;
+  white-space: pre-line;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--km-text);
+
+  ${({ $variant }) => $variant === 'titleMain' && `
+    font-family: var(--km-font-display);
+    font-size: 26px;
+    line-height: 1.25;
+    text-align: center;
+    margin: 8px 0 18px;
+  `}
+
+  ${({ $variant }) => $variant === 'title' && `
+    font-size: 18px;
+    font-weight: 700;
+    text-align: center;
+    margin: 14px 0 18px;
+  `}
+
+  ${({ $variant }) => $variant === 'headerItalic' && `
+    font-size: 12px;
+    font-style: italic;
+    text-align: right;
+    color: var(--km-muted);
+    margin: 6px 0 22px;
+  `}
+
+  ${({ $variant }) => $variant === 'header' && `
+    font-size: 16px;
+    font-weight: 800;
+    text-align: center;
+    letter-spacing: 0.02em;
+    color: var(--km-accent);
+    margin: 28px 0 12px;
+  `}
+
+  ${({ $variant }) => $variant === 'textMain' && `
+    font-weight: 700;
+    margin: 10px 0 6px;
+  `}
+
+  ${({ $variant }) => $variant === 'text' && `
+    margin: 8px 0;
+  `}
+
+  ${({ $variant }) => $variant === 'list' && `
+    font-style: italic;
+    color: var(--km-muted);
+    margin: 4px 0 4px 14px;
+  `}
+`;
 
 export const PrivacyPolicy = () => {
- 
-  const [language, setLanguage] = useState('en');
+  const navigate = useNavigate();
+  const { language } = useAppSettings();
+  const [showDotsMenu, setShowDotsMenu] = useState(false);
 
-const switchLanguage = () => {
-  const newLanguage = language === 'en' ? 'uk' : 'en';
-  setLanguage(newLanguage);
-};
-  
-   const getParagraphStyle = style => {
-     const fontSize = {
-       titleMain: 22,
-       title: 18,
-       small: 14,
-     }; 
+  const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
+  const access = resolveAccess({
+    uid: localStorage.getItem('ownerId') || '',
+    accessLevel: localStorage.getItem('accessLevel') || '',
+    userRole: localStorage.getItem('userRole') || '',
+  });
 
-     const fontStyle = style === 'headerItalic' || style === 'list' ? 'italic' : 'normal';
-     const fontWeight = ['header', 'titleMain', 'title', 'textMain'].includes(style) ? 'bold' : 'normal';
-     const textAlign = style === 'headerItalic' ? 'right' : ['title', 'titleMain', 'header'].includes(style) ? 'center' : 'auto';
-const marginBottom = style === 'titleMain' || style === 'title' || style === 'headerItalic' || style === 'header' ? 20: 5;
-const marginTop = style === 'titleMain' || style === 'title' || style === 'headerItalic' || style === 'header' ? 20 : 5;
-
-     return {
-       fontSize: fontSize[style] || fontSize.small,
-       fontWeight,
-       fontStyle,
-       marginVertical: 5,
-       color: style === 'header' ? '#805300' : 'black',
-       textAlign,
-       marginBottom,
-       marginTop,
-     };
-   };
-
+  const dotsMenu = () => (
+    <ProfileDotsMenu
+      navigate={navigate}
+      isAdmin={access.isAdmin}
+      access={access}
+      isSessionActive={isLoggedIn}
+      onSelect={() => setShowDotsMenu(false)}
+    />
+  );
 
   return (
-      <Container>
-        <Button onClick={switchLanguage}>{language === 'uk' ? 'EN' : 'UK'}</Button>
-        <div>
+    <KmPage>
+      <KmTopbar>
+        <KnowMeBrand />
+        <KmIconButton
+          type="button"
+          aria-label="Відкрити меню"
+          title="Відкрити меню"
+          onClick={() => setShowDotsMenu(true)}
+        >
+          ⋮
+        </KmIconButton>
+      </KmTopbar>
+
+      <ContentWrap>
+        <TermsCard>
           {termsAndConditions.map((paragraph, index) => (
-            <div key={index} style={getParagraphStyle(paragraph.style)}>
-              <p>{language ? paragraph[language] : paragraph.en}</p>
-            </div>
+            <Paragraph key={index} $variant={paragraph.style || 'text'}>
+              {paragraph[language] || paragraph.en}
+            </Paragraph>
           ))}
-        </div>
-      </Container>
+        </TermsCard>
+      </ContentWrap>
+
+      {showDotsMenu && (
+        <InfoModal onClose={() => setShowDotsMenu(false)} text="dotsMenu" Context={dotsMenu} />
+      )}
+    </KmPage>
   );
 };

--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
-import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign } from 'react-icons/fa';
+import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
 import { MdPersonAddAlt1 } from 'react-icons/md';
 import { VerifyEmail } from './VerifyEmail';
+import { useAppSettings } from 'hooks/useAppSettings';
 
 const MenuShell = styled.nav`
   width: 100%;
   min-width: 280px;
   text-align: left;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--km-font);
+  color: var(--km-text);
 `;
 
 const MenuHeader = styled.div`
@@ -18,7 +20,7 @@ const MenuHeader = styled.div`
 
 const MenuTitle = styled.h3`
   margin: 0;
-  color: #1a1a1a;
+  color: var(--km-text);
   font-size: 18px;
   font-weight: 800;
   letter-spacing: -0.02em;
@@ -26,14 +28,14 @@ const MenuTitle = styled.h3`
 
 const MenuSubtitle = styled.p`
   margin: 5px 0 0;
-  color: #7a7a72;
+  color: var(--km-muted);
   font-size: 12px;
   line-height: 1.4;
 `;
 
 const MenuSection = styled.div`
   padding: 10px 0;
-  border-top: 1px solid #e8e8e2;
+  border-top: 1px solid var(--km-border);
 
   &:first-of-type {
     border-top: none;
@@ -43,7 +45,7 @@ const MenuSection = styled.div`
 
 const SectionLabel = styled.div`
   margin: 0 4px 8px;
-  color: #9a9a92;
+  color: var(--km-muted);
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.12em;
@@ -57,10 +59,10 @@ const MenuItem = styled.button`
   align-items: center;
   gap: 10px;
   padding: 10px;
-  border: 1px solid ${({ $active, $danger }) => ($danger ? '#f2c9c9' : $active ? '#e8791a' : 'transparent')};
-  border-radius: 14px;
-  background: ${({ $active, $danger }) => ($danger ? '#fff7f7' : $active ? '#fff0e0' : '#fff')};
-  color: ${({ $danger }) => ($danger ? '#b42318' : '#1a1a1a')};
+  border: 1px solid ${({ $active, $danger }) => ($danger ? 'var(--km-danger-border)' : $active ? 'var(--km-accent)' : 'transparent')};
+  border-radius: var(--km-radius);
+  background: ${({ $active, $danger }) => ($danger ? 'var(--km-danger-bg)' : $active ? 'var(--km-accent-light)' : 'var(--km-card)')};
+  color: ${({ $danger }) => ($danger ? 'var(--km-danger)' : 'var(--km-text)')};
   cursor: pointer;
   text-align: left;
   transition: transform 0.18s ease, border-color 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
@@ -71,15 +73,15 @@ const MenuItem = styled.button`
 
   &:hover {
     transform: translateY(-1px);
-    border-color: ${({ $danger }) => ($danger ? '#e8a8a8' : '#f5a24b')};
-    background: ${({ $danger }) => ($danger ? '#fff1f1' : '#fff8ef')};
+    border-color: ${({ $danger }) => ($danger ? 'var(--km-danger-border)' : 'var(--km-accent-mid)')};
+    background: ${({ $danger }) => ($danger ? 'var(--km-danger-bg)' : 'var(--km-accent-light)')};
     box-shadow: 0 8px 22px rgba(26, 26, 26, 0.08);
   }
 
   &:focus-visible {
     outline: none;
-    border-color: ${({ $danger }) => ($danger ? '#b42318' : '#e8791a')};
-    box-shadow: 0 0 0 3px ${({ $danger }) => ($danger ? 'rgba(180, 35, 24, .14)' : 'rgba(232, 121, 26, .16)')};
+    border-color: ${({ $danger }) => ($danger ? 'var(--km-danger)' : 'var(--km-accent)')};
+    box-shadow: 0 0 0 3px ${({ $danger }) => ($danger ? 'rgba(180, 35, 24, .14)' : 'var(--km-accent-ring)')};
   }
 
   &:active {
@@ -94,8 +96,8 @@ const ItemIcon = styled.span`
   align-items: center;
   justify-content: center;
   border-radius: 12px;
-  background: ${({ $danger }) => ($danger ? '#fee9e9' : '#fff0e0')};
-  color: ${({ $danger }) => ($danger ? '#b42318' : '#e8791a')};
+  background: ${({ $danger }) => ($danger ? 'var(--km-danger-bg)' : 'var(--km-accent-light)')};
+  color: ${({ $danger }) => ($danger ? 'var(--km-danger)' : 'var(--km-accent)')};
   font-size: 15px;
 `;
 
@@ -108,7 +110,7 @@ const ItemLabel = styled.span`
 const ItemDescription = styled.span`
   display: block;
   margin-top: 2px;
-  color: #7a7a72;
+  color: var(--km-muted);
   font-size: 11px;
   line-height: 1.35;
 `;
@@ -116,7 +118,7 @@ const ItemDescription = styled.span`
 const ActivePill = styled.span`
   padding: 3px 8px;
   border-radius: 999px;
-  background: #e8791a;
+  background: var(--km-accent);
   color: #fff;
   font-size: 10px;
   font-weight: 800;
@@ -124,6 +126,53 @@ const ActivePill = styled.span`
 
 const VerifyWrap = styled.div`
   margin-top: 8px;
+`;
+
+const SettingRow = styled.div`
+  display: grid;
+  grid-template-columns: 34px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: var(--km-radius);
+
+  & + & {
+    margin-top: 6px;
+  }
+`;
+
+const SegmentedControl = styled.div`
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  border: 1px solid var(--km-border);
+  border-radius: 99px;
+  background: var(--km-bg);
+`;
+
+const SegmentedOption = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 99px;
+  background: ${({ $active }) => ($active ? 'var(--km-accent)' : 'transparent')};
+  color: ${({ $active }) => ($active ? '#fff' : 'var(--km-muted)')};
+  font-family: var(--km-font);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.18s ease, color 0.18s ease;
+
+  &:hover {
+    color: ${({ $active }) => ($active ? '#fff' : 'var(--km-accent)')};
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
+  }
 `;
 
 const normalizeAccess = access => ({
@@ -145,6 +194,7 @@ export const ProfileDotsMenu = ({
   beforeNavigate,
 }) => {
   const location = useLocation();
+  const { themeMode, setThemeMode, language, setLanguage } = useAppSettings();
   const resolvedAccess = normalizeAccess(access);
   const canSeePrivilegedNav = isAdmin || resolvedAccess.canAccessAdd || resolvedAccess.canAccessMatching;
 
@@ -200,6 +250,60 @@ export const ProfileDotsMenu = ({
             </MenuItem>
           );
         })}
+      </MenuSection>
+
+      <MenuSection>
+        <SectionLabel>Налаштування</SectionLabel>
+        <SettingRow>
+          <ItemIcon>{themeMode === 'dark' ? <FaMoon /> : <FaSun />}</ItemIcon>
+          <span>
+            <ItemLabel>Тема</ItemLabel>
+            <ItemDescription>Оформлення застосунку</ItemDescription>
+          </span>
+          <SegmentedControl role="group" aria-label="Перемкнути тему">
+            <SegmentedOption
+              type="button"
+              $active={themeMode === 'light'}
+              aria-pressed={themeMode === 'light'}
+              onClick={() => setThemeMode('light')}
+            >
+              <FaSun aria-hidden="true" /> Світла
+            </SegmentedOption>
+            <SegmentedOption
+              type="button"
+              $active={themeMode === 'dark'}
+              aria-pressed={themeMode === 'dark'}
+              onClick={() => setThemeMode('dark')}
+            >
+              <FaMoon aria-hidden="true" /> Темна
+            </SegmentedOption>
+          </SegmentedControl>
+        </SettingRow>
+        <SettingRow>
+          <ItemIcon><FaGlobe /></ItemIcon>
+          <span>
+            <ItemLabel>Мова</ItemLabel>
+            <ItemDescription>Мова документів і правил</ItemDescription>
+          </span>
+          <SegmentedControl role="group" aria-label="Перемкнути мову">
+            <SegmentedOption
+              type="button"
+              $active={language === 'uk'}
+              aria-pressed={language === 'uk'}
+              onClick={() => setLanguage('uk')}
+            >
+              UK
+            </SegmentedOption>
+            <SegmentedOption
+              type="button"
+              $active={language === 'en'}
+              aria-pressed={language === 'en'}
+              onClick={() => setLanguage('en')}
+            >
+              EN
+            </SegmentedOption>
+          </SegmentedControl>
+        </SettingRow>
       </MenuSection>
 
       {(onDeleteProfile || onViewProfile) && (

--- a/src/components/SearchFilters.jsx
+++ b/src/components/SearchFilters.jsx
@@ -8,11 +8,12 @@ import { CheckboxGroup } from './CheckboxGroup';
 import { REACTION_FILTER_OPTIONS } from 'utils/reactionCategory';
 
 const FiltersCard = styled.div`
-  background: var(--matching-section-bg, #fff);
-  border: 1px solid var(--matching-section-border, #eee);
-  color: var(--matching-panel-text, inherit);
-  border-radius: 10px;
-  padding: 8px 12px 4px;
+  background: var(--matching-section-bg, var(--km-card));
+  border: 1px solid var(--matching-section-border, var(--km-border));
+  color: var(--matching-panel-text, var(--km-text));
+  font-family: var(--km-font);
+  border-radius: var(--km-radius);
+  padding: 10px 12px 6px;
   margin: 0 0 8px;
 `;
 

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -830,13 +830,11 @@ const profilePdfStyles = StyleSheet.create({
 const pdfFooter = (
   <View style={profilePdfStyles.footer} fixed>
     <Text>
-      REPRODUCTIVE AGENCY "UKRCOM"{'\n'}
-      31/16 Reitarska Str., 1st floor, Kyiv, 01034, Ukraine
+      KnowMe: Egg donor
     </Text>
     <Text style={profilePdfStyles.footerRight}>
-      Website: http://ukrcom.hol.es/{'\n'}
-      E-mail: sm.kiev.ukr@gmail.com{'\n'}
-      Telegram: @Contact_Us_Kyiv
+      E-mail: KnowMeEggDonor@gmail.com{'\n'}
+      Google Play: KnowMe: Egg donor
     </Text>
   </View>
 );
@@ -994,7 +992,7 @@ const buildProfilePdfFileName = data => {
     .replace(/[\\/:*?"<>|]+/g, '')
     .replace(/\s+/g, '-')
     .slice(0, 80);
-  return `${safeName || 'profile'}-UKRCOM.pdf`;
+  return `${safeName || 'profile'}-KnowMe.pdf`;
 };
 
 const ProfilePdfDocument = ({ userData, photoUrls }) => {
@@ -1004,9 +1002,9 @@ const ProfilePdfDocument = ({ userData, photoUrls }) => {
     photo && typeof photo === 'object' ? photo : { src: photo }
   )).filter(photo => photo?.src);
   return (
-    <Document title={`${buildName(userData) || 'Profile'} - UKRCOM`}>
+    <Document title={`${buildName(userData) || 'Profile'} - KnowMe: Egg donor`}>
       <Page size="A4" style={profilePdfStyles.page}>
-        <Text style={profilePdfStyles.watermark}>UKRCOM</Text>
+        <Text style={profilePdfStyles.watermark}>KnowMe</Text>
         <Text style={profilePdfStyles.title}>
           Surrogacy mother’s{'\n'}profile
         </Text>
@@ -1022,7 +1020,7 @@ const ProfilePdfDocument = ({ userData, photoUrls }) => {
       {photoEntries.map((photo, index) => (
         <Page key={`${photo.src}-${index}`} size="A4" style={profilePdfStyles.imagePage}>
           <View style={profilePdfStyles.profileImageWrap}>
-            <Text style={profilePdfStyles.imageWatermark}>UKRCOM</Text>
+            <Text style={profilePdfStyles.imageWatermark}>KnowMe</Text>
             <Image src={photo.src} style={profilePdfStyles.profileImage} />
           </View>
           {pdfFooter}

--- a/src/components/styles/knowme.js
+++ b/src/components/styles/knowme.js
@@ -1,0 +1,221 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// Спільні примітиви дизайн-системи KnowMe.
+// Кольори й розміри беруться з --km-* токенів (src/index.css),
+// тому всі компоненти автоматично підтримують світлу/темну тему.
+
+export const KmPage = styled.div`
+  min-height: 100vh;
+  background: var(--km-bg);
+  color: var(--km-text);
+  font-family: var(--km-font);
+`;
+
+export const KmTopbar = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  background: var(--km-card);
+  border-bottom: 1px solid var(--km-border);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+`;
+
+const BrandWrap = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+`;
+
+const BrandName = styled.span`
+  font-family: var(--km-font-display);
+  font-size: 18px;
+  color: var(--km-text);
+  white-space: nowrap;
+`;
+
+const BrandAccent = styled.span`
+  color: var(--km-accent);
+  font-style: italic;
+`;
+
+const BrandTagline = styled.span`
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--km-muted);
+  white-space: nowrap;
+
+  @media (max-width: 380px) {
+    display: none;
+  }
+`;
+
+export const KnowMeBrand = ({ tagline = 'Egg donor' }) => (
+  <BrandWrap>
+    <BrandName>
+      Know<BrandAccent>Me</BrandAccent>
+    </BrandName>
+    {tagline ? <BrandTagline>{tagline}</BrandTagline> : null}
+  </BrandWrap>
+);
+
+export const KmCard = styled.div`
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  border-radius: var(--km-radius);
+  box-shadow: var(--km-shadow);
+`;
+
+export const KmIconButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease,
+    transform 0.18s ease, color 0.18s ease;
+
+  &:hover {
+    background: var(--km-accent-light);
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--km-accent);
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+`;
+
+export const KmPrimaryButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 10px 20px;
+  border: none;
+  border-radius: var(--km-radius);
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+  color: #fff;
+  font-family: var(--km-font);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: box-shadow 0.18s ease, transform 0.18s ease, filter 0.18s ease;
+
+  &:hover {
+    filter: brightness(1.05);
+    box-shadow: 0 8px 22px rgba(232, 121, 26, 0.28);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+`;
+
+export const KmGhostButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 10px 20px;
+  border: 1.5px solid var(--km-border);
+  border-radius: var(--km-radius);
+  background: var(--km-card);
+  color: var(--km-text);
+  font-family: var(--km-font);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease,
+    transform 0.18s ease;
+
+  &:hover {
+    background: var(--km-accent-light);
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--km-accent);
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+`;
+
+export const KmDangerButton = styled(KmPrimaryButton)`
+  background: var(--km-danger);
+
+  &:hover {
+    box-shadow: 0 8px 22px rgba(180, 35, 24, 0.25);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba(180, 35, 24, 0.18);
+  }
+`;
+
+export const KmChip = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 6px 13px;
+  border-radius: 99px;
+  border: 1.5px solid ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-border)')};
+  background: ${({ $active }) => ($active ? 'var(--km-accent-light)' : 'var(--km-card)')};
+  color: ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-muted)')};
+  font-family: var(--km-font);
+  font-size: 13px;
+  font-weight: ${({ $active }) => ($active ? '600' : '400')};
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
+
+  &:hover {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
+  }
+`;

--- a/src/hooks/useAppSettings.js
+++ b/src/hooks/useAppSettings.js
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// Global app settings: colour theme (light/dark) and interface language (uk/en).
+// Persisted in localStorage and synced between mounted components via a window event,
+// so the toggles in the three-dots menu update every open screen immediately.
+
+const THEME_STORAGE_KEY = 'appThemeMode';
+const LEGACY_THEME_STORAGE_KEY = 'matchingThemeMode';
+const LANGUAGE_STORAGE_KEY = 'appLanguage';
+const SETTINGS_EVENT = 'knowme-app-settings-change';
+
+export const getStoredThemeMode = () => {
+  try {
+    const stored =
+      localStorage.getItem(THEME_STORAGE_KEY)
+      || localStorage.getItem(LEGACY_THEME_STORAGE_KEY)
+      || sessionStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+    return stored === 'dark' ? 'dark' : 'light';
+  } catch (error) {
+    return 'light';
+  }
+};
+
+export const getStoredLanguage = () => {
+  try {
+    return localStorage.getItem(LANGUAGE_STORAGE_KEY) === 'en' ? 'en' : 'uk';
+  } catch (error) {
+    return 'uk';
+  }
+};
+
+export const applyThemeModeToDocument = mode => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.dataset.kmTheme = mode;
+  document.documentElement.dataset.matchingTheme = mode;
+};
+
+export const applyStoredAppSettings = () => {
+  applyThemeModeToDocument(getStoredThemeMode());
+};
+
+const readSettingsSnapshot = () => ({
+  themeMode: getStoredThemeMode(),
+  language: getStoredLanguage(),
+});
+
+const notifySettingsChange = () => {
+  window.dispatchEvent(new Event(SETTINGS_EVENT));
+};
+
+export const useAppSettings = () => {
+  const [settings, setSettings] = useState(readSettingsSnapshot);
+
+  useEffect(() => {
+    const sync = () => setSettings(readSettingsSnapshot());
+    window.addEventListener(SETTINGS_EVENT, sync);
+    window.addEventListener('storage', sync);
+    return () => {
+      window.removeEventListener(SETTINGS_EVENT, sync);
+      window.removeEventListener('storage', sync);
+    };
+  }, []);
+
+  const setThemeMode = useCallback(mode => {
+    const nextMode = mode === 'dark' ? 'dark' : 'light';
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, nextMode);
+      // Matching читає стару адресу теми — тримаємо її синхронізованою.
+      localStorage.setItem(LEGACY_THEME_STORAGE_KEY, nextMode);
+      sessionStorage.setItem(LEGACY_THEME_STORAGE_KEY, nextMode);
+    } catch (error) {
+      // localStorage може бути недоступним (приватний режим) — тема просто не збережеться.
+    }
+    applyThemeModeToDocument(nextMode);
+    setSettings(prev => ({ ...prev, themeMode: nextMode }));
+    notifySettingsChange();
+  }, []);
+
+  const toggleThemeMode = useCallback(() => {
+    setThemeMode(getStoredThemeMode() === 'light' ? 'dark' : 'light');
+  }, [setThemeMode]);
+
+  const setLanguage = useCallback(lang => {
+    const nextLanguage = lang === 'en' ? 'en' : 'uk';
+    try {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, nextLanguage);
+    } catch (error) {
+      // ignore storage errors
+    }
+    setSettings(prev => ({ ...prev, language: nextLanguage }));
+    notifySettingsChange();
+  }, []);
+
+  return {
+    themeMode: settings.themeMode,
+    language: settings.language,
+    setThemeMode,
+    toggleThemeMode,
+    setLanguage,
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,48 @@
   --box-shadow: 0px 0px 10px 5px rgba(0, 0, 0, 0.2);
   --border: 1px solid #122236;
   --animation-timing-function: 300ms cubic-bezier(0.4, 0, 0.2, 1) 0s;
+
+  /* KnowMe design tokens (shared across all screens) */
+  --km-accent: #E8791A;
+  --km-accent-mid: #F5A24B;
+  --km-accent-light: #FFF0E0;
+  --km-accent-ring: rgba(232, 121, 26, 0.16);
+  --km-bg: #FAFAF8;
+  --km-card: #FFFFFF;
+  --km-text: #1A1A1A;
+  --km-muted: #7A7A72;
+  --km-border: #E8E8E2;
+  --km-danger: #B42318;
+  --km-danger-bg: #FFF7F7;
+  --km-danger-border: #F2C9C9;
+  --km-success: #2E9B55;
+  --km-success-bg: #EBF8EF;
+  --km-radius: 14px;
+  --km-radius-lg: 18px;
+  --km-shadow: 0 2px 16px rgba(0, 0, 0, 0.06);
+  --km-shadow-pop: 0 24px 80px rgba(0, 0, 0, 0.22);
+  --km-font: 'DM Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --km-font-display: 'Playfair Display', Georgia, serif;
+}
+
+:root[data-km-theme='dark'] {
+  --km-accent: #F08A2C;
+  --km-accent-mid: #F5A24B;
+  --km-accent-light: rgba(240, 138, 44, 0.16);
+  --km-accent-ring: rgba(240, 138, 44, 0.22);
+  --km-bg: #14100C;
+  --km-card: #1C1712;
+  --km-text: #FFF8EC;
+  --km-muted: rgba(255, 248, 236, 0.72);
+  --km-border: rgba(255, 214, 148, 0.16);
+  --km-danger: #F08A80;
+  --km-danger-bg: rgba(180, 35, 24, 0.16);
+  --km-danger-border: rgba(240, 138, 128, 0.35);
+  --km-success: #6FCF97;
+  --km-success-bg: rgba(46, 155, 85, 0.16);
+  --km-shadow: 0 2px 16px rgba(0, 0, 0, 0.35);
+  --km-shadow-pop: 0 24px 80px rgba(0, 0, 0, 0.55);
+  color-scheme: dark;
 }
 
 body,
@@ -65,13 +107,11 @@ button {
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--km-font);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: var(--primary-text-color);
-  background-color: #f5f5f5;
+  background-color: var(--km-bg);
 }
 
 code {


### PR DESCRIPTION
- Add shared --km-* design tokens (light + dark) in index.css and
  reusable UI primitives (brand, buttons, cards, chips) in styles/knowme.js
- Load DM Sans / Playfair Display fonts that were referenced but never linked
- Add useAppSettings hook: global theme (light/dark) and language (uk/en),
  persisted and synced across screens; theme applied via data-km-theme
- Move theme and language switching into the three-dots menu
  (ProfileDotsMenu), remove the theme toggle from the Matching header
  and the EN/UK button from the terms page
- Restyle terms page (PrivacyPolicy) as a KnowMe-branded card page with
  topbar and dots menu
- Restyle InfoModal to shared tokens; add shared confirmation-modal
  buttons and use them in the delete-profile confirmation
- Unify filter menu chips (SearchFilters/CheckboxGroup) to the KnowMe accent
- Align Matching palette with KnowMe accent and neutrals; theme now global
- Map MyProfile local CSS vars to shared tokens (dark theme support)
- BudgetPage: swap brown/cream palette to KnowMe tokens, keep UKRCOM branding
- Rebrand profile PDF export from UKRCOM to KnowMe: Egg donor
  (UKRCOM remains only in Budget)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013A9YUPujsZ6BojpHBoR5we