### PR TITLE
Fix custom package invoice handling

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1670,7 +1670,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   // "% of package" only makes sense once a package is already part of this invoice - it's a
   // share of that package's price, not a standalone add option (spec item C).
   const firstTopLevelPackage = useMemo(
-    () => invoiceServiceRows.find(row => row.kind === 'package') || null,
+    () => invoiceServiceRows.find(row => row.kind === 'package' && row.catalogId) || null,
     [invoiceServiceRows],
   );
 
@@ -2485,17 +2485,31 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         return;
       }
       const uploadedData = normalizeInvoiceData(parsed);
-      // The uploaded file's customers describe a single case - add it as a new case on top of
-      // whatever payer history already exists here, rather than overwriting it, so uploading a
-      // JSON for a different client never merges into (or wipes out) a previous client's payer.
-      const uploadedCase = { id: createEntryId(), customers: uploadedData.customers };
-      const nextPayerCases = [...data.payerCases, uploadedCase];
-      const nextPayerCaseIds = reorderPayerCaseIds(data.payerCaseIds, uploadedCase.id);
+      // Preserve every payer case stored in the uploaded file, but clone their ids before
+      // appending them to local history so an imported backup never collides with existing
+      // cases (for example another file that still uses the legacy id). The uploaded active
+      // case stays active after import by reordering the combined id list around its clone.
+      const uploadedActiveCaseId = uploadedData.payerCaseIds[0];
+      const uploadedCases = uploadedData.payerCases.map(payerCase => ({
+        id: createEntryId(),
+        customers: payerCase.customers,
+        sourceId: payerCase.id,
+      }));
+      const uploadedActiveCase = uploadedCases.find(payerCase => String(payerCase.sourceId) === String(uploadedActiveCaseId))
+        || uploadedCases[0];
+      const nextPayerCases = [
+        ...data.payerCases,
+        ...uploadedCases.map(({ sourceId, ...payerCase }) => payerCase),
+      ];
+      const nextPayerCaseIds = reorderPayerCaseIds(
+        [...data.payerCaseIds, ...uploadedCases.map(payerCase => payerCase.id)],
+        uploadedActiveCase.id,
+      );
       const nextData = {
         ...uploadedData,
         payerCases: nextPayerCases,
         payerCaseIds: nextPayerCaseIds,
-        customers: uploadedCase.customers,
+        customers: uploadedActiveCase.customers,
       };
       await Promise.all([
         set(ref(database, `${INVOICE_DATA_PATH}/beneficiaries`), nextData.beneficiaries),

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -515,12 +515,13 @@ export const resolveInvoiceServiceRows = (invoiceServices, catalogItemsById, pri
 export const resolveInvoiceDocType = rows => ((Array.isArray(rows) ? rows : [])
   .some(row => row?.kind === 'package' || row?.kind === 'percent') ? 'programme_milestone' : 'service');
 
-// A top-level 'package' row is never billed by its own price - it's a reference block (its
-// included-services list and Payment Schedule mirror the catalog programme for context, same as
-// Budget), not a line item of this specific invoice. What's actually billed alongside it is
-// whatever other rows sit next to it - custom/catalog items, or a 'percent' share of that package.
+// A catalog-backed top-level 'package' row is never billed by its own price - it's a
+// reference block (its included-services list and Payment Schedule mirror the catalog
+// programme for context, same as Budget). Custom packages have no catalog payment-share
+// row to bill alongside them, so their resolved price (children total or override) is a
+// real invoice line and must stay in totals.
 export const computeInvoiceSubtotal = rows => rows
-  .filter(row => row?.kind !== 'package')
+  .filter(row => row?.kind !== 'package' || !row.catalogId)
   .reduce((sum, row) => sum + (Number(row.price) || 0), 0);
 
 export const computeInvoiceTotal = (subtotal, taxPercent) => subtotal * (1 + (Number(taxPercent) || 0) / 100);

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -449,9 +449,9 @@ describe('invoiceCatalogUtils', () => {
       expect(row.price).toBe(0);
     });
 
-    // P0 bug: a package row is a reference block (Payment Schedule mirrors the catalog programme for
-    // context, like Budget) - its own price must never be billed into this invoice's Subtotal, only
-    // the other rows actually invoiced alongside it (custom/catalog items, or a % share of it) are.
+    // Catalog package rows are reference blocks (Payment Schedule mirrors the catalog programme for
+    // context, like Budget) - their own prices must never be billed into this invoice's Subtotal,
+    // only the other rows actually invoiced alongside them (custom/catalog items, or a % share) are.
     it('excludes a package row\'s own price from the subtotal, billing only the invoice\'s other rows', () => {
       const catalogItemsById = new Map([
         ['15', { id: '15', name: 'Scheduled payment', price: 3000 }],
@@ -480,6 +480,14 @@ describe('invoiceCatalogUtils', () => {
       const subtotal = computeInvoiceSubtotal(rows);
       // 20% of 40000 (8000) + the 300 deposit - the package's own 40000 reference price is excluded.
       expect(subtotal).toBe(8300);
+    });
+
+    it('includes a custom package row in the subtotal because there is no catalog share row', () => {
+      const catalogItemsById = new Map([['1', { id: '1', name: 'Consultation', price: 300 }]]);
+      const customPackage = addCatalogChildToPackage(makeCustomPackageEntry({ name: 'From-scratch package' }), '1');
+      const rows = resolveInvoiceServiceRows([customPackage], catalogItemsById);
+      expect(rows[0]).toMatchObject({ kind: 'package', catalogId: '', price: 300, childrenTotal: 300 });
+      expect(computeInvoiceSubtotal(rows)).toBe(300);
     });
   });
 


### PR DESCRIPTION
### Motivation

- Ensure custom (from‑scratch) package rows created by the admin are included in invoice totals because they have no catalog payment‑share row to bill alongside them.
- Prevent creating broken "% of package" percent rows for custom packages that lack a catalog id.
- Preserve all payer/case history when importing/uploading invoice JSON so existing inactive cases from backups are not dropped.

### Description

- Change subtotal logic in `src/components/invoiceCatalogUtils.js` so `computeInvoiceSubtotal` excludes only catalog-backed package rows and includes packages with an empty `catalogId` (custom packages) by filtering with `row => row?.kind !== 'package' || !row.catalogId`.
- Limit the UI percent action in `src/components/InvoiceBuilderPage.jsx` by making `firstTopLevelPackage` pick only packages with a `catalogId` (`row.kind === 'package' && row.catalogId`), hiding the "% of package" button for custom packages.
- Preserve uploaded payer cases in `InvoiceBuilderPage.jsx` by cloning/imported case ids via `createEntryId()`, appending all uploaded `payerCases` to local history, and reordering ids so the uploaded active case remains active after import.
- Add a regression test in `src/components/invoiceCatalogUtils.test.js` that asserts a custom package row (no `catalogId`) is resolved with a price and included in the subtotal.

### Testing

- Ran component tests: `npm test -- --watchAll=false src/components/invoiceCatalogUtils.test.js src/components/InvoiceBuilderPage.test.js`, and both suites passed (invoice-related tests passed).
- Ran linter: `npm run lint:js`, which completed with no lint errors.
- Ran full test suite: `npm test -- --watchAll=false` which surfaced existing unrelated failures in matching/cache storage tests; invoice-related tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b65ea7448326be0e184ada88cbcd)