### PR TITLE
Invoice Builder design round: plain-text inputs, one-page Invoice PDF, EE selectors, backend agency identity

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -349,11 +349,13 @@ async function checkBudget() {
     'Service item 1, week checkup', 'Programme package 1',
   ]);
 
+  // Client-facing reading order is Programs -> Payment schedule -> Included services (round7 spec
+  // A.2, see BudgetPdfDocument) - the schedule stays on page 1 right after Programs.
   const combined = pagesText.join('\n');
   const includedIndex = combined.indexOf('Included services by program');
   const scheduleIndex = combined.indexOf('Payment schedule');
-  if (includedIndex === -1 || scheduleIndex === -1 || includedIndex > scheduleIndex) {
-    fail('Program Budget: expected section order Programmes -> Included services -> Payment schedule -> Other expenses');
+  if (includedIndex === -1 || scheduleIndex === -1 || scheduleIndex > includedIndex) {
+    fail('Program Budget: expected section order Programmes -> Payment schedule -> Included services -> Other expenses');
   }
 }
 

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -24,6 +24,7 @@ import {
   KNOWN_CATEGORY_KEYS,
   KNOWN_CLIENT_NOTE_GROUPS,
 } from './budgetCatalogUtils';
+import { setPdfAgencyConfig } from './pdfTheme';
 
 const INCLUDED_PREVIEW_LIMIT = 6;
 const POPULAR_PACKAGE_ID = '3';
@@ -1050,6 +1051,9 @@ const BudgetPage = ({ isAdmin = false }) => {
       const value = snapshot.exists() ? snapshot.val() : null;
       historyLoadRef.current = true;
       setCatalog(normalizeCatalog(value));
+      // Agency identity (wordmark/footer of every generated PDF) is backend data, shared with the
+      // other documents through pdfTheme's config store.
+      setPdfAgencyConfig(value?.technical?.agency);
     } catch (loadError) {
       console.error('Unable to load budget catalog', loadError);
       setError('Budget catalog is not available right now.');
@@ -2043,7 +2047,7 @@ const BudgetPage = ({ isAdmin = false }) => {
       <Shell>
         <Header>
           <div>
-            <Eyebrow>{UKRCOM_MARKER}</Eyebrow>
+            <Eyebrow>{(catalog.technical?.agency?.name || UKRCOM_MARKER).toUpperCase()}</Eyebrow>
             <Title>Program Budget</Title>
           </div>
           <HeaderActions>

--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -124,6 +124,17 @@ const styles = StyleSheet.create({
     color: PDF_COLOR.docInk,
     lineHeight: 1.4,
   },
+  labelCellDescription: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 7.5,
+    color: PDF_COLOR.inkSoft,
+    lineHeight: 1.4,
+    marginTop: 1.5,
+  },
+  // Dense variant: tighter row padding for the single-page Invoice (design-tasks §3).
+  denseCell: {
+    paddingVertical: 2,
+  },
   programCell: {
     width: PROGRAM_COL_WIDTH,
     paddingVertical: 3.5,
@@ -257,13 +268,13 @@ const styles = StyleSheet.create({
   },
 });
 
-const ProgramColumnsHead = ({ packages, leadLabel }) => (
+const ProgramColumnsHead = ({ packages, leadLabel, dense = false }) => (
   <View style={styles.tableHeadRow} wrap={false}>
-    <View style={styles.labelCell}>
+    <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
       <Text style={styles.labelCellHeadText}>{leadLabel}</Text>
     </View>
     {packages.map(program => (
-      <View key={program.id} style={styles.programCell}>
+      <View key={program.id} style={[styles.programCell, dense ? styles.denseCell : null]}>
         {program.label ? <Text style={styles.programCellHead}>{program.label}</Text> : null}
         <Text style={styles.programCellHeadPrice}>{program.priceLabel}</Text>
       </View>
@@ -281,21 +292,23 @@ export const IncludedServicesTable = ({
   includedRows,
   title = 'Included services by program',
   note = 'An "x" marks the services included in each program package.',
+  sectionStyle,
+  dense = false,
 }) => (includedRows.length ? (
-  <View style={styles.section}>
+  <View style={sectionStyle || styles.section}>
     <View wrap={false} minPresenceAhead={70}>
       <Text style={styles.sectionTitle}>{title}</Text>
-      <Text style={styles.sectionNote}>{note}</Text>
+      {note ? <Text style={styles.sectionNote}>{note}</Text> : null}
     </View>
     <View style={styles.table}>
-      <ProgramColumnsHead packages={packages} leadLabel="Provided service" />
+      <ProgramColumnsHead packages={packages} leadLabel="Provided service" dense={dense} />
       {includedRows.map(item => (
         <View key={item.id} style={styles.tableRow} wrap={false}>
-          <View style={styles.labelCell}>
+          <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
             <Text style={styles.labelCellText}>{sanitizePdfText(item.name)}</Text>
           </View>
           {packages.map(program => (
-            <View key={`${item.id}-${program.id}`} style={styles.programCell}>
+            <View key={`${item.id}-${program.id}`} style={[styles.programCell, dense ? styles.denseCell : null]}>
               <Text style={styles.markCellText}>{item.includedByPackageId.has(String(program.id)) ? 'x' : ''}</Text>
             </View>
           ))}
@@ -310,21 +323,26 @@ export const IncludedServicesTable = ({
 // (one per package column, same order as `packages`) - omit it when a column's total is already
 // shown once in that program's own header cell (ProgramColumnsHead), so the table doesn't just
 // repeat the same numbers at its foot (round7 spec A.1).
-export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment schedule' }) => (rows.length ? (
-  <View style={styles.scheduleSection}>
+// A cell amount may also be a free-text label (e.g. "GIFT") when the table renders invoice
+// breakdown rows - a string passes through as-is instead of being coerced to a number.
+export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment schedule', leadLabel = 'Milestone', sectionStyle, dense = false }) => (rows.length ? (
+  <View style={sectionStyle || styles.scheduleSection}>
     <View wrap={false} minPresenceAhead={70}>
       <Text style={styles.sectionTitle}>{title}</Text>
     </View>
     <View style={styles.table}>
-      <ProgramColumnsHead packages={packages} leadLabel="Milestone" />
+      <ProgramColumnsHead packages={packages} leadLabel={leadLabel} dense={dense} />
       {rows.map((row, rowIndex) => (
         <View key={`schedule-row-${rowIndex}`} style={styles.tableRow} wrap={false}>
-          <View style={styles.labelCell}>
+          <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
             <Text style={styles.labelCellText}>{`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}</Text>
+            {row.description ? <Text style={styles.labelCellDescription}>{sanitizePdfText(row.description)}</Text> : null}
           </View>
           {row.amounts.map((amount, columnIndex) => (
-            <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={styles.programCell}>
-              <Text style={styles.amountCellText}>{amount == null ? '-' : formatAmount(amount)}</Text>
+            <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={[styles.programCell, dense ? styles.denseCell : null]}>
+              <Text style={styles.amountCellText}>
+                {amount == null ? '-' : (typeof amount === 'string' ? sanitizePdfText(amount) : formatAmount(amount))}
+              </Text>
             </View>
           ))}
         </View>

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -58,13 +58,6 @@ const styles = StyleSheet.create({
     fontSize: 11.5,
     color: PDF_COLOR.docInk,
   },
-  scheduledLine: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 9,
-    fontVariantNumeric: 'tabular-nums',
-    color: PDF_COLOR.docInk,
-    marginBottom: 2,
-  },
   additionalRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -108,10 +101,11 @@ const styles = StyleSheet.create({
 });
 
 // One compact block per payment (spec §1.2): "Payment #N - {milestone title}" - a header line, the
-// scheduled share of the programme fee expressed as a percent (never a bare number with no
-// context), then every other row (SM deposits, catalog add-ons, gifts) as a plain line, and the
-// milestone's own total. Never repeats the package name, included services, or payment schedule -
-// those render exactly once, above, in the shared programme-overview block.
+// scheduled share of the programme fee as a "Scheduled payment" line with the amount right-aligned
+// (design-tasks §3/§4: same style as every other service line, never "N% of programme fee"), then
+// every other row (SM deposits, catalog add-ons, gifts) as the same plain line, and the milestone's
+// own total. Never repeats the package name, included services, or payment schedule - those render
+// exactly once, above, in the shared programme-overview block.
 const PaymentBlock = ({ index, milestone, rows, currency }) => {
   const { scheduledRows, additionalRows } = splitScheduledRows(rows);
   const subtotal = computeMilestoneSubtotal(rows);
@@ -123,9 +117,10 @@ const PaymentBlock = ({ index, milestone, rows, currency }) => {
         <Text style={styles.paymentTitle}>{sanitizePdfText(`Payment #${index + 1} — ${milestone.title}`)}</Text>
       </View>
       {scheduledRows.map(row => (
-        <Text key={row.key} style={styles.scheduledLine}>
-          {sanitizePdfText(`${formatPercentValue(row.percent)}% of programme fee — ${formatMoney(row.price, currency)}`)}
-        </Text>
+        <View key={row.key} style={styles.additionalRow}>
+          <Text style={styles.additionalName}>{sanitizePdfText('Scheduled payment')}</Text>
+          <Text style={styles.additionalPrice}>{formatMoney(row.price, currency)}</Text>
+        </View>
       ))}
       {additionalRows.map(row => (
         <View key={row.key} style={styles.additionalRow}>
@@ -178,7 +173,6 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
     title: milestone.title || `Payment ${index + 1}`,
     amounts: [milestoneSubtotals[index]],
   }));
-  const scheduleTotal = milestoneSubtotals.reduce((sum, amount) => sum + (Number(amount) || 0), 0);
 
   return (
     <Document title={`Expected expenses - ${caseTitle}`} subject="Expected expenses" creator="UKRCOM">
@@ -201,18 +195,17 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
 
         <SummaryCard label="What this programme includes" text={plan?.packageSnapshot?.description} />
 
-        <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} totals={[scheduleTotal]} />
+        {/* Included services first, then the payment schedule (design-tasks §4) - the schedule's
+            own Total row is dropped too: the programme fee is already stated once in the title
+            block and each column's header. */}
+        <IncludedServicesTable
+          packages={packagesMeta}
+          includedRows={includedRows}
+          title="Included in this programme"
+          note="Every item below is already covered by the programme fee."
+        />
 
-        {/* `break` starts Included services on a fresh page, matching the Program Budget layout
-            (spec §2) - so the schedule above stays with the title block/summary on page 1. */}
-        <View break={includedRows.length > 0}>
-          <IncludedServicesTable
-            packages={packagesMeta}
-            includedRows={includedRows}
-            title="Included in this programme"
-            note="Every item below is already covered by the programme fee."
-          />
-        </View>
+        <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} />
 
         {milestones.length ? (
           <View>

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -17,6 +17,7 @@ import {
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
+import { setPdfAgencyConfig } from './pdfTheme';
 import { formatEuroSmart, getSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
@@ -46,6 +47,7 @@ import {
   movePackageChild,
   normalizeInvoiceData,
   parseCustomPriceInput,
+  parsePercentOrAmountInput,
   removePackageChild,
   reorderBeneficiaryIds,
   reorderPayerCaseIds,
@@ -238,8 +240,8 @@ const iconButtonBase = css`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: ${({ $dense }) => ($dense ? '18px' : '22px')};
-  height: ${({ $dense }) => ($dense ? '18px' : '22px')};
+  width: ${({ $dense }) => ($dense ? '18px' : '20px')};
+  height: ${({ $dense }) => ($dense ? '18px' : '20px')};
   flex-shrink: 0;
   border: none;
   border-radius: 6px;
@@ -430,24 +432,30 @@ const StackedFieldTag = styled.span`
   color: var(--km-muted);
 `;
 
-// $bare (round7 spec E): a minimal, single-line-tall field with no visual "input" chrome at all,
-// not even on hover/focus - it reads as plain text that happens to be editable, exactly like the
-// DescriptionToggle/text it sits next to. Used for Beneficiary/Payer fields, where the regular
-// hover/focus wash (still used everywhere else) reads as unnecessarily tall/boxy for a name/address
-// line.
+// One shared line-height every element of a row (index number, name, price, % sign, EUR chip,
+// arrows, trash icon) aligns to - the single-baseline rule of design-tasks §1. Everything below
+// that sits on a row either uses this line-height directly or centers itself inside it.
+const ROW_LINE_HEIGHT = '20px';
+
+// The one "plain editable text" field style (design-tasks §1): no box, border, background, or
+// focus ring - ever, not even while focused - a single line of text tall, auto-growing only as
+// its content wraps (useAutoResize). Font, padding, and line-height are normalized here so an
+// input, plain text, and "text styled as input" on the same row all share one baseline instead of
+// each carrying its own padding. ($bare predates this - every field is bare now; the prop is
+// still accepted so call sites don't have to change.)
 const plainFieldStyle = css`
   flex: 1 1 auto;
   min-width: 0;
   display: block;
   border: none;
-  border-radius: 6px;
+  border-radius: 0;
   background: transparent;
   color: var(--km-text);
   font-family: inherit;
   font-size: ${({ $size }) => $size || '13px'};
   font-weight: ${({ $weight }) => $weight || '600'};
-  line-height: ${({ $bare }) => ($bare ? '1.25' : '1.45')};
-  padding: ${({ $bare }) => ($bare ? '1px 2px' : '5px 6px')};
+  line-height: ${ROW_LINE_HEIGHT};
+  padding: 0 2px;
   margin: 0;
   resize: none;
   overflow: hidden;
@@ -458,14 +466,11 @@ const plainFieldStyle = css`
     opacity: 0.8;
   }
 
-  &:hover {
-    background: ${({ $bare }) => ($bare ? 'transparent' : 'var(--km-accent-light)')};
-  }
-
+  &:hover,
   &:focus {
     outline: none;
-    background: ${({ $bare }) => ($bare ? 'transparent' : 'var(--km-accent-light)')};
-    box-shadow: ${({ $bare }) => ($bare ? 'none' : 'inset 0 0 0 1px var(--km-accent-mid)')};
+    background: transparent;
+    box-shadow: none;
   }
 `;
 
@@ -488,19 +493,19 @@ const PlainSelect = styled.select`
   flex: 1 1 auto;
   min-width: 0;
   border: none;
-  border-radius: 6px;
   background: transparent;
   color: var(--km-text);
   font-family: inherit;
   font-size: 13px;
   font-weight: 700;
-  padding: 6px;
+  line-height: ${ROW_LINE_HEIGHT};
+  padding: 0 2px;
   cursor: pointer;
 
   &:hover,
   &:focus {
     outline: none;
-    background: var(--km-accent-light);
+    background: transparent;
   }
 `;
 
@@ -559,7 +564,7 @@ const LineMainRow = styled.div`
 const RowIndex = styled.span`
   flex: 0 0 auto;
   width: 16px;
-  padding-top: 7px;
+  line-height: ${ROW_LINE_HEIGHT};
   font-size: 10.5px;
   font-weight: 700;
   color: var(--km-muted);
@@ -569,13 +574,14 @@ const RowIndex = styled.span`
 const RowActions = styled.div`
   flex: 0 0 auto;
   display: flex;
+  align-items: flex-start;
   gap: ${({ $dense }) => ($dense ? '0' : '1px')};
-  padding-top: ${({ $dense }) => ($dense ? '0' : '2px')};
 `;
 
 const CustomizedTag = styled.span`
   flex: 0 0 auto;
-  align-self: center;
+  align-self: flex-start;
+  margin-top: 2px;
   font-size: 9px;
   font-weight: 800;
   letter-spacing: 0.03em;
@@ -584,6 +590,7 @@ const CustomizedTag = styled.span`
   background: var(--km-accent-light);
   border-radius: 999px;
   padding: 2px 7px;
+  line-height: 12px;
   white-space: nowrap;
 `;
 
@@ -603,15 +610,15 @@ const DescriptionToggle = styled.button`
   width: 100%;
   max-width: 100%;
   border: none;
-  border-radius: 6px;
+  border-radius: 0;
   background: transparent;
   color: var(--km-muted);
   font-family: inherit;
   font-size: 11.5px;
   font-style: ${({ $hasValue }) => ($hasValue ? 'normal' : 'italic')};
-  line-height: 1.45;
+  line-height: ${ROW_LINE_HEIGHT};
   text-align: left;
-  padding: 5px 6px;
+  padding: 0 2px;
   margin: 0;
   cursor: pointer;
   white-space: nowrap;
@@ -620,12 +627,24 @@ const DescriptionToggle = styled.button`
 
   &:hover {
     color: var(--km-accent);
-    background: var(--km-accent-light);
   }
 `;
 
-// A "% of package" row has no name/description of its own (it's derived: "20% of IVF+ED+SM") -
-// what's editable is the percent value and which catalog package it's a share of.
+// The unit that follows a percent/amount value ("%", "EUR") - same line-height as everything else
+// on the row so it sits on the shared baseline (design-tasks §2).
+const UnitSign = styled.span`
+  flex: 0 0 auto;
+  font-size: 12.5px;
+  font-weight: 700;
+  line-height: ${ROW_LINE_HEIGHT};
+  color: var(--km-muted);
+`;
+
+// A "% of package" row is the invoice's scheduled share of the programme fee, so it reads as
+// "Scheduled payment" - the same one-style line a normal service item uses (design-tasks §3) -
+// unless the package is still choosable, in which case the package selector doubles as the name.
+// Its one value field accepts a percent or an absolute euro amount interchangeably (design-tasks
+// §1: "25" -> 25%, "10000" -> 10,000 EUR), with the equivalent in the other unit shown as a chip.
 const PercentShareRow = ({
   row,
   index,
@@ -640,12 +659,9 @@ const PercentShareRow = ({
   canMoveUp,
   canMoveDown,
 }) => {
-  const [percentDraft, setPercentDraft, percentEditingRef] = useFieldDraft(String(row.percent ?? ''));
-
-  const lockedPackageName = useMemo(
-    () => catalogPackages.find(pkg => String(pkg.id) === String(row.packageId))?.name || `Package ${row.packageId}`,
-    [catalogPackages, row.packageId],
-  );
+  const isAmountMode = row.amount != null;
+  const committedValue = String((isAmountMode ? row.amount : row.percent) ?? '');
+  const [valueDraft, setValueDraft, valueEditingRef] = useFieldDraft(committedValue);
 
   return (
     <LineCard>
@@ -655,10 +671,10 @@ const PercentShareRow = ({
           <span
             title="This invoice's package is fixed at the top - see the Package field above"
             style={{
-              flex: '1 1 auto', minWidth: 0, padding: '6px', fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              flex: '1 1 auto', minWidth: 0, padding: '0 2px', fontWeight: 700, lineHeight: ROW_LINE_HEIGHT, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
             }}
           >
-            {lockedPackageName}
+            Scheduled payment
           </span>
         ) : (
           <PlainSelect
@@ -679,18 +695,22 @@ const PercentShareRow = ({
           $size={isChild ? '12.5px' : '13px'}
           $width="52px"
           inputMode="decimal"
-          value={percentDraft}
+          value={valueDraft}
           placeholder="0"
-          aria-label="Percent of package price"
-          onFocus={() => { percentEditingRef.current = true; }}
-          onChange={event => setPercentDraft(event.target.value)}
+          aria-label="Percent of package price, or an absolute EUR amount"
+          onFocus={() => { valueEditingRef.current = true; }}
+          onChange={event => setValueDraft(event.target.value)}
           onBlur={() => {
-            percentEditingRef.current = false;
-            if (percentDraft !== String(row.percent ?? '')) onCommit('percent', percentDraft);
+            valueEditingRef.current = false;
+            if (valueDraft !== committedValue) onCommit('percent', valueDraft);
           }}
         />
-        <span style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--km-muted)' }}>%</span>
-        <CustomizedTag title="Recalculated live from the package's price">≈ {formatEuroPreview(row.price)}</CustomizedTag>
+        <UnitSign>{isAmountMode ? 'EUR' : '%'}</UnitSign>
+        {isAmountMode ? (
+          <CustomizedTag title="Share of the package's price this amount corresponds to">≈ {row.percent}%</CustomizedTag>
+        ) : (
+          <CustomizedTag title="Recalculated live from the package's price">≈ {formatEuroPreview(row.price)}</CustomizedTag>
+        )}
         {row.missing ? <MissingTag title="This catalog package no longer exists">Missing</MissingTag> : null}
         <RowActions>
           {onMoveUp ? (
@@ -856,9 +876,8 @@ const PackageIcon = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
-  margin-top: 3px;
+  width: 20px;
+  height: 20px;
   border-radius: 7px;
   background: var(--km-card);
   color: var(--km-accent);
@@ -888,18 +907,14 @@ const PackageAddRow = styled.div`
   }
 `;
 
+// Same plain-text look as every other field (design-tasks §1) - the flex bases are the only
+// thing these add.
 const PackageQuickField = styled(PlainTextBase)`
   flex: 1 1 140px;
-  background: var(--km-card);
-  border-radius: 8px;
-  padding: 5px 8px;
 `;
 
 const PackageQuickPrice = styled(PlainPriceBase)`
   flex: 0 0 76px;
-  background: var(--km-card);
-  border-radius: 8px;
-  padding: 5px 8px;
 `;
 
 const InlinePickerBox = styled.div`
@@ -1032,9 +1047,10 @@ const PackageEntryCard = ({
     <PackageCard>
       <PackageHeaderRow>
         <PackageIcon><FaBoxOpen /></PackageIcon>
+        {/* Same size/weight as a normal service line's name (design-tasks §2): the package name
+            must never render differently here than a line item does in Invoice Services. */}
         <AutoTextArea
-          $size="13.5px"
-          $weight="800"
+          $weight="700"
           value={nameDraft}
           placeholder="Package name"
           aria-label="Package name"
@@ -1136,7 +1152,8 @@ const PackageEntryCard = ({
         />
         <PackageQuickPrice
           rows={1}
-          placeholder="Price or GIFT"
+          placeholder="100"
+          aria-label="New custom line price"
           value={customPrice}
           onChange={event => setCustomPrice(event.target.value)}
         />
@@ -1423,7 +1440,8 @@ const MilestoneCard = ({
           />
           <PackageQuickPrice
             rows={1}
-            placeholder="Price or GIFT"
+            placeholder="100"
+            aria-label="New milestone service price"
             value={customPrice}
             onChange={event => setCustomPrice(event.target.value)}
           />
@@ -1597,7 +1615,11 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       setData(normalizeInvoiceData(invoiceSnapshot.exists() ? invoiceSnapshot.val() : null));
       setCatalogItems(toArray(itemsSnapshot.exists() ? itemsSnapshot.val() : []));
       setCatalogPackages(toArray(packagesSnapshot.exists() ? packagesSnapshot.val() : []));
-      setCatalogTechnical(technicalSnapshot.exists() ? technicalSnapshot.val() : {});
+      const technicalValue = technicalSnapshot.exists() ? technicalSnapshot.val() : {};
+      setCatalogTechnical(technicalValue);
+      // Agency identity (wordmark/footer of every generated PDF) is backend data, shared with the
+      // other documents through pdfTheme's config store.
+      setPdfAgencyConfig(technicalValue?.agency);
       setExpectedExpenses(normalizeExpectedExpensesData(expectedExpensesSnapshot.exists() ? expectedExpensesSnapshot.val() : null));
     } catch (loadError) {
       console.error('Unable to load invoice builder data', loadError);
@@ -1789,22 +1811,37 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     if (!expectedExpenses) return null;
     const pkg = catalogPackagesById.get(String(expectedExpenses.packageId)) || expectedExpenses.packageSnapshot || null;
     const shouldCheckPackageSharePercent = Boolean(expectedExpenses.packageId);
+    const packagePrice = resolveBudgetPriceAmount(pkg?.listedPrice, priceContext)
+      ?? (Number(expectedExpenses.packageSnapshot?.listedPrice) || null);
     const milestoneRows = expectedExpenses.milestones.map(milestone => {
       const serviceRows = resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext);
       const subtotal = computeMilestoneSubtotal(serviceRows);
       const amountDue = computeMilestoneAmountDue(subtotal, milestone.taxPercent);
       return { milestone, serviceRows, subtotal, amountDue };
     });
+    // One plan-wide tax rate (design-tasks §4): shown as a single value only while every milestone
+    // agrees; mixed per-milestone rates read as blank until re-applied.
+    const taxValues = expectedExpenses.milestones.map(milestone => Number(milestone.taxPercent) || 0);
+    const sharedTaxPercent = taxValues.length && taxValues.every(value => value === taxValues[0])
+      ? String(taxValues[0])
+      : '';
     return {
       pkg,
       milestoneRows,
+      sharedTaxPercent,
       totalPlanned: computeMilestonesTotal(expectedExpenses.milestones, catalogItemsById, priceContext),
       packageSharePercent: shouldCheckPackageSharePercent
-        ? computeMilestonesPackageSharePercent(expectedExpenses.milestones, expectedExpenses.packageId)
+        ? computeMilestonesPackageSharePercent(expectedExpenses.milestones, expectedExpenses.packageId, packagePrice)
         : null,
       shouldCheckPackageSharePercent,
     };
   }, [expectedExpenses, catalogItemsById, catalogPackagesById, priceContext]);
+
+  // Draft for the plan-wide Expected Expenses tax field (design-tasks §4) - resynced from the
+  // shared per-milestone value whenever the milestones change elsewhere.
+  const [expectedExpensesTaxDraft, setExpectedExpensesTaxDraft, expectedExpensesTaxEditingRef] = useFieldDraft(
+    expectedExpensesView?.sharedTaxPercent ?? '',
+  );
 
   const persistPath = async (path, value, successMessage) => {
     try {
@@ -2050,6 +2087,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     setCatalogQuery('');
   };
 
+  // The Package panel's programme selector (design-tasks §2): swaps the invoice's package for a
+  // different catalog programme in place - the fresh entry drops any per-invoice customisation of
+  // the old one, exactly like removing the package and adding the new one, but in a single step.
+  const replacePackageEntry = pkg => {
+    const next = data.invoiceServices.map(entry => (entry.kind === 'package' ? makeCatalogPackageEntry(pkg) : entry));
+    persistInvoiceServices(next, 'Package switched.');
+  };
+
   const addCatalogPackagePercentEntry = pkg => {
     addPercentServiceEntry(pkg.id);
     setShowCatalogPicker(false);
@@ -2173,10 +2218,18 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   // The first edit "materializes" whatever schedule is currently showing (live from the catalog, or
   // an existing override) into a fresh per-invoice override, then applies the one field edit on top.
+  // The amount field accepts a percent too (design-tasks §1: "25" -> 25% of the package's billed
+  // price, "10000" -> 10,000 EUR) - a percent is resolved to euros against the package price once,
+  // at commit time, since a schedule override stores plain euro amounts.
   const updateScheduleRow = (rowIndex, field, value) => {
     if (!packageRow) return;
+    const resolveAmount = raw => {
+      const { percent, amount } = parsePercentOrAmountInput(raw);
+      if (amount != null) return amount;
+      return roundToCents(((Number(packageRow.price) || 0) * percent) / 100) || 0;
+    };
     const rows = packageRow.scheduleRows.map((row, index) => (index === rowIndex
-      ? { ...row, [field]: field === 'amount' ? (Number(String(value).replace(',', '.')) || 0) : value }
+      ? { ...row, [field]: field === 'amount' ? resolveAmount(value) : value }
       : row));
     commitPackageSchedule(packageRow.id, rows);
   };
@@ -2323,14 +2376,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     setCustomScheduleRows([{ title: '', amount: '' }]);
   };
 
-  const recalculateExpectedExpensesSchedule = () => {
+  // Shared by "Recalculate" (the package's own catalog schedule) and the payment-schedule selector
+  // (any named schedule from the catalog - design-tasks §4): rebuilds the milestones from the given
+  // schedule while keeping each milestone's extra services, tax rate, and overview flag.
+  const rebuildExpectedExpensesFromSchedule = (schedule, successMessage) => {
     if (!expectedExpenses) return;
     const pkg = catalogPackagesById.get(String(expectedExpenses.packageId));
     if (!pkg) {
       toast.error('The original package is no longer in the catalog.');
       return;
     }
-    const schedule = resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg);
     if (!schedule || !Array.isArray(schedule.payments) || !schedule.payments.length) {
       toast.error('This package has no payment schedule in the catalog.');
       return;
@@ -2341,7 +2396,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     const resolvedPackage = getResolvedExpectedExpensesPackage(pkg);
     if (!resolvedPackage) return;
     if (typeof window !== 'undefined' && !window.confirm(
-      'Recalculate milestones from the catalog schedule? Titles reset to the catalog and the package-share row is recomputed; extra services on each milestone are kept.',
+      'Recalculate milestones from this schedule? Titles reset to the schedule and the package-share row is recomputed; extra services on each milestone are kept.',
     )) return;
     const freshMilestones = buildMilestonesFromSchedule(resolvedPackage, schedule, { taxPercent: defaultExpectedExpensesTaxPercent });
     // A milestone saved before expectedExpenseRole existed has no explicit marker on its scheduled
@@ -2377,7 +2432,53 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         listedPrice: resolvedPackage.listedPrice,
       },
       milestones: nextMilestones,
-    }, 'Schedule recalculated.');
+    }, successMessage);
+  };
+
+  const recalculateExpectedExpensesSchedule = () => {
+    if (!expectedExpenses) return;
+    const pkg = catalogPackagesById.get(String(expectedExpenses.packageId));
+    if (!pkg) {
+      toast.error('The original package is no longer in the catalog.');
+      return;
+    }
+    const schedule = resolveProgramPaymentSchedule({ technical: catalogTechnical }, pkg);
+    rebuildExpectedExpensesFromSchedule(schedule, 'Schedule recalculated.');
+  };
+
+  // Payment-schedule selector (design-tasks §4): applies any named schedule from the catalog to
+  // the plan, same pattern as the Package panel's schedule selector.
+  const applyExpectedExpensesSchedule = scheduleId => {
+    const schedule = (catalogTechnical.paymentSchedules || []).find(candidate => String(candidate.id) === String(scheduleId));
+    if (!schedule) return;
+    rebuildExpectedExpensesFromSchedule(schedule, 'Payment schedule applied.');
+  };
+
+  // Package selector (design-tasks §4): switching programme rebuilds the whole plan from the new
+  // package's own catalog schedule - the same flow as picking a package for a brand-new plan.
+  const switchExpectedExpensesPackage = packageId => {
+    const pkg = catalogPackagesById.get(String(packageId));
+    if (!pkg || String(pkg.id) === String(expectedExpenses?.packageId)) return;
+    if (typeof window !== 'undefined' && !window.confirm(
+      `Switch the plan to "${pkg.name}"? Milestones are rebuilt from that package's payment schedule.`,
+    )) return;
+    createExpectedExpensesPlan(pkg);
+  };
+
+  // Plan-wide tax rate (design-tasks §4) - one value applied to every milestone, joining the same
+  // recent-rates quick-pick list the invoice Summary tax uses.
+  const applyExpectedExpensesTaxPercent = value => {
+    if (!expectedExpenses) return;
+    const numeric = Number(String(value).replace(',', '.')) || 0;
+    const nextMilestones = expectedExpenses.milestones.map(milestone => ({ ...milestone, taxPercent: numeric }));
+    persistExpectedExpensesMilestones(nextMilestones, 'Tax updated for all milestones.');
+    if (numeric <= 0) return;
+    const existing = data.recentTaxRates.find(rate => Number(rate.value) === numeric);
+    const nextRecentTaxRates = existing
+      ? touchRecentEntry(data.recentTaxRates, existing.id)
+      : upsertRecentEntry(data.recentTaxRates, { id: createEntryId(), value: numeric });
+    setData(current => ({ ...current, recentTaxRates: nextRecentTaxRates }));
+    persistPath(`${INVOICE_DATA_PATH}/recentTaxRates`, nextRecentTaxRates);
   };
 
   const deleteExpectedExpensesPlan = () => {
@@ -3043,6 +3144,26 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
               {data.includePackageInPdf ? (
                 packageRow ? (
+                  <>
+                    {/* Package/programme selector (design-tasks §2) - same select-from-catalog
+                        pattern as the payment-schedule selector below: picking a different
+                        programme replaces the current package outright. */}
+                    <PlainSelect
+                      aria-label="Switch to a different package from the catalog"
+                      value=""
+                      onChange={event => {
+                        const pkg = visibleCatalogPackages.find(candidate => String(candidate.id) === event.target.value);
+                        if (pkg) replacePackageEntry(pkg);
+                      }}
+                      style={{ marginBottom: 6 }}
+                    >
+                      <option value="">Switch package from catalog…</option>
+                      {visibleCatalogPackages
+                        .filter(pkg => String(pkg.id) !== String(packageRow.catalogId))
+                        .map(pkg => (
+                          <option key={pkg.id} value={pkg.id}>{pkg.hidden ? `${pkg.name} (Special offer)` : pkg.name}</option>
+                        ))}
+                    </PlainSelect>
                   <PackageEntryCard
                     row={packageRow}
                     catalogItems={catalogItems}
@@ -3056,6 +3177,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     onAddCustomChild={fields => addCustomChildEntry(packageRow.id, fields)}
                     onAddCatalogChild={catalogId => addCatalogChildEntry(packageRow.id, catalogId)}
                   />
+                  </>
                 ) : (
                   <>
                     <FieldRow $align="center" style={{ marginTop: 8 }}>
@@ -3152,10 +3274,6 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               <PanelHeading>
                 <H2>Invoice services</H2>
               </PanelHeading>
-              <PanelNote>
-                A flat breakdown of items/custom lines and package-percent shares. The programme
-                package itself lives in the Package panel above.
-              </PanelNote>
 
               {serviceLineRows.map((row, index) => (
                 <ServiceLineRow
@@ -3192,7 +3310,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   <PlainPriceBase
                     $bare
                     rows={1}
-                    placeholder="Price or GIFT"
+                    placeholder="100"
+                    aria-label="New custom service price"
                     value={newCustomServicePrice}
                     onChange={event => setNewCustomServicePrice(event.target.value)}
                   />
@@ -3552,11 +3671,83 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                 <>
                   <FieldRow $align="center">
                     <FieldTag>Package</FieldTag>
-                    <div style={{ flex: 1, padding: '5px 6px', fontWeight: 700 }}>{expectedExpensesView?.pkg?.name || expectedExpenses.packageId}</div>
-                    <span style={{ fontWeight: 800, color: 'var(--km-accent)', padding: '5px 6px' }}>
+                    {expectedExpenses.packageId ? (
+                      <PlainSelect
+                        aria-label="Switch the plan to a different package"
+                        value={String(expectedExpenses.packageId)}
+                        onChange={event => switchExpectedExpensesPackage(event.target.value)}
+                      >
+                        {!visibleCatalogPackages.some(pkg => String(pkg.id) === String(expectedExpenses.packageId)) ? (
+                          <option value={String(expectedExpenses.packageId)}>
+                            {expectedExpensesView?.pkg?.name || `Package ${expectedExpenses.packageId}`}
+                          </option>
+                        ) : null}
+                        {visibleCatalogPackages.map(pkg => (
+                          <option key={pkg.id} value={pkg.id}>{pkg.hidden ? `${pkg.name} (Special offer)` : pkg.name}</option>
+                        ))}
+                      </PlainSelect>
+                    ) : (
+                      <div style={{ flex: 1, padding: '0 2px', fontWeight: 700, lineHeight: '20px' }}>{expectedExpensesView?.pkg?.name || expectedExpenses.packageId}</div>
+                    )}
+                    <span style={{ fontWeight: 800, color: 'var(--km-accent)', padding: '0 2px', lineHeight: '20px' }}>
                       {formatEuroPreview(resolveBudgetPriceAmount(expectedExpensesView?.pkg?.listedPrice, priceContext) ?? expectedExpensesView?.pkg?.listedPrice)}
                     </span>
                   </FieldRow>
+                  {expectedExpenses.packageId && (catalogTechnical.paymentSchedules || []).length ? (
+                    <FieldRow $align="center">
+                      <FieldTag>Payment schedule</FieldTag>
+                      <PlainSelect
+                        aria-label="Apply a payment schedule from the catalog"
+                        value=""
+                        onChange={event => { if (event.target.value) applyExpectedExpensesSchedule(event.target.value); }}
+                      >
+                        <option value="">Apply schedule from catalog…</option>
+                        {catalogTechnical.paymentSchedules.map(schedule => (
+                          <option key={schedule.id} value={schedule.id}>
+                            {`${schedule.id} (${(schedule.payments || []).length} payment${(schedule.payments || []).length === 1 ? '' : 's'})`}
+                          </option>
+                        ))}
+                      </PlainSelect>
+                    </FieldRow>
+                  ) : null}
+                  <FieldRow $align="center">
+                    <FieldTag>Tax (%)</FieldTag>
+                    <AutoTextArea
+                      as={PlainPriceBase}
+                      $width="48px"
+                      inputMode="decimal"
+                      value={expectedExpensesTaxDraft}
+                      placeholder="0"
+                      aria-label="Tax percent for all milestones"
+                      onFocus={() => { expectedExpensesTaxEditingRef.current = true; }}
+                      onChange={event => setExpectedExpensesTaxDraft(event.target.value)}
+                      onBlur={() => {
+                        expectedExpensesTaxEditingRef.current = false;
+                        if (expectedExpensesTaxDraft !== (expectedExpensesView?.sharedTaxPercent ?? '')) {
+                          applyExpectedExpensesTaxPercent(expectedExpensesTaxDraft);
+                        }
+                      }}
+                    />
+                  </FieldRow>
+                  {data.recentTaxRates.length ? (
+                    <ChipRow style={{ marginTop: 0, marginBottom: 8 }}>
+                      {data.recentTaxRates.map(rate => (
+                        <ChipContainer key={rate.id}>
+                          <ChipButton type="button" onClick={() => applyExpectedExpensesTaxPercent(rate.value)}>
+                            <span>{rate.value}%</span>
+                          </ChipButton>
+                          <ChipDeleteButton
+                            type="button"
+                            onClick={() => removeRecentTaxRate(rate.id)}
+                            title="Remove this rate from recent"
+                            aria-label="Remove this rate from recent"
+                          >
+                            <FaTrash />
+                          </ChipDeleteButton>
+                        </ChipContainer>
+                      ))}
+                    </ChipRow>
+                  ) : null}
                   {expectedExpensesView?.shouldCheckPackageSharePercent && Math.round(expectedExpensesView.packageSharePercent * 100) / 100 !== 100 ? (
                     <PanelNote style={{ color: 'var(--km-danger)' }}>
                       The percent-of-package rows add up to {expectedExpensesView.packageSharePercent}% of the package price, not 100%.

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -332,7 +332,7 @@ describe('InvoiceBuilderPage', () => {
     await flush();
 
     const nameField = container.querySelector('textarea[placeholder="New custom service name"]');
-    const priceField = container.querySelector('textarea[placeholder="Price or GIFT"]');
+    const priceField = container.querySelector('textarea[aria-label="New custom service price"]');
     await act(async () => {
       nameField.focus();
       setFieldValue(nameField, 'Courier fee');
@@ -366,7 +366,7 @@ describe('InvoiceBuilderPage', () => {
     await flush();
 
     const nameField = container.querySelector('textarea[placeholder="New custom service name"]');
-    const priceField = container.querySelector('textarea[placeholder="Price or GIFT"]');
+    const priceField = container.querySelector('textarea[aria-label="New custom service price"]');
     await act(async () => {
       nameField.focus();
       setFieldValue(nameField, 'Courier fee');
@@ -596,7 +596,7 @@ describe('InvoiceBuilderPage', () => {
       const milestoneNameFields = Array.from(container.querySelectorAll('textarea[placeholder="Custom line name…"]'));
       expect(milestoneNameFields).toHaveLength(2);
       const milestoneAddRow = milestoneNameFields[0].parentElement;
-      const priceField = milestoneAddRow.querySelector('textarea[placeholder="Price or GIFT"]');
+      const priceField = milestoneAddRow.querySelector('textarea[aria-label="New milestone service price"]');
       const addButton = Array.from(milestoneAddRow.querySelectorAll('button')).find(btn => btn.textContent.trim() === 'Add');
 
       await act(async () => {
@@ -853,9 +853,12 @@ describe('InvoiceBuilderPage', () => {
       expect(findButton('Recalculate')).toBeFalsy();
 
       const savedSchedules = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/recentPaymentSchedules').pop();
+      // `price` rides along so reloading the schedule from Recent restores the package total too
+      // (see loadRecentSchedule).
       expect(savedSchedules[1]).toEqual([{
         id: expect.any(String),
         name: 'Bespoke concierge programme',
+        price: 10000,
         payments: [{ title: 'Deposit', amount: 4000 }, { title: 'Final payment', amount: 6000 }],
       }]);
 

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -42,30 +42,29 @@ const isPaymentCaveatNote = note => PAYMENT_CAVEAT_PATTERNS.some(pattern => patt
 
 const styles = StyleSheet.create({
   page: pdfBaseStyles.page,
+  // Tighter than the 26pt rhythm the multi-page documents use: the Invoice's blocks (Programme
+  // package, Included in this package, Payment schedule, Breakdown) are compacted so the whole
+  // document fits a single page whenever the content allows (design-tasks §3).
   section: {
-    marginTop: 26,
+    marginTop: 10,
   },
   // The very first block under the title carries no preceding marginBottom of its own to offset -
-  // TitleBlock's trailing margin already does that job, so stacking the full 26pt section rhythm
+  // TitleBlock's trailing margin already does that job, so stacking the full section rhythm
   // on top of it doubles the gap. Used only when that block is the first thing after TitleBlock.
   sectionAfterTitle: {
     marginTop: 2,
   },
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
-  table: {
-    borderRadius: 8,
-    overflow: 'hidden',
-  },
   packageBlock: {
     marginTop: 2,
   },
   packageBlockHeader: {
     backgroundColor: PDF_COLOR.card,
     borderRadius: 8,
-    paddingVertical: 10,
+    paddingVertical: 8,
     paddingHorizontal: 12,
-    marginBottom: 12,
+    marginBottom: 6,
   },
   packageBlockName: {
     fontFamily: PDF_FONT.display,
@@ -81,55 +80,6 @@ const styles = StyleSheet.create({
     color: PDF_COLOR.bronzeDeep,
     marginTop: 4,
   },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    borderTopWidth: 1,
-    borderTopColor: PDF_COLOR.docLine,
-    borderTopStyle: 'solid',
-    paddingVertical: 8,
-  },
-  firstRow: {
-    borderTopWidth: 0,
-  },
-  packageRow: {
-    backgroundColor: PDF_COLOR.card,
-    borderRadius: 5,
-    paddingHorizontal: 8,
-    marginBottom: 1,
-  },
-  indexCell: {
-    width: 26,
-  },
-  indexText: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontSize: 8.5,
-    color: PDF_COLOR.bronze,
-  },
-  nameCell: {
-    flex: 1,
-    paddingRight: 10,
-  },
-  nameCellChild: {
-    paddingLeft: 14,
-  },
-  nameText: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 9.5,
-    color: PDF_COLOR.docInk,
-  },
-  nameTextPackage: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontSize: 10.5,
-    color: PDF_COLOR.docInk,
-  },
-  nameTextChild: {
-    fontFamily: PDF_FONT.body,
-    fontSize: 9,
-    color: PDF_COLOR.inkSoft,
-  },
   descriptionText: {
     fontFamily: PDF_FONT.body,
     fontSize: 8,
@@ -137,28 +87,22 @@ const styles = StyleSheet.create({
     lineHeight: 1.4,
     marginTop: 2,
   },
-  priceCell: {
-    width: 96,
-    textAlign: 'right',
+  // A compacted copy of the shared total-card (same tokens, tighter metrics): together with the
+  // 14pt section rhythm above it keeps a full package invoice - package block, included services,
+  // payment schedule, breakdown, total - on one physical page whenever possible (design-tasks §3).
+  totalCard: {
+    ...pdfBaseStyles.totalCard,
+    marginTop: 8,
+    paddingVertical: 10,
   },
-  priceText: {
-    fontFamily: PDF_FONT.body,
-    fontVariantNumeric: 'tabular-nums',
-    fontSize: 9.5,
-    color: PDF_COLOR.docInk,
+  totalCardAmount: {
+    ...pdfBaseStyles.totalCardAmount,
+    fontSize: 24,
   },
-  priceTextPackage: {
-    fontFamily: PDF_FONT.body,
-    fontWeight: 600,
-    fontVariantNumeric: 'tabular-nums',
-    fontSize: 10.5,
-    color: PDF_COLOR.bronzeDeep,
-  },
-  priceTextChild: {
-    fontFamily: PDF_FONT.body,
-    fontVariantNumeric: 'tabular-nums',
-    fontSize: 9,
-    color: PDF_COLOR.inkSoft,
+  totalCardRule: {
+    ...pdfBaseStyles.totalCardRule,
+    marginTop: 8,
+    marginBottom: 6,
   },
   noteRow: {
     flexDirection: 'row',
@@ -180,56 +124,15 @@ const styles = StyleSheet.create({
   },
 });
 
-// Flattens resolved rows into a display list: a package becomes its own bold header row
-// ("2.") followed by its children indented underneath ("2.1", "2.2", ...).
-const buildDisplayRows = rows => {
-  const display = [];
-  rows.forEach((row, index) => {
-    const number = String(index + 1);
-    display.push({ ...row, number, depth: 0 });
-    if (row.kind === 'package') {
-      (row.children || []).forEach((child, childIndex) => {
-        display.push({ ...child, number: `${number}.${childIndex + 1}`, depth: 1 });
-      });
-    }
-  });
-  return display;
-};
-
-// One line of the "Breakdown" list - shared, byte-for-byte, across Service Invoice, milestone-share,
-// and Package Invoice layouts, so a service/custom/percent row never renders two different ways.
-const ServiceItemRow = ({ row, isFirst }) => {
-  const isChild = row.depth > 0;
-  const isPackageHeader = row.kind === 'package';
-  // A "% of package" row reads as "Scheduled payment" here - the same one-style breakdown line as
-  // every other row - without repeating the underlying percentage/package wording in the PDF.
-  const isPercent = row.kind === 'percent';
-  const displayName = isPercent ? 'Scheduled payment' : row.name;
-  return (
-    <View
-      style={[
-        isPackageHeader ? styles.packageRow : styles.row,
-        !isPackageHeader && !isChild && isFirst ? styles.firstRow : null,
-      ]}
-      wrap={false}
-    >
-      <View style={styles.indexCell}>
-        <Text style={styles.indexText}>{row.number}</Text>
-      </View>
-      <View style={[styles.nameCell, isChild ? styles.nameCellChild : null]}>
-        <Text style={isPackageHeader ? styles.nameTextPackage : (isChild ? styles.nameTextChild : styles.nameText)}>
-          {sanitizePdfText(displayName)}
-        </Text>
-        {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
-      </View>
-      <View style={styles.priceCell}>
-        <Text style={isPackageHeader ? styles.priceTextPackage : (isChild ? styles.priceTextChild : styles.priceText)}>
-          {formatRowAmount(row)}
-        </Text>
-      </View>
-    </View>
-  );
-};
+// One row of the "Breakdown" table. A "% of package" row reads as "Scheduled payment" - the same
+// one-style breakdown line as every other row - without repeating the underlying percentage/
+// package wording in the PDF (design-tasks §3). Amounts stay bare numbers (or a free-text label
+// like "GIFT"): the table's own EUR column header already carries the currency.
+const buildBreakdownTableRow = row => ({
+  title: row.kind === 'percent' ? 'Scheduled payment' : (row.name || ''),
+  description: row.description || '',
+  amounts: [row.priceLabel ? row.priceLabel : row.price],
+});
 
 // The "Package block" (round7 spec C): a compact name/fee header, then the package's full
 // composition - always shown, since the Builder's own "Package" checkbox already gates whether
@@ -263,20 +166,24 @@ const PackageBlock = ({ row, showSchedule }) => {
       <View style={styles.packageBlockHeader} wrap={false}>
         <Text style={styles.packageBlockName}>{sanitizePdfText(row.name)}</Text>
         {row.description ? <Text style={styles.descriptionText}>{sanitizePdfText(row.description)}</Text> : null}
-        <Text style={styles.packageBlockFee}>{`Total programme fee ${totalLabel}`}</Text>
+        <Text style={styles.packageBlockFee}>{`Cost of the package ${totalLabel}`}</Text>
       </View>
       {fullDetailNote ? <Text style={styles.sectionNote}>{sanitizePdfText(fullDetailNote)}</Text> : null}
       <IncludedServicesTable
         packages={packageMeta}
         includedRows={includedRows}
         title="Included in this package"
-        note="These services reflect the customisation made to this package."
+        note={null}
+        sectionStyle={styles.section}
+        dense
       />
       {showSchedule ? (
         <PaymentScheduleTable
           packages={packageMeta}
           rows={scheduleRows}
           title="Payment schedule for this package"
+          sectionStyle={styles.section}
+          dense
         />
       ) : null}
     </View>
@@ -324,10 +231,13 @@ const InvoicePdfDocument = ({
   const packageRows = includePackageInPdf ? rows.filter(row => row.kind === 'package') : [];
   const isPackageInvoice = packageRows.length > 0;
   // A "% of package" row (a programme milestone share) and any custom/catalog service row share one
-  // "Breakdown" list, one row style, one running numbering - splitting them into two headed
+  // "Breakdown" table, one row style, one running numbering - splitting them into two headed
   // sections was the second-biggest source of clutter on this document (declutter spec §2).
   const breakdownRows = rows.filter(row => row.kind !== 'package');
-  const breakdownDisplayRows = buildDisplayRows(breakdownRows);
+  const breakdownTableRows = breakdownRows.map(buildBreakdownTableRow);
+  // Single amount column, same visual style as the Payment Schedule table (design-tasks §3) - the
+  // column header carries the currency once, so cells stay bare numbers.
+  const breakdownMeta = [{ id: 'amount', label: '', priceLabel: 'EUR' }];
   // The DD.MM.YYYY `invoiceDate` string (invoiceCatalogUtils.generateInvoiceIdentifiers) is the
   // legal-text date used inside the payment-purpose placeholder only - the human-readable date
   // shown here always uses the one shared display format (spec §4), never that dotted form or the
@@ -345,6 +255,7 @@ const InvoicePdfDocument = ({
           eyebrow={eyebrow}
           title={`Invoice No. ${invoiceNumber || ''}`}
           subtitle={`Prepared exclusively for ${payerName}${payerLocation ? ` · ${payerLocation}` : ''}.`}
+          style={{ marginBottom: 14 }}
         />
 
         {isPackageInvoice ? (
@@ -353,15 +264,15 @@ const InvoicePdfDocument = ({
           ))
         ) : null}
 
-        {breakdownDisplayRows.length ? (
-          <View style={[styles.section, !isPackageInvoice ? styles.sectionAfterTitle : null]}>
-            <Text style={styles.sectionTitle}>Breakdown</Text>
-            <View style={styles.table}>
-              {breakdownDisplayRows.map((row, rowIndex) => (
-                <ServiceItemRow key={`${row.key || rowIndex}-${row.number}`} row={row} isFirst={rowIndex === 0} />
-              ))}
-            </View>
-          </View>
+        {breakdownTableRows.length ? (
+          <PaymentScheduleTable
+            packages={breakdownMeta}
+            rows={breakdownTableRows}
+            title="Breakdown"
+            leadLabel="Provided service"
+            sectionStyle={!isPackageInvoice ? styles.sectionAfterTitle : styles.section}
+            dense
+          />
         ) : null}
 
         {/* No extra top margin here - noteRow/totalCard already carry their own spacing (spec §1.4),
@@ -375,10 +286,12 @@ const InvoicePdfDocument = ({
             </View>
           ))}
 
-          <View style={pdfBaseStyles.totalCard}>
+          {/* wrap={false}: the card either fits under the breakdown or moves to the next page
+              whole - it must never split its amount from its subtotal/tax rows. */}
+          <View style={styles.totalCard} wrap={false}>
             <Text style={pdfBaseStyles.totalCardLabel}>Amount due</Text>
-            <Text style={pdfBaseStyles.totalCardAmount}>{formatMoney(amountDue)}</Text>
-            <View style={pdfBaseStyles.totalCardRule} />
+            <Text style={styles.totalCardAmount}>{formatMoney(amountDue)}</Text>
+            <View style={styles.totalCardRule} />
             <View style={pdfBaseStyles.totalCardRow}>
               <Text style={pdfBaseStyles.totalCardRowLabel}>Subtotal</Text>
               <Text style={pdfBaseStyles.totalCardRowValue}>{formatMoney(subtotal)}</Text>

--- a/src/components/expectedExpensesUtils.js
+++ b/src/components/expectedExpensesUtils.js
@@ -301,8 +301,18 @@ export const computeMilestonesTotal = (milestones, catalogItemsById, priceContex
 // euros) - the sanity check for "does the schedule breakdown still cover the whole package price".
 // Kept separate from computeMilestonesTotal because that one also includes one-off extras (SM
 // deposits, gifts, ...), which are expected to push the real bill above the package price.
-export const computeMilestonesPackageSharePercent = (milestones, packageId) =>
+// A row carrying a fixed euro `amount` (typed instead of a percent - design-tasks §1) contributes
+// its equivalent share of `packagePrice` when one is given; without a resolvable package price its
+// share is unknowable, so it contributes nothing rather than a made-up figure.
+export const computeMilestonesPackageSharePercent = (milestones, packageId, packagePrice) =>
   (Array.isArray(milestones) ? milestones : []).reduce((sum, milestone) => sum
     + (Array.isArray(milestone.services) ? milestone.services : [])
       .filter(entry => entry?.kind === 'percent' && String(entry.packageId) === String(packageId))
-      .reduce((entrySum, entry) => entrySum + (Number(entry.percent) || 0), 0), 0);
+      .reduce((entrySum, entry) => {
+        const fixedAmount = Number(entry.amount);
+        if (entry.amount != null && Number.isFinite(fixedAmount)) {
+          const price = Number(packagePrice);
+          return entrySum + (Number.isFinite(price) && price > 0 ? Math.round((fixedAmount / price) * 1e4) / 100 : 0);
+        }
+        return entrySum + (Number(entry.percent) || 0);
+      }, 0), 0);

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -56,6 +56,25 @@ export const parseCustomPriceInput = raw => {
   return { price: 0, priceLabel: text };
 };
 
+// One field accepts either a percent or an absolute euro amount interchangeably (design-tasks §1):
+// "25" or "25%" reads as 25% of the package price; "10000", "€10,000" or "10000 EUR" reads as a
+// fixed 10,000 EUR amount. An explicit % / € / EUR marker always wins; a bare number splits on the
+// only unambiguous boundary available - a percent share can't exceed 100.
+export const parsePercentOrAmountInput = raw => {
+  const text = String(raw ?? '').trim();
+  if (!text) return { percent: 0 };
+  const hasPercentMark = /%/.test(text);
+  const hasCurrencyMark = /€|eur/i.test(text);
+  const cleaned = text.replace(/%|€|eur/gi, '').replace(/\s+/g, '');
+  // "10,000" uses the comma as a thousands separator; "8,5" uses it as a decimal one.
+  const normalized = /,\d{3}(?:\D|$)/.test(cleaned) ? cleaned.replace(/,/g, '') : cleaned.replace(',', '.');
+  const numeric = Number(normalized);
+  if (!Number.isFinite(numeric)) return { percent: 0 };
+  if (hasPercentMark) return { percent: numeric };
+  if (hasCurrencyMark || numeric > 100) return { amount: numeric };
+  return { percent: numeric };
+};
+
 // One invoice belongs to one case/payer: payerCases is a catalog of every payer/case ever used
 // (each a group of one-or-more customers, e.g. a couple), payerCaseIds orders them with the
 // active case first - the same "catalog + activate by reordering ids" pattern beneficiaries use.
@@ -168,14 +187,18 @@ export const makeCustomEntry = ({ name = '', price = 0, description = '', priceL
 
 // A share of a budget/packages program's listed price, e.g. "20% of package 1". The euro amount
 // is intentionally never stored - resolveServiceRow recalculates it from the package's price.
+// The one exception is an admin who typed an absolute euro figure instead of a percent (design-
+// tasks §1: "25" reads as 25%, "10000" as 10,000 EUR) - that fixed `amount` is stored as typed and
+// wins over `percent` when the row is priced, so what they entered is exactly what gets billed.
 // `expectedExpenseRole: 'scheduled'` marks the one row that was auto-generated from the package's
 // payment schedule (as opposed to one an admin added by hand) - see recalculateExpectedExpensesSchedule
 // in InvoiceBuilderPage.jsx, which only ever replaces rows carrying that marker.
-export const makePercentOfPackageEntry = (packageId, percent, { id, expectedExpenseRole } = {}) => ({
+export const makePercentOfPackageEntry = (packageId, percent, { id, expectedExpenseRole, amount } = {}) => ({
   id: id || createEntryId(),
   kind: 'percent',
   packageId: String(packageId ?? ''),
   percent: toNumber(percent),
+  ...(amount != null && amount !== '' && Number.isFinite(Number(amount)) ? { amount: toNumber(amount) } : {}),
   ...(expectedExpenseRole ? { expectedExpenseRole } : {}),
 });
 
@@ -267,7 +290,7 @@ export const normalizeServiceEntry = raw => {
   const id = raw.id || createEntryId();
 
   if (raw.kind === 'percent') {
-    return makePercentOfPackageEntry(raw.packageId, raw.percent, { id, expectedExpenseRole: raw.expectedExpenseRole });
+    return makePercentOfPackageEntry(raw.packageId, raw.percent, { id, expectedExpenseRole: raw.expectedExpenseRole, amount: raw.amount });
   }
 
   if (raw.kind === 'package') {
@@ -342,7 +365,14 @@ export const setEntryField = (entry, field, value) => {
     return { ...entry, [field]: value };
   }
   if (entry.kind === 'percent') {
-    if (field === 'percent') return { ...entry, percent: toNumber(value) };
+    if (field === 'percent') {
+      // The one editable value field accepts a percent OR an absolute euro amount (design-tasks
+      // §1) - whichever the admin typed is what gets stored, never a silent conversion.
+      const { percent, amount } = parsePercentOrAmountInput(value);
+      const { amount: previousAmount, ...rest } = entry;
+      if (amount != null) return { ...rest, percent: 0, amount: toNumber(amount) };
+      return { ...rest, percent: toNumber(percent) };
+    }
     if (field === 'packageId') return { ...entry, packageId: String(value ?? '') };
     return entry;
   }
@@ -426,7 +456,11 @@ export const getEntryIdentityKey = entry => {
   if (entry.kind === 'package') return entry.catalogId ? `package:${entry.catalogId}` : `package:custom:${entry.id}`;
   if (entry.kind === 'packagePercent') return `package-percent:${entry.catalogId}:${entry.percent || 0}`;
   if (entry.kind === 'item') return `item:${entry.catalogId}`;
-  if (entry.kind === 'percent') return `percent:${entry.packageId}:${entry.percent}`;
+  if (entry.kind === 'percent') {
+    return entry.amount != null
+      ? `percent:${entry.packageId}:eur${entry.amount}`
+      : `percent:${entry.packageId}:${entry.percent}`;
+  }
   return `custom:${entry.name || ''}:${entry.price || 0}:${entry.description || ''}`;
 };
 
@@ -477,17 +511,29 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
     const packageAmount = pkg
       ? resolveBudgetPriceAmount(pkg.listedPrice, { ...priceContext, itemsById: catalogItemsById })
       : null;
-    const percent = Number(entry.percent) || 0;
-    const price = packageAmount == null ? 0 : roundMoney((packageAmount * percent) / 100);
+    // A fixed euro `amount` (typed instead of a percent - design-tasks §1) wins over `percent`:
+    // the row bills exactly that amount, and the percent becomes the derived, display-only figure.
+    const hasFixedAmount = entry.amount != null && entry.amount !== '' && Number.isFinite(Number(entry.amount));
+    const fixedAmount = hasFixedAmount ? roundMoney(entry.amount) : null;
+    const percent = hasFixedAmount
+      ? (packageAmount ? Math.round((fixedAmount / packageAmount) * 1e6) / 1e4 : 0)
+      : (Number(entry.percent) || 0);
+    const price = hasFixedAmount
+      ? fixedAmount
+      : (packageAmount == null ? 0 : roundMoney((packageAmount * percent) / 100));
+    const packageName = pkg?.name ?? `Package ${entry.packageId}`;
     return {
       key: entry.id,
       id: entry.id,
       kind: 'percent',
       packageId: entry.packageId,
       percent,
+      ...(hasFixedAmount ? { amount: fixedAmount } : {}),
       missing: !pkg,
       isCustomized: false,
-      name: `${formatPercentValue(percent)}% of ${pkg?.name ?? `Package ${entry.packageId}`}`,
+      name: hasFixedAmount
+        ? `${fixedAmount} EUR of ${packageName}`
+        : `${formatPercentValue(percent)}% of ${packageName}`,
       description: '',
       price,
       ...(entry.expectedExpenseRole ? { expectedExpenseRole: entry.expectedExpenseRole } : {}),

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -24,6 +24,7 @@ import {
   normalizeInvoiceData,
   normalizeServiceEntry,
   parseLegacyServiceString,
+  parsePercentOrAmountInput,
   removePackageChild,
   removeRecentEntry,
   reorderBeneficiaryIds,
@@ -607,6 +608,43 @@ describe('invoiceCatalogUtils', () => {
     expect(generateInvoiceIdentifiers('2026-05-23')).toEqual({
       invoiceNumber: '23/05/2026',
       invoiceDate: '23.05.2026',
+    });
+  });
+
+  describe('dual percent/amount input (design-tasks §1)', () => {
+    it('reads "25" and "25%" as a percent, "10000" and "€10,000" as an absolute EUR amount', () => {
+      expect(parsePercentOrAmountInput('25')).toEqual({ percent: 25 });
+      expect(parsePercentOrAmountInput('25%')).toEqual({ percent: 25 });
+      expect(parsePercentOrAmountInput('8,5')).toEqual({ percent: 8.5 });
+      expect(parsePercentOrAmountInput('10000')).toEqual({ amount: 10000 });
+      expect(parsePercentOrAmountInput('€10,000')).toEqual({ amount: 10000 });
+      expect(parsePercentOrAmountInput('10000 EUR')).toEqual({ amount: 10000 });
+      // An explicit marker always wins over the >100 heuristic.
+      expect(parsePercentOrAmountInput('150%')).toEqual({ percent: 150 });
+      expect(parsePercentOrAmountInput('50 EUR')).toEqual({ amount: 50 });
+    });
+
+    it('stores a typed EUR amount on a percent row, and it wins over the percent when priced', () => {
+      const entry = makePercentOfPackageEntry('7', 25);
+      const amountEntry = setEntryField(entry, 'percent', '10000');
+      expect(amountEntry).toMatchObject({ kind: 'percent', packageId: '7', amount: 10000 });
+
+      const priceContext = { packagesById: new Map([['7', { id: '7', name: 'FET program. Special offer', listedPrice: 29700 }]]) };
+      const row = resolveServiceRow(amountEntry, new Map(), priceContext);
+      expect(row.price).toBe(10000);
+      expect(row.amount).toBe(10000);
+      expect(row.percent).toBeCloseTo(33.67, 2);
+
+      // Typing a percent again drops the fixed amount and goes back to live tracking.
+      const percentEntry = setEntryField(amountEntry, 'percent', '25');
+      expect(percentEntry.amount).toBeUndefined();
+      expect(resolveServiceRow(percentEntry, new Map(), priceContext).price).toBe(7425);
+    });
+
+    it('round-trips the fixed amount through normalizeServiceEntry', () => {
+      const entry = normalizeServiceEntry({ id: 'e1', kind: 'percent', packageId: '7', percent: 0, amount: 10000 });
+      expect(entry).toMatchObject({ kind: 'percent', packageId: '7', amount: 10000 });
+      expect(getEntryIdentityKey(entry)).toBe('percent:7:eur10000');
     });
   });
 

--- a/src/components/pdfAgency.js
+++ b/src/components/pdfAgency.js
@@ -1,0 +1,24 @@
+// Loads the agency identity record (budget/technical/agency) into pdfTheme's shared config store,
+// for export paths that don't otherwise load the budget catalog (the SM profile PDF). Pages that
+// already fetch budget/technical (Budget, Invoice Builder) push the same record into the store
+// directly via setPdfAgencyConfig at load time instead of re-fetching it here.
+import { get, ref } from 'firebase/database';
+import { database } from './config';
+import { setPdfAgencyConfig } from './pdfTheme';
+
+let loadPromise = null;
+
+export const ensurePdfAgencyConfigLoaded = () => {
+  if (!loadPromise) {
+    loadPromise = get(ref(database, 'budget/technical/agency'))
+      .then(snapshot => {
+        if (snapshot.exists()) setPdfAgencyConfig(snapshot.val());
+      })
+      .catch(loadError => {
+        // The document still renders with pdfTheme's built-in fallback identity; retry next time.
+        console.error('Unable to load agency config for PDF branding', loadError);
+        loadPromise = null;
+      });
+  }
+  return loadPromise;
+};

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -66,6 +66,56 @@ export const sanitizePdfText = value => String(value ?? '')
   .replace(/\s+/g, ' ')
   .trim();
 
+// --- Agency identity (backend-driven) ------------------------------------------------------
+//
+// Every branded document shows the same agency identity (wordmark + tagline in the brand row,
+// name/address/contacts in the footer). The values are data, not layout: they live on the backend
+// at budget/technical/agency and are pushed into this module (setPdfAgencyConfig) by whichever
+// page loads that config - Budget, Invoice Builder, or the SM profile export. The constants below
+// are only the offline fallback for when the backend record hasn't loaded (or lacks a field), so
+// a document is never rendered with a blank identity.
+const DEFAULT_AGENCY = {
+  name: 'Reproductive Agency "UKRCOM"',
+  name2: 'UKRCOM Reproductive Agency, Kyiv',
+  address: '31/16 Reitarska Str., 1st floor, Kyiv, 01034, Ukraine',
+  website: 'http://ukrcom.kyiv.ua/',
+  email: 'sm.kiev.ukr@gmail.com',
+  telegram: '@Contact_Us_Kyiv',
+};
+
+// The backend may store telegram as a full link (https://t.me/Contact_Us_Kyiv) - documents always
+// display the compact @handle form.
+const toTelegramHandle = value => {
+  const text = String(value || '').trim();
+  if (!text) return '';
+  const match = /t(?:elegram)?\.me\/([^/?#\s]+)/i.exec(text);
+  const handle = match ? match[1] : text;
+  return handle.startsWith('@') ? handle : `@${handle}`;
+};
+
+let pdfAgency = { ...DEFAULT_AGENCY };
+
+export const setPdfAgencyConfig = raw => {
+  const source = raw && typeof raw === 'object' ? raw : {};
+  pdfAgency = Object.keys(DEFAULT_AGENCY).reduce((merged, key) => {
+    const value = String(source[key] ?? '').trim();
+    return { ...merged, [key]: value || DEFAULT_AGENCY[key] };
+  }, {});
+  pdfAgency.telegram = toTelegramHandle(pdfAgency.telegram);
+};
+
+export const getPdfAgencyConfig = () => pdfAgency;
+
+// The full name/line ("UKRCOM Reproductive Agency, Kyiv") splits into the big wordmark (its first
+// word) and the tagline underneath it - the brand row never hardcodes either.
+const splitAgencyWordmark = () => {
+  const [wordmark, ...rest] = String(getPdfAgencyConfig().name2 || '').trim().split(/\s+/);
+  return {
+    wordmark: wordmark || DEFAULT_AGENCY.name2.split(' ')[0],
+    tagline: rest.join(' '),
+  };
+};
+
 // The one date format every document displays to a client (spec §4): "9 July 2026" - never
 // DD.MM.YYYY or DD/MM/YYYY. (The invoice number and the payment-purpose placeholder are a
 // separate concern - they intentionally keep their own numeric formats, since those are
@@ -318,20 +368,24 @@ export const DocSeries = ({ index, total, label, optional = false }) => (
   </Text>
 );
 
-// wordmark + tagline on the left, document meta (number/date/client) on the right.
-export const BrandRow = ({ metaLines = [] }) => (
-  <View style={pdfSharedStyles.brandRow}>
-    <View>
-      <Text style={pdfSharedStyles.wordmark}>UKRCOM</Text>
-      <Text style={pdfSharedStyles.wordmarkTagline}>Reproductive Agency, Kyiv</Text>
+// wordmark + tagline on the left, document meta (number/date/client) on the right. Both come from
+// the backend agency config (name2), never a per-document hardcoded string.
+export const BrandRow = ({ metaLines = [] }) => {
+  const { wordmark, tagline } = splitAgencyWordmark();
+  return (
+    <View style={pdfSharedStyles.brandRow}>
+      <View>
+        <Text style={pdfSharedStyles.wordmark}>{sanitizePdfText(wordmark)}</Text>
+        {tagline ? <Text style={pdfSharedStyles.wordmarkTagline}>{sanitizePdfText(tagline)}</Text> : null}
+      </View>
+      <View style={pdfSharedStyles.brandMeta}>
+        {metaLines.filter(Boolean).map((line, index) => (
+          <Text key={`meta-${index}`} style={pdfSharedStyles.brandMetaText}>{sanitizePdfText(line)}</Text>
+        ))}
+      </View>
     </View>
-    <View style={pdfSharedStyles.brandMeta}>
-      {metaLines.filter(Boolean).map((line, index) => (
-        <Text key={`meta-${index}`} style={pdfSharedStyles.brandMetaText}>{sanitizePdfText(line)}</Text>
-      ))}
-    </View>
-  </View>
-);
+  );
+};
 
 const ruleStyles = StyleSheet.create({
   wrap: {
@@ -389,8 +443,9 @@ export const BronzeMotif = () => (
 );
 
 // eyebrow -> H1 -> subrow with the key sum/context. Always left-aligned, never centered.
-export const TitleBlock = ({ eyebrow, title, subtitle }) => (
-  <View style={pdfSharedStyles.titleBlock}>
+// `style` lets a space-constrained document (the one-page Invoice) tighten the trailing margin.
+export const TitleBlock = ({ eyebrow, title, subtitle, style }) => (
+  <View style={style ? [pdfSharedStyles.titleBlock, style] : pdfSharedStyles.titleBlock}>
     {eyebrow ? <Text style={pdfSharedStyles.docEyebrow}>{sanitizePdfText(eyebrow)}</Text> : null}
     <Text style={pdfSharedStyles.docTitle}>{sanitizePdfText(title)}</Text>
     {subtitle ? <Text style={pdfSharedStyles.docSubtitle}>{sanitizePdfText(subtitle)}</Text> : null}
@@ -431,28 +486,29 @@ export const SummaryCard = ({ label, text }) => (text ? (
   </View>
 ) : null);
 
-const AGENCY_NAME = 'Reproductive Agency "UKRCOM"';
-const AGENCY_ADDRESS = '31/16 Reitarska Str., 1st floor, Kyiv, 01034, Ukraine';
-const AGENCY_CONTACT = 'http://ukrcom.kyiv.ua/  ·  sm.kiev.ukr@gmail.com  ·  @Contact_Us_Kyiv';
-
 // Identical agency footer on every page of every branded document (spec §1.2). `variant="neutral"`
 // drops the UKRCOM agency block entirely - required on the Payment Details page/document, whose
 // beneficiary (a sole proprietorship) is a legally separate party from the agency (spec §1.5).
-export const Footer = ({ variant = 'branded' } = {}) => (
-  <View style={pdfSharedStyles.footer} fixed>
-    {variant === 'neutral' ? <View style={pdfSharedStyles.footerColumn} /> : (
-      <View style={pdfSharedStyles.footerColumn}>
-        <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(AGENCY_NAME)}</Text>
-        <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(AGENCY_ADDRESS)}</Text>
-        <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(AGENCY_CONTACT)}</Text>
-      </View>
-    )}
-    <Text
-      style={pdfSharedStyles.footerPage}
-      render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}
-    />
-  </View>
-);
+// The identity lines themselves come from the backend agency config (see setPdfAgencyConfig above).
+export const Footer = ({ variant = 'branded' } = {}) => {
+  const agency = getPdfAgencyConfig();
+  const contactLine = [agency.website, agency.email, agency.telegram].filter(Boolean).join(' · ');
+  return (
+    <View style={pdfSharedStyles.footer} fixed>
+      {variant === 'neutral' ? <View style={pdfSharedStyles.footerColumn} /> : (
+        <View style={pdfSharedStyles.footerColumn}>
+          <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(agency.name)}</Text>
+          <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(agency.address)}</Text>
+          <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(contactLine)}</Text>
+        </View>
+      )}
+      <Text
+        style={pdfSharedStyles.footerPage}
+        render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}
+      />
+    </View>
+  );
+};
 
 // Short colophon shown at the top of overflow pages instead of repeating brand-row/title-block
 // (spec §1.10: "перехід на другу сторінку без повторення brand-row/title-block"). `fixed` makes

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -13,6 +13,7 @@ import {
   BrandRow, BrandRule, BronzeMotif, CoordinatorLine, Footer, PDF_COLOR, PDF_FONT,
   ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, SummaryCard, TitleBlock,
 } from '../pdfTheme';
+import { ensurePdfAgencyConfigLoaded } from '../pdfAgency';
 import { btnDel } from './btnDel';
 import { btnExport } from './btnExport';
 import { btnEdit } from './btnEdit';
@@ -1264,6 +1265,9 @@ const ProfilePdfExportButton = ({ cardData, photoUrls, photosCollection }) => {
     };
 
     try {
+      // The document's wordmark/footer identity comes from budget/technical/agency - this export
+      // path doesn't otherwise load the budget catalog, so fetch it before rendering.
+      await ensurePdfAgencyConfigLoaded();
       const effectivePhotoUrls = await resolvePdfPhotoUrls({ cardData, photoUrls, photosCollection });
       const embeddedPhotoEntries = await Promise.all(
         effectivePhotoUrls.map(photoUrl => loadPdfEmbeddedImage(photoUrl))


### PR DESCRIPTION
Design-tasks 2026-07-13:

§1 Global input styling
- plainFieldStyle is now truly plain text: no box/background/focus ring ever,
  single 20px line-height shared by every row element (index, name, price,
  % sign, EUR chip, arrows, trash) so a row sits on one baseline.
- Percent-of-package value field accepts a percent OR an absolute EUR amount
  ("25" -> 25%, "10000" -> 10,000 EUR): parsePercentOrAmountInput, a stored
  `amount` on percent entries that wins over `percent` when priced, with the
  equivalent in the other unit shown as a chip. Package schedule amount rows
  accept both formats too (percent resolved against the package price).

§2 Package & PDF components
- "Switch package from catalog…" selector when a package is already chosen
  (same pattern as the schedule selector); placeholder "Price or GIFT" -> "100";
  package name styled like a normal service line; Invoice Services description
  block removed.

§3 Invoice PDF
- "These services reflect the customisation…" note removed; block spacing
  compacted (10pt rhythm, dense table rows, tighter total card, wrap={false})
  so a full package invoice fits one page; Breakdown is now a table in the
  Payment Schedule style with a single EUR-headed column (no per-amount "EUR");
  "Total programme fee" -> "Cost of the package"; percent rows render as
  "Scheduled payment" in the PDF and the Builder.

§4 Expected Expenses
- Page: package / payment-schedule / plan-wide tax selectors (with the shared
  recent-tax-rates chips); rebuild logic shared with Recalculate.
- PDF: schedule Total row dropped, Payment schedule moved after "Included in
  this programme", scheduled shares render as "Scheduled payment" lines with
  right-aligned amounts.

§5 Backend-driven agency identity
- BrandRow wordmark/tagline and the branded Footer now read budget/technical/
  agency (setPdfAgencyConfig; t.me links display as @handle) with the previous
  strings as offline fallback; pushed at load time by Budget/Invoice Builder
  and fetched on demand for the SM profile export (pdfAgency.js); Budget page
  eyebrow reads the same record.

Also fixes two stale test expectations (recent-schedule `price` field, Program
Budget section order in pdfQaCheck) that failed on main.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BXaeTgR6haUZL3H8uhA6uo