### PR TITLE
Fix float-noise rounding root cause and make Beneficiary/Payer fields vertical

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -17,7 +17,7 @@ import {
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
-import { formatEuroSmart, getVisibleSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
+import { formatEuroSmart, getVisibleSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isAdminUid } from 'utils/accessLevel';
 import {
@@ -389,6 +389,16 @@ const StackedFieldRow = styled.div`
   }
 `;
 
+// Groups one payer/customer's fields together (name/address, each its own StackedFieldRow) with a
+// heavier separator between customers than the light one between fields of the same customer.
+const CustomerBlock = styled.div`
+  padding: 8px 0;
+
+  & + & {
+    border-top: 1px solid var(--km-border);
+  }
+`;
+
 const StackedFieldHeader = styled.div`
   display: flex;
   align-items: center;
@@ -701,7 +711,7 @@ const ServiceLineRow = ({
 }) => {
   const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
   const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
-  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(row.priceLabel || String(row.price ?? ''));
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(row.priceLabel || String(roundToCents(row.price) ?? ''));
   const [descriptionOpen, setDescriptionOpen] = useState(false);
 
   if (row.kind === 'percent') {
@@ -947,7 +957,7 @@ const PackageEntryCard = ({
 }) => {
   const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
   const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
-  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(row.price ?? ''));
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(roundToCents(row.price) ?? ''));
   const [showPicker, setShowPicker] = useState(false);
   const [query, setQuery] = useState('');
   const [customName, setCustomName] = useState('');
@@ -2356,46 +2366,61 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   </FieldRow>
                   {activeBeneficiary ? (
                     <>
-                      <FieldRow>
-                        <FieldTag>Title</FieldTag>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>Title</StackedFieldTag>
+                        </StackedFieldHeader>
                         <AutoTextArea
+                          style={{ width: '100%' }}
                           value={activeBeneficiary.title || ''}
                           onChange={event => updateActiveBeneficiaryField('title', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('title', event.target.value)}
                         />
-                      </FieldRow>
-                      <FieldRow>
-                        <FieldTag>Address</FieldTag>
+                      </StackedFieldRow>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>Address</StackedFieldTag>
+                        </StackedFieldHeader>
                         <AutoTextArea
+                          style={{ width: '100%' }}
                           value={activeBeneficiary.address || ''}
                           onChange={event => updateActiveBeneficiaryField('address', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('address', event.target.value)}
                         />
-                      </FieldRow>
-                      <FieldRow>
-                        <FieldTag>IBAN</FieldTag>
+                      </StackedFieldRow>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>IBAN</StackedFieldTag>
+                        </StackedFieldHeader>
                         <AutoTextArea
+                          style={{ width: '100%' }}
                           value={activeBeneficiary.iban || ''}
                           onChange={event => updateActiveBeneficiaryField('iban', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('iban', event.target.value)}
                         />
-                      </FieldRow>
-                      <FieldRow>
-                        <FieldTag>Bank name</FieldTag>
+                      </StackedFieldRow>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>Bank name</StackedFieldTag>
+                        </StackedFieldHeader>
                         <AutoTextArea
+                          style={{ width: '100%' }}
                           value={activeBeneficiary.bankName || ''}
                           onChange={event => updateActiveBeneficiaryField('bankName', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('bankName', event.target.value)}
                         />
-                      </FieldRow>
-                      <FieldRow>
-                        <FieldTag>SWIFT code</FieldTag>
+                      </StackedFieldRow>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>SWIFT code</StackedFieldTag>
+                        </StackedFieldHeader>
                         <AutoTextArea
+                          style={{ width: '100%' }}
                           value={activeBeneficiary.swiftCode || ''}
                           onChange={event => updateActiveBeneficiaryField('swiftCode', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('swiftCode', event.target.value)}
                         />
-                      </FieldRow>
+                      </StackedFieldRow>
                       <StackedFieldRow>
                         <StackedFieldHeader>
                           <StackedFieldTag>Payment purpose</StackedFieldTag>
@@ -2435,24 +2460,38 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   </PanelHeading>
                   <PanelNote>{`Payer: ${payerName || '—'} · ${caseTitle}`}</PanelNote>
                   {data.customers.map((customer, index) => (
-                    <FieldRow key={`customer-${index}`}>
-                      <FieldTag>Customer {index + 1}</FieldTag>
-                      <AutoTextArea
-                        placeholder="Name"
-                        value={customer.name || ''}
-                        onChange={event => updateCustomerField(index, 'name', event.target.value)}
-                        onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
-                      />
-                      <AutoTextArea
-                        placeholder="Address / country"
-                        value={customer.address || ''}
-                        onChange={event => updateCustomerField(index, 'address', event.target.value)}
-                        onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
-                      />
-                      <IconDangerButton type="button" onClick={() => removeCustomer(index)} title="Remove customer" aria-label="Remove customer">
-                        <FaTrash />
-                      </IconDangerButton>
-                    </FieldRow>
+                    <CustomerBlock key={`customer-${index}`}>
+                      <StackedFieldHeader>
+                        <StackedFieldTag>Customer {index + 1}</StackedFieldTag>
+                        <IconDangerButton type="button" onClick={() => removeCustomer(index)} title="Remove customer" aria-label="Remove customer">
+                          <FaTrash />
+                        </IconDangerButton>
+                      </StackedFieldHeader>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>Name</StackedFieldTag>
+                        </StackedFieldHeader>
+                        <AutoTextArea
+                          style={{ width: '100%' }}
+                          placeholder="Name"
+                          value={customer.name || ''}
+                          onChange={event => updateCustomerField(index, 'name', event.target.value)}
+                          onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
+                        />
+                      </StackedFieldRow>
+                      <StackedFieldRow>
+                        <StackedFieldHeader>
+                          <StackedFieldTag>Address</StackedFieldTag>
+                        </StackedFieldHeader>
+                        <AutoTextArea
+                          style={{ width: '100%' }}
+                          placeholder="Address / country"
+                          value={customer.address || ''}
+                          onChange={event => updateCustomerField(index, 'address', event.target.value)}
+                          onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
+                        />
+                      </StackedFieldRow>
+                    </CustomerBlock>
                   ))}
                 </>
               ) : null}

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -114,6 +114,15 @@ export const normalizeBudgetPriceInput = raw => {
   return text;
 };
 
+// Rounds to the nearest cent - the one point every price resolution path (plain numbers, NBU-rate
+// formulas, USD conversion) funnels through, so float noise from division/multiplication never
+// reaches a display or a further computation (spec: single shared rounding function, applied
+// everywhere a computed amount is produced, not just at the final formatMoney/formatEuroSmart call).
+export const roundToCents = value => {
+  const amount = Number(value);
+  return Number.isFinite(amount) ? Math.round(amount * 100) / 100 : amount;
+};
+
 // Resolves a stored price to a EUR number: plain numbers pass through, formulas
 // are evaluated with the NBU rates and idNN references to other items.
 export const resolveBudgetPriceAmount = (raw, context = {}, seenIds = new Set()) => {
@@ -121,11 +130,11 @@ export const resolveBudgetPriceAmount = (raw, context = {}, seenIds = new Set())
   if (parsed.isEmpty) return null;
   if (!parsed.isFormula) {
     const numeric = Number(parsed.expression.replace(',', '.'));
-    return Number.isFinite(numeric) ? numeric : null;
+    return Number.isFinite(numeric) ? roundToCents(numeric) : null;
   }
   const { itemsById, rates } = context;
   try {
-    return evaluateBudgetPriceFormula(parsed.expression, name => {
+    return roundToCents(evaluateBudgetPriceFormula(parsed.expression, name => {
       const lower = String(name).toLowerCase();
       if (lower === 'eur') return rates?.eur;
       if (lower === 'usd') return rates?.usd;
@@ -139,7 +148,7 @@ export const resolveBudgetPriceAmount = (raw, context = {}, seenIds = new Set())
       nextSeen.add(itemId);
       const amount = resolveBudgetPriceAmount(item.price, context, nextSeen);
       return amount == null ? NaN : amount;
-    });
+    }));
   } catch (error) {
     return null;
   }
@@ -214,7 +223,7 @@ export const getItemDisplayAmount = (item, context = {}) => {
   const basePrice = resolveBudgetPriceAmount(item?.price, context);
   if (basePrice == null) return null;
   const isUsd = USD_ITEM_IDS.has(String(item?.id || '').trim());
-  return isUsd ? basePrice * USD_TO_EUR_RATE : basePrice;
+  return isUsd ? roundToCents(basePrice * USD_TO_EUR_RATE) : basePrice;
 };
 
 export const getItemDisplayPrice = (item, context = {}) => {

--- a/src/components/budgetCatalogUtils.test.js
+++ b/src/components/budgetCatalogUtils.test.js
@@ -18,6 +18,24 @@ describe('budgetCatalogUtils', () => {
     expect(getItemDisplayAmount(item)).toBeCloseTo(23000 * USD_TO_EUR_RATE);
   });
 
+  // P0 bug: the USD->EUR conversion (rate 0.92) leaks float noise like 18514.292958... into the
+  // displayed/stored price unless it's rounded to the cent right where it's produced - e.g.
+  // "Compensation to surrogate mother for the program" (id22-style USD item).
+  it('rounds the USD->EUR conversion to the cent, never leaking float noise', () => {
+    const item = { id: 22, price: 20124.23 };
+    const amount = getItemDisplayAmount(item);
+    expect(amount).toBe(Math.round(amount * 100) / 100);
+    expect(String(amount).split('.')[1]?.length ?? 0).toBeLessThanOrEqual(2);
+  });
+
+  // Same guarantee for a formula-priced item (division/multiplication by NBU rates) - resolved
+  // amounts must never carry more than 2 decimal digits, whether or not USD conversion applies.
+  it('rounds formula-resolved prices to the cent', () => {
+    const context = { rates: { eur: 41.7123456, usd: 38.919283 } };
+    const amount = resolveBudgetPriceAmount('=1000/EUR*7', context);
+    expect(amount).toBe(Math.round(amount * 100) / 100);
+  });
+
   it('keeps EUR items unchanged', () => {
     expect(getItemDisplayAmount({ id: 1, price: 5000 })).toBe(5000);
   });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -413,7 +413,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       isCustomized: true,
       name: entry.name || '',
       description: entry.description || '',
-      price: Number(entry.price) || 0,
+      price: roundMoney(entry.price),
       ...(entry.priceLabel ? { priceLabel: entry.priceLabel } : {}),
     };
   }
@@ -430,7 +430,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
     isCustomized: Boolean(entry?.customized),
     name: entry?.name ?? item?.name ?? `Unknown catalog service (id${catalogId})`,
     description: entry?.description ?? item?.description ?? '',
-    price: entry?.price ?? (catalogAmount == null ? 0 : catalogAmount),
+    price: entry?.price !== undefined && entry?.price !== null ? roundMoney(entry.price) : roundMoney(catalogAmount),
   };
 };
 

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -256,8 +256,20 @@ describe('invoiceCatalogUtils', () => {
         ['22', { id: '22', name: 'USD compensation', price: 23000 }],
         ['30', { id: '30', name: 'Formula price', price: '=USD/EUR*100' }],
       ]);
-      expect(resolveServiceRow(makeCatalogItemEntry('22'), catalogItemsById).price).toBeCloseTo(21160);
-      expect(resolveServiceRow(makeCatalogItemEntry('30'), catalogItemsById, { rates: { usd: 40, eur: 50 } }).price).toBeCloseTo(80);
+      expect(resolveServiceRow(makeCatalogItemEntry('22'), catalogItemsById).price).toBe(21160);
+      expect(resolveServiceRow(makeCatalogItemEntry('30'), catalogItemsById, { rates: { usd: 40, eur: 50 } }).price).toBe(80);
+    });
+
+    // P0 bug repro: "Compensation to surrogate mother for the program" is a USD-priced catalog item
+    // (surrogate-mother-compensation is in budgetCatalogUtils.USD_ITEM_IDS) - its price must resolve
+    // to an exact cents amount (e.g. via a plain Number equality check), never a float like
+    // 18514.292958... leaking through to the invoice row / price input.
+    it('never leaks float noise for a USD-priced surrogate-mother-compensation row', () => {
+      const catalogItemsById = new Map([
+        ['surrogate-mother-compensation', { id: 'surrogate-mother-compensation', name: 'Compensation to surrogate mother for the program', price: 20124.23 }],
+      ]);
+      const row = resolveServiceRow(makeCatalogItemEntry('surrogate-mother-compensation'), catalogItemsById);
+      expect(row.price).toBe(Math.round(row.price * 100) / 100);
     });
 
     it('flags a catalog reference that no longer exists', () => {


### PR DESCRIPTION
Round every computed EUR amount at the point it's derived (resolveBudgetPriceAmount,
USD->EUR conversion, invoice row resolution), not only at final display formatting -
this was leaking floats like 18514.292958... into price inputs for formula/USD-priced
catalog items (e.g. surrogate mother compensation). Also stopped the Invoice Builder's
custom/item price drafts from stringifying an unrounded row.price directly.

Restructured Beneficiary (title/address/IBAN/bank name/SWIFT) and Payer (customer
name/address) fields to the existing label-on-top, full-width-value-below layout
(previously only used for Payment purpose), so both blocks are vertical and
structured identically instead of side-by-side.

Verified against the master checklist: Subtotal package-exclusion, the "% of
package" UI control, and the package-child name wrapping fix were already correct
in the current code (confirmed via unit tests and a live rendered snapshot) - only
the rounding and Beneficiary/Payer layout items were still broken.