### PR TITLE
Fix flow currency formula parsing

### DIFF
--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -729,7 +729,10 @@ const resolveFlowDisplayAmount = ({
 const getFlowAmountNumberForTotals = options => toAmountNumber(resolveFlowDisplayAmount(options));
 
 const FLOW_FORMULA_TOKEN_REGEX = /[0-9.,+\-*/%()\s×xXхХ÷:−–—$]/;
+const FLOW_FORMULA_OPERATOR_END_REGEX = /[+\-*/%(×xXхХ÷:−–—]$/;
 const FLOW_AMOUNT_START_REGEX = /^(?:[+-]?\d+(?:[.,]\d+)?|=)/;
+const normalizeFlowCurrencyFormulaAmount = amount =>
+  String(amount || '').startsWith('=') ? String(amount || '').replace(/\$/g, 'USD') : amount;
 
 const splitFlowAmountAndDescription = value => {
   const raw = String(value || '').trim();
@@ -740,7 +743,7 @@ const splitFlowAmountAndDescription = value => {
     const canConsumeFormulaValue = () => {
       const prefix = raw.slice(1, index).trimEnd();
       if (!prefix) return true;
-      return /[+\-*/%(]$/.test(prefix);
+      return FLOW_FORMULA_OPERATOR_END_REGEX.test(prefix);
     };
 
     while (index < raw.length) {
@@ -796,7 +799,7 @@ export const parseFlowEntryLine = (line, fallbackDate = '') => {
 
   const fallbackYear = Number(String(fallbackDate).split('-')[0]) || new Date().getFullYear();
   const parsedDate = lineMatch[1] ? parseDisplayDate(lineMatch[1], fallbackYear) : fallbackDate;
-  const parsedAmount = normalizeFlowAmount(amountParts.amountRaw || '');
+  const parsedAmount = normalizeFlowCurrencyFormulaAmount(normalizeFlowAmount(amountParts.amountRaw || ''));
   const { text: descriptionWithoutCustomRate, customUsdRate } = extractCustomUsdRateFromText(
     amountParts.description || ''
   );

--- a/src/components/FlowManager.test.jsx
+++ b/src/components/FlowManager.test.jsx
@@ -1,0 +1,39 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+global.TextDecoder = TextDecoder;
+global.TextEncoder = TextEncoder;
+
+jest.mock('./config', () => ({
+  deleteFlowEntry: jest.fn(),
+  deleteFlowCategory: jest.fn(),
+  renameFlowCategory: jest.fn(),
+  clearFlowData: jest.fn(),
+  fetchFlowData: jest.fn(),
+  fetchMonobankUahExchangeRates: jest.fn(),
+  fetchNbuUahExchangeRatesByDate: jest.fn(),
+  resolveFlowExchangeRatesForMode: jest.fn(),
+  saveFlowEntry: jest.fn(),
+  updateFlowEntry: jest.fn(),
+}));
+
+const { parseFlowEntryLine } = require('./FlowManager');
+
+describe('parseFlowEntryLine', () => {
+  it('keeps dollar-only formulas as a persistable USD formula amount', () => {
+    expect(parseFlowEntryLine('=$ lunch', '2026-07-07')).toMatchObject({
+      amount: '=USD',
+      description: 'lunch',
+    });
+  });
+
+  it('accepts currency tokens after localized formula operators', () => {
+    expect(parseFlowEntryLine('=100×USD rent', '2026-07-07')).toMatchObject({
+      amount: '=100×USD',
+      description: 'rent',
+    });
+    expect(parseFlowEntryLine('=100÷EUR coffee', '2026-07-07')).toMatchObject({
+      amount: '=100÷EUR',
+      description: 'coffee',
+    });
+  });
+});

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1207,7 +1207,8 @@ const sanitizeFlowValuePart = value =>
     .replace(/\s+/g, ' ')
     .trim();
 
-const normalizeFlowStoredAmount = value => sanitizeFlowValuePart(String(value || '').replace(/,/g, '.'));
+const normalizeFlowStoredAmount = value =>
+  sanitizeFlowValuePart(String(value || '').replace(/,/g, '.').replace(/\$/g, 'USD'));
 
 const buildFlowEntryValue = ({ amount, description = '' }) => {
   const safeAmount = normalizeFlowStoredAmount(amount);


### PR DESCRIPTION
### Motivation
- Prevent dollar-only formula tokens like `=$ lunch` from being sanitized into an empty/invalid stored amount so they remain evaluable after reload.
- Ensure currency identifiers (USD/EUR/$) are consumed after localized formula operators such as `×`, `÷`, `:`, and unicode minus variants so formulas like `=100×USD rent` parse correctly.

### Description
- Added `FLOW_FORMULA_OPERATOR_END_REGEX` and switched the localized-operator check in `splitFlowAmountAndDescription` to use it so the parser recognizes the same operator variants used during evaluation (`src/components/FlowManager.jsx`).
- Added `normalizeFlowCurrencyFormulaAmount` and applied it when producing the parsed amount in `parseFlowEntryLine` so formula amounts keep `$` mapped to `USD` before further normalization (`src/components/FlowManager.jsx`).
- Updated `normalizeFlowStoredAmount` to map `$` to `USD` prior to sanitization so stored values remain evaluable (`src/components/config.js`).
- Added regression tests covering dollar-only formulas and localized-operator currency formulas in `src/components/FlowManager.test.jsx`.

### Testing
- Ran `CI=true npm test -- --watchAll=false src/components/FlowManager.test.jsx` and the new regression tests passed.
- Ran `CI=true npm test -- --watchAll=false src/utils/flowAmountFormula.test.js` and all existing formula unit tests passed.
- Ran `npx eslint src/components/FlowManager.jsx src/components/config.js src/components/FlowManager.test.jsx` and linting completed without errors (Browserslist notice only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d5b318b5c83269c71ca606cedc534)