### PR TITLE
Move payment-only notes to Payment Details PDF and improve service picker search/UI

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -136,7 +136,7 @@ async function checkInvoice() {
   ]);
 
   // Service invoice - plain catalog items, no package/percent rows.
-  const servicePages = await renderPdf(React.createElement(InvoicePdfDocument, {
+  const serviceProps = {
     beneficiary,
     customers,
     invoiceServices: [{ id: 'e1', kind: 'item', catalogId: '1' }, { id: 'e2', kind: 'item', catalogId: '2' }],
@@ -151,7 +151,8 @@ async function checkInvoice() {
     invoiceNumber: '09/07/2026',
     invoiceDate: '09.07.2026',
     purposeOfPayment: 'Payment for services.',
-  }));
+  };
+  const servicePages = await renderPdf(React.createElement(InvoicePdfDocument, serviceProps));
   checkNoDebugStrings('Invoice (service)', servicePages);
   checkNoBlankPages('Invoice (service)', servicePages);
   checkStringsRoundTrip('Invoice (service)', servicePages, [
@@ -163,6 +164,29 @@ async function checkInvoice() {
     'Please make sure you pay the whole amount. Do not use SHA option while making payment.',
   ]);
   checkNoBrandOnPages('Invoice (service)', servicePages, [1], 'UKRCOM');
+
+  const invoiceOnlyPages = await renderPdf(React.createElement(InvoicePdfDocument, {
+    ...serviceProps,
+    generatePaymentDetails: false,
+  }));
+  checkStringsAbsent('Invoice (service, no payment details companion)', invoiceOnlyPages, [
+    'Purpose of the payment must be exactly like in invoice.',
+    'Please make sure you pay the whole amount. Do not use SHA option while making payment.',
+  ]);
+
+  const PaymentDetailsPdfDocument = require('../src/components/PaymentDetailsPdfDocument').default;
+  const paymentDetailsPages = await renderPdf(React.createElement(PaymentDetailsPdfDocument, {
+    beneficiary,
+    customers,
+    invoiceNumber: '09/07/2026',
+    invoiceDate: '09.07.2026',
+    purposeOfPayment: 'Payment for services.',
+    amountDue: 180,
+  }));
+  checkStringsRoundTrip('Payment details', paymentDetailsPages, [
+    'Purpose of the payment must be exactly like in invoice.',
+    'Please make sure you pay the whole amount. Do not use SHA option while making payment.',
+  ]);
   if (!servicePages[0].replace(/\s+/g, '').toUpperCase().includes('SERVICEINVOICE')) {
     fail('Invoice (service): expected a "Service invoice" eyebrow, got something else');
   }

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -297,12 +297,26 @@ const ServicePickerList = styled.div`
 `;
 
 const ServicePickerButton = styled(MiniButton)`
-  justify-content: flex-start;
+  justify-content: space-between;
   width: 100%;
   text-align: left;
   padding: 9px 12px;
   min-height: 38px;
   font-size: 13px;
+  gap: 12px;
+`;
+
+const ServicePickerName = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+`;
+
+const ServicePickerPrice = styled.span`
+  color: var(--km-accent);
+  font-weight: 900;
+  white-space: nowrap;
 `;
 
 const Section = styled.section`
@@ -1013,6 +1027,7 @@ const BudgetPage = ({ isAdmin = false }) => {
   const [showStickyContact, setShowStickyContact] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [insertChildTarget, setInsertChildTarget] = useState(null);
+  const [insertChildQuery, setInsertChildQuery] = useState('');
   const [isExporting, setIsExporting] = useState(false);
   const [categoryDrafts, setCategoryDrafts] = useState({});
   const [exchangeRates, setExchangeRates] = useState(null);
@@ -1413,6 +1428,7 @@ const BudgetPage = ({ isAdmin = false }) => {
       ...children.slice(insertIndex),
     ];
     setInsertChildTarget(null);
+    setInsertChildQuery('');
     persistProgramChildren(program.id, nextChildren, 'Service added to package.');
   };
 
@@ -2414,9 +2430,21 @@ const BudgetPage = ({ isAdmin = false }) => {
       {insertChildTarget ? (() => {
         const program = catalog.packages.find(record => String(record.id) === String(insertChildTarget.programId));
         const children = Array.isArray(program?.children) ? program.children : [];
-        const availableItems = catalog.items.filter(item => !children.some(id => String(id) === String(item.id)));
+        const normalizedInsertQuery = insertChildQuery.trim().toLowerCase();
+        const allAvailableItems = catalog.items.filter(item => {
+          const itemId = String(item.id);
+          if (children.some(id => String(id) === itemId)) return false;
+          if (!isEditMode && item.hidden) return false;
+          if (!isEditMode && formulaReferencedItemIds.has(itemId)) return false;
+          return true;
+        });
+        const availableItems = allAvailableItems.filter(item => {
+          if (!normalizedInsertQuery) return true;
+          const searchableText = `${item.name || ''} ${item.description || ''} ${isEditMode ? item.internalNote || '' : ''}`.toLowerCase();
+          return searchableText.includes(normalizedInsertQuery);
+        });
         return (
-          <ModalBackdrop role="presentation" onMouseDown={() => setInsertChildTarget(null)}>
+          <ModalBackdrop role="presentation" onMouseDown={() => { setInsertChildTarget(null); setInsertChildQuery(''); }}>
             <ConfirmModal
               role="dialog"
               aria-modal="true"
@@ -2425,6 +2453,13 @@ const BudgetPage = ({ isAdmin = false }) => {
             >
               <ModalTitle id="budget-insert-child-title">Add service to package</ModalTitle>
               <ModalText>Choose a service to insert in the selected position.</ModalText>
+              <SearchInput
+                type="search"
+                value={insertChildQuery}
+                onChange={event => setInsertChildQuery(event.target.value)}
+                placeholder="Search available services..."
+                aria-label="Search available services"
+              />
               {availableItems.length ? (
                 <ModalScrollArea>
                   <ServicePickerList>
@@ -2434,14 +2469,21 @@ const BudgetPage = ({ isAdmin = false }) => {
                         key={item.id}
                         onClick={() => insertProgramChild(item.id)}
                       >
-                        <FaPlus /> {item.name || `Service ${item.id}`}
+                        <ServicePickerName><FaPlus /> {item.name || `Service ${item.id}`}</ServicePickerName>
+                        <ServicePickerPrice>{getExpensePriceLabel(item, priceContext)}</ServicePickerPrice>
                       </ServicePickerButton>
                     ))}
                   </ServicePickerList>
                 </ModalScrollArea>
-              ) : <ModalText>All available services are already included in this package.</ModalText>}
+              ) : (
+                <ModalText>
+                  {normalizedInsertQuery && allAvailableItems.length
+                    ? 'No matching available services.'
+                    : 'All available services are already included in this package.'}
+                </ModalText>
+              )}
               <ModalActions>
-                <SoftButton type="button" onClick={() => setInsertChildTarget(null)}>Cancel</SoftButton>
+                <SoftButton type="button" onClick={() => { setInsertChildTarget(null); setInsertChildQuery(''); }}>Cancel</SoftButton>
               </ModalActions>
             </ConfirmModal>
           </ModalBackdrop>

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -241,7 +241,7 @@ const InvoicePdfDocument = ({
   const noteList = Array.isArray(notes)
     ? notes
       .filter(note => String(note || '').trim())
-      .filter(note => !generatePaymentDetails || !isPaymentCaveatNote(note))
+      .filter(note => !isPaymentCaveatNote(note))
     : [];
   const docType = invoiceType === 'service' || invoiceType === 'programme_milestone'
     ? invoiceType

--- a/src/data/invoiceBuilderSeed.json
+++ b/src/data/invoiceBuilderSeed.json
@@ -33,9 +33,6 @@
     "Deposit for transportation of SM || 300",
     "Deposit for medical expenses of SM || 300"
   ],
-  "notes": [
-    "Purpose of the payment must be exactly like in invoice.",
-    "Please make sure you pay the whole amount (don't use SHA option while making payment)."
-  ],
+  "notes": [],
   "taxPercent": 14
 }


### PR DESCRIPTION
### Motivation

- Keep payment-specific instructions out of the invoice PDF and surface them in a dedicated payment details companion document to avoid leaking payment-only text into invoices.
- Improve the package "Add service" picker UX by adding search, price display, and more robust filtering/clearing behavior.
- Ensure seed data reflects the new note handling by removing payment-caveat notes from the default invoice builder seed.

### Description

- Change `InvoicePdfDocument` to always filter out payment-caveat notes from the invoice `noteList` so payment instructions are not embedded in invoice PDFs.
- Update `scripts/pdfQaCheck.js` to render invoices both with and without payment details, render the new `PaymentDetailsPdfDocument`, and adjust QA checks to verify payment notes are absent from invoices and present in the payment details PDF; also refactor service props for reuse.
- Enhance `BudgetPage.jsx` by adding `insertChildQuery` state, a `SearchInput` in the add-service modal, query-based filtering of available items, exclusion of hidden/formula-referenced items when not in edit mode, styled `ServicePickerName` and `ServicePickerPrice` components, and clearing the search on cancel/insert.
- Remove default payment-caveat notes from `src/data/invoiceBuilderSeed.json` to align seed content with the new separation of payment notes.

### Testing

- Ran the PDF QA script via `node scripts/pdfQaCheck.js`, which validated that payment-only strings are absent from invoices and present in the payment details PDF.
- Ran the test suite via `yarn test`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57d6967b948326865b976e918f7c31)