### PR TITLE
Round 7: Budget/Invoice PDF fixes + Invoice Builder restructuring

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -306,8 +306,10 @@ export const IncludedServicesTable = ({
 ) : null);
 
 // The "Payment schedule" table (spec §1.2/§2) - same sharing rationale as IncludedServicesTable
-// above. rows: [{ title, amounts: [amountOrNull, ...] }] · totals: [amountOrNull, ...] (one per
-// package column, same order as `packages`).
+// above. rows: [{ title, amounts: [amountOrNull, ...] }] · totals: optional [amountOrNull, ...]
+// (one per package column, same order as `packages`) - omit it when a column's total is already
+// shown once in that program's own header cell (ProgramColumnsHead), so the table doesn't just
+// repeat the same numbers at its foot (round7 spec A.1).
 export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment schedule' }) => (rows.length ? (
   <View style={styles.scheduleSection}>
     <View wrap={false} minPresenceAhead={70}>
@@ -369,12 +371,6 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
       }),
     };
   });
-  const scheduleTotals = programSchedules.map((schedule, programIndex) => (Array.isArray(schedule?.payments)
-    ? schedule.payments.reduce(
-      (sum, payment) => sum + (resolvePaymentAmount(payment, resolveListedPrice(packages[programIndex])) || 0),
-      0,
-    )
-    : null));
 
   const includedIds = [];
   packages.forEach(program => {
@@ -460,17 +456,16 @@ const BudgetPdfDocument = ({ catalog, rates = null }) => {
           ))}
         </View>
 
-        {/* Client-facing reading order is Programs -> Included services -> Payment schedule ->
-            Other expenses (first round of feedback, item 8): the client should understand what
-            they're buying before how they pay for it. Each of the three sections below starts on
-            its own fresh page (`break`) regardless of how much room is left on the previous one,
-            so a large table is never forced to split mid-page. */}
+        {/* Client-facing reading order is Programs -> Payment schedule -> Included services ->
+            Other expenses (round7 spec A.2): the payment schedule stays on page 1, right after
+            Programs, since its numbers are the direct continuation of what's shown there. Included
+            services (and Other expenses) each start on their own fresh page (`break`) regardless
+            of how much room is left on the previous one, so a large table is never forced to split
+            mid-page. */}
+        <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} />
+
         <View break={includedRows.length > 0}>
           <IncludedServicesTable packages={packagesMeta} includedRows={includedRows} />
-        </View>
-
-        <View break={scheduleRows.length > 0}>
-          <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} totals={scheduleTotals} />
         </View>
 
         {Object.keys(groupedExpenses).length ? (

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -56,6 +56,7 @@ import {
   resolveInvoiceServiceRows,
   resolveServiceRow,
   setEntryField,
+  setPackageSchedule,
   touchRecentEntry,
   updatePackageChildField,
   upsertRecentEntry,
@@ -429,6 +430,11 @@ const StackedFieldTag = styled.span`
   color: var(--km-muted);
 `;
 
+// $bare (round7 spec E): a minimal, single-line-tall field with no visual "input" chrome at all,
+// not even on hover/focus - it reads as plain text that happens to be editable, exactly like the
+// DescriptionToggle/text it sits next to. Used for Beneficiary/Payer fields, where the regular
+// hover/focus wash (still used everywhere else) reads as unnecessarily tall/boxy for a name/address
+// line.
 const plainFieldStyle = css`
   flex: 1 1 auto;
   min-width: 0;
@@ -440,8 +446,8 @@ const plainFieldStyle = css`
   font-family: inherit;
   font-size: ${({ $size }) => $size || '13px'};
   font-weight: ${({ $weight }) => $weight || '600'};
-  line-height: 1.45;
-  padding: 5px 6px;
+  line-height: ${({ $bare }) => ($bare ? '1.25' : '1.45')};
+  padding: ${({ $bare }) => ($bare ? '1px 2px' : '5px 6px')};
   margin: 0;
   resize: none;
   overflow: hidden;
@@ -453,13 +459,13 @@ const plainFieldStyle = css`
   }
 
   &:hover {
-    background: var(--km-accent-light);
+    background: ${({ $bare }) => ($bare ? 'transparent' : 'var(--km-accent-light)')};
   }
 
   &:focus {
     outline: none;
-    background: var(--km-accent-light);
-    box-shadow: inset 0 0 0 1px var(--km-accent-mid);
+    background: ${({ $bare }) => ($bare ? 'transparent' : 'var(--km-accent-light)')};
+    box-shadow: ${({ $bare }) => ($bare ? 'none' : 'inset 0 0 0 1px var(--km-accent-mid)')};
   }
 `;
 
@@ -857,28 +863,6 @@ const PackageHeaderRow = styled(LineMainRow)`
   align-items: flex-start;
 `;
 
-// The explicit "which package/schedule to render in the PDF" selector (round5 #4 / round6 #1) -
-// same visual pattern as the Beneficiary/Active-case PlainSelect, not a toggle.
-const PackageDetailModeRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 6px 0 0 28px;
-
-  @media (max-width: 560px) {
-    margin-left: 10px;
-  }
-`;
-
-const PackageDetailModeLabel = styled.span`
-  flex: 0 0 auto;
-  font-size: 9.5px;
-  font-weight: 800;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--km-muted);
-`;
-
 const PackageIcon = styled.span`
   flex: 0 0 auto;
   display: inline-flex;
@@ -972,34 +956,6 @@ const CatalogPickerButton = styled.button`
   }
 `;
 
-// A package in the catalog picker offers two ways in, side by side: the full package at its
-// listed price (CatalogPickerButton), or just a share of it billed on this invoice (this button) -
-// so an admin building a milestone invoice never has to add the whole package first just to reach
-// the percent option, then delete it again.
-const CatalogPickerRow = styled.div`
-  display: flex;
-  gap: 4px;
-  align-items: stretch;
-`;
-
-const CatalogPickerPercentButton = styled.button`
-  flex: 0 0 auto;
-  border: 1px solid var(--km-border);
-  background: var(--km-card);
-  color: var(--km-muted);
-  border-radius: 8px;
-  padding: 6px 9px;
-  font-size: 11px;
-  font-weight: 700;
-  white-space: nowrap;
-  cursor: pointer;
-
-  &:hover {
-    border-color: var(--km-accent);
-    color: var(--km-accent);
-  }
-`;
-
 // A package hidden from the public Program Budget PDF (a manually-offered "special offer") is
 // still pickable here - this badge is the only thing telling the admin it's not one of the
 // public programs.
@@ -1040,14 +996,9 @@ const CatalogTabButton = styled.button`
 
 const PackageEntryCard = ({
   row,
-  index,
-  canMoveUp,
-  canMoveDown,
   catalogItems,
   onCommitField,
   onRemove,
-  onMoveUp,
-  onMoveDown,
   onReset,
   onCommitChildField,
   onResetChildField,
@@ -1093,7 +1044,6 @@ const PackageEntryCard = ({
     <PackageCard>
       <PackageHeaderRow>
         <PackageIcon><FaBoxOpen /></PackageIcon>
-        <RowIndex>{index + 1}</RowIndex>
         <AutoTextArea
           $size="13.5px"
           $weight="800"
@@ -1136,12 +1086,6 @@ const PackageEntryCard = ({
           </IconButton>
         ) : null}
         <RowActions $dense>
-          <IconButton $dense type="button" onClick={onMoveUp} disabled={!canMoveUp} title="Move up" aria-label="Move package up">
-            <FaChevronUp />
-          </IconButton>
-          <IconButton $dense type="button" onClick={onMoveDown} disabled={!canMoveDown} title="Move down" aria-label="Move package down">
-            <FaChevronDown />
-          </IconButton>
           <IconDangerButton $dense type="button" onClick={onRemove} title="Remove package" aria-label="Remove package">
             <FaTrash />
           </IconDangerButton>
@@ -1174,22 +1118,6 @@ const PackageEntryCard = ({
           {row.description || '+ Add description'}
         </DescriptionToggle>
       )}
-
-      {row.catalogId ? (
-        <PackageDetailModeRow>
-          <PackageDetailModeLabel>PDF detail</PackageDetailModeLabel>
-          <PlainSelect
-            style={{ flex: '0 1 auto', width: 'auto' }}
-            value={row.detailMode || 'auto'}
-            aria-label="Package detail shown in the Invoice PDF"
-            onChange={event => onCommitField('detailMode', event.target.value)}
-          >
-            <option value="auto">{`Auto (${row.isHiddenCatalog ? 'full details – no Budget' : 'reference to Budget'})`}</option>
-            <option value="full">Full details in PDF</option>
-            <option value="reference">Reference to Budget only</option>
-          </PlainSelect>
-        </PackageDetailModeRow>
-      ) : null}
 
       <PackageChildren>
         {row.children.map((child, childIndex) => (
@@ -1249,6 +1177,54 @@ const PackageEntryCard = ({
         </InlinePickerBox>
       ) : null}
     </PackageCard>
+  );
+};
+
+// --- Package payment schedule (round7 spec C.2) ------------------------------------------------------
+//
+// One editable {title, amount} row of the package's Payment Schedule, shown/edited only while the
+// "Payment schedule" checkbox is on (InvoiceBuilderPage) - the same draft/commit-on-blur pattern
+// every other row in this file uses.
+
+const ScheduleRow = ({ row, index, onCommit, onRemove }) => {
+  const [titleDraft, setTitleDraft, titleEditingRef] = useFieldDraft(row.title);
+  const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(String(roundToCents(row.amount) ?? ''));
+
+  return (
+    <LineCard>
+      <LineMainRow>
+        <RowIndex>{index + 1}</RowIndex>
+        <AutoTextArea
+          value={titleDraft}
+          placeholder="Payment title"
+          aria-label="Payment title"
+          onFocus={() => { titleEditingRef.current = true; }}
+          onChange={event => setTitleDraft(event.target.value)}
+          onBlur={() => {
+            titleEditingRef.current = false;
+            if (titleDraft !== (row.title ?? '')) onCommit(index, 'title', titleDraft);
+          }}
+        />
+        <AutoTextArea
+          as={PlainPriceBase}
+          $width="88px"
+          inputMode="decimal"
+          value={amountDraft}
+          placeholder="0"
+          aria-label="Payment amount (EUR)"
+          onFocus={() => { amountEditingRef.current = true; }}
+          onChange={event => setAmountDraft(event.target.value)}
+          onBlur={() => {
+            amountEditingRef.current = false;
+            const original = String(roundToCents(row.amount) ?? '');
+            if (amountDraft !== original) onCommit(index, 'amount', amountDraft);
+          }}
+        />
+        <IconDangerButton type="button" onClick={() => onRemove(index)} title="Remove payment" aria-label="Remove payment">
+          <FaTrash />
+        </IconDangerButton>
+      </LineMainRow>
+    </LineCard>
   );
 };
 
@@ -1605,6 +1581,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [newCustomPackageName, setNewCustomPackageName] = useState('');
   const [catalogQuery, setCatalogQuery] = useState('');
   const [showCatalogPicker, setShowCatalogPicker] = useState(false);
+  const [showPackagePicker, setShowPackagePicker] = useState(false);
+  const [packagePickerQuery, setPackagePickerQuery] = useState('');
   const [catalogTab, setCatalogTab] = useState('items');
   const [showExpectedExpensesPicker, setShowExpectedExpensesPicker] = useState(false);
   const [showCustomSchedulePicker, setShowCustomSchedulePicker] = useState(false);
@@ -1613,6 +1591,9 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [customScheduleRows, setCustomScheduleRows] = useState([{ title: '', amount: '' }]);
   const [beneficiaryExpanded, setBeneficiaryExpanded] = useState(false);
   const [payerExpanded, setPayerExpanded] = useState(false);
+  // round7 spec D: Expected Expenses is a standalone section of the Builder, not a step inside the
+  // regular invoice-creation flow - a top-level tab keeps the two entirely separate on screen.
+  const [activeTab, setActiveTab] = useState('invoice');
   const fileInputRef = useRef(null);
   const expectedExpensesFileInputRef = useRef(null);
 
@@ -1717,9 +1698,13 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       itemsById: catalogItemsById,
       rates: exchangeRates,
       packagesById: catalogPackagesById,
+      // Read by resolvePackageEntrySchedule (invoiceCatalogUtils) to resolve a package row's live
+      // Payment Schedule from the catalog - the same budget/technical record Program Budget/
+      // Expected Expenses read it from.
+      technical: catalogTechnical,
       resolvePackagePrice: pkg => resolveBudgetPriceAmount(pkg?.listedPrice, { itemsById: catalogItemsById, rates: exchangeRates, packagesById: catalogPackagesById }),
     }),
-    [catalogItemsById, exchangeRates, catalogPackagesById],
+    [catalogItemsById, exchangeRates, catalogPackagesById, catalogTechnical],
   );
 
   const invoiceServiceRows = useMemo(
@@ -1727,10 +1712,21 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     [data.invoiceServices, catalogItemsById, priceContext],
   );
 
-  // "% of package" only makes sense once a package is already part of this invoice - it's a
-  // share of that package's price, not a standalone add option (spec item C).
-  const firstTopLevelPackage = useMemo(
-    () => invoiceServiceRows.find(row => row.kind === 'package' && row.catalogId) || null,
+  // round7 spec C: the invoice's package is no longer just another "Invoice services" row - the
+  // Builder surfaces at most one at a time, in its own "Package & PDF components" panel.
+  const packageRow = useMemo(
+    () => invoiceServiceRows.find(row => row.kind === 'package') || null,
+    [invoiceServiceRows],
+  );
+
+  // "% of package" only makes sense once a catalog-linked package is already part of this invoice -
+  // it's a share of that package's price, not a standalone add option (spec item C).
+  const percentSharePackage = packageRow && packageRow.catalogId ? packageRow : null;
+
+  // The flat "Invoice services" list (item/custom/percent rows) - the package itself is rendered
+  // separately, in its own panel (round7 spec C).
+  const serviceLineRows = useMemo(
+    () => invoiceServiceRows.filter(row => row.kind !== 'package'),
     [invoiceServiceRows],
   );
 
@@ -1798,6 +1794,15 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       .filter(pkg => !usedCatalogPackageIds.has(String(pkg.id)))
       .filter(pkg => !normalizedQuery || String(pkg.name || '').toLowerCase().includes(normalizedQuery));
   }, [visibleCatalogPackages, usedCatalogPackageIds, catalogQuery]);
+
+  // The Package panel's own catalog picker (round7 spec C.1) - a separate query from Invoice
+  // Services' "% of package" picker above, so typing in one never clears the other.
+  const filteredPackagePickerOptions = useMemo(() => {
+    const normalizedQuery = packagePickerQuery.trim().toLowerCase();
+    return visibleCatalogPackages
+      .filter(pkg => !usedCatalogPackageIds.has(String(pkg.id)))
+      .filter(pkg => !normalizedQuery || String(pkg.name || '').toLowerCase().includes(normalizedQuery));
+  }, [visibleCatalogPackages, usedCatalogPackageIds, packagePickerQuery]);
 
   const defaultExpectedExpensesTaxPercent = Number.isFinite(Number(catalogTechnical?.wireTransferSurchargeRate))
     ? Math.round(Number(catalogTechnical.wireTransferSurchargeRate) * 10000) / 100
@@ -2022,8 +2027,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   const moveTopLevelEntry = (id, offset) => {
     const index = data.invoiceServices.findIndex(entry => entry.id === id);
-    const targetIndex = index + offset;
-    if (index === -1 || targetIndex < 0 || targetIndex >= data.invoiceServices.length) return;
+    if (index === -1) return;
+    // The package row is no longer rendered inside Invoice Services (round7 spec C) and must never
+    // be an invisible "neighbor" a service row silently swaps places with - skip over it (if one
+    // sits in between) when looking for the next/previous *visible* row to swap with.
+    const step = offset > 0 ? 1 : -1;
+    let targetIndex = index + step;
+    while (targetIndex >= 0 && targetIndex < data.invoiceServices.length && data.invoiceServices[targetIndex].kind === 'package') {
+      targetIndex += step;
+    }
+    if (targetIndex < 0 || targetIndex >= data.invoiceServices.length) return;
     const next = [...data.invoiceServices];
     [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
     persistInvoiceServices(next, 'Service order updated.');
@@ -2158,6 +2171,47 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const addCatalogChildEntry = (packageId, catalogId) => {
     const next = data.invoiceServices.map(entry => (entry.id === packageId ? addCatalogChildToPackage(entry, catalogId) : entry));
     persistInvoiceServices(next, 'Service added to package.');
+  };
+
+  // Package & PDF components ------------------------------------------------------------
+  // round7 spec C: which optional PDF components (the package block, its payment schedule, the
+  // Payment Details document) are included is decided here, independent of the invoice's flat
+  // service breakdown - a checkbox both gates PDF inclusion and shows/hides that component's own
+  // editing area (spec C.2).
+
+  const setIncludePackageInPdf = value => {
+    setData(current => ({ ...current, includePackageInPdf: value }));
+    persistPath(`${INVOICE_DATA_PATH}/includePackageInPdf`, value);
+  };
+
+  const setIncludeScheduleInPdf = value => {
+    setData(current => ({ ...current, includeScheduleInPdf: value }));
+    persistPath(`${INVOICE_DATA_PATH}/includeScheduleInPdf`, value);
+  };
+
+  const commitPackageSchedule = (packageId, schedule) => {
+    const next = data.invoiceServices.map(entry => (entry.id === packageId ? setPackageSchedule(entry, schedule) : entry));
+    persistInvoiceServices(next, 'Payment schedule updated.');
+  };
+
+  // The first edit "materializes" whatever schedule is currently showing (live from the catalog, or
+  // an existing override) into a fresh per-invoice override, then applies the one field edit on top.
+  const updateScheduleRow = (rowIndex, field, value) => {
+    if (!packageRow) return;
+    const rows = packageRow.scheduleRows.map((row, index) => (index === rowIndex
+      ? { ...row, [field]: field === 'amount' ? (Number(String(value).replace(',', '.')) || 0) : value }
+      : row));
+    commitPackageSchedule(packageRow.id, rows);
+  };
+
+  const addScheduleRow = () => {
+    if (!packageRow) return;
+    commitPackageSchedule(packageRow.id, [...packageRow.scheduleRows, { title: '', amount: 0 }]);
+  };
+
+  const removeScheduleRow = rowIndex => {
+    if (!packageRow) return;
+    commitPackageSchedule(packageRow.id, packageRow.scheduleRows.filter((_, index) => index !== rowIndex));
   };
 
   // Expected expenses ------------------------------------------------------------
@@ -2679,8 +2733,9 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         debtOrDeposit: data.debtOrDeposit,
         invoiceNumber,
         invoiceDisplayDate,
-        catalogTechnical,
         generatePaymentDetails,
+        includePackageInPdf: data.includePackageInPdf,
+        includeScheduleInPdf: data.includeScheduleInPdf,
       };
 
       // @react-pdf/renderer's WASM layout engine can still be warming up on the
@@ -2756,27 +2811,44 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               style={{ display: 'none' }}
               onChange={handleFileChange}
             />
-            <MiniButton type="button" onClick={handleUploadClick} title="Upload an invoice JSON to the backend (an expectedExpenses array of groups is picked up too)">
-              <FaUpload /> Upload JSON
-            </MiniButton>
-            <PrimaryMiniButton
-              type="button"
-              onClick={handleGeneratePdf}
-              disabled={isGenerateDisabled}
-              title="Generate and download the invoice PDF"
-            >
-              <FaFilePdf /> {isGenerating ? 'Generating…' : 'Generate PDF'}
-            </PrimaryMiniButton>
+            {activeTab === 'invoice' ? (
+              <>
+                <MiniButton type="button" onClick={handleUploadClick} title="Upload an invoice JSON to the backend (an expectedExpenses array of groups is picked up too)">
+                  <FaUpload /> Upload JSON
+                </MiniButton>
+                <PrimaryMiniButton
+                  type="button"
+                  onClick={handleGeneratePdf}
+                  disabled={isGenerateDisabled}
+                  title="Generate and download the invoice PDF"
+                >
+                  <FaFilePdf /> {isGenerating ? 'Generating…' : 'Generate PDF'}
+                </PrimaryMiniButton>
+              </>
+            ) : null}
           </HeaderActions>
         </Header>
 
         {loading ? <StateCard>Loading invoice data…</StateCard> : null}
         {!loading && error ? <StateCard>{error}</StateCard> : null}
-        {!loading && !error && isFormulaRatePending ? <StateCard>Loading NBU exchange rates for formula-priced services…</StateCard> : null}
-        {!loading && !error && formulaRateError ? <StateCard>{formulaRateError}</StateCard> : null}
+        {!loading && !error && activeTab === 'invoice' && isFormulaRatePending ? <StateCard>Loading NBU exchange rates for formula-priced services…</StateCard> : null}
+        {!loading && !error && activeTab === 'invoice' && formulaRateError ? <StateCard>{formulaRateError}</StateCard> : null}
 
         {!loading && !error ? (
           <>
+            {/* round7 spec D: Expected Expenses is a standalone section, structurally separate from
+                the regular invoice-creation flow below - never a step inside the same scroll. */}
+            <CatalogTabs>
+              <CatalogTabButton type="button" $active={activeTab === 'invoice'} onClick={() => setActiveTab('invoice')}>
+                Invoice
+              </CatalogTabButton>
+              <CatalogTabButton type="button" $active={activeTab === 'expected-expenses'} onClick={() => setActiveTab('expected-expenses')}>
+                Expected expenses
+              </CatalogTabButton>
+            </CatalogTabs>
+
+            {activeTab === 'invoice' ? (
+              <>
             <Panel>
               <CompactSection
                 $expanded={beneficiaryExpanded}
@@ -2813,6 +2885,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     <>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="Title"
                           value={activeBeneficiary.title || ''}
@@ -2823,6 +2896,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldRow>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="Address"
                           value={activeBeneficiary.address || ''}
@@ -2833,6 +2907,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldRow>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="IBAN"
                           value={activeBeneficiary.iban || ''}
@@ -2843,6 +2918,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldRow>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="Bank name"
                           value={activeBeneficiary.bankName || ''}
@@ -2853,6 +2929,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldRow>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="SWIFT code"
                           value={activeBeneficiary.swiftCode || ''}
@@ -2863,6 +2940,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldRow>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           value={activeBeneficiary.paymentPurpose || ''}
                           placeholder="Payment purpose - {invoiceNumber} and {invoiceDate} are filled in automatically"
@@ -2922,6 +3000,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldHeader>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="Name"
                           value={customer.name || ''}
@@ -2932,6 +3011,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                       </StackedFieldRow>
                       <StackedFieldRow>
                         <AutoTextArea
+                          $bare
                           style={{ width: '100%' }}
                           placeholder="Address / country"
                           value={customer.address || ''}
@@ -2948,30 +3028,138 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
             <Panel>
               <PanelHeading>
+                <H2>Package & PDF components</H2>
+              </PanelHeading>
+              <PanelNote>
+                Choose which components are added to the generated Invoice PDF. A component enabled
+                below is shown and editable here; disabled, it is hidden from both this page and
+                the PDF.
+              </PanelNote>
+
+              <FieldRow $align="center">
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={data.includePackageInPdf}
+                    onChange={event => setIncludePackageInPdf(event.target.checked)}
+                  />
+                  <span>{`Package${packageRow ? ` — ${packageRow.name}` : ''}`}</span>
+                </label>
+              </FieldRow>
+
+              {data.includePackageInPdf ? (
+                packageRow ? (
+                  <PackageEntryCard
+                    row={packageRow}
+                    catalogItems={catalogItems}
+                    onCommitField={(field, value) => commitTopLevelField(packageRow.id, field, value)}
+                    onRemove={() => removeTopLevelEntry(packageRow.id)}
+                    onReset={packageRow.catalogId && packageRow.isCustomized ? () => resetTopLevelEntry(packageRow.id) : undefined}
+                    onCommitChildField={(childId, field, value) => commitPackageChildField(packageRow.id, childId, field, value)}
+                    onResetChildField={childId => resetPackageChildEntry(packageRow.id, childId)}
+                    onRemoveChild={childId => removePackageChildEntry(packageRow.id, childId)}
+                    onMoveChild={(childId, offset) => movePackageChildEntry(packageRow.id, childId, offset)}
+                    onAddCustomChild={fields => addCustomChildEntry(packageRow.id, fields)}
+                    onAddCatalogChild={catalogId => addCatalogChildEntry(packageRow.id, catalogId)}
+                  />
+                ) : (
+                  <>
+                    <FieldRow $align="center" style={{ marginTop: 8 }}>
+                      <PlainTextBase
+                        rows={1}
+                        placeholder="New custom package name"
+                        value={newCustomPackageName}
+                        onChange={event => setNewCustomPackageName(event.target.value)}
+                      />
+                      <SmallButton
+                        type="button"
+                        title="A package with no Budget catalog entry - saved fully on this invoice"
+                        onClick={addCustomPackageEntry}
+                      >
+                        <FaLayerGroup /> Add custom package
+                      </SmallButton>
+                    </FieldRow>
+                    <div style={{ marginTop: 8 }}>
+                      <SmallButton type="button" onClick={() => setShowPackagePicker(current => !current)}>
+                        <FaPlus /> {showPackagePicker ? 'Hide catalog' : 'Choose from catalog'}
+                      </SmallButton>
+                      {showPackagePicker ? (
+                        <div style={{ marginTop: 8 }}>
+                          <CatalogSearchField
+                            rows={1}
+                            placeholder="Search catalog packages…"
+                            value={packagePickerQuery}
+                            onChange={event => setPackagePickerQuery(event.target.value)}
+                          />
+                          <CatalogPickerList>
+                            {filteredPackagePickerOptions.map(pkg => (
+                              <CatalogPickerButton
+                                key={pkg.id}
+                                type="button"
+                                onClick={() => { addCatalogPackageEntry(pkg); setShowPackagePicker(false); setPackagePickerQuery(''); }}
+                              >
+                                <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}{pkg.hidden ? <SpecialOfferBadge>Special offer</SpecialOfferBadge> : null}</span>
+                              </CatalogPickerButton>
+                            ))}
+                            {!filteredPackagePickerOptions.length ? <PanelNote style={{ margin: 0 }}>No matching catalog packages.</PanelNote> : null}
+                          </CatalogPickerList>
+                        </div>
+                      ) : null}
+                    </div>
+                  </>
+                )
+              ) : null}
+
+              <FieldRow $align="center" style={{ marginTop: 10 }}>
+                <label
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 6, cursor: packageRow ? 'pointer' : 'not-allowed', opacity: packageRow ? 1 : 0.5,
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={data.includeScheduleInPdf}
+                    disabled={!packageRow}
+                    onChange={event => setIncludeScheduleInPdf(event.target.checked)}
+                  />
+                  <span>Payment schedule</span>
+                </label>
+              </FieldRow>
+
+              {data.includeScheduleInPdf && packageRow ? (
+                <div style={{ marginTop: 4 }}>
+                  {packageRow.scheduleRows.map((row, index) => (
+                    <ScheduleRow key={row.key} row={row} index={index} onCommit={updateScheduleRow} onRemove={removeScheduleRow} />
+                  ))}
+                  {!packageRow.scheduleRows.length ? <PanelNote style={{ margin: '8px 0' }}>No payments yet.</PanelNote> : null}
+                  <SmallButton type="button" style={{ marginTop: 6 }} onClick={addScheduleRow}>
+                    <FaPlus /> Add payment
+                  </SmallButton>
+                </div>
+              ) : null}
+
+              <FieldRow $align="center" style={{ marginTop: 10 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={generatePaymentDetails}
+                    onChange={event => setGeneratePaymentDetails(event.target.checked)}
+                  />
+                  <span>Payment details (separate PDF)</span>
+                </label>
+              </FieldRow>
+            </Panel>
+
+            <Panel>
+              <PanelHeading>
                 <H2>Invoice services</H2>
               </PanelHeading>
+              <PanelNote>
+                A flat breakdown of items/custom lines and package-percent shares. The programme
+                package itself lives in the Package panel above.
+              </PanelNote>
 
-              {invoiceServiceRows.map((row, index) => (row.kind === 'package' ? (
-                <PackageEntryCard
-                  key={row.key}
-                  row={row}
-                  index={index}
-                  canMoveUp={index > 0}
-                  canMoveDown={index < invoiceServiceRows.length - 1}
-                  catalogItems={catalogItems}
-                  onCommitField={(field, value) => commitTopLevelField(row.id, field, value)}
-                  onRemove={() => removeTopLevelEntry(row.id)}
-                  onMoveUp={() => moveTopLevelEntry(row.id, -1)}
-                  onMoveDown={() => moveTopLevelEntry(row.id, 1)}
-                  onReset={row.catalogId && row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
-                  onCommitChildField={(childId, field, value) => commitPackageChildField(row.id, childId, field, value)}
-                  onResetChildField={childId => resetPackageChildEntry(row.id, childId)}
-                  onRemoveChild={childId => removePackageChildEntry(row.id, childId)}
-                  onMoveChild={(childId, offset) => movePackageChildEntry(row.id, childId, offset)}
-                  onAddCustomChild={fields => addCustomChildEntry(row.id, fields)}
-                  onAddCatalogChild={catalogId => addCatalogChildEntry(row.id, catalogId)}
-                />
-              ) : (
+              {serviceLineRows.map((row, index) => (
                 <ServiceLineRow
                   key={row.key}
                   row={row}
@@ -2982,11 +3170,11 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   onMoveUp={() => moveTopLevelEntry(row.id, -1)}
                   onMoveDown={() => moveTopLevelEntry(row.id, 1)}
                   canMoveUp={index > 0}
-                  canMoveDown={index < invoiceServiceRows.length - 1}
+                  canMoveDown={index < serviceLineRows.length - 1}
                   onReset={row.kind === 'item' && row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
                 />
-              )))}
-              {!invoiceServiceRows.length ? <PanelNote style={{ margin: 0 }}>No services on this invoice yet.</PanelNote> : null}
+              ))}
+              {!serviceLineRows.length ? <PanelNote style={{ margin: 0 }}>No services on this invoice yet.</PanelNote> : null}
 
               {recentServiceSuggestions.length ? (
                 <>
@@ -3037,31 +3225,15 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   onChange={event => setNewCustomServicePrice(event.target.value)}
                 />
                 <SmallButton type="button" onClick={addCustomServiceEntry}><FaPlus /> Add</SmallButton>
-                {firstTopLevelPackage ? (
+                {percentSharePackage ? (
                   <SmallButton
                     type="button"
                     title="Add a share of this invoice's package price (e.g. 20%)"
-                    onClick={() => addPercentServiceEntry(firstTopLevelPackage.catalogId)}
+                    onClick={() => addPercentServiceEntry(percentSharePackage.catalogId)}
                   >
                     <FaPlus /> % of package
                   </SmallButton>
                 ) : null}
-              </FieldRow>
-
-              <FieldRow $align="center" style={{ marginTop: 8 }}>
-                <PlainTextBase
-                  rows={1}
-                  placeholder="New custom package name"
-                  value={newCustomPackageName}
-                  onChange={event => setNewCustomPackageName(event.target.value)}
-                />
-                <SmallButton
-                  type="button"
-                  title="A package with no Budget catalog entry - saved fully on this invoice"
-                  onClick={addCustomPackageEntry}
-                >
-                  <FaLayerGroup /> Add custom package
-                </SmallButton>
               </FieldRow>
 
               <div style={{ marginTop: 8 }}>
@@ -3075,7 +3247,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                         Services
                       </CatalogTabButton>
                       <CatalogTabButton type="button" $active={catalogTab === 'packages'} onClick={() => setCatalogTab('packages')}>
-                        Packages
+                        % of package
                       </CatalogTabButton>
                     </CatalogTabs>
                     <CatalogSearchField
@@ -3090,18 +3262,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                           <span>{item.name}</span>
                         </CatalogPickerButton>
                       )) : filteredCatalogPackages.map(pkg => (
-                        <CatalogPickerRow key={pkg.id}>
-                          <CatalogPickerButton type="button" style={{ flex: '1 1 auto' }} onClick={() => addCatalogPackageEntry(pkg)} title="Add the whole package at its full listed price">
-                            <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}{pkg.hidden ? <SpecialOfferBadge>Special offer</SpecialOfferBadge> : null}</span>
-                          </CatalogPickerButton>
-                          <CatalogPickerPercentButton
-                            type="button"
-                            onClick={() => addCatalogPackagePercentEntry(pkg)}
-                            title="Bill only a share of this package on this invoice (e.g. one Payment Schedule milestone) - no need to add the full package first"
-                          >
-                            % of package
-                          </CatalogPickerPercentButton>
-                        </CatalogPickerRow>
+                        <CatalogPickerButton
+                          key={pkg.id}
+                          type="button"
+                          onClick={() => addCatalogPackagePercentEntry(pkg)}
+                          title="Bill only a share of this package's price on this invoice (e.g. one Payment Schedule milestone) - the whole package itself is chosen in the Package panel above"
+                        >
+                          <span><FaLayerGroup style={{ marginRight: 6 }} />{pkg.name}{pkg.hidden ? <SpecialOfferBadge>Special offer</SpecialOfferBadge> : null}</span>
+                        </CatalogPickerButton>
                       ))}
                       {catalogTab === 'items' && !filteredCatalogItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
                       {catalogTab === 'packages' && !filteredCatalogPackages.length ? <PanelNote style={{ margin: 0 }}>No matching catalog packages.</PanelNote> : null}
@@ -3168,16 +3336,6 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   style={{ flex: '0 0 auto' }}
                 />
               </FieldRow>
-              <FieldRow $align="center">
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
-                  <input
-                    type="checkbox"
-                    checked={generatePaymentDetails}
-                    onChange={event => setGeneratePaymentDetails(event.target.checked)}
-                  />
-                  <span>Generate Payment Details (separate PDF)</span>
-                </label>
-              </FieldRow>
               <StackedFieldRow style={{ marginTop: 10 }}>
                 <StackedFieldHeader>
                   <StackedFieldTag>Purpose of the payment</StackedFieldTag>
@@ -3234,7 +3392,11 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               ))}
               {!data.notes.length ? <PanelNote style={{ margin: 0 }}>No notes yet.</PanelNote> : null}
             </Panel>
+              </>
+            ) : null}
 
+            {activeTab === 'expected-expenses' ? (
+              <>
             <Panel>
               <PanelHeading>
                 <H2>Expected expenses</H2>
@@ -3421,6 +3583,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 </>
               )}
             </Panel>
+              </>
+            ) : null}
           </>
         ) : null}
       </Shell>

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -184,9 +184,7 @@ describe('InvoiceBuilderPage', () => {
     const root = mount();
     await flush();
 
-    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    await flush();
-    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { findButton('Choose from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
     const packageButton = findButton('Full program');
@@ -248,9 +246,7 @@ describe('InvoiceBuilderPage', () => {
     const root = mount();
     await flush();
 
-    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    await flush();
-    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { findButton('Choose from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
     expect(container.innerHTML).toContain('Special Offer — Initial Payment');
@@ -279,9 +275,7 @@ describe('InvoiceBuilderPage', () => {
     const root = mount();
     await flush();
 
-    await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    await flush();
-    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { findButton('Choose from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
     await act(async () => { findButton('Full program').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
@@ -318,10 +312,10 @@ describe('InvoiceBuilderPage', () => {
 
     await act(async () => { findButton('Add from catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
-    await act(async () => { findButton('Packages', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { findButton('% of package', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
-    const percentButton = findButton('% of package');
+    const percentButton = findButton('Full program');
     expect(percentButton).toBeTruthy();
     await act(async () => { percentButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
@@ -522,6 +516,13 @@ describe('InvoiceBuilderPage', () => {
   });
 
   describe('expected expenses', () => {
+    // round7 spec D: Expected Expenses lives behind its own top-level tab, structurally separate
+    // from the regular invoice-creation flow - every test below must switch to it first.
+    const switchToExpectedExpensesTab = async () => {
+      await act(async () => { findButton('Expected expenses', true).dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+    };
+
     const createPlan = async () => {
       await act(async () => { findButton('Choose a package').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
       await flush();
@@ -534,6 +535,7 @@ describe('InvoiceBuilderPage', () => {
     it('builds a template from a package, auto-calculating package-percent rows from its catalog schedule', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       await createPlan();
 
@@ -561,6 +563,7 @@ describe('InvoiceBuilderPage', () => {
     it('builds an Expected Expenses plan from a percent-based schedule (ps-6 format)', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       await act(async () => { findButton('Choose a package').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
       await flush();
@@ -586,6 +589,7 @@ describe('InvoiceBuilderPage', () => {
     it('adding a service to a schedule group updates its due amount and is persisted on that group only', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       await createPlan();
 
@@ -646,6 +650,7 @@ describe('InvoiceBuilderPage', () => {
       });
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       const recalculateButton = findButton('Recalculate');
       expect(recalculateButton).toBeTruthy();
@@ -684,6 +689,7 @@ describe('InvoiceBuilderPage', () => {
       });
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       const recalculateButton = findButton('Recalculate');
       expect(recalculateButton).toBeTruthy();
@@ -722,6 +728,7 @@ describe('InvoiceBuilderPage', () => {
       });
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       const recalculateButton = findButton('Recalculate');
       expect(recalculateButton).toBeTruthy();
@@ -743,6 +750,7 @@ describe('InvoiceBuilderPage', () => {
     it('deletes the whole plan', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       await createPlan();
       expect(container.innerHTML).toContain('To start the program');
@@ -763,6 +771,7 @@ describe('InvoiceBuilderPage', () => {
     it('uploads a standalone expected-expenses JSON straight into invoiceBuilder/expectedExpenses', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       const heading = Array.from(container.querySelectorAll('h2')).find(h => h.textContent === 'Expected expenses');
       const panel = heading.closest('section');
@@ -795,6 +804,7 @@ describe('InvoiceBuilderPage', () => {
     it('builds an Expected Expenses plan from a hand-built custom schedule, and saves it to Recent for reuse', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       await act(async () => { findButton('Custom package/schedule').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
       await flush();
@@ -855,6 +865,7 @@ describe('InvoiceBuilderPage', () => {
     it('reloads a saved custom schedule from Recent, and deleting it removes it from the list', async () => {
       const root = mount();
       await flush();
+      await switchToExpectedExpensesTab();
 
       // Seed one recent schedule the way createExpectedExpensesPlanFromCustomSchedule would.
       await act(async () => { findButton('Custom package/schedule').dispatchEvent(new MouseEvent('click', { bubbles: true })); });

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -4,7 +4,7 @@ import {
   BrandRow, BrandRule, BronzeMotif, ContinuedTag, Footer, PDF_COLOR, PDF_FONT,
   ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
-import { formatMoney, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule } from './budgetCatalogUtils';
+import { formatMoney } from './budgetCatalogUtils';
 import { IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
 import {
   buildCaseTitle,
@@ -15,7 +15,6 @@ import {
   computeInvoiceTotal,
   resolveInvoiceDocType,
   resolveInvoiceServiceRows,
-  shouldRenderPackageDetail,
 } from './invoiceCatalogUtils';
 
 ensurePdfFontsRegistered();
@@ -232,36 +231,28 @@ const ServiceItemRow = ({ row, isFirst }) => {
   );
 };
 
-// The "Package block" (spec §1.1): a compact name/fee header, plus a single reference sentence
-// pointing at the Budget instead of repeating its "Included in this programme" and "Payment
-// schedule" tables verbatim - that full breakdown already lives in the Budget, and duplicating it
-// here was the single biggest source of clutter on this document.
-const PackageBlock = ({ row, schedule, scheduleTotal }) => {
-  const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
+// The "Package block" (round7 spec C): a compact name/fee header, then the package's full
+// composition - always shown, since the Builder's own "Package" checkbox already gates whether
+// this block is rendered at all (InvoiceBuilderPage) - and an optional payment schedule table,
+// gated separately by the Builder's "Payment schedule" checkbox (`showSchedule`).
+const PackageBlock = ({ row, showSchedule }) => {
   const totalLabel = formatRowAmount(row);
-  const showFullDetail = shouldRenderPackageDetail(row);
   const packageMeta = [{ id: row.id || row.key || 'package', label: row.name, priceLabel: totalLabel }];
-  const includedRows = showFullDetail
-    ? (row.children || []).map((child, index) => ({
-      id: child.id || child.key || `child-${index}`,
-      name: child.name || '',
-      includedByPackageId: new Set([String(packageMeta[0].id)]),
-    }))
-    : [];
-  const scheduleRows = showFullDetail
-    ? payments.map(payment => ({
-      title: payment.title || 'Payment',
-      amounts: [Number.isFinite(Number(payment.amount)) ? Number(payment.amount) : null],
-    }))
-    : [];
-  const budgetReferenceNote = payments.length
-    ? `Part of a ${payments.length}-instalment programme totalling ${totalLabel}. Full programme details and the complete payment schedule are set out in your Budget.`
-    : `Full programme details and the complete payment schedule are set out in your Budget.`;
-  // A hidden/special-offer package has no public Budget document at all - "see your Budget" would
-  // point the client nowhere, so the note explains the detail is shown here instead.
-  const fullDetailNote = row.isHiddenCatalog && !row.isCustomized
-    ? 'This programme has no separate Budget document - its full details are shown below.'
-    : 'This invoice includes customised programme details shown below.';
+  const includedRows = (row.children || []).map((child, index) => ({
+    id: child.id || child.key || `child-${index}`,
+    name: child.name || '',
+    includedByPackageId: new Set([String(packageMeta[0].id)]),
+  }));
+  const scheduleRows = (row.scheduleRows || []).map(payment => ({
+    title: payment.title || 'Payment',
+    amounts: [payment.amount],
+  }));
+  // Only a customised package gets an explanatory note above its breakdown - a stock catalog
+  // package just shows its detail below with no note at all (round7 spec B.1: it no longer claims
+  // "no separate Budget document exists").
+  const fullDetailNote = row.isCustomized
+    ? 'This invoice includes customised programme details shown below.'
+    : null;
 
   return (
     <View style={styles.packageBlock}>
@@ -271,25 +262,20 @@ const PackageBlock = ({ row, schedule, scheduleTotal }) => {
         {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
         <Text style={styles.packageBlockFee}>{`Total programme fee ${totalLabel}`}</Text>
       </View>
-      {showFullDetail ? (
-        <>
-          <Text style={styles.sectionNote}>{sanitizePdfText(fullDetailNote)}</Text>
-          <IncludedServicesTable
-            packages={packageMeta}
-            includedRows={includedRows}
-            title="Included in this invoice"
-            note="These services reflect the customised package configured for this invoice."
-          />
-          <PaymentScheduleTable
-            packages={packageMeta}
-            rows={scheduleRows}
-            totals={[scheduleTotal]}
-            title="Payment schedule for this invoice"
-          />
-        </>
-      ) : (
-        <Text style={styles.sectionNote}>{sanitizePdfText(budgetReferenceNote)}</Text>
-      )}
+      {fullDetailNote ? <Text style={styles.sectionNote}>{sanitizePdfText(fullDetailNote)}</Text> : null}
+      <IncludedServicesTable
+        packages={packageMeta}
+        includedRows={includedRows}
+        title="Included in this package"
+        note="These services reflect the customisation made to this package."
+      />
+      {showSchedule ? (
+        <PaymentScheduleTable
+          packages={packageMeta}
+          rows={scheduleRows}
+          title="Payment schedule for this package"
+        />
+      ) : null}
     </View>
   );
 };
@@ -304,9 +290,10 @@ const InvoicePdfDocument = ({
   invoiceDisplayDate,
   priceContext,
   invoiceType,
-  catalogTechnical,
   debtOrDeposit,
   generatePaymentDetails = true,
+  includePackageInPdf = true,
+  includeScheduleInPdf = true,
 }) => {
   const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById, priceContext);
   const subtotal = computeInvoiceSubtotal(rows);
@@ -326,49 +313,18 @@ const InvoicePdfDocument = ({
   const docLabel = DOC_LABEL_BY_TYPE[docType];
   const eyebrow = EYEBROW_BY_TYPE[docType];
 
-  // Package Invoice (spec §1): adding a whole standard package - as opposed to a single
-  // percent-of-package milestone share, or a handful of one-off services - gets its own package
-  // block (name/fee header + a reference sentence to the Budget) above the flat itemized breakdown
-  // below. Any other top-level row alongside the package is, by definition, a service confirmed
-  // for this case that sits outside the standard package.
-  const packageRows = rows.filter(row => row.kind === 'package');
+  // Package Invoice (round7 spec C): a package now lives outside Invoice Services structurally -
+  // whether its block renders here at all is decided solely by the Builder's own "Package"
+  // checkbox (includePackageInPdf), never implicitly by whether one happens to be on the invoice.
+  // Any other top-level row is, by definition, a service confirmed for this case that sits outside
+  // the standard package.
+  const packageRows = includePackageInPdf ? rows.filter(row => row.kind === 'package') : [];
   const isPackageInvoice = packageRows.length > 0;
   // A "% of package" row (a programme milestone share) and any custom/catalog service row share one
   // "Breakdown" list, one row style, one running numbering - splitting them into two headed
   // sections was the second-biggest source of clutter on this document (declutter spec §2).
   const breakdownRows = rows.filter(row => row.kind !== 'package');
   const breakdownDisplayRows = buildDisplayRows(breakdownRows);
-  // The package entry's own `children` are a frozen name-only snapshot (invoiceCatalogUtils.js) -
-  // its payment schedule instead always comes live from the catalog package it was added from, the
-  // same source Program Budget/Expected Expenses read it from, so a schedule edit in the catalog is
-  // reflected here too.
-  const resolvePackageSchedule = row => {
-    const catalogPackage = priceContext?.packagesById?.get?.(String(row.catalogId));
-    const schedule = catalogPackage ? resolveProgramPaymentSchedule({ technical: catalogTechnical }, catalogPackage) : null;
-    if (!schedule?.payments?.length || !catalogPackage) return schedule;
-    const catalogTotal = resolveBudgetPriceAmount(catalogPackage.listedPrice, { ...priceContext, itemsById: catalogItemsById });
-    // Resolve every payment (amount- or percent-based) to a concrete euro amount up front, so the
-    // rest of this file - and PackageBlock below - only ever reads a plain `payment.amount` number.
-    const resolvedPayments = schedule.payments.map(payment => ({
-      ...payment,
-      amount: resolvePaymentAmount(payment, catalogTotal),
-    }));
-    if (!row.isCustomized) return { ...schedule, payments: resolvedPayments };
-    const rowTotal = Number(row.price);
-    if (!catalogTotal || !Number.isFinite(rowTotal)) return { ...schedule, payments: resolvedPayments };
-    const scale = rowTotal / catalogTotal;
-    return {
-      ...schedule,
-      payments: resolvedPayments.map(payment => ({
-        ...payment,
-        amount: Number.isFinite(payment.amount) ? Math.round(payment.amount * scale * 100) / 100 : payment.amount,
-      })),
-    };
-  };
-  const getPackageScheduleTotal = schedule => {
-    const payments = Array.isArray(schedule?.payments) ? schedule.payments : [];
-    return payments.length ? payments.reduce((sum, payment) => sum + (Number(payment.amount) || 0), 0) : null;
-  };
   // The DD.MM.YYYY `invoiceDate` string (invoiceCatalogUtils.generateInvoiceIdentifiers) is the
   // legal-text date used inside the payment-purpose placeholder only - the human-readable date
   // shown here always uses the one shared display format (spec §4), never that dotted form or the
@@ -389,17 +345,9 @@ const InvoicePdfDocument = ({
         />
 
         {isPackageInvoice ? (
-          packageRows.map(row => {
-            const schedule = resolvePackageSchedule(row);
-            return (
-              <PackageBlock
-                key={row.key}
-                row={row}
-                schedule={schedule}
-                scheduleTotal={getPackageScheduleTotal(schedule)}
-              />
-            );
-          })
+          packageRows.map(row => (
+            <PackageBlock key={row.key} row={row} showSchedule={includeScheduleInPdf} />
+          ))
         ) : null}
 
         {breakdownDisplayRows.length ? (

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -24,7 +24,9 @@
 // normalizeServiceEntry upgrades those to the object shape on load, so the rest of the app only
 // ever sees objects.
 
-import { getItemDisplayAmount, resolveBudgetPriceAmount } from './budgetCatalogUtils';
+import {
+  getItemDisplayAmount, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule,
+} from './budgetCatalogUtils';
 
 const SERVICE_PRICE_SEPARATOR = '||';
 const CATALOG_ID_PREFIX = 'id';
@@ -86,6 +88,12 @@ export const normalizeInvoiceData = raw => {
     customers: activeCase?.customers || [],
     recentServices: normalizeServiceEntries(raw?.recentServices),
     invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
+    // Which optional components the generated Invoice PDF includes (round7 spec C.1) - each is
+    // independently toggled, editable in the Builder while on, and takes no space in the PDF (or
+    // the Builder's own editing area) while off. Defaults to "on" so an admin who never touches
+    // these checkboxes gets the same complete PDF as before this panel existed.
+    includePackageInPdf: raw?.includePackageInPdf !== undefined ? Boolean(raw.includePackageInPdf) : true,
+    includeScheduleInPdf: raw?.includeScheduleInPdf !== undefined ? Boolean(raw.includeScheduleInPdf) : true,
     // Every payment schedule an admin has ever built for a custom package (round4 #4), most
     // recently used first - offered when a package has no catalog schedule to fall back on.
     recentPaymentSchedules: Array.isArray(raw?.recentPaymentSchedules)
@@ -273,6 +281,12 @@ export const normalizeServiceEntry = raw => {
       ...(raw.priceOverride !== undefined && raw.priceOverride !== null && raw.priceOverride !== ''
         ? { priceOverride: toNumber(raw.priceOverride) }
         : {}),
+      // A per-invoice override of the package's payment schedule (round7 spec C.2) - absent until
+      // an admin edits it in the Builder, at which point it freezes the schedule shown/billed on
+      // this invoice instead of continuing to track the catalog's live payment schedule.
+      ...(Array.isArray(raw.schedule)
+        ? { schedule: raw.schedule.map(payment => ({ title: String(payment?.title || ''), amount: toNumber(payment?.amount) })) }
+        : {}),
       children: normalizeServiceEntries(raw.children),
     };
   }
@@ -340,11 +354,6 @@ export const setEntryField = (entry, field, value) => {
   if (entry.kind === 'package') {
     if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
     if (field === 'name' || field === 'description') return { ...entry, [field]: value, customized: true };
-    // detailMode is a rendering choice for this one invoice, not a content edit - it must never
-    // flip `customized` (that flag means "no longer matches the catalog package's actual content").
-    if (field === 'detailMode') {
-      return { ...entry, detailMode: ['full', 'reference'].includes(value) ? value : 'auto' };
-    }
     return entry;
   }
   return { ...entry, [field]: field === 'price' ? toNumber(value) : value, customized: true };
@@ -396,21 +405,17 @@ export const addCatalogChildToPackage = (entry, catalogId) => {
   return { ...entry, children: [...(entry.children || []), makeCatalogItemEntry(catalogId)], customized: true };
 };
 
+// Freezes a per-invoice override of the package's payment schedule (round7 spec C.2): once set, it
+// wins over the catalog's live payment schedule in resolvePackageEntrySchedule below - a rendering/
+// billing choice for this one invoice, not a content edit, so it never flips `customized` (which
+// means "no longer matches the catalog package's actual line items").
+export const setPackageSchedule = (entry, schedule) => (entry?.kind === 'package'
+  ? { ...entry, schedule: (Array.isArray(schedule) ? schedule : []).map(payment => ({ title: String(payment?.title || ''), amount: toNumber(payment?.amount) })) }
+  : entry);
+
 // --- Queries ------------------------------------------------------------
 
 export const isEntryCustomized = entry => (entry?.kind === 'custom' ? true : Boolean(entry?.customized));
-
-// Whether a package row's full "Included in this programme" + "Payment schedule" detail should be
-// rendered inline on the Invoice PDF, instead of the one-sentence Budget reference (round6 #1).
-// An explicit detailMode always wins; left on 'auto', it renders full detail exactly when there's
-// no Budget document to point at instead - a customized package (content no longer matches the
-// catalog) or a hidden/special-offer package (no public Budget page at all).
-export const shouldRenderPackageDetail = row => {
-  if (!row) return false;
-  if (row.detailMode === 'full') return true;
-  if (row.detailMode === 'reference') return false;
-  return Boolean(row.isCustomized) || Boolean(row.isHiddenCatalog);
-};
 
 // A stable identity for an entry, ignoring its id - used to dedupe "recent services" chips and to
 // stop the same catalog item/package being added to the invoice twice.
@@ -434,6 +439,37 @@ export const getEntryIdentityKey = entry => {
 // `children` are always a frozen snapshot taken when it was added - they never live-track the
 // catalog, since that's the whole point of pinning a specific set of services to an invoice.
 const formatPercentValue = percent => (Number.isInteger(percent) ? String(percent) : String(Math.round(percent * 100) / 100));
+
+// The payment schedule shown/edited for a package row on this invoice (round7 spec C.2): an
+// explicit per-invoice `entry.schedule` (set via setPackageSchedule, once an admin edits it) always
+// wins; otherwise it's derived live from the catalog package's own payment schedule, scaled to
+// match a price override the same way the package's own billed price already is. priceContext may
+// carry `technical` (budget/technical, for catalog.paymentSchedules lookups) alongside the usual
+// itemsById/rates/packagesById.
+export const resolvePackageEntrySchedule = (entry, listedPriceAmount, billedPrice, priceContext = {}) => {
+  if (entry?.kind !== 'package') return [];
+  if (Array.isArray(entry.schedule)) {
+    return entry.schedule.map((payment, index) => ({
+      key: `${entry.id}-schedule-${index}`,
+      title: payment.title || `Payment ${index + 1}`,
+      amount: roundMoney(payment.amount),
+    }));
+  }
+  const pkg = priceContext.packagesById?.get?.(String(entry.catalogId));
+  if (!pkg) return [];
+  const catalogSchedule = resolveProgramPaymentSchedule({ technical: priceContext.technical }, pkg);
+  const payments = Array.isArray(catalogSchedule?.payments) ? catalogSchedule.payments : [];
+  if (!payments.length) return [];
+  const scale = listedPriceAmount ? (Number(billedPrice) || 0) / listedPriceAmount : 1;
+  return payments.map((payment, index) => {
+    const amount = resolvePaymentAmount(payment, listedPriceAmount);
+    return {
+      key: `${entry.id}-schedule-${index}`,
+      title: payment.title || `Payment ${index + 1}`,
+      amount: amount == null ? 0 : roundMoney(amount * scale),
+    };
+  });
+};
 
 export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) => {
   if (entry?.kind === 'percent') {
@@ -486,16 +522,18 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       // of its own - there is nothing for the Invoice's "see your Budget" reference sentence to
       // point at, so PackageBlock must fall back to rendering the full details inline instead.
       isHiddenCatalog: Boolean(pkg?.hidden),
-      // 'auto' (default) lets shouldRenderPackageDetail decide from isCustomized/isHiddenCatalog;
-      // 'full'/'reference' are an explicit per-invoice admin override of that default (round5 #4 /
-      // round6 #1 - a selector, not an implicit toggle).
-      detailMode: ['full', 'reference'].includes(entry.detailMode) ? entry.detailMode : 'auto',
       name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
       description: entry.description ?? pkg?.description ?? '',
       price: hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,
       childrenTotal,
       hasPriceOverride,
       children: resolvedChildren,
+      scheduleRows: resolvePackageEntrySchedule(
+        entry,
+        listedPriceAmount,
+        hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,
+        { ...priceContext, itemsById: catalogItemsById },
+      ),
     };
   }
 

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -34,7 +34,7 @@ import {
   resolveInvoiceServiceRows,
   resolveServiceRow,
   setEntryField,
-  shouldRenderPackageDetail,
+  setPackageSchedule,
   touchRecentEntry,
   updatePackageChildField,
   upsertRecentEntry,
@@ -51,6 +51,8 @@ describe('invoiceCatalogUtils', () => {
       customers: [],
       recentServices: [],
       invoiceServices: [],
+      includePackageInPdf: true,
+      includeScheduleInPdf: true,
       recentPaymentSchedules: [],
       recentTaxRates: [],
       notes: [],
@@ -312,44 +314,63 @@ describe('invoiceCatalogUtils', () => {
     });
   });
 
-  describe('hidden/special-offer packages render full detail on the Invoice (round6 #1)', () => {
+  describe('hidden/special-offer packages (round6 #1)', () => {
     it('flags a package row as isHiddenCatalog when its catalog package is hidden', () => {
       const packagesById = new Map([['p6', { id: 'p6', name: 'Special Offer', hidden: true, children: ['1'] }]]);
       const row = resolveServiceRow(makeCatalogPackageEntry({ id: 'p6', children: ['1'] }), new Map(), { packagesById });
       expect(row.isHiddenCatalog).toBe(true);
       expect(row.isCustomized).toBe(false);
     });
+  });
 
-    it('left on "auto", renders full detail for a hidden package but only a Budget reference for a standard one', () => {
-      const packagesById = new Map([
-        ['hidden-1', { id: 'hidden-1', name: 'Special Offer', hidden: true, children: ['1'] }],
-        ['standard-1', { id: 'standard-1', name: 'Programme', children: ['1'] }],
+  // round7 spec C: whether/how a package's composition and payment schedule appear on the Invoice
+  // PDF is now decided by the Builder's own checkboxes (InvoiceBuilderPage), not by a per-package
+  // detailMode field - a package row's composition (`children`) is always resolved and available.
+  describe('package payment schedule (round7 spec C.2)', () => {
+    const packagesById = new Map([['p1', {
+      id: 'p1', name: 'Full program', listedPrice: 250, children: ['1'],
+    }]]);
+    const technical = { paymentSchedules: [{ id: 'ps-1', payments: [{ title: 'Deposit', amount: 150 }, { title: 'Final payment', amount: 100 }] }] };
+    const withSchedule = { ...packagesById.get('p1'), paymentScheduleId: 'ps-1' };
+    const packagesByIdWithSchedule = new Map([['p1', withSchedule]]);
+
+    it('derives the schedule live from the catalog package when no per-invoice override is set', () => {
+      const row = resolveServiceRow(makeCatalogPackageEntry({ id: 'p1', children: ['1'] }), new Map(), { packagesById: packagesByIdWithSchedule, technical });
+      expect(row.scheduleRows).toEqual([
+        { key: expect.any(String), title: 'Deposit', amount: 150 },
+        { key: expect.any(String), title: 'Final payment', amount: 100 },
       ]);
-      const hiddenRow = resolveServiceRow(makeCatalogPackageEntry({ id: 'hidden-1', children: ['1'] }), new Map(), { packagesById });
-      const standardRow = resolveServiceRow(makeCatalogPackageEntry({ id: 'standard-1', children: ['1'] }), new Map(), { packagesById });
-      expect(shouldRenderPackageDetail(hiddenRow)).toBe(true);
-      expect(shouldRenderPackageDetail(standardRow)).toBe(false);
     });
 
-    it('an explicit detailMode override always wins over the auto default', () => {
-      const packagesById = new Map([
-        ['hidden-1', { id: 'hidden-1', name: 'Special Offer', hidden: true, children: ['1'] }],
-        ['standard-1', { id: 'standard-1', name: 'Programme', children: ['1'] }],
+    it('scales the live schedule to match a price override', () => {
+      const overridden = setEntryField(makeCatalogPackageEntry({ id: 'p1', children: ['1'] }), 'price', 500);
+      const row = resolveServiceRow(overridden, new Map(), { packagesById: packagesByIdWithSchedule, technical });
+      expect(row.scheduleRows).toEqual([
+        { key: expect.any(String), title: 'Deposit', amount: 300 },
+        { key: expect.any(String), title: 'Final payment', amount: 200 },
       ]);
-      const hiddenEntry = setEntryField(makeCatalogPackageEntry({ id: 'hidden-1', children: ['1'] }), 'detailMode', 'reference');
-      const standardEntry = setEntryField(makeCatalogPackageEntry({ id: 'standard-1', children: ['1'] }), 'detailMode', 'full');
-      const hiddenRow = resolveServiceRow(hiddenEntry, new Map(), { packagesById });
-      const standardRow = resolveServiceRow(standardEntry, new Map(), { packagesById });
-      expect(shouldRenderPackageDetail(hiddenRow)).toBe(false);
-      expect(shouldRenderPackageDetail(standardRow)).toBe(true);
-      // Setting detailMode is a display choice, not a content edit - it must never flip `customized`.
-      expect(hiddenEntry.customized).toBeUndefined();
-      expect(standardEntry.customized).toBeUndefined();
     });
 
-    it('a custom (self-contained) package always renders full detail regardless of detailMode', () => {
+    it('an explicit per-invoice schedule override wins over the live catalog schedule', () => {
+      const withOverride = setPackageSchedule(
+        makeCatalogPackageEntry({ id: 'p1', children: ['1'] }),
+        [{ title: 'Only payment', amount: 999 }],
+      );
+      const row = resolveServiceRow(withOverride, new Map(), { packagesById: packagesByIdWithSchedule, technical });
+      expect(row.scheduleRows).toEqual([{ key: expect.any(String), title: 'Only payment', amount: 999 }]);
+      // Setting a schedule override is a rendering/billing choice for this invoice, not a content
+      // edit - it must never flip `customized`.
+      expect(withOverride.customized).toBeUndefined();
+    });
+
+    it('resolves no schedule rows when the catalog package has no payment schedule', () => {
+      const row = resolveServiceRow(makeCatalogPackageEntry({ id: 'p1', children: ['1'] }), new Map(), { packagesById, technical });
+      expect(row.scheduleRows).toEqual([]);
+    });
+
+    it('resolves no schedule rows for a custom package with no override', () => {
       const row = resolveServiceRow(makeCustomPackageEntry({ name: 'Bespoke' }), new Map(), { packagesById: new Map() });
-      expect(shouldRenderPackageDetail(row)).toBe(true);
+      expect(row.scheduleRows).toEqual([]);
     });
   });
 


### PR DESCRIPTION
A. Program Budget PDF: drop the Payment Schedule table's duplicate Total
   row (each column's total already shows in its header cell), and move
   Payment Schedule to page 1 right after Programs, ahead of Included
   Services.

B. Invoice PDF: drop the "no separate Budget document" line for
   non-customized hidden packages, and rename "Included in this
   invoice"/"Payment schedule for this invoice" to "...this package" to
   match the package, not invoice, framing.

C. Invoice Builder: pull the package out of the "Invoice Services" list
   into its own "Package & PDF components" panel with independent
   checkboxes for the package block, its payment schedule (now editable
   per invoice, not just derived live from the catalog), and Payment
   Details - each hides/shows its own editing area and PDF inclusion.

D. Expected Expenses now lives behind its own top-level tab, structurally
   separate from the regular invoice-creation flow.

E. Beneficiary/Payer text fields are now minimal single-line height with
   no visual box on hover/focus.