### PR TITLE
Support invoice builder price formula display

### DIFF
--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -601,6 +601,12 @@ const useFieldDraft = externalValue => {
 
 const formatEuroPreview = formatEuroSmart;
 
+const getFormulaAwarePriceDraft = row => {
+  const rawPrice = row?.priceInput || row?.priceLabel || String(roundToCents(row?.price) ?? '');
+  const displayPrice = row?.priceInput ? String(roundToCents(row?.price) ?? '') : rawPrice;
+  return { rawPrice, displayPrice };
+};
+
 // --- Service line item (top-level custom/catalog row, or a row nested inside a package) ------------------------------------------------------
 
 const LineCard = styled.div`
@@ -811,7 +817,8 @@ const ServiceLineRow = ({
 }) => {
   const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
   const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
-  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(row.priceInput || row.priceLabel || String(roundToCents(row.price) ?? ''));
+  const { rawPrice, displayPrice } = getFormulaAwarePriceDraft(row);
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(displayPrice);
   const [descriptionOpen, setDescriptionOpen] = useState(false);
 
   if (row.kind === 'percent') {
@@ -859,12 +866,15 @@ const ServiceLineRow = ({
           value={priceDraft}
           placeholder="100"
           aria-label="Price (EUR)"
-          onFocus={() => { priceEditingRef.current = true; }}
+          onFocus={() => {
+            priceEditingRef.current = true;
+            setPriceDraft(rawPrice);
+          }}
           onChange={event => setPriceDraft(event.target.value)}
           onBlur={() => {
             priceEditingRef.current = false;
-            const originalPriceDraft = row.priceInput || row.priceLabel || String(roundToCents(row.price) ?? '');
-            if (priceDraft !== originalPriceDraft) onCommit('price', priceDraft);
+            if (priceDraft !== rawPrice) onCommit('price', priceDraft);
+            setPriceDraft(priceDraft !== rawPrice ? priceDraft : displayPrice);
           }}
         />
         {row.missing ? <MissingTag title="This catalog reference no longer exists">Missing</MissingTag> : null}
@@ -1260,7 +1270,8 @@ const PackageEntryCard = ({
 }) => {
   const [nameDraft, setNameDraft, nameEditingRef] = useFieldDraft(row.name);
   const [descriptionDraft, setDescriptionDraft, descriptionEditingRef] = useFieldDraft(row.description);
-  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(String(roundToCents(row.price) ?? ''));
+  const { rawPrice, displayPrice } = getFormulaAwarePriceDraft(row);
+  const [priceDraft, setPriceDraft, priceEditingRef] = useFieldDraft(displayPrice);
   const [descriptionOpen, setDescriptionOpen] = useState(false);
 
   const childCatalogIds = useMemo(
@@ -1293,12 +1304,15 @@ const PackageEntryCard = ({
           value={priceDraft}
           placeholder="0"
           aria-label="Package price (EUR)"
-          onFocus={() => { priceEditingRef.current = true; }}
+          onFocus={() => {
+            priceEditingRef.current = true;
+            setPriceDraft(rawPrice);
+          }}
           onChange={event => setPriceDraft(event.target.value)}
           onBlur={() => {
             priceEditingRef.current = false;
-            const originalPriceDraft = String(roundToCents(row.price) ?? '');
-            if (priceDraft !== originalPriceDraft) onCommitField('price', priceDraft);
+            if (priceDraft !== rawPrice) onCommitField('price', priceDraft);
+            setPriceDraft(priceDraft !== rawPrice ? priceDraft : displayPrice);
           }}
         />
         {row.hasPriceOverride ? (

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -409,7 +409,7 @@ export const normalizeServiceEntry = raw => {
       ...(raw.name !== undefined ? { name: raw.name } : {}),
       ...(raw.description !== undefined ? { description: raw.description } : {}),
       ...(raw.priceOverride !== undefined && raw.priceOverride !== null && raw.priceOverride !== ''
-        ? { priceOverride: toNumber(raw.priceOverride) }
+        ? { priceOverride: isPriceFormulaInput(raw.priceOverride) ? String(raw.priceOverride).trim() : toNumber(raw.priceOverride) }
         : {}),
       ...(raw.billDirectly ? { billDirectly: true } : {}),
       // A per-invoice override of the package's payment schedule (round7 spec C.2) - absent until
@@ -498,7 +498,10 @@ export const setEntryField = (entry, field, value) => {
     return entry;
   }
   if (entry.kind === 'package') {
-    if (field === 'price') return { ...entry, priceOverride: toNumber(value), customized: true };
+    if (field === 'price') {
+      const text = String(value ?? '').trim();
+      return { ...entry, priceOverride: isPriceFormulaInput(text) ? text : toNumber(text), customized: true };
+    }
     if (field === 'name' || field === 'description') return { ...entry, [field]: value, customized: true };
     // A billing preference, not a content override - toggling it never marks the package
     // "customized" (that flag drives the PDF's "customised programme details" note and the
@@ -686,7 +689,7 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
     const children = Array.isArray(entry.children) ? entry.children : [];
     const resolvedChildren = children.map(child => resolveServiceRow(child, catalogItemsById, priceContext));
     const childrenTotal = roundMoney(resolvedChildren.reduce((sum, row) => sum + (Number(row.price) || 0), 0));
-    const hasPriceOverride = entry.priceOverride !== undefined && entry.priceOverride !== null;
+    const hasPriceOverride = entry.priceOverride !== undefined && entry.priceOverride !== null && entry.priceOverride !== '';
     // The billed price is the package's own listed price (a deliberately curated catalog figure),
     // not the sum of whatever line items happen to be attached - that sum is only a reference for
     // the admin to sanity-check budget coverage (see childrenTotal below), and is only ever billed
@@ -711,15 +714,22 @@ export const resolveServiceRow = (entry, catalogItemsById, priceContext = {}) =>
       isHiddenCatalog: Boolean(pkg?.hidden),
       name: entry.name ?? pkg?.name ?? `Package ${entry.catalogId}`,
       description: entry.description ?? pkg?.description ?? '',
-      price: hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,
+      price: hasPriceOverride
+        ? roundMoney(resolveBudgetPriceAmount(entry.priceOverride, { ...priceContext, itemsById: catalogItemsById }) ?? entry.priceOverride)
+        : defaultPrice,
       billDirectly: Boolean(entry.billDirectly),
       childrenTotal,
       hasPriceOverride,
+      ...((hasPriceOverride && isPriceFormulaInput(entry.priceOverride))
+        ? { priceInput: String(entry.priceOverride).trim() }
+        : (!hasPriceOverride && isPriceFormulaInput(pkg?.listedPrice) ? { priceInput: String(pkg.listedPrice).trim() } : {})),
       children: resolvedChildren,
       scheduleRows: resolvePackageEntrySchedule(
         entry,
         listedPriceAmount,
-        hasPriceOverride ? roundMoney(entry.priceOverride) : defaultPrice,
+        hasPriceOverride
+          ? roundMoney(resolveBudgetPriceAmount(entry.priceOverride, { ...priceContext, itemsById: catalogItemsById }) ?? entry.priceOverride)
+          : defaultPrice,
         { ...priceContext, itemsById: catalogItemsById },
       ),
     };


### PR DESCRIPTION
## Summary
- Show resolved prices for formula-backed invoice builder rows until the price field is focused, then reveal the raw formula for editing.
- Reuse the same formula-aware price draft behavior for service rows and package rows.
- Allow package price overrides to store and resolve formula inputs consistently with custom/catalog service prices.

## Testing
- npm test -- --runTestsByPath src/utils/budgetPriceFormula.test.js src/components/InvoiceBuilderPage.test.js --watchAll=false
- git diff --check

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e35e9c708326b441cf7eb1bc6512)