### PR TITLE
Render hidden packages fully in the Invoice PDF, add explicit detail selector

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -403,10 +403,13 @@ const StackedFieldRow = styled.div`
 // the Name/Address text lines up with the summary text instead of sitting flush against the panel
 // edge, a step to the left of everything above it.
 const CustomerBlock = styled.div`
-  padding: 8px 0 8px 12px;
+  padding: 8px 10px 8px 12px;
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  background: var(--km-bg);
 
   & + & {
-    border-top: 1px solid var(--km-border);
+    margin-top: 8px;
   }
 `;
 
@@ -854,6 +857,28 @@ const PackageHeaderRow = styled(LineMainRow)`
   align-items: flex-start;
 `;
 
+// The explicit "which package/schedule to render in the PDF" selector (round5 #4 / round6 #1) -
+// same visual pattern as the Beneficiary/Active-case PlainSelect, not a toggle.
+const PackageDetailModeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0 0 28px;
+
+  @media (max-width: 560px) {
+    margin-left: 10px;
+  }
+`;
+
+const PackageDetailModeLabel = styled.span`
+  flex: 0 0 auto;
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--km-muted);
+`;
+
 const PackageIcon = styled.span`
   flex: 0 0 auto;
   display: inline-flex;
@@ -1149,6 +1174,22 @@ const PackageEntryCard = ({
           {row.description || '+ Add description'}
         </DescriptionToggle>
       )}
+
+      {row.catalogId ? (
+        <PackageDetailModeRow>
+          <PackageDetailModeLabel>PDF detail</PackageDetailModeLabel>
+          <PlainSelect
+            style={{ flex: '0 1 auto', width: 'auto' }}
+            value={row.detailMode || 'auto'}
+            aria-label="Package detail shown in the Invoice PDF"
+            onChange={event => onCommitField('detailMode', event.target.value)}
+          >
+            <option value="auto">{`Auto (${row.isHiddenCatalog ? 'full details – no Budget' : 'reference to Budget'})`}</option>
+            <option value="full">Full details in PDF</option>
+            <option value="reference">Reference to Budget only</option>
+          </PlainSelect>
+        </PackageDetailModeRow>
+      ) : null}
 
       <PackageChildren>
         {row.children.map((child, childIndex) => (

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -15,6 +15,7 @@ import {
   computeInvoiceTotal,
   resolveInvoiceDocType,
   resolveInvoiceServiceRows,
+  shouldRenderPackageDetail,
 } from './invoiceCatalogUtils';
 
 ensurePdfFontsRegistered();
@@ -238,16 +239,16 @@ const ServiceItemRow = ({ row, isFirst }) => {
 const PackageBlock = ({ row, schedule, scheduleTotal }) => {
   const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
   const totalLabel = formatRowAmount(row);
-  const isCustomized = Boolean(row.isCustomized);
+  const showFullDetail = shouldRenderPackageDetail(row);
   const packageMeta = [{ id: row.id || row.key || 'package', label: row.name, priceLabel: totalLabel }];
-  const includedRows = isCustomized
+  const includedRows = showFullDetail
     ? (row.children || []).map((child, index) => ({
       id: child.id || child.key || `child-${index}`,
       name: child.name || '',
       includedByPackageId: new Set([String(packageMeta[0].id)]),
     }))
     : [];
-  const scheduleRows = isCustomized
+  const scheduleRows = showFullDetail
     ? payments.map(payment => ({
       title: payment.title || 'Payment',
       amounts: [Number.isFinite(Number(payment.amount)) ? Number(payment.amount) : null],
@@ -256,6 +257,11 @@ const PackageBlock = ({ row, schedule, scheduleTotal }) => {
   const budgetReferenceNote = payments.length
     ? `Part of a ${payments.length}-instalment programme totalling ${totalLabel}. Full programme details and the complete payment schedule are set out in your Budget.`
     : `Full programme details and the complete payment schedule are set out in your Budget.`;
+  // A hidden/special-offer package has no public Budget document at all - "see your Budget" would
+  // point the client nowhere, so the note explains the detail is shown here instead.
+  const fullDetailNote = row.isHiddenCatalog && !row.isCustomized
+    ? 'This programme has no separate Budget document - its full details are shown below.'
+    : 'This invoice includes customised programme details shown below.';
 
   return (
     <View style={styles.packageBlock}>
@@ -265,11 +271,9 @@ const PackageBlock = ({ row, schedule, scheduleTotal }) => {
         {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
         <Text style={styles.packageBlockFee}>{`Total programme fee ${totalLabel}`}</Text>
       </View>
-      {isCustomized ? (
+      {showFullDetail ? (
         <>
-          <Text style={styles.sectionNote}>
-            {sanitizePdfText('This invoice includes customised programme details shown below.')}
-          </Text>
+          <Text style={styles.sectionNote}>{sanitizePdfText(fullDetailNote)}</Text>
           <IncludedServicesTable
             packages={packageMeta}
             includedRows={includedRows}

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -340,6 +340,11 @@ export const setEntryField = (entry, field, value) => {
   if (entry.kind === 'package') {
     if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
     if (field === 'name' || field === 'description') return { ...entry, [field]: value, customized: true };
+    // detailMode is a rendering choice for this one invoice, not a content edit - it must never
+    // flip `customized` (that flag means "no longer matches the catalog package's actual content").
+    if (field === 'detailMode') {
+      return { ...entry, detailMode: ['full', 'reference'].includes(value) ? value : 'auto' };
+    }
     return entry;
   }
   return { ...entry, [field]: field === 'price' ? toNumber(value) : value, customized: true };
@@ -394,6 +399,18 @@ export const addCatalogChildToPackage = (entry, catalogId) => {
 // --- Queries ------------------------------------------------------------
 
 export const isEntryCustomized = entry => (entry?.kind === 'custom' ? true : Boolean(entry?.customized));
+
+// Whether a package row's full "Included in this programme" + "Payment schedule" detail should be
+// rendered inline on the Invoice PDF, instead of the one-sentence Budget reference (round6 #1).
+// An explicit detailMode always wins; left on 'auto', it renders full detail exactly when there's
+// no Budget document to point at instead - a customized package (content no longer matches the
+// catalog) or a hidden/special-offer package (no public Budget page at all).
+export const shouldRenderPackageDetail = row => {
+  if (!row) return false;
+  if (row.detailMode === 'full') return true;
+  if (row.detailMode === 'reference') return false;
+  return Boolean(row.isCustomized) || Boolean(row.isHiddenCatalog);
+};
 
 // A stable identity for an entry, ignoring its id - used to dedupe "recent services" chips and to
 // stop the same catalog item/package being added to the invoice twice.
@@ -465,6 +482,14 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       // resolves, never for a package that's custom by design.
       missing: Boolean(entry.catalogId) && !pkg,
       isCustomized: Boolean(entry.customized),
+      // A "hidden" catalog package (a manually-offered special offer) has no public Budget document
+      // of its own - there is nothing for the Invoice's "see your Budget" reference sentence to
+      // point at, so PackageBlock must fall back to rendering the full details inline instead.
+      isHiddenCatalog: Boolean(pkg?.hidden),
+      // 'auto' (default) lets shouldRenderPackageDetail decide from isCustomized/isHiddenCatalog;
+      // 'full'/'reference' are an explicit per-invoice admin override of that default (round5 #4 /
+      // round6 #1 - a selector, not an implicit toggle).
+      detailMode: ['full', 'reference'].includes(entry.detailMode) ? entry.detailMode : 'auto',
       name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
       description: entry.description ?? pkg?.description ?? '',
       price: hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -34,6 +34,7 @@ import {
   resolveInvoiceServiceRows,
   resolveServiceRow,
   setEntryField,
+  shouldRenderPackageDetail,
   touchRecentEntry,
   updatePackageChildField,
   upsertRecentEntry,
@@ -308,6 +309,47 @@ describe('invoiceCatalogUtils', () => {
       const pkg = addCustomChildToPackage(makeCustomPackageEntry({ name: 'Bespoke' }), { name: 'Extra', price: 50 });
       const reverted = resetPackageEntryToCatalog(pkg, undefined);
       expect(reverted).toBe(pkg);
+    });
+  });
+
+  describe('hidden/special-offer packages render full detail on the Invoice (round6 #1)', () => {
+    it('flags a package row as isHiddenCatalog when its catalog package is hidden', () => {
+      const packagesById = new Map([['p6', { id: 'p6', name: 'Special Offer', hidden: true, children: ['1'] }]]);
+      const row = resolveServiceRow(makeCatalogPackageEntry({ id: 'p6', children: ['1'] }), new Map(), { packagesById });
+      expect(row.isHiddenCatalog).toBe(true);
+      expect(row.isCustomized).toBe(false);
+    });
+
+    it('left on "auto", renders full detail for a hidden package but only a Budget reference for a standard one', () => {
+      const packagesById = new Map([
+        ['hidden-1', { id: 'hidden-1', name: 'Special Offer', hidden: true, children: ['1'] }],
+        ['standard-1', { id: 'standard-1', name: 'Programme', children: ['1'] }],
+      ]);
+      const hiddenRow = resolveServiceRow(makeCatalogPackageEntry({ id: 'hidden-1', children: ['1'] }), new Map(), { packagesById });
+      const standardRow = resolveServiceRow(makeCatalogPackageEntry({ id: 'standard-1', children: ['1'] }), new Map(), { packagesById });
+      expect(shouldRenderPackageDetail(hiddenRow)).toBe(true);
+      expect(shouldRenderPackageDetail(standardRow)).toBe(false);
+    });
+
+    it('an explicit detailMode override always wins over the auto default', () => {
+      const packagesById = new Map([
+        ['hidden-1', { id: 'hidden-1', name: 'Special Offer', hidden: true, children: ['1'] }],
+        ['standard-1', { id: 'standard-1', name: 'Programme', children: ['1'] }],
+      ]);
+      const hiddenEntry = setEntryField(makeCatalogPackageEntry({ id: 'hidden-1', children: ['1'] }), 'detailMode', 'reference');
+      const standardEntry = setEntryField(makeCatalogPackageEntry({ id: 'standard-1', children: ['1'] }), 'detailMode', 'full');
+      const hiddenRow = resolveServiceRow(hiddenEntry, new Map(), { packagesById });
+      const standardRow = resolveServiceRow(standardEntry, new Map(), { packagesById });
+      expect(shouldRenderPackageDetail(hiddenRow)).toBe(false);
+      expect(shouldRenderPackageDetail(standardRow)).toBe(true);
+      // Setting detailMode is a display choice, not a content edit - it must never flip `customized`.
+      expect(hiddenEntry.customized).toBeUndefined();
+      expect(standardEntry.customized).toBeUndefined();
+    });
+
+    it('a custom (self-contained) package always renders full detail regardless of detailMode', () => {
+      const row = resolveServiceRow(makeCustomPackageEntry({ name: 'Bespoke' }), new Map(), { packagesById: new Map() });
+      expect(shouldRenderPackageDetail(row)).toBe(true);
     });
   });
 


### PR DESCRIPTION
Hidden/special-offer catalog packages have no public Budget document, so
the Invoice's default "see your Budget" reference sentence pointed
nowhere. Package rows now carry isHiddenCatalog, and PackageBlock renders
the full Included/Payment-schedule detail inline whenever there's no
Budget to reference - matching what a customized package already did.

Also adds an explicit per-package detailMode selector (auto/full/
reference) in the Invoice Builder UI, so an admin can override the
default for any package, standard or hidden, on a given invoice - a
selector rather than an implicit toggle.

Also gives each payer/customer block its own card (border + background)
instead of a bare border-top separator, so multiple payers on one case
read as visually distinct groups.