### PR TITLE
Remove invoice breakdown note from Payment Details

### DIFF
--- a/src/components/PaymentDetailsPdfDocument.jsx
+++ b/src/components/PaymentDetailsPdfDocument.jsx
@@ -156,7 +156,6 @@ const PaymentDetailsPdfDocument = ({
           <View style={styles.amountCard}>
             <Text style={styles.amountLabel}>Amount due</Text>
             <Text style={styles.amountValue}>{formatMoney(amountDue)}</Text>
-            <Text style={styles.amountSub}>{sanitizePdfText(`See Invoice No. ${invoiceNumber || ''} for the full breakdown.`)}</Text>
           </View>
 
           {/* These payment caveats used to live on the Invoice PDF itself - they belong here,


### PR DESCRIPTION
### Motivation
- Remove the redundant helper sentence that points to the invoice for a full breakdown so the standalone Payment Details document contains only payment instructions and amounts.

### Description
- Deleted the `Text` node that rendered `See Invoice No. ${invoiceNumber || ''} for the full breakdown.` from `src/components/PaymentDetailsPdfDocument.jsx`, leaving only the amount label and value in the amount card.

### Testing
- Ran `npm test -- --watchAll=false --runInBand src/components/InvoiceBuilderPage.test.js` and the test suite passed.
- Ran `npm run qa:pdf` and the PDF QA check passed with no debug strings, blank pages, corrupted text, or brand leakage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57dc22f3b88326842b103f27251eaf)