### PR TITLE
Fix invoice builder marking items customized just from viewing a description

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -675,7 +675,10 @@ const PercentShareRow = ({
           aria-label="Percent of package price"
           onFocus={() => { percentEditingRef.current = true; }}
           onChange={event => setPercentDraft(event.target.value)}
-          onBlur={() => { percentEditingRef.current = false; onCommit('percent', percentDraft); }}
+          onBlur={() => {
+            percentEditingRef.current = false;
+            if (percentDraft !== String(row.percent ?? '')) onCommit('percent', percentDraft);
+          }}
         />
         <span style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--km-muted)' }}>%</span>
         <CustomizedTag title="Recalculated live from the package's price">≈ {formatEuroPreview(row.price)}</CustomizedTag>
@@ -751,7 +754,10 @@ const ServiceLineRow = ({
           aria-label="Service name"
           onFocus={() => { nameEditingRef.current = true; }}
           onChange={event => setNameDraft(event.target.value)}
-          onBlur={() => { nameEditingRef.current = false; onCommit('name', nameDraft); }}
+          onBlur={() => {
+            nameEditingRef.current = false;
+            if (nameDraft !== (row.name ?? '')) onCommit('name', nameDraft);
+          }}
         />
       </LineMainRow>
       {descriptionOpen ? (
@@ -765,7 +771,11 @@ const ServiceLineRow = ({
           autoFocus
           onFocus={() => { descriptionEditingRef.current = true; }}
           onChange={event => setDescriptionDraft(event.target.value)}
-          onBlur={() => { descriptionEditingRef.current = false; onCommit('description', descriptionDraft); setDescriptionOpen(false); }}
+          onBlur={() => {
+            descriptionEditingRef.current = false;
+            if (descriptionDraft !== (row.description ?? '')) onCommit('description', descriptionDraft);
+            setDescriptionOpen(false);
+          }}
         />
       ) : (
         <DescriptionToggle type="button" $hasValue={Boolean(row.description)} onClick={() => setDescriptionOpen(true)}>
@@ -782,7 +792,11 @@ const ServiceLineRow = ({
           aria-label="Price (EUR)"
           onFocus={() => { priceEditingRef.current = true; }}
           onChange={event => setPriceDraft(event.target.value)}
-          onBlur={() => { priceEditingRef.current = false; onCommit('price', priceDraft); }}
+          onBlur={() => {
+            priceEditingRef.current = false;
+            const originalPriceDraft = row.priceLabel || String(roundToCents(row.price) ?? '');
+            if (priceDraft !== originalPriceDraft) onCommit('price', priceDraft);
+          }}
         />
         {row.isCustomized ? <CustomizedTag title="Overridden for this invoice only - the shared budget is unchanged">Custom</CustomizedTag> : null}
         {row.missing ? <MissingTag title="This catalog reference no longer exists">Missing</MissingTag> : null}
@@ -1035,7 +1049,10 @@ const PackageEntryCard = ({
           aria-label="Package name"
           onFocus={() => { nameEditingRef.current = true; }}
           onChange={event => setNameDraft(event.target.value)}
-          onBlur={() => { nameEditingRef.current = false; onCommitField('name', nameDraft); }}
+          onBlur={() => {
+            nameEditingRef.current = false;
+            if (nameDraft !== (row.name ?? '')) onCommitField('name', nameDraft);
+          }}
         />
         <AutoTextArea
           as={PlainPriceBase}
@@ -1046,7 +1063,11 @@ const PackageEntryCard = ({
           aria-label="Package price (EUR)"
           onFocus={() => { priceEditingRef.current = true; }}
           onChange={event => setPriceDraft(event.target.value)}
-          onBlur={() => { priceEditingRef.current = false; onCommitField('price', priceDraft); }}
+          onBlur={() => {
+            priceEditingRef.current = false;
+            const originalPriceDraft = String(roundToCents(row.price) ?? '');
+            if (priceDraft !== originalPriceDraft) onCommitField('price', priceDraft);
+          }}
         />
         {row.hasPriceOverride ? (
           <CustomizedTag title="Real total of the services below">Σ {formatEuroPreview(row.childrenTotal)}</CustomizedTag>
@@ -1080,7 +1101,11 @@ const PackageEntryCard = ({
           autoFocus
           onFocus={() => { descriptionEditingRef.current = true; }}
           onChange={event => setDescriptionDraft(event.target.value)}
-          onBlur={() => { descriptionEditingRef.current = false; onCommitField('description', descriptionDraft); setDescriptionOpen(false); }}
+          onBlur={() => {
+            descriptionEditingRef.current = false;
+            if (descriptionDraft !== (row.description ?? '')) onCommitField('description', descriptionDraft);
+            setDescriptionOpen(false);
+          }}
         />
       ) : (
         <DescriptionToggle

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -393,8 +393,11 @@ const StackedFieldRow = styled.div`
 
 // Groups one payer/customer's fields together (name/address, each its own StackedFieldRow) with a
 // heavier separator between customers than the light one between fields of the same customer.
+// Indented to match the collapsed compact row's own inner padding (CompactSection) above it, so
+// the Name/Address text lines up with the summary text instead of sitting flush against the panel
+// edge, a step to the left of everything above it.
 const CustomerBlock = styled.div`
-  padding: 8px 0;
+  padding: 8px 0 8px 12px;
 
   & + & {
     border-top: 1px solid var(--km-border);

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -110,6 +110,33 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // Regression: opening a description just to read the full text (then clicking away without
+  // typing anything) used to unconditionally commit it on blur, which flipped `customized: true`
+  // and detached the row from the shared catalog - merely viewing a description should never do that.
+  it('opening and closing a description without editing it does not mark the item customized', async () => {
+    const root = mount();
+    await flush();
+
+    const descriptionToggle = findButton('Daily care in hospital.', true);
+    expect(descriptionToggle).toBeTruthy();
+    await act(async () => { descriptionToggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const descriptionField = container.querySelector('textarea[aria-label="Description"]');
+    expect(descriptionField).toBeTruthy();
+    await act(async () => {
+      descriptionField.focus();
+      descriptionField.blur();
+    });
+    await flush();
+
+    expect(set.mock.calls.some(([path]) => path === 'invoiceBuilder/invoiceServices')).toBe(false);
+    expect(container.innerHTML).not.toContain('Custom<');
+    expect(findButton('Daily care in hospital.', true)).toBeTruthy();
+
+    await act(async () => { root.unmount(); });
+  });
+
   it('overriding a catalog item price only writes invoiceBuilder/invoiceServices, never budget/items', async () => {
     const root = mount();
     await flush();


### PR DESCRIPTION
## Summary
- Fixes a bug found while testing the Invoice Builder's "% of package" feature: opening a service/package description just to read the full text, then clicking away without typing anything, unconditionally committed on blur - flipping `customized: true` and permanently detaching that row (or the whole package) from the shared catalog, plus writing an unnecessary Firebase update.
- Name, description, price, and percent fields on invoice service rows (top-level and package children) now only commit when the draft actually differs from the row's current value.

## Test plan
- [x] Added a regression test: opening and closing a description without editing it no longer marks the item customized or writes to `invoiceBuilder/invoiceServices`.
- [x] Full `InvoiceBuilderPage.test.js` suite passes (15/15), including existing tests that edit a name/price/description and expect the commit to still happen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WvyZtkg2jfBrhMzBzmPV2T)_