### PR TITLE
Resolve currency identifiers in flow amount formulas and show computed amounts in UI

### DIFF
--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -17,7 +17,7 @@ import {
 } from './config';
 import { useAutoResize } from 'hooks/useAutoResize';
 import { color } from './styles';
-import { resolveFlowAmountInput } from 'utils/flowAmountFormula';
+import { isFormulaFlowAmount, resolveFlowAmountInput } from 'utils/flowAmountFormula';
 
 const Wrap = styled.div`
   display: flex;
@@ -683,7 +683,42 @@ const calculateFlowRowCurrencyAmount = ({
   return storedAmount > 0 ? storedAmount : 0;
 };
 
-const FORMULA_AMOUNT_CHAR_REGEX = /[0-9.,+\-*/%()\s×xXхХ÷:−–—]/;
+const makeFlowCurrencyFormulaResolver = rates => name => {
+  const normalizedName = String(name || '').trim().toUpperCase();
+  if (normalizedName === 'USD') return Number(rates?.usd);
+  if (normalizedName === 'EUR') return Number(rates?.eur);
+  return undefined;
+};
+
+const resolveFlowDisplayAmount = ({
+  amount,
+  row,
+  exchangeRateMode,
+  exchangeRates,
+  historicalRatesByDate,
+  customUsdRate,
+}) => {
+  const rawAmount = normalizeFlowAmount(amount);
+  if (!isFormulaFlowAmount(rawAmount)) return rawAmount;
+
+  const rates = getFlowRatesForRow({
+    row: row || {},
+    exchangeRateMode,
+    exchangeRates,
+    historicalRatesByDate,
+    customUsdRate,
+  });
+
+  try {
+    return normalizeFlowAmount(resolveFlowAmountInput(rawAmount, makeFlowCurrencyFormulaResolver(rates)));
+  } catch {
+    return rawAmount;
+  }
+};
+
+const getFlowAmountNumberForTotals = options => toAmountNumber(resolveFlowDisplayAmount(options));
+
+const FLOW_FORMULA_TOKEN_REGEX = /[0-9.,+\-*/%()\s×xXхХ÷:−–—$]/;
 const FLOW_AMOUNT_START_REGEX = /^(?:[+-]?\d+(?:[.,]\d+)?|=)/;
 
 const splitFlowAmountAndDescription = value => {
@@ -692,8 +727,18 @@ const splitFlowAmountAndDescription = value => {
 
   if (raw.startsWith('=')) {
     let index = 1;
-    while (index < raw.length && FORMULA_AMOUNT_CHAR_REGEX.test(raw[index])) {
-      index += 1;
+    while (index < raw.length) {
+      const tail = raw.slice(index);
+      const identifierMatch = tail.match(/^(?:USD|EUR)\b/i);
+      if (identifierMatch) {
+        index += identifierMatch[0].length;
+        continue;
+      }
+      if (FLOW_FORMULA_TOKEN_REGEX.test(raw[index])) {
+        index += 1;
+        continue;
+      }
+      break;
     }
     const amountRaw = raw.slice(0, index).trim();
     const description = raw.slice(index).trim();
@@ -708,34 +753,6 @@ const splitFlowAmountAndDescription = value => {
     description: numberMatch[2] || '',
   };
 };
-
-const resolveFlowEntryLineForDisplay = line => {
-  const trimmedLine = String(line || '').trim();
-  if (!trimmedLine) return line;
-
-  const lineMatch = trimmedLine.match(/^(?:(\d{1,2}\.\d{1,2}(?:\.\d{4})?)\s+)?(.+)$/);
-  if (!lineMatch) return line;
-
-  const amountParts = splitFlowAmountAndDescription(lineMatch[2]);
-  if (!amountParts) return line;
-
-  let resolvedAmount = '';
-  try {
-    resolvedAmount = normalizeFlowAmount(resolveFlowAmountInput(amountParts.amountRaw));
-  } catch {
-    return line;
-  }
-  if (!resolvedAmount || resolvedAmount === amountParts.amountRaw) return line;
-
-  const datePrefix = lineMatch[1] ? `${lineMatch[1]} ` : '';
-  return `${datePrefix}${resolvedAmount} ${amountParts.description || ''}`.trim();
-};
-
-const resolveFlowEntryInputForDisplay = rawText =>
-  String(rawText || '')
-    .split(/(\r?\n)/)
-    .map(part => (/\r?\n/.test(part) ? part : resolveFlowEntryLineForDisplay(part)))
-    .join('');
 
 export const parseFlowEntryLine = (line, fallbackDate = '') => {
   const trimmedLine = String(line || '').trim();
@@ -1095,9 +1112,17 @@ export const FlowManager = ({ ownerId }) => {
         if (!acc[group]) {
           acc[group] = { uah: 0, usd: 0, eur: 0 };
         }
-        const amountUah = toAmountNumber(row.amount);
-        const amountUsdDerived = calculateFlowRowCurrencyAmount({
+        const amountUah = getFlowAmountNumberForTotals({
+          amount: row.amount,
           row,
+          exchangeRateMode,
+          exchangeRates,
+          historicalRatesByDate,
+          customUsdRate,
+        });
+        const displayAmountRow = { ...row, amount: formatCategorySum(amountUah) };
+        const amountUsdDerived = calculateFlowRowCurrencyAmount({
+          row: displayAmountRow,
           currency: 'usd',
           exchangeRateMode,
           exchangeRates,
@@ -1105,7 +1130,7 @@ export const FlowManager = ({ ownerId }) => {
           customUsdRate,
         });
         const amountEurDerived = calculateFlowRowCurrencyAmount({
-          row,
+          row: displayAmountRow,
           currency: 'eur',
           exchangeRateMode,
           exchangeRates,
@@ -1551,7 +1576,7 @@ export const FlowManager = ({ ownerId }) => {
         const title = subgroup ? `${group}, ${subgroup}` : group;
         const lines = sortRowsByDate(rows).map(row => {
           const displayDate = formatDisplayDate(row.date);
-          const formattedAmount = formatFlowAmountForClipboard(row.amount);
+          const formattedAmount = formatFlowAmountForClipboard(resolveFlowDisplayAmount({ amount: row.amount, row, exchangeRateMode, exchangeRates, historicalRatesByDate, customUsdRate }));
           return `${displayDate}\t${formattedAmount}\t\t${row.description || ''}`.trimEnd();
         });
         return [title, ...lines].join('\n');
@@ -1994,11 +2019,7 @@ export const FlowManager = ({ ownerId }) => {
               onKeyDown={e => {
                 if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();
-                  const resolvedInput = resolveFlowEntryInputForDisplay(entryInput);
-                  if (resolvedInput !== entryInput) {
-                    setEntryInput(resolvedInput);
-                  }
-                  handleSave({ rawText: resolvedInput });
+                  handleSave({ rawText: entryInput });
                   categoryInputRef.current?.focus();
                 }
               }}
@@ -2084,10 +2105,11 @@ export const FlowManager = ({ ownerId }) => {
                     ) : (
                       <>
                         <EventText>
-                          {formatDisplayDate(row.date)} {row.amount} {row.description}
+                          {formatDisplayDate(row.date)} {resolveFlowDisplayAmount({ amount: row.amount, row, exchangeRateMode, exchangeRates, historicalRatesByDate, customUsdRate })} {row.description}
                           {(() => {
+                            const displayAmount = resolveFlowDisplayAmount({ amount: row.amount, row, exchangeRateMode, exchangeRates, historicalRatesByDate, customUsdRate });
                             const amountUsd = calculateFlowRowCurrencyAmount({
-                              row,
+                              row: { ...row, amount: displayAmount },
                               currency: 'usd',
                               exchangeRateMode,
                               exchangeRates,

--- a/src/utils/flowAmountFormula.js
+++ b/src/utils/flowAmountFormula.js
@@ -49,6 +49,28 @@ const tokenizeFormula = rawExpression => {
       continue;
     }
 
+    if (rawChar === '$') {
+      tokens.push({ type: 'identifier', name: 'USD' });
+      index += 1;
+      continue;
+    }
+
+    if (/[A-Za-z_]/.test(rawChar) && !/[xX]/.test(rawChar)) {
+      let name = '';
+      while (index < expression.length && /[A-Za-z0-9_]/.test(expression[index])) {
+        name += expression[index];
+        index += 1;
+      }
+      tokens.push({ type: 'identifier', name });
+      continue;
+    }
+
+    if (/[xX]/.test(rawChar)) {
+      tokens.push({ type: '*' });
+      index += 1;
+      continue;
+    }
+
     if ('+-*/()%'.includes(char)) {
       tokens.push({ type: char });
       index += 1;
@@ -69,7 +91,7 @@ export const formatFlowAmountResult = value => {
   return rounded.toFixed(2).replace(/\.?0+$/, '');
 };
 
-export const evaluateFlowAmountFormula = rawFormula => {
+export const evaluateFlowAmountFormula = (rawFormula, resolveIdentifier) => {
   const formulaText = String(rawFormula || '').trim();
   const expression = formulaText.startsWith(FLOW_FORMULA_PREFIX)
     ? formulaText.slice(FLOW_FORMULA_PREFIX.length)
@@ -123,6 +145,14 @@ export const evaluateFlowAmountFormula = rawFormula => {
     } else if (peek()?.type === 'number') {
       value = peek().value;
       position += 1;
+    } else if (peek()?.type === 'identifier') {
+      const name = peek().name;
+      const resolved = Number(resolveIdentifier?.(name));
+      if (!Number.isFinite(resolved)) {
+        throw new Error(`Formula identifier "${name}" is unresolved`);
+      }
+      value = resolved;
+      position += 1;
     } else {
       throw new Error('Formula value is missing');
     }
@@ -147,11 +177,11 @@ export const evaluateFlowAmountFormula = rawFormula => {
   return result;
 };
 
-export const resolveFlowAmountInput = rawAmount => {
+export const resolveFlowAmountInput = (rawAmount, resolveIdentifier) => {
   const amountText = String(rawAmount || '').trim().replace(/,/g, '.');
   if (!amountText) return '';
   if (!amountText.startsWith(FLOW_FORMULA_PREFIX)) return amountText;
-  return formatFlowAmountResult(evaluateFlowAmountFormula(amountText));
+  return formatFlowAmountResult(evaluateFlowAmountFormula(amountText, resolveIdentifier));
 };
 
 export const isFormulaFlowAmount = rawAmount =>

--- a/src/utils/flowAmountFormula.test.js
+++ b/src/utils/flowAmountFormula.test.js
@@ -23,6 +23,14 @@ describe('flowAmountFormula', () => {
     expect(resolveFlowAmountInput('=10×5÷2')).toBe('25');
   });
 
+  it('resolves USD, EUR and dollar identifiers through the provided rates', () => {
+    const resolveRate = name => ({ USD: 44.6, EUR: 48.2 }[String(name).toUpperCase()]);
+
+    expect(resolveFlowAmountInput('=500*USD', resolveRate)).toBe('22300');
+    expect(resolveFlowAmountInput('=100*EUR', resolveRate)).toBe('4820');
+    expect(resolveFlowAmountInput('=25*$', resolveRate)).toBe('1115');
+  });
+
   it('rounds final flow amounts to two decimal places without trailing zeroes', () => {
     expect(formatFlowAmountResult(10 / 3)).toBe('3.33');
     expect(formatFlowAmountResult(-0)).toBe('0');
@@ -30,6 +38,6 @@ describe('flowAmountFormula', () => {
 
   it('rejects invalid formulas', () => {
     expect(() => resolveFlowAmountInput('=100/0')).toThrow('division by zero');
-    expect(() => resolveFlowAmountInput('=100+abc')).toThrow('unsupported characters');
+    expect(() => resolveFlowAmountInput('=100+abc')).toThrow('identifier "abc" is unresolved');
   });
 });


### PR DESCRIPTION
### Motivation
- Allow formula amounts to reference currency identifiers like `USD`, `EUR`, and `$` so formulas can use exchange rates in calculations.
- Ensure formula amounts are evaluated consistently across displays, clipboard export, and category totals so users see resolved values everywhere.

### Description
- Extend `tokenizeFormula` and evaluator to support identifiers and `$` as a shorthand for `USD`, and treat `x`/`X` as multiplication, and add identifier resolution in `evaluateFlowAmountFormula` via a `resolveIdentifier` callback.
- Update `resolveFlowAmountInput` to accept an optional `resolveIdentifier` argument and thread it to the evaluator so `=500*USD` and `=$` style formulas resolve using provided rates.
- Add `resolveFlowDisplayAmount` and `makeFlowCurrencyFormulaResolver` in `FlowManager.jsx` to compute rendered amounts using current exchange rates, and use this for row display, clipboard export, and category totals calculations.
- Improve formula token parsing in `splitFlowAmountAndDescription` by allowing currency identifiers inside formula tokens and update related regexes.
- Update unit tests in `flowAmountFormula.test.js` to assert identifier resolution and to reflect new error messages for unresolved identifiers.

### Testing
- Ran unit tests for formula utilities with `flowAmountFormula.test.js`, and the updated tests covering identifier resolution and existing formula behaviors passed.
- Executed the project's test suite (`npm test`/`yarn test`) locally and observed no failing tests related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d09c591e083268a5aa93a2382a21f)