### PR TITLE
Fix renderTopBlock modal colors to follow light/dark theme

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -221,7 +221,7 @@ const Container = styled.div`
 const MoreActionsInfo = styled.p`
   margin: 0 0 10px;
   font-size: 14px;
-  color: #333;
+  color: var(--km-text);
 `;
 
 const MoreActionsCommandButton = styled.button`
@@ -266,7 +266,7 @@ const MatchingMiniList = styled.div`
   max-height: 50vh;
   overflow: auto;
   margin-top: 8px;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--km-border);
   padding-top: 8px;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -280,8 +280,8 @@ const MatchingMiniList = styled.div`
 const MatchingMiniCard = styled.div`
   border-radius: 12px;
   overflow: hidden;
-  background: #fff;
-  border: 1px solid #e7e7e7;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 `;
 
@@ -289,14 +289,14 @@ const MatchingMiniCardShell = styled.div`
   position: relative;
   width: 100%;
   min-height: 180px;
-  background: #f3f3f3;
+  background: var(--km-border);
   cursor: pointer;
 `;
 
 const MatchingMiniReactionBadge = styled.div`
   font-size: 12px;
   line-height: 1.2;
-  color: #4a4a4a;
+  color: var(--km-muted);
   padding: 8px 10px 0;
 `;
 
@@ -313,7 +313,7 @@ const MatchingMiniFallback = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #888;
+  color: var(--km-muted);
   font-size: 13px;
 `;
 
@@ -343,7 +343,7 @@ const InnerContainer = styled.div`
   max-width: 560px;
   width: 100%;
   box-sizing: border-box;
-  background-color: #f0f0f0;
+  background-color: var(--km-card);
   padding: 16px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
@@ -351,7 +351,7 @@ const InnerContainer = styled.div`
   @media (max-width: 768px) {
     // Медіа-запит для пристроїв з шириною екрану до 768px
     background-color: ${uiTokens.colors.pageBg};
-    box-shadow: 0 4px 8px #f5f5f5;
+    box-shadow: 0 4px 8px var(--km-border);
     border-radius: 0;
     padding: 0;
   }
@@ -366,7 +366,7 @@ const DotsButton = styled.button`
   border-radius: 12px;
   font-size: 22px;
   line-height: 1;
-  color: ${color.accent5};
+  color: var(--km-accent);
   cursor: pointer;
   padding: 0;
   margin-left: auto;
@@ -379,16 +379,16 @@ const DotsButton = styled.button`
     color 0.2s ease;
 
   &:hover {
-    background-color: ${color.paleAccent2};
-    border-color: ${color.paleAccent5};
-    color: ${color.accent};
+    background-color: var(--km-accent-light);
+    border-color: var(--km-accent-mid);
+    color: var(--km-accent);
   }
 `;
 
 
 export const SubmitButton = styled.button`
   padding: 11px 14px;
-  color: ${color.black};
+  color: var(--km-text);
   border: 1px solid transparent;
   border-radius: 10px;
   cursor: pointer;
@@ -397,8 +397,8 @@ export const SubmitButton = styled.button`
   align-self: flex-start;
   width: 100%;
   text-align: left;
-  background: linear-gradient(180deg, ${color.oppositeAccent} 0%, #fffaf2 100%);
-  box-shadow: inset 0 -1px 0 ${color.gray};
+  background: var(--km-card);
+  box-shadow: inset 0 -1px 0 var(--km-border);
   transition:
     background-color 0.2s ease,
     border-color 0.2s ease,
@@ -410,19 +410,19 @@ export const SubmitButton = styled.button`
   }
 
   &:hover {
-    background: ${color.paleAccent2};
-    border-color: ${color.paleAccent5};
+    background: var(--km-accent-light);
+    border-color: var(--km-accent-mid);
     transform: translateY(-1px);
   }
 `;
 
 export const ExitButton = styled(SubmitButton)`
-  background: #fff;
-  color: ${color.accent3};
-  border-color: ${color.gray};
+  background: var(--km-card);
+  color: var(--km-accent);
+  border-color: var(--km-border);
 
   &:hover {
-    background-color: ${color.paleAccent2};
+    background-color: var(--km-accent-light);
   }
 `;
 
@@ -440,7 +440,7 @@ const EditActionButton = styled.button`
   border-radius: 12px;
   border: 1px solid transparent;
   background: none;
-  color: ${color.accent5};
+  color: var(--km-accent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -452,9 +452,9 @@ const EditActionButton = styled.button`
     transform 0.2s ease;
 
   &:hover {
-    background-color: ${color.paleAccent2};
-    border-color: ${color.paleAccent5};
-    color: ${color.accent};
+    background-color: var(--km-accent-light);
+    border-color: var(--km-accent-mid);
+    color: var(--km-accent);
     transform: translateY(-1px);
   }
 
@@ -475,9 +475,9 @@ const DownloadSizeToastToggleButton = styled(EditActionButton)`
   min-width: 40px;
   padding: 0 10px;
   gap: 6px;
-  color: ${({ $active }) => ($active ? color.accent : color.accent5)};
-  background-color: ${({ $active }) => ($active ? color.paleAccent2 : 'transparent')};
-  border-color: ${({ $active }) => ($active ? color.paleAccent5 : 'transparent')};
+  color: var(--km-accent);
+  background-color: ${({ $active }) => ($active ? 'var(--km-accent-light)' : 'transparent')};
+  border-color: ${({ $active }) => ($active ? 'var(--km-accent-mid)' : 'transparent')};
   font-size: 13px;
   font-weight: 700;
 `;
@@ -501,9 +501,9 @@ const DownloadSizeToastStatus = styled.span`
 const Button = styled.button`
   padding: 0 12px;
   height: 30px;
-  border: 1.5px solid #e5e5e5;
-  background: #fff;
-  color: #444;
+  border: 1.5px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
   border-radius: 8px;
   cursor: pointer;
   font-size: 12px;
@@ -516,9 +516,9 @@ const Button = styled.button`
   transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 
   &:hover {
-    background: #FFF3E0;
-    border-color: #FF8C00;
-    color: #CC5500;
+    background: var(--km-accent-light);
+    border-color: var(--km-accent);
+    color: var(--km-accent);
   }
 
   &:active {
@@ -539,8 +539,8 @@ const ButtonsContainer = styled.div`
   flex-wrap: wrap;
   gap: 6px;
   padding: 10px 12px;
-  background: #fff;
-  border: 1px solid #eee;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   border-radius: 10px;
   margin: 8px 0;
 `;
@@ -552,8 +552,8 @@ const SortModeContainer = styled.div`
   gap: 4px;
   margin: 8px 0;
   padding: 8px 12px;
-  background: #fff;
-  border: 1px solid #eee;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   border-radius: 10px;
 `;
 
@@ -578,8 +578,8 @@ const GearButton = styled(Button)`
 
 const LoadOptionsPopover = styled.div`
   width: 100%;
-  background: #fff;
-  border: 1px solid #eee;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   border-radius: 10px;
   padding: 8px;
 `;
@@ -587,7 +587,7 @@ const LoadOptionsPopover = styled.div`
 const SortModeTitle = styled.span`
   font-size: 10px;
   font-weight: 700;
-  color: #aaa;
+  color: var(--km-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-right: 4px;
@@ -598,7 +598,7 @@ const SortModeLabel = styled.label`
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: #444;
+  color: var(--km-text);
   cursor: pointer;
   padding: 3px 8px;
   border-radius: 6px;
@@ -610,15 +610,15 @@ const SortModeLabel = styled.label`
   }
 
   &:has(input:checked) {
-    background: #FFF3E0;
-    border-color: #FF8C00;
-    color: #CC5500;
+    background: var(--km-accent-light);
+    border-color: var(--km-accent);
+    color: var(--km-accent);
     font-weight: 600;
   }
 
   &:hover:not(:has(input:checked)) {
-    background: #f5f5f5;
-    border-color: #ddd;
+    background: var(--km-border);
+    border-color: var(--km-border);
   }
 `;
 
@@ -634,8 +634,8 @@ const SearchScopeContainer = styled.div`
 `;
 
 const SearchScopeBlock = styled.div`
-  background: #fff;
-  border: 1px solid #eee;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   border-radius: 10px;
   padding: 8px 12px 10px;
 `;
@@ -643,7 +643,7 @@ const SearchScopeBlock = styled.div`
 const SearchScopeBlockTitle = styled.div`
   font-size: 10px;
   font-weight: 700;
-  color: #aaa;
+  color: var(--km-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   line-height: 1;
@@ -665,7 +665,7 @@ const SearchScopeItems = styled.div`
 const SearchScopeDivider = styled.hr`
   flex-basis: 100%;
   border: 0;
-  border-top: 1px solid #e8e8e8;
+  border-top: 1px solid var(--km-border);
   margin: 4px 0;
 `;
 
@@ -674,7 +674,7 @@ const SearchScopeLabel = styled.label`
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: #1f1f1f;
+  color: var(--km-text);
 `;
 
 const SearchScopeLabelTextGroup = styled.span`
@@ -686,9 +686,9 @@ const SearchScopeLabelTextGroup = styled.span`
 const ScopeChip = styled.button`
   padding: 3px 9px;
   border-radius: 20px;
-  border: 1.5px solid ${({ $active }) => ($active ? '#FF8C00' : '#e0e0e0')};
-  background: ${({ $active }) => ($active ? '#FFF3E0' : '#fafafa')};
-  color: ${({ $active }) => ($active ? '#CC5500' : '#666')};
+  border: 1.5px solid ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-border)')};
+  background: ${({ $active }) => ($active ? 'var(--km-accent-light)' : 'var(--km-card)')};
+  color: ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-muted)')};
   font-size: 12px;
   font-weight: ${({ $active }) => ($active ? '600' : '400')};
   cursor: pointer;
@@ -703,16 +703,16 @@ const ScopeChip = styled.button`
   }
 
   &:hover:not(:disabled) {
-    border-color: #FF8C00;
-    color: #CC5500;
+    border-color: var(--km-accent);
+    color: var(--km-accent);
   }
 `;
 
 const ToggleSearchScopeButton = styled.button`
-  border: 1px solid #c8d0ff;
+  border: 1px solid var(--km-accent-mid);
   border-radius: 6px;
-  background: #f3f5ff;
-  color: #2f4db9;
+  background: var(--km-accent-light);
+  color: var(--km-accent);
   font-size: 11px;
   line-height: 1;
   padding: 5px 8px;
@@ -720,7 +720,7 @@ const ToggleSearchScopeButton = styled.button`
   flex-shrink: 0;
 
   &:hover {
-    background: #e9edff;
+    background: var(--km-accent-light);
   }
 `;
 
@@ -733,21 +733,21 @@ const SearchBarRow = styled.div`
 const SearchSettingsButton = styled.button`
   width: 38px;
   height: 38px;
-  border: 1.5px solid ${({ $active }) => ($active ? '#FF8C00' : '#d5d5d5')};
+  border: 1.5px solid ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-border)')};
   border-radius: 8px;
-  background: ${({ $active }) => ($active ? '#FFF3E0' : '#fff')};
+  background: ${({ $active }) => ($active ? 'var(--km-accent-light)' : 'var(--km-card)')};
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: ${({ $active }) => ($active ? '#CC5500' : '#666')};
+  color: ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-muted)')};
   flex-shrink: 0;
   transition: border-color 0.15s, background 0.15s, color 0.15s;
 
   &:hover {
-    border-color: #FF8C00;
-    color: #CC5500;
-    background: #FFF3E0;
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+    background: var(--km-accent-light);
   }
 `;
 
@@ -755,9 +755,9 @@ const IndexModal = styled.div`
   width: 100%;
   margin: 6px 0 10px;
   padding: 10px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--km-border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--km-card);
 `;
 
 const IndexModalList = styled.div`
@@ -782,7 +782,7 @@ const LocalIndexModal = styled.div`
   width: min(560px, 100%);
   max-height: calc(100vh - 32px);
   overflow-y: auto;
-  background: #fff;
+  background: var(--km-card);
   border-radius: 10px;
   padding: 16px;
   box-shadow: 0 10px 35px rgba(0, 0, 0, 0.2);
@@ -801,19 +801,19 @@ const SaveModalTitle = styled.h3`
 
 const SaveModalHint = styled.p`
   margin: 0 0 12px;
-  color: #555;
+  color: var(--km-muted);
   font-size: 13px;
 `;
 
 const SaveModalSection = styled.div`
   padding: 10px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--km-border);
 `;
 
 const SaveModalSectionTitle = styled.div`
   margin-bottom: 8px;
   font-weight: 700;
-  color: #333;
+  color: var(--km-text);
 `;
 
 const SaveModalRadioRow = styled.label`
@@ -826,7 +826,7 @@ const SaveModalRadioRow = styled.label`
 
 const SaveModalComment = styled.span`
   display: block;
-  color: #666;
+  color: var(--km-muted);
   font-size: 12px;
   line-height: 1.35;
 `;
@@ -840,16 +840,16 @@ const SaveModalActions = styled.div`
 const SaveModalActionButton = styled.button`
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #ffd39a;
+  border: 1px solid var(--km-accent-mid);
   border-radius: 8px;
-  background: #fff8ef;
-  color: #5d3b00;
+  background: var(--km-accent-light);
+  color: var(--km-accent);
   text-align: left;
   cursor: pointer;
 
   &:hover {
-    background: #fff3e0;
-    border-color: #ff8c00;
+    background: var(--km-accent-light);
+    border-color: var(--km-accent);
   }
 
   &:disabled {
@@ -6781,7 +6781,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         ) : (
           <div>
             {(searchLoading || hasSearched) && !userNotFound && (
-              <p style={{ textAlign: 'center', color: 'black' }}>
+              <p style={{ textAlign: 'center', color: 'var(--km-text)' }}>
                 Знайдено{' '}
                 {searchLoading ? (
                   <span className="spinner" />
@@ -6792,7 +6792,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               </p>
             )}
             {userNotFound && hasSearched && (
-              <p style={{ textAlign: 'center', color: 'black' }}>No result</p>
+              <p style={{ textAlign: 'center', color: 'var(--km-text)' }}>No result</p>
             )}
             <ButtonsContainer>
               {userNotFound && (

--- a/src/components/App.styled.jsx
+++ b/src/components/App.styled.jsx
@@ -5,11 +5,9 @@ export const Container = styled.div`
   min-height: calc(100vh - 400px);
   margin: 0 auto 0;
   padding: 30px;
-  /* background-color: var(--primary-background-color); */
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--km-shadow);
   display: flex;
   flex-direction: column;
-  /* background: linear-gradient(to bottom, #ffa500, #ff8c00); */
 `;
 
 export const TitleH1 = styled.h1`
@@ -24,19 +22,18 @@ export const TitleH2 = styled.h2`
 
 export const Button = styled.button`
   margin-left: 10px;
-  /* margin-bottom: 10px; */
   padding: 5px 5px;
   width: 40px;
   height: 40px;
-  background-color: var(--accent-color);
-  color: var(--primary-text-color);
-  border: var(--border);
+  background-color: var(--km-accent);
+  color: #fff;
+  border: 1px solid var(--km-border);
   border-radius: 50px;
   font-weight: 700;
-  transition: background-color var(--animation-timing-function);
+  transition: background-color 0.18s ease;
   &:hover,
   &:focus {
-    background-color: var(--accent-color-hover);
+    background-color: var(--km-accent-mid);
   };
   align-self: flex-end;
 `;

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -16,6 +16,8 @@ import { makeUploadedInfo } from './makeUploadedInfo';
 import { TopBlock } from './smallCard/renderTopBlock';
 import StimulationSchedule from './StimulationSchedule';
 import { coloredCard } from './styles';
+import { KmPage, KmGhostButton } from './styles/knowme';
+import { FaArrowLeft } from 'react-icons/fa';
 import { updateCachedUser } from '../utils/cache';
 import { getCard } from '../utils/cardIndex';
 import {
@@ -38,7 +40,7 @@ import {
   saveOverlayForUserCard,
 } from 'utils/multiAccountEdits';
 
-const Container = styled.div`
+const Container = styled(KmPage)`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -49,18 +51,20 @@ const Container = styled.div`
   margin: 0 auto;
 `;
 
-const BackButton = styled.button`
+const BackButton = styled(KmGhostButton)`
   align-self: flex-start;
+  min-height: 36px;
+  padding: 6px 14px;
   margin-bottom: 10px;
 `;
 
 const SkeletonCard = styled.div`
   width: 100%;
-  border-radius: 12px;
+  border-radius: var(--km-radius);
   padding: 14px;
   margin-bottom: 8px;
-  background: #f6f7fb;
-  border: 1px solid #e7e9f5;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
 `;
 
 const SkeletonLine = styled.div`
@@ -68,7 +72,7 @@ const SkeletonLine = styled.div`
   width: ${props => props.width || '100%'};
   border-radius: 8px;
   margin-bottom: 10px;
-  background: linear-gradient(90deg, #eceef7 25%, #f7f8fc 50%, #eceef7 75%);
+  background: linear-gradient(90deg, var(--km-border) 25%, var(--km-card) 50%, var(--km-border) 75%);
   background-size: 200% 100%;
   animation: skeletonPulse 1.2s ease-in-out infinite;
 
@@ -956,7 +960,9 @@ const EditProfile = () => {
 
   return (
     <Container>
-      <BackButton onClick={() => navigate(-1)}>Back</BackButton>
+      <BackButton type="button" onClick={() => navigate(-1)}>
+        <FaArrowLeft size={12} /> Back
+      </BackButton>
       {shouldShowEditorSkeleton ? (
         <TopBlockSkeleton />
       ) : (

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -15,16 +15,16 @@ import {
 } from './authProfilePersistence';
 
 const Container = styled.div`
-  --accent: #E8791A;
-  --accent-light: #FFF0E0;
-  --accent-mid: #F5A24B;
-  --bg: #FAFAF8;
-  --card: #FFFFFF;
-  --text: #1A1A1A;
-  --muted: #7A7A72;
-  --border: #E8E8E2;
-  --radius: 14px;
-  --shadow: 0 2px 16px rgba(0, 0, 0, 0.06);
+  --accent: var(--km-accent);
+  --accent-light: var(--km-accent-light);
+  --accent-mid: var(--km-accent-mid);
+  --bg: var(--km-bg);
+  --card: var(--km-card);
+  --text: var(--km-text);
+  --muted: var(--km-muted);
+  --border: var(--km-border);
+  --radius: var(--km-radius);
+  --shadow: var(--km-shadow);
   min-height: 100vh;
   display: flex;
   align-items: center;
@@ -34,7 +34,7 @@ const Container = styled.div`
     radial-gradient(circle at top left, rgba(232, 121, 26, 0.12), transparent 30%),
     var(--bg);
   color: var(--text);
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--km-font);
   box-sizing: border-box;
 `;
 
@@ -139,7 +139,7 @@ const SubmitButton = styled.button`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   font-size: 16px;
   font-weight: 800;
-  background: ${({ disabled }) => (disabled ? '#c9c9c2' : 'linear-gradient(135deg, #E8791A 0%, #F5A24B 100%)')};
+  background: ${({ disabled }) => (disabled ? 'var(--border)' : 'linear-gradient(135deg, var(--accent) 0%, var(--accent-mid) 100%)')};
   box-shadow: ${({ disabled }) => (disabled ? 'none' : '0 10px 24px rgba(232, 121, 26, 0.22)')};
   transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
 
@@ -266,7 +266,7 @@ const CustomCheckbox = styled.input`
 const LoadingOverlay = styled.div`
   position: fixed;
   inset: 0;
-  background: rgba(250, 250, 248, 0.78);
+  background: color-mix(in srgb, var(--bg) 80%, transparent);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
@@ -278,7 +278,7 @@ const LoadingOverlay = styled.div`
 const Spinner = styled.div`
   width: 44px;
   height: 44px;
-  border: 4px solid #f2ded0;
+  border: 4px solid var(--accent-light);
   border-top-color: var(--accent);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;

--- a/src/components/MedicationInteractionControls.jsx
+++ b/src/components/MedicationInteractionControls.jsx
@@ -7,9 +7,9 @@ export const COLOR_OPTIONS = [
   {
     key: 'none',
     label: 'Без кольору',
-    background: 'white',
-    border: '#d0d0d0',
-    text: 'black',
+    background: 'var(--km-card)',
+    border: 'var(--km-border)',
+    text: 'var(--km-text)',
   },
   {
     key: 'morning',
@@ -45,10 +45,10 @@ const MenuContainer = styled.div`
   top: ${({ $anchor }) => `${$anchor.y}px`};
   left: ${({ $anchor }) => `${$anchor.x}px`};
   transform: translate(-50%, 8px);
-  background: white;
-  border: 1px solid #d0d0d0;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   border-radius: 10px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--km-shadow-pop);
   padding: 6px;
   z-index: 20;
   min-width: 160px;
@@ -86,7 +86,7 @@ const MenuItem = styled.button`
 const MenuHint = styled.span`
   display: block;
   padding: 4px 6px 0;
-  color: #666;
+  color: var(--km-muted);
   font-size: 12px;
 `;
 

--- a/src/components/MedicationSchedule.jsx
+++ b/src/components/MedicationSchedule.jsx
@@ -45,7 +45,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  color: black;
+  color: var(--km-text);
 `;
 
 const IssuedList = styled.div`
@@ -98,28 +98,28 @@ const IssuedInput = styled.input`
   width: 120px;
   padding: 6px 10px;
   border-radius: 6px;
-  border: 1px solid #d0d0d0;
+  border: 1px solid var(--km-border);
   font-size: 14px;
-  color: black;
+  color: var(--km-text);
 
   &::placeholder {
-    color: #888;
+    color: var(--km-muted);
   }
 `;
 
 const IssuedStats = styled.span`
   font-size: 13px;
-  color: #666;
+  color: var(--km-muted);
 `;
 
 const RemainingValue = styled.span`
   color: ${props => {
     if (props.$negative) {
-      return '#d1433f';
+      return 'var(--km-danger)';
     }
 
     if (props.$positive) {
-      return '#1a7f37';
+      return 'var(--km-success)';
     }
 
     return 'inherit';
@@ -129,7 +129,7 @@ const RemainingValue = styled.span`
 
 const FormulaHint = styled.span`
   font-size: 12px;
-  color: #888;
+  color: var(--km-muted);
 `;
 
 const AddMedicationRow = styled.div`
@@ -137,7 +137,7 @@ const AddMedicationRow = styled.div`
   flex-direction: column;
   gap: 8px;
   padding-top: 12px;
-  border-top: 1px solid #e6e6e6;
+  border-top: 1px solid var(--km-border);
 `;
 
 const AddMedicationLabel = styled.span`
@@ -156,9 +156,9 @@ const AddMedicationInput = styled.input`
   width: ${props => (props.$wide ? '200px' : '120px')};
   padding: 6px 10px;
   border-radius: 6px;
-  border: 1px solid #d0d0d0;
+  border: 1px solid var(--km-border);
   font-size: 14px;
-  color: black;
+  color: var(--km-text);
   box-sizing: border-box;
 `;
 
@@ -166,7 +166,7 @@ const AddMedicationButton = styled.button`
   padding: 6px 10px;
   border-radius: 6px;
   border: none;
-  background-color: #2e7d32;
+  background-color: var(--km-success);
   color: white;
   font-size: 16px;
   cursor: pointer;
@@ -174,10 +174,10 @@ const AddMedicationButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease;
 
   &:hover:not(:disabled) {
-    background-color: #276528;
+    filter: brightness(0.9);
   }
 
   &:disabled {
@@ -188,12 +188,12 @@ const AddMedicationButton = styled.button`
 
 const AddMedicationHint = styled.span`
   font-size: 12px;
-  color: #777;
+  color: var(--km-muted);
 `;
 
 const AddMedicationGuide = styled.span`
   font-size: 12px;
-  color: #555;
+  color: var(--km-muted);
   white-space: nowrap;
 `;
 
@@ -201,14 +201,14 @@ const TableWrapper = styled.div`
   position: relative;
   max-height: 60vh;
   overflow: auto;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--km-border);
   border-radius: 8px;
 `;
 
 const StyledTable = styled.table`
   width: 100%;
   border-collapse: collapse;
-  color: black;
+  color: var(--km-text);
   table-layout: fixed;
 `;
 
@@ -219,15 +219,15 @@ const TableHead = styled.thead`
 `;
 
 const TableHeaderRow = styled.tr`
-  background: #fafafa;
+  background: var(--km-card);
 `;
 
 const Th = styled.th`
   position: sticky;
   top: 0;
-  background: #fafafa;
+  background: var(--km-card);
   padding: 2px 4px;
-  border-bottom: 1px solid #d9d9d9;
+  border-bottom: 1px solid var(--km-border);
   font-weight: 500;
   text-align: center;
   vertical-align: middle;
@@ -236,7 +236,7 @@ const Th = styled.th`
 
 const Td = styled.td`
   padding: 4px 4px;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--km-border);
   vertical-align: middle;
 `;
 
@@ -246,23 +246,23 @@ const CellInput = styled.input`
   min-width: 0;
   padding: 2.4px;
   border-radius: 6px;
-  border: 1px solid ${({ $visual }) => $visual?.border || '#d0d0d0'};
+  border: 1px solid ${({ $visual }) => $visual?.border || 'var(--km-border)'};
   font-size: 13px;
   text-align: center;
-  color: ${({ $visual }) => $visual?.text || 'black'};
+  color: ${({ $visual }) => $visual?.text || 'var(--km-text)'};
   box-sizing: border-box;
   display: inline-block;
-  background-color: ${({ $visual }) => $visual?.background || 'white'};
+  background-color: ${({ $visual }) => $visual?.background || 'var(--km-card)'};
   transition: background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease;
   &::placeholder {
-    color: #b0b0b0;
+    color: var(--km-muted);
   }
 `;
 
 const MedicationTh = styled(Th)`
   text-align: center;
   padding: 2px;
-  background: #fafafa;
+  background: var(--km-card);
   overflow: visible;
 `;
 
@@ -300,16 +300,16 @@ const MedicationHeaderButton = styled.button`
   ${({ $reorderTarget }) =>
     $reorderTarget &&
     css`
-      box-shadow: inset 0 0 0 1px #ffb74d;
+      box-shadow: inset 0 0 0 1px var(--km-accent);
     `}
 
   &:hover {
     background: rgba(183, 28, 28, 0.1);
-    color: #b71c1c;
+    color: var(--km-danger);
   }
 
   &:focus-visible {
-    outline: 2px solid #b71c1c;
+    outline: 2px solid var(--km-danger);
     outline-offset: 2px;
   }
 `;
@@ -335,7 +335,7 @@ const DayCell = styled.div`
 
 const DayBadge = styled.span`
   font-size: 11px;
-  color: #555;
+  color: var(--km-muted);
   font-weight: 600;
   white-space: nowrap;
 `;
@@ -357,35 +357,35 @@ const DateText = styled.span`
 
 const WeekdayTag = styled.span`
   font-size: 12px;
-  color: #777;
+  color: var(--km-muted);
   text-transform: lowercase;
 `;
 
 const YearSeparatorRow = styled.tr`
-  background: #f3f3f3;
+  background: var(--km-border);
 `;
 
 const YearSeparatorCell = styled.td`
   padding: 6px 10px;
   font-weight: 600;
   font-size: 13px;
-  color: #444;
-  border-bottom: 1px solid #e0e0e0;
+  color: var(--km-text);
+  border-bottom: 1px solid var(--km-border);
 `;
 
 const HighlightedRow = styled.tr`
-  background: #fff6e5;
+  background: var(--km-accent-light);
 `;
 
 const DescriptionRow = styled.tr`
-  background: #fffaf0;
+  background: var(--km-accent-light);
 `;
 
 const DescriptionCell = styled.td`
   padding: 6px 8px;
-  border-bottom: 1px solid #f0e0c5;
+  border-bottom: 1px solid var(--km-border);
   font-size: 13px;
-  color: #6a4b16;
+  color: var(--km-accent);
 `;
 
 const MedicationTd = styled(Td)`
@@ -417,7 +417,7 @@ const ModalOverlay = styled.div`
 `;
 
 const ModalContainer = styled.div`
-  background: white;
+  background: var(--km-card);
   border-radius: 12px;
   padding: 24px;
   width: min(90vw, 360px);
@@ -436,7 +436,7 @@ const ModalTitle = styled.h2`
 const ModalMessage = styled.p`
   margin: 0;
   font-size: 14px;
-  color: #444;
+  color: var(--km-text);
   white-space: pre-line;
 `;
 
@@ -465,47 +465,52 @@ const ModalButton = styled.button`
 `;
 
 const ModalCancelButton = styled(ModalButton)`
-  background: #e0e0e0;
-  color: #333;
+  background: var(--km-border);
+  color: var(--km-text);
+  transition: filter 0.2s ease;
 
   &:hover {
-    background: #cfcfcf;
+    filter: brightness(0.92);
   }
 `;
 
 const ModalSecondaryButton = styled(ModalButton)`
   background: #1976d2;
   color: white;
+  transition: filter 0.2s ease;
 
   &:hover {
-    background: #115293;
+    filter: brightness(0.85);
   }
 `;
 
 const ModalDirectionButton = styled(ModalButton)`
-  background: #eeeeee;
-  color: #333;
+  background: var(--km-border);
+  color: var(--km-text);
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  transition: filter 0.2s ease;
 
   &:hover {
-    background: #e0e0e0;
+    filter: brightness(0.92);
   }
 
   &:disabled {
-    background: #f5f5f5;
-    color: #aaaaaa;
+    background: var(--km-border);
+    color: var(--km-muted);
+    filter: none;
     cursor: not-allowed;
   }
 `;
 
 const ModalConfirmButton = styled(ModalButton)`
-  background: #d84315;
+  background: var(--km-danger);
   color: white;
+  transition: filter 0.2s ease;
 
   &:hover {
-    background: #bf360c;
+    filter: brightness(0.9);
   }
 `;
 
@@ -519,13 +524,13 @@ const ModalSectionTitle = styled.h3`
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: #222;
+  color: var(--km-text);
 `;
 
 const ModalHint = styled.p`
   margin: 0;
   font-size: 13px;
-  color: #555;
+  color: var(--km-muted);
   white-space: pre-line;
 `;
 
@@ -538,22 +543,22 @@ const HiddenOptionList = styled.div`
 const HiddenOptionButton = styled.button`
   padding: 8px 10px;
   border-radius: 6px;
-  border: 1px solid #d0d0d0;
-  background: white;
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
   cursor: pointer;
   text-align: left;
   font-size: 14px;
   transition: background-color 0.2s ease, border-color 0.2s ease;
 
   &:hover {
-    background: #f5f5f5;
-    border-color: #bdbdbd;
+    background: var(--km-border);
+    border-color: var(--km-accent);
   }
 `;
 
 const HiddenOptionEmpty = styled.span`
   font-size: 13px;
-  color: #777;
+  color: var(--km-muted);
 `;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;

--- a/src/components/MedicationsPage.jsx
+++ b/src/components/MedicationsPage.jsx
@@ -20,6 +20,7 @@ import {
 import { formatMedicationScheduleForClipboard } from '../utils/medicationClipboard';
 import { isMedicationPhotoUrl } from '../utils/photoFilters';
 import { MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
+import { KmPage } from './styles/knowme';
 
 const onValue = wrapAdminOnValue(firebaseOnValue, {
   operation: 'onValue',
@@ -59,7 +60,7 @@ const arePhotoListsEqual = (first = [], second = []) => {
   return first.every((item, index) => item === second[index]);
 };
 
-const PageContainer = styled.div`
+const PageContainer = styled(KmPage)`
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -67,7 +68,6 @@ const PageContainer = styled.div`
   max-width: 960px;
   margin: 0 auto;
   box-sizing: border-box;
-  color: black;
 `;
 
 const Header = styled.div`
@@ -88,14 +88,14 @@ const BackButton = styled.button`
   padding: 6px 12px;
   border-radius: 6px;
   border: none;
-  background-color: #ffb347;
-  color: white;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+  color: #fff;
   cursor: pointer;
   font-size: 14px;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease;
 
   &:hover {
-    background-color: #ff9a1a;
+    filter: brightness(1.05);
   }
 `;
 
@@ -107,14 +107,14 @@ const IconSquareButton = styled.button`
   height: 34px;
   border-radius: 6px;
   border: none;
-  background-color: #ffb347;
-  color: white;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+  color: #fff;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease;
   padding: 0;
 
   &:hover:not(:disabled) {
-    background-color: #ff9a1a;
+    filter: brightness(1.05);
   }
 
   &:disabled {
@@ -141,7 +141,7 @@ const Title = styled.h1`
 
 const Subtitle = styled.span`
   font-size: 14px;
-  color: #555;
+  color: var(--km-muted);
 `;
 
 const DeleteButtonsWrapper = styled.div`
@@ -155,14 +155,14 @@ const DeleteButton = styled.button`
   padding: 6px 12px;
   border-radius: 6px;
   border: none;
-  background-color: #d32f2f;
+  background-color: var(--km-danger);
   color: white;
   cursor: pointer;
   font-size: 14px;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease;
 
   &:hover:not(:disabled) {
-    background-color: #b71c1c;
+    filter: brightness(0.9);
   }
 
   &:disabled {
@@ -172,29 +172,29 @@ const DeleteButton = styled.button`
 `;
 
 const ClearScheduleButton = styled(DeleteButton)`
-  background-color: #f57c00;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
 
   &:hover:not(:disabled) {
-    background-color: #ef6c00;
+    filter: brightness(1.05);
   }
 `;
 
 const Card = styled.div`
-  background-color: #f9f9f9;
+  background-color: var(--km-card);
   border-radius: 12px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--km-shadow);
   padding: 20px;
 `;
 
 const Message = styled.p`
   margin: 0;
   font-size: 14px;
-  color: #444;
+  color: var(--km-text);
 `;
 
 const LoadingState = styled.div`
   font-size: 14px;
-  color: #666;
+  color: var(--km-muted);
 `;
 
 const PhotosModalOverlay = styled.div`
@@ -213,9 +213,10 @@ const PhotosModalOverlay = styled.div`
 `;
 
 const PhotosModal = styled.div`
-  background: #fff;
+  background: var(--km-card);
+  color: var(--km-text);
   border-radius: 12px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--km-shadow-pop);
   width: min(700px, 100%);
   max-height: 90vh;
   display: flex;
@@ -228,7 +229,7 @@ const PhotosModalHeader = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--km-border);
 `;
 
 const PhotosModalTitle = styled.h2`
@@ -240,12 +241,12 @@ const PhotosModalTitle = styled.h2`
 const CloseModalButton = styled.button`
   border: none;
   background: transparent;
-  color: #333;
+  color: var(--km-muted);
   cursor: pointer;
   padding: 4px;
 
   &:hover {
-    color: #000;
+    color: var(--km-text);
   }
 `;
 
@@ -272,7 +273,7 @@ const PhotoThumbnailButton = styled.button`
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
-  background: #f2f2f2;
+  background: var(--km-border);
   position: relative;
   width: 100%;
   aspect-ratio: 1;
@@ -305,14 +306,14 @@ const PhotoDeleteButton = styled.button`
   padding: 4px 6px;
   border: none;
   border-radius: 6px;
-  background-color: #d32f2f;
+  background-color: var(--km-danger);
   color: #fff;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease;
   font-size: 12px;
 
   &:hover:not(:disabled) {
-    background-color: #b71c1c;
+    filter: brightness(0.9);
   }
 
   &:disabled {
@@ -333,10 +334,10 @@ const UploadLabel = styled.label`
   gap: 8px;
   padding: 8px 16px;
   border-radius: 6px;
-  background-color: #ffb347;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
   color: #fff;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease;
 
   ${({ $disabled }) =>
     $disabled
@@ -347,7 +348,7 @@ const UploadLabel = styled.label`
   `
       : `
     &:hover {
-      background-color: #ff9a1a;
+      filter: brightness(1.05);
     }
   `}
 `;

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FaArrowLeft, FaArrowRight } from 'react-icons/fa';
+import { KmIconButton } from './styles/knowme';
 
 export const Pagination = ({ currentPage, totalPages, onPageChange }) => {
   if (totalPages <= 1) return null;
@@ -12,11 +13,6 @@ export const Pagination = ({ currentPage, totalPages, onPageChange }) => {
     if (currentPage < totalPages) onPageChange(currentPage + 1);
   };
 
-  const buttonStyle = {
-    margin: '0 5px',
-    padding: '5px 10px',
-  };
-
   return (
     <div
       style={{
@@ -24,23 +20,28 @@ export const Pagination = ({ currentPage, totalPages, onPageChange }) => {
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
+        gap: '10px',
       }}
     >
-      <button
+      <KmIconButton
+        type="button"
         onClick={handlePrev}
         disabled={currentPage === 1}
-        style={buttonStyle}
+        aria-label="Попередня сторінка"
+        title="Попередня сторінка"
       >
-        <FaArrowLeft />
-      </button>
-      <span style={{ margin: '0 10px' }}>{`${currentPage} / ${totalPages}`}</span>
-      <button
+        <FaArrowLeft size={14} />
+      </KmIconButton>
+      <span style={{ color: 'var(--km-text)', fontSize: '14px' }}>{`${currentPage} / ${totalPages}`}</span>
+      <KmIconButton
+        type="button"
         onClick={handleNext}
         disabled={currentPage === totalPages}
-        style={buttonStyle}
+        aria-label="Наступна сторінка"
+        title="Наступна сторінка"
       >
-        <FaArrowRight />
-      </button>
+        <FaArrowRight size={14} />
+      </KmIconButton>
     </div>
   );
 };

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -869,7 +869,7 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
                               style={removeButtonStyle}
                               onClick={() => handleRemove(arrayKey)}
                             >
-                              <FaTimes size={12} color={color.white} />
+                              <FaTimes size={12} />
                             </OrangeBtn>
                           )}
                         </div>
@@ -889,7 +889,7 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
                             style={removeButtonStyle}
                             onClick={() => handleRemove(arrayKey)}
                           >
-                            <FaTimes size={12} color={color.white} />
+                            <FaTimes size={12} />
                           </OrangeBtn>
                         )}
                       </div>
@@ -906,7 +906,7 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
                 style={removeButtonStyle}
                 onClick={() => handleRemove(nestedKey)}
               >
-                <FaTimes size={12} color={color.white} />
+                <FaTimes size={12} />
               </OrangeBtn>
             )}
           </div>
@@ -931,7 +931,7 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
                 style={removeButtonStyle}
                 onClick={() => handleRemove(nestedKey)}
               >
-                <FaTimes size={12} color={color.white} />
+                <FaTimes size={12} />
               </OrangeBtn>
             )}
           </div>
@@ -952,7 +952,7 @@ export const renderAllFields = (data, parentKey = '', options = {}) => {
             style={removeButtonStyle}
             onClick={() => handleRemove(nestedKey)}
           >
-            <FaTimes size={12} color={color.white} />
+            <FaTimes size={12} />
           </OrangeBtn>
         )}
       </div>
@@ -3622,7 +3622,7 @@ const SearchIdBackendButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: ${color.accent};
+  color: var(--km-accent);
   font-size: 16px;
   width: 35px;
   height: 35px;
@@ -3630,7 +3630,7 @@ const SearchIdBackendButton = styled.button`
   z-index: 1;
 
   &:hover {
-    color: ${color.iconActive};
+    color: var(--km-text);
   }
 `;
 
@@ -4046,8 +4046,8 @@ const Button = styled.button`
   height: 34px;
   min-height: 34px;
   padding: 0 8px;
-  border: 1px solid rgba(255, 140, 0, 0.35);
-  background: linear-gradient(135deg, #ffb347 0%, #ff9800 100%);
+  border: 1px solid var(--km-accent-mid);
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
   color: #fff;
   border-radius: 999px;
   cursor: pointer;
@@ -4061,7 +4061,7 @@ const Button = styled.button`
 
   &:hover {
     filter: brightness(1.04);
-    box-shadow: 0 3px 8px rgba(255, 140, 0, 0.22);
+    box-shadow: 0 8px 22px rgba(232, 121, 26, 0.28);
   }
 
   &:active {

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -24,10 +24,11 @@ const SearchIcon = (
     height="16"
     viewBox="0 0 24 24"
     fill="none"
-    stroke="gray"
+    stroke="currentColor"
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
+    style={{ color: 'var(--km-muted)' }}
   >
     <circle cx="11" cy="11" r="8" />
     <line x1="21" y1="21" x2="16.65" y2="16.65" />
@@ -39,15 +40,20 @@ const InputDiv = styled.div`
   align-items: center;
   position: relative;
   margin: 10px 0;
-  padding: 10px;
-  background-color: #fff;
-  border: 3px solid;
-  border-image: linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1;
-  border-radius: 5px;
+  padding: 10px 14px;
+  background-color: var(--km-card);
+  border: 1.5px solid var(--km-border);
+  border-radius: var(--km-radius);
   box-sizing: border-box;
   flex: 1 1 auto;
   min-width: 0;
   height: auto;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+
+  &:focus-within {
+    border-color: var(--km-accent);
+    box-shadow: 0 0 0 3px var(--km-accent-ring);
+  }
 `;
 
 const InputFieldContainer = styled.div`
@@ -73,7 +79,9 @@ const InputField = styled.textarea`
   overflow: hidden;
   min-height: 24px;
   line-height: normal;
-  
+  background: transparent;
+  color: var(--km-text);
+  font-family: var(--km-font);
 `;
 
 const ClearButton = styled.button`
@@ -85,13 +93,13 @@ const ClearButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: gray;
+  color: var(--km-muted);
   font-size: 18px;
   width: 35px;
   height: 35px;
 
   &:hover {
-    color: black;
+    color: var(--km-accent);
   }
 `;
 
@@ -100,23 +108,27 @@ const HistoryList = styled.ul`
   top: 100%;
   left: 0;
   right: 0;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  border-radius: 0 0 var(--km-radius) var(--km-radius);
+  box-shadow: var(--km-shadow);
   z-index: 10;
   list-style: none;
   margin: 0;
   padding: 0;
+  overflow: hidden;
 `;
 
 const HistoryItem = styled.li`
   display: flex;
   justify-content: space-between;
-  padding: 5px 10px;
+  padding: 8px 14px;
   cursor: pointer;
-  color: black;
+  color: var(--km-text);
+  font-size: 14px;
 
   &:hover {
-    background-color: #f0f0f0;
+    background-color: var(--km-accent-light);
   }
 `;
 
@@ -124,10 +136,10 @@ const HistoryRemove = styled.button`
   border: none;
   background: none;
   cursor: pointer;
-  color: gray;
+  color: var(--km-muted);
 
   &:hover {
-    color: black;
+    color: var(--km-accent);
   }
 `;
 

--- a/src/components/StimulationSchedule.jsx
+++ b/src/components/StimulationSchedule.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { handleChange, handleSubmit } from './smallCard/actions';
 import { formatDateToServer } from 'components/inputValidations';
-import { OrangeBtn, color } from 'components/styles';
+import { OrangeBtn } from 'components/styles';
 import { ReactComponent as ClipboardIcon } from 'assets/icons/clipboard.svg';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 
@@ -3101,13 +3101,13 @@ const StimulationSchedule = ({
           <div
             onClick={event => event.stopPropagation()}
             style={{
-              backgroundColor: '#fff',
+              backgroundColor: 'var(--km-card)',
               padding: '24px 20px',
               borderRadius: '8px',
               maxWidth: '320px',
               width: '90%',
-              color: '#000',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.2)',
+              color: 'var(--km-text)',
+              boxShadow: 'var(--km-shadow-pop)',
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
@@ -3142,8 +3142,9 @@ const StimulationSchedule = ({
                   minWidth: '120px',
                   padding: '10px 16px',
                   borderRadius: '6px',
-                  border: '1px solid #ccc',
-                  backgroundColor: '#fff',
+                  border: '1px solid var(--km-border)',
+                  backgroundColor: 'var(--km-card)',
+                  color: 'var(--km-text)',
                   cursor: 'pointer',
                   fontWeight: 600,
                 }}
@@ -3158,7 +3159,7 @@ const StimulationSchedule = ({
                   padding: '10px 16px',
                   borderRadius: '6px',
                   border: 'none',
-                  backgroundColor: color.accent,
+                  backgroundColor: 'var(--km-danger)',
                   color: '#fff',
                   cursor: 'pointer',
                   fontWeight: 600,

--- a/src/components/VerifyEmail.jsx
+++ b/src/components/VerifyEmail.jsx
@@ -1,15 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { onAuthStateChanged, sendEmailVerification } from 'firebase/auth';
 import { auth } from './config';
-import { fontSize } from './styles';
 import styled from 'styled-components';
-import {SubmitButton} from './ProfileScreen';
 
-const ButtonText = styled.span`
-font-size: ${fontSize.biggest}px;
-margin-bottom: 20px;
+const VerifyButton = styled.button`
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 16px;
+  border: none;
+  border-radius: var(--km-radius);
+  background: ${({ disabled }) => (disabled ? 'var(--km-border)' : 'linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%)')};
+  color: ${({ disabled }) => (disabled ? 'var(--km-muted)' : '#fff')};
+  font-family: var(--km-font);
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  transition: filter 0.18s ease, box-shadow 0.18s ease;
+
+  &:hover {
+    filter: ${({ disabled }) => (disabled ? 'none' : 'brightness(1.05)')};
+  }
 `;
-  
+
     export   const VerifyEmail = () => {
 
         const language = 'uk';
@@ -76,22 +89,18 @@ margin-bottom: 20px;
         }, [isCounting]);
 
       return (
-          <div>
-            <SubmitButton 
-            disabled={isCounting} 
-            onClick={handleVerifyAgain} 
-            style={{backgroundColor: isCounting ? 'gray' : null }}
-            >
-            {!isCounting ? 'Підтвердити email':
-            (
-              <ButtonText style={{fontSize: fontSize.big, textAlign: 'center', color: 'white' }}>
-                {language==='uk'? 'Лист відправлено. Повторити через ':'Verify again in '}
-                {Math.floor(countdown / 60)}:{countdown % 60}
-                {language==='uk'? ' хв':' min'}
-              </ButtonText>
+          <VerifyButton
+            type="button"
+            disabled={isCounting}
+            onClick={handleVerifyAgain}
+          >
+            {!isCounting ? 'Підтвердити email' : (
+              <>
+                {language === 'uk' ? 'Лист відправлено. Повторити через ' : 'Verify again in '}
+                {Math.floor(countdown / 60)}:{String(countdown % 60).padStart(2, '0')}
+                {language === 'uk' ? ' хв' : ' min'}
+              </>
             )}
-            </SubmitButton>
-            
-          </div>
+          </VerifyButton>
       );
     }

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -441,8 +441,8 @@ const inlineModalOverlayStyle = {
 
 const inlineModalCardStyle = {
   width: 'min(92vw, 560px)',
-  background: '#fff',
-  color: '#111',
+  background: 'var(--km-card)',
+  color: 'var(--km-text)',
   borderRadius: '12px',
   padding: '14px',
   boxShadow: '0 18px 40px rgba(0, 0, 0, 0.35)',
@@ -452,12 +452,12 @@ const photosModalCardStyle = {
   width: 'min(94vw, 560px)',
   maxHeight: 'min(88vh, 720px)',
   overflowY: 'auto',
-  background: 'linear-gradient(180deg, #fffaf4 0%, #ffffff 42%)',
-  color: '#111827',
+  background: 'linear-gradient(180deg, var(--km-accent-light) 0%, var(--km-card) 42%)',
+  color: 'var(--km-text)',
   borderRadius: '20px',
   padding: '18px',
   boxShadow: '0 24px 70px rgba(0, 0, 0, 0.38)',
-  border: '1px solid rgba(245, 162, 75, 0.24)',
+  border: '1px solid var(--km-border)',
 };
 
 const photosModalHeaderStyle = {
@@ -470,14 +470,14 @@ const photosModalHeaderStyle = {
 
 const photosModalTitleStyle = {
   margin: 0,
-  color: '#111827',
+  color: 'var(--km-text)',
   fontSize: '18px',
   lineHeight: 1.2,
 };
 
 const photosModalSubtitleStyle = {
   margin: '4px 0 0',
-  color: '#6b7280',
+  color: 'var(--km-muted)',
   fontSize: '12px',
   lineHeight: 1.35,
 };
@@ -489,16 +489,16 @@ const photosCollectionToggleStyle = {
   padding: '3px',
   marginTop: '8px',
   borderRadius: '999px',
-  background: 'rgba(245, 162, 75, 0.12)',
-  border: '1px solid rgba(245, 162, 75, 0.22)',
+  background: 'var(--km-accent-light)',
+  border: '1px solid var(--km-border)',
 };
 
 const getPhotosCollectionToggleButtonStyle = isActive => ({
   border: 'none',
   borderRadius: '999px',
   padding: '5px 10px',
-  background: isActive ? '#e8791a' : 'transparent',
-  color: isActive ? '#fff' : '#7a4b23',
+  background: isActive ? 'var(--km-accent)' : 'transparent',
+  color: isActive ? '#fff' : 'var(--km-muted)',
   cursor: 'pointer',
   fontSize: '12px',
   fontWeight: 700,
@@ -510,9 +510,9 @@ const photosModalCloseButtonStyle = {
   width: '34px',
   height: '34px',
   borderRadius: '50%',
-  border: '1px solid #f0d8c2',
-  background: '#fff',
-  color: '#7a4b23',
+  border: '1px solid var(--km-border)',
+  background: 'var(--km-card)',
+  color: 'var(--km-text)',
   cursor: 'pointer',
   fontSize: '22px',
   lineHeight: 1,
@@ -522,7 +522,9 @@ const inlineModalTextareaStyle = {
   width: '100%',
   minHeight: '120px',
   borderRadius: '8px',
-  border: '1px solid #c7c7c7',
+  border: '1px solid var(--km-border)',
+  background: 'var(--km-card)',
+  color: 'var(--km-text)',
   padding: '10px',
   resize: 'vertical',
   fontSize: '14px',
@@ -548,8 +550,8 @@ const modalButtonBaseStyle = {
 
 const modalCancelButtonStyle = {
   ...modalButtonBaseStyle,
-  background: '#e5e7eb',
-  color: '#374151',
+  background: 'var(--km-border)',
+  color: 'var(--km-text)',
 };
 
 const modalSaveButtonStyle = {
@@ -560,7 +562,7 @@ const modalSaveButtonStyle = {
 
 const modalDeleteButtonStyle = {
   ...modalButtonBaseStyle,
-  background: '#d32f2f',
+  background: 'var(--km-danger)',
   color: '#fff',
 };
 

--- a/src/components/styles/index.js
+++ b/src/components/styles/index.js
@@ -373,15 +373,15 @@ export const UnderlinedInput = styled.input`
 
 export const uiTokens = {
   colors: {
-    pageBg: '#f4f6fb',
-    cardBg: '#ffffff',
-    textPrimary: '#1f2937',
-    textSecondary: '#6b7280',
-    border: '#eadfce',
-    borderFocus: '#ff8c00',
-    accent: '#ff8c00',
-    danger: '#e53935',
-    mutedBg: '#f8f3eb',
+    pageBg: 'var(--km-bg)',
+    cardBg: 'var(--km-card)',
+    textPrimary: 'var(--km-text)',
+    textSecondary: 'var(--km-muted)',
+    border: 'var(--km-border)',
+    borderFocus: 'var(--km-accent)',
+    accent: 'var(--km-accent)',
+    danger: 'var(--km-danger)',
+    mutedBg: 'color-mix(in srgb, var(--km-text) 6%, var(--km-card))',
   },
   radius: {
     sm: '8px',

--- a/src/components/styles/knowme.js
+++ b/src/components/styles/knowme.js
@@ -105,6 +105,11 @@ export const KmIconButton = styled.button`
   &:active {
     transform: scale(0.98);
   }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
 `;
 
 export const KmPrimaryButton = styled.button`


### PR DESCRIPTION
The photo viewer, comment-edit, and delete-confirmation popups in
renderTopBlock were hardcoded to light-theme colors (#fff, #111827,
#e5e7eb, etc.) and stayed light even when the app is in dark mode.
Swap them for the existing --km-* theme tokens (same ones InfoModal
already uses) so they follow the active theme. No layout/structure
changes.