### PR TITLE
Fix percent-only flow amount sums

### DIFF
--- a/src/utils/__tests__/flowAmountFormula.test.js
+++ b/src/utils/__tests__/flowAmountFormula.test.js
@@ -1,0 +1,12 @@
+import { evaluateFlowAmountFormula } from '../flowAmountFormula';
+
+describe('evaluateFlowAmountFormula', () => {
+  it('adds percent-only sums as decimal rates before multiplication', () => {
+    expect(evaluateFlowAmountFormula('=100*(6%+1%)')).toBeCloseTo(7);
+    expect(evaluateFlowAmountFormula('=100*(6%-1%)')).toBeCloseTo(5);
+  });
+
+  it('keeps percent adjustment behavior for non-percent left operands', () => {
+    expect(evaluateFlowAmountFormula('=100+6%')).toBeCloseTo(106);
+  });
+});

--- a/src/utils/flowAmountFormula.js
+++ b/src/utils/flowAmountFormula.js
@@ -113,9 +113,10 @@ export const evaluateFlowAmountFormula = (rawFormula, resolveIdentifier) => {
       const operator = peek().type;
       position += 1;
       const right = parseTerm();
-      const rightValue = right.isPercent ? value * right.value : right.value;
+      const isPercentSum = term.isPercent && right.isPercent;
+      const rightValue = right.isPercent && !term.isPercent ? value * right.value : right.value;
       value = operator === '+' ? value + rightValue : value - rightValue;
-      term = { value, isPercent: false };
+      term = { value, isPercent: isPercentSum };
     }
     return term;
   };


### PR DESCRIPTION
### Motivation
- Prevent percent-only additions from compounding when used as a decimal rate inside multiplication so expressions like `=100*(6%+1%)` evaluate to 7 instead of 6.06.

### Description
- Modify `parseExpression` in `src/utils/flowAmountFormula.js` to detect when both operands are percent literals and treat their sum as a decimal-rate sum by computing `isPercentSum` and adjusting `rightValue` accordingly, while preserving existing behavior for cases like `=100+6%`.
- Add focused unit tests in `src/utils/__tests__/flowAmountFormula.test.js` that cover `=100*(6%+1%)`, `=100*(6%-1%)`, and `=100+6%`.

### Testing
- Ran targeted unit tests with `npm test -- --watchAll=false --runInBand src/utils/__tests__/flowAmountFormula.test.js` and they passed.
- Ran linter with `npm run lint:js -- src/utils/flowAmountFormula.js src/utils/__tests__/flowAmountFormula.test.js` and it passed.
- Ran full test suite with `npm test -- --watchAll=false --runInBand` which revealed unrelated existing failures in other suites (e.g. `Matching.sharedReactions`, `cardsStorage`, `matchingSourceBackfill`, `cardIndex`, `favoritesStorage`, `getFilteredCardsByList`, `load2Storage`, `dplStorage`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e2105538c8326b1aec604a10b3b93)