### PR TITLE
Fix invoice catalog pricing, preserve price editing, and validate invoice uploads

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import { get, ref, set } from 'firebase/database';
 import { FaFilePdf, FaPlus, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
-import { auth, database } from './config';
+import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
 import { isAdminUid } from 'utils/accessLevel';
 import {
   applyPaymentPurposePlaceholders,
@@ -18,6 +18,7 @@ import {
   getTodayYmd,
   makeCatalogServiceEntry,
   makeCustomServiceEntry,
+  isInvoiceDataShape,
   normalizeInvoiceData,
   parseServiceEntry,
   reorderBeneficiaryIds,
@@ -347,12 +348,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const [data, setData] = useState(() => normalizeInvoiceData(null));
   const [catalogItems, setCatalogItems] = useState([]);
+  const [exchangeRates, setExchangeRates] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [invoiceDateInput, setInvoiceDateInput] = useState(getTodayYmd());
   const [newCustomServiceName, setNewCustomServiceName] = useState('');
   const [newCustomServicePrice, setNewCustomServicePrice] = useState('');
+  const [invoiceServicePriceDrafts, setInvoiceServicePriceDrafts] = useState({});
   const [catalogQuery, setCatalogQuery] = useState('');
   const [showCatalogPicker, setShowCatalogPicker] = useState(false);
   const fileInputRef = useRef(null);
@@ -379,13 +382,32 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     loadInvoiceData();
   }, [loadInvoiceData]);
 
+  useEffect(() => {
+    let cancelled = false;
+    fetchNbuUahExchangeRatesByDate(getTodayYmd())
+      .then(rates => {
+        if (!cancelled && rates) setExchangeRates(rates);
+      })
+      .catch(ratesError => {
+        console.error('Unable to load NBU exchange rates for invoice catalog formulas', ratesError);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const catalogItemsById = useMemo(() => new Map(catalogItems.map(item => [String(item.id), item])), [catalogItems]);
 
   const activeBeneficiary = useMemo(() => getActiveBeneficiary(data), [data]);
 
+  const priceContext = useMemo(
+    () => ({ itemsById: catalogItemsById, rates: exchangeRates }),
+    [catalogItemsById, exchangeRates],
+  );
+
   const invoiceServiceRows = useMemo(
-    () => resolveInvoiceServiceRows(data.invoiceServices, catalogItemsById),
-    [data.invoiceServices, catalogItemsById],
+    () => resolveInvoiceServiceRows(data.invoiceServices, catalogItemsById, priceContext),
+    [data.invoiceServices, catalogItemsById, priceContext],
   );
 
   const subtotal = useMemo(() => computeInvoiceSubtotal(invoiceServiceRows), [invoiceServiceRows]);
@@ -540,7 +562,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const updateInvoiceServiceRow = (index, field, value) => {
     setData(current => {
       const entries = [...current.invoiceServices];
-      const resolved = resolveServiceRow(entries[index], catalogItemsById);
+      const resolved = resolveServiceRow(entries[index], catalogItemsById, priceContext);
       const nextName = field === 'name' ? value : resolved.name;
       const nextPrice = field === 'price' ? (Number(String(value).replace(',', '.')) || 0) : resolved.price;
       entries[index] = makeCustomServiceEntry(nextName, nextPrice);
@@ -548,8 +570,24 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     });
   };
 
-  const commitInvoiceServiceRow = () => {
-    persistInvoiceServices(data.invoiceServices, 'Service updated.');
+  const commitInvoiceServiceRow = index => {
+    const draft = invoiceServicePriceDrafts[index];
+    if (draft === undefined) {
+      persistInvoiceServices(data.invoiceServices, 'Service updated.');
+      return;
+    }
+
+    const entries = [...data.invoiceServices];
+    const resolved = resolveServiceRow(entries[index], catalogItemsById, priceContext);
+    const parsedPrice = Number(String(draft).replace(',', '.'));
+    entries[index] = makeCustomServiceEntry(resolved.name, Number.isFinite(parsedPrice) ? parsedPrice : 0);
+    setData(current => ({ ...current, invoiceServices: entries }));
+    setInvoiceServicePriceDrafts(current => {
+      const next = { ...current };
+      delete next[index];
+      return next;
+    });
+    persistInvoiceServices(entries, 'Service updated.');
   };
 
   const removeInvoiceServiceRow = index => {
@@ -640,6 +678,10 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     try {
       const text = await file.text();
       const parsed = JSON.parse(text);
+      if (!isInvoiceDataShape(parsed)) {
+        toast.error('Upload an invoice-builder JSON with beneficiaries, customers, services, and notes.');
+        return;
+      }
       const nextData = normalizeInvoiceData(parsed);
       await Promise.all([
         set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextData.beneficiaries),
@@ -685,6 +727,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         customers: data.customers,
         invoiceServices: data.invoiceServices,
         catalogItemsById,
+        priceContext,
         notes: data.notes,
         taxPercent: data.taxPercent,
         invoiceNumber,
@@ -865,8 +908,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     <Input
                       type="text"
                       inputMode="decimal"
-                      value={row.price}
-                      onChange={event => updateInvoiceServiceRow(index, 'price', event.target.value)}
+                      value={invoiceServicePriceDrafts[index] ?? row.price}
+                      onChange={event => setInvoiceServicePriceDrafts(current => ({ ...current, [index]: event.target.value }))}
                       onBlur={() => commitInvoiceServiceRow(index)}
                     />
                     <DangerButton type="button" onClick={() => removeInvoiceServiceRow(index)}><FaTrash /></DangerButton>
@@ -880,7 +923,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   <PanelNote style={{ marginTop: 14, marginBottom: 4 }}>Recent services (click to add)</PanelNote>
                   <ChipRow>
                     {recentServiceSuggestions.map(entry => {
-                      const resolved = resolveServiceRow(entry, catalogItemsById);
+                      const resolved = resolveServiceRow(entry, catalogItemsById, priceContext);
                       return (
                         <Chip key={entry} type="button" onClick={() => addServiceEntry(entry)}>
                           {resolved.name} · {formatEuroPreview(resolved.price)}

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -268,8 +268,9 @@ const InvoicePdfDocument = ({
   invoiceNumber,
   invoiceDate,
   purposeOfPayment,
+  priceContext,
 }) => {
-  const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById);
+  const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById, priceContext);
   const subtotal = computeInvoiceSubtotal(rows);
   const total = computeInvoiceTotal(subtotal, taxPercent);
   const payerName = buildPayerName(customers);

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -5,7 +5,7 @@
 //   "Deposit for transportation of SM || 300" -> a custom one-off service, "Name || Price"
 // "||" is used instead of "-" as the separator so it never collides with a dash inside a name.
 
-import { resolveBudgetPriceAmount } from './budgetCatalogUtils';
+import { getItemDisplayAmount } from './budgetCatalogUtils';
 
 const SERVICE_PRICE_SEPARATOR = '||';
 const CATALOG_ID_PREFIX = 'id';
@@ -21,6 +21,13 @@ export const normalizeInvoiceData = raw => ({
   notes: Array.isArray(raw?.notes) ? raw.notes : [],
   taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
 });
+
+export const isInvoiceDataShape = raw => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
+  return ['beneficiaries', 'beneficiaryIds', 'customers', 'recentServices', 'invoiceServices', 'notes']
+    .every(field => Array.isArray(raw[field]))
+    && (raw.taxPercent === undefined || Number.isFinite(Number(raw.taxPercent)));
+};
 
 // The active beneficiary is always the first id in beneficiaryIds.
 export const getActiveBeneficiary = data => {
@@ -63,7 +70,7 @@ export const parseServiceEntry = entry => {
 
 // Resolves a stored service row to its display name + EUR price, looking up
 // catalog references in the budget catalog (budget/items, keyed by id).
-export const resolveServiceRow = (entry, catalogItemsById) => {
+export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) => {
   const parsed = parseServiceEntry(entry);
   if (parsed.isCatalog) {
     const item = catalogItemsById?.get?.(String(parsed.catalogId));
@@ -72,7 +79,7 @@ export const resolveServiceRow = (entry, catalogItemsById) => {
         key: entry, isCatalog: true, catalogId: parsed.catalogId, missing: true, name: `Unknown catalog service (id${parsed.catalogId})`, price: 0,
       };
     }
-    const amount = resolveBudgetPriceAmount(item.price, { itemsById: catalogItemsById });
+    const amount = getItemDisplayAmount(item, { ...priceContext, itemsById: catalogItemsById });
     return {
       key: entry,
       isCatalog: true,
@@ -88,8 +95,8 @@ export const resolveServiceRow = (entry, catalogItemsById) => {
   };
 };
 
-export const resolveInvoiceServiceRows = (invoiceServices, catalogItemsById) =>
-  (Array.isArray(invoiceServices) ? invoiceServices : []).map(entry => resolveServiceRow(entry, catalogItemsById));
+export const resolveInvoiceServiceRows = (invoiceServices, catalogItemsById, priceContext = {}) =>
+  (Array.isArray(invoiceServices) ? invoiceServices : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
 export const computeInvoiceSubtotal = rows => rows.reduce((sum, row) => sum + (Number(row.price) || 0), 0);
 
@@ -147,4 +154,7 @@ export const applyPaymentPurposePlaceholders = (template, { invoiceNumber, invoi
     .replaceAll('{invoiceNumber}', invoiceNumber || '')
     .replaceAll('{invoiceDate}', invoiceDate || '');
 
-export const getTodayYmd = () => new Date().toISOString().slice(0, 10);
+export const getTodayYmd = () => {
+  const today = new Date();
+  return `${today.getFullYear()}-${pad2(today.getMonth() + 1)}-${pad2(today.getDate())}`;
+};

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -7,8 +7,10 @@ import {
   computeInvoiceTotal,
   generateInvoiceIdentifiers,
   getActiveBeneficiary,
+  getTodayYmd,
   makeCatalogServiceEntry,
   makeCustomServiceEntry,
+  isInvoiceDataShape,
   normalizeInvoiceData,
   parseServiceEntry,
   reorderBeneficiaryIds,
@@ -29,6 +31,21 @@ describe('invoiceCatalogUtils', () => {
       notes: [],
       taxPercent: 0,
     });
+  });
+
+
+  it('validates the invoice upload shape before normalization can empty missing collections', () => {
+    expect(isInvoiceDataShape({})).toBe(false);
+    expect(isInvoiceDataShape({ items: [] })).toBe(false);
+    expect(isInvoiceDataShape({
+      beneficiaries: [],
+      beneficiaryIds: [],
+      customers: [],
+      recentServices: [],
+      invoiceServices: [],
+      notes: [],
+      taxPercent: 0,
+    })).toBe(true);
   });
 
   it('picks the active beneficiary from the first beneficiaryId', () => {
@@ -68,6 +85,17 @@ describe('invoiceCatalogUtils', () => {
     });
   });
 
+
+
+  it('resolves catalog invoice rows with budget display conversion and formula rates', () => {
+    const catalogItemsById = new Map([
+      ['22', { id: '22', name: 'USD compensation', price: 23000 }],
+      ['30', { id: '30', name: 'Formula price', price: '=USD/EUR*100' }],
+    ]);
+    expect(resolveServiceRow('id22', catalogItemsById).price).toBeCloseTo(21160);
+    expect(resolveServiceRow('id30', catalogItemsById, { rates: { usd: 40, eur: 50 } }).price).toBeCloseTo(80);
+  });
+
   it('flags a catalog reference that no longer exists', () => {
     const row = resolveServiceRow('id999', new Map());
     expect(row.missing).toBe(true);
@@ -102,6 +130,29 @@ describe('invoiceCatalogUtils', () => {
       invoiceNumber: '23/05/2026',
       invoiceDate: '23.05.2026',
     });
+  });
+
+
+
+  it('uses local date components for the default invoice date', () => {
+    const RealDate = Date;
+    const fixed = new RealDate('2026-05-24T06:30:00.000Z');
+    global.Date = class extends RealDate {
+      constructor(...args) {
+        super(...(args.length === 0 ? [fixed.getTime()] : args));
+      }
+      getFullYear() { return this.getTime() === fixed.getTime() ? 2026 : super.getFullYear(); }
+      getMonth() { return this.getTime() === fixed.getTime() ? 4 : super.getMonth(); }
+      getDate() { return this.getTime() === fixed.getTime() ? 23 : super.getDate(); }
+      static now() { return fixed.getTime(); }
+      static parse(value) { return RealDate.parse(value); }
+      static UTC(...args) { return RealDate.UTC(...args); }
+    };
+    try {
+      expect(getTodayYmd()).toBe('2026-05-23');
+    } finally {
+      global.Date = RealDate;
+    }
   });
 
   it('fills invoiceNumber/invoiceDate placeholders into the payment purpose', () => {


### PR DESCRIPTION
### Motivation

- Ensure invoice builder uses the same budget pricing/display logic (including USD-item conversion and formula rate context) as the Budget page so catalog-linked services resolve to correct EUR amounts.
- Allow admins to type decimal prices interactively without intermediate coercion losing trailing decimal separators and preventing cent entry.
- Prevent accidental backend overwrite by rejecting uploaded JSON that does not match the expected invoice-builder shape.
- Avoid UTC-derived off-by-one-day defaults by building the default invoice date from local date components.

### Description

- Resolve catalog-linked invoice service prices with the budget display path by switching to `getItemDisplayAmount` and threading a `priceContext` with `itemsById` and NBU rates into `resolveServiceRow`, `resolveInvoiceServiceRows`, the invoice preview and PDF renderer. (files: `invoiceCatalogUtils.js`, `InvoiceBuilderPage.jsx`, `InvoicePdfDocument.jsx`)
- Preserve in-progress decimal entry by keeping per-row price draft strings (`invoiceServicePriceDrafts`) and only parsing/committing the value on blur/commit. (file: `InvoiceBuilderPage.jsx`)
- Validate uploaded invoice JSON before normalizing and writing backend paths by adding `isInvoiceDataShape` and rejecting files that don't contain the expected arrays/fields. (files: `invoiceCatalogUtils.js`, `InvoiceBuilderPage.jsx`)
- Replace `toISOString().slice(0,10)` default date with a local-component `getTodayYmd()` implementation to use local date components. (file: `invoiceCatalogUtils.js`)
- Add unit test coverage for upload-shape validation, catalog USD/formula price resolution with rate context, and local-date default behavior. (file: `invoiceCatalogUtils.test.js`)

### Testing

- Ran unit tests: `npm test -- --runTestsByPath src/components/invoiceCatalogUtils.test.js --watchAll=false`, all tests in that file passed (16/16). 
- Ran linting: `npm run lint:js`, linter exited successfully with no blocking errors. 
- Built the production bundle: `npm run build`, build completed successfully and produced the optimized bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e31c859a883268107359e763eb798)