### PR TITLE
Fix InvoiceBuilderPage test lint by allowing required act around createRoot.render

### DIFF
--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -84,6 +84,7 @@ describe('InvoiceBuilderPage', () => {
 
   const mount = () => {
     const root = createRoot(container);
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- createRoot.render must be wrapped in act to flush the initial React 18 render in this test harness.
     act(() => {
       root.render(<InvoiceBuilderPage isAdmin />);
     });


### PR DESCRIPTION
### Motivation
- Silence a false-positive `testing-library/no-unnecessary-act` lint error while keeping the React 18 `createRoot.render` call wrapped in `act` so the test harness flushes the initial render correctly.

### Description
- Added a targeted ESLint disable comment above the `act` wrapper for `root.render(<InvoiceBuilderPage isAdmin />)` in `src/components/InvoiceBuilderPage.test.js` to document and suppress the lint rule for this specific React 18 render pattern.

### Testing
- Ran `npm test -- --watchAll=false --runTestsByPath src/components/InvoiceBuilderPage.test.js` which passed all tests for that file. 
- Ran `npm run lint:js -- src/components/InvoiceBuilderPage.test.js` which completed without the previous lint error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e7a406ee88326a766dcb0d587200c)