### PR TITLE
Fix % of package default, restore Invoice payment caveats, fix Expected Expenses PDF QA gate

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -210,16 +210,29 @@ async function checkExpectedExpenses() {
   checkStringsRoundTrip('Expected Expenses', pagesText, [
     NAMES[32], NAMES[61], NAMES[62], NAMES[63], NAMES[64],
   ]);
-  if (pagesText.length !== plan.milestones.length) {
-    fail(`Expected Expenses: expected exactly one page per milestone (${plan.milestones.length}), got ${pagesText.length} - the Budget-duplication regression may be back`);
+
+  // This document is one flowing, auto-paginating <Page> (spec's "Consolidate UKRCOM document
+  // system" brief) - the programme overview (included services + payment schedule) renders exactly
+  // once at the top, followed by one compact "Payment #N" block per milestone. So the regression
+  // to guard against isn't a fixed page count (physical page count depends on how much content
+  // fits per sheet), it's the overview or any milestone block being duplicated - the original
+  // "Budget-duplication" bug this document was fixed for.
+  const combined = pagesText.join('\n');
+  const countOccurrences = (text, pattern) => (text.match(pattern) || []).length;
+
+  const overviewCount = countOccurrences(combined, /Included in this programme/gi);
+  if (overviewCount !== 1) {
+    fail(`Expected Expenses: "Included in this programme" should appear exactly once (found ${overviewCount}) - the Budget-duplication regression may be back`);
   }
-  // Every milestone copy must point back to the Budget document instead of repeating it.
-  pagesText.forEach((text, index) => {
-    if (!/full programme details are in your Budget document/i.test(text)) {
-      fail(`Expected Expenses page ${index + 1}: missing the "full details in your Budget" pointer`);
-    }
-    if (/Included in this programme/i.test(text) || /^Payment schedule$/im.test(text)) {
-      fail(`Expected Expenses page ${index + 1}: repeats the full programme overview/payment schedule again`);
+  const scheduleHeadingCount = countOccurrences(combined, /^Payment schedule$/gim);
+  if (scheduleHeadingCount !== 1) {
+    fail(`Expected Expenses: "Payment schedule" heading should appear exactly once (found ${scheduleHeadingCount}) - the Budget-duplication regression may be back`);
+  }
+  plan.milestones.forEach((milestone, index) => {
+    const marker = new RegExp(`Payment #${index + 1}\\s*[—-]\\s*${milestone.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'g');
+    const count = countOccurrences(combined, marker);
+    if (count !== 1) {
+      fail(`Expected Expenses: "Payment #${index + 1} — ${milestone.title}" block should appear exactly once (found ${count})`);
     }
   });
 }

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1803,8 +1803,24 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     setNewCustomServicePrice('');
   };
 
+  // Never defaults to 0% or 100% - that's just swapping one wrong constant for another. The
+  // starting value is the package's next unused Payment Schedule milestone (so a first "% of
+  // package" row on a fresh invoice matches what the catalog actually expects to be billed at
+  // this stage); once every schedule step already has a row, it falls back to whatever share of
+  // the package price is still unbilled.
   const addPercentServiceEntry = packageId => {
-    addEntryToInvoice(makePercentOfPackageEntry(packageId, 0), 'Service added.');
+    const pkg = catalogPackagesById.get(String(packageId));
+    const schedule = pkg ? resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg) : null;
+    const listedPriceAmount = pkg ? resolveBudgetPriceAmount(pkg.listedPrice, priceContext) : null;
+    const existingPercentRows = data.invoiceServices.filter(
+      entry => entry.kind === 'percent' && String(entry.packageId) === String(packageId),
+    );
+    const usedPercentTotal = existingPercentRows.reduce((sum, entry) => sum + (Number(entry.percent) || 0), 0);
+    const nextPayment = schedule?.payments?.[existingPercentRows.length];
+    const defaultPercent = (nextPayment && listedPriceAmount)
+      ? Math.round((Number(nextPayment.amount || 0) / listedPriceAmount) * 1e6) / 1e4
+      : Math.max(0, Math.round((100 - usedPercentTotal) * 100) / 100);
+    addEntryToInvoice(makePercentOfPackageEntry(packageId, defaultPercent), 'Service added.');
   };
 
   const addRecentServiceEntry = entry => addEntryToInvoice(cloneEntryWithNewId(entry), 'Service added.');

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -169,6 +169,43 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // Regression: "% of package" used to always default to 0% (previously always 100%) with no
+  // link to the catalog's own Payment Schedule - an admin had to know the right number by heart.
+  // It should now seed the first click from the package's first unbilled schedule milestone
+  // (150/250 = 60% here), not a hardcoded constant.
+  it('"% of package" defaults to the package\'s next unused Payment Schedule share, not 0% or 100%', async () => {
+    const root = mount();
+    await flush();
+
+    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    await act(async () => { findButton('Full program').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const percentButton = findButton('% of package');
+    expect(percentButton).toBeTruthy();
+    await act(async () => { percentButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    let lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    let percentEntry = lastServicesCall[1].find(entry => entry.kind === 'percent');
+    expect(percentEntry.percent).toBe(60);
+
+    // A second click should seed from the schedule's next step (Final payment: 100/250 = 40%),
+    // not repeat 0%/100% or the same 60% again.
+    await act(async () => { percentButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    const percentEntries = lastServicesCall[1].filter(entry => entry.kind === 'percent');
+    expect(percentEntries).toHaveLength(2);
+    expect(percentEntries[1].percent).toBe(40);
+
+    await act(async () => { root.unmount(); });
+  });
+
   it('deletes a custom service from the invoice', async () => {
     const root = mount();
     await flush();
@@ -218,8 +255,8 @@ describe('InvoiceBuilderPage', () => {
 
       expect(container.innerHTML).toContain('To start the program');
       expect(container.innerHTML).toContain('Final payment');
-      expect(container.innerHTML).toContain('Due: €171.00');
-      expect(container.innerHTML).toContain('Due: €114.00');
+      expect(container.innerHTML).toContain('Due: €171');
+      expect(container.innerHTML).toContain('Due: €114');
 
       const persistedCalls = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses');
       expect(persistedCalls.length).toBeGreaterThan(0);
@@ -255,7 +292,7 @@ describe('InvoiceBuilderPage', () => {
       await flush();
 
       expect(container.innerHTML).toContain('Deposit for transportation of SM');
-      expect(container.innerHTML).toContain('Due: €513.00');
+      expect(container.innerHTML).toContain('Due: €513');
 
       const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
       expect(plan.milestones[0].services).toHaveLength(2);

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -293,7 +293,13 @@ const InvoicePdfDocument = ({
   // service confirmed for this case that sits outside the standard package.
   const packageRows = rows.filter(row => row.kind === 'package');
   const isPackageInvoice = packageRows.length > 0;
-  const otherRows = isPackageInvoice ? rows.filter(row => row.kind !== 'package') : rows;
+  // A "% of package" row (a programme milestone share) is never mixed into the same table as
+  // custom/catalog services - it prices a slice of the standard package, not a one-off item
+  // confirmed for this case, so it always gets its own section/heading even on a plain milestone
+  // invoice that carries no full package block.
+  const percentRows = rows.filter(row => row.kind === 'percent');
+  const otherRows = rows.filter(row => row.kind !== 'package' && row.kind !== 'percent');
+  const percentDisplayRows = buildDisplayRows(percentRows);
   const displayRows = buildDisplayRows(otherRows);
   // The package entry's own `children` are a frozen name-only snapshot (invoiceCatalogUtils.js) -
   // its payment schedule instead always comes live from the catalog package it was added from, the
@@ -323,31 +329,38 @@ const InvoicePdfDocument = ({
         />
 
         {isPackageInvoice ? (
-          <>
-            {packageRows.map(row => (
-              <PackageBlock key={row.key} row={row} schedule={resolvePackageSchedule(row)} />
-            ))}
-            {displayRows.length ? (
-              <View style={styles.section}>
+          packageRows.map(row => (
+            <PackageBlock key={row.key} row={row} schedule={resolvePackageSchedule(row)} />
+          ))
+        ) : null}
+
+        {percentDisplayRows.length ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>% of package</Text>
+            <Text style={styles.sectionNote}>This invoice bills a share of the standard package's price.</Text>
+            <View style={styles.table}>
+              {percentDisplayRows.map((row, rowIndex) => (
+                <ServiceItemRow key={`${row.key || rowIndex}-${row.number}`} row={row} isFirst={rowIndex === 0} />
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {displayRows.length ? (
+          <View style={styles.section}>
+            {isPackageInvoice || percentDisplayRows.length ? (
+              <>
                 <Text style={styles.sectionTitle}>Additional services outside the package</Text>
                 <Text style={styles.sectionNote}>Confirmed for this case, billed alongside the standard package.</Text>
-                <View style={styles.table}>
-                  {displayRows.map((row, rowIndex) => (
-                    <ServiceItemRow key={`${row.key || rowIndex}-${row.number}`} row={row} isFirst={rowIndex === 0} />
-                  ))}
-                </View>
-              </View>
+              </>
             ) : null}
-          </>
-        ) : (
-          <View style={styles.section}>
             <View style={styles.table}>
               {displayRows.map((row, rowIndex) => (
                 <ServiceItemRow key={`${row.key || rowIndex}-${row.number}`} row={row} isFirst={rowIndex === 0} />
               ))}
             </View>
           </View>
-        )}
+        ) : null}
 
         {/* No extra top margin here - noteRow/totalCard already carry their own spacing (spec §1.4),
             same as the flat layout above where they sit directly under the table with no gap of

--- a/src/components/PaymentDetailsPdfDocument.jsx
+++ b/src/components/PaymentDetailsPdfDocument.jsx
@@ -93,6 +93,24 @@ const styles = StyleSheet.create({
     color: PDF_COLOR.neutralBg,
     marginTop: 4,
   },
+  noteRow: {
+    flexDirection: 'row',
+    marginTop: 14,
+  },
+  noteMark: {
+    width: 16,
+    fontFamily: PDF_FONT.body,
+    fontWeight: 600,
+    fontSize: 8.5,
+    color: PDF_COLOR.neutralSoft,
+  },
+  noteText: {
+    flex: 1,
+    fontFamily: PDF_FONT.body,
+    fontSize: 8.5,
+    lineHeight: 1.45,
+    color: PDF_COLOR.neutralInk,
+  },
 });
 
 const PaymentDetailsPdfDocument = ({
@@ -152,6 +170,22 @@ const PaymentDetailsPdfDocument = ({
             <Text style={styles.amountLabel}>Amount due</Text>
             <Text style={styles.amountValue}>{formatMoney(amountDue)}</Text>
             <Text style={styles.amountSub}>{sanitizePdfText(`See Invoice No. ${invoiceNumber || ''} for the full breakdown.`)}</Text>
+          </View>
+
+          {/* These payment caveats used to live on the Invoice PDF itself - they belong here,
+              next to the wire instructions they actually govern, not on the itemized invoice. */}
+          <View style={styles.noteRow}>
+            <Text style={styles.noteMark}>*</Text>
+            <Text style={styles.noteText}>
+              Purpose of the payment must be exactly like in invoice.
+            </Text>
+          </View>
+          <View style={styles.noteRow}>
+            <Text style={styles.noteMark}>**</Text>
+            <Text style={styles.noteText}>
+              Please make sure you pay the whole amount due - any bank transfer fees on your side must not be
+              deducted from it.
+            </Text>
           </View>
         </View>
 


### PR DESCRIPTION
- InvoiceBuilderPage: "% of package" quick-add no longer defaults to a hardcoded
  0% - it seeds from the package's next unused Payment Schedule milestone (or
  the remaining unbilled share once the schedule is exhausted), so an admin
  never has to guess the right number. Adds regression coverage.
- InvoicePdfDocument: "% of package" rows now render in their own section
  instead of being mixed into "Additional services outside the package".
- PaymentDetailsPdfDocument: restores the two payment caveats ("purpose must
  match the invoice exactly", "pay the full amount due") that were dropped
  without replacement when Payment Details was split out of the Invoice PDF.
- pdfQaCheck.js: the Expected Expenses regression checks still asserted the
  pre-redesign one-page-per-milestone layout; updated them to guard against
  the actual regression class (the programme overview or a milestone block
  being duplicated) under the current single-flowing-document design, and
  fixed two stale "€X.00" test assertions left over from the rounding fix.

Also verified (no code changes needed - already correct): Subtotal/rounding
fix, package-child name wrapping, Beneficiary/Payer vertical layout, 3-line
service rows, editable Purpose of payment, collapsed milestone accordions,
UKRCOM design tokens/theme-color, removed PDF Preview section, Expected
Expenses package-name/percent/title deduplication and per-milestone tax, and
that the Invoice Builder never writes to budget/*.