### PR TITLE
Move payment caveats to Payment Details and strengthen Invoice QA checks

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -111,6 +111,15 @@ const checkNoBrandOnPages = (docName, pagesText, pageIndexes, brand) => {
   });
 };
 
+const checkStringsAbsent = (docName, pagesText, forbiddenStrings) => {
+  const combined = pagesText.join('\n');
+  forbiddenStrings.forEach(forbidden => {
+    if (combined.includes(forbidden)) {
+      fail(`${docName}: payment-only text "${forbidden}" must not appear in this document`);
+    }
+  });
+};
+
 async function checkInvoice() {
   const InvoicePdfDocument = require('../src/components/InvoicePdfDocument').default;
   const beneficiary = {
@@ -133,7 +142,11 @@ async function checkInvoice() {
     invoiceServices: [{ id: 'e1', kind: 'item', catalogId: '1' }, { id: 'e2', kind: 'item', catalogId: '2' }],
     catalogItemsById,
     priceContext: { itemsById: catalogItemsById, rates: null },
-    notes: [],
+    notes: [
+      'Purpose of the payment must be exactly like in invoice.',
+      'Please make sure you pay the whole amount. Do not use SHA option while making payment.',
+      'Regular invoice note for the client.',
+    ],
     taxPercent: 0,
     invoiceNumber: '09/07/2026',
     invoiceDate: '09.07.2026',
@@ -143,6 +156,11 @@ async function checkInvoice() {
   checkNoBlankPages('Invoice (service)', servicePages);
   checkStringsRoundTrip('Invoice (service)', servicePages, [
     'Pregnancy blood test', 'Blood test to confirm pregnancy, week 8.', 'Consultation services',
+    'Regular invoice note for the client.',
+  ]);
+  checkStringsAbsent('Invoice (service)', servicePages, [
+    'Purpose of the payment must be exactly like in invoice.',
+    'Please make sure you pay the whole amount. Do not use SHA option while making payment.',
   ]);
   checkNoBrandOnPages('Invoice (service)', servicePages, [1], 'UKRCOM');
   if (!servicePages[0].replace(/\s+/g, '').toUpperCase().includes('SERVICEINVOICE')) {

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -37,7 +37,11 @@ const formatRowAmount = row => row?.priceLabel || formatMoney(row?.price);
 // to the instructions they actually govern (see PaymentDetailsPdfDocument) - they no longer belong
 // on the Invoice itself. Matched by keyword rather than exact string so pre-existing notes data
 // (already carrying an older phrasing) is filtered out too, not just freshly authored ones.
-const PAYMENT_CAVEAT_PATTERNS = [/purpose of the payment/i, /sha option/i];
+const PAYMENT_CAVEAT_PATTERNS = [
+  /purpose of the payment/i,
+  /please make sure you pay the whole amount/i,
+  /sha option/i,
+];
 const isPaymentCaveatNote = note => PAYMENT_CAVEAT_PATTERNS.some(pattern => pattern.test(note));
 
 const styles = StyleSheet.create({

--- a/src/components/PaymentDetailsPdfDocument.jsx
+++ b/src/components/PaymentDetailsPdfDocument.jsx
@@ -183,8 +183,7 @@ const PaymentDetailsPdfDocument = ({
           <View style={styles.noteRow}>
             <Text style={styles.noteMark}>**</Text>
             <Text style={styles.noteText}>
-              Please make sure you pay the whole amount due - any bank transfer fees on your side must not be
-              deducted from it.
+              Please make sure you pay the whole amount. Do not use SHA option while making payment.
             </Text>
           </View>
         </View>


### PR DESCRIPTION
### Motivation
- Payment-related caveats should not appear on the itemized Invoice PDF and must live on the standalone Payment Details document, and the QA checks should assert that migrated text no longer appears on invoices.
- Improve detection of legacy/variants of the payment caveat phrasing so older notes are filtered out of invoices.

### Description
- Add `checkStringsAbsent` to `scripts/pdfQaCheck.js` and use it in the invoice QA to assert that payment-only strings do not appear in the Invoice PDF. 
- Extend `PAYMENT_CAVEAT_PATTERNS` in `InvoicePdfDocument.jsx` to match additional phrasing variants so such notes are filtered from invoice `notes` before rendering. 
- Update `PaymentDetailsPdfDocument.jsx` to host the caveat copy and adjust the second caveat wording to: "Please make sure you pay the whole amount. Do not use SHA option while making payment.". 
- Update the invoice test fixture to include a normal client note (which must remain) and to assert that the migrated payment-caveat strings are absent from the rendered invoice. 

### Testing
- Ran the PDF QA script via `node scripts/pdfQaCheck.js` which exercises `checkInvoice` and the invoice rendering checks, and the updated checks passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55058cd1a083268d19d02e55a6b1be)