### PR TITLE
Serialize expected-expenses plan for compact storage and preserve legacy uploads

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -62,6 +62,7 @@ import {
   removeExpectedExpenseService,
   resetExpectedExpenseService,
   resolveExpectedExpenseRows,
+  serializeExpectedExpensesData,
   updateExpectedExpenseServiceField,
 } from './expectedExpensesUtils';
 
@@ -1472,7 +1473,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const persistExpectedExpenses = (nextPlan, successMessage) => {
     setExpectedExpenses(nextPlan);
-    persistPath(EXPECTED_EXPENSES_PATH, nextPlan, successMessage);
+    persistPath(EXPECTED_EXPENSES_PATH, serializeExpectedExpensesData(nextPlan), successMessage);
   };
 
   const getResolvedExpectedExpensesPackage = pkg => {
@@ -1688,7 +1689,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         return;
       }
       const nextPlan = normalizeExpectedExpensesData(parsed);
-      await set(ref(database, EXPECTED_EXPENSES_PATH), nextPlan);
+      await set(ref(database, EXPECTED_EXPENSES_PATH), parsed);
       setExpectedExpenses(nextPlan);
       toast.success('Expected expenses JSON uploaded to backend.');
     } catch (uploadError) {

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -226,8 +226,8 @@ describe('InvoiceBuilderPage', () => {
       const plan = persistedCalls[persistedCalls.length - 1][1];
       expect(plan.packageId).toBe('p1');
       expect(plan.expectedExpenses).toHaveLength(2);
-      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60 });
-      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40 });
+      expect(plan.expectedExpenses[0][0]).toBe('idp1 || 60%');
+      expect(plan.expectedExpenses[1][0]).toBe('idp1 || 40%');
 
       await act(async () => { root.unmount(); });
     });
@@ -257,7 +257,7 @@ describe('InvoiceBuilderPage', () => {
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
       expect(plan.expectedExpenses[0]).toHaveLength(2);
-      expect(plan.expectedExpenses[0][1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.expectedExpenses[0][1]).toBe('Deposit for transportation of SM || 300');
       expect(plan.expectedExpenses[1]).toHaveLength(1);
 
       await act(async () => { root.unmount(); });
@@ -295,9 +295,9 @@ describe('InvoiceBuilderPage', () => {
       await flush();
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60 });
-      expect(plan.expectedExpenses[0][1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
-      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40 });
+      expect(plan.expectedExpenses[0][0]).toBe('idp1 || 60%');
+      expect(plan.expectedExpenses[0][1]).toBe('Deposit for transportation of SM || 300');
+      expect(plan.expectedExpenses[1][0]).toBe('idp1 || 40%');
 
       await act(async () => { root.unmount(); });
     });
@@ -345,8 +345,9 @@ describe('InvoiceBuilderPage', () => {
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
       expect(plan.packageId).toBe('3');
+      expect(plan).toEqual(expectedExpensesSeed);
       expect(plan.expectedExpenses).toHaveLength(6);
-      expect(plan.expectedExpenses[1][1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.expectedExpenses[1][1]).toBe('Deposit for transportation of SM || 300');
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -14,6 +14,32 @@ import {
   setEntryField,
 } from './invoiceCatalogUtils';
 
+
+const formatCleanNumber = value => {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return String(value ?? '').trim();
+  return Number.isInteger(number) ? String(number) : String(number);
+};
+
+export const serializeExpectedExpenseEntry = entry => {
+  if (typeof entry === 'string') return entry;
+  if (!entry || typeof entry !== 'object') return '';
+  if (entry.kind === 'packagePercent') return `id${entry.catalogId ?? ''} || ${formatCleanNumber(entry.percent)}%`;
+  if (entry.kind === 'item') return `id${entry.catalogId ?? ''}`;
+  if (entry.kind === 'custom') return `${String(entry.name || '').trim()} || ${formatCleanNumber(entry.price)}`;
+  return '';
+};
+
+export const serializeExpectedExpensesGroups = groups => (Array.isArray(groups)
+  ? groups.map(group => (Array.isArray(group) ? group.map(serializeExpectedExpenseEntry).filter(Boolean) : []))
+  : []);
+
+export const serializeExpectedExpensesData = plan => (plan ? {
+  packageId: String(plan.packageId ?? ''),
+  expectedExpenses: serializeExpectedExpensesGroups(plan.expectedExpenses),
+  ...(Array.isArray(plan.notes) ? { notes: [...plan.notes] } : {}),
+} : null);
+
 export const normalizeExpectedExpensesGroups = groups => (Array.isArray(groups) ? groups.map(normalizeServiceEntries) : []);
 
 export const getExpectedExpensesPackagePrice = pkg => {

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -8,6 +8,7 @@ import {
   normalizeExpectedExpensesData,
   removeExpectedExpenseService,
   resolveExpectedExpenseRows,
+  serializeExpectedExpensesData,
   updateExpectedExpenseServiceField,
 } from './expectedExpensesUtils';
 import expectedExpensesSeed from '../data/expectedExpensesSeed.json';
@@ -59,6 +60,10 @@ describe('expectedExpensesUtils', () => {
       { kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
       { kind: 'item', catalogId: '32' },
     ]);
+    expect(serializeExpectedExpensesData(normalized)).toEqual({
+      packageId: '3',
+      expectedExpenses: [['id3 || 20%', 'Deposit for transportation of SM || 300', 'id32']],
+    });
     expect(normalizeExpectedExpensesData(null)).toBeNull();
   });
 


### PR DESCRIPTION
### Motivation
- Persist expected-expenses in a compact, storage-friendly form (string rows) while keeping internal normalized objects for UI and computations.
- Accept legacy/standalone expected-expenses JSON uploads verbatim into the backend while normalizing for runtime use.
- Make persisted data deterministic and smaller by serializing package-percent, item and custom rows to concise strings.

### Description
- Added serialization helpers in `expectedExpensesUtils.js`: `formatCleanNumber`, `serializeExpectedExpenseEntry`, `serializeExpectedExpensesGroups`, and `serializeExpectedExpensesData` to convert plan entries to compact string rows for storage.
- Updated persistence in `InvoiceBuilderPage.jsx` to call `serializeExpectedExpensesData` when writing expected-expenses to the database and to write uploaded JSON directly (un-normalized) into the backend while normalizing state for the UI.
- Adjusted tests and expectations to assert persisted expected-expenses are serialized strings and added a unit test verifying round-trip serialization in `expectedExpensesUtils.test.js`.

### Testing
- Ran updated unit tests for `expectedExpensesUtils.test.js` which assert normalization and `serializeExpectedExpensesData` behavior, and they passed.
- Ran updated component tests in `InvoiceBuilderPage.test.js` which now expect serialized storage values and upload behavior, and they passed.
- Executed the test suite (`npm test`/`yarn test`) and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ea30238cc8326a3357ba7bca2f79a)