### PR TITLE
Avoid double-counting legacy scheduled package-percent rows on recalculation

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1519,9 +1519,23 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     const resolvedPackage = getResolvedExpectedExpensesPackage(pkg);
     if (!resolvedPackage) return;
     const fresh = buildExpectedExpensesPlan(resolvedPackage, schedule);
+    const packageId = String(expectedExpenses.packageId ?? '');
+    const isLegacyScheduledEntry = entry => (
+      entry?.expectedExpenseRole !== 'scheduled'
+      && entry?.kind === 'packagePercent'
+      && String(entry.catalogId ?? '') === packageId
+    );
+    const hasLegacyScheduledRows = fresh.expectedExpenses.length > 0
+      && fresh.expectedExpenses.every((_, index) => {
+        const existingGroup = Array.isArray(expectedExpenses.expectedExpenses?.[index]) ? expectedExpenses.expectedExpenses[index] : [];
+        return isLegacyScheduledEntry(existingGroup[0]);
+      });
     const nextGroups = fresh.expectedExpenses.map((group, index) => {
       const existingGroup = Array.isArray(expectedExpenses.expectedExpenses?.[index]) ? expectedExpenses.expectedExpenses[index] : [];
-      const extraServices = existingGroup.filter(entry => entry?.expectedExpenseRole !== 'scheduled');
+      const extraServices = existingGroup.filter((entry, entryIndex) => (
+        entry?.expectedExpenseRole !== 'scheduled'
+        && !(hasLegacyScheduledRows && entryIndex === 0 && isLegacyScheduledEntry(entry))
+      ));
       return [...group, ...extraServices];
     });
     persistExpectedExpenses({ ...expectedExpenses, expectedExpenses: nextGroups }, 'Schedule groups refreshed.');

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -302,6 +302,47 @@ describe('InvoiceBuilderPage', () => {
       await act(async () => { root.unmount(); });
     });
 
+    it('replaces legacy unmarked scheduled package rows while preserving extra services', async () => {
+      get.mockImplementation(path => {
+        if (path === 'invoiceBuilder') return Promise.resolve({ exists: () => true, val: () => fixtureInvoiceData });
+        if (path === 'budget/items') return Promise.resolve({ exists: () => true, val: () => fixtureItems });
+        if (path === 'budget/packages') return Promise.resolve({ exists: () => true, val: () => fixturePackages });
+        if (path === 'budget/technical') return Promise.resolve({ exists: () => true, val: () => fixtureTechnical });
+        if (path === 'invoiceBuilder/expectedExpenses') {
+          return Promise.resolve({
+            exists: () => true,
+            val: () => ({
+              packageId: 'p1',
+              expectedExpenses: [
+                [
+                  'idp1 || 10%',
+                  'Deposit for transportation of SM || 300',
+                ],
+                ['idp1 || 10%'],
+              ],
+            }),
+          });
+        }
+        return Promise.resolve({ exists: () => false, val: () => null });
+      });
+      const root = mount();
+      await flush();
+
+      const recalculateButton = findButton('Recalculate');
+      expect(recalculateButton).toBeTruthy();
+      await act(async () => { recalculateButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan.expectedExpenses[0]).toHaveLength(2);
+      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
+      expect(plan.expectedExpenses[0][1]).toBe('Deposit for transportation of SM || 300');
+      expect(plan.expectedExpenses[1]).toHaveLength(1);
+      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
+
+      await act(async () => { root.unmount(); });
+    });
+
     it('preserves user-added package percent rows when recalculating', async () => {
       get.mockImplementation(path => {
         if (path === 'invoiceBuilder') return Promise.resolve({ exists: () => true, val: () => fixtureInvoiceData });


### PR DESCRIPTION
### Motivation
- Recalculate previously created expected-expenses plans without duplicating scheduled package-percent rows that were stored in the legacy string form `id<package> || <percent>%` and normalize into package-percent entries lacking the `expectedExpenseRole: 'scheduled'` marker.

### Description
- Detect legacy unmarked scheduled entries by checking entries where `expectedExpenseRole` is not `scheduled`, `kind` is `packagePercent`, and `catalogId` matches the plan `packageId` in `src/components/InvoiceBuilderPage.jsx`.
- Determine when an entire plan appears to contain legacy scheduled rows (the first row of every group matches the legacy pattern) and, in that case, drop only those legacy first-row entries while collecting extra services during recalculation.
- Preserve existing behavior for user-added rows and non-scheduled extra services so manual package-percent rows and custom services are kept.
- Add a regression test in `src/components/InvoiceBuilderPage.test.js` that exercises recalculation against legacy string-form scheduled rows to ensure the stale legacy rows are replaced rather than prepended.

### Testing
- Ran `CI=true npm test -- --runTestsByPath src/components/InvoiceBuilderPage.test.js --watchAll=false` and the test suite passed.
- The run reported `PASS src/components/InvoiceBuilderPage.test.js` with all tests in that file succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eae3af8908326b3f7621f7295f7c5)