### PR TITLE
Center brand alignment and restyle BrandTagline as badge

### DIFF
--- a/src/components/styles/knowme.js
+++ b/src/components/styles/knowme.js
@@ -28,7 +28,7 @@ export const KmTopbar = styled.div`
 
 const BrandWrap = styled.div`
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   min-width: 0;
 `;
@@ -46,11 +46,16 @@ const BrandAccent = styled.span`
 `;
 
 const BrandTagline = styled.span`
-  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border: 1px solid var(--km-border);
+  border-radius: 999px;
+  background: var(--km-accent-light);
+  color: var(--km-accent);
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--km-muted);
+  letter-spacing: 0.02em;
   white-space: nowrap;
 
   @media (max-width: 380px) {


### PR DESCRIPTION
### Motivation
- Align the brand elements and make the tagline more visually prominent and consistent by converting it into a compact badge-style element.

### Description
- Updated `BrandWrap` to use `align-items: center` and restyled `BrandTagline` to `display: inline-flex` with padding, border, rounded radius, accent background and color, adjusted `font-size` and `letter-spacing`, while keeping the mobile hide at `@media (max-width: 380px)`.

### Testing
- Ran the existing automated test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6684110c832694bb5a4113d599e8)