### PR TITLE
Allow removing and inserting package services in edit mode (with selection modal)

### DIFF
--- a/src/components/BudgetPage.editMode.test.js
+++ b/src/components/BudgetPage.editMode.test.js
@@ -27,6 +27,13 @@ const fixtureCatalog = {
       description: 'Daily care in hospital.',
       category: 'deliveryAndNewborn',
     },
+    {
+      id: '11',
+      name: 'Airport transfer',
+      price: 90,
+      description: 'Transfer from the airport.',
+      category: 'logistics',
+    },
   ],
   technical: {
     paymentSchedules: [
@@ -202,4 +209,71 @@ describe('BudgetPage edit mode', () => {
       root.unmount();
     });
   });
+
+  it('removes package children and inserts a selected service after the requested child', async () => {
+    const root = createRoot(container);
+    await act(async () => {
+      mountBudgetPage(root);
+    });
+    await flush();
+
+    const includedToggle = Array.from(container.querySelectorAll('button')).find(btn => btn.textContent.includes("What's included"));
+    expect(includedToggle).toBeTruthy();
+    await act(async () => {
+      includedToggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const removeChildButton = Array.from(container.querySelectorAll('button')).find(btn => btn.title === 'Remove this service from the package');
+    expect(removeChildButton).toBeTruthy();
+    await act(async () => {
+      removeChildButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    expect(update).toHaveBeenCalledWith('budget/packages/0', { children: [] });
+
+    const freshCatalog = {
+      ...fixtureCatalog,
+      packages: [{ ...fixtureCatalog.packages[0], children: ['10'] }],
+    };
+    get.mockImplementation(() => Promise.resolve({ exists: () => true, val: () => freshCatalog }));
+    update.mockClear();
+    await act(async () => {
+      root.unmount();
+    });
+
+    const secondRoot = createRoot(container);
+    await act(async () => {
+      mountBudgetPage(secondRoot);
+    });
+    await flush();
+
+    const secondIncludedToggle = Array.from(container.querySelectorAll('button')).find(btn => btn.textContent.includes("What's included"));
+    await act(async () => {
+      secondIncludedToggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const insertAfterButton = Array.from(container.querySelectorAll('button')).find(btn => btn.title === 'Insert service after this one');
+    expect(insertAfterButton).toBeTruthy();
+    await act(async () => {
+      insertAfterButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const transferButton = Array.from(container.querySelectorAll('button')).find(btn => btn.textContent.includes('Airport transfer'));
+    expect(transferButton).toBeTruthy();
+    await act(async () => {
+      transferButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    expect(update).toHaveBeenCalledWith('budget/packages/0', { children: ['10', '11'] });
+
+    await act(async () => {
+      secondRoot.unmount();
+    });
+  });
+
 });

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -974,6 +974,7 @@ const BudgetPage = ({ isAdmin = false }) => {
   const [query, setQuery] = useState('');
   const [showStickyContact, setShowStickyContact] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const [insertChildTarget, setInsertChildTarget] = useState(null);
   const [isExporting, setIsExporting] = useState(false);
   const [categoryDrafts, setCategoryDrafts] = useState({});
   const [exchangeRates, setExchangeRates] = useState(null);
@@ -1304,6 +1305,54 @@ const BudgetPage = ({ isAdmin = false }) => {
     const url = buildBudgetBackendUrl(collection, index);
     if (!url) return;
     window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const persistProgramChildren = async (programId, nextChildren, successMessage = 'Package services updated.') => {
+    const packageIndex = catalog.packages.findIndex(record => String(record.id) === String(programId));
+    if (packageIndex === -1) return;
+    setCatalog(current => ({
+      ...current,
+      packages: current.packages.map(record => (String(record.id) === String(programId)
+        ? { ...record, children: nextChildren }
+        : record)),
+    }));
+    try {
+      await update(ref(database, `budget/packages/${packageIndex}`), { children: nextChildren });
+      toast.success(successMessage);
+    } catch (saveError) {
+      console.error('Unable to update package services', saveError);
+      toast.error('Unable to update package services.');
+      loadBudget();
+    }
+  };
+
+  const removeProgramChild = (program, itemId) => {
+    const nextChildren = (Array.isArray(program.children) ? program.children : [])
+      .filter(id => String(id) !== String(itemId));
+    persistProgramChildren(program.id, nextChildren, 'Service removed from package.');
+  };
+
+  const insertProgramChild = itemId => {
+    if (!insertChildTarget) return;
+    const program = catalog.packages.find(record => String(record.id) === String(insertChildTarget.programId));
+    if (!program) {
+      setInsertChildTarget(null);
+      return;
+    }
+    const children = Array.isArray(program.children) ? program.children : [];
+    const normalizedItemId = String(itemId);
+    if (children.some(id => String(id) === normalizedItemId)) {
+      toast.error('This service is already included in the package.');
+      return;
+    }
+    const insertIndex = Math.max(0, Math.min(children.length, insertChildTarget.insertIndex));
+    const nextChildren = [
+      ...children.slice(0, insertIndex),
+      normalizedItemId,
+      ...children.slice(insertIndex),
+    ];
+    setInsertChildTarget(null);
+    persistProgramChildren(program.id, nextChildren, 'Service added to package.');
   };
 
   const persistCatalogRecordHidden = async (collection, recordId, hidden) => {
@@ -1754,9 +1803,10 @@ const BudgetPage = ({ isAdmin = false }) => {
 
   // Name, price and description are edited in place (see renderInlineRecordEditor) at their
   // normal read-mode position, so this grid only carries the fields that have no such spot.
-  const renderEditableFields = (collection, record) => {
+  const renderEditableFields = (collection, record, options = {}) => {
     const recordIndex = catalog[collection].findIndex(item => String(item.id) === String(record.id));
     const collectionLabel = BUDGET_COLLECTION_LABELS[collection] || 'item';
+    const { programChildContext = null } = options;
 
     return (
       <EditableGrid>
@@ -1800,12 +1850,35 @@ const BudgetPage = ({ isAdmin = false }) => {
           >
             {record.hidden ? `Show ${collectionLabel}` : `Hide ${collectionLabel}`}
           </MiniButton>
-          <MiniDangerButton
-            type="button"
-            onClick={() => setDeleteTarget({ collection, recordId: record.id, name: record.name || record.id })}
-          >
-            <FaTrash /> Delete
-          </MiniDangerButton>
+          {programChildContext ? (
+            <>
+              <MiniButton
+                type="button"
+                title="Insert service after this one"
+                aria-label="Insert service after this one"
+                onClick={() => setInsertChildTarget({
+                  programId: programChildContext.program.id,
+                  insertIndex: programChildContext.index + 1,
+                })}
+              >
+                <FaPlus />
+              </MiniButton>
+              <MiniDangerButton
+                type="button"
+                title="Remove this service from the package"
+                onClick={() => removeProgramChild(programChildContext.program, record.id)}
+              >
+                <FaTrash /> Delete
+              </MiniDangerButton>
+            </>
+          ) : (
+            <MiniDangerButton
+              type="button"
+              onClick={() => setDeleteTarget({ collection, recordId: record.id, name: record.name || record.id })}
+            >
+              <FaTrash /> Delete
+            </MiniDangerButton>
+          )}
           {record.hidden ? <HiddenBadge>Hidden from clients</HiddenBadge> : null}
         </InlineActionRow>
       </EditableGrid>
@@ -1989,7 +2062,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                       </Toggle>
                       {isOpen ? (
                         <IncludedList>
-                          {visibleIncludedItems.map(item => {
+                          {visibleIncludedItems.map((item, index) => {
                             const detailOpen = Boolean(openDetails[item.id]);
                             return (
                               <IncludedItem key={item.id}>
@@ -2016,7 +2089,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                                     </>
                                   )}
                                   {isEditMode ? renderInternalNote('items', item) : null}
-                                  {isEditMode ? renderEditableFields('items', item) : null}
+                                  {isEditMode ? renderEditableFields('items', item, { programChildContext: { program, index } }) : null}
                                 </div>
                               </IncludedItem>
                             );
@@ -2229,6 +2302,33 @@ const BudgetPage = ({ isAdmin = false }) => {
           </>
         ) : null}
       </Shell>
+      {insertChildTarget ? (() => {
+        const program = catalog.packages.find(record => String(record.id) === String(insertChildTarget.programId));
+        const children = Array.isArray(program?.children) ? program.children : [];
+        const availableItems = catalog.items.filter(item => !children.some(id => String(id) === String(item.id)));
+        return (
+          <ModalBackdrop>
+            <ConfirmModal>
+              <ModalTitle>Add service to package</ModalTitle>
+              <ModalText>Choose a service to insert in the selected position.</ModalText>
+              <PaymentScheduleEditor>
+                {availableItems.length ? availableItems.map(item => (
+                  <MiniButton
+                    type="button"
+                    key={item.id}
+                    onClick={() => insertProgramChild(item.id)}
+                  >
+                    <FaPlus /> {item.name || `Service ${item.id}`}
+                  </MiniButton>
+                )) : <ModalText>All available services are already included in this package.</ModalText>}
+              </PaymentScheduleEditor>
+              <ModalActions>
+                <SoftButton type="button" onClick={() => setInsertChildTarget(null)}>Cancel</SoftButton>
+              </ModalActions>
+            </ConfirmModal>
+          </ModalBackdrop>
+        );
+      })() : null}
       {deleteTarget ? (
         <ModalBackdrop role="presentation" onMouseDown={() => setDeleteTarget(null)}>
           <ConfirmModal role="dialog" aria-modal="true" aria-labelledby="budget-delete-title" onMouseDown={event => event.stopPropagation()}>


### PR DESCRIPTION
### Motivation
- Enable admins to manage package children (services) inline: remove services from a package and insert a selected service at a requested position.
- Provide a clearer UX for inserting services by opening a modal that lists only services not already included in the package.

### Description
- Added new state `insertChildTarget` and functions `persistProgramChildren`, `removeProgramChild`, and `insertProgramChild` to handle updating a package's `children` and persisting changes with `update(ref(database, ...))`.
- Extended `renderEditableFields` to accept a `programChildContext` option and show contextual action buttons (`Insert service after this one` and `Remove this service from the package`) when rendering an item that belongs to a package.
- Modified included-list rendering to pass `{ programChildContext: { program, index } }` into `renderEditableFields` for package child items.
- Implemented a modal that opens when `insertChildTarget` is set and lists available items (excluding children already in the package) so an admin can choose a service to insert in the selected position, and added a cancel action.
- Updated tests and fixtures in `BudgetPage.editMode.test.js` to include a new item and to exercise removal and insertion flows through the UI, asserting backend `update` calls.

### Testing
- Ran the `BudgetPage` edit-mode unit tests in `BudgetPage.editMode.test.js`, including the new test `removes package children and inserts a selected service after the requested child`, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6f74bf70832698970502d18af593)