### PR TITLE
Fix custom package invoice billing

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1614,7 +1614,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   // "% of package" only makes sense once a package is already part of this invoice - it's a
   // share of that package's price, not a standalone add option (spec item C).
   const firstTopLevelPackage = useMemo(
-    () => invoiceServiceRows.find(row => row.kind === 'package') || null,
+    () => invoiceServiceRows.find(row => row.kind === 'package' && row.catalogId) || null,
     [invoiceServiceRows],
   );
 
@@ -2322,17 +2322,27 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         return;
       }
       const uploadedData = normalizeInvoiceData(parsed);
-      // The uploaded file's customers describe a single case - add it as a new case on top of
-      // whatever payer history already exists here, rather than overwriting it, so uploading a
-      // JSON for a different client never merges into (or wipes out) a previous client's payer.
-      const uploadedCase = { id: createEntryId(), customers: uploadedData.customers };
-      const nextPayerCases = [...data.payerCases, uploadedCase];
-      const nextPayerCaseIds = reorderPayerCaseIds(data.payerCaseIds, uploadedCase.id);
+      // Preserve every payer case carried by the uploaded file, but clone their ids before
+      // appending them to this browser's current history so imported backups never collide with
+      // existing local cases. The uploaded active case stays active after import.
+      const uploadedCasesById = new Map(uploadedData.payerCases.map(payerCase => [String(payerCase.id), payerCase]));
+      const orderedUploadedCases = uploadedData.payerCaseIds
+        .map(id => uploadedCasesById.get(String(id)))
+        .filter(Boolean);
+      const uploadedCases = orderedUploadedCases.map(payerCase => ({
+        id: createEntryId(),
+        customers: payerCase.customers,
+      }));
+      const activeUploadedCase = uploadedCases[0] || { id: createEntryId(), customers: uploadedData.customers };
+      const casesToAppend = uploadedCases.length ? uploadedCases : [activeUploadedCase];
+      const uploadedCaseIds = casesToAppend.map(payerCase => payerCase.id);
+      const nextPayerCases = [...data.payerCases, ...casesToAppend];
+      const nextPayerCaseIds = [...uploadedCaseIds, ...data.payerCaseIds.map(String).filter(id => !uploadedCaseIds.includes(id))];
       const nextData = {
         ...uploadedData,
         payerCases: nextPayerCases,
         payerCaseIds: nextPayerCaseIds,
-        customers: uploadedCase.customers,
+        customers: activeUploadedCase.customers,
       };
       await Promise.all([
         set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextData.beneficiaries),

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -219,6 +219,7 @@ describe('InvoiceBuilderPage', () => {
     expect(container.innerHTML).toContain('Bespoke concierge programme');
     expect(container.innerHTML).toContain('Custom package');
     expect(container.innerHTML).not.toContain('Missing');
+    expect(findButton('% of package')).toBeFalsy();
 
     await act(async () => { root.unmount(); });
   });
@@ -399,6 +400,48 @@ describe('InvoiceBuilderPage', () => {
     await flush();
 
     expect(activeNameFieldValues()).toEqual(['Amny Athamny']);
+
+    await act(async () => { root.unmount(); });
+  });
+
+  it('preserves every payer case from an uploaded invoice JSON while appending current history', async () => {
+    const root = mount();
+    await flush();
+
+    const fileInput = container.querySelector('input[type="file"][accept="application/json"]');
+    expect(fileInput).toBeTruthy();
+
+    const uploadedInvoice = {
+      beneficiaries: fixtureInvoiceData.beneficiaries,
+      beneficiaryIds: fixtureInvoiceData.beneficiaryIds,
+      customers: [{ name: 'Active Upload', address: 'Germany' }],
+      payerCases: [
+        { id: 'upload-active', customers: [{ name: 'Active Upload', address: 'Germany' }] },
+        { id: 'upload-history', customers: [{ name: 'Historical Upload', address: 'France' }] },
+      ],
+      payerCaseIds: ['upload-active', 'upload-history'],
+      recentServices: [],
+      invoiceServices: [],
+      notes: [],
+      taxPercent: 0,
+    };
+    const fileText = JSON.stringify(uploadedInvoice);
+    const file = new File([fileText], 'invoice.json', { type: 'application/json' });
+    file.text = () => Promise.resolve(fileText);
+    Object.defineProperty(fileInput, 'files', { value: [file] });
+
+    await act(async () => { fileInput.dispatchEvent(new Event('change', { bubbles: true })); });
+    await flush();
+
+    const payerCases = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/payerCases').pop()[1];
+    expect(payerCases.map(payerCase => payerCase.customers[0]?.name)).toEqual([
+      'Amny Athamny',
+      'Active Upload',
+      'Historical Upload',
+    ]);
+    const payerCaseIds = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/payerCaseIds').pop()[1];
+    expect(payerCases.find(payerCase => payerCase.id === payerCaseIds[0]).customers[0].name).toBe('Active Upload');
+    expect(payerCases.find(payerCase => payerCase.id === payerCaseIds[1]).customers[0].name).toBe('Historical Upload');
 
     await act(async () => { root.unmount(); });
   });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -506,12 +506,12 @@ export const resolveInvoiceServiceRows = (invoiceServices, catalogItemsById, pri
 export const resolveInvoiceDocType = rows => ((Array.isArray(rows) ? rows : [])
   .some(row => row?.kind === 'package' || row?.kind === 'percent') ? 'programme_milestone' : 'service');
 
-// A top-level 'package' row is never billed by its own price - it's a reference block (its
-// included-services list and Payment Schedule mirror the catalog programme for context, same as
-// Budget), not a line item of this specific invoice. What's actually billed alongside it is
-// whatever other rows sit next to it - custom/catalog items, or a 'percent' share of that package.
+// A catalog-backed top-level 'package' row is never billed by its own price - it's a
+// reference block (its included-services list and Payment Schedule mirror the catalog programme
+// for context, same as Budget), not a line item of this specific invoice. Custom packages have no
+// catalog payment-share row to bill alongside them, so their resolved package price is billable.
 export const computeInvoiceSubtotal = rows => rows
-  .filter(row => row?.kind !== 'package')
+  .filter(row => row?.kind !== 'package' || !row?.catalogId)
   .reduce((sum, row) => sum + (Number(row.price) || 0), 0);
 
 export const computeInvoiceTotal = (subtotal, taxPercent) => subtotal * (1 + (Number(taxPercent) || 0) / 100);

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -476,6 +476,18 @@ describe('invoiceCatalogUtils', () => {
       // 20% of 40000 (8000) + the 300 deposit - the package's own 40000 reference price is excluded.
       expect(subtotal).toBe(8300);
     });
+
+    it('includes a custom package in the subtotal because there is no catalog share row to bill alongside it', () => {
+      const catalogItemsById = new Map([['1', { id: '1', name: 'Consultation', price: 300 }]]);
+      const customPackage = setEntryField(
+        addCatalogChildToPackage(makeCustomPackageEntry({ name: 'Bespoke package' }), '1'),
+        'price',
+        1200,
+      );
+      const rows = resolveInvoiceServiceRows([customPackage], catalogItemsById);
+      expect(rows[0]).toMatchObject({ kind: 'package', catalogId: '', price: 1200 });
+      expect(computeInvoiceSubtotal(rows)).toBe(1200);
+    });
   });
 
   describe('identity keys and recent services', () => {


### PR DESCRIPTION
### Motivation
- Custom packages created on an invoice were being treated like catalog packages and therefore excluded from invoice subtotals, causing invoices with only custom packages to total €0. 
- The top-level "% of package" action was exposed for custom packages and could create invalid percent rows because they have no `catalogId` to resolve against. 
- Uploading/importing invoice JSON dropped non-active `payerCases`, losing imported payer-case history.

### Description
- Adjusted subtotal logic so only catalog-backed package rows remain reference-only by changing `computeInvoiceSubtotal` to include package rows when `catalogId` is empty (`!row?.catalogId`).
- Prevented the package-share shortcut from appearing for custom packages by making `firstTopLevelPackage` only match packages that have a `catalogId` in `InvoiceBuilderPage.jsx`.
- Preserved uploaded payer-case history by cloning and appending every payer case from imported JSON (cloning ids to avoid collisions) and keeping the uploaded active case selected when composing `nextData` in the file upload handler.
- Added/updated unit tests to cover custom package subtotal inclusion, hiding the "% of package" action for custom packages, and preserving uploaded payer-case history (`invoiceCatalogUtils.test.js` and `InvoiceBuilderPage.test.js`).

### Testing
- Ran `npm test -- --watchAll=false --runInBand src/components/invoiceCatalogUtils.test.js src/components/InvoiceBuilderPage.test.js` and all targeted suites passed.
- Test run summary: 2 test suites, 71 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b51336c48326b6e4f2337492e501)