### PR TITLE
Consolidate UKRCOM document system per update brief

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -14,7 +14,7 @@ import {
 } from './budgetCatalogUtils';
 import {
   BrandRow, BrandRule, BronzeMotif, ContinuedTag, Footer, PDF_COLOR, PDF_FONT,
-  ensurePdfFontsRegistered, pdfBaseStyles, sanitizePdfText, TitleBlock,
+  ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
 
 ensurePdfFontsRegistered();
@@ -22,7 +22,9 @@ ensurePdfFontsRegistered();
 const DOC_LABEL = 'Program Budget';
 const PROGRAM_COL_WIDTH = 56;
 
-const formatAmount = value => {
+// Bare (no-currency) number for a table cell, as opposed to formatMoney (budgetCatalogUtils),
+// the one currency-labeled money format shared by every UKRCOM document (spec §4).
+export const formatAmount = value => {
   const amount = Number(value);
   if (!Number.isFinite(amount)) return '-';
   return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(amount);
@@ -32,6 +34,11 @@ const styles = StyleSheet.create({
   page: pdfBaseStyles.page,
   section: {
     marginTop: 26,
+  },
+  // Extra breathing room above Payment schedule so Programs and Payment schedule don't sit flush
+  // against each other on page 1 (spec §2).
+  scheduleSection: {
+    marginTop: 46,
   },
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
@@ -249,6 +256,92 @@ const styles = StyleSheet.create({
   },
 });
 
+const ProgramColumnsHead = ({ packages, leadLabel }) => (
+  <View style={styles.tableHeadRow} wrap={false}>
+    <View style={styles.labelCell}>
+      <Text style={styles.labelCellHeadText}>{leadLabel}</Text>
+    </View>
+    {packages.map(program => (
+      <View key={program.id} style={styles.programCell}>
+        <Text style={styles.programCellHead}>{program.label}</Text>
+        <Text style={styles.programCellHeadPrice}>{program.priceLabel}</Text>
+      </View>
+    ))}
+  </View>
+);
+
+// The "Included in this programme" table (spec §1.2/§2). Shared, byte-for-byte, between the
+// catalog-wide Program Budget (one column per programme) and the case-specific Expected Expenses
+// overview (a single column for the one chosen programme) - so the two documents can never drift
+// apart on how included services are listed.
+// packages: [{ id, label, priceLabel }] · includedRows: [{ id, name, includedByPackageId: Set<id> }]
+export const IncludedServicesTable = ({
+  packages,
+  includedRows,
+  title = 'Included services by program',
+  note = 'An "x" marks the services included in each program package.',
+}) => (includedRows.length ? (
+  <View style={styles.section}>
+    <View wrap={false} minPresenceAhead={70}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <Text style={styles.sectionNote}>{note}</Text>
+    </View>
+    <View style={styles.table}>
+      <ProgramColumnsHead packages={packages} leadLabel="Provided service" />
+      {includedRows.map(item => (
+        <View key={item.id} style={styles.tableRow} wrap={false}>
+          <View style={styles.labelCell}>
+            <Text style={styles.labelCellText}>{sanitizePdfText(item.name)}</Text>
+          </View>
+          {packages.map(program => (
+            <View key={`${item.id}-${program.id}`} style={styles.programCell}>
+              <Text style={styles.markCellText}>{item.includedByPackageId.has(String(program.id)) ? 'x' : ''}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+    </View>
+  </View>
+) : null);
+
+// The "Payment schedule" table (spec §1.2/§2) - same sharing rationale as IncludedServicesTable
+// above. rows: [{ title, amounts: [amountOrNull, ...] }] · totals: [amountOrNull, ...] (one per
+// package column, same order as `packages`).
+export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment schedule' }) => (rows.length ? (
+  <View style={styles.scheduleSection}>
+    <View wrap={false} minPresenceAhead={70}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+    </View>
+    <View style={styles.table}>
+      <ProgramColumnsHead packages={packages} leadLabel="Milestone" />
+      {rows.map((row, rowIndex) => (
+        <View key={`schedule-row-${rowIndex}`} style={styles.tableRow} wrap={false}>
+          <View style={styles.labelCell}>
+            <Text style={styles.labelCellText}>{`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}</Text>
+          </View>
+          {row.amounts.map((amount, columnIndex) => (
+            <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={styles.programCell}>
+              <Text style={styles.amountCellText}>{amount == null ? '-' : formatAmount(amount)}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+      {Array.isArray(totals) ? (
+        <View style={[styles.tableRow, styles.totalRow]} wrap={false}>
+          <View style={styles.labelCell}>
+            <Text style={styles.labelCellHeadText}>Total</Text>
+          </View>
+          {totals.map((total, columnIndex) => (
+            <View key={`schedule-total-${columnIndex}`} style={styles.programCell}>
+              <Text style={styles.programCellHead}>{total == null ? '-' : formatAmount(total)}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  </View>
+) : null);
+
 const BudgetPdfDocument = ({ catalog, rates = null }) => {
   const items = Array.isArray(catalog?.items) ? catalog.items : [];
   const visibleItems = items.filter(item => !item.hidden);
@@ -287,7 +380,21 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
   // that includes it wins), so reordering services in a package reorders this table.
   const includedRows = includedIds
     .map(id => itemsById.get(id))
-    .filter(Boolean);
+    .filter(Boolean)
+    .map(item => ({
+      id: item.id,
+      name: item.name,
+      includedByPackageId: new Set(
+        packages.filter(program => Array.isArray(program.children)
+          && program.children.some(childId => String(childId) === String(item.id))).map(program => String(program.id)),
+      ),
+    }));
+
+  const packagesMeta = packages.map((program, index) => ({
+    id: program.id,
+    label: `#${index + 1}`,
+    priceLabel: formatAmount(resolveListedPrice(program)),
+  }));
 
   const groupedExpenses = visibleItems.reduce((groups, item) => {
     if (includedIdSet.has(String(item.id))) return groups;
@@ -308,21 +415,7 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
     .map(key => [key, clientNotes[key] || []])
     .filter(([, notes]) => notes.length);
 
-  const dateLabel = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
-
-  const renderProgramColumnsHead = () => (
-    <View style={styles.tableHeadRow} wrap={false}>
-      <View style={styles.labelCell}>
-        <Text style={styles.labelCellHeadText}>Provided service</Text>
-      </View>
-      {packages.map((program, index) => (
-        <View key={program.id} style={styles.programCell}>
-          <Text style={styles.programCellHead}>{`#${index + 1}`}</Text>
-          <Text style={styles.programCellHeadPrice}>{formatAmount(resolveListedPrice(program))}</Text>
-        </View>
-      ))}
-    </View>
-  );
+  const dateLabel = formatDisplayDate(new Date());
 
   return (
     <Document title="UKRCOM - Program Budget" subject="Surrogacy program budget" creator="UKRCOM">
@@ -359,76 +452,13 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
           ))}
         </View>
 
-        {includedRows.length ? (
-          <View style={styles.section}>
-            <View wrap={false} minPresenceAhead={70}>
-              <Text style={styles.sectionTitle}>Included services by program</Text>
-              <Text style={styles.sectionNote}>An "x" marks the services included in each program package.</Text>
-            </View>
-            <View style={styles.table}>
-              {renderProgramColumnsHead()}
-              {includedRows.map(item => (
-                <View key={item.id} style={styles.tableRow} wrap={false}>
-                  <View style={styles.labelCell}>
-                    <Text style={styles.labelCellText}>{sanitizePdfText(item.name)}</Text>
-                  </View>
-                  {packages.map(program => {
-                    const included = Array.isArray(program.children)
-                      && program.children.some(id => String(id) === String(item.id));
-                    return (
-                      <View key={`${item.id}-${program.id}`} style={styles.programCell}>
-                        <Text style={styles.markCellText}>{included ? 'x' : ''}</Text>
-                      </View>
-                    );
-                  })}
-                </View>
-              ))}
-            </View>
-          </View>
-        ) : null}
+        <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} totals={scheduleTotals} />
 
-        {scheduleRowCount > 0 ? (
-          <View style={styles.section}>
-            <View wrap={false} minPresenceAhead={70}>
-              <Text style={styles.sectionTitle}>Payment schedule</Text>
-            </View>
-            <View style={styles.table}>
-              <View style={styles.tableHeadRow} wrap={false}>
-                <View style={styles.labelCell}>
-                  <Text style={styles.labelCellHeadText}>Milestone</Text>
-                </View>
-                {packages.map((program, index) => (
-                  <View key={program.id} style={styles.programCell}>
-                    <Text style={styles.programCellHead}>{`#${index + 1}`}</Text>
-                    <Text style={styles.programCellHeadPrice}>{formatAmount(resolveListedPrice(program))}</Text>
-                  </View>
-                ))}
-              </View>
-              {scheduleRows.map((row, rowIndex) => (
-                <View key={`schedule-row-${rowIndex}`} style={styles.tableRow} wrap={false}>
-                  <View style={styles.labelCell}>
-                    <Text style={styles.labelCellText}>{`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}</Text>
-                  </View>
-                  {row.amounts.map((amount, columnIndex) => (
-                    <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={styles.programCell}>
-                      <Text style={styles.amountCellText}>{amount == null ? '-' : formatAmount(amount)}</Text>
-                    </View>
-                  ))}
-                </View>
-              ))}
-              <View style={[styles.tableRow, styles.totalRow]} wrap={false}>
-                <View style={styles.labelCell}>
-                  <Text style={styles.labelCellHeadText}>Total</Text>
-                </View>
-                {scheduleTotals.map((total, columnIndex) => (
-                  <View key={`schedule-total-${columnIndex}`} style={styles.programCell}>
-                    <Text style={styles.programCellHead}>{total == null ? '-' : formatAmount(total)}</Text>
-                  </View>
-                ))}
-              </View>
-            </View>
-          </View>
-        ) : null}
+        {/* `break` starts Included services on a fresh page (spec §2), so the schedule above stays
+            on page 1 with Programs and this large table never splits mid-page. */}
+        <View break={includedRows.length > 0}>
+          <IncludedServicesTable packages={packagesMeta} includedRows={includedRows} />
+        </View>
 
         {Object.keys(groupedExpenses).length ? (
           <View style={styles.section}>

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -1,181 +1,208 @@
 import React from 'react';
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import {
-  BrandRow, BrandRule, BronzeMotif, DocSeries, Footer, PDF_COLOR, PDF_FONT,
-  ensurePdfFontsRegistered, pdfBaseStyles, sanitizePdfText, TitleBlock,
+  BrandRow, BrandRule, BronzeMotif, ContinuedTag, Footer, PDF_COLOR, PDF_FONT, PreparedForBlock,
+  SummaryCard, ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
-import { buildCaseTitle } from './invoiceCatalogUtils';
+import { formatMoney } from './budgetCatalogUtils';
+import { formatAmount, IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
+import { buildCaseTitle, buildPayerName } from './invoiceCatalogUtils';
 import {
   computeMilestoneSubtotal,
   resolveMilestoneServiceRows,
+  resolvePackageOverviewRows,
+  splitScheduledRows,
 } from './expectedExpensesUtils';
 
 ensurePdfFontsRegistered();
 
-// No copies past the decimal for round or four-figure sums; two decimals only when the
-// amount genuinely carries cents (spec §1.8).
-const formatMoney = (value, currency = 'EUR') => {
-  const amount = Number(value);
-  if (!Number.isFinite(amount)) return '-';
-  const rounded = Math.round(amount * 100) / 100;
-  const isInteger = Number.isInteger(rounded);
-  const formatted = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: isInteger ? 0 : 2,
-    maximumFractionDigits: isInteger ? 0 : 2,
-  }).format(rounded);
-  return `${formatted} ${currency}`;
-};
-
-const formatRowAmount = row => row?.priceLabel || formatMoney(row?.price);
-
-const formatPlanDate = date => {
-  const safeDate = date instanceof Date && !Number.isNaN(date.getTime()) ? date : new Date();
-  return safeDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
-};
+const formatPercentValue = percent => (Number.isInteger(percent) ? String(percent) : String(Math.round(percent * 100) / 100));
 
 const styles = StyleSheet.create({
   page: pdfBaseStyles.page,
-  dateText: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 8.5,
-    color: PDF_COLOR.inkSoft,
-    marginBottom: 4,
-  },
   section: {
-    marginTop: 22,
+    marginTop: 26,
   },
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
-  contextNote: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 9,
-    color: PDF_COLOR.inkSoft,
-    marginBottom: 4,
-  },
-  expenseRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    borderTopWidth: 1,
-    borderTopColor: PDF_COLOR.docLine,
-    borderTopStyle: 'solid',
-    paddingVertical: 8,
-  },
-  expenseRowFirst: {
-    borderTopWidth: 0,
-  },
-  expenseIndexCell: {
-    width: 22,
-  },
-  expenseIndexText: {
+  forecastNotice: {
     fontFamily: PDF_FONT.body,
     fontWeight: 600,
-    fontSize: 8.5,
-    color: PDF_COLOR.bronze,
+    fontSize: 10,
+    color: PDF_COLOR.bronzeDeep,
+    marginBottom: 22,
   },
-  expenseNameCell: {
-    flex: 1,
-    paddingRight: 10,
+  paymentsHeading: {
+    ...pdfBaseStyles.sectionTitle,
+    marginTop: 40,
+    marginBottom: 12,
   },
-  expenseNameText: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 9.5,
+  paymentBlock: {
+    borderWidth: 1,
+    borderColor: PDF_COLOR.docLine,
+    borderStyle: 'solid',
+    borderRadius: 6,
+    padding: 10,
+    marginBottom: 10,
+  },
+  paymentHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    marginBottom: 4,
+  },
+  paymentTitle: {
+    fontFamily: PDF_FONT.display,
+    fontWeight: 600,
+    fontSize: 11.5,
     color: PDF_COLOR.docInk,
   },
-  expenseDescription: {
+  paymentTotal: {
     fontFamily: PDF_FONT.body,
-    fontSize: 8,
-    color: PDF_COLOR.inkSoft,
-    lineHeight: 1.4,
+    fontWeight: 600,
+    fontVariantNumeric: 'tabular-nums',
+    fontSize: 11,
+    color: PDF_COLOR.bronzeDeep,
+  },
+  scheduledLine: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 9,
+    fontVariantNumeric: 'tabular-nums',
+    color: PDF_COLOR.docInk,
+    marginBottom: 2,
+  },
+  additionalRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     marginTop: 2,
   },
-  expensePriceCell: {
-    width: 96,
-    textAlign: 'right',
-  },
-  expensePriceText: {
+  additionalName: {
+    flex: 1,
     fontFamily: PDF_FONT.body,
+    fontSize: 8.5,
+    color: PDF_COLOR.inkSoft,
+    paddingRight: 10,
+  },
+  additionalPrice: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 8.5,
     fontVariantNumeric: 'tabular-nums',
-    fontSize: 9.5,
-    color: PDF_COLOR.docInk,
+    color: PDF_COLOR.inkSoft,
   },
   refundNote: {
     fontFamily: PDF_FONT.body,
     fontSize: 8,
     lineHeight: 1.45,
     color: PDF_COLOR.inkSoft,
-    marginTop: 10,
+    marginTop: 14,
   },
 });
 
-const renderExpensesRows = rows => (
-  <View>
-    {rows.map((row, index) => (
-      <View
-        key={row.key || index}
-        style={[styles.expenseRow, index === 0 ? styles.expenseRowFirst : null]}
-        wrap={false}
-      >
-        <View style={styles.expenseIndexCell}><Text style={styles.expenseIndexText}>{index + 1}</Text></View>
-        <View style={styles.expenseNameCell}>
-          <Text style={styles.expenseNameText}>{sanitizePdfText(row.name)}</Text>
-          {row.description ? <Text style={styles.expenseDescription}>{sanitizePdfText(row.description)}</Text> : null}
-        </View>
-        <View style={styles.expensePriceCell}><Text style={styles.expensePriceText}>{formatRowAmount(row)}</Text></View>
+// One compact block per payment (spec §1.2): "Payment #N - {milestone title}" - a header line, the
+// scheduled share of the programme fee expressed as a percent (never a bare number with no
+// context), then every other row (SM deposits, catalog add-ons, gifts) as a plain line, and the
+// milestone's own total. Never repeats the package name, included services, or payment schedule -
+// those render exactly once, above, in the shared programme-overview block.
+const PaymentBlock = ({ index, milestone, rows, currency }) => {
+  const { scheduledRows, additionalRows } = splitScheduledRows(rows);
+  const subtotal = computeMilestoneSubtotal(rows);
+  return (
+    <View style={styles.paymentBlock} wrap={false}>
+      <View style={styles.paymentHeaderRow}>
+        <Text style={styles.paymentTitle}>{sanitizePdfText(`Payment #${index + 1} — ${milestone.title}`)}</Text>
+        <Text style={styles.paymentTotal}>{formatMoney(subtotal, currency)}</Text>
       </View>
-    ))}
-  </View>
-);
+      {scheduledRows.map(row => (
+        <Text key={row.key} style={styles.scheduledLine}>
+          {sanitizePdfText(`${formatPercentValue(row.percent)}% of programme fee — ${formatMoney(row.price, currency)}`)}
+        </Text>
+      ))}
+      {additionalRows.map(row => (
+        <View key={row.key} style={styles.additionalRow}>
+          <Text style={styles.additionalName}>{sanitizePdfText(row.name)}</Text>
+          <Text style={styles.additionalPrice}>{row.priceLabel || formatMoney(row.price, currency)}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
 
-// Each milestone gets its own compact page: this payment's line items, the estimated total, and a
-// one-line pointer back to the Budget document - never the full programme overview or payment
-// schedule (those already live in the Budget PDF; repeating them here on every one of the plan's
-// milestones was the source of a bloated, near-duplicate document).
+// One combined PDF for the whole case (spec §1.1): the full programme block - title block,
+// "prepared exclusively for", coordinator line, programme summary, included services, payment
+// schedule - rendered exactly once via the same table components BudgetPdfDocument uses (so the
+// two documents can never drift apart), followed by a compact "Payment #N" block per milestone.
+// Everything lives on one flowing, auto-paginating <Page>, so several compact payment blocks land
+// on the same physical page instead of each getting its own.
 const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate }) => {
   const caseTitle = buildCaseTitle(customers);
-  const dateLabel = formatPlanDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
+  const payerName = buildPayerName(customers);
+  const dateLabel = formatDisplayDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
   const programmeName = plan?.packageSnapshot?.name || 'Programme';
+  const listedPrice = Number(plan?.packageSnapshot?.listedPrice) || 0;
+  const currency = plan?.packageSnapshot?.currency || 'EUR';
   const milestones = Array.isArray(plan?.milestones) ? plan.milestones : [];
+
+  const overviewRows = resolvePackageOverviewRows(plan?.packageSnapshot?.children, catalogItemsById, priceContext);
+  const includedRows = overviewRows.map(row => ({ id: row.id, name: row.name, includedByPackageId: new Set(['programme']) }));
+  const packagesMeta = [{ id: 'programme', label: 'Programme', priceLabel: formatAmount(listedPrice) }];
+
+  const milestoneRows = milestones.map(milestone => resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext));
+  const milestoneSubtotals = milestoneRows.map(rows => computeMilestoneSubtotal(rows));
+  const scheduleRows = milestones.map((milestone, index) => ({
+    title: milestone.title || `Payment ${index + 1}`,
+    amounts: [milestoneSubtotals[index]],
+  }));
+  const scheduleTotal = milestoneSubtotals.reduce((sum, amount) => sum + (Number(amount) || 0), 0);
 
   return (
     <Document title={`Expected expenses - ${caseTitle}`} subject="Expected expenses" creator="UKRCOM">
-      {milestones.map((milestone, index) => {
-        const serviceRows = resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext);
-        const subtotal = computeMilestoneSubtotal(serviceRows);
+      <Page size="A4" style={styles.page} wrap>
+        <BronzeMotif />
+        <ContinuedTag label="Expected Expenses" />
+        <BrandRow metaLines={[dateLabel, caseTitle]} />
+        <BrandRule />
+        <TitleBlock
+          eyebrow="Programme schedule"
+          title={programmeName}
+          subtitle={`Total programme fee ${formatMoney(listedPrice, currency)}.`}
+        />
+        <PreparedForBlock clientName={payerName} />
+        {/* Spec §1.4: a short, visible disclaimer under the title on every page of this document -
+            in addition to, not instead of, the existing small-print note at the very end. */}
+        <Text style={styles.forecastNotice}>
+          {sanitizePdfText('This is a forecast, not an invoice — actual amounts are confirmed separately.')}
+        </Text>
 
-        return (
-          <Page key={`${plan?.packageId || 'package'}-${index}`} size="A4" style={styles.page} wrap>
-            <BronzeMotif />
-            <DocSeries label="Expected Expenses" optional />
-            <BrandRow metaLines={[`Invoice #${index + 1}`, dateLabel, caseTitle]} />
-            <BrandRule />
-            <TitleBlock
-              eyebrow="Expected expenses"
-              title={`Expected expenses of the invoice #${index + 1}`}
-              subtitle={milestone.title}
-            />
-            <Text style={styles.contextNote}>
-              {sanitizePdfText(`${programmeName} - full programme details are in your Budget document.`)}
-            </Text>
+        <SummaryCard label="What this programme includes" text={plan?.packageSnapshot?.description} />
 
-            {serviceRows.length ? (
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Expected expenses</Text>
-                {renderExpensesRows(serviceRows)}
-              </View>
-            ) : null}
+        <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} totals={[scheduleTotal]} />
 
-            <View style={pdfBaseStyles.totalCard}>
-              <Text style={pdfBaseStyles.totalCardLabel}>Estimated total (pre-tax)</Text>
-              <Text style={pdfBaseStyles.totalCardAmount}>{formatMoney(subtotal)}</Text>
-            </View>
-            <Text style={styles.refundNote}>
-              {sanitizePdfText('Estimate only, not an invoice. Any unused portion of a deposit is refunded or carried forward at the next stage.')}
-            </Text>
+        {/* `break` starts Included services on a fresh page, matching the Program Budget layout
+            (spec §2) - so the schedule above stays with the title block/summary on page 1. */}
+        <View break={includedRows.length > 0}>
+          <IncludedServicesTable
+            packages={packagesMeta}
+            includedRows={includedRows}
+            title="Included in this programme"
+            note="Every item below is already covered by the programme fee."
+          />
+        </View>
 
-            <Footer />
-          </Page>
-        );
-      })}
+        {milestones.length ? (
+          <View>
+            <Text style={styles.paymentsHeading}>Payments</Text>
+            {milestones.map((milestone, index) => (
+              <PaymentBlock key={milestone.id || index} index={index} milestone={milestone} rows={milestoneRows[index]} currency={currency} />
+            ))}
+          </View>
+        ) : null}
+
+        <Text style={styles.refundNote}>
+          {sanitizePdfText('Estimate only, not an invoice. Any unused portion of a deposit is refunded or carried forward at the next stage.')}
+        </Text>
+
+        <Footer />
+      </Page>
     </Document>
   );
 };

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -27,6 +27,7 @@ import {
   buildCaseTitle,
   buildPayerLocation,
   buildPayerName,
+  buildUkrcomFileName,
   cloneEntryWithNewId,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
@@ -1153,6 +1154,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [error, setError] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [isGeneratingExpectedExpenses, setIsGeneratingExpectedExpenses] = useState(false);
+  const [generatePaymentDetails, setGeneratePaymentDetails] = useState(true);
   const [invoiceDateInput, setInvoiceDateInput] = useState(getTodayYmd());
   const [newCustomServiceName, setNewCustomServiceName] = useState('');
   const [newCustomServicePrice, setNewCustomServicePrice] = useState('');
@@ -1726,7 +1728,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         console.error('Expected expenses PDF generation failed on first attempt, retrying', firstAttemptError);
         blob = await pdf(React.createElement(ExpectedExpensesPdfDocument, documentProps)).toBlob();
       }
-      saveAs(blob, `expected-expenses-${(caseTitle || 'plan').replace(/[^a-z0-9]+/gi, '-').toLowerCase()}.pdf`);
+      saveAs(blob, buildUkrcomFileName('ExpectedExpenses', data.customers, invoiceDateInput));
       toast.success('Expected expenses PDF generated.');
     } catch (generateError) {
       console.error('Unable to generate expected expenses PDF', generateError);
@@ -1896,12 +1898,15 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     }
     setIsGenerating(true);
     try {
-      const [{ pdf }, { default: InvoicePdfDocument }] = await Promise.all([
+      const importPromises = [
         import('@react-pdf/renderer'),
         import('./InvoicePdfDocument'),
-      ]);
+      ];
+      if (generatePaymentDetails) importPromises.push(import('./PaymentDetailsPdfDocument'));
+      const [{ pdf }, { default: InvoicePdfDocument }, paymentDetailsModule] = await Promise.all(importPromises);
+
+      const invoiceDisplayDate = new Date(`${invoiceDateInput || getTodayYmd()}T00:00:00`);
       const documentProps = {
-        beneficiary: activeBeneficiary,
         customers: data.customers,
         invoiceServices: data.invoiceServices,
         catalogItemsById,
@@ -1909,8 +1914,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         notes: data.notes,
         taxPercent: data.taxPercent,
         invoiceNumber,
-        invoiceDate,
-        purposeOfPayment,
+        invoiceDisplayDate,
       };
 
       // @react-pdf/renderer's WASM layout engine can still be warming up on the
@@ -1925,11 +1929,32 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       }
       saveAs(blob, `invoice-${invoiceNumber.replace(/\//g, '-')}.pdf`);
 
+      // Payment Details is always its own file now, generated together with the Invoice so its
+      // amount due is guaranteed to stay in sync (spec §3) - never a second page of the invoice.
+      if (generatePaymentDetails && paymentDetailsModule) {
+        const PaymentDetailsPdfDocument = paymentDetailsModule.default;
+        const paymentDetailsProps = {
+          beneficiary: activeBeneficiary,
+          customers: data.customers,
+          invoiceNumber,
+          purposeOfPayment,
+          amountDue: total,
+        };
+        let paymentDetailsBlob;
+        try {
+          paymentDetailsBlob = await pdf(React.createElement(PaymentDetailsPdfDocument, paymentDetailsProps)).toBlob();
+        } catch (firstAttemptError) {
+          console.error('Payment details PDF generation failed on first attempt, retrying', firstAttemptError);
+          paymentDetailsBlob = await pdf(React.createElement(PaymentDetailsPdfDocument, paymentDetailsProps)).toBlob();
+        }
+        saveAs(paymentDetailsBlob, buildUkrcomFileName('PaymentDetails', data.customers, invoiceDateInput));
+      }
+
       const nextRecentServices = reorderRecentServices(data.recentServices, data.invoiceServices);
       setData(current => ({ ...current, recentServices: nextRecentServices }));
       await persistPath(`${INVOICE_DATA_PATH}/recentServices`, nextRecentServices);
 
-      toast.success('Invoice PDF generated.');
+      toast.success(generatePaymentDetails ? 'Invoice and payment details PDFs generated.' : 'Invoice PDF generated.');
     } catch (generateError) {
       console.error('Unable to generate invoice PDF', generateError);
       const reason = generateError?.message ? `: ${generateError.message}` : '';
@@ -2233,6 +2258,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   onBlur={commitTaxPercent}
                   style={{ flex: '0 0 auto' }}
                 />
+              </FieldRow>
+              <FieldRow $align="center">
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={generatePaymentDetails}
+                    onChange={event => setGeneratePaymentDetails(event.target.checked)}
+                  />
+                  <span>Generate Payment Details (separate PDF)</span>
+                </label>
               </FieldRow>
               <SummaryGrid style={{ marginTop: 10 }}>
                 <SummaryLine><span>Invoice number</span><span>{invoiceNumber}</span></SummaryLine>

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import {
   BrandRow, BrandRule, BronzeMotif, ContinuedTag, Footer, PDF_COLOR, PDF_FONT,
-  ensurePdfFontsRegistered, pdfBaseStyles, sanitizePdfText, TitleBlock,
+  ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
+import { formatMoney } from './budgetCatalogUtils';
 import {
   buildCaseTitle,
   buildPayerLocation,
@@ -25,20 +26,6 @@ const DOC_LABEL_BY_TYPE = {
 const EYEBROW_BY_TYPE = {
   programme_milestone: 'Programme milestone invoice',
   service: 'Service invoice',
-};
-
-// No copies past the decimal for round or four-figure sums; two decimals only when the
-// amount genuinely carries cents (spec §1.8).
-const formatMoney = (value, currency = 'EUR') => {
-  const amount = Number(value);
-  if (!Number.isFinite(amount)) return '-';
-  const rounded = Math.round(amount * 100) / 100;
-  const isInteger = Number.isInteger(rounded);
-  const formatted = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: isInteger ? 0 : 2,
-    maximumFractionDigits: isInteger ? 0 : 2,
-  }).format(rounded);
-  return `${formatted} ${currency}`;
 };
 
 // A row may carry a free-text price label (e.g. "GIFT") instead of a euro amount.
@@ -160,52 +147,6 @@ const styles = StyleSheet.create({
     lineHeight: 1.45,
     color: PDF_COLOR.inkSoft,
   },
-  paymentCard: {
-    backgroundColor: PDF_COLOR.neutralBg,
-    borderWidth: 1,
-    borderColor: PDF_COLOR.neutralLine,
-    borderStyle: 'solid',
-    borderRadius: 8,
-    padding: 14,
-  },
-  paymentCardTitle: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontSize: 7.5,
-    letterSpacing: 1.2,
-    textTransform: 'uppercase',
-    color: PDF_COLOR.neutralSoft,
-    marginBottom: 8,
-  },
-  paymentRow: {
-    flexDirection: 'row',
-    borderTopWidth: 1,
-    borderTopColor: PDF_COLOR.neutralLine,
-    borderTopStyle: 'solid',
-    paddingVertical: 6,
-  },
-  paymentRowFirst: {
-    borderTopWidth: 0,
-    paddingTop: 0,
-  },
-  paymentLabelCell: {
-    width: '32%',
-  },
-  paymentLabelText: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontSize: 8.5,
-    color: PDF_COLOR.neutralInk,
-  },
-  paymentValueCell: {
-    flex: 1,
-  },
-  paymentValueText: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 8.5,
-    lineHeight: 1.4,
-    color: PDF_COLOR.neutralInk,
-  },
 });
 
 // Flattens resolved rows into a display list: a package becomes its own bold header row
@@ -225,15 +166,13 @@ const buildDisplayRows = rows => {
 };
 
 const InvoicePdfDocument = ({
-  beneficiary,
   customers,
   invoiceServices,
   catalogItemsById,
   notes,
   taxPercent,
   invoiceNumber,
-  invoiceDate,
-  purposeOfPayment,
+  invoiceDisplayDate,
   priceContext,
   invoiceType,
 }) => {
@@ -250,18 +189,23 @@ const InvoicePdfDocument = ({
     : resolveInvoiceDocType(rows);
   const docLabel = DOC_LABEL_BY_TYPE[docType];
   const eyebrow = EYEBROW_BY_TYPE[docType];
+  // The DD.MM.YYYY `invoiceDate` string (invoiceCatalogUtils.generateInvoiceIdentifiers) is the
+  // legal-text date used inside the payment-purpose placeholder only - the human-readable date
+  // shown here always uses the one shared display format (spec §4), never that dotted form or the
+  // invoice number's own slash format.
+  const dateLabel = formatDisplayDate(invoiceDisplayDate);
 
   return (
     <Document title={`Invoice ${invoiceNumber || ''}`} subject="Invoice" creator="UKRCOM">
       <Page size="A4" style={styles.page} wrap>
         <BronzeMotif />
         <ContinuedTag label={docLabel} />
-        <BrandRow metaLines={[`Invoice No. ${invoiceNumber || ''}`, invoiceDate, caseTitle]} />
+        <BrandRow metaLines={[`Invoice No. ${invoiceNumber || ''}`, dateLabel, caseTitle]} />
         <BrandRule />
         <TitleBlock
           eyebrow={eyebrow}
           title={`Invoice No. ${invoiceNumber || ''}`}
-          subtitle={`Prepared for ${payerName}${payerLocation ? ` · ${payerLocation}` : ''}.`}
+          subtitle={`Prepared exclusively for ${payerName}${payerLocation ? ` · ${payerLocation}` : ''}.`}
         />
 
         <View style={styles.section}>
@@ -321,52 +265,6 @@ const InvoicePdfDocument = ({
         </View>
 
         <Footer variant="branded" />
-      </Page>
-
-      {/* Payment details gets its own page with a neutral (unbranded) footer: the beneficiary (a
-          sole proprietorship) is a legally separate party from the UKRCOM agency, so this page must
-          not carry the agency's name/address (spec §1.5). */}
-      <Page size="A4" style={styles.page} wrap>
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Payment details</Text>
-          <View style={styles.paymentCard}>
-            <Text style={styles.paymentCardTitle}>Beneficiary details</Text>
-            <View style={[styles.paymentRow, styles.paymentRowFirst]}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Beneficiary</Text></View>
-              <View style={styles.paymentValueCell}>
-                <Text style={styles.paymentValueText}>
-                  {sanitizePdfText(`${beneficiary?.title || ''}, ${beneficiary?.address || ''}`)}
-                </Text>
-              </View>
-            </View>
-            <View style={styles.paymentRow}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>IBAN</Text></View>
-              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(beneficiary?.iban)}</Text></View>
-            </View>
-            <View style={styles.paymentRow}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Bank</Text></View>
-              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(beneficiary?.bankName)}</Text></View>
-            </View>
-            <View style={styles.paymentRow}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>SWIFT/BIC</Text></View>
-              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(beneficiary?.swiftCode)}</Text></View>
-            </View>
-            <View style={styles.paymentRow}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Payer</Text></View>
-              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(payerName)}</Text></View>
-            </View>
-            <View style={styles.paymentRow}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Location</Text></View>
-              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(payerLocation)}</Text></View>
-            </View>
-            <View style={styles.paymentRow}>
-              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Purpose of payment</Text></View>
-              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(purposeOfPayment)}</Text></View>
-            </View>
-          </View>
-        </View>
-
-        <Footer variant="neutral" />
       </Page>
     </Document>
   );

--- a/src/components/PaymentDetailsPdfDocument.jsx
+++ b/src/components/PaymentDetailsPdfDocument.jsx
@@ -1,0 +1,166 @@
+// Payment Details - a standalone document (spec §3), split out of what used to be page 2 of the
+// Invoice PDF. The beneficiary (a sole proprietorship) is a legally separate party from the
+// UKRCOM agency, so this document deliberately carries no UKRCOM wordmark/motif/agency footer
+// (variant="neutral" throughout) and gets its own page numbering starting at "Page 1 of 1" -
+// nothing here should read as "page 2 of the invoice".
+import React from 'react';
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import {
+  Footer, PDF_COLOR, PDF_FONT, ensurePdfFontsRegistered, pdfBaseStyles, sanitizePdfText,
+} from './pdfTheme';
+import { formatMoney } from './budgetCatalogUtils';
+import { buildPayerLocation, buildPayerName } from './invoiceCatalogUtils';
+
+ensurePdfFontsRegistered();
+
+const styles = StyleSheet.create({
+  page: pdfBaseStyles.page,
+  section: {
+    marginTop: 26,
+  },
+  sectionTitle: pdfBaseStyles.sectionTitle,
+  paymentCard: {
+    backgroundColor: PDF_COLOR.neutralBg,
+    borderWidth: 1,
+    borderColor: PDF_COLOR.neutralLine,
+    borderStyle: 'solid',
+    borderRadius: 8,
+    padding: 14,
+  },
+  paymentCardTitle: {
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 7.5,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    color: PDF_COLOR.neutralSoft,
+    marginBottom: 8,
+  },
+  paymentRow: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: PDF_COLOR.neutralLine,
+    borderTopStyle: 'solid',
+    paddingVertical: 6,
+  },
+  paymentRowFirst: {
+    borderTopWidth: 0,
+    paddingTop: 0,
+  },
+  paymentLabelCell: {
+    width: '32%',
+  },
+  paymentLabelText: {
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 8.5,
+    color: PDF_COLOR.neutralInk,
+  },
+  paymentValueCell: {
+    flex: 1,
+  },
+  paymentValueText: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 8.5,
+    lineHeight: 1.4,
+    color: PDF_COLOR.neutralInk,
+  },
+  amountCard: {
+    backgroundColor: PDF_COLOR.neutralTotal,
+    borderRadius: 8,
+    paddingVertical: 16,
+    paddingHorizontal: 18,
+    marginTop: 22,
+  },
+  amountLabel: {
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 7.5,
+    letterSpacing: 1.4,
+    color: PDF_COLOR.neutralSoft,
+    textTransform: 'uppercase',
+    marginBottom: 6,
+  },
+  amountValue: {
+    fontFamily: PDF_FONT.display,
+    fontWeight: 600,
+    fontSize: 26,
+    color: PDF_COLOR.white,
+  },
+  amountSub: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 8.5,
+    color: PDF_COLOR.neutralBg,
+    marginTop: 4,
+  },
+});
+
+const PaymentDetailsPdfDocument = ({
+  beneficiary,
+  customers,
+  invoiceNumber,
+  purposeOfPayment,
+  amountDue,
+}) => {
+  const payerName = buildPayerName(customers);
+  const payerLocation = buildPayerLocation(customers);
+
+  return (
+    <Document title={`Payment Details ${invoiceNumber || ''}`} subject="Payment details" creator="UKRCOM">
+      <Page size="A4" style={styles.page} wrap>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Payment details</Text>
+          <View style={styles.paymentCard}>
+            <Text style={styles.paymentCardTitle}>Beneficiary details</Text>
+            <View style={[styles.paymentRow, styles.paymentRowFirst]}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Beneficiary</Text></View>
+              <View style={styles.paymentValueCell}>
+                <Text style={styles.paymentValueText}>
+                  {sanitizePdfText(`${beneficiary?.title || ''}, ${beneficiary?.address || ''}`)}
+                </Text>
+              </View>
+            </View>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>IBAN</Text></View>
+              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(beneficiary?.iban)}</Text></View>
+            </View>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Bank</Text></View>
+              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(beneficiary?.bankName)}</Text></View>
+            </View>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>SWIFT/BIC</Text></View>
+              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(beneficiary?.swiftCode)}</Text></View>
+            </View>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Payer</Text></View>
+              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(payerName)}</Text></View>
+            </View>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Location</Text></View>
+              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(payerLocation)}</Text></View>
+            </View>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentLabelCell}><Text style={styles.paymentLabelText}>Purpose of payment</Text></View>
+              <View style={styles.paymentValueCell}><Text style={styles.paymentValueText}>{sanitizePdfText(purposeOfPayment)}</Text></View>
+            </View>
+          </View>
+
+          {/* Amount due is generated together with, and always kept in sync with, the matching
+              Invoice (spec §3) - it is simply passed in as a prop rather than recomputed here. */}
+          <View style={styles.amountCard}>
+            <Text style={styles.amountLabel}>Amount due</Text>
+            <Text style={styles.amountValue}>{formatMoney(amountDue)}</Text>
+            <Text style={styles.amountSub}>{sanitizePdfText(`See Invoice No. ${invoiceNumber || ''} for the full breakdown.`)}</Text>
+          </View>
+        </View>
+
+        {/* Own, independent page numbering - "Page 1 of 1" for a one-page document (spec §3) -
+            never a continuation of the Invoice's own numbering. */}
+        <Footer variant="neutral" />
+      </Page>
+    </Document>
+  );
+};
+
+export default PaymentDetailsPdfDocument;

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -45,10 +45,20 @@ const prettifyKey = key => String(key || '')
   .replace(/\s+/g, ' ')
   .replace(/\b\w/g, char => char.toUpperCase());
 
+// The one money format every UKRCOM document (Budget/Invoice/Payment Details/Expected Expenses)
+// and the admin screens use (spec §4): tabular tens/hundreds/thousands with a comma, no copies
+// past the decimal for round sums, and exactly two decimals only when the amount genuinely
+// carries cents - never silently rounded away.
 export const formatMoney = (value, currency = 'EUR') => {
   const amount = Number(value);
   if (!Number.isFinite(amount)) return `— ${currency || 'EUR'}`;
-  return `${new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(amount)} ${currency || 'EUR'}`;
+  const rounded = Math.round(amount * 100) / 100;
+  const isInteger = Number.isInteger(rounded);
+  const formatted = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: isInteger ? 0 : 2,
+    maximumFractionDigits: isInteger ? 0 : 2,
+  }).format(rounded);
+  return `${formatted} ${currency || 'EUR'}`;
 };
 
 export const formatEuroAmount = value => {

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -273,6 +273,18 @@ export const computeMilestoneAmountDue = (subtotal, taxPercent) => computeInvoic
 export const resolveExpectedExpenseRows = (group, catalogItemsById, priceContext = {}) =>
   (Array.isArray(group) ? group : []).map(entry => resolveServiceRow(entry, catalogItemsById, priceContext));
 
+// Splits a milestone's resolved rows into the one auto-generated "share of the programme fee" row
+// (expectedExpenseRole === 'scheduled') and every other row (SM deposits, catalog add-ons, gifts,
+// ...) - the Expected Expenses PDF shows the scheduled share as "N% of programme fee" and every
+// other row as a plain compact line (spec §1.2).
+export const splitScheduledRows = rows => {
+  const list = Array.isArray(rows) ? rows : [];
+  return {
+    scheduledRows: list.filter(row => row.expectedExpenseRole === 'scheduled'),
+    additionalRows: list.filter(row => row.expectedExpenseRole !== 'scheduled'),
+  };
+};
+
 // Sum of every milestone's resolved total (percent-of-package rows resolved to euros, plus every
 // catalog/custom extra) - the actual amount the whole plan bills for.
 export const computeMilestonesTotal = (milestones, catalogItemsById, priceContext = {}) =>

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -354,6 +354,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       name: `${formatPercentValue(percent)}% of ${pkg?.name ?? `Package ${entry.packageId}`}`,
       description: '',
       price,
+      ...(entry.expectedExpenseRole ? { expectedExpenseRole: entry.expectedExpenseRole } : {}),
     };
   }
 
@@ -457,6 +458,22 @@ export const buildPayerLocation = customers => {
 export const buildCaseTitle = customers => {
   const payerName = buildPayerName(customers);
   return payerName ? `Case of ${payerName}` : 'Case';
+};
+
+// The first customer's surname (last whitespace-separated token of their name) - used to build the
+// `UKRCOM-{DocType}-{ClientLastName}-YYYY-MM-DD.pdf` filenames every generated document shares.
+export const buildClientLastName = customers => {
+  const firstName = String((Array.isArray(customers) ? customers : [])[0]?.name || '').trim();
+  if (!firstName) return 'Client';
+  const tokens = firstName.split(/\s+/).filter(Boolean);
+  return tokens[tokens.length - 1] || 'Client';
+};
+
+// `UKRCOM-{DocType}-{ClientLastName}-YYYY-MM-DD.pdf`, filesystem-safe (spec §1.1/§2/§3).
+export const buildUkrcomFileName = (docType, customers, dateYmd) => {
+  const lastName = buildClientLastName(customers).replace(/[^a-z0-9]+/gi, '');
+  const datePart = String(dateYmd || getTodayYmd());
+  return `UKRCOM-${docType}-${lastName}-${datePart}.pdf`;
 };
 
 export const formatInvoiceNumberDate = date => `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()}`;

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -5,55 +5,19 @@
 // product. Tokens below mirror the UKRCOM Invoice Builder design spec (ukrcom-invoice-fullset.html).
 import React from 'react';
 import { Font, StyleSheet, Svg, Defs, LinearGradient, Stop, Line, Text, View } from '@react-pdf/renderer';
+import designTokens from '../data/designTokens.json';
 
-// NOTE ON BACKWARDS COMPATIBILITY: `renderTopBlock.js` (surrogate/donor ProfilePdfDocument) and
-// `PdfPagePreviewStrip.jsx` (admin UI preview strip) already depend on the original palette below
+// Colors and font families are never hardcoded here - they live in src/data/designTokens.json,
+// the single shared source of truth for the UKRCOM document system's visual language (see that
+// file's header comment). `renderTopBlock.js` (surrogate/donor ProfilePdfDocument) and
+// `PdfPagePreviewStrip.jsx` (admin UI preview strip) depend on the original key names below
 // (ink/muted/soft/accent/accentStrong/line/lineSoft/headBg/rowAlt/cardBg/totalBg/watermark/white)
-// and on PDF_FONT.base/bold — those keys and values are kept exactly as they were so those two
-// files keep rendering unchanged. The Budget/Invoice/Expected-Expenses redesign uses the new,
-// separately-named spec tokens added below instead of overloading the old keys.
-export const PDF_COLOR = {
-  ink: '#2b2118',
-  muted: '#786a5c',
-  soft: '#9a6b48',
-  accent: '#8a5527',
-  accentStrong: '#6b3f18',
-  line: '#e6d7c0',
-  lineSoft: '#efe3d1',
-  headBg: '#f3e6d1',
-  rowAlt: '#faf3e6',
-  cardBg: '#fdf8ef',
-  totalBg: '#ead9b8',
-  watermark: '#f1e2c6',
-  white: '#ffffff',
+// and on PDF_FONT.base/bold — those keys are kept as-is in the token file so those two files keep
+// rendering unchanged. The Budget/Invoice/Payment-Details/Expected-Expenses documents use the
+// separately-named spec tokens (paper/card/docLine/docInk/... below) from the same file instead.
+export const PDF_COLOR = designTokens.color;
 
-  // Spec tokens (§1.1) for the redesigned Budget/Invoice/Expected-Expenses documents.
-  paper: '#FBF7F0',
-  card: '#F2E9D6',
-  docLine: '#E6DCC7',
-  docInk: '#2B2620',
-  inkSoft: '#726858',
-  footerSoft: '#A79C88',
-  bronze: '#A2793F',
-  bronzeDeep: '#7C5B2E',
-  totalCardBg: '#362C22',
-  totalCardAmount: '#EFDDB0',
-
-  // Separate neutral palette — reserved for the Payment Instructions document, which is
-  // deliberately not branded (see spec §1.5).
-  neutralBg: '#FDFCFA',
-  neutralInk: '#3A362F',
-  neutralSoft: '#8A8478',
-  neutralLine: '#D8D2C2',
-  neutralTotal: '#3A362F',
-};
-
-export const PDF_FONT = {
-  base: 'Helvetica',
-  bold: 'Helvetica-Bold',
-  display: 'Fraunces',
-  body: 'Inter',
-};
+export const PDF_FONT = designTokens.font;
 
 let fontsRegistered = false;
 
@@ -101,6 +65,15 @@ export const sanitizePdfText = value => String(value ?? '')
   .replace(/[✓✔]/g, 'x')
   .replace(/\s+/g, ' ')
   .trim();
+
+// The one date format every document displays to a client (spec §4): "9 July 2026" - never
+// DD.MM.YYYY or DD/MM/YYYY. (The invoice number and the payment-purpose placeholder are a
+// separate concern - they intentionally keep their own numeric formats, since those are
+// identifiers/legal text, not a human-readable "as of" date.)
+export const formatDisplayDate = date => {
+  const safeDate = date instanceof Date && !Number.isNaN(date.getTime()) ? date : new Date();
+  return safeDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+};
 
 const PAGE_MARGIN = 56;
 const MOTIF_INSET = 30;
@@ -193,6 +166,46 @@ export const pdfBaseStyles = {
   },
   titleBlock: {
     marginBottom: 24,
+  },
+  preparedFor: {
+    // No italic here: only Regular/Medium/SemiBold/Bold are embedded for Inter (see
+    // ensurePdfFontsRegistered) - react-pdf can't fake-italicize a custom font without a matching
+    // italic source file, so emphasis comes from color/weight/tracking instead.
+    fontFamily: PDF_FONT.body,
+    fontWeight: 500,
+    letterSpacing: 0.2,
+    fontSize: 9,
+    color: PDF_COLOR.bronzeDeep,
+    marginTop: 2,
+    marginBottom: 3,
+  },
+  coordinatorLine: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 9,
+    color: PDF_COLOR.inkSoft,
+    marginBottom: 24,
+  },
+  summaryCard: {
+    backgroundColor: PDF_COLOR.card,
+    borderRadius: 6,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    marginBottom: 22,
+  },
+  summaryCardLabel: {
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 8,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    color: PDF_COLOR.bronzeDeep,
+    marginBottom: 6,
+  },
+  summaryCardText: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 9.5,
+    lineHeight: 1.6,
+    color: PDF_COLOR.docInk,
   },
   sectionTitle: {
     fontFamily: PDF_FONT.display,
@@ -383,6 +396,32 @@ export const TitleBlock = ({ eyebrow, title, subtitle }) => (
     {subtitle ? <Text style={pdfSharedStyles.docSubtitle}>{sanitizePdfText(subtitle)}</Text> : null}
   </View>
 );
+
+const COORDINATOR_NAME = 'Irina Koval';
+const COORDINATOR_TITLE = 'Co-Founder, UKRCOM';
+
+// "Prepared exclusively for {client}" + the coordinator line - the two lines every case-specific
+// document (Invoice, Payment Details, Expected Expenses) shows under its title block, right above
+// any programme summary (spec §1.2/§4). Never shown on the catalog-wide Program Budget document,
+// which has no client to prepare it for.
+export const PreparedForBlock = ({ clientName }) => (
+  <>
+    {clientName ? <Text style={pdfSharedStyles.preparedFor}>{sanitizePdfText(`Prepared exclusively for ${clientName}`)}</Text> : null}
+    <Text style={pdfSharedStyles.coordinatorLine}>
+      {'Your programme coordinator — '}
+      <Text style={{ fontWeight: 600, color: PDF_COLOR.docInk }}>{sanitizePdfText(COORDINATOR_NAME)}</Text>
+      {sanitizePdfText(`, ${COORDINATOR_TITLE}`)}
+    </Text>
+  </>
+);
+
+// The highlighted "what this programme includes" card (spec §1.2's "program-summary").
+export const SummaryCard = ({ label, text }) => (text ? (
+  <View style={pdfSharedStyles.summaryCard} wrap={false}>
+    {label ? <Text style={pdfSharedStyles.summaryCardLabel}>{sanitizePdfText(label)}</Text> : null}
+    <Text style={pdfSharedStyles.summaryCardText}>{sanitizePdfText(text)}</Text>
+  </View>
+) : null);
 
 const AGENCY_NAME = 'Reproductive Agency "UKRCOM"';
 const AGENCY_ADDRESS = '31/16 Reitarska Str., 1st floor, Kyiv, 01034, Ukraine';

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -9,7 +9,10 @@ import {
   Text,
   View,
 } from '@react-pdf/renderer';
-import { PDF_COLOR, PDF_FONT, pdfBaseStyles, sanitizePdfText } from '../pdfTheme';
+import {
+  BrandRow, BrandRule, BronzeMotif, Footer, PDF_COLOR, PDF_FONT,
+  ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
+} from '../pdfTheme';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
 import { btnEdit } from './btnEdit';
@@ -740,47 +743,27 @@ const extractMultiDataComments = cardData => {
   return normalized.filter(comment => comment.text);
 };
 
+// The SM Profile PDF is only ever exported for surrogate mother candidates (gated by
+// isSurrogateMotherRole below), so - like Budget/Invoice/Payment Details/Expected Expenses - it
+// uses the shared UKRCOM wordmark, bronze motif and Fraunces/Inter type scale (spec §6) instead of
+// its own one-off look. Fonts must be registered here since this module never otherwise imports a
+// document that does so.
+ensurePdfFontsRegistered();
+
 const profilePdfStyles = StyleSheet.create({
-  page: {
-    position: 'relative',
-    paddingTop: 78,
-    paddingHorizontal: 88,
-    paddingBottom: 74,
-    fontFamily: PDF_FONT.base,
-    color: PDF_COLOR.ink,
-    backgroundColor: PDF_COLOR.white,
-  },
-  eyebrow: {
-    ...pdfBaseStyles.eyebrow,
-    textAlign: 'center',
-    marginBottom: 8,
-  },
-  title: {
-    fontFamily: PDF_FONT.bold,
-    marginBottom: 6,
-    textAlign: 'center',
-    fontSize: 20,
-    lineHeight: 1.25,
-    color: PDF_COLOR.ink,
-  },
-  titleRule: {
-    alignSelf: 'center',
-    width: 64,
-    height: 2,
-    borderRadius: 1,
-    backgroundColor: PDF_COLOR.accent,
-    marginBottom: 28,
-  },
+  page: pdfBaseStyles.page,
   table: {
     borderWidth: 1,
-    borderColor: PDF_COLOR.line,
+    borderColor: PDF_COLOR.docLine,
     borderStyle: 'solid',
-    borderRadius: 6,
+    borderRadius: 8,
+    overflow: 'hidden',
+    marginTop: 22,
   },
   row: {
     flexDirection: 'row',
     borderTopWidth: 1,
-    borderTopColor: PDF_COLOR.line,
+    borderTopColor: PDF_COLOR.docLine,
     borderTopStyle: 'solid',
   },
   firstRow: {
@@ -788,18 +771,19 @@ const profilePdfStyles = StyleSheet.create({
   },
   labelCell: {
     width: '38%',
-    backgroundColor: PDF_COLOR.headBg,
+    backgroundColor: PDF_COLOR.card,
     borderRightWidth: 1,
-    borderRightColor: PDF_COLOR.line,
+    borderRightColor: PDF_COLOR.docLine,
     borderRightStyle: 'solid',
     paddingVertical: 7,
     paddingHorizontal: 10,
     justifyContent: 'center',
   },
   labelText: {
-    fontFamily: PDF_FONT.bold,
-    fontSize: 10.5,
-    color: '#4d3a26',
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 8.5,
+    color: PDF_COLOR.bronzeDeep,
   },
   valueCell: {
     width: '62%',
@@ -808,8 +792,39 @@ const profilePdfStyles = StyleSheet.create({
     justifyContent: 'center',
   },
   valueText: {
-    fontSize: 11,
+    fontFamily: PDF_FONT.body,
+    fontSize: 9.5,
     lineHeight: 1.4,
+    color: PDF_COLOR.docInk,
+  },
+  // "Картки-акценти для ключових даних" (spec §6): the handful of fields a coordinator scans
+  // first sit in their own bronze accent cards above the full table, instead of blending into it.
+  accentRow: {
+    flexDirection: 'row',
+    gap: 10,
+    marginTop: 20,
+  },
+  accentCard: {
+    flex: 1,
+    backgroundColor: PDF_COLOR.totalCardBg,
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  accentLabel: {
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 7,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    color: PDF_COLOR.footerSoft,
+    marginBottom: 4,
+  },
+  accentValue: {
+    fontFamily: PDF_FONT.display,
+    fontWeight: 600,
+    fontSize: 16,
+    color: PDF_COLOR.totalCardAmount,
   },
   watermark: {
     position: 'absolute',
@@ -817,38 +832,14 @@ const profilePdfStyles = StyleSheet.create({
     top: 330,
     width: 520,
     textAlign: 'center',
-    fontFamily: PDF_FONT.bold,
+    fontFamily: PDF_FONT.display,
+    fontWeight: 700,
     fontSize: 106,
-    color: PDF_COLOR.watermark,
+    color: PDF_COLOR.card,
     opacity: 0.9,
     transform: 'rotate(-42deg)',
   },
-  footer: {
-    position: 'absolute',
-    left: 88,
-    right: 88,
-    bottom: 28,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    borderTopWidth: 1,
-    borderTopColor: PDF_COLOR.line,
-    borderTopStyle: 'solid',
-    paddingTop: 8,
-    color: PDF_COLOR.muted,
-    fontSize: 7.5,
-    lineHeight: 1.4,
-  },
-  footerRight: {
-    textAlign: 'right',
-  },
-  imagePage: {
-    position: 'relative',
-    paddingTop: 78,
-    paddingHorizontal: 70,
-    paddingBottom: 74,
-    fontFamily: PDF_FONT.base,
-    backgroundColor: PDF_COLOR.white,
-  },
+  imagePage: pdfBaseStyles.page,
   profileImageWrap: {
     position: 'relative',
     alignSelf: 'center',
@@ -870,25 +861,14 @@ const profilePdfStyles = StyleSheet.create({
     top: 230,
     width: 520,
     textAlign: 'center',
-    fontFamily: PDF_FONT.bold,
+    fontFamily: PDF_FONT.display,
+    fontWeight: 700,
     fontSize: 86,
-    color: PDF_COLOR.watermark,
+    color: PDF_COLOR.card,
     opacity: 0.9,
     transform: 'rotate(-42deg)',
   },
 });
-
-const pdfFooter = (
-  <View style={profilePdfStyles.footer} fixed>
-    <Text>
-      KnowMe: Egg donor
-    </Text>
-    <Text style={profilePdfStyles.footerRight}>
-      E-mail: KnowMeEggDonor@gmail.com{'\n'}
-      Google Play: KnowMe: Egg donor
-    </Text>
-  </View>
-);
 
 const CYRILLIC_TO_LATIN = {
   а: 'a', б: 'b', в: 'v', г: 'h', ґ: 'g', д: 'd', е: 'e', є: 'ie', ж: 'zh', з: 'z', и: 'y', і: 'i', ї: 'i', й: 'i',
@@ -1046,38 +1026,57 @@ const buildProfilePdfFileName = data => {
   return `${safeName || 'profile'}-KnowMe.pdf`;
 };
 
+// The two fields a coordinator scans first get their own bronze accent cards above the full
+// table (spec §6); every other field stays in the plain label/value table.
+const ACCENT_ROW_LABELS = ['Name', 'Age'];
+
 const ProfilePdfDocument = ({ userData, photoUrls }) => {
   const rows = buildProfilePdfRows(userData);
+  const accentRows = rows.filter(([label]) => ACCENT_ROW_LABELS.includes(label));
+  const tableRows = rows.filter(([label]) => !ACCENT_ROW_LABELS.includes(label));
   const photos = Array.isArray(photoUrls) ? photoUrls : [];
   const photoEntries = photos.map(photo => (
     photo && typeof photo === 'object' ? photo : { src: photo }
   )).filter(photo => photo?.src);
+  const dateLabel = formatDisplayDate(new Date());
   return (
-    <Document title={`${buildName(userData) || 'Profile'} - KnowMe: Egg donor`}>
+    <Document title={`${buildName(userData) || 'Profile'} - UKRCOM Surrogate Mother Profile`} subject="Surrogate mother profile" creator="UKRCOM">
       <Page size="A4" style={profilePdfStyles.page}>
-        <Text style={profilePdfStyles.watermark}>KnowMe</Text>
-        <Text style={profilePdfStyles.eyebrow}>{sanitizePdfText('KnowMe · Egg donor')}</Text>
-        <Text style={profilePdfStyles.title}>
-          {sanitizePdfText("Surrogacy mother's profile")}
-        </Text>
-        <View style={profilePdfStyles.titleRule} />
+        <BronzeMotif />
+        <Text style={profilePdfStyles.watermark}>UKRCOM</Text>
+        <BrandRow metaLines={[dateLabel, 'Confidential']} />
+        <BrandRule />
+        <TitleBlock
+          eyebrow="Surrogate mother profile"
+          title={buildName(userData) || 'Surrogate Mother Profile'}
+        />
+        {accentRows.length ? (
+          <View style={profilePdfStyles.accentRow} wrap={false}>
+            {accentRows.map(([label, value]) => (
+              <View key={label} style={profilePdfStyles.accentCard}>
+                <Text style={profilePdfStyles.accentLabel}>{sanitizePdfText(label)}</Text>
+                <Text style={profilePdfStyles.accentValue}>{sanitizePdfText(value)}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
         <View style={profilePdfStyles.table}>
-          {rows.map(([label, value], index) => (
+          {tableRows.map(([label, value], index) => (
             <View key={label} style={[profilePdfStyles.row, index === 0 ? profilePdfStyles.firstRow : null]} wrap={false}>
               <View style={profilePdfStyles.labelCell}><Text style={profilePdfStyles.labelText}>{sanitizePdfText(label)}</Text></View>
               <View style={profilePdfStyles.valueCell}><Text style={profilePdfStyles.valueText}>{sanitizePdfText(value)}</Text></View>
             </View>
           ))}
         </View>
-        {pdfFooter}
+        <Footer />
       </Page>
       {photoEntries.map((photo, index) => (
         <Page key={`${photo.src}-${index}`} size="A4" style={profilePdfStyles.imagePage}>
           <View style={profilePdfStyles.profileImageWrap}>
-            <Text style={profilePdfStyles.imageWatermark}>KnowMe</Text>
+            <Text style={profilePdfStyles.imageWatermark}>UKRCOM</Text>
             <Image src={photo.src} style={profilePdfStyles.profileImage} />
           </View>
-          {pdfFooter}
+          <Footer />
         </Page>
       ))}
     </Document>

--- a/src/data/designTokens.json
+++ b/src/data/designTokens.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "Single source of truth for the UKRCOM document system's visual language (colors + type families). Consumed by src/components/pdfTheme.js for every @react-pdf export (Budget/Invoice/Payment Details/Expected Expenses); any future web UI for the same client-facing documents should read from this file too instead of duplicating values.",
+  "color": {
+    "ink": "#2b2118",
+    "muted": "#786a5c",
+    "soft": "#9a6b48",
+    "accent": "#8a5527",
+    "accentStrong": "#6b3f18",
+    "line": "#e6d7c0",
+    "lineSoft": "#efe3d1",
+    "headBg": "#f3e6d1",
+    "rowAlt": "#faf3e6",
+    "cardBg": "#fdf8ef",
+    "totalBg": "#ead9b8",
+    "watermark": "#f1e2c6",
+    "white": "#ffffff",
+
+    "paper": "#FBF7F0",
+    "card": "#F2E9D6",
+    "docLine": "#E6DCC7",
+    "docInk": "#2B2620",
+    "inkSoft": "#726858",
+    "footerSoft": "#A79C88",
+    "bronze": "#A2793F",
+    "bronzeDeep": "#7C5B2E",
+    "totalCardBg": "#362C22",
+    "totalCardAmount": "#EFDDB0",
+
+    "neutralBg": "#FDFCFA",
+    "neutralInk": "#3A362F",
+    "neutralSoft": "#8A8478",
+    "neutralLine": "#D8D2C2",
+    "neutralTotal": "#3A362F"
+  },
+  "font": {
+    "base": "Helvetica",
+    "bold": "Helvetica-Bold",
+    "display": "Fraunces",
+    "body": "Inter"
+  }
+}


### PR DESCRIPTION
- Program Budget: Payment schedule moves above Included services with a
  page break, plus more breathing room on page 1
- Invoice: Payment Details splits into its own PDF/document with its own
  page numbering, generated alongside the invoice via a new checkbox;
  "Prepared exclusively for" wording; unified display date format
- Expected Expenses: single flowing PDF that shows the programme overview
  once (reusing Budget's included-services/payment-schedule tables) followed
  by compact "Payment #N" blocks showing each scheduled share as a percent
  of the programme fee, with the new forecast disclaimer under the title
- Shared money/date formatting and a single design-tokens file consumed by
  every PDF document
- SM Profile PDF (surrogate-mother-only export) now uses the same UKRCOM
  wordmark, bronze motif, and Fraunces/Inter type scale as the rest of the
  document system, with accent cards for name/age

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CEef77R3Q5e51tVim2aid1