### PR TITLE
Invoice Builder batch 4: issued-invoice fixes, fluid amount inputs, compact PDF tables

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -131,9 +131,21 @@ const styles = StyleSheet.create({
     lineHeight: 1.4,
     marginTop: 1.5,
   },
-  // Dense variant: tighter row padding for the single-page Invoice (design-tasks §3).
+  // Dense variant: tighter row padding + slightly smaller cell text for the single-page Invoice
+  // (design-tasks §3, tightened further in design-tasks-4 §7 so a package invoice fits one page).
   denseCell: {
-    paddingVertical: 2,
+    paddingVertical: 1.5,
+  },
+  denseCellText: {
+    fontSize: 8,
+    lineHeight: 1.35,
+  },
+  // Column divider between the two service cells of a compact included-services row - the same
+  // hairline the program columns use, so the compact table still reads as part of one table family.
+  compactSecondCell: {
+    borderLeftWidth: 1,
+    borderLeftColor: PDF_COLOR.docLine,
+    borderLeftStyle: 'solid',
   },
   programCell: {
     width: PROGRAM_COL_WIDTH,
@@ -283,40 +295,81 @@ const ProgramColumnsHead = ({ packages, leadLabel, dense = false }) => (
 );
 
 // The "Included in this programme" table (spec §1.2/§2). Shared, byte-for-byte, between the
-// catalog-wide Program Budget (one column per programme) and the case-specific Expected Expenses
-// overview (a single column for the one chosen programme) - so the two documents can never drift
-// apart on how included services are listed.
+// catalog-wide Program Budget (one column per programme) and the case-specific single-programme
+// documents (the package Invoice and Expected Expenses) - so the documents can never drift apart
+// on how included services are listed.
 // packages: [{ id, label, priceLabel }] · includedRows: [{ id, name, includedByPackageId: Set<id> }]
+//
+// `compact` (design-tasks-4 §7) is the single-programme layout the Invoice and Expected Expenses
+// share: every listed service is included by definition, so the inclusion-mark column would be a
+// column of identical "x" marks against a mostly-empty right edge. Instead the services flow two
+// per row - same table frame, header, hairlines, and type as everywhere else - roughly halving
+// the table's height so a package invoice can fit one page.
 export const IncludedServicesTable = ({
-  packages,
+  packages = [],
   includedRows,
   title = 'Included services by program',
   note = 'An "x" marks the services included in each program package.',
   sectionStyle,
   dense = false,
-}) => (includedRows.length ? (
-  <View style={sectionStyle || styles.section}>
-    <View wrap={false} minPresenceAhead={70}>
-      <Text style={styles.sectionTitle}>{title}</Text>
-      {note ? <Text style={styles.sectionNote}>{note}</Text> : null}
-    </View>
-    <View style={styles.table}>
-      <ProgramColumnsHead packages={packages} leadLabel="Provided service" dense={dense} />
-      {includedRows.map(item => (
-        <View key={item.id} style={styles.tableRow} wrap={false}>
-          <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
-            <Text style={styles.labelCellText}>{sanitizePdfText(item.name)}</Text>
+  compact = false,
+}) => {
+  if (!includedRows.length) return null;
+  if (compact) {
+    const pairedRows = [];
+    for (let index = 0; index < includedRows.length; index += 2) {
+      pairedRows.push(includedRows.slice(index, index + 2));
+    }
+    return (
+      <View style={sectionStyle || styles.section}>
+        <View wrap={false} minPresenceAhead={70}>
+          <Text style={styles.sectionTitle}>{title}</Text>
+          {note ? <Text style={styles.sectionNote}>{note}</Text> : null}
+        </View>
+        <View style={styles.table}>
+          <View style={styles.tableHeadRow} wrap={false}>
+            <View style={[styles.labelCell, styles.denseCell]}>
+              <Text style={styles.labelCellHeadText}>Provided service</Text>
+            </View>
           </View>
-          {packages.map(program => (
-            <View key={`${item.id}-${program.id}`} style={[styles.programCell, dense ? styles.denseCell : null]}>
-              <Text style={styles.markCellText}>{item.includedByPackageId.has(String(program.id)) ? 'x' : ''}</Text>
+          {pairedRows.map((pair, rowIndex) => (
+            <View key={pair[0].id} style={styles.tableRow} wrap={false}>
+              <View style={[styles.labelCell, styles.denseCell]}>
+                <Text style={[styles.labelCellText, styles.denseCellText]}>{sanitizePdfText(pair[0].name)}</Text>
+              </View>
+              <View style={[styles.labelCell, styles.denseCell, styles.compactSecondCell]}>
+                {pair[1] ? <Text style={[styles.labelCellText, styles.denseCellText]}>{sanitizePdfText(pair[1].name)}</Text> : null}
+              </View>
             </View>
           ))}
         </View>
-      ))}
+      </View>
+    );
+  }
+  return (
+    <View style={sectionStyle || styles.section}>
+      <View wrap={false} minPresenceAhead={70}>
+        <Text style={styles.sectionTitle}>{title}</Text>
+        {note ? <Text style={styles.sectionNote}>{note}</Text> : null}
+      </View>
+      <View style={styles.table}>
+        <ProgramColumnsHead packages={packages} leadLabel="Provided service" dense={dense} />
+        {includedRows.map(item => (
+          <View key={item.id} style={styles.tableRow} wrap={false}>
+            <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
+              <Text style={styles.labelCellText}>{sanitizePdfText(item.name)}</Text>
+            </View>
+            {packages.map(program => (
+              <View key={`${item.id}-${program.id}`} style={[styles.programCell, dense ? styles.denseCell : null]}>
+                <Text style={styles.markCellText}>{item.includedByPackageId.has(String(program.id)) ? 'x' : ''}</Text>
+              </View>
+            ))}
+          </View>
+        ))}
+      </View>
     </View>
-  </View>
-) : null);
+  );
+};
 
 // The "Payment schedule" table (spec §1.2/§2) - same sharing rationale as IncludedServicesTable
 // above. rows: [{ title, amounts: [amountOrNull, ...] }] · totals: optional [amountOrNull, ...]
@@ -335,12 +388,14 @@ export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment 
       {rows.map((row, rowIndex) => (
         <View key={`schedule-row-${rowIndex}`} style={styles.tableRow} wrap={false}>
           <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
-            <Text style={styles.labelCellText}>{`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}</Text>
+            <Text style={dense ? [styles.labelCellText, styles.denseCellText] : styles.labelCellText}>
+              {`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}
+            </Text>
             {row.description ? <Text style={styles.labelCellDescription}>{sanitizePdfText(row.description)}</Text> : null}
           </View>
           {row.amounts.map((amount, columnIndex) => (
             <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={[styles.programCell, dense ? styles.denseCell : null]}>
-              <Text style={styles.amountCellText}>
+              <Text style={dense ? [styles.amountCellText, styles.denseCellText] : styles.amountCellText}>
                 {amount == null ? '-' : (typeof amount === 'string' ? sanitizePdfText(amount) : formatAmount(amount))}
               </Text>
             </View>

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -164,7 +164,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
   const milestones = Array.isArray(plan?.milestones) ? plan.milestones : [];
 
   const overviewRows = resolvePackageOverviewRows(plan?.packageSnapshot?.children, catalogItemsById, priceContext);
-  const includedRows = overviewRows.map(row => ({ id: row.id, name: row.name, includedByPackageId: new Set(['programme']) }));
+  const includedRows = overviewRows.map(row => ({ id: row.id, name: row.name }));
   const packagesMeta = [{ id: 'programme', label: 'Programme', priceLabel: formatAmount(listedPrice) }];
 
   const milestoneRows = milestones.map(milestone => resolveMilestoneServiceRows(milestone, catalogItemsById, priceContext));
@@ -203,8 +203,10 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
         {/* Included services first, then the payment schedule (design-tasks §4) - the schedule's
             own Total row is dropped too: the programme fee is already stated once in the title
             block and each column's header. */}
+        {/* Compact two-per-row layout (design-tasks-4 §7) - the same variant the package Invoice's
+            "Included in this package" uses, so the single-programme documents stay identical. */}
         <IncludedServicesTable
-          packages={packagesMeta}
+          compact
           includedRows={includedRows}
           title="Included in this programme"
           note="Every item below is already covered by the programme fee."

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -35,7 +35,10 @@ import {
   computeInvoiceAmountDue,
   computeInvoiceSubtotal,
   computeInvoiceTotal,
+  convertAmountToEur,
   createEntryId,
+  dedupePackageEntries,
+  formatInvoicePurposeDate,
   generateInvoiceIdentifiers,
   getActiveBeneficiary,
   getEntryIdentityKey,
@@ -51,12 +54,14 @@ import {
   normalizeInvoiceData,
   parseCustomPriceInput,
   parsePercentOrAmountInput,
+  parseReceivedOnYmd,
   removePackageChild,
   reorderBeneficiaryIds,
   reorderPayerCaseIds,
   reorderRecentServices,
   resetItemEntryOverrides,
   resetPackageEntryToCatalog,
+  resolveIssuedInvoicePaymentStatus,
   removeRecentEntry,
   resolveInvoiceServiceRows,
   resolveServiceRow,
@@ -521,6 +526,16 @@ const PlainPriceBase = styled.textarea.attrs({ wrap: 'off' })`
   color: var(--km-accent);
   white-space: nowrap;
   overflow-x: auto;
+
+  /* Every amount/price input hugs its content (design-tasks-4 §5): ~3 digits wide when short,
+     growing fluidly as more digits are typed. field-sizing does the measuring natively; browsers
+     without it keep the fixed fallback width above. */
+  @supports (field-sizing: content) {
+    field-sizing: content;
+    width: auto;
+    min-width: 3ch;
+    max-width: 132px;
+  }
 `;
 
 const PlainSelect = styled.select`
@@ -1008,6 +1023,11 @@ const PackageQuickField = styled(PlainTextBase)`
 
 const PackageQuickPrice = styled(PlainPriceBase)`
   flex: 0 0 76px;
+
+  /* The fixed flex-basis above would defeat the content-hugging width (design-tasks-4 §5). */
+  @supports (field-sizing: content) {
+    flex: 0 0 auto;
+  }
 `;
 
 const InlinePickerBox = styled.div`
@@ -1623,9 +1643,45 @@ const ReadOnlyRowPrice = styled.span`
 
 const ISSUED_INVOICE_CURRENCIES = ['EUR', 'USD', 'UAH', 'GBP'];
 
-const IssuedInvoiceCard = ({ record, onCommitPayment, onReissue }) => {
+// Header-amount color by payment status (design-tasks-4 §4): green once fully received,
+// yellow while only part of the amount has landed.
+const PAYMENT_STATUS_COLORS = {
+  full: '#3E7C4F',
+  partial: '#C08A2D',
+};
+
+const IssuedInvoiceCard = ({ record, exchangeRates, onCommitPayment, onReissue, onDelete }) => {
   const [receivedDraft, setReceivedDraft, receivedEditingRef] = useFieldDraft(record.payment.receivedOn);
   const [amountDraft, setAmountDraft, amountEditingRef] = useFieldDraft(record.payment.amount);
+
+  // One package header line above the payment lines, never a numbered/priced row of its own
+  // (design-tasks-4 §3) - and legacy records that accumulated duplicate package rows collapse
+  // to that single header. The scheduled "% of package" line reads as "Scheduled payment".
+  const packageHeaderRow = record.rows.find(row => row.kind === 'package') || null;
+  const lineRows = record.rows.filter(row => row.kind !== 'package');
+
+  // A non-EUR receipt shows its EUR equivalent at the NBU rate for the day it landed
+  // (design-tasks-4 §6), falling back to the invoice-date rates already loaded by the page while
+  // the received-on date is missing/unparseable or its archive lookup fails.
+  const paymentCurrency = record.payment.currency || 'EUR';
+  const receivedAmountNumber = Number(String(record.payment.amount ?? '').replace(',', '.'));
+  const needsEurConversion = paymentCurrency !== 'EUR' && Number.isFinite(receivedAmountNumber) && receivedAmountNumber > 0;
+  const receivedOnYmd = parseReceivedOnYmd(record.payment.receivedOn);
+  const [receivedDateRates, setReceivedDateRates] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    setReceivedDateRates(null);
+    if (!needsEurConversion || !receivedOnYmd) return undefined;
+    fetchNbuUahExchangeRatesByDate(receivedOnYmd)
+      .then(rates => { if (!cancelled && rates) setReceivedDateRates(rates); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [needsEurConversion, receivedOnYmd]);
+  const conversionRates = receivedDateRates || exchangeRates;
+  const receivedEurAmount = needsEurConversion
+    ? convertAmountToEur(receivedAmountNumber, paymentCurrency, conversionRates)
+    : null;
+  const paymentStatus = resolveIssuedInvoicePaymentStatus(record, conversionRates);
 
   return (
     <MilestoneDetails>
@@ -1633,26 +1689,35 @@ const IssuedInvoiceCard = ({ record, onCommitPayment, onReissue }) => {
         <MilestoneSummaryLeft>
           <MilestoneNum>{record.invoiceDate}</MilestoneNum>
           <MilestoneTitleText title={`Invoice No. ${record.invoiceNumber}`}>{`Invoice No. ${record.invoiceNumber}`}</MilestoneTitleText>
-          <MilestoneCount>{record.rows.length} item{record.rows.length === 1 ? '' : 's'}</MilestoneCount>
+          <MilestoneCount>{lineRows.length} item{lineRows.length === 1 ? '' : 's'}</MilestoneCount>
         </MilestoneSummaryLeft>
         <MilestoneSummaryRight>
-          <MilestoneDue>{formatEuroPreview(record.amountDue)}</MilestoneDue>
+          <MilestoneDue style={PAYMENT_STATUS_COLORS[paymentStatus] ? { color: PAYMENT_STATUS_COLORS[paymentStatus] } : undefined}>
+            {formatEuroPreview(record.amountDue)}
+          </MilestoneDue>
           <MilestoneChevron>›</MilestoneChevron>
         </MilestoneSummaryRight>
       </MilestoneSummary>
 
       <MilestoneBody>
         <PackageChildren>
-          {record.rows.map((row, index) => (
+          {packageHeaderRow ? (
+            <LineCard>
+              <LineMainRow>
+                <ReadOnlyRowName style={{ fontWeight: 800 }} title="Programme package">{packageHeaderRow.name}</ReadOnlyRowName>
+              </LineMainRow>
+            </LineCard>
+          ) : null}
+          {lineRows.map((row, index) => (
             <LineCard key={`${record.id}-row-${index}`}>
               <LineMainRow>
                 <RowIndex>{index + 1}</RowIndex>
-                <ReadOnlyRowName>{row.name}</ReadOnlyRowName>
+                <ReadOnlyRowName>{row.kind === 'percent' ? 'Scheduled payment' : row.name}</ReadOnlyRowName>
                 <ReadOnlyRowPrice>{row.priceLabel || formatEuroPreview(row.price)}</ReadOnlyRowPrice>
               </LineMainRow>
             </LineCard>
           ))}
-          {!record.rows.length ? <PanelNote style={{ margin: '8px 0' }}>No services recorded.</PanelNote> : null}
+          {!lineRows.length && !packageHeaderRow ? <PanelNote style={{ margin: '8px 0' }}>No services recorded.</PanelNote> : null}
         </PackageChildren>
         <MilestoneCheckboxRow>
           <CustomizedTag title="Tax rate billed on this invoice">Tax: {record.taxPercent}%</CustomizedTag>
@@ -1664,7 +1729,7 @@ const IssuedInvoiceCard = ({ record, onCommitPayment, onReissue }) => {
           <AutoTextArea
             $size="12.5px"
             value={receivedDraft}
-            placeholder="Not received yet - add a date"
+            placeholder={formatInvoicePurposeDate(new Date())}
             aria-label="Payment received on"
             onFocus={() => { receivedEditingRef.current = true; }}
             onChange={event => setReceivedDraft(event.target.value)}
@@ -1699,8 +1764,15 @@ const IssuedInvoiceCard = ({ record, onCommitPayment, onReissue }) => {
             ))}
           </PlainSelect>
         </FieldRow>
+        {needsEurConversion ? (
+          <div style={{ textAlign: 'right', fontSize: '11px', color: 'var(--km-muted)', padding: '0 2px' }}>
+            {receivedEurAmount != null
+              ? `≈ ${formatEuroPreview(receivedEurAmount)} at the NBU rate`
+              : 'NBU rate unavailable for this currency/date'}
+          </div>
+        ) : null}
 
-        <div style={{ marginTop: 8 }}>
+        <div style={{ marginTop: 8, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
           <SmallButton
             type="button"
             onClick={onReissue}
@@ -1708,6 +1780,13 @@ const IssuedInvoiceCard = ({ record, onCommitPayment, onReissue }) => {
           >
             <FaSyncAlt /> Reissue invoice
           </SmallButton>
+          <DangerButton
+            type="button"
+            onClick={onDelete}
+            title="Delete this invoice from Issued Invoices"
+          >
+            <FaTrash /> Delete
+          </DangerButton>
         </div>
       </MilestoneBody>
     </MilestoneDetails>
@@ -2354,12 +2433,24 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     persistIssuedInvoices(nextIssuedInvoices, 'Payment record updated.');
   };
 
+  // Removes one entry from the Issued Invoices history (design-tasks-4 §2). Payment tracking
+  // lives on the record itself, so this drops it too - hence the confirm.
+  const deleteIssuedInvoice = record => {
+    if (typeof window !== 'undefined' && !window.confirm(`Delete invoice No. ${record.invoiceNumber} from Issued Invoices?`)) return;
+    persistIssuedInvoices(
+      data.issuedInvoices.filter(existing => String(existing.id) !== String(record.id)),
+      'Issued invoice deleted.',
+    );
+  };
+
   // The Reissue flow (design-tasks-3 §7): the issued invoice's contents move back into the active
   // editor, and whatever the editor held drops into "Recent (click to add)" - then the admin edits
   // and hits Generate PDF, which records the reissued version as a new issued invoice below.
   const reissueInvoice = record => {
     const nextRecentServices = reorderRecentServices(data.recentServices, data.invoiceServices);
-    const nextInvoiceServices = record.entries.map(cloneEntryWithNewId);
+    // Records saved while duplicate package rows could still accumulate reissue as one package,
+    // not several invisible copies (design-tasks-4 §3).
+    const nextInvoiceServices = dedupePackageEntries(record.entries).map(cloneEntryWithNewId);
     setData(current => ({ ...current, recentServices: nextRecentServices, invoiceServices: nextInvoiceServices }));
     persistPath(`${INVOICE_DATA_PATH}/recentServices`, nextRecentServices);
     persistPath(`${INVOICE_DATA_PATH}/invoiceServices`, nextInvoiceServices, 'Invoice moved back to the editor - edit and Generate PDF to reissue.');
@@ -3940,8 +4031,10 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     <IssuedInvoiceCard
                       key={record.id}
                       record={record}
+                      exchangeRates={exchangeRates}
                       onCommitPayment={(field, value) => commitIssuedInvoicePayment(record.id, field, value)}
                       onReissue={() => reissueInvoice(record)}
+                      onDelete={() => deleteIssuedInvoice(record)}
                     />
                   ))}
                   {!payerIssuedInvoices.length ? <PanelNote style={{ margin: 0 }}>No invoices issued for this payer yet.</PanelNote> : null}

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -1126,5 +1126,133 @@ describe('InvoiceBuilderPage', () => {
 
       await act(async () => { root.unmount(); });
     });
+
+    const openIssuedInvoices = async () => {
+      const revealButton = Array.from(container.querySelectorAll('[role="button"]'))
+        .find(node => node.textContent.includes('Issued invoices'));
+      await act(async () => { revealButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+    };
+
+    // design-tasks-4 §3: one package header line (duplicates collapsed), the scheduled share reads
+    // "Scheduled payment", and one-off services keep their own lines.
+    it('renders an issued invoice as package header + scheduled payment + one-off lines, deduping package rows', async () => {
+      mockInvoiceData({
+        issuedInvoices: [{
+          ...issuedInvoice,
+          rows: [
+            { name: 'IVF + ED + SM', price: 46000, kind: 'package' },
+            { name: 'IVF + ED + SM', price: 46000, kind: 'package' },
+            { name: 'IVF + ED + SM', price: 46000, kind: 'package' },
+            { name: '16000 EUR of IVF + ED + SM', price: 16000, kind: 'percent' },
+            { name: 'Deposit for medical expenses of SM', price: 300, kind: 'custom' },
+          ],
+          amountDue: 17686,
+        }],
+      });
+      const root = mount();
+      await flush();
+      await openIssuedInvoices();
+
+      // The package name appears exactly once, as an unnumbered header line.
+      expect(container.innerHTML.split('IVF + ED + SM').length - 1).toBe(1);
+      // The percent row reads "Scheduled payment", never "16000 EUR of ...".
+      expect(container.innerHTML).toContain('Scheduled payment');
+      expect(container.innerHTML).not.toContain('16000 EUR of');
+      expect(container.innerHTML).toContain('Deposit for medical expenses of SM');
+      // The summary counts the billed lines only (scheduled payment + deposit), not the header.
+      expect(container.innerHTML).toContain('2 items');
+
+      await act(async () => { root.unmount(); });
+    });
+
+    // design-tasks-4 §2: an issued invoice can be deleted from the history.
+    it('deletes an issued invoice from the history after confirmation', async () => {
+      mockInvoiceData({ issuedInvoices: [issuedInvoice] });
+      const root = mount();
+      await flush();
+      await openIssuedInvoices();
+
+      const deleteButton = Array.from(container.querySelectorAll('button'))
+        .find(btn => btn.title === 'Delete this invoice from Issued Invoices');
+      expect(deleteButton).toBeTruthy();
+      await act(async () => { deleteButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      expect(window.confirm).toHaveBeenCalled();
+      const lastIssuedCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/issuedInvoices').pop();
+      expect(lastIssuedCall[1]).toEqual([]);
+
+      await act(async () => { root.unmount(); });
+    });
+
+    // design-tasks-4 §4/§6: a non-EUR receipt shows its EUR equivalent at the NBU rate, and the
+    // header amount goes green once the (converted) amount covers the Amount Due.
+    it('shows the NBU EUR conversion for a USD receipt and colors a fully-paid invoice green', async () => {
+      mockInvoiceData({
+        issuedInvoices: [{
+          ...issuedInvoice,
+          amountDue: 18011,
+          // 20000 USD -> 20000 * 42 / 46 = 18,260.87 EUR at the mocked NBU rates - full coverage.
+          payment: { receivedOn: '', amount: '20000', currency: 'USD' },
+        }],
+      });
+      const root = mount();
+      await flush();
+      await openIssuedInvoices();
+
+      expect(container.innerHTML).toContain('18,260.87');
+      expect(container.innerHTML).toContain('at the NBU rate');
+      // #3E7C4F -> jsdom serializes inline styles as rgb().
+      expect(container.innerHTML).toContain('rgb(62, 124, 79)');
+
+      await act(async () => { root.unmount(); });
+    });
+
+    it('colors a partially-paid invoice yellow', async () => {
+      mockInvoiceData({
+        issuedInvoices: [{
+          ...issuedInvoice,
+          amountDue: 18011,
+          payment: { receivedOn: '', amount: '5000', currency: 'EUR' },
+        }],
+      });
+      const root = mount();
+      await flush();
+      await openIssuedInvoices();
+
+      // #C08A2D -> rgb(192, 138, 45); no conversion line for a EUR receipt.
+      expect(container.innerHTML).toContain('rgb(192, 138, 45)');
+      expect(container.innerHTML).not.toContain('at the NBU rate');
+
+      await act(async () => { root.unmount(); });
+    });
+
+    // design-tasks-4 §3: duplicate package entries accumulated in older data collapse on load, so
+    // a reissue puts one package back into the editor, not several invisible copies.
+    it('reissuing a record with duplicated package entries restores a single package', async () => {
+      mockInvoiceData({
+        issuedInvoices: [{
+          ...issuedInvoice,
+          entries: [
+            { id: 'dup-1', kind: 'package', catalogId: 'p1', children: [] },
+            { id: 'dup-2', kind: 'package', catalogId: 'p1', children: [] },
+            { id: 'dup-3', kind: 'percent', packageId: 'p1', percent: 25 },
+          ],
+        }],
+      });
+      const root = mount();
+      await flush();
+      await openIssuedInvoices();
+
+      await act(async () => { findButton('Reissue invoice').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+
+      const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+      expect(lastServicesCall[1].filter(entry => entry.kind === 'package')).toHaveLength(1);
+      expect(lastServicesCall[1].some(entry => entry.kind === 'percent')).toBe(true);
+
+      await act(async () => { root.unmount(); });
+    });
   });
 });

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -45,12 +45,17 @@ const PAYMENT_CAVEAT_PATTERNS = [
 const isPaymentCaveatNote = note => PAYMENT_CAVEAT_PATTERNS.some(pattern => pattern.test(note));
 
 const styles = StyleSheet.create({
-  page: pdfBaseStyles.page,
+  // Slightly tighter top padding than the multi-page documents (design-tasks-4 §7): together with
+  // the compact metrics below it buys the ~100pt that keeps a full package invoice on one page.
+  page: {
+    ...pdfBaseStyles.page,
+    paddingTop: 38,
+  },
   // Tighter than the 26pt rhythm the multi-page documents use: the Invoice's blocks (Programme
   // package, Included in this package, Payment schedule, Breakdown) are compacted so the whole
   // document fits a single page whenever the content allows (design-tasks §3).
   section: {
-    marginTop: 10,
+    marginTop: 6,
   },
   // The very first block under the title carries no preceding marginBottom of its own to offset -
   // TitleBlock's trailing margin already does that job, so stacking the full section rhythm
@@ -66,9 +71,9 @@ const styles = StyleSheet.create({
   packageBlockHeader: {
     backgroundColor: PDF_COLOR.card,
     borderRadius: 8,
-    paddingVertical: 8,
+    paddingVertical: 4,
     paddingHorizontal: 12,
-    marginBottom: 6,
+    marginBottom: 3,
   },
   packageBlockName: {
     fontFamily: PDF_FONT.display,
@@ -96,17 +101,21 @@ const styles = StyleSheet.create({
   // payment schedule, breakdown, total - on one physical page whenever possible (design-tasks §3).
   totalCard: {
     ...pdfBaseStyles.totalCard,
-    marginTop: 8,
-    paddingVertical: 10,
+    marginTop: 6,
+    paddingVertical: 7,
+  },
+  totalCardLabel: {
+    ...pdfBaseStyles.totalCardLabel,
+    marginBottom: 2,
   },
   totalCardAmount: {
     ...pdfBaseStyles.totalCardAmount,
-    fontSize: 24,
+    fontSize: 18,
   },
   totalCardRule: {
     ...pdfBaseStyles.totalCardRule,
-    marginTop: 8,
-    marginBottom: 6,
+    marginTop: 5,
+    marginBottom: 4,
   },
   noteRow: {
     flexDirection: 'row',
@@ -151,11 +160,9 @@ const PackageBlock = ({ row, showSchedule }) => {
   // column has no amount at all (its cells are inclusion marks, not money), so it gets a blank
   // header instead of reusing the schedule's "EUR" one.
   const scheduleMeta = [{ id: packageId, label: '', priceLabel: 'EUR' }];
-  const includedMeta = [{ id: packageId, label: '', priceLabel: '' }];
   const includedRows = (row.children || []).map((child, index) => ({
     id: child.id || child.key || `child-${index}`,
     name: child.name || '',
-    includedByPackageId: new Set([String(packageId)]),
   }));
   const scheduleRows = (row.scheduleRows || []).map(payment => ({
     title: payment.title || 'Payment',
@@ -177,13 +184,14 @@ const PackageBlock = ({ row, showSchedule }) => {
         <Text style={styles.packageBlockFee}>{`Cost of the package ${totalLabel}`}</Text>
       </View>
       {fullDetailNote ? <Text style={styles.sectionNote}>{sanitizePdfText(fullDetailNote)}</Text> : null}
+      {/* Compact two-per-row layout (design-tasks-4 §7) - shared with Expected Expenses'
+          "Included in this programme" so the single-programme documents stay identical. */}
       <IncludedServicesTable
-        packages={includedMeta}
+        compact
         includedRows={includedRows}
         title="Included in this package"
         note={null}
         sectionStyle={styles.section}
-        dense
       />
       {showSchedule ? (
         <PaymentScheduleTable
@@ -271,12 +279,12 @@ const InvoicePdfDocument = ({
         <BronzeMotif />
         <ContinuedTag label={docLabel} />
         <BrandRow metaLines={[`Invoice No. ${invoiceNumber || ''}`, dateLabel, caseTitle]} />
-        <BrandRule />
+        <BrandRule style={{ marginBottom: 10 }} />
         <TitleBlock
           eyebrow={eyebrow}
           title={`Invoice No. ${invoiceNumber || ''}`}
           subtitle={`Prepared exclusively for ${payerName}${payerLocation ? ` · ${payerLocation}` : ''}.`}
-          style={{ marginBottom: 14 }}
+          style={{ marginBottom: 4 }}
         />
 
         {isPackageInvoice ? (
@@ -310,7 +318,7 @@ const InvoicePdfDocument = ({
           {/* wrap={false}: the card either fits under the breakdown or moves to the next page
               whole - it must never split its amount from its subtotal/tax rows. */}
           <View style={styles.totalCard} wrap={false}>
-            <Text style={pdfBaseStyles.totalCardLabel}>Amount due</Text>
+            <Text style={styles.totalCardLabel}>Amount due</Text>
             <Text style={styles.totalCardAmount}>{formatMoney(amountDue)}</Text>
             <View style={styles.totalCardRule} />
             <View style={pdfBaseStyles.totalCardRow}>

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -102,6 +102,23 @@ const normalizePayerCases = raw => {
   return { payerCases, payerCaseIds };
 };
 
+// A catalog-backed package may appear at most once on an invoice (the Builder only ever surfaces
+// the first package row, and the PDF caps catalog packages at one) - but data saved before that
+// restructure could carry the same package several times, each copy invisible and uneditable.
+// Duplicates are dropped on load so they can't leak into issued-invoice snapshots (design-tasks-4
+// §3). Only same-catalog package copies are deduped: 'percent' rows legitimately repeat (two equal
+// installments), and custom packages are distinct by construction.
+export const dedupePackageEntries = entries => {
+  const seenPackageIds = new Set();
+  return (Array.isArray(entries) ? entries : []).filter(entry => {
+    if (entry?.kind !== 'package' || !entry.catalogId) return true;
+    const key = String(entry.catalogId);
+    if (seenPackageIds.has(key)) return false;
+    seenPackageIds.add(key);
+    return true;
+  });
+};
+
 export const normalizeInvoiceData = raw => {
   const { payerCases, payerCaseIds } = normalizePayerCases(raw);
   const activeCase = payerCases.find(payerCase => String(payerCase.id) === String(payerCaseIds[0])) || payerCases[0];
@@ -112,7 +129,7 @@ export const normalizeInvoiceData = raw => {
     payerCaseIds,
     customers: activeCase?.customers || [],
     recentServices: normalizeServiceEntries(raw?.recentServices),
-    invoiceServices: normalizeServiceEntries(raw?.invoiceServices),
+    invoiceServices: dedupePackageEntries(normalizeServiceEntries(raw?.invoiceServices)),
     // Which optional components the generated Invoice PDF includes (round7 spec C.1) - each is
     // independently toggled, editable in the Builder while on, and takes no space in the PDF (or
     // the Builder's own editing area) while off. Defaults to "on" so an admin who never touches
@@ -180,6 +197,47 @@ export const makeIssuedInvoiceRecord = ({
 } = {}) => normalizeIssuedInvoice({
   id: createEntryId(), payerCaseId, invoiceNumber, invoiceDate, rows, entries, taxPercent, debtOrDeposit, amountDue,
 });
+
+// "30.01.2026" (the format the Payment Received field suggests) or "2026-01-30" -> "2026-01-30",
+// so the NBU archive rates for the day the payment landed can be looked up. Anything else
+// (free text, a partial date) resolves to '' - callers fall back to the invoice-date rates.
+export const parseReceivedOnYmd = raw => {
+  const text = String(raw ?? '').trim();
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(text);
+  if (isoMatch) return text;
+  const dottedMatch = /^(\d{1,2})[./](\d{1,2})[./](\d{4})$/.exec(text);
+  if (dottedMatch) return `${dottedMatch[3]}-${pad2(dottedMatch[2])}-${pad2(dottedMatch[1])}`;
+  return '';
+};
+
+// Converts a received amount to EUR through the NBU UAH cross-rates ({ usd, eur } = UAH per unit,
+// the same shape fetchNbuUahExchangeRatesByDate returns and formula pricing already consumes).
+// Returns null when the rates don't cover the currency (e.g. GBP) or haven't loaded.
+export const convertAmountToEur = (amount, currency, rates) => {
+  const numeric = Number(String(amount ?? '').replace(',', '.'));
+  if (!Number.isFinite(numeric)) return null;
+  const code = String(currency || 'EUR').trim().toUpperCase();
+  if (code === 'EUR') return roundMoney(numeric);
+  const eurToUah = Number(rates?.eur);
+  if (!Number.isFinite(eurToUah) || eurToUah <= 0) return null;
+  if (code === 'UAH') return roundMoney(numeric / eurToUah);
+  const currencyToUah = Number(rates?.[code.toLowerCase()]);
+  if (!Number.isFinite(currencyToUah) || currencyToUah <= 0) return null;
+  return roundMoney((numeric * currencyToUah) / eurToUah);
+};
+
+// Payment-status color coding for an issued invoice's header amount (design-tasks-4 §4):
+// 'full' once the received amount covers the Amount Due, 'partial' while something (but not
+// everything) has landed, 'none' otherwise. A non-EUR receipt is compared through its EUR
+// equivalent; if the rates can't resolve it, any positive amount reads as 'partial' - never
+// 'full' on an unverifiable figure.
+export const resolveIssuedInvoicePaymentStatus = (record, rates) => {
+  const numeric = Number(String(record?.payment?.amount ?? '').replace(',', '.'));
+  if (!Number.isFinite(numeric) || numeric <= 0) return 'none';
+  const eurAmount = convertAmountToEur(numeric, record?.payment?.currency, rates);
+  if (eurAmount != null && eurAmount >= (Number(record?.amountDue) || 0) - 0.01) return 'full';
+  return 'partial';
+};
 
 export const isInvoiceDataShape = raw => {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -409,8 +409,9 @@ const ruleStyles = StyleSheet.create({
 
 // Thin rule with a bronze diamond marker — the required brand motif under the wordmark
 // on every branded document (all types except Payment Instructions, per spec §1.1/§1.5).
-export const BrandRule = () => (
-  <View style={ruleStyles.wrap}>
+// `style` lets a space-constrained document (the one-page Invoice) tighten the trailing margin.
+export const BrandRule = ({ style } = {}) => (
+  <View style={style ? [ruleStyles.wrap, style] : ruleStyles.wrap}>
     <View style={ruleStyles.line} />
     <View style={ruleStyles.diamond} />
     <View style={ruleStyles.line} />


### PR DESCRIPTION
- Payment Received empty state now shows a plain date-format placeholder
  (today's date as DD.MM.YYYY) instead of a descriptive sentence.
- Issued Invoices entries can be deleted (confirm-guarded Delete button).
- An issued invoice's item list renders the package name once as a header
  line (legacy duplicate package rows collapse), the scheduled share as a
  "Scheduled payment" line, and one-off services below; duplicate catalog
  package entries are also deduped on load and on Reissue.
- The issued-invoice header amount is color-coded: green when the received
  amount covers the Amount Due, yellow when only partially received.
- Amount/price inputs across the Builder hug their content (min ~3 digits,
  growing fluidly) via field-sizing, with the old fixed widths as fallback.
- Non-EUR Payment Received shows its EUR equivalent at the NBU rate for the
  received-on date (falling back to the invoice-date rates already loaded).
- "Included in this package/programme" redesigned as a compact two-per-row
  table shared by the package Invoice and Expected Expenses, plus tightened
  invoice metrics, so a full package invoice fits on one page.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LfraJq6N14fsu6pAiR3GyX