### PR TITLE
Invoice Builder: per-invoice overrides, whole packages, premium redesign

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -12,30 +12,20 @@ import {
   resolveProgramPaymentSchedule,
   KNOWN_CLIENT_NOTE_GROUPS,
 } from './budgetCatalogUtils';
+import { PDF_COLOR, sanitizePdfText } from './pdfTheme';
 
 const UKRCOM_MARKER = 'REPRODUCTIVE AGENCY "UKRCOM"';
 
-const INK = '#33291f';
-const MUTED = '#6f6359';
-const ACCENT = '#7a4c2f';
-const SOFT = '#9a6b48';
-const LINE = '#e6d7c4';
-const HEAD_BG = '#f3e6d2';
-const ROW_ALT = '#faf3e8';
-const CARD_BG = '#fdf8f0';
+const INK = PDF_COLOR.ink;
+const MUTED = PDF_COLOR.muted;
+const ACCENT = PDF_COLOR.accent;
+const SOFT = PDF_COLOR.soft;
+const LINE = PDF_COLOR.line;
+const HEAD_BG = PDF_COLOR.headBg;
+const ROW_ALT = PDF_COLOR.rowAlt;
+const CARD_BG = PDF_COLOR.cardBg;
 
 const PROGRAM_COL_WIDTH = 52;
-
-// The built-in Helvetica font only covers WinAnsi glyphs, so swap the few
-// characters from the catalog data that would otherwise render blank.
-const sanitizePdfText = value => String(value ?? '')
-  .replace(/№/g, 'No.')
-  .replace(/[’‘]/g, "'")
-  .replace(/[“”]/g, '"')
-  .replace(/[–—]/g, '-')
-  .replace(/[✓✔]/g, 'x')
-  .replace(/\s+/g, ' ')
-  .trim();
 
 const formatAmount = value => {
   const amount = Number(value);

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -1,0 +1,419 @@
+import React from 'react';
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { PDF_COLOR, PDF_FONT, pdfBaseStyles, sanitizePdfText } from './pdfTheme';
+import { buildCaseTitle } from './invoiceCatalogUtils';
+import {
+  computeMilestoneAmountDue,
+  computeMilestoneSubtotal,
+  resolveMilestoneAdditionalRows,
+  resolvePackageOverviewRows,
+} from './expectedExpensesUtils';
+
+const AGENCY_NAME = 'REPRODUCTIVE AGENCY "UKRCOM"';
+const AGENCY_ADDRESS_LINE_1 = '31/16 Reitarska Str., 1st floor,';
+const AGENCY_ADDRESS_LINE_2 = 'Kyiv, 01034, Ukraine';
+const AGENCY_WEBSITE = 'Website: http://ukrcom.kyiv.ua/';
+const AGENCY_EMAIL = 'E-mail: sm.kiev.ukr@gmail.com';
+const AGENCY_TELEGRAM = 'Telegram: @Contact_Us_Kyiv';
+
+const formatPlainAmount = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '-';
+  return Number.isInteger(amount) ? String(amount) : amount.toFixed(2).replace('.', ',');
+};
+
+const formatEuroTotal = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '-';
+  const [whole, decimals] = amount.toFixed(2).split('.');
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  return `${grouped},${decimals} EUR`;
+};
+
+const formatPlanDate = date => {
+  const safeDate = date instanceof Date && !Number.isNaN(date.getTime()) ? date : new Date();
+  return safeDate.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' }).replace(/ /g, '-');
+};
+
+const styles = StyleSheet.create({
+  page: pdfBaseStyles.page,
+  sectionTitle: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 19,
+    letterSpacing: -0.2,
+    textAlign: 'center',
+    marginBottom: 4,
+    color: PDF_COLOR.ink,
+  },
+  sectionSubtitle: {
+    fontSize: 10.5,
+    fontFamily: PDF_FONT.bold,
+    textAlign: 'center',
+    color: PDF_COLOR.soft,
+  },
+  dateText: {
+    fontSize: 9,
+    textAlign: 'center',
+    color: PDF_COLOR.muted,
+    marginBottom: 20,
+  },
+  overviewTable: {
+    borderWidth: 1,
+    borderColor: PDF_COLOR.line,
+    borderStyle: 'solid',
+    borderRadius: 6,
+    marginBottom: 4,
+  },
+  overviewHeadRow: {
+    flexDirection: 'row',
+    backgroundColor: PDF_COLOR.headBg,
+  },
+  overviewHeadCell: {
+    flex: 1,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
+  },
+  overviewHeadText: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 10,
+    textAlign: 'center',
+    color: '#4d3a26',
+  },
+  overviewRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.line,
+    borderTopStyle: 'solid',
+  },
+  overviewRowAlt: {
+    backgroundColor: PDF_COLOR.rowAlt,
+  },
+  overviewIndexCell: {
+    width: 26,
+    borderRightWidth: 1,
+    borderRightColor: PDF_COLOR.line,
+    borderRightStyle: 'solid',
+    paddingVertical: 5,
+    paddingHorizontal: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  overviewNameCell: {
+    flex: 1,
+    paddingVertical: 5,
+    paddingHorizontal: 9,
+    justifyContent: 'center',
+  },
+  overviewIndexText: {
+    fontSize: 8.5,
+    color: PDF_COLOR.soft,
+    fontFamily: PDF_FONT.bold,
+  },
+  overviewText: {
+    fontSize: 9.5,
+  },
+  overviewTotalRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.line,
+    borderTopStyle: 'solid',
+    backgroundColor: PDF_COLOR.headBg,
+  },
+  overviewTotalLabelCell: {
+    flex: 1,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
+  },
+  overviewTotalLabelText: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 10,
+  },
+  overviewTotalAmountCell: {
+    width: 100,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
+    borderLeftWidth: 1,
+    borderLeftColor: PDF_COLOR.line,
+    borderLeftStyle: 'solid',
+  },
+  overviewTotalAmountText: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 10,
+  },
+  scheduleHeading: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 11,
+    marginTop: 18,
+    marginBottom: 8,
+  },
+  scheduleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 3,
+    paddingHorizontal: 4,
+    borderRadius: 4,
+  },
+  scheduleRowCurrent: {
+    backgroundColor: PDF_COLOR.headBg,
+  },
+  scheduleLabelText: {
+    fontSize: 9.5,
+  },
+  scheduleLabelTextCurrent: {
+    fontFamily: PDF_FONT.bold,
+  },
+  scheduleAmountText: {
+    fontSize: 9.5,
+  },
+  expensesTable: {
+    borderWidth: 1,
+    borderColor: PDF_COLOR.line,
+    borderStyle: 'solid',
+    borderRadius: 6,
+    marginTop: 16,
+    marginBottom: 4,
+  },
+  expensesHeadRow: {
+    flexDirection: 'row',
+    backgroundColor: PDF_COLOR.headBg,
+  },
+  expensesRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.line,
+    borderTopStyle: 'solid',
+  },
+  expensesRowAlt: {
+    backgroundColor: PDF_COLOR.rowAlt,
+  },
+  expenseIndexCell: {
+    width: 26,
+    borderRightWidth: 1,
+    borderRightColor: PDF_COLOR.line,
+    borderRightStyle: 'solid',
+    paddingVertical: 6,
+    paddingHorizontal: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  expenseNameCell: {
+    flex: 1,
+    borderRightWidth: 1,
+    borderRightColor: PDF_COLOR.line,
+    borderRightStyle: 'solid',
+    paddingVertical: 6,
+    paddingHorizontal: 9,
+    justifyContent: 'center',
+  },
+  expenseAmountCell: {
+    width: 88,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  expenseHeadText: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 9.5,
+    color: '#4d3a26',
+  },
+  expenseIndexText: {
+    fontSize: 8.5,
+    color: PDF_COLOR.soft,
+    fontFamily: PDF_FONT.bold,
+  },
+  expenseText: {
+    fontSize: 9.5,
+  },
+  expenseDescription: {
+    fontSize: 8,
+    color: PDF_COLOR.muted,
+    lineHeight: 1.4,
+    marginTop: 1.5,
+  },
+  expensePriceText: {
+    fontSize: 9.5,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderColor: PDF_COLOR.line,
+    borderStyle: 'solid',
+    borderTopWidth: 0,
+  },
+  summaryRowLast: {
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+  },
+  summaryLabelCell: {
+    flex: 1,
+    paddingVertical: 7,
+    paddingHorizontal: 9,
+    justifyContent: 'center',
+  },
+  summaryAmountCell: {
+    width: 118,
+    paddingVertical: 7,
+    paddingHorizontal: 9,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    borderLeftWidth: 1,
+    borderLeftColor: PDF_COLOR.line,
+    borderLeftStyle: 'solid',
+  },
+  summaryLabelText: {
+    fontSize: 9.5,
+  },
+  summaryAmountText: {
+    fontSize: 9.5,
+  },
+  totalAmountCell: {
+    backgroundColor: PDF_COLOR.totalBg,
+  },
+  totalAmountText: {
+    fontFamily: PDF_FONT.bold,
+  },
+  footer: pdfBaseStyles.footer,
+  footerColumn: pdfBaseStyles.footerColumn,
+  footerText: pdfBaseStyles.footerText,
+  footerPage: pdfBaseStyles.footerPage,
+});
+
+const renderFooter = pageLabel => (
+  <View style={styles.footer} fixed>
+    <View style={styles.footerColumn}>
+      <Text style={styles.footerText}>{sanitizePdfText(AGENCY_NAME)}</Text>
+      <Text style={styles.footerText}>{sanitizePdfText(AGENCY_ADDRESS_LINE_1)}</Text>
+      <Text style={styles.footerText}>{sanitizePdfText(AGENCY_ADDRESS_LINE_2)}</Text>
+    </View>
+    <View style={styles.footerColumn}>
+      <Text style={[styles.footerText, { textAlign: 'right' }]}>{sanitizePdfText(AGENCY_WEBSITE)}</Text>
+      <Text style={[styles.footerText, { textAlign: 'right' }]}>{sanitizePdfText(AGENCY_EMAIL)}</Text>
+      <Text style={[styles.footerText, { textAlign: 'right' }]}>{sanitizePdfText(AGENCY_TELEGRAM)}</Text>
+    </View>
+    <Text style={styles.footerPage}>{pageLabel}</Text>
+  </View>
+);
+
+const renderExpensesTable = (rows, { includeScheduledRow, scheduledAmount }) => {
+  const allRows = includeScheduledRow
+    ? [{ key: 'scheduled', name: 'Scheduled payment', price: scheduledAmount }, ...rows]
+    : rows;
+  return (
+    <View style={styles.expensesTable}>
+      <View style={styles.expensesHeadRow} wrap={false}>
+        <View style={styles.expenseIndexCell}><Text style={styles.expenseHeadText}>#</Text></View>
+        <View style={styles.expenseNameCell}><Text style={styles.expenseHeadText}>Expenses</Text></View>
+        <View style={styles.expenseAmountCell}><Text style={styles.expenseHeadText}>EUR</Text></View>
+      </View>
+      {allRows.map((row, index) => (
+        <View
+          key={row.key || index}
+          style={[styles.expensesRow, index % 2 ? styles.expensesRowAlt : null]}
+          wrap={false}
+        >
+          <View style={styles.expenseIndexCell}><Text style={styles.expenseIndexText}>{index + 1}</Text></View>
+          <View style={styles.expenseNameCell}>
+            <Text style={styles.expenseText}>{sanitizePdfText(row.name)}</Text>
+            {row.description ? <Text style={styles.expenseDescription}>{sanitizePdfText(row.description)}</Text> : null}
+          </View>
+          <View style={styles.expenseAmountCell}><Text style={styles.expensePriceText}>{formatPlainAmount(row.price)}</Text></View>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate }) => {
+  const caseTitle = buildCaseTitle(customers);
+  const dateLabel = formatPlanDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
+  const overviewRows = resolvePackageOverviewRows(plan?.packageSnapshot?.children, catalogItemsById, priceContext);
+  const milestones = Array.isArray(plan?.milestones) ? plan.milestones : [];
+
+  return (
+    <Document title={`Expected expenses - ${caseTitle}`} subject="Expected expenses" creator="UKRCOM">
+      {milestones.map((milestone, index) => {
+        const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById, priceContext);
+        const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
+        const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
+        const pageLabel = `${index + 1}/${milestones.length}`;
+
+        return (
+          <Page key={milestone.id || index} size="A4" style={styles.page} wrap>
+            {milestone.showPackageOverview ? (
+              <>
+                <Text style={styles.sectionTitle}>Description</Text>
+                <Text style={styles.sectionSubtitle}>{sanitizePdfText(caseTitle)}</Text>
+                <Text style={styles.dateText}>{dateLabel}</Text>
+
+                <View style={styles.overviewTable}>
+                  <View style={styles.overviewHeadRow} wrap={false}>
+                    <View style={styles.overviewHeadCell}><Text style={styles.overviewHeadText}>{sanitizePdfText(plan.packageSnapshot.name)}</Text></View>
+                  </View>
+                  {overviewRows.map((row, rowIndex) => (
+                    <View
+                      key={row.key || rowIndex}
+                      style={[styles.overviewRow, rowIndex % 2 ? styles.overviewRowAlt : null]}
+                      wrap={false}
+                    >
+                      <View style={styles.overviewIndexCell}><Text style={styles.overviewIndexText}>{rowIndex + 1}</Text></View>
+                      <View style={styles.overviewNameCell}><Text style={styles.overviewText}>{sanitizePdfText(row.name)}</Text></View>
+                    </View>
+                  ))}
+                  <View style={styles.overviewTotalRow} wrap={false}>
+                    <View style={styles.overviewTotalLabelCell}><Text style={styles.overviewTotalLabelText}>Total:</Text></View>
+                    <View style={styles.overviewTotalAmountCell}><Text style={styles.overviewTotalAmountText}>{formatEuroTotal(plan.packageSnapshot.listedPrice)}</Text></View>
+                  </View>
+                </View>
+
+                <Text style={styles.scheduleHeading}>Payment schedule:</Text>
+                {milestones.map((scheduleMilestone, scheduleIndex) => (
+                  <View
+                    key={scheduleMilestone.id || scheduleIndex}
+                    style={[styles.scheduleRow, scheduleIndex === index ? styles.scheduleRowCurrent : null]}
+                    wrap={false}
+                  >
+                    <Text style={[styles.scheduleLabelText, scheduleIndex === index ? styles.scheduleLabelTextCurrent : null]}>
+                      {sanitizePdfText(`${scheduleIndex + 1}. ${scheduleMilestone.title}`)}
+                    </Text>
+                    <Text style={styles.scheduleAmountText}>{formatEuroTotal(scheduleMilestone.scheduledAmount)}</Text>
+                  </View>
+                ))}
+
+                {additionalRows.length ? renderExpensesTable(additionalRows, { includeScheduledRow: false }) : null}
+              </>
+            ) : (
+              <>
+                <Text style={styles.sectionTitle}>{sanitizePdfText(`Expected expenses of the invoice #${index + 1}`)}</Text>
+                <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${milestone.title}`)}</Text>
+                <Text style={styles.dateText}>{dateLabel}</Text>
+
+                {renderExpensesTable(additionalRows, { includeScheduledRow: true, scheduledAmount: milestone.scheduledAmount })}
+              </>
+            )}
+
+            <View style={[styles.summaryRow, styles.summaryRowLast]} wrap={false}>
+              <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Total:</Text></View>
+              <View style={styles.summaryAmountCell}><Text style={[styles.summaryAmountText, { fontFamily: PDF_FONT.bold }]}>{formatEuroTotal(subtotal)}</Text></View>
+            </View>
+
+            <View style={{ marginTop: 16 }}>
+              <View style={styles.summaryRow} wrap={false}>
+                <View style={styles.summaryLabelCell}><Text style={styles.summaryLabelText}>Taxes (%)</Text></View>
+                <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(milestone.taxPercent)}</Text></View>
+              </View>
+              <View style={[styles.summaryRow, styles.summaryRowLast]} wrap={false}>
+                <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Amount need to be paid (EUR)</Text></View>
+                <View style={[styles.summaryAmountCell, styles.totalAmountCell]}><Text style={[styles.summaryAmountText, styles.totalAmountText]}>{formatEuroTotal(amountDue)}</Text></View>
+              </View>
+            </View>
+
+            {renderFooter(pageLabel)}
+          </Page>
+        );
+      })}
+    </Document>
+  );
+};
+
+export default ExpectedExpensesPdfDocument;

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -56,6 +56,7 @@ import {
   computeMilestoneAmountDue,
   computeMilestoneSubtotal,
   computeMilestonesScheduledTotal,
+  isExpectedExpensesShape,
   normalizeExpectedExpensesData,
   removeMilestoneAdditionalService,
   resolveMilestoneAdditionalRows,
@@ -1095,6 +1096,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [catalogTab, setCatalogTab] = useState('items');
   const [showExpectedExpensesPicker, setShowExpectedExpensesPicker] = useState(false);
   const fileInputRef = useRef(null);
+  const expectedExpensesFileInputRef = useRef(null);
 
   const loadInvoiceData = useCallback(async () => {
     setLoading(true);
@@ -1689,6 +1691,31 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     }
   };
 
+  // Upload a standalone expected-expenses JSON (see src/data/expectedExpensesSeed.json for the
+  // shape) straight into invoiceBuilder/expectedExpenses, replacing any existing plan.
+  const handleExpectedExpensesUploadClick = () => expectedExpensesFileInputRef.current?.click();
+
+  const handleExpectedExpensesFileChange = async event => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      if (!isExpectedExpensesShape(parsed)) {
+        toast.error('Upload an expected-expenses JSON with packageSnapshot and milestones.');
+        return;
+      }
+      const nextPlan = normalizeExpectedExpensesData(parsed);
+      await set(ref(database, EXPECTED_EXPENSES_PATH), nextPlan);
+      setExpectedExpenses(nextPlan);
+      toast.success('Expected expenses JSON uploaded to backend.');
+    } catch (uploadError) {
+      console.error('Unable to upload expected expenses JSON', uploadError);
+      toast.error('Unable to upload expected expenses JSON.');
+    }
+  };
+
   // Generate PDF ------------------------------------------------------------
 
   const handleGeneratePdf = async () => {
@@ -2077,22 +2104,38 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
             <Panel>
               <PanelHeading>
                 <H2>Expected expenses</H2>
-                {expectedExpenses ? (
-                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                    <SmallButton type="button" onClick={recalculateExpectedExpensesSchedule}>
-                      <FaSyncAlt /> Recalculate
-                    </SmallButton>
-                    <PrimaryMiniButton
-                      type="button"
-                      onClick={handleGenerateExpectedExpensesPdf}
-                      disabled={isGeneratingExpectedExpenses}
-                      title="Generate the full payment-schedule forecast PDF"
-                    >
-                      <FaFilePdf /> {isGeneratingExpectedExpenses ? 'Generating…' : 'Generate PDF'}
-                    </PrimaryMiniButton>
-                    <DangerButton type="button" onClick={deleteExpectedExpensesPlan}><FaTrash /> Delete plan</DangerButton>
-                  </div>
-                ) : null}
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  <input
+                    ref={expectedExpensesFileInputRef}
+                    type="file"
+                    accept="application/json"
+                    style={{ display: 'none' }}
+                    onChange={handleExpectedExpensesFileChange}
+                  />
+                  <SmallButton
+                    type="button"
+                    onClick={handleExpectedExpensesUploadClick}
+                    title="Upload a standalone expected-expenses JSON (see src/data/expectedExpensesSeed.json)"
+                  >
+                    <FaUpload /> Upload JSON
+                  </SmallButton>
+                  {expectedExpenses ? (
+                    <>
+                      <SmallButton type="button" onClick={recalculateExpectedExpensesSchedule}>
+                        <FaSyncAlt /> Recalculate
+                      </SmallButton>
+                      <PrimaryMiniButton
+                        type="button"
+                        onClick={handleGenerateExpectedExpensesPdf}
+                        disabled={isGeneratingExpectedExpenses}
+                        title="Generate the full payment-schedule forecast PDF"
+                      >
+                        <FaFilePdf /> {isGeneratingExpectedExpenses ? 'Generating…' : 'Generate PDF'}
+                      </PrimaryMiniButton>
+                      <DangerButton type="button" onClick={deleteExpectedExpensesPlan}><FaTrash /> Delete plan</DangerButton>
+                    </>
+                  ) : null}
+                </div>
               </PanelHeading>
               <PanelNote>
                 Pick a program package to auto-build a full billing forecast: one milestone per scheduled payment

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -9,13 +9,14 @@ import {
   FaFilePdf,
   FaLayerGroup,
   FaPlus,
+  FaSyncAlt,
   FaTrash,
   FaUndoAlt,
   FaUpload,
 } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
-import { getVisibleSortedPackages, parseBudgetPriceValue } from './budgetCatalogUtils';
+import { getVisibleSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isAdminUid } from 'utils/accessLevel';
 import {
@@ -48,10 +49,26 @@ import {
   setEntryField,
   updatePackageChildField,
 } from './invoiceCatalogUtils';
+import {
+  addMilestoneAdditionalService,
+  buildExpectedExpensesPlan,
+  buildMilestonesFromSchedule,
+  computeMilestoneAmountDue,
+  computeMilestoneSubtotal,
+  computeMilestonesScheduledTotal,
+  normalizeExpectedExpensesData,
+  removeMilestoneAdditionalService,
+  resolveMilestoneAdditionalRows,
+  resolvePackageOverviewRows,
+  setMilestoneField,
+  updateMilestoneAdditionalServiceField,
+} from './expectedExpensesUtils';
 
 const INVOICE_DATA_PATH = 'invoiceBuilder';
 const CATALOG_ITEMS_PATH = 'budget/items';
 const CATALOG_PACKAGES_PATH = 'budget/packages';
+const CATALOG_TECHNICAL_PATH = 'budget/technical';
+const EXPECTED_EXPENSES_PATH = 'invoiceBuilder/expectedExpenses';
 
 const toArray = value => {
   if (Array.isArray(value)) return value;
@@ -830,6 +847,184 @@ const PackageEntryCard = ({
   );
 };
 
+// --- Expected expenses milestone (one payment-schedule entry -> one future invoice) ------------------------------------------------------
+
+const MilestoneCheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 2px 0 0 28px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--km-muted);
+
+  @media (max-width: 560px) {
+    margin-left: 10px;
+  }
+`;
+
+const MilestoneCheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+`;
+
+const MilestoneCard = ({
+  index,
+  milestone,
+  additionalRows,
+  amountDue,
+  catalogItems,
+  onCommitField,
+  onToggleOverview,
+  onCommitServiceField,
+  onRemoveService,
+  onResetService,
+  onAddCustomService,
+  onAddCatalogService,
+}) => {
+  const [titleDraft, setTitleDraft, titleEditingRef] = useFieldDraft(milestone.title);
+  const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(String(milestone.scheduledAmount ?? ''));
+  const [taxDraft, setTaxDraft, taxEditingRef] = useFieldDraft(String(milestone.taxPercent ?? ''));
+  const [showPicker, setShowPicker] = useState(false);
+  const [query, setQuery] = useState('');
+  const [customName, setCustomName] = useState('');
+  const [customPrice, setCustomPrice] = useState('');
+
+  const usedCatalogIds = useMemo(
+    () => new Set(additionalRows.filter(row => row.kind === 'item').map(row => String(row.catalogId))),
+    [additionalRows],
+  );
+
+  const availableItems = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return catalogItems
+      .filter(item => !usedCatalogIds.has(String(item.id)))
+      .filter(item => !normalizedQuery || String(item.name || '').toLowerCase().includes(normalizedQuery))
+      .slice(0, 30);
+  }, [catalogItems, usedCatalogIds, query]);
+
+  const handleAddCustom = () => {
+    const name = customName.trim();
+    const price = Number(customPrice.replace(',', '.'));
+    if (!name) {
+      toast.error('Enter a name for the new service.');
+      return;
+    }
+    if (!Number.isFinite(price)) {
+      toast.error('Enter a valid price for the new service.');
+      return;
+    }
+    onAddCustomService({ name, price });
+    setCustomName('');
+    setCustomPrice('');
+  };
+
+  return (
+    <PackageCard>
+      <PackageHeaderRow>
+        <RowIndex>{index + 1}</RowIndex>
+        <AutoTextArea
+          $size="13.5px"
+          $weight="800"
+          value={titleDraft}
+          placeholder="Milestone title"
+          aria-label="Milestone title"
+          onFocus={() => { titleEditingRef.current = true; }}
+          onChange={event => setTitleDraft(event.target.value)}
+          onBlur={() => { titleEditingRef.current = false; onCommitField('title', titleDraft); }}
+        />
+        <AutoTextArea
+          as={PlainPriceBase}
+          $width="88px"
+          inputMode="decimal"
+          value={amountDraft}
+          placeholder="0"
+          aria-label="Scheduled amount (EUR)"
+          onFocus={() => { amountEditingRef.current = true; }}
+          onChange={event => setAmountDraft(event.target.value)}
+          onBlur={() => { amountEditingRef.current = false; onCommitField('scheduledAmount', amountDraft); }}
+        />
+        <AutoTextArea
+          as={PlainPriceBase}
+          $width="48px"
+          inputMode="decimal"
+          value={taxDraft}
+          placeholder="%"
+          title="Tax (%)"
+          aria-label="Tax percent"
+          onFocus={() => { taxEditingRef.current = true; }}
+          onChange={event => setTaxDraft(event.target.value)}
+          onBlur={() => { taxEditingRef.current = false; onCommitField('taxPercent', taxDraft); }}
+        />
+      </PackageHeaderRow>
+      <MilestoneCheckboxRow>
+        <MilestoneCheckboxLabel>
+          <input type="checkbox" checked={Boolean(milestone.showPackageOverview)} onChange={onToggleOverview} />
+          Show full package overview on this invoice
+        </MilestoneCheckboxLabel>
+        <CustomizedTag title="Scheduled amount + additional services, taxed">Due: {formatEuroPreview(amountDue)}</CustomizedTag>
+      </MilestoneCheckboxRow>
+
+      <PackageChildren>
+        {additionalRows.map((row, rowIndex) => (
+          <ServiceLineRow
+            key={row.key}
+            row={row}
+            index={rowIndex}
+            isChild
+            onCommit={(field, value) => onCommitServiceField(row.id, field, value)}
+            onRemove={() => onRemoveService(row.id)}
+            onReset={row.kind === 'item' && row.isCustomized ? () => onResetService(row.id) : undefined}
+          />
+        ))}
+        {!additionalRows.length ? <PanelNote style={{ margin: '8px 0' }}>No additional services on this invoice yet.</PanelNote> : null}
+      </PackageChildren>
+
+      <PackageAddRow>
+        <PackageQuickField
+          rows={1}
+          placeholder="Add a custom line to this invoice…"
+          value={customName}
+          onChange={event => setCustomName(event.target.value)}
+        />
+        <PackageQuickPrice
+          rows={1}
+          inputMode="decimal"
+          placeholder="Price"
+          value={customPrice}
+          onChange={event => setCustomPrice(event.target.value)}
+        />
+        <SmallButton type="button" onClick={handleAddCustom}><FaPlus /> Add</SmallButton>
+        <SmallButton type="button" onClick={() => setShowPicker(current => !current)}>
+          <FaPlus /> {showPicker ? 'Hide catalog' : 'From catalog'}
+        </SmallButton>
+      </PackageAddRow>
+
+      {showPicker ? (
+        <InlinePickerBox>
+          <CatalogSearchField
+            rows={1}
+            placeholder="Search catalog services…"
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+          />
+          <CatalogPickerList>
+            {availableItems.map(item => (
+              <CatalogPickerButton key={item.id} type="button" onClick={() => { onAddCatalogService(item.id); setShowPicker(false); setQuery(''); }}>
+                <span>{item.name}</span>
+              </CatalogPickerButton>
+            ))}
+            {!availableItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
+          </CatalogPickerList>
+        </InlinePickerBox>
+      ) : null}
+    </PackageCard>
+  );
+};
+
 // --- Summary ------------------------------------------------------
 
 const SummaryGrid = styled.div`
@@ -883,32 +1078,40 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [data, setData] = useState(() => normalizeInvoiceData(null));
   const [catalogItems, setCatalogItems] = useState([]);
   const [catalogPackages, setCatalogPackages] = useState([]);
+  const [catalogTechnical, setCatalogTechnical] = useState({});
+  const [expectedExpenses, setExpectedExpenses] = useState(null);
   const [exchangeRates, setExchangeRates] = useState(null);
   const [exchangeRatesLoading, setExchangeRatesLoading] = useState(false);
   const [exchangeRatesError, setExchangeRatesError] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isGeneratingExpectedExpenses, setIsGeneratingExpectedExpenses] = useState(false);
   const [invoiceDateInput, setInvoiceDateInput] = useState(getTodayYmd());
   const [newCustomServiceName, setNewCustomServiceName] = useState('');
   const [newCustomServicePrice, setNewCustomServicePrice] = useState('');
   const [catalogQuery, setCatalogQuery] = useState('');
   const [showCatalogPicker, setShowCatalogPicker] = useState(false);
   const [catalogTab, setCatalogTab] = useState('items');
+  const [showExpectedExpensesPicker, setShowExpectedExpensesPicker] = useState(false);
   const fileInputRef = useRef(null);
 
   const loadInvoiceData = useCallback(async () => {
     setLoading(true);
     setError('');
     try {
-      const [invoiceSnapshot, itemsSnapshot, packagesSnapshot] = await Promise.all([
+      const [invoiceSnapshot, itemsSnapshot, packagesSnapshot, technicalSnapshot, expectedExpensesSnapshot] = await Promise.all([
         get(ref(database, INVOICE_DATA_PATH)),
         get(ref(database, CATALOG_ITEMS_PATH)),
         get(ref(database, CATALOG_PACKAGES_PATH)),
+        get(ref(database, CATALOG_TECHNICAL_PATH)),
+        get(ref(database, EXPECTED_EXPENSES_PATH)),
       ]);
       setData(normalizeInvoiceData(invoiceSnapshot.exists() ? invoiceSnapshot.val() : null));
       setCatalogItems(toArray(itemsSnapshot.exists() ? itemsSnapshot.val() : []));
       setCatalogPackages(toArray(packagesSnapshot.exists() ? packagesSnapshot.val() : []));
+      setCatalogTechnical(technicalSnapshot.exists() ? technicalSnapshot.val() : {});
+      setExpectedExpenses(normalizeExpectedExpensesData(expectedExpensesSnapshot.exists() ? expectedExpensesSnapshot.val() : null));
     } catch (loadError) {
       console.error('Unable to load invoice builder data', loadError);
       setError('Invoice data is not available right now.');
@@ -1027,6 +1230,18 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       .filter(pkg => !usedCatalogPackageIds.has(String(pkg.id)))
       .filter(pkg => !normalizedQuery || String(pkg.name || '').toLowerCase().includes(normalizedQuery));
   }, [visibleCatalogPackages, usedCatalogPackageIds, catalogQuery]);
+
+  const expectedExpensesView = useMemo(() => {
+    if (!expectedExpenses) return null;
+    const overviewRows = resolvePackageOverviewRows(expectedExpenses.packageSnapshot.children, catalogItemsById, priceContext);
+    const milestoneRows = expectedExpenses.milestones.map(milestone => {
+      const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById, priceContext);
+      const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
+      const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
+      return { milestone, additionalRows, subtotal, amountDue };
+    });
+    return { overviewRows, milestoneRows, scheduledTotal: computeMilestonesScheduledTotal(expectedExpenses.milestones) };
+  }, [expectedExpenses, catalogItemsById, priceContext]);
 
   const persistPath = async (path, value, successMessage) => {
     try {
@@ -1245,6 +1460,161 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const addCatalogChildEntry = (packageId, catalogId) => {
     const next = data.invoiceServices.map(entry => (entry.id === packageId ? addCatalogChildToPackage(entry, catalogId) : entry));
     persistInvoiceServices(next, 'Service added to package.');
+  };
+
+  // Expected expenses ------------------------------------------------------------
+  // A whole program's billing forecast: one milestone per payment-schedule entry, auto-computed
+  // from the chosen budget/packages program, stored as its own object at invoiceBuilder/expectedExpenses.
+
+  const defaultExpectedExpensesTaxPercent = Number.isFinite(Number(catalogTechnical?.wireTransferSurchargeRate))
+    ? Math.round(Number(catalogTechnical.wireTransferSurchargeRate) * 10000) / 100
+    : (Number(data.taxPercent) || 0);
+
+  const persistExpectedExpenses = (nextPlan, successMessage) => {
+    setExpectedExpenses(nextPlan);
+    persistPath(EXPECTED_EXPENSES_PATH, nextPlan, successMessage);
+  };
+
+  const persistExpectedExpensesMilestones = (nextMilestones, successMessage) => {
+    persistExpectedExpenses({ ...expectedExpenses, milestones: nextMilestones }, successMessage);
+  };
+
+  const createExpectedExpensesPlan = pkg => {
+    const schedule = resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg);
+    if (!schedule || !Array.isArray(schedule.payments) || !schedule.payments.length) {
+      toast.error('This package has no payment schedule in the catalog.');
+      return;
+    }
+    const resolvedPackage = { ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice };
+    const plan = buildExpectedExpensesPlan(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
+    persistExpectedExpenses(plan, 'Expected expenses plan created.');
+    setShowExpectedExpensesPicker(false);
+  };
+
+  const recalculateExpectedExpensesSchedule = () => {
+    if (!expectedExpenses) return;
+    const pkg = catalogPackagesById.get(String(expectedExpenses.packageId));
+    if (!pkg) {
+      toast.error('The original package is no longer in the catalog.');
+      return;
+    }
+    const schedule = resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg);
+    if (!schedule || !Array.isArray(schedule.payments) || !schedule.payments.length) {
+      toast.error('This package has no payment schedule in the catalog.');
+      return;
+    }
+    if (typeof window !== 'undefined' && !window.confirm(
+      'Recalculate milestones from the catalog schedule? Titles/amounts reset to the catalog; extra services on each milestone are kept.',
+    )) return;
+    const freshMilestones = buildMilestonesFromSchedule(schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
+    const nextMilestones = freshMilestones.map((milestone, index) => ({
+      ...milestone,
+      additionalServices: expectedExpenses.milestones[index]?.additionalServices || [],
+      taxPercent: expectedExpenses.milestones[index]?.taxPercent ?? milestone.taxPercent,
+    }));
+    persistExpectedExpenses({
+      ...expectedExpenses,
+      packageSnapshot: {
+        ...expectedExpenses.packageSnapshot,
+        listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? Number(pkg.listedPrice) ?? 0,
+      },
+      milestones: nextMilestones,
+    }, 'Schedule recalculated.');
+  };
+
+  const deleteExpectedExpensesPlan = () => {
+    if (typeof window !== 'undefined' && !window.confirm('Delete the whole expected expenses plan?')) return;
+    persistExpectedExpenses(null, 'Expected expenses plan deleted.');
+  };
+
+  const commitMilestoneField = (milestoneId, field, value) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? setMilestoneField(milestone, field, value)
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Milestone updated.');
+  };
+
+  const toggleMilestoneOverview = milestoneId => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? { ...milestone, showPackageOverview: !milestone.showPackageOverview }
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Milestone updated.');
+  };
+
+  const commitMilestoneServiceField = (milestoneId, entryId, field, value) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? updateMilestoneAdditionalServiceField(milestone, entryId, field, value)
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Service updated.');
+  };
+
+  const resetMilestoneServiceEntry = (milestoneId, entryId) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id !== milestoneId ? milestone : {
+      ...milestone,
+      additionalServices: milestone.additionalServices.map(entry => (entry.id === entryId ? resetItemEntryOverrides(entry) : entry)),
+    }));
+    persistExpectedExpensesMilestones(nextMilestones, 'Reverted to catalog values.');
+  };
+
+  const removeMilestoneServiceEntry = (milestoneId, entryId) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? removeMilestoneAdditionalService(milestone, entryId)
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Service removed.');
+  };
+
+  const addMilestoneCustomService = (milestoneId, fields) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? addMilestoneAdditionalService(milestone, makeCustomEntry(fields))
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
+  };
+
+  const addMilestoneCatalogService = (milestoneId, catalogId) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? addMilestoneAdditionalService(milestone, makeCatalogItemEntry(catalogId))
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
+  };
+
+  const handleGenerateExpectedExpensesPdf = async () => {
+    if (!expectedExpenses || !expectedExpenses.milestones.length) {
+      toast.error('Choose a package to build the plan first.');
+      return;
+    }
+    if (!data.customers.length) {
+      toast.error('Add at least one customer first.');
+      return;
+    }
+    if (isGeneratingExpectedExpenses) return;
+    setIsGeneratingExpectedExpenses(true);
+    try {
+      const [{ pdf }, { default: ExpectedExpensesPdfDocument }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('./ExpectedExpensesPdfDocument'),
+      ]);
+      const documentProps = {
+        plan: expectedExpenses,
+        customers: data.customers,
+        catalogItemsById,
+        priceContext,
+        planDate: new Date(`${invoiceDateInput || getTodayYmd()}T00:00:00`),
+      };
+      let blob;
+      try {
+        blob = await pdf(React.createElement(ExpectedExpensesPdfDocument, documentProps)).toBlob();
+      } catch (firstAttemptError) {
+        console.error('Expected expenses PDF generation failed on first attempt, retrying', firstAttemptError);
+        blob = await pdf(React.createElement(ExpectedExpensesPdfDocument, documentProps)).toBlob();
+      }
+      saveAs(blob, `expected-expenses-${(caseTitle || 'plan').replace(/[^a-z0-9]+/gi, '-').toLowerCase()}.pdf`);
+      toast.success('Expected expenses PDF generated.');
+    } catch (generateError) {
+      console.error('Unable to generate expected expenses PDF', generateError);
+      toast.error('Unable to generate expected expenses PDF.');
+    } finally {
+      setIsGeneratingExpectedExpenses(false);
+    }
   };
 
   // Notes ------------------------------------------------------------
@@ -1702,6 +2072,87 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 </FieldRow>
               ))}
               {!data.notes.length ? <PanelNote style={{ margin: 0 }}>No notes yet.</PanelNote> : null}
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
+                <H2>Expected expenses</H2>
+                {expectedExpenses ? (
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    <SmallButton type="button" onClick={recalculateExpectedExpensesSchedule}>
+                      <FaSyncAlt /> Recalculate
+                    </SmallButton>
+                    <PrimaryMiniButton
+                      type="button"
+                      onClick={handleGenerateExpectedExpensesPdf}
+                      disabled={isGeneratingExpectedExpenses}
+                      title="Generate the full payment-schedule forecast PDF"
+                    >
+                      <FaFilePdf /> {isGeneratingExpectedExpenses ? 'Generating…' : 'Generate PDF'}
+                    </PrimaryMiniButton>
+                    <DangerButton type="button" onClick={deleteExpectedExpensesPlan}><FaTrash /> Delete plan</DangerButton>
+                  </div>
+                ) : null}
+              </PanelHeading>
+              <PanelNote>
+                Pick a program package to auto-build a full billing forecast: one milestone per scheduled payment
+                (amount calculated automatically from the catalog), each editable, with room for extra one-off
+                services. The first milestone doubles as the program-introduction invoice (included services,
+                no per-item price, plus the whole schedule).
+              </PanelNote>
+
+              {!expectedExpenses ? (
+                <div>
+                  <SmallButton type="button" onClick={() => setShowExpectedExpensesPicker(current => !current)}>
+                    <FaLayerGroup /> {showExpectedExpensesPicker ? 'Hide packages' : 'Choose a package'}
+                  </SmallButton>
+                  {showExpectedExpensesPicker ? (
+                    <CatalogPickerList style={{ marginTop: 8 }}>
+                      {visibleCatalogPackages.map(pkg => (
+                        <CatalogPickerButton key={pkg.id} type="button" onClick={() => createExpectedExpensesPlan(pkg)}>
+                          <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}</span>
+                          <span>{formatEuroPreview(resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice)}</span>
+                        </CatalogPickerButton>
+                      ))}
+                      {!visibleCatalogPackages.length ? <PanelNote style={{ margin: 0 }}>No packages in the catalog.</PanelNote> : null}
+                    </CatalogPickerList>
+                  ) : null}
+                </div>
+              ) : (
+                <>
+                  <FieldRow $align="center">
+                    <FieldTag>Package</FieldTag>
+                    <div style={{ flex: 1, padding: '5px 6px', fontWeight: 700 }}>{expectedExpenses.packageSnapshot.name}</div>
+                    <span style={{ fontWeight: 800, color: 'var(--km-accent)', padding: '5px 6px' }}>
+                      {formatEuroPreview(expectedExpenses.packageSnapshot.listedPrice)}
+                    </span>
+                  </FieldRow>
+                  {expectedExpensesView && expectedExpensesView.scheduledTotal !== expectedExpenses.packageSnapshot.listedPrice ? (
+                    <PanelNote style={{ color: 'var(--km-danger)' }}>
+                      Milestones add up to {formatEuroPreview(expectedExpensesView.scheduledTotal)}, the package price is{' '}
+                      {formatEuroPreview(expectedExpenses.packageSnapshot.listedPrice)}.
+                    </PanelNote>
+                  ) : null}
+
+                  {expectedExpensesView?.milestoneRows.map(({ milestone, additionalRows, amountDue }, index) => (
+                    <MilestoneCard
+                      key={milestone.id}
+                      index={index}
+                      milestone={milestone}
+                      additionalRows={additionalRows}
+                      amountDue={amountDue}
+                      catalogItems={catalogItems}
+                      onCommitField={(field, value) => commitMilestoneField(milestone.id, field, value)}
+                      onToggleOverview={() => toggleMilestoneOverview(milestone.id)}
+                      onCommitServiceField={(entryId, field, value) => commitMilestoneServiceField(milestone.id, entryId, field, value)}
+                      onRemoveService={entryId => removeMilestoneServiceEntry(milestone.id, entryId)}
+                      onResetService={entryId => resetMilestoneServiceEntry(milestone.id, entryId)}
+                      onAddCustomService={fields => addMilestoneCustomService(milestone.id, fields)}
+                      onAddCatalogService={catalogId => addMilestoneCatalogService(milestone.id, catalogId)}
+                    />
+                  ))}
+                </>
+              )}
             </Panel>
           </>
         ) : null}

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1,35 +1,57 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set } from 'firebase/database';
-import { FaChevronDown, FaChevronUp, FaFilePdf, FaPlus, FaTrash, FaUpload } from 'react-icons/fa';
+import {
+  FaBoxOpen,
+  FaChevronDown,
+  FaChevronUp,
+  FaFilePdf,
+  FaLayerGroup,
+  FaPlus,
+  FaTrash,
+  FaUndoAlt,
+  FaUpload,
+} from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
-import { parseBudgetPriceValue } from './budgetCatalogUtils';
+import { getVisibleSortedPackages, parseBudgetPriceValue } from './budgetCatalogUtils';
+import { useAutoResize } from '../hooks/useAutoResize';
 import { isAdminUid } from 'utils/accessLevel';
 import {
+  addCatalogChildToPackage,
+  addCustomChildToPackage,
   applyPaymentPurposePlaceholders,
   buildCaseTitle,
   buildPayerLocation,
   buildPayerName,
+  cloneEntryWithNewId,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
   generateInvoiceIdentifiers,
   getActiveBeneficiary,
+  getEntryIdentityKey,
   getTodayYmd,
-  makeCatalogServiceEntry,
-  makeCustomServiceEntry,
   isInvoiceDataShape,
+  makeCatalogItemEntry,
+  makeCatalogPackageEntry,
+  makeCustomEntry,
+  movePackageChild,
   normalizeInvoiceData,
-  parseServiceEntry,
+  removePackageChild,
   reorderBeneficiaryIds,
   reorderRecentServices,
+  resetItemEntryOverrides,
+  resetPackageEntryToCatalog,
   resolveInvoiceServiceRows,
   resolveServiceRow,
+  setEntryField,
+  updatePackageChildField,
 } from './invoiceCatalogUtils';
 
 const INVOICE_DATA_PATH = 'invoiceBuilder';
 const CATALOG_ITEMS_PATH = 'budget/items';
+const CATALOG_PACKAGES_PATH = 'budget/packages';
 
 const toArray = value => {
   if (Array.isArray(value)) return value;
@@ -47,6 +69,8 @@ const emptyBeneficiary = () => ({
   paymentPurpose: '',
 });
 
+// --- Layout shell ------------------------------------------------------
+
 const Page = styled.main`
   min-height: 100vh;
   background: var(--km-bg);
@@ -57,7 +81,7 @@ const Page = styled.main`
 `;
 
 const Shell = styled.div`
-  width: min(100%, 900px);
+  width: min(100%, 880px);
   margin: 0 auto;
 `;
 
@@ -85,9 +109,10 @@ const Eyebrow = styled.div`
 
 const Title = styled.h1`
   margin: 0;
-  font-size: clamp(20px, 4vw, 26px);
+  font-family: var(--km-font-display);
+  font-size: clamp(20px, 4vw, 27px);
   line-height: 1.05;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 `;
 
 const HeaderActions = styled.div`
@@ -108,7 +133,7 @@ const MiniButton = styled.button`
   background: var(--km-card);
   color: var(--km-text);
   border-radius: 10px;
-  min-height: 32px;
+  min-height: 30px;
   padding: 6px 12px;
   font-size: 12px;
   font-weight: 700;
@@ -118,7 +143,7 @@ const MiniButton = styled.button`
   gap: 6px;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
-  transition: border-color 0.15s ease, color 0.15s ease;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
 
   &:hover:not(:disabled) {
     border-color: var(--km-accent);
@@ -138,10 +163,10 @@ const PrimaryMiniButton = styled(MiniButton)`
 `;
 
 const SmallButton = styled(MiniButton)`
-  min-height: 26px;
+  min-height: 24px;
   padding: 3px 9px;
-  font-size: 11px;
-  border-radius: 8px;
+  font-size: 10.5px;
+  border-radius: 7px;
 `;
 
 const DangerButton = styled(SmallButton)`
@@ -154,31 +179,34 @@ const DangerButton = styled(SmallButton)`
   }
 `;
 
-const IconButton = styled.button`
+const iconButtonBase = css`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   flex-shrink: 0;
-  border: 1px solid var(--km-border);
-  border-radius: 7px;
-  background: var(--km-card);
+  border: none;
+  border-radius: 6px;
+  background: transparent;
   color: var(--km-muted);
-  font-size: 11px;
+  font-size: 10.5px;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  opacity: ${({ disabled }) => (disabled ? 0.35 : 1)};
-  transition: border-color 0.15s ease, color 0.15s ease;
+  opacity: ${({ disabled }) => (disabled ? 0.3 : 1)};
+  transition: color 0.15s ease, background 0.15s ease;
 
   &:hover:not(:disabled) {
-    border-color: var(--km-accent);
+    background: var(--km-accent-light);
     color: var(--km-accent);
   }
 `;
 
-const IconDangerButton = styled(IconButton)`
+const IconButton = styled.button`${iconButtonBase}`;
+
+const IconDangerButton = styled.button`
+  ${iconButtonBase}
   &:hover:not(:disabled) {
-    border-color: var(--km-danger);
+    background: rgba(180, 35, 24, 0.12);
     color: var(--km-danger);
   }
 `;
@@ -186,7 +214,7 @@ const IconDangerButton = styled(IconButton)`
 const Panel = styled.section`
   margin-top: 10px;
   border: 1px solid var(--km-border);
-  border-radius: 14px;
+  border-radius: 16px;
   background: var(--km-card);
   padding: 12px 14px;
 `;
@@ -196,199 +224,390 @@ const PanelHeading = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 `;
 
 const H2 = styled.h2`
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 800;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--km-muted);
 `;
 
 const PanelNote = styled.p`
-  margin: -4px 0 8px;
+  margin: -2px 0 8px;
   color: var(--km-muted);
   font-size: 11.5px;
   line-height: 1.4;
 `;
 
-const FieldGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 8px;
-`;
-
-const FieldLabel = styled.label`
-  display: grid;
-  gap: 3px;
-  font-size: 10px;
-  font-weight: 800;
+const StateCard = styled.div`
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
   color: var(--km-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+  font-size: 13px;
 `;
 
-const Input = styled.input`
-  box-sizing: border-box;
-  width: 100%;
-  border: 1px solid var(--km-border);
-  border-radius: 8px;
-  background: var(--km-bg);
-  color: var(--km-text);
-  padding: 7px 9px;
-  font-size: 12.5px;
-  font-weight: 600;
+// --- Plain, borderless "editable text" fields ------------------------------------------------------
+//
+// No boxes, no visible borders: a field reads as plain text until you hover/focus it, at which
+// point a soft accent wash + underline appear. Every text field auto-grows vertically with its
+// content (useAutoResize) instead of clipping or scrolling.
 
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--km-accent-light);
+const FieldRow = styled.div`
+  display: flex;
+  align-items: ${({ $align }) => $align || 'flex-start'};
+  gap: 8px;
+  padding: 5px 0;
+
+  & + & {
+    border-top: 1px solid var(--km-border);
   }
 `;
 
-const Textarea = styled.textarea`
-  box-sizing: border-box;
-  width: 100%;
-  border: 1px solid var(--km-border);
-  border-radius: 8px;
-  background: var(--km-bg);
-  color: var(--km-text);
-  padding: 7px 9px;
-  font-size: 12.5px;
-  font-weight: 600;
-  line-height: 1.35;
-  resize: vertical;
-  min-height: 44px;
-
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--km-accent-light);
-  }
-`;
-
-const Select = styled.select`
-  box-sizing: border-box;
-  width: 100%;
-  border: 1px solid var(--km-border);
-  border-radius: 8px;
-  background: var(--km-bg);
-  color: var(--km-text);
-  padding: 7px 9px;
-  font-size: 12.5px;
-  font-weight: 700;
-`;
-
-const RowList = styled.div`
-  display: grid;
-  gap: 5px;
-`;
-
-const CustomerRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr auto;
-  gap: 6px;
-  align-items: center;
-
-  @media (max-width: 480px) {
-    grid-template-columns: 1fr 1fr;
-
-    > *:last-child {
-      grid-column: 1 / -1;
-      justify-self: start;
-    }
-  }
-`;
-
-const ServiceTableHead = styled.div`
-  display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) 76px 88px;
-  gap: 6px;
-  padding: 0 2px 4px;
+const FieldTag = styled.span`
+  flex: 0 0 auto;
+  width: 128px;
+  padding-top: 6px;
   font-size: 9.5px;
   font-weight: 800;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--km-muted);
 
-  @media (max-width: 480px) {
-    display: none;
+  @media (max-width: 560px) {
+    width: 84px;
   }
 `;
 
-const ServiceRow = styled.div`
-  display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) 76px 88px;
-  gap: 6px;
-  align-items: center;
-  padding: 4px 0;
+const plainFieldStyle = css`
+  flex: 1 1 auto;
+  min-width: 0;
+  display: block;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--km-text);
+  font-family: inherit;
+  font-size: ${({ $size }) => $size || '13px'};
+  font-weight: ${({ $weight }) => $weight || '600'};
+  line-height: 1.45;
+  padding: 5px 6px;
+  margin: 0;
+  resize: none;
+  overflow: hidden;
+
+  &::placeholder {
+    color: var(--km-muted);
+    font-weight: 500;
+    opacity: 0.8;
+  }
+
+  &:hover {
+    background: var(--km-accent-light);
+  }
+
+  &:focus {
+    outline: none;
+    background: var(--km-accent-light);
+    box-shadow: inset 0 0 0 1px var(--km-accent-mid);
+  }
+`;
+
+const PlainTextBase = styled.textarea`
+  ${plainFieldStyle}
+`;
+
+const PlainPriceBase = styled.textarea`
+  ${plainFieldStyle}
+  flex: 0 0 auto;
+  width: ${({ $width }) => $width || '92px'};
+  text-align: right;
+  font-weight: 800;
+  color: var(--km-accent);
+`;
+
+const PlainSelect = styled.select`
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--km-text);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 6px;
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    outline: none;
+    background: var(--km-accent-light);
+  }
+`;
+
+// Wraps a textarea with useAutoResize so it grows with its content instead of clipping/scrolling.
+const AutoTextArea = React.forwardRef(({ as: Component = PlainTextBase, value, ...rest }, forwardedRef) => {
+  const localRef = useRef(null);
+  const autoResize = useAutoResize(localRef, value);
+  return (
+    <Component
+      ref={node => {
+        localRef.current = node;
+        autoResize(node);
+        if (typeof forwardedRef === 'function') forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      }}
+      rows={1}
+      value={value}
+      {...rest}
+    />
+  );
+});
+AutoTextArea.displayName = 'AutoTextArea';
+
+// Keeps a locally-editable draft of one field, resynced from the resolved value whenever it
+// changes elsewhere - unless the field currently has focus (so an in-progress keystroke never
+// gets clobbered by a re-render triggered by an unrelated commit).
+const useFieldDraft = externalValue => {
+  const [draft, setDraft] = useState(externalValue ?? '');
+  const editingRef = useRef(false);
+  useEffect(() => {
+    if (!editingRef.current) setDraft(externalValue ?? '');
+  }, [externalValue]);
+  return [draft, setDraft, editingRef];
+};
+
+const formatEuroPreview = value => {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? `€${amount.toFixed(2)}` : '€—';
+};
+
+// --- Service line item (top-level custom/catalog row, or a row nested inside a package) ------------------------------------------------------
+
+const LineCard = styled.div`
+  padding: 4px 0 6px;
   border-top: 1px solid var(--km-border);
 
   &:first-child {
     border-top: 0;
   }
+`;
 
-  @media (max-width: 480px) {
-    grid-template-columns: 1fr auto;
-    row-gap: 4px;
-
-    > *:nth-child(1) {
-      display: none;
-    }
-
-    > *:nth-child(2) {
-      grid-column: 1 / -1;
-    }
-  }
+const LineMainRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
 `;
 
 const RowIndex = styled.span`
-  font-size: 11px;
+  flex: 0 0 auto;
+  width: 16px;
+  padding-top: 7px;
+  font-size: 10.5px;
   font-weight: 700;
   color: var(--km-muted);
   text-align: center;
 `;
 
 const RowActions = styled.div`
+  flex: 0 0 auto;
   display: flex;
-  gap: 3px;
-  justify-content: flex-end;
+  gap: 1px;
+  padding-top: 2px;
 `;
 
-const AddRow = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 90px auto;
-  gap: 6px;
-  align-items: center;
-  margin-top: 8px;
+const CustomizedTag = styled.span`
+  flex: 0 0 auto;
+  align-self: center;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--km-accent);
+  background: var(--km-accent-light);
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+`;
 
-  @media (max-width: 480px) {
-    grid-template-columns: 1fr;
+const MissingTag = styled(CustomizedTag)`
+  color: var(--km-danger);
+  background: rgba(180, 35, 24, 0.1);
+`;
+
+const ServiceLineRow = ({
+  row,
+  index,
+  isChild = false,
+  onCommit,
+  onRemove,
+  removeTitle = 'Remove',
+  onMoveUp,
+  onMoveDown,
+  canMoveUp = false,
+  canMoveDown = false,
+  onReset,
+}) => {
+  const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
+  const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(row.price ?? ''));
+
+  return (
+    <LineCard>
+      <LineMainRow>
+        <RowIndex>{index + 1}</RowIndex>
+        <AutoTextArea
+          $size={isChild ? '12.5px' : '13px'}
+          $weight="700"
+          value={nameDraft}
+          placeholder="Service name"
+          aria-label="Service name"
+          onFocus={() => { nameEditingRef.current = true; }}
+          onChange={event => setNameDraft(event.target.value)}
+          onBlur={() => { nameEditingRef.current = false; onCommit('name', nameDraft); }}
+        />
+        <AutoTextArea
+          as={PlainPriceBase}
+          $size={isChild ? '12.5px' : '13px'}
+          $width={isChild ? '76px' : '88px'}
+          inputMode="decimal"
+          value={priceDraft}
+          placeholder="0"
+          aria-label="Price (EUR)"
+          onFocus={() => { priceEditingRef.current = true; }}
+          onChange={event => setPriceDraft(event.target.value)}
+          onBlur={() => { priceEditingRef.current = false; onCommit('price', priceDraft); }}
+        />
+        {row.isCustomized ? <CustomizedTag title="Overridden for this invoice only - the shared budget is unchanged">Custom</CustomizedTag> : null}
+        {row.missing ? <MissingTag title="This catalog reference no longer exists">Missing</MissingTag> : null}
+        {onReset ? (
+          <IconButton type="button" onClick={onReset} title="Revert to the catalog value" aria-label="Revert to catalog value">
+            <FaUndoAlt />
+          </IconButton>
+        ) : null}
+        <RowActions>
+          {onMoveUp ? (
+            <IconButton type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move up">
+              <FaChevronUp />
+            </IconButton>
+          ) : null}
+          {onMoveDown ? (
+            <IconButton type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move down">
+              <FaChevronDown />
+            </IconButton>
+          ) : null}
+          <IconDangerButton type="button" onClick={onRemove} title={removeTitle} aria-label={removeTitle}>
+            <FaTrash />
+          </IconDangerButton>
+        </RowActions>
+      </LineMainRow>
+      <AutoTextArea
+        $size="11.5px"
+        $weight="500"
+        style={{ color: 'var(--km-muted)' }}
+        value={descriptionDraft}
+        placeholder="Add description…"
+        aria-label="Description"
+        onFocus={() => { descriptionEditingRef.current = true; }}
+        onChange={event => setDescriptionDraft(event.target.value)}
+        onBlur={() => { descriptionEditingRef.current = false; onCommit('description', descriptionDraft); }}
+      />
+    </LineCard>
+  );
+};
+
+// --- Package group (a whole budget/packages program, editable/removable per line) ------------------------------------------------------
+
+const PackageCard = styled.div`
+  margin-top: 10px;
+  border: 1px solid var(--km-border);
+  border-radius: 12px;
+  background: var(--km-accent-light);
+  padding: 8px 10px 10px;
+
+  &:first-child {
+    margin-top: 0;
   }
 `;
 
-const ChipRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  margin-top: 8px;
+const PackageHeaderRow = styled(LineMainRow)`
+  align-items: flex-start;
 `;
 
-const Chip = styled.button`
-  border: 1px dashed var(--km-border);
-  background: var(--km-bg);
-  color: var(--km-text);
-  border-radius: 999px;
-  padding: 4px 9px;
+const PackageIcon = styled.span`
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-top: 3px;
+  border-radius: 7px;
+  background: var(--km-card);
+  color: var(--km-accent);
   font-size: 11px;
-  font-weight: 700;
-  cursor: pointer;
+`;
+
+const PackageChildren = styled.div`
+  margin: 6px 0 4px 28px;
+  border-radius: 10px;
+  background: var(--km-card);
+  padding: 0 8px;
+
+  @media (max-width: 560px) {
+    margin-left: 10px;
+  }
+`;
+
+const PackageAddRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin: 6px 0 0 28px;
+
+  @media (max-width: 560px) {
+    margin-left: 10px;
+  }
+`;
+
+const PackageQuickField = styled(PlainTextBase)`
+  flex: 1 1 140px;
+  background: var(--km-card);
+  border-radius: 8px;
+  padding: 5px 8px;
+`;
+
+const PackageQuickPrice = styled(PlainPriceBase)`
+  flex: 0 0 76px;
+  background: var(--km-card);
+  border-radius: 8px;
+  padding: 5px 8px;
+`;
+
+const InlinePickerBox = styled.div`
+  margin: 6px 0 0 28px;
+
+  @media (max-width: 560px) {
+    margin-left: 10px;
+  }
+`;
+
+const CatalogSearchField = styled(PlainTextBase)`
+  background: var(--km-card);
+  border-radius: 8px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
 `;
 
 const CatalogPickerList = styled.div`
-  margin-top: 8px;
-  max-height: 200px;
+  max-height: 190px;
   overflow-y: auto;
   display: grid;
   gap: 4px;
@@ -396,7 +615,7 @@ const CatalogPickerList = styled.div`
 
 const CatalogPickerButton = styled.button`
   border: 1px solid var(--km-border);
-  background: var(--km-bg);
+  background: var(--km-card);
   color: var(--km-text);
   border-radius: 8px;
   padding: 6px 9px;
@@ -407,7 +626,211 @@ const CatalogPickerButton = styled.button`
   display: flex;
   justify-content: space-between;
   gap: 8px;
+
+  &:hover {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
 `;
+
+const CatalogTabs = styled.div`
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+  margin-bottom: 8px;
+  border-radius: 999px;
+  background: var(--km-bg);
+  border: 1px solid var(--km-border);
+`;
+
+const CatalogTabButton = styled.button`
+  border: none;
+  border-radius: 999px;
+  padding: 5px 12px;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+  color: ${({ $active }) => ($active ? '#fff' : 'var(--km-muted)')};
+  background: ${({ $active }) => ($active ? 'linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%)' : 'transparent')};
+`;
+
+const PackageEntryCard = ({
+  row,
+  index,
+  canMoveUp,
+  canMoveDown,
+  catalogItems,
+  onCommitField,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+  onReset,
+  onCommitChildField,
+  onResetChildField,
+  onRemoveChild,
+  onMoveChild,
+  onAddCustomChild,
+  onAddCatalogChild,
+}) => {
+  const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
+  const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(row.price ?? ''));
+  const [showPicker, setShowPicker] = useState(false);
+  const [query, setQuery] = useState('');
+  const [customName, setCustomName] = useState('');
+  const [customPrice, setCustomPrice] = useState('');
+
+  const childCatalogIds = useMemo(
+    () => new Set(row.children.filter(child => child.kind === 'item').map(child => String(child.catalogId))),
+    [row.children],
+  );
+
+  const availableItems = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return catalogItems
+      .filter(item => !childCatalogIds.has(String(item.id)))
+      .filter(item => !normalizedQuery || String(item.name || '').toLowerCase().includes(normalizedQuery))
+      .slice(0, 30);
+  }, [catalogItems, childCatalogIds, query]);
+
+  const handleAddCustom = () => {
+    const name = customName.trim();
+    const price = Number(customPrice.replace(',', '.'));
+    if (!name) {
+      toast.error('Enter a name for the new service.');
+      return;
+    }
+    if (!Number.isFinite(price)) {
+      toast.error('Enter a valid price for the new service.');
+      return;
+    }
+    onAddCustomChild({ name, price });
+    setCustomName('');
+    setCustomPrice('');
+  };
+
+  return (
+    <PackageCard>
+      <PackageHeaderRow>
+        <PackageIcon><FaBoxOpen /></PackageIcon>
+        <RowIndex>{index + 1}</RowIndex>
+        <AutoTextArea
+          $size="13.5px"
+          $weight="800"
+          value={nameDraft}
+          placeholder="Package name"
+          aria-label="Package name"
+          onFocus={() => { nameEditingRef.current = true; }}
+          onChange={event => setNameDraft(event.target.value)}
+          onBlur={() => { nameEditingRef.current = false; onCommitField('name', nameDraft); }}
+        />
+        <AutoTextArea
+          as={PlainPriceBase}
+          $width="92px"
+          inputMode="decimal"
+          value={priceDraft}
+          placeholder="0"
+          aria-label="Package price (EUR)"
+          onFocus={() => { priceEditingRef.current = true; }}
+          onChange={event => setPriceDraft(event.target.value)}
+          onBlur={() => { priceEditingRef.current = false; onCommitField('price', priceDraft); }}
+        />
+        {row.hasPriceOverride ? (
+          <CustomizedTag title="Real total of the services below">Σ {formatEuroPreview(row.childrenTotal)}</CustomizedTag>
+        ) : null}
+        {row.isCustomized ? <CustomizedTag title="No longer matches the shared budget package">Custom package</CustomizedTag> : null}
+        {onReset ? (
+          <IconButton type="button" onClick={onReset} title="Revert to the catalog package" aria-label="Revert to catalog package">
+            <FaUndoAlt />
+          </IconButton>
+        ) : null}
+        <RowActions>
+          <IconButton type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move package up">
+            <FaChevronUp />
+          </IconButton>
+          <IconButton type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move package down">
+            <FaChevronDown />
+          </IconButton>
+          <IconDangerButton type="button" onClick={onRemove} title="Remove package" aria-label="Remove package">
+            <FaTrash />
+          </IconDangerButton>
+        </RowActions>
+      </PackageHeaderRow>
+      <AutoTextArea
+        $size="11.5px"
+        $weight="500"
+        style={{ color: 'var(--km-muted)', marginLeft: 28 }}
+        value={descriptionDraft}
+        placeholder="Add description…"
+        aria-label="Package description"
+        onFocus={() => { descriptionEditingRef.current = true; }}
+        onChange={event => setDescriptionDraft(event.target.value)}
+        onBlur={() => { descriptionEditingRef.current = false; onCommitField('description', descriptionDraft); }}
+      />
+
+      <PackageChildren>
+        {row.children.map((child, childIndex) => (
+          <ServiceLineRow
+            key={child.key}
+            row={child}
+            index={childIndex}
+            isChild
+            removeTitle="Remove from package"
+            onCommit={(field, value) => onCommitChildField(child.id, field, value)}
+            onRemove={() => onRemoveChild(child.id)}
+            onMoveUp={() => onMoveChild(child.id, -1)}
+            onMoveDown={() => onMoveChild(child.id, 1)}
+            canMoveUp={childIndex > 0}
+            canMoveDown={childIndex < row.children.length - 1}
+            onReset={child.kind === 'item' && child.isCustomized ? () => onResetChildField(child.id) : undefined}
+          />
+        ))}
+        {!row.children.length ? <PanelNote style={{ margin: '8px 0' }}>No services in this package.</PanelNote> : null}
+      </PackageChildren>
+
+      <PackageAddRow>
+        <PackageQuickField
+          rows={1}
+          placeholder="Add a custom line to this package…"
+          value={customName}
+          onChange={event => setCustomName(event.target.value)}
+        />
+        <PackageQuickPrice
+          rows={1}
+          inputMode="decimal"
+          placeholder="Price"
+          value={customPrice}
+          onChange={event => setCustomPrice(event.target.value)}
+        />
+        <SmallButton type="button" onClick={handleAddCustom}><FaPlus /> Add</SmallButton>
+        <SmallButton type="button" onClick={() => setShowPicker(current => !current)}>
+          <FaPlus /> {showPicker ? 'Hide catalog' : 'From catalog'}
+        </SmallButton>
+      </PackageAddRow>
+
+      {showPicker ? (
+        <InlinePickerBox>
+          <CatalogSearchField
+            rows={1}
+            placeholder="Search catalog services…"
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+          />
+          <CatalogPickerList>
+            {availableItems.map(item => (
+              <CatalogPickerButton key={item.id} type="button" onClick={() => { onAddCatalogChild(item.id); setShowPicker(false); setQuery(''); }}>
+                <span>{item.name}</span>
+              </CatalogPickerButton>
+            ))}
+            {!availableItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
+          </CatalogPickerList>
+        </InlinePickerBox>
+      ) : null}
+    </PackageCard>
+  );
+};
+
+// --- Summary ------------------------------------------------------
 
 const SummaryGrid = styled.div`
   display: grid;
@@ -430,19 +853,28 @@ const SummaryLine = styled.div`
   }
 `;
 
-const StateCard = styled.div`
-  padding: 20px;
-  border-radius: 16px;
-  background: var(--km-card);
-  border: 1px solid var(--km-border);
-  color: var(--km-muted);
-  font-size: 13px;
+const Chip = styled.button`
+  border: 1px dashed var(--km-border);
+  background: var(--km-bg);
+  color: var(--km-text);
+  border-radius: 999px;
+  padding: 4px 9px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
 `;
 
-const formatEuroPreview = value => {
-  const amount = Number(value);
-  return Number.isFinite(amount) ? `€${amount.toFixed(2)}` : '€—';
-};
+const ChipRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+`;
 
 const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const isInvoiceAdmin = Boolean(isAdmin) || isAdminUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
@@ -450,6 +882,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const [data, setData] = useState(() => normalizeInvoiceData(null));
   const [catalogItems, setCatalogItems] = useState([]);
+  const [catalogPackages, setCatalogPackages] = useState([]);
   const [exchangeRates, setExchangeRates] = useState(null);
   const [exchangeRatesLoading, setExchangeRatesLoading] = useState(false);
   const [exchangeRatesError, setExchangeRatesError] = useState('');
@@ -459,21 +892,23 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [invoiceDateInput, setInvoiceDateInput] = useState(getTodayYmd());
   const [newCustomServiceName, setNewCustomServiceName] = useState('');
   const [newCustomServicePrice, setNewCustomServicePrice] = useState('');
-  const [invoiceServicePriceDrafts, setInvoiceServicePriceDrafts] = useState({});
   const [catalogQuery, setCatalogQuery] = useState('');
   const [showCatalogPicker, setShowCatalogPicker] = useState(false);
+  const [catalogTab, setCatalogTab] = useState('items');
   const fileInputRef = useRef(null);
 
   const loadInvoiceData = useCallback(async () => {
     setLoading(true);
     setError('');
     try {
-      const [invoiceSnapshot, catalogSnapshot] = await Promise.all([
+      const [invoiceSnapshot, itemsSnapshot, packagesSnapshot] = await Promise.all([
         get(ref(database, INVOICE_DATA_PATH)),
         get(ref(database, CATALOG_ITEMS_PATH)),
+        get(ref(database, CATALOG_PACKAGES_PATH)),
       ]);
       setData(normalizeInvoiceData(invoiceSnapshot.exists() ? invoiceSnapshot.val() : null));
-      setCatalogItems(toArray(catalogSnapshot.exists() ? catalogSnapshot.val() : []));
+      setCatalogItems(toArray(itemsSnapshot.exists() ? itemsSnapshot.val() : []));
+      setCatalogPackages(toArray(packagesSnapshot.exists() ? packagesSnapshot.val() : []));
     } catch (loadError) {
       console.error('Unable to load invoice builder data', loadError);
       setError('Invoice data is not available right now.');
@@ -515,23 +950,30 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   }, [invoiceDateInput]);
 
   const catalogItemsById = useMemo(() => new Map(catalogItems.map(item => [String(item.id), item])), [catalogItems]);
+  const catalogPackagesById = useMemo(() => new Map(catalogPackages.map(pkg => [String(pkg.id), pkg])), [catalogPackages]);
 
   const activeBeneficiary = useMemo(() => getActiveBeneficiary(data), [data]);
 
-  const hasFormulaInvoiceService = useMemo(() => data.invoiceServices.some(entry => {
-    const parsed = parseServiceEntry(entry);
-    if (!parsed.isCatalog) return false;
-    const item = catalogItemsById.get(String(parsed.catalogId));
+  const entryReferencesFormulaItem = useCallback(entry => {
+    if (!entry) return false;
+    if (entry.kind === 'package') return (entry.children || []).some(entryReferencesFormulaItem);
+    if (entry.kind !== 'item') return false;
+    const item = catalogItemsById.get(String(entry.catalogId));
     return parseBudgetPriceValue(item?.price).isFormula;
-  }), [data.invoiceServices, catalogItemsById]);
+  }, [catalogItemsById]);
+
+  const hasFormulaInvoiceService = useMemo(
+    () => data.invoiceServices.some(entryReferencesFormulaItem),
+    [data.invoiceServices, entryReferencesFormulaItem],
+  );
 
   const isFormulaRatePending = hasFormulaInvoiceService && exchangeRatesLoading;
   const formulaRateError = hasFormulaInvoiceService ? exchangeRatesError : '';
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || isFormulaRatePending || Boolean(formulaRateError);
 
   const priceContext = useMemo(
-    () => ({ itemsById: catalogItemsById, rates: exchangeRates }),
-    [catalogItemsById, exchangeRates],
+    () => ({ itemsById: catalogItemsById, rates: exchangeRates, packagesById: catalogPackagesById }),
+    [catalogItemsById, exchangeRates, catalogPackagesById],
   );
 
   const invoiceServiceRows = useMemo(
@@ -554,23 +996,37 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const caseTitle = useMemo(() => buildCaseTitle(data.customers), [data.customers]);
 
   const recentServiceSuggestions = useMemo(() => {
-    const used = new Set(data.invoiceServices);
-    return data.recentServices.filter(entry => !used.has(entry)).slice(0, 8);
+    const used = new Set(data.invoiceServices.map(getEntryIdentityKey));
+    return data.recentServices.filter(entry => !used.has(getEntryIdentityKey(entry))).slice(0, 8);
   }, [data.recentServices, data.invoiceServices]);
 
+  const usedCatalogItemIds = useMemo(() => new Set(
+    data.invoiceServices.filter(entry => entry.kind === 'item').map(entry => String(entry.catalogId)),
+  ), [data.invoiceServices]);
+
+  const usedCatalogPackageIds = useMemo(() => new Set(
+    data.invoiceServices.filter(entry => entry.kind === 'package').map(entry => String(entry.catalogId)),
+  ), [data.invoiceServices]);
+
   const filteredCatalogItems = useMemo(() => {
-    const usedCatalogIds = new Set(
-      data.invoiceServices
-        .map(entry => parseServiceEntry(entry))
-        .filter(parsed => parsed.isCatalog)
-        .map(parsed => String(parsed.catalogId)),
-    );
     const normalizedQuery = catalogQuery.trim().toLowerCase();
     return catalogItems
-      .filter(item => !usedCatalogIds.has(String(item.id)))
+      .filter(item => !usedCatalogItemIds.has(String(item.id)))
       .filter(item => !normalizedQuery || String(item.name || '').toLowerCase().includes(normalizedQuery))
       .slice(0, 30);
-  }, [catalogItems, data.invoiceServices, catalogQuery]);
+  }, [catalogItems, usedCatalogItemIds, catalogQuery]);
+
+  const visibleCatalogPackages = useMemo(
+    () => getVisibleSortedPackages({ packages: catalogPackages }, priceContext),
+    [catalogPackages, priceContext],
+  );
+
+  const filteredCatalogPackages = useMemo(() => {
+    const normalizedQuery = catalogQuery.trim().toLowerCase();
+    return visibleCatalogPackages
+      .filter(pkg => !usedCatalogPackageIds.has(String(pkg.id)))
+      .filter(pkg => !normalizedQuery || String(pkg.name || '').toLowerCase().includes(normalizedQuery));
+  }, [visibleCatalogPackages, usedCatalogPackageIds, catalogQuery]);
 
   const persistPath = async (path, value, successMessage) => {
     try {
@@ -681,71 +1137,56 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   // Invoice services ------------------------------------------------------------
 
-  const persistInvoiceServices = async (nextInvoiceServices, successMessage) => {
-    await persistPath(`${INVOICE_DATA_PATH}/invoiceServices`, nextInvoiceServices, successMessage);
-  };
-
-  // Editing name/price of a row (catalog-linked or custom) always writes it back
-  // as a plain "Name || Price" row - a catalog reference only makes sense while
-  // it still mirrors the catalog, so editing it detaches it into its own copy.
-  const updateInvoiceServiceRow = (index, field, value) => {
-    setData(current => {
-      const entries = [...current.invoiceServices];
-      const resolved = resolveServiceRow(entries[index], catalogItemsById, priceContext);
-      const nextName = field === 'name' ? value : resolved.name;
-      const nextPrice = field === 'price' ? (Number(String(value).replace(',', '.')) || 0) : resolved.price;
-      entries[index] = makeCustomServiceEntry(nextName, nextPrice);
-      return { ...current, invoiceServices: entries };
-    });
-  };
-
-  const commitInvoiceServiceRow = index => {
-    const draft = invoiceServicePriceDrafts[index];
-    if (draft === undefined) {
-      persistInvoiceServices(data.invoiceServices, 'Service updated.');
-      return;
-    }
-
-    const entries = [...data.invoiceServices];
-    const resolved = resolveServiceRow(entries[index], catalogItemsById, priceContext);
-    const parsedPrice = Number(String(draft).replace(',', '.'));
-    entries[index] = makeCustomServiceEntry(resolved.name, Number.isFinite(parsedPrice) ? parsedPrice : 0);
-    setData(current => ({ ...current, invoiceServices: entries }));
-    setInvoiceServicePriceDrafts(current => {
-      const next = { ...current };
-      delete next[index];
-      return next;
-    });
-    persistInvoiceServices(entries, 'Service updated.');
-  };
-
-  const removeInvoiceServiceRow = index => {
-    const nextInvoiceServices = data.invoiceServices.filter((entry, entryIndex) => entryIndex !== index);
+  const persistInvoiceServices = (nextInvoiceServices, successMessage) => {
     setData(current => ({ ...current, invoiceServices: nextInvoiceServices }));
-    persistInvoiceServices(nextInvoiceServices, 'Service removed.');
+    persistPath(`${INVOICE_DATA_PATH}/invoiceServices`, nextInvoiceServices, successMessage);
   };
 
-  const moveInvoiceServiceRow = (index, offset) => {
+  const commitTopLevelField = (id, field, value) => {
+    const next = data.invoiceServices.map(entry => (entry.id === id ? setEntryField(entry, field, value) : entry));
+    persistInvoiceServices(next, 'Service updated.');
+  };
+
+  const removeTopLevelEntry = id => {
+    persistInvoiceServices(data.invoiceServices.filter(entry => entry.id !== id), 'Service removed.');
+  };
+
+  const moveTopLevelEntry = (id, offset) => {
+    const index = data.invoiceServices.findIndex(entry => entry.id === id);
     const targetIndex = index + offset;
-    if (targetIndex < 0 || targetIndex >= data.invoiceServices.length) return;
-    const nextInvoiceServices = [...data.invoiceServices];
-    [nextInvoiceServices[index], nextInvoiceServices[targetIndex]] = [nextInvoiceServices[targetIndex], nextInvoiceServices[index]];
-    setData(current => ({ ...current, invoiceServices: nextInvoiceServices }));
-    persistInvoiceServices(nextInvoiceServices, 'Service order updated.');
+    if (index === -1 || targetIndex < 0 || targetIndex >= data.invoiceServices.length) return;
+    const next = [...data.invoiceServices];
+    [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+    persistInvoiceServices(next, 'Service order updated.');
   };
 
-  const addServiceEntry = entry => {
-    if (data.invoiceServices.includes(entry)) {
-      toast.error('This service is already on the invoice.');
+  const resetTopLevelEntry = id => {
+    const next = data.invoiceServices.map(entry => {
+      if (entry.id !== id) return entry;
+      if (entry.kind === 'item') return resetItemEntryOverrides(entry);
+      if (entry.kind === 'package') return resetPackageEntryToCatalog(entry, catalogPackagesById.get(String(entry.catalogId)));
+      return entry;
+    });
+    persistInvoiceServices(next, 'Reverted to catalog values.');
+  };
+
+  const addEntryToInvoice = (entry, successMessage) => {
+    const identity = getEntryIdentityKey(entry);
+    if (data.invoiceServices.some(existing => getEntryIdentityKey(existing) === identity)) {
+      toast.error('This is already on the invoice.');
       return;
     }
-    const nextInvoiceServices = [...data.invoiceServices, entry];
-    setData(current => ({ ...current, invoiceServices: nextInvoiceServices }));
-    persistInvoiceServices(nextInvoiceServices, 'Service added.');
+    persistInvoiceServices([...data.invoiceServices, entry], successMessage);
   };
 
   const addCatalogServiceEntry = catalogId => {
-    addServiceEntry(makeCatalogServiceEntry(catalogId));
+    addEntryToInvoice(makeCatalogItemEntry(catalogId), 'Service added.');
+    setShowCatalogPicker(false);
+    setCatalogQuery('');
+  };
+
+  const addCatalogPackageEntry = pkg => {
+    addEntryToInvoice(makeCatalogPackageEntry(pkg), 'Package added.');
     setShowCatalogPicker(false);
     setCatalogQuery('');
   };
@@ -761,9 +1202,49 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       toast.error('Enter a valid price for the new service.');
       return;
     }
-    addServiceEntry(makeCustomServiceEntry(name, price));
+    addEntryToInvoice(makeCustomEntry({ name, price }), 'Service added.');
     setNewCustomServiceName('');
     setNewCustomServicePrice('');
+  };
+
+  const addRecentServiceEntry = entry => addEntryToInvoice(cloneEntryWithNewId(entry), 'Service added.');
+
+  // Package children ------------------------------------------------------------
+
+  const commitPackageChildField = (packageId, childId, field, value) => {
+    const next = data.invoiceServices.map(entry => (entry.id === packageId
+      ? updatePackageChildField(entry, childId, field, value)
+      : entry));
+    persistInvoiceServices(next, 'Package updated.');
+  };
+
+  const resetPackageChildEntry = (packageId, childId) => {
+    const next = data.invoiceServices.map(entry => {
+      if (entry.id !== packageId) return entry;
+      const children = (entry.children || []).map(child => (child.id === childId ? resetItemEntryOverrides(child) : child));
+      return { ...entry, children, customized: true };
+    });
+    persistInvoiceServices(next, 'Reverted to catalog values.');
+  };
+
+  const removePackageChildEntry = (packageId, childId) => {
+    const next = data.invoiceServices.map(entry => (entry.id === packageId ? removePackageChild(entry, childId) : entry));
+    persistInvoiceServices(next, 'Service removed from package.');
+  };
+
+  const movePackageChildEntry = (packageId, childId, offset) => {
+    const next = data.invoiceServices.map(entry => (entry.id === packageId ? movePackageChild(entry, childId, offset) : entry));
+    persistInvoiceServices(next, 'Package order updated.');
+  };
+
+  const addCustomChildEntry = (packageId, fields) => {
+    const next = data.invoiceServices.map(entry => (entry.id === packageId ? addCustomChildToPackage(entry, fields) : entry));
+    persistInvoiceServices(next, 'Service added to package.');
+  };
+
+  const addCatalogChildEntry = (packageId, catalogId) => {
+    const next = data.invoiceServices.map(entry => (entry.id === packageId ? addCatalogChildToPackage(entry, catalogId) : entry));
+    persistInvoiceServices(next, 'Service added to package.');
   };
 
   // Notes ------------------------------------------------------------
@@ -957,72 +1438,71 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
             <Panel>
               <PanelHeading>
                 <H2>Beneficiary</H2>
-                <div style={{ display: 'flex', gap: 8 }}>
+                <div style={{ display: 'flex', gap: 6 }}>
                   <SmallButton type="button" onClick={addBeneficiary}><FaPlus /> Add</SmallButton>
                   <DangerButton type="button" onClick={deleteActiveBeneficiary}><FaTrash /> Delete</DangerButton>
                 </div>
               </PanelHeading>
-              <FieldGrid style={{ marginBottom: 10 }}>
-                <FieldLabel>
-                  Active beneficiary
-                  <Select value={activeBeneficiary?.id || ''} onChange={event => handleSelectBeneficiary(event.target.value)}>
-                    {data.beneficiaries.map(beneficiary => (
-                      <option key={beneficiary.id} value={beneficiary.id}>{beneficiary.title || beneficiary.id}</option>
-                    ))}
-                  </Select>
-                </FieldLabel>
-              </FieldGrid>
+              <FieldRow>
+                <FieldTag>Active</FieldTag>
+                <PlainSelect value={activeBeneficiary?.id || ''} onChange={event => handleSelectBeneficiary(event.target.value)}>
+                  {data.beneficiaries.map(beneficiary => (
+                    <option key={beneficiary.id} value={beneficiary.id}>{beneficiary.title || beneficiary.id}</option>
+                  ))}
+                </PlainSelect>
+              </FieldRow>
               {activeBeneficiary ? (
-                <FieldGrid>
-                  <FieldLabel>
-                    Title
-                    <Input
+                <>
+                  <FieldRow>
+                    <FieldTag>Title</FieldTag>
+                    <AutoTextArea
                       value={activeBeneficiary.title || ''}
                       onChange={event => updateActiveBeneficiaryField('title', event.target.value)}
                       onBlur={event => persistActiveBeneficiaryField('title', event.target.value)}
                     />
-                  </FieldLabel>
-                  <FieldLabel>
-                    Address
-                    <Input
+                  </FieldRow>
+                  <FieldRow>
+                    <FieldTag>Address</FieldTag>
+                    <AutoTextArea
                       value={activeBeneficiary.address || ''}
                       onChange={event => updateActiveBeneficiaryField('address', event.target.value)}
                       onBlur={event => persistActiveBeneficiaryField('address', event.target.value)}
                     />
-                  </FieldLabel>
-                  <FieldLabel>
-                    IBAN
-                    <Input
+                  </FieldRow>
+                  <FieldRow>
+                    <FieldTag>IBAN</FieldTag>
+                    <AutoTextArea
                       value={activeBeneficiary.iban || ''}
                       onChange={event => updateActiveBeneficiaryField('iban', event.target.value)}
                       onBlur={event => persistActiveBeneficiaryField('iban', event.target.value)}
                     />
-                  </FieldLabel>
-                  <FieldLabel>
-                    Bank name
-                    <Input
+                  </FieldRow>
+                  <FieldRow>
+                    <FieldTag>Bank name</FieldTag>
+                    <AutoTextArea
                       value={activeBeneficiary.bankName || ''}
                       onChange={event => updateActiveBeneficiaryField('bankName', event.target.value)}
                       onBlur={event => persistActiveBeneficiaryField('bankName', event.target.value)}
                     />
-                  </FieldLabel>
-                  <FieldLabel>
-                    SWIFT code
-                    <Input
+                  </FieldRow>
+                  <FieldRow>
+                    <FieldTag>SWIFT code</FieldTag>
+                    <AutoTextArea
                       value={activeBeneficiary.swiftCode || ''}
                       onChange={event => updateActiveBeneficiaryField('swiftCode', event.target.value)}
                       onBlur={event => persistActiveBeneficiaryField('swiftCode', event.target.value)}
                     />
-                  </FieldLabel>
-                  <FieldLabel style={{ gridColumn: '1 / -1' }}>
-                    Payment purpose ({'{invoiceNumber}'} and {'{invoiceDate}'} are filled in automatically)
-                    <Textarea
+                  </FieldRow>
+                  <FieldRow>
+                    <FieldTag>Payment purpose</FieldTag>
+                    <AutoTextArea
                       value={activeBeneficiary.paymentPurpose || ''}
+                      placeholder="{invoiceNumber} and {invoiceDate} are filled in automatically"
                       onChange={event => updateActiveBeneficiaryField('paymentPurpose', event.target.value)}
                       onBlur={event => persistActiveBeneficiaryField('paymentPurpose', event.target.value)}
                     />
-                  </FieldLabel>
-                </FieldGrid>
+                  </FieldRow>
+                </>
               ) : null}
             </Panel>
 
@@ -1032,91 +1512,78 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <SmallButton type="button" onClick={addCustomer}><FaPlus /> Add customer</SmallButton>
               </PanelHeading>
               <PanelNote>{`Payer: ${payerName || '—'} · ${caseTitle}`}</PanelNote>
-              <RowList>
-                {data.customers.map((customer, index) => (
-                  <CustomerRow key={`customer-${index}`}>
-                    <Input
-                      placeholder="Name"
-                      value={customer.name || ''}
-                      onChange={event => updateCustomerField(index, 'name', event.target.value)}
-                      onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
-                    />
-                    <Input
-                      placeholder="Address / country"
-                      value={customer.address || ''}
-                      onChange={event => updateCustomerField(index, 'address', event.target.value)}
-                      onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
-                    />
-                    <DangerButton type="button" onClick={() => removeCustomer(index)}><FaTrash /></DangerButton>
-                  </CustomerRow>
-                ))}
-              </RowList>
+              {data.customers.map((customer, index) => (
+                <FieldRow key={`customer-${index}`}>
+                  <FieldTag>Customer {index + 1}</FieldTag>
+                  <AutoTextArea
+                    placeholder="Name"
+                    value={customer.name || ''}
+                    onChange={event => updateCustomerField(index, 'name', event.target.value)}
+                    onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
+                  />
+                  <AutoTextArea
+                    placeholder="Address / country"
+                    value={customer.address || ''}
+                    onChange={event => updateCustomerField(index, 'address', event.target.value)}
+                    onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
+                  />
+                  <IconDangerButton type="button" onClick={() => removeCustomer(index)} title="Remove customer" aria-label="Remove customer">
+                    <FaTrash />
+                  </IconDangerButton>
+                </FieldRow>
+              ))}
             </Panel>
 
             <Panel>
               <PanelHeading>
                 <H2>Invoice services</H2>
               </PanelHeading>
-              {invoiceServiceRows.length ? (
-                <ServiceTableHead>
-                  <span>#</span>
-                  <span>Service</span>
-                  <span>EUR</span>
-                  <span />
-                </ServiceTableHead>
-              ) : null}
-              <RowList>
-                {invoiceServiceRows.map((row, index) => (
-                  <ServiceRow key={`${row.key}-${index}`}>
-                    <RowIndex>{index + 1}</RowIndex>
-                    <Input
-                      value={row.name}
-                      onChange={event => updateInvoiceServiceRow(index, 'name', event.target.value)}
-                      onBlur={() => commitInvoiceServiceRow(index)}
-                    />
-                    <Input
-                      type="text"
-                      inputMode="decimal"
-                      value={invoiceServicePriceDrafts[index] ?? row.price}
-                      onChange={event => setInvoiceServicePriceDrafts(current => ({ ...current, [index]: event.target.value }))}
-                      onBlur={() => commitInvoiceServiceRow(index)}
-                    />
-                    <RowActions>
-                      <IconButton
-                        type="button"
-                        onClick={() => moveInvoiceServiceRow(index, -1)}
-                        disabled={index === 0}
-                        title="Move up"
-                        aria-label="Move service up"
-                      >
-                        <FaChevronUp />
-                      </IconButton>
-                      <IconButton
-                        type="button"
-                        onClick={() => moveInvoiceServiceRow(index, 1)}
-                        disabled={index === invoiceServiceRows.length - 1}
-                        title="Move down"
-                        aria-label="Move service down"
-                      >
-                        <FaChevronDown />
-                      </IconButton>
-                      <IconDangerButton type="button" onClick={() => removeInvoiceServiceRow(index)} title="Remove" aria-label="Remove service">
-                        <FaTrash />
-                      </IconDangerButton>
-                    </RowActions>
-                  </ServiceRow>
-                ))}
-                {!invoiceServiceRows.length ? <PanelNote style={{ margin: 0 }}>No services on this invoice yet.</PanelNote> : null}
-              </RowList>
+
+              {invoiceServiceRows.map((row, index) => (row.kind === 'package' ? (
+                <PackageEntryCard
+                  key={row.key}
+                  row={row}
+                  index={index}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < invoiceServiceRows.length - 1}
+                  catalogItems={catalogItems}
+                  onCommitField={(field, value) => commitTopLevelField(row.id, field, value)}
+                  onRemove={() => removeTopLevelEntry(row.id)}
+                  onMoveUp={() => moveTopLevelEntry(row.id, -1)}
+                  onMoveDown={() => moveTopLevelEntry(row.id, 1)}
+                  onReset={row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
+                  onCommitChildField={(childId, field, value) => commitPackageChildField(row.id, childId, field, value)}
+                  onResetChildField={childId => resetPackageChildEntry(row.id, childId)}
+                  onRemoveChild={childId => removePackageChildEntry(row.id, childId)}
+                  onMoveChild={(childId, offset) => movePackageChildEntry(row.id, childId, offset)}
+                  onAddCustomChild={fields => addCustomChildEntry(row.id, fields)}
+                  onAddCatalogChild={catalogId => addCatalogChildEntry(row.id, catalogId)}
+                />
+              ) : (
+                <ServiceLineRow
+                  key={row.key}
+                  row={row}
+                  index={index}
+                  onCommit={(field, value) => commitTopLevelField(row.id, field, value)}
+                  onRemove={() => removeTopLevelEntry(row.id)}
+                  onMoveUp={() => moveTopLevelEntry(row.id, -1)}
+                  onMoveDown={() => moveTopLevelEntry(row.id, 1)}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < invoiceServiceRows.length - 1}
+                  onReset={row.kind === 'item' && row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
+                />
+              )))}
+              {!invoiceServiceRows.length ? <PanelNote style={{ margin: 0 }}>No services on this invoice yet.</PanelNote> : null}
 
               {recentServiceSuggestions.length ? (
                 <>
-                  <PanelNote style={{ marginTop: 14, marginBottom: 4 }}>Recent services (click to add)</PanelNote>
+                  <PanelNote style={{ marginTop: 14, marginBottom: 4 }}>Recent (click to add)</PanelNote>
                   <ChipRow>
                     {recentServiceSuggestions.map(entry => {
                       const resolved = resolveServiceRow(entry, catalogItemsById, priceContext);
                       return (
-                        <Chip key={entry} type="button" onClick={() => addServiceEntry(entry)}>
+                        <Chip key={entry.id} type="button" onClick={() => addRecentServiceEntry(entry)}>
+                          {entry.kind === 'package' ? <FaLayerGroup style={{ marginRight: 4 }} /> : null}
                           {resolved.name} · {formatEuroPreview(resolved.price)}
                         </Chip>
                       );
@@ -1125,43 +1592,58 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 </>
               ) : null}
 
-              <AddRow>
-                <Input
+              <FieldRow $align="center" style={{ marginTop: 14 }}>
+                <FieldTag>Add custom</FieldTag>
+                <PlainTextBase
+                  rows={1}
                   placeholder="New custom service name"
                   value={newCustomServiceName}
                   onChange={event => setNewCustomServiceName(event.target.value)}
                 />
-                <Input
-                  placeholder="Price"
-                  type="text"
+                <PlainPriceBase
+                  rows={1}
                   inputMode="decimal"
+                  placeholder="Price"
                   value={newCustomServicePrice}
                   onChange={event => setNewCustomServicePrice(event.target.value)}
                 />
                 <SmallButton type="button" onClick={addCustomServiceEntry}><FaPlus /> Add</SmallButton>
-              </AddRow>
+              </FieldRow>
 
-              <div style={{ marginTop: 10 }}>
+              <div style={{ marginTop: 8 }}>
                 <SmallButton type="button" onClick={() => setShowCatalogPicker(current => !current)}>
-                  <FaPlus /> {showCatalogPicker ? 'Hide catalog' : 'Add from services catalog'}
+                  <FaPlus /> {showCatalogPicker ? 'Hide catalog' : 'Add from catalog'}
                 </SmallButton>
                 {showCatalogPicker ? (
-                  <>
-                    <Input
-                      style={{ marginTop: 8 }}
-                      placeholder="Search catalog services…"
+                  <div style={{ marginTop: 8 }}>
+                    <CatalogTabs>
+                      <CatalogTabButton type="button" $active={catalogTab === 'items'} onClick={() => setCatalogTab('items')}>
+                        Services
+                      </CatalogTabButton>
+                      <CatalogTabButton type="button" $active={catalogTab === 'packages'} onClick={() => setCatalogTab('packages')}>
+                        Packages
+                      </CatalogTabButton>
+                    </CatalogTabs>
+                    <CatalogSearchField
+                      rows={1}
+                      placeholder={catalogTab === 'items' ? 'Search catalog services…' : 'Search catalog packages…'}
                       value={catalogQuery}
                       onChange={event => setCatalogQuery(event.target.value)}
                     />
                     <CatalogPickerList>
-                      {filteredCatalogItems.map(item => (
+                      {catalogTab === 'items' ? filteredCatalogItems.map(item => (
                         <CatalogPickerButton key={item.id} type="button" onClick={() => addCatalogServiceEntry(item.id)}>
                           <span>{item.name}</span>
                         </CatalogPickerButton>
+                      )) : filteredCatalogPackages.map(pkg => (
+                        <CatalogPickerButton key={pkg.id} type="button" onClick={() => addCatalogPackageEntry(pkg)}>
+                          <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}</span>
+                        </CatalogPickerButton>
                       ))}
-                      {!filteredCatalogItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
+                      {catalogTab === 'items' && !filteredCatalogItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
+                      {catalogTab === 'packages' && !filteredCatalogPackages.length ? <PanelNote style={{ margin: 0 }}>No matching catalog packages.</PanelNote> : null}
                     </CatalogPickerList>
-                  </>
+                  </div>
                 ) : null}
               </div>
             </Panel>
@@ -1170,27 +1652,29 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               <PanelHeading>
                 <H2>Summary</H2>
               </PanelHeading>
-              <FieldGrid style={{ marginBottom: 12 }}>
-                <FieldLabel>
-                  Invoice date
-                  <Input
-                    type="date"
-                    value={invoiceDateInput}
-                    onChange={event => setInvoiceDateInput(event.target.value)}
-                  />
-                </FieldLabel>
-                <FieldLabel>
-                  Taxes (%)
-                  <Input
-                    type="text"
-                    inputMode="decimal"
-                    value={data.taxPercent}
-                    onChange={event => updateTaxPercent(event.target.value)}
-                    onBlur={commitTaxPercent}
-                  />
-                </FieldLabel>
-              </FieldGrid>
-              <SummaryGrid>
+              <FieldRow>
+                <FieldTag>Invoice date</FieldTag>
+                <input
+                  type="date"
+                  value={invoiceDateInput}
+                  onChange={event => setInvoiceDateInput(event.target.value)}
+                  style={{
+                    flex: '0 0 auto', border: 'none', background: 'transparent', color: 'var(--km-text)', font: 'inherit', fontWeight: 700, padding: '5px 6px', borderRadius: 6,
+                  }}
+                />
+              </FieldRow>
+              <FieldRow>
+                <FieldTag>Taxes (%)</FieldTag>
+                <PlainPriceBase
+                  rows={1}
+                  inputMode="decimal"
+                  value={data.taxPercent}
+                  onChange={event => updateTaxPercent(event.target.value)}
+                  onBlur={commitTaxPercent}
+                  style={{ flex: '0 0 auto' }}
+                />
+              </FieldRow>
+              <SummaryGrid style={{ marginTop: 10 }}>
                 <SummaryLine><span>Invoice number</span><span>{invoiceNumber}</span></SummaryLine>
                 <SummaryLine><span>Purpose of the payment</span><span style={{ textAlign: 'right', maxWidth: 420 }}>{purposeOfPayment || '—'}</span></SummaryLine>
                 <SummaryLine><span>Location</span><span>{payerLocation || '—'}</span></SummaryLine>
@@ -1204,19 +1688,20 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <H2>Notes</H2>
                 <SmallButton type="button" onClick={addNote}><FaPlus /> Add note</SmallButton>
               </PanelHeading>
-              <RowList>
-                {data.notes.map((note, index) => (
-                  <CustomerRow key={`note-${index}`} style={{ gridTemplateColumns: '1fr auto' }}>
-                    <Textarea
-                      value={note}
-                      onChange={event => updateNote(index, event.target.value)}
-                      onBlur={commitNote}
-                    />
-                    <DangerButton type="button" onClick={() => removeNote(index)}><FaTrash /></DangerButton>
-                  </CustomerRow>
-                ))}
-                {!data.notes.length ? <PanelNote style={{ margin: 0 }}>No notes yet.</PanelNote> : null}
-              </RowList>
+              {data.notes.map((note, index) => (
+                <FieldRow key={`note-${index}`}>
+                  <FieldTag>Note {index + 1}</FieldTag>
+                  <AutoTextArea
+                    value={note}
+                    onChange={event => updateNote(index, event.target.value)}
+                    onBlur={commitNote}
+                  />
+                  <IconDangerButton type="button" onClick={() => removeNote(index)} title="Remove note" aria-label="Remove note">
+                    <FaTrash />
+                  </IconDangerButton>
+                </FieldRow>
+              ))}
+              {!data.notes.length ? <PanelNote style={{ margin: 0 }}>No notes yet.</PanelNote> : null}
             </Panel>
           </>
         ) : null}

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -1,0 +1,189 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import InvoiceBuilderPage from './InvoiceBuilderPage';
+import { fetchNbuUahExchangeRatesByDate } from './config';
+import { get, set } from 'firebase/database';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const fixtureItems = [
+  { id: '10', name: 'Baby care in hospital per day', price: 200, description: 'Daily care in hospital.' },
+  { id: '11', name: 'Airport transfer', price: 90, description: 'Transfer from the airport.' },
+];
+
+const fixturePackages = [
+  { id: 'p1', name: 'Full program', listedPrice: 250, description: 'Everything included.', children: ['10', '11'] },
+];
+
+const fixtureInvoiceData = {
+  beneficiaries: [{ id: 'b1', title: 'PE KOVAL OLEKSANDR', address: 'Kyiv', iban: 'UA1', bankName: 'Bank', swiftCode: 'SWIFT', paymentPurpose: '' }],
+  beneficiaryIds: ['b1'],
+  customers: [{ name: 'Amny Athamny', address: 'Netherlands' }],
+  recentServices: [],
+  invoiceServices: ['id10'],
+  notes: [],
+  taxPercent: 0,
+};
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'admin-uid' } },
+  database: {},
+  fetchNbuUahExchangeRatesByDate: jest.fn(),
+}));
+
+jest.mock('firebase/database', () => ({
+  ref: (_database, path) => path,
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+jest.mock('utils/accessLevel', () => ({
+  isAdminUid: () => true,
+}));
+
+describe('InvoiceBuilderPage', () => {
+  let container;
+
+  beforeEach(() => {
+    fetchNbuUahExchangeRatesByDate.mockImplementation(() => Promise.resolve({ eur: 46, usd: 42 }));
+    get.mockImplementation(path => {
+      if (path === 'invoiceBuilder') return Promise.resolve({ exists: () => true, val: () => fixtureInvoiceData });
+      if (path === 'budget/items') return Promise.resolve({ exists: () => true, val: () => fixtureItems });
+      if (path === 'budget/packages') return Promise.resolve({ exists: () => true, val: () => fixturePackages });
+      return Promise.resolve({ exists: () => false, val: () => null });
+    });
+    set.mockImplementation(() => Promise.resolve());
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+    jest.clearAllMocks();
+  });
+
+  const flush = () => act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  const mount = () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(<InvoiceBuilderPage isAdmin />);
+    });
+    return root;
+  };
+
+  const findButton = (text, exact = false) => Array.from(container.querySelectorAll('button'))
+    .find(btn => (exact ? btn.textContent.trim() === text : btn.textContent.includes(text)));
+
+  const nativeTextareaValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+  const setFieldValue = (field, value) => {
+    nativeTextareaValueSetter.call(field, value);
+    field.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+
+  it('renders the catalog-linked service from budget/items without touching the shared catalog', async () => {
+    const root = mount();
+    await flush();
+
+    expect(container.innerHTML).toContain('Baby care in hospital per day');
+    expect(container.innerHTML).toContain('200');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('overriding a catalog item price only writes invoiceBuilder/invoiceServices, never budget/items', async () => {
+    const root = mount();
+    await flush();
+
+    const priceField = container.querySelector('textarea[aria-label="Price (EUR)"]');
+    expect(priceField).toBeTruthy();
+    expect(priceField.value).toBe('200');
+
+    await act(async () => {
+      priceField.focus();
+      setFieldValue(priceField, '350');
+      priceField.blur();
+    });
+    await flush();
+
+    const persistedCalls = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices');
+    expect(persistedCalls).toHaveLength(1);
+    const [, persistedValue] = persistedCalls[0];
+    expect(persistedValue[0]).toMatchObject({ kind: 'item', catalogId: '10', price: 350, customized: true });
+    expect(set.mock.calls.some(([path]) => path.startsWith('budget/'))).toBe(false);
+    expect(container.innerHTML).toContain('Custom');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('adds a whole package from the catalog, then removing one of its services makes it a custom package', async () => {
+    const root = mount();
+    await flush();
+
+    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const packageButton = findButton('Full program');
+    expect(packageButton).toBeTruthy();
+    await act(async () => { packageButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.innerHTML).toContain('Airport transfer');
+    let lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    expect(lastServicesCall[1][1]).toMatchObject({ kind: 'package', catalogId: 'p1' });
+    expect(lastServicesCall[1][1].children).toHaveLength(2);
+
+    const removeFromPackageButton = Array.from(container.querySelectorAll('button'))
+      .find(btn => btn.title === 'Remove from package');
+    expect(removeFromPackageButton).toBeTruthy();
+    await act(async () => { removeFromPackageButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    const packageEntry = lastServicesCall[1].find(entry => entry.kind === 'package');
+    expect(packageEntry.children).toHaveLength(1);
+    expect(packageEntry.customized).toBe(true);
+    expect(container.innerHTML).toContain('Custom package');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('deletes a custom service from the invoice', async () => {
+    const root = mount();
+    await flush();
+
+    const nameField = container.querySelector('textarea[placeholder="New custom service name"]');
+    const priceField = container.querySelector('textarea[placeholder="Price"]');
+    await act(async () => {
+      nameField.focus();
+      setFieldValue(nameField, 'Courier fee');
+      setFieldValue(priceField, '25');
+    });
+
+    const addCustomButton = nameField.parentElement.querySelector('button');
+    expect(addCustomButton.textContent.trim()).toBe('Add');
+    await act(async () => { addCustomButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.innerHTML).toContain('Courier fee');
+
+    const removeButtons = Array.from(container.querySelectorAll('button[title="Remove"]'));
+    expect(removeButtons.length).toBeGreaterThan(0);
+    await act(async () => { removeButtons[removeButtons.length - 1].dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.innerHTML).not.toContain('Courier fee');
+    const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    expect(lastServicesCall[1].some(entry => entry.name === 'Courier fee')).toBe(false);
+
+    await act(async () => { root.unmount(); });
+  });
+});

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -13,8 +13,17 @@ const fixtureItems = [
 ];
 
 const fixturePackages = [
-  { id: 'p1', name: 'Full program', listedPrice: 250, description: 'Everything included.', children: ['10', '11'] },
+  {
+    id: 'p1', name: 'Full program', listedPrice: 250, description: 'Everything included.', children: ['10', '11'], paymentScheduleId: 'ps-1',
+  },
 ];
+
+const fixtureTechnical = {
+  paymentSchedules: [
+    { id: 'ps-1', payments: [{ title: 'To start the program', amount: 150 }, { title: 'Final payment', amount: 100 }] },
+  ],
+  wireTransferSurchargeRate: 0.14,
+};
 
 const fixtureInvoiceData = {
   beneficiaries: [{ id: 'b1', title: 'PE KOVAL OLEKSANDR', address: 'Kyiv', iban: 'UA1', bankName: 'Bank', swiftCode: 'SWIFT', paymentPurpose: '' }],
@@ -51,9 +60,11 @@ describe('InvoiceBuilderPage', () => {
       if (path === 'invoiceBuilder') return Promise.resolve({ exists: () => true, val: () => fixtureInvoiceData });
       if (path === 'budget/items') return Promise.resolve({ exists: () => true, val: () => fixtureItems });
       if (path === 'budget/packages') return Promise.resolve({ exists: () => true, val: () => fixturePackages });
+      if (path === 'budget/technical') return Promise.resolve({ exists: () => true, val: () => fixtureTechnical });
       return Promise.resolve({ exists: () => false, val: () => null });
     });
     set.mockImplementation(() => Promise.resolve());
+    window.confirm = jest.fn(() => true);
     container = document.createElement('div');
     document.body.appendChild(container);
   });
@@ -185,5 +196,89 @@ describe('InvoiceBuilderPage', () => {
     expect(lastServicesCall[1].some(entry => entry.name === 'Courier fee')).toBe(false);
 
     await act(async () => { root.unmount(); });
+  });
+
+  describe('expected expenses', () => {
+    const createPlan = async () => {
+      await act(async () => { findButton('Choose a package').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+      const packageButton = findButton('Full program');
+      expect(packageButton).toBeTruthy();
+      await act(async () => { packageButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+    };
+
+    it('builds a plan from a package, auto-calculating each milestone amount from its catalog schedule', async () => {
+      const root = mount();
+      await flush();
+
+      await createPlan();
+
+      expect(container.innerHTML).toContain('To start the program');
+      expect(container.innerHTML).toContain('Final payment');
+      expect(container.innerHTML).toContain('Due: €171.00');
+      expect(container.innerHTML).toContain('Due: €114.00');
+
+      const persistedCalls = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses');
+      expect(persistedCalls.length).toBeGreaterThan(0);
+      const plan = persistedCalls[persistedCalls.length - 1][1];
+      expect(plan.packageId).toBe('p1');
+      expect(plan.milestones).toHaveLength(2);
+      expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', scheduledAmount: 150, taxPercent: 14, showPackageOverview: true });
+      expect(plan.milestones[1]).toMatchObject({ title: 'Final payment', scheduledAmount: 100, showPackageOverview: false });
+
+      await act(async () => { root.unmount(); });
+    });
+
+    it('adding a service to a milestone updates its due amount and is persisted on that milestone only', async () => {
+      const root = mount();
+      await flush();
+
+      await createPlan();
+
+      const milestoneNameFields = Array.from(container.querySelectorAll('textarea[placeholder="Add a custom line to this invoice…"]'));
+      expect(milestoneNameFields).toHaveLength(2);
+      const milestoneAddRow = milestoneNameFields[0].parentElement;
+      const priceField = milestoneAddRow.querySelector('textarea[placeholder="Price"]');
+      const addButton = Array.from(milestoneAddRow.querySelectorAll('button')).find(btn => btn.textContent.trim() === 'Add');
+
+      await act(async () => {
+        milestoneNameFields[0].focus();
+        setFieldValue(milestoneNameFields[0], 'Deposit for transportation of SM');
+        setFieldValue(priceField, '300');
+      });
+      await act(async () => { addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(container.innerHTML).toContain('Deposit for transportation of SM');
+      expect(container.innerHTML).toContain('Due: €513.00');
+
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan.milestones[0].additionalServices).toHaveLength(1);
+      expect(plan.milestones[0].additionalServices[0]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.milestones[1].additionalServices).toHaveLength(0);
+
+      await act(async () => { root.unmount(); });
+    });
+
+    it('deletes the whole plan', async () => {
+      const root = mount();
+      await flush();
+
+      await createPlan();
+      expect(container.innerHTML).toContain('To start the program');
+
+      const deleteButton = findButton('Delete plan');
+      expect(deleteButton).toBeTruthy();
+      await act(async () => { deleteButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(container.innerHTML).not.toContain('To start the program');
+      expect(container.innerHTML).toContain('Choose a package');
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan).toBeNull();
+
+      await act(async () => { root.unmount(); });
+    });
   });
 });

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client';
 import InvoiceBuilderPage from './InvoiceBuilderPage';
 import { fetchNbuUahExchangeRatesByDate } from './config';
 import { get, set } from 'firebase/database';
+import expectedExpensesSeed from '../data/expectedExpensesSeed.json';
 
 global.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -277,6 +278,35 @@ describe('InvoiceBuilderPage', () => {
       expect(container.innerHTML).toContain('Choose a package');
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
       expect(plan).toBeNull();
+
+      await act(async () => { root.unmount(); });
+    });
+
+    it('uploads a standalone expected-expenses JSON straight into invoiceBuilder/expectedExpenses', async () => {
+      const root = mount();
+      await flush();
+
+      const heading = Array.from(container.querySelectorAll('h2')).find(h => h.textContent === 'Expected expenses');
+      const panel = heading.closest('section');
+      const uploadButton = Array.from(panel.querySelectorAll('button')).find(btn => btn.textContent.includes('Upload JSON'));
+      const fileInput = panel.querySelector('input[type="file"]');
+      expect(uploadButton).toBeTruthy();
+      expect(fileInput).toBeTruthy();
+
+      const fileText = JSON.stringify(expectedExpensesSeed);
+      const file = new File([fileText], 'expected-expenses.json', { type: 'application/json' });
+      // jsdom's File/Blob doesn't implement .text() - the component relies on it, so stub it here.
+      file.text = () => Promise.resolve(fileText);
+      Object.defineProperty(fileInput, 'files', { value: [file] });
+      await act(async () => { fileInput.dispatchEvent(new Event('change', { bubbles: true })); });
+      await flush();
+
+      expect(container.innerHTML).toContain('To start the program');
+      expect(container.innerHTML).toContain('Deposit for transportation of SM');
+
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan.packageId).toBe('3');
+      expect(plan.milestones).toHaveLength(6);
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { PDF_COLOR, PDF_FONT, pdfBaseStyles, sanitizePdfText } from './pdfTheme';
 import {
   buildCaseTitle,
   buildPayerLocation,
@@ -15,22 +16,6 @@ const AGENCY_ADDRESS_LINE_2 = 'Kyiv, 01034, Ukraine';
 const AGENCY_WEBSITE = 'Website: http://ukrcom.kyiv.ua/';
 const AGENCY_EMAIL = 'E-mail: sm.kiev.ukr@gmail.com';
 const AGENCY_TELEGRAM = 'Telegram: @Contact_Us_Kyiv';
-
-const INK = '#33291f';
-const MUTED = '#6f6359';
-const ACCENT = '#7a4c2f';
-const HEAD_BG = '#f3e6d2';
-const TOTAL_BG = '#cfe0f5';
-
-// The built-in Helvetica font only covers WinAnsi glyphs, so swap the few
-// characters that would otherwise render blank.
-const sanitizePdfText = value => String(value ?? '')
-  .replace(/№/g, 'No.')
-  .replace(/[’‘]/g, "'")
-  .replace(/[“”]/g, '"')
-  .replace(/[–—]/g, '-')
-  .replace(/\s+/g, ' ')
-  .trim();
 
 // Row-level amounts show as plain numbers ("3000", "300"); only the
 // tax-adjusted totals use the space-grouped, comma-decimal EUR format.
@@ -49,46 +34,48 @@ const formatEuroTotal = value => {
 };
 
 const styles = StyleSheet.create({
-  page: {
-    paddingTop: 44,
-    paddingBottom: 62,
-    paddingHorizontal: 44,
-    fontFamily: 'Helvetica',
-    fontSize: 10,
-    color: INK,
-    backgroundColor: '#ffffff',
-  },
+  page: pdfBaseStyles.page,
+  eyebrow: pdfBaseStyles.eyebrow,
   title: {
-    fontFamily: 'Helvetica-Bold',
-    fontSize: 20,
-    letterSpacing: -0.2,
-    textAlign: 'center',
-    marginBottom: 26,
-  },
-  sectionTitle: {
-    fontFamily: 'Helvetica-Bold',
-    fontSize: 20,
-    letterSpacing: -0.2,
+    ...pdfBaseStyles.docTitle,
+    fontSize: 21,
     textAlign: 'center',
     marginBottom: 4,
   },
+  titleRule: {
+    alignSelf: 'center',
+    width: 64,
+    height: 2,
+    borderRadius: 1,
+    backgroundColor: PDF_COLOR.accent,
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 19,
+    letterSpacing: -0.2,
+    textAlign: 'center',
+    marginBottom: 4,
+    color: PDF_COLOR.ink,
+  },
   sectionSubtitle: {
     fontSize: 10.5,
-    fontFamily: 'Helvetica-Bold',
+    fontFamily: PDF_FONT.bold,
     textAlign: 'center',
-    color: MUTED,
-    marginBottom: 20,
+    color: PDF_COLOR.soft,
+    marginBottom: 22,
   },
   table: {
     borderWidth: 1,
-    borderColor: '#111111',
+    borderColor: PDF_COLOR.line,
     borderStyle: 'solid',
+    borderRadius: 6,
     marginBottom: 18,
   },
   row: {
     flexDirection: 'row',
     borderTopWidth: 1,
-    borderTopColor: '#111111',
+    borderTopColor: PDF_COLOR.line,
     borderTopStyle: 'solid',
   },
   firstRow: {
@@ -96,27 +83,33 @@ const styles = StyleSheet.create({
   },
   labelCell: {
     width: '38%',
-    backgroundColor: HEAD_BG,
+    backgroundColor: PDF_COLOR.headBg,
     borderRightWidth: 1,
-    borderRightColor: '#111111',
+    borderRightColor: PDF_COLOR.line,
     borderRightStyle: 'solid',
-    paddingVertical: 6,
-    paddingHorizontal: 8,
+    paddingVertical: 7,
+    paddingHorizontal: 9,
     justifyContent: 'center',
   },
   labelText: {
-    fontFamily: 'Helvetica-Bold',
+    fontFamily: PDF_FONT.bold,
     fontSize: 9.5,
+    color: '#4d3a26',
   },
   valueCell: {
     width: '62%',
-    paddingVertical: 6,
-    paddingHorizontal: 8,
+    paddingVertical: 7,
+    paddingHorizontal: 9,
     justifyContent: 'center',
   },
   valueText: {
     fontSize: 9.5,
     lineHeight: 1.4,
+  },
+  totalValueText: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 11,
+    color: PDF_COLOR.accent,
   },
   noteRow: {
     flexDirection: 'row',
@@ -125,36 +118,44 @@ const styles = StyleSheet.create({
   noteMark: {
     width: 20,
     fontSize: 9,
-    fontFamily: 'Helvetica-Bold',
-    color: ACCENT,
+    fontFamily: PDF_FONT.bold,
+    color: PDF_COLOR.accent,
   },
   noteText: {
     flex: 1,
     fontSize: 9,
     lineHeight: 1.45,
+    color: PDF_COLOR.muted,
   },
   expensesTable: {
     borderWidth: 1,
-    borderColor: '#111111',
+    borderColor: PDF_COLOR.line,
     borderStyle: 'solid',
+    borderRadius: 6,
     marginBottom: 4,
   },
   expensesHeadRow: {
     flexDirection: 'row',
-    backgroundColor: HEAD_BG,
+    backgroundColor: PDF_COLOR.headBg,
   },
   expensesRow: {
     flexDirection: 'row',
     borderTopWidth: 1,
-    borderTopColor: '#111111',
+    borderTopColor: PDF_COLOR.line,
     borderTopStyle: 'solid',
   },
+  expensesRowAlt: {
+    backgroundColor: PDF_COLOR.rowAlt,
+  },
+  packageHeadRow: {
+    backgroundColor: PDF_COLOR.headBg,
+  },
   expenseIndexCell: {
-    width: 26,
+    width: 30,
     borderRightWidth: 1,
-    borderRightColor: '#111111',
+    borderRightColor: PDF_COLOR.line,
     borderRightStyle: 'solid',
-    paddingVertical: 5,
+    paddingVertical: 6,
     paddingHorizontal: 6,
     justifyContent: 'center',
     alignItems: 'center',
@@ -162,47 +163,84 @@ const styles = StyleSheet.create({
   expenseNameCell: {
     flex: 1,
     borderRightWidth: 1,
-    borderRightColor: '#111111',
+    borderRightColor: PDF_COLOR.line,
     borderRightStyle: 'solid',
-    paddingVertical: 5,
-    paddingHorizontal: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
     justifyContent: 'center',
   },
+  expenseNameCellChild: {
+    paddingLeft: 20,
+  },
   expenseAmountCell: {
-    width: 84,
-    paddingVertical: 5,
-    paddingHorizontal: 8,
+    width: 88,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
     justifyContent: 'center',
     alignItems: 'flex-end',
   },
   expenseHeadText: {
-    fontFamily: 'Helvetica-Bold',
+    fontFamily: PDF_FONT.bold,
     fontSize: 9.5,
+    color: '#4d3a26',
+  },
+  expenseIndexText: {
+    fontSize: 8.5,
+    color: PDF_COLOR.soft,
+    fontFamily: PDF_FONT.bold,
   },
   expenseText: {
     fontSize: 9.5,
   },
+  expenseTextChild: {
+    fontSize: 9,
+    color: PDF_COLOR.ink,
+  },
+  expenseTextPackage: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 10,
+  },
+  expenseDescription: {
+    fontSize: 8,
+    color: PDF_COLOR.muted,
+    lineHeight: 1.4,
+    marginTop: 1.5,
+  },
+  expensePriceText: {
+    fontSize: 9.5,
+  },
+  expensePriceTextChild: {
+    fontSize: 9,
+    color: PDF_COLOR.muted,
+  },
+  expensePriceTextPackage: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 10,
+    color: PDF_COLOR.accent,
+  },
   summaryRow: {
     flexDirection: 'row',
     borderWidth: 1,
-    borderColor: '#111111',
+    borderColor: PDF_COLOR.line,
     borderStyle: 'solid',
     borderTopWidth: 0,
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
   },
   summaryLabelCell: {
     flex: 1,
-    paddingVertical: 6,
-    paddingHorizontal: 8,
+    paddingVertical: 7,
+    paddingHorizontal: 9,
     justifyContent: 'center',
   },
   summaryAmountCell: {
-    width: 110,
-    paddingVertical: 6,
-    paddingHorizontal: 8,
+    width: 118,
+    paddingVertical: 7,
+    paddingHorizontal: 9,
     justifyContent: 'center',
     alignItems: 'flex-end',
     borderLeftWidth: 1,
-    borderLeftColor: '#111111',
+    borderLeftColor: PDF_COLOR.line,
     borderLeftStyle: 'solid',
   },
   summaryLabelText: {
@@ -212,34 +250,15 @@ const styles = StyleSheet.create({
     fontSize: 9.5,
   },
   totalAmountCell: {
-    backgroundColor: TOTAL_BG,
+    backgroundColor: PDF_COLOR.totalBg,
   },
   totalAmountText: {
-    fontFamily: 'Helvetica-Bold',
+    fontFamily: PDF_FONT.bold,
   },
-  footer: {
-    position: 'absolute',
-    left: 44,
-    right: 44,
-    bottom: 24,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  footerColumn: {
-    maxWidth: 260,
-  },
-  footerText: {
-    fontSize: 8,
-    color: MUTED,
-    lineHeight: 1.4,
-  },
-  footerPage: {
-    position: 'absolute',
-    right: 44,
-    bottom: 24,
-    fontSize: 8,
-    color: MUTED,
-  },
+  footer: pdfBaseStyles.footer,
+  footerColumn: pdfBaseStyles.footerColumn,
+  footerText: pdfBaseStyles.footerText,
+  footerPage: pdfBaseStyles.footerPage,
 });
 
 const renderFooter = pageLabel => (
@@ -258,6 +277,22 @@ const renderFooter = pageLabel => (
   </View>
 );
 
+// Flattens resolved rows into a display list: a package becomes its own bold header row
+// ("2.") followed by its children indented underneath ("2.1", "2.2", ...).
+const buildDisplayRows = rows => {
+  const display = [];
+  rows.forEach((row, index) => {
+    const number = String(index + 1);
+    display.push({ ...row, number, depth: 0 });
+    if (row.kind === 'package') {
+      (row.children || []).forEach((child, childIndex) => {
+        display.push({ ...child, number: `${number}.${childIndex + 1}`, depth: 1 });
+      });
+    }
+  });
+  return display;
+};
+
 const InvoicePdfDocument = ({
   beneficiary,
   customers,
@@ -271,6 +306,7 @@ const InvoicePdfDocument = ({
   priceContext,
 }) => {
   const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById, priceContext);
+  const displayRows = buildDisplayRows(rows);
   const subtotal = computeInvoiceSubtotal(rows);
   const total = computeInvoiceTotal(subtotal, taxPercent);
   const payerName = buildPayerName(customers);
@@ -281,7 +317,9 @@ const InvoicePdfDocument = ({
   return (
     <Document title={`Invoice ${invoiceNumber || ''}`} subject="Invoice" creator="UKRCOM">
       <Page size="A4" style={styles.page} wrap>
-        <Text style={styles.title}>{sanitizePdfText(`INVOICE # ${invoiceNumber || ''}`)}</Text>
+        <Text style={styles.eyebrow}>{sanitizePdfText(AGENCY_NAME)}</Text>
+        <Text style={styles.title}>{sanitizePdfText(`INVOICE No. ${invoiceNumber || ''}`)}</Text>
+        <View style={styles.titleRule} />
 
         <View style={styles.table}>
           <View style={[styles.row, styles.firstRow]} wrap={false}>
@@ -321,7 +359,7 @@ const InvoicePdfDocument = ({
           </View>
           <View style={styles.row} wrap={false}>
             <View style={styles.labelCell}><Text style={styles.labelText}>Total:</Text></View>
-            <View style={styles.valueCell}><Text style={styles.valueText}>{formatEuroTotal(total)}</Text></View>
+            <View style={styles.valueCell}><Text style={styles.totalValueText}>{formatEuroTotal(total)}</Text></View>
           </View>
         </View>
 
@@ -336,6 +374,7 @@ const InvoicePdfDocument = ({
       </Page>
 
       <Page size="A4" style={styles.page} wrap>
+        <Text style={styles.eyebrow}>{sanitizePdfText(AGENCY_NAME)}</Text>
         <Text style={styles.sectionTitle}>Description</Text>
         <Text style={styles.sectionSubtitle}>{sanitizePdfText(caseTitle)}</Text>
 
@@ -345,18 +384,39 @@ const InvoicePdfDocument = ({
             <View style={styles.expenseNameCell}><Text style={styles.expenseHeadText}>Expenses</Text></View>
             <View style={styles.expenseAmountCell}><Text style={styles.expenseHeadText}>EUR</Text></View>
           </View>
-          {rows.map((row, index) => (
-            <View key={row.key || index} style={styles.expensesRow} wrap={false}>
-              <View style={styles.expenseIndexCell}><Text style={styles.expenseText}>{index + 1}</Text></View>
-              <View style={styles.expenseNameCell}><Text style={styles.expenseText}>{sanitizePdfText(row.name)}</Text></View>
-              <View style={styles.expenseAmountCell}><Text style={styles.expenseText}>{formatPlainAmount(row.price)}</Text></View>
-            </View>
-          ))}
+          {displayRows.map((row, rowIndex) => {
+            const isChild = row.depth > 0;
+            const isPackageHeader = row.kind === 'package';
+            return (
+              <View
+                key={`${row.key || rowIndex}-${row.number}`}
+                style={[
+                  styles.expensesRow,
+                  isPackageHeader ? styles.packageHeadRow : null,
+                  !isPackageHeader && rowIndex % 2 ? styles.expensesRowAlt : null,
+                ]}
+                wrap={false}
+              >
+                <View style={styles.expenseIndexCell}><Text style={styles.expenseIndexText}>{row.number}</Text></View>
+                <View style={[styles.expenseNameCell, isChild ? styles.expenseNameCellChild : null]}>
+                  <Text style={isPackageHeader ? styles.expenseTextPackage : (isChild ? styles.expenseTextChild : styles.expenseText)}>
+                    {sanitizePdfText(row.name)}
+                  </Text>
+                  {row.description ? <Text style={styles.expenseDescription}>{sanitizePdfText(row.description)}</Text> : null}
+                </View>
+                <View style={styles.expenseAmountCell}>
+                  <Text style={isPackageHeader ? styles.expensePriceTextPackage : (isChild ? styles.expensePriceTextChild : styles.expensePriceText)}>
+                    {formatPlainAmount(row.price)}
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
         </View>
 
         <View style={styles.summaryRow} wrap={false}>
-          <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: 'Helvetica-Bold' }]}>Total:</Text></View>
-          <View style={styles.summaryAmountCell}><Text style={[styles.summaryAmountText, { fontFamily: 'Helvetica-Bold' }]}>{formatEuroTotal(subtotal)}</Text></View>
+          <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Total:</Text></View>
+          <View style={styles.summaryAmountCell}><Text style={[styles.summaryAmountText, { fontFamily: PDF_FONT.bold }]}>{formatEuroTotal(subtotal)}</Text></View>
         </View>
 
         <View style={{ marginTop: 16 }}>
@@ -365,7 +425,7 @@ const InvoicePdfDocument = ({
             <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(taxPercent)}</Text></View>
           </View>
           <View style={styles.summaryRow} wrap={false}>
-            <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: 'Helvetica-Bold' }]}>Amount need to be paid (EUR)</Text></View>
+            <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Amount need to be paid (EUR)</Text></View>
             <View style={[styles.summaryAmountCell, styles.totalAmountCell]}><Text style={[styles.summaryAmountText, styles.totalAmountText]}>{formatEuroTotal(total)}</Text></View>
           </View>
         </View>

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -76,6 +76,17 @@ export const normalizeExpectedExpensesData = raw => {
   };
 };
 
+// Loose validation for an uploaded expected-expenses JSON, before normalizeExpectedExpensesData
+// fills in any missing pieces - mirrors isInvoiceDataShape's role for the main invoice JSON.
+export const isExpectedExpensesShape = raw => Boolean(
+  raw
+  && typeof raw === 'object'
+  && !Array.isArray(raw)
+  && raw.packageSnapshot
+  && typeof raw.packageSnapshot === 'object'
+  && Array.isArray(raw.milestones),
+);
+
 // --- Editing ------------------------------------------------------------
 
 export const setMilestoneField = (milestone, field, value) => {

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -1,0 +1,122 @@
+// "Expected expenses" is a billing forecast for a whole surrogacy program: pick a budget/packages
+// program once, and its payment schedule (budget/technical.paymentSchedules) is turned into a
+// series of milestones - one future invoice per scheduled payment. Each milestone's amount is
+// calculated automatically from the schedule, and stays a plain editable number from then on (the
+// plan is its own frozen copy, same as a package entry's children on a regular invoice - it does
+// not keep re-syncing with the shared catalog). Admins can attach extra one-off services (custom
+// or catalog-linked, e.g. the recurring SM transportation/medical deposits) to any milestone.
+//
+// The whole plan is stored as invoiceBuilder/expectedExpenses - a single object, not a list of
+// documents - so it lives right next to the rest of the invoice-builder JSON on the backend.
+
+import {
+  createEntryId,
+  computeInvoiceSubtotal,
+  computeInvoiceTotal,
+  makeCatalogItemEntry,
+  normalizeServiceEntries,
+  resolveServiceRow,
+  setEntryField,
+} from './invoiceCatalogUtils';
+
+// --- Building a plan from a chosen catalog package + its payment schedule ------------------------------------------------------
+
+// The package overview only ever lists service names (its listed price already covers all of
+// them) - no per-item prices are stored or shown.
+export const buildPackageOverviewChildren = pkg => (Array.isArray(pkg?.children) ? pkg.children : [])
+  .map(catalogId => makeCatalogItemEntry(catalogId));
+
+export const buildMilestonesFromSchedule = (schedule, { taxPercent = 0 } = {}) =>
+  (Array.isArray(schedule?.payments) ? schedule.payments : []).map((payment, index) => ({
+    id: createEntryId(),
+    title: payment?.title || `Payment ${index + 1}`,
+    scheduledAmount: Number(payment?.amount) || 0,
+    taxPercent,
+    // The first milestone doubles as the "introducing the program" invoice: it shows the full
+    // package overview (included services + the whole schedule) instead of just its own line.
+    showPackageOverview: index === 0,
+    additionalServices: [],
+  }));
+
+export const buildExpectedExpensesPlan = (pkg, schedule, { taxPercent = 0 } = {}) => ({
+  packageId: String(pkg?.id ?? ''),
+  packageSnapshot: {
+    name: pkg?.name || '',
+    description: pkg?.description || '',
+    listedPrice: Number(pkg?.listedPrice) || 0,
+    currency: pkg?.currency || 'EUR',
+    children: buildPackageOverviewChildren(pkg),
+  },
+  milestones: buildMilestonesFromSchedule(schedule, { taxPercent }),
+});
+
+// --- Normalization (defensive parsing of whatever's stored on the backend) ------------------------------------------------------
+
+export const normalizeExpectedExpensesMilestone = raw => ({
+  id: raw?.id || createEntryId(),
+  title: raw?.title || '',
+  scheduledAmount: Number(raw?.scheduledAmount) || 0,
+  taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
+  showPackageOverview: Boolean(raw?.showPackageOverview),
+  additionalServices: normalizeServiceEntries(raw?.additionalServices),
+});
+
+export const normalizeExpectedExpensesData = raw => {
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    packageId: String(raw.packageId ?? ''),
+    packageSnapshot: {
+      name: raw.packageSnapshot?.name || '',
+      description: raw.packageSnapshot?.description || '',
+      listedPrice: Number(raw.packageSnapshot?.listedPrice) || 0,
+      currency: raw.packageSnapshot?.currency || 'EUR',
+      children: normalizeServiceEntries(raw.packageSnapshot?.children),
+    },
+    milestones: Array.isArray(raw.milestones) ? raw.milestones.map(normalizeExpectedExpensesMilestone) : [],
+  };
+};
+
+// --- Editing ------------------------------------------------------------
+
+export const setMilestoneField = (milestone, field, value) => {
+  if (field === 'scheduledAmount' || field === 'taxPercent') {
+    const numeric = Number(String(value).replace(',', '.'));
+    return { ...milestone, [field]: Number.isFinite(numeric) ? numeric : 0 };
+  }
+  return { ...milestone, [field]: value };
+};
+
+export const addMilestoneAdditionalService = (milestone, entry) => ({
+  ...milestone,
+  additionalServices: [...(milestone.additionalServices || []), entry],
+});
+
+export const removeMilestoneAdditionalService = (milestone, entryId) => ({
+  ...milestone,
+  additionalServices: (milestone.additionalServices || []).filter(entry => entry.id !== entryId),
+});
+
+export const updateMilestoneAdditionalServiceField = (milestone, entryId, field, value) => ({
+  ...milestone,
+  additionalServices: (milestone.additionalServices || [])
+    .map(entry => (entry.id === entryId ? setEntryField(entry, field, value) : entry)),
+});
+
+// --- Resolving for display/PDF ------------------------------------------------------
+
+export const resolvePackageOverviewRows = (children, catalogItemsById, priceContext = {}) =>
+  (Array.isArray(children) ? children : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
+
+export const resolveMilestoneAdditionalRows = (milestone, catalogItemsById, priceContext = {}) =>
+  (Array.isArray(milestone?.additionalServices) ? milestone.additionalServices : [])
+    .map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
+
+export const computeMilestoneSubtotal = (milestone, additionalRows) =>
+  (Number(milestone?.scheduledAmount) || 0) + computeInvoiceSubtotal(additionalRows);
+
+export const computeMilestoneAmountDue = (subtotal, taxPercent) => computeInvoiceTotal(subtotal, taxPercent);
+
+// Sum of every milestone's scheduled amount - shown next to the package's listed price so a
+// mismatched schedule (edited milestones that no longer add up to the program price) is obvious.
+export const computeMilestonesScheduledTotal = milestones =>
+  (Array.isArray(milestones) ? milestones : []).reduce((sum, milestone) => sum + (Number(milestone?.scheduledAmount) || 0), 0);

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -4,6 +4,7 @@ import {
   computeMilestoneAmountDue,
   computeMilestoneSubtotal,
   computeMilestonesScheduledTotal,
+  isExpectedExpensesShape,
   normalizeExpectedExpensesData,
   removeMilestoneAdditionalService,
   resolveMilestoneAdditionalRows,
@@ -11,6 +12,7 @@ import {
   setMilestoneField,
   updateMilestoneAdditionalServiceField,
 } from './expectedExpensesUtils';
+import expectedExpensesSeed from '../data/expectedExpensesSeed.json';
 import { makeCustomEntry } from './invoiceCatalogUtils';
 
 const pkg = {
@@ -115,5 +117,27 @@ describe('expectedExpensesUtils', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule);
     const rows = resolvePackageOverviewRows(plan.packageSnapshot.children.slice(0, 2), catalogItemsById);
     expect(rows.map(row => row.name)).toEqual(['Program coordination and support', 'Surrogacy document preparation']);
+  });
+
+  describe('isExpectedExpensesShape', () => {
+    it('accepts a plan-shaped object and rejects anything else', () => {
+      const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+      expect(isExpectedExpensesShape(plan)).toBe(true);
+      expect(isExpectedExpensesShape(null)).toBe(false);
+      expect(isExpectedExpensesShape({})).toBe(false);
+      expect(isExpectedExpensesShape({ packageSnapshot: {}, milestones: 'nope' })).toBe(false);
+    });
+  });
+
+  describe('expectedExpensesSeed.json', () => {
+    it('is a valid, normalizable expected-expenses plan whose milestones add up to the package price', () => {
+      expect(isExpectedExpensesShape(expectedExpensesSeed)).toBe(true);
+      const normalized = normalizeExpectedExpensesData(expectedExpensesSeed);
+      expect(normalized.packageId).toBe('3');
+      expect(normalized.milestones).toHaveLength(6);
+      expect(computeMilestonesScheduledTotal(normalized.milestones)).toBe(normalized.packageSnapshot.listedPrice);
+      expect(normalized.milestones[0].showPackageOverview).toBe(true);
+      expect(normalized.milestones.slice(1).every(milestone => !milestone.showPackageOverview)).toBe(true);
+    });
   });
 });

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -1,0 +1,119 @@
+import {
+  addMilestoneAdditionalService,
+  buildExpectedExpensesPlan,
+  computeMilestoneAmountDue,
+  computeMilestoneSubtotal,
+  computeMilestonesScheduledTotal,
+  normalizeExpectedExpensesData,
+  removeMilestoneAdditionalService,
+  resolveMilestoneAdditionalRows,
+  resolvePackageOverviewRows,
+  setMilestoneField,
+  updateMilestoneAdditionalServiceField,
+} from './expectedExpensesUtils';
+import { makeCustomEntry } from './invoiceCatalogUtils';
+
+const pkg = {
+  id: '3',
+  name: 'IVF+ED+SM',
+  description: 'For cases where embryos need to be created using donor oocytes.',
+  listedPrice: 40000,
+  currency: 'EUR',
+  children: [1, 2, 3],
+};
+
+const schedule = {
+  id: 'ps-3',
+  payments: [
+    { title: 'To start the program', amount: 8772 },
+    { title: 'To start stimulation of a SM', amount: 6228 },
+    { title: 'In a week before embryo transfer', amount: 3000 },
+    { title: 'After confirmation of pregnancy by ultrasound', amount: 4000 },
+    { title: 'On the 12th week of pregnancy', amount: 6000 },
+    { title: 'On the 18th week of pregnancy', amount: 6000 },
+    { title: 'On the 36th week of pregnancy', amount: 6000 },
+  ],
+};
+
+describe('expectedExpensesUtils', () => {
+  it('builds a plan whose milestones mirror the schedule, first one flagged as the package overview', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+    expect(plan.packageId).toBe('3');
+    expect(plan.packageSnapshot).toMatchObject({ name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR' });
+    expect(plan.packageSnapshot.children).toEqual([
+      { id: plan.packageSnapshot.children[0].id, kind: 'item', catalogId: '1' },
+      { id: plan.packageSnapshot.children[1].id, kind: 'item', catalogId: '2' },
+      { id: plan.packageSnapshot.children[2].id, kind: 'item', catalogId: '3' },
+    ]);
+
+    expect(plan.milestones).toHaveLength(7);
+    expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', scheduledAmount: 8772, taxPercent: 14, showPackageOverview: true });
+    expect(plan.milestones[1]).toMatchObject({ title: 'To start stimulation of a SM', scheduledAmount: 6228, showPackageOverview: false });
+  });
+
+  it('sums the milestones back up to the package listed price', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule);
+    expect(computeMilestonesScheduledTotal(plan.milestones)).toBe(40000);
+  });
+
+  it('round-trips through normalization, assigning ids where missing', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+    const normalized = normalizeExpectedExpensesData(JSON.parse(JSON.stringify(plan)));
+    expect(normalized).toEqual(plan);
+    expect(normalizeExpectedExpensesData(null)).toBeNull();
+  });
+
+  it('edits a milestone field, parsing numeric fields and leaving text fields as-is', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+    const edited = setMilestoneField(plan.milestones[1], 'scheduledAmount', '6 500,50'.replace(' ', ''));
+    expect(edited.scheduledAmount).toBe(6500.5);
+    expect(setMilestoneField(plan.milestones[1], 'title', 'Renamed step').title).toBe('Renamed step');
+  });
+
+  it('adds, edits, and removes an additional service on a milestone', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+    const deposit = makeCustomEntry({ name: 'Deposit for transportation of SM', price: 300 });
+    let milestone = addMilestoneAdditionalService(plan.milestones[1], deposit);
+    expect(milestone.additionalServices).toHaveLength(1);
+
+    milestone = updateMilestoneAdditionalServiceField(milestone, deposit.id, 'price', '350');
+    expect(milestone.additionalServices[0].price).toBe(350);
+
+    milestone = removeMilestoneAdditionalService(milestone, deposit.id);
+    expect(milestone.additionalServices).toHaveLength(0);
+  });
+
+  it('computes the amount due for a milestone exactly like the "To start the program" sample invoice (8772 taxed at 14%)', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+    const catalogItemsById = new Map();
+    const additionalRows = resolveMilestoneAdditionalRows(plan.milestones[0], catalogItemsById);
+    const subtotal = computeMilestoneSubtotal(plan.milestones[0], additionalRows);
+    expect(subtotal).toBe(8772);
+    expect(computeMilestoneAmountDue(subtotal, plan.milestones[0].taxPercent)).toBeCloseTo(10000.08);
+  });
+
+  it('adds extra services into the amount due, matching the Mullins sample (13000 scheduled + 2500 PGS, taxed at 13%)', () => {
+    const plan = buildExpectedExpensesPlan(
+      { ...pkg, listedPrice: 41500 },
+      { payments: [{ title: 'To start the program', amount: 13000 }] },
+      { taxPercent: 13 },
+    );
+    const pgs = makeCustomEntry({ name: 'PGS of 24 chromosomes', price: 2500 });
+    const milestone = addMilestoneAdditionalService(plan.milestones[0], pgs);
+    const catalogItemsById = new Map();
+    const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById);
+    const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
+    expect(subtotal).toBe(15500);
+    expect(computeMilestoneAmountDue(subtotal, milestone.taxPercent)).toBeCloseTo(17515);
+  });
+
+  it('resolves package overview rows by name, without prices, following the catalog', () => {
+    const catalogItemsById = new Map([
+      ['1', { id: '1', name: 'Program coordination and support', price: 5000 }],
+      ['2', { id: '2', name: 'Surrogacy document preparation', price: 350 }],
+    ]);
+    const plan = buildExpectedExpensesPlan(pkg, schedule);
+    const rows = resolvePackageOverviewRows(plan.packageSnapshot.children.slice(0, 2), catalogItemsById);
+    expect(rows.map(row => row.name)).toEqual(['Program coordination and support', 'Surrogacy document preparation']);
+  });
+});

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -1,9 +1,21 @@
 // Shared helpers for the admin invoice builder (InvoiceBuilderPage + InvoicePdfDocument).
 //
-// invoiceServices / recentServices rows are stored as plain strings:
-//   "id15"                              -> a service from the main budget catalog (budget/items), by id
-//   "Deposit for transportation of SM || 300" -> a custom one-off service, "Name || Price"
-// "||" is used instead of "-" as the separator so it never collides with a dash inside a name.
+// invoiceServices / recentServices rows are stored as small JSON objects (an "entry"):
+//   { id, kind: 'item', catalogId }                 -> a live reference to a budget/items row
+//   { id, kind: 'item', catalogId, customized: true, name?, description?, price? }
+//                                                     -> the same reference, but with one or more
+//                                                        fields pinned to a local value instead of
+//                                                        following the shared budget catalog
+//   { id, kind: 'custom', name, price, description? } -> a one-off line with no catalog link
+//   { id, kind: 'package', catalogId, children: [...] } -> a whole budget/packages program, its
+//                                                        line items copied in as child entries
+//                                                        (each child is itself an 'item' or 'custom'
+//                                                        entry). Editing/removing/reordering a
+//                                                        child, or renaming the package, flips
+//                                                        `customized: true` on the package.
+//
+// Older data may still contain plain strings ("id15", "Name || Price") - normalizeServiceEntry
+// upgrades those to the object shape on load, so the rest of the app only ever sees objects.
 
 import { getItemDisplayAmount } from './budgetCatalogUtils';
 
@@ -12,12 +24,19 @@ const CATALOG_ID_PREFIX = 'id';
 
 const pad2 = value => String(value).padStart(2, '0');
 
+const toNumber = value => {
+  const parsed = Number(String(value ?? '').replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const createEntryId = () => `entry-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`;
+
 export const normalizeInvoiceData = raw => ({
   beneficiaries: Array.isArray(raw?.beneficiaries) ? raw.beneficiaries : [],
   beneficiaryIds: Array.isArray(raw?.beneficiaryIds) ? raw.beneficiaryIds.map(String) : [],
   customers: Array.isArray(raw?.customers) ? raw.customers : [],
-  recentServices: Array.isArray(raw?.recentServices) ? raw.recentServices : [],
-  invoiceServices: Array.isArray(raw?.invoiceServices) ? raw.invoiceServices : [],
+  recentServices: normalizeServiceEntries(raw?.recentServices),
+  invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
   notes: Array.isArray(raw?.notes) ? raw.notes : [],
   taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
 });
@@ -44,75 +63,263 @@ export const reorderBeneficiaryIds = (beneficiaryIds, activeId) => {
   return [id, ...rest];
 };
 
-export const makeCatalogServiceEntry = catalogId => `${CATALOG_ID_PREFIX}${catalogId}`;
+// --- Entry constructors ------------------------------------------------------
 
-export const makeCustomServiceEntry = (name, price) => `${String(name || '').trim()} ${SERVICE_PRICE_SEPARATOR} ${price}`;
+export const makeCatalogItemEntry = (catalogId, { id } = {}) => ({
+  id: id || createEntryId(),
+  kind: 'item',
+  catalogId: String(catalogId),
+});
 
-// Splits a stored service row into either a catalog reference or a custom name/price pair.
-export const parseServiceEntry = entry => {
-  const text = String(entry ?? '').trim();
-  if (text.includes(SERVICE_PRICE_SEPARATOR)) {
-    const [namePart, ...priceParts] = text.split(SERVICE_PRICE_SEPARATOR);
-    const priceText = priceParts.join(SERVICE_PRICE_SEPARATOR).trim();
-    const price = Number(priceText.replace(',', '.'));
-    return {
-      isCatalog: false,
-      name: namePart.trim(),
-      price: Number.isFinite(price) ? price : 0,
-    };
+export const makeCustomEntry = ({ name = '', price = 0, description = '' } = {}, { id } = {}) => ({
+  id: id || createEntryId(),
+  kind: 'custom',
+  name: String(name || '').trim(),
+  price: toNumber(price),
+  ...(String(description || '').trim() ? { description: String(description).trim() } : {}),
+});
+
+// pkg: a budget/packages record ({ id, children: [itemId, ...] }). Its children are copied in as
+// plain catalog-item entries - editing/removing any of them below marks the package as customized.
+export const makeCatalogPackageEntry = (pkg, { id } = {}) => ({
+  id: id || createEntryId(),
+  kind: 'package',
+  catalogId: String(pkg?.id ?? ''),
+  children: (Array.isArray(pkg?.children) ? pkg.children : []).map(childId => makeCatalogItemEntry(childId)),
+});
+
+// Deep-clones an entry (and, for packages, its children) with fresh ids - used whenever a
+// recent/suggested entry is re-added, so two invoice rows never share a React key.
+export const cloneEntryWithNewId = entry => {
+  if (!entry || typeof entry !== 'object') return entry;
+  const clone = { ...entry, id: createEntryId() };
+  if (entry.kind === 'package') {
+    clone.children = (Array.isArray(entry.children) ? entry.children : []).map(cloneEntryWithNewId);
   }
-  const catalogMatch = /^id(.+)$/i.exec(text);
-  if (catalogMatch) {
-    return { isCatalog: true, catalogId: catalogMatch[1] };
-  }
-  return { isCatalog: false, name: text, price: 0 };
+  return clone;
 };
 
-// Resolves a stored service row to its display name + EUR price, looking up
-// catalog references in the budget catalog (budget/items, keyed by id).
-export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) => {
-  const parsed = parseServiceEntry(entry);
-  if (parsed.isCatalog) {
-    const item = catalogItemsById?.get?.(String(parsed.catalogId));
-    if (!item) {
-      return {
-        key: entry, isCatalog: true, catalogId: parsed.catalogId, missing: true, name: `Unknown catalog service (id${parsed.catalogId})`, price: 0,
-      };
-    }
-    const amount = getItemDisplayAmount(item, { ...priceContext, itemsById: catalogItemsById });
+// --- Legacy string parsing / normalization ------------------------------------------------------
+
+// "id15" -> catalog reference · "Name || Price" -> a custom one-off line.
+export const parseLegacyServiceString = raw => {
+  const text = String(raw ?? '').trim();
+  if (text.includes(SERVICE_PRICE_SEPARATOR)) {
+    const [namePart, ...priceParts] = text.split(SERVICE_PRICE_SEPARATOR);
+    return { kind: 'custom', name: namePart.trim(), price: toNumber(priceParts.join(SERVICE_PRICE_SEPARATOR)) };
+  }
+  const catalogMatch = new RegExp(`^${CATALOG_ID_PREFIX}(.+)$`, 'i').exec(text);
+  if (catalogMatch) return { kind: 'item', catalogId: catalogMatch[1] };
+  return { kind: 'custom', name: text, price: 0 };
+};
+
+// Upgrades a raw stored row (legacy string, or an already-object entry that may be missing an id
+// or have stale shape) into the canonical entry object. Idempotent.
+export const normalizeServiceEntry = raw => {
+  if (typeof raw === 'string') {
+    const parsed = parseLegacyServiceString(raw);
+    return parsed.kind === 'item' ? makeCatalogItemEntry(parsed.catalogId) : makeCustomEntry(parsed);
+  }
+  if (!raw || typeof raw !== 'object') return makeCustomEntry({});
+
+  const id = raw.id || createEntryId();
+
+  if (raw.kind === 'package') {
     return {
-      key: entry,
-      isCatalog: true,
-      catalogId: parsed.catalogId,
-      missing: false,
-      name: item.name || `id${parsed.catalogId}`,
-      description: item.description || '',
-      price: amount == null ? 0 : amount,
+      id,
+      kind: 'package',
+      catalogId: String(raw.catalogId ?? ''),
+      ...(raw.customized ? { customized: true } : {}),
+      ...(raw.name !== undefined ? { name: raw.name } : {}),
+      ...(raw.description !== undefined ? { description: raw.description } : {}),
+      ...(raw.priceOverride !== undefined && raw.priceOverride !== null && raw.priceOverride !== ''
+        ? { priceOverride: toNumber(raw.priceOverride) }
+        : {}),
+      children: normalizeServiceEntries(raw.children),
     };
   }
+
+  if (raw.kind === 'custom') {
+    return {
+      id,
+      kind: 'custom',
+      name: raw.name || '',
+      price: toNumber(raw.price),
+      ...(raw.description ? { description: raw.description } : {}),
+    };
+  }
+
+  // Default / kind === 'item'.
   return {
-    key: entry, isCatalog: false, missing: false, name: parsed.name, price: parsed.price,
+    id,
+    kind: 'item',
+    catalogId: String(raw.catalogId ?? ''),
+    ...(raw.customized ? { customized: true } : {}),
+    ...(raw.name !== undefined ? { name: raw.name } : {}),
+    ...(raw.description !== undefined ? { description: raw.description } : {}),
+    ...(raw.price !== undefined && raw.price !== null && raw.price !== '' ? { price: toNumber(raw.price) } : {}),
+  };
+};
+
+export const normalizeServiceEntries = list => (Array.isArray(list) ? list.map(normalizeServiceEntry) : []);
+
+// --- Editing ------------------------------------------------------------
+
+// Applies a local override for one field of an entry, without ever touching the shared budget
+// catalog. On catalog-linked entries (kind 'item'/'package') this flips `customized: true`; on
+// packages only name/description/price (stored as priceOverride) are settable this way, since a
+// package's own line items are edited individually via the package-children helpers below.
+export const setEntryField = (entry, field, value) => {
+  if (!entry) return entry;
+  if (entry.kind === 'custom') {
+    return { ...entry, [field]: field === 'price' ? toNumber(value) : value };
+  }
+  if (entry.kind === 'package') {
+    if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
+    if (field === 'name' || field === 'description') return { ...entry, [field]: value, customized: true };
+    return entry;
+  }
+  return { ...entry, [field]: field === 'price' ? toNumber(value) : value, customized: true };
+};
+
+// Drops all local overrides on a catalog-item entry, reverting it to a plain live reference.
+export const resetItemEntryOverrides = entry => (entry?.kind === 'item'
+  ? { id: entry.id, kind: 'item', catalogId: entry.catalogId }
+  : entry);
+
+// Reverts a package entry back to a fresh snapshot of the given budget/packages record, dropping
+// every local override and child edit.
+export const resetPackageEntryToCatalog = (entry, pkg) => (entry?.kind === 'package'
+  ? makeCatalogPackageEntry(pkg, { id: entry.id })
+  : entry);
+
+export const updatePackageChildField = (entry, childId, field, value) => {
+  if (entry?.kind !== 'package') return entry;
+  const children = (entry.children || []).map(child => (child.id === childId ? setEntryField(child, field, value) : child));
+  return { ...entry, children, customized: true };
+};
+
+export const removePackageChild = (entry, childId) => {
+  if (entry?.kind !== 'package') return entry;
+  return { ...entry, children: (entry.children || []).filter(child => child.id !== childId), customized: true };
+};
+
+export const movePackageChild = (entry, childId, offset) => {
+  if (entry?.kind !== 'package') return entry;
+  const children = [...(entry.children || [])];
+  const index = children.findIndex(child => child.id === childId);
+  const targetIndex = index + offset;
+  if (index === -1 || targetIndex < 0 || targetIndex >= children.length) return entry;
+  [children[index], children[targetIndex]] = [children[targetIndex], children[index]];
+  return { ...entry, children, customized: true };
+};
+
+export const addCustomChildToPackage = (entry, fields) => {
+  if (entry?.kind !== 'package') return entry;
+  return { ...entry, children: [...(entry.children || []), makeCustomEntry(fields)], customized: true };
+};
+
+export const addCatalogChildToPackage = (entry, catalogId) => {
+  if (entry?.kind !== 'package') return entry;
+  const alreadyIncluded = (entry.children || []).some(child => child.kind === 'item' && String(child.catalogId) === String(catalogId));
+  if (alreadyIncluded) return entry;
+  return { ...entry, children: [...(entry.children || []), makeCatalogItemEntry(catalogId)], customized: true };
+};
+
+// --- Queries ------------------------------------------------------------
+
+export const isEntryCustomized = entry => (entry?.kind === 'custom' ? true : Boolean(entry?.customized));
+
+// A stable identity for an entry, ignoring its id - used to dedupe "recent services" chips and to
+// stop the same catalog item/package being added to the invoice twice.
+export const getEntryIdentityKey = entry => {
+  if (!entry) return '';
+  if (entry.kind === 'package') return `package:${entry.catalogId}`;
+  if (entry.kind === 'item') return `item:${entry.catalogId}`;
+  return `custom:${entry.name || ''}:${entry.price || 0}:${entry.description || ''}`;
+};
+
+// --- Resolving entries to display rows ------------------------------------------------------
+
+// priceContext: { itemsById, rates, packagesById } - the same itemsById/rates shape
+// BudgetPdfDocument/BudgetPage use to resolve formula prices against NBU exchange rates, plus an
+// optional packagesById map (budget/packages, keyed by id) so an un-renamed package entry keeps
+// following its catalog name/description the same way an un-edited item entry does. A package's
+// `children` are always a frozen snapshot taken when it was added - they never live-track the
+// catalog, since that's the whole point of pinning a specific set of services to an invoice.
+export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) => {
+  if (entry?.kind === 'package') {
+    const pkg = priceContext.packagesById?.get?.(String(entry.catalogId));
+    const children = Array.isArray(entry.children) ? entry.children : [];
+    const resolvedChildren = children.map(child => resolveServiceRow(child, catalogItemsById, priceContext));
+    const childrenTotal = resolvedChildren.reduce((sum, row) => sum + (Number(row.price) || 0), 0);
+    const hasPriceOverride = entry.priceOverride !== undefined && entry.priceOverride !== null;
+    return {
+      key: entry.id,
+      id: entry.id,
+      kind: 'package',
+      catalogId: entry.catalogId,
+      missing: !pkg,
+      isCustomized: Boolean(entry.customized),
+      name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
+      description: entry.description ?? pkg?.description ?? '',
+      price: hasPriceOverride ? Number(entry.priceOverride) || 0 : childrenTotal,
+      childrenTotal,
+      hasPriceOverride,
+      children: resolvedChildren,
+    };
+  }
+
+  if (entry?.kind === 'custom') {
+    return {
+      key: entry.id,
+      id: entry.id,
+      kind: 'custom',
+      missing: false,
+      isCustomized: true,
+      name: entry.name || '',
+      description: entry.description || '',
+      price: Number(entry.price) || 0,
+    };
+  }
+
+  const catalogId = entry?.catalogId;
+  const item = catalogItemsById?.get?.(String(catalogId));
+  const catalogAmount = item ? getItemDisplayAmount(item, { ...priceContext, itemsById: catalogItemsById }) : null;
+  return {
+    key: entry?.id,
+    id: entry?.id,
+    kind: 'item',
+    catalogId,
+    missing: !item,
+    isCustomized: Boolean(entry?.customized),
+    name: entry?.name ?? item?.name ?? `Unknown catalog service (id${catalogId})`,
+    description: entry?.description ?? item?.description ?? '',
+    price: entry?.price ?? (catalogAmount == null ? 0 : catalogAmount),
   };
 };
 
 export const resolveInvoiceServiceRows = (invoiceServices, catalogItemsById, priceContext = {}) =>
   (Array.isArray(invoiceServices) ? invoiceServices : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
+// Subtotal only walks top-level rows: a package row's price already sums its children, so nested
+// children are never double-counted.
 export const computeInvoiceSubtotal = rows => rows.reduce((sum, row) => sum + (Number(row.price) || 0), 0);
 
 export const computeInvoiceTotal = (subtotal, taxPercent) => subtotal * (1 + (Number(taxPercent) || 0) / 100);
 
-// After an invoice is generated, its services move to the front of recentServices
-// (same order, deduped) so they're the first quick-pick choices next time.
+// After an invoice is generated, its top-level services move to the front of recentServices (same
+// order, deduped by identity) so they're the first quick-pick choices next time.
 export const reorderRecentServices = (recentServices, invoiceServices) => {
   const seen = new Set();
   const used = [];
   (Array.isArray(invoiceServices) ? invoiceServices : []).forEach(entry => {
-    if (!entry || seen.has(entry)) return;
-    seen.add(entry);
+    const key = getEntryIdentityKey(entry);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
     used.push(entry);
   });
-  const rest = (Array.isArray(recentServices) ? recentServices : []).filter(entry => !seen.has(entry));
+  const rest = (Array.isArray(recentServices) ? recentServices : []).filter(entry => !seen.has(getEntryIdentityKey(entry)));
   return [...used, ...rest];
 };
 

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -1,22 +1,35 @@
 import {
+  addCatalogChildToPackage,
+  addCustomChildToPackage,
   applyPaymentPurposePlaceholders,
   buildCaseTitle,
   buildPayerLocation,
   buildPayerName,
+  cloneEntryWithNewId,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
   generateInvoiceIdentifiers,
   getActiveBeneficiary,
+  getEntryIdentityKey,
   getTodayYmd,
-  makeCatalogServiceEntry,
-  makeCustomServiceEntry,
+  isEntryCustomized,
   isInvoiceDataShape,
+  makeCatalogItemEntry,
+  makeCatalogPackageEntry,
+  makeCustomEntry,
+  movePackageChild,
   normalizeInvoiceData,
-  parseServiceEntry,
+  normalizeServiceEntry,
+  parseLegacyServiceString,
+  removePackageChild,
   reorderBeneficiaryIds,
   reorderRecentServices,
+  resetItemEntryOverrides,
+  resetPackageEntryToCatalog,
   resolveInvoiceServiceRows,
   resolveServiceRow,
+  setEntryField,
+  updatePackageChildField,
 } from './invoiceCatalogUtils';
 
 describe('invoiceCatalogUtils', () => {
@@ -32,7 +45,6 @@ describe('invoiceCatalogUtils', () => {
       taxPercent: 0,
     });
   });
-
 
   it('validates the invoice upload shape before normalization can empty missing collections', () => {
     expect(isInvoiceDataShape({})).toBe(false);
@@ -61,61 +73,240 @@ describe('invoiceCatalogUtils', () => {
     expect(reorderBeneficiaryIds(['a', 'b'], 'a')).toEqual(['a', 'b']);
   });
 
-  it('parses catalog-referenced service rows ("idNN")', () => {
-    expect(parseServiceEntry('id15')).toEqual({ isCatalog: true, catalogId: '15' });
-  });
+  describe('legacy string upgrade', () => {
+    it('parses catalog-referenced legacy rows ("idNN")', () => {
+      expect(parseLegacyServiceString('id15')).toEqual({ kind: 'item', catalogId: '15' });
+    });
 
-  it('parses custom "Name || Price" service rows', () => {
-    expect(parseServiceEntry('Deposit for transportation of SM || 300')).toEqual({
-      isCatalog: false,
-      name: 'Deposit for transportation of SM',
-      price: 300,
+    it('parses legacy "Name || Price" rows as custom', () => {
+      expect(parseLegacyServiceString('Deposit for transportation of SM || 300')).toEqual({
+        kind: 'custom', name: 'Deposit for transportation of SM', price: 300,
+      });
+    });
+
+    it('upgrades a legacy string into the canonical object entry', () => {
+      const item = normalizeServiceEntry('id15');
+      expect(item.kind).toBe('item');
+      expect(item.catalogId).toBe('15');
+      expect(typeof item.id).toBe('string');
+
+      const custom = normalizeServiceEntry('Extra fee || 50');
+      expect(custom.kind).toBe('custom');
+      expect(custom.name).toBe('Extra fee');
+      expect(custom.price).toBe(50);
+    });
+
+    it('normalizes a whole invoiceServices/recentServices array from a legacy upload', () => {
+      const data = normalizeInvoiceData({
+        beneficiaries: [], beneficiaryIds: [], customers: [], notes: [],
+        recentServices: ['id15'],
+        invoiceServices: ['id15', 'Deposit for transportation of SM || 300'],
+      });
+      expect(data.invoiceServices).toHaveLength(2);
+      expect(data.invoiceServices[0]).toMatchObject({ kind: 'item', catalogId: '15' });
+      expect(data.invoiceServices[1]).toMatchObject({ kind: 'custom', name: 'Deposit for transportation of SM', price: 300 });
+    });
+
+    it('is idempotent on an already-normalized entry (keeps its id)', () => {
+      const entry = makeCatalogItemEntry('15');
+      expect(normalizeServiceEntry(entry)).toEqual(entry);
     });
   });
 
-  it('round-trips catalog and custom service entries', () => {
-    expect(makeCatalogServiceEntry('15')).toBe('id15');
-    expect(makeCustomServiceEntry('Extra fee', 50)).toBe('Extra fee || 50');
-  });
+  describe('entry constructors and cloning', () => {
+    it('builds catalog item / custom / package entries with stable, unique ids', () => {
+      const item = makeCatalogItemEntry('15');
+      expect(item).toMatchObject({ kind: 'item', catalogId: '15' });
 
-  it('resolves a catalog service row against the budget catalog', () => {
-    const catalogItemsById = new Map([['15', { id: '15', name: 'Scheduled payment', price: 3000 }]]);
-    expect(resolveServiceRow('id15', catalogItemsById)).toEqual({
-      key: 'id15', isCatalog: true, catalogId: '15', missing: false, name: 'Scheduled payment', description: '', price: 3000,
+      const custom = makeCustomEntry({ name: 'Extra fee', price: 50 });
+      expect(custom).toMatchObject({ kind: 'custom', name: 'Extra fee', price: 50 });
+
+      const pkg = makeCatalogPackageEntry({ id: 'full-program', children: ['1', '2'] });
+      expect(pkg.kind).toBe('package');
+      expect(pkg.catalogId).toBe('full-program');
+      expect(pkg.children).toEqual([
+        { id: pkg.children[0].id, kind: 'item', catalogId: '1' },
+        { id: pkg.children[1].id, kind: 'item', catalogId: '2' },
+      ]);
+    });
+
+    it('clones an entry (and a package entry deeply) with fresh ids', () => {
+      const pkg = makeCatalogPackageEntry({ id: 'p1', children: ['1', '2'] });
+      const clone = cloneEntryWithNewId(pkg);
+      expect(clone.id).not.toBe(pkg.id);
+      expect(clone.children[0].id).not.toBe(pkg.children[0].id);
+      expect(clone.children[1].id).not.toBe(pkg.children[1].id);
+      expect(clone.catalogId).toBe(pkg.catalogId);
     });
   });
 
+  describe('editing overrides without touching the catalog', () => {
+    it('overrides one field of a catalog item and flags it customized, keeping the catalog link', () => {
+      const item = makeCatalogItemEntry('15');
+      const priced = setEntryField(item, 'price', '450,50');
+      expect(priced).toMatchObject({ kind: 'item', catalogId: '15', price: 450.5, customized: true });
+      expect(isEntryCustomized(priced)).toBe(true);
+      // Name was never touched, so it still isn't stored locally (keeps following the catalog).
+      expect(priced.name).toBeUndefined();
+    });
 
+    it('reverts an overridden item back to a plain catalog reference', () => {
+      const item = makeCatalogItemEntry('15');
+      const overridden = setEntryField(item, 'name', 'Renamed for this invoice');
+      expect(resetItemEntryOverrides(overridden)).toEqual({ id: item.id, kind: 'item', catalogId: '15' });
+    });
 
-  it('resolves catalog invoice rows with budget display conversion and formula rates', () => {
-    const catalogItemsById = new Map([
-      ['22', { id: '22', name: 'USD compensation', price: 23000 }],
-      ['30', { id: '30', name: 'Formula price', price: '=USD/EUR*100' }],
-    ]);
-    expect(resolveServiceRow('id22', catalogItemsById).price).toBeCloseTo(21160);
-    expect(resolveServiceRow('id30', catalogItemsById, { rates: { usd: 40, eur: 50 } }).price).toBeCloseTo(80);
+    it('a custom entry is always considered customized', () => {
+      expect(isEntryCustomized(makeCustomEntry({ name: 'X', price: 1 }))).toBe(true);
+    });
+
+    it('overrides a package price and flags it customized, without touching its children', () => {
+      const pkg = makeCatalogPackageEntry({ id: 'p1', children: ['1'] });
+      const overridden = setEntryField(pkg, 'price', '999');
+      expect(overridden.priceOverride).toBe(999);
+      expect(overridden.customized).toBe(true);
+      expect(overridden.children).toEqual(pkg.children);
+    });
   });
 
-  it('flags a catalog reference that no longer exists', () => {
-    const row = resolveServiceRow('id999', new Map());
-    expect(row.missing).toBe(true);
+  describe('package children (add/edit/remove/reorder -> customized)', () => {
+    const basePackage = () => makeCatalogPackageEntry({ id: 'p1', children: ['1', '2'] });
+
+    it('removing a child flags the package as customized', () => {
+      const pkg = basePackage();
+      const [firstChild] = pkg.children;
+      const next = removePackageChild(pkg, firstChild.id);
+      expect(next.children).toHaveLength(1);
+      expect(next.customized).toBe(true);
+    });
+
+    it('editing a child field flags both the child and the package as customized', () => {
+      const pkg = basePackage();
+      const [firstChild] = pkg.children;
+      const next = updatePackageChildField(pkg, firstChild.id, 'price', '120');
+      expect(next.customized).toBe(true);
+      expect(next.children[0]).toMatchObject({ price: 120, customized: true });
+      expect(next.children[1]).toEqual(pkg.children[1]);
+    });
+
+    it('reorders two children by id', () => {
+      const pkg = basePackage();
+      const [firstChild, secondChild] = pkg.children;
+      const next = movePackageChild(pkg, firstChild.id, 1);
+      expect(next.children.map(child => child.id)).toEqual([secondChild.id, firstChild.id]);
+    });
+
+    it('adds a custom line and a catalog item into a package, both flagging it customized', () => {
+      const pkg = basePackage();
+      const withCustom = addCustomChildToPackage(pkg, { name: 'Extra', price: 10 });
+      expect(withCustom.children).toHaveLength(3);
+      expect(withCustom.customized).toBe(true);
+
+      const withCatalogChild = addCatalogChildToPackage(withCustom, '3');
+      expect(withCatalogChild.children).toHaveLength(4);
+      // Adding an item already present is a no-op.
+      expect(addCatalogChildToPackage(withCatalogChild, '3').children).toHaveLength(4);
+    });
+
+    it('reverts a customized package back to a fresh catalog snapshot', () => {
+      const pkg = basePackage();
+      const edited = removePackageChild(setEntryField(pkg, 'name', 'Renamed'), pkg.children[0].id);
+      const reverted = resetPackageEntryToCatalog(edited, { id: 'p1', children: ['1', '2'] });
+      expect(reverted.id).toBe(pkg.id);
+      expect(reverted.customized).toBeUndefined();
+      expect(reverted.children.map(child => child.catalogId)).toEqual(['1', '2']);
+    });
   });
 
-  it('computes subtotal and tax-inclusive total from resolved rows', () => {
-    const catalogItemsById = new Map([['15', { id: '15', name: 'Scheduled payment', price: 3000 }]]);
-    const rows = resolveInvoiceServiceRows(
-      ['id15', 'Deposit for transportation of SM || 300', 'Deposit for medical expenses of SM || 300'],
-      catalogItemsById,
-    );
-    const subtotal = computeInvoiceSubtotal(rows);
-    expect(subtotal).toBe(3600);
-    expect(computeInvoiceTotal(subtotal, 14)).toBeCloseTo(4104);
+  describe('resolving entries to display rows', () => {
+    it('resolves a catalog item row against the budget catalog', () => {
+      const catalogItemsById = new Map([['15', { id: '15', name: 'Scheduled payment', price: 3000, description: 'Milestone 1' }]]);
+      const row = resolveServiceRow(makeCatalogItemEntry('15'), catalogItemsById);
+      expect(row).toMatchObject({
+        kind: 'item', catalogId: '15', missing: false, isCustomized: false, name: 'Scheduled payment', description: 'Milestone 1', price: 3000,
+      });
+    });
+
+    it('an overridden price wins over the catalog price, but the name keeps following the catalog', () => {
+      const catalogItemsById = new Map([['15', { id: '15', name: 'Scheduled payment', price: 3000 }]]);
+      const entry = setEntryField(makeCatalogItemEntry('15'), 'price', 3500);
+      const row = resolveServiceRow(entry, catalogItemsById);
+      expect(row.name).toBe('Scheduled payment');
+      expect(row.price).toBe(3500);
+      expect(row.isCustomized).toBe(true);
+    });
+
+    it('resolves catalog rows with USD conversion and formula rates', () => {
+      const catalogItemsById = new Map([
+        ['22', { id: '22', name: 'USD compensation', price: 23000 }],
+        ['30', { id: '30', name: 'Formula price', price: '=USD/EUR*100' }],
+      ]);
+      expect(resolveServiceRow(makeCatalogItemEntry('22'), catalogItemsById).price).toBeCloseTo(21160);
+      expect(resolveServiceRow(makeCatalogItemEntry('30'), catalogItemsById, { rates: { usd: 40, eur: 50 } }).price).toBeCloseTo(80);
+    });
+
+    it('flags a catalog reference that no longer exists', () => {
+      expect(resolveServiceRow(makeCatalogItemEntry('999'), new Map()).missing).toBe(true);
+    });
+
+    it('resolves a package row as the sum of its resolved children, with a name that follows the catalog until overridden', () => {
+      const catalogItemsById = new Map([
+        ['1', { id: '1', name: 'Consultation', price: 300 }],
+        ['2', { id: '2', name: 'Legal support', price: 700 }],
+      ]);
+      const packagesById = new Map([['p1', { id: 'p1', name: 'Full program', children: ['1', '2'] }]]);
+      const pkg = makeCatalogPackageEntry({ id: 'p1', children: ['1', '2'] });
+
+      const row = resolveServiceRow(pkg, catalogItemsById, { packagesById });
+      expect(row.name).toBe('Full program');
+      expect(row.price).toBe(1000);
+      expect(row.children).toHaveLength(2);
+      expect(row.isCustomized).toBe(false);
+
+      const renamed = setEntryField(pkg, 'name', 'Custom bundle for Amny');
+      expect(resolveServiceRow(renamed, catalogItemsById, { packagesById }).name).toBe('Custom bundle for Amny');
+    });
+
+    it('an explicit package price override replaces the children total, which is still exposed for reference', () => {
+      const catalogItemsById = new Map([['1', { id: '1', name: 'Consultation', price: 300 }]]);
+      const pkg = setEntryField(makeCatalogPackageEntry({ id: 'p1', children: ['1'] }), 'price', 250);
+      const row = resolveServiceRow(pkg, catalogItemsById);
+      expect(row.price).toBe(250);
+      expect(row.childrenTotal).toBe(300);
+      expect(row.hasPriceOverride).toBe(true);
+    });
+
+    it('computes subtotal/total without double-counting package children', () => {
+      const catalogItemsById = new Map([
+        ['15', { id: '15', name: 'Scheduled payment', price: 3000 }],
+        ['1', { id: '1', name: 'Consultation', price: 300 }],
+      ]);
+      const invoiceServices = [
+        makeCatalogItemEntry('15'),
+        makeCatalogPackageEntry({ id: 'p1', children: ['1'] }),
+        makeCustomEntry({ name: 'Extra fee', price: 300 }),
+      ];
+      const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById);
+      const subtotal = computeInvoiceSubtotal(rows);
+      expect(subtotal).toBe(3600);
+      expect(computeInvoiceTotal(subtotal, 14)).toBeCloseTo(4104);
+    });
   });
 
-  it('moves used services to the front of recentServices, deduped', () => {
-    const recentServices = ['id1', 'id2', 'id3'];
-    const invoiceServices = ['id3', 'id2'];
-    expect(reorderRecentServices(recentServices, invoiceServices)).toEqual(['id3', 'id2', 'id1']);
+  describe('identity keys and recent services', () => {
+    it('gives catalog/package/custom entries a stable identity independent of their id', () => {
+      expect(getEntryIdentityKey(makeCatalogItemEntry('15'))).toBe('item:15');
+      expect(getEntryIdentityKey(makeCatalogPackageEntry({ id: 'p1', children: [] }))).toBe('package:p1');
+      expect(getEntryIdentityKey(makeCustomEntry({ name: 'Extra', price: 50 })))
+        .toBe(getEntryIdentityKey(makeCustomEntry({ name: 'Extra', price: 50 })));
+    });
+
+    it('moves used services to the front of recentServices, deduped by identity', () => {
+      const recentServices = [makeCatalogItemEntry('1'), makeCatalogItemEntry('2'), makeCatalogItemEntry('3')];
+      const invoiceServices = [makeCatalogItemEntry('3'), makeCatalogItemEntry('2')];
+      const reordered = reorderRecentServices(recentServices, invoiceServices);
+      expect(reordered.map(entry => entry.catalogId)).toEqual(['3', '2', '1']);
+    });
   });
 
   it('builds the payer name and "Case of ..." title from customers', () => {
@@ -131,8 +322,6 @@ describe('invoiceCatalogUtils', () => {
       invoiceDate: '23.05.2026',
     });
   });
-
-
 
   it('uses local date components for the default invoice date', () => {
     const RealDate = Date;

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -1,0 +1,93 @@
+// Shared visual language for every @react-pdf/renderer export in the app (BudgetPdfDocument,
+// InvoicePdfDocument, and the surrogate/donor ProfilePdfDocument in smallCard/renderTopBlock.js).
+// Each document keeps its own StyleSheet and layout, but pulls its palette, type scale and the
+// header/footer/watermark building blocks from here so the three read as one product.
+
+export const PDF_COLOR = {
+  ink: '#2b2118',
+  muted: '#786a5c',
+  soft: '#9a6b48',
+  accent: '#8a5527',
+  accentStrong: '#6b3f18',
+  line: '#e6d7c0',
+  lineSoft: '#efe3d1',
+  headBg: '#f3e6d1',
+  rowAlt: '#faf3e6',
+  cardBg: '#fdf8ef',
+  totalBg: '#ead9b8',
+  watermark: '#f1e2c6',
+  white: '#ffffff',
+};
+
+export const PDF_FONT = {
+  base: 'Helvetica',
+  bold: 'Helvetica-Bold',
+};
+
+// The built-in Helvetica font only covers WinAnsi glyphs, so every document should run its text
+// through this before rendering (swaps the handful of characters that would otherwise be blank).
+export const sanitizePdfText = value => String(value ?? '')
+  .replace(/№/g, 'No.')
+  .replace(/[’‘]/g, "'")
+  .replace(/[“”]/g, '"')
+  .replace(/[–—]/g, '-')
+  .replace(/[✓✔]/g, 'x')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+// Common building blocks every document's own StyleSheet.create(...) can spread in.
+export const pdfBaseStyles = {
+  page: {
+    paddingTop: 44,
+    paddingBottom: 62,
+    paddingHorizontal: 44,
+    fontFamily: PDF_FONT.base,
+    fontSize: 10,
+    color: PDF_COLOR.ink,
+    backgroundColor: PDF_COLOR.white,
+  },
+  eyebrow: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 7.5,
+    letterSpacing: 1.8,
+    color: PDF_COLOR.soft,
+    textTransform: 'uppercase',
+    marginBottom: 5,
+  },
+  docTitle: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 22,
+    letterSpacing: -0.4,
+    color: PDF_COLOR.ink,
+  },
+  footer: {
+    position: 'absolute',
+    left: 44,
+    right: 44,
+    bottom: 24,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.line,
+    borderTopStyle: 'solid',
+    paddingTop: 8,
+  },
+  footerColumn: {
+    maxWidth: 260,
+  },
+  footerText: {
+    fontSize: 7.5,
+    color: PDF_COLOR.muted,
+    lineHeight: 1.4,
+  },
+  footerPage: {
+    fontSize: 7.5,
+    color: PDF_COLOR.muted,
+  },
+  watermarkText: {
+    position: 'absolute',
+    fontFamily: PDF_FONT.bold,
+    color: PDF_COLOR.watermark,
+    opacity: 0.9,
+  },
+};

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -4,12 +4,12 @@ import {
   Document,
   Image,
   Page,
-  Font,
   pdf,
   StyleSheet,
   Text,
   View,
 } from '@react-pdf/renderer';
+import { PDF_COLOR, PDF_FONT, pdfBaseStyles, sanitizePdfText } from '../pdfTheme';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
 import { btnEdit } from './btnEdit';
@@ -740,33 +740,76 @@ const extractMultiDataComments = cardData => {
   return normalized.filter(comment => comment.text);
 };
 
-Font.register({
-  family: 'NotoSans',
-  src: 'https://fonts.gstatic.com/s/notosans/v42/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d.ttf',
-});
-
 const profilePdfStyles = StyleSheet.create({
   page: {
     position: 'relative',
     paddingTop: 78,
     paddingHorizontal: 88,
     paddingBottom: 74,
-    fontFamily: 'NotoSans',
-    color: '#111',
-    backgroundColor: '#fff',
+    fontFamily: PDF_FONT.base,
+    color: PDF_COLOR.ink,
+    backgroundColor: PDF_COLOR.white,
+  },
+  eyebrow: {
+    ...pdfBaseStyles.eyebrow,
+    textAlign: 'center',
+    marginBottom: 8,
   },
   title: {
-    marginBottom: 38,
+    fontFamily: PDF_FONT.bold,
+    marginBottom: 6,
     textAlign: 'center',
     fontSize: 20,
     lineHeight: 1.25,
+    color: PDF_COLOR.ink,
   },
-  profileRows: {
-    fontSize: 17,
-    lineHeight: 1.35,
+  titleRule: {
+    alignSelf: 'center',
+    width: 64,
+    height: 2,
+    borderRadius: 1,
+    backgroundColor: PDF_COLOR.accent,
+    marginBottom: 28,
   },
-  profileRow: {
-    marginBottom: 1,
+  table: {
+    borderWidth: 1,
+    borderColor: PDF_COLOR.line,
+    borderStyle: 'solid',
+    borderRadius: 6,
+  },
+  row: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.line,
+    borderTopStyle: 'solid',
+  },
+  firstRow: {
+    borderTopWidth: 0,
+  },
+  labelCell: {
+    width: '38%',
+    backgroundColor: PDF_COLOR.headBg,
+    borderRightWidth: 1,
+    borderRightColor: PDF_COLOR.line,
+    borderRightStyle: 'solid',
+    paddingVertical: 7,
+    paddingHorizontal: 10,
+    justifyContent: 'center',
+  },
+  labelText: {
+    fontFamily: PDF_FONT.bold,
+    fontSize: 10.5,
+    color: '#4d3a26',
+  },
+  valueCell: {
+    width: '62%',
+    paddingVertical: 7,
+    paddingHorizontal: 10,
+    justifyContent: 'center',
+  },
+  valueText: {
+    fontSize: 11,
+    lineHeight: 1.4,
   },
   watermark: {
     position: 'absolute',
@@ -774,21 +817,26 @@ const profilePdfStyles = StyleSheet.create({
     top: 330,
     width: 520,
     textAlign: 'center',
+    fontFamily: PDF_FONT.bold,
     fontSize: 106,
-    color: '#dbeafa',
-    opacity: 0.72,
+    color: PDF_COLOR.watermark,
+    opacity: 0.9,
     transform: 'rotate(-42deg)',
   },
   footer: {
     position: 'absolute',
     left: 88,
     right: 88,
-    bottom: 32,
+    bottom: 28,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    color: '#777',
-    fontSize: 7,
-    lineHeight: 1.2,
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.line,
+    borderTopStyle: 'solid',
+    paddingTop: 8,
+    color: PDF_COLOR.muted,
+    fontSize: 7.5,
+    lineHeight: 1.4,
   },
   footerRight: {
     textAlign: 'right',
@@ -798,8 +846,8 @@ const profilePdfStyles = StyleSheet.create({
     paddingTop: 78,
     paddingHorizontal: 70,
     paddingBottom: 74,
-    fontFamily: 'NotoSans',
-    backgroundColor: '#fff',
+    fontFamily: PDF_FONT.base,
+    backgroundColor: PDF_COLOR.white,
   },
   profileImageWrap: {
     position: 'relative',
@@ -822,9 +870,10 @@ const profilePdfStyles = StyleSheet.create({
     top: 230,
     width: 520,
     textAlign: 'center',
+    fontFamily: PDF_FONT.bold,
     fontSize: 86,
-    color: '#dbeafa',
-    opacity: 0.72,
+    color: PDF_COLOR.watermark,
+    opacity: 0.9,
     transform: 'rotate(-42deg)',
   },
 });
@@ -1007,14 +1056,17 @@ const ProfilePdfDocument = ({ userData, photoUrls }) => {
     <Document title={`${buildName(userData) || 'Profile'} - KnowMe: Egg donor`}>
       <Page size="A4" style={profilePdfStyles.page}>
         <Text style={profilePdfStyles.watermark}>KnowMe</Text>
+        <Text style={profilePdfStyles.eyebrow}>{sanitizePdfText('KnowMe · Egg donor')}</Text>
         <Text style={profilePdfStyles.title}>
-          Surrogacy mother’s{'\n'}profile
+          {sanitizePdfText("Surrogacy mother's profile")}
         </Text>
-        <View style={profilePdfStyles.profileRows}>
-          {rows.map(([label, value]) => (
-            <Text key={label} style={profilePdfStyles.profileRow}>
-              {label}: {value}
-            </Text>
+        <View style={profilePdfStyles.titleRule} />
+        <View style={profilePdfStyles.table}>
+          {rows.map(([label, value], index) => (
+            <View key={label} style={[profilePdfStyles.row, index === 0 ? profilePdfStyles.firstRow : null]} wrap={false}>
+              <View style={profilePdfStyles.labelCell}><Text style={profilePdfStyles.labelText}>{sanitizePdfText(label)}</Text></View>
+              <View style={profilePdfStyles.valueCell}><Text style={profilePdfStyles.valueText}>{sanitizePdfText(value)}</Text></View>
+            </View>
           ))}
         </View>
         {pdfFooter}

--- a/src/data/expectedExpensesSeed.json
+++ b/src/data/expectedExpensesSeed.json
@@ -1,0 +1,101 @@
+{
+  "packageId": "3",
+  "packageSnapshot": {
+    "name": "IVF + ED + SM",
+    "description": "For cases where embryos need to be created using donor oocytes.",
+    "listedPrice": 46000,
+    "currency": "EUR",
+    "children": [
+      { "id": "pkg3-child-1", "kind": "item", "catalogId": "1" },
+      { "id": "pkg3-child-2", "kind": "item", "catalogId": "2" },
+      { "id": "pkg3-child-3", "kind": "item", "catalogId": "3" },
+      { "id": "pkg3-child-4", "kind": "item", "catalogId": "4" },
+      { "id": "pkg3-child-5", "kind": "item", "catalogId": "5" },
+      { "id": "pkg3-child-6", "kind": "item", "catalogId": "6" },
+      { "id": "pkg3-child-7", "kind": "item", "catalogId": "7" },
+      { "id": "pkg3-child-8", "kind": "item", "catalogId": "8" },
+      { "id": "pkg3-child-9", "kind": "item", "catalogId": "9" },
+      { "id": "pkg3-child-10", "kind": "item", "catalogId": "10" },
+      { "id": "pkg3-child-11", "kind": "item", "catalogId": "11" },
+      { "id": "pkg3-child-12", "kind": "item", "catalogId": "12" },
+      { "id": "pkg3-child-13", "kind": "item", "catalogId": "14" },
+      { "id": "pkg3-child-14", "kind": "item", "catalogId": "15" },
+      { "id": "pkg3-child-15", "kind": "item", "catalogId": "16" },
+      { "id": "pkg3-child-16", "kind": "item", "catalogId": "18" },
+      { "id": "pkg3-child-17", "kind": "item", "catalogId": "19" },
+      { "id": "pkg3-child-18", "kind": "item", "catalogId": "21" },
+      { "id": "pkg3-child-19", "kind": "item", "catalogId": "22" },
+      { "id": "pkg3-child-20", "kind": "item", "catalogId": "23" },
+      { "id": "pkg3-child-21", "kind": "item", "catalogId": "24" },
+      { "id": "pkg3-child-22", "kind": "item", "catalogId": "25" }
+    ]
+  },
+  "milestones": [
+    {
+      "id": "milestone-1",
+      "title": "To start the program",
+      "scheduledAmount": 16000,
+      "taxPercent": 14,
+      "showPackageOverview": true,
+      "additionalServices": []
+    },
+    {
+      "id": "milestone-2",
+      "title": "Two weeks before embryo transfer",
+      "scheduledAmount": 6000,
+      "taxPercent": 14,
+      "showPackageOverview": false,
+      "additionalServices": [
+        { "id": "milestone-2-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-2-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      ]
+    },
+    {
+      "id": "milestone-3",
+      "title": "After confirmation of pregnancy by ultrasound",
+      "scheduledAmount": 6000,
+      "taxPercent": 14,
+      "showPackageOverview": false,
+      "additionalServices": [
+        { "id": "milestone-3-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-3-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      ]
+    },
+    {
+      "id": "milestone-4",
+      "title": "On the 12th week of pregnancy",
+      "scheduledAmount": 6000,
+      "taxPercent": 14,
+      "showPackageOverview": false,
+      "additionalServices": [
+        { "id": "milestone-4-extra-1", "kind": "item", "catalogId": "40" },
+        { "id": "milestone-4-extra-2", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-4-extra-3", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      ]
+    },
+    {
+      "id": "milestone-5",
+      "title": "On the 18th week of pregnancy",
+      "scheduledAmount": 6000,
+      "taxPercent": 14,
+      "showPackageOverview": false,
+      "additionalServices": [
+        { "id": "milestone-5-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-5-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      ]
+    },
+    {
+      "id": "milestone-6",
+      "title": "On the 36th week of pregnancy",
+      "scheduledAmount": 6000,
+      "taxPercent": 14,
+      "showPackageOverview": false,
+      "additionalServices": [
+        { "id": "milestone-6-extra-1", "kind": "custom", "name": "Deposit. Medications for SM during and after delivery", "price": 500 },
+        { "id": "milestone-6-extra-2", "kind": "custom", "name": "Deposit. For C-section (is returned if not used)", "price": 2700 },
+        { "id": "milestone-6-extra-3", "kind": "custom", "name": "Deposit. For baby clothes / diapers / formulas / etc", "price": 110 },
+        { "id": "milestone-6-extra-4", "kind": "custom", "name": "Deposit. For unexpected expenses (e.g. staying in hospital, service of nanny etc.)", "price": 600 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- invoiceServices entries become small objects (item/custom/package kind)
  instead of plain strings. Editing a catalog item's name/description/price
  now stores a local override without ever writing to budget/items; the row
  stays linked to the catalog until it is explicitly reset. Custom services
  can be deleted like before.
- Whole budget/packages programs can be added to an invoice as a package
  entry, with its own editable name/price and a nested, reorderable list of
  its services. Editing, removing, or adding a service inside a package (or
  renaming it) flags it "Custom package"; it can be reverted back to the
  catalog snapshot at any time.
- Reworked the Invoice Builder UI: borderless, auto-growing text fields with
  labels and inputs on one line instead of boxed inputs, replacing the
  previous fixed-height bordered form controls.
- Rebuilt InvoicePdfDocument with a premium layout (package groups with
  indented, numbered children and subtotals) and introduced a shared
  pdfTheme module so BudgetPdfDocument, InvoicePdfDocument, and the
  surrogate/donor ProfilePdfDocument use one consistent color and type
  system.
- Added coverage for the new entry model (overrides, package customization,
  resolution/subtotal math) and a component-level test exercising the
  override, package, and delete flows end-to-end.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RM17vSi6Ze89ZyybdXNg7y