### PR TITLE
Fix mobile admin page navigation dropdown

### DIFF
--- a/src/components/PageNavMenu.jsx
+++ b/src/components/PageNavMenu.jsx
@@ -41,12 +41,19 @@ const Dropdown = styled.div`
   top: calc(100% + 4px);
   right: 0;
   min-width: 150px;
+  max-width: calc(100vw - 24px);
+  overflow: visible;
   background: var(--km-card, #fff);
   border: 1px solid var(--km-border, #d9d2c2);
   border-radius: 8px;
   box-shadow: 0 8px 22px rgba(43, 38, 32, 0.14);
   padding: 4px;
-  z-index: 40;
+  z-index: 1000;
+
+  @media (max-width: 560px) {
+    left: 0;
+    right: auto;
+  }
 `;
 
 const MenuItem = styled.button`


### PR DESCRIPTION
### Motivation
- The page navigation dropdown could extend off-screen or be clipped on narrow viewports when the header actions wrap, causing the modal/dropdown to appear in the top-left and be partially hidden.

### Description
- Update `src/components/PageNavMenu.jsx` to constrain the dropdown to the viewport (`max-width: calc(100vw - 24px)`), allow visible overflow, raise stacking (`z-index: 1000`) and anchor the menu to the left on small screens (`@media (max-width: 560px) { left: 0; right: auto; }`).

### Testing
- Ran `npm test -- --watchAll=false src/components/InvoiceBuilderPage.test.js --runInBand` and the suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a572df9969c8326a7dc9adbf379feb4)