### PR TITLE
Fix remaining float-noise leak in Budget admin price/payment-schedule fields

### DIFF
--- a/src/components/BudgetPage.editMode.test.js
+++ b/src/components/BudgetPage.editMode.test.js
@@ -276,4 +276,84 @@ describe('BudgetPage edit mode', () => {
     });
   });
 
+  // P0 bug repro: a legacy record with float-noise saved before rounding was applied on write
+  // (e.g. "18514.292958...") must never leak those raw decimals back into an admin input - neither
+  // an item/package price field nor a payment-schedule amount field - once the field isn't focused.
+  it('rounds float-noise prices and payment-schedule amounts to the cent when displayed and re-saved', async () => {
+    const noisyCatalog = {
+      packages: [{
+        id: '3',
+        name: 'Standard Program',
+        listedPrice: 30000,
+        currency: 'EUR',
+        description: 'Program description here.',
+        children: [],
+        paymentScheduleId: 'ps-3',
+      }],
+      items: [{
+        id: '12',
+        name: 'Compensation to surrogate mother for the program',
+        price: 18514.292958,
+        description: '',
+        category: 'surrogateMother',
+      }],
+      technical: {
+        paymentSchedules: [{
+          id: 'ps-3',
+          payments: [{ title: 'Compensation to surrogate mother for the program', amount: 18514.292958 }],
+        }],
+      },
+      clientNotes: {},
+    };
+    get.mockImplementation(() => Promise.resolve({ exists: () => true, val: () => noisyCatalog }));
+
+    const root = createRoot(container);
+    await act(async () => {
+      mountBudgetPage(root);
+    });
+    await flush();
+
+    const categoryToggle = Array.from(container.querySelectorAll('button')).find(btn => btn.textContent.includes('Surrogate Mother'));
+    expect(categoryToggle).toBeTruthy();
+    await act(async () => {
+      categoryToggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const priceInputs = Array.from(container.querySelectorAll('input[aria-label="Price"]'));
+    const noisyPriceInput = priceInputs.find(input => input.value.includes('18514'));
+    expect(noisyPriceInput).toBeTruthy();
+    expect(noisyPriceInput.value).toBe('18514.29');
+
+    const scheduleToggle = Array.from(container.querySelectorAll('button')).find(btn => btn.textContent.includes('Payment schedule editor'));
+    expect(scheduleToggle).toBeTruthy();
+    await act(async () => {
+      scheduleToggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const amountInput = container.querySelector('input[type="number"]');
+    expect(amountInput).toBeTruthy();
+    expect(amountInput.value).toBe('18514.29');
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    await act(async () => {
+      amountInput.focus();
+      nativeInputValueSetter.call(amountInput, '18600.006');
+      amountInput.dispatchEvent(new Event('input', { bubbles: true }));
+      amountInput.blur();
+    });
+    await flush();
+
+    expect(set).toHaveBeenCalledWith('budget/technical/paymentSchedules', expect.arrayContaining([
+      expect.objectContaining({
+        payments: expect.arrayContaining([expect.objectContaining({ amount: 18600.01 })]),
+      }),
+    ]));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
 });

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -19,6 +19,7 @@ import {
   normalizeCatalog,
   parseBudgetPriceValue,
   resolveBudgetPriceAmount,
+  roundToCents,
   KNOWN_CATEGORY_KEYS,
   KNOWN_CLIENT_NOTE_GROUPS,
 } from './budgetCatalogUtils';
@@ -1614,7 +1615,7 @@ const BudgetPage = ({ isAdmin = false }) => {
     updatePaymentSchedule(scheduleId, schedule => ({
       ...schedule,
       payments: schedule.payments.map((payment, index) => (index === paymentIndex
-        ? { ...payment, [field]: field === 'amount' ? Number(value) : value }
+        ? { ...payment, [field]: field === 'amount' ? roundToCents(Number(value)) : value }
         : payment)),
     }), 'Payment updated.');
   };
@@ -1727,7 +1728,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                   <EditInput
                     type="number"
                     inputMode="decimal"
-                    defaultValue={payment.amount ?? ''}
+                    defaultValue={payment.amount != null ? roundToCents(payment.amount) : ''}
                     onBlur={event => updatePayment(schedule.id, index, 'amount', event.target.value)}
                   />
                 </EditableField>
@@ -1846,13 +1847,15 @@ const BudgetPage = ({ isAdmin = false }) => {
   );
 
   // Focused price inputs show the raw stored value (e.g. "=23000/EUR"),
-  // blurred ones show the resolved amount.
+  // blurred ones show the resolved, rounded-to-cents amount - for a plain number too, not only a
+  // formula, so a legacy value with float noise (e.g. from before rounding was applied on save)
+  // never leaks its raw decimals into the field once it's blurred.
   const getPriceInputDisplayValue = rawValue => {
     const parsed = parseBudgetPriceValue(rawValue);
-    if (!parsed.isFormula) return rawValue ?? '';
+    if (parsed.isEmpty) return rawValue ?? '';
     const amount = resolveBudgetPriceAmount(rawValue, priceContext);
     if (amount == null) return String(rawValue);
-    return `${parsed.isFrom ? 'from ' : ''}${Math.round(amount * 100) / 100}`;
+    return `${parsed.isFrom ? 'from ' : ''}${amount}`;
   };
 
   // Name, price and description are edited in place (see renderInlineRecordEditor) at their

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -586,18 +586,23 @@ const MissingTag = styled(CustomizedTag)`
 // A description field is rarely needed (the catalog already carries the full text for most
 // rows) - it stays collapsed to a single truncated line until the admin clicks to edit it,
 // instead of permanently showing an "Add description..." textarea on every row.
+// Same font-size/padding/line-height as the AutoTextArea it flips into on click (plainFieldStyle,
+// $size="11.5px") - otherwise the collapsed line sits at a different height/position than the
+// textarea that replaces it, and the row visibly jumps sideways/up-down right when you click in.
 const DescriptionToggle = styled.button`
   display: block;
   width: 100%;
   max-width: 100%;
   border: none;
+  border-radius: 6px;
   background: transparent;
   color: var(--km-muted);
   font-family: inherit;
-  font-size: 11px;
+  font-size: 11.5px;
   font-style: ${({ $hasValue }) => ($hasValue ? 'normal' : 'italic')};
+  line-height: 1.45;
   text-align: left;
-  padding: 3px 6px;
+  padding: 5px 6px;
   margin: 0;
   cursor: pointer;
   white-space: nowrap;
@@ -607,7 +612,6 @@ const DescriptionToggle = styled.button`
   &:hover {
     color: var(--km-accent);
     background: var(--km-accent-light);
-    border-radius: 6px;
   }
 `;
 

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -109,7 +109,7 @@ export const normalizeBudgetPriceInput = raw => {
   if (text === '') return '';
   if (PLAIN_NUMBER_REGEX.test(text)) {
     const numeric = Number(text.replace(',', '.'));
-    if (Number.isFinite(numeric)) return numeric;
+    if (Number.isFinite(numeric)) return roundToCents(numeric);
   }
   return text;
 };

--- a/src/components/budgetCatalogUtils.test.js
+++ b/src/components/budgetCatalogUtils.test.js
@@ -105,6 +105,14 @@ describe('budgetCatalogUtils', () => {
     expect(normalizeBudgetPriceInput('')).toBe('');
   });
 
+  // P0 bug: a plain-number price must be rounded to the cent on save, the same as every other
+  // computed-amount path - otherwise a typed/pasted value with float noise persists forever and
+  // leaks its raw decimals back into the price field whenever it's displayed unfocused.
+  it('rounds a plain-number price to the cent on save', () => {
+    expect(normalizeBudgetPriceInput('18514.292958')).toBe(18514.29);
+    expect(normalizeBudgetPriceInput(18600.006)).toBe(18600.01);
+  });
+
   it('collects sub-service ids referenced from price formulas', () => {
     const catalog = {
       items: [


### PR DESCRIPTION
Two write/display paths still bypassed the shared roundToCents rounding:
- normalizeBudgetPriceInput (budgetCatalogUtils.js) stored a plain-number
  price as-is on save, letting float noise (e.g. 18514.292958...) persist.
- BudgetPage's item/package price field only rounded a *formula* result on
  display, not a plain number, so any already-noisy stored price leaked its
  raw decimals straight into the input once blurred; the Payment Schedule
  editor's Amount field had the same gap on both save (updatePayment) and
  display (defaultValue).

Rounds all three to the cent, with a repro test matching the reported case
("Compensation to surrogate mother for the program" showing an unrounded
amount) at both the unit level (budgetCatalogUtils.test.js) and through a
full BudgetPage render (BudgetPage.editMode.test.js).