### PR TITLE
Upload clinic logo to Firebase Storage and persist `storageUrl` in settings

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -11,7 +11,7 @@ import { get, ref, set, update } from 'firebase/database';
 import { FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
-import { auth, database } from './config';
+import { auth, database, getUrlofUploadedAvatar } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
 import {
@@ -621,15 +621,31 @@ const DocumentsPage = ({ isAdmin }) => {
       const dataUrl = String(reader.result || '');
       const image = new window.Image();
       image.onload = async () => {
-        const saved = await persistSettings({
-          clinicLogo: {
-            dataUrl,
-            width: image.naturalWidth || 0,
-            height: image.naturalHeight || 0,
-            name: file.name,
-          },
-        });
-        if (saved) toast.success('Clinic logo uploaded to the backend.');
+        const userId = auth.currentUser?.uid;
+        if (!userId) {
+          toast.error('Sign in before uploading the clinic logo.');
+          return;
+        }
+
+        try {
+          const storageUrl = await getUrlofUploadedAvatar(file, userId, {
+            disableCompression: true,
+            rootFolder: 'documentsBuilder',
+          });
+          const saved = await persistSettings({
+            clinicLogo: {
+              dataUrl,
+              storageUrl,
+              width: image.naturalWidth || 0,
+              height: image.naturalHeight || 0,
+              name: file.name,
+            },
+          });
+          if (saved) toast.success('Clinic logo uploaded to the backend.');
+        } catch (uploadError) {
+          console.error('Unable to upload clinic logo', uploadError);
+          toast.error('Could not upload the logo to the backend.');
+        }
       };
       image.onerror = () => toast.error('Could not read the image file.');
       image.src = dataUrl;

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -289,15 +289,25 @@ const generateUploadFileId = () => {
   return `${Date.now()}-${randomSuffix}`;
 };
 
+const getUploadFileExtension = file => {
+  const originalExtension = String(file?.name || '').split('.').pop();
+  if (originalExtension && originalExtension !== file?.name) {
+    return originalExtension.replace(/[^a-z0-9]/gi, '').toLowerCase() || 'jpg';
+  }
+
+  const mimeExtension = String(file?.type || '').split('/').pop();
+  return mimeExtension ? mimeExtension.replace(/[^a-z0-9]/gi, '').toLowerCase() : 'jpg';
+};
+
 export const getUrlofUploadedAvatar = async (photo, userId, options = {}) => {
-  const { disableCompression = false, maxSizeKB = 1024 } = options;
+  const { disableCompression = false, maxSizeKB = 1024, rootFolder = 'avatar' } = options;
   const file = shouldKeepOriginalUpload(photo, disableCompression, maxSizeKB)
     ? photo
     : await getFileBlob(await compressPhoto(photo, maxSizeKB));
 
   const uniqueId = generateUploadFileId(); // генеруємо унікальне ім"я для фото
-  const fileName = `${uniqueId}.jpg`; // Використовуємо унікальне ім'я для файлу
-  const pathSegments = ['avatar', userId];
+  const fileName = `${uniqueId}.${getUploadFileExtension(file)}`; // Використовуємо унікальне ім'я для файлу
+  const pathSegments = [rootFolder, userId];
   if (options?.subfolder) {
     pathSegments.push(options.subfolder);
   }

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -344,6 +344,7 @@ export const normalizeDocumentsSettings = raw => {
   const logo = isPlainObject(source.clinicLogo) && typeof source.clinicLogo.dataUrl === 'string' && source.clinicLogo.dataUrl.startsWith('data:image/')
     ? {
       dataUrl: source.clinicLogo.dataUrl,
+      storageUrl: typeof source.clinicLogo.storageUrl === 'string' ? source.clinicLogo.storageUrl : '',
       width: clampNumber(source.clinicLogo.width, 1, 10000, 0) || 0,
       height: clampNumber(source.clinicLogo.height, 1, 10000, 0) || 0,
       name: String(source.clinicLogo.name || ''),


### PR DESCRIPTION
### Motivation
- Allow clinic logos to be uploaded to Firebase Storage instead of only storing data URLs in the backend settings to support larger/reusable assets and serve them directly.
- Preserve original file extensions and allow configurable storage folder paths for uploaded images.

### Description
- Replaced direct settings persistence of logo data with a storage upload flow by calling `getUrlofUploadedAvatar` from `DocumentsPage.jsx` and persisting `storageUrl` plus existing `dataUrl` and metadata.
- Extended `getUrlofUploadedAvatar` in `config.js` to accept `rootFolder`, to preserve the uploaded file extension via `getUploadFileExtension`, and to build file paths using the configurable `rootFolder` and optional `subfolder`.
- Updated `normalizeDocumentsSettings` in `documentsCatalogUtils.js` to include a `storageUrl` string on the normalized `clinicLogo` when present.
- Added sign-in check and error handling around the logo upload in `DocumentsPage.jsx` and kept existing image size/type validation and compression logic.

### Testing
- Ran the existing automated unit test suite and linting checks for the repository; they completed without failures.
- Exercised the logo upload flow in automated component tests that cover `getUrlofUploadedAvatar` behavior; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57372c0ad88326ab55bc224f86fa40)