### PR TITLE
Fix invoice/budget schedule and package-visibility bugs from Codex review

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1193,7 +1193,9 @@ const PackageEntryCard = ({
 
 const ScheduleRow = ({ row, index, onCommit, onRemove }) => {
   const [titleDraft, setTitleDraft, titleEditingRef] = useFieldDraft(row.title);
-  const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(String(roundToCents(row.amount) ?? ''));
+  // row.amount == null means "not yet resolved" (e.g. a formula price waiting on NBU rates) -
+  // roundToCents(null) coerces to 0, so the null check must happen before calling it, not after.
+  const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(row.amount != null ? String(roundToCents(row.amount)) : '');
 
   return (
     <LineCard>
@@ -1221,7 +1223,7 @@ const ScheduleRow = ({ row, index, onCommit, onRemove }) => {
           onChange={event => setAmountDraft(event.target.value)}
           onBlur={() => {
             amountEditingRef.current = false;
-            const original = String(roundToCents(row.amount) ?? '');
+            const original = row.amount != null ? String(roundToCents(row.amount)) : '';
             if (amountDraft !== original) onCommit(index, 'amount', amountDraft);
           }}
         />
@@ -1727,6 +1729,12 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     [invoiceServiceRows],
   );
 
+  // A catalog-backed package's schedule only ever renders inside its own PackageBlock in the PDF
+  // (round8 spec B), so it has nothing to attach to once that block is hidden by the Package
+  // checkbox. A custom package's block always stays visible (it's a real billed line, not a
+  // reference block - see computeInvoiceSubtotal), so its schedule checkbox stays enabled.
+  const scheduleCheckboxDisabled = !packageRow || (!data.includePackageInPdf && Boolean(packageRow.catalogId));
+
   // "% of package" only makes sense once a catalog-linked package is already part of this invoice -
   // it's a share of that package's price, not a standalone add option (spec item C).
   const percentSharePackage = packageRow && packageRow.catalogId ? packageRow : null;
@@ -2067,10 +2075,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   };
 
   const addEntryToInvoice = (entry, successMessage) => {
-    const identity = getEntryIdentityKey(entry);
-    if (data.invoiceServices.some(existing => getEntryIdentityKey(existing) === identity)) {
-      toast.error('This is already on the invoice.');
-      return;
+    // A "% of package" row represents one milestone of a payment schedule, not a single
+    // conceptual line - a schedule can legitimately have two equal-percent steps (e.g. two 25%
+    // installments), so unlike every other entry kind it must never be deduped by its resolved
+    // value alone.
+    if (entry?.kind !== 'percent') {
+      const identity = getEntryIdentityKey(entry);
+      if (data.invoiceServices.some(existing => getEntryIdentityKey(existing) === identity)) {
+        toast.error('This is already on the invoice.');
+        return;
+      }
     }
     persistInvoiceServices([...data.invoiceServices, entry], successMessage);
   };
@@ -2202,8 +2216,20 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   // editing area (spec C.2).
 
   const setIncludePackageInPdf = value => {
-    setData(current => ({ ...current, includePackageInPdf: value }));
+    // The Payment schedule table only ever renders inside a catalog-backed package's own block
+    // (InvoicePdfDocument's PackageBlock) - hiding that block also silently drops its schedule
+    // from the PDF, so clear the schedule checkbox along with it instead of leaving it checked
+    // but with nothing left to render. A custom package's block stays visible regardless of this
+    // checkbox (it's a real billed line, not a reference block - see computeInvoiceSubtotal), so
+    // its schedule is unaffected.
+    const alsoHidesSchedule = !value && Boolean(packageRow?.catalogId) && data.includeScheduleInPdf;
+    setData(current => ({
+      ...current,
+      includePackageInPdf: value,
+      ...(alsoHidesSchedule ? { includeScheduleInPdf: false } : {}),
+    }));
     persistPath(`${INVOICE_DATA_PATH}/includePackageInPdf`, value);
+    if (alsoHidesSchedule) persistPath(`${INVOICE_DATA_PATH}/includeScheduleInPdf`, false);
   };
 
   const setIncludeScheduleInPdf = value => {
@@ -2254,10 +2280,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     if (!schedule) return;
     const pkg = catalogPackagesById.get(String(packageRow.catalogId));
     const listedPriceAmount = pkg ? resolveBudgetPriceAmount(pkg.listedPrice, priceContext) : null;
-    const rows = (schedule.payments || []).map(payment => ({
-      title: payment.title || '',
-      amount: resolvePaymentAmount(payment, listedPriceAmount) ?? 0,
-    }));
+    // Scaled to the package's own billed price (priceOverride included) the same way the live
+    // catalog-derived schedule already is in resolvePackageEntrySchedule - otherwise applying a
+    // catalog schedule to a package billed above/below its listed price would make the schedule
+    // total drift from "Total programme fee".
+    const billedPrice = Number(packageRow.price) || 0;
+    const scale = listedPriceAmount ? billedPrice / listedPriceAmount : 1;
+    const rows = (schedule.payments || []).map(payment => {
+      const amount = resolvePaymentAmount(payment, listedPriceAmount);
+      return { title: payment.title || '', amount: amount == null ? null : roundToCents(amount * scale) };
+    });
     commitPackageSchedule(packageRow.id, rows);
   };
 
@@ -3218,13 +3250,13 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               <FieldRow $align="center" style={{ marginTop: 10 }}>
                 <label
                   style={{
-                    display: 'flex', alignItems: 'center', gap: 6, cursor: packageRow ? 'pointer' : 'not-allowed', opacity: packageRow ? 1 : 0.5,
+                    display: 'flex', alignItems: 'center', gap: 6, cursor: scheduleCheckboxDisabled ? 'not-allowed' : 'pointer', opacity: scheduleCheckboxDisabled ? 0.5 : 1,
                   }}
                 >
                   <input
                     type="checkbox"
                     checked={data.includeScheduleInPdf}
-                    disabled={!packageRow}
+                    disabled={scheduleCheckboxDisabled}
                     onChange={event => setIncludeScheduleInPdf(event.target.checked)}
                   />
                   <span>Payment schedule</span>

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -300,6 +300,34 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // Bug report: ps-6-style schedules (Special Offer - Programme Fee, p7) have several equal-percent
+  // milestones (25%, 25%, 25%, 25%) - clicking "% of package" a second time used to be rejected as
+  // "already on the invoice" because the two resulting rows shared the same (packageId, percent)
+  // identity, even though they represent two distinct schedule milestones.
+  it('allows two equal-percent schedule milestones from the same package on one invoice', async () => {
+    const root = mount();
+    await flush();
+
+    const packageSelect = container.querySelector('select[aria-label="Choose package from catalog"]');
+    await act(async () => { selectOption(packageSelect, 'p7'); });
+    await flush();
+
+    const percentButton = findButton('% of package');
+    expect(percentButton).toBeTruthy();
+    await act(async () => { percentButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    await act(async () => { percentButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    const percentEntries = lastServicesCall[1].filter(entry => entry.kind === 'percent');
+    expect(percentEntries).toHaveLength(2);
+    expect(percentEntries[0].percent).toBe(25);
+    expect(percentEntries[1].percent).toBe(25);
+
+    await act(async () => { root.unmount(); });
+  });
+
   // Bug report: adding a package used to only offer the full listed price, with no way to bill
   // just a share of it (e.g. the first Payment Schedule milestone) - the only route to a percent
   // row required adding the whole package first, then deleting it again. The catalog picker's

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -140,14 +140,18 @@ const buildBreakdownTableRow = row => ({
 // gated separately by the Builder's "Payment schedule" checkbox (`showSchedule`).
 const PackageBlock = ({ row, showSchedule }) => {
   const totalLabel = formatRowAmount(row);
+  const packageId = row.id || row.key || 'package';
   // The package's own name and total fee are already shown just above, in packageBlockHeader -
   // repeating them as this single column's header (round8 spec A) would just say the same thing
-  // twice, so the column here carries only the currency.
-  const packageMeta = [{ id: row.id || row.key || 'package', label: '', priceLabel: 'EUR' }];
+  // twice, so the schedule column here carries only the currency. The included-services table's
+  // column has no amount at all (its cells are inclusion marks, not money), so it gets a blank
+  // header instead of reusing the schedule's "EUR" one.
+  const scheduleMeta = [{ id: packageId, label: '', priceLabel: 'EUR' }];
+  const includedMeta = [{ id: packageId, label: '', priceLabel: '' }];
   const includedRows = (row.children || []).map((child, index) => ({
     id: child.id || child.key || `child-${index}`,
     name: child.name || '',
-    includedByPackageId: new Set([String(packageMeta[0].id)]),
+    includedByPackageId: new Set([String(packageId)]),
   }));
   const scheduleRows = (row.scheduleRows || []).map(payment => ({
     title: payment.title || 'Payment',
@@ -170,7 +174,7 @@ const PackageBlock = ({ row, showSchedule }) => {
       </View>
       {fullDetailNote ? <Text style={styles.sectionNote}>{sanitizePdfText(fullDetailNote)}</Text> : null}
       <IncludedServicesTable
-        packages={packageMeta}
+        packages={includedMeta}
         includedRows={includedRows}
         title="Included in this package"
         note={null}
@@ -179,7 +183,7 @@ const PackageBlock = ({ row, showSchedule }) => {
       />
       {showSchedule ? (
         <PaymentScheduleTable
-          packages={packageMeta}
+          packages={scheduleMeta}
           rows={scheduleRows}
           title="Payment schedule for this package"
           sectionStyle={styles.section}
@@ -228,7 +232,20 @@ const InvoicePdfDocument = ({
   // checkbox (includePackageInPdf), never implicitly by whether one happens to be on the invoice.
   // Any other top-level row is, by definition, a service confirmed for this case that sits outside
   // the standard package.
-  const packageRows = includePackageInPdf ? rows.filter(row => row.kind === 'package') : [];
+  // A custom package (no catalogId) has no catalog "% of package" row to bill alongside it - its
+  // own resolved price is a real, always-billed invoice line (computeInvoiceSubtotal). Unlike a
+  // catalog-backed package (a reference-only block the checkbox may freely hide), hiding it would
+  // leave the Amount due including a charge with no visible line item explaining it, so every
+  // custom package always renders regardless of the checkbox. A catalog-backed package is capped
+  // at one: the Builder itself only ever surfaces/edits the first package row it finds (spec C),
+  // so an invoice saved before that restructure with several catalog packages would otherwise
+  // still render every extra one here with no way for the admin to see, edit, or remove it.
+  const packageRows = rows.reduce((acc, row) => {
+    if (row.kind !== 'package') return acc;
+    if (!row.catalogId) return [...acc, row];
+    if (!includePackageInPdf || acc.some(existing => existing.catalogId)) return acc;
+    return [...acc, row];
+  }, []);
   const isPackageInvoice = packageRows.length > 0;
   // A "% of package" row (a programme milestone share) and any custom/catalog service row share one
   // "Breakdown" table, one row style, one running numbering - splitting them into two headed

--- a/src/components/budgetCatalogUtils.js
+++ b/src/components/budgetCatalogUtils.js
@@ -294,7 +294,7 @@ export const resolveProgramPaymentSchedule = (catalog, program) => {
 // (Budget/Invoice/Expected Expenses) funnels through here instead of reading `payment.amount`
 // directly, so the two formats can freely coexist in the same schedule.
 export const resolvePaymentAmount = (payment, listedPrice) => {
-  if (Number.isFinite(Number(payment?.amount))) return roundToCents(Number(payment.amount));
+  if (payment?.amount != null && Number.isFinite(Number(payment.amount))) return roundToCents(Number(payment.amount));
   if (Number.isFinite(Number(payment?.percent)) && listedPrice != null && Number.isFinite(Number(listedPrice))) {
     return roundToCents((Number(listedPrice) * Number(payment.percent)) / 100);
   }

--- a/src/components/budgetCatalogUtils.test.js
+++ b/src/components/budgetCatalogUtils.test.js
@@ -205,5 +205,13 @@ describe('budgetCatalogUtils', () => {
       expect(resolvePaymentAmount({ title: 'No figure' }, 1000)).toBeNull();
       expect(resolvePaymentAmount({ percent: 25 }, null)).toBeNull();
     });
+
+    // A percent-based payment stored as { amount: null, percent: 25 } (e.g. round-tripped through
+    // a backend that always writes the `amount` key) must fall through to the percent branch -
+    // Number(null) is 0, which is finite, so a naive `Number.isFinite(Number(payment.amount))`
+    // check would wrongly treat a null amount as a real, billed 0.
+    it('falls through to percent when amount is explicitly null', () => {
+      expect(resolvePaymentAmount({ amount: null, percent: 25 }, 40000)).toBe(10000);
+    });
   });
 });

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -308,7 +308,12 @@ export const normalizeServiceEntry = raw => {
       // an admin edits it in the Builder, at which point it freezes the schedule shown/billed on
       // this invoice instead of continuing to track the catalog's live payment schedule.
       ...(Array.isArray(raw.schedule)
-        ? { schedule: raw.schedule.map(payment => ({ title: String(payment?.title || ''), amount: toNumber(payment?.amount) })) }
+        ? {
+          schedule: raw.schedule.map(payment => ({
+            title: String(payment?.title || ''),
+            amount: payment?.amount == null ? null : toNumber(payment.amount),
+          })),
+        }
         : {}),
       children: normalizeServiceEntries(raw.children),
     };
@@ -440,7 +445,17 @@ export const addCatalogChildToPackage = (entry, catalogId) => {
 // billing choice for this one invoice, not a content edit, so it never flips `customized` (which
 // means "no longer matches the catalog package's actual line items").
 export const setPackageSchedule = (entry, schedule) => (entry?.kind === 'package'
-  ? { ...entry, schedule: (Array.isArray(schedule) ? schedule : []).map(payment => ({ title: String(payment?.title || ''), amount: toNumber(payment?.amount) })) }
+  ? {
+    ...entry,
+    // An unresolved (null) amount is kept null rather than coerced through toNumber - otherwise
+    // editing just one field of a schedule still showing an unresolved catalog price (e.g. its
+    // title) would silently freeze every other row's amount at 0 the moment it's materialized
+    // into this per-invoice override.
+    schedule: (Array.isArray(schedule) ? schedule : []).map(payment => ({
+      title: String(payment?.title || ''),
+      amount: payment?.amount == null ? null : toNumber(payment.amount),
+    })),
+  }
   : entry);
 
 // --- Queries ------------------------------------------------------------
@@ -486,7 +501,9 @@ export const resolvePackageEntrySchedule = (entry, listedPriceAmount, billedPric
     return entry.schedule.map((payment, index) => ({
       key: `${entry.id}-schedule-${index}`,
       title: payment.title || `Payment ${index + 1}`,
-      amount: roundMoney(payment.amount),
+      // Left unresolved (null) rather than zeroed - see the amount==null branch below, which
+      // is where an unresolved amount first reaches a stored per-invoice schedule.
+      amount: payment.amount == null ? null : roundMoney(payment.amount),
     }));
   }
   const pkg = priceContext.packagesById?.get?.(String(entry.catalogId));
@@ -500,7 +517,10 @@ export const resolvePackageEntrySchedule = (entry, listedPriceAmount, billedPric
     return {
       key: `${entry.id}-schedule-${index}`,
       title: payment.title || `Payment ${index + 1}`,
-      amount: amount == null ? 0 : roundMoney(amount * scale),
+      // A percent-based payment with no resolvable listed price (e.g. a formula-priced package
+      // while NBU rates are missing) has no real amount yet - stays null (rendered as "-") rather
+      // than a misleading €0, until the price resolves.
+      amount: amount == null ? null : roundMoney(amount * scale),
     };
   });
 };

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -373,6 +373,34 @@ describe('invoiceCatalogUtils', () => {
       const row = resolveServiceRow(makeCustomPackageEntry({ name: 'Bespoke' }), new Map(), { packagesById: new Map() });
       expect(row.scheduleRows).toEqual([]);
     });
+
+    // A percent-based schedule (ps-6 onwards) needs the package's listed price resolved to turn
+    // into a euro amount - a formula-priced package with missing NBU rates has no such price yet.
+    // The payment must stay unresolved (null, rendered as "-") rather than a misleading €0.
+    it('leaves a percent-based payment unresolved when the listed price cannot be resolved', () => {
+      const unresolvedPackagesById = new Map([['p1', { id: 'p1', name: 'Full program', listedPrice: '=id99', children: ['1'] }]]);
+      const percentTechnical = { paymentSchedules: [{ id: 'ps-6', payments: [{ title: 'Deposit', percent: 25 }] }] };
+      const withPercentSchedule = { ...unresolvedPackagesById.get('p1'), paymentScheduleId: 'ps-6' };
+      const row = resolveServiceRow(
+        makeCatalogPackageEntry({ id: 'p1', children: ['1'] }),
+        new Map(),
+        { packagesById: new Map([['p1', withPercentSchedule]]), technical: percentTechnical },
+      );
+      expect(row.scheduleRows).toEqual([{ key: expect.any(String), title: 'Deposit', amount: null }]);
+    });
+
+    it('preserves an unresolved (null) amount through a per-invoice schedule override', () => {
+      const withOverride = setPackageSchedule(
+        makeCatalogPackageEntry({ id: 'p1', children: ['1'] }),
+        [{ title: 'Deposit', amount: null }, { title: 'Final payment', amount: 100 }],
+      );
+      expect(withOverride.schedule).toEqual([{ title: 'Deposit', amount: null }, { title: 'Final payment', amount: 100 }]);
+      const row = resolveServiceRow(withOverride, new Map(), { packagesById: packagesByIdWithSchedule, technical });
+      expect(row.scheduleRows).toEqual([
+        { key: expect.any(String), title: 'Deposit', amount: null },
+        { key: expect.any(String), title: 'Final payment', amount: 100 },
+      ]);
+    });
   });
 
   describe('resolving entries to display rows', () => {


### PR DESCRIPTION
## Summary

This redoes PR #2759, which was merged and then reverted (#2761) because it conflicted with the parallel "Invoice Builder design round" PR (#2760) touching the same files. This PR is rebased on top of #2760's current `main` and reapplies the same fixes, adjusted where #2760 changed the surrounding code (e.g. `parsePercentOrAmountInput`, the dense/table-based PDF layout, the "Switch package from catalog" selector). Two of the original nine fixes are no longer needed: #2760 already fixed the PDF QA section-order check and the `recentPaymentSchedules` price-field test on its own.

Fixes 9 issues raised in a Codex review of the Invoice Builder / Budget PDF work (skipping #2 per earlier instruction; #1 and #4 from that review were already moot, superseded by an earlier restructuring):

- **Allow repeated equal-percent schedule milestones**: `addEntryToInvoice` no longer dedupes `percent`-kind entries by their resolved value, so a ps-6-style schedule with several equal-percent steps (e.g. four 25% milestones) can have more than one added to the same invoice instead of the second being rejected as "already on the invoice".
- **Treat a null payment amount as absent**: `resolvePaymentAmount` no longer treats `{ amount: null, percent: 25 }` as a real 0 EUR payment (`Number(null)` is 0, which is finite) — it now falls through to the percent branch.
- **Scale applied catalog schedules against the invoice's own package price**: `applyCatalogPaymentSchedule` now scales against `packageRow.price` (which includes any per-invoice price override) instead of the catalog's listed price, matching how the live catalog-derived schedule already scales.
- **Don't label the included-services table "EUR"**: `PackageBlock` now passes a blank header to `IncludedServicesTable` and keeps "EUR" only for `PaymentScheduleTable`, since the two tables were sharing one `packageMeta`.
- **Preserve unresolved schedule amounts instead of zeroing them**: an unresolved (`null`) payment amount (e.g. a formula-priced package before NBU rates load) now stays `null` end-to-end — through resolution, the per-invoice override, and the schedule editor — and renders as "-" instead of a misleading €0. Also fixed a latent inconsistency in `ScheduleRow`'s draft value (`roundToCents(null)` coerces to 0; the null check now happens before calling it).
- **Keep billable custom packages visible / cap schedule to its package**: a custom package's block (its only real invoice line, always billed) now always renders in the PDF regardless of the "Package" checkbox; only catalog-backed reference packages can be hidden by it. The "Payment schedule" checkbox is now disabled/auto-cleared whenever it would have no package block left to render into.
- **Cap the PDF to one catalog-backed package block**: matches the Builder's own "surfaces at most one package at a time" design, so a legacy invoice saved with several catalog packages doesn't render extras the admin can no longer see or edit (custom packages are never capped, since each one is a distinct billed line).

## Test plan

- [x] `npm test` — all 427 tests across the suite pass except 8 pre-existing, unrelated failures in `utils/__tests__/*Storage*`/`Matching.sharedReactions` (localStorage-related, unrelated files, present on `main` before this change too).
- [x] `npm run qa:pdf` — passes.
- [x] Re-added the targeted unit tests for the null-amount/percent fix, the unresolved-schedule-amount fix, and the repeated-equal-percent-milestone fix (these were lost in the revert).
- [x] `npx eslint` on all changed source files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9yDLpNxvbrazVECxxzSPH)_