### PR TITLE
Normalize age input to birth date and auto-submit on blur in ProfileForm

### DIFF
--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -161,6 +161,21 @@ const nestedIndentStyle = {
 
 const resolveFieldNameBase = fieldName => String(fieldName || '').replace(/-\d+$/, '');
 
+export const resolveBirthDateFromAgeInput = (rawValue, currentDate = new Date()) => {
+  const ageMatch = String(rawValue ?? '').trim().match(/\d+/);
+  if (!ageMatch) return '';
+
+  const age = Number.parseInt(ageMatch[0], 10);
+  if (!Number.isFinite(age) || age < 15 || age > 90) return '';
+
+  const currentYear =
+    currentDate instanceof Date && !Number.isNaN(currentDate.getTime())
+      ? currentDate.getFullYear()
+      : new Date().getFullYear();
+
+  return `01.01.${currentYear - age}`;
+};
+
 
 const PROFILE_FORM_RESTORE_LOG_PREFIX = '[ProfileRestore][ProfileForm]';
 
@@ -2954,6 +2969,25 @@ ${entries.join('\n')}`;
 
                               if (!trimmed) {
                                 handleDelKeyValue('getInTouch');
+                                return;
+                              }
+                            }
+
+                            if (field.name === 'age') {
+                              const birthFromAge = resolveBirthDateFromAgeInput(latestDraft.age);
+
+                              if (birthFromAge) {
+                                const nextState = {
+                                  ...latestDraft,
+                                  birth: birthFromAge,
+                                };
+
+                                setState(nextState, {
+                                  source: 'blur',
+                                  caller: 'ProfileForm.scalarInput.onBlur',
+                                  reason: 'age-to-birth-normalized',
+                                });
+                                submitWithNormalization(nextState, 'overwrite');
                                 return;
                               }
                             }


### PR DESCRIPTION
### Motivation
- Allow users who enter an `age` value to have a canonical `birth` date auto-derived and saved, improving data consistency and UX.

### Description
- Added and exported `resolveBirthDateFromAgeInput(rawValue, currentDate)` which parses a numeric age, validates it between 15 and 90, and returns a standardized date string in the form `01.01.YYYY` using the current year minus the age.
- Integrated the resolver into the scalar input `onBlur` handler for the `age` field so that when a valid birth date is derived the form `state` is updated with `birth`, `setState` is called with a reason of `age-to-birth-normalized`, and `submitWithNormalization` is invoked with `overwrite` before returning early.
- Kept existing normalization and social-field cleanup behavior intact for other fields and preserved the debug logging and timestamp helpers.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ea6bfa8fc832699059790d59c735f)