### PR TITLE
Add percent-of-package service rows and rework expected-expenses groups

### DIFF
--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -5,7 +5,7 @@ import { buildCaseTitle } from './invoiceCatalogUtils';
 import {
   computeMilestoneAmountDue,
   computeMilestoneSubtotal,
-  resolveMilestoneAdditionalRows,
+  resolveMilestoneServiceRows,
   resolvePackageOverviewRows,
 } from './expectedExpensesUtils';
 
@@ -21,6 +21,9 @@ const formatPlainAmount = value => {
   if (!Number.isFinite(amount)) return '-';
   return Number.isInteger(amount) ? String(amount) : amount.toFixed(2).replace('.', ',');
 };
+
+// A row may carry a free-text price label (e.g. "GIFT") instead of a euro amount.
+const formatRowAmount = row => row?.priceLabel || formatPlainAmount(row?.price);
 
 const formatEuroTotal = value => {
   const amount = Number(value);
@@ -295,46 +298,43 @@ const renderFooter = pageLabel => (
   </View>
 );
 
-const renderExpensesTable = (rows, { includeScheduledRow, scheduledAmount }) => {
-  const allRows = includeScheduledRow
-    ? [{ key: 'scheduled', name: 'Scheduled payment', price: scheduledAmount }, ...rows]
-    : rows;
-  return (
-    <View style={styles.expensesTable}>
-      <View style={styles.expensesHeadRow} wrap={false}>
-        <View style={styles.expenseIndexCell}><Text style={styles.expenseHeadText}>#</Text></View>
-        <View style={styles.expenseNameCell}><Text style={styles.expenseHeadText}>Expenses</Text></View>
-        <View style={styles.expenseAmountCell}><Text style={styles.expenseHeadText}>EUR</Text></View>
-      </View>
-      {allRows.map((row, index) => (
-        <View
-          key={row.key || index}
-          style={[styles.expensesRow, index % 2 ? styles.expensesRowAlt : null]}
-          wrap={false}
-        >
-          <View style={styles.expenseIndexCell}><Text style={styles.expenseIndexText}>{index + 1}</Text></View>
-          <View style={styles.expenseNameCell}>
-            <Text style={styles.expenseText}>{sanitizePdfText(row.name)}</Text>
-            {row.description ? <Text style={styles.expenseDescription}>{sanitizePdfText(row.description)}</Text> : null}
-          </View>
-          <View style={styles.expenseAmountCell}><Text style={styles.expensePriceText}>{formatPlainAmount(row.price)}</Text></View>
-        </View>
-      ))}
+const renderExpensesTable = rows => (
+  <View style={styles.expensesTable}>
+    <View style={styles.expensesHeadRow} wrap={false}>
+      <View style={styles.expenseIndexCell}><Text style={styles.expenseHeadText}>#</Text></View>
+      <View style={styles.expenseNameCell}><Text style={styles.expenseHeadText}>Expenses</Text></View>
+      <View style={styles.expenseAmountCell}><Text style={styles.expenseHeadText}>EUR</Text></View>
     </View>
-  );
-};
+    {rows.map((row, index) => (
+      <View
+        key={row.key || index}
+        style={[styles.expensesRow, index % 2 ? styles.expensesRowAlt : null]}
+        wrap={false}
+      >
+        <View style={styles.expenseIndexCell}><Text style={styles.expenseIndexText}>{index + 1}</Text></View>
+        <View style={styles.expenseNameCell}>
+          <Text style={styles.expenseText}>{sanitizePdfText(row.name)}</Text>
+          {row.description ? <Text style={styles.expenseDescription}>{sanitizePdfText(row.description)}</Text> : null}
+        </View>
+        <View style={styles.expenseAmountCell}><Text style={styles.expensePriceText}>{formatRowAmount(row)}</Text></View>
+      </View>
+    ))}
+  </View>
+);
 
 const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate }) => {
   const caseTitle = buildCaseTitle(customers);
   const dateLabel = formatPlanDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
   const overviewRows = resolvePackageOverviewRows(plan?.packageSnapshot?.children, catalogItemsById, priceContext);
   const milestones = Array.isArray(plan?.milestones) ? plan.milestones : [];
+  const milestoneServiceRows = milestones.map(milestone => resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext));
+  const milestoneSubtotals = milestoneServiceRows.map(computeMilestoneSubtotal);
 
   return (
     <Document title={`Expected expenses - ${caseTitle}`} subject="Expected expenses" creator="UKRCOM">
       {milestones.map((milestone, index) => {
-        const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById, priceContext);
-        const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
+        const serviceRows = milestoneServiceRows[index];
+        const subtotal = milestoneSubtotals[index];
         const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
         const pageLabel = `${index + 1}/${milestones.length}`;
 
@@ -376,11 +376,11 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
                     <Text style={[styles.scheduleLabelText, scheduleIndex === index ? styles.scheduleLabelTextCurrent : null]}>
                       {sanitizePdfText(`${scheduleIndex + 1}. ${scheduleMilestone.title}`)}
                     </Text>
-                    <Text style={styles.scheduleAmountText}>{formatEuroTotal(scheduleMilestone.scheduledAmount)}</Text>
+                    <Text style={styles.scheduleAmountText}>{formatEuroTotal(milestoneSubtotals[scheduleIndex])}</Text>
                   </View>
                 ))}
 
-                {additionalRows.length ? renderExpensesTable(additionalRows, { includeScheduledRow: false }) : null}
+                {serviceRows.length ? renderExpensesTable(serviceRows) : null}
               </>
             ) : (
               <>
@@ -388,7 +388,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
                 <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${milestone.title}`)}</Text>
                 <Text style={styles.dateText}>{dateLabel}</Text>
 
-                {renderExpensesTable(additionalRows, { includeScheduledRow: true, scheduledAmount: milestone.scheduledAmount })}
+                {renderExpensesTable(serviceRows)}
               </>
             )}
 

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -16,6 +16,7 @@ import {
 } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
+import PdfPagePreviewStrip from './PdfPagePreviewStrip';
 import { getVisibleSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isAdminUid } from 'utils/accessLevel';
@@ -37,8 +38,10 @@ import {
   makeCatalogItemEntry,
   makeCatalogPackageEntry,
   makeCustomEntry,
+  makePercentOfPackageEntry,
   movePackageChild,
   normalizeInvoiceData,
+  parseCustomPriceInput,
   removePackageChild,
   reorderBeneficiaryIds,
   reorderRecentServices,
@@ -50,19 +53,22 @@ import {
   updatePackageChildField,
 } from './invoiceCatalogUtils';
 import {
-  addMilestoneAdditionalService,
+  addMilestoneService,
   buildExpectedExpensesPlan,
+  buildExpectedExpensesPlanFromRawGroups,
   buildMilestonesFromSchedule,
   computeMilestoneAmountDue,
   computeMilestoneSubtotal,
-  computeMilestonesScheduledTotal,
+  computeMilestonesPackageSharePercent,
+  computeMilestonesTotal,
   isExpectedExpensesShape,
+  isRawExpectedExpensesGroups,
   normalizeExpectedExpensesData,
-  removeMilestoneAdditionalService,
-  resolveMilestoneAdditionalRows,
+  removeMilestoneService,
+  resolveMilestoneServiceRows,
   resolvePackageOverviewRows,
   setMilestoneField,
-  updateMilestoneAdditionalServiceField,
+  updateMilestoneServiceField,
 } from './expectedExpensesUtils';
 
 const INVOICE_DATA_PATH = 'invoiceBuilder';
@@ -459,10 +465,77 @@ const MissingTag = styled(CustomizedTag)`
   background: rgba(180, 35, 24, 0.1);
 `;
 
+// A "% of package" row has no name/description of its own (it's derived: "20% of IVF+ED+SM") -
+// what's editable is the percent value and which catalog package it's a share of.
+const PercentShareRow = ({
+  row,
+  index,
+  isChild,
+  catalogPackages,
+  onCommit,
+  onRemove,
+  removeTitle,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
+}) => {
+  const [percentDraft, setPercentDraft, percentEditingRef] = useFieldDraft(String(row.percent ?? ''));
+
+  return (
+    <LineCard>
+      <LineMainRow>
+        <RowIndex>{index + 1}</RowIndex>
+        <PlainSelect
+          aria-label="Package this share is calculated from"
+          value={row.packageId}
+          onChange={event => onCommit('packageId', event.target.value)}
+        >
+          {!catalogPackages.some(pkg => String(pkg.id) === String(row.packageId)) ? (
+            <option value={row.packageId}>{`Package ${row.packageId}`}</option>
+          ) : null}
+          {catalogPackages.map(pkg => <option key={pkg.id} value={pkg.id}>{pkg.name}</option>)}
+        </PlainSelect>
+        <AutoTextArea
+          as={PlainPriceBase}
+          $size={isChild ? '12.5px' : '13px'}
+          $width="52px"
+          inputMode="decimal"
+          value={percentDraft}
+          placeholder="0"
+          aria-label="Percent of package price"
+          onFocus={() => { percentEditingRef.current = true; }}
+          onChange={event => setPercentDraft(event.target.value)}
+          onBlur={() => { percentEditingRef.current = false; onCommit('percent', percentDraft); }}
+        />
+        <span style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--km-muted)' }}>%</span>
+        <CustomizedTag title="Recalculated live from the package's price">≈ {formatEuroPreview(row.price)}</CustomizedTag>
+        {row.missing ? <MissingTag title="This catalog package no longer exists">Missing</MissingTag> : null}
+        <RowActions>
+          {onMoveUp ? (
+            <IconButton type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move up">
+              <FaChevronUp />
+            </IconButton>
+          ) : null}
+          {onMoveDown ? (
+            <IconButton type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move down">
+              <FaChevronDown />
+            </IconButton>
+          ) : null}
+          <IconDangerButton type="button" onClick={onRemove} title={removeTitle} aria-label={removeTitle}>
+            <FaTrash />
+          </IconDangerButton>
+        </RowActions>
+      </LineMainRow>
+    </LineCard>
+  );
+};
+
 const ServiceLineRow = ({
   row,
   index,
   isChild = false,
+  catalogPackages = [],
   onCommit,
   onRemove,
   removeTitle = 'Remove',
@@ -474,7 +547,25 @@ const ServiceLineRow = ({
 }) => {
   const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
   const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
-  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(row.price ?? ''));
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(row.priceLabel || String(row.price ?? ''));
+
+  if (row.kind === 'percent') {
+    return (
+      <PercentShareRow
+        row={row}
+        index={index}
+        isChild={isChild}
+        catalogPackages={catalogPackages}
+        onCommit={onCommit}
+        onRemove={onRemove}
+        removeTitle={removeTitle}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        canMoveUp={canMoveUp}
+        canMoveDown={canMoveDown}
+      />
+    );
+  }
 
   return (
     <LineCard>
@@ -494,9 +585,8 @@ const ServiceLineRow = ({
           as={PlainPriceBase}
           $size={isChild ? '12.5px' : '13px'}
           $width={isChild ? '76px' : '88px'}
-          inputMode="decimal"
           value={priceDraft}
-          placeholder="0"
+          placeholder="0 or GIFT"
           aria-label="Price (EUR)"
           onFocus={() => { priceEditingRef.current = true; }}
           onChange={event => setPriceDraft(event.target.value)}
@@ -713,16 +803,11 @@ const PackageEntryCard = ({
 
   const handleAddCustom = () => {
     const name = customName.trim();
-    const price = Number(customPrice.replace(',', '.'));
     if (!name) {
       toast.error('Enter a name for the new service.');
       return;
     }
-    if (!Number.isFinite(price)) {
-      toast.error('Enter a valid price for the new service.');
-      return;
-    }
-    onAddCustomChild({ name, price });
+    onAddCustomChild({ name, ...parseCustomPriceInput(customPrice) });
     setCustomName('');
     setCustomPrice('');
   };
@@ -815,8 +900,7 @@ const PackageEntryCard = ({
         />
         <PackageQuickPrice
           rows={1}
-          inputMode="decimal"
-          placeholder="Price"
+          placeholder="Price or GIFT"
           value={customPrice}
           onChange={event => setCustomPrice(event.target.value)}
         />
@@ -875,9 +959,11 @@ const MilestoneCheckboxLabel = styled.label`
 const MilestoneCard = ({
   index,
   milestone,
-  additionalRows,
+  serviceRows,
+  subtotal,
   amountDue,
   catalogItems,
+  catalogPackages,
   onCommitField,
   onToggleOverview,
   onCommitServiceField,
@@ -885,9 +971,9 @@ const MilestoneCard = ({
   onResetService,
   onAddCustomService,
   onAddCatalogService,
+  onAddPercentService,
 }) => {
   const [titleDraft, setTitleDraft, titleEditingRef] = useFieldDraft(milestone.title);
-  const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(String(milestone.scheduledAmount ?? ''));
   const [taxDraft, setTaxDraft, taxEditingRef] = useFieldDraft(String(milestone.taxPercent ?? ''));
   const [showPicker, setShowPicker] = useState(false);
   const [query, setQuery] = useState('');
@@ -895,8 +981,8 @@ const MilestoneCard = ({
   const [customPrice, setCustomPrice] = useState('');
 
   const usedCatalogIds = useMemo(
-    () => new Set(additionalRows.filter(row => row.kind === 'item').map(row => String(row.catalogId))),
-    [additionalRows],
+    () => new Set(serviceRows.filter(row => row.kind === 'item').map(row => String(row.catalogId))),
+    [serviceRows],
   );
 
   const availableItems = useMemo(() => {
@@ -909,16 +995,11 @@ const MilestoneCard = ({
 
   const handleAddCustom = () => {
     const name = customName.trim();
-    const price = Number(customPrice.replace(',', '.'));
     if (!name) {
       toast.error('Enter a name for the new service.');
       return;
     }
-    if (!Number.isFinite(price)) {
-      toast.error('Enter a valid price for the new service.');
-      return;
-    }
-    onAddCustomService({ name, price });
+    onAddCustomService({ name, ...parseCustomPriceInput(customPrice) });
     setCustomName('');
     setCustomPrice('');
   };
@@ -939,17 +1020,6 @@ const MilestoneCard = ({
         />
         <AutoTextArea
           as={PlainPriceBase}
-          $width="88px"
-          inputMode="decimal"
-          value={amountDraft}
-          placeholder="0"
-          aria-label="Scheduled amount (EUR)"
-          onFocus={() => { amountEditingRef.current = true; }}
-          onChange={event => setAmountDraft(event.target.value)}
-          onBlur={() => { amountEditingRef.current = false; onCommitField('scheduledAmount', amountDraft); }}
-        />
-        <AutoTextArea
-          as={PlainPriceBase}
           $width="48px"
           inputMode="decimal"
           value={taxDraft}
@@ -966,22 +1036,24 @@ const MilestoneCard = ({
           <input type="checkbox" checked={Boolean(milestone.showPackageOverview)} onChange={onToggleOverview} />
           Show full package overview on this invoice
         </MilestoneCheckboxLabel>
-        <CustomizedTag title="Scheduled amount + additional services, taxed">Due: {formatEuroPreview(amountDue)}</CustomizedTag>
+        <CustomizedTag title="Sum of this milestone's rows">Subtotal: {formatEuroPreview(subtotal)}</CustomizedTag>
+        <CustomizedTag title="Subtotal + tax">Due: {formatEuroPreview(amountDue)}</CustomizedTag>
       </MilestoneCheckboxRow>
 
       <PackageChildren>
-        {additionalRows.map((row, rowIndex) => (
+        {serviceRows.map((row, rowIndex) => (
           <ServiceLineRow
             key={row.key}
             row={row}
             index={rowIndex}
             isChild
+            catalogPackages={catalogPackages}
             onCommit={(field, value) => onCommitServiceField(row.id, field, value)}
             onRemove={() => onRemoveService(row.id)}
             onReset={row.kind === 'item' && row.isCustomized ? () => onResetService(row.id) : undefined}
           />
         ))}
-        {!additionalRows.length ? <PanelNote style={{ margin: '8px 0' }}>No additional services on this invoice yet.</PanelNote> : null}
+        {!serviceRows.length ? <PanelNote style={{ margin: '8px 0' }}>No services on this milestone yet.</PanelNote> : null}
       </PackageChildren>
 
       <PackageAddRow>
@@ -993,14 +1065,16 @@ const MilestoneCard = ({
         />
         <PackageQuickPrice
           rows={1}
-          inputMode="decimal"
-          placeholder="Price"
+          placeholder="Price or GIFT"
           value={customPrice}
           onChange={event => setCustomPrice(event.target.value)}
         />
         <SmallButton type="button" onClick={handleAddCustom}><FaPlus /> Add</SmallButton>
         <SmallButton type="button" onClick={() => setShowPicker(current => !current)}>
           <FaPlus /> {showPicker ? 'Hide catalog' : 'From catalog'}
+        </SmallButton>
+        <SmallButton type="button" onClick={onAddPercentService} title="Add a share of the package price (e.g. 20%)">
+          <FaPlus /> % of package
         </SmallButton>
       </PackageAddRow>
 
@@ -1237,12 +1311,17 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     if (!expectedExpenses) return null;
     const overviewRows = resolvePackageOverviewRows(expectedExpenses.packageSnapshot.children, catalogItemsById, priceContext);
     const milestoneRows = expectedExpenses.milestones.map(milestone => {
-      const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById, priceContext);
-      const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
+      const serviceRows = resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext);
+      const subtotal = computeMilestoneSubtotal(serviceRows);
       const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
-      return { milestone, additionalRows, subtotal, amountDue };
+      return { milestone, serviceRows, subtotal, amountDue };
     });
-    return { overviewRows, milestoneRows, scheduledTotal: computeMilestonesScheduledTotal(expectedExpenses.milestones) };
+    return {
+      overviewRows,
+      milestoneRows,
+      totalPlanned: computeMilestonesTotal(expectedExpenses.milestones, catalogItemsById, priceContext),
+      packageSharePercent: computeMilestonesPackageSharePercent(expectedExpenses.milestones, expectedExpenses.packageId),
+    };
   }, [expectedExpenses, catalogItemsById, priceContext]);
 
   const persistPath = async (path, value, successMessage) => {
@@ -1410,18 +1489,17 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const addCustomServiceEntry = () => {
     const name = newCustomServiceName.trim();
-    const price = Number(newCustomServicePrice.replace(',', '.'));
     if (!name) {
       toast.error('Enter a name for the new service.');
       return;
     }
-    if (!Number.isFinite(price)) {
-      toast.error('Enter a valid price for the new service.');
-      return;
-    }
-    addEntryToInvoice(makeCustomEntry({ name, price }), 'Service added.');
+    addEntryToInvoice(makeCustomEntry({ name, ...parseCustomPriceInput(newCustomServicePrice) }), 'Service added.');
     setNewCustomServiceName('');
     setNewCustomServicePrice('');
+  };
+
+  const addPercentServiceEntry = packageId => {
+    addEntryToInvoice(makePercentOfPackageEntry(packageId, 0), 'Service added.');
   };
 
   const addRecentServiceEntry = entry => addEntryToInvoice(cloneEntryWithNewId(entry), 'Service added.');
@@ -1506,14 +1584,20 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       return;
     }
     if (typeof window !== 'undefined' && !window.confirm(
-      'Recalculate milestones from the catalog schedule? Titles/amounts reset to the catalog; extra services on each milestone are kept.',
+      'Recalculate milestones from the catalog schedule? Titles reset to the catalog and the package-share row is recomputed; extra services on each milestone are kept.',
     )) return;
-    const freshMilestones = buildMilestonesFromSchedule(schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
-    const nextMilestones = freshMilestones.map((milestone, index) => ({
-      ...milestone,
-      additionalServices: expectedExpenses.milestones[index]?.additionalServices || [],
-      taxPercent: expectedExpenses.milestones[index]?.taxPercent ?? milestone.taxPercent,
-    }));
+    const resolvedPackage = { ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice };
+    const freshMilestones = buildMilestonesFromSchedule(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
+    const nextMilestones = freshMilestones.map((milestone, index) => {
+      const previous = expectedExpenses.milestones[index];
+      const previousExtras = (previous?.services || []).filter(entry => entry.kind !== 'percent' || String(entry.packageId) !== String(expectedExpenses.packageId));
+      return {
+        ...milestone,
+        services: [...milestone.services, ...previousExtras],
+        taxPercent: previous?.taxPercent ?? milestone.taxPercent,
+        showPackageOverview: previous?.showPackageOverview ?? milestone.showPackageOverview,
+      };
+    });
     persistExpectedExpenses({
       ...expectedExpenses,
       packageSnapshot: {
@@ -1545,7 +1629,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const commitMilestoneServiceField = (milestoneId, entryId, field, value) => {
     const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? updateMilestoneAdditionalServiceField(milestone, entryId, field, value)
+      ? updateMilestoneServiceField(milestone, entryId, field, value)
       : milestone));
     persistExpectedExpensesMilestones(nextMilestones, 'Service updated.');
   };
@@ -1553,28 +1637,35 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const resetMilestoneServiceEntry = (milestoneId, entryId) => {
     const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id !== milestoneId ? milestone : {
       ...milestone,
-      additionalServices: milestone.additionalServices.map(entry => (entry.id === entryId ? resetItemEntryOverrides(entry) : entry)),
+      services: milestone.services.map(entry => (entry.id === entryId ? resetItemEntryOverrides(entry) : entry)),
     }));
     persistExpectedExpensesMilestones(nextMilestones, 'Reverted to catalog values.');
   };
 
   const removeMilestoneServiceEntry = (milestoneId, entryId) => {
     const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? removeMilestoneAdditionalService(milestone, entryId)
+      ? removeMilestoneService(milestone, entryId)
       : milestone));
     persistExpectedExpensesMilestones(nextMilestones, 'Service removed.');
   };
 
   const addMilestoneCustomService = (milestoneId, fields) => {
     const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? addMilestoneAdditionalService(milestone, makeCustomEntry(fields))
+      ? addMilestoneService(milestone, makeCustomEntry(fields))
       : milestone));
     persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
   };
 
   const addMilestoneCatalogService = (milestoneId, catalogId) => {
     const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
-      ? addMilestoneAdditionalService(milestone, makeCatalogItemEntry(catalogId))
+      ? addMilestoneService(milestone, makeCatalogItemEntry(catalogId))
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
+  };
+
+  const addMilestonePercentService = milestoneId => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? addMilestoneService(milestone, makePercentOfPackageEntry(expectedExpenses.packageId, 0))
       : milestone));
     persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
   };
@@ -1662,6 +1753,36 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const handleUploadClick = () => fileInputRef.current?.click();
 
+  // Shared by both upload buttons: accepts either the lean array-of-groups shape (lined up 1:1
+  // with the chosen package's default payment schedule - the package itself is inferred from the
+  // "idX || Y%" rows inside the groups) or an already-normalized { packageId, packageSnapshot,
+  // milestones } plan. Returns the persisted plan, or null if nothing could be built/persisted
+  // (a toast has already explained why).
+  const uploadExpectedExpenses = async rawExpectedExpenses => {
+    let nextPlan;
+    if (isRawExpectedExpensesGroups(rawExpectedExpenses)) {
+      const { plan, missingPackage, droppedGroupsCount } = buildExpectedExpensesPlanFromRawGroups(rawExpectedExpenses, {
+        catalog: { packages: catalogPackages, technical: catalogTechnical },
+        taxPercent: defaultExpectedExpensesTaxPercent,
+      });
+      if (missingPackage) {
+        toast.error('Expected expenses: none of the groups reference a catalog package ("idX || Y%") - nothing was imported.');
+        return null;
+      }
+      if (droppedGroupsCount) {
+        toast.error(`Expected expenses: ${droppedGroupsCount} extra group(s) beyond the package's payment schedule were ignored.`);
+      }
+      nextPlan = plan;
+    } else if (isExpectedExpensesShape(rawExpectedExpenses)) {
+      nextPlan = normalizeExpectedExpensesData(rawExpectedExpenses);
+    } else {
+      return null;
+    }
+    await set(ref(database, EXPECTED_EXPENSES_PATH), nextPlan);
+    setExpectedExpenses(nextPlan);
+    return nextPlan;
+  };
+
   const handleFileChange = async event => {
     const file = event.target.files?.[0];
     event.target.value = '';
@@ -1684,6 +1805,11 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         set(ref(database, `${INVOICE_DATA_PATH}/taxPercent`), nextData.taxPercent),
       ]);
       setData(nextData);
+      // The combined invoice-template upload (beneficiaries/customers/services/notes) may also
+      // carry an `expectedExpenses` field - build/persist that plan too, in the same upload.
+      if (parsed.expectedExpenses !== undefined) {
+        await uploadExpectedExpenses(parsed.expectedExpenses);
+      }
       toast.success('Invoice JSON uploaded to backend.');
     } catch (uploadError) {
       console.error('Unable to upload invoice JSON', uploadError);
@@ -1692,7 +1818,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   };
 
   // Upload a standalone expected-expenses JSON (see src/data/expectedExpensesSeed.json for the
-  // shape) straight into invoiceBuilder/expectedExpenses, replacing any existing plan.
+  // normalized shape, or the invoice-template upload for the lean array-of-groups shape) straight
+  // into invoiceBuilder/expectedExpenses, replacing any existing plan.
   const handleExpectedExpensesUploadClick = () => expectedExpensesFileInputRef.current?.click();
 
   const handleExpectedExpensesFileChange = async event => {
@@ -1702,13 +1829,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     try {
       const text = await file.text();
       const parsed = JSON.parse(text);
-      if (!isExpectedExpensesShape(parsed)) {
-        toast.error('Upload an expected-expenses JSON with packageSnapshot and milestones.');
+      const source = parsed && typeof parsed === 'object' && !Array.isArray(parsed) && parsed.expectedExpenses !== undefined
+        ? parsed.expectedExpenses
+        : parsed;
+      const nextPlan = await uploadExpectedExpenses(source);
+      if (!nextPlan) {
+        toast.error('Upload an expected-expenses JSON: either { packageSnapshot, milestones }, or an array of groups.');
         return;
       }
-      const nextPlan = normalizeExpectedExpensesData(parsed);
-      await set(ref(database, EXPECTED_EXPENSES_PATH), nextPlan);
-      setExpectedExpenses(nextPlan);
       toast.success('Expected expenses JSON uploaded to backend.');
     } catch (uploadError) {
       console.error('Unable to upload expected expenses JSON', uploadError);
@@ -1811,7 +1939,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               style={{ display: 'none' }}
               onChange={handleFileChange}
             />
-            <MiniButton type="button" onClick={handleUploadClick} title="Upload an invoice JSON to the backend">
+            <MiniButton type="button" onClick={handleUploadClick} title="Upload an invoice JSON to the backend (an expectedExpenses array of groups is picked up too)">
               <FaUpload /> Upload JSON
             </MiniButton>
             <PrimaryMiniButton
@@ -1961,6 +2089,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   key={row.key}
                   row={row}
                   index={index}
+                  catalogPackages={visibleCatalogPackages}
                   onCommit={(field, value) => commitTopLevelField(row.id, field, value)}
                   onRemove={() => removeTopLevelEntry(row.id)}
                   onMoveUp={() => moveTopLevelEntry(row.id, -1)}
@@ -1999,12 +2128,20 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 />
                 <PlainPriceBase
                   rows={1}
-                  inputMode="decimal"
-                  placeholder="Price"
+                  placeholder="Price or GIFT"
                   value={newCustomServicePrice}
                   onChange={event => setNewCustomServicePrice(event.target.value)}
                 />
                 <SmallButton type="button" onClick={addCustomServiceEntry}><FaPlus /> Add</SmallButton>
+                <SmallButton
+                  type="button"
+                  title="Add a share of a catalog package's price (e.g. 20%)"
+                  onClick={() => (visibleCatalogPackages.length
+                    ? addPercentServiceEntry(visibleCatalogPackages[0].id)
+                    : toast.error('No packages in the catalog yet.'))}
+                >
+                  <FaPlus /> % of package
+                </SmallButton>
               </FieldRow>
 
               <div style={{ marginTop: 8 }}>
@@ -2115,7 +2252,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   <SmallButton
                     type="button"
                     onClick={handleExpectedExpensesUploadClick}
-                    title="Upload a standalone expected-expenses JSON (see src/data/expectedExpensesSeed.json)"
+                    title="Upload an expected-expenses JSON: { packageSnapshot, milestones } or an array of groups lined up with the package's schedule"
                   >
                     <FaUpload /> Upload JSON
                   </SmallButton>
@@ -2170,21 +2307,25 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       {formatEuroPreview(expectedExpenses.packageSnapshot.listedPrice)}
                     </span>
                   </FieldRow>
-                  {expectedExpensesView && expectedExpensesView.scheduledTotal !== expectedExpenses.packageSnapshot.listedPrice ? (
+                  {expectedExpensesView && Math.round(expectedExpensesView.packageSharePercent * 100) / 100 !== 100 ? (
                     <PanelNote style={{ color: 'var(--km-danger)' }}>
-                      Milestones add up to {formatEuroPreview(expectedExpensesView.scheduledTotal)}, the package price is{' '}
-                      {formatEuroPreview(expectedExpenses.packageSnapshot.listedPrice)}.
+                      The percent-of-package rows add up to {expectedExpensesView.packageSharePercent}% of the package price, not 100%.
                     </PanelNote>
                   ) : null}
+                  <PanelNote>
+                    Plan totals {formatEuroPreview(expectedExpensesView?.totalPlanned)} across all milestones (package share + extras).
+                  </PanelNote>
 
-                  {expectedExpensesView?.milestoneRows.map(({ milestone, additionalRows, amountDue }, index) => (
+                  {expectedExpensesView?.milestoneRows.map(({ milestone, serviceRows, subtotal, amountDue }, index) => (
                     <MilestoneCard
                       key={milestone.id}
                       index={index}
                       milestone={milestone}
-                      additionalRows={additionalRows}
+                      serviceRows={serviceRows}
+                      subtotal={subtotal}
                       amountDue={amountDue}
                       catalogItems={catalogItems}
+                      catalogPackages={visibleCatalogPackages}
                       onCommitField={(field, value) => commitMilestoneField(milestone.id, field, value)}
                       onToggleOverview={() => toggleMilestoneOverview(milestone.id)}
                       onCommitServiceField={(entryId, field, value) => commitMilestoneServiceField(milestone.id, entryId, field, value)}
@@ -2192,10 +2333,49 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       onResetService={entryId => resetMilestoneServiceEntry(milestone.id, entryId)}
                       onAddCustomService={fields => addMilestoneCustomService(milestone.id, fields)}
                       onAddCatalogService={catalogId => addMilestoneCatalogService(milestone.id, catalogId)}
+                      onAddPercentService={() => addMilestonePercentService(milestone.id)}
                     />
                   ))}
                 </>
               )}
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
+                <H2>PDF preview</H2>
+              </PanelHeading>
+              <PanelNote>
+                Scaled-down mock-ups of the pages "Generate PDF" would produce, built from the same rows and totals -
+                a quick way to spot a too-long name or a lopsided total before generating the real file.
+              </PanelNote>
+              <PdfPagePreviewStrip
+                title="Invoice"
+                emptyMessage="Add services to preview the invoice PDF."
+                pages={invoiceServiceRows.length ? [{
+                  key: 'invoice',
+                  label: `Invoice ${invoiceNumber}`,
+                  subtitle: caseTitle,
+                  rows: invoiceServiceRows,
+                  subtotal,
+                  taxPercent: data.taxPercent,
+                  total,
+                }] : []}
+              />
+              <div style={{ marginTop: 14 }}>
+                <PdfPagePreviewStrip
+                  title="Expected expenses"
+                  emptyMessage="Choose a package to preview the expected-expenses PDF."
+                  pages={(expectedExpensesView?.milestoneRows || []).map(({ milestone, serviceRows, subtotal: milestoneSubtotal, amountDue }, index) => ({
+                    key: milestone.id,
+                    label: `#${index + 1} ${milestone.title}`,
+                    badge: milestone.showPackageOverview ? 'Overview' : null,
+                    rows: serviceRows,
+                    subtotal: milestoneSubtotal,
+                    taxPercent: milestone.taxPercent,
+                    total: amountDue,
+                  }))}
+                />
+              </div>
             </Panel>
           </>
         ) : null}

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -174,7 +174,7 @@ describe('InvoiceBuilderPage', () => {
     await flush();
 
     const nameField = container.querySelector('textarea[placeholder="New custom service name"]');
-    const priceField = container.querySelector('textarea[placeholder="Price"]');
+    const priceField = container.querySelector('textarea[placeholder="Price or GIFT"]');
     await act(async () => {
       nameField.focus();
       setFieldValue(nameField, 'Courier fee');
@@ -226,8 +226,10 @@ describe('InvoiceBuilderPage', () => {
       const plan = persistedCalls[persistedCalls.length - 1][1];
       expect(plan.packageId).toBe('p1');
       expect(plan.milestones).toHaveLength(2);
-      expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', scheduledAmount: 150, taxPercent: 14, showPackageOverview: true });
-      expect(plan.milestones[1]).toMatchObject({ title: 'Final payment', scheduledAmount: 100, showPackageOverview: false });
+      expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', taxPercent: 14, showPackageOverview: true });
+      expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 60 });
+      expect(plan.milestones[1]).toMatchObject({ title: 'Final payment', showPackageOverview: false });
+      expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 40 });
 
       await act(async () => { root.unmount(); });
     });
@@ -241,7 +243,7 @@ describe('InvoiceBuilderPage', () => {
       const milestoneNameFields = Array.from(container.querySelectorAll('textarea[placeholder="Add a custom line to this invoice…"]'));
       expect(milestoneNameFields).toHaveLength(2);
       const milestoneAddRow = milestoneNameFields[0].parentElement;
-      const priceField = milestoneAddRow.querySelector('textarea[placeholder="Price"]');
+      const priceField = milestoneAddRow.querySelector('textarea[placeholder="Price or GIFT"]');
       const addButton = Array.from(milestoneAddRow.querySelectorAll('button')).find(btn => btn.textContent.trim() === 'Add');
 
       await act(async () => {
@@ -256,9 +258,9 @@ describe('InvoiceBuilderPage', () => {
       expect(container.innerHTML).toContain('Due: €513.00');
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.milestones[0].additionalServices).toHaveLength(1);
-      expect(plan.milestones[0].additionalServices[0]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
-      expect(plan.milestones[1].additionalServices).toHaveLength(0);
+      expect(plan.milestones[0].services).toHaveLength(2);
+      expect(plan.milestones[0].services[1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.milestones[1].services).toHaveLength(1);
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -33,6 +33,9 @@ const formatEuroTotal = value => {
   return `${grouped},${decimals} EUR`;
 };
 
+// A row may carry a free-text price label (e.g. "GIFT") instead of a euro amount.
+const formatRowAmount = row => row?.priceLabel || formatPlainAmount(row?.price);
+
 const styles = StyleSheet.create({
   page: pdfBaseStyles.page,
   eyebrow: pdfBaseStyles.eyebrow,
@@ -406,7 +409,7 @@ const InvoicePdfDocument = ({
                 </View>
                 <View style={styles.expenseAmountCell}>
                   <Text style={isPackageHeader ? styles.expensePriceTextPackage : (isChild ? styles.expensePriceTextChild : styles.expensePriceText)}>
-                    {formatPlainAmount(row.price)}
+                    {formatRowAmount(row)}
                   </Text>
                 </View>
               </View>

--- a/src/components/PdfPagePreviewStrip.jsx
+++ b/src/components/PdfPagePreviewStrip.jsx
@@ -1,0 +1,200 @@
+// A cheap, dependency-free "does this look right at a glance" preview: small A4-shaped mock-ups
+// of the pages @react-pdf/renderer will produce, built from the exact same resolved rows the real
+// PDF documents render (InvoicePdfDocument / ExpectedExpensesPdfDocument). It's not a pixel-exact
+// rasterization of the generated PDF (that would need a PDF-reading library, not just the
+// PDF-writing one this app already ships) - it's a fast layout sanity check so an admin can catch
+// an overlong name, a missing row, or a lopsided total before spending time generating the real
+// file.
+
+import React from 'react';
+import styled from 'styled-components';
+import { PDF_COLOR } from './pdfTheme';
+
+const MAX_PREVIEW_ROWS = 9;
+
+const Strip = styled.div`
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 4px 2px 10px;
+`;
+
+const Page = styled.div`
+  flex: 0 0 auto;
+  width: 132px;
+  aspect-ratio: 210 / 297;
+  background: ${PDF_COLOR.white};
+  border: 1px solid var(--km-border);
+  border-radius: 3px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  padding: 7px 6px;
+  display: flex;
+  flex-direction: column;
+  font-size: 5px;
+  line-height: 1.35;
+  color: ${PDF_COLOR.ink};
+  position: relative;
+`;
+
+const PageNumber = styled.span`
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 6px;
+  font-weight: 700;
+  color: var(--km-muted);
+`;
+
+const PageBadge = styled.span`
+  align-self: flex-start;
+  font-size: 4.5px;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: ${PDF_COLOR.accent};
+  background: ${PDF_COLOR.headBg};
+  border-radius: 999px;
+  padding: 1.5px 4px;
+  margin-bottom: 3px;
+`;
+
+const PageTitle = styled.div`
+  font-weight: 800;
+  font-size: 6px;
+  color: ${PDF_COLOR.ink};
+  margin-bottom: 1px;
+`;
+
+const PageSubtitle = styled.div`
+  font-size: 4.8px;
+  color: ${PDF_COLOR.muted};
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const RowsBox = styled.div`
+  flex: 1 1 auto;
+  border: 0.5px solid ${PDF_COLOR.line};
+  border-radius: 2px;
+  overflow: hidden;
+`;
+
+const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 3px;
+  padding: 1.6px 3px;
+  background: ${({ $alt }) => ($alt ? PDF_COLOR.rowAlt : 'transparent')};
+  border-top: 0.5px solid ${PDF_COLOR.line};
+
+  &:first-child {
+    border-top: none;
+  }
+`;
+
+const RowName = styled.span`
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const RowPrice = styled.span`
+  flex: 0 0 auto;
+  font-weight: 700;
+`;
+
+const MoreRow = styled(Row)`
+  color: var(--km-muted);
+  font-style: italic;
+`;
+
+const TotalsBox = styled.div`
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5px;
+`;
+
+const TotalLine = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 4.8px;
+  color: var(--km-muted);
+`;
+
+const DueLine = styled(TotalLine)`
+  font-weight: 800;
+  font-size: 5.6px;
+  color: ${PDF_COLOR.accentStrong};
+  background: ${PDF_COLOR.totalBg};
+  border-radius: 2px;
+  padding: 2px 3px;
+  margin-top: 1px;
+`;
+
+const EmptyState = styled.div`
+  font-size: 11px;
+  color: var(--km-muted);
+  padding: 6px 2px;
+`;
+
+const formatThumbPrice = row => {
+  if (row?.priceLabel) return row.priceLabel;
+  const amount = Number(row?.price);
+  return Number.isFinite(amount) ? Math.round(amount) : '-';
+};
+
+const formatThumbTotal = value => {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? `€${amount.toFixed(2)}` : '€-';
+};
+
+// pages: [{ key, label, subtitle?, badge?, rows: [{name, price, priceLabel}], subtotal, taxPercent, total }]
+const PdfPagePreviewStrip = ({ title, emptyMessage, pages }) => {
+  const safePages = Array.isArray(pages) ? pages : [];
+  return (
+    <div>
+      {title ? <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 6, color: 'var(--km-muted)' }}>{title}</div> : null}
+      {safePages.length ? (
+        <Strip>
+          {safePages.map((page, index) => {
+            const rows = Array.isArray(page.rows) ? page.rows : [];
+            const visibleRows = rows.slice(0, MAX_PREVIEW_ROWS);
+            const hiddenCount = rows.length - visibleRows.length;
+            return (
+              <Page key={page.key || index}>
+                <PageNumber>{index + 1}/{safePages.length}</PageNumber>
+                {page.badge ? <PageBadge>{page.badge}</PageBadge> : null}
+                <PageTitle>{page.label || `Page ${index + 1}`}</PageTitle>
+                {page.subtitle ? <PageSubtitle>{page.subtitle}</PageSubtitle> : null}
+                <RowsBox>
+                  {visibleRows.map((row, rowIndex) => (
+                    <Row key={row.key || rowIndex} $alt={Boolean(rowIndex % 2)}>
+                      <RowName>{row.name || 'Service'}</RowName>
+                      <RowPrice>{formatThumbPrice(row)}</RowPrice>
+                    </Row>
+                  ))}
+                  {hiddenCount > 0 ? <MoreRow><RowName>+{hiddenCount} more</RowName></MoreRow> : null}
+                  {!rows.length ? <Row><RowName>No services yet</RowName></Row> : null}
+                </RowsBox>
+                <TotalsBox>
+                  <TotalLine><span>Subtotal</span><span>{formatThumbTotal(page.subtotal)}</span></TotalLine>
+                  <TotalLine><span>Tax</span><span>{Number(page.taxPercent) || 0}%</span></TotalLine>
+                  <DueLine><span>Due</span><span>{formatThumbTotal(page.total)}</span></DueLine>
+                </TotalsBox>
+              </Page>
+            );
+          })}
+        </Strip>
+      ) : (
+        <EmptyState>{emptyMessage || 'Nothing to preview yet.'}</EmptyState>
+      )}
+    </div>
+  );
+};
+
+export default PdfPagePreviewStrip;

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -1,23 +1,37 @@
 // "Expected expenses" is a billing forecast for a whole surrogacy program: pick a budget/packages
 // program once, and its payment schedule (budget/technical.paymentSchedules) is turned into a
-// series of milestones - one future invoice per scheduled payment. Each milestone's amount is
-// calculated automatically from the schedule, and stays a plain editable number from then on (the
-// plan is its own frozen copy, same as a package entry's children on a regular invoice - it does
-// not keep re-syncing with the shared catalog). Admins can attach extra one-off services (custom
-// or catalog-linked, e.g. the recurring SM transportation/medical deposits) to any milestone.
+// series of groups - one future invoice per scheduled payment, in the same order as the schedule.
+// The package is only ever referenced by id (its own default payment schedule is already attached
+// to it in the catalog, so no separate paymentScheduleId is stored here).
+//
+// Each group is nothing more than a list of service rows (the same catalog-item / custom /
+// percent-of-package entries used everywhere else in the invoice builder - see
+// invoiceCatalogUtils.js). There is no separate "scheduled amount" field: a group's total is
+// simply the sum of its rows, and the row that carries the bulk of a payment is normally a
+// percent-of-package entry (e.g. "20% of the package price"), so the euro amount recalculates
+// automatically whenever the package price changes instead of going stale. Admins can freely add,
+// edit, or remove any row - catalog-linked, custom, or percent - on any group.
 //
 // The whole plan is stored as invoiceBuilder/expectedExpenses - a single object, not a list of
-// documents - so it lives right next to the rest of the invoice-builder JSON on the backend.
+// documents - so it lives right next to the rest of the invoice-builder JSON on the backend. A
+// group's title/date/stage is never stored on the group itself - it's read from the package's
+// payment schedule by index (mirrors the schedule 1:1) - but the plan does cache the resolved
+// title on each milestone at build time (same "frozen snapshot" convention the rest of the
+// invoice builder uses for a package entry's children), so rendering never depends on the
+// schedule still existing unchanged in the catalog.
 
 import {
   createEntryId,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
   makeCatalogItemEntry,
+  makeCustomEntry,
+  makePercentOfPackageEntry,
   normalizeServiceEntries,
   resolveServiceRow,
   setEntryField,
 } from './invoiceCatalogUtils';
+import { resolveProgramPaymentSchedule } from './budgetCatalogUtils';
 
 // --- Building a plan from a chosen catalog package + its payment schedule ------------------------------------------------------
 
@@ -26,58 +40,144 @@ import {
 export const buildPackageOverviewChildren = pkg => (Array.isArray(pkg?.children) ? pkg.children : [])
   .map(catalogId => makeCatalogItemEntry(catalogId));
 
-export const buildMilestonesFromSchedule = (schedule, { taxPercent = 0 } = {}) =>
+// A schedule payment's euro amount is only ever used once, to seed a percent-of-package row (e.g.
+// a 8772 EUR first payment on a 40000 EUR package becomes "21.93% of the package") - from then on
+// that row is a normal, independently editable service row like any other.
+const buildGroupFromSchedulePayment = (pkg, payment) => {
+  const listedPrice = Number(pkg?.listedPrice) || 0;
+  const amount = Number(payment?.amount) || 0;
+  if (!listedPrice || !amount) return [];
+  const percent = Math.round((amount / listedPrice) * 10000) / 100;
+  return [makePercentOfPackageEntry(pkg?.id, percent)];
+};
+
+export const buildMilestonesFromSchedule = (pkg, schedule, { taxPercent = 0 } = {}) =>
   (Array.isArray(schedule?.payments) ? schedule.payments : []).map((payment, index) => ({
     id: createEntryId(),
     title: payment?.title || `Payment ${index + 1}`,
-    scheduledAmount: Number(payment?.amount) || 0,
     taxPercent,
     // The first milestone doubles as the "introducing the program" invoice: it shows the full
     // package overview (included services + the whole schedule) instead of just its own line.
     showPackageOverview: index === 0,
-    additionalServices: [],
+    services: buildGroupFromSchedulePayment(pkg, payment),
   }));
+
+const buildPackageSnapshot = pkg => ({
+  name: pkg?.name || '',
+  description: pkg?.description || '',
+  listedPrice: Number(pkg?.listedPrice) || 0,
+  currency: pkg?.currency || 'EUR',
+  children: buildPackageOverviewChildren(pkg),
+});
 
 export const buildExpectedExpensesPlan = (pkg, schedule, { taxPercent = 0 } = {}) => ({
   packageId: String(pkg?.id ?? ''),
-  packageSnapshot: {
-    name: pkg?.name || '',
-    description: pkg?.description || '',
-    listedPrice: Number(pkg?.listedPrice) || 0,
-    currency: pkg?.currency || 'EUR',
-    children: buildPackageOverviewChildren(pkg),
-  },
-  milestones: buildMilestonesFromSchedule(schedule, { taxPercent }),
+  packageSnapshot: buildPackageSnapshot(pkg),
+  milestones: buildMilestonesFromSchedule(pkg, schedule, { taxPercent }),
 });
 
-// --- Normalization (defensive parsing of whatever's stored on the backend) ------------------------------------------------------
+// --- Building a plan from a raw "expectedExpenses" upload -----------------------------------------------------------------------
+//
+// The lean upload shape (see the invoice-builder JSON upload) is just an array of groups, each
+// group an array of legacy-style service strings ("id32", "Custom name || 300", "id1 || 20%"),
+// lined up 1:1 with the chosen package's default payment schedule. There is no packageId field in
+// that shape - the package is implied by the "idX || Y%" rows inside the groups, since every such
+// row already names the package it's a share of.
 
-export const normalizeExpectedExpensesMilestone = raw => ({
-  id: raw?.id || createEntryId(),
-  title: raw?.title || '',
-  scheduledAmount: Number(raw?.scheduledAmount) || 0,
-  taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
-  showPackageOverview: Boolean(raw?.showPackageOverview),
-  additionalServices: normalizeServiceEntries(raw?.additionalServices),
-});
+export const isRawExpectedExpensesGroups = raw => Array.isArray(raw) && raw.every(group => Array.isArray(group));
 
-export const normalizeExpectedExpensesData = raw => {
-  if (!raw || typeof raw !== 'object') return null;
+// Finds the package id referenced by the first percent-of-package row across all groups.
+export const inferPackageIdFromRawGroups = rawGroups => {
+  for (const group of (Array.isArray(rawGroups) ? rawGroups : [])) {
+    for (const row of (Array.isArray(group) ? group : [])) {
+      if (typeof row !== 'string') continue;
+      const match = /^\s*id(.+?)\s*\|\|\s*\d+(?:[.,]\d+)?\s*%\s*$/i.exec(row);
+      if (match) return match[1];
+    }
+    for (const entry of (Array.isArray(group) ? group : [])) {
+      if (entry && typeof entry === 'object' && entry.kind === 'percent' && entry.packageId) return String(entry.packageId);
+    }
+  }
+  return '';
+};
+
+// Builds a full plan from raw groups + the loaded budget catalog. Returns `missingPackage: true`
+// when no package could be resolved (nothing is built in that case), and `droppedGroupsCount` for
+// any groups beyond the schedule's own step count (they're dropped rather than silently merged).
+export const buildExpectedExpensesPlanFromRawGroups = (rawGroups, { catalog, taxPercent = 0, packageId: explicitPackageId } = {}) => {
+  const groups = (Array.isArray(rawGroups) ? rawGroups : []).map(normalizeServiceEntries);
+  const packageId = String(explicitPackageId || inferPackageIdFromRawGroups(rawGroups) || '');
+  const packages = Array.isArray(catalog?.packages) ? catalog.packages : [];
+  const pkg = packages.find(candidate => String(candidate.id) === packageId) || null;
+  const schedule = pkg ? resolveProgramPaymentSchedule(catalog, pkg) : null;
+  const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+
+  const milestones = payments.map((payment, index) => ({
+    id: createEntryId(),
+    title: payment?.title || `Payment ${index + 1}`,
+    taxPercent,
+    showPackageOverview: index === 0,
+    services: groups[index] || [],
+  }));
+
   return {
-    packageId: String(raw.packageId ?? ''),
-    packageSnapshot: {
-      name: raw.packageSnapshot?.name || '',
-      description: raw.packageSnapshot?.description || '',
-      listedPrice: Number(raw.packageSnapshot?.listedPrice) || 0,
-      currency: raw.packageSnapshot?.currency || 'EUR',
-      children: normalizeServiceEntries(raw.packageSnapshot?.children),
-    },
-    milestones: Array.isArray(raw.milestones) ? raw.milestones.map(normalizeExpectedExpensesMilestone) : [],
+    plan: pkg ? { packageId, packageSnapshot: buildPackageSnapshot(pkg), milestones } : null,
+    missingPackage: !pkg,
+    droppedGroupsCount: Math.max(0, groups.length - payments.length),
   };
 };
 
-// Loose validation for an uploaded expected-expenses JSON, before normalizeExpectedExpensesData
-// fills in any missing pieces - mirrors isInvoiceDataShape's role for the main invoice JSON.
+// --- Normalization (defensive parsing of whatever's stored on the backend) ------------------------------------------------------
+
+// Old persisted milestones may still carry a frozen `scheduledAmount` number (and/or the old
+// `additionalServices` field name) from before groups became plain row lists - migrate it into an
+// equivalent percent-of-package row (or a plain custom row, if the package price isn't known) so
+// the euro total is preserved instead of silently dropped.
+export const normalizeExpectedExpensesMilestone = (raw, { packageId = '', listedPrice = 0 } = {}) => {
+  const hasOwnServices = Array.isArray(raw?.services);
+  const services = normalizeServiceEntries(raw?.services ?? raw?.additionalServices);
+  const legacyAmount = Number(raw?.scheduledAmount);
+  const migratedServices = !hasOwnServices && Number.isFinite(legacyAmount) && legacyAmount !== 0
+    ? [
+      listedPrice
+        ? makePercentOfPackageEntry(packageId, Math.round((legacyAmount / listedPrice) * 10000) / 100)
+        : makeCustomEntry({ name: raw?.title ? `Scheduled payment (${raw.title})` : 'Scheduled payment', price: legacyAmount }),
+      ...services,
+    ]
+    : services;
+
+  return {
+    id: raw?.id || createEntryId(),
+    title: raw?.title || '',
+    taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
+    showPackageOverview: Boolean(raw?.showPackageOverview),
+    services: migratedServices,
+  };
+};
+
+export const normalizeExpectedExpensesData = raw => {
+  if (!raw || typeof raw !== 'object') return null;
+  const packageId = String(raw.packageId ?? '');
+  const listedPrice = Number(raw.packageSnapshot?.listedPrice) || 0;
+  return {
+    packageId,
+    packageSnapshot: {
+      name: raw.packageSnapshot?.name || '',
+      description: raw.packageSnapshot?.description || '',
+      listedPrice,
+      currency: raw.packageSnapshot?.currency || 'EUR',
+      children: normalizeServiceEntries(raw.packageSnapshot?.children),
+    },
+    milestones: Array.isArray(raw.milestones)
+      ? raw.milestones.map(milestone => normalizeExpectedExpensesMilestone(milestone, { packageId, listedPrice }))
+      : [],
+  };
+};
+
+// Loose validation for an uploaded, already-normalized expected-expenses JSON, before
+// normalizeExpectedExpensesData fills in any missing pieces - mirrors isInvoiceDataShape's role
+// for the main invoice JSON. A raw array-of-groups upload is validated separately, with
+// isRawExpectedExpensesGroups, since it has no packageSnapshot/milestones wrapper of its own.
 export const isExpectedExpensesShape = raw => Boolean(
   raw
   && typeof raw === 'object'
@@ -90,26 +190,26 @@ export const isExpectedExpensesShape = raw => Boolean(
 // --- Editing ------------------------------------------------------------
 
 export const setMilestoneField = (milestone, field, value) => {
-  if (field === 'scheduledAmount' || field === 'taxPercent') {
+  if (field === 'taxPercent') {
     const numeric = Number(String(value).replace(',', '.'));
-    return { ...milestone, [field]: Number.isFinite(numeric) ? numeric : 0 };
+    return { ...milestone, taxPercent: Number.isFinite(numeric) ? numeric : 0 };
   }
   return { ...milestone, [field]: value };
 };
 
-export const addMilestoneAdditionalService = (milestone, entry) => ({
+export const addMilestoneService = (milestone, entry) => ({
   ...milestone,
-  additionalServices: [...(milestone.additionalServices || []), entry],
+  services: [...(milestone.services || []), entry],
 });
 
-export const removeMilestoneAdditionalService = (milestone, entryId) => ({
+export const removeMilestoneService = (milestone, entryId) => ({
   ...milestone,
-  additionalServices: (milestone.additionalServices || []).filter(entry => entry.id !== entryId),
+  services: (milestone.services || []).filter(entry => entry.id !== entryId),
 });
 
-export const updateMilestoneAdditionalServiceField = (milestone, entryId, field, value) => ({
+export const updateMilestoneServiceField = (milestone, entryId, field, value) => ({
   ...milestone,
-  additionalServices: (milestone.additionalServices || [])
+  services: (milestone.services || [])
     .map(entry => (entry.id === entryId ? setEntryField(entry, field, value) : entry)),
 });
 
@@ -118,16 +218,26 @@ export const updateMilestoneAdditionalServiceField = (milestone, entryId, field,
 export const resolvePackageOverviewRows = (children, catalogItemsById, priceContext = {}) =>
   (Array.isArray(children) ? children : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
-export const resolveMilestoneAdditionalRows = (milestone, catalogItemsById, priceContext = {}) =>
-  (Array.isArray(milestone?.additionalServices) ? milestone.additionalServices : [])
+export const resolveMilestoneServiceRows = (milestone, catalogItemsById, priceContext = {}) =>
+  (Array.isArray(milestone?.services) ? milestone.services : [])
     .map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
-export const computeMilestoneSubtotal = (milestone, additionalRows) =>
-  (Number(milestone?.scheduledAmount) || 0) + computeInvoiceSubtotal(additionalRows);
+export const computeMilestoneSubtotal = rows => computeInvoiceSubtotal(rows);
 
 export const computeMilestoneAmountDue = (subtotal, taxPercent) => computeInvoiceTotal(subtotal, taxPercent);
 
-// Sum of every milestone's scheduled amount - shown next to the package's listed price so a
-// mismatched schedule (edited milestones that no longer add up to the program price) is obvious.
-export const computeMilestonesScheduledTotal = milestones =>
-  (Array.isArray(milestones) ? milestones : []).reduce((sum, milestone) => sum + (Number(milestone?.scheduledAmount) || 0), 0);
+// Sum of every milestone's resolved total (percent-of-package rows resolved to euros, plus every
+// catalog/custom extra) - the actual amount the whole plan bills for.
+export const computeMilestonesTotal = (milestones, catalogItemsById, priceContext = {}) =>
+  (Array.isArray(milestones) ? milestones : []).reduce((sum, milestone) => sum
+    + computeMilestoneSubtotal(resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext)), 0);
+
+// Sum of only the percent-of-package rows that share the plan's own package id, in percent (not
+// euros) - the sanity check for "does the schedule breakdown still cover the whole package price".
+// Kept separate from computeMilestonesTotal because that one also includes one-off extras (SM
+// deposits, gifts, ...), which are expected to push the real bill above the package price.
+export const computeMilestonesPackageSharePercent = (milestones, packageId) =>
+  (Array.isArray(milestones) ? milestones : []).reduce((sum, milestone) => sum
+    + (Array.isArray(milestone.services) ? milestone.services : [])
+      .filter(entry => entry?.kind === 'percent' && String(entry.packageId) === String(packageId))
+      .reduce((entrySum, entry) => entrySum + (Number(entry.percent) || 0), 0), 0);

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -1,16 +1,20 @@
 import {
-  addMilestoneAdditionalService,
+  addMilestoneService,
   buildExpectedExpensesPlan,
+  buildExpectedExpensesPlanFromRawGroups,
   computeMilestoneAmountDue,
   computeMilestoneSubtotal,
-  computeMilestonesScheduledTotal,
+  computeMilestonesPackageSharePercent,
+  computeMilestonesTotal,
+  inferPackageIdFromRawGroups,
   isExpectedExpensesShape,
+  isRawExpectedExpensesGroups,
   normalizeExpectedExpensesData,
-  removeMilestoneAdditionalService,
-  resolveMilestoneAdditionalRows,
+  removeMilestoneService,
+  resolveMilestoneServiceRows,
   resolvePackageOverviewRows,
   setMilestoneField,
-  updateMilestoneAdditionalServiceField,
+  updateMilestoneServiceField,
 } from './expectedExpensesUtils';
 import expectedExpensesSeed from '../data/expectedExpensesSeed.json';
 import { makeCustomEntry } from './invoiceCatalogUtils';
@@ -27,13 +31,13 @@ const pkg = {
 const schedule = {
   id: 'ps-3',
   payments: [
-    { title: 'To start the program', amount: 8772 },
-    { title: 'To start stimulation of a SM', amount: 6228 },
+    { title: 'To start the program', amount: 8000 },
+    { title: 'To start stimulation of a SM', amount: 6000 },
     { title: 'In a week before embryo transfer', amount: 3000 },
     { title: 'After confirmation of pregnancy by ultrasound', amount: 4000 },
     { title: 'On the 12th week of pregnancy', amount: 6000 },
     { title: 'On the 18th week of pregnancy', amount: 6000 },
-    { title: 'On the 36th week of pregnancy', amount: 6000 },
+    { title: 'On the 36th week of pregnancy', amount: 7000 },
   ],
 };
 
@@ -49,13 +53,25 @@ describe('expectedExpensesUtils', () => {
     ]);
 
     expect(plan.milestones).toHaveLength(7);
-    expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', scheduledAmount: 8772, taxPercent: 14, showPackageOverview: true });
-    expect(plan.milestones[1]).toMatchObject({ title: 'To start stimulation of a SM', scheduledAmount: 6228, showPackageOverview: false });
+    expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', taxPercent: 14, showPackageOverview: true });
+    expect(plan.milestones[0].services).toEqual([
+      { id: plan.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20 },
+    ]);
+    expect(plan.milestones[1]).toMatchObject({ title: 'To start stimulation of a SM', showPackageOverview: false });
+    expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: '3', percent: 15 });
   });
 
-  it('sums the milestones back up to the package listed price', () => {
+  it('never stores a euro amount on a milestone - the percent-of-package row recalculates it', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule);
-    expect(computeMilestonesScheduledTotal(plan.milestones)).toBe(40000);
+    expect(computeMilestonesTotal(plan.milestones, new Map(), { packagesById: new Map([['3', pkg]]) })).toBe(40000);
+
+    const bumped = { ...pkg, listedPrice: 80000 };
+    expect(computeMilestonesTotal(plan.milestones, new Map(), { packagesById: new Map([['3', bumped]]) })).toBe(80000);
+  });
+
+  it('sums the percent-of-package rows back up to 100% of the schedule', () => {
+    const plan = buildExpectedExpensesPlan(pkg, schedule);
+    expect(computeMilestonesPackageSharePercent(plan.milestones, plan.packageId)).toBe(100);
   });
 
   it('round-trips through normalization, assigning ids where missing', () => {
@@ -65,47 +81,58 @@ describe('expectedExpensesUtils', () => {
     expect(normalizeExpectedExpensesData(null)).toBeNull();
   });
 
-  it('edits a milestone field, parsing numeric fields and leaving text fields as-is', () => {
+  it('migrates a legacy milestone with a frozen scheduledAmount into an equivalent percent-of-package row', () => {
+    const legacy = {
+      packageId: '3',
+      packageSnapshot: { name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR', children: [] },
+      milestones: [
+        { id: 'm1', title: 'To start the program', scheduledAmount: 8000, taxPercent: 14, showPackageOverview: true, additionalServices: [] },
+      ],
+    };
+    const normalized = normalizeExpectedExpensesData(legacy);
+    expect(normalized.milestones[0].services).toEqual([
+      { id: normalized.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20 },
+    ]);
+    expect(computeMilestonesTotal(normalized.milestones, new Map(), { packagesById: new Map([['3', pkg]]) })).toBe(8000);
+  });
+
+  it('edits a milestone field, parsing the numeric taxPercent and leaving text fields as-is', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-    const edited = setMilestoneField(plan.milestones[1], 'scheduledAmount', '6 500,50'.replace(' ', ''));
-    expect(edited.scheduledAmount).toBe(6500.5);
+    const edited = setMilestoneField(plan.milestones[1], 'taxPercent', '6,5');
+    expect(edited.taxPercent).toBe(6.5);
     expect(setMilestoneField(plan.milestones[1], 'title', 'Renamed step').title).toBe('Renamed step');
   });
 
-  it('adds, edits, and removes an additional service on a milestone', () => {
+  it('adds, edits, and removes a service on a milestone', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
     const deposit = makeCustomEntry({ name: 'Deposit for transportation of SM', price: 300 });
-    let milestone = addMilestoneAdditionalService(plan.milestones[1], deposit);
-    expect(milestone.additionalServices).toHaveLength(1);
+    let milestone = addMilestoneService(plan.milestones[1], deposit);
+    expect(milestone.services).toHaveLength(2);
 
-    milestone = updateMilestoneAdditionalServiceField(milestone, deposit.id, 'price', '350');
-    expect(milestone.additionalServices[0].price).toBe(350);
+    milestone = updateMilestoneServiceField(milestone, deposit.id, 'price', '350');
+    expect(milestone.services.find(entry => entry.id === deposit.id).price).toBe(350);
 
-    milestone = removeMilestoneAdditionalService(milestone, deposit.id);
-    expect(milestone.additionalServices).toHaveLength(0);
+    milestone = removeMilestoneService(milestone, deposit.id);
+    expect(milestone.services).toHaveLength(1);
   });
 
-  it('computes the amount due for a milestone exactly like the "To start the program" sample invoice (8772 taxed at 14%)', () => {
+  it('computes the amount due for a milestone from its resolved rows (percent share + tax)', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
-    const catalogItemsById = new Map();
-    const additionalRows = resolveMilestoneAdditionalRows(plan.milestones[0], catalogItemsById);
-    const subtotal = computeMilestoneSubtotal(plan.milestones[0], additionalRows);
-    expect(subtotal).toBe(8772);
-    expect(computeMilestoneAmountDue(subtotal, plan.milestones[0].taxPercent)).toBeCloseTo(10000.08);
+    const packagesById = new Map([['3', pkg]]);
+    const rows = resolveMilestoneServiceRows(plan.milestones[0], new Map(), { packagesById });
+    const subtotal = computeMilestoneSubtotal(rows);
+    expect(subtotal).toBe(8000);
+    expect(computeMilestoneAmountDue(subtotal, plan.milestones[0].taxPercent)).toBeCloseTo(9120);
   });
 
-  it('adds extra services into the amount due, matching the Mullins sample (13000 scheduled + 2500 PGS, taxed at 13%)', () => {
-    const plan = buildExpectedExpensesPlan(
-      { ...pkg, listedPrice: 41500 },
-      { payments: [{ title: 'To start the program', amount: 13000 }] },
-      { taxPercent: 13 },
-    );
+  it('adds extra services into the amount due on top of the percent-of-package share', () => {
+    const plan = buildExpectedExpensesPlan({ ...pkg, listedPrice: 40000 }, { payments: [{ title: 'To start the program', amount: 13000 }] }, { taxPercent: 13 });
     const pgs = makeCustomEntry({ name: 'PGS of 24 chromosomes', price: 2500 });
-    const milestone = addMilestoneAdditionalService(plan.milestones[0], pgs);
-    const catalogItemsById = new Map();
-    const additionalRows = resolveMilestoneAdditionalRows(milestone, catalogItemsById);
-    const subtotal = computeMilestoneSubtotal(milestone, additionalRows);
-    expect(subtotal).toBe(15500);
+    const milestone = addMilestoneService(plan.milestones[0], pgs);
+    const packagesById = new Map([['3', { ...pkg, listedPrice: 40000 }]]);
+    const rows = resolveMilestoneServiceRows(milestone, new Map(), { packagesById });
+    const subtotal = computeMilestoneSubtotal(rows);
+    expect(subtotal).toBeCloseTo(15500);
     expect(computeMilestoneAmountDue(subtotal, milestone.taxPercent)).toBeCloseTo(17515);
   });
 
@@ -129,15 +156,73 @@ describe('expectedExpensesUtils', () => {
     });
   });
 
+  describe('raw group upload (array of arrays of legacy service strings)', () => {
+    const rawGroups = [
+      ['id1 || 20%', 'Deposit for transportation of SM || 300', 'Deposit for medical expenses of SM || 300'],
+      ['id1 || 10%', 'Deposit for transportation of SM || 300'],
+      ['id1 || 15%', 'id32', 'Deposit for medical expenses of SM || 300'],
+    ];
+    const rawCatalog = {
+      packages: [{ id: '1', name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR', children: ['1', '2'] }],
+      technical: { paymentSchedules: [{ id: 'ps-1', payments: schedule.payments.slice(0, 4) }] },
+    };
+    const rawCatalogWithLink = {
+      ...rawCatalog,
+      packages: [{ ...rawCatalog.packages[0], paymentScheduleId: 'ps-1' }],
+    };
+
+    it('detects the raw array-of-groups shape', () => {
+      expect(isRawExpectedExpensesGroups(rawGroups)).toBe(true);
+      expect(isRawExpectedExpensesGroups({})).toBe(false);
+      expect(isRawExpectedExpensesGroups([['ok'], 'nope'])).toBe(false);
+    });
+
+    it('infers the package id from the first percent-of-package row', () => {
+      expect(inferPackageIdFromRawGroups(rawGroups)).toBe('1');
+      expect(inferPackageIdFromRawGroups([['Just a custom || 300']])).toBe('');
+    });
+
+    it('builds a plan by lining groups up with the package\'s default schedule, index by index', () => {
+      const { plan, missingPackage, droppedGroupsCount } = buildExpectedExpensesPlanFromRawGroups(rawGroups, { catalog: rawCatalogWithLink, taxPercent: 14 });
+      expect(missingPackage).toBe(false);
+      expect(droppedGroupsCount).toBe(0);
+      expect(plan.packageId).toBe('1');
+      expect(plan.milestones).toHaveLength(4);
+      expect(plan.milestones[0].showPackageOverview).toBe(true);
+      expect(plan.milestones[0].services).toHaveLength(3);
+      expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'percent', packageId: '1', percent: 20 });
+      // The schedule has 4 steps but only 3 groups were uploaded - the last step is left empty
+      // instead of breaking.
+      expect(plan.milestones[3].services).toEqual([]);
+    });
+
+    it('drops groups beyond the schedule\'s step count and reports how many', () => {
+      const shortSchedule = { ...rawCatalogWithLink, technical: { paymentSchedules: [{ id: 'ps-1', payments: schedule.payments.slice(0, 2) }] } };
+      const { plan, droppedGroupsCount } = buildExpectedExpensesPlanFromRawGroups(rawGroups, { catalog: shortSchedule });
+      expect(plan.milestones).toHaveLength(2);
+      expect(droppedGroupsCount).toBe(1);
+    });
+
+    it('reports a missing package instead of guessing when no percent row names one', () => {
+      const { plan, missingPackage } = buildExpectedExpensesPlanFromRawGroups([['Custom line || 300']], { catalog: rawCatalogWithLink });
+      expect(missingPackage).toBe(true);
+      expect(plan).toBeNull();
+    });
+  });
+
   describe('expectedExpensesSeed.json', () => {
-    it('is a valid, normalizable expected-expenses plan whose milestones add up to the package price', () => {
+    it('is a valid, normalizable expected-expenses plan whose percent shares add up to 100%', () => {
       expect(isExpectedExpensesShape(expectedExpensesSeed)).toBe(true);
       const normalized = normalizeExpectedExpensesData(expectedExpensesSeed);
       expect(normalized.packageId).toBe('3');
       expect(normalized.milestones).toHaveLength(6);
-      expect(computeMilestonesScheduledTotal(normalized.milestones)).toBe(normalized.packageSnapshot.listedPrice);
+      expect(computeMilestonesPackageSharePercent(normalized.milestones, normalized.packageId)).toBe(100);
+      expect(computeMilestonesTotal(normalized.milestones, new Map(), { packagesById: new Map([['3', normalized.packageSnapshot]]) }))
+        .toBeGreaterThan(normalized.packageSnapshot.listedPrice);
       expect(normalized.milestones[0].showPackageOverview).toBe(true);
       expect(normalized.milestones.slice(1).every(milestone => !milestone.showPackageOverview)).toBe(true);
+      const giftRow = normalized.milestones[5].services.find(entry => entry.priceLabel === 'GIFT');
+      expect(giftRow).toMatchObject({ price: 0, priceLabel: 'GIFT' });
     });
   });
 });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -7,17 +7,24 @@
 //                                                        fields pinned to a local value instead of
 //                                                        following the shared budget catalog
 //   { id, kind: 'custom', name, price, description? } -> a one-off line with no catalog link
+//     (price may be paired with a non-numeric `priceLabel`, e.g. "GIFT", for a free-text amount)
 //   { id, kind: 'package', catalogId, children: [...] } -> a whole budget/packages program, its
 //                                                        line items copied in as child entries
 //                                                        (each child is itself an 'item' or 'custom'
 //                                                        entry). Editing/removing/reordering a
 //                                                        child, or renaming the package, flips
 //                                                        `customized: true` on the package.
+//   { id, kind: 'percent', packageId, percent }        -> a share of a budget/packages program's
+//                                                        listed price (e.g. "20% of package 1").
+//                                                        The euro amount is never stored - it's
+//                                                        recalculated from the package's live/
+//                                                        resolved price every time it's resolved.
 //
-// Older data may still contain plain strings ("id15", "Name || Price") - normalizeServiceEntry
-// upgrades those to the object shape on load, so the rest of the app only ever sees objects.
+// Older data may still contain plain strings ("id15", "Name || Price", "id1 || 20%") -
+// normalizeServiceEntry upgrades those to the object shape on load, so the rest of the app only
+// ever sees objects.
 
-import { getItemDisplayAmount } from './budgetCatalogUtils';
+import { getItemDisplayAmount, resolveBudgetPriceAmount } from './budgetCatalogUtils';
 
 const SERVICE_PRICE_SEPARATOR = '||';
 const CATALOG_ID_PREFIX = 'id';
@@ -30,6 +37,14 @@ const toNumber = value => {
 };
 
 export const createEntryId = () => `entry-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`;
+
+// Splits a manually-typed price field into a numeric price or a free-text priceLabel (e.g.
+// "GIFT") - the interactive-editing counterpart of parseLegacyServiceString's price handling.
+export const parseCustomPriceInput = raw => {
+  const text = String(raw ?? '').trim();
+  if (!text || PLAIN_NUMBER_STRING_REGEX.test(text)) return { price: toNumber(text), priceLabel: '' };
+  return { price: 0, priceLabel: text };
+};
 
 export const normalizeInvoiceData = raw => ({
   beneficiaries: Array.isArray(raw?.beneficiaries) ? raw.beneficiaries : [],
@@ -71,12 +86,22 @@ export const makeCatalogItemEntry = (catalogId, { id } = {}) => ({
   catalogId: String(catalogId),
 });
 
-export const makeCustomEntry = ({ name = '', price = 0, description = '' } = {}, { id } = {}) => ({
+export const makeCustomEntry = ({ name = '', price = 0, description = '', priceLabel = '' } = {}, { id } = {}) => ({
   id: id || createEntryId(),
   kind: 'custom',
   name: String(name || '').trim(),
   price: toNumber(price),
   ...(String(description || '').trim() ? { description: String(description).trim() } : {}),
+  ...(String(priceLabel || '').trim() ? { priceLabel: String(priceLabel).trim() } : {}),
+});
+
+// A share of a budget/packages program's listed price, e.g. "20% of package 1". The euro amount
+// is intentionally never stored - resolveServiceRow recalculates it from the package's price.
+export const makePercentOfPackageEntry = (packageId, percent, { id } = {}) => ({
+  id: id || createEntryId(),
+  kind: 'percent',
+  packageId: String(packageId ?? ''),
+  percent: toNumber(percent),
 });
 
 // pkg: a budget/packages record ({ id, children: [itemId, ...] }). Its children are copied in as
@@ -101,14 +126,31 @@ export const cloneEntryWithNewId = entry => {
 
 // --- Legacy string parsing / normalization ------------------------------------------------------
 
-// "id15" -> catalog reference · "Name || Price" -> a custom one-off line.
+const CATALOG_ID_REGEX = new RegExp(`^${CATALOG_ID_PREFIX}(.+)$`, 'i');
+const PERCENT_VALUE_REGEX = /^(\d+(?:[.,]\d+)?)\s*%$/;
+const PLAIN_NUMBER_STRING_REGEX = /^[-+]?\d+(?:[.,]\d+)?$/;
+
+// "id15" -> catalog reference · "Name || Price" -> a custom one-off line ·
+// "id1 || 20%" -> a share of that catalog package's listed price ·
+// "Name || GIFT" (or any other non-numeric, non-percent price) -> a custom line with a free-text
+// price label instead of a euro amount.
 export const parseLegacyServiceString = raw => {
   const text = String(raw ?? '').trim();
   if (text.includes(SERVICE_PRICE_SEPARATOR)) {
     const [namePart, ...priceParts] = text.split(SERVICE_PRICE_SEPARATOR);
-    return { kind: 'custom', name: namePart.trim(), price: toNumber(priceParts.join(SERVICE_PRICE_SEPARATOR)) };
+    const trimmedName = namePart.trim();
+    const pricePart = priceParts.join(SERVICE_PRICE_SEPARATOR).trim();
+    const percentMatch = PERCENT_VALUE_REGEX.exec(pricePart);
+    const packageIdMatch = CATALOG_ID_REGEX.exec(trimmedName);
+    if (percentMatch && packageIdMatch) {
+      return { kind: 'percent', packageId: packageIdMatch[1], percent: toNumber(percentMatch[1]) };
+    }
+    if (pricePart && !PLAIN_NUMBER_STRING_REGEX.test(pricePart)) {
+      return { kind: 'custom', name: trimmedName, price: 0, priceLabel: pricePart };
+    }
+    return { kind: 'custom', name: trimmedName, price: toNumber(pricePart) };
   }
-  const catalogMatch = new RegExp(`^${CATALOG_ID_PREFIX}(.+)$`, 'i').exec(text);
+  const catalogMatch = CATALOG_ID_REGEX.exec(text);
   if (catalogMatch) return { kind: 'item', catalogId: catalogMatch[1] };
   return { kind: 'custom', name: text, price: 0 };
 };
@@ -118,11 +160,17 @@ export const parseLegacyServiceString = raw => {
 export const normalizeServiceEntry = raw => {
   if (typeof raw === 'string') {
     const parsed = parseLegacyServiceString(raw);
-    return parsed.kind === 'item' ? makeCatalogItemEntry(parsed.catalogId) : makeCustomEntry(parsed);
+    if (parsed.kind === 'item') return makeCatalogItemEntry(parsed.catalogId);
+    if (parsed.kind === 'percent') return makePercentOfPackageEntry(parsed.packageId, parsed.percent);
+    return makeCustomEntry(parsed);
   }
   if (!raw || typeof raw !== 'object') return makeCustomEntry({});
 
   const id = raw.id || createEntryId();
+
+  if (raw.kind === 'percent') {
+    return makePercentOfPackageEntry(raw.packageId, raw.percent, { id });
+  }
 
   if (raw.kind === 'package') {
     return {
@@ -146,6 +194,7 @@ export const normalizeServiceEntry = raw => {
       name: raw.name || '',
       price: toNumber(raw.price),
       ...(raw.description ? { description: raw.description } : {}),
+      ...(raw.priceLabel ? { priceLabel: raw.priceLabel } : {}),
     };
   }
 
@@ -172,7 +221,19 @@ export const normalizeServiceEntries = list => (Array.isArray(list) ? list.map(n
 export const setEntryField = (entry, field, value) => {
   if (!entry) return entry;
   if (entry.kind === 'custom') {
-    return { ...entry, [field]: field === 'price' ? toNumber(value) : value };
+    if (field === 'price') {
+      const text = String(value ?? '').trim();
+      const { priceLabel, ...rest } = entry;
+      if (!text || PLAIN_NUMBER_STRING_REGEX.test(text)) return { ...rest, price: toNumber(text) };
+      // A non-numeric price (e.g. "GIFT") is kept as a free-text label instead of being coerced to 0.
+      return { ...rest, price: 0, priceLabel: text };
+    }
+    return { ...entry, [field]: value };
+  }
+  if (entry.kind === 'percent') {
+    if (field === 'percent') return { ...entry, percent: toNumber(value) };
+    if (field === 'packageId') return { ...entry, packageId: String(value ?? '') };
+    return entry;
   }
   if (entry.kind === 'package') {
     if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
@@ -236,6 +297,7 @@ export const getEntryIdentityKey = entry => {
   if (!entry) return '';
   if (entry.kind === 'package') return `package:${entry.catalogId}`;
   if (entry.kind === 'item') return `item:${entry.catalogId}`;
+  if (entry.kind === 'percent') return `percent:${entry.packageId}:${entry.percent}`;
   return `custom:${entry.name || ''}:${entry.price || 0}:${entry.description || ''}`;
 };
 
@@ -247,7 +309,30 @@ export const getEntryIdentityKey = entry => {
 // following its catalog name/description the same way an un-edited item entry does. A package's
 // `children` are always a frozen snapshot taken when it was added - they never live-track the
 // catalog, since that's the whole point of pinning a specific set of services to an invoice.
+const formatPercentValue = percent => (Number.isInteger(percent) ? String(percent) : String(Math.round(percent * 100) / 100));
+
 export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) => {
+  if (entry?.kind === 'percent') {
+    const pkg = priceContext.packagesById?.get?.(String(entry.packageId));
+    const packageAmount = pkg
+      ? resolveBudgetPriceAmount(pkg.listedPrice, { ...priceContext, itemsById: catalogItemsById })
+      : null;
+    const percent = Number(entry.percent) || 0;
+    const price = packageAmount == null ? 0 : (packageAmount * percent) / 100;
+    return {
+      key: entry.id,
+      id: entry.id,
+      kind: 'percent',
+      packageId: entry.packageId,
+      percent,
+      missing: !pkg,
+      isCustomized: false,
+      name: `${formatPercentValue(percent)}% of ${pkg?.name ?? `Package ${entry.packageId}`}`,
+      description: '',
+      price,
+    };
+  }
+
   if (entry?.kind === 'package') {
     const pkg = priceContext.packagesById?.get?.(String(entry.catalogId));
     const children = Array.isArray(entry.children) ? entry.children : [];
@@ -280,6 +365,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       name: entry.name || '',
       description: entry.description || '',
       price: Number(entry.price) || 0,
+      ...(entry.priceLabel ? { priceLabel: entry.priceLabel } : {}),
     };
   }
 

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -17,6 +17,7 @@ import {
   makeCatalogItemEntry,
   makeCatalogPackageEntry,
   makeCustomEntry,
+  makePercentOfPackageEntry,
   movePackageChild,
   normalizeInvoiceData,
   normalizeServiceEntry,
@@ -84,6 +85,17 @@ describe('invoiceCatalogUtils', () => {
       });
     });
 
+    it('parses legacy "idX || Y%" rows as a share of that package\'s price', () => {
+      expect(parseLegacyServiceString('id1 || 20%')).toEqual({ kind: 'percent', packageId: '1', percent: 20 });
+      expect(parseLegacyServiceString('id1 || 12.5%')).toEqual({ kind: 'percent', packageId: '1', percent: 12.5 });
+    });
+
+    it('parses a non-numeric, non-percent price as a free-text price label', () => {
+      expect(parseLegacyServiceString('Standard service until 6 months after delivery || GIFT')).toEqual({
+        kind: 'custom', name: 'Standard service until 6 months after delivery', price: 0, priceLabel: 'GIFT',
+      });
+    });
+
     it('upgrades a legacy string into the canonical object entry', () => {
       const item = normalizeServiceEntry('id15');
       expect(item.kind).toBe('item');
@@ -100,11 +112,12 @@ describe('invoiceCatalogUtils', () => {
       const data = normalizeInvoiceData({
         beneficiaries: [], beneficiaryIds: [], customers: [], notes: [],
         recentServices: ['id15'],
-        invoiceServices: ['id15', 'Deposit for transportation of SM || 300'],
+        invoiceServices: ['id15', 'Deposit for transportation of SM || 300', 'id1 || 20%'],
       });
-      expect(data.invoiceServices).toHaveLength(2);
+      expect(data.invoiceServices).toHaveLength(3);
       expect(data.invoiceServices[0]).toMatchObject({ kind: 'item', catalogId: '15' });
       expect(data.invoiceServices[1]).toMatchObject({ kind: 'custom', name: 'Deposit for transportation of SM', price: 300 });
+      expect(data.invoiceServices[2]).toMatchObject({ kind: 'percent', packageId: '1', percent: 20 });
     });
 
     it('is idempotent on an already-normalized entry (keeps its id)', () => {
@@ -276,6 +289,47 @@ describe('invoiceCatalogUtils', () => {
       expect(row.hasPriceOverride).toBe(true);
     });
 
+    it('resolves a percent-of-package row from the package\'s live listed price, never storing the euro amount', () => {
+      const packagesById = new Map([['1', { id: '1', name: 'IVF+ED+SM', listedPrice: 40000 }]]);
+      const entry = makePercentOfPackageEntry('1', 20);
+      const row = resolveServiceRow(entry, new Map(), { packagesById });
+      expect(row).toMatchObject({ kind: 'percent', packageId: '1', percent: 20, missing: false, price: 8000 });
+      expect(row.name).toBe('20% of IVF+ED+SM');
+
+      // Bumping the package price recalculates the row automatically - no stored amount to go stale.
+      const bumped = new Map([['1', { id: '1', name: 'IVF+ED+SM', listedPrice: 50000 }]]);
+      expect(resolveServiceRow(entry, new Map(), { packagesById: bumped }).price).toBe(10000);
+    });
+
+    it('flags a percent-of-package row whose package no longer exists', () => {
+      const row = resolveServiceRow(makePercentOfPackageEntry('999', 20), new Map(), { packagesById: new Map() });
+      expect(row.missing).toBe(true);
+      expect(row.price).toBe(0);
+    });
+
+    it('edits the percent and target package of a percent-of-package entry', () => {
+      const entry = makePercentOfPackageEntry('1', 20);
+      expect(setEntryField(entry, 'percent', '15,5').percent).toBe(15.5);
+      expect(setEntryField(entry, 'packageId', '2').packageId).toBe('2');
+    });
+
+    it('editing a custom row\'s price with non-numeric text sets a free-text priceLabel instead of coercing to 0', () => {
+      const entry = makeCustomEntry({ name: 'Post-delivery support', price: 500 });
+      const gifted = setEntryField(entry, 'price', 'GIFT');
+      expect(gifted).toMatchObject({ price: 0, priceLabel: 'GIFT' });
+      // Typing a real number back in clears the label again.
+      expect(setEntryField(gifted, 'price', '650')).toMatchObject({ price: 650 });
+      expect(setEntryField(gifted, 'price', '650').priceLabel).toBeUndefined();
+    });
+
+    it('carries a free-text priceLabel (e.g. "GIFT") through resolution instead of a euro amount', () => {
+      const entry = makeCustomEntry({ name: 'Post-delivery support', priceLabel: 'GIFT' });
+      expect(entry.price).toBe(0);
+      const row = resolveServiceRow(entry, new Map());
+      expect(row.priceLabel).toBe('GIFT');
+      expect(row.price).toBe(0);
+    });
+
     it('computes subtotal/total without double-counting package children', () => {
       const catalogItemsById = new Map([
         ['15', { id: '15', name: 'Scheduled payment', price: 3000 }],
@@ -299,6 +353,7 @@ describe('invoiceCatalogUtils', () => {
       expect(getEntryIdentityKey(makeCatalogPackageEntry({ id: 'p1', children: [] }))).toBe('package:p1');
       expect(getEntryIdentityKey(makeCustomEntry({ name: 'Extra', price: 50 })))
         .toBe(getEntryIdentityKey(makeCustomEntry({ name: 'Extra', price: 50 })));
+      expect(getEntryIdentityKey(makePercentOfPackageEntry('1', 20))).toBe('percent:1:20');
     });
 
     it('moves used services to the front of recentServices, deduped by identity', () => {

--- a/src/data/expectedExpensesSeed.json
+++ b/src/data/expectedExpensesSeed.json
@@ -34,18 +34,21 @@
     {
       "id": "milestone-1",
       "title": "To start the program",
-      "scheduledAmount": 16000,
       "taxPercent": 14,
       "showPackageOverview": true,
-      "additionalServices": []
+      "services": [
+        { "id": "milestone-1-share", "kind": "percent", "packageId": "3", "percent": 20 },
+        { "id": "milestone-1-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-1-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      ]
     },
     {
       "id": "milestone-2",
       "title": "Two weeks before embryo transfer",
-      "scheduledAmount": 6000,
       "taxPercent": 14,
       "showPackageOverview": false,
-      "additionalServices": [
+      "services": [
+        { "id": "milestone-2-share", "kind": "percent", "packageId": "3", "percent": 10 },
         { "id": "milestone-2-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-2-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
@@ -53,33 +56,33 @@
     {
       "id": "milestone-3",
       "title": "After confirmation of pregnancy by ultrasound",
-      "scheduledAmount": 6000,
       "taxPercent": 14,
       "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-3-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
-        { "id": "milestone-3-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      "services": [
+        { "id": "milestone-3-share", "kind": "percent", "packageId": "3", "percent": 15 },
+        { "id": "milestone-3-extra-1", "kind": "item", "catalogId": "32" },
+        { "id": "milestone-3-extra-2", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-3-extra-3", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
     },
     {
       "id": "milestone-4",
       "title": "On the 12th week of pregnancy",
-      "scheduledAmount": 6000,
       "taxPercent": 14,
       "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-4-extra-1", "kind": "item", "catalogId": "40" },
-        { "id": "milestone-4-extra-2", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
-        { "id": "milestone-4-extra-3", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
+      "services": [
+        { "id": "milestone-4-share", "kind": "percent", "packageId": "3", "percent": 20 },
+        { "id": "milestone-4-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
+        { "id": "milestone-4-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
     },
     {
       "id": "milestone-5",
       "title": "On the 18th week of pregnancy",
-      "scheduledAmount": 6000,
       "taxPercent": 14,
       "showPackageOverview": false,
-      "additionalServices": [
+      "services": [
+        { "id": "milestone-5-share", "kind": "percent", "packageId": "3", "percent": 20 },
         { "id": "milestone-5-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-5-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
@@ -87,14 +90,21 @@
     {
       "id": "milestone-6",
       "title": "On the 36th week of pregnancy",
-      "scheduledAmount": 6000,
       "taxPercent": 14,
       "showPackageOverview": false,
-      "additionalServices": [
-        { "id": "milestone-6-extra-1", "kind": "custom", "name": "Deposit. Medications for SM during and after delivery", "price": 500 },
-        { "id": "milestone-6-extra-2", "kind": "custom", "name": "Deposit. For C-section (is returned if not used)", "price": 2700 },
-        { "id": "milestone-6-extra-3", "kind": "custom", "name": "Deposit. For baby clothes / diapers / formulas / etc", "price": 110 },
-        { "id": "milestone-6-extra-4", "kind": "custom", "name": "Deposit. For unexpected expenses (e.g. staying in hospital, service of nanny etc.)", "price": 600 }
+      "services": [
+        { "id": "milestone-6-share", "kind": "percent", "packageId": "3", "percent": 15 },
+        { "id": "milestone-6-extra-1", "kind": "item", "catalogId": "61" },
+        { "id": "milestone-6-extra-2", "kind": "item", "catalogId": "62" },
+        { "id": "milestone-6-extra-3", "kind": "item", "catalogId": "63" },
+        { "id": "milestone-6-extra-4", "kind": "item", "catalogId": "64" },
+        {
+          "id": "milestone-6-extra-5",
+          "kind": "custom",
+          "name": "Standard service of the independent lawyer, notary and post until the 6 months after delivery",
+          "price": 0,
+          "priceLabel": "GIFT"
+        }
       ]
     }
   ]


### PR DESCRIPTION
- New "percent" entry kind ("id1 || 20%") usable anywhere a service row
  can appear (recentServices, invoiceServices, package children, expected
  expenses) - resolves live against the referenced package's price instead
  of freezing a euro amount, and is fully editable (percent + target
  package) in the UI.
- Custom rows can carry a free-text price label (e.g. "Name || GIFT")
  instead of a numeric price.
- Expected-expenses milestones no longer store a frozen scheduledAmount;
  each milestone's total is the sum of its own service rows (typically a
  percent-of-package row plus one-off extras), recalculated automatically.
- Invoice-builder JSON uploads (and the dedicated expected-expenses
  upload) now also accept the lean array-of-groups shape, lined up 1:1
  with the chosen package's default payment schedule; the package is
  inferred from the groups' percent rows.
- Added a scaled-down PDF page preview strip at the bottom of the invoice
  builder so the invoice and expected-expenses PDFs can be eyeballed
  before generating the real file.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HQ9FoNywryAmrwN76rFFK7