### PR TITLE
Fix expected-expenses/package pricing bugs and PDF layout

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1481,13 +1481,21 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const activeBeneficiary = useMemo(() => getActiveBeneficiary(data), [data]);
 
+  // A 'percent' row's price formula lives on the *package* it shares (pkg.listedPrice), not on the
+  // row itself - same pending/error treatment as a formula-priced catalog item, otherwise a package
+  // invoice or expected-expenses plan can be generated with every package-share row silently priced
+  // at 0 while the NBU rates are still loading.
   const entryReferencesFormulaItem = useCallback(entry => {
     if (!entry) return false;
     if (entry.kind === 'package') return (entry.children || []).some(entryReferencesFormulaItem);
+    if (entry.kind === 'percent') {
+      const pkg = catalogPackagesById.get(String(entry.packageId));
+      return parseBudgetPriceValue(pkg?.listedPrice).isFormula;
+    }
     if (entry.kind !== 'item') return false;
     const item = catalogItemsById.get(String(entry.catalogId));
     return parseBudgetPriceValue(item?.price).isFormula;
-  }, [catalogItemsById]);
+  }, [catalogItemsById, catalogPackagesById]);
 
   const hasFormulaInvoiceService = useMemo(
     () => data.invoiceServices.some(entryReferencesFormulaItem),
@@ -1497,6 +1505,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const isFormulaRatePending = hasFormulaInvoiceService && exchangeRatesLoading;
   const formulaRateError = hasFormulaInvoiceService ? exchangeRatesError : '';
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || isFormulaRatePending || Boolean(formulaRateError);
+
+  const hasFormulaExpectedExpensesService = useMemo(
+    () => (expectedExpenses?.milestones || []).some(milestone => (milestone.services || []).some(entryReferencesFormulaItem)),
+    [expectedExpenses, entryReferencesFormulaItem],
+  );
+  const isExpectedExpensesFormulaRatePending = hasFormulaExpectedExpensesService && exchangeRatesLoading;
+  const expectedExpensesFormulaRateError = hasFormulaExpectedExpensesService ? exchangeRatesError : '';
+  const isExpectedExpensesGenerateDisabled = isGeneratingExpectedExpenses
+    || isExpectedExpensesFormulaRatePending
+    || Boolean(expectedExpensesFormulaRateError);
 
   const priceContext = useMemo(
     () => ({
@@ -1868,10 +1886,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       toast.error('This package has no payment schedule in the catalog.');
       return;
     }
+    // Resolved (and validated positive) the same way a brand-new plan is - an unresolved formula
+    // price must never silently fall back to the raw "=..." string, which would zero out every
+    // freshly-rebuilt percent-of-package row below.
+    const resolvedPackage = getResolvedExpectedExpensesPackage(pkg);
+    if (!resolvedPackage) return;
     if (typeof window !== 'undefined' && !window.confirm(
       'Recalculate milestones from the catalog schedule? Titles reset to the catalog and the package-share row is recomputed; extra services on each milestone are kept.',
     )) return;
-    const resolvedPackage = { ...pkg, listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice };
     const freshMilestones = buildMilestonesFromSchedule(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
     // A milestone saved before expectedExpenseRole existed has no explicit marker on its scheduled
     // row, so it can't be told apart from a manually-added percent-of-package row by itself. Only
@@ -1903,7 +1925,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       ...expectedExpenses,
       packageSnapshot: {
         ...expectedExpenses.packageSnapshot,
-        listedPrice: resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? Number(pkg.listedPrice) ?? 0,
+        listedPrice: resolvedPackage.listedPrice,
       },
       milestones: nextMilestones,
     }, 'Schedule recalculated.');
@@ -1968,6 +1990,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     }
     if (!data.customers.length) {
       toast.error('Add at least one customer first.');
+      return;
+    }
+    if (isExpectedExpensesFormulaRatePending) {
+      toast.error('Wait until the package price formula resolves before generating the PDF.');
+      return;
+    }
+    if (expectedExpensesFormulaRateError) {
+      toast.error('Exchange rates failed to load - cannot resolve the package price formula.');
       return;
     }
     if (isGeneratingExpectedExpenses) return;
@@ -2064,12 +2094,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const uploadExpectedExpenses = async rawExpectedExpenses => {
     let nextPlan;
     if (isRawExpectedExpensesGroups(rawExpectedExpenses)) {
-      const { plan, missingPackage, droppedGroupsCount } = buildExpectedExpensesPlanFromRawGroups(rawExpectedExpenses, {
+      const { plan, missingPackage, missingSchedule, droppedGroupsCount } = buildExpectedExpensesPlanFromRawGroups(rawExpectedExpenses, {
         catalog: { packages: catalogPackages, technical: catalogTechnical },
         taxPercent: defaultExpectedExpensesTaxPercent,
       });
       if (missingPackage) {
         toast.error('Expected expenses: none of the groups reference a catalog package ("idX || Y%") - nothing was imported.');
+        return null;
+      }
+      if (missingSchedule) {
+        toast.error('This package has no payment schedule in the catalog.');
         return null;
       }
       if (droppedGroupsCount) {
@@ -2676,8 +2710,10 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       <PrimaryMiniButton
                         type="button"
                         onClick={handleGenerateExpectedExpensesPdf}
-                        disabled={isGeneratingExpectedExpenses}
-                        title="Generate the full payment-schedule forecast PDF"
+                        disabled={isExpectedExpensesGenerateDisabled}
+                        title={isExpectedExpensesFormulaRatePending
+                          ? 'Waiting for the package price formula to resolve…'
+                          : 'Generate the full payment-schedule forecast PDF'}
                       >
                         <FaFilePdf /> {isGeneratingExpectedExpenses ? 'Generating…' : 'Generate PDF'}
                       </PrimaryMiniButton>

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -5,7 +5,7 @@ import {
   ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
 import { formatMoney, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
-import { formatAmount, IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
+import { IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
 import {
   buildCaseTitle,
   buildPayerLocation,
@@ -124,15 +124,6 @@ const styles = StyleSheet.create({
     lineHeight: 1.4,
     marginTop: 2,
   },
-  itemNote: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontSize: 7,
-    letterSpacing: 0.6,
-    color: PDF_COLOR.bronze,
-    textTransform: 'uppercase',
-    marginTop: 2,
-  },
   priceCell: {
     width: 96,
     textAlign: 'right',
@@ -214,7 +205,6 @@ const ServiceItemRow = ({ row, isFirst }) => {
           {sanitizePdfText(row.name)}
         </Text>
         {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
-        {row.isCustomized ? <Text style={styles.itemNote}>Confirmed for this case</Text> : null}
       </View>
       <View style={styles.priceCell}>
         <Text style={isPackageHeader ? styles.priceTextPackage : (isChild ? styles.priceTextChild : styles.priceText)}>
@@ -235,13 +225,20 @@ const PackageBlock = ({ row, schedule }) => {
     name: child.name,
     includedByPackageId: new Set(['programme']),
   }));
-  const packagesMeta = [{ id: 'programme', label: row.name, priceLabel: formatAmount(row.price) }];
+  // A short, fixed column header - the package's own name/fee is already shown in full in the
+  // header block above the table, and doesn't need repeating (and stretching every row) here.
+  const packagesMeta = [{ id: 'programme', label: 'Price', priceLabel: '' }];
   const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+  const scheduleRawTotal = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
+  // The catalog schedule's own amounts only add up to the invoice total when the package is billed
+  // at its plain catalog listed price - scale them to the row's actual price (a manual override, or
+  // a customized set of children) so this table's total never disagrees with what's actually billed.
+  const scaleRatio = scheduleRawTotal > 0 ? row.price / scheduleRawTotal : 1;
   const scheduleRows = payments.map((payment, index) => ({
     title: payment?.title || `Payment ${index + 1}`,
-    amounts: [Number(payment?.amount) || 0],
+    amounts: [Math.round((Number(payment?.amount) || 0) * scaleRatio * 100) / 100],
   }));
-  const scheduleTotal = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
+  const scheduleTotal = Math.round((Number(row.price) || 0) * 100) / 100;
 
   return (
     <View style={styles.packageBlock}>

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -41,13 +41,15 @@ export const buildPackageOverviewChildren = pkg => (Array.isArray(pkg?.children)
   .map(catalogId => makeCatalogItemEntry(catalogId));
 
 // A schedule payment's euro amount is only ever used once, to seed a percent-of-package row (e.g.
-// a 8772 EUR first payment on a 40000 EUR package becomes "21.93% of the package") - from then on
-// that row is a normal, independently editable service row like any other.
+// a 8772 EUR first payment on a 40000 EUR package becomes "21.9300% of the package") - from then on
+// that row is a normal, independently editable service row like any other. Kept to 4 decimal places
+// (not 2) so resolving the percent back to euros lands on the same cent the schedule specified,
+// instead of drifting by tens of euros on packages whose payments aren't a round percentage.
 const buildGroupFromSchedulePayment = (pkg, payment) => {
   const listedPrice = Number(pkg?.listedPrice) || 0;
   const amount = Number(payment?.amount) || 0;
   if (!listedPrice || !amount) return [];
-  const percent = Math.round((amount / listedPrice) * 10000) / 100;
+  const percent = Math.round((amount / listedPrice) * 1e6) / 1e4;
   return [makePercentOfPackageEntry(pkg?.id, percent, { expectedExpenseRole: 'scheduled' })];
 };
 
@@ -126,8 +128,11 @@ export const inferPackageIdFromRawGroups = rawGroups => {
 };
 
 // Builds a full plan from raw groups + the loaded budget catalog. Returns `missingPackage: true`
-// when no package could be resolved (nothing is built in that case), and `droppedGroupsCount` for
-// any groups beyond the schedule's own step count (they're dropped rather than silently merged).
+// when no package could be resolved, `missingSchedule: true` when the resolved package has no
+// payment schedule of its own - either way nothing is built, the same "no payment schedule" failure
+// a manually-created plan gets, instead of silently persisting a plan with zero milestones. Also
+// returns `droppedGroupsCount` for any groups beyond the schedule's own step count (they're dropped
+// rather than silently merged).
 export const buildExpectedExpensesPlanFromRawGroups = (rawGroups, { catalog, taxPercent = 0, packageId: explicitPackageId } = {}) => {
   const groups = (Array.isArray(rawGroups) ? rawGroups : []).map(normalizeServiceEntries);
   const packageId = String(explicitPackageId || inferPackageIdFromRawGroups(rawGroups) || '');
@@ -135,6 +140,7 @@ export const buildExpectedExpensesPlanFromRawGroups = (rawGroups, { catalog, tax
   const pkg = packages.find(candidate => String(candidate.id) === packageId) || null;
   const schedule = pkg ? resolveProgramPaymentSchedule(catalog, pkg) : null;
   const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+  const missingSchedule = Boolean(pkg) && payments.length === 0;
 
   const milestones = payments.map((payment, index) => ({
     id: createEntryId(),
@@ -145,8 +151,9 @@ export const buildExpectedExpensesPlanFromRawGroups = (rawGroups, { catalog, tax
   }));
 
   return {
-    plan: pkg ? { packageId, packageSnapshot: buildPackageSnapshot(pkg), milestones } : null,
+    plan: (pkg && !missingSchedule) ? { packageId, packageSnapshot: buildPackageSnapshot(pkg), milestones } : null,
     missingPackage: !pkg,
+    missingSchedule,
     droppedGroupsCount: Math.max(0, groups.length - payments.length),
   };
 };
@@ -154,18 +161,19 @@ export const buildExpectedExpensesPlanFromRawGroups = (rawGroups, { catalog, tax
 // --- Normalization (defensive parsing of whatever's stored on the backend) ------------------------------------------------------
 
 // Old persisted milestones may still carry a frozen `scheduledAmount` number (and/or the old
-// `additionalServices` field name) from before groups became plain row lists - migrate it into an
-// equivalent percent-of-package row (or a plain custom row, if the package price isn't known) so
-// the euro total is preserved instead of silently dropped.
-export const normalizeExpectedExpensesMilestone = (raw, { packageId = '', listedPrice = 0 } = {}) => {
+// `additionalServices` field name) from before groups became plain row lists - migrate it into a
+// fixed custom row carrying that exact euro amount, so the total is preserved even if the plan's
+// package has since been removed from the catalog. A percent-of-package row would be nicer (it'd
+// track the package price live), but resolveServiceRow only ever prices one against the *current*
+// live catalog package, never the frozen packageSnapshot - so for a package that's gone missing,
+// seeding a percent row here would silently price this migrated row at 0 instead of preserving it.
+export const normalizeExpectedExpensesMilestone = raw => {
   const hasOwnServices = Array.isArray(raw?.services);
   const services = normalizeServiceEntries(raw?.services ?? raw?.additionalServices);
   const legacyAmount = Number(raw?.scheduledAmount);
   const migratedServices = !hasOwnServices && Number.isFinite(legacyAmount) && legacyAmount !== 0
     ? [
-      listedPrice
-        ? makePercentOfPackageEntry(packageId, Math.round((legacyAmount / listedPrice) * 10000) / 100, { expectedExpenseRole: 'scheduled' })
-        : makeCustomEntry({ name: raw?.title ? `Scheduled payment (${raw.title})` : 'Scheduled payment', price: legacyAmount }),
+      makeCustomEntry({ name: raw?.title ? `Scheduled payment (${raw.title})` : 'Scheduled payment', price: legacyAmount }),
       ...services,
     ]
     : services;
@@ -181,19 +189,17 @@ export const normalizeExpectedExpensesMilestone = (raw, { packageId = '', listed
 
 export const normalizeExpectedExpensesData = raw => {
   if (!raw || typeof raw !== 'object') return null;
-  const packageId = String(raw.packageId ?? '');
-  const listedPrice = Number(raw.packageSnapshot?.listedPrice) || 0;
   return {
-    packageId,
+    packageId: String(raw.packageId ?? ''),
     packageSnapshot: {
       name: raw.packageSnapshot?.name || '',
       description: raw.packageSnapshot?.description || '',
-      listedPrice,
+      listedPrice: Number(raw.packageSnapshot?.listedPrice) || 0,
       currency: raw.packageSnapshot?.currency || 'EUR',
       children: normalizeServiceEntries(raw.packageSnapshot?.children),
     },
     milestones: Array.isArray(raw.milestones)
-      ? raw.milestones.map(milestone => normalizeExpectedExpensesMilestone(milestone, { packageId, listedPrice }))
+      ? raw.milestones.map(normalizeExpectedExpensesMilestone)
       : [],
   };
 };

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -97,7 +97,7 @@ describe('expectedExpensesUtils', () => {
     expect(serializeExpectedExpensesData(null)).toBeNull();
   });
 
-  it('migrates a legacy milestone with a frozen scheduledAmount into an equivalent percent-of-package row', () => {
+  it('migrates a legacy milestone with a frozen scheduledAmount into a fixed custom row, independent of the live package', () => {
     const legacy = {
       packageId: '3',
       packageSnapshot: { name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR', children: [] },
@@ -107,9 +107,11 @@ describe('expectedExpensesUtils', () => {
     };
     const normalized = normalizeExpectedExpensesData(legacy);
     expect(normalized.milestones[0].services).toEqual([
-      { id: normalized.milestones[0].services[0].id, kind: 'percent', packageId: '3', percent: 20, expectedExpenseRole: 'scheduled' },
+      { id: normalized.milestones[0].services[0].id, kind: 'custom', name: 'Scheduled payment (To start the program)', price: 8000 },
     ]);
-    expect(computeMilestonesTotal(normalized.milestones, new Map(), { packagesById: new Map([['3', pkg]]) })).toBe(8000);
+    // The amount survives even if the package that used to price it no longer exists in the
+    // catalog - a percent-of-package row would have resolved to 0 in that case instead.
+    expect(computeMilestonesTotal(normalized.milestones, new Map(), { packagesById: new Map() })).toBe(8000);
   });
 
   it('edits a milestone field, parsing the numeric taxPercent and leaving text fields as-is', () => {
@@ -222,6 +224,14 @@ describe('expectedExpensesUtils', () => {
     it('reports a missing package instead of guessing when no percent row names one', () => {
       const { plan, missingPackage } = buildExpectedExpensesPlanFromRawGroups([['Custom line || 300']], { catalog: rawCatalogWithLink });
       expect(missingPackage).toBe(true);
+      expect(plan).toBeNull();
+    });
+
+    it('reports a missing schedule instead of persisting an empty plan when the package has none', () => {
+      const catalogWithoutSchedule = { packages: [{ id: '1', name: 'IVF+ED+SM', listedPrice: 40000, currency: 'EUR', children: ['1', '2'] }] };
+      const { plan, missingPackage, missingSchedule } = buildExpectedExpensesPlanFromRawGroups(rawGroups, { catalog: catalogWithoutSchedule });
+      expect(missingPackage).toBe(false);
+      expect(missingSchedule).toBe(true);
       expect(plan).toBeNull();
     });
   });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -380,6 +380,14 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
     const resolvedChildren = children.map(child => resolveServiceRow(child, catalogItemsById, priceContext));
     const childrenTotal = roundMoney(resolvedChildren.reduce((sum, row) => sum + (Number(row.price) || 0), 0));
     const hasPriceOverride = entry.priceOverride !== undefined && entry.priceOverride !== null;
+    // The billed price is the package's own listed price (a deliberately curated catalog figure),
+    // not the sum of whatever line items happen to be attached - that sum is only a reference for
+    // the admin to sanity-check budget coverage (see childrenTotal below), and is only ever billed
+    // when the package's listed price can't be resolved at all.
+    const listedPriceAmount = pkg
+      ? resolveBudgetPriceAmount(pkg.listedPrice, { ...priceContext, itemsById: catalogItemsById })
+      : null;
+    const defaultPrice = listedPriceAmount == null ? childrenTotal : roundMoney(listedPriceAmount);
     return {
       key: entry.id,
       id: entry.id,
@@ -389,7 +397,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       isCustomized: Boolean(entry.customized),
       name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
       description: entry.description ?? pkg?.description ?? '',
-      price: hasPriceOverride ? roundMoney(entry.priceOverride) : childrenTotal,
+      price: hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,
       childrenTotal,
       hasPriceOverride,
       children: resolvedChildren,

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -282,6 +282,23 @@ describe('invoiceCatalogUtils', () => {
       expect(resolveServiceRow(renamed, catalogItemsById, { packagesById }).name).toBe('Custom bundle for Amny');
     });
 
+    it('defaults an unoverridden package row to its catalog listed price, not the sum of its children', () => {
+      const catalogItemsById = new Map([
+        ['1', { id: '1', name: 'Consultation', price: 300 }],
+        ['2', { id: '2', name: 'Legal support', price: 700 }],
+      ]);
+      // The catalog's own listed price (40000) deliberately doesn't match the sum of these two
+      // sample children (1000) - childrenTotal is only a reference figure for the admin to check
+      // budget coverage, it must never itself be billed unless the price is explicitly overridden.
+      const packagesById = new Map([['p1', { id: 'p1', name: 'Full program', listedPrice: 40000, children: ['1', '2'] }]]);
+      const pkg = makeCatalogPackageEntry({ id: 'p1', children: ['1', '2'] });
+
+      const row = resolveServiceRow(pkg, catalogItemsById, { packagesById });
+      expect(row.price).toBe(40000);
+      expect(row.childrenTotal).toBe(1000);
+      expect(row.hasPriceOverride).toBe(false);
+    });
+
     it('an explicit package price override replaces the children total, which is still exposed for reference', () => {
       const catalogItemsById = new Map([['1', { id: '1', name: 'Consultation', price: 300 }]]);
       const pkg = setEntryField(makeCatalogPackageEntry({ id: 'p1', children: ['1'] }), 'price', 250);


### PR DESCRIPTION
- Never fall back to a raw formula-price string when recalculating a
  schedule or seeding a percent-of-package row; block with a toast
  instead of silently zeroing the row (both create and recalculate paths
  now share getResolvedExpectedExpensesPackage).
- Migrate legacy scheduledAmount milestones into a fixed custom row
  instead of a percent-of-package row, so the amount survives even if
  the package has since been removed from the catalog.
- Keep 4 decimal places when seeding a percent-of-package row from a
  schedule payment, so resolving it back to euros lands on the same
  cent instead of drifting.
- Treat a raw expected-expenses import whose package has no payment
  schedule as a failure (same "no payment schedule" error as manual
  creation) instead of persisting an empty-milestone plan.
- Block invoice/expected-expenses PDF generation while a percent-of-
  package row's package price formula is still resolving, matching the
  existing guard for formula-priced catalog items.
- Default an un-overridden package row's billed price to the package's
  own catalog listed price instead of the sum of its currently attached
  children - that sum is only a budget-reference figure, never itself
  billed unless the admin explicitly overrides the price.
- Package Invoice PDF: scale the payment-schedule table to the actual
  billed package price so it never disagrees with the invoice total,
  shorten its column header instead of the full package name + price,
  and drop the redundant "Confirmed for this case" per-row note.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EdrDXzCuyNtF5ddNnCuYae