### PR TITLE
Force Other expenses to start on a fresh page in Program Budget PDF

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -461,7 +461,10 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
         </View>
 
         {Object.keys(groupedExpenses).length ? (
-          <View style={styles.section}>
+          // `break` starts Other expenses on a fresh page so it never trails onto the
+          // last line of the Included services table above (only the section start is forced;
+          // page breaks between categories inside this section remain natural).
+          <View style={styles.section} break>
             <View wrap={false} minPresenceAhead={70}>
               <Text style={styles.sectionTitle}>Other expenses</Text>
               <Text style={styles.sectionNote}>"From" prices are lower bounds of a range.</Text>


### PR DESCRIPTION
The section used to begin partway down the Included services page,
leaving only the title, note, and one item before the next page break.
Adding the same `break` prop already used for Included services makes
Other expenses always open on a clean page.