### PR TITLE
Refactor expected-expenses to compact template with package-percent rows and update UI/PDF generation

### DIFF
--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -3,10 +3,9 @@ import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import { PDF_COLOR, PDF_FONT, pdfBaseStyles, sanitizePdfText } from './pdfTheme';
 import { buildCaseTitle } from './invoiceCatalogUtils';
 import {
-  computeMilestoneAmountDue,
-  computeMilestoneSubtotal,
-  resolveMilestoneAdditionalRows,
-  resolvePackageOverviewRows,
+  computeExpectedExpenseAmountDue,
+  computeExpectedExpenseSubtotal,
+  resolveExpectedExpenseRows,
 } from './expectedExpensesUtils';
 
 const AGENCY_NAME = 'REPRODUCTIVE AGENCY "UKRCOM"';
@@ -324,73 +323,27 @@ const renderExpensesTable = (rows, { includeScheduledRow, scheduledAmount }) => 
   );
 };
 
-const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate }) => {
+const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate, schedule, taxPercent = 0 }) => {
   const caseTitle = buildCaseTitle(customers);
   const dateLabel = formatPlanDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
-  const overviewRows = resolvePackageOverviewRows(plan?.packageSnapshot?.children, catalogItemsById, priceContext);
-  const milestones = Array.isArray(plan?.milestones) ? plan.milestones : [];
+  const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
 
   return (
     <Document title={`Expected expenses - ${caseTitle}`} subject="Expected expenses" creator="UKRCOM">
-      {milestones.map((milestone, index) => {
-        const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById, priceContext);
-        const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
-        const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
-        const pageLabel = `${index + 1}/${milestones.length}`;
+      {payments.map((payment, index) => {
+        const group = plan?.expectedExpenses?.[index] || [];
+        const rows = resolveExpectedExpenseRows(group, catalogItemsById, priceContext);
+        const subtotal = computeExpectedExpenseSubtotal(rows);
+        const amountDue = computeExpectedExpenseAmountDue(subtotal, taxPercent);
+        const pageLabel = `${index + 1}/${payments.length}`;
 
         return (
-          <Page key={milestone.id || index} size="A4" style={styles.page} wrap>
-            {milestone.showPackageOverview ? (
-              <>
-                <Text style={styles.sectionTitle}>Description</Text>
-                <Text style={styles.sectionSubtitle}>{sanitizePdfText(caseTitle)}</Text>
-                <Text style={styles.dateText}>{dateLabel}</Text>
+          <Page key={`${plan?.packageId || 'package'}-${index}`} size="A4" style={styles.page} wrap>
+            <Text style={styles.sectionTitle}>{sanitizePdfText(`Expected expenses of the invoice #${index + 1}`)}</Text>
+            <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${payment?.title || `Payment ${index + 1}`}`)}</Text>
+            <Text style={styles.dateText}>{dateLabel}</Text>
 
-                <View style={styles.overviewTable}>
-                  <View style={styles.overviewHeadRow} wrap={false}>
-                    <View style={styles.overviewHeadCell}><Text style={styles.overviewHeadText}>{sanitizePdfText(plan.packageSnapshot.name)}</Text></View>
-                  </View>
-                  {overviewRows.map((row, rowIndex) => (
-                    <View
-                      key={row.key || rowIndex}
-                      style={[styles.overviewRow, rowIndex % 2 ? styles.overviewRowAlt : null]}
-                      wrap={false}
-                    >
-                      <View style={styles.overviewIndexCell}><Text style={styles.overviewIndexText}>{rowIndex + 1}</Text></View>
-                      <View style={styles.overviewNameCell}><Text style={styles.overviewText}>{sanitizePdfText(row.name)}</Text></View>
-                    </View>
-                  ))}
-                  <View style={styles.overviewTotalRow} wrap={false}>
-                    <View style={styles.overviewTotalLabelCell}><Text style={styles.overviewTotalLabelText}>Total:</Text></View>
-                    <View style={styles.overviewTotalAmountCell}><Text style={styles.overviewTotalAmountText}>{formatEuroTotal(plan.packageSnapshot.listedPrice)}</Text></View>
-                  </View>
-                </View>
-
-                <Text style={styles.scheduleHeading}>Payment schedule:</Text>
-                {milestones.map((scheduleMilestone, scheduleIndex) => (
-                  <View
-                    key={scheduleMilestone.id || scheduleIndex}
-                    style={[styles.scheduleRow, scheduleIndex === index ? styles.scheduleRowCurrent : null]}
-                    wrap={false}
-                  >
-                    <Text style={[styles.scheduleLabelText, scheduleIndex === index ? styles.scheduleLabelTextCurrent : null]}>
-                      {sanitizePdfText(`${scheduleIndex + 1}. ${scheduleMilestone.title}`)}
-                    </Text>
-                    <Text style={styles.scheduleAmountText}>{formatEuroTotal(scheduleMilestone.scheduledAmount)}</Text>
-                  </View>
-                ))}
-
-                {additionalRows.length ? renderExpensesTable(additionalRows, { includeScheduledRow: false }) : null}
-              </>
-            ) : (
-              <>
-                <Text style={styles.sectionTitle}>{sanitizePdfText(`Expected expenses of the invoice #${index + 1}`)}</Text>
-                <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${milestone.title}`)}</Text>
-                <Text style={styles.dateText}>{dateLabel}</Text>
-
-                {renderExpensesTable(additionalRows, { includeScheduledRow: true, scheduledAmount: milestone.scheduledAmount })}
-              </>
-            )}
+            {renderExpensesTable(rows, { includeScheduledRow: false })}
 
             <View style={[styles.summaryRow, styles.summaryRowLast]} wrap={false}>
               <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Total:</Text></View>
@@ -400,7 +353,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
             <View style={{ marginTop: 16 }}>
               <View style={styles.summaryRow} wrap={false}>
                 <View style={styles.summaryLabelCell}><Text style={styles.summaryLabelText}>Taxes (%)</Text></View>
-                <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(milestone.taxPercent)}</Text></View>
+                <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(taxPercent)}</Text></View>
               </View>
               <View style={[styles.summaryRow, styles.summaryRowLast]} wrap={false}>
                 <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Amount need to be paid (EUR)</Text></View>

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -37,6 +37,7 @@ import {
   makeCatalogItemEntry,
   makeCatalogPackageEntry,
   makeCustomEntry,
+  makePackagePercentEntry,
   movePackageChild,
   normalizeInvoiceData,
   removePackageChild,
@@ -50,19 +51,17 @@ import {
   updatePackageChildField,
 } from './invoiceCatalogUtils';
 import {
-  addMilestoneAdditionalService,
+  addExpectedExpenseService,
   buildExpectedExpensesPlan,
-  buildMilestonesFromSchedule,
-  computeMilestoneAmountDue,
-  computeMilestoneSubtotal,
-  computeMilestonesScheduledTotal,
+  computeExpectedExpenseAmountDue,
+  computeExpectedExpenseSubtotal,
+  getExpectedExpensesValidation,
   isExpectedExpensesShape,
   normalizeExpectedExpensesData,
-  removeMilestoneAdditionalService,
-  resolveMilestoneAdditionalRows,
-  resolvePackageOverviewRows,
-  setMilestoneField,
-  updateMilestoneAdditionalServiceField,
+  removeExpectedExpenseService,
+  resetExpectedExpenseService,
+  resolveExpectedExpenseRows,
+  updateExpectedExpenseServiceField,
 } from './expectedExpensesUtils';
 
 const INVOICE_DATA_PATH = 'invoiceBuilder';
@@ -474,7 +473,7 @@ const ServiceLineRow = ({
 }) => {
   const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
   const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
-  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(row.price ?? ''));
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(row.kind === 'packagePercent' ? row.percent : (row.price ?? '')));
 
   return (
     <LineCard>
@@ -496,8 +495,8 @@ const ServiceLineRow = ({
           $width={isChild ? '76px' : '88px'}
           inputMode="decimal"
           value={priceDraft}
-          placeholder="0"
-          aria-label="Price (EUR)"
+          placeholder={row.kind === 'packagePercent' ? '%' : '0'}
+          aria-label={row.kind === 'packagePercent' ? 'Package percent' : 'Price (EUR)'}
           onFocus={() => { priceEditingRef.current = true; }}
           onChange={event => setPriceDraft(event.target.value)}
           onBlur={() => { priceEditingRef.current = false; onCommit('price', priceDraft); }}
@@ -848,55 +847,84 @@ const PackageEntryCard = ({
   );
 };
 
-// --- Expected expenses milestone (one payment-schedule entry -> one future invoice) ------------------------------------------------------
-
-const MilestoneCheckboxRow = styled.div`
+const PdfPreviewStrip = styled.div`
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 2px 0 0 28px;
-  font-size: 11px;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 12px 2px 4px;
+  margin-top: 8px;
+`;
+
+const PdfPreviewPage = styled.div`
+  flex: 0 0 165px;
+  min-height: 232px;
+  background: #fff;
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+  padding: 14px 12px;
+  color: #111827;
+  font-size: 7px;
+`;
+
+const PdfPreviewTitle = styled.div`
+  text-align: center;
+  font-weight: 900;
+  font-size: 10px;
+  margin-bottom: 4px;
+`;
+
+const PdfPreviewSubtitle = styled.div`
+  text-align: center;
   font-weight: 700;
-  color: var(--km-muted);
-
-  @media (max-width: 560px) {
-    margin-left: 10px;
-  }
+  margin-bottom: 10px;
 `;
 
-const MilestoneCheckboxLabel = styled.label`
+const PdfPreviewTable = styled.div`
+  border: 1px solid #111827;
+`;
+
+const PdfPreviewRow = styled.div`
   display: flex;
-  align-items: center;
-  gap: 6px;
-  cursor: pointer;
+  justify-content: space-between;
+  gap: 5px;
+  border-bottom: 1px solid #111827;
+  padding: 3px;
+
+  &:last-child { border-bottom: 0; }
 `;
+
+const PdfPreviewFooter = styled.div`
+  margin-top: 10px;
+  font-weight: 800;
+  text-align: right;
+`;
+
+// --- Expected expenses milestone (one payment-schedule entry -> one future invoice) ------------------------------------------------------
 
 const MilestoneCard = ({
   index,
-  milestone,
-  additionalRows,
+  payment,
+  rows,
   amountDue,
+  taxPercent,
   catalogItems,
-  onCommitField,
-  onToggleOverview,
   onCommitServiceField,
   onRemoveService,
   onResetService,
   onAddCustomService,
   onAddCatalogService,
+  onAddPackagePercent,
 }) => {
-  const [titleDraft, setTitleDraft, titleEditingRef] = useFieldDraft(milestone.title);
-  const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(String(milestone.scheduledAmount ?? ''));
-  const [taxDraft, setTaxDraft, taxEditingRef] = useFieldDraft(String(milestone.taxPercent ?? ''));
   const [showPicker, setShowPicker] = useState(false);
   const [query, setQuery] = useState('');
   const [customName, setCustomName] = useState('');
   const [customPrice, setCustomPrice] = useState('');
+  const [percentDraft, setPercentDraft] = useState('');
 
   const usedCatalogIds = useMemo(
-    () => new Set(additionalRows.filter(row => row.kind === 'item').map(row => String(row.catalogId))),
-    [additionalRows],
+    () => new Set(rows.filter(row => row.kind === 'item').map(row => String(row.catalogId))),
+    [rows],
   );
 
   const availableItems = useMemo(() => {
@@ -923,82 +951,46 @@ const MilestoneCard = ({
     setCustomPrice('');
   };
 
+  const handleAddPackagePercent = () => {
+    const percent = Number(percentDraft.replace(',', '.'));
+    if (!Number.isFinite(percent)) {
+      toast.error('Enter a valid package percent.');
+      return;
+    }
+    onAddPackagePercent(percent);
+    setPercentDraft('');
+  };
+
   return (
     <PackageCard>
       <PackageHeaderRow>
         <RowIndex>{index + 1}</RowIndex>
-        <AutoTextArea
-          $size="13.5px"
-          $weight="800"
-          value={titleDraft}
-          placeholder="Milestone title"
-          aria-label="Milestone title"
-          onFocus={() => { titleEditingRef.current = true; }}
-          onChange={event => setTitleDraft(event.target.value)}
-          onBlur={() => { titleEditingRef.current = false; onCommitField('title', titleDraft); }}
-        />
-        <AutoTextArea
-          as={PlainPriceBase}
-          $width="88px"
-          inputMode="decimal"
-          value={amountDraft}
-          placeholder="0"
-          aria-label="Scheduled amount (EUR)"
-          onFocus={() => { amountEditingRef.current = true; }}
-          onChange={event => setAmountDraft(event.target.value)}
-          onBlur={() => { amountEditingRef.current = false; onCommitField('scheduledAmount', amountDraft); }}
-        />
-        <AutoTextArea
-          as={PlainPriceBase}
-          $width="48px"
-          inputMode="decimal"
-          value={taxDraft}
-          placeholder="%"
-          title="Tax (%)"
-          aria-label="Tax percent"
-          onFocus={() => { taxEditingRef.current = true; }}
-          onChange={event => setTaxDraft(event.target.value)}
-          onBlur={() => { taxEditingRef.current = false; onCommitField('taxPercent', taxDraft); }}
-        />
+        <div style={{ flex: 1, fontWeight: 800 }}>{index + 1}. {payment?.title || `Payment ${index + 1}`}</div>
+        <CustomizedTag title="Rows total with taxes">Due: {formatEuroPreview(amountDue)}</CustomizedTag>
+        <CustomizedTag title="Tax percent">Tax {formatEuroPreview(taxPercent).replace(' EUR', '%')}</CustomizedTag>
       </PackageHeaderRow>
-      <MilestoneCheckboxRow>
-        <MilestoneCheckboxLabel>
-          <input type="checkbox" checked={Boolean(milestone.showPackageOverview)} onChange={onToggleOverview} />
-          Show full package overview on this invoice
-        </MilestoneCheckboxLabel>
-        <CustomizedTag title="Scheduled amount + additional services, taxed">Due: {formatEuroPreview(amountDue)}</CustomizedTag>
-      </MilestoneCheckboxRow>
 
       <PackageChildren>
-        {additionalRows.map((row, rowIndex) => (
+        {rows.map((row, rowIndex) => (
           <ServiceLineRow
             key={row.key}
             row={row}
             index={rowIndex}
             isChild
-            onCommit={(field, value) => onCommitServiceField(row.id, field, value)}
+            onCommit={(field, value) => onCommitServiceField(row.id, row.kind === 'packagePercent' && field === 'price' ? 'percent' : field, value)}
             onRemove={() => onRemoveService(row.id)}
             onReset={row.kind === 'item' && row.isCustomized ? () => onResetService(row.id) : undefined}
           />
         ))}
-        {!additionalRows.length ? <PanelNote style={{ margin: '8px 0' }}>No additional services on this invoice yet.</PanelNote> : null}
+        {!rows.length ? <PanelNote style={{ margin: '8px 0' }}>No expected services for this schedule step yet.</PanelNote> : null}
       </PackageChildren>
 
       <PackageAddRow>
-        <PackageQuickField
-          rows={1}
-          placeholder="Add a custom line to this invoice…"
-          value={customName}
-          onChange={event => setCustomName(event.target.value)}
-        />
-        <PackageQuickPrice
-          rows={1}
-          inputMode="decimal"
-          placeholder="Price"
-          value={customPrice}
-          onChange={event => setCustomPrice(event.target.value)}
-        />
+        <PackageQuickField rows={1} placeholder="Custom line name…" value={customName} onChange={event => setCustomName(event.target.value)} />
+        <PackageQuickPrice rows={1} inputMode="decimal" placeholder="Price" value={customPrice} onChange={event => setCustomPrice(event.target.value)} />
         <SmallButton type="button" onClick={handleAddCustom}><FaPlus /> Add</SmallButton>
+        <PackageQuickPrice rows={1} inputMode="decimal" placeholder="% of package" value={percentDraft} onChange={event => setPercentDraft(event.target.value)} />
+        <SmallButton type="button" onClick={handleAddPackagePercent}><FaPlus /> Percent</SmallButton>
         <SmallButton type="button" onClick={() => setShowPicker(current => !current)}>
           <FaPlus /> {showPicker ? 'Hide catalog' : 'From catalog'}
         </SmallButton>
@@ -1006,12 +998,7 @@ const MilestoneCard = ({
 
       {showPicker ? (
         <InlinePickerBox>
-          <CatalogSearchField
-            rows={1}
-            placeholder="Search catalog services…"
-            value={query}
-            onChange={event => setQuery(event.target.value)}
-          />
+          <CatalogSearchField rows={1} placeholder="Search catalog services…" value={query} onChange={event => setQuery(event.target.value)} />
           <CatalogPickerList>
             {availableItems.map(item => (
               <CatalogPickerButton key={item.id} type="button" onClick={() => { onAddCatalogService(item.id); setShowPicker(false); setQuery(''); }}>
@@ -1177,7 +1164,12 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || isFormulaRatePending || Boolean(formulaRateError);
 
   const priceContext = useMemo(
-    () => ({ itemsById: catalogItemsById, rates: exchangeRates, packagesById: catalogPackagesById }),
+    () => ({
+      itemsById: catalogItemsById,
+      rates: exchangeRates,
+      packagesById: catalogPackagesById,
+      resolvePackagePrice: pkg => resolveBudgetPriceAmount(pkg?.listedPrice, { itemsById: catalogItemsById, rates: exchangeRates, packagesById: catalogPackagesById }),
+    }),
     [catalogItemsById, exchangeRates, catalogPackagesById],
   );
 
@@ -1233,17 +1225,26 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       .filter(pkg => !normalizedQuery || String(pkg.name || '').toLowerCase().includes(normalizedQuery));
   }, [visibleCatalogPackages, usedCatalogPackageIds, catalogQuery]);
 
+  const defaultExpectedExpensesTaxPercent = Number.isFinite(Number(catalogTechnical?.wireTransferSurchargeRate))
+    ? Math.round(Number(catalogTechnical.wireTransferSurchargeRate) * 10000) / 100
+    : (Number(data.taxPercent) || 0);
+
   const expectedExpensesView = useMemo(() => {
     if (!expectedExpenses) return null;
-    const overviewRows = resolvePackageOverviewRows(expectedExpenses.packageSnapshot.children, catalogItemsById, priceContext);
-    const milestoneRows = expectedExpenses.milestones.map(milestone => {
-      const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById, priceContext);
-      const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
-      const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
-      return { milestone, additionalRows, subtotal, amountDue };
+    const pkg = catalogPackagesById.get(String(expectedExpenses.packageId));
+    const schedule = pkg ? resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg) : null;
+    const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+    const taxPercent = defaultExpectedExpensesTaxPercent;
+    const validation = getExpectedExpensesValidation(expectedExpenses, schedule);
+    const pages = payments.map((payment, index) => {
+      const group = expectedExpenses.expectedExpenses?.[index] || [];
+      const rows = resolveExpectedExpenseRows(group, catalogItemsById, priceContext);
+      const subtotal = computeExpectedExpenseSubtotal(rows);
+      const amountDue = computeExpectedExpenseAmountDue(subtotal, taxPercent);
+      return { payment, group, rows, subtotal, amountDue, taxPercent };
     });
-    return { overviewRows, milestoneRows, scheduledTotal: computeMilestonesScheduledTotal(expectedExpenses.milestones) };
-  }, [expectedExpenses, catalogItemsById, priceContext]);
+    return { pkg, schedule, pages, validation };
+  }, [expectedExpenses, catalogPackagesById, catalogTechnical, catalogItemsById, priceContext, defaultExpectedExpensesTaxPercent]);
 
   const persistPath = async (path, value, successMessage) => {
     try {
@@ -1468,17 +1469,9 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   // A whole program's billing forecast: one milestone per payment-schedule entry, auto-computed
   // from the chosen budget/packages program, stored as its own object at invoiceBuilder/expectedExpenses.
 
-  const defaultExpectedExpensesTaxPercent = Number.isFinite(Number(catalogTechnical?.wireTransferSurchargeRate))
-    ? Math.round(Number(catalogTechnical.wireTransferSurchargeRate) * 10000) / 100
-    : (Number(data.taxPercent) || 0);
-
   const persistExpectedExpenses = (nextPlan, successMessage) => {
     setExpectedExpenses(nextPlan);
     persistPath(EXPECTED_EXPENSES_PATH, nextPlan, successMessage);
-  };
-
-  const persistExpectedExpensesMilestones = (nextMilestones, successMessage) => {
-    persistExpectedExpenses({ ...expectedExpenses, milestones: nextMilestones }, successMessage);
   };
 
   const createExpectedExpensesPlan = pkg => {
@@ -1488,8 +1481,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       return;
     }
     const resolvedPackage = { ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice };
-    const plan = buildExpectedExpensesPlan(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
-    persistExpectedExpenses(plan, 'Expected expenses plan created.');
+    const plan = buildExpectedExpensesPlan(resolvedPackage, schedule);
+    persistExpectedExpenses(plan, 'Expected expenses template created.');
     setShowExpectedExpensesPicker(false);
   };
 
@@ -1505,82 +1498,42 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       toast.error('This package has no payment schedule in the catalog.');
       return;
     }
-    if (typeof window !== 'undefined' && !window.confirm(
-      'Recalculate milestones from the catalog schedule? Titles/amounts reset to the catalog; extra services on each milestone are kept.',
-    )) return;
-    const freshMilestones = buildMilestonesFromSchedule(schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
-    const nextMilestones = freshMilestones.map((milestone, index) => ({
-      ...milestone,
-      additionalServices: expectedExpenses.milestones[index]?.additionalServices || [],
-      taxPercent: expectedExpenses.milestones[index]?.taxPercent ?? milestone.taxPercent,
-    }));
-    persistExpectedExpenses({
-      ...expectedExpenses,
-      packageSnapshot: {
-        ...expectedExpenses.packageSnapshot,
-        listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? Number(pkg.listedPrice) ?? 0,
-      },
-      milestones: nextMilestones,
-    }, 'Schedule recalculated.');
+    const fresh = buildExpectedExpensesPlan({ ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice }, schedule);
+    const nextGroups = fresh.expectedExpenses.map((group, index) => expectedExpenses.expectedExpenses?.[index] || group);
+    persistExpectedExpenses({ ...expectedExpenses, expectedExpenses: nextGroups }, 'Schedule groups refreshed.');
   };
 
   const deleteExpectedExpensesPlan = () => {
-    if (typeof window !== 'undefined' && !window.confirm('Delete the whole expected expenses plan?')) return;
-    persistExpectedExpenses(null, 'Expected expenses plan deleted.');
+    if (typeof window !== 'undefined' && !window.confirm('Delete the whole expected expenses template?')) return;
+    persistExpectedExpenses(null, 'Expected expenses template deleted.');
   };
 
-  const commitMilestoneField = (milestoneId, field, value) => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? setMilestoneField(milestone, field, value)
-      : milestone));
-    persistExpectedExpensesMilestones(nextMilestones, 'Milestone updated.');
+  const commitExpectedExpenseServiceField = (groupIndex, entryId, field, value) => {
+    persistExpectedExpenses(updateExpectedExpenseServiceField(expectedExpenses, groupIndex, entryId, field, value), 'Service updated.');
   };
 
-  const toggleMilestoneOverview = milestoneId => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? { ...milestone, showPackageOverview: !milestone.showPackageOverview }
-      : milestone));
-    persistExpectedExpensesMilestones(nextMilestones, 'Milestone updated.');
+  const resetExpectedExpenseServiceEntry = (groupIndex, entryId) => {
+    persistExpectedExpenses(resetExpectedExpenseService(expectedExpenses, groupIndex, entryId), 'Reverted to catalog values.');
   };
 
-  const commitMilestoneServiceField = (milestoneId, entryId, field, value) => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? updateMilestoneAdditionalServiceField(milestone, entryId, field, value)
-      : milestone));
-    persistExpectedExpensesMilestones(nextMilestones, 'Service updated.');
+  const removeExpectedExpenseServiceEntry = (groupIndex, entryId) => {
+    persistExpectedExpenses(removeExpectedExpenseService(expectedExpenses, groupIndex, entryId), 'Service removed.');
   };
 
-  const resetMilestoneServiceEntry = (milestoneId, entryId) => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id !== milestoneId ? milestone : {
-      ...milestone,
-      additionalServices: milestone.additionalServices.map(entry => (entry.id === entryId ? resetItemEntryOverrides(entry) : entry)),
-    }));
-    persistExpectedExpensesMilestones(nextMilestones, 'Reverted to catalog values.');
+  const addExpectedExpenseCustomService = (groupIndex, fields) => {
+    persistExpectedExpenses(addExpectedExpenseService(expectedExpenses, groupIndex, makeCustomEntry(fields)), 'Service added.');
   };
 
-  const removeMilestoneServiceEntry = (milestoneId, entryId) => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? removeMilestoneAdditionalService(milestone, entryId)
-      : milestone));
-    persistExpectedExpensesMilestones(nextMilestones, 'Service removed.');
+  const addExpectedExpenseCatalogService = (groupIndex, catalogId) => {
+    persistExpectedExpenses(addExpectedExpenseService(expectedExpenses, groupIndex, makeCatalogItemEntry(catalogId)), 'Service added.');
   };
 
-  const addMilestoneCustomService = (milestoneId, fields) => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? addMilestoneAdditionalService(milestone, makeCustomEntry(fields))
-      : milestone));
-    persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
-  };
-
-  const addMilestoneCatalogService = (milestoneId, catalogId) => {
-    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? addMilestoneAdditionalService(milestone, makeCatalogItemEntry(catalogId))
-      : milestone));
-    persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
+  const addExpectedExpensePackagePercent = (groupIndex, percent) => {
+    persistExpectedExpenses(addExpectedExpenseService(expectedExpenses, groupIndex, makePackagePercentEntry({ catalogId: expectedExpenses.packageId, percent })), 'Package percent added.');
   };
 
   const handleGenerateExpectedExpensesPdf = async () => {
-    if (!expectedExpenses || !expectedExpenses.milestones.length) {
+    if (!expectedExpenses || !expectedExpensesView?.pages?.length) {
       toast.error('Choose a package to build the plan first.');
       return;
     }
@@ -1601,6 +1554,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         catalogItemsById,
         priceContext,
         planDate: new Date(`${invoiceDateInput || getTodayYmd()}T00:00:00`),
+        schedule: expectedExpensesView?.schedule,
+        taxPercent: defaultExpectedExpensesTaxPercent,
       };
       let blob;
       try {
@@ -1703,7 +1658,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       const text = await file.text();
       const parsed = JSON.parse(text);
       if (!isExpectedExpensesShape(parsed)) {
-        toast.error('Upload an expected-expenses JSON with packageSnapshot and milestones.');
+        toast.error('Upload an expected-expenses JSON with packageId and expectedExpenses groups.');
         return;
       }
       const nextPlan = normalizeExpectedExpensesData(parsed);
@@ -2165,35 +2120,52 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <>
                   <FieldRow $align="center">
                     <FieldTag>Package</FieldTag>
-                    <div style={{ flex: 1, padding: '5px 6px', fontWeight: 700 }}>{expectedExpenses.packageSnapshot.name}</div>
+                    <div style={{ flex: 1, padding: '5px 6px', fontWeight: 700 }}>{expectedExpensesView?.pkg?.name || expectedExpenses.packageId}</div>
                     <span style={{ fontWeight: 800, color: 'var(--km-accent)', padding: '5px 6px' }}>
-                      {formatEuroPreview(expectedExpenses.packageSnapshot.listedPrice)}
+                      {formatEuroPreview(resolveBudgetPriceAmount(expectedExpensesView?.pkg?.listedPrice, priceContext) ?? expectedExpensesView?.pkg?.listedPrice)}
                     </span>
                   </FieldRow>
-                  {expectedExpensesView && expectedExpensesView.scheduledTotal !== expectedExpenses.packageSnapshot.listedPrice ? (
-                    <PanelNote style={{ color: 'var(--km-danger)' }}>
-                      Milestones add up to {formatEuroPreview(expectedExpensesView.scheduledTotal)}, the package price is{' '}
-                      {formatEuroPreview(expectedExpenses.packageSnapshot.listedPrice)}.
-                    </PanelNote>
+                  {expectedExpensesView?.validation ? (
+                    <PanelNote style={{ color: 'var(--km-danger)' }}>{expectedExpensesView.validation}</PanelNote>
                   ) : null}
 
-                  {expectedExpensesView?.milestoneRows.map(({ milestone, additionalRows, amountDue }, index) => (
+                  {expectedExpensesView?.pages.map(({ payment, rows, amountDue, taxPercent }, index) => (
                     <MilestoneCard
-                      key={milestone.id}
+                      key={`${expectedExpenses.packageId}-${index}`}
                       index={index}
-                      milestone={milestone}
-                      additionalRows={additionalRows}
+                      payment={payment}
+                      rows={rows}
                       amountDue={amountDue}
+                      taxPercent={taxPercent}
                       catalogItems={catalogItems}
-                      onCommitField={(field, value) => commitMilestoneField(milestone.id, field, value)}
-                      onToggleOverview={() => toggleMilestoneOverview(milestone.id)}
-                      onCommitServiceField={(entryId, field, value) => commitMilestoneServiceField(milestone.id, entryId, field, value)}
-                      onRemoveService={entryId => removeMilestoneServiceEntry(milestone.id, entryId)}
-                      onResetService={entryId => resetMilestoneServiceEntry(milestone.id, entryId)}
-                      onAddCustomService={fields => addMilestoneCustomService(milestone.id, fields)}
-                      onAddCatalogService={catalogId => addMilestoneCatalogService(milestone.id, catalogId)}
+                      onCommitServiceField={(entryId, field, value) => commitExpectedExpenseServiceField(index, entryId, field, value)}
+                      onRemoveService={entryId => removeExpectedExpenseServiceEntry(index, entryId)}
+                      onResetService={entryId => resetExpectedExpenseServiceEntry(index, entryId)}
+                      onAddCustomService={fields => addExpectedExpenseCustomService(index, fields)}
+                      onAddCatalogService={catalogId => addExpectedExpenseCatalogService(index, catalogId)}
+                      onAddPackagePercent={percent => addExpectedExpensePackagePercent(index, percent)}
                     />
                   ))}
+
+                  {expectedExpensesView?.pages?.length ? (
+                    <PdfPreviewStrip>
+                      {expectedExpensesView.pages.map(({ payment, rows, amountDue, taxPercent }, index) => (
+                        <PdfPreviewPage key={`preview-${index}`}>
+                          <PdfPreviewTitle>Expected expenses of the invoice #{index + 1}</PdfPreviewTitle>
+                          <PdfPreviewSubtitle>{index + 1}. {payment?.title || `Payment ${index + 1}`}</PdfPreviewSubtitle>
+                          <PdfPreviewTable>
+                            {rows.map((row, rowIndex) => (
+                              <PdfPreviewRow key={row.key || rowIndex}>
+                                <span>{rowIndex + 1}. {row.name}</span>
+                                <b>{formatEuroPreview(row.price)}</b>
+                              </PdfPreviewRow>
+                            ))}
+                          </PdfPreviewTable>
+                          <PdfPreviewFooter>Tax {taxPercent}% · Due {formatEuroPreview(amountDue)}</PdfPreviewFooter>
+                        </PdfPreviewPage>
+                      ))}
+                    </PdfPreviewStrip>
+                  ) : null}
                 </>
               )}
             </Panel>

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -210,7 +210,7 @@ describe('InvoiceBuilderPage', () => {
       await flush();
     };
 
-    it('builds a plan from a package, auto-calculating each milestone amount from its catalog schedule', async () => {
+    it('builds a template from a package, auto-calculating package-percent rows from its catalog schedule', async () => {
       const root = mount();
       await flush();
 
@@ -225,20 +225,20 @@ describe('InvoiceBuilderPage', () => {
       expect(persistedCalls.length).toBeGreaterThan(0);
       const plan = persistedCalls[persistedCalls.length - 1][1];
       expect(plan.packageId).toBe('p1');
-      expect(plan.milestones).toHaveLength(2);
-      expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', scheduledAmount: 150, taxPercent: 14, showPackageOverview: true });
-      expect(plan.milestones[1]).toMatchObject({ title: 'Final payment', scheduledAmount: 100, showPackageOverview: false });
+      expect(plan.expectedExpenses).toHaveLength(2);
+      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60 });
+      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40 });
 
       await act(async () => { root.unmount(); });
     });
 
-    it('adding a service to a milestone updates its due amount and is persisted on that milestone only', async () => {
+    it('adding a service to a schedule group updates its due amount and is persisted on that group only', async () => {
       const root = mount();
       await flush();
 
       await createPlan();
 
-      const milestoneNameFields = Array.from(container.querySelectorAll('textarea[placeholder="Add a custom line to this invoice…"]'));
+      const milestoneNameFields = Array.from(container.querySelectorAll('textarea[placeholder="Custom line name…"]'));
       expect(milestoneNameFields).toHaveLength(2);
       const milestoneAddRow = milestoneNameFields[0].parentElement;
       const priceField = milestoneAddRow.querySelector('textarea[placeholder="Price"]');
@@ -256,9 +256,9 @@ describe('InvoiceBuilderPage', () => {
       expect(container.innerHTML).toContain('Due: €513.00');
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.milestones[0].additionalServices).toHaveLength(1);
-      expect(plan.milestones[0].additionalServices[0]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
-      expect(plan.milestones[1].additionalServices).toHaveLength(0);
+      expect(plan.expectedExpenses[0]).toHaveLength(2);
+      expect(plan.expectedExpenses[0][1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.expectedExpenses[1]).toHaveLength(1);
 
       await act(async () => { root.unmount(); });
     });
@@ -302,12 +302,12 @@ describe('InvoiceBuilderPage', () => {
       await act(async () => { fileInput.dispatchEvent(new Event('change', { bubbles: true })); });
       await flush();
 
-      expect(container.innerHTML).toContain('To start the program');
-      expect(container.innerHTML).toContain('Deposit for transportation of SM');
+      expect(container.innerHTML).toContain('Expected expenses has 6 groups');
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
       expect(plan.packageId).toBe('3');
-      expect(plan.milestones).toHaveLength(6);
+      expect(plan.expectedExpenses).toHaveLength(6);
+      expect(plan.expectedExpenses[1][1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -1,133 +1,108 @@
-// "Expected expenses" is a billing forecast for a whole surrogacy program: pick a budget/packages
-// program once, and its payment schedule (budget/technical.paymentSchedules) is turned into a
-// series of milestones - one future invoice per scheduled payment. Each milestone's amount is
-// calculated automatically from the schedule, and stays a plain editable number from then on (the
-// plan is its own frozen copy, same as a package entry's children on a regular invoice - it does
-// not keep re-syncing with the shared catalog). Admins can attach extra one-off services (custom
-// or catalog-linked, e.g. the recurring SM transportation/medical deposits) to any milestone.
-//
-// The whole plan is stored as invoiceBuilder/expectedExpenses - a single object, not a list of
-// documents - so it lives right next to the rest of the invoice-builder JSON on the backend.
+// Expected expenses is a template for future invoices tied to a chosen budget/packages program.
+// Stored JSON is intentionally small: { packageId, expectedExpenses }, where expectedExpenses is
+// an array of service-line groups. Group #0 belongs to payment schedule step #0, group #1 to step
+// #1, etc. Schedule titles/amount metadata stay in the budget catalog; service-line strings/objects
+// use the same normalization as invoiceServices/recentServices, including "id1 || 20%" package
+// percentage rows that calculate from the current package price at render time.
 
 import {
-  createEntryId,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
-  makeCatalogItemEntry,
+  makePackagePercentEntry,
   normalizeServiceEntries,
   resolveServiceRow,
   setEntryField,
 } from './invoiceCatalogUtils';
 
-// --- Building a plan from a chosen catalog package + its payment schedule ------------------------------------------------------
+export const normalizeExpectedExpensesGroups = groups => (Array.isArray(groups) ? groups.map(normalizeServiceEntries) : []);
 
-// The package overview only ever lists service names (its listed price already covers all of
-// them) - no per-item prices are stored or shown.
-export const buildPackageOverviewChildren = pkg => (Array.isArray(pkg?.children) ? pkg.children : [])
-  .map(catalogId => makeCatalogItemEntry(catalogId));
+export const buildExpectedExpensesGroupsFromSchedule = (schedule, pkg) => {
+  const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+  const packagePrice = Number(pkg?.listedPrice) || 0;
+  return payments.map(payment => {
+    const amount = Number(payment?.amount) || 0;
+    const percent = packagePrice ? (amount / packagePrice) * 100 : 0;
+    return [makePackagePercentEntry({ catalogId: pkg?.id ?? '', percent })];
+  });
+};
 
-export const buildMilestonesFromSchedule = (schedule, { taxPercent = 0 } = {}) =>
-  (Array.isArray(schedule?.payments) ? schedule.payments : []).map((payment, index) => ({
-    id: createEntryId(),
-    title: payment?.title || `Payment ${index + 1}`,
-    scheduledAmount: Number(payment?.amount) || 0,
-    taxPercent,
-    // The first milestone doubles as the "introducing the program" invoice: it shows the full
-    // package overview (included services + the whole schedule) instead of just its own line.
-    showPackageOverview: index === 0,
-    additionalServices: [],
-  }));
-
-export const buildExpectedExpensesPlan = (pkg, schedule, { taxPercent = 0 } = {}) => ({
+export const buildExpectedExpensesPlan = (pkg, schedule) => ({
   packageId: String(pkg?.id ?? ''),
-  packageSnapshot: {
-    name: pkg?.name || '',
-    description: pkg?.description || '',
-    listedPrice: Number(pkg?.listedPrice) || 0,
-    currency: pkg?.currency || 'EUR',
-    children: buildPackageOverviewChildren(pkg),
-  },
-  milestones: buildMilestonesFromSchedule(schedule, { taxPercent }),
-});
-
-// --- Normalization (defensive parsing of whatever's stored on the backend) ------------------------------------------------------
-
-export const normalizeExpectedExpensesMilestone = raw => ({
-  id: raw?.id || createEntryId(),
-  title: raw?.title || '',
-  scheduledAmount: Number(raw?.scheduledAmount) || 0,
-  taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
-  showPackageOverview: Boolean(raw?.showPackageOverview),
-  additionalServices: normalizeServiceEntries(raw?.additionalServices),
+  expectedExpenses: buildExpectedExpensesGroupsFromSchedule(schedule, pkg),
 });
 
 export const normalizeExpectedExpensesData = raw => {
   if (!raw || typeof raw !== 'object') return null;
+
+  // Backward compatibility: old plans stored frozen milestones with additionalServices.
+  if (Array.isArray(raw.milestones)) {
+    return {
+      packageId: String(raw.packageId ?? ''),
+      expectedExpenses: raw.milestones.map(milestone => normalizeServiceEntries([
+        ...(Number(milestone?.scheduledAmount) ? [
+          makePackagePercentEntry({
+            catalogId: raw.packageId ?? '',
+            percent: Number(raw?.packageSnapshot?.listedPrice) ? (Number(milestone.scheduledAmount) / Number(raw.packageSnapshot.listedPrice)) * 100 : 0,
+          }),
+        ] : []),
+        ...(Array.isArray(milestone?.additionalServices) ? milestone.additionalServices : []),
+      ])),
+      ...(Array.isArray(raw.notes) ? { notes: raw.notes } : {}),
+    };
+  }
+
   return {
     packageId: String(raw.packageId ?? ''),
-    packageSnapshot: {
-      name: raw.packageSnapshot?.name || '',
-      description: raw.packageSnapshot?.description || '',
-      listedPrice: Number(raw.packageSnapshot?.listedPrice) || 0,
-      currency: raw.packageSnapshot?.currency || 'EUR',
-      children: normalizeServiceEntries(raw.packageSnapshot?.children),
-    },
-    milestones: Array.isArray(raw.milestones) ? raw.milestones.map(normalizeExpectedExpensesMilestone) : [],
+    expectedExpenses: normalizeExpectedExpensesGroups(raw.expectedExpenses),
+    ...(Array.isArray(raw.notes) ? { notes: raw.notes } : {}),
   };
 };
 
-// Loose validation for an uploaded expected-expenses JSON, before normalizeExpectedExpensesData
-// fills in any missing pieces - mirrors isInvoiceDataShape's role for the main invoice JSON.
 export const isExpectedExpensesShape = raw => Boolean(
   raw
   && typeof raw === 'object'
   && !Array.isArray(raw)
-  && raw.packageSnapshot
-  && typeof raw.packageSnapshot === 'object'
-  && Array.isArray(raw.milestones),
+  && raw.packageId !== undefined
+  && (Array.isArray(raw.expectedExpenses) || Array.isArray(raw.milestones))
 );
 
-// --- Editing ------------------------------------------------------------
-
-export const setMilestoneField = (milestone, field, value) => {
-  if (field === 'scheduledAmount' || field === 'taxPercent') {
-    const numeric = Number(String(value).replace(',', '.'));
-    return { ...milestone, [field]: Number.isFinite(numeric) ? numeric : 0 };
-  }
-  return { ...milestone, [field]: value };
+export const getExpectedExpensesValidation = (plan, schedule) => {
+  const groupCount = Array.isArray(plan?.expectedExpenses) ? plan.expectedExpenses.length : 0;
+  const paymentCount = Array.isArray(schedule?.payments) ? schedule.payments.length : 0;
+  if (groupCount > paymentCount) return `Expected expenses has ${groupCount} groups but the package schedule has only ${paymentCount} steps. Extra groups are not used.`;
+  return '';
 };
 
-export const addMilestoneAdditionalService = (milestone, entry) => ({
-  ...milestone,
-  additionalServices: [...(milestone.additionalServices || []), entry],
+export const updateExpectedExpenseServiceField = (plan, groupIndex, entryId, field, value) => ({
+  ...plan,
+  expectedExpenses: (plan.expectedExpenses || []).map((group, index) => (index === groupIndex
+    ? group.map(entry => (entry.id === entryId ? setEntryField(entry, field, value) : entry))
+    : group)),
 });
 
-export const removeMilestoneAdditionalService = (milestone, entryId) => ({
-  ...milestone,
-  additionalServices: (milestone.additionalServices || []).filter(entry => entry.id !== entryId),
+export const addExpectedExpenseService = (plan, groupIndex, entry) => {
+  const groups = [...(plan.expectedExpenses || [])];
+  while (groups.length <= groupIndex) groups.push([]);
+  groups[groupIndex] = [...groups[groupIndex], entry];
+  return { ...plan, expectedExpenses: groups };
+};
+
+export const removeExpectedExpenseService = (plan, groupIndex, entryId) => ({
+  ...plan,
+  expectedExpenses: (plan.expectedExpenses || []).map((group, index) => (index === groupIndex
+    ? group.filter(entry => entry.id !== entryId)
+    : group)),
 });
 
-export const updateMilestoneAdditionalServiceField = (milestone, entryId, field, value) => ({
-  ...milestone,
-  additionalServices: (milestone.additionalServices || [])
-    .map(entry => (entry.id === entryId ? setEntryField(entry, field, value) : entry)),
+export const resetExpectedExpenseService = (plan, groupIndex, entryId) => ({
+  ...plan,
+  expectedExpenses: (plan.expectedExpenses || []).map((group, index) => (index === groupIndex
+    ? group.map(entry => (entry.id === entryId && entry.kind === 'item' ? { id: entry.id, kind: 'item', catalogId: entry.catalogId } : entry))
+    : group)),
 });
 
-// --- Resolving for display/PDF ------------------------------------------------------
+export const resolveExpectedExpenseRows = (group, catalogItemsById, priceContext = {}) =>
+  (Array.isArray(group) ? group : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
-export const resolvePackageOverviewRows = (children, catalogItemsById, priceContext = {}) =>
-  (Array.isArray(children) ? children : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
-
-export const resolveMilestoneAdditionalRows = (milestone, catalogItemsById, priceContext = {}) =>
-  (Array.isArray(milestone?.additionalServices) ? milestone.additionalServices : [])
-    .map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
-
-export const computeMilestoneSubtotal = (milestone, additionalRows) =>
-  (Number(milestone?.scheduledAmount) || 0) + computeInvoiceSubtotal(additionalRows);
-
-export const computeMilestoneAmountDue = (subtotal, taxPercent) => computeInvoiceTotal(subtotal, taxPercent);
-
-// Sum of every milestone's scheduled amount - shown next to the package's listed price so a
-// mismatched schedule (edited milestones that no longer add up to the program price) is obvious.
-export const computeMilestonesScheduledTotal = milestones =>
-  (Array.isArray(milestones) ? milestones : []).reduce((sum, milestone) => sum + (Number(milestone?.scheduledAmount) || 0), 0);
+export const computeExpectedExpenseSubtotal = rows => computeInvoiceSubtotal(rows);
+export const computeExpectedExpenseAmountDue = (subtotal, taxPercent) => computeInvoiceTotal(subtotal, taxPercent);

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -1,16 +1,14 @@
 import {
-  addMilestoneAdditionalService,
+  addExpectedExpenseService,
   buildExpectedExpensesPlan,
-  computeMilestoneAmountDue,
-  computeMilestoneSubtotal,
-  computeMilestonesScheduledTotal,
+  computeExpectedExpenseAmountDue,
+  computeExpectedExpenseSubtotal,
+  getExpectedExpensesValidation,
   isExpectedExpensesShape,
   normalizeExpectedExpensesData,
-  removeMilestoneAdditionalService,
-  resolveMilestoneAdditionalRows,
-  resolvePackageOverviewRows,
-  setMilestoneField,
-  updateMilestoneAdditionalServiceField,
+  removeExpectedExpenseService,
+  resolveExpectedExpenseRows,
+  updateExpectedExpenseServiceField,
 } from './expectedExpensesUtils';
 import expectedExpensesSeed from '../data/expectedExpensesSeed.json';
 import { makeCustomEntry } from './invoiceCatalogUtils';
@@ -18,7 +16,6 @@ import { makeCustomEntry } from './invoiceCatalogUtils';
 const pkg = {
   id: '3',
   name: 'IVF+ED+SM',
-  description: 'For cases where embryos need to be created using donor oocytes.',
   listedPrice: 40000,
   currency: 'EUR',
   children: [1, 2, 3],
@@ -30,114 +27,72 @@ const schedule = {
     { title: 'To start the program', amount: 8772 },
     { title: 'To start stimulation of a SM', amount: 6228 },
     { title: 'In a week before embryo transfer', amount: 3000 },
-    { title: 'After confirmation of pregnancy by ultrasound', amount: 4000 },
-    { title: 'On the 12th week of pregnancy', amount: 6000 },
-    { title: 'On the 18th week of pregnancy', amount: 6000 },
-    { title: 'On the 36th week of pregnancy', amount: 6000 },
   ],
 };
 
+const priceContext = {
+  packagesById: new Map([['3', pkg]]),
+  resolvePackagePrice: packageRow => Number(packageRow?.listedPrice) || 0,
+};
+
 describe('expectedExpensesUtils', () => {
-  it('builds a plan whose milestones mirror the schedule, first one flagged as the package overview', () => {
-    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-    expect(plan.packageId).toBe('3');
-    expect(plan.packageSnapshot).toMatchObject({ name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR' });
-    expect(plan.packageSnapshot.children).toEqual([
-      { id: plan.packageSnapshot.children[0].id, kind: 'item', catalogId: '1' },
-      { id: plan.packageSnapshot.children[1].id, kind: 'item', catalogId: '2' },
-      { id: plan.packageSnapshot.children[2].id, kind: 'item', catalogId: '3' },
-    ]);
-
-    expect(plan.milestones).toHaveLength(7);
-    expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', scheduledAmount: 8772, taxPercent: 14, showPackageOverview: true });
-    expect(plan.milestones[1]).toMatchObject({ title: 'To start stimulation of a SM', scheduledAmount: 6228, showPackageOverview: false });
-  });
-
-  it('sums the milestones back up to the package listed price', () => {
+  it('builds a compact template with one service group per schedule payment', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule);
-    expect(computeMilestonesScheduledTotal(plan.milestones)).toBe(40000);
+    expect(plan.packageId).toBe('3');
+    expect(plan.expectedExpenses).toHaveLength(3);
+    expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: '3' });
+    expect(plan.expectedExpenses[0][0].percent).toBeCloseTo(21.93, 2);
   });
 
-  it('round-trips through normalization, assigning ids where missing', () => {
-    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-    const normalized = normalizeExpectedExpensesData(JSON.parse(JSON.stringify(plan)));
-    expect(normalized).toEqual(plan);
+  it('round-trips through normalization and supports legacy string rows', () => {
+    const normalized = normalizeExpectedExpensesData({
+      packageId: '3',
+      expectedExpenses: [['id3 || 20%', 'Deposit for transportation of SM || 300', 'id32']],
+    });
+    expect(normalized.packageId).toBe('3');
+    expect(normalized.expectedExpenses[0]).toMatchObject([
+      { kind: 'packagePercent', catalogId: '3', percent: 20 },
+      { kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
+      { kind: 'item', catalogId: '32' },
+    ]);
     expect(normalizeExpectedExpensesData(null)).toBeNull();
   });
 
-  it('edits a milestone field, parsing numeric fields and leaving text fields as-is', () => {
-    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-    const edited = setMilestoneField(plan.milestones[1], 'scheduledAmount', '6 500,50'.replace(' ', ''));
-    expect(edited.scheduledAmount).toBe(6500.5);
-    expect(setMilestoneField(plan.milestones[1], 'title', 'Renamed step').title).toBe('Renamed step');
-  });
-
-  it('adds, edits, and removes an additional service on a milestone', () => {
-    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
+  it('adds, edits, removes, resolves, and totals expected service rows', () => {
+    let plan = buildExpectedExpensesPlan(pkg, schedule);
     const deposit = makeCustomEntry({ name: 'Deposit for transportation of SM', price: 300 });
-    let milestone = addMilestoneAdditionalService(plan.milestones[1], deposit);
-    expect(milestone.additionalServices).toHaveLength(1);
+    plan = addExpectedExpenseService(plan, 0, deposit);
+    plan = updateExpectedExpenseServiceField(plan, 0, deposit.id, 'price', '350');
+    expect(plan.expectedExpenses[0].find(row => row.id === deposit.id).price).toBe(350);
 
-    milestone = updateMilestoneAdditionalServiceField(milestone, deposit.id, 'price', '350');
-    expect(milestone.additionalServices[0].price).toBe(350);
+    const rows = resolveExpectedExpenseRows(plan.expectedExpenses[0], new Map(), priceContext);
+    const subtotal = computeExpectedExpenseSubtotal(rows);
+    expect(subtotal).toBeCloseTo(9122);
+    expect(computeExpectedExpenseAmountDue(subtotal, 14)).toBeCloseTo(10399.08);
 
-    milestone = removeMilestoneAdditionalService(milestone, deposit.id);
-    expect(milestone.additionalServices).toHaveLength(0);
+    plan = removeExpectedExpenseService(plan, 0, deposit.id);
+    expect(plan.expectedExpenses[0]).toHaveLength(1);
   });
 
-  it('computes the amount due for a milestone exactly like the "To start the program" sample invoice (8772 taxed at 14%)', () => {
-    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-    const catalogItemsById = new Map();
-    const additionalRows = resolveMilestoneAdditionalRows(plan.milestones[0], catalogItemsById);
-    const subtotal = computeMilestoneSubtotal(plan.milestones[0], additionalRows);
-    expect(subtotal).toBe(8772);
-    expect(computeMilestoneAmountDue(subtotal, plan.milestones[0].taxPercent)).toBeCloseTo(10000.08);
+  it('validates extra groups against the schedule length', () => {
+    const plan = { packageId: '3', expectedExpenses: [[], [], [], []] };
+    expect(getExpectedExpensesValidation(plan, schedule)).toContain('4 groups');
+    expect(getExpectedExpensesValidation({ packageId: '3', expectedExpenses: [[]] }, schedule)).toBe('');
   });
 
-  it('adds extra services into the amount due, matching the Mullins sample (13000 scheduled + 2500 PGS, taxed at 13%)', () => {
-    const plan = buildExpectedExpensesPlan(
-      { ...pkg, listedPrice: 41500 },
-      { payments: [{ title: 'To start the program', amount: 13000 }] },
-      { taxPercent: 13 },
-    );
-    const pgs = makeCustomEntry({ name: 'PGS of 24 chromosomes', price: 2500 });
-    const milestone = addMilestoneAdditionalService(plan.milestones[0], pgs);
-    const catalogItemsById = new Map();
-    const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById);
-    const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
-    expect(subtotal).toBe(15500);
-    expect(computeMilestoneAmountDue(subtotal, milestone.taxPercent)).toBeCloseTo(17515);
-  });
-
-  it('resolves package overview rows by name, without prices, following the catalog', () => {
-    const catalogItemsById = new Map([
-      ['1', { id: '1', name: 'Program coordination and support', price: 5000 }],
-      ['2', { id: '2', name: 'Surrogacy document preparation', price: 350 }],
-    ]);
-    const plan = buildExpectedExpensesPlan(pkg, schedule);
-    const rows = resolvePackageOverviewRows(plan.packageSnapshot.children.slice(0, 2), catalogItemsById);
-    expect(rows.map(row => row.name)).toEqual(['Program coordination and support', 'Surrogacy document preparation']);
-  });
-
-  describe('isExpectedExpensesShape', () => {
-    it('accepts a plan-shaped object and rejects anything else', () => {
-      const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-      expect(isExpectedExpensesShape(plan)).toBe(true);
-      expect(isExpectedExpensesShape(null)).toBe(false);
-      expect(isExpectedExpensesShape({})).toBe(false);
-      expect(isExpectedExpensesShape({ packageSnapshot: {}, milestones: 'nope' })).toBe(false);
-    });
+  it('accepts new templates and legacy milestone plans', () => {
+    expect(isExpectedExpensesShape(buildExpectedExpensesPlan(pkg, schedule))).toBe(true);
+    expect(isExpectedExpensesShape({ packageId: '3', milestones: [] })).toBe(true);
+    expect(isExpectedExpensesShape({})).toBe(false);
   });
 
   describe('expectedExpensesSeed.json', () => {
-    it('is a valid, normalizable expected-expenses plan whose milestones add up to the package price', () => {
+    it('is a valid, normalizable expected-expenses template', () => {
       expect(isExpectedExpensesShape(expectedExpensesSeed)).toBe(true);
       const normalized = normalizeExpectedExpensesData(expectedExpensesSeed);
       expect(normalized.packageId).toBe('3');
-      expect(normalized.milestones).toHaveLength(6);
-      expect(computeMilestonesScheduledTotal(normalized.milestones)).toBe(normalized.packageSnapshot.listedPrice);
-      expect(normalized.milestones[0].showPackageOverview).toBe(true);
-      expect(normalized.milestones.slice(1).every(milestone => !milestone.showPackageOverview)).toBe(true);
+      expect(normalized.expectedExpenses).toHaveLength(6);
+      expect(normalized.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: '3' });
     });
   });
 });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -13,6 +13,8 @@
 //                                                        entry). Editing/removing/reordering a
 //                                                        child, or renaming the package, flips
 //                                                        `customized: true` on the package.
+//   { id, kind: 'packagePercent', catalogId, percent } -> a live percentage of a package price
+//                                                        (legacy string: "id1 || 20%").
 //
 // Older data may still contain plain strings ("id15", "Name || Price") - normalizeServiceEntry
 // upgrades those to the object shape on load, so the rest of the app only ever sees objects.
@@ -79,6 +81,13 @@ export const makeCustomEntry = ({ name = '', price = 0, description = '' } = {},
   ...(String(description || '').trim() ? { description: String(description).trim() } : {}),
 });
 
+export const makePackagePercentEntry = ({ catalogId = '', percent = 0 } = {}, { id } = {}) => ({
+  id: id || createEntryId(),
+  kind: 'packagePercent',
+  catalogId: String(catalogId),
+  percent: toNumber(percent),
+});
+
 // pkg: a budget/packages record ({ id, children: [itemId, ...] }). Its children are copied in as
 // plain catalog-item entries - editing/removing any of them below marks the package as customized.
 export const makeCatalogPackageEntry = (pkg, { id } = {}) => ({
@@ -101,12 +110,17 @@ export const cloneEntryWithNewId = entry => {
 
 // --- Legacy string parsing / normalization ------------------------------------------------------
 
-// "id15" -> catalog reference · "Name || Price" -> a custom one-off line.
+// "id15" -> catalog reference · "Name || Price" -> custom · "id1 || 20%" -> package percentage.
 export const parseLegacyServiceString = raw => {
   const text = String(raw ?? '').trim();
   if (text.includes(SERVICE_PRICE_SEPARATOR)) {
     const [namePart, ...priceParts] = text.split(SERVICE_PRICE_SEPARATOR);
-    return { kind: 'custom', name: namePart.trim(), price: toNumber(priceParts.join(SERVICE_PRICE_SEPARATOR)) };
+    const left = namePart.trim();
+    const right = priceParts.join(SERVICE_PRICE_SEPARATOR).trim();
+    const catalogMatch = new RegExp(`^${CATALOG_ID_PREFIX}(.+)$`, 'i').exec(left);
+    const percentMatch = /^(-?\d+(?:[.,]\d+)?)\s*%$/.exec(right);
+    if (catalogMatch && percentMatch) return { kind: 'packagePercent', catalogId: catalogMatch[1], percent: toNumber(percentMatch[1]) };
+    return { kind: 'custom', name: left, price: toNumber(right) };
   }
   const catalogMatch = new RegExp(`^${CATALOG_ID_PREFIX}(.+)$`, 'i').exec(text);
   if (catalogMatch) return { kind: 'item', catalogId: catalogMatch[1] };
@@ -118,7 +132,9 @@ export const parseLegacyServiceString = raw => {
 export const normalizeServiceEntry = raw => {
   if (typeof raw === 'string') {
     const parsed = parseLegacyServiceString(raw);
-    return parsed.kind === 'item' ? makeCatalogItemEntry(parsed.catalogId) : makeCustomEntry(parsed);
+    if (parsed.kind === 'item') return makeCatalogItemEntry(parsed.catalogId);
+    if (parsed.kind === 'packagePercent') return makePackagePercentEntry(parsed);
+    return makeCustomEntry(parsed);
   }
   if (!raw || typeof raw !== 'object') return makeCustomEntry({});
 
@@ -137,6 +153,10 @@ export const normalizeServiceEntry = raw => {
         : {}),
       children: normalizeServiceEntries(raw.children),
     };
+  }
+
+  if (raw.kind === 'packagePercent') {
+    return makePackagePercentEntry({ catalogId: raw.catalogId, percent: raw.percent }, { id });
   }
 
   if (raw.kind === 'custom') {
@@ -173,6 +193,11 @@ export const setEntryField = (entry, field, value) => {
   if (!entry) return entry;
   if (entry.kind === 'custom') {
     return { ...entry, [field]: field === 'price' ? toNumber(value) : value };
+  }
+  if (entry.kind === 'packagePercent') {
+    if (field === 'percent' || field === 'price') return { ...entry, percent: toNumber(value) };
+    if (field === 'catalogId') return { ...entry, catalogId: String(value) };
+    return entry;
   }
   if (entry.kind === 'package') {
     if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
@@ -235,6 +260,7 @@ export const isEntryCustomized = entry => (entry?.kind === 'custom' ? true : Boo
 export const getEntryIdentityKey = entry => {
   if (!entry) return '';
   if (entry.kind === 'package') return `package:${entry.catalogId}`;
+  if (entry.kind === 'packagePercent') return `package-percent:${entry.catalogId}:${entry.percent || 0}`;
   if (entry.kind === 'item') return `item:${entry.catalogId}`;
   return `custom:${entry.name || ''}:${entry.price || 0}:${entry.description || ''}`;
 };
@@ -248,6 +274,26 @@ export const getEntryIdentityKey = entry => {
 // `children` are always a frozen snapshot taken when it was added - they never live-track the
 // catalog, since that's the whole point of pinning a specific set of services to an invoice.
 export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) => {
+  if (entry?.kind === 'packagePercent') {
+    const pkg = priceContext.packagesById?.get?.(String(entry.catalogId));
+    const rawPackagePrice = pkg?.listedPrice ?? pkg?.price ?? 0;
+    const packagePrice = Number(priceContext.resolvePackagePrice?.(pkg) ?? rawPackagePrice) || 0;
+    const percent = Number(entry.percent) || 0;
+    return {
+      key: entry.id,
+      id: entry.id,
+      kind: 'packagePercent',
+      catalogId: entry.catalogId,
+      missing: !pkg,
+      isCustomized: true,
+      name: 'Scheduled payment',
+      description: pkg?.name ? `${percent}% of ${pkg.name}` : `${percent}% of package id${entry.catalogId}`,
+      price: packagePrice * percent / 100,
+      percent,
+      packagePrice,
+    };
+  }
+
   if (entry?.kind === 'package') {
     const pkg = priceContext.packagesById?.get?.(String(entry.catalogId));
     const children = Array.isArray(entry.children) ? entry.children : [];

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -17,6 +17,7 @@ import {
   makeCatalogItemEntry,
   makeCatalogPackageEntry,
   makeCustomEntry,
+  makePackagePercentEntry,
   movePackageChild,
   normalizeInvoiceData,
   normalizeServiceEntry,
@@ -82,6 +83,12 @@ describe('invoiceCatalogUtils', () => {
       expect(parseLegacyServiceString('Deposit for transportation of SM || 300')).toEqual({
         kind: 'custom', name: 'Deposit for transportation of SM', price: 300,
       });
+    });
+
+    it('parses legacy "idNN || Percent%" rows as package percentages', () => {
+      expect(parseLegacyServiceString('id3 || 20%')).toEqual({ kind: 'packagePercent', catalogId: '3', percent: 20 });
+      const entry = normalizeServiceEntry('id3 || 12,5%');
+      expect(entry).toMatchObject({ kind: 'packagePercent', catalogId: '3', percent: 12.5 });
     });
 
     it('upgrades a legacy string into the canonical object entry', () => {
@@ -274,6 +281,14 @@ describe('invoiceCatalogUtils', () => {
       expect(row.price).toBe(250);
       expect(row.childrenTotal).toBe(300);
       expect(row.hasPriceOverride).toBe(true);
+    });
+
+    it('resolves a package percentage from the current package price without storing the amount', () => {
+      const packagesById = new Map([['p1', { id: 'p1', name: 'Full program', listedPrice: 40000 }]]);
+      const row = resolveServiceRow(makePackagePercentEntry({ catalogId: 'p1', percent: 20 }), new Map(), { packagesById });
+      expect(row.name).toBe('Scheduled payment');
+      expect(row.description).toBe('20% of Full program');
+      expect(row.price).toBe(8000);
     });
 
     it('computes subtotal/total without double-counting package children', () => {

--- a/src/data/expectedExpensesSeed.json
+++ b/src/data/expectedExpensesSeed.json
@@ -1,101 +1,41 @@
 {
   "packageId": "3",
-  "packageSnapshot": {
-    "name": "IVF + ED + SM",
-    "description": "For cases where embryos need to be created using donor oocytes.",
-    "listedPrice": 46000,
-    "currency": "EUR",
-    "children": [
-      { "id": "pkg3-child-1", "kind": "item", "catalogId": "1" },
-      { "id": "pkg3-child-2", "kind": "item", "catalogId": "2" },
-      { "id": "pkg3-child-3", "kind": "item", "catalogId": "3" },
-      { "id": "pkg3-child-4", "kind": "item", "catalogId": "4" },
-      { "id": "pkg3-child-5", "kind": "item", "catalogId": "5" },
-      { "id": "pkg3-child-6", "kind": "item", "catalogId": "6" },
-      { "id": "pkg3-child-7", "kind": "item", "catalogId": "7" },
-      { "id": "pkg3-child-8", "kind": "item", "catalogId": "8" },
-      { "id": "pkg3-child-9", "kind": "item", "catalogId": "9" },
-      { "id": "pkg3-child-10", "kind": "item", "catalogId": "10" },
-      { "id": "pkg3-child-11", "kind": "item", "catalogId": "11" },
-      { "id": "pkg3-child-12", "kind": "item", "catalogId": "12" },
-      { "id": "pkg3-child-13", "kind": "item", "catalogId": "14" },
-      { "id": "pkg3-child-14", "kind": "item", "catalogId": "15" },
-      { "id": "pkg3-child-15", "kind": "item", "catalogId": "16" },
-      { "id": "pkg3-child-16", "kind": "item", "catalogId": "18" },
-      { "id": "pkg3-child-17", "kind": "item", "catalogId": "19" },
-      { "id": "pkg3-child-18", "kind": "item", "catalogId": "21" },
-      { "id": "pkg3-child-19", "kind": "item", "catalogId": "22" },
-      { "id": "pkg3-child-20", "kind": "item", "catalogId": "23" },
-      { "id": "pkg3-child-21", "kind": "item", "catalogId": "24" },
-      { "id": "pkg3-child-22", "kind": "item", "catalogId": "25" }
+  "expectedExpenses": [
+    [
+      "id3 || 34.7826086957%"
+    ],
+    [
+      "id3 || 13.0434782609%",
+      "Deposit for transportation of SM || 300",
+      "Deposit for medical expenses of SM || 300"
+    ],
+    [
+      "id3 || 13.0434782609%",
+      "Deposit for transportation of SM || 300",
+      "Deposit for medical expenses of SM || 300"
+    ],
+    [
+      "id3 || 13.0434782609%",
+      "id40",
+      "Deposit for transportation of SM || 300",
+      "Deposit for medical expenses of SM || 300"
+    ],
+    [
+      "id3 || 13.0434782609%",
+      "Deposit for transportation of SM || 300",
+      "Deposit for medical expenses of SM || 300"
+    ],
+    [
+      "id3 || 13.0434782609%",
+      "Deposit. Medications for SM during and after delivery || 500",
+      "Deposit. For C-section (is returned if not used) || 2700",
+      "Deposit. For baby clothes / diapers / formulas / etc || 110",
+      "Deposit. For unexpected expenses (e.g. staying in hospital, service of nanny etc.) || 600",
+      "Standard service of the independent lawyer, notary and post until the 6 months after delivery || GIFT"
     ]
-  },
-  "milestones": [
-    {
-      "id": "milestone-1",
-      "title": "To start the program",
-      "scheduledAmount": 16000,
-      "taxPercent": 14,
-      "showPackageOverview": true,
-      "additionalServices": []
-    },
-    {
-      "id": "milestone-2",
-      "title": "Two weeks before embryo transfer",
-      "scheduledAmount": 6000,
-      "taxPercent": 14,
-      "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-2-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
-        { "id": "milestone-2-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
-      ]
-    },
-    {
-      "id": "milestone-3",
-      "title": "After confirmation of pregnancy by ultrasound",
-      "scheduledAmount": 6000,
-      "taxPercent": 14,
-      "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-3-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
-        { "id": "milestone-3-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
-      ]
-    },
-    {
-      "id": "milestone-4",
-      "title": "On the 12th week of pregnancy",
-      "scheduledAmount": 6000,
-      "taxPercent": 14,
-      "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-4-extra-1", "kind": "item", "catalogId": "40" },
-        { "id": "milestone-4-extra-2", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
-        { "id": "milestone-4-extra-3", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
-      ]
-    },
-    {
-      "id": "milestone-5",
-      "title": "On the 18th week of pregnancy",
-      "scheduledAmount": 6000,
-      "taxPercent": 14,
-      "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-5-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
-        { "id": "milestone-5-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
-      ]
-    },
-    {
-      "id": "milestone-6",
-      "title": "On the 36th week of pregnancy",
-      "scheduledAmount": 6000,
-      "taxPercent": 14,
-      "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-6-extra-1", "kind": "custom", "name": "Deposit. Medications for SM during and after delivery", "price": 500 },
-        { "id": "milestone-6-extra-2", "kind": "custom", "name": "Deposit. For C-section (is returned if not used)", "price": 2700 },
-        { "id": "milestone-6-extra-3", "kind": "custom", "name": "Deposit. For baby clothes / diapers / formulas / etc", "price": 110 },
-        { "id": "milestone-6-extra-4", "kind": "custom", "name": "Deposit. For unexpected expenses (e.g. staying in hospital, service of nanny etc.)", "price": 600 }
-      ]
-    }
+  ],
+  "notes": [
+    "Purpose of the payment must be exactly like in invoice.",
+    "Please make sure you pay the whole amount. Do not use SHA option while making payment."
   ]
 }


### PR DESCRIPTION
### Motivation
- Move expected-expenses from a frozen milestone model to a compact template (`{ packageId, expectedExpenses }`) that stores service-line groups per payment step and supports live package-percentage rows.
- Support legacy stored shapes while simplifying stored JSON size and enabling per-group editable services that calculate from current package price at render time.
- Improve admin UX by adding inline PDF preview pages and making PDF generation use the program schedule instead of frozen milestone metadata.

### Description
- Reworked core expected-expenses logic in `src/components/expectedExpensesUtils.js` to produce and normalize the new `expectedExpenses` groups, add editing helpers (`addExpectedExpenseService`, `removeExpectedExpenseService`, `updateExpectedExpenseServiceField`, `resetExpectedExpenseService`), validation via `getExpectedExpensesValidation`, and converters for legacy milestone plans.
- Added package-percentage entry support across the codebase by introducing `makePackagePercentEntry` and parsing `idNN || 20%` legacy strings in `src/components/invoiceCatalogUtils.js`, updating `normalizeServiceEntry`, `parseLegacyServiceString`, `setEntryField`, `getEntryIdentityKey`, and `resolveServiceRow` to resolve `packagePercent` rows into calculated prices.
- Updated the expected-expenses PDF renderer (`src/components/ExpectedExpensesPdfDocument.jsx`) to iterate program `schedule.payments` and use `resolveExpectedExpenseRows`, `computeExpectedExpenseSubtotal`, and `computeExpectedExpenseAmountDue`, passing `schedule` and `taxPercent` into the document.
- Refactored admin editor (`src/components/InvoiceBuilderPage.jsx`) to build/refetch expected-expenses templates from chosen packages, expose per-group editing, add package-percent quick-add, replace milestone-centric UI with `PdfPreviewStrip` and per-page previews, and wire new persistence helpers (create/update/refresh/delete expected-expenses template).
- Replaced the verbose seed and storage shape with the compact `src/data/expectedExpensesSeed.json` that uses legacy-strings for easier authoring and included backward-compatibility in normalization.
- Updated and extended tests to match the new model: `invoiceCatalogUtils.test.js`, `expectedExpensesUtils.test.js`, and `InvoiceBuilderPage.test.js` adjusted to assert `expectedExpenses` groups and `packagePercent` behavior.

### Testing
- Ran unit tests for `invoiceCatalogUtils.test.js`, `expectedExpensesUtils.test.js`, and `InvoiceBuilderPage.test.js` to cover parsing, normalization, CRUD helpers, resolution and subtotal/total calculations; all tests passed.
- Ran the full automated test suite for the invoice builder components including PDF generation paths; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e9396b7cc8326b15dd0f34877604b)