### PR TITLE
Support hidden "special offer" packages and percent-based payment schedules

### DIFF
--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -19,6 +19,7 @@ import {
   normalizeCatalog,
   parseBudgetPriceValue,
   resolveBudgetPriceAmount,
+  resolvePaymentAmount,
   roundToCents,
   KNOWN_CATEGORY_KEYS,
   KNOWN_CLIENT_NOTE_GROUPS,
@@ -1642,10 +1643,11 @@ const BudgetPage = ({ isAdmin = false }) => {
     }), 'Payment deleted.');
   };
 
-  const renderPaymentSchedule = schedule => {
+  const renderPaymentSchedule = (schedule, program) => {
     const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
     if (!payments.length) return null;
-    const total = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
+    const packagePrice = resolveBudgetPriceAmount(program?.listedPrice, priceContext);
+    const total = payments.reduce((sum, payment) => sum + (resolvePaymentAmount(payment, packagePrice) || 0), 0);
 
     return (
       <PaymentScheduleCard aria-label="Payment schedule">
@@ -1654,7 +1656,7 @@ const BudgetPage = ({ isAdmin = false }) => {
           {payments.map((payment, index) => (
             <PaymentScheduleRow key={`${schedule.id || 'payment'}-${index}`}>
               <PaymentScheduleLabel>{`${index + 1}. ${payment.title || ''}`}</PaymentScheduleLabel>
-              <PaymentScheduleAmount>{formatEuroAmount(payment.amount)}</PaymentScheduleAmount>
+              <PaymentScheduleAmount>{formatEuroAmount(resolvePaymentAmount(payment, packagePrice))}</PaymentScheduleAmount>
             </PaymentScheduleRow>
           ))}
         </PaymentScheduleList>
@@ -1680,8 +1682,8 @@ const BudgetPage = ({ isAdmin = false }) => {
     }
 
     const payments = Array.isArray(schedule.payments) ? schedule.payments : [];
-    const scheduleTotal = payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0);
     const packagePrice = resolveBudgetPriceAmount(program.listedPrice, priceContext);
+    const scheduleTotal = payments.reduce((sum, payment) => sum + (resolvePaymentAmount(payment, packagePrice) || 0), 0);
     // Collapsed by default so an edit screen full of programs stays scannable.
     const isCollapsed = collapsedScheduleEditors[program.id] !== false;
 
@@ -1725,12 +1727,21 @@ const BudgetPage = ({ isAdmin = false }) => {
                 </EditableField>
                 <EditableField>
                   <FieldLabel>Amount</FieldLabel>
-                  <EditInput
-                    type="number"
-                    inputMode="decimal"
-                    defaultValue={payment.amount != null ? roundToCents(payment.amount) : ''}
-                    onBlur={event => updatePayment(schedule.id, index, 'amount', event.target.value)}
-                  />
+                  {payment.amount == null && payment.percent != null ? (
+                    // Percent-based payment (e.g. ps-6): shown read-only here - editing it as a raw
+                    // amount would silently overwrite `percent` with a frozen euro figure on blur,
+                    // which defeats the point of a percent-of-listed-price schedule step.
+                    <PaymentScheduleAmount title="Percent-based payment - edit the percent in the catalog JSON">
+                      {`${payment.percent}% (${formatEuroAmount(resolvePaymentAmount(payment, packagePrice))})`}
+                    </PaymentScheduleAmount>
+                  ) : (
+                    <EditInput
+                      type="number"
+                      inputMode="decimal"
+                      defaultValue={payment.amount != null ? roundToCents(payment.amount) : ''}
+                      onBlur={event => updatePayment(schedule.id, index, 'amount', event.target.value)}
+                    />
+                  )}
                 </EditableField>
                 <PaymentEditorActions>
                   <MiniButton type="button" title="Insert payment after this one" onClick={() => addPayment(schedule.id, index)}>
@@ -2129,7 +2140,7 @@ const BudgetPage = ({ isAdmin = false }) => {
                       )}
                       {isEditMode ? renderInternalNote('packages', program) : null}
                       {isEditMode ? renderEditableFields('packages', program) : null}
-                      {!isEditMode ? renderPaymentSchedule(resolveProgramPaymentSchedule(program)) : null}
+                      {!isEditMode ? renderPaymentSchedule(resolveProgramPaymentSchedule(program), program) : null}
                       {renderPaymentScheduleEditor(program, resolveProgramPaymentSchedule(program))}
                       <Toggle type="button" onClick={() => toggleProgram(program.id)} aria-expanded={isOpen}>
                         <span>What's included</span>

--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -9,6 +9,7 @@ import {
   getVisibleSortedPackages,
   normalizeClientNotes,
   resolveBudgetPriceAmount,
+  resolvePaymentAmount,
   resolveProgramPaymentSchedule,
   KNOWN_CLIENT_NOTE_GROUPS,
 } from './budgetCatalogUtils';
@@ -361,11 +362,18 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
     const titleSource = programSchedules.find(schedule => schedule?.payments?.[index]?.title);
     return {
       title: titleSource?.payments[index].title || `Payment ${index + 1}`,
-      amounts: programSchedules.map(schedule => schedule?.payments?.[index]?.amount),
+      amounts: programSchedules.map((schedule, programIndex) => {
+        const payment = schedule?.payments?.[index];
+        if (!payment) return undefined;
+        return resolvePaymentAmount(payment, resolveListedPrice(packages[programIndex]));
+      }),
     };
   });
-  const scheduleTotals = programSchedules.map(schedule => (Array.isArray(schedule?.payments)
-    ? schedule.payments.reduce((sum, payment) => sum + (Number(payment?.amount) || 0), 0)
+  const scheduleTotals = programSchedules.map((schedule, programIndex) => (Array.isArray(schedule?.payments)
+    ? schedule.payments.reduce(
+      (sum, payment) => sum + (resolvePaymentAmount(payment, resolveListedPrice(packages[programIndex])) || 0),
+      0,
+    )
     : null));
 
   const includedIds = [];

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -17,7 +17,7 @@ import {
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
-import { formatEuroSmart, getVisibleSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
+import { formatEuroSmart, getSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import {
@@ -671,7 +671,9 @@ const PercentShareRow = ({
             {!catalogPackages.some(pkg => String(pkg.id) === String(row.packageId)) ? (
               <option value={row.packageId}>{`Package ${row.packageId}`}</option>
             ) : null}
-            {catalogPackages.map(pkg => <option key={pkg.id} value={pkg.id}>{pkg.name}</option>)}
+            {catalogPackages.map(pkg => (
+              <option key={pkg.id} value={pkg.id}>{pkg.hidden ? `${pkg.name} (Special offer)` : pkg.name}</option>
+            ))}
           </PlainSelect>
         )}
         <AutoTextArea
@@ -971,6 +973,23 @@ const CatalogPickerPercentButton = styled.button`
     border-color: var(--km-accent);
     color: var(--km-accent);
   }
+`;
+
+// A package hidden from the public Program Budget PDF (a manually-offered "special offer") is
+// still pickable here - this badge is the only thing telling the admin it's not one of the
+// public programs.
+const SpecialOfferBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--km-accent-light);
+  color: var(--km-accent);
+  padding: 2px 7px;
+  margin-left: 6px;
+  font-size: 9px;
+  font-weight: 900;
+  text-transform: uppercase;
 `;
 
 const CatalogTabs = styled.div`
@@ -1725,8 +1744,10 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       .slice(0, 30);
   }, [catalogItems, usedCatalogItemIds, catalogQuery]);
 
+  // Hidden ("special offer") packages are excluded from the public Program Budget PDF but must
+  // stay pickable here - an admin selects them deliberately, they're just not advertised.
   const visibleCatalogPackages = useMemo(
-    () => getVisibleSortedPackages({ packages: catalogPackages }, priceContext),
+    () => getSortedPackages({ packages: catalogPackages }, priceContext),
     [catalogPackages, priceContext],
   );
 
@@ -2043,8 +2064,9 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     );
     const usedPercentTotal = existingPercentRows.reduce((sum, entry) => sum + (Number(entry.percent) || 0), 0);
     const nextPayment = schedule?.payments?.[existingPercentRows.length];
-    const defaultPercent = (nextPayment && listedPriceAmount)
-      ? Math.round((Number(nextPayment.amount || 0) / listedPriceAmount) * 1e6) / 1e4
+    const nextPaymentAmount = nextPayment ? resolvePaymentAmount(nextPayment, listedPriceAmount) : null;
+    const defaultPercent = (nextPaymentAmount != null && listedPriceAmount)
+      ? Math.round((nextPaymentAmount / listedPriceAmount) * 1e6) / 1e4
       : Math.max(0, Math.round((100 - usedPercentTotal) * 100) / 100);
     addEntryToInvoice(makePercentOfPackageEntry(packageId, defaultPercent), 'Service added.');
   };
@@ -3029,7 +3051,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       )) : filteredCatalogPackages.map(pkg => (
                         <CatalogPickerRow key={pkg.id}>
                           <CatalogPickerButton type="button" style={{ flex: '1 1 auto' }} onClick={() => addCatalogPackageEntry(pkg)} title="Add the whole package at its full listed price">
-                            <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}</span>
+                            <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}{pkg.hidden ? <SpecialOfferBadge>Special offer</SpecialOfferBadge> : null}</span>
                           </CatalogPickerButton>
                           <CatalogPickerPercentButton
                             type="button"
@@ -3233,7 +3255,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     <CatalogPickerList style={{ marginTop: 8 }}>
                       {visibleCatalogPackages.map(pkg => (
                         <CatalogPickerButton key={pkg.id} type="button" onClick={() => createExpectedExpensesPlan(pkg)}>
-                          <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}</span>
+                          <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}{pkg.hidden ? <SpecialOfferBadge>Special offer</SpecialOfferBadge> : null}</span>
                           <span>{formatEuroPreview(resolveBudgetPriceAmount(pkg.listedPrice, priceContext) ?? pkg.listedPrice)}</span>
                         </CatalogPickerButton>
                       ))}

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -17,11 +17,29 @@ const fixturePackages = [
   {
     id: 'p1', name: 'Full program', listedPrice: 250, description: 'Everything included.', children: ['10', '11'], paymentScheduleId: 'ps-1',
   },
+  // Special Offer, initial payment: hidden from the public catalog, no payment schedule at all -
+  // a single lump-sum package (spec §2.2).
+  {
+    id: 'p6', name: 'Special Offer — Initial Payment', listedPrice: 7580, description: '', children: ['10'], hidden: true,
+  },
+  // Special Offer, programme fee: hidden, with a percent-based schedule (spec §2.3, ps-6 format).
+  {
+    id: 'p7', name: 'Special Offer — Programme Fee', listedPrice: 29700, description: '', children: ['11'], hidden: true, paymentScheduleId: 'ps-6',
+  },
 ];
 
 const fixtureTechnical = {
   paymentSchedules: [
     { id: 'ps-1', payments: [{ title: 'To start the program', amount: 150 }, { title: 'Final payment', amount: 100 }] },
+    {
+      id: 'ps-6',
+      payments: [
+        { percent: 25, title: 'On confirmation of pregnancy by ultrasound' },
+        { percent: 25, title: 'Milestone 2' },
+        { percent: 25, title: 'Milestone 3' },
+        { percent: 25, title: 'Milestone 4' },
+      ],
+    },
   ],
   wireTransferSurchargeRate: 0.14,
 };
@@ -219,6 +237,36 @@ describe('InvoiceBuilderPage', () => {
     expect(container.innerHTML).toContain('Bespoke concierge programme');
     expect(container.innerHTML).toContain('Custom package');
     expect(container.innerHTML).not.toContain('Missing');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  // Special Offer packages (hidden: true) are deliberately excluded from the public Program
+  // Budget PDF, but an admin must still be able to pick them here - labeled so they're never
+  // mistaken for one of the public programs.
+  it('lists hidden "Special Offer" packages in the catalog picker, and adds one with no payment schedule at its full listed price', async () => {
+    const root = mount();
+    await flush();
+
+    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(container.innerHTML).toContain('Special Offer — Initial Payment');
+    expect(container.innerHTML).toContain('Special offer');
+
+    const packageButton = findButton('Special Offer — Initial Payment');
+    expect(packageButton).toBeTruthy();
+    await act(async () => { packageButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    const packageEntry = lastServicesCall[1].find(entry => entry.kind === 'package' && entry.catalogId === 'p6');
+    expect(packageEntry).toBeTruthy();
+    // No payment schedule on this package (spec §2.2) - the whole package is billed as a single
+    // payment at its full listed price, with no milestone/percent breakdown to pick from.
+    expect(container.innerHTML).toContain('7580');
 
     await act(async () => { root.unmount(); });
   });
@@ -503,6 +551,34 @@ describe('InvoiceBuilderPage', () => {
       expect(plan.milestones[0].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 60 });
       expect(plan.milestones[1]).toMatchObject({ title: 'Final payment', showPackageOverview: false });
       expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: 'p1', percent: 40 });
+
+      await act(async () => { root.unmount(); });
+    });
+
+    // Special Offer — Programme Fee (ps-6): its payment schedule uses { percent: 25 } entries
+    // instead of { amount }, so building the plan must resolve them the same way an amount-based
+    // schedule (like ps-1) is resolved.
+    it('builds an Expected Expenses plan from a percent-based schedule (ps-6 format)', async () => {
+      const root = mount();
+      await flush();
+
+      await act(async () => { findButton('Choose a package').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+      const packageButton = findButton('Special Offer — Programme Fee');
+      expect(packageButton).toBeTruthy();
+      await act(async () => { packageButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const persistedCalls = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/expectedExpenses');
+      expect(persistedCalls.length).toBeGreaterThan(0);
+      const plan = persistedCalls[persistedCalls.length - 1][1];
+      expect(plan.packageId).toBe('p7');
+      expect(plan.milestones).toHaveLength(4);
+      plan.milestones.forEach(milestone => {
+        expect(milestone.services[0]).toMatchObject({ kind: 'percent', packageId: 'p7', percent: 25 });
+      });
+      // 29,700 EUR x 25% = 7,425 EUR per milestone (checklist item in the import spec), before tax.
+      expect(container.innerHTML).toContain('Subtotal: €7,425');
 
       await act(async () => { root.unmount(); });
     });

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -4,7 +4,7 @@ import {
   BrandRow, BrandRule, BronzeMotif, ContinuedTag, Footer, PDF_COLOR, PDF_FONT,
   ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
-import { formatMoney, resolveBudgetPriceAmount, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
+import { formatMoney, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
 import { IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
 import {
   buildCaseTitle,
@@ -341,16 +341,23 @@ const InvoicePdfDocument = ({
   const resolvePackageSchedule = row => {
     const catalogPackage = priceContext?.packagesById?.get?.(String(row.catalogId));
     const schedule = catalogPackage ? resolveProgramPaymentSchedule({ technical: catalogTechnical }, catalogPackage) : null;
-    if (!row.isCustomized || !schedule?.payments?.length || !catalogPackage) return schedule;
+    if (!schedule?.payments?.length || !catalogPackage) return schedule;
     const catalogTotal = resolveBudgetPriceAmount(catalogPackage.listedPrice, { ...priceContext, itemsById: catalogItemsById });
+    // Resolve every payment (amount- or percent-based) to a concrete euro amount up front, so the
+    // rest of this file - and PackageBlock below - only ever reads a plain `payment.amount` number.
+    const resolvedPayments = schedule.payments.map(payment => ({
+      ...payment,
+      amount: resolvePaymentAmount(payment, catalogTotal),
+    }));
+    if (!row.isCustomized) return { ...schedule, payments: resolvedPayments };
     const rowTotal = Number(row.price);
-    if (!catalogTotal || !Number.isFinite(rowTotal)) return schedule;
+    if (!catalogTotal || !Number.isFinite(rowTotal)) return { ...schedule, payments: resolvedPayments };
     const scale = rowTotal / catalogTotal;
     return {
       ...schedule,
-      payments: schedule.payments.map(payment => ({
+      payments: resolvedPayments.map(payment => ({
         ...payment,
-        amount: Number.isFinite(Number(payment.amount)) ? Math.round(Number(payment.amount) * scale * 100) / 100 : payment.amount,
+        amount: Number.isFinite(payment.amount) ? Math.round(payment.amount * scale * 100) / 100 : payment.amount,
       })),
     };
   };

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -268,6 +268,15 @@ export const getVisibleSortedPackages = (catalog, context = {}) =>
     .sort((a, b) => (resolveBudgetPriceAmount(a.listedPrice, context) || 0)
       - (resolveBudgetPriceAmount(b.listedPrice, context) || 0));
 
+// Every package, hidden ones included, sorted by price - for admin-facing pickers (Invoice
+// Builder, Expected Expenses) where a "special offer" package must stay selectable even though
+// it's deliberately kept out of the public Program Budget PDF (getVisibleSortedPackages above).
+export const getSortedPackages = (catalog, context = {}) =>
+  (Array.isArray(catalog?.packages) ? catalog.packages : [])
+    .slice()
+    .sort((a, b) => (resolveBudgetPriceAmount(a.listedPrice, context) || 0)
+      - (resolveBudgetPriceAmount(b.listedPrice, context) || 0));
+
 export const resolveProgramPaymentSchedule = (catalog, program) => {
   const schedules = Array.isArray(catalog?.technical?.paymentSchedules)
     ? catalog.technical.paymentSchedules
@@ -278,4 +287,16 @@ export const resolveProgramPaymentSchedule = (catalog, program) => {
   return program?.paymentSchedule && typeof program.paymentSchedule === 'object'
     ? program.paymentSchedule
     : null;
+};
+
+// A payment-schedule entry is either a fixed euro amount ({ amount }, ps-1..ps-5) or a share of
+// the package's listed price ({ percent }, ps-6 onwards) - every reader of `paymentSchedules`
+// (Budget/Invoice/Expected Expenses) funnels through here instead of reading `payment.amount`
+// directly, so the two formats can freely coexist in the same schedule.
+export const resolvePaymentAmount = (payment, listedPrice) => {
+  if (Number.isFinite(Number(payment?.amount))) return roundToCents(Number(payment.amount));
+  if (Number.isFinite(Number(payment?.percent)) && listedPrice != null && Number.isFinite(Number(listedPrice))) {
+    return roundToCents((Number(listedPrice) * Number(payment.percent)) / 100);
+  }
+  return null;
 };

--- a/src/components/budgetCatalogUtils.test.js
+++ b/src/components/budgetCatalogUtils.test.js
@@ -5,10 +5,13 @@ import {
   formatMoney,
   getExpensePriceLabel,
   getItemDisplayAmount,
+  getSortedPackages,
+  getVisibleSortedPackages,
   normalizeBudgetPriceInput,
   normalizeCatalog,
   normalizeClientNotes,
   resolveBudgetPriceAmount,
+  resolvePaymentAmount,
   USD_TO_EUR_RATE,
 } from './budgetCatalogUtils';
 
@@ -161,5 +164,46 @@ describe('budgetCatalogUtils', () => {
     expect(catalog.packages).toHaveLength(1);
     expect(catalog.clientNotes.programMilestones).toEqual(['Note']);
     expect(catalog.technical.wireTransferSurchargeRate).toBe(0.14);
+  });
+
+  // Special Offer packages (hidden: true) must stay out of the public Program Budget PDF but
+  // remain pickable in Invoice Builder / Expected Expenses - two catalogs, one filtered, one not.
+  describe('hidden packages', () => {
+    const catalog = {
+      packages: [
+        { id: 1, name: 'Public A', listedPrice: 40000 },
+        { id: 6, name: 'Special Offer — Initial Payment', listedPrice: 7580, hidden: true },
+        { id: 2, name: 'Public B', listedPrice: 15000 },
+      ],
+    };
+
+    it('excludes hidden packages from getVisibleSortedPackages', () => {
+      const ids = getVisibleSortedPackages(catalog).map(pkg => pkg.id);
+      expect(ids).toEqual([2, 1]);
+    });
+
+    it('keeps hidden packages in getSortedPackages, still sorted by price', () => {
+      const ids = getSortedPackages(catalog).map(pkg => pkg.id);
+      expect(ids).toEqual([6, 2, 1]);
+    });
+  });
+
+  describe('resolvePaymentAmount', () => {
+    it('uses the fixed amount when present', () => {
+      expect(resolvePaymentAmount({ amount: 15000 }, 40000)).toBe(15000);
+    });
+
+    it('derives the amount from a percent of the listed price', () => {
+      expect(resolvePaymentAmount({ percent: 25 }, 29700)).toBe(7425);
+    });
+
+    it('prefers amount over percent when both are somehow present', () => {
+      expect(resolvePaymentAmount({ amount: 100, percent: 50 }, 1000)).toBe(100);
+    });
+
+    it('returns null when neither amount nor a resolvable percent is present', () => {
+      expect(resolvePaymentAmount({ title: 'No figure' }, 1000)).toBeNull();
+      expect(resolvePaymentAmount({ percent: 25 }, null)).toBeNull();
+    });
   });
 });

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -31,7 +31,7 @@ import {
   resolveServiceRow,
   setEntryField,
 } from './invoiceCatalogUtils';
-import { resolveProgramPaymentSchedule } from './budgetCatalogUtils';
+import { resolveProgramPaymentSchedule, resolvePaymentAmount } from './budgetCatalogUtils';
 
 // --- Building a plan from a chosen catalog package + its payment schedule ------------------------------------------------------
 
@@ -47,7 +47,7 @@ export const buildPackageOverviewChildren = pkg => (Array.isArray(pkg?.children)
 // instead of drifting by tens of euros on packages whose payments aren't a round percentage.
 const buildGroupFromSchedulePayment = (pkg, payment) => {
   const listedPrice = Number(pkg?.listedPrice) || 0;
-  const amount = Number(payment?.amount) || 0;
+  const amount = resolvePaymentAmount(payment, listedPrice) || 0;
   if (!listedPrice || !amount) return [];
   const percent = Math.round((amount / listedPrice) * 1e6) / 1e4;
   return [makePercentOfPackageEntry(pkg?.id, percent, { expectedExpenseRole: 'scheduled' })];

--- a/src/components/expectedExpensesUtils.test.js
+++ b/src/components/expectedExpensesUtils.test.js
@@ -61,6 +61,28 @@ describe('expectedExpensesUtils', () => {
     expect(plan.milestones[1].services[0]).toMatchObject({ kind: 'percent', packageId: '3', percent: 15 });
   });
 
+  // ps-6 (Special Offer — Programme Fee): 4 payments of { percent: 25 } instead of { amount }.
+  it('builds milestones from a percent-based schedule (ps-6 format), same as an amount-based one', () => {
+    const specialOfferPkg = { id: '7', name: 'Special Offer — Programme Fee', listedPrice: 29700, currency: 'EUR', children: [] };
+    const percentSchedule = {
+      id: 'ps-6',
+      payments: [
+        { percent: 25, title: 'On confirmation of pregnancy by ultrasound' },
+        { percent: 25, title: 'Milestone 2' },
+        { percent: 25, title: 'Milestone 3' },
+        { percent: 25, title: 'Milestone 4' },
+      ],
+    };
+    const plan = buildExpectedExpensesPlan(specialOfferPkg, percentSchedule);
+    expect(plan.milestones).toHaveLength(4);
+    plan.milestones.forEach(milestone => {
+      expect(milestone.services[0]).toMatchObject({ kind: 'percent', packageId: '7', percent: 25 });
+    });
+    expect(computeMilestonesTotal(
+      plan.milestones, new Map(), { packagesById: new Map([['7', specialOfferPkg]]) },
+    )).toBe(7425 * 4);
+  });
+
   it('never stores a euro amount on a milestone - the percent-of-package row recalculates it', () => {
     const plan = buildExpectedExpensesPlan(pkg, schedule);
     expect(computeMilestonesTotal(plan.milestones, new Map(), { packagesById: new Map([['3', pkg]]) })).toBe(40000);


### PR DESCRIPTION
The upcoming budget catalog update adds hidden:true packages (id 6/7,
Special Offer) and a percent-based payment schedule (ps-6, { percent }
instead of { amount }). This wires the code up to handle both:

- Program Budget PDF keeps excluding hidden packages (unchanged); Invoice
  Builder and Expected Expenses now keep them selectable, badged "Special
  offer" (new getSortedPackages, vs. the hidden-filtering
  getVisibleSortedPackages).
- A package with no paymentScheduleId (id 6) already degrades gracefully
  to a single full-price payment - verified with a test instead of relying
  on incidental behavior.
- Added a shared resolvePaymentAmount(payment, listedPrice) helper so every
  payment-schedule reader (Budget admin screen/PDF, Invoice PDF, Expected
  Expenses) resolves either format instead of reading payment.amount
  directly.