### PR TITLE
Improve clinic logo loading/preview, invoice package handling, amount parsing, and PDF amount formatting

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -407,6 +407,7 @@ const DocumentsPage = ({ isAdmin }) => {
   const [error, setError] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [clinicLogoPreview, setClinicLogoPreview] = useState(null);
+  const [clinicLogoLoading, setClinicLogoLoading] = useState(false);
   const logoInputRef = useRef(null);
   // Mirror of `settings` that persistSettings can read synchronously: two quick successive
   // saves (e.g. logo upload + favourite formatting) must each build on the other's result, and
@@ -669,6 +670,20 @@ const DocumentsPage = ({ isAdmin }) => {
     reader.readAsDataURL(file);
   };
 
+  const readImageDimensions = useCallback(dataUrl => new Promise(resolve => {
+    if (typeof window === 'undefined' || !dataUrl) {
+      resolve({ width: 0, height: 0 });
+      return;
+    }
+    const image = new window.Image();
+    image.onload = () => resolve({
+      width: image.naturalWidth || 0,
+      height: image.naturalHeight || 0,
+    });
+    image.onerror = () => resolve({ width: 0, height: 0 });
+    image.src = dataUrl;
+  }), []);
+
   const handleRemoveLogo = async () => {
     if (typeof window !== 'undefined' && !window.confirm('Remove the clinic logo from the backend?')) return;
     const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
@@ -722,33 +737,42 @@ const DocumentsPage = ({ isAdmin }) => {
   const selectedTemplates = catalog.documents.filter(template => selectedDocIds[template.id]);
   const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
   const selectedClinic = catalog.parties.clinics.find(item => String(item.id) === String(selectedCase?.clinicId || '')) || null;
-  const isGenerateDisabled = loading || Boolean(error) || isGenerating || !selectedTemplates.length || !selectedCase;
+  const isGenerateDisabled = loading || Boolean(error) || isGenerating || clinicLogoLoading || !selectedTemplates.length || !selectedCase;
 
   useEffect(() => {
     let cancelled = false;
     const logoNames = Array.isArray(selectedClinic?.logo) ? selectedClinic.logo.filter(Boolean).map(String) : [];
     const fileName = logoNames[logoNames.length - 1] || '';
+    setClinicLogoPreview(null);
     if (!selectedClinic?.id || !fileName) {
-      setClinicLogoPreview(null);
+      setClinicLogoLoading(false);
       return () => {
         cancelled = true;
       };
     }
 
+    setClinicLogoLoading(true);
     const filePath = `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${selectedClinic.id}/logo/${fileName}`;
     getStorageFileDataUrl(filePath)
-      .then(dataUrl => {
-        if (!cancelled) setClinicLogoPreview(dataUrl ? { dataUrl, name: fileName, width: 0, height: 0 } : null);
+      .then(async dataUrl => {
+        const dimensions = dataUrl ? await readImageDimensions(dataUrl) : { width: 0, height: 0 };
+        if (!cancelled) {
+          setClinicLogoPreview(dataUrl ? { dataUrl, name: fileName, ...dimensions } : null);
+          setClinicLogoLoading(false);
+        }
       })
       .catch(loadLogoError => {
         console.error('Unable to load clinic logo from Storage', loadLogoError);
-        if (!cancelled) setClinicLogoPreview(null);
+        if (!cancelled) {
+          setClinicLogoPreview(null);
+          setClinicLogoLoading(false);
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [selectedClinic]);
+  }, [readImageDimensions, selectedClinic]);
 
   const prepareGeneration = () => {
     const context = resolveCaseContext(catalog, selectedCaseId);

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -2525,7 +2525,16 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   // different catalog programme in place - the fresh entry drops any per-invoice customisation of
   // the old one, exactly like removing the package and adding the new one, but in a single step.
   const replacePackageEntry = pkg => {
-    const next = data.invoiceServices.map(entry => (entry.kind === 'package' ? makeCatalogPackageEntry(pkg) : entry));
+    const currentPackageEntry = data.invoiceServices.find(entry => entry.kind === 'package');
+    const oldPackageId = currentPackageEntry?.catalogId;
+    const newPackageId = String(pkg?.id ?? '');
+    const next = data.invoiceServices.map(entry => {
+      if (entry.kind === 'package') return makeCatalogPackageEntry(pkg);
+      if (entry.kind === 'percent' && oldPackageId && String(entry.packageId) === String(oldPackageId)) {
+        return { ...entry, packageId: newPackageId };
+      }
+      return entry;
+    });
     persistInvoiceServices(next, 'Package switched.');
   };
 
@@ -2559,7 +2568,13 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
     const existingPercentRows = data.invoiceServices.filter(
       entry => entry.kind === 'percent' && String(entry.packageId) === String(packageId),
     );
-    const usedPercentTotal = existingPercentRows.reduce((sum, entry) => sum + (Number(entry.percent) || 0), 0);
+    const getEntrySharePercent = entry => {
+      if (entry.amount != null && listedPriceAmount) {
+        return Math.round(((Number(entry.amount) || 0) / listedPriceAmount) * 1e6) / 1e4;
+      }
+      return Number(entry.percent) || 0;
+    };
+    const usedPercentTotal = existingPercentRows.reduce((sum, entry) => sum + getEntrySharePercent(entry), 0);
     const nextPayment = schedule?.payments?.[existingPercentRows.length];
     const nextPaymentAmount = nextPayment ? resolvePaymentAmount(nextPayment, listedPriceAmount) : null;
     const defaultPercent = (nextPaymentAmount != null && listedPriceAmount)
@@ -2679,15 +2694,21 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
 
   // The first edit "materializes" whatever schedule is currently showing (live from the catalog, or
   // an existing override) into a fresh per-invoice override, then applies the one field edit on top.
-  // The amount field accepts a percent too (design-tasks §1: "25" -> 25% of the package's billed
-  // price, "10000" -> 10,000 EUR) - a percent is resolved to euros against the package price once,
+  // The amount field remains EUR-first: bare values and explicit EUR values are stored as fixed
+  // amounts, while an explicit percent (for example "25%") is resolved against the package price once,
   // at commit time, since a schedule override stores plain euro amounts.
   const updateScheduleRow = (rowIndex, field, value) => {
     if (!packageRow) return;
     const resolveAmount = raw => {
-      const { percent, amount } = parsePercentOrAmountInput(raw);
-      if (amount != null) return amount;
-      return roundToCents(((Number(packageRow.price) || 0) * percent) / 100) || 0;
+      const text = String(raw ?? '').trim();
+      if (/%/.test(text)) {
+        const { percent } = parsePercentOrAmountInput(text);
+        return roundToCents(((Number(packageRow.price) || 0) * percent) / 100) || 0;
+      }
+      const normalized = text.replace(/€|eur/gi, '').replace(/\s+/g, '');
+      const numericText = /,\d{3}(?:\D|$)/.test(normalized) ? normalized.replace(/,/g, '') : normalized.replace(',', '.');
+      const amount = Number(numericText);
+      return Number.isFinite(amount) ? amount : 0;
     };
     const rows = packageRow.scheduleRows.map((row, index) => (index === rowIndex
       ? { ...row, [field]: field === 'amount' ? resolveAmount(value) : value }

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -141,10 +141,20 @@ const styles = StyleSheet.create({
 // one-style breakdown line as every other row - without repeating the underlying percentage/
 // package wording in the PDF (design-tasks §3). Amounts stay bare numbers (or a free-text label
 // like "GIFT"): the table's own EUR column header already carries the currency.
+const formatBareAmount = value => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return '-';
+  const rounded = Math.round(amount * 100) / 100;
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: Number.isInteger(rounded) ? 0 : 2,
+    maximumFractionDigits: Number.isInteger(rounded) ? 0 : 2,
+  }).format(rounded);
+};
+
 const buildBreakdownTableRow = row => ({
   title: row.kind === 'percent' ? 'Scheduled payment' : (row.name || ''),
   description: row.description || '',
-  amounts: [row.priceLabel ? row.priceLabel : row.price],
+  amounts: [row.priceLabel ? row.priceLabel : formatBareAmount(row.price)],
 });
 
 // The "Package block" (round7 spec C): a compact name/fee header, then the package's full


### PR DESCRIPTION
### Motivation
- Prevent document generation while a clinic logo is still loading and capture logo image dimensions for accurate previews.
- Ensure package replacement preserves package-linked percent rows and that percent accounting includes rows stored as fixed amounts.
- Improve parsing of user-entered currency/percent schedule amounts and present bare amounts consistently in PDF breakdowns.

### Description
- Added `clinicLogoLoading` state and included it in `isGenerateDisabled` to block PDF generation until logo load completes, plus logic to set/clear the flag during logo fetches.
- Introduced `readImageDimensions` to compute image natural width/height from a data URL and populate `clinicLogoPreview` with dimensions and filename.
- Updated clinic logo load effect to reset preview when clinic changes, read dimensions asynchronously, and handle error cases by clearing loading state.
- Modified package replacement to update `packageId` on any `percent` entries that referenced the old package when switching to a new package.
- Adjusted percent-row accounting so existing percent rows contribute their share either from an explicit `percent` or by deriving percent from a fixed `amount` against the package price.
- Reworked `updateScheduleRow` amount parsing to treat explicit `%` as percent, otherwise normalize currency-style text (handle `€`, `eur`, commas, spaces) into a numeric EUR amount.
- Added `formatBareAmount` helper and used it in the invoice PDF `buildBreakdownTableRow` so bare numeric amounts are formatted consistently (omit decimals for integer euros, show two decimals otherwise).

### Testing
- Ran unit tests with `npm test` and the test suite completed successfully.
- Ran linting with `npm run lint` and no new lint errors were reported.
- Built the production bundle with `npm run build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5784b867f88326a0b0b9dc6ead9293)