### PR TITLE
Fix document logo import and override edge cases

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -666,6 +666,22 @@ const DocumentsPage = ({ isAdmin }) => {
     const pruned = pruneDocOverride(caseRecord.docOverrides?.[docId], baseline);
     try {
       await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/docOverrides/${docId}`), pruned);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          cases: previous.parties.cases.map(item => {
+            if (String(item.id) !== String(caseRecord.id)) return item;
+            const docOverrides = { ...(item.docOverrides || {}) };
+            if (pruned) docOverrides[docId] = pruned;
+            else delete docOverrides[docId];
+            return {
+              ...item,
+              docOverrides: Object.keys(docOverrides).length ? docOverrides : undefined,
+            };
+          }),
+        },
+      }));
       setDirtyOverrideDocIds(previous => {
         const next = { ...previous };
         delete next[docId];

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -92,7 +92,15 @@ export const parseDocumentsTechnicalInput = rawText => {
   const dataSource = isPlainObject(parsed.data) ? parsed.data : parsed;
   const incoming = emptyDocumentsCatalog();
   PARTY_COLLECTIONS.forEach(collection => {
-    incoming.parties[collection] = toArray(dataSource[collection]).filter(record => isPlainObject(record));
+    let rawCollection = dataSource[collection];
+    // Backend exports include `data.cases.clinics` for clinic-logo filenames; it mirrors the
+    // Realtime Database storage path and is not a case record. Keep Technical merges from
+    // importing that logo node as a generated case.
+    if (collection === 'cases' && isPlainObject(rawCollection)) {
+      const { clinics: _clinicLogos, ...caseRecords } = rawCollection;
+      rawCollection = caseRecords;
+    }
+    incoming.parties[collection] = toArray(rawCollection).filter(record => isPlainObject(record));
   });
   incoming.documents = toArray(parsed.documents).filter(record => isPlainObject(record));
 
@@ -375,7 +383,8 @@ export const pickLogoVariantForLayout = (logoVariants, layout) => {
     const preferWide = layout !== 'two-column';
     const bestRatio = aspectRatio(best);
     const ratio = aspectRatio(variant);
-    return (preferWide ? ratio > bestRatio : ratio < bestRatio) ? variant : best;
+    const isBetter = preferWide ? ratio > bestRatio : Math.abs(ratio - 1) < Math.abs(bestRatio - 1);
+    return isBetter ? variant : best;
   }, null);
 };
 

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -101,6 +101,18 @@ describe('parseDocumentsTechnicalInput', () => {
     expect(parsed.parties.clinics[0].id).toBe('clinic-2');
   });
 
+  it('strips exported clinic-logo nodes from parsed case records', () => {
+    const parsed = parseDocumentsTechnicalInput(JSON.stringify({
+      data: {
+        cases: {
+          'case-1': { id: 'case-1', clinicId: 'clinic-1' },
+          clinics: { 'clinic-1': { logo: ['square.jpg'] } },
+        },
+      },
+    }));
+    expect(parsed.parties.cases.map(record => record.id)).toEqual(['case-1']);
+  });
+
   it('rejects invalid or empty input', () => {
     expect(() => parseDocumentsTechnicalInput('')).toThrow(/Paste/);
     expect(() => parseDocumentsTechnicalInput('not json')).toThrow(/Invalid JSON/);
@@ -292,7 +304,9 @@ describe('clinic logos', () => {
   it('picks the squarest variant for two columns and the widest for one column', () => {
     const compact = { fileName: 'square.jpg', dataUrl: 'data:1', width: 200, height: 180 };
     const long = { fileName: 'wide.jpg', dataUrl: 'data:2', width: 900, height: 120 };
+    const portrait = { fileName: 'portrait.jpg', dataUrl: 'data:3', width: 100, height: 400 };
     expect(pickLogoVariantForLayout([compact, long], 'two-column')).toBe(compact);
+    expect(pickLogoVariantForLayout([portrait, compact], 'two-column')).toBe(compact);
     expect(pickLogoVariantForLayout([compact, long], 'one-column-uk')).toBe(long);
     expect(pickLogoVariantForLayout([compact, long], 'one-column-en')).toBe(long);
     expect(pickLogoVariantForLayout([long], 'two-column')).toBe(long);

--- a/storage.rules
+++ b/storage.rules
@@ -11,23 +11,29 @@
 // admin list (src/utils/accessLevel.js) contains '0ghb1LphfASV0Y3b6J010v4CDyD2' (…v4…) - a one
 // letter mismatch that silently rejects that admin's uploads ("Could not upload the logo to the
 // backend"). The UIDs below mirror accessLevel.js exactly: ADMIN_UIDS + INVOICE_BUILDER_UIDS
-// (the accounts that can open the Documents/Invoice builder pages).
+// (the accounts that can open the Documents/Invoice builder pages). Avatar writes intentionally
+// stay limited to owners and full admins only.
 rules_version = '2';
 
 service firebase.storage {
   match /b/{bucket}/o {
-    // Accounts allowed to use the admin builder pages (keep in sync with accessLevel.js).
-    function isBuilderAdmin() {
+    // Full admins (keep in sync with ADMIN_UIDS in accessLevel.js).
+    function isFullAdmin() {
       return request.auth != null && (
         request.auth.uid == '3LiD7JGCJTSJoVMU7fdR1ZrcIZH2'
         || request.auth.uid == '0ghb1LphfASV0Y3b6J010v4CDyD2'
-        || request.auth.uid == 'S0VhDLCYjuTFDNLalRa85u7fPcg2'
       );
+    }
+
+    // Accounts allowed to use the admin builder pages (keep in sync with accessLevel.js).
+    function isBuilderAdmin() {
+      return isFullAdmin()
+        || (request.auth != null && request.auth.uid == 'S0VhDLCYjuTFDNLalRa85u7fPcg2');
     }
 
     match /avatar/{userId}/{allPaths=**} {
       allow read: if request.auth != null;
-      allow write: if request.auth.uid == userId || isBuilderAdmin();
+      allow write: if request.auth.uid == userId || isFullAdmin();
     }
 
     // Everything the builder pages store (invoice assets, clinic logos under


### PR DESCRIPTION
### Motivation
- Backend exports persist clinic logo file names under `data.cases.clinics/...`, which was being parsed as a case and created bogus case records during Technical imports.  
- Two-column logo selection favored portrait images instead of the squarest variant, causing incorrect compact logos in generated documents.  
- When a pruned per-case doc override was removed on the backend, the stale override remained in local state and could be written back later.  
- The Storage rules allowed builder accounts to write avatars, expanding their permissions beyond intended full-admin/owner scope.

### Description
- In `parseDocumentsTechnicalInput` the parser now strips the `clinics` child from `data.cases` before converting to records so exported clinic-logo nodes are not imported as cases (`src/components/documentsCatalogUtils.js`).  
- `pickLogoVariantForLayout` now selects the two-column compact logo by closeness to a 1:1 aspect ratio while keeping the existing widest selection for one-column layouts (`src/components/documentsCatalogUtils.js`).  
- `persistDocOverride` now updates the local `catalog.parties.cases` entry to reflect the pruned override (or remove it) after a successful save so local state matches the backend (`src/components/DocumentsPage.jsx`).  
- `storage.rules` splits `isFullAdmin` and `isBuilderAdmin` checks and restricts avatar writes to the owner or full admins while preserving builder access to `documentsBuilder` assets (`storage.rules`).  
- Added unit test coverage for the clinic-logo stripping and the logo-selection regression and updated tests accordingly (`src/components/documentsCatalogUtils.test.js`).

### Testing
- Ran unit tests with `CI=true npm test -- --watchAll=false src/components/documentsCatalogUtils.test.js` and all tests passed (`29 passed, 29 total`).  
- Ran the linter with `npm run lint:js -- src/components/documentsCatalogUtils.js src/components/DocumentsPage.jsx` and it completed (no blocking errors).  
- The repository changes were exercised by the above test suite which includes the new regression tests for parsing and logo selection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57c8baea888326800deb05aaa59328)