### PR TITLE
Assign clinic logo variants to column layouts explicitly

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -23,9 +23,12 @@ import {
   DOCUMENTS_TEMPLATES_PATH,
   DOCUMENT_LAYOUTS,
   PARTY_COLLECTIONS,
+  applyLogoLayoutAssignment,
   buildCaseLabel,
   buildDocumentsFileName,
   buildGeneratedDocument,
+  clinicLogoDbPath,
+  clinicLogoEntriesToBackend,
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
   emptyDocumentsCatalog,
@@ -48,6 +51,13 @@ const isStaleChunkError = error => /loading (?:css )?chunk|chunkloaderror/i.test
 const STALE_APP_MESSAGE = 'The app has been updated since this page was opened. Refresh the page and try again.';
 
 const MAX_LOGO_FILE_BYTES = 1024 * 1024;
+
+// The two layout tags a logo variant can be assigned to (one tap on the variant row); the column
+// mode selected at the top of the page then picks the matching variant automatically.
+const LOGO_LAYOUT_OPTIONS = [
+  { tag: '2col', label: '2 col', title: 'Use this variant above the two-column (UA + EN) layout' },
+  { tag: '1col', label: '1 col', title: 'Use this variant full-width on the one-column (UA or EN) layouts' },
+];
 
 // Mobile admins can't easily reach the browser devtools console, so every Storage failure below
 // is folded into the on-screen message with the real Firebase/network error code - "see the
@@ -427,11 +437,21 @@ const LogoPreview = styled.img`
   background: #fff;
 `;
 
+// An unassigned variant is kept in the list but visually muted - it is not used on documents.
 const LogoVariant = styled.div`
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  opacity: ${({ $muted }) => ($muted ? 0.5 : 1)};
+`;
+
+// Live logo preview above the document list: swaps with the column-mode toggle, confirming which
+// variant is assigned where before anything is generated.
+const DocLogoPreviewRow = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
 `;
 
 const LogoVariantCaption = styled.div`
@@ -491,7 +511,8 @@ const DocumentsPage = ({ isAdmin }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
-  // Every uploaded logo variant of the selected clinic: { fileName, dataUrl, width, height }.
+  // Every uploaded logo variant of the selected clinic: { fileName, dataUrl, width, height,
+  // layout } where layout is the '2col' / '1col' assignment ('' while unassigned).
   const [clinicLogos, setClinicLogos] = useState([]);
   const [clinicLogoLoading, setClinicLogoLoading] = useState(false);
   const [clinicLogoError, setClinicLogoError] = useState('');
@@ -504,6 +525,13 @@ const DocumentsPage = ({ isAdmin }) => {
   useEffect(() => {
     settingsRef.current = settings;
   }, [settings]);
+  // Layout assignments ({ file, layout } entries per clinic) live in the catalog; the Storage
+  // listing effect reads them through this ref so a local assignment change never re-lists the
+  // whole Storage folder.
+  const clinicLogoAssignmentsRef = useRef(catalog.clinicLogos);
+  useEffect(() => {
+    clinicLogoAssignmentsRef.current = catalog.clinicLogos || {};
+  }, [catalog.clinicLogos]);
 
   const loadDocumentsData = useCallback(async () => {
     setLoading(true);
@@ -808,9 +836,12 @@ const DocumentsPage = ({ isAdmin }) => {
           const { fileName } = await uploadFileToStorageFolder(file, clinicLogoStorageFolder(clinicId), {
             disableCompression: true,
           });
+          // New variants start unassigned - the admin taps "2 col" / "1 col" on the row to say
+          // which column layout the file is for.
           setClinicLogos(previous => [...previous.filter(variant => variant.fileName !== fileName), {
             fileName,
             dataUrl,
+            layout: '',
             width: image.naturalWidth || 0,
             height: image.naturalHeight || 0,
           }]);
@@ -845,14 +876,47 @@ const DocumentsPage = ({ isAdmin }) => {
     image.src = dataUrl;
   }), []);
 
+  // Writes the clinic's DB logo node ({ file, layout } per variant) and, once the write landed,
+  // syncs the in-memory catalog mirror so a later Storage re-list re-applies the assignments.
+  const persistLogoAssignments = async (clinicId, variants) => {
+    const entries = clinicLogoEntriesToBackend(variants);
+    await set(ref(database, clinicLogoDbPath(clinicId)), entries);
+    setCatalog(previous => ({
+      ...previous,
+      clinicLogos: {
+        ...previous.clinicLogos,
+        [clinicId]: entries.map(entry => ({ file: entry.file, layout: entry.layout || '' })),
+      },
+    }));
+  };
+
+  const handleAssignLogoLayout = async (fileName, layoutTag) => {
+    const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
+    if (!clinicId) return;
+    const previousVariants = clinicLogos;
+    const nextVariants = applyLogoLayoutAssignment(previousVariants, fileName, layoutTag);
+    setClinicLogos(nextVariants);
+    try {
+      await persistLogoAssignments(clinicId, nextVariants);
+    } catch (assignError) {
+      console.error('Unable to save clinic logo layout assignment', assignError);
+      setClinicLogos(previousVariants);
+      toast.error('Could not save the logo layout assignment.');
+    }
+  };
+
   const handleRemoveLogoVariant = async fileName => {
     if (typeof window !== 'undefined' && !window.confirm('Remove this clinic logo variant from the backend?')) return;
     const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
     if (!clinicId) return;
     try {
       await deleteStorageFile(clinicLogoStorageFilePath(clinicId, fileName));
-      setClinicLogos(previous => previous.filter(variant => variant.fileName !== fileName));
+      const remaining = clinicLogos.filter(variant => variant.fileName !== fileName);
+      setClinicLogos(remaining);
       setClinicLogoRefreshKey(previous => previous + 1);
+      // Best effort: drop the deleted file's DB entry too. A stale entry is harmless - the
+      // assignments only apply to files Storage still lists.
+      persistLogoAssignments(clinicId, remaining).catch(() => {});
       toast.success('Clinic logo variant removed.');
     } catch (removeError) {
       console.error('Unable to remove clinic logo', removeError);
@@ -892,6 +956,9 @@ const DocumentsPage = ({ isAdmin }) => {
   const selectedTemplates = catalog.documents.filter(template => selectedDocIds[template.id]);
   const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
   const caseContext = resolveCaseContext(catalog, selectedCaseId);
+  // Exactly the variant PDF/Word generation will use for the selected column mode - shown as the
+  // live preview above the document list, so switching the mode swaps the logo immediately.
+  const activeLogoVariant = pickLogoVariantForLayout(clinicLogos, layout);
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || clinicLogoLoading || !selectedTemplates.length || !selectedCase;
 
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
@@ -933,6 +1000,10 @@ const DocumentsPage = ({ isAdmin }) => {
         return;
       }
 
+      // Storage lists the files; the DB logo node (catalog.clinicLogos) says which of them is
+      // assigned to which column layout.
+      const assignments = clinicLogoAssignmentsRef.current?.[clinicId] || [];
+      const layoutFor = fileName => assignments.find(entry => entry.file === fileName)?.layout || '';
       const results = await Promise.all(fileNames.map(async fileName => {
         try {
           const rawDataUrl = await getStorageFileDataUrl(clinicLogoStorageFilePath(clinicId, fileName));
@@ -942,7 +1013,7 @@ const DocumentsPage = ({ isAdmin }) => {
           // EXIF-rotated logo can fail to appear in the generated PDF with no error.
           const dataUrl = await reencodePdfImageDataUrl(rawDataUrl);
           const dimensions = await readImageDimensions(dataUrl);
-          return { fileName, variant: { fileName, dataUrl, ...dimensions } };
+          return { fileName, variant: { fileName, dataUrl, layout: layoutFor(fileName), ...dimensions } };
         } catch (loadLogoError) {
           console.error('[ClinicLogo] Unable to load', fileName, 'from', clinicLogoStorageFolder(clinicId), loadLogoError);
           return { fileName, error: describeStorageError(loadLogoError) };
@@ -1126,6 +1197,16 @@ const DocumentsPage = ({ isAdmin }) => {
                   </ToggleOption>
                 </ToggleGroup>
               </SectionHead>
+              {formatting.showLogo && activeLogoVariant ? (
+                <DocLogoPreviewRow>
+                  <LogoPreview
+                    src={activeLogoVariant.dataUrl}
+                    alt="Clinic logo for the selected column mode"
+                    title="The logo variant the selected column mode will render (also used by PDF/Word generation)"
+                    style={layout === 'two-column' ? undefined : { width: '100%', maxWidth: '100%' }}
+                  />
+                </DocLogoPreviewRow>
+              ) : null}
               {!catalog.documents.length ? (
                 <DocSubtitle style={{ marginTop: 8 }}>No document templates yet — paste them in the technical field below.</DocSubtitle>
               ) : null}
@@ -1253,27 +1334,33 @@ const DocumentsPage = ({ isAdmin }) => {
               {formattingOpen ? (
                 <>
                   <RowLine style={{ marginTop: 10 }}>
-                    {clinicLogos.length ? clinicLogos.map(variant => {
-                      const usedFor = [
-                        pickLogoVariantForLayout(clinicLogos, 'two-column')?.fileName === variant.fileName ? '2 col' : '',
-                        pickLogoVariantForLayout(clinicLogos, 'one-column-uk')?.fileName === variant.fileName ? '1 col' : '',
-                      ].filter(Boolean).join(' · ');
-                      return (
-                        <LogoVariant key={variant.fileName}>
-                          <LogoPreview src={variant.dataUrl} alt="Clinic logo variant" />
-                          <LogoVariantCaption>
-                            {usedFor ? <span>Used: {usedFor}</span> : null}
-                            <DangerButton
-                              type="button"
-                              onClick={() => handleRemoveLogoVariant(variant.fileName)}
-                              title="Remove this logo variant"
-                            >
-                              <FaTrash />
-                            </DangerButton>
-                          </LogoVariantCaption>
-                        </LogoVariant>
-                      );
-                    }) : (
+                    {clinicLogos.length ? clinicLogos.map(variant => (
+                      <LogoVariant key={variant.fileName} $muted={!variant.layout}>
+                        <LogoPreview src={variant.dataUrl} alt="Clinic logo variant" />
+                        <LogoVariantCaption>
+                          <ToggleGroup>
+                            {LOGO_LAYOUT_OPTIONS.map(option => (
+                              <ToggleOption
+                                key={option.tag}
+                                type="button"
+                                $active={variant.layout === option.tag}
+                                onClick={() => handleAssignLogoLayout(variant.fileName, option.tag)}
+                                title={option.title}
+                              >
+                                {option.label}
+                              </ToggleOption>
+                            ))}
+                          </ToggleGroup>
+                          <DangerButton
+                            type="button"
+                            onClick={() => handleRemoveLogoVariant(variant.fileName)}
+                            title="Remove this logo variant"
+                          >
+                            <FaTrash />
+                          </DangerButton>
+                        </LogoVariantCaption>
+                      </LogoVariant>
+                    )) : (
                       <DocSubtitle>{clinicLogoLoading ? 'Loading the clinic logo…' : (clinicLogoError || 'No clinic logo uploaded yet.')}</DocSubtitle>
                     )}
                     <input

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -8,8 +8,10 @@ export const DOCUMENTS_PARTIES_PATH = 'documentsBuilder/parties';
 export const DOCUMENTS_TEMPLATES_PATH = 'documentsBuilder/templates';
 export const DOCUMENTS_SETTINGS_PATH = 'documentsBuilder/settings';
 
-// Legacy clinic-logo filename helpers. Current UI lists the Storage folder directly, but these
-// paths still normalize older Realtime Database filename mirrors without treating them as cases.
+// Clinic-logo paths. The Storage folder holds the image files themselves (and is listed directly
+// as the source of truth for which variants exist); the Realtime Database node at the same path
+// holds the per-variant layout assignments as `{ file, layout }` entries (legacy nodes stored
+// bare filenames - both shapes are normalized by normalizeClinicLogoEntries).
 export const clinicLogoDbPath = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const clinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoStorageFolder(clinicId)}/${fileName}`;
@@ -25,6 +27,50 @@ const toArray = value => {
 };
 
 const makeRecordId = prefix => `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+// --- Clinic logo variants --------------------------------------------------------------------
+
+// The column mode selected at the top of the page is the flag that decides which logo variant is
+// used (spec: batch 10): each variant carries one of these assignments, or '' when unassigned.
+export const LOGO_LAYOUT_TAGS = ['2col', '1col'];
+
+const normalizeLogoLayoutTag = value => (LOGO_LAYOUT_TAGS.includes(value) ? value : '');
+
+// The DB logo node stores one entry per uploaded variant. Current shape is `{ file, layout }`;
+// legacy nodes stored bare filenames, which normalize to unassigned entries.
+export const normalizeClinicLogoEntries = raw => toArray(raw)
+  .map(entry => {
+    if (typeof entry === 'string') return entry ? { file: entry, layout: '' } : null;
+    if (isPlainObject(entry) && entry.file) {
+      return { file: String(entry.file), layout: normalizeLogoLayoutTag(entry.layout) };
+    }
+    return null;
+  })
+  .filter(Boolean);
+
+// One tap on a variant's layout tag: assign that column mode to the variant, moving the
+// assignment off any other variant that held it (at most one variant per layout); tapping the
+// already-active tag unassigns. Works on both DB entries ({ file }) and the page's loaded
+// variants ({ fileName }).
+export const applyLogoLayoutAssignment = (variants, fileName, layoutTag) => {
+  const tag = normalizeLogoLayoutTag(layoutTag);
+  if (!tag) return [...(variants || [])];
+  return (variants || []).map(variant => {
+    const name = variant.file ?? variant.fileName;
+    if (name === fileName) return { ...variant, layout: variant.layout === tag ? '' : tag };
+    return variant.layout === tag ? { ...variant, layout: '' } : variant;
+  });
+};
+
+// Firebase persistence shape of the DB logo node: one entry per variant, the layout key present
+// only while assigned (Realtime Database has no use for the '' placeholder).
+export const clinicLogoEntriesToBackend = variants => (variants || [])
+  .map(variant => {
+    const file = String(variant.file ?? variant.fileName ?? '');
+    if (!file) return null;
+    return variant.layout ? { file, layout: variant.layout } : { file };
+  })
+  .filter(Boolean);
 
 // --- Catalog -------------------------------------------------------------------------------
 
@@ -52,15 +98,15 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
   const rawClinicLogos = rawParties?.cases?.clinics;
   if (isPlainObject(rawClinicLogos)) {
     Object.entries(rawClinicLogos).forEach(([clinicId, node]) => {
-      const names = toArray(node?.logo).map(String).filter(Boolean);
-      if (names.length) catalog.clinicLogos[clinicId] = names;
+      const entries = normalizeClinicLogoEntries(node?.logo);
+      if (entries.length) catalog.clinicLogos[clinicId] = entries;
     });
   }
   // Legacy fallback: earlier builds kept the file names on the clinic record itself.
   catalog.parties.clinics.forEach(clinic => {
     if (!catalog.clinicLogos[String(clinic.id)] && Array.isArray(clinic.logo)) {
-      const names = clinic.logo.map(String).filter(Boolean);
-      if (names.length) catalog.clinicLogos[String(clinic.id)] = names;
+      const entries = normalizeClinicLogoEntries(clinic.logo);
+      if (entries.length) catalog.clinicLogos[String(clinic.id)] = entries;
     }
   });
   return catalog;
@@ -369,13 +415,22 @@ export const DOCUMENT_LAYOUTS = [
   { id: 'one-column-en', label: 'EN · 1 column' },
 ];
 
-// A clinic can keep several logo file variants (spec §7): a compact/square one for the shared
-// logo above the two-column layout and a long full-width one for the one-column layouts. The
-// variant is picked by aspect ratio: squarest for two columns, widest for one column. With a
-// single uploaded file both layouts fall back to it.
+// A clinic can keep several logo file variants (spec §7): a compact one for the shared logo
+// above the two-column layout and a long full-width one for the one-column layouts. The column
+// mode selected at the top of the page is the flag that picks the variant: the one explicitly
+// assigned '2col' or '1col' (see applyLogoLayoutAssignment). If the mode's assigned variant is
+// missing, the variant assigned to the other layout is the fallback - generation never fails
+// over a logo. Unassigned variants are not used, except when no variant is assigned at all
+// (single legacy upload, freshly uploaded files): then the pre-assignment aspect-ratio heuristic
+// keeps picking - squarest for two columns, widest for one column.
 export const pickLogoVariantForLayout = (logoVariants, layout) => {
   const variants = (logoVariants || []).filter(variant => variant && variant.dataUrl);
   if (!variants.length) return null;
+  const desiredTag = layout === 'two-column' ? '2col' : '1col';
+  const otherTag = desiredTag === '2col' ? '1col' : '2col';
+  const assignedTo = tag => variants.find(variant => variant.layout === tag) || null;
+  const assigned = assignedTo(desiredTag) || assignedTo(otherTag);
+  if (assigned) return assigned;
   const aspectRatio = variant => (variant.width > 0 && variant.height > 0 ? variant.width / variant.height : 1);
   return variants.reduce((best, variant) => {
     if (!best) return variant;

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -1,7 +1,9 @@
 import {
   DEFAULT_DOC_FORMATTING,
+  applyLogoLayoutAssignment,
   buildCaseLabel,
   buildGeneratedDocument,
+  clinicLogoEntriesToBackend,
   deepMergeRecords,
   emptyDocumentsCatalog,
   fillPlaceholders,
@@ -278,7 +280,7 @@ describe('data-mode overrides', () => {
 });
 
 describe('clinic logos', () => {
-  it('reads file names from parties/cases/clinics without leaking them into cases', () => {
+  it('reads legacy bare file names from parties/cases/clinics as unassigned entries', () => {
     const catalog = normalizeDocumentsCatalog(
       {
         clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
@@ -289,8 +291,37 @@ describe('clinic logos', () => {
       },
       null,
     );
-    expect(catalog.clinicLogos['clinic-1']).toEqual(['a.jpg', 'b.png']);
+    expect(catalog.clinicLogos['clinic-1']).toEqual([
+      { file: 'a.jpg', layout: '' },
+      { file: 'b.png', layout: '' },
+    ]);
     expect(catalog.parties.cases.map(record => record.id)).toEqual(['case-1']);
+  });
+
+  it('reads { file, layout } entries and drops unknown layout tags', () => {
+    const catalog = normalizeDocumentsCatalog(
+      {
+        cases: {
+          clinics: {
+            'clinic-1': {
+              logo: [
+                { file: 'square.jpg', layout: '2col' },
+                { file: 'wide.jpg', layout: '1col' },
+                { file: 'spare.jpg', layout: 'diagonal' },
+                'legacy.jpg',
+              ],
+            },
+          },
+        },
+      },
+      null,
+    );
+    expect(catalog.clinicLogos['clinic-1']).toEqual([
+      { file: 'square.jpg', layout: '2col' },
+      { file: 'wide.jpg', layout: '1col' },
+      { file: 'spare.jpg', layout: '' },
+      { file: 'legacy.jpg', layout: '' },
+    ]);
   });
 
   it('falls back to legacy file names stored on the clinic record', () => {
@@ -298,10 +329,28 @@ describe('clinic logos', () => {
       { clinics: { 'clinic-1': { id: 'clinic-1', logo: ['legacy.jpg'] } } },
       null,
     );
-    expect(catalog.clinicLogos['clinic-1']).toEqual(['legacy.jpg']);
+    expect(catalog.clinicLogos['clinic-1']).toEqual([{ file: 'legacy.jpg', layout: '' }]);
   });
 
-  it('picks the squarest variant for two columns and the widest for one column', () => {
+  it('picks the variant assigned to the selected column mode', () => {
+    const twoCol = { fileName: 'square.jpg', dataUrl: 'data:1', layout: '2col', width: 200, height: 180 };
+    const oneCol = { fileName: 'wide.jpg', dataUrl: 'data:2', layout: '1col', width: 900, height: 120 };
+    const spare = { fileName: 'spare.jpg', dataUrl: 'data:3', layout: '', width: 1200, height: 100 };
+    expect(pickLogoVariantForLayout([oneCol, twoCol, spare], 'two-column')).toBe(twoCol);
+    expect(pickLogoVariantForLayout([oneCol, twoCol, spare], 'one-column-uk')).toBe(oneCol);
+    expect(pickLogoVariantForLayout([oneCol, twoCol, spare], 'one-column-en')).toBe(oneCol);
+  });
+
+  it('falls back to the other assigned variant instead of rendering no logo', () => {
+    const twoCol = { fileName: 'square.jpg', dataUrl: 'data:1', layout: '2col', width: 200, height: 180 };
+    const spare = { fileName: 'spare.jpg', dataUrl: 'data:3', layout: '', width: 1200, height: 100 };
+    // The '1 col' variant was deleted: the '2 col' variant is used, the unassigned one is not.
+    expect(pickLogoVariantForLayout([twoCol, spare], 'one-column-uk')).toBe(twoCol);
+    const oneCol = { fileName: 'wide.jpg', dataUrl: 'data:2', layout: '1col', width: 900, height: 120 };
+    expect(pickLogoVariantForLayout([oneCol, spare], 'two-column')).toBe(oneCol);
+  });
+
+  it('keeps the aspect-ratio heuristic while no variant is assigned', () => {
     const compact = { fileName: 'square.jpg', dataUrl: 'data:1', width: 200, height: 180 };
     const long = { fileName: 'wide.jpg', dataUrl: 'data:2', width: 900, height: 120 };
     const portrait = { fileName: 'portrait.jpg', dataUrl: 'data:3', width: 100, height: 400 };
@@ -311,6 +360,42 @@ describe('clinic logos', () => {
     expect(pickLogoVariantForLayout([compact, long], 'one-column-en')).toBe(long);
     expect(pickLogoVariantForLayout([long], 'two-column')).toBe(long);
     expect(pickLogoVariantForLayout([], 'two-column')).toBeNull();
+  });
+
+  it('assigns a layout with one tap, keeping at most one variant per layout', () => {
+    const variants = [
+      { fileName: 'a.jpg', layout: '1col' },
+      { fileName: 'b.jpg', layout: '' },
+    ];
+    // Assigning '1col' to b moves the assignment off a.
+    expect(applyLogoLayoutAssignment(variants, 'b.jpg', '1col')).toEqual([
+      { fileName: 'a.jpg', layout: '' },
+      { fileName: 'b.jpg', layout: '1col' },
+    ]);
+    // Tapping the active tag again unassigns.
+    expect(applyLogoLayoutAssignment(variants, 'a.jpg', '1col')).toEqual([
+      { fileName: 'a.jpg', layout: '' },
+      { fileName: 'b.jpg', layout: '' },
+    ]);
+    // Assigning the other layout leaves the '1col' assignment alone.
+    expect(applyLogoLayoutAssignment(variants, 'b.jpg', '2col')).toEqual([
+      { fileName: 'a.jpg', layout: '1col' },
+      { fileName: 'b.jpg', layout: '2col' },
+    ]);
+    // DB-shaped entries ({ file }) work the same way.
+    expect(applyLogoLayoutAssignment([{ file: 'a.jpg', layout: '' }], 'a.jpg', '2col')).toEqual([
+      { file: 'a.jpg', layout: '2col' },
+    ]);
+  });
+
+  it('persists every variant as { file, layout }, omitting layout while unassigned', () => {
+    expect(clinicLogoEntriesToBackend([
+      { fileName: 'square.jpg', dataUrl: 'data:1', layout: '2col', width: 200, height: 180 },
+      { fileName: 'spare.jpg', dataUrl: 'data:2', layout: '', width: 900, height: 120 },
+    ])).toEqual([
+      { file: 'square.jpg', layout: '2col' },
+      { file: 'spare.jpg' },
+    ]);
   });
 });
 


### PR DESCRIPTION
The column mode selected at the top of the Documents page now picks the
logo variant through an explicit per-variant assignment instead of the
aspect-ratio guess:

- Each DB logo entry (parties/cases/clinics/{id}/logo) is extended from
  a bare filename to { file, layout } with layout '2col' | '1col';
  legacy bare-filename nodes still normalize.
- Each variant row in the Format panel gets a one-tap "2 col" / "1 col"
  toggle; at most one variant per layout (assigning moves the tag),
  tapping the active tag unassigns, unassigned variants are muted.
- pickLogoVariantForLayout prefers the mode's assigned variant, falls
  back to the other assigned variant (never fails generation over a
  logo), and keeps the aspect-ratio heuristic only while nothing is
  assigned.
- The Documents section shows a live preview of the variant the
  selected column mode will render, swapping immediately with the
  layout toggle and matching PDF/Word output.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FEFxwWz52Eufjsc1ek8tuK