### PR TITLE
Fix % of package discoverability, description auto-collapse, and icon sizing

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -225,18 +225,20 @@ const DangerButton = styled(SmallButton)`
   }
 `;
 
+// $dense shrinks the button footprint (package-card header cluster wants less height, a package
+// child row's footer cluster wants less width) without touching every other IconButton on the page.
 const iconButtonBase = css`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: ${({ $dense }) => ($dense ? '18px' : '22px')};
+  height: ${({ $dense }) => ($dense ? '18px' : '22px')};
   flex-shrink: 0;
   border: none;
   border-radius: 6px;
   background: transparent;
   color: var(--km-muted);
-  font-size: 10.5px;
+  font-size: ${({ $dense }) => ($dense ? '9px' : '10.5px')};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   opacity: ${({ disabled }) => (disabled ? 0.3 : 1)};
   transition: color 0.15s ease, background 0.15s ease;
@@ -560,8 +562,8 @@ const RowIndex = styled.span`
 const RowActions = styled.div`
   flex: 0 0 auto;
   display: flex;
-  gap: 1px;
-  padding-top: 2px;
+  gap: ${({ $dense }) => ($dense ? '0' : '1px')};
+  padding-top: ${({ $dense }) => ($dense ? '0' : '2px')};
 `;
 
 const CustomizedTag = styled.span`
@@ -763,7 +765,7 @@ const ServiceLineRow = ({
           autoFocus
           onFocus={() => { descriptionEditingRef.current = true; }}
           onChange={event => setDescriptionDraft(event.target.value)}
-          onBlur={() => { descriptionEditingRef.current = false; onCommit('description', descriptionDraft); }}
+          onBlur={() => { descriptionEditingRef.current = false; onCommit('description', descriptionDraft); setDescriptionOpen(false); }}
         />
       ) : (
         <DescriptionToggle type="button" $hasValue={Boolean(row.description)} onClick={() => setDescriptionOpen(true)}>
@@ -785,22 +787,22 @@ const ServiceLineRow = ({
         {row.isCustomized ? <CustomizedTag title="Overridden for this invoice only - the shared budget is unchanged">Custom</CustomizedTag> : null}
         {row.missing ? <MissingTag title="This catalog reference no longer exists">Missing</MissingTag> : null}
         {onReset ? (
-          <IconButton type="button" onClick={onReset} title="Revert to the catalog value" aria-label="Revert to catalog value">
+          <IconButton $dense={isChild} type="button" onClick={onReset} title="Revert to the catalog value" aria-label="Revert to catalog value">
             <FaUndoAlt />
           </IconButton>
         ) : null}
-        <RowActions>
+        <RowActions $dense={isChild}>
           {onMoveUp ? (
-            <IconButton type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move up">
+            <IconButton $dense={isChild} type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move up">
               <FaChevronUp />
             </IconButton>
           ) : null}
           {onMoveDown ? (
-            <IconButton type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move down">
+            <IconButton $dense={isChild} type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move down">
               <FaChevronDown />
             </IconButton>
           ) : null}
-          <IconDangerButton type="button" onClick={onRemove} title={removeTitle} aria-label={removeTitle}>
+          <IconDangerButton $dense={isChild} type="button" onClick={onRemove} title={removeTitle} aria-label={removeTitle}>
             <FaTrash />
           </IconDangerButton>
         </RowActions>
@@ -920,6 +922,34 @@ const CatalogPickerButton = styled.button`
   }
 `;
 
+// A package in the catalog picker offers two ways in, side by side: the full package at its
+// listed price (CatalogPickerButton), or just a share of it billed on this invoice (this button) -
+// so an admin building a milestone invoice never has to add the whole package first just to reach
+// the percent option, then delete it again.
+const CatalogPickerRow = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: stretch;
+`;
+
+const CatalogPickerPercentButton = styled.button`
+  flex: 0 0 auto;
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-muted);
+  border-radius: 8px;
+  padding: 6px 9px;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+`;
+
 const CatalogTabs = styled.div`
   display: inline-flex;
   gap: 3px;
@@ -1023,18 +1053,18 @@ const PackageEntryCard = ({
         ) : null}
         {row.isCustomized ? <CustomizedTag title="No longer matches the shared budget package">Custom package</CustomizedTag> : null}
         {onReset ? (
-          <IconButton type="button" onClick={onReset} title="Revert to the catalog package" aria-label="Revert to catalog package">
+          <IconButton $dense type="button" onClick={onReset} title="Revert to the catalog package" aria-label="Revert to catalog package">
             <FaUndoAlt />
           </IconButton>
         ) : null}
-        <RowActions>
-          <IconButton type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move package up">
+        <RowActions $dense>
+          <IconButton $dense type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move package up">
             <FaChevronUp />
           </IconButton>
-          <IconButton type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move package down">
+          <IconButton $dense type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move package down">
             <FaChevronDown />
           </IconButton>
-          <IconDangerButton type="button" onClick={onRemove} title="Remove package" aria-label="Remove package">
+          <IconDangerButton $dense type="button" onClick={onRemove} title="Remove package" aria-label="Remove package">
             <FaTrash />
           </IconDangerButton>
         </RowActions>
@@ -1050,7 +1080,7 @@ const PackageEntryCard = ({
           autoFocus
           onFocus={() => { descriptionEditingRef.current = true; }}
           onChange={event => setDescriptionDraft(event.target.value)}
-          onBlur={() => { descriptionEditingRef.current = false; onCommitField('description', descriptionDraft); }}
+          onBlur={() => { descriptionEditingRef.current = false; onCommitField('description', descriptionDraft); setDescriptionOpen(false); }}
         />
       ) : (
         <DescriptionToggle
@@ -1792,6 +1822,12 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const addCatalogPackageEntry = pkg => {
     addEntryToInvoice(makeCatalogPackageEntry(pkg), 'Package added.');
+    setShowCatalogPicker(false);
+    setCatalogQuery('');
+  };
+
+  const addCatalogPackagePercentEntry = pkg => {
+    addPercentServiceEntry(pkg.id);
     setShowCatalogPicker(false);
     setCatalogQuery('');
   };
@@ -2627,9 +2663,18 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                           <span>{item.name}</span>
                         </CatalogPickerButton>
                       )) : filteredCatalogPackages.map(pkg => (
-                        <CatalogPickerButton key={pkg.id} type="button" onClick={() => addCatalogPackageEntry(pkg)}>
-                          <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}</span>
-                        </CatalogPickerButton>
+                        <CatalogPickerRow key={pkg.id}>
+                          <CatalogPickerButton type="button" style={{ flex: '1 1 auto' }} onClick={() => addCatalogPackageEntry(pkg)} title="Add the whole package at its full listed price">
+                            <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}</span>
+                          </CatalogPickerButton>
+                          <CatalogPickerPercentButton
+                            type="button"
+                            onClick={() => addCatalogPackagePercentEntry(pkg)}
+                            title="Bill only a share of this package on this invoice (e.g. one Payment Schedule milestone) - no need to add the full package first"
+                          >
+                            % of package
+                          </CatalogPickerPercentButton>
+                        </CatalogPickerRow>
                       ))}
                       {catalogTab === 'items' && !filteredCatalogItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
                       {catalogTab === 'packages' && !filteredCatalogPackages.length ? <PanelNote style={{ margin: 0 }}>No matching catalog packages.</PanelNote> : null}

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -206,6 +206,33 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // Bug report: adding a package used to only offer the full listed price, with no way to bill
+  // just a share of it (e.g. the first Payment Schedule milestone) - the only route to a percent
+  // row required adding the whole package first, then deleting it again. The catalog picker's
+  // package entry now offers a "% of package" action directly, with no full package row involved.
+  it('adds a "% of package" share straight from the catalog picker, without adding the full package first', async () => {
+    const root = mount();
+    await flush();
+
+    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const percentButton = findButton('% of package');
+    expect(percentButton).toBeTruthy();
+    await act(async () => { percentButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    const services = lastServicesCall[1];
+    expect(services.some(entry => entry.kind === 'package')).toBe(false);
+    const percentEntry = services.find(entry => entry.kind === 'percent');
+    expect(percentEntry).toMatchObject({ packageId: 'p1', percent: 60 });
+
+    await act(async () => { root.unmount(); });
+  });
+
   it('deletes a custom service from the invoice', async () => {
     const root = mount();
     await flush();
@@ -233,6 +260,44 @@ describe('InvoiceBuilderPage', () => {
     expect(container.innerHTML).not.toContain('Courier fee');
     const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
     expect(lastServicesCall[1].some(entry => entry.name === 'Courier fee')).toBe(false);
+
+    await act(async () => { root.unmount(); });
+  });
+
+  // Bug report: after editing a service's description, the field stayed permanently expanded
+  // (full multi-line textarea) instead of collapsing back to the single-line toggle like every
+  // sibling row - descriptionOpen never reset to false on blur.
+  it('collapses a service description back to the single-line toggle after editing it', async () => {
+    const root = mount();
+    await flush();
+
+    const nameField = container.querySelector('textarea[placeholder="New custom service name"]');
+    const priceField = container.querySelector('textarea[placeholder="Price or GIFT"]');
+    await act(async () => {
+      nameField.focus();
+      setFieldValue(nameField, 'Courier fee');
+      setFieldValue(priceField, '25');
+    });
+    const addCustomButton = nameField.parentElement.querySelector('button');
+    await act(async () => { addCustomButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const descriptionToggle = findButton('+ Add description', true);
+    expect(descriptionToggle).toBeTruthy();
+    await act(async () => { descriptionToggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const descriptionField = container.querySelector('textarea[aria-label="Description"]');
+    expect(descriptionField).toBeTruthy();
+    await act(async () => {
+      descriptionField.focus();
+      setFieldValue(descriptionField, 'Same-day courier from the clinic.');
+      descriptionField.blur();
+    });
+    await flush();
+
+    expect(container.querySelector('textarea[aria-label="Description"]')).toBeFalsy();
+    expect(findButton('Same-day courier from the clinic.', true)).toBeTruthy();
 
     await act(async () => { root.unmount(); });
   });


### PR DESCRIPTION
## Summary
- Add a "% of package" action directly next to each package in the "Add from catalog" picker, seeded from that package's next unused Payment Schedule milestone. Previously the only way to bill a partial share of a package was to add the whole package first (full listed price), find the separate "% of package" quick-add button that only appeared once a package row already existed, then delete the full package row again.
- Fix `descriptionOpen` never resetting to `false` on blur (both the top-level service row and the package-card's own description), which left an edited description permanently expanded to a multi-line textarea instead of collapsing back to the single-line toggle like every untouched sibling row.
- Add a `$dense` size variant to the shared icon-button/row-actions styles: shrinks the package header's reorder/delete cluster (height) and a package child row's footer cluster (width), per screenshot feedback.

## Test plan
- `npx react-scripts test` for `budgetCatalogUtils`, `BudgetPage`, `invoiceCatalogUtils`, `expectedExpensesUtils`, `InvoiceBuilderPage`, `__pdfSmoke` — 99 tests pass, including new regression tests for the catalog-picker percent action and the description auto-collapse.
- `npm run qa:pdf` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQ6GyZAdHE7NihYqkoMi6i)_