### PR TITLE
Add admin-only invoice builder page with PDF export

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -11,6 +11,7 @@ import EditProfile from './EditProfile';
 import MedicationsPage from './MedicationsPage';
 import FlowManager from './FlowManager';
 import BudgetPage from './BudgetPage';
+import InvoiceBuilderPage from './InvoiceBuilderPage';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth, fetchUserById } from './config';
 import { resolveAccess } from 'utils/accessLevel';
@@ -99,6 +100,7 @@ export const App = () => {
       {isAdmin && <Route path="/medications/:userId" element={<MedicationsPage />} />}
       {isAdmin && <Route path="/flow" element={<FlowManager ownerId={auth.currentUser?.uid} />} />}
       {isAdmin && <Route path="/budget" element={<BudgetPage isAdmin={isAdmin} />} />}
+      {isAdmin && <Route path="/invoices" element={<InvoiceBuilderPage isAdmin={isAdmin} />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1,0 +1,994 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import toast from 'react-hot-toast';
+import { get, ref, set } from 'firebase/database';
+import { FaFilePdf, FaPlus, FaTrash, FaUpload } from 'react-icons/fa';
+import { saveAs } from 'file-saver';
+import { auth, database } from './config';
+import { isAdminUid } from 'utils/accessLevel';
+import {
+  applyPaymentPurposePlaceholders,
+  buildCaseTitle,
+  buildPayerLocation,
+  buildPayerName,
+  computeInvoiceSubtotal,
+  computeInvoiceTotal,
+  generateInvoiceIdentifiers,
+  getActiveBeneficiary,
+  getTodayYmd,
+  makeCatalogServiceEntry,
+  makeCustomServiceEntry,
+  normalizeInvoiceData,
+  parseServiceEntry,
+  reorderBeneficiaryIds,
+  reorderRecentServices,
+  resolveInvoiceServiceRows,
+  resolveServiceRow,
+} from './invoiceCatalogUtils';
+
+const INVOICE_DATA_PATH = 'invoiceBuilder';
+const CATALOG_ITEMS_PATH = 'budget/items';
+
+const toArray = value => {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === 'object') return Object.values(value);
+  return [];
+};
+
+const emptyBeneficiary = () => ({
+  id: `beneficiary-${Date.now()}`,
+  title: 'New beneficiary',
+  address: '',
+  iban: '',
+  bankName: '',
+  swiftCode: '',
+  paymentPurpose: '',
+});
+
+const Page = styled.main`
+  min-height: 100vh;
+  background: var(--km-bg);
+  color: var(--km-text);
+  padding: 22px 14px 96px;
+  font-family: var(--km-font);
+`;
+
+const Shell = styled.div`
+  width: min(100%, 980px);
+  margin: 0 auto;
+`;
+
+const Header = styled.header`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 22px;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+  }
+`;
+
+const Eyebrow = styled.div`
+  color: var(--km-accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  font-size: clamp(28px, 6vw, 44px);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+`;
+
+const HeaderActions = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+
+  @media (max-width: 640px) {
+    width: 100%;
+    justify-content: flex-start;
+  }
+`;
+
+const MiniButton = styled.button`
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
+  border-radius: 999px;
+  min-height: 38px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
+`;
+
+const SmallButton = styled(MiniButton)`
+  min-height: 28px;
+  padding: 4px 10px;
+  font-size: 11.5px;
+`;
+
+const DangerButton = styled(SmallButton)`
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
+`;
+
+const Panel = styled.section`
+  margin-top: 18px;
+  border: 1px solid var(--km-border);
+  border-radius: 22px;
+  background: var(--km-card);
+  padding: 18px;
+`;
+
+const PanelHeading = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
+const H2 = styled.h2`
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+`;
+
+const PanelNote = styled.p`
+  margin: -6px 0 12px;
+  color: var(--km-muted);
+  font-size: 12.5px;
+  line-height: 1.5;
+`;
+
+const FieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+`;
+
+const FieldLabel = styled.label`
+  display: grid;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--km-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`;
+
+const Input = styled.input`
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--km-border);
+  border-radius: 10px;
+  background: var(--km-bg);
+  color: var(--km-text);
+  padding: 9px 10px;
+  font-size: 13.5px;
+  font-weight: 600;
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--km-accent-light);
+  }
+`;
+
+const Textarea = styled.textarea`
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--km-border);
+  border-radius: 10px;
+  background: var(--km-bg);
+  color: var(--km-text);
+  padding: 9px 10px;
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.4;
+  resize: vertical;
+  min-height: 60px;
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--km-accent-light);
+  }
+`;
+
+const Select = styled.select`
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--km-border);
+  border-radius: 10px;
+  background: var(--km-bg);
+  color: var(--km-text);
+  padding: 9px 10px;
+  font-size: 13.5px;
+  font-weight: 700;
+`;
+
+const RowList = styled.div`
+  display: grid;
+  gap: 8px;
+`;
+
+const CustomerRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ServiceRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 110px auto;
+  gap: 8px;
+  align-items: center;
+  border-top: 1px solid var(--km-border);
+  padding-top: 8px;
+
+  &:first-child {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const AddRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 110px auto;
+  gap: 8px;
+  align-items: center;
+  margin-top: 12px;
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ChipRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+`;
+
+const Chip = styled.button`
+  border: 1px dashed var(--km-border);
+  background: var(--km-bg);
+  color: var(--km-text);
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 11.5px;
+  font-weight: 700;
+  cursor: pointer;
+`;
+
+const CatalogPickerList = styled.div`
+  margin-top: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+  display: grid;
+  gap: 6px;
+`;
+
+const CatalogPickerButton = styled.button`
+  border: 1px solid var(--km-border);
+  background: var(--km-bg);
+  color: var(--km-text);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 12.5px;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
+const SummaryGrid = styled.div`
+  display: grid;
+  gap: 6px;
+  font-size: 13.5px;
+`;
+
+const SummaryLine = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+
+  &:last-child {
+    border-top: 1px solid var(--km-border);
+    margin-top: 4px;
+    padding-top: 8px;
+    font-weight: 900;
+    color: var(--km-accent);
+  }
+`;
+
+const StateCard = styled.div`
+  padding: 28px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--km-muted);
+`;
+
+const formatEuroPreview = value => {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? `€${amount.toFixed(2)}` : '€—';
+};
+
+const InvoiceBuilderPage = ({ isAdmin = false }) => {
+  const isInvoiceAdmin = Boolean(isAdmin) || isAdminUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
+    && new URLSearchParams(window.location.search).get('admin') === '1');
+
+  const [data, setData] = useState(() => normalizeInvoiceData(null));
+  const [catalogItems, setCatalogItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [invoiceDateInput, setInvoiceDateInput] = useState(getTodayYmd());
+  const [newCustomServiceName, setNewCustomServiceName] = useState('');
+  const [newCustomServicePrice, setNewCustomServicePrice] = useState('');
+  const [catalogQuery, setCatalogQuery] = useState('');
+  const [showCatalogPicker, setShowCatalogPicker] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const loadInvoiceData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [invoiceSnapshot, catalogSnapshot] = await Promise.all([
+        get(ref(database, INVOICE_DATA_PATH)),
+        get(ref(database, CATALOG_ITEMS_PATH)),
+      ]);
+      setData(normalizeInvoiceData(invoiceSnapshot.exists() ? invoiceSnapshot.val() : null));
+      setCatalogItems(toArray(catalogSnapshot.exists() ? catalogSnapshot.val() : []));
+    } catch (loadError) {
+      console.error('Unable to load invoice builder data', loadError);
+      setError('Invoice data is not available right now.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadInvoiceData();
+  }, [loadInvoiceData]);
+
+  const catalogItemsById = useMemo(() => new Map(catalogItems.map(item => [String(item.id), item])), [catalogItems]);
+
+  const activeBeneficiary = useMemo(() => getActiveBeneficiary(data), [data]);
+
+  const invoiceServiceRows = useMemo(
+    () => resolveInvoiceServiceRows(data.invoiceServices, catalogItemsById),
+    [data.invoiceServices, catalogItemsById],
+  );
+
+  const subtotal = useMemo(() => computeInvoiceSubtotal(invoiceServiceRows), [invoiceServiceRows]);
+  const total = useMemo(() => computeInvoiceTotal(subtotal, data.taxPercent), [subtotal, data.taxPercent]);
+
+  const { invoiceNumber, invoiceDate } = useMemo(() => generateInvoiceIdentifiers(invoiceDateInput), [invoiceDateInput]);
+
+  const purposeOfPayment = useMemo(
+    () => applyPaymentPurposePlaceholders(activeBeneficiary?.paymentPurpose, { invoiceNumber, invoiceDate }),
+    [activeBeneficiary, invoiceNumber, invoiceDate],
+  );
+
+  const payerName = useMemo(() => buildPayerName(data.customers), [data.customers]);
+  const payerLocation = useMemo(() => buildPayerLocation(data.customers), [data.customers]);
+  const caseTitle = useMemo(() => buildCaseTitle(data.customers), [data.customers]);
+
+  const recentServiceSuggestions = useMemo(() => {
+    const used = new Set(data.invoiceServices);
+    return data.recentServices.filter(entry => !used.has(entry)).slice(0, 8);
+  }, [data.recentServices, data.invoiceServices]);
+
+  const filteredCatalogItems = useMemo(() => {
+    const usedCatalogIds = new Set(
+      data.invoiceServices
+        .map(entry => parseServiceEntry(entry))
+        .filter(parsed => parsed.isCatalog)
+        .map(parsed => String(parsed.catalogId)),
+    );
+    const normalizedQuery = catalogQuery.trim().toLowerCase();
+    return catalogItems
+      .filter(item => !usedCatalogIds.has(String(item.id)))
+      .filter(item => !normalizedQuery || String(item.name || '').toLowerCase().includes(normalizedQuery))
+      .slice(0, 30);
+  }, [catalogItems, data.invoiceServices, catalogQuery]);
+
+  const persistPath = async (path, value, successMessage) => {
+    try {
+      await set(ref(database, path), value);
+      if (successMessage) toast.success(successMessage);
+    } catch (saveError) {
+      console.error(`Unable to save ${path}`, saveError);
+      toast.error('Unable to save. Reloading latest data.');
+      loadInvoiceData();
+    }
+  };
+
+  // Beneficiaries ------------------------------------------------------------
+
+  const handleSelectBeneficiary = async id => {
+    if (String(id) === String(data.beneficiaryIds[0])) return;
+    const nextIds = reorderBeneficiaryIds(data.beneficiaryIds, id);
+    setData(current => ({ ...current, beneficiaryIds: nextIds }));
+    await persistPath(`${INVOICE_DATA_PATH}/beneficiaryIds`, nextIds, 'Active beneficiary updated.');
+  };
+
+  const updateActiveBeneficiaryField = (field, value) => {
+    setData(current => {
+      const activeId = current.beneficiaryIds[0];
+      return {
+        ...current,
+        beneficiaries: current.beneficiaries.map(beneficiary => (String(beneficiary.id) === String(activeId)
+          ? { ...beneficiary, [field]: value }
+          : beneficiary)),
+      };
+    });
+  };
+
+  const persistActiveBeneficiaryField = async (field, value) => {
+    const activeId = data.beneficiaryIds[0];
+    const index = data.beneficiaries.findIndex(beneficiary => String(beneficiary.id) === String(activeId));
+    if (index === -1) return;
+    await persistPath(`${INVOICE_DATA_PATH}/beneficiaries/${index}/${field}`, value, 'Beneficiary updated.');
+  };
+
+  const addBeneficiary = async () => {
+    const nextBeneficiary = emptyBeneficiary();
+    const nextBeneficiaries = [...data.beneficiaries, nextBeneficiary];
+    const nextIds = reorderBeneficiaryIds(data.beneficiaryIds, nextBeneficiary.id);
+    setData(current => ({ ...current, beneficiaries: nextBeneficiaries, beneficiaryIds: nextIds }));
+    try {
+      await Promise.all([
+        set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextBeneficiaries),
+        set(ref(database, `${INVOICE_DATA_PATH}/beneficiaryIds`), nextIds),
+      ]);
+      toast.success('Beneficiary added.');
+    } catch (saveError) {
+      console.error('Unable to add beneficiary', saveError);
+      toast.error('Unable to add beneficiary.');
+      loadInvoiceData();
+    }
+  };
+
+  const deleteActiveBeneficiary = async () => {
+    if (!activeBeneficiary) return;
+    if (data.beneficiaries.length <= 1) {
+      toast.error('At least one beneficiary is required.');
+      return;
+    }
+    if (typeof window !== 'undefined' && !window.confirm(`Delete beneficiary "${activeBeneficiary.title || activeBeneficiary.id}"?`)) return;
+    const nextBeneficiaries = data.beneficiaries.filter(beneficiary => String(beneficiary.id) !== String(activeBeneficiary.id));
+    const nextIds = data.beneficiaryIds.filter(id => String(id) !== String(activeBeneficiary.id));
+    setData(current => ({ ...current, beneficiaries: nextBeneficiaries, beneficiaryIds: nextIds }));
+    try {
+      await Promise.all([
+        set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextBeneficiaries),
+        set(ref(database, `${INVOICE_DATA_PATH}/beneficiaryIds`), nextIds),
+      ]);
+      toast.success('Beneficiary deleted.');
+    } catch (saveError) {
+      console.error('Unable to delete beneficiary', saveError);
+      toast.error('Unable to delete beneficiary.');
+      loadInvoiceData();
+    }
+  };
+
+  // Customers ------------------------------------------------------------
+
+  const updateCustomerField = (index, field, value) => {
+    setData(current => ({
+      ...current,
+      customers: current.customers.map((customer, customerIndex) => (customerIndex === index
+        ? { ...customer, [field]: value }
+        : customer)),
+    }));
+  };
+
+  const persistCustomers = async (nextCustomers, successMessage) => {
+    await persistPath(`${INVOICE_DATA_PATH}/customers`, nextCustomers, successMessage);
+  };
+
+  const addCustomer = () => {
+    const nextCustomers = [...data.customers, { name: '', address: '' }];
+    setData(current => ({ ...current, customers: nextCustomers }));
+    persistCustomers(nextCustomers, 'Customer added.');
+  };
+
+  const removeCustomer = index => {
+    const nextCustomers = data.customers.filter((customer, customerIndex) => customerIndex !== index);
+    setData(current => ({ ...current, customers: nextCustomers }));
+    persistCustomers(nextCustomers, 'Customer removed.');
+  };
+
+  // Invoice services ------------------------------------------------------------
+
+  const persistInvoiceServices = async (nextInvoiceServices, successMessage) => {
+    await persistPath(`${INVOICE_DATA_PATH}/invoiceServices`, nextInvoiceServices, successMessage);
+  };
+
+  // Editing name/price of a row (catalog-linked or custom) always writes it back
+  // as a plain "Name || Price" row - a catalog reference only makes sense while
+  // it still mirrors the catalog, so editing it detaches it into its own copy.
+  const updateInvoiceServiceRow = (index, field, value) => {
+    setData(current => {
+      const entries = [...current.invoiceServices];
+      const resolved = resolveServiceRow(entries[index], catalogItemsById);
+      const nextName = field === 'name' ? value : resolved.name;
+      const nextPrice = field === 'price' ? (Number(String(value).replace(',', '.')) || 0) : resolved.price;
+      entries[index] = makeCustomServiceEntry(nextName, nextPrice);
+      return { ...current, invoiceServices: entries };
+    });
+  };
+
+  const commitInvoiceServiceRow = () => {
+    persistInvoiceServices(data.invoiceServices, 'Service updated.');
+  };
+
+  const removeInvoiceServiceRow = index => {
+    const nextInvoiceServices = data.invoiceServices.filter((entry, entryIndex) => entryIndex !== index);
+    setData(current => ({ ...current, invoiceServices: nextInvoiceServices }));
+    persistInvoiceServices(nextInvoiceServices, 'Service removed.');
+  };
+
+  const addServiceEntry = entry => {
+    if (data.invoiceServices.includes(entry)) {
+      toast.error('This service is already on the invoice.');
+      return;
+    }
+    const nextInvoiceServices = [...data.invoiceServices, entry];
+    setData(current => ({ ...current, invoiceServices: nextInvoiceServices }));
+    persistInvoiceServices(nextInvoiceServices, 'Service added.');
+  };
+
+  const addCatalogServiceEntry = catalogId => {
+    addServiceEntry(makeCatalogServiceEntry(catalogId));
+    setShowCatalogPicker(false);
+    setCatalogQuery('');
+  };
+
+  const addCustomServiceEntry = () => {
+    const name = newCustomServiceName.trim();
+    const price = Number(newCustomServicePrice.replace(',', '.'));
+    if (!name) {
+      toast.error('Enter a name for the new service.');
+      return;
+    }
+    if (!Number.isFinite(price)) {
+      toast.error('Enter a valid price for the new service.');
+      return;
+    }
+    addServiceEntry(makeCustomServiceEntry(name, price));
+    setNewCustomServiceName('');
+    setNewCustomServicePrice('');
+  };
+
+  // Notes ------------------------------------------------------------
+
+  const persistNotes = async (nextNotes, successMessage) => {
+    await persistPath(`${INVOICE_DATA_PATH}/notes`, nextNotes, successMessage);
+  };
+
+  const updateNote = (index, value) => {
+    setData(current => ({
+      ...current,
+      notes: current.notes.map((note, noteIndex) => (noteIndex === index ? value : note)),
+    }));
+  };
+
+  const commitNote = () => persistNotes(data.notes, 'Notes updated.');
+
+  const addNote = () => {
+    const nextNotes = [...data.notes, ''];
+    setData(current => ({ ...current, notes: nextNotes }));
+    persistNotes(nextNotes, 'Note added.');
+  };
+
+  const removeNote = index => {
+    const nextNotes = data.notes.filter((note, noteIndex) => noteIndex !== index);
+    setData(current => ({ ...current, notes: nextNotes }));
+    persistNotes(nextNotes, 'Note removed.');
+  };
+
+  // Tax ------------------------------------------------------------
+
+  const updateTaxPercent = value => {
+    setData(current => ({ ...current, taxPercent: value }));
+  };
+
+  const commitTaxPercent = () => {
+    const value = Number(String(data.taxPercent).replace(',', '.')) || 0;
+    setData(current => ({ ...current, taxPercent: value }));
+    persistPath(`${INVOICE_DATA_PATH}/taxPercent`, value, 'Tax updated.');
+  };
+
+  // Upload seed JSON ------------------------------------------------------------
+
+  const handleUploadClick = () => fileInputRef.current?.click();
+
+  const handleFileChange = async event => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      const nextData = normalizeInvoiceData(parsed);
+      await Promise.all([
+        set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextData.beneficiaries),
+        set(ref(database, `${INVOICE_DATA_PATH}/beneficiaryIds`), nextData.beneficiaryIds),
+        set(ref(database, `${INVOICE_DATA_PATH}/customers`), nextData.customers),
+        set(ref(database, `${INVOICE_DATA_PATH}/recentServices`), nextData.recentServices),
+        set(ref(database, `${INVOICE_DATA_PATH}/invoiceServices`), nextData.invoiceServices),
+        set(ref(database, `${INVOICE_DATA_PATH}/notes`), nextData.notes),
+        set(ref(database, `${INVOICE_DATA_PATH}/taxPercent`), nextData.taxPercent),
+      ]);
+      setData(nextData);
+      toast.success('Invoice JSON uploaded to backend.');
+    } catch (uploadError) {
+      console.error('Unable to upload invoice JSON', uploadError);
+      toast.error('Unable to upload invoice JSON.');
+    }
+  };
+
+  // Generate PDF ------------------------------------------------------------
+
+  const handleGeneratePdf = async () => {
+    if (!activeBeneficiary) {
+      toast.error('Add a beneficiary first.');
+      return;
+    }
+    if (!data.customers.length) {
+      toast.error('Add at least one customer first.');
+      return;
+    }
+    if (!data.invoiceServices.length) {
+      toast.error('Add at least one service first.');
+      return;
+    }
+    if (isGenerating) return;
+    setIsGenerating(true);
+    try {
+      const [{ pdf }, { default: InvoicePdfDocument }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('./InvoicePdfDocument'),
+      ]);
+      const blob = await pdf(React.createElement(InvoicePdfDocument, {
+        beneficiary: activeBeneficiary,
+        customers: data.customers,
+        invoiceServices: data.invoiceServices,
+        catalogItemsById,
+        notes: data.notes,
+        taxPercent: data.taxPercent,
+        invoiceNumber,
+        invoiceDate,
+        purposeOfPayment,
+      })).toBlob();
+      saveAs(blob, `invoice-${invoiceNumber.replace(/\//g, '-')}.pdf`);
+
+      const nextRecentServices = reorderRecentServices(data.recentServices, data.invoiceServices);
+      setData(current => ({ ...current, recentServices: nextRecentServices }));
+      await persistPath(`${INVOICE_DATA_PATH}/recentServices`, nextRecentServices);
+
+      toast.success('Invoice PDF generated.');
+    } catch (generateError) {
+      console.error('Unable to generate invoice PDF', generateError);
+      toast.error('Unable to generate invoice PDF.');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  if (!isInvoiceAdmin) {
+    return (
+      <Page>
+        <Shell>
+          <StateCard>This page is only available to admins.</StateCard>
+        </Shell>
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <Shell>
+        <Header>
+          <div>
+            <Eyebrow>Admin only</Eyebrow>
+            <Title>Invoice Builder</Title>
+          </div>
+          <HeaderActions>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json"
+              style={{ display: 'none' }}
+              onChange={handleFileChange}
+            />
+            <MiniButton type="button" onClick={handleUploadClick} title="Upload an invoice JSON to the backend">
+              <FaUpload /> Upload JSON
+            </MiniButton>
+            <MiniButton
+              type="button"
+              onClick={handleGeneratePdf}
+              disabled={loading || Boolean(error) || isGenerating}
+              title="Generate and download the invoice PDF"
+            >
+              <FaFilePdf /> {isGenerating ? 'Generating…' : 'Generate PDF'}
+            </MiniButton>
+          </HeaderActions>
+        </Header>
+
+        {loading ? <StateCard>Loading invoice data…</StateCard> : null}
+        {!loading && error ? <StateCard>{error}</StateCard> : null}
+
+        {!loading && !error ? (
+          <>
+            <Panel>
+              <PanelHeading>
+                <H2>Beneficiary</H2>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <SmallButton type="button" onClick={addBeneficiary}><FaPlus /> Add</SmallButton>
+                  <DangerButton type="button" onClick={deleteActiveBeneficiary}><FaTrash /> Delete</DangerButton>
+                </div>
+              </PanelHeading>
+              <FieldGrid style={{ marginBottom: 10 }}>
+                <FieldLabel>
+                  Active beneficiary
+                  <Select value={activeBeneficiary?.id || ''} onChange={event => handleSelectBeneficiary(event.target.value)}>
+                    {data.beneficiaries.map(beneficiary => (
+                      <option key={beneficiary.id} value={beneficiary.id}>{beneficiary.title || beneficiary.id}</option>
+                    ))}
+                  </Select>
+                </FieldLabel>
+              </FieldGrid>
+              {activeBeneficiary ? (
+                <FieldGrid>
+                  <FieldLabel>
+                    Title
+                    <Input
+                      value={activeBeneficiary.title || ''}
+                      onChange={event => updateActiveBeneficiaryField('title', event.target.value)}
+                      onBlur={event => persistActiveBeneficiaryField('title', event.target.value)}
+                    />
+                  </FieldLabel>
+                  <FieldLabel>
+                    Address
+                    <Input
+                      value={activeBeneficiary.address || ''}
+                      onChange={event => updateActiveBeneficiaryField('address', event.target.value)}
+                      onBlur={event => persistActiveBeneficiaryField('address', event.target.value)}
+                    />
+                  </FieldLabel>
+                  <FieldLabel>
+                    IBAN
+                    <Input
+                      value={activeBeneficiary.iban || ''}
+                      onChange={event => updateActiveBeneficiaryField('iban', event.target.value)}
+                      onBlur={event => persistActiveBeneficiaryField('iban', event.target.value)}
+                    />
+                  </FieldLabel>
+                  <FieldLabel>
+                    Bank name
+                    <Input
+                      value={activeBeneficiary.bankName || ''}
+                      onChange={event => updateActiveBeneficiaryField('bankName', event.target.value)}
+                      onBlur={event => persistActiveBeneficiaryField('bankName', event.target.value)}
+                    />
+                  </FieldLabel>
+                  <FieldLabel>
+                    SWIFT code
+                    <Input
+                      value={activeBeneficiary.swiftCode || ''}
+                      onChange={event => updateActiveBeneficiaryField('swiftCode', event.target.value)}
+                      onBlur={event => persistActiveBeneficiaryField('swiftCode', event.target.value)}
+                    />
+                  </FieldLabel>
+                  <FieldLabel style={{ gridColumn: '1 / -1' }}>
+                    Payment purpose ({'{invoiceNumber}'} and {'{invoiceDate}'} are filled in automatically)
+                    <Textarea
+                      value={activeBeneficiary.paymentPurpose || ''}
+                      onChange={event => updateActiveBeneficiaryField('paymentPurpose', event.target.value)}
+                      onBlur={event => persistActiveBeneficiaryField('paymentPurpose', event.target.value)}
+                    />
+                  </FieldLabel>
+                </FieldGrid>
+              ) : null}
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
+                <H2>Payer (customers)</H2>
+                <SmallButton type="button" onClick={addCustomer}><FaPlus /> Add customer</SmallButton>
+              </PanelHeading>
+              <PanelNote>{`Payer: ${payerName || '—'} · ${caseTitle}`}</PanelNote>
+              <RowList>
+                {data.customers.map((customer, index) => (
+                  <CustomerRow key={`customer-${index}`}>
+                    <Input
+                      placeholder="Name"
+                      value={customer.name || ''}
+                      onChange={event => updateCustomerField(index, 'name', event.target.value)}
+                      onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
+                    />
+                    <Input
+                      placeholder="Address / country"
+                      value={customer.address || ''}
+                      onChange={event => updateCustomerField(index, 'address', event.target.value)}
+                      onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
+                    />
+                    <DangerButton type="button" onClick={() => removeCustomer(index)}><FaTrash /></DangerButton>
+                  </CustomerRow>
+                ))}
+              </RowList>
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
+                <H2>Invoice services</H2>
+              </PanelHeading>
+              <RowList>
+                {invoiceServiceRows.map((row, index) => (
+                  <ServiceRow key={`${row.key}-${index}`}>
+                    <Input
+                      value={row.name}
+                      onChange={event => updateInvoiceServiceRow(index, 'name', event.target.value)}
+                      onBlur={() => commitInvoiceServiceRow(index)}
+                    />
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      value={row.price}
+                      onChange={event => updateInvoiceServiceRow(index, 'price', event.target.value)}
+                      onBlur={() => commitInvoiceServiceRow(index)}
+                    />
+                    <DangerButton type="button" onClick={() => removeInvoiceServiceRow(index)}><FaTrash /></DangerButton>
+                  </ServiceRow>
+                ))}
+                {!invoiceServiceRows.length ? <PanelNote style={{ margin: 0 }}>No services on this invoice yet.</PanelNote> : null}
+              </RowList>
+
+              {recentServiceSuggestions.length ? (
+                <>
+                  <PanelNote style={{ marginTop: 14, marginBottom: 4 }}>Recent services (click to add)</PanelNote>
+                  <ChipRow>
+                    {recentServiceSuggestions.map(entry => {
+                      const resolved = resolveServiceRow(entry, catalogItemsById);
+                      return (
+                        <Chip key={entry} type="button" onClick={() => addServiceEntry(entry)}>
+                          {resolved.name} · {formatEuroPreview(resolved.price)}
+                        </Chip>
+                      );
+                    })}
+                  </ChipRow>
+                </>
+              ) : null}
+
+              <AddRow>
+                <Input
+                  placeholder="New custom service name"
+                  value={newCustomServiceName}
+                  onChange={event => setNewCustomServiceName(event.target.value)}
+                />
+                <Input
+                  placeholder="Price"
+                  type="text"
+                  inputMode="decimal"
+                  value={newCustomServicePrice}
+                  onChange={event => setNewCustomServicePrice(event.target.value)}
+                />
+                <SmallButton type="button" onClick={addCustomServiceEntry}><FaPlus /> Add</SmallButton>
+              </AddRow>
+
+              <div style={{ marginTop: 10 }}>
+                <SmallButton type="button" onClick={() => setShowCatalogPicker(current => !current)}>
+                  <FaPlus /> {showCatalogPicker ? 'Hide catalog' : 'Add from services catalog'}
+                </SmallButton>
+                {showCatalogPicker ? (
+                  <>
+                    <Input
+                      style={{ marginTop: 8 }}
+                      placeholder="Search catalog services…"
+                      value={catalogQuery}
+                      onChange={event => setCatalogQuery(event.target.value)}
+                    />
+                    <CatalogPickerList>
+                      {filteredCatalogItems.map(item => (
+                        <CatalogPickerButton key={item.id} type="button" onClick={() => addCatalogServiceEntry(item.id)}>
+                          <span>{item.name}</span>
+                        </CatalogPickerButton>
+                      ))}
+                      {!filteredCatalogItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
+                    </CatalogPickerList>
+                  </>
+                ) : null}
+              </div>
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
+                <H2>Summary</H2>
+              </PanelHeading>
+              <FieldGrid style={{ marginBottom: 12 }}>
+                <FieldLabel>
+                  Invoice date
+                  <Input
+                    type="date"
+                    value={invoiceDateInput}
+                    onChange={event => setInvoiceDateInput(event.target.value)}
+                  />
+                </FieldLabel>
+                <FieldLabel>
+                  Taxes (%)
+                  <Input
+                    type="text"
+                    inputMode="decimal"
+                    value={data.taxPercent}
+                    onChange={event => updateTaxPercent(event.target.value)}
+                    onBlur={commitTaxPercent}
+                  />
+                </FieldLabel>
+              </FieldGrid>
+              <SummaryGrid>
+                <SummaryLine><span>Invoice number</span><span>{invoiceNumber}</span></SummaryLine>
+                <SummaryLine><span>Purpose of the payment</span><span style={{ textAlign: 'right', maxWidth: 420 }}>{purposeOfPayment || '—'}</span></SummaryLine>
+                <SummaryLine><span>Location</span><span>{payerLocation || '—'}</span></SummaryLine>
+                <SummaryLine><span>Subtotal</span><span>{formatEuroPreview(subtotal)}</span></SummaryLine>
+                <SummaryLine><span>Amount to be paid</span><span>{formatEuroPreview(total)}</span></SummaryLine>
+              </SummaryGrid>
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
+                <H2>Notes</H2>
+                <SmallButton type="button" onClick={addNote}><FaPlus /> Add note</SmallButton>
+              </PanelHeading>
+              <RowList>
+                {data.notes.map((note, index) => (
+                  <CustomerRow key={`note-${index}`} style={{ gridTemplateColumns: '1fr auto' }}>
+                    <Textarea
+                      value={note}
+                      onChange={event => updateNote(index, event.target.value)}
+                      onBlur={commitNote}
+                    />
+                    <DangerButton type="button" onClick={() => removeNote(index)}><FaTrash /></DangerButton>
+                  </CustomerRow>
+                ))}
+                {!data.notes.length ? <PanelNote style={{ margin: 0 }}>No notes yet.</PanelNote> : null}
+              </RowList>
+            </Panel>
+          </>
+        ) : null}
+      </Shell>
+    </Page>
+  );
+};
+
+export default InvoiceBuilderPage;

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -1,0 +1,378 @@
+import React from 'react';
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import {
+  buildCaseTitle,
+  buildPayerLocation,
+  buildPayerName,
+  computeInvoiceSubtotal,
+  computeInvoiceTotal,
+  resolveInvoiceServiceRows,
+} from './invoiceCatalogUtils';
+
+const AGENCY_NAME = 'REPRODUCTIVE AGENCY "UKRCOM"';
+const AGENCY_ADDRESS_LINE_1 = '31/16 Reitarska Str., 1st floor,';
+const AGENCY_ADDRESS_LINE_2 = 'Kyiv, 01034, Ukraine';
+const AGENCY_WEBSITE = 'Website: http://ukrcom.kyiv.ua/';
+const AGENCY_EMAIL = 'E-mail: sm.kiev.ukr@gmail.com';
+const AGENCY_TELEGRAM = 'Telegram: @Contact_Us_Kyiv';
+
+const INK = '#33291f';
+const MUTED = '#6f6359';
+const ACCENT = '#7a4c2f';
+const HEAD_BG = '#f3e6d2';
+const TOTAL_BG = '#cfe0f5';
+
+// The built-in Helvetica font only covers WinAnsi glyphs, so swap the few
+// characters that would otherwise render blank.
+const sanitizePdfText = value => String(value ?? '')
+  .replace(/№/g, 'No.')
+  .replace(/[’‘]/g, "'")
+  .replace(/[“”]/g, '"')
+  .replace(/[–—]/g, '-')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+// Row-level amounts show as plain numbers ("3000", "300"); only the
+// tax-adjusted totals use the space-grouped, comma-decimal EUR format.
+const formatPlainAmount = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '-';
+  return Number.isInteger(amount) ? String(amount) : amount.toFixed(2).replace('.', ',');
+};
+
+const formatEuroTotal = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '-';
+  const [whole, decimals] = amount.toFixed(2).split('.');
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  return `${grouped},${decimals} EUR`;
+};
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 44,
+    paddingBottom: 62,
+    paddingHorizontal: 44,
+    fontFamily: 'Helvetica',
+    fontSize: 10,
+    color: INK,
+    backgroundColor: '#ffffff',
+  },
+  title: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 20,
+    letterSpacing: -0.2,
+    textAlign: 'center',
+    marginBottom: 26,
+  },
+  sectionTitle: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 20,
+    letterSpacing: -0.2,
+    textAlign: 'center',
+    marginBottom: 4,
+  },
+  sectionSubtitle: {
+    fontSize: 10.5,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'center',
+    color: MUTED,
+    marginBottom: 20,
+  },
+  table: {
+    borderWidth: 1,
+    borderColor: '#111111',
+    borderStyle: 'solid',
+    marginBottom: 18,
+  },
+  row: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: '#111111',
+    borderTopStyle: 'solid',
+  },
+  firstRow: {
+    borderTopWidth: 0,
+  },
+  labelCell: {
+    width: '38%',
+    backgroundColor: HEAD_BG,
+    borderRightWidth: 1,
+    borderRightColor: '#111111',
+    borderRightStyle: 'solid',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+  },
+  labelText: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 9.5,
+  },
+  valueCell: {
+    width: '62%',
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+  },
+  valueText: {
+    fontSize: 9.5,
+    lineHeight: 1.4,
+  },
+  noteRow: {
+    flexDirection: 'row',
+    marginBottom: 8,
+  },
+  noteMark: {
+    width: 20,
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    color: ACCENT,
+  },
+  noteText: {
+    flex: 1,
+    fontSize: 9,
+    lineHeight: 1.45,
+  },
+  expensesTable: {
+    borderWidth: 1,
+    borderColor: '#111111',
+    borderStyle: 'solid',
+    marginBottom: 4,
+  },
+  expensesHeadRow: {
+    flexDirection: 'row',
+    backgroundColor: HEAD_BG,
+  },
+  expensesRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: '#111111',
+    borderTopStyle: 'solid',
+  },
+  expenseIndexCell: {
+    width: 26,
+    borderRightWidth: 1,
+    borderRightColor: '#111111',
+    borderRightStyle: 'solid',
+    paddingVertical: 5,
+    paddingHorizontal: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  expenseNameCell: {
+    flex: 1,
+    borderRightWidth: 1,
+    borderRightColor: '#111111',
+    borderRightStyle: 'solid',
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+  },
+  expenseAmountCell: {
+    width: 84,
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  expenseHeadText: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 9.5,
+  },
+  expenseText: {
+    fontSize: 9.5,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderColor: '#111111',
+    borderStyle: 'solid',
+    borderTopWidth: 0,
+  },
+  summaryLabelCell: {
+    flex: 1,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+  },
+  summaryAmountCell: {
+    width: 110,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    borderLeftWidth: 1,
+    borderLeftColor: '#111111',
+    borderLeftStyle: 'solid',
+  },
+  summaryLabelText: {
+    fontSize: 9.5,
+  },
+  summaryAmountText: {
+    fontSize: 9.5,
+  },
+  totalAmountCell: {
+    backgroundColor: TOTAL_BG,
+  },
+  totalAmountText: {
+    fontFamily: 'Helvetica-Bold',
+  },
+  footer: {
+    position: 'absolute',
+    left: 44,
+    right: 44,
+    bottom: 24,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  footerColumn: {
+    maxWidth: 260,
+  },
+  footerText: {
+    fontSize: 8,
+    color: MUTED,
+    lineHeight: 1.4,
+  },
+  footerPage: {
+    position: 'absolute',
+    right: 44,
+    bottom: 24,
+    fontSize: 8,
+    color: MUTED,
+  },
+});
+
+const renderFooter = pageLabel => (
+  <View style={styles.footer} fixed>
+    <View style={styles.footerColumn}>
+      <Text style={styles.footerText}>{sanitizePdfText(AGENCY_NAME)}</Text>
+      <Text style={styles.footerText}>{sanitizePdfText(AGENCY_ADDRESS_LINE_1)}</Text>
+      <Text style={styles.footerText}>{sanitizePdfText(AGENCY_ADDRESS_LINE_2)}</Text>
+    </View>
+    <View style={styles.footerColumn}>
+      <Text style={[styles.footerText, { textAlign: 'right' }]}>{sanitizePdfText(AGENCY_WEBSITE)}</Text>
+      <Text style={[styles.footerText, { textAlign: 'right' }]}>{sanitizePdfText(AGENCY_EMAIL)}</Text>
+      <Text style={[styles.footerText, { textAlign: 'right' }]}>{sanitizePdfText(AGENCY_TELEGRAM)}</Text>
+    </View>
+    <Text style={styles.footerPage}>{pageLabel}</Text>
+  </View>
+);
+
+const InvoicePdfDocument = ({
+  beneficiary,
+  customers,
+  invoiceServices,
+  catalogItemsById,
+  notes,
+  taxPercent,
+  invoiceNumber,
+  invoiceDate,
+  purposeOfPayment,
+}) => {
+  const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById);
+  const subtotal = computeInvoiceSubtotal(rows);
+  const total = computeInvoiceTotal(subtotal, taxPercent);
+  const payerName = buildPayerName(customers);
+  const payerLocation = buildPayerLocation(customers);
+  const caseTitle = buildCaseTitle(customers);
+  const noteList = Array.isArray(notes) ? notes.filter(note => String(note || '').trim()) : [];
+
+  return (
+    <Document title={`Invoice ${invoiceNumber || ''}`} subject="Invoice" creator="UKRCOM">
+      <Page size="A4" style={styles.page} wrap>
+        <Text style={styles.title}>{sanitizePdfText(`INVOICE # ${invoiceNumber || ''}`)}</Text>
+
+        <View style={styles.table}>
+          <View style={[styles.row, styles.firstRow]} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Beneficiary:</Text></View>
+            <View style={styles.valueCell}>
+              <Text style={styles.valueText}>
+                {sanitizePdfText(`${beneficiary?.title || ''}, ${beneficiary?.address || ''}`)}
+              </Text>
+            </View>
+          </View>
+          <View style={styles.row} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>International bank account number</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{sanitizePdfText(beneficiary?.iban)}</Text></View>
+          </View>
+          <View style={styles.row} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Name of the bank</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{sanitizePdfText(beneficiary?.bankName)}</Text></View>
+          </View>
+          <View style={styles.row} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Bank SWIFT Code</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{sanitizePdfText(beneficiary?.swiftCode)}</Text></View>
+          </View>
+        </View>
+
+        <View style={styles.table}>
+          <View style={[styles.row, styles.firstRow]} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Payer:</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{sanitizePdfText(payerName)}</Text></View>
+          </View>
+          <View style={styles.row} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Location:</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{sanitizePdfText(payerLocation)}</Text></View>
+          </View>
+          <View style={styles.row} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Purpose of the payment:</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{sanitizePdfText(purposeOfPayment)}</Text></View>
+          </View>
+          <View style={styles.row} wrap={false}>
+            <View style={styles.labelCell}><Text style={styles.labelText}>Total:</Text></View>
+            <View style={styles.valueCell}><Text style={styles.valueText}>{formatEuroTotal(total)}</Text></View>
+          </View>
+        </View>
+
+        {noteList.map((note, index) => (
+          <View key={`note-${index}`} style={styles.noteRow}>
+            <Text style={styles.noteMark}>{'*'.repeat(index + 1)}</Text>
+            <Text style={styles.noteText}>{sanitizePdfText(note)}</Text>
+          </View>
+        ))}
+
+        {renderFooter('1/2')}
+      </Page>
+
+      <Page size="A4" style={styles.page} wrap>
+        <Text style={styles.sectionTitle}>Description</Text>
+        <Text style={styles.sectionSubtitle}>{sanitizePdfText(caseTitle)}</Text>
+
+        <View style={styles.expensesTable}>
+          <View style={styles.expensesHeadRow} wrap={false}>
+            <View style={styles.expenseIndexCell}><Text style={styles.expenseHeadText}>#</Text></View>
+            <View style={styles.expenseNameCell}><Text style={styles.expenseHeadText}>Expenses</Text></View>
+            <View style={styles.expenseAmountCell}><Text style={styles.expenseHeadText}>EUR</Text></View>
+          </View>
+          {rows.map((row, index) => (
+            <View key={row.key || index} style={styles.expensesRow} wrap={false}>
+              <View style={styles.expenseIndexCell}><Text style={styles.expenseText}>{index + 1}</Text></View>
+              <View style={styles.expenseNameCell}><Text style={styles.expenseText}>{sanitizePdfText(row.name)}</Text></View>
+              <View style={styles.expenseAmountCell}><Text style={styles.expenseText}>{formatPlainAmount(row.price)}</Text></View>
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.summaryRow} wrap={false}>
+          <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: 'Helvetica-Bold' }]}>Total:</Text></View>
+          <View style={styles.summaryAmountCell}><Text style={[styles.summaryAmountText, { fontFamily: 'Helvetica-Bold' }]}>{formatEuroTotal(subtotal)}</Text></View>
+        </View>
+
+        <View style={{ marginTop: 16 }}>
+          <View style={styles.summaryRow} wrap={false}>
+            <View style={styles.summaryLabelCell}><Text style={styles.summaryLabelText}>Taxes (%)</Text></View>
+            <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(taxPercent)}</Text></View>
+          </View>
+          <View style={styles.summaryRow} wrap={false}>
+            <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: 'Helvetica-Bold' }]}>Amount need to be paid (EUR)</Text></View>
+            <View style={[styles.summaryAmountCell, styles.totalAmountCell]}><Text style={[styles.summaryAmountText, styles.totalAmountText]}>{formatEuroTotal(total)}</Text></View>
+          </View>
+        </View>
+
+        {renderFooter('2/2')}
+      </Page>
+    </Document>
+  );
+};
+
+export default InvoicePdfDocument;

--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
-import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
+import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaFileInvoiceDollar, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
 import { MdPersonAddAlt1 } from 'react-icons/md';
 import { VerifyEmail } from './VerifyEmail';
 import { useAppSettings } from 'hooks/useAppSettings';
@@ -220,6 +220,7 @@ export const ProfileDotsMenu = ({
       : []),
     ...(isAdmin ? [{ path: '/flow', label: 'Flow', icon: <FaProjectDiagram /> }] : []),
     ...(isAdmin ? [{ path: '/budget', label: 'Budget', description: 'Program budget and other expenses', icon: <FaEuroSign /> }] : []),
+    ...(isAdmin ? [{ path: '/invoices', label: 'Invoices', description: 'Create and export client invoices', icon: <FaFileInvoiceDollar /> }] : []),
   ];
 
   return (

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -1,0 +1,150 @@
+// Shared helpers for the admin invoice builder (InvoiceBuilderPage + InvoicePdfDocument).
+//
+// invoiceServices / recentServices rows are stored as plain strings:
+//   "id15"                              -> a service from the main budget catalog (budget/items), by id
+//   "Deposit for transportation of SM || 300" -> a custom one-off service, "Name || Price"
+// "||" is used instead of "-" as the separator so it never collides with a dash inside a name.
+
+import { resolveBudgetPriceAmount } from './budgetCatalogUtils';
+
+const SERVICE_PRICE_SEPARATOR = '||';
+const CATALOG_ID_PREFIX = 'id';
+
+const pad2 = value => String(value).padStart(2, '0');
+
+export const normalizeInvoiceData = raw => ({
+  beneficiaries: Array.isArray(raw?.beneficiaries) ? raw.beneficiaries : [],
+  beneficiaryIds: Array.isArray(raw?.beneficiaryIds) ? raw.beneficiaryIds.map(String) : [],
+  customers: Array.isArray(raw?.customers) ? raw.customers : [],
+  recentServices: Array.isArray(raw?.recentServices) ? raw.recentServices : [],
+  invoiceServices: Array.isArray(raw?.invoiceServices) ? raw.invoiceServices : [],
+  notes: Array.isArray(raw?.notes) ? raw.notes : [],
+  taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
+});
+
+// The active beneficiary is always the first id in beneficiaryIds.
+export const getActiveBeneficiary = data => {
+  const activeId = data?.beneficiaryIds?.[0];
+  const beneficiaries = Array.isArray(data?.beneficiaries) ? data.beneficiaries : [];
+  return beneficiaries.find(beneficiary => String(beneficiary.id) === String(activeId)) || beneficiaries[0] || null;
+};
+
+// Brings a beneficiary id to the front of beneficiaryIds without touching the
+// beneficiaries array order.
+export const reorderBeneficiaryIds = (beneficiaryIds, activeId) => {
+  const id = String(activeId);
+  const rest = (Array.isArray(beneficiaryIds) ? beneficiaryIds : []).filter(existing => String(existing) !== id);
+  return [id, ...rest];
+};
+
+export const makeCatalogServiceEntry = catalogId => `${CATALOG_ID_PREFIX}${catalogId}`;
+
+export const makeCustomServiceEntry = (name, price) => `${String(name || '').trim()} ${SERVICE_PRICE_SEPARATOR} ${price}`;
+
+// Splits a stored service row into either a catalog reference or a custom name/price pair.
+export const parseServiceEntry = entry => {
+  const text = String(entry ?? '').trim();
+  if (text.includes(SERVICE_PRICE_SEPARATOR)) {
+    const [namePart, ...priceParts] = text.split(SERVICE_PRICE_SEPARATOR);
+    const priceText = priceParts.join(SERVICE_PRICE_SEPARATOR).trim();
+    const price = Number(priceText.replace(',', '.'));
+    return {
+      isCatalog: false,
+      name: namePart.trim(),
+      price: Number.isFinite(price) ? price : 0,
+    };
+  }
+  const catalogMatch = /^id(.+)$/i.exec(text);
+  if (catalogMatch) {
+    return { isCatalog: true, catalogId: catalogMatch[1] };
+  }
+  return { isCatalog: false, name: text, price: 0 };
+};
+
+// Resolves a stored service row to its display name + EUR price, looking up
+// catalog references in the budget catalog (budget/items, keyed by id).
+export const resolveServiceRow = (entry, catalogItemsById) => {
+  const parsed = parseServiceEntry(entry);
+  if (parsed.isCatalog) {
+    const item = catalogItemsById?.get?.(String(parsed.catalogId));
+    if (!item) {
+      return {
+        key: entry, isCatalog: true, catalogId: parsed.catalogId, missing: true, name: `Unknown catalog service (id${parsed.catalogId})`, price: 0,
+      };
+    }
+    const amount = resolveBudgetPriceAmount(item.price, { itemsById: catalogItemsById });
+    return {
+      key: entry,
+      isCatalog: true,
+      catalogId: parsed.catalogId,
+      missing: false,
+      name: item.name || `id${parsed.catalogId}`,
+      description: item.description || '',
+      price: amount == null ? 0 : amount,
+    };
+  }
+  return {
+    key: entry, isCatalog: false, missing: false, name: parsed.name, price: parsed.price,
+  };
+};
+
+export const resolveInvoiceServiceRows = (invoiceServices, catalogItemsById) =>
+  (Array.isArray(invoiceServices) ? invoiceServices : []).map(entry => resolveServiceRow(entry, catalogItemsById));
+
+export const computeInvoiceSubtotal = rows => rows.reduce((sum, row) => sum + (Number(row.price) || 0), 0);
+
+export const computeInvoiceTotal = (subtotal, taxPercent) => subtotal * (1 + (Number(taxPercent) || 0) / 100);
+
+// After an invoice is generated, its services move to the front of recentServices
+// (same order, deduped) so they're the first quick-pick choices next time.
+export const reorderRecentServices = (recentServices, invoiceServices) => {
+  const seen = new Set();
+  const used = [];
+  (Array.isArray(invoiceServices) ? invoiceServices : []).forEach(entry => {
+    if (!entry || seen.has(entry)) return;
+    seen.add(entry);
+    used.push(entry);
+  });
+  const rest = (Array.isArray(recentServices) ? recentServices : []).filter(entry => !seen.has(entry));
+  return [...used, ...rest];
+};
+
+export const buildPayerName = customers =>
+  (Array.isArray(customers) ? customers : [])
+    .map(customer => String(customer?.name || '').trim())
+    .filter(Boolean)
+    .join(' and ');
+
+export const buildPayerLocation = customers => {
+  const addresses = (Array.isArray(customers) ? customers : [])
+    .map(customer => String(customer?.address || '').trim())
+    .filter(Boolean);
+  return [...new Set(addresses)].join('; ');
+};
+
+export const buildCaseTitle = customers => {
+  const payerName = buildPayerName(customers);
+  return payerName ? `Case of ${payerName}` : 'Case';
+};
+
+export const formatInvoiceNumberDate = date => `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()}`;
+
+export const formatInvoicePurposeDate = date => `${pad2(date.getDate())}.${pad2(date.getMonth() + 1)}.${date.getFullYear()}`;
+
+// Invoice number/date are never stored - they're derived from the chosen invoice
+// date at generation time (number uses "/", the purpose placeholder uses ".").
+export const generateInvoiceIdentifiers = dateInput => {
+  const date = dateInput instanceof Date ? dateInput : new Date(`${dateInput}T00:00:00`);
+  const safeDate = Number.isNaN(date.getTime()) ? new Date() : date;
+  return {
+    invoiceNumber: formatInvoiceNumberDate(safeDate),
+    invoiceDate: formatInvoicePurposeDate(safeDate),
+  };
+};
+
+export const applyPaymentPurposePlaceholders = (template, { invoiceNumber, invoiceDate }) =>
+  String(template || '')
+    .replaceAll('{invoiceNumber}', invoiceNumber || '')
+    .replaceAll('{invoiceDate}', invoiceDate || '');
+
+export const getTodayYmd = () => new Date().toISOString().slice(0, 10);

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -1,0 +1,112 @@
+import {
+  applyPaymentPurposePlaceholders,
+  buildCaseTitle,
+  buildPayerLocation,
+  buildPayerName,
+  computeInvoiceSubtotal,
+  computeInvoiceTotal,
+  generateInvoiceIdentifiers,
+  getActiveBeneficiary,
+  makeCatalogServiceEntry,
+  makeCustomServiceEntry,
+  normalizeInvoiceData,
+  parseServiceEntry,
+  reorderBeneficiaryIds,
+  reorderRecentServices,
+  resolveInvoiceServiceRows,
+  resolveServiceRow,
+} from './invoiceCatalogUtils';
+
+describe('invoiceCatalogUtils', () => {
+  it('normalizes a partial/empty document into the full shape', () => {
+    const data = normalizeInvoiceData(null);
+    expect(data).toEqual({
+      beneficiaries: [],
+      beneficiaryIds: [],
+      customers: [],
+      recentServices: [],
+      invoiceServices: [],
+      notes: [],
+      taxPercent: 0,
+    });
+  });
+
+  it('picks the active beneficiary from the first beneficiaryId', () => {
+    const data = normalizeInvoiceData({
+      beneficiaries: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
+      beneficiaryIds: ['b', 'a'],
+    });
+    expect(getActiveBeneficiary(data)).toEqual({ id: 'b', title: 'B' });
+  });
+
+  it('reorders beneficiaryIds without touching the beneficiaries array', () => {
+    expect(reorderBeneficiaryIds(['a', 'b', 'c'], 'c')).toEqual(['c', 'a', 'b']);
+    expect(reorderBeneficiaryIds(['a', 'b'], 'a')).toEqual(['a', 'b']);
+  });
+
+  it('parses catalog-referenced service rows ("idNN")', () => {
+    expect(parseServiceEntry('id15')).toEqual({ isCatalog: true, catalogId: '15' });
+  });
+
+  it('parses custom "Name || Price" service rows', () => {
+    expect(parseServiceEntry('Deposit for transportation of SM || 300')).toEqual({
+      isCatalog: false,
+      name: 'Deposit for transportation of SM',
+      price: 300,
+    });
+  });
+
+  it('round-trips catalog and custom service entries', () => {
+    expect(makeCatalogServiceEntry('15')).toBe('id15');
+    expect(makeCustomServiceEntry('Extra fee', 50)).toBe('Extra fee || 50');
+  });
+
+  it('resolves a catalog service row against the budget catalog', () => {
+    const catalogItemsById = new Map([['15', { id: '15', name: 'Scheduled payment', price: 3000 }]]);
+    expect(resolveServiceRow('id15', catalogItemsById)).toEqual({
+      key: 'id15', isCatalog: true, catalogId: '15', missing: false, name: 'Scheduled payment', description: '', price: 3000,
+    });
+  });
+
+  it('flags a catalog reference that no longer exists', () => {
+    const row = resolveServiceRow('id999', new Map());
+    expect(row.missing).toBe(true);
+  });
+
+  it('computes subtotal and tax-inclusive total from resolved rows', () => {
+    const catalogItemsById = new Map([['15', { id: '15', name: 'Scheduled payment', price: 3000 }]]);
+    const rows = resolveInvoiceServiceRows(
+      ['id15', 'Deposit for transportation of SM || 300', 'Deposit for medical expenses of SM || 300'],
+      catalogItemsById,
+    );
+    const subtotal = computeInvoiceSubtotal(rows);
+    expect(subtotal).toBe(3600);
+    expect(computeInvoiceTotal(subtotal, 14)).toBeCloseTo(4104);
+  });
+
+  it('moves used services to the front of recentServices, deduped', () => {
+    const recentServices = ['id1', 'id2', 'id3'];
+    const invoiceServices = ['id3', 'id2'];
+    expect(reorderRecentServices(recentServices, invoiceServices)).toEqual(['id3', 'id2', 'id1']);
+  });
+
+  it('builds the payer name and "Case of ..." title from customers', () => {
+    const customers = [{ name: 'Amny Athamny', address: 'Netherlands' }, { name: 'Fons Mitchell Drost', address: 'Netherlands' }];
+    expect(buildPayerName(customers)).toBe('Amny Athamny and Fons Mitchell Drost');
+    expect(buildCaseTitle(customers)).toBe('Case of Amny Athamny and Fons Mitchell Drost');
+    expect(buildPayerLocation(customers)).toBe('Netherlands');
+  });
+
+  it('generates invoice number ("/") and purpose date (".") from a date', () => {
+    expect(generateInvoiceIdentifiers('2026-05-23')).toEqual({
+      invoiceNumber: '23/05/2026',
+      invoiceDate: '23.05.2026',
+    });
+  });
+
+  it('fills invoiceNumber/invoiceDate placeholders into the payment purpose', () => {
+    const template = 'Payment by the invoice № {invoiceNumber} of {invoiceDate} without VAT.';
+    expect(applyPaymentPurposePlaceholders(template, { invoiceNumber: '23/05/2026', invoiceDate: '23.05.2026' }))
+      .toBe('Payment by the invoice № 23/05/2026 of 23.05.2026 without VAT.');
+  });
+});

--- a/src/data/invoiceBuilderSeed.json
+++ b/src/data/invoiceBuilderSeed.json
@@ -1,0 +1,41 @@
+{
+  "beneficiaries": [
+    {
+      "title": "PE KOVAL OLEKSANDR",
+      "id": "ua-fop-koval",
+      "address": "Ukraine, c. Kyiv, st. Bohatyrska, build. 6/1, fl. 129",
+      "iban": "UA743220010000026000300004046",
+      "bankName": "JSC UNIVERSAL BANK, KYIV, UKRAINE",
+      "swiftCode": "UNJSUAUKXXX",
+      "paymentPurpose": "Payment for information and consultation services by the invoice № {invoiceNumber} of {invoiceDate} without VAT, KOVAL O.V. (3281009190)."
+    }
+  ],
+  "beneficiaryIds": [
+    "ua-fop-koval"
+  ],
+  "customers": [
+    {
+      "name": "Amny Athamny",
+      "address": "Netherlands"
+    },
+    {
+      "name": "Fons Mitchell Drost",
+      "address": "Netherlands"
+    }
+  ],
+  "recentServices": [
+    "id15",
+    "Deposit for transportation of SM || 300",
+    "Deposit for medical expenses of SM || 300"
+  ],
+  "invoiceServices": [
+    "id15",
+    "Deposit for transportation of SM || 300",
+    "Deposit for medical expenses of SM || 300"
+  ],
+  "notes": [
+    "Purpose of the payment must be exactly like in invoice.",
+    "Please make sure you pay the whole amount (don't use SHA option while making payment)."
+  ],
+  "taxPercent": 14
+}


### PR DESCRIPTION
New independent /invoices route (admin only, modeled on the Budget page's
conventions) for managing beneficiaries, payer/customers, invoice services
(catalog-linked or custom), notes and tax %, autosaving each edit to Firebase
RTDB under invoiceBuilder/*. Generating an invoice resolves catalog-referenced
services against the existing budget catalog (budget/items), fills the
{invoiceNumber}/{invoiceDate} placeholders into the beneficiary's payment
purpose, renders a two-page PDF matching the provided template via
@react-pdf/renderer, and rolls the used services to the front of
recentServices for next time.

Added a JSON seed file (src/data/invoiceBuilderSeed.json) matching the given
sample invoice, uploadable from the page the same way BudgetPage seeds its
catalog. Also added a swiftCode field to the beneficiary schema since the
sample invoice needs it but the originally described schema didn't include it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lv8CBKDiyoMVjEmtLL8VMx