### PR TITLE
Documents Builder batch 6: layout modes, pencil edit, logo variants

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaPencilAlt, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, getStorageFileDataUrl, uploadFileToStorageFolder } from './config';
@@ -24,6 +24,9 @@ import {
   buildCaseLabel,
   buildDocumentsFileName,
   buildGeneratedDocument,
+  clinicLogoDbPath,
+  clinicLogoStorageFilePath,
+  clinicLogoStorageFolder,
   emptyDocumentsCatalog,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
@@ -31,6 +34,8 @@ import {
   normalizeDocumentsSettings,
   orderCasesByRecent,
   parseDocumentsTechnicalInput,
+  pickLogoVariantForLayout,
+  pruneDocOverride,
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
   upsertRecentCaseId,
@@ -205,17 +210,30 @@ const RowLine = styled.div`
   flex-wrap: wrap;
 `;
 
+// Plain-text convention (spec §3): every input on this page reads as editable text - borderless
+// and background-free until hovered or focused, like the app's other inline-editable fields.
 const Select = styled.select`
   flex: 1;
   min-width: 200px;
-  border: 1px solid var(--km-border);
-  background: var(--km-card);
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--km-text);
   border-radius: 6px;
   min-height: 30px;
   padding: 4px 8px;
   font-size: 12.5px;
   font-family: var(--km-font);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--km-border);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--km-accent);
+    background: var(--km-card);
+  }
 `;
 
 const ToggleGroup = styled.div`
@@ -305,11 +323,19 @@ const InlineTextarea = styled.textarea`
   }
 `;
 
+// In the two-column layout each UA paragraph is boxed together with its EN counterpart (spec §4)
+// so the pairing stays visible; one-column layouts render a single unboxed cell.
 const ParagraphPair = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: ${({ $single }) => ($single ? '1fr' : '1fr 1fr')};
   gap: 6px;
   margin-top: 6px;
+  ${({ $single }) => ($single ? '' : `
+    border: 1px solid var(--km-border);
+    border-radius: 8px;
+    padding: 4px 6px;
+    background: rgba(162, 121, 63, 0.04);
+  `)}
 
   @media (max-width: 560px) {
     grid-template-columns: 1fr;
@@ -333,8 +359,8 @@ const Field = styled.label`
 `;
 
 const FieldInput = styled.input`
-  border: 1px solid var(--km-border);
-  background: var(--km-card);
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--km-text);
   border-radius: 6px;
   min-height: 28px;
@@ -342,9 +368,14 @@ const FieldInput = styled.input`
   font-size: 12px;
   font-family: var(--km-font);
 
+  &:hover {
+    border-color: var(--km-border);
+  }
+
   &:focus {
     outline: none;
     border-color: var(--km-accent);
+    background: var(--km-card);
   }
 `;
 
@@ -367,12 +398,28 @@ const LogoPreview = styled.img`
   background: #fff;
 `;
 
+const LogoVariant = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+`;
+
+const LogoVariantCaption = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--km-muted);
+  font-size: 10px;
+  font-weight: 700;
+`;
+
 const TechnicalTextarea = styled.textarea`
   width: 100%;
   min-height: 110px;
-  border: 1px solid var(--km-border);
+  border: 1px solid transparent;
   border-radius: 8px;
-  background: var(--km-card);
+  background: transparent;
   color: var(--km-text);
   font-family: monospace;
   font-size: 11.5px;
@@ -380,9 +427,14 @@ const TechnicalTextarea = styled.textarea`
   margin-top: 8px;
   resize: vertical;
 
+  &:hover {
+    border-color: var(--km-border);
+  }
+
   &:focus {
     outline: none;
     border-color: var(--km-accent);
+    background: var(--km-card);
   }
 `;
 
@@ -399,14 +451,19 @@ const DocumentsPage = ({ isAdmin }) => {
   const [selectedDocIds, setSelectedDocIds] = useState({});
   const [layout, setLayout] = useState('two-column');
   const [expandedDocId, setExpandedDocId] = useState('');
+  // Pencil toggle (spec §2): 'data' shows the resolved values and edits them as per-case
+  // overrides, 'template' shows the raw {{placeholder}} tokens and edits the shared template.
+  const [editMode, setEditMode] = useState('data');
   const [dirtyDocIds, setDirtyDocIds] = useState({});
+  const [dirtyOverrideDocIds, setDirtyOverrideDocIds] = useState({});
   const [technicalInput, setTechnicalInput] = useState('');
   const [isApplyingTechnical, setIsApplyingTechnical] = useState(false);
   const [formattingOpen, setFormattingOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
-  const [clinicLogoPreview, setClinicLogoPreview] = useState(null);
+  // Every uploaded logo variant of the selected clinic: { fileName, dataUrl, width, height }.
+  const [clinicLogos, setClinicLogos] = useState([]);
   const [clinicLogoLoading, setClinicLogoLoading] = useState(false);
   const logoInputRef = useRef(null);
   // Mirror of `settings` that persistSettings can read synchronously: two quick successive
@@ -558,6 +615,68 @@ const DocumentsPage = ({ isAdmin }) => {
     }
   };
 
+  // --- Data-mode editing (pencil "Data" mode, spec §2) ------------------------------------------
+  // Edits to the resolved text are kept per case as sparse overrides (case.docOverrides[docId])
+  // so the shared template with its {{tokens}} stays untouched.
+
+  const updateCaseDocOverride = (docId, updater) => {
+    if (!selectedCaseId) return;
+    setCatalog(previous => ({
+      ...previous,
+      parties: {
+        ...previous.parties,
+        cases: previous.parties.cases.map(caseRecord => (String(caseRecord.id) === selectedCaseId
+          ? {
+            ...caseRecord,
+            docOverrides: {
+              ...(caseRecord.docOverrides || {}),
+              [docId]: updater(caseRecord.docOverrides?.[docId] || {}),
+            },
+          }
+          : caseRecord)),
+      },
+    }));
+    setDirtyOverrideDocIds(previous => ({ ...previous, [docId]: true }));
+  };
+
+  const handleDataTitleChange = (docId, langKey, value) => {
+    updateCaseDocOverride(docId, override => ({
+      ...override,
+      title: { ...(override.title || {}), [langKey]: value },
+    }));
+  };
+
+  const handleDataParagraphChange = (docId, index, langKey, value) => {
+    updateCaseDocOverride(docId, override => ({
+      ...override,
+      paragraphs: {
+        ...(override.paragraphs || {}),
+        [index]: { ...(override.paragraphs?.[index] || {}), [langKey]: value },
+      },
+    }));
+  };
+
+  const persistDocOverride = async docId => {
+    if (!dirtyOverrideDocIds[docId] || !selectedCaseId) return;
+    const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId);
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!caseRecord || !template) return;
+    // Only real deviations from the resolved template survive on the backend.
+    const baseline = buildGeneratedDocument(template, resolveCaseContext(catalog, selectedCaseId));
+    const pruned = pruneDocOverride(caseRecord.docOverrides?.[docId], baseline);
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/docOverrides/${docId}`), pruned);
+      setDirtyOverrideDocIds(previous => {
+        const next = { ...previous };
+        delete next[docId];
+        return next;
+      });
+    } catch (saveError) {
+      console.error('Unable to save document data edits', saveError);
+      toast.error('Could not save the data edits.');
+    }
+  };
+
   // --- Deletes (always behind an explicit confirmation) ----------------------------------------
 
   const handleDeleteTemplate = async template => {
@@ -636,31 +755,40 @@ const DocumentsPage = ({ isAdmin }) => {
         }
 
         try {
-          const folderPath = `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
-          const { fileName } = await uploadFileToStorageFolder(file, folderPath, {
+          // Filename-based storage (spec §5): the image goes into the clinic's Storage logo
+          // folder, and only its file name is appended to the same-shaped Realtime Database node.
+          const { fileName } = await uploadFileToStorageFolder(file, clinicLogoStorageFolder(clinicId), {
             disableCompression: true,
           });
-          const nextLogoNames = [...(Array.isArray(selectedClinic?.logo) ? selectedClinic.logo : []), fileName];
-          await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/clinics/${clinicId}/logo`), nextLogoNames);
+          const nextLogoNames = [...(catalog.clinicLogos[clinicId] || []), fileName];
+          await set(ref(database, clinicLogoDbPath(clinicId)), nextLogoNames);
+          // Clear the legacy on-clinic-record node so the normalize fallback can't resurrect
+          // stale file names after the migration to clinicLogoDbPath.
+          await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/clinics/${clinicId}/logo`), null);
           setCatalog(previous => ({
             ...previous,
+            clinicLogos: { ...previous.clinicLogos, [clinicId]: nextLogoNames },
             parties: {
               ...previous.parties,
-              clinics: previous.parties.clinics.map(clinic => (String(clinic.id) === clinicId
-                ? { ...clinic, logo: nextLogoNames }
-                : clinic)),
+              clinics: previous.parties.clinics.map(clinic => {
+                if (String(clinic.id) !== clinicId) return clinic;
+                const { logo: _legacyLogo, ...rest } = clinic;
+                return rest;
+              }),
             },
           }));
-          setClinicLogoPreview({
+          setClinicLogos(previous => [...previous, {
+            fileName,
             dataUrl,
             width: image.naturalWidth || 0,
             height: image.naturalHeight || 0,
-            name: fileName,
-          });
+          }]);
           toast.success('Clinic logo uploaded to the backend.');
         } catch (uploadError) {
           console.error('Unable to upload clinic logo', uploadError);
-          toast.error('Could not upload the logo to the backend.');
+          toast.error(String(uploadError?.code || '').includes('unauthorized')
+            ? 'The Storage security rules rejected the upload — the documentsBuilder path must allow this account to write.'
+            : 'Could not upload the logo to the backend.');
         }
       };
       image.onerror = () => toast.error('Could not read the image file.');
@@ -684,21 +812,28 @@ const DocumentsPage = ({ isAdmin }) => {
     image.src = dataUrl;
   }), []);
 
-  const handleRemoveLogo = async () => {
-    if (typeof window !== 'undefined' && !window.confirm('Remove the clinic logo from the backend?')) return;
+  const handleRemoveLogoVariant = async fileName => {
+    if (typeof window !== 'undefined' && !window.confirm('Remove this clinic logo variant from the backend?')) return;
     const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
     if (!clinicId) return;
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/clinics/${clinicId}/logo`), []);
+      const nextLogoNames = (catalog.clinicLogos[clinicId] || []).filter(name => name !== fileName);
+      await set(ref(database, clinicLogoDbPath(clinicId)), nextLogoNames.length ? nextLogoNames : null);
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/clinics/${clinicId}/logo`), null);
       setCatalog(previous => ({
         ...previous,
+        clinicLogos: { ...previous.clinicLogos, [clinicId]: nextLogoNames },
         parties: {
           ...previous.parties,
-          clinics: previous.parties.clinics.map(clinic => (String(clinic.id) === clinicId ? { ...clinic, logo: [] } : clinic)),
+          clinics: previous.parties.clinics.map(clinic => {
+            if (String(clinic.id) !== clinicId) return clinic;
+            const { logo: _legacyLogo, ...rest } = clinic;
+            return rest;
+          }),
         },
       }));
-      setClinicLogoPreview(null);
-      toast.success('Clinic logo removed.');
+      setClinicLogos(previous => previous.filter(variant => variant.fileName !== fileName));
+      toast.success('Clinic logo variant removed.');
     } catch (removeError) {
       console.error('Unable to remove clinic logo', removeError);
       toast.error('Could not remove the clinic logo.');
@@ -737,14 +872,20 @@ const DocumentsPage = ({ isAdmin }) => {
   const selectedTemplates = catalog.documents.filter(template => selectedDocIds[template.id]);
   const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
   const selectedClinic = catalog.parties.clinics.find(item => String(item.id) === String(selectedCase?.clinicId || '')) || null;
+  const caseContext = resolveCaseContext(catalog, selectedCaseId);
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || clinicLogoLoading || !selectedTemplates.length || !selectedCase;
 
+  const clinicLogoNames = (selectedClinic?.id && catalog.clinicLogos[String(selectedClinic.id)]) || [];
+  const clinicLogoNamesKey = `${selectedClinic?.id || ''}:${clinicLogoNames.join('|')}`;
+
+  // Fetch every stored logo variant of the selected clinic from Storage by its file name; the
+  // dimensions are what pickLogoVariantForLayout uses to tell compact from full-width variants.
   useEffect(() => {
     let cancelled = false;
-    const logoNames = Array.isArray(selectedClinic?.logo) ? selectedClinic.logo.filter(Boolean).map(String) : [];
-    const fileName = logoNames[logoNames.length - 1] || '';
-    setClinicLogoPreview(null);
-    if (!selectedClinic?.id || !fileName) {
+    const [clinicId, namesJoined] = clinicLogoNamesKey.split(':');
+    const names = namesJoined ? namesJoined.split('|').filter(Boolean) : [];
+    setClinicLogos([]);
+    if (!clinicId || !names.length) {
       setClinicLogoLoading(false);
       return () => {
         cancelled = true;
@@ -752,32 +893,40 @@ const DocumentsPage = ({ isAdmin }) => {
     }
 
     setClinicLogoLoading(true);
-    const filePath = `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${selectedClinic.id}/logo/${fileName}`;
-    getStorageFileDataUrl(filePath)
-      .then(async dataUrl => {
-        const dimensions = dataUrl ? await readImageDimensions(dataUrl) : { width: 0, height: 0 };
-        if (!cancelled) {
-          setClinicLogoPreview(dataUrl ? { dataUrl, name: fileName, ...dimensions } : null);
-          setClinicLogoLoading(false);
-        }
-      })
-      .catch(loadLogoError => {
+    Promise.all(names.map(async fileName => {
+      try {
+        const dataUrl = await getStorageFileDataUrl(clinicLogoStorageFilePath(clinicId, fileName));
+        if (!dataUrl) return null;
+        const dimensions = await readImageDimensions(dataUrl);
+        return { fileName, dataUrl, ...dimensions };
+      } catch (loadLogoError) {
         console.error('Unable to load clinic logo from Storage', loadLogoError);
-        if (!cancelled) {
-          setClinicLogoPreview(null);
-          setClinicLogoLoading(false);
-        }
-      });
+        return null;
+      }
+    })).then(variants => {
+      if (!cancelled) {
+        setClinicLogos(variants.filter(Boolean));
+        setClinicLogoLoading(false);
+      }
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [readImageDimensions, selectedClinic]);
+  }, [readImageDimensions, clinicLogoNamesKey]);
 
   const prepareGeneration = () => {
     const context = resolveCaseContext(catalog, selectedCaseId);
-    const generated = selectedTemplates.map(template => buildGeneratedDocument(template, context));
-    return { generated, normalizedFormatting: normalizeDocFormatting(formatting) };
+    const generated = selectedTemplates.map(template => buildGeneratedDocument(
+      template,
+      context,
+      selectedCase?.docOverrides?.[template.id],
+    ));
+    return {
+      generated,
+      normalizedFormatting: normalizeDocFormatting(formatting),
+      logoVariant: pickLogoVariantForLayout(clinicLogos, layout),
+    };
   };
 
   const rememberRecentCase = () => {
@@ -788,7 +937,7 @@ const DocumentsPage = ({ isAdmin }) => {
     if (isGenerateDisabled) return;
     setIsGenerating(true);
     try {
-      const { generated, normalizedFormatting } = prepareGeneration();
+      const { generated, normalizedFormatting, logoVariant } = prepareGeneration();
       const [{ pdf }, documentsModule] = await Promise.all([
         import('@react-pdf/renderer'),
         import('./DocumentsPdfDocument'),
@@ -799,7 +948,7 @@ const DocumentsPage = ({ isAdmin }) => {
         documents: generated,
         layout,
         formatting: normalizedFormatting,
-        logoDataUrl: clinicLogoPreview?.dataUrl || null,
+        logoDataUrl: logoVariant?.dataUrl || null,
       })).toBlob();
       saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'pdf'));
       rememberRecentCase();
@@ -815,13 +964,13 @@ const DocumentsPage = ({ isAdmin }) => {
     if (isGenerateDisabled) return;
     setIsGenerating(true);
     try {
-      const { generated, normalizedFormatting } = prepareGeneration();
+      const { generated, normalizedFormatting, logoVariant } = prepareGeneration();
       const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
       const blob = await buildDocumentsDocx({
         documents: generated,
         layout,
         formatting: normalizedFormatting,
-        logo: clinicLogoPreview,
+        logo: logoVariant,
       });
       saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'docx'));
       rememberRecentCase();
@@ -908,12 +1057,51 @@ const DocumentsPage = ({ isAdmin }) => {
             <Section>
               <SectionHead>
                 <SectionTitle>Documents</SectionTitle>
+                <ToggleGroup>
+                  <ToggleOption
+                    type="button"
+                    $active={editMode === 'template'}
+                    onClick={() => setEditMode('template')}
+                    title="Edit the raw {{placeholder}} tokens of the shared template"
+                  >
+                    <FaPencilAlt /> Template
+                  </ToggleOption>
+                  <ToggleOption
+                    type="button"
+                    $active={editMode === 'data'}
+                    onClick={() => setEditMode('data')}
+                    title="Edit the resolved values of the selected case directly"
+                  >
+                    <FaPencilAlt /> Data
+                  </ToggleOption>
+                </ToggleGroup>
               </SectionHead>
               {!catalog.documents.length ? (
                 <DocSubtitle style={{ marginTop: 8 }}>No document templates yet — paste them in the technical field below.</DocSubtitle>
               ) : null}
               {catalog.documents.map(template => {
                 const isExpanded = expandedDocId === String(template.id);
+                const isDataMode = editMode === 'data';
+                // The builder view mirrors the selected layout mode (spec §1): both languages as
+                // grouped pairs in two-column mode, a single language otherwise.
+                const showUk = layout !== 'one-column-en';
+                const showEn = layout !== 'one-column-uk';
+                const isSingle = !(showUk && showEn);
+                const resolvedDoc = isExpanded && isDataMode
+                  ? buildGeneratedDocument(template, caseContext, selectedCase?.docOverrides?.[template.id])
+                  : null;
+                const titleValue = langKey => (isDataMode ? resolvedDoc?.title?.[langKey] ?? '' : template.title?.[langKey] || '');
+                const paragraphValue = (paragraph, index, langKey) => (isDataMode
+                  ? resolvedDoc?.paragraphs?.[index]?.[langKey] ?? ''
+                  : paragraph?.[langKey] || '');
+                const onTitleChange = langKey => event => (isDataMode
+                  ? handleDataTitleChange(template.id, langKey, event.target.value)
+                  : handleTitleChange(template.id, langKey, event.target.value));
+                const onParagraphChange = (index, langKey) => event => (isDataMode
+                  ? handleDataParagraphChange(template.id, index, langKey, event.target.value)
+                  : handleParagraphChange(template.id, index, langKey, event.target.value));
+                const onFieldBlur = () => (isDataMode ? persistDocOverride(template.id) : persistTemplate(template.id));
+                const dataEditLocked = isDataMode && !selectedCase;
                 return (
                   <DocRow key={template.id}>
                     <DocRowHead>
@@ -942,34 +1130,49 @@ const DocumentsPage = ({ isAdmin }) => {
                     </DocRowHead>
                     {isExpanded ? (
                       <div style={{ marginTop: 6 }}>
-                        <ParagraphPair>
-                          <InlineTextarea
-                            value={template.title?.uk || ''}
-                            placeholder="Title (uk)"
-                            onChange={event => handleTitleChange(template.id, 'uk', event.target.value)}
-                            onBlur={() => persistTemplate(template.id)}
-                          />
-                          <InlineTextarea
-                            value={template.title?.en || ''}
-                            placeholder="Title (en)"
-                            onChange={event => handleTitleChange(template.id, 'en', event.target.value)}
-                            onBlur={() => persistTemplate(template.id)}
-                          />
+                        {dataEditLocked ? (
+                          <DocSubtitle>Select a case first — Data mode shows and edits its resolved values.</DocSubtitle>
+                        ) : null}
+                        <ParagraphPair $single={isSingle}>
+                          {showUk ? (
+                            <InlineTextarea
+                              value={titleValue('uk')}
+                              placeholder="Title (uk)"
+                              readOnly={dataEditLocked}
+                              onChange={onTitleChange('uk')}
+                              onBlur={onFieldBlur}
+                            />
+                          ) : null}
+                          {showEn ? (
+                            <InlineTextarea
+                              value={titleValue('en')}
+                              placeholder="Title (en)"
+                              readOnly={dataEditLocked}
+                              onChange={onTitleChange('en')}
+                              onBlur={onFieldBlur}
+                            />
+                          ) : null}
                         </ParagraphPair>
                         {(template.paragraphs || []).map((paragraph, index) => (
-                          <ParagraphPair key={`${template.id}-p-${index}`}>
-                            <InlineTextarea
-                              value={paragraph?.uk || ''}
-                              placeholder="Paragraph (uk)"
-                              onChange={event => handleParagraphChange(template.id, index, 'uk', event.target.value)}
-                              onBlur={() => persistTemplate(template.id)}
-                            />
-                            <InlineTextarea
-                              value={paragraph?.en || ''}
-                              placeholder="Paragraph (en)"
-                              onChange={event => handleParagraphChange(template.id, index, 'en', event.target.value)}
-                              onBlur={() => persistTemplate(template.id)}
-                            />
+                          <ParagraphPair key={`${template.id}-p-${index}`} $single={isSingle}>
+                            {showUk ? (
+                              <InlineTextarea
+                                value={paragraphValue(paragraph, index, 'uk')}
+                                placeholder="Paragraph (uk)"
+                                readOnly={dataEditLocked}
+                                onChange={onParagraphChange(index, 'uk')}
+                                onBlur={onFieldBlur}
+                              />
+                            ) : null}
+                            {showEn ? (
+                              <InlineTextarea
+                                value={paragraphValue(paragraph, index, 'en')}
+                                placeholder="Paragraph (en)"
+                                readOnly={dataEditLocked}
+                                onChange={onParagraphChange(index, 'en')}
+                                onBlur={onFieldBlur}
+                              />
+                            ) : null}
                           </ParagraphPair>
                         ))}
                       </div>
@@ -1000,10 +1203,28 @@ const DocumentsPage = ({ isAdmin }) => {
               {formattingOpen ? (
                 <>
                   <RowLine style={{ marginTop: 10 }}>
-                    {clinicLogoPreview ? (
-                      <LogoPreview src={clinicLogoPreview.dataUrl} alt="Clinic logo" />
-                    ) : (
-                      <DocSubtitle>No clinic logo uploaded yet.</DocSubtitle>
+                    {clinicLogos.length ? clinicLogos.map(variant => {
+                      const usedFor = [
+                        pickLogoVariantForLayout(clinicLogos, 'two-column')?.fileName === variant.fileName ? '2 col' : '',
+                        pickLogoVariantForLayout(clinicLogos, 'one-column-uk')?.fileName === variant.fileName ? '1 col' : '',
+                      ].filter(Boolean).join(' · ');
+                      return (
+                        <LogoVariant key={variant.fileName}>
+                          <LogoPreview src={variant.dataUrl} alt="Clinic logo variant" />
+                          <LogoVariantCaption>
+                            {usedFor ? <span>Used: {usedFor}</span> : null}
+                            <DangerButton
+                              type="button"
+                              onClick={() => handleRemoveLogoVariant(variant.fileName)}
+                              title="Remove this logo variant"
+                            >
+                              <FaTrash />
+                            </DangerButton>
+                          </LogoVariantCaption>
+                        </LogoVariant>
+                      );
+                    }) : (
+                      <DocSubtitle>{clinicLogoLoading ? 'Loading the clinic logo…' : 'No clinic logo uploaded yet.'}</DocSubtitle>
                     )}
                     <input
                       ref={logoInputRef}
@@ -1013,13 +1234,8 @@ const DocumentsPage = ({ isAdmin }) => {
                       onChange={handleLogoFileChange}
                     />
                     <SmallButton type="button" onClick={() => logoInputRef.current?.click()}>
-                      <FaUpload /> {clinicLogoPreview ? 'Replace logo' : 'Upload logo'}
+                      <FaUpload /> {clinicLogos.length ? 'Add logo variant' : 'Upload logo'}
                     </SmallButton>
-                    {clinicLogoPreview ? (
-                      <DangerButton type="button" onClick={handleRemoveLogo}>
-                        <FaTrash /> Remove
-                      </DangerButton>
-                    ) : null}
                     <CheckLine>
                       <DocCheckbox
                         type="checkbox"

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -32,6 +32,12 @@ export const ensureDocumentsPdfFontsRegistered = () => {
   Font.registerHyphenationCallback(word => [word]);
 };
 
+// Word/PDF parity (spec §6): the gap under the clinic logo is the one fixed metric shared with
+// the DOCX builder (10 pt = 200 twips); everything else comes from the Format panel values.
+export const LOGO_BOTTOM_GAP_PT = 10;
+
+const A4_WIDTH_PT = 595.28;
+
 const styles = StyleSheet.create({
   headerText: {
     position: 'absolute',
@@ -45,20 +51,17 @@ const styles = StyleSheet.create({
   logo: {
     alignSelf: 'center',
   },
-  titleWrap: {
-    marginBottom: 8,
-  },
   row: {
     flexDirection: 'row',
   },
 });
 
-const DocumentBlock = ({ doc, layout, cellStyles }) => {
+const DocumentBlock = ({ doc, layout, cellStyles, titleGap }) => {
   const isTwoColumn = layout === 'two-column';
   const lang = layout === 'one-column-en' ? 'en' : 'uk';
   return (
     <View>
-      <View style={styles.titleWrap}>
+      <View style={{ marginBottom: titleGap }}>
         {isTwoColumn ? (
           <View style={styles.row}>
             <Text style={[cellStyles.title, cellStyles.leftCell]}>{doc.title.uk}</Text>
@@ -95,6 +98,10 @@ const DocumentsPdfDocument = ({
   const columnGap = formatting.columnGapCm * CM_TO_PT;
   const hasHeader = Boolean(formatting.headerText);
   const hasFooter = Boolean(formatting.footerText) || formatting.showPageNumbers;
+  // Spec §7: two-column pages share one compact logo at the tuned width; one-column pages get the
+  // long variant stretched across the full text width.
+  const contentWidth = A4_WIDTH_PT - marginLeft - marginRight;
+  const logoWidth = layout === 'two-column' ? formatting.logoWidthMm * MM_TO_PT : contentWidth;
 
   const cellStyles = StyleSheet.create({
     title: {
@@ -154,12 +161,12 @@ const DocumentsPdfDocument = ({
             <Image
               src={logoDataUrl}
               style={[styles.logo, {
-                width: formatting.logoWidthMm * MM_TO_PT,
-                marginBottom: 10,
+                width: logoWidth,
+                marginBottom: LOGO_BOTTOM_GAP_PT,
               }]}
             />
           ) : null}
-          <DocumentBlock doc={doc} layout={layout} cellStyles={cellStyles} />
+          <DocumentBlock doc={doc} layout={layout} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} />
           {hasFooter ? (
             <View
               fixed

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -8,6 +8,13 @@ export const DOCUMENTS_PARTIES_PATH = 'documentsBuilder/parties';
 export const DOCUMENTS_TEMPLATES_PATH = 'documentsBuilder/templates';
 export const DOCUMENTS_SETTINGS_PATH = 'documentsBuilder/settings';
 
+// Clinic logos are stored as plain file names (never URLs): the image files live in the Storage
+// folder below and the same-shaped Realtime Database node keeps the array of file names
+// (`parties/cases/clinics/{clinicId}/logo/[a.jpg, b.jpg, ...]`, spec §5).
+export const clinicLogoDbPath = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
+export const clinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
+export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoStorageFolder(clinicId)}/${fileName}`;
+
 export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases'];
 
 export const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -25,6 +32,7 @@ const makeRecordId = prefix => `${prefix}-${Date.now().toString(36)}-${Math.rand
 export const emptyDocumentsCatalog = () => ({
   parties: { couples: [], surrogateMothers: [], representatives: [], clinics: [], cases: [] },
   documents: [],
+  clinicLogos: {},
 });
 
 // Backend stores every collection keyed by record id (so merges/deletes touch single children);
@@ -32,9 +40,30 @@ export const emptyDocumentsCatalog = () => ({
 export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
   const catalog = emptyDocumentsCatalog();
   PARTY_COLLECTIONS.forEach(collection => {
-    catalog.parties[collection] = toArray(rawParties?.[collection]).filter(record => isPlainObject(record));
+    let rawCollection = rawParties?.[collection];
+    // `parties/cases/clinics` is the clinic-logo file-name store (see clinicLogoDbPath), not a
+    // case record - it must never leak into the cases list.
+    if (collection === 'cases' && isPlainObject(rawCollection)) {
+      const { clinics: _clinicLogos, ...caseRecords } = rawCollection;
+      rawCollection = caseRecords;
+    }
+    catalog.parties[collection] = toArray(rawCollection).filter(record => isPlainObject(record));
   });
   catalog.documents = toArray(rawTemplates).filter(record => isPlainObject(record));
+  const rawClinicLogos = rawParties?.cases?.clinics;
+  if (isPlainObject(rawClinicLogos)) {
+    Object.entries(rawClinicLogos).forEach(([clinicId, node]) => {
+      const names = toArray(node?.logo).map(String).filter(Boolean);
+      if (names.length) catalog.clinicLogos[clinicId] = names;
+    });
+  }
+  // Legacy fallback: earlier builds kept the file names on the clinic record itself.
+  catalog.parties.clinics.forEach(clinic => {
+    if (!catalog.clinicLogos[String(clinic.id)] && Array.isArray(clinic.logo)) {
+      const names = clinic.logo.map(String).filter(Boolean);
+      if (names.length) catalog.clinicLogos[String(clinic.id)] = names;
+    }
+  });
   return catalog;
 };
 
@@ -148,6 +177,7 @@ export const mergeDocumentsCatalog = (current, incoming) => {
     );
   });
   catalog.documents = mergeCollection(current?.documents || [], incoming?.documents || [], 'document', summary);
+  catalog.clinicLogos = { ...(current?.clinicLogos || {}) };
   return { catalog, summary };
 };
 
@@ -233,19 +263,64 @@ const localizedText = (value, lang) => {
   return String(value ?? '');
 };
 
+// Data-mode edits (spec: the "pencil" Data mode) are stored per case as sparse overrides of the
+// resolved text: `case.docOverrides[docId] = { title: {uk,en}, paragraphs: { [index]: {uk,en} } }`.
+// Firebase may hand dense numeric-keyed nodes back as arrays, so both shapes are accepted.
+const overrideAt = (overrides, index) => {
+  if (Array.isArray(overrides)) return overrides[index];
+  if (isPlainObject(overrides)) return overrides[index] ?? overrides[String(index)];
+  return undefined;
+};
+
+const overriddenText = (override, langKey, fallback) => (
+  typeof override?.[langKey] === 'string' ? override[langKey] : fallback
+);
+
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
-// with every placeholder already substituted from the case context.
-export const buildGeneratedDocument = (template, context) => ({
-  id: template.id,
-  title: {
-    uk: fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk'),
-    en: fillPlaceholders(localizedText(template.title, 'en'), context, 'en'),
-  },
-  paragraphs: toArray(template.paragraphs).map(paragraph => ({
-    uk: fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk'),
-    en: fillPlaceholders(localizedText(paragraph, 'en'), context, 'en'),
-  })),
-});
+// with every placeholder already substituted from the case context, then any per-case data-mode
+// overrides applied on top.
+export const buildGeneratedDocument = (template, context, docOverride = null) => {
+  const override = isPlainObject(docOverride) ? docOverride : {};
+  return {
+    id: template.id,
+    title: {
+      uk: overriddenText(override.title, 'uk', fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk')),
+      en: overriddenText(override.title, 'en', fillPlaceholders(localizedText(template.title, 'en'), context, 'en')),
+    },
+    paragraphs: toArray(template.paragraphs).map((paragraph, index) => {
+      const paragraphOverride = overrideAt(override.paragraphs, index);
+      return {
+        uk: overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
+        en: overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
+      };
+    }),
+  };
+};
+
+// Drops override entries that match the resolved template text again, so the backend only keeps
+// real deviations. Returns null when nothing is left (the node can then be deleted).
+export const pruneDocOverride = (docOverride, baselineDoc) => {
+  if (!isPlainObject(docOverride) || !baselineDoc) return null;
+  const pruned = {};
+  const title = {};
+  ['uk', 'en'].forEach(langKey => {
+    const value = docOverride.title?.[langKey];
+    if (typeof value === 'string' && value !== baselineDoc.title?.[langKey]) title[langKey] = value;
+  });
+  if (Object.keys(title).length) pruned.title = title;
+  const paragraphs = {};
+  (baselineDoc.paragraphs || []).forEach((baseline, index) => {
+    const paragraphOverride = overrideAt(docOverride.paragraphs, index);
+    const entry = {};
+    ['uk', 'en'].forEach(langKey => {
+      const value = paragraphOverride?.[langKey];
+      if (typeof value === 'string' && value !== baseline?.[langKey]) entry[langKey] = value;
+    });
+    if (Object.keys(entry).length) paragraphs[index] = entry;
+  });
+  if (Object.keys(paragraphs).length) pruned.paragraphs = paragraphs;
+  return Object.keys(pruned).length ? pruned : null;
+};
 
 // --- Case selector --------------------------------------------------------------------------
 
@@ -286,6 +361,23 @@ export const DOCUMENT_LAYOUTS = [
   { id: 'one-column-uk', label: 'UA · 1 column' },
   { id: 'one-column-en', label: 'EN · 1 column' },
 ];
+
+// A clinic can keep several logo file variants (spec §7): a compact/square one for the shared
+// logo above the two-column layout and a long full-width one for the one-column layouts. The
+// variant is picked by aspect ratio: squarest for two columns, widest for one column. With a
+// single uploaded file both layouts fall back to it.
+export const pickLogoVariantForLayout = (logoVariants, layout) => {
+  const variants = (logoVariants || []).filter(variant => variant && variant.dataUrl);
+  if (!variants.length) return null;
+  const aspectRatio = variant => (variant.width > 0 && variant.height > 0 ? variant.width / variant.height : 1);
+  return variants.reduce((best, variant) => {
+    if (!best) return variant;
+    const preferWide = layout !== 'two-column';
+    const bestRatio = aspectRatio(best);
+    const ratio = aspectRatio(variant);
+    return (preferWide ? ratio > bestRatio : ratio < bestRatio) ? variant : best;
+  }, null);
+};
 
 // Defaults mirror the reference statements docx: Times ~10pt body / 11pt bold titles,
 // single line spacing, zero after-paragraph spacing, A4 with 1.2/1.5/1.2/2.0 cm margins and a
@@ -338,7 +430,7 @@ export const normalizeDocFormatting = raw => {
 };
 
 // The backend settings record stores formatting values and the recently-used case order.
-// Clinic logos live on each clinic record as Storage file names, not as URLs/data URLs here.
+// Clinic logos live as Storage file names under clinicLogoDbPath, not as URLs/data URLs here.
 export const normalizeDocumentsSettings = raw => {
   const source = isPlainObject(raw) ? raw : {};
   return {

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -12,6 +12,8 @@ import {
   normalizeDocumentsSettings,
   orderCasesByRecent,
   parseDocumentsTechnicalInput,
+  pickLogoVariantForLayout,
+  pruneDocOverride,
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
   upsertRecentCaseId,
@@ -217,6 +219,84 @@ describe('placeholders', () => {
     const generated = buildGeneratedDocument(catalog.documents[0], context);
     expect(generated.paragraphs[0].uk).toBe('Я, Тестова Марія, 01.01.1990 р.н.');
     expect(generated.paragraphs[0].en).toBe('I, Testova Mariia, born 01.01.1990');
+  });
+});
+
+describe('data-mode overrides', () => {
+  it('applies per-case overrides on top of the resolved template text', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const generated = buildGeneratedDocument(catalog.documents[0], context, {
+      title: { en: 'Edited consent' },
+      paragraphs: { 0: { uk: 'Відредагований абзац' } },
+    });
+    expect(generated.title.en).toBe('Edited consent');
+    expect(generated.title.uk).toBe('Згода');
+    expect(generated.paragraphs[0].uk).toBe('Відредагований абзац');
+    expect(generated.paragraphs[0].en).toBe('I, Testova Mariia, born 01.01.1990');
+  });
+
+  it('accepts array-shaped paragraph overrides (Firebase dense-node shape)', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const generated = buildGeneratedDocument(catalog.documents[0], context, {
+      paragraphs: [{ en: 'Array override' }],
+    });
+    expect(generated.paragraphs[0].en).toBe('Array override');
+  });
+
+  it('pruneDocOverride keeps only real deviations from the baseline', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const baseline = buildGeneratedDocument(catalog.documents[0], context);
+    const pruned = pruneDocOverride({
+      title: { uk: 'Згода', en: 'Edited consent' },
+      paragraphs: { 0: { uk: baseline.paragraphs[0].uk, en: 'Changed' } },
+    }, baseline);
+    expect(pruned).toEqual({ title: { en: 'Edited consent' }, paragraphs: { 0: { en: 'Changed' } } });
+  });
+
+  it('pruneDocOverride returns null when everything matches the baseline again', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const baseline = buildGeneratedDocument(catalog.documents[0], context);
+    expect(pruneDocOverride({ title: { uk: baseline.title.uk } }, baseline)).toBeNull();
+    expect(pruneDocOverride(null, baseline)).toBeNull();
+  });
+});
+
+describe('clinic logos', () => {
+  it('reads file names from parties/cases/clinics without leaking them into cases', () => {
+    const catalog = normalizeDocumentsCatalog(
+      {
+        clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
+        cases: {
+          'case-1': { id: 'case-1', clinicId: 'clinic-1' },
+          clinics: { 'clinic-1': { logo: ['a.jpg', 'b.png'] } },
+        },
+      },
+      null,
+    );
+    expect(catalog.clinicLogos['clinic-1']).toEqual(['a.jpg', 'b.png']);
+    expect(catalog.parties.cases.map(record => record.id)).toEqual(['case-1']);
+  });
+
+  it('falls back to legacy file names stored on the clinic record', () => {
+    const catalog = normalizeDocumentsCatalog(
+      { clinics: { 'clinic-1': { id: 'clinic-1', logo: ['legacy.jpg'] } } },
+      null,
+    );
+    expect(catalog.clinicLogos['clinic-1']).toEqual(['legacy.jpg']);
+  });
+
+  it('picks the squarest variant for two columns and the widest for one column', () => {
+    const compact = { fileName: 'square.jpg', dataUrl: 'data:1', width: 200, height: 180 };
+    const long = { fileName: 'wide.jpg', dataUrl: 'data:2', width: 900, height: 120 };
+    expect(pickLogoVariantForLayout([compact, long], 'two-column')).toBe(compact);
+    expect(pickLogoVariantForLayout([compact, long], 'one-column-uk')).toBe(long);
+    expect(pickLogoVariantForLayout([compact, long], 'one-column-en')).toBe(long);
+    expect(pickLogoVariantForLayout([long], 'two-column')).toBe(long);
+    expect(pickLogoVariantForLayout([], 'two-column')).toBeNull();
   });
 });
 

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -57,9 +57,11 @@ export const buildDocumentsDocx = async ({
     children: [new TextRun({ text, size: bodySize })],
   });
 
+  // Exactly the Format panel's paragraph spacing - no hidden minimum - so the Word output keeps
+  // the same title-to-body rhythm as the PDF and the reference statements (spec §6).
   const titleParagraph = text => new Paragraph({
     alignment: AlignmentType.CENTER,
-    spacing: { after: Math.max(afterTwips, 120), line: lineTwips, lineRule: 'auto' },
+    spacing: paragraphSpacing,
     children: [new TextRun({ text, bold: true, size: titleSize })],
   });
 
@@ -89,11 +91,19 @@ export const buildDocumentsDocx = async ({
     if (formatting.showLogo && logo?.dataUrl) {
       const decoded = decodeLogoDataUrl(logo.dataUrl);
       if (decoded) {
-        const widthPx = Math.round(formatting.logoWidthMm * MM_TO_PX);
+        // Spec §7: compact logo at the tuned width above the two-column layout, the long variant
+        // stretched to the full text width in one-column layouts. 10 pt (200 twips) below the
+        // logo matches the PDF's LOGO_BOTTOM_GAP_PT.
+        const contentWidthTwips = 11906
+          - Math.round(formatting.marginLeftCm * CM_TO_TWIP)
+          - Math.round(formatting.marginRightCm * CM_TO_TWIP);
+        const widthPx = isTwoColumn
+          ? Math.round(formatting.logoWidthMm * MM_TO_PX)
+          : Math.round((contentWidthTwips / 1440) * 96);
         const ratio = logo.width && logo.height ? logo.height / logo.width : 0.25;
         children.push(new Paragraph({
           alignment: AlignmentType.CENTER,
-          spacing: { after: 160 },
+          spacing: { after: 200 },
           children: [new ImageRun({
             data: decoded.bytes,
             type: decoded.type,

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,39 @@
+// Firebase Storage security rules for the WeBringIt app.
+//
+// NOTE: this file is documentation + the deployable source of truth for the rules, but it is NOT
+// applied automatically - deploy it in the Firebase console (Storage -> Rules) or via
+// `firebase deploy --only storage` with a firebase.json that points at this file.
+//
+// Why this file exists: the Documents Builder uploads clinic logos to
+// `documentsBuilder/parties/cases/clinics/{clinicId}/logo/{fileName}` and the previously deployed
+// rules only allowed writes under /documentsBuilder/** for two hardcoded UIDs. On top of that, the
+// deployed rules listed the admin UID as '0ghb1LphfASV0Y3b6J010y4CDyD2' (…y4…) while the app's
+// admin list (src/utils/accessLevel.js) contains '0ghb1LphfASV0Y3b6J010v4CDyD2' (…v4…) - a one
+// letter mismatch that silently rejects that admin's uploads ("Could not upload the logo to the
+// backend"). The UIDs below mirror accessLevel.js exactly: ADMIN_UIDS + INVOICE_BUILDER_UIDS
+// (the accounts that can open the Documents/Invoice builder pages).
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Accounts allowed to use the admin builder pages (keep in sync with accessLevel.js).
+    function isBuilderAdmin() {
+      return request.auth != null && (
+        request.auth.uid == '3LiD7JGCJTSJoVMU7fdR1ZrcIZH2'
+        || request.auth.uid == '0ghb1LphfASV0Y3b6J010v4CDyD2'
+        || request.auth.uid == 'S0VhDLCYjuTFDNLalRa85u7fPcg2'
+      );
+    }
+
+    match /avatar/{userId}/{allPaths=**} {
+      allow read: if request.auth != null;
+      allow write: if request.auth.uid == userId || isBuilderAdmin();
+    }
+
+    // Everything the builder pages store (invoice assets, clinic logos under
+    // documentsBuilder/parties/cases/clinics/{clinicId}/logo/..., etc.).
+    match /documentsBuilder/{allPaths=**} {
+      allow read, write: if isBuilderAdmin();
+    }
+  }
+}


### PR DESCRIPTION
- Layout switcher now drives the builder view: two-column shows UA/EN
  paragraph pairs grouped in one visible box each, one-column modes show
  only the selected language.
- New pencil toggle with Template mode (raw {{tokens}}, edits the shared
  template) and Data mode (resolved values, edits saved as sparse
  per-case overrides under case.docOverrides and applied at generation).
- All page inputs (case select, format fields, technical textarea) are
  styled as plain editable text, borderless until hover/focus.
- Clinic logos reworked to filename-only storage: the file-name array
  lives at parties/cases/clinics/{clinicId}/logo (mirroring the Storage
  folder), legacy on-clinic-record names are migrated on write, and the
  logo store node no longer leaks into the cases list.
- Multiple logo variants per clinic: every variant is loaded with its
  dimensions, the squarest one is used as the single shared logo in the
  two-column layout and the widest one is stretched to full text width
  in one-column layouts (PDF and DOCX).
- Word/PDF parity: the DOCX title no longer forces a hidden 6pt-after
  minimum and the PDF title gap now follows the Format panel's paragraph
  spacing, so both outputs match the reference statement metrics.
- Add storage.rules documenting the Storage rules the upload needs
  (including the y4/v4 admin-UID mismatch that breaks logo uploads).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VcpiaQmBgrhhRApvupfQqf