### PR TITLE
Invoice Builder batch 7: footer links/icons, formula and picker fixes, document input polish

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -298,12 +298,13 @@ const DocSubtitle = styled.div`
   font-weight: 400;
 `;
 
-// "Styled as plain editable text": borderless until hovered/focused, same convention as the
-// app's other inline-editable fields.
+// "Styled as plain editable text" (the app-wide rule the Invoice Builder's plainFieldStyle also
+// follows): no border, no fill, no focus box - ever. The paragraph must read as document text
+// that happens to be editable, never as a form field sitting in the document.
 const InlineTextarea = styled.textarea`
   width: 100%;
-  border: 1px solid transparent;
-  border-radius: 6px;
+  border: none;
+  border-radius: 0;
   background: transparent;
   color: var(--km-text);
   font-family: var(--km-font);
@@ -314,14 +315,11 @@ const InlineTextarea = styled.textarea`
   min-height: 0;
   overflow: hidden;
 
-  &:hover {
-    border-color: var(--km-border);
-  }
-
+  &:hover,
   &:focus {
     outline: none;
-    border-color: var(--km-accent);
-    background: var(--km-card);
+    background: transparent;
+    box-shadow: none;
   }
 `;
 

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -20,7 +20,7 @@ import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, fetchNbuUahExchangeRatesByDate } from './config';
 import { setPdfAgencyConfig } from './pdfTheme';
-import { formatEuroSmart, getSortedPackages, parseBudgetPriceValue, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
+import { formatEuroSmart, getItemDisplayAmount, getSortedPackages, isFromPricedItem, parseBudgetPriceValue, resolveBudgetPriceAmount, resolvePaymentAmount, resolveProgramPaymentSchedule, roundToCents } from './budgetCatalogUtils';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
@@ -1083,6 +1083,17 @@ const CatalogPickerButton = styled.button`
   }
 `;
 
+// The catalog price shown next to each service in the picker (design-tasks-7 §6) - the same
+// accent/weight the row's own price field uses once the service is added, so the admin can pick
+// the right service at a glance without adding it first.
+const PickerPriceTag = styled.span`
+  flex: 0 0 auto;
+  align-self: center;
+  font-weight: 800;
+  color: var(--km-accent);
+  white-space: nowrap;
+`;
+
 // A package hidden from the public Program Budget PDF (a manually-offered "special offer") is
 // still pickable here - this badge is the only thing telling the admin it's not one of the
 // public programs.
@@ -1137,6 +1148,7 @@ const CustomLineAdder = ({
   extraButtons = null,
   indent = false,
   addOnBlur = false,
+  priceContext = null,
 }) => {
   const [name, setName] = useState('');
   const [price, setPrice] = useState('');
@@ -1144,13 +1156,25 @@ const CustomLineAdder = ({
   const [query, setQuery] = useState('');
   const [pickerTab, setPickerTab] = useState('items');
 
+  // Never capped: the picker must offer the complete backend catalog (design-tasks-7 §7) - the
+  // list box scrolls, and the search field is the tool for narrowing it down, so truncating here
+  // silently hides real services.
   const availableItems = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return catalogItems
       .filter(item => !excludeCatalogIds.has(String(item.id)))
-      .filter(item => !normalizedQuery || String(item.name || '').toLowerCase().includes(normalizedQuery))
-      .slice(0, 30);
+      .filter(item => !normalizedQuery || String(item.name || '').toLowerCase().includes(normalizedQuery));
   }, [catalogItems, excludeCatalogIds, query]);
+
+  // "from"-priced catalog services keep their prefix so the picker never presents a minimum as
+  // the fixed price. No resolvable amount (formula waiting on NBU rates) shows nothing rather
+  // than a misleading €0.
+  const itemPriceLabel = item => {
+    if (!priceContext) return '';
+    const amount = getItemDisplayAmount(item, priceContext);
+    if (amount == null) return '';
+    return `${isFromPricedItem(item) ? 'from ' : ''}${formatEuroPreview(amount)}`;
+  };
 
   const availablePackages = useMemo(() => {
     if (!catalogPackages) return [];
@@ -1240,11 +1264,15 @@ const CustomLineAdder = ({
               </>
             ) : (
               <>
-                {availableItems.map(item => (
-                  <CatalogPickerButton key={item.id} type="button" onClick={() => { onAddCatalogItem(item.id); closePicker(); }}>
-                    <span>{item.name}</span>
-                  </CatalogPickerButton>
-                ))}
+                {availableItems.map(item => {
+                  const priceLabel = itemPriceLabel(item);
+                  return (
+                    <CatalogPickerButton key={item.id} type="button" onClick={() => { onAddCatalogItem(item.id); closePicker(); }}>
+                      <span>{item.name}</span>
+                      {priceLabel ? <PickerPriceTag>{priceLabel}</PickerPriceTag> : null}
+                    </CatalogPickerButton>
+                  );
+                })}
                 {!availableItems.length ? <PanelNote style={{ margin: 0 }}>No matching catalog services.</PanelNote> : null}
               </>
             )}
@@ -3879,6 +3907,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   addOnBlur
                   catalogItems={catalogItems}
                   excludeCatalogIds={usedCatalogItemIds}
+                  priceContext={priceContext}
                   onAddCustom={addCustomServiceEntry}
                   onAddCatalogItem={addCatalogServiceEntry}
                   catalogPackages={availablePercentPackages}

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -188,6 +188,45 @@ describe('InvoiceBuilderPage', () => {
     await act(async () => { root.unmount(); });
   });
 
+  // design-tasks-7 §5 (verification): a "=..." formula typed into an Other Expenses price field
+  // must persist as the formula and display as the computed amount, never turn into a free-text
+  // price label or a zero.
+  it('computes a "=500/1,16" formula typed into an Other Expenses price field', async () => {
+    const root = mount();
+    await flush();
+
+    const priceField = container.querySelector('textarea[aria-label="Price (EUR)"]');
+    expect(priceField).toBeTruthy();
+    await act(async () => {
+      priceField.focus();
+      setFieldValue(priceField, '=500/1,16');
+      priceField.blur();
+    });
+    await flush();
+
+    const lastServicesCall = set.mock.calls.filter(([path]) => path === 'invoiceBuilder/invoiceServices').pop();
+    expect(lastServicesCall[1][0]).toMatchObject({ kind: 'item', catalogId: '10', price: '=500/1,16', customized: true });
+    expect(priceField.value).toBe('431.03');
+
+    await act(async () => { root.unmount(); });
+  });
+
+  // design-tasks-7 §6/§7: the Other Expenses catalog picker shows every not-yet-added service
+  // with its catalog price next to the name.
+  it('lists catalog services with their prices in the Other Expenses picker', async () => {
+    const root = mount();
+    await flush();
+
+    await act(async () => { findButton('From catalog').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    const pickerButton = findButton('Airport transfer');
+    expect(pickerButton).toBeTruthy();
+    expect(pickerButton.textContent).toContain('€90');
+
+    await act(async () => { root.unmount(); });
+  });
+
   it('adds a whole package from the catalog, then removing one of its services makes it a custom package', async () => {
     const root = mount();
     await flush();

--- a/src/components/invoiceCatalogUtils.js
+++ b/src/components/invoiceCatalogUtils.js
@@ -61,9 +61,17 @@ export const parseCustomPriceInput = raw => {
 // "25" or "25%" reads as 25% of the package price; "10000", "€10,000" or "10000 EUR" reads as a
 // fixed 10,000 EUR amount. An explicit % / € / EUR marker always wins; a bare number splits on the
 // only unambiguous boundary available - a percent share can't exceed 100.
+// A "=..." formula works here too (design-tasks-7 §5) - same engine as every other price field:
+// it's evaluated first, then the computed number goes through the same percent-vs-amount split
+// (e.g. "=500/1,16" -> 431.03, over 100, so a fixed EUR amount).
 export const parsePercentOrAmountInput = raw => {
   const text = String(raw ?? '').trim();
   if (!text) return { percent: 0 };
+  if (isPriceFormulaInput(text)) {
+    const computed = resolveBudgetPriceAmount(text);
+    if (computed == null) return { percent: 0 };
+    return computed > 100 ? { amount: computed } : { percent: computed };
+  }
   const hasPercentMark = /%/.test(text);
   const hasCurrencyMark = /€|eur/i.test(text);
   const cleaned = text.replace(/%|€|eur/gi, '').replace(/\s+/g, '');

--- a/src/components/invoiceCatalogUtils.test.js
+++ b/src/components/invoiceCatalogUtils.test.js
@@ -704,6 +704,13 @@ describe('invoiceCatalogUtils', () => {
       expect(parsePercentOrAmountInput('50 EUR')).toEqual({ amount: 50 });
     });
 
+    it('computes a "=..." formula first, then applies the same percent-vs-amount split (design-tasks-7 §5)', () => {
+      expect(parsePercentOrAmountInput('=500/1,16')).toEqual({ amount: 431.03 });
+      expect(parsePercentOrAmountInput('=50/2')).toEqual({ percent: 25 });
+      // An unresolvable formula falls back to a harmless zero percent, never NaN.
+      expect(parsePercentOrAmountInput('=500/')).toEqual({ percent: 0 });
+    });
+
     it('stores a typed EUR amount on a percent row, and it wins over the percent when priced', () => {
       const entry = makePercentOfPackageEntry('7', 25);
       const amountEntry = setEntryField(entry, 'percent', '10000');

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -4,7 +4,7 @@
 // / bronze-motif / title-block / footer building blocks from here so every document reads as one
 // product. Tokens below mirror the UKRCOM Invoice Builder design spec (ukrcom-invoice-fullset.html).
 import React from 'react';
-import { Font, StyleSheet, Svg, Defs, LinearGradient, Stop, Line, Text, View } from '@react-pdf/renderer';
+import { Circle, Defs, Ellipse, Font, LinearGradient, Line, Link, Path, Rect, Stop, StyleSheet, Svg, Text, View } from '@react-pdf/renderer';
 import designTokens from '../data/designTokens.json';
 
 // Colors and font families are never hardcoded here - they live in src/data/designTokens.json,
@@ -93,12 +93,26 @@ const toTelegramHandle = value => {
   return handle.startsWith('@') ? handle : `@${handle}`;
 };
 
+// The clickable counterpart of the @handle above - the footer's Telegram contact opens a chat the
+// same way the email opens a mail client.
+const toTelegramLink = handle => {
+  const text = String(handle || '').trim().replace(/^@/, '');
+  return text ? `https://t.me/${text}` : '';
+};
+
+// One quotation-mark style across every document (design-tasks-7 §3): the backend agency record
+// may carry typographic quotes in one field and straight ones in another - normalized once here,
+// at config time, so 'Reproductive Agency "UKRCOM"' reads identically in every header and footer.
+const normalizeQuoteStyle = text => String(text ?? '')
+  .replace(/[“”«»]/g, '"')
+  .replace(/[‘’]/g, "'");
+
 let pdfAgency = { ...DEFAULT_AGENCY };
 
 export const setPdfAgencyConfig = raw => {
   const source = raw && typeof raw === 'object' ? raw : {};
   pdfAgency = Object.keys(DEFAULT_AGENCY).reduce((merged, key) => {
-    const value = String(source[key] ?? '').trim();
+    const value = normalizeQuoteStyle(source[key]).trim();
     return { ...merged, [key]: value || DEFAULT_AGENCY[key] };
   }, {});
   pdfAgency.telegram = toTelegramHandle(pdfAgency.telegram);
@@ -338,6 +352,30 @@ export const pdfBaseStyles = {
     color: PDF_COLOR.footerSoft,
     lineHeight: 1.5,
   },
+  footerContactRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 1,
+  },
+  footerContactItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  // Same metrics as footerText, as a Link: no browser-blue, no underline - the icon next to each
+  // contact is what signals it's actionable, the text stays part of the quiet footer line.
+  footerLink: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 7,
+    color: PDF_COLOR.footerSoft,
+    textDecoration: 'none',
+  },
+  footerContactDivider: {
+    fontFamily: PDF_FONT.body,
+    fontSize: 7,
+    color: PDF_COLOR.footerSoft,
+    opacity: 0.5,
+    marginHorizontal: 5,
+  },
   footerPage: {
     fontFamily: PDF_FONT.body,
     fontSize: 7,
@@ -487,20 +525,76 @@ export const SummaryCard = ({ label, text }) => (text ? (
   </View>
 ) : null);
 
+// Tiny inline icons for the footer contact row, drawn with SVG primitives in the footer's own
+// muted color. The Telegram one is the recognizable paper plane - never a generic/other-platform
+// mark, so the @handle next to it can't be mistaken for e.g. an Instagram account
+// (design-tasks-7 §1).
+const FOOTER_ICON_SIZE = 6.5;
+const footerIconStyle = { width: FOOTER_ICON_SIZE, height: FOOTER_ICON_SIZE, marginRight: 3 };
+const footerIconStroke = { stroke: PDF_COLOR.footerSoft, strokeWidth: 2, fill: 'none' };
+
+const FooterGlobeIcon = () => (
+  <Svg style={footerIconStyle} viewBox="0 0 24 24">
+    <Circle cx="12" cy="12" r="10" {...footerIconStroke} />
+    <Ellipse cx="12" cy="12" rx="4.5" ry="10" {...footerIconStroke} />
+    <Line x1="2" y1="12" x2="22" y2="12" {...footerIconStroke} />
+  </Svg>
+);
+
+const FooterMailIcon = () => (
+  <Svg style={footerIconStyle} viewBox="0 0 24 24">
+    <Rect x="2" y="4.5" width="20" height="15" rx="2.5" {...footerIconStroke} />
+    <Path d="M3 6.5 L12 13.5 L21 6.5" {...footerIconStroke} />
+  </Svg>
+);
+
+// The Font Awesome paper-plane silhouette (FaTelegramPlane), filled - the unmistakable Telegram
+// glyph.
+const FooterTelegramIcon = () => (
+  <Svg style={footerIconStyle} viewBox="0 0 448 512">
+    <Path
+      fill={PDF_COLOR.footerSoft}
+      d="M446.7 98.6l-67.6 318.8c-5.1 22.5-18.4 28.1-37.3 17.5l-103-75.9-49.7 47.8c-5.5 5.5-10.1 10.1-20.7 10.1l7.4-104.9 190.9-172.5c8.3-7.4-1.8-11.5-12.9-4.1L117.8 284 16.2 252.2c-22.1-6.9-22.5-22.1 4.6-32.7L418.2 66.4c18.4-6.9 34.5 4.1 28.5 32.2z"
+    />
+  </Svg>
+);
+
+// One icon + clickable-text contact for the footer row below. Rendered only when both the value
+// and its target link resolve.
+const FooterContact = ({ icon, label, href }) => (label && href ? (
+  <View style={pdfSharedStyles.footerContactItem}>
+    {icon}
+    <Link src={href} style={pdfSharedStyles.footerLink}>{sanitizePdfText(label)}</Link>
+  </View>
+) : null);
+
 // Identical agency footer on every page of every branded document (spec §1.2). `variant="neutral"`
 // drops the UKRCOM agency block entirely - required on the Payment Details page/document, whose
 // beneficiary (a sole proprietorship) is a legally separate party from the agency (spec §1.5).
 // The identity lines themselves come from the backend agency config (see setPdfAgencyConfig above).
+// Website/email/Telegram render as icon-labelled live links (design-tasks-7 §1): the site opens in
+// a browser, the email as a mailto: draft, the @handle as a t.me chat.
 export const Footer = ({ variant = 'branded' } = {}) => {
   const agency = getPdfAgencyConfig();
-  const contactLine = [agency.website, agency.email, agency.telegram].filter(Boolean).join(' · ');
+  const contacts = [
+    { key: 'website', icon: <FooterGlobeIcon />, label: agency.website, href: agency.website },
+    { key: 'email', icon: <FooterMailIcon />, label: agency.email, href: agency.email ? `mailto:${agency.email}` : '' },
+    { key: 'telegram', icon: <FooterTelegramIcon />, label: agency.telegram, href: toTelegramLink(agency.telegram) },
+  ].filter(contact => contact.label && contact.href);
   return (
     <View style={pdfSharedStyles.footer} fixed>
       {variant === 'neutral' ? <View style={pdfSharedStyles.footerColumn} /> : (
         <View style={pdfSharedStyles.footerColumn}>
           <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(agency.name)}</Text>
           <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(agency.address)}</Text>
-          <Text style={pdfSharedStyles.footerText}>{sanitizePdfText(contactLine)}</Text>
+          <View style={pdfSharedStyles.footerContactRow}>
+            {contacts.map((contact, index) => (
+              <React.Fragment key={contact.key}>
+                {index > 0 ? <Text style={pdfSharedStyles.footerContactDivider}>|</Text> : null}
+                <FooterContact icon={contact.icon} label={contact.label} href={contact.href} />
+              </React.Fragment>
+            ))}
+          </View>
         </View>
       )}
       <Text

--- a/src/hooks/useAutoResize.js
+++ b/src/hooks/useAutoResize.js
@@ -4,12 +4,29 @@ export const useAutoResize = (ref, value) => {
   const autoResize = useCallback(textarea => {
     if (!textarea) return;
     textarea.style.height = 'auto';
-    textarea.style.height = `${textarea.scrollHeight}px`;
+    // scrollHeight is content + padding only. With box-sizing: border-box (the app default) the
+    // height style must also cover the borders, otherwise the field measures a couple px shorter
+    // than its own text and clips the last line's descenders.
+    const borderHeight = textarea.offsetHeight - textarea.clientHeight;
+    textarea.style.height = `${textarea.scrollHeight + (borderHeight > 0 ? borderHeight : 0)}px`;
   }, []);
 
   useEffect(() => {
     autoResize(ref.current);
   }, [ref, value, autoResize]);
+
+  // The value isn't the only thing that changes how tall the text renders: the field re-wraps
+  // when the viewport (and therefore the column) gets narrower, and when the custom webfont
+  // finishes loading with different metrics than the fallback it replaced. Both would otherwise
+  // leave the field at a stale, too-short height with the overflow clipped.
+  useEffect(() => {
+    const remeasure = () => autoResize(ref.current);
+    window.addEventListener('resize', remeasure);
+    if (typeof document !== 'undefined' && document.fonts?.ready?.then) {
+      document.fonts.ready.then(remeasure).catch(() => {});
+    }
+    return () => window.removeEventListener('resize', remeasure);
+  }, [ref, autoResize]);
 
   return autoResize;
 };


### PR DESCRIPTION
- Invoice PDF footer: website, email, and Telegram are now clickable links
  (browser / mailto: / t.me), each with a small inline icon - the Telegram
  handle gets the recognizable paper-plane glyph so it can't be mistaken
  for another platform's account.
- One quotation-mark style for the agency name: quotes are normalized once
  in setPdfAgencyConfig, so 'Reproductive Agency "UKRCOM"' reads the same
  in every header/footer regardless of what the backend record carries.
- Other Expenses: a '=...' formula typed into the percent/amount field of a
  'Scheduled payment' share now computes (parsePercentOrAmountInput runs it
  through the shared formula engine before the percent-vs-amount split).
- Other Expenses catalog picker: every not-yet-added service is listed (the
  silent 30-item cap is gone - the list scrolls) and each service shows its
  catalog price next to the name.
- Documents Builder: paragraph inputs auto-size to their real rendered text
  height (border-box compensation, re-measure on window resize and webfont
  load) and are styled as plain editable text - no hover/focus box.

Verified: Tax row already shows the percentage in one place only, and the
two wire-transfer caveat lines already render only on Payment Details (the
Invoice filters them; covered by the qa:pdf gate).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QBjYe6DnVomU3Sjuw5G8Jg