### PR TITLE
Fix payer/case merge bug and add self-contained custom packages (round4 P0 #1-2)

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -172,6 +172,41 @@ async function checkInvoice() {
   if (!milestonePages[0].replace(/\s+/g, '').toUpperCase().includes('PROGRAMMEMILESTONEINVOICE')) {
     fail('Invoice (milestone): expected a "Programme milestone invoice" eyebrow, got something else');
   }
+
+  // Custom package (P0, round4 #2) - a package with no Budget catalog entry (catalogId '') must
+  // render its full name/children/price straight from the invoice, never depend on a catalog
+  // lookup or crash when priceContext.packagesById has nothing for it.
+  const customPackagePages = await renderPdf(React.createElement(InvoicePdfDocument, {
+    beneficiary,
+    customers,
+    invoiceServices: [{
+      id: 'e1',
+      kind: 'package',
+      catalogId: '',
+      customized: true,
+      name: 'Bespoke concierge programme',
+      children: [
+        { id: 'c1', kind: 'custom', name: 'Dedicated case manager', price: 2000 },
+        { id: 'c2', kind: 'item', catalogId: '1' },
+      ],
+    }],
+    catalogItemsById,
+    priceContext: { itemsById: catalogItemsById, rates: null, packagesById: new Map() },
+    notes: [],
+    taxPercent: 0,
+    invoiceNumber: '09/07/2026',
+    invoiceDate: '09.07.2026',
+    purposeOfPayment: 'Payment for the bespoke programme.',
+  }));
+  checkNoDebugStrings('Invoice (custom package)', customPackagePages);
+  checkNoBlankPages('Invoice (custom package)', customPackagePages);
+  checkStringsRoundTrip('Invoice (custom package)', customPackagePages, [
+    'Bespoke concierge programme', 'Dedicated case manager', 'Pregnancy blood test',
+  ]);
+  const customPackageCombined = customPackagePages.join('\n');
+  if (/set out in your Budget/i.test(customPackageCombined)) {
+    fail('Invoice (custom package): a package with no Budget catalog entry pointed the client at "your Budget" instead of showing its own contents');
+  }
 }
 
 async function checkExpectedExpenses() {

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -32,6 +32,7 @@ import {
   computeInvoiceAmountDue,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
+  createEntryId,
   generateInvoiceIdentifiers,
   getActiveBeneficiary,
   getEntryIdentityKey,
@@ -40,12 +41,14 @@ import {
   makeCatalogItemEntry,
   makeCatalogPackageEntry,
   makeCustomEntry,
+  makeCustomPackageEntry,
   makePercentOfPackageEntry,
   movePackageChild,
   normalizeInvoiceData,
   parseCustomPriceInput,
   removePackageChild,
   reorderBeneficiaryIds,
+  reorderPayerCaseIds,
   reorderRecentServices,
   resetItemEntryOverrides,
   resetPackageEntryToCatalog,
@@ -1075,7 +1078,11 @@ const PackageEntryCard = ({
         {row.hasPriceOverride ? (
           <CustomizedTag title="Real total of the services below">Σ {formatEuroPreview(row.childrenTotal)}</CustomizedTag>
         ) : null}
-        {row.isCustomized ? <CustomizedTag title="No longer matches the shared budget package">Custom package</CustomizedTag> : null}
+        {row.isCustomized ? (
+          <CustomizedTag title={row.catalogId ? 'No longer matches the shared budget package' : 'Not in the Budget catalog - saved entirely on this invoice'}>
+            Custom package
+          </CustomizedTag>
+        ) : null}
         {onReset ? (
           <IconButton $dense type="button" onClick={onReset} title="Revert to the catalog package" aria-label="Revert to catalog package">
             <FaUndoAlt />
@@ -1483,6 +1490,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [invoiceDateInput, setInvoiceDateInput] = useState(getTodayYmd());
   const [newCustomServiceName, setNewCustomServiceName] = useState('');
   const [newCustomServicePrice, setNewCustomServicePrice] = useState('');
+  const [newCustomPackageName, setNewCustomPackageName] = useState('');
   const [catalogQuery, setCatalogQuery] = useState('');
   const [showCatalogPicker, setShowCatalogPicker] = useState(false);
   const [catalogTab, setCatalogTab] = useState('items');
@@ -1638,6 +1646,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const payerName = useMemo(() => buildPayerName(data.customers), [data.customers]);
   const payerLocation = useMemo(() => buildPayerLocation(data.customers), [data.customers]);
   const caseTitle = useMemo(() => buildCaseTitle(data.customers), [data.customers]);
+  const activePayerCaseId = data.payerCaseIds[0];
 
   const recentServiceSuggestions = useMemo(() => {
     const used = new Set(data.invoiceServices.map(getEntryIdentityKey));
@@ -1771,31 +1780,104 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     }
   };
 
-  // Customers ------------------------------------------------------------
+  // Customers / payer cases ------------------------------------------------------------
+  // One invoice belongs to one case/payer: `data.customers` is always a mirror of the active
+  // payer case (data.payerCases[i] where payerCases[i].id === payerCaseIds[0]). Editing customers
+  // writes through to that active case. Switching or starting a case never merges customers from
+  // different cases into one payer - it replaces the active case outright (see startNewPayerCase/
+  // selectPayerCase below), while still keeping every previously-used case saved for reuse.
+
+  // Keeps `customers` (the convenience mirror every PDF/export/display site reads) and the active
+  // entry inside `payerCases` in sync with each other.
+  const withActiveCaseCustomers = (current, nextCustomers) => ({
+    ...current,
+    customers: nextCustomers,
+    payerCases: current.payerCases.map(payerCase => (String(payerCase.id) === String(current.payerCaseIds[0])
+      ? { ...payerCase, customers: nextCustomers }
+      : payerCase)),
+  });
+
+  const persistPayerCases = async (nextPayerCases, nextPayerCaseIds, successMessage) => {
+    try {
+      await Promise.all([
+        set(ref(database, `${INVOICE_DATA_PATH}/payerCases`), nextPayerCases),
+        set(ref(database, `${INVOICE_DATA_PATH}/payerCaseIds`), nextPayerCaseIds),
+      ]);
+      if (successMessage) toast.success(successMessage);
+    } catch (saveError) {
+      console.error('Unable to save payer cases', saveError);
+      toast.error('Unable to save. Reloading latest data.');
+      loadInvoiceData();
+    }
+  };
 
   const updateCustomerField = (index, field, value) => {
-    setData(current => ({
-      ...current,
-      customers: current.customers.map((customer, customerIndex) => (customerIndex === index
+    setData(current => {
+      const nextCustomers = current.customers.map((customer, customerIndex) => (customerIndex === index
         ? { ...customer, [field]: value }
-        : customer)),
-    }));
+        : customer));
+      return withActiveCaseCustomers(current, nextCustomers);
+    });
   };
 
   const persistCustomers = async (nextCustomers, successMessage) => {
-    await persistPath(`${INVOICE_DATA_PATH}/customers`, nextCustomers, successMessage);
+    const nextPayerCases = data.payerCases.map(payerCase => (String(payerCase.id) === String(data.payerCaseIds[0])
+      ? { ...payerCase, customers: nextCustomers }
+      : payerCase));
+    await persistPayerCases(nextPayerCases, data.payerCaseIds, successMessage);
   };
 
+  // Adds a co-payer within the CURRENT case (e.g. a couple) - it never creates a new case.
   const addCustomer = () => {
     const nextCustomers = [...data.customers, { name: '', address: '' }];
-    setData(current => ({ ...current, customers: nextCustomers }));
+    setData(current => withActiveCaseCustomers(current, nextCustomers));
     persistCustomers(nextCustomers, 'Customer added.');
   };
 
   const removeCustomer = index => {
     const nextCustomers = data.customers.filter((customer, customerIndex) => customerIndex !== index);
-    setData(current => ({ ...current, customers: nextCustomers }));
+    setData(current => withActiveCaseCustomers(current, nextCustomers));
     persistCustomers(nextCustomers, 'Customer removed.');
+  };
+
+  // Starts a brand-new case: the active payer switches to a blank customer, while every
+  // previously-used case (and its customers) stays saved in payerCases for later reuse - this is
+  // the "select a new client replaces the previous selection" fix (P0, round4 #1).
+  const startNewPayerCase = async () => {
+    const nextCase = { id: createEntryId(), customers: [{ name: '', address: '' }] };
+    const nextPayerCases = [...data.payerCases, nextCase];
+    const nextPayerCaseIds = reorderPayerCaseIds(data.payerCaseIds, nextCase.id);
+    setData(current => ({ ...current, payerCases: nextPayerCases, payerCaseIds: nextPayerCaseIds, customers: nextCase.customers }));
+    await persistPayerCases(nextPayerCases, nextPayerCaseIds, 'New case started.');
+  };
+
+  // Switches the active case without touching any case's saved customers - most-recently-selected
+  // case is brought to the front, so it's offered first the next time this list is shown.
+  const selectPayerCase = async id => {
+    if (String(id) === String(data.payerCaseIds[0])) return;
+    const nextPayerCaseIds = reorderPayerCaseIds(data.payerCaseIds, id);
+    const nextCase = data.payerCases.find(payerCase => String(payerCase.id) === String(id));
+    setData(current => ({ ...current, payerCaseIds: nextPayerCaseIds, customers: nextCase?.customers || [] }));
+    await persistPayerCases(data.payerCases, nextPayerCaseIds, 'Active case switched.');
+  };
+
+  const deleteActivePayerCase = async () => {
+    if (data.payerCases.length <= 1) {
+      toast.error('At least one case is required.');
+      return;
+    }
+    const activeId = data.payerCaseIds[0];
+    if (typeof window !== 'undefined' && !window.confirm(`Delete case "${payerName || activeId}" from history?`)) return;
+    const nextPayerCases = data.payerCases.filter(payerCase => String(payerCase.id) !== String(activeId));
+    const nextPayerCaseIds = data.payerCaseIds.filter(id => String(id) !== String(activeId));
+    const nextActiveCase = nextPayerCases.find(payerCase => String(payerCase.id) === String(nextPayerCaseIds[0])) || nextPayerCases[0];
+    setData(current => ({
+      ...current,
+      payerCases: nextPayerCases,
+      payerCaseIds: nextPayerCaseIds,
+      customers: nextActiveCase?.customers || [],
+    }));
+    await persistPayerCases(nextPayerCases, nextPayerCaseIds, 'Case deleted.');
   };
 
   // Invoice services ------------------------------------------------------------
@@ -1869,6 +1951,20 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     addEntryToInvoice(makeCustomEntry({ name, ...parseCustomPriceInput(newCustomServicePrice) }), 'Service added.');
     setNewCustomServiceName('');
     setNewCustomServicePrice('');
+  };
+
+  // A package with no Budget catalog entry - it can't reference the catalog because there is
+  // nothing there to reference, so it's saved fully on this invoice (P0, round4 #2). Its price
+  // starts at 0/sum-of-children; the admin fills in children (custom or catalog-linked) and/or a
+  // price override on the resulting package card, same as any catalog-sourced package.
+  const addCustomPackageEntry = () => {
+    const name = newCustomPackageName.trim();
+    if (!name) {
+      toast.error('Enter a name for the new package.');
+      return;
+    }
+    addEntryToInvoice(makeCustomPackageEntry({ name }), 'Custom package added.');
+    setNewCustomPackageName('');
   };
 
   // Never defaults to 0% or 100% - that's just swapping one wrong constant for another. The
@@ -2225,11 +2321,24 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         toast.error('Upload an invoice-builder JSON with beneficiaries, customers, services, and notes.');
         return;
       }
-      const nextData = normalizeInvoiceData(parsed);
+      const uploadedData = normalizeInvoiceData(parsed);
+      // The uploaded file's customers describe a single case - add it as a new case on top of
+      // whatever payer history already exists here, rather than overwriting it, so uploading a
+      // JSON for a different client never merges into (or wipes out) a previous client's payer.
+      const uploadedCase = { id: createEntryId(), customers: uploadedData.customers };
+      const nextPayerCases = [...data.payerCases, uploadedCase];
+      const nextPayerCaseIds = reorderPayerCaseIds(data.payerCaseIds, uploadedCase.id);
+      const nextData = {
+        ...uploadedData,
+        payerCases: nextPayerCases,
+        payerCaseIds: nextPayerCaseIds,
+        customers: uploadedCase.customers,
+      };
       await Promise.all([
         set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextData.beneficiaries),
         set(ref(database, `${INVOICE_DATA_PATH}/beneficiaryIds`), nextData.beneficiaryIds),
-        set(ref(database, `${INVOICE_DATA_PATH}/customers`), nextData.customers),
+        set(ref(database, `${INVOICE_DATA_PATH}/payerCases`), nextData.payerCases),
+        set(ref(database, `${INVOICE_DATA_PATH}/payerCaseIds`), nextData.payerCaseIds),
         set(ref(database, `${INVOICE_DATA_PATH}/recentServices`), nextData.recentServices),
         set(ref(database, `${INVOICE_DATA_PATH}/invoiceServices`), nextData.invoiceServices),
         set(ref(database, `${INVOICE_DATA_PATH}/notes`), nextData.notes),
@@ -2541,8 +2650,24 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <>
                   <PanelHeading>
                     <H2>Payer (customers)</H2>
-                    <SmallButton type="button" onClick={addCustomer}><FaPlus /> Add customer</SmallButton>
+                    <div style={{ display: 'flex', gap: 6 }}>
+                      <SmallButton type="button" onClick={addCustomer}><FaPlus /> Add customer</SmallButton>
+                      <SmallButton type="button" onClick={startNewPayerCase}><FaPlus /> New case</SmallButton>
+                      <DangerButton type="button" onClick={deleteActivePayerCase}><FaTrash /> Delete case</DangerButton>
+                    </div>
                   </PanelHeading>
+                  <FieldRow>
+                    <FieldTag>Active case</FieldTag>
+                    <PlainSelect value={activePayerCaseId || ''} onChange={event => selectPayerCase(event.target.value)}>
+                      {data.payerCaseIds.map(id => {
+                        const payerCase = data.payerCases.find(candidate => String(candidate.id) === String(id));
+                        if (!payerCase) return null;
+                        return (
+                          <option key={id} value={id}>{buildPayerName(payerCase.customers) || `Case ${id}`}</option>
+                        );
+                      })}
+                    </PlainSelect>
+                  </FieldRow>
                   <PanelNote>{`Payer: ${payerName || '—'} · ${caseTitle}`}</PanelNote>
                   {data.customers.map((customer, index) => (
                     <CustomerBlock key={`customer-${index}`}>
@@ -2599,7 +2724,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   onRemove={() => removeTopLevelEntry(row.id)}
                   onMoveUp={() => moveTopLevelEntry(row.id, -1)}
                   onMoveDown={() => moveTopLevelEntry(row.id, 1)}
-                  onReset={row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
+                  onReset={row.catalogId && row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
                   onCommitChildField={(childId, field, value) => commitPackageChildField(row.id, childId, field, value)}
                   onResetChildField={childId => resetPackageChildEntry(row.id, childId)}
                   onRemoveChild={childId => removePackageChildEntry(row.id, childId)}
@@ -2664,6 +2789,22 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     <FaPlus /> % of package
                   </SmallButton>
                 ) : null}
+              </FieldRow>
+
+              <FieldRow $align="center" style={{ marginTop: 8 }}>
+                <PlainTextBase
+                  rows={1}
+                  placeholder="New custom package name"
+                  value={newCustomPackageName}
+                  onChange={event => setNewCustomPackageName(event.target.value)}
+                />
+                <SmallButton
+                  type="button"
+                  title="A package with no Budget catalog entry - saved fully on this invoice"
+                  onClick={addCustomPackageEntry}
+                >
+                  <FaLayerGroup /> Add custom package
+                </SmallButton>
               </FieldRow>
 
               <div style={{ marginTop: 8 }}>

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -196,6 +196,33 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // P0 (round4 #2): a package with no Budget catalog entry must be creatable straight from the
+  // invoice - it should never claim to be "missing from the catalog" (it was never in one), and
+  // its own children/name/price must persist on the invoice itself.
+  it('adds a custom package with no Budget catalog entry, storing its full contents on the invoice', async () => {
+    const root = mount();
+    await flush();
+
+    const nameField = container.querySelector('textarea[placeholder="New custom package name"]');
+    expect(nameField).toBeTruthy();
+    await act(async () => {
+      nameField.focus();
+      setFieldValue(nameField, 'Bespoke concierge programme');
+    });
+    await act(async () => { findButton('Add custom package').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    const packageEntry = lastServicesCall[1].find(entry => entry.kind === 'package' && entry.name === 'Bespoke concierge programme');
+    expect(packageEntry).toMatchObject({ catalogId: '', customized: true, children: [] });
+
+    expect(container.innerHTML).toContain('Bespoke concierge programme');
+    expect(container.innerHTML).toContain('Custom package');
+    expect(container.innerHTML).not.toContain('Missing');
+
+    await act(async () => { root.unmount(); });
+  });
+
   // Regression: "% of package" used to always default to 0% (previously always 100%) with no
   // link to the catalog's own Payment Schedule - an admin had to know the right number by heart.
   // It should now seed the first click from the package's first unbilled schedule milestone
@@ -325,6 +352,53 @@ describe('InvoiceBuilderPage', () => {
 
     expect(container.querySelector('textarea[aria-label="Description"]')).toBeFalsy();
     expect(findButton('Same-day courier from the clinic.', true)).toBeTruthy();
+
+    await act(async () => { root.unmount(); });
+  });
+
+  // Regression (P0, round4 #1): selecting/starting a different client used to have no dedicated
+  // affordance at all, so admins fell back to "Add customer", which appended the new client's
+  // name onto the previous one instead of replacing it - two unrelated cases then rendered as one
+  // merged payer. "New case" must start a blank payer while keeping the old one selectable again.
+  it('starting a new payer case replaces the active payer instead of merging with the previous client', async () => {
+    const root = mount();
+    await flush();
+
+    const payerToggle = Array.from(container.querySelectorAll('[role="button"]')).find(el => el.textContent.includes('Payer'));
+    await act(async () => { payerToggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const activeNameFieldValues = () => Array.from(container.querySelectorAll('textarea[placeholder="Name"]')).map(field => field.value);
+    expect(activeNameFieldValues()).toEqual(['Amny Athamny']);
+
+    await act(async () => { findButton('New case').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    // The previous client's name field must be gone from the active payer, not merged alongside a
+    // second, blank one - "New case" replaces the active payer, it never appends to it.
+    expect(activeNameFieldValues()).toEqual(['']);
+
+    const nameField = container.querySelector('textarea[placeholder="Name"]');
+    await act(async () => {
+      nameField.focus();
+      setFieldValue(nameField, 'Kyogoku');
+      nameField.blur();
+    });
+    await flush();
+
+    expect(activeNameFieldValues()).toEqual(['Kyogoku']);
+
+    // Switching back to the previous case must restore it exactly, still with no merging.
+    const caseSelect = Array.from(container.querySelectorAll('select')).find(select => Array.from(select.options).some(option => option.text.includes('Amny Athamny')));
+    expect(caseSelect).toBeTruthy();
+    const originalCaseOption = Array.from(caseSelect.options).find(option => option.text.includes('Amny Athamny'));
+    await act(async () => {
+      caseSelect.value = originalCaseOption.value;
+      caseSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    expect(activeNameFieldValues()).toEqual(['Amny Athamny']);
 
     await act(async () => { root.unmount(); });
   });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -54,22 +54,49 @@ export const parseCustomPriceInput = raw => {
   return { price: 0, priceLabel: text };
 };
 
-export const normalizeInvoiceData = raw => ({
-  beneficiaries: Array.isArray(raw?.beneficiaries) ? raw.beneficiaries : [],
-  beneficiaryIds: Array.isArray(raw?.beneficiaryIds) ? raw.beneficiaryIds.map(String) : [],
-  customers: Array.isArray(raw?.customers) ? raw.customers : [],
-  recentServices: normalizeServiceEntries(raw?.recentServices),
-  invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
-  notes: Array.isArray(raw?.notes) ? raw.notes : [],
-  taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
-  // A signed carry-over from the client's previous payment, settled after tax (never itself
-  // taxed): positive = the client still owes a debt from before, negative = they're sitting on a
-  // deposit/credit. Zero (the default) means "nothing to carry over" and is never rendered.
-  debtOrDeposit: Number.isFinite(Number(raw?.debtOrDeposit)) ? Number(raw.debtOrDeposit) : 0,
-  // Empty string (the default) means "keep auto-generating it from the beneficiary's template" -
-  // any other value is an admin edit for this invoice only and wins over the auto-generated text.
-  paymentPurposeOverride: typeof raw?.paymentPurposeOverride === 'string' ? raw.paymentPurposeOverride : '',
-});
+// One invoice belongs to one case/payer: payerCases is a catalog of every payer/case ever used
+// (each a group of one-or-more customers, e.g. a couple), payerCaseIds orders them with the
+// active case first - the same "catalog + activate by reordering ids" pattern beneficiaries use.
+// `customers` stays in the normalized shape too, always mirroring the active case, so every other
+// read site (PDF generation, exports, buildPayerName/buildCaseTitle) keeps reading `data.customers`
+// unchanged; only the handful of mutation sites need to know payerCases/payerCaseIds exist.
+const normalizePayerCases = raw => {
+  const legacyCustomers = Array.isArray(raw?.customers) ? raw.customers : [];
+  const rawPayerCases = Array.isArray(raw?.payerCases) ? raw.payerCases : [];
+  const payerCases = rawPayerCases.length
+    ? rawPayerCases.map(payerCase => ({
+      id: String(payerCase?.id ?? createEntryId()),
+      customers: Array.isArray(payerCase?.customers) ? payerCase.customers : [],
+    }))
+    : [{ id: 'legacy', customers: legacyCustomers }];
+  const knownIds = payerCases.map(payerCase => payerCase.id);
+  const rawIds = (Array.isArray(raw?.payerCaseIds) ? raw.payerCaseIds : []).map(String).filter(id => knownIds.includes(id));
+  const payerCaseIds = [...rawIds, ...knownIds.filter(id => !rawIds.includes(id))];
+  return { payerCases, payerCaseIds };
+};
+
+export const normalizeInvoiceData = raw => {
+  const { payerCases, payerCaseIds } = normalizePayerCases(raw);
+  const activeCase = payerCases.find(payerCase => String(payerCase.id) === String(payerCaseIds[0])) || payerCases[0];
+  return {
+    beneficiaries: Array.isArray(raw?.beneficiaries) ? raw.beneficiaries : [],
+    beneficiaryIds: Array.isArray(raw?.beneficiaryIds) ? raw.beneficiaryIds.map(String) : [],
+    payerCases,
+    payerCaseIds,
+    customers: activeCase?.customers || [],
+    recentServices: normalizeServiceEntries(raw?.recentServices),
+    invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
+    notes: Array.isArray(raw?.notes) ? raw.notes : [],
+    taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
+    // A signed carry-over from the client's previous payment, settled after tax (never itself
+    // taxed): positive = the client still owes a debt from before, negative = they're sitting on a
+    // deposit/credit. Zero (the default) means "nothing to carry over" and is never rendered.
+    debtOrDeposit: Number.isFinite(Number(raw?.debtOrDeposit)) ? Number(raw.debtOrDeposit) : 0,
+    // Empty string (the default) means "keep auto-generating it from the beneficiary's template" -
+    // any other value is an admin edit for this invoice only and wins over the auto-generated text.
+    paymentPurposeOverride: typeof raw?.paymentPurposeOverride === 'string' ? raw.paymentPurposeOverride : '',
+  };
+};
 
 export const isInvoiceDataShape = raw => {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
@@ -86,13 +113,24 @@ export const getActiveBeneficiary = data => {
   return beneficiaries.find(beneficiary => String(beneficiary.id) === String(activeId)) || beneficiaries[0] || null;
 };
 
-// Brings a beneficiary id to the front of beneficiaryIds without touching the
-// beneficiaries array order.
-export const reorderBeneficiaryIds = (beneficiaryIds, activeId) => {
+// Brings an id to the front of an id-ordering array without touching the underlying catalog's
+// order - shared by beneficiaries (reorderBeneficiaryIds) and payer cases (reorderPayerCaseIds).
+const reorderIdsToFront = (ids, activeId) => {
   const id = String(activeId);
-  const rest = (Array.isArray(beneficiaryIds) ? beneficiaryIds : []).filter(existing => String(existing) !== id);
+  const rest = (Array.isArray(ids) ? ids : []).filter(existing => String(existing) !== id);
   return [id, ...rest];
 };
+
+export const reorderBeneficiaryIds = (beneficiaryIds, activeId) => reorderIdsToFront(beneficiaryIds, activeId);
+
+// The active payer case is always the first id in payerCaseIds (same pattern as beneficiaries).
+export const getActivePayerCase = data => {
+  const activeId = data?.payerCaseIds?.[0];
+  const payerCases = Array.isArray(data?.payerCases) ? data.payerCases : [];
+  return payerCases.find(payerCase => String(payerCase.id) === String(activeId)) || payerCases[0] || null;
+};
+
+export const reorderPayerCaseIds = (payerCaseIds, activeId) => reorderIdsToFront(payerCaseIds, activeId);
 
 // --- Entry constructors ------------------------------------------------------
 
@@ -138,6 +176,22 @@ export const makeCatalogPackageEntry = (pkg, { id } = {}) => ({
   kind: 'package',
   catalogId: String(pkg?.id ?? ''),
   children: (Array.isArray(pkg?.children) ? pkg.children : []).map(childId => makeCatalogItemEntry(childId)),
+});
+
+// A package that has no Budget catalog entry at all (catalogId '') - it can't reference the
+// catalog because there is nothing there to reference, so its name/children/price are the
+// invoice's own record from the moment it's created. `customized: true` is what makes
+// resolveServiceRow/PDF rendering treat it as fully self-contained rather than "missing from the
+// catalog": see resolveServiceRow's `missing` flag below and InvoicePdfDocument's PackageBlock,
+// which renders a customized package's included services/schedule inline instead of pointing at
+// the Budget (there being no Budget entry to point at).
+export const makeCustomPackageEntry = ({ name = '' } = {}, { id } = {}) => ({
+  id: id || createEntryId(),
+  kind: 'package',
+  catalogId: '',
+  customized: true,
+  name: String(name || '').trim() || 'Custom package',
+  children: [],
 });
 
 // Deep-clones an entry (and, for packages, its children) with fresh ids - used whenever a
@@ -288,8 +342,10 @@ export const resetItemEntryOverrides = entry => (entry?.kind === 'item'
   : entry);
 
 // Reverts a package entry back to a fresh snapshot of the given budget/packages record, dropping
-// every local override and child edit.
-export const resetPackageEntryToCatalog = (entry, pkg) => (entry?.kind === 'package'
+// every local override and child edit. A custom package (no catalogId, so no `pkg` to revert to)
+// is left untouched - there is nothing in the Budget to revert it to without destroying its only
+// copy of its own name/children.
+export const resetPackageEntryToCatalog = (entry, pkg) => (entry?.kind === 'package' && pkg
   ? makeCatalogPackageEntry(pkg, { id: entry.id })
   : entry);
 
@@ -334,7 +390,9 @@ export const isEntryCustomized = entry => (entry?.kind === 'custom' ? true : Boo
 // stop the same catalog item/package being added to the invoice twice.
 export const getEntryIdentityKey = entry => {
   if (!entry) return '';
-  if (entry.kind === 'package') return `package:${entry.catalogId}`;
+  // A custom package (catalogId '') has no shared catalog identity to dedupe against - two
+  // different custom packages must never collide on `package:` and get treated as duplicates.
+  if (entry.kind === 'package') return entry.catalogId ? `package:${entry.catalogId}` : `package:custom:${entry.id}`;
   if (entry.kind === 'packagePercent') return `package-percent:${entry.catalogId}:${entry.percent || 0}`;
   if (entry.kind === 'item') return `item:${entry.catalogId}`;
   if (entry.kind === 'percent') return `percent:${entry.packageId}:${entry.percent}`;
@@ -393,7 +451,10 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       id: entry.id,
       kind: 'package',
       catalogId: entry.catalogId,
-      missing: !pkg,
+      // A package with no catalogId was never meant to reference the catalog (see
+      // makeCustomPackageEntry) - only flag "missing" when a catalogId was set but no longer
+      // resolves, never for a package that's custom by design.
+      missing: Boolean(entry.catalogId) && !pkg,
       isCustomized: Boolean(entry.customized),
       name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
       description: entry.description ?? pkg?.description ?? '',

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -10,6 +10,7 @@ import {
   computeInvoiceTotal,
   generateInvoiceIdentifiers,
   getActiveBeneficiary,
+  getActivePayerCase,
   getEntryIdentityKey,
   getTodayYmd,
   isEntryCustomized,
@@ -17,6 +18,7 @@ import {
   makeCatalogItemEntry,
   makeCatalogPackageEntry,
   makeCustomEntry,
+  makeCustomPackageEntry,
   makePercentOfPackageEntry,
   movePackageChild,
   normalizeInvoiceData,
@@ -24,6 +26,7 @@ import {
   parseLegacyServiceString,
   removePackageChild,
   reorderBeneficiaryIds,
+  reorderPayerCaseIds,
   reorderRecentServices,
   resetItemEntryOverrides,
   resetPackageEntryToCatalog,
@@ -39,6 +42,8 @@ describe('invoiceCatalogUtils', () => {
     expect(data).toEqual({
       beneficiaries: [],
       beneficiaryIds: [],
+      payerCases: [{ id: 'legacy', customers: [] }],
+      payerCaseIds: ['legacy'],
       customers: [],
       recentServices: [],
       invoiceServices: [],
@@ -74,6 +79,35 @@ describe('invoiceCatalogUtils', () => {
   it('reorders beneficiaryIds without touching the beneficiaries array', () => {
     expect(reorderBeneficiaryIds(['a', 'b', 'c'], 'c')).toEqual(['c', 'a', 'b']);
     expect(reorderBeneficiaryIds(['a', 'b'], 'a')).toEqual(['a', 'b']);
+  });
+
+  describe('payer cases (P0: selecting a new client replaces, never merges, the active payer)', () => {
+    it('migrates a legacy flat customers array into a single payer case', () => {
+      const data = normalizeInvoiceData({ customers: [{ name: 'Amny Athamny', address: 'Netherlands' }] });
+      expect(data.payerCases).toEqual([{ id: 'legacy', customers: [{ name: 'Amny Athamny', address: 'Netherlands' }] }]);
+      expect(data.payerCaseIds).toEqual(['legacy']);
+      expect(data.customers).toEqual([{ name: 'Amny Athamny', address: 'Netherlands' }]);
+    });
+
+    it('picks the active case customers from the first payerCaseId, mirrored onto data.customers', () => {
+      const data = normalizeInvoiceData({
+        payerCases: [
+          { id: 'case-1', customers: [{ name: 'Kyogoku', address: 'Japan' }] },
+          { id: 'case-2', customers: [{ name: 'Amny Athamny', address: 'Netherlands' }, { name: 'Fons Mitchell Drost', address: 'Netherlands' }] },
+        ],
+        payerCaseIds: ['case-2', 'case-1'],
+      });
+      expect(getActivePayerCase(data).id).toBe('case-2');
+      expect(data.customers).toEqual([
+        { name: 'Amny Athamny', address: 'Netherlands' },
+        { name: 'Fons Mitchell Drost', address: 'Netherlands' },
+      ]);
+    });
+
+    it('reorders payerCaseIds without touching any case\'s stored customers', () => {
+      expect(reorderPayerCaseIds(['a', 'b', 'c'], 'c')).toEqual(['c', 'a', 'b']);
+      expect(reorderPayerCaseIds(['a', 'b'], 'a')).toEqual(['a', 'b']);
+    });
   });
 
   describe('legacy string upgrade', () => {
@@ -230,6 +264,45 @@ describe('invoiceCatalogUtils', () => {
       expect(reverted.id).toBe(pkg.id);
       expect(reverted.customized).toBeUndefined();
       expect(reverted.children.map(child => child.catalogId)).toEqual(['1', '2']);
+    });
+  });
+
+  // P0 (round4 #2): a package with no Budget catalog entry can't reference the catalog - it must
+  // be saved fully on the invoice itself (name + children + price), never depend on a catalog
+  // lookup succeeding.
+  describe('custom packages (no Budget catalog entry)', () => {
+    it('creates a self-contained package entry with an empty catalogId, pre-flagged customized', () => {
+      const pkg = makeCustomPackageEntry({ name: 'Bespoke programme' });
+      expect(pkg).toMatchObject({ kind: 'package', catalogId: '', customized: true, name: 'Bespoke programme', children: [] });
+    });
+
+    it('never reports a custom package as "missing" - it was never meant to match a catalog entry', () => {
+      const pkg = makeCustomPackageEntry({ name: 'Bespoke programme' });
+      const row = resolveServiceRow(pkg, new Map(), { packagesById: new Map() });
+      expect(row.missing).toBe(false);
+      expect(row.isCustomized).toBe(true);
+      expect(row.name).toBe('Bespoke programme');
+    });
+
+    it('bills the sum of its own children when no price override is set', () => {
+      const catalogItemsById = new Map([['1', { id: '1', name: 'Consult', price: 100 }]]);
+      const withChild = addCustomChildToPackage(makeCustomPackageEntry({ name: 'Bespoke' }), { name: 'Extra', price: 50 });
+      const withCatalogChild = addCatalogChildToPackage(withChild, '1');
+      const row = resolveServiceRow(withCatalogChild, catalogItemsById, { itemsById: catalogItemsById, packagesById: new Map() });
+      expect(row.children).toHaveLength(2);
+      expect(row.price).toBe(150);
+    });
+
+    it('two different custom packages never collide on the same identity key', () => {
+      const a = makeCustomPackageEntry({ name: 'Package A' });
+      const b = makeCustomPackageEntry({ name: 'Package B' });
+      expect(getEntryIdentityKey(a)).not.toBe(getEntryIdentityKey(b));
+    });
+
+    it('leaves a custom package untouched when "reset to catalog" is attempted (no catalog entry to revert to)', () => {
+      const pkg = addCustomChildToPackage(makeCustomPackageEntry({ name: 'Bespoke' }), { name: 'Extra', price: 50 });
+      const reverted = resetPackageEntryToCatalog(pkg, undefined);
+      expect(reverted).toBe(pkg);
     });
   });
 


### PR DESCRIPTION
Payer selection was one flat customers array with no case concept, so
switching between unrelated clients across sessions kept appending to it
instead of replacing it, merging different cases into one payer. Introduces
a payerCases/payerCaseIds catalog (same activate-by-reordering-ids pattern
already used for beneficiaries): "New case" replaces the active payer,
"Add customer" still adds a co-payer within the current case, and switching
cases brings the selected one to the front so it's offered first next time.
Legacy flat customers data and JSON uploads both migrate into this model
without losing existing history.

Adds makeCustomPackageEntry for a package with no Budget catalog entry
(catalogId ''), fixing resolveServiceRow's "missing" flag and the reset-to-
catalog action so a from-scratch custom package is never flagged as broken
or silently wiped - its name/children/price are stored fully on the invoice,
verified end-to-end through the real PDF renderer in pdfQaCheck.js.

Verified the master checklist's other two open P0s (unrounded float noise
in USD-converted catalog prices, and package-child text wrapping into a
vertical stripe) are already fixed by prior commits on this branch
(a4137b6, 74f699c, 3b1185e) - reproduced the exact "18514.292958..." case
directly to confirm.