### PR TITLE
Make English the default app language in `getStoredLanguage`

### DIFF
--- a/src/hooks/useAppSettings.js
+++ b/src/hooks/useAppSettings.js
@@ -23,9 +23,9 @@ export const getStoredThemeMode = () => {
 
 export const getStoredLanguage = () => {
   try {
-    return localStorage.getItem(LANGUAGE_STORAGE_KEY) === 'en' ? 'en' : 'uk';
+    return localStorage.getItem(LANGUAGE_STORAGE_KEY) === 'uk' ? 'uk' : 'en';
   } catch (error) {
-    return 'uk';
+    return 'en';
   }
 };
 


### PR DESCRIPTION
### Motivation
- Ensure the app falls back to English when no language is stored or when an error occurs by adjusting the language fallback logic in `getStoredLanguage`.

### Description
- Update `getStoredLanguage` so it returns `'uk'` only if the stored value strictly equals `'uk'`, otherwise it returns `'en'`, and change the catch fallback to `'en'`.

### Testing
- Ran unit tests with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ce20f8f7c8326abcd8bb8cdba043e)