### PR TITLE
Fix expected-expenses build errors and recalculate logic bugs

### DIFF
--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -322,7 +322,7 @@ const renderExpensesTable = rows => (
   </View>
 );
 
-const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate, schedule, taxPercent = 0 }) => {
+const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate }) => {
   const caseTitle = buildCaseTitle(customers);
   const dateLabel = formatPlanDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
   const overviewRows = resolvePackageOverviewRows(plan?.packageSnapshot?.children, catalogItemsById, priceContext);
@@ -341,9 +341,11 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
         return (
           <Page key={`${plan?.packageId || 'package'}-${index}`} size="A4" style={styles.page} wrap>
             <Text style={styles.sectionTitle}>{sanitizePdfText(`Expected expenses of the invoice #${index + 1}`)}</Text>
-            <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${payment?.title || `Payment ${index + 1}`}`)}</Text>
+            <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${milestone.title}`)}</Text>
             <Text style={styles.dateText}>{dateLabel}</Text>
 
+            {milestone.showPackageOverview ? (
+              <>
                 <View style={styles.overviewTable}>
                   <View style={styles.overviewHeadRow} wrap={false}>
                     <View style={styles.overviewHeadCell}><Text style={styles.overviewHeadText}>{sanitizePdfText(plan.packageSnapshot.name)}</Text></View>
@@ -381,13 +383,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
                 {serviceRows.length ? renderExpensesTable(serviceRows) : null}
               </>
             ) : (
-              <>
-                <Text style={styles.sectionTitle}>{sanitizePdfText(`Expected expenses of the invoice #${index + 1}`)}</Text>
-                <Text style={styles.sectionSubtitle}>{sanitizePdfText(`${index + 1}. ${milestone.title}`)}</Text>
-                <Text style={styles.dateText}>{dateLabel}</Text>
-
-                {renderExpensesTable(serviceRows)}
-              </>
+              renderExpensesTable(serviceRows)
             )}
 
             <View style={[styles.summaryRow, styles.summaryRowLast]} wrap={false}>
@@ -398,7 +394,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
             <View style={{ marginTop: 16 }}>
               <View style={styles.summaryRow} wrap={false}>
                 <View style={styles.summaryLabelCell}><Text style={styles.summaryLabelText}>Taxes (%)</Text></View>
-                <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(taxPercent)}</Text></View>
+                <View style={styles.summaryAmountCell}><Text style={styles.summaryAmountText}>{formatPlainAmount(milestone.taxPercent)}</Text></View>
               </View>
               <View style={[styles.summaryRow, styles.summaryRowLast]} wrap={false}>
                 <View style={styles.summaryLabelCell}><Text style={[styles.summaryLabelText, { fontFamily: PDF_FONT.bold }]}>Amount need to be paid (EUR)</Text></View>

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -61,12 +61,14 @@ import {
   computeMilestoneSubtotal,
   computeMilestonesPackageSharePercent,
   computeMilestonesTotal,
+  getExpectedExpensesPackagePrice,
   isExpectedExpensesShape,
   isRawExpectedExpensesGroups,
   normalizeExpectedExpensesData,
   removeMilestoneService,
   resolveMilestoneServiceRows,
   resolvePackageOverviewRows,
+  serializeExpectedExpensesData,
   setMilestoneField,
   updateMilestoneServiceField,
 } from './expectedExpensesUtils';
@@ -932,60 +934,25 @@ const PackageEntryCard = ({
   );
 };
 
-const PdfPreviewStrip = styled.div`
-  display: flex;
-  gap: 10px;
-  overflow-x: auto;
-  padding: 12px 2px 4px;
-  margin-top: 8px;
-`;
-
-const PdfPreviewPage = styled.div`
-  flex: 0 0 165px;
-  min-height: 232px;
-  background: #fff;
-  border: 1px solid var(--km-border);
-  border-radius: 8px;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
-  padding: 14px 12px;
-  color: #111827;
-  font-size: 7px;
-`;
-
-const PdfPreviewTitle = styled.div`
-  text-align: center;
-  font-weight: 900;
-  font-size: 10px;
-  margin-bottom: 4px;
-`;
-
-const PdfPreviewSubtitle = styled.div`
-  text-align: center;
-  font-weight: 700;
-  margin-bottom: 10px;
-`;
-
-const PdfPreviewTable = styled.div`
-  border: 1px solid #111827;
-`;
-
-const PdfPreviewRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  gap: 5px;
-  border-bottom: 1px solid #111827;
-  padding: 3px;
-
-  &:last-child { border-bottom: 0; }
-`;
-
-const PdfPreviewFooter = styled.div`
-  margin-top: 10px;
-  font-weight: 800;
-  text-align: right;
-`;
-
 // --- Expected expenses milestone (one payment-schedule entry -> one future invoice) ------------------------------------------------------
+
+const MilestoneCheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 8px;
+`;
+
+const MilestoneCheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--km-muted);
+  cursor: pointer;
+`;
 
 const MilestoneCard = ({
   index,
@@ -993,7 +960,6 @@ const MilestoneCard = ({
   serviceRows,
   subtotal,
   amountDue,
-  taxPercent,
   catalogItems,
   catalogPackages,
   onCommitField,
@@ -1004,6 +970,7 @@ const MilestoneCard = ({
   onAddCustomService,
   onAddCatalogService,
   onAddPercentService,
+  onAddPackagePercent,
 }) => {
   const [titleDraft, setTitleDraft, titleEditingRef] = useFieldDraft(milestone.title);
   const [taxDraft, setTaxDraft, taxEditingRef] = useFieldDraft(String(milestone.taxPercent ?? ''));
@@ -1102,7 +1069,7 @@ const MilestoneCard = ({
       <PackageAddRow>
         <PackageQuickField
           rows={1}
-          placeholder="Add a custom line to this invoice…"
+          placeholder="Custom line name…"
           value={customName}
           onChange={event => setCustomName(event.target.value)}
         />
@@ -1623,7 +1590,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     }
     const resolvedPackage = getResolvedExpectedExpensesPackage(pkg);
     if (!resolvedPackage) return;
-    const plan = buildExpectedExpensesPlan(resolvedPackage, schedule);
+    const plan = buildExpectedExpensesPlan(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
     persistExpectedExpenses(plan, 'Expected expenses template created.');
     setShowExpectedExpensesPicker(false);
   };
@@ -1645,9 +1612,25 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     )) return;
     const resolvedPackage = { ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice };
     const freshMilestones = buildMilestonesFromSchedule(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
+    // A milestone saved before expectedExpenseRole existed has no explicit marker on its scheduled
+    // row, so it can't be told apart from a manually-added percent-of-package row by itself. Only
+    // guess when EVERY existing milestone's first row looks like that same unmarked pattern - one
+    // manual row surrounded by otherwise-fresh milestones is left alone instead of being swallowed
+    // as if it were the old scheduled amount. Evaluated over the existing milestones (not the fresh
+    // ones), so a schedule that grew a new step doesn't silently defeat this check.
+    const packageId = String(expectedExpenses.packageId ?? '');
+    const isUnmarkedPackagePercent = entry => entry?.kind === 'percent'
+      && !entry.expectedExpenseRole
+      && String(entry.packageId) === packageId;
+    const existingMilestones = expectedExpenses.milestones || [];
+    const hasLegacyScheduledRows = existingMilestones.length > 0
+      && existingMilestones.every(milestone => isUnmarkedPackagePercent((milestone.services || [])[0]));
     const nextMilestones = freshMilestones.map((milestone, index) => {
-      const previous = expectedExpenses.milestones[index];
-      const previousExtras = (previous?.services || []).filter(entry => entry.kind !== 'percent' || String(entry.packageId) !== String(expectedExpenses.packageId));
+      const previous = existingMilestones[index];
+      const previousExtras = (previous?.services || []).filter((entry, entryIndex) => (
+        entry?.expectedExpenseRole !== 'scheduled'
+        && !(hasLegacyScheduledRows && entryIndex === 0 && isUnmarkedPackagePercent(entry))
+      ));
       return {
         ...milestone,
         services: [...milestone.services, ...previousExtras],
@@ -1670,12 +1653,22 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     persistExpectedExpenses(null, 'Expected expenses template deleted.');
   };
 
-  const commitExpectedExpenseServiceField = (groupIndex, entryId, field, value) => {
-    persistExpectedExpenses(updateExpectedExpenseServiceField(expectedExpenses, groupIndex, entryId, field, value), 'Service updated.');
+  const persistExpectedExpensesMilestones = (nextMilestones, successMessage) => {
+    persistExpectedExpenses({ ...expectedExpenses, milestones: nextMilestones }, successMessage);
   };
 
-  const resetExpectedExpenseServiceEntry = (groupIndex, entryId) => {
-    persistExpectedExpenses(resetExpectedExpenseService(expectedExpenses, groupIndex, entryId), 'Reverted to catalog values.');
+  const commitMilestoneField = (milestoneId, field, value) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? setMilestoneField(milestone, field, value)
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Milestone updated.');
+  };
+
+  const toggleMilestoneOverview = milestoneId => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? { ...milestone, showPackageOverview: !milestone.showPackageOverview }
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Milestone updated.');
   };
 
   const commitMilestoneServiceField = (milestoneId, entryId, field, value) => {
@@ -1721,8 +1714,15 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
   };
 
+  const addMilestonePackagePercentService = (milestoneId, percent) => {
+    const nextMilestones = expectedExpenses.milestones.map(milestone => (milestone.id === milestoneId
+      ? addMilestoneService(milestone, makePercentOfPackageEntry(expectedExpenses.packageId, percent))
+      : milestone));
+    persistExpectedExpensesMilestones(nextMilestones, 'Service added.');
+  };
+
   const handleGenerateExpectedExpensesPdf = async () => {
-    if (!expectedExpenses || !expectedExpensesView?.pages?.length) {
+    if (!expectedExpenses || !expectedExpensesView?.milestoneRows?.length) {
       toast.error('Choose a package to build the plan first.');
       return;
     }
@@ -1743,8 +1743,6 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         catalogItemsById,
         priceContext,
         planDate: new Date(`${invoiceDateInput || getTodayYmd()}T00:00:00`),
-        schedule: expectedExpensesView?.schedule,
-        taxPercent: defaultExpectedExpensesTaxPercent,
       };
       let blob;
       try {
@@ -2377,7 +2375,6 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       serviceRows={serviceRows}
                       subtotal={subtotal}
                       amountDue={amountDue}
-                      taxPercent={taxPercent}
                       catalogItems={catalogItems}
                       catalogPackages={visibleCatalogPackages}
                       onCommitField={(field, value) => commitMilestoneField(milestone.id, field, value)}
@@ -2388,28 +2385,9 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       onAddCustomService={fields => addMilestoneCustomService(milestone.id, fields)}
                       onAddCatalogService={catalogId => addMilestoneCatalogService(milestone.id, catalogId)}
                       onAddPercentService={() => addMilestonePercentService(milestone.id)}
+                      onAddPackagePercent={percent => addMilestonePackagePercentService(milestone.id, percent)}
                     />
                   ))}
-
-                  {expectedExpensesView?.pages?.length ? (
-                    <PdfPreviewStrip>
-                      {expectedExpensesView.pages.map(({ payment, rows, amountDue, taxPercent }, index) => (
-                        <PdfPreviewPage key={`preview-${index}`}>
-                          <PdfPreviewTitle>Expected expenses of the invoice #{index + 1}</PdfPreviewTitle>
-                          <PdfPreviewSubtitle>{index + 1}. {payment?.title || `Payment ${index + 1}`}</PdfPreviewSubtitle>
-                          <PdfPreviewTable>
-                            {rows.map((row, rowIndex) => (
-                              <PdfPreviewRow key={row.key || rowIndex}>
-                                <span>{rowIndex + 1}. {row.name}</span>
-                                <b>{formatEuroPreview(row.price)}</b>
-                              </PdfPreviewRow>
-                            ))}
-                          </PdfPreviewTable>
-                          <PdfPreviewFooter>Tax {taxPercent}% · Due {formatEuroPreview(amountDue)}</PdfPreviewFooter>
-                        </PdfPreviewPage>
-                      ))}
-                    </PdfPreviewStrip>
-                  ) : null}
                 </>
               )}
             </Panel>

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -276,12 +276,19 @@ describe('InvoiceBuilderPage', () => {
             exists: () => true,
             val: () => ({
               packageId: 'p1',
-              expectedExpenses: [
-                [
-                  { id: 'stale-1', kind: 'packagePercent', catalogId: 'p1', percent: 10, expectedExpenseRole: 'scheduled' },
-                  { id: 'custom-1', kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
-                ],
-                [{ id: 'stale-2', kind: 'packagePercent', catalogId: 'p1', percent: 10, expectedExpenseRole: 'scheduled' }],
+              packageSnapshot: { name: 'Full program', listedPrice: 250, currency: 'EUR', children: [] },
+              milestones: [
+                {
+                  id: 'm1', title: 'Old title 1', taxPercent: 14, showPackageOverview: true,
+                  services: [
+                    { id: 'stale-1', kind: 'percent', packageId: 'p1', percent: 10, expectedExpenseRole: 'scheduled' },
+                    { id: 'custom-1', kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
+                  ],
+                },
+                {
+                  id: 'm2', title: 'Old title 2', taxPercent: 14, showPackageOverview: false,
+                  services: [{ id: 'stale-2', kind: 'percent', packageId: 'p1', percent: 10, expectedExpenseRole: 'scheduled' }],
+                },
               ],
             }),
           });
@@ -297,9 +304,11 @@ describe('InvoiceBuilderPage', () => {
       await flush();
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
-      expect(plan.expectedExpenses[0][1]).toBe('Deposit for transportation of SM || 300');
-      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
+      expect(plan.milestones[0].services).toHaveLength(2);
+      expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
+      expect(plan.milestones[0].services[1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.milestones[1].services).toHaveLength(1);
+      expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
 
       await act(async () => { root.unmount(); });
     });
@@ -315,12 +324,9 @@ describe('InvoiceBuilderPage', () => {
             exists: () => true,
             val: () => ({
               packageId: 'p1',
-              expectedExpenses: [
-                [
-                  'idp1 || 10%',
-                  'Deposit for transportation of SM || 300',
-                ],
-                ['idp1 || 10%'],
+              milestones: [
+                { id: 'm1', title: 'Old title 1', taxPercent: 14, showPackageOverview: true, services: ['idp1 || 10%', 'Deposit for transportation of SM || 300'] },
+                { id: 'm2', title: 'Old title 2', taxPercent: 14, showPackageOverview: false, services: ['idp1 || 10%'] },
               ],
             }),
           });
@@ -336,11 +342,11 @@ describe('InvoiceBuilderPage', () => {
       await flush();
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.expectedExpenses[0]).toHaveLength(2);
-      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
-      expect(plan.expectedExpenses[0][1]).toBe('Deposit for transportation of SM || 300');
-      expect(plan.expectedExpenses[1]).toHaveLength(1);
-      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
+      expect(plan.milestones[0].services).toHaveLength(2);
+      expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
+      expect(plan.milestones[0].services[1]).toMatchObject({ kind: 'custom', name: 'Deposit for transportation of SM', price: 300 });
+      expect(plan.milestones[1].services).toHaveLength(1);
+      expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
 
       await act(async () => { root.unmount(); });
     });
@@ -356,9 +362,9 @@ describe('InvoiceBuilderPage', () => {
             exists: () => true,
             val: () => ({
               packageId: 'p1',
-              expectedExpenses: [
-                [{ id: 'manual-percent', kind: 'packagePercent', catalogId: 'p1', percent: 10 }],
-                [],
+              milestones: [
+                { id: 'm1', title: 'Old title 1', taxPercent: 14, showPackageOverview: true, services: [{ id: 'manual-percent', kind: 'percent', packageId: 'p1', percent: 10 }] },
+                { id: 'm2', title: 'Old title 2', taxPercent: 14, showPackageOverview: false, services: [] },
               ],
             }),
           });
@@ -374,9 +380,12 @@ describe('InvoiceBuilderPage', () => {
       await flush();
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
-      expect(plan.expectedExpenses[0][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
-      expect(plan.expectedExpenses[0][1]).toBe('idp1 || 10%');
-      expect(plan.expectedExpenses[1][0]).toMatchObject({ kind: 'packagePercent', catalogId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
+      expect(plan.milestones[0].services).toHaveLength(2);
+      expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 60, expectedExpenseRole: 'scheduled' });
+      expect(plan.milestones[0].services[1]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 10 });
+      expect(plan.milestones[0].services[1].expectedExpenseRole).toBeUndefined();
+      expect(plan.milestones[1].services).toHaveLength(1);
+      expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 40, expectedExpenseRole: 'scheduled' });
 
       await act(async () => { root.unmount(); });
     });
@@ -421,13 +430,13 @@ describe('InvoiceBuilderPage', () => {
       await act(async () => { fileInput.dispatchEvent(new Event('change', { bubbles: true })); });
       await flush();
 
-      expect(container.innerHTML).toContain('Expected expenses has 6 groups');
+      expect(container.innerHTML).toContain('To start the program');
+      expect(container.innerHTML).toContain('On the 36th week of pregnancy');
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
       expect(plan.packageId).toBe('3');
-      expect(plan).toEqual(expectedExpensesSeed);
-      expect(plan.expectedExpenses).toHaveLength(6);
-      expect(plan.expectedExpenses[1][1]).toBe('Deposit for transportation of SM || 300');
+      expect(plan.milestones).toHaveLength(6);
+      expect(plan.milestones[1].services[1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -23,6 +23,7 @@
 import {
   computeInvoiceSubtotal,
   computeInvoiceTotal,
+  createEntryId,
   makeCatalogItemEntry,
   makeCustomEntry,
   makePercentOfPackageEntry,
@@ -47,7 +48,17 @@ const buildGroupFromSchedulePayment = (pkg, payment) => {
   const amount = Number(payment?.amount) || 0;
   if (!listedPrice || !amount) return [];
   const percent = Math.round((amount / listedPrice) * 10000) / 100;
-  return [makePercentOfPackageEntry(pkg?.id, percent)];
+  return [makePercentOfPackageEntry(pkg?.id, percent, { expectedExpenseRole: 'scheduled' })];
+};
+
+// A package needs a resolved, positive listed price before a plan can be built from it - otherwise
+// every percent-of-package row would divide by zero. Throws instead of silently building an empty plan.
+export const getExpectedExpensesPackagePrice = pkg => {
+  const packagePrice = Number(pkg?.listedPrice);
+  if (!Number.isFinite(packagePrice) || packagePrice <= 0) {
+    throw new Error('Expected expenses require a resolved positive package price.');
+  }
+  return packagePrice;
 };
 
 export const buildMilestonesFromSchedule = (pkg, schedule, { taxPercent = 0 } = {}) =>
@@ -85,6 +96,20 @@ export const buildExpectedExpensesPlan = (pkg, schedule, { taxPercent = 0 } = {}
 
 export const isRawExpectedExpensesGroups = raw => Array.isArray(raw) && raw.every(group => Array.isArray(group));
 
+// A freshly uploaded array-of-groups plan has no way to mark which row is "the" auto-generated
+// schedule row - by convention it's always the first percent-of-package row of each group (see the
+// module docstring), so it's safe to tag unconditionally here. This is only ever run once, at
+// upload time - an already-saved plan's milestones are never re-guessed like this on load, since by
+// then a user may have deliberately removed the scheduled row and kept only a manual one; that
+// ambiguous case is resolved by recalculateExpectedExpensesSchedule (InvoiceBuilderPage.jsx) instead.
+export const markLegacyScheduledRow = (services, packageId) => {
+  const rows = Array.isArray(services) ? services : [];
+  if (!rows.length || rows.some(entry => entry?.expectedExpenseRole)) return rows;
+  const [first, ...rest] = rows;
+  if (first?.kind !== 'percent' || String(first.packageId) !== String(packageId)) return rows;
+  return [{ ...first, expectedExpenseRole: 'scheduled' }, ...rest];
+};
+
 // Finds the package id referenced by the first percent-of-package row across all groups.
 export const inferPackageIdFromRawGroups = rawGroups => {
   for (const group of (Array.isArray(rawGroups) ? rawGroups : [])) {
@@ -116,7 +141,7 @@ export const buildExpectedExpensesPlanFromRawGroups = (rawGroups, { catalog, tax
     title: payment?.title || `Payment ${index + 1}`,
     taxPercent,
     showPackageOverview: index === 0,
-    services: groups[index] || [],
+    services: markLegacyScheduledRow(groups[index] || [], packageId),
   }));
 
   return {
@@ -139,7 +164,7 @@ export const normalizeExpectedExpensesMilestone = (raw, { packageId = '', listed
   const migratedServices = !hasOwnServices && Number.isFinite(legacyAmount) && legacyAmount !== 0
     ? [
       listedPrice
-        ? makePercentOfPackageEntry(packageId, Math.round((legacyAmount / listedPrice) * 10000) / 100)
+        ? makePercentOfPackageEntry(packageId, Math.round((legacyAmount / listedPrice) * 10000) / 100, { expectedExpenseRole: 'scheduled' })
         : makeCustomEntry({ name: raw?.title ? `Scheduled payment (${raw.title})` : 'Scheduled payment', price: legacyAmount }),
       ...services,
     ]
@@ -182,8 +207,29 @@ export const isExpectedExpensesShape = raw => Boolean(
   && typeof raw === 'object'
   && !Array.isArray(raw)
   && raw.packageId !== undefined
-  && (Array.isArray(raw.expectedExpenses) || Array.isArray(raw.milestones))
+  && Array.isArray(raw.milestones)
 );
+
+// The compact form persisted to invoiceBuilder/expectedExpenses: every editable field a milestone
+// can carry (title/tax/overview/services), with no resolved amounts - the inverse of
+// normalizeExpectedExpensesData, so persistExpectedExpenses can round-trip through it.
+export const serializeExpectedExpensesData = plan => (plan ? {
+  packageId: String(plan.packageId ?? ''),
+  packageSnapshot: {
+    name: plan.packageSnapshot?.name || '',
+    description: plan.packageSnapshot?.description || '',
+    listedPrice: Number(plan.packageSnapshot?.listedPrice) || 0,
+    currency: plan.packageSnapshot?.currency || 'EUR',
+    children: normalizeServiceEntries(plan.packageSnapshot?.children),
+  },
+  milestones: (Array.isArray(plan.milestones) ? plan.milestones : []).map(milestone => ({
+    id: milestone.id || createEntryId(),
+    title: milestone.title || '',
+    taxPercent: Number(milestone.taxPercent) || 0,
+    showPackageOverview: Boolean(milestone.showPackageOverview),
+    services: normalizeServiceEntries(milestone.services),
+  })),
+} : null);
 
 // --- Editing ------------------------------------------------------------
 
@@ -221,6 +267,8 @@ export const resolveMilestoneServiceRows = (milestone, catalogItemsById, priceCo
     .map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
 export const computeMilestoneSubtotal = rows => computeInvoiceSubtotal(rows);
+
+export const computeMilestoneAmountDue = (subtotal, taxPercent) => computeInvoiceTotal(subtotal, taxPercent);
 
 export const resolveExpectedExpenseRows = (group, catalogItemsById, priceContext = {}) =>
   (Array.isArray(group) ? group : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -13,6 +13,7 @@ import {
   removeMilestoneService,
   resolveMilestoneServiceRows,
   resolvePackageOverviewRows,
+  serializeExpectedExpensesData,
   setMilestoneField,
   updateMilestoneServiceField,
 } from './expectedExpensesUtils';
@@ -40,14 +41,9 @@ const schedule = {
   ],
 };
 
-const priceContext = {
-  packagesById: new Map([['3', pkg]]),
-  resolvePackagePrice: packageRow => Number(packageRow?.listedPrice) || 0,
-};
-
 describe('expectedExpensesUtils', () => {
   it('builds a compact template with one service group per schedule payment', () => {
-    const plan = buildExpectedExpensesPlan(pkg, schedule);
+    const plan = buildExpectedExpensesPlan(pkg, schedule, { taxPercent: 14 });
     expect(plan.packageId).toBe('3');
     expect(plan.packageSnapshot).toMatchObject({ name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR' });
     expect(plan.packageSnapshot.children).toEqual([
@@ -59,7 +55,7 @@ describe('expectedExpensesUtils', () => {
     expect(plan.milestones).toHaveLength(7);
     expect(plan.milestones[0]).toMatchObject({ title: 'To start the program', taxPercent: 14, showPackageOverview: true });
     expect(plan.milestones[0].services).toEqual([
-      { id: plan.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20 },
+      { id: plan.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20, expectedExpenseRole: 'scheduled' },
     ]);
     expect(plan.milestones[1]).toMatchObject({ title: 'To start stimulation of a SM', showPackageOverview: false });
     expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: '3', percent: 15 });
@@ -78,22 +74,27 @@ describe('expectedExpensesUtils', () => {
     expect(computeMilestonesPackageSharePercent(plan.milestones, plan.packageId)).toBe(100);
   });
 
-  it('round-trips through normalization and supports legacy string rows', () => {
-    const normalized = normalizeExpectedExpensesData({
-      packageId: '3',
-      expectedExpenses: [['id3 || 20%', 'Deposit for transportation of SM || 300', 'id32']],
-    });
-    expect(normalized.packageId).toBe('3');
-    expect(normalized.expectedExpenses[0]).toMatchObject([
-      { kind: 'packagePercent', catalogId: '3', percent: 20 },
+  it('round-trips through serialization/normalization and supports legacy string rows', () => {
+    const rawCatalog = {
+      packages: [{ id: '3', name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR', children: [], paymentScheduleId: 'ps-3' }],
+      technical: { paymentSchedules: [{ id: 'ps-3', payments: [{ title: 'To start the program', amount: 8000 }] }] },
+    };
+    const { plan } = buildExpectedExpensesPlanFromRawGroups(
+      [['id3 || 20%', 'Deposit for transportation of SM || 300', 'id32']],
+      { catalog: rawCatalog },
+    );
+    expect(plan.packageId).toBe('3');
+    expect(plan.milestones[0].services).toMatchObject([
+      { kind: 'percent', packageId: '3', percent: 20, expectedExpenseRole: 'scheduled' },
       { kind: 'custom', name: 'Deposit for transportation of SM', price: 300 },
       { kind: 'item', catalogId: '32' },
     ]);
-    expect(serializeExpectedExpensesData(normalized)).toEqual({
-      packageId: '3',
-      expectedExpenses: [['id3 || 20%', 'Deposit for transportation of SM || 300', 'id32']],
-    });
+
+    const renormalized = normalizeExpectedExpensesData(serializeExpectedExpensesData(plan));
+    expect(renormalized.packageId).toBe(plan.packageId);
+    expect(renormalized.milestones[0].services).toMatchObject(plan.milestones[0].services);
     expect(normalizeExpectedExpensesData(null)).toBeNull();
+    expect(serializeExpectedExpensesData(null)).toBeNull();
   });
 
   it('migrates a legacy milestone with a frozen scheduledAmount into an equivalent percent-of-package row', () => {
@@ -106,7 +107,7 @@ describe('expectedExpensesUtils', () => {
     };
     const normalized = normalizeExpectedExpensesData(legacy);
     expect(normalized.milestones[0].services).toEqual([
-      { id: normalized.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20 },
+      { id: normalized.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20, expectedExpenseRole: 'scheduled' },
     ]);
     expect(computeMilestonesTotal(normalized.milestones, new Map(), { packagesById: new Map([['3', pkg]]) })).toBe(8000);
   });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -97,11 +97,15 @@ export const makeCustomEntry = ({ name = '', price = 0, description = '', priceL
 
 // A share of a budget/packages program's listed price, e.g. "20% of package 1". The euro amount
 // is intentionally never stored - resolveServiceRow recalculates it from the package's price.
-export const makePercentOfPackageEntry = (packageId, percent, { id } = {}) => ({
+// `expectedExpenseRole: 'scheduled'` marks the one row that was auto-generated from the package's
+// payment schedule (as opposed to one an admin added by hand) - see recalculateExpectedExpensesSchedule
+// in InvoiceBuilderPage.jsx, which only ever replaces rows carrying that marker.
+export const makePercentOfPackageEntry = (packageId, percent, { id, expectedExpenseRole } = {}) => ({
   id: id || createEntryId(),
   kind: 'percent',
   packageId: String(packageId ?? ''),
   percent: toNumber(percent),
+  ...(expectedExpenseRole ? { expectedExpenseRole } : {}),
 });
 
 export const makePackagePercentEntry = ({ catalogId = '', percent = 0 } = {}, { id } = {}) => ({
@@ -176,7 +180,7 @@ export const normalizeServiceEntry = raw => {
   const id = raw.id || createEntryId();
 
   if (raw.kind === 'percent') {
-    return makePercentOfPackageEntry(raw.packageId, raw.percent, { id });
+    return makePercentOfPackageEntry(raw.packageId, raw.percent, { id, expectedExpenseRole: raw.expectedExpenseRole });
   }
 
   if (raw.kind === 'package') {

--- a/src/data/expectedExpensesSeed.json
+++ b/src/data/expectedExpensesSeed.json
@@ -1,37 +1,33 @@
 {
   "packageId": "3",
-  "expectedExpenses": [
-    [
-      "id3 || 34.7826086957%"
-    ],
-    [
-      "id3 || 13.0434782609%",
-      "Deposit for transportation of SM || 300",
-      "Deposit for medical expenses of SM || 300"
-    ],
-    [
-      "id3 || 13.0434782609%",
-      "Deposit for transportation of SM || 300",
-      "Deposit for medical expenses of SM || 300"
-    ],
-    [
-      "id3 || 13.0434782609%",
-      "id40",
-      "Deposit for transportation of SM || 300",
-      "Deposit for medical expenses of SM || 300"
-    ],
-    [
-      "id3 || 13.0434782609%",
-      "Deposit for transportation of SM || 300",
-      "Deposit for medical expenses of SM || 300"
-    ],
-    [
-      "id3 || 13.0434782609%",
-      "Deposit. Medications for SM during and after delivery || 500",
-      "Deposit. For C-section (is returned if not used) || 2700",
-      "Deposit. For baby clothes / diapers / formulas / etc || 110",
-      "Deposit. For unexpected expenses (e.g. staying in hospital, service of nanny etc.) || 600",
-      "Standard service of the independent lawyer, notary and post until the 6 months after delivery || GIFT"
+  "packageSnapshot": {
+    "name": "IVF + ED + SM",
+    "description": "For cases where embryos need to be created using donor oocytes.",
+    "listedPrice": 46000,
+    "currency": "EUR",
+    "children": [
+      { "id": "pkg3-child-1", "kind": "item", "catalogId": "1" },
+      { "id": "pkg3-child-2", "kind": "item", "catalogId": "2" },
+      { "id": "pkg3-child-3", "kind": "item", "catalogId": "3" },
+      { "id": "pkg3-child-4", "kind": "item", "catalogId": "4" },
+      { "id": "pkg3-child-5", "kind": "item", "catalogId": "5" },
+      { "id": "pkg3-child-6", "kind": "item", "catalogId": "6" },
+      { "id": "pkg3-child-7", "kind": "item", "catalogId": "7" },
+      { "id": "pkg3-child-8", "kind": "item", "catalogId": "8" },
+      { "id": "pkg3-child-9", "kind": "item", "catalogId": "9" },
+      { "id": "pkg3-child-10", "kind": "item", "catalogId": "10" },
+      { "id": "pkg3-child-11", "kind": "item", "catalogId": "11" },
+      { "id": "pkg3-child-12", "kind": "item", "catalogId": "12" },
+      { "id": "pkg3-child-13", "kind": "item", "catalogId": "14" },
+      { "id": "pkg3-child-14", "kind": "item", "catalogId": "15" },
+      { "id": "pkg3-child-15", "kind": "item", "catalogId": "16" },
+      { "id": "pkg3-child-16", "kind": "item", "catalogId": "18" },
+      { "id": "pkg3-child-17", "kind": "item", "catalogId": "19" },
+      { "id": "pkg3-child-18", "kind": "item", "catalogId": "21" },
+      { "id": "pkg3-child-19", "kind": "item", "catalogId": "22" },
+      { "id": "pkg3-child-20", "kind": "item", "catalogId": "23" },
+      { "id": "pkg3-child-21", "kind": "item", "catalogId": "24" },
+      { "id": "pkg3-child-22", "kind": "item", "catalogId": "25" }
     ]
   },
   "milestones": [
@@ -41,7 +37,7 @@
       "taxPercent": 14,
       "showPackageOverview": true,
       "services": [
-        { "id": "milestone-1-share", "kind": "percent", "packageId": "3", "percent": 20 },
+        { "id": "milestone-1-share", "kind": "percent", "packageId": "3", "percent": 20, "expectedExpenseRole": "scheduled" },
         { "id": "milestone-1-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-1-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
@@ -52,7 +48,7 @@
       "taxPercent": 14,
       "showPackageOverview": false,
       "services": [
-        { "id": "milestone-2-share", "kind": "percent", "packageId": "3", "percent": 10 },
+        { "id": "milestone-2-share", "kind": "percent", "packageId": "3", "percent": 10, "expectedExpenseRole": "scheduled" },
         { "id": "milestone-2-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-2-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
@@ -63,7 +59,7 @@
       "taxPercent": 14,
       "showPackageOverview": false,
       "services": [
-        { "id": "milestone-3-share", "kind": "percent", "packageId": "3", "percent": 15 },
+        { "id": "milestone-3-share", "kind": "percent", "packageId": "3", "percent": 15, "expectedExpenseRole": "scheduled" },
         { "id": "milestone-3-extra-1", "kind": "item", "catalogId": "32" },
         { "id": "milestone-3-extra-2", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-3-extra-3", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
@@ -75,7 +71,7 @@
       "taxPercent": 14,
       "showPackageOverview": false,
       "services": [
-        { "id": "milestone-4-share", "kind": "percent", "packageId": "3", "percent": 20 },
+        { "id": "milestone-4-share", "kind": "percent", "packageId": "3", "percent": 20, "expectedExpenseRole": "scheduled" },
         { "id": "milestone-4-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-4-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
@@ -86,7 +82,7 @@
       "taxPercent": 14,
       "showPackageOverview": false,
       "services": [
-        { "id": "milestone-5-share", "kind": "percent", "packageId": "3", "percent": 20 },
+        { "id": "milestone-5-share", "kind": "percent", "packageId": "3", "percent": 20, "expectedExpenseRole": "scheduled" },
         { "id": "milestone-5-extra-1", "kind": "custom", "name": "Deposit for transportation of SM", "price": 300 },
         { "id": "milestone-5-extra-2", "kind": "custom", "name": "Deposit for medical expenses of SM", "price": 300 }
       ]
@@ -97,7 +93,7 @@
       "taxPercent": 14,
       "showPackageOverview": false,
       "services": [
-        { "id": "milestone-6-share", "kind": "percent", "packageId": "3", "percent": 15 },
+        { "id": "milestone-6-share", "kind": "percent", "packageId": "3", "percent": 15, "expectedExpenseRole": "scheduled" },
         { "id": "milestone-6-extra-1", "kind": "item", "catalogId": "61" },
         { "id": "milestone-6-extra-2", "kind": "item", "catalogId": "62" },
         { "id": "milestone-6-extra-3", "kind": "item", "catalogId": "63" },


### PR DESCRIPTION
The expected-expenses milestones rework was left mid-merge: several
handlers (persistExpectedExpensesMilestones, commitMilestoneField,
toggleMilestoneOverview, getExpectedExpensesPackagePrice,
serializeExpectedExpensesData, computeMilestoneAmountDue), two styled
components (MilestoneCheckboxRow/Label), and a createEntryId import were
referenced but never defined/exported, and a JSX fragment in
ExpectedExpensesPdfDocument was left unclosed - all now restored/wired
up. Also removed dead groups-era handlers left over from before the
milestones rework, wired the "Percent" quick-add button, and dropped a
duplicate/dead PDF preview block that read a nonexistent
expectedExpensesView.pages field (which also silently broke the
"Generate PDF" button).

Fixes the recalculate-schedule bug reported in review: replacing a
milestone's auto-generated payment-schedule row now uses an explicit
expectedExpenseRole: 'scheduled' marker instead of matching on
kind+packageId, so manually-added percent-of-package rows on the same
package survive a recalculate. For legacy unmarked data, the marker is
inferred per-recalculate from a plan-wide check (every existing
milestone's first row looks auto-generated) evaluated over the existing
milestones rather than the freshly-rebuilt schedule, so a schedule that
grew a new step no longer defeats the check.

Repaired the corrupted expectedExpensesSeed.json (an unclosed array left
two competing formats concatenated together) and fixed the missing
default tax percent on newly created plans.