### PR TITLE
Exclude Breakdown/Payments extras from the Expected Expenses schedule total

### DIFF
--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -168,10 +168,15 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
   const packagesMeta = [{ id: 'programme', label: 'Programme', priceLabel: formatAmount(listedPrice) }];
 
   const milestoneRows = milestones.map(milestone => resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext));
-  const milestoneSubtotals = milestoneRows.map(rows => computeMilestoneSubtotal(rows));
+  // Only the auto-generated "share of the programme fee" row belongs in this schedule - it mirrors
+  // the package's own payment schedule, whose column already sums to the whole programme fee
+  // (Programme 46,000 above). Any other row (SM deposits, catalog add-ons, gifts, ...) is a one-off
+  // extra that belongs solely in that milestone's own Payments block below, never folded into this
+  // total - otherwise a milestone with an extra would show more than its actual scheduled share here.
+  const milestoneScheduledAmounts = milestoneRows.map(rows => computeMilestoneSubtotal(splitScheduledRows(rows).scheduledRows));
   const scheduleRows = milestones.map((milestone, index) => ({
     title: milestone.title || `Payment ${index + 1}`,
-    amounts: [milestoneSubtotals[index]],
+    amounts: [milestoneScheduledAmounts[index]],
   }));
 
   return (

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -1795,9 +1795,20 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const caseTitle = useMemo(() => buildCaseTitle(data.customers), [data.customers]);
   const activePayerCaseId = data.payerCaseIds[0];
 
+  // recentServices is already ordered most-recently-used first (reorderRecentServices) - so
+  // deduping here by keeping only the first occurrence of each identity naturally keeps the
+  // newest copy of any repeat and drops the older, stale ones from the chip row.
   const recentServiceSuggestions = useMemo(() => {
     const used = new Set(data.invoiceServices.map(getEntryIdentityKey));
-    return data.recentServices.filter(entry => !used.has(getEntryIdentityKey(entry))).slice(0, 8);
+    const seen = new Set();
+    const deduped = [];
+    for (const entry of data.recentServices) {
+      const key = getEntryIdentityKey(entry);
+      if (used.has(key) || seen.has(key)) continue;
+      seen.add(key);
+      deduped.push(entry);
+    }
+    return deduped.slice(0, 8);
   }, [data.recentServices, data.invoiceServices]);
 
   const usedCatalogItemIds = useMemo(() => new Set(
@@ -3232,6 +3243,24 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     onAddCustomChild={fields => addCustomChildEntry(packageRow.id, fields)}
                     onAddCatalogChild={catalogId => addCatalogChildEntry(packageRow.id, catalogId)}
                   />
+                  {/* A catalog package's price is normally a reference figure only (the actual
+                      charge is a separate "% of package" row in Other expenses) - but some
+                      packages (e.g. a lump-sum "Initial payment" special offer) already *are*
+                      the whole charge, with no percent row to carry it. This checkbox bills the
+                      package's own price directly instead of requiring one. A custom package
+                      (no catalogId) is always billed already, so it never needs this toggle. */}
+                  {packageRow.catalogId ? (
+                    <FieldRow $align="center" style={{ marginTop: 8 }}>
+                      <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                        <input
+                          type="checkbox"
+                          checked={Boolean(packageRow.billDirectly)}
+                          onChange={event => commitTopLevelField(packageRow.id, 'billDirectly', event.target.checked)}
+                        />
+                        <span>Bill package price on this invoice</span>
+                      </label>
+                    </FieldRow>
+                  ) : null}
                   </>
                 ) : (
                   <>
@@ -3327,7 +3356,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
             <Panel>
               <PanelHeading>
-                <H2>Invoice services</H2>
+                <H2>Other expenses</H2>
               </PanelHeading>
 
               {serviceLineRows.map((row, index) => (
@@ -3345,7 +3374,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   onReset={row.kind === 'item' && row.isCustomized ? () => resetTopLevelEntry(row.id) : undefined}
                 />
               ))}
-              {!serviceLineRows.length ? <PanelNote style={{ margin: 0 }}>No services on this invoice yet.</PanelNote> : null}
+              {!serviceLineRows.length ? <PanelNote style={{ margin: 0 }}>No other expenses on this invoice yet.</PanelNote> : null}
 
               <div
                 style={{ marginTop: 14 }}

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -304,6 +304,7 @@ export const normalizeServiceEntry = raw => {
       ...(raw.priceOverride !== undefined && raw.priceOverride !== null && raw.priceOverride !== ''
         ? { priceOverride: toNumber(raw.priceOverride) }
         : {}),
+      ...(raw.billDirectly ? { billDirectly: true } : {}),
       // A per-invoice override of the package's payment schedule (round7 spec C.2) - absent until
       // an admin edits it in the Builder, at which point it freezes the schedule shown/billed on
       // this invoice instead of continuing to track the catalog's live payment schedule.
@@ -389,6 +390,10 @@ export const setEntryField = (entry, field, value) => {
   if (entry.kind === 'package') {
     if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
     if (field === 'name' || field === 'description') return { ...entry, [field]: value, customized: true };
+    // A billing preference, not a content override - toggling it never marks the package
+    // "customized" (that flag drives the PDF's "customised programme details" note and the
+    // catalog Reset button, neither of which applies here).
+    if (field === 'billDirectly') return { ...entry, billDirectly: Boolean(value) };
     return entry;
   }
   return { ...entry, [field]: field === 'price' ? toNumber(value) : value, customized: true };
@@ -591,6 +596,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
       description: entry.description ?? pkg?.description ?? '',
       price: hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,
+      billDirectly: Boolean(entry.billDirectly),
       childrenTotal,
       hasPriceOverride,
       children: resolvedChildren,
@@ -646,11 +652,14 @@ export const resolveInvoiceDocType = rows => ((Array.isArray(rows) ? rows : [])
 
 // A catalog-backed top-level 'package' row is never billed by its own price - it's a
 // reference block (its included-services list and Payment Schedule mirror the catalog
-// programme for context, same as Budget). Custom packages have no catalog payment-share
-// row to bill alongside them, so their resolved price (children total or override) is a
-// real invoice line and must stay in totals.
+// programme for context, same as Budget) - unless the admin has explicitly flagged it
+// `billDirectly` (the "Bill package price" checkbox), for a package that already *is* the
+// invoice's whole charge (e.g. a lump-sum "Initial payment" catalog package) with no separate
+// "% of package" row to carry the amount. Custom packages have no catalog payment-share row to
+// bill alongside them, so their resolved price (children total or override) is always a real
+// invoice line and must stay in totals regardless of that flag.
 export const computeInvoiceSubtotal = rows => rows
-  .filter(row => row?.kind !== 'package' || !row.catalogId)
+  .filter(row => row?.kind !== 'package' || !row.catalogId || row.billDirectly)
   .reduce((sum, row) => sum + (Number(row.price) || 0), 0);
 
 export const computeInvoiceTotal = (subtotal, taxPercent) => subtotal * (1 + (Number(taxPercent) || 0) / 100);

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -560,6 +560,17 @@ describe('invoiceCatalogUtils', () => {
       expect(computeInvoiceTotal(subtotal, 14)).toBeCloseTo(3762);
     });
 
+    // Some catalog packages (e.g. a lump-sum "Initial payment" special offer) are already the
+    // whole invoice charge, with no separate "% of package" row to carry it - the `billDirectly`
+    // flag (set via the Builder's "Bill package price on this invoice" checkbox) opts a specific
+    // package row into being billed by its own price, same as a custom package always is.
+    it('bills a catalog package row\'s own price when billDirectly is set', () => {
+      const packagesById = new Map([['p1', { id: 'p1', name: 'Special Offer - Initial Payment', listedPrice: 8300, children: [] }]]);
+      const invoiceServices = [{ ...makeCatalogPackageEntry({ id: 'p1', children: [] }), billDirectly: true }];
+      const rows = resolveInvoiceServiceRows(invoiceServices, new Map(), { packagesById });
+      expect(computeInvoiceSubtotal(rows)).toBe(8300);
+    });
+
     it('still bills a "% of package" row even though the package row itself is reference-only', () => {
       const packagesById = new Map([['p1', { id: 'p1', name: 'Full program', listedPrice: 40000, children: ['1'] }]]);
       const catalogItemsById = new Map([['1', { id: '1', name: 'Consultation', price: 300 }]]);


### PR DESCRIPTION
The Payment schedule table mirrored each milestone's full resolved
subtotal, which included one-off extras (deposits, gifts, ...) added in
that milestone's own Payments block - so a milestone with a 500 EUR extra
on top of its 16,000 EUR scheduled share showed 16,500 in the schedule
table instead of matching the package's own payment schedule. Only the
auto-generated "share of the programme fee" row now feeds the schedule.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WXHMGz5Qvfg97nHEdXRVCN