### PR TITLE
Fix expected expenses package schedule percentages

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -55,6 +55,7 @@ import {
   buildExpectedExpensesPlan,
   computeExpectedExpenseAmountDue,
   computeExpectedExpenseSubtotal,
+  getExpectedExpensesPackagePrice,
   getExpectedExpensesValidation,
   isExpectedExpensesShape,
   normalizeExpectedExpensesData,
@@ -1474,13 +1475,29 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     persistPath(EXPECTED_EXPENSES_PATH, nextPlan, successMessage);
   };
 
+  const getResolvedExpectedExpensesPackage = pkg => {
+    const resolvedPrice = resolveBudgetPriceAmount(pkg.listedPrice, priceContext);
+    if (resolvedPrice == null) {
+      toast.error('Wait until the package price formula resolves before creating expected expenses.');
+      return null;
+    }
+    try {
+      getExpectedExpensesPackagePrice({ ...pkg, listedPrice: resolvedPrice });
+    } catch (error) {
+      toast.error('Expected expenses require a resolved positive package price.');
+      return null;
+    }
+    return { ...pkg, listedPrice: resolvedPrice };
+  };
+
   const createExpectedExpensesPlan = pkg => {
     const schedule = resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg);
     if (!schedule || !Array.isArray(schedule.payments) || !schedule.payments.length) {
       toast.error('This package has no payment schedule in the catalog.');
       return;
     }
-    const resolvedPackage = { ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice };
+    const resolvedPackage = getResolvedExpectedExpensesPackage(pkg);
+    if (!resolvedPackage) return;
     const plan = buildExpectedExpensesPlan(resolvedPackage, schedule);
     persistExpectedExpenses(plan, 'Expected expenses template created.');
     setShowExpectedExpensesPicker(false);
@@ -1498,8 +1515,17 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       toast.error('This package has no payment schedule in the catalog.');
       return;
     }
-    const fresh = buildExpectedExpensesPlan({ ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice }, schedule);
-    const nextGroups = fresh.expectedExpenses.map((group, index) => expectedExpenses.expectedExpenses?.[index] || group);
+    const resolvedPackage = getResolvedExpectedExpensesPackage(pkg);
+    if (!resolvedPackage) return;
+    const fresh = buildExpectedExpensesPlan(resolvedPackage, schedule);
+    const nextGroups = fresh.expectedExpenses.map((group, index) => {
+      const existingGroup = Array.isArray(expectedExpenses.expectedExpenses?.[index]) ? expectedExpenses.expectedExpenses[index] : [];
+      const scheduledIndex = existingGroup.findIndex(entry => entry?.kind === 'packagePercent' && String(entry.catalogId) === String(expectedExpenses.packageId));
+      const extraServices = scheduledIndex === -1
+        ? existingGroup
+        : existingGroup.filter((_, entryIndex) => entryIndex !== scheduledIndex);
+      return [...group, ...extraServices];
+    });
     persistExpectedExpenses({ ...expectedExpenses, expectedExpenses: nextGroups }, 'Schedule groups refreshed.');
   };
 

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -263,6 +263,45 @@ describe('InvoiceBuilderPage', () => {
       await act(async () => { root.unmount(); });
     });
 
+    it('recalculates scheduled package rows while preserving extra services', async () => {
+      get.mockImplementation(path => {
+        if (path === 'invoiceBuilder') return Promise.resolve({ exists: () => true, val: () => fixtureInvoiceData });
+        if (path === 'budget/items') return Promise.resolve({ exists: () => true, val: () => fixtureItems });
+        if (path === 'budget/packages') return Promise.resolve({ exists: () => true, val: () => fixturePackages });
+        if (path === 'budget/technical') return Promise.resolve({ exists: () => true, val: () => fixtureTechnical });
+        if (path === 'invoiceBuilder/expectedExpenses') {
+          return Promise.resolve({
+            exists: () => true,
+            val: () => ({
+              packageId: 'p1',
+              expectedExpenses: [
+                [
+                  { id: 'stale-1', kind: 'packagePercent', catalogId: 'p1', percent: 10 },
+                  { id: 'custom-1', kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
+                ],
+                [{ id: 'stale-2', kind: 'packagePercent', catalogId: 'p1', percent: 10 }],
+              ],
+            }),
+          });
+        }
+        return Promise.resolve({ exists: () => false, val: () => null });
+      });
+      const root = mount();
+      await flush();
+
+      const recalculateButton = findButton('Recalculate');
+      expect(recalculateButton).toBeTruthy();
+      await act(async () => { recalculateButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60 });
+      expect(plan.expectedExpenses[0][1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40 });
+
+      await act(async () => { root.unmount(); });
+    });
+
     it('deletes the whole plan', async () => {
       const root = mount();
       await flush();

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -16,9 +16,17 @@ import {
 
 export const normalizeExpectedExpensesGroups = groups => (Array.isArray(groups) ? groups.map(normalizeServiceEntries) : []);
 
+export const getExpectedExpensesPackagePrice = pkg => {
+  const packagePrice = Number(pkg?.listedPrice);
+  if (!Number.isFinite(packagePrice) || packagePrice <= 0) {
+    throw new Error('Expected expenses require a resolved positive package price.');
+  }
+  return packagePrice;
+};
+
 export const buildExpectedExpensesGroupsFromSchedule = (schedule, pkg) => {
   const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
-  const packagePrice = Number(pkg?.listedPrice) || 0;
+  const packagePrice = getExpectedExpensesPackagePrice(pkg);
   return payments.map(payment => {
     const amount = Number(payment?.amount) || 0;
     const percent = packagePrice ? (amount / packagePrice) * 100 : 0;

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -44,6 +44,10 @@ describe('expectedExpensesUtils', () => {
     expect(plan.expectedExpenses[0][0].percent).toBeCloseTo(21.93, 2);
   });
 
+  it('rejects unresolved package prices before generating percentage rows', () => {
+    expect(() => buildExpectedExpensesPlan({ ...pkg, listedPrice: '=usd * 1000' }, schedule)).toThrow('resolved positive package price');
+  });
+
   it('round-trips through normalization and supports legacy string rows', () => {
     const normalized = normalizeExpectedExpensesData({
       packageId: '3',


### PR DESCRIPTION
### Motivation
- Prevent generating `packagePercent` rows from unresolved or non-numeric package `listedPrice`, which previously produced `0%` rows that remained persisted and produced incorrect PDFs. 
- Stop users from creating/recalculating expected-expenses templates when a package price formula (e.g. using NBU rates) has not resolved yet. 
- Ensure that recalculation refreshes the scheduled percentage row while keeping any user-added extra service rows in each schedule group. 

### Description
- Added `getExpectedExpensesPackagePrice` in `src/components/expectedExpensesUtils.js` to validate that `pkg.listedPrice` is a resolved positive numeric price and throw otherwise. 
- Updated `buildExpectedExpensesGroupsFromSchedule` to use `getExpectedExpensesPackagePrice` so percentage rows are only built from a validated numeric package price. 
- Introduced `getResolvedExpectedExpensesPackage` in `src/components/InvoiceBuilderPage.jsx` to resolve formula prices with `resolveBudgetPriceAmount`, show a toast and abort when unresolved, and validate the resolved numeric price before calling `buildExpectedExpensesPlan`. 
- Changed the recalculation flow in `InvoiceBuilderPage.jsx` to merge the freshly computed `packagePercent` row with existing extra service rows by removing the old scheduled percent entry and appending non-scheduled entries, so user additions are preserved while scheduled percentages are updated. 
- Added regression tests covering rejection of unresolved package prices and verifying recalculation merges scheduled percent rows while preserving extra services in `src/components/expectedExpensesUtils.test.js` and `src/components/InvoiceBuilderPage.test.js`. 

### Testing
- Ran `npm test -- --runInBand src/components/expectedExpensesUtils.test.js src/components/InvoiceBuilderPage.test.js`, and both test suites passed. 
- Also ran the CI-flavored run `CI=true npm test -- --runInBand src/components/expectedExpensesUtils.test.js src/components/InvoiceBuilderPage.test.js`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ea11f7dd483268845e007dfc9d3b6)