### PR TITLE
Fix package child insertion controls

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -2020,8 +2020,8 @@ const BudgetPage = ({ isAdmin = false }) => {
                   const isGuaranteed = GUARANTEED_PACKAGE_IDS.has(String(program.id));
                   const includedItems = Array.isArray(program.children)
                     ? program.children
-                      .map(id => itemsById.get(String(id)))
-                      .filter(item => item && (isEditMode || !item.hidden))
+                      .map((id, childIndex) => ({ item: itemsById.get(String(id)), childIndex }))
+                      .filter(({ item }) => item && (isEditMode || !item.hidden))
                     : [];
                   const includedExpanded = Boolean(expandedIncluded[program.id]);
                   const visibleIncludedItems = includedExpanded
@@ -2062,7 +2062,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                       </Toggle>
                       {isOpen ? (
                         <IncludedList>
-                          {visibleIncludedItems.map((item, index) => {
+                          {visibleIncludedItems.map(({ item, childIndex }) => {
                             const detailOpen = Boolean(openDetails[item.id]);
                             return (
                               <IncludedItem key={item.id}>
@@ -2089,11 +2089,22 @@ const BudgetPage = ({ isAdmin = false }) => {
                                     </>
                                   )}
                                   {isEditMode ? renderInternalNote('items', item) : null}
-                                  {isEditMode ? renderEditableFields('items', item, { programChildContext: { program, index } }) : null}
+                                  {isEditMode ? renderEditableFields('items', item, { programChildContext: { program, index: childIndex } }) : null}
                                 </div>
                               </IncludedItem>
                             );
                           })}
+                          {isEditMode ? (
+                            <MiniButton
+                              type="button"
+                              onClick={() => setInsertChildTarget({
+                                programId: program.id,
+                                insertIndex: Array.isArray(program.children) ? program.children.length : 0,
+                              })}
+                            >
+                              <FaPlus /> Add service to package
+                            </MiniButton>
+                          ) : null}
                           {includedItems.length > INCLUDED_PREVIEW_LIMIT ? (
                             <ShowMoreButton type="button" onClick={() => toggleIncluded(program.id)}>
                               {includedExpanded


### PR DESCRIPTION
### Motivation
- Preserve the original `program.children` indexes for rendered package children so inline "Insert service after this one" actions insert at the correct position in the full children array.
- Provide a visible insert control for packages with no rendered children so admins can open the service-selection modal instead of editing backend JSON.

### Description
- Change the included-items mapping to `program.children.map((id, childIndex) => ({ item: itemsById.get(String(id)), childIndex }))` and filter by `item` visibility so the original `childIndex` is retained after filtering.
- Update the included-items render to iterate `visibleIncludedItems.map(({ item, childIndex }) => ...)` and pass `childIndex` into `renderEditableFields('items', item, { programChildContext: { program, index: childIndex } })` so insertion uses the correct index.
- Add an edit-mode package-level `MiniButton` inside the included list that calls `setInsertChildTarget({ programId: program.id, insertIndex: Array.isArray(program.children) ? program.children.length : 0 })` to allow adding services to empty packages.

### Testing
- Ran `npm run lint:js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ddaaa2fbc8326a2ace076cec1766b)