### PR TITLE
Finish round4 #3-7 recent-list persistence and Beneficiary/Payer label cleanup

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -270,6 +270,29 @@ async function checkExpectedExpenses() {
       fail(`Expected Expenses: "Payment #${index + 1} — ${milestone.title}" block should appear exactly once (found ${count})`);
     }
   });
+
+  // Custom package + hand-built schedule (round4 #4) - no catalog package/schedule behind it at
+  // all (packageId '', empty packageSnapshot.children), must still render without crashing.
+  const customSchedulePlan = {
+    packageId: '',
+    packageSnapshot: { name: 'Bespoke concierge programme', description: '', listedPrice: 10000, currency: 'EUR', children: [] },
+    milestones: [
+      { id: 'm1', title: 'Deposit', taxPercent: 0, showPackageOverview: true, services: [{ id: 's1', kind: 'custom', name: 'Deposit', price: 4000 }] },
+      { id: 'm2', title: 'Final payment', taxPercent: 0, showPackageOverview: false, services: [{ id: 's2', kind: 'custom', name: 'Final payment', price: 6000 }] },
+    ],
+  };
+  const customSchedulePages = await renderPdf(React.createElement(ExpectedExpensesPdfDocument, {
+    plan: customSchedulePlan,
+    customers,
+    catalogItemsById: new Map(),
+    priceContext: { itemsById: new Map(), rates: null },
+    planDate: new Date('2026-07-11'),
+  }));
+  checkNoDebugStrings('Expected Expenses (custom schedule)', customSchedulePages);
+  checkNoBlankPages('Expected Expenses (custom schedule)', customSchedulePages);
+  checkStringsRoundTrip('Expected Expenses (custom schedule)', customSchedulePages, [
+    'Bespoke concierge programme', 'Deposit', 'Final payment',
+  ]);
 }
 
 async function checkBudget() {

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -52,10 +52,13 @@ import {
   reorderRecentServices,
   resetItemEntryOverrides,
   resetPackageEntryToCatalog,
+  removeRecentEntry,
   resolveInvoiceServiceRows,
   resolveServiceRow,
   setEntryField,
+  touchRecentEntry,
   updatePackageChildField,
+  upsertRecentEntry,
 } from './invoiceCatalogUtils';
 import {
   addMilestoneService,
@@ -1447,19 +1450,68 @@ const SummaryLine = styled.div`
   }
 `;
 
-const Chip = styled.button`
+// Shared "recent list" chip shape (round4 #6): one click-to-apply button plus one small delete
+// button, used identically for recent services/packages, recent payment schedules, and recent tax
+// rates - the same save/display/delete pattern rendered three times instead of three UIs.
+const ChipContainer = styled.div`
+  display: inline-flex;
+  align-items: stretch;
+  gap: 1px;
   border: 1px dashed var(--km-border);
   background: var(--km-bg);
-  color: var(--km-text);
   border-radius: 999px;
-  padding: 4px 9px;
-  font-size: 11px;
-  font-weight: 700;
-  cursor: pointer;
+  padding: 2px 3px 2px 10px;
 
   &:hover {
     border-color: var(--km-accent);
+  }
+`;
+
+const ChipButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border: none;
+  background: transparent;
+  color: var(--km-text);
+  font-size: 11px;
+  font-weight: 700;
+  text-align: left;
+  padding: 4px 0;
+  cursor: pointer;
+
+  &:hover {
     color: var(--km-accent);
+  }
+`;
+
+// Small-print composition line under a package chip's name (round4 #3.1) - e.g. the services
+// included in a saved custom package, so the admin can tell packages apart without expanding one.
+const ChipComposition = styled.span`
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--km-muted);
+  margin-top: 1px;
+`;
+
+const ChipDeleteButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--km-muted);
+  font-size: 8.5px;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--km-danger-border);
+    color: var(--km-danger);
   }
 `;
 
@@ -1495,6 +1547,10 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [showCatalogPicker, setShowCatalogPicker] = useState(false);
   const [catalogTab, setCatalogTab] = useState('items');
   const [showExpectedExpensesPicker, setShowExpectedExpensesPicker] = useState(false);
+  const [showCustomSchedulePicker, setShowCustomSchedulePicker] = useState(false);
+  const [customPlanPackageName, setCustomPlanPackageName] = useState('');
+  const [customPlanPackagePrice, setCustomPlanPackagePrice] = useState('');
+  const [customScheduleRows, setCustomScheduleRows] = useState([{ title: '', amount: '' }]);
   const [beneficiaryExpanded, setBeneficiaryExpanded] = useState(false);
   const [payerExpanded, setPayerExpanded] = useState(false);
   const fileInputRef = useRef(null);
@@ -1989,6 +2045,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const addRecentServiceEntry = entry => addEntryToInvoice(cloneEntryWithNewId(entry), 'Service added.');
 
+  // round4 #3.2 (and, by the shared mechanism, #6): a trash icon on a recent entry removes just
+  // that one record from the backend list - it never touches the current invoice's own services.
+  const removeRecentServiceEntry = entryId => {
+    const nextRecentServices = data.recentServices.filter(entry => String(entry.id) !== String(entryId));
+    setData(current => ({ ...current, recentServices: nextRecentServices }));
+    persistPath(`${INVOICE_DATA_PATH}/recentServices`, nextRecentServices, 'Removed from recent.');
+  };
+
   // Package children ------------------------------------------------------------
 
   const commitPackageChildField = (packageId, childId, field, value) => {
@@ -2062,6 +2126,79 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     const plan = buildExpectedExpensesPlan(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
     persistExpectedExpenses(plan, 'Expected expenses template created.');
     setShowExpectedExpensesPicker(false);
+  };
+
+  // round4 #4: a custom package has no catalog payment schedule to build from, so the admin builds
+  // one by hand (title + amount rows) instead. Each row becomes a fixed custom line on its own
+  // milestone (never a "% of package" row - there is no catalog package price for that percent to
+  // track live against), matching round4 #2's "stored fully on the invoice" rule for custom packages.
+  const addCustomScheduleRow = () => setCustomScheduleRows(rows => [...rows, { title: '', amount: '' }]);
+
+  const removeCustomScheduleRow = index => setCustomScheduleRows(rows => (rows.length > 1
+    ? rows.filter((row, rowIndex) => rowIndex !== index)
+    : rows));
+
+  const updateCustomScheduleRow = (index, field, value) => setCustomScheduleRows(rows => rows.map(
+    (row, rowIndex) => (rowIndex === index ? { ...row, [field]: value } : row),
+  ));
+
+  // Loads a saved schedule (round4 #4's "recent" list) back into the editable rows, most-recently-
+  // used first thanks to touchRecentEntry bringing it to the front of recentPaymentSchedules.
+  const loadRecentSchedule = scheduleEntry => {
+    setCustomScheduleRows(scheduleEntry.payments.map(payment => ({ title: payment.title, amount: String(payment.amount) })));
+    setCustomPlanPackageName(current => current || scheduleEntry.name || '');
+    const nextRecentPaymentSchedules = touchRecentEntry(data.recentPaymentSchedules, scheduleEntry.id);
+    setData(current => ({ ...current, recentPaymentSchedules: nextRecentPaymentSchedules }));
+    persistPath(`${INVOICE_DATA_PATH}/recentPaymentSchedules`, nextRecentPaymentSchedules);
+  };
+
+  const removeRecentSchedule = scheduleId => {
+    const nextRecentPaymentSchedules = removeRecentEntry(data.recentPaymentSchedules, scheduleId);
+    setData(current => ({ ...current, recentPaymentSchedules: nextRecentPaymentSchedules }));
+    persistPath(`${INVOICE_DATA_PATH}/recentPaymentSchedules`, nextRecentPaymentSchedules, 'Removed from recent.');
+  };
+
+  const createExpectedExpensesPlanFromCustomSchedule = () => {
+    const name = customPlanPackageName.trim();
+    const price = Number(String(customPlanPackagePrice).replace(',', '.'));
+    const payments = customScheduleRows
+      .map(row => ({ title: row.title.trim(), amount: Number(String(row.amount).replace(',', '.')) }))
+      .filter(payment => payment.title && Number.isFinite(payment.amount) && payment.amount > 0);
+    if (!name) {
+      toast.error('Enter a package name.');
+      return;
+    }
+    if (!Number.isFinite(price) || price <= 0) {
+      toast.error('Enter a positive package price.');
+      return;
+    }
+    if (!payments.length) {
+      toast.error('Add at least one payment schedule row (title + amount).');
+      return;
+    }
+    const milestones = payments.map((payment, index) => ({
+      id: createEntryId(),
+      title: payment.title,
+      taxPercent: defaultExpectedExpensesTaxPercent,
+      showPackageOverview: index === 0,
+      services: [makeCustomEntry({ name: payment.title, price: payment.amount })],
+    }));
+    const plan = {
+      packageId: '',
+      packageSnapshot: { name, description: '', listedPrice: price, currency: 'EUR', children: [] },
+      milestones,
+    };
+    persistExpectedExpenses(plan, 'Expected expenses template created from custom schedule.');
+
+    const scheduleEntry = { id: createEntryId(), name, payments };
+    const nextRecentPaymentSchedules = upsertRecentEntry(data.recentPaymentSchedules, scheduleEntry);
+    setData(current => ({ ...current, recentPaymentSchedules: nextRecentPaymentSchedules }));
+    persistPath(`${INVOICE_DATA_PATH}/recentPaymentSchedules`, nextRecentPaymentSchedules);
+
+    setShowCustomSchedulePicker(false);
+    setCustomPlanPackageName('');
+    setCustomPlanPackagePrice('');
+    setCustomScheduleRows([{ title: '', amount: '' }]);
   };
 
   const recalculateExpectedExpensesSchedule = () => {
@@ -2255,9 +2392,35 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   };
 
   const commitTaxPercent = () => {
+    // Accepts both "8.5" and "8,5" (round4 #5) - comma and period both read as the decimal
+    // separator, always stored as a single plain number.
     const value = Number(String(data.taxPercent).replace(',', '.')) || 0;
     setData(current => ({ ...current, taxPercent: value }));
     persistPath(`${INVOICE_DATA_PATH}/taxPercent`, value, 'Tax updated.');
+    // 0% is the untouched default, not a deliberately "applied" rate - only genuinely used rates
+    // join the recent list, and re-applying an already-saved one just bumps it instead of
+    // duplicating it.
+    if (value <= 0) return;
+    const existing = data.recentTaxRates.find(rate => Number(rate.value) === value);
+    const nextRecentTaxRates = existing
+      ? touchRecentEntry(data.recentTaxRates, existing.id)
+      : upsertRecentEntry(data.recentTaxRates, { id: createEntryId(), value });
+    setData(current => ({ ...current, recentTaxRates: nextRecentTaxRates }));
+    persistPath(`${INVOICE_DATA_PATH}/recentTaxRates`, nextRecentTaxRates);
+  };
+
+  // Applies a saved rate (round4 #5's "last selected as default" - here, a one-click quick-pick
+  // rather than a silent auto-fill, so it never overwrites a rate someone is mid-typing).
+  const applyRecentTaxRate = rate => {
+    setData(current => ({ ...current, taxPercent: rate.value, recentTaxRates: touchRecentEntry(current.recentTaxRates, rate.id) }));
+    persistPath(`${INVOICE_DATA_PATH}/taxPercent`, rate.value);
+    persistPath(`${INVOICE_DATA_PATH}/recentTaxRates`, touchRecentEntry(data.recentTaxRates, rate.id));
+  };
+
+  const removeRecentTaxRate = rateId => {
+    const nextRecentTaxRates = removeRecentEntry(data.recentTaxRates, rateId);
+    setData(current => ({ ...current, recentTaxRates: nextRecentTaxRates }));
+    persistPath(`${INVOICE_DATA_PATH}/recentTaxRates`, nextRecentTaxRates, 'Removed from recent.');
   };
 
   // Debt / deposit of the previous payment ------------------------------------------------------
@@ -2561,68 +2724,61 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   {activeBeneficiary ? (
                     <>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>Title</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
+                          placeholder="Title"
                           value={activeBeneficiary.title || ''}
+                          aria-label="Title"
                           onChange={event => updateActiveBeneficiaryField('title', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('title', event.target.value)}
                         />
                       </StackedFieldRow>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>Address</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
+                          placeholder="Address"
                           value={activeBeneficiary.address || ''}
+                          aria-label="Address"
                           onChange={event => updateActiveBeneficiaryField('address', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('address', event.target.value)}
                         />
                       </StackedFieldRow>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>IBAN</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
+                          placeholder="IBAN"
                           value={activeBeneficiary.iban || ''}
+                          aria-label="IBAN"
                           onChange={event => updateActiveBeneficiaryField('iban', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('iban', event.target.value)}
                         />
                       </StackedFieldRow>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>Bank name</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
+                          placeholder="Bank name"
                           value={activeBeneficiary.bankName || ''}
+                          aria-label="Bank name"
                           onChange={event => updateActiveBeneficiaryField('bankName', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('bankName', event.target.value)}
                         />
                       </StackedFieldRow>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>SWIFT code</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
+                          placeholder="SWIFT code"
                           value={activeBeneficiary.swiftCode || ''}
+                          aria-label="SWIFT code"
                           onChange={event => updateActiveBeneficiaryField('swiftCode', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('swiftCode', event.target.value)}
                         />
                       </StackedFieldRow>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>Payment purpose</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
                           value={activeBeneficiary.paymentPurpose || ''}
-                          placeholder="{invoiceNumber} and {invoiceDate} are filled in automatically"
+                          placeholder="Payment purpose - {invoiceNumber} and {invoiceDate} are filled in automatically"
+                          aria-label="Payment purpose"
                           onChange={event => updateActiveBeneficiaryField('paymentPurpose', event.target.value)}
                           onBlur={event => persistActiveBeneficiaryField('paymentPurpose', event.target.value)}
                         />
@@ -2672,31 +2828,26 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   {data.customers.map((customer, index) => (
                     <CustomerBlock key={`customer-${index}`}>
                       <StackedFieldHeader>
-                        <StackedFieldTag>Customer {index + 1}</StackedFieldTag>
-                        <IconDangerButton type="button" onClick={() => removeCustomer(index)} title="Remove customer" aria-label="Remove customer">
+                        <IconDangerButton type="button" onClick={() => removeCustomer(index)} title="Remove customer" aria-label="Remove customer" style={{ marginLeft: 'auto' }}>
                           <FaTrash />
                         </IconDangerButton>
                       </StackedFieldHeader>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>Name</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
                           placeholder="Name"
                           value={customer.name || ''}
+                          aria-label={`Customer ${index + 1} name`}
                           onChange={event => updateCustomerField(index, 'name', event.target.value)}
                           onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
                         />
                       </StackedFieldRow>
                       <StackedFieldRow>
-                        <StackedFieldHeader>
-                          <StackedFieldTag>Address</StackedFieldTag>
-                        </StackedFieldHeader>
                         <AutoTextArea
                           style={{ width: '100%' }}
                           placeholder="Address / country"
                           value={customer.address || ''}
+                          aria-label={`Customer ${index + 1} address`}
                           onChange={event => updateCustomerField(index, 'address', event.target.value)}
                           onBlur={() => persistCustomers(data.customers, 'Customer updated.')}
                         />
@@ -2755,11 +2906,29 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   <ChipRow>
                     {recentServiceSuggestions.map(entry => {
                       const resolved = resolveServiceRow(entry, catalogItemsById, priceContext);
+                      // Small-print composition line so a saved custom package can be told apart
+                      // from another without expanding it (round4 #3.1).
+                      const composition = entry.kind === 'package'
+                        ? (resolved.children || []).map(child => child.name).filter(Boolean).join(', ')
+                        : '';
                       return (
-                        <Chip key={entry.id} type="button" onClick={() => addRecentServiceEntry(entry)}>
-                          {entry.kind === 'package' ? <FaLayerGroup style={{ marginRight: 4 }} /> : null}
-                          {resolved.name} · {formatEuroPreview(resolved.price)}
-                        </Chip>
+                        <ChipContainer key={entry.id}>
+                          <ChipButton type="button" onClick={() => addRecentServiceEntry(entry)}>
+                            <span>
+                              {entry.kind === 'package' ? <FaLayerGroup style={{ marginRight: 4 }} /> : null}
+                              {resolved.name} · {formatEuroPreview(resolved.price)}
+                            </span>
+                            {composition ? <ChipComposition>{composition}</ChipComposition> : null}
+                          </ChipButton>
+                          <ChipDeleteButton
+                            type="button"
+                            onClick={() => removeRecentServiceEntry(entry.id)}
+                            title="Remove from recent"
+                            aria-label="Remove from recent"
+                          >
+                            <FaTrash />
+                          </ChipDeleteButton>
+                        </ChipContainer>
                       );
                     })}
                   </ChipRow>
@@ -2874,12 +3043,32 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <PlainPriceBase
                   rows={1}
                   inputMode="decimal"
+                  aria-label="Taxes (%)"
                   value={data.taxPercent}
                   onChange={event => updateTaxPercent(event.target.value)}
                   onBlur={commitTaxPercent}
                   style={{ flex: '0 0 auto' }}
                 />
               </FieldRow>
+              {data.recentTaxRates.length ? (
+                <ChipRow style={{ marginTop: 0, marginBottom: 8 }}>
+                  {data.recentTaxRates.map(rate => (
+                    <ChipContainer key={rate.id}>
+                      <ChipButton type="button" onClick={() => applyRecentTaxRate(rate)}>
+                        <span>{rate.value}%</span>
+                      </ChipButton>
+                      <ChipDeleteButton
+                        type="button"
+                        onClick={() => removeRecentTaxRate(rate.id)}
+                        title="Remove this rate from recent"
+                        aria-label="Remove this rate from recent"
+                      >
+                        <FaTrash />
+                      </ChipDeleteButton>
+                    </ChipContainer>
+                  ))}
+                </ChipRow>
+              ) : null}
               <FieldRow>
                 <FieldTag title="Applied after tax. Positive = debt owed from before, negative = deposit/credit.">Debt/Deposit</FieldTag>
                 <PlainPriceBase
@@ -2978,9 +3167,11 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   </SmallButton>
                   {expectedExpenses ? (
                     <>
-                      <SmallButton type="button" onClick={recalculateExpectedExpensesSchedule}>
-                        <FaSyncAlt /> Recalculate
-                      </SmallButton>
+                      {expectedExpenses.packageId ? (
+                        <SmallButton type="button" onClick={recalculateExpectedExpensesSchedule}>
+                          <FaSyncAlt /> Recalculate
+                        </SmallButton>
+                      ) : null}
                       <PrimaryMiniButton
                         type="button"
                         onClick={handleGenerateExpectedExpensesPdf}
@@ -3005,9 +3196,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
               {!expectedExpenses ? (
                 <div>
-                  <SmallButton type="button" onClick={() => setShowExpectedExpensesPicker(current => !current)}>
-                    <FaLayerGroup /> {showExpectedExpensesPicker ? 'Hide packages' : 'Choose a package'}
-                  </SmallButton>
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    <SmallButton type="button" onClick={() => setShowExpectedExpensesPicker(current => !current)}>
+                      <FaLayerGroup /> {showExpectedExpensesPicker ? 'Hide packages' : 'Choose a package'}
+                    </SmallButton>
+                    <SmallButton type="button" onClick={() => setShowCustomSchedulePicker(current => !current)}>
+                      <FaLayerGroup /> {showCustomSchedulePicker ? 'Hide custom schedule' : 'Custom package/schedule'}
+                    </SmallButton>
+                  </div>
                   {showExpectedExpensesPicker ? (
                     <CatalogPickerList style={{ marginTop: 8 }}>
                       {visibleCatalogPackages.map(pkg => (
@@ -3018,6 +3214,84 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       ))}
                       {!visibleCatalogPackages.length ? <PanelNote style={{ margin: 0 }}>No packages in the catalog.</PanelNote> : null}
                     </CatalogPickerList>
+                  ) : null}
+                  {showCustomSchedulePicker ? (
+                    <div style={{ marginTop: 8 }}>
+                      <PanelNote style={{ margin: '0 0 8px' }}>
+                        For a package with no Budget catalog entry: name it, set its total price, and build its
+                        payment schedule by hand (round4 #4). Each row bills a fixed amount - it has no live
+                        catalog price to track a percentage against.
+                      </PanelNote>
+                      <FieldRow $align="center">
+                        <PlainTextBase
+                          rows={1}
+                          placeholder="Package name"
+                          value={customPlanPackageName}
+                          onChange={event => setCustomPlanPackageName(event.target.value)}
+                        />
+                        <PlainPriceBase
+                          rows={1}
+                          placeholder="Total price"
+                          inputMode="decimal"
+                          value={customPlanPackagePrice}
+                          onChange={event => setCustomPlanPackagePrice(event.target.value)}
+                        />
+                      </FieldRow>
+                      {customScheduleRows.map((row, index) => (
+                        <FieldRow key={`schedule-row-${index}`} $align="center">
+                          <PlainTextBase
+                            rows={1}
+                            placeholder="Payment title"
+                            value={row.title}
+                            onChange={event => updateCustomScheduleRow(index, 'title', event.target.value)}
+                          />
+                          <PlainPriceBase
+                            rows={1}
+                            placeholder="Amount"
+                            inputMode="decimal"
+                            value={row.amount}
+                            onChange={event => updateCustomScheduleRow(index, 'amount', event.target.value)}
+                          />
+                          <IconDangerButton
+                            type="button"
+                            onClick={() => removeCustomScheduleRow(index)}
+                            title="Remove this row"
+                            aria-label="Remove this row"
+                          >
+                            <FaTrash />
+                          </IconDangerButton>
+                        </FieldRow>
+                      ))}
+                      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+                        <SmallButton type="button" onClick={addCustomScheduleRow}><FaPlus /> Add row</SmallButton>
+                        <PrimaryMiniButton type="button" onClick={createExpectedExpensesPlanFromCustomSchedule}>
+                          Create plan
+                        </PrimaryMiniButton>
+                      </div>
+                      {data.recentPaymentSchedules.length ? (
+                        <>
+                          <PanelNote style={{ marginTop: 14, marginBottom: 4 }}>Recent schedules (click to load)</PanelNote>
+                          <ChipRow>
+                            {data.recentPaymentSchedules.map(scheduleEntry => (
+                              <ChipContainer key={scheduleEntry.id}>
+                                <ChipButton type="button" onClick={() => loadRecentSchedule(scheduleEntry)}>
+                                  <span>{scheduleEntry.name || 'Custom schedule'}</span>
+                                  <ChipComposition>{scheduleEntry.payments.map(payment => payment.title).join(', ')}</ChipComposition>
+                                </ChipButton>
+                                <ChipDeleteButton
+                                  type="button"
+                                  onClick={() => removeRecentSchedule(scheduleEntry.id)}
+                                  title="Remove this schedule from recent"
+                                  aria-label="Remove this schedule from recent"
+                                >
+                                  <FaTrash />
+                                </ChipDeleteButton>
+                              </ChipContainer>
+                            ))}
+                          </ChipRow>
+                        </>
+                      ) : null}
+                    </div>
                   ) : null}
                 </div>
               ) : (

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -403,6 +403,76 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // Round4 #7: Beneficiary/Payer fields should show only the value (or a placeholder when empty),
+  // never a "TITLE"/"IBAN"/"CUSTOMER 1"-style label above every field.
+  it('shows no field labels above Beneficiary/Payer values, only placeholders', async () => {
+    const root = mount();
+    await flush();
+
+    const beneficiaryToggle = Array.from(container.querySelectorAll('[role="button"]')).find(el => el.textContent.includes('Beneficiary'));
+    const payerToggle = Array.from(container.querySelectorAll('[role="button"]')).find(el => el.textContent.includes('Payer'));
+    await act(async () => { beneficiaryToggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { payerToggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const removedLabels = ['Title', 'IBAN', 'Bank name', 'SWIFT code', 'Customer 1'];
+    const spanTexts = Array.from(container.querySelectorAll('span')).map(span => span.textContent.trim());
+    removedLabels.forEach(label => expect(spanTexts).not.toContain(label));
+
+    expect(container.querySelector('textarea[placeholder="Title"]')).toBeTruthy();
+    expect(container.querySelector('textarea[placeholder="IBAN"]')).toBeTruthy();
+    expect(container.querySelector('textarea[placeholder="Name"]')).toBeTruthy();
+
+    await act(async () => { root.unmount(); });
+  });
+
+  // round4 #5/#6: a committed tax rate joins a shared recent-rates list (comma or period decimal),
+  // offered as a one-click quick-pick with its own delete, the same pattern used for services.
+  it('remembers a committed tax rate for one-click reuse, with a trash icon to forget it', async () => {
+    const root = mount();
+    await flush();
+
+    const taxField = container.querySelector('textarea[aria-label="Taxes (%)"]');
+    expect(taxField).toBeTruthy();
+    await act(async () => {
+      taxField.focus();
+      setFieldValue(taxField, '8,5');
+      taxField.blur();
+    });
+    await flush();
+
+    let persistedTaxPercent = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/taxPercent').pop();
+    expect(persistedTaxPercent[1]).toBe(8.5);
+    let persistedRates = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/recentTaxRates').pop();
+    expect(persistedRates[1]).toEqual([{ id: expect.any(String), value: 8.5 }]);
+    expect(findButton('8.5%')).toBeTruthy();
+
+    // Change the field away, then click the saved 8.5% chip to reapply it in one click.
+    await act(async () => {
+      taxField.focus();
+      setFieldValue(taxField, '0');
+      taxField.blur();
+    });
+    await flush();
+    await act(async () => { findButton('8.5%').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    persistedTaxPercent = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/taxPercent').pop();
+    expect(persistedTaxPercent[1]).toBe(8.5);
+
+    // Delete it from recent - it disappears from the quick-pick list without touching the invoice's own tax field.
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(btn => btn.title === 'Remove this rate from recent');
+    expect(deleteButton).toBeTruthy();
+    await act(async () => { deleteButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(findButton('8.5%')).toBeFalsy();
+    persistedRates = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/recentTaxRates').pop();
+    expect(persistedRates[1]).toEqual([]);
+
+    await act(async () => { root.unmount(); });
+  });
+
   describe('expected expenses', () => {
     const createPlan = async () => {
       await act(async () => { findButton('Choose a package').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
@@ -640,6 +710,109 @@ describe('InvoiceBuilderPage', () => {
       expect(plan.packageId).toBe('3');
       expect(plan.milestones).toHaveLength(6);
       expect(plan.milestones[1].services[1]).toMatchObject({ name: 'Deposit for transportation of SM', price: 300 });
+
+      await act(async () => { root.unmount(); });
+    });
+
+    // round4 #4: a package with no Budget catalog entry has no catalog schedule to build a plan
+    // from, so the admin builds one by hand - each row is a fixed amount, not a live percent share.
+    it('builds an Expected Expenses plan from a hand-built custom schedule, and saves it to Recent for reuse', async () => {
+      const root = mount();
+      await flush();
+
+      await act(async () => { findButton('Custom package/schedule').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const nameField = container.querySelector('textarea[placeholder="Package name"]');
+      const priceField = container.querySelector('textarea[placeholder="Total price"]');
+      await act(async () => {
+        nameField.focus();
+        setFieldValue(nameField, 'Bespoke concierge programme');
+        priceField.focus();
+        setFieldValue(priceField, '10000');
+      });
+
+      const titleField = container.querySelector('textarea[placeholder="Payment title"]');
+      const amountField = container.querySelector('textarea[placeholder="Amount"]');
+      await act(async () => {
+        titleField.focus();
+        setFieldValue(titleField, 'Deposit');
+        amountField.focus();
+        setFieldValue(amountField, '4000');
+      });
+
+      await act(async () => { findButton('Add row').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+      const titleFields = container.querySelectorAll('textarea[placeholder="Payment title"]');
+      const amountFields = container.querySelectorAll('textarea[placeholder="Amount"]');
+      await act(async () => {
+        titleFields[1].focus();
+        setFieldValue(titleFields[1], 'Final payment');
+        amountFields[1].focus();
+        setFieldValue(amountFields[1], '6000');
+      });
+
+      await act(async () => { findButton('Create plan').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const plan = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses').pop()[1];
+      expect(plan.packageId).toBe('');
+      expect(plan.packageSnapshot).toMatchObject({ name: 'Bespoke concierge programme', listedPrice: 10000 });
+      expect(plan.milestones).toHaveLength(2);
+      expect(plan.milestones[0]).toMatchObject({ title: 'Deposit' });
+      expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'custom', name: 'Deposit', price: 4000 });
+      expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'custom', name: 'Final payment', price: 6000 });
+
+      // A catalog-schedule-only action must not appear for a plan with no catalog package behind it.
+      expect(findButton('Recalculate')).toBeFalsy();
+
+      const savedSchedules = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/recentPaymentSchedules').pop();
+      expect(savedSchedules[1]).toEqual([{
+        id: expect.any(String),
+        name: 'Bespoke concierge programme',
+        payments: [{ title: 'Deposit', amount: 4000 }, { title: 'Final payment', amount: 6000 }],
+      }]);
+
+      await act(async () => { root.unmount(); });
+    });
+
+    it('reloads a saved custom schedule from Recent, and deleting it removes it from the list', async () => {
+      const root = mount();
+      await flush();
+
+      // Seed one recent schedule the way createExpectedExpensesPlanFromCustomSchedule would.
+      await act(async () => { findButton('Custom package/schedule').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+      await act(async () => {
+        setFieldValue(container.querySelector('textarea[placeholder="Package name"]'), 'Saved plan');
+        setFieldValue(container.querySelector('textarea[placeholder="Total price"]'), '5000');
+        setFieldValue(container.querySelector('textarea[placeholder="Payment title"]'), 'Only payment');
+        setFieldValue(container.querySelector('textarea[placeholder="Amount"]'), '5000');
+      });
+      await act(async () => { findButton('Create plan').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+      await act(async () => { findButton('Delete plan').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      await act(async () => { findButton('Custom package/schedule').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const savedChip = findButton('Saved plan');
+      expect(savedChip).toBeTruthy();
+      await act(async () => { savedChip.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(container.querySelector('textarea[placeholder="Payment title"]').value).toBe('Only payment');
+      expect(container.querySelector('textarea[placeholder="Amount"]').value).toBe('5000');
+
+      const deleteButton = Array.from(container.querySelectorAll('button')).find(btn => btn.title === 'Remove this schedule from recent');
+      expect(deleteButton).toBeTruthy();
+      await act(async () => { deleteButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(findButton('Saved plan')).toBeFalsy();
+      const savedSchedules = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/recentPaymentSchedules').pop();
+      expect(savedSchedules[1]).toEqual([]);
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -86,6 +86,15 @@ export const normalizeInvoiceData = raw => {
     customers: activeCase?.customers || [],
     recentServices: normalizeServiceEntries(raw?.recentServices),
     invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
+    // Every payment schedule an admin has ever built for a custom package (round4 #4), most
+    // recently used first - offered when a package has no catalog schedule to fall back on.
+    recentPaymentSchedules: Array.isArray(raw?.recentPaymentSchedules)
+      ? raw.recentPaymentSchedules.filter(schedule => schedule && typeof schedule === 'object')
+      : [],
+    // Every tax rate an admin has ever applied (round4 #5), most recently used first.
+    recentTaxRates: Array.isArray(raw?.recentTaxRates)
+      ? raw.recentTaxRates.filter(rate => rate && typeof rate === 'object' && Number.isFinite(Number(rate.value)))
+      : [],
     notes: Array.isArray(raw?.notes) ? raw.notes : [],
     taxPercent: Number.isFinite(Number(raw?.taxPercent)) ? Number(raw.taxPercent) : 0,
     // A signed carry-over from the client's previous payment, settled after tax (never itself
@@ -535,6 +544,26 @@ export const reorderRecentServices = (recentServices, invoiceServices) => {
   const rest = (Array.isArray(recentServices) ? recentServices : []).filter(entry => !seen.has(getEntryIdentityKey(entry)));
   return [...used, ...rest];
 };
+
+// The shared "recent list" mechanism (round4 #6): every recent list beyond recentServices (custom
+// payment schedules, tax rates) is a plain array of objects with a stable `id`, offered most-
+// recently-used first - one save/display/delete pattern reused for both, instead of building two
+// separate ad hoc systems.
+export const upsertRecentEntry = (list, entry) => {
+  const rest = (Array.isArray(list) ? list : []).filter(existing => String(existing?.id) !== String(entry?.id));
+  return [entry, ...rest];
+};
+
+// Re-applies an already-saved entry (found by id) to the front of the list, without creating a
+// duplicate copy - used when picking an existing recent schedule/tax rate rather than a new one.
+export const touchRecentEntry = (list, id) => {
+  const items = Array.isArray(list) ? list : [];
+  const found = items.find(entry => String(entry?.id) === String(id));
+  return found ? upsertRecentEntry(items, found) : items;
+};
+
+export const removeRecentEntry = (list, id) =>
+  (Array.isArray(list) ? list : []).filter(entry => String(entry?.id) !== String(id));
 
 export const buildPayerName = customers =>
   (Array.isArray(customers) ? customers : [])

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -25,6 +25,7 @@ import {
   normalizeServiceEntry,
   parseLegacyServiceString,
   removePackageChild,
+  removeRecentEntry,
   reorderBeneficiaryIds,
   reorderPayerCaseIds,
   reorderRecentServices,
@@ -33,7 +34,9 @@ import {
   resolveInvoiceServiceRows,
   resolveServiceRow,
   setEntryField,
+  touchRecentEntry,
   updatePackageChildField,
+  upsertRecentEntry,
 } from './invoiceCatalogUtils';
 
 describe('invoiceCatalogUtils', () => {
@@ -47,6 +50,8 @@ describe('invoiceCatalogUtils', () => {
       customers: [],
       recentServices: [],
       invoiceServices: [],
+      recentPaymentSchedules: [],
+      recentTaxRates: [],
       notes: [],
       taxPercent: 0,
       debtOrDeposit: 0,
@@ -492,6 +497,31 @@ describe('invoiceCatalogUtils', () => {
       const invoiceServices = [makeCatalogItemEntry('3'), makeCatalogItemEntry('2')];
       const reordered = reorderRecentServices(recentServices, invoiceServices);
       expect(reordered.map(entry => entry.catalogId)).toEqual(['3', '2', '1']);
+    });
+  });
+
+  // round4 #6: one shared save/display/delete pattern for both recent payment schedules and
+  // recent tax rates, instead of two separate ad hoc systems.
+  describe('shared recent-list mechanism (payment schedules, tax rates)', () => {
+    it('adds a new entry to the front, and re-adding an existing id moves it to the front instead of duplicating', () => {
+      const a = { id: 'a', value: 14 };
+      const b = { id: 'b', value: 20 };
+      const withBoth = upsertRecentEntry(upsertRecentEntry([], a), b);
+      expect(withBoth).toEqual([b, a]);
+      expect(upsertRecentEntry(withBoth, a)).toEqual([a, b]);
+    });
+
+    it('touches an existing entry by id to the front without needing the full object again', () => {
+      const a = { id: 'a', value: 14 };
+      const b = { id: 'b', value: 20 };
+      expect(touchRecentEntry([a, b], 'b')).toEqual([b, a]);
+      expect(touchRecentEntry([a, b], 'missing')).toEqual([a, b]);
+    });
+
+    it('removes an entry by id, leaving the rest untouched', () => {
+      const a = { id: 'a', value: 14 };
+      const b = { id: 'b', value: 20 };
+      expect(removeRecentEntry([a, b], 'a')).toEqual([b]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a shared "recent list" save/display/delete mechanism (round4 #6) and wires it up for recent packages (with composition preview + delete, round4 #3), custom payment schedules for packages with no Budget catalog entry (round4 #4), and tax rate history with one-click reuse (round4 #5, decimal comma/period already worked).
- Removes the remaining Beneficiary/Payer field labels (Title/Address/IBAN/Bank name/SWIFT code/Customer N), leaving only the value or a placeholder (round4 #7).
- Verified (no changes needed - already fixed by prior commits already on `main`): "% of package" UI/defaulting, Beneficiary/Payer vertical layout, 3-row service line structure, milestone accordion, UKRCOM design tokens/theme-color, PDF Preview removal, icon cluster sizing, Invoice PDF payment-caveat removal/Budget-block duplication/spacing, Expected Expenses tax-per-milestone and duplication cleanup, Program Budget page-break-before per section, and that Invoice Builder never mutates canonical Budget data.

## Test plan
- [x] `npx react-scripts test` for `invoiceCatalogUtils`, `InvoiceBuilderPage`, `budgetCatalogUtils`, `expectedExpensesUtils`, `BudgetPage` - all passing, including new tests for the payer-case switch, custom packages, recent-tax-rate reuse/delete, and custom-schedule creation/reload/delete.
- [x] `npm run qa:pdf` - renders real Invoice/Expected Expenses/Budget PDFs (including new custom-package and custom-schedule scenarios) and checks for no debug strings, no blank pages, no corrupted text, no brand leakage.
- [ ] Live verification on the deployed site (not possible from this sandbox - no real Firebase credentials here).


---
_Generated by [Claude Code](https://claude.ai/code/session_0121TR5FX9xtzuwtJBZu43D8)_