### PR TITLE
Round 9: Invoice Builder design tasks — plain-text inputs, one-page Invoice PDF, EE selectors, backend agency identity

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -95,6 +95,13 @@ const toArray = value => {
   return [];
 };
 
+// A dynamic chunk that fails to load almost always means the deployed app was updated after this
+// tab was opened - the previous build's hashed chunk files are gone from the server, so webpack's
+// "Loading chunk NNN failed" is really "this page is stale". Detect it so the toast can say the
+// actual fix (refresh) instead of surfacing the cryptic chunk error.
+const isStaleChunkError = error => /loading (?:css )?chunk|chunkloaderror/i.test(`${error?.name || ''} ${error?.message || ''}`);
+const STALE_APP_MESSAGE = 'The app has been updated since this page was opened. Refresh the page and try again.';
+
 const emptyBeneficiary = () => ({
   id: `beneficiary-${Date.now()}`,
   title: 'New beneficiary',
@@ -1633,6 +1640,18 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     loadInvoiceData();
   }, [loadInvoiceData]);
 
+  // Warm the lazy PDF chunks the moment the page opens. Each deployment deletes the previous
+  // build's hashed chunk files, so a tab opened before a deploy can no longer fetch them at
+  // "Generate PDF" time ("Loading chunk NNN failed") - fetching them up front, while this page's
+  // own build is still live, keeps generation working for the whole session. Failures are
+  // ignored: generation itself retries and reports properly.
+  useEffect(() => {
+    import('@react-pdf/renderer').catch(() => {});
+    import('./InvoicePdfDocument').catch(() => {});
+    import('./PaymentDetailsPdfDocument').catch(() => {});
+    import('./ExpectedExpensesPdfDocument').catch(() => {});
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     const ratesDate = invoiceDateInput || getTodayYmd();
@@ -2575,7 +2594,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       toast.success('Expected expenses PDF generated.');
     } catch (generateError) {
       console.error('Unable to generate expected expenses PDF', generateError);
-      toast.error('Unable to generate expected expenses PDF.');
+      toast.error(isStaleChunkError(generateError) ? STALE_APP_MESSAGE : 'Unable to generate expected expenses PDF.');
     } finally {
       setIsGeneratingExpectedExpenses(false);
     }
@@ -2873,8 +2892,12 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
       toast.success(generatePaymentDetails ? 'Invoice and payment details PDFs generated.' : 'Invoice PDF generated.');
     } catch (generateError) {
       console.error('Unable to generate invoice PDF', generateError);
-      const reason = generateError?.message ? `: ${generateError.message}` : '';
-      toast.error(`Unable to generate invoice PDF${reason}`);
+      if (isStaleChunkError(generateError)) {
+        toast.error(STALE_APP_MESSAGE);
+      } else {
+        const reason = generateError?.message ? `: ${generateError.message}` : '';
+        toast.error(`Unable to generate invoice PDF${reason}`);
+      }
     } finally {
       setIsGenerating(false);
     }


### PR DESCRIPTION
Implements the 2026-07-13 design/data task list, plus a fix for the "Loading chunk NNN failed" error on PDF generation.

## §1 Global input styling
- Every builder field now reads as plain editable text: no box/border/background/focus ring (ever), one shared 20px line-height so the index number, name, price, % sign, EUR chip, arrows and trash icon of a row sit on a single baseline.
- Percent/amount fields accept both formats interchangeably: `25` → 25%, `10000` → 10,000 EUR (explicit `%`/`€`/`EUR` marker always wins). A typed euro amount is stored as-is (`amount` on the percent entry) and wins over the percent when priced; the equivalent in the other unit shows as a chip. Package payment-schedule rows accept both formats too.

## §2 Package & PDF components
- "Switch package from catalog…" selector when a package is already chosen (same pattern as the schedule selector).
- `Price or GIFT` placeholders → `100`; package name styled identically to a service line; numbering aligned with names; the "A flat breakdown of items…" block under Invoice Services removed.

## §3 Invoice PDF
- Customisation note removed; spacing compacted (10pt rhythm, dense table rows, tighter non-splitting total card) — a full package invoice (package block + included services + schedule + breakdown + total) now fits **one page**.
- Breakdown converted to a table in the Payment Schedule style; single EUR column header, no per-amount "EUR".
- "Total programme fee" → "Cost of the package"; percent rows render as "Scheduled payment" in the PDF and the builder.

## §4 Expected Expenses
- Page: package / payment-schedule / plan-wide tax selectors (with the shared recent-tax-rate chips); rebuild logic shared with Recalculate.
- PDF: schedule Total row removed; Payment schedule moved after "Included in this programme"; scheduled shares render as right-aligned "Scheduled payment" lines.

## §5 Backend-driven agency identity
- BrandRow wordmark/tagline and the branded footer of every PDF (Budget / Invoice / Expected Expenses / SM Profile) read `budget/technical/agency` (t.me links display as @handle), previous strings kept as offline fallback. Budget page eyebrow reads the same record.
- Note: the package rename "Special Offer — Programme Fee" → "FET program. Special offer" and dropping "(part 2 of 2)" are backend data — an updated budget export JSON was provided separately for upload.

## Deployment resilience
- PDF chunks are pre-warmed on page open, and a stale-deployment chunk failure now shows "refresh the page" instead of the raw webpack error (each gh-pages deploy deletes the previous build's hashed chunks, which broke Generate PDF in tabs opened before the deploy).

## Verification
- `npm run lint:js` clean, production build passes, `npm run qa:pdf` passes.
- Invoice/budget/EE test suites: 108/108 (new unit tests for dual %/EUR parsing). Two stale expectations that already failed on `main` fixed (recent-schedule `price`, QA section order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXaeTgR6haUZL3H8uhA6uo

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXaeTgR6haUZL3H8uhA6uo)_