### PR TITLE
Fix document paste persistence for generated IDs

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -32,6 +32,7 @@ import {
   orderCasesByRecent,
   parseDocumentsTechnicalInput,
   resolveCaseContext,
+  resolveMergedRecordsForPersistence,
   upsertRecentCaseId,
 } from './documentsCatalogUtils';
 
@@ -486,15 +487,16 @@ const DocumentsPage = ({ isAdmin }) => {
       // so concurrent edits to other records on the backend are never clobbered.
       const partiesPatch = {};
       PARTY_COLLECTIONS.forEach(collection => {
-        incoming.parties[collection].forEach(record => {
-          const mergedRecord = merged.parties[collection].find(item => String(item.id) === String(record.id))
-            || record;
+        resolveMergedRecordsForPersistence(
+          catalog.parties[collection],
+          merged.parties[collection],
+          incoming.parties[collection],
+        ).forEach(mergedRecord => {
           partiesPatch[`${collection}/${mergedRecord.id}`] = mergedRecord;
         });
       });
       const templatesPatch = {};
-      incoming.documents.forEach(record => {
-        const mergedRecord = merged.documents.find(item => String(item.id) === String(record.id)) || record;
+      resolveMergedRecordsForPersistence(catalog.documents, merged.documents, incoming.documents).forEach(mergedRecord => {
         templatesPatch[mergedRecord.id] = mergedRecord;
       });
       if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -114,6 +114,26 @@ const mergeCollection = (existing, incoming, idPrefix, summary) => {
   return merged;
 };
 
+
+export const resolveMergedRecordsForPersistence = (currentRecords, mergedRecords, incomingRecords) => {
+  const existingIds = new Set((currentRecords || []).map(record => String(record?.id)));
+  const usedMergedIndexes = new Set();
+
+  return (incomingRecords || []).map(incomingRecord => {
+    const hasIncomingId = Boolean(incomingRecord?.id);
+    const incomingId = String(incomingRecord?.id);
+    const mergedIndex = (mergedRecords || []).findIndex((mergedRecord, index) => {
+      if (usedMergedIndexes.has(index)) return false;
+      if (hasIncomingId) return String(mergedRecord?.id) === incomingId;
+      return mergedRecord?.id && !existingIds.has(String(mergedRecord.id));
+    });
+
+    if (mergedIndex === -1) return incomingRecord;
+    usedMergedIndexes.add(mergedIndex);
+    return mergedRecords[mergedIndex];
+  });
+};
+
 // Never destructive: existing records survive untouched unless the incoming payload updates them
 // by id, and even then only field-by-field (see deepMergeRecords).
 export const mergeDocumentsCatalog = (current, incoming) => {

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -13,6 +13,7 @@ import {
   orderCasesByRecent,
   parseDocumentsTechnicalInput,
   resolveCaseContext,
+  resolveMergedRecordsForPersistence,
   upsertRecentCaseId,
 } from './documentsCatalogUtils';
 
@@ -147,6 +148,31 @@ describe('mergeDocumentsCatalog', () => {
       '{"documents":[{"title":{"uk":"Без id","en":"No id"}}]}',
     ));
     expect(catalog.documents[0].id).toMatch(/^document-/);
+  });
+
+  it('resolves generated ids when building additive persistence patches', () => {
+    const current = sampleCatalog();
+    const incoming = parseDocumentsTechnicalInput(JSON.stringify({
+      data: { clinics: [{ name: { en: 'Generated Clinic' } }] },
+      documents: [{ title: { uk: 'Без id', en: 'No id' } }],
+    }));
+    const { catalog } = mergeDocumentsCatalog(current, incoming);
+
+    const [clinicPatchRecord] = resolveMergedRecordsForPersistence(
+      current.parties.clinics,
+      catalog.parties.clinics,
+      incoming.parties.clinics,
+    );
+    const [templatePatchRecord] = resolveMergedRecordsForPersistence(
+      current.documents,
+      catalog.documents,
+      incoming.documents,
+    );
+
+    expect(clinicPatchRecord.id).toMatch(/^clinic-/);
+    expect(clinicPatchRecord.name.en).toBe('Generated Clinic');
+    expect(templatePatchRecord.id).toMatch(/^document-/);
+    expect(templatePatchRecord.title.en).toBe('No id');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Pasted party or template records without an `id` received generated IDs during merge, but the persistence step looked up records by the raw pasted `id` and sometimes wrote them under `undefined`, causing collisions after reload. 
- The goal is to ensure additive persistence writes records under the merged/generated backend keys so pasted records without an `id` are stored reliably. 

### Description
- Added `resolveMergedRecordsForPersistence` in `src/components/documentsCatalogUtils.js` to map incoming pasted records to their corresponding merged records, including those that received generated IDs. 
- Updated `src/components/DocumentsPage.jsx` to import and use `resolveMergedRecordsForPersistence` when building `partiesPatch` and `templatesPatch` so patches use the merged/generated `id` keys. 
- Added a regression test in `src/components/documentsCatalogUtils.test.js` to verify generated clinic and document IDs are resolved for persistence patches. 

### Testing
- Ran `npm test -- --runTestsByPath src/components/documentsCatalogUtils.test.js --watchAll=false`, and the suite passed successfully (1 test suite, 21 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a572da0529c8326a7e648501b64967d)