### PR TITLE
Preserve manual expected expense percent rows

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1521,10 +1521,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     const fresh = buildExpectedExpensesPlan(resolvedPackage, schedule);
     const nextGroups = fresh.expectedExpenses.map((group, index) => {
       const existingGroup = Array.isArray(expectedExpenses.expectedExpenses?.[index]) ? expectedExpenses.expectedExpenses[index] : [];
-      const scheduledIndex = existingGroup.findIndex(entry => entry?.kind === 'packagePercent' && String(entry.catalogId) === String(expectedExpenses.packageId));
-      const extraServices = scheduledIndex === -1
-        ? existingGroup
-        : existingGroup.filter((_, entryIndex) => entryIndex !== scheduledIndex);
+      const extraServices = existingGroup.filter(entry => entry?.expectedExpenseRole !== 'scheduled');
       return [...group, ...extraServices];
     });
     persistExpectedExpenses({ ...expectedExpenses, expectedExpenses: nextGroups }, 'Schedule groups refreshed.');

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -226,8 +226,8 @@ describe('InvoiceBuilderPage', () => {
       const plan = persistedCalls[persistedCalls.length - 1][1];
       expect(plan.packageId).toBe('p1');
       expect(plan.expectedExpenses).toHaveLength(2);
-      expect(plan.expectedExpenses[0][0]).toBe('idp1 || 60%');
-      expect(plan.expectedExpenses[1][0]).toBe('idp1 || 40%');
+      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
+      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
 
       await act(async () => { root.unmount(); });
     });
@@ -276,10 +276,10 @@ describe('InvoiceBuilderPage', () => {
               packageId: 'p1',
               expectedExpenses: [
                 [
-                  { id: 'stale-1', kind: 'packagePercent', catalogId: 'p1', percent: 10 },
+                  { id: 'stale-1', kind: 'packagePercent', catalogId: 'p1', percent: 10, expectedExpenseRole: 'scheduled' },
                   { id: 'custom-1', kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
                 ],
-                [{ id: 'stale-2', kind: 'packagePercent', catalogId: 'p1', percent: 10 }],
+                [{ id: 'stale-2', kind: 'packagePercent', catalogId: 'p1', percent: 10, expectedExpenseRole: 'scheduled' }],
               ],
             }),
           });
@@ -295,12 +295,49 @@ describe('InvoiceBuilderPage', () => {
       await flush();
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.expectedExpenses[0][0]).toBe('idp1 || 60%');
+      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
       expect(plan.expectedExpenses[0][1]).toBe('Deposit for transportation of SM || 300');
-      expect(plan.expectedExpenses[1][0]).toBe('idp1 || 40%');
+      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
 
       await act(async () => { root.unmount(); });
     });
+
+    it('preserves user-added package percent rows when recalculating', async () => {
+      get.mockImplementation(path => {
+        if (path === 'invoiceBuilder') return Promise.resolve({ exists: () => true, val: () => fixtureInvoiceData });
+        if (path === 'budget/items') return Promise.resolve({ exists: () => true, val: () => fixtureItems });
+        if (path === 'budget/packages') return Promise.resolve({ exists: () => true, val: () => fixturePackages });
+        if (path === 'budget/technical') return Promise.resolve({ exists: () => true, val: () => fixtureTechnical });
+        if (path === 'invoiceBuilder/expectedExpenses') {
+          return Promise.resolve({
+            exists: () => true,
+            val: () => ({
+              packageId: 'p1',
+              expectedExpenses: [
+                [{ id: 'manual-percent', kind: 'packagePercent', catalogId: 'p1', percent: 10 }],
+                [],
+              ],
+            }),
+          });
+        }
+        return Promise.resolve({ exists: () => false, val: () => null });
+      });
+      const root = mount();
+      await flush();
+
+      const recalculateButton = findButton('Recalculate');
+      expect(recalculateButton).toBeTruthy();
+      await act(async () => { recalculateButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
+      expect(plan.expectedExpenses[0][1]).toBe('idp1 || 10%');
+      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
+
+      await act(async () => { root.unmount(); });
+    });
+
 
     it('deletes the whole plan', async () => {
       const root = mount();

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -24,7 +24,15 @@ const formatCleanNumber = value => {
 export const serializeExpectedExpenseEntry = entry => {
   if (typeof entry === 'string') return entry;
   if (!entry || typeof entry !== 'object') return '';
-  if (entry.kind === 'packagePercent') return `id${entry.catalogId ?? ''} || ${formatCleanNumber(entry.percent)}%`;
+  if (entry.kind === 'packagePercent' && entry.expectedExpenseRole !== 'scheduled') return `id${entry.catalogId ?? ''} || ${formatCleanNumber(entry.percent)}%`;
+  if (entry.kind === 'packagePercent') {
+    return {
+      kind: 'packagePercent',
+      catalogId: String(entry.catalogId ?? ''),
+      percent: Number(entry.percent) || 0,
+      expectedExpenseRole: 'scheduled',
+    };
+  }
   if (entry.kind === 'item') return `id${entry.catalogId ?? ''}`;
   if (entry.kind === 'custom') return `${String(entry.name || '').trim()} || ${formatCleanNumber(entry.price)}`;
   return '';
@@ -56,7 +64,10 @@ export const buildExpectedExpensesGroupsFromSchedule = (schedule, pkg) => {
   return payments.map(payment => {
     const amount = Number(payment?.amount) || 0;
     const percent = packagePrice ? (amount / packagePrice) * 100 : 0;
-    return [makePackagePercentEntry({ catalogId: pkg?.id ?? '', percent })];
+    return [{
+      ...makePackagePercentEntry({ catalogId: pkg?.id ?? '', percent }),
+      expectedExpenseRole: 'scheduled',
+    }];
   });
 };
 

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -156,7 +156,10 @@ export const normalizeServiceEntry = raw => {
   }
 
   if (raw.kind === 'packagePercent') {
-    return makePackagePercentEntry({ catalogId: raw.catalogId, percent: raw.percent }, { id });
+    return {
+      ...makePackagePercentEntry({ catalogId: raw.catalogId, percent: raw.percent }, { id }),
+      ...(raw.expectedExpenseRole ? { expectedExpenseRole: raw.expectedExpenseRole } : {}),
+    };
   }
 
   if (raw.kind === 'custom') {


### PR DESCRIPTION
### Motivation
- Recalculation treated any same-package `packagePercent` entry as the scheduled row and could drop user-added `% of package` rows, which broke the intended behavior of preserving manual additions when refreshing the schedule.

### Description
- Mark generated schedule percent rows with an explicit `expectedExpenseRole: 'scheduled'` when building groups from the catalog schedule in `expectedExpensesUtils.js`.
- Serialize scheduled percent rows as objects but keep unmarked/manual percent rows serialized as legacy strings so manual rows remain distinguishable in storage in `expectedExpensesUtils.js`.
- Preserve the `expectedExpenseRole` marker during normalization so reloaded plans retain the scheduled marker in `invoiceCatalogUtils.js`.
- Change recalculation in `InvoiceBuilderPage.jsx` to replace only rows marked as `scheduled`, and add a regression test to ensure manual percent rows are preserved in `InvoiceBuilderPage.test.js`.

### Testing
- Ran unit tests with `npm test -- --runTestsByPath src/components/InvoiceBuilderPage.test.js src/components/expectedExpensesUtils.test.js --watchAll=false` and all tests passed.
- Ran linter with `npm run lint:js` and it completed successfully (no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eab5e95288326b13d2d47fa0dd989)