### PR TITLE
Add scoped Invoice Builder access separate from full admin

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -23,6 +23,7 @@ export const App = () => {
   const [isAdmin, setIsAdmin] = useState(null);
   const [canAccessAdd, setCanAccessAdd] = useState(false);
   const [canAccessMatching, setCanAccessMatching] = useState(false);
+  const [canAccessInvoices, setCanAccessInvoices] = useState(false);
   const [isAccessResolved, setIsAccessResolved] = useState(false);
   // console.log('isLoggedIn :>> ', isLoggedIn);
 
@@ -70,6 +71,7 @@ export const App = () => {
         setIsAdmin(access.isAdmin);
         setCanAccessAdd(access.canAccessAdd);
         setCanAccessMatching(access.canAccessMatching);
+        setCanAccessInvoices(access.canAccessInvoices);
         localStorage.setItem('accessLevel', accessLevel);
         localStorage.setItem('userRole', userRole);
         setIsAccessResolved(true);
@@ -80,6 +82,7 @@ export const App = () => {
         setIsAdmin(false);
         setCanAccessAdd(false);
         setCanAccessMatching(false);
+        setCanAccessInvoices(false);
         setIsAccessResolved(true);
       }
     });
@@ -100,7 +103,7 @@ export const App = () => {
       {isAdmin && <Route path="/medications/:userId" element={<MedicationsPage />} />}
       {isAdmin && <Route path="/flow" element={<FlowManager ownerId={auth.currentUser?.uid} />} />}
       {isAdmin && <Route path="/budget" element={<BudgetPage isAdmin={isAdmin} />} />}
-      {isAdmin && <Route path="/invoices" element={<InvoiceBuilderPage isAdmin={isAdmin} />} />}
+      {canAccessInvoices && <Route path="/invoices" element={<InvoiceBuilderPage isAdmin={canAccessInvoices} />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -19,7 +19,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
 import { formatEuroSmart, getVisibleSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
-import { isAdminUid } from 'utils/accessLevel';
+import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import {
   addCatalogChildToPackage,
   addCustomChildToPackage,
@@ -1406,7 +1406,7 @@ const ChipRow = styled.div`
 `;
 
 const InvoiceBuilderPage = ({ isAdmin = false }) => {
-  const isInvoiceAdmin = Boolean(isAdmin) || isAdminUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
+  const isInvoiceAdmin = Boolean(isAdmin) || isInvoiceBuilderUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
     && new URLSearchParams(window.location.search).get('admin') === '1');
 
   const [data, setData] = useState(() => normalizeInvoiceData(null));

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -49,7 +49,7 @@ jest.mock('firebase/database', () => ({
 }));
 
 jest.mock('utils/accessLevel', () => ({
-  isAdminUid: () => true,
+  isInvoiceBuilderUid: () => true,
 }));
 
 describe('InvoiceBuilderPage', () => {

--- a/src/utils/accessLevel.js
+++ b/src/utils/accessLevel.js
@@ -2,6 +2,11 @@ export const ADMIN_UIDS = ['3LiD7JGCJTSJoVMU7fdR1ZrcIZH2', '0ghb1LphfASV0Y3b6J01
 
 export const isAdminUid = uid => !!uid && ADMIN_UIDS.includes(uid);
 
+// UIDs granted Invoice Builder access without full admin rights.
+export const INVOICE_BUILDER_UIDS = ['S0VhDLCYjuTFDNLalRa85u7fPcg2'];
+
+export const isInvoiceBuilderUid = uid => !!uid && (isAdminUid(uid) || INVOICE_BUILDER_UIDS.includes(uid));
+
 const normalize = level =>
   String(level || '')
     .toLowerCase()
@@ -44,10 +49,12 @@ export const resolveAccess = ({ uid, accessLevel, role, userRole } = {}) => {
   const isAdmin = isAdminUid(uid);
   const canAccessMatching = isAdmin || canAccessMatchingByLevel(accessLevel) || canAccessMatchingByRole({ role, userRole });
   const canAccessAdd = isAdmin || canAccessAddByLevel(accessLevel);
+  const canAccessInvoices = isInvoiceBuilderUid(uid);
 
   return {
     isAdmin,
     canAccessMatching,
     canAccessAdd,
+    canAccessInvoices,
   };
 };

--- a/src/utils/accessLevel.test.js
+++ b/src/utils/accessLevel.test.js
@@ -1,5 +1,6 @@
 import {
   ADMIN_UIDS,
+  INVOICE_BUILDER_UIDS,
   canAccessMatchingByRole,
   resolveAccess,
 } from './accessLevel';
@@ -27,6 +28,7 @@ describe('accessLevel', () => {
       isAdmin: true,
       canAccessMatching: true,
       canAccessAdd: true,
+      canAccessInvoices: true,
     });
   });
 
@@ -35,6 +37,14 @@ describe('accessLevel', () => {
       isAdmin: false,
       canAccessMatching: true,
       canAccessAdd: false,
+      canAccessInvoices: false,
     });
+  });
+
+  it('grants invoice builder access without full admin rights', () => {
+    const access = resolveAccess({ uid: INVOICE_BUILDER_UIDS[0], accessLevel: '', userRole: '' });
+    expect(access.canAccessInvoices).toBe(true);
+    expect(access.isAdmin).toBe(false);
+    expect(access.canAccessAdd).toBe(false);
   });
 });


### PR DESCRIPTION
Introduces a canAccessInvoices permission (INVOICE_BUILDER_UIDS) so the
/invoices route no longer requires full isAdmin rights, and grants it
to the test account S0VhDLCYjuTFDNLalRa85u7fPcg2.