### PR TITLE
Preserve and evaluate formula-style flow amounts, fix percent parsing and storage

### DIFF
--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -947,6 +947,10 @@ export const flattenFlowEntriesFromBackend = flowNode => {
       return { amountUah: '', amountUsd: '', amountEur: '', customUsdRate: '' };
     }
 
+    if (isFormulaFlowAmount(normalizedRawAmount)) {
+      return { amountUah: normalizedRawAmount, amountUsd: '', amountEur: '', customUsdRate: '' };
+    }
+
     const slashSeparated = normalizedRawAmount
       .split('/')
       .map(item => String(item || '').trim());

--- a/src/components/FlowManager.test.jsx
+++ b/src/components/FlowManager.test.jsx
@@ -16,13 +16,40 @@ jest.mock('./config', () => ({
   updateFlowEntry: jest.fn(),
 }));
 
-const { parseFlowEntryLine } = require('./FlowManager');
+const { flattenFlowEntriesFromBackend, parseFlowEntryLine } = require('./FlowManager');
 
 describe('parseFlowEntryLine', () => {
   it('keeps dollar-only formulas as a persistable USD formula amount', () => {
     expect(parseFlowEntryLine('=$ lunch', '2026-07-07')).toMatchObject({
       amount: '=USD',
       description: 'lunch',
+    });
+  });
+
+  it('keeps division operators inside formula amounts while parsing a line', () => {
+    expect(parseFlowEntryLine('08.07.2026 =(86000-(86000*6/100)-100) Лена', '2026-07-07')).toMatchObject({
+      date: '2026-07-08',
+      amount: '=(86000-(86000*6/100)-100)',
+      description: 'Лена',
+    });
+  });
+
+  it('keeps division operators inside persisted object formula amounts', () => {
+    expect(
+      flattenFlowEntriesFromBackend({
+        general: {
+          '2026-07-08': {
+            abc: {
+              amount: '=(86000-(86000*6/100)-100)',
+              description: 'Лена',
+            },
+          },
+        },
+      })[0]
+    ).toMatchObject({
+      date: '2026-07-08',
+      amount: '=(86000-(86000*6/100)-100)',
+      description: 'Лена',
     });
   });
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1200,15 +1200,19 @@ const buildFlowGroupPath = groupPath => {
   return sanitizedSegments.join('/');
 };
 
-const sanitizeFlowValuePart = value =>
+const isFlowFormulaAmount = value => String(value || '').trim().startsWith('=');
+
+const sanitizeFlowValuePart = (value, { preserveSlash = false } = {}) =>
   String(value || '')
     .trim()
-    .replace(/[#$[\]/]/g, ' ')
+    .replace(preserveSlash ? /[#$[\]]/g : /[#$[\]/]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 
-const normalizeFlowStoredAmount = value =>
-  sanitizeFlowValuePart(String(value || '').replace(/,/g, '.').replace(/\$/g, 'USD'));
+const normalizeFlowStoredAmount = value => {
+  const normalized = String(value || '').replace(/,/g, '.').replace(/\$/g, 'USD');
+  return sanitizeFlowValuePart(normalized, { preserveSlash: isFlowFormulaAmount(normalized) });
+};
 
 const buildFlowEntryValue = ({ amount, description = '' }) => {
   const safeAmount = normalizeFlowStoredAmount(amount);
@@ -1616,13 +1620,21 @@ export const saveFlowEntry = async ({
       ? formatFlowStoredCurrencyAmount(amountUahNumber / effectiveRates.eur)
       : '';
   const normalizedRowCustomUsdRate = normalizeFlowCustomUsdRate(rowCustomUsdRate);
-  const amountPayload = [
-    normalizedAmountUah,
-    amountUsd,
-    amountEur,
-    normalizedRowCustomUsdRate ? formatFlowStoredCurrencyAmount(normalizedRowCustomUsdRate) : '',
-  ].join('/');
-  const value = buildFlowEntryValue({ amount: amountPayload, description });
+  const normalizedCustomUsdRateAmount = normalizedRowCustomUsdRate
+    ? formatFlowStoredCurrencyAmount(normalizedRowCustomUsdRate)
+    : '';
+  const value = isFlowFormulaAmount(normalizedAmountUah)
+    ? {
+        amount: normalizedAmountUah,
+        amountUsd,
+        amountEur,
+        customUsdRate: normalizedCustomUsdRateAmount,
+        description: sanitizeFlowValuePart(description),
+      }
+    : buildFlowEntryValue({
+        amount: [normalizedAmountUah, amountUsd, amountEur, normalizedCustomUsdRateAmount].join('/'),
+        description,
+      });
   const entryId = generateFlowEntryId();
   await set(ref2(database, `multiData/flow/${ownerId}/${datePath}/${entryId}`), value);
 };

--- a/src/utils/flowAmountFormula.js
+++ b/src/utils/flowAmountFormula.js
@@ -107,38 +107,51 @@ export const evaluateFlowAmountFormula = (rawFormula, resolveIdentifier) => {
   };
 
   const parseExpression = () => {
-    let value = parseTerm();
+    let term = parseTerm();
+    let value = term.value;
     while (peek()?.type === '+' || peek()?.type === '-') {
       const operator = peek().type;
       position += 1;
       const right = parseTerm();
-      value = operator === '+' ? value + right : value - right;
+      const rightValue = right.isPercent ? value * right.value : right.value;
+      value = operator === '+' ? value + rightValue : value - rightValue;
+      term = { value, isPercent: false };
     }
-    return value;
+    return term;
   };
 
   const parseTerm = () => {
-    let value = parseFactor();
+    let factor = parseFactor();
+    let value = factor.value;
+    let isPercent = factor.isPercent;
     while (peek()?.type === '*' || peek()?.type === '/') {
       const operator = peek().type;
       position += 1;
       const right = parseFactor();
-      if (operator === '/' && right === 0) {
+      if (operator === '/' && right.value === 0) {
         throw new Error('Formula division by zero');
       }
-      value = operator === '*' ? value * right : value / right;
+      value = operator === '*' ? value * right.value : value / right.value;
+      isPercent = false;
     }
-    return value;
+    return { value, isPercent };
   };
 
   const parseFactor = () => {
     let value;
+    let isPercent = false;
     if (consume('+')) {
-      value = parseFactor();
+      const factor = parseFactor();
+      value = factor.value;
+      isPercent = factor.isPercent;
     } else if (consume('-')) {
-      value = -parseFactor();
+      const factor = parseFactor();
+      value = -factor.value;
+      isPercent = factor.isPercent;
     } else if (consume('(')) {
-      value = parseExpression();
+      const expressionResult = parseExpression();
+      value = expressionResult.value;
+      isPercent = expressionResult.isPercent;
       if (!consume(')')) {
         throw new Error('Formula closing parenthesis is missing');
       }
@@ -159,15 +172,16 @@ export const evaluateFlowAmountFormula = (rawFormula, resolveIdentifier) => {
 
     while (consume('%')) {
       value /= 100;
+      isPercent = true;
     }
-    return value;
+    return { value, isPercent };
   };
 
   if (tokens.length === 0) {
     throw new Error('Formula is empty');
   }
 
-  const result = parseExpression();
+  const result = parseExpression().value;
   if (position !== tokens.length) {
     throw new Error('Formula has an unexpected token');
   }

--- a/src/utils/flowAmountFormula.test.js
+++ b/src/utils/flowAmountFormula.test.js
@@ -15,7 +15,10 @@ describe('flowAmountFormula', () => {
 
   it('supports postfix percent values in formulas', () => {
     expect(evaluateFlowAmountFormula('=20%')).toBeCloseTo(0.2);
-    expect(resolveFlowAmountInput('=100+20%')).toBe('100.2');
+    expect(resolveFlowAmountInput('=100+20%')).toBe('120');
+    expect(resolveFlowAmountInput('=86000-6%')).toBe('80840');
+    expect(resolveFlowAmountInput('=86000*6%')).toBe('5160');
+    expect(resolveFlowAmountInput('=86000-(86000*6/100)-100')).toBe('80740');
   });
 
   it('supports unary minus and localized operators', () => {


### PR DESCRIPTION
### Motivation
- Allow users to enter formula amounts (starting with `=`) that include division and other operators and ensure those formulas are preserved end-to-end instead of being mangled by slash-splitting and sanitization. 
- Fix formula evaluation semantics so postfix percent values apply relative to the appropriate left-hand value and formulas with mixed operators produce correct results.

### Description
- Add `isFlowFormulaAmount` and a `preserveSlash` option to sanitization so formula strings keep `/` characters intact during storage normalization. 
- Change `saveFlowEntry` to persist formula amounts as an object `{ amount, amountUsd, amountEur, customUsdRate, description }` while keeping legacy slash-joined strings for non-formula rows. 
- Update `flattenFlowEntriesFromBackend` to detect persisted formula objects and return the formula string as the entry amount without splitting on slashes. 
- Rework the formula parser in `flowAmountFormula.js` to propagate a percent flag through parsing so expressions like `=100+20%`, `=86000-(86000*6/100)-100` and mixed operator sequences evaluate correctly and to guard against division-by-zero errors; add/adjust helper exports accordingly.

### Testing
- Ran unit tests with `yarn test` covering `src/utils/flowAmountFormula.test.js` and `src/components/FlowManager.test.jsx`. 
- All automated tests executed successfully and are passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e0fb96fec8326b6665de2940d69d1)