### PR TITLE
Preserve flow formula operators & allow currency-only formulas

### DIFF
--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -559,7 +559,17 @@ const sanitizeAmountChunk = value =>
     .replace(/\s+/g, ' ')
     .trim();
 
-const normalizeFlowAmount = value => sanitizeAmountChunk(String(value || '').replace(/,/g, '.'));
+const normalizeFlowAmount = value => {
+  const normalized = String(value || '').replace(/,/g, '.');
+  if (isFormulaFlowAmount(normalized)) {
+    return normalized
+      .trim()
+      .replace(/[#[\]]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+  return sanitizeAmountChunk(normalized);
+};
 const FLOW_DATE_YMD_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 const toAmountNumber = value => {
@@ -727,11 +737,23 @@ const splitFlowAmountAndDescription = value => {
 
   if (raw.startsWith('=')) {
     let index = 1;
+    const canConsumeFormulaValue = () => {
+      const prefix = raw.slice(1, index).trimEnd();
+      if (!prefix) return true;
+      return /[+\-*/%(]$/.test(prefix);
+    };
+
     while (index < raw.length) {
       const tail = raw.slice(index);
       const identifierMatch = tail.match(/^(?:USD|EUR)\b/i);
       if (identifierMatch) {
+        if (!canConsumeFormulaValue()) break;
         index += identifierMatch[0].length;
+        continue;
+      }
+      if (raw[index] === '$') {
+        if (!canConsumeFormulaValue()) break;
+        index += 1;
         continue;
       }
       if (FLOW_FORMULA_TOKEN_REGEX.test(raw[index])) {
@@ -742,7 +764,7 @@ const splitFlowAmountAndDescription = value => {
     }
     const amountRaw = raw.slice(0, index).trim();
     const description = raw.slice(index).trim();
-    if (!/\d/.test(amountRaw)) return null;
+    if (!/(?:\d|\$|\b(?:USD|EUR)\b)/i.test(amountRaw)) return null;
     return { amountRaw, description };
   }
 


### PR DESCRIPTION
### Motivation
- Formula normalization removed `/` and `$`, corrupting valid formulas like `=100/2` and `=$` so they evaluated as invalid text. 
- Currency identifier tokens such as `USD`, `EUR` and the `$` shorthand were rejected when used as the entire formula value, preventing `=USD` or `=$` from being saved.
- Descriptions beginning with currency words (e.g. `=100 USD cash`) were being consumed into the formula, causing valid numeric formulas to fail evaluation.

### Description
- Updated `normalizeFlowAmount` to special-case formula values detected by `isFormulaFlowAmount` so `/` and `$` are preserved while still removing problematic characters like `#` and `[`/`]` for formulas, and leaving the existing sanitization for non-formula amounts. (`src/components/FlowManager.jsx`) 
- Enhanced `splitFlowAmountAndDescription` to introduce `canConsumeFormulaValue` logic which only consumes `USD`, `EUR`, or `$` into the formula when the parser is currently expecting a formula value (i.e. after an operator or at formula start). (`src/components/FlowManager.jsx`) 
- Added support for `$` in the formula scanner and widened the final validation to accept amounts that are digits or a currency identifier (`USD|EUR`) or the `$` shorthand so currency-only formulas like `=USD` or `=$` are accepted. (`src/components/FlowManager.jsx`)

### Testing
- Ran lint: `npm run lint:js -- src/components/FlowManager.jsx` which completed successfully. 
- Ran test suite: `npm test -- --watchAll=false --runInBand` which executed but reported existing unrelated failures (8 failed, 37 passed) in storage/matching tests; these failures are pre-existing and not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d4b0bb6748326bb91a97c68132fe8)