### PR TITLE
Add Package Invoice layout and fix Expected Expenses tax calculation

### DIFF
--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -8,6 +8,7 @@ import { formatMoney } from './budgetCatalogUtils';
 import { formatAmount, IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
 import { buildCaseTitle, buildPayerName } from './invoiceCatalogUtils';
 import {
+  computeMilestoneAmountDue,
   computeMilestoneSubtotal,
   resolveMilestoneServiceRows,
   resolvePackageOverviewRows,
@@ -57,13 +58,6 @@ const styles = StyleSheet.create({
     fontSize: 11.5,
     color: PDF_COLOR.docInk,
   },
-  paymentTotal: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontVariantNumeric: 'tabular-nums',
-    fontSize: 11,
-    color: PDF_COLOR.bronzeDeep,
-  },
   scheduledLine: {
     fontFamily: PDF_FONT.body,
     fontSize: 9,
@@ -96,6 +90,21 @@ const styles = StyleSheet.create({
     color: PDF_COLOR.inkSoft,
     marginTop: 14,
   },
+  // Same background/rule/row tokens as pdfBaseStyles.totalCard (the Invoice's total-card), just
+  // scaled down to fit inside a compact, repeated-per-milestone card instead of a whole-document one.
+  paymentTotalCard: {
+    backgroundColor: PDF_COLOR.totalCardBg,
+    borderRadius: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginTop: 6,
+  },
+  paymentTotalAmount: {
+    fontFamily: PDF_FONT.display,
+    fontWeight: 600,
+    fontSize: 16,
+    color: PDF_COLOR.totalCardAmount,
+  },
 });
 
 // One compact block per payment (spec §1.2): "Payment #N - {milestone title}" - a header line, the
@@ -106,11 +115,12 @@ const styles = StyleSheet.create({
 const PaymentBlock = ({ index, milestone, rows, currency }) => {
   const { scheduledRows, additionalRows } = splitScheduledRows(rows);
   const subtotal = computeMilestoneSubtotal(rows);
+  const taxPercent = Number(milestone.taxPercent) || 0;
+  const amountDue = computeMilestoneAmountDue(subtotal, taxPercent);
   return (
     <View style={styles.paymentBlock} wrap={false}>
       <View style={styles.paymentHeaderRow}>
         <Text style={styles.paymentTitle}>{sanitizePdfText(`Payment #${index + 1} — ${milestone.title}`)}</Text>
-        <Text style={styles.paymentTotal}>{formatMoney(subtotal, currency)}</Text>
       </View>
       {scheduledRows.map(row => (
         <Text key={row.key} style={styles.scheduledLine}>
@@ -123,6 +133,22 @@ const PaymentBlock = ({ index, milestone, rows, currency }) => {
           <Text style={styles.additionalPrice}>{row.priceLabel || formatMoney(row.price, currency)}</Text>
         </View>
       ))}
+      {/* Spec §3 fix: this used to show only the pre-tax subtotal, silently dropping the milestone's
+          own tax rate - reuse the exact same total-card (label/amount/rule/rows) the Invoice uses so
+          the figure a client sees here already matches the amount they'll later be billed. */}
+      <View style={styles.paymentTotalCard}>
+        <Text style={pdfBaseStyles.totalCardLabel}>Estimated total</Text>
+        <Text style={styles.paymentTotalAmount}>{formatMoney(amountDue, currency)}</Text>
+        <View style={pdfBaseStyles.totalCardRule} />
+        <View style={pdfBaseStyles.totalCardRow}>
+          <Text style={pdfBaseStyles.totalCardRowLabel}>Subtotal</Text>
+          <Text style={pdfBaseStyles.totalCardRowValue}>{formatMoney(subtotal, currency)}</Text>
+        </View>
+        <View style={pdfBaseStyles.totalCardRow}>
+          <Text style={pdfBaseStyles.totalCardRowLabel}>Tax</Text>
+          <Text style={pdfBaseStyles.totalCardRowValue}>{`${formatPercentValue(taxPercent)}%`}</Text>
+        </View>
+      </View>
     </View>
   );
 };

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1915,6 +1915,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         taxPercent: data.taxPercent,
         invoiceNumber,
         invoiceDisplayDate,
+        catalogTechnical,
       };
 
       // @react-pdf/renderer's WASM layout engine can still be warming up on the

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -29,6 +29,7 @@ import {
   buildPayerName,
   buildUkrcomFileName,
   cloneEntryWithNewId,
+  computeInvoiceAmountDue,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
   generateInvoiceIdentifiers,
@@ -1260,6 +1261,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const subtotal = useMemo(() => computeInvoiceSubtotal(invoiceServiceRows), [invoiceServiceRows]);
   const total = useMemo(() => computeInvoiceTotal(subtotal, data.taxPercent), [subtotal, data.taxPercent]);
+  const amountDue = useMemo(() => computeInvoiceAmountDue(total, data.debtOrDeposit), [total, data.debtOrDeposit]);
 
   const { invoiceNumber, invoiceDate } = useMemo(() => generateInvoiceIdentifiers(invoiceDateInput), [invoiceDateInput]);
 
@@ -1777,6 +1779,18 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     persistPath(`${INVOICE_DATA_PATH}/taxPercent`, value, 'Tax updated.');
   };
 
+  // Debt / deposit of the previous payment ------------------------------------------------------
+
+  const updateDebtOrDeposit = value => {
+    setData(current => ({ ...current, debtOrDeposit: value }));
+  };
+
+  const commitDebtOrDeposit = () => {
+    const value = Number(String(data.debtOrDeposit).replace(',', '.')) || 0;
+    setData(current => ({ ...current, debtOrDeposit: value }));
+    persistPath(`${INVOICE_DATA_PATH}/debtOrDeposit`, value, 'Debt/deposit updated.');
+  };
+
   // Upload seed JSON ------------------------------------------------------------
 
   const handleUploadClick = () => fileInputRef.current?.click();
@@ -1913,6 +1927,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         priceContext,
         notes: data.notes,
         taxPercent: data.taxPercent,
+        debtOrDeposit: data.debtOrDeposit,
         invoiceNumber,
         invoiceDisplayDate,
         catalogTechnical,
@@ -1939,7 +1954,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
           customers: data.customers,
           invoiceNumber,
           purposeOfPayment,
-          amountDue: total,
+          amountDue,
         };
         let paymentDetailsBlob;
         try {
@@ -2260,6 +2275,17 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   style={{ flex: '0 0 auto' }}
                 />
               </FieldRow>
+              <FieldRow>
+                <FieldTag title="Applied after tax. Positive = debt owed from before, negative = deposit/credit.">Debt/Deposit</FieldTag>
+                <PlainPriceBase
+                  rows={1}
+                  inputMode="decimal"
+                  value={data.debtOrDeposit}
+                  onChange={event => updateDebtOrDeposit(event.target.value)}
+                  onBlur={commitDebtOrDeposit}
+                  style={{ flex: '0 0 auto' }}
+                />
+              </FieldRow>
               <FieldRow $align="center">
                 <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
                   <input
@@ -2275,7 +2301,13 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <SummaryLine><span>Purpose of the payment</span><span style={{ textAlign: 'right', maxWidth: 420 }}>{purposeOfPayment || '—'}</span></SummaryLine>
                 <SummaryLine><span>Location</span><span>{payerLocation || '—'}</span></SummaryLine>
                 <SummaryLine><span>Subtotal</span><span>{formatEuroPreview(subtotal)}</span></SummaryLine>
-                <SummaryLine><span>Amount to be paid</span><span>{formatEuroPreview(total)}</span></SummaryLine>
+                {data.debtOrDeposit ? (
+                  <SummaryLine>
+                    <span>{data.debtOrDeposit > 0 ? 'Debt of the previous payment' : 'Deposit of the previous payment'}</span>
+                    <span>{`${data.debtOrDeposit > 0 ? '+' : '-'}${formatEuroPreview(Math.abs(data.debtOrDeposit))}`}</span>
+                  </SummaryLine>
+                ) : null}
+                <SummaryLine><span>Amount to be paid</span><span>{formatEuroPreview(amountDue)}</span></SummaryLine>
               </SummaryGrid>
             </Panel>
 

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -4,7 +4,8 @@ import {
   BrandRow, BrandRule, BronzeMotif, ContinuedTag, Footer, PDF_COLOR, PDF_FONT,
   ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
-import { formatMoney } from './budgetCatalogUtils';
+import { formatMoney, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
+import { formatAmount, IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
 import {
   buildCaseTitle,
   buildPayerLocation,
@@ -37,9 +38,34 @@ const styles = StyleSheet.create({
     marginTop: 26,
   },
   sectionTitle: pdfBaseStyles.sectionTitle,
+  sectionNote: pdfBaseStyles.sectionNote,
   table: {
     borderRadius: 8,
     overflow: 'hidden',
+  },
+  packageBlock: {
+    marginTop: 26,
+  },
+  packageBlockHeader: {
+    backgroundColor: PDF_COLOR.card,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 12,
+  },
+  packageBlockName: {
+    fontFamily: PDF_FONT.display,
+    fontWeight: 600,
+    fontSize: 13,
+    color: PDF_COLOR.docInk,
+  },
+  packageBlockFee: {
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontVariantNumeric: 'tabular-nums',
+    fontSize: 9.5,
+    color: PDF_COLOR.bronzeDeep,
+    marginTop: 4,
   },
   row: {
     flexDirection: 'row',
@@ -165,6 +191,76 @@ const buildDisplayRows = rows => {
   return display;
 };
 
+// One line of the "Invoice breakdown" - shared, byte-for-byte, between the plain flat table
+// (Service Invoice / a single milestone share) and the "Additional services outside the package"
+// section of a Package Invoice, so a service/custom row never renders two different ways.
+const ServiceItemRow = ({ row, isFirst }) => {
+  const isChild = row.depth > 0;
+  const isPackageHeader = row.kind === 'package';
+  return (
+    <View
+      style={[
+        isPackageHeader ? styles.packageRow : styles.row,
+        !isPackageHeader && !isChild && isFirst ? styles.firstRow : null,
+      ]}
+      wrap={false}
+    >
+      <View style={styles.indexCell}>
+        <Text style={styles.indexText}>{row.number}</Text>
+      </View>
+      <View style={[styles.nameCell, isChild ? styles.nameCellChild : null]}>
+        <Text style={isPackageHeader ? styles.nameTextPackage : (isChild ? styles.nameTextChild : styles.nameText)}>
+          {sanitizePdfText(row.name)}
+        </Text>
+        {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
+        {row.isCustomized ? <Text style={styles.itemNote}>Confirmed for this case</Text> : null}
+      </View>
+      <View style={styles.priceCell}>
+        <Text style={isPackageHeader ? styles.priceTextPackage : (isChild ? styles.priceTextChild : styles.priceText)}>
+          {formatRowAmount(row)}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+// The "Package block" (spec §1.1): the same shared IncludedServicesTable used by the Program
+// Budget/Expected Expenses documents, so the standard-package contents can never drift between
+// documents - preceded by a compact name/fee header (this document has no spare TitleBlock to
+// reuse for it, that one already carries the invoice's own title).
+const PackageBlock = ({ row, schedule }) => {
+  const includedRows = (row.children || []).map(child => ({
+    id: child.key || child.id,
+    name: child.name,
+    includedByPackageId: new Set(['programme']),
+  }));
+  const packagesMeta = [{ id: 'programme', label: row.name, priceLabel: formatAmount(row.price) }];
+  const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+  const scheduleRows = payments.map((payment, index) => ({
+    title: payment?.title || `Payment ${index + 1}`,
+    amounts: [Number(payment?.amount) || 0],
+  }));
+  const scheduleTotal = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
+
+  return (
+    <View style={styles.packageBlock}>
+      <Text style={styles.sectionTitle}>Programme package</Text>
+      <View style={styles.packageBlockHeader} wrap={false}>
+        <Text style={styles.packageBlockName}>{sanitizePdfText(row.name)}</Text>
+        {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
+        <Text style={styles.packageBlockFee}>{`Total programme fee ${formatRowAmount(row)}`}</Text>
+      </View>
+      <IncludedServicesTable
+        packages={packagesMeta}
+        includedRows={includedRows}
+        title="Included in this programme"
+        note="Every item below is already covered by the programme fee."
+      />
+      <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} totals={[scheduleTotal]} />
+    </View>
+  );
+};
+
 const InvoicePdfDocument = ({
   customers,
   invoiceServices,
@@ -175,9 +271,9 @@ const InvoicePdfDocument = ({
   invoiceDisplayDate,
   priceContext,
   invoiceType,
+  catalogTechnical,
 }) => {
   const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById, priceContext);
-  const displayRows = buildDisplayRows(rows);
   const subtotal = computeInvoiceSubtotal(rows);
   const total = computeInvoiceTotal(subtotal, taxPercent);
   const payerName = buildPayerName(customers);
@@ -189,6 +285,24 @@ const InvoicePdfDocument = ({
     : resolveInvoiceDocType(rows);
   const docLabel = DOC_LABEL_BY_TYPE[docType];
   const eyebrow = EYEBROW_BY_TYPE[docType];
+
+  // Package Invoice (spec §1): adding a whole standard package - as opposed to a single
+  // percent-of-package milestone share, or a handful of one-off services - gets its own
+  // three-block layout (package block, payment schedule, additional services) instead of the flat
+  // itemized breakdown below. Any other top-level row alongside the package is, by definition, a
+  // service confirmed for this case that sits outside the standard package.
+  const packageRows = rows.filter(row => row.kind === 'package');
+  const isPackageInvoice = packageRows.length > 0;
+  const otherRows = isPackageInvoice ? rows.filter(row => row.kind !== 'package') : rows;
+  const displayRows = buildDisplayRows(otherRows);
+  // The package entry's own `children` are a frozen name-only snapshot (invoiceCatalogUtils.js) -
+  // its payment schedule instead always comes live from the catalog package it was added from, the
+  // same source Program Budget/Expected Expenses read it from, so a schedule edit in the catalog is
+  // reflected here too.
+  const resolvePackageSchedule = row => {
+    const catalogPackage = priceContext?.packagesById?.get?.(String(row.catalogId));
+    return catalogPackage ? resolveProgramPaymentSchedule({ technical: catalogTechnical }, catalogPackage) : null;
+  };
   // The DD.MM.YYYY `invoiceDate` string (invoiceCatalogUtils.generateInvoiceIdentifiers) is the
   // legal-text date used inside the payment-purpose placeholder only - the human-readable date
   // shown here always uses the one shared display format (spec §4), never that dotted form or the
@@ -208,40 +322,37 @@ const InvoicePdfDocument = ({
           subtitle={`Prepared exclusively for ${payerName}${payerLocation ? ` · ${payerLocation}` : ''}.`}
         />
 
-        <View style={styles.section}>
-          <View style={styles.table}>
-            {displayRows.map((row, rowIndex) => {
-              const isChild = row.depth > 0;
-              const isPackageHeader = row.kind === 'package';
-              return (
-                <View
-                  key={`${row.key || rowIndex}-${row.number}`}
-                  style={[
-                    isPackageHeader ? styles.packageRow : styles.row,
-                    !isPackageHeader && !isChild && rowIndex === 0 ? styles.firstRow : null,
-                  ]}
-                  wrap={false}
-                >
-                  <View style={styles.indexCell}>
-                    <Text style={styles.indexText}>{row.number}</Text>
-                  </View>
-                  <View style={[styles.nameCell, isChild ? styles.nameCellChild : null]}>
-                    <Text style={isPackageHeader ? styles.nameTextPackage : (isChild ? styles.nameTextChild : styles.nameText)}>
-                      {sanitizePdfText(row.name)}
-                    </Text>
-                    {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
-                    {row.isCustomized ? <Text style={styles.itemNote}>Confirmed for this case</Text> : null}
-                  </View>
-                  <View style={styles.priceCell}>
-                    <Text style={isPackageHeader ? styles.priceTextPackage : (isChild ? styles.priceTextChild : styles.priceText)}>
-                      {formatRowAmount(row)}
-                    </Text>
-                  </View>
+        {isPackageInvoice ? (
+          <>
+            {packageRows.map(row => (
+              <PackageBlock key={row.key} row={row} schedule={resolvePackageSchedule(row)} />
+            ))}
+            {displayRows.length ? (
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Additional services outside the package</Text>
+                <Text style={styles.sectionNote}>Confirmed for this case, billed alongside the standard package.</Text>
+                <View style={styles.table}>
+                  {displayRows.map((row, rowIndex) => (
+                    <ServiceItemRow key={`${row.key || rowIndex}-${row.number}`} row={row} isFirst={rowIndex === 0} />
+                  ))}
                 </View>
-              );
-            })}
+              </View>
+            ) : null}
+          </>
+        ) : (
+          <View style={styles.section}>
+            <View style={styles.table}>
+              {displayRows.map((row, rowIndex) => (
+                <ServiceItemRow key={`${row.key || rowIndex}-${row.number}`} row={row} isFirst={rowIndex === 0} />
+              ))}
+            </View>
           </View>
+        )}
 
+        {/* No extra top margin here - noteRow/totalCard already carry their own spacing (spec §1.4),
+            same as the flat layout above where they sit directly under the table with no gap of
+            their own. */}
+        <View>
           {noteList.map((note, index) => (
             <View key={`note-${index}`} style={styles.noteRow}>
               <Text style={styles.noteMark}>{'*'.repeat(index + 1)}</Text>

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -10,6 +10,7 @@ import {
   buildCaseTitle,
   buildPayerLocation,
   buildPayerName,
+  computeInvoiceAmountDue,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
   resolveInvoiceDocType,
@@ -272,10 +273,12 @@ const InvoicePdfDocument = ({
   priceContext,
   invoiceType,
   catalogTechnical,
+  debtOrDeposit,
 }) => {
   const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById, priceContext);
   const subtotal = computeInvoiceSubtotal(rows);
   const total = computeInvoiceTotal(subtotal, taxPercent);
+  const amountDue = computeInvoiceAmountDue(total, debtOrDeposit);
   const payerName = buildPayerName(customers);
   const payerLocation = buildPayerLocation(customers);
   const caseTitle = buildCaseTitle(customers);
@@ -362,7 +365,7 @@ const InvoicePdfDocument = ({
 
           <View style={pdfBaseStyles.totalCard}>
             <Text style={pdfBaseStyles.totalCardLabel}>Amount due</Text>
-            <Text style={pdfBaseStyles.totalCardAmount}>{formatMoney(total)}</Text>
+            <Text style={pdfBaseStyles.totalCardAmount}>{formatMoney(amountDue)}</Text>
             <View style={pdfBaseStyles.totalCardRule} />
             <View style={pdfBaseStyles.totalCardRow}>
               <Text style={pdfBaseStyles.totalCardRowLabel}>Subtotal</Text>
@@ -372,6 +375,19 @@ const InvoicePdfDocument = ({
               <Text style={pdfBaseStyles.totalCardRowLabel}>Tax</Text>
               <Text style={pdfBaseStyles.totalCardRowValue}>{`${sanitizePdfText(String(taxPercent ?? 0))}%`}</Text>
             </View>
+            {/* Applied after tax, never folded into the taxable subtotal above it (spec follow-up):
+                a carried-over debt/deposit is settled money, not a billable service - zero (the
+                default) renders nothing. */}
+            {debtOrDeposit ? (
+              <View style={pdfBaseStyles.totalCardRow}>
+                <Text style={pdfBaseStyles.totalCardRowLabel}>
+                  {debtOrDeposit > 0 ? 'Debt of the previous payment' : 'Deposit of the previous payment'}
+                </Text>
+                <Text style={pdfBaseStyles.totalCardRowValue}>
+                  {`${debtOrDeposit > 0 ? '+' : '-'}${formatMoney(Math.abs(debtOrDeposit))}`}
+                </Text>
+              </View>
+            ) : null}
           </View>
         </View>
 

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -54,13 +54,18 @@ export const normalizeInvoiceData = raw => ({
   invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
   notes: Array.isArray(raw?.notes) ? raw.notes : [],
   taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
+  // A signed carry-over from the client's previous payment, settled after tax (never itself
+  // taxed): positive = the client still owes a debt from before, negative = they're sitting on a
+  // deposit/credit. Zero (the default) means "nothing to carry over" and is never rendered.
+  debtOrDeposit: Number.isFinite(Number(raw?.debtOrDeposit)) ? Number(raw.debtOrDeposit) : 0,
 });
 
 export const isInvoiceDataShape = raw => {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
   return ['beneficiaries', 'beneficiaryIds', 'customers', 'recentServices', 'invoiceServices', 'notes']
     .every(field => Array.isArray(raw[field]))
-    && (raw.taxPercent === undefined || Number.isFinite(Number(raw.taxPercent)));
+    && (raw.taxPercent === undefined || Number.isFinite(Number(raw.taxPercent)))
+    && (raw.debtOrDeposit === undefined || Number.isFinite(Number(raw.debtOrDeposit)));
 };
 
 // The active beneficiary is always the first id in beneficiaryIds.
@@ -426,6 +431,11 @@ export const resolveInvoiceDocType = rows => ((Array.isArray(rows) ? rows : [])
 export const computeInvoiceSubtotal = rows => rows.reduce((sum, row) => sum + (Number(row.price) || 0), 0);
 
 export const computeInvoiceTotal = (subtotal, taxPercent) => subtotal * (1 + (Number(taxPercent) || 0) / 100);
+
+// Applied after tax, never before it - a debt/deposit carried over from a previous payment is
+// already-settled money, not a taxable service, so it never goes through computeInvoiceTotal's
+// tax multiplier the way a service row would.
+export const computeInvoiceAmountDue = (total, debtOrDeposit) => total + (Number(debtOrDeposit) || 0);
 
 // After an invoice is generated, its top-level services move to the front of recentServices (same
 // order, deduped by identity) so they're the first quick-pick choices next time.

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -44,6 +44,7 @@ describe('invoiceCatalogUtils', () => {
       invoiceServices: [],
       notes: [],
       taxPercent: 0,
+      debtOrDeposit: 0,
     });
   });
 


### PR DESCRIPTION
When a whole standard package is added to an invoice, render it as three
separate blocks - package overview (reusing the shared IncludedServicesTable),
its payment schedule (reusing PaymentScheduleTable), and any additional
services confirmed outside the package - instead of the flat itemized table,
which now only applies to plain service/milestone invoices.

Also fix Expected Expenses' per-payment total, which showed only the
pre-tax subtotal: each Payment block now applies the milestone's tax rate
and shows Subtotal/Tax/Estimated total, matching the on-screen admin
preview and the Invoice's own total-card.