### PR TITLE
Invoice Builder batch 9: PDF polish for Invoice and Expected Expenses

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -109,11 +109,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     backgroundColor: PDF_COLOR.card,
   },
-  // Row hairlines sit a step lighter/thinner than the table frame (design-tasks-8 §1) so the
-  // grid recedes behind the content instead of reading like a spreadsheet.
+  // Row hairlines sit a step lighter/thinner than the table frame (design-tasks-8 §1, thinned
+  // again to a true 0.5pt hairline in design-tasks-9 §1) so the grid recedes behind the content
+  // instead of reading like a spreadsheet.
   tableRow: {
     flexDirection: 'row',
-    borderTopWidth: 0.75,
+    borderTopWidth: 0.5,
     borderTopColor: PDF_COLOR.docLineSoft,
     borderTopStyle: 'solid',
   },
@@ -153,10 +154,17 @@ const styles = StyleSheet.create({
     fontSize: 8,
     lineHeight: 1.35,
   },
+  // Extra breathing room inside the data rows of `light` tables - the Invoice's Breakdown and the
+  // single-programme payment schedules (design-tasks-9 §1). Listed after denseCell wherever both
+  // apply, so this padding wins over the dense metrics.
+  lightCell: {
+    paddingVertical: 4.5,
+  },
   // Column divider between the two service cells of a compact included-services row - the same
-  // hairline the program columns use, so the compact table still reads as part of one table family.
+  // 0.5pt hairline the row dividers use, so the compact table still reads as part of one table
+  // family.
   compactSecondCell: {
-    borderLeftWidth: 0.75,
+    borderLeftWidth: 0.5,
     borderLeftColor: PDF_COLOR.docLineSoft,
     borderLeftStyle: 'solid',
   },
@@ -426,7 +434,7 @@ export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment 
       <ProgramColumnsHead packages={packages} leadLabel={leadLabel} dense={dense} light={light} />
       {rows.map((row, rowIndex) => (
         <View key={`schedule-row-${rowIndex}`} style={styles.tableRow} wrap={false}>
-          <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
+          <View style={[styles.labelCell, dense ? styles.denseCell : null, light ? styles.lightCell : null]}>
             <Text style={dense ? [styles.labelCellText, styles.denseCellText] : styles.labelCellText}>
               {`${rowIndex + 1}. ${sanitizePdfText(row.title)}`}
             </Text>
@@ -435,7 +443,7 @@ export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment 
           {row.amounts.map((amount, columnIndex) => {
             const cell = renderAmountCell(amount);
             return (
-              <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={[styles.programCell, dense ? styles.denseCell : null, light ? styles.lightProgramCell : null]}>
+              <View key={`schedule-cell-${rowIndex}-${columnIndex}`} style={[styles.programCell, dense ? styles.denseCell : null, light ? styles.lightProgramCell : null, light ? styles.lightCell : null]}>
                 <Text
                   style={[
                     styles.amountCellText,
@@ -456,7 +464,7 @@ export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment 
             <Text style={styles.labelCellHeadText}>Total</Text>
           </View>
           {totals.map((total, columnIndex) => (
-            <View key={`schedule-total-${columnIndex}`} style={styles.programCell}>
+            <View key={`schedule-total-${columnIndex}`} style={[styles.programCell, light ? styles.lightProgramCell : null]}>
               <Text style={styles.programCellHead}>{total == null ? '-' : formatAmount(total)}</Text>
             </View>
           ))}

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -33,9 +33,18 @@ const styles = StyleSheet.create({
     color: PDF_COLOR.bronzeDeep,
     marginBottom: 22,
   },
+  // Same hairline seam the Invoice draws between its Breakdown and Amount Due card
+  // (design-tasks-9 §4), here between the payment-schedule table and the Payments blocks that
+  // carry the amount cards - keeping the three documents' section seams identical.
+  paymentsDivider: {
+    borderTopWidth: 0.75,
+    borderTopColor: PDF_COLOR.docLine,
+    borderTopStyle: 'solid',
+    marginTop: 26,
+  },
   paymentsHeading: {
     ...pdfBaseStyles.sectionTitle,
-    marginTop: 40,
+    marginTop: 12,
     marginBottom: 12,
   },
   paymentBlock: {
@@ -220,10 +229,23 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
 
         {milestones.length ? (
           <View>
-            <Text style={styles.paymentsHeading}>Payments</Text>
-            {milestones.map((milestone, index) => (
-              <PaymentBlock key={milestone.id || index} index={index} milestone={milestone} rows={milestoneRows[index]} currency={currency} />
-            ))}
+            {/* The divider + heading share one non-wrapping group with the first payment block:
+                minPresenceAhead is not honored this deep in the tree, so this is what actually
+                keeps the heading from stranding at a page bottom with every block on the next. */}
+            {milestones.map((milestone, index) => {
+              const block = (
+                <PaymentBlock index={index} milestone={milestone} rows={milestoneRows[index]} currency={currency} />
+              );
+              return index === 0 ? (
+                <View key={milestone.id || index} wrap={false}>
+                  <View style={styles.paymentsDivider} />
+                  <Text style={styles.paymentsHeading}>Payments</Text>
+                  {block}
+                </View>
+              ) : (
+                <React.Fragment key={milestone.id || index}>{block}</React.Fragment>
+              );
+            })}
           </View>
         ) : null}
 

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -65,16 +65,18 @@ const styles = StyleSheet.create({
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
   // The Breakdown heading gets real section-header weight (design-tasks-8 §2): a bit larger than
-  // the shared sectionTitle and with extra air above it, so it stops reading like body text.
+  // the shared sectionTitle and with extra air above it - opened up further in design-tasks-9 §2
+  // so the heading separates cleanly from the "Prepared exclusively for..." intro line above and
+  // the table header row below.
   breakdownSection: {
-    marginTop: 14,
+    marginTop: 20,
   },
   breakdownSectionAfterTitle: {
-    marginTop: 6,
+    marginTop: 14,
   },
   breakdownTitle: {
     fontSize: 15,
-    marginBottom: 6,
+    marginBottom: 9,
   },
   packageBlock: {
     marginTop: 2,
@@ -137,6 +139,15 @@ const styles = StyleSheet.create({
     ...pdfBaseStyles.totalCardRule,
     marginTop: 7,
     marginBottom: 5,
+  },
+  // Hairline seam between the Breakdown (with its footnotes) and the Amount Due card
+  // (design-tasks-9 §4) - the same docLine hairline the document already uses for its rules,
+  // not a new visual element. The card's own marginTop provides the spacing below it.
+  amountDueDivider: {
+    borderTopWidth: 0.75,
+    borderTopColor: PDF_COLOR.docLine,
+    borderTopStyle: 'solid',
+    marginTop: 16,
   },
   noteRow: {
     flexDirection: 'row',
@@ -385,6 +396,8 @@ const InvoicePdfDocument = ({
               <Text style={styles.noteText}>{sanitizePdfText(note)}</Text>
             </View>
           ))}
+
+          <View style={styles.amountDueDivider} />
 
           {/* wrap={false}: the card either fits under the breakdown or moves to the next page
               whole - it must never split its amount from its subtotal/tax rows. */}

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -159,8 +159,8 @@ export const pdfBaseStyles = {
   page: {
     paddingTop: 48,
     // Extra clearance above the footer (design-tasks-8 §3) so the last content block never sits
-    // flush against it.
-    paddingBottom: 78,
+    // flush against it - grown in step with the footer's taller rule spacing (design-tasks-9 §5).
+    paddingBottom: 82,
     paddingLeft: PAGE_MARGIN,
     paddingRight: PAGE_MARGIN,
     fontFamily: PDF_FONT.body,
@@ -332,12 +332,16 @@ export const pdfBaseStyles = {
   totalCardRowValue: {
     fontFamily: PDF_FONT.body,
     fontWeight: 600,
+    // Tabular figures (design-tasks-9 §3): the card's Services/Credits/Subtotal/Tax values stack
+    // vertically, so their digits and decimal points must line up like the tables' amount columns.
+    fontVariantNumeric: 'tabular-nums',
     fontSize: 8.5,
     color: PDF_COLOR.card,
   },
   // The footer frames the page bottom with the same diamond-rule brand element the page opens
-  // with (design-tasks-8 §3/§10), replacing the plain border-top hairline, and its text steps up
-  // from footerSoft to footerInk so the agency identity stops reading like an afterthought.
+  // with (design-tasks-8 §3/§10), replacing the plain border-top hairline. Its text has stepped
+  // up one more tone, footerInk -> inkSoft (design-tasks-9 §5), so the agency identity reads
+  // clearly without competing with body text.
   footer: {
     position: 'absolute',
     left: PAGE_MARGIN,
@@ -347,7 +351,8 @@ export const pdfBaseStyles = {
   footerRuleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 9,
+    // More air between the diamond-rule and the text block below it (design-tasks-9 §5).
+    marginBottom: 13,
   },
   footerRuleLine: {
     flex: 1,
@@ -372,7 +377,7 @@ export const pdfBaseStyles = {
   footerText: {
     fontFamily: PDF_FONT.body,
     fontSize: 7,
-    color: PDF_COLOR.footerInk,
+    color: PDF_COLOR.inkSoft,
     lineHeight: 1.5,
   },
   footerContactRow: {
@@ -389,20 +394,20 @@ export const pdfBaseStyles = {
   footerLink: {
     fontFamily: PDF_FONT.body,
     fontSize: 7,
-    color: PDF_COLOR.footerInk,
+    color: PDF_COLOR.inkSoft,
     textDecoration: 'none',
   },
   footerContactDivider: {
     fontFamily: PDF_FONT.body,
     fontSize: 7,
-    color: PDF_COLOR.footerInk,
+    color: PDF_COLOR.inkSoft,
     opacity: 0.5,
     marginHorizontal: 5,
   },
   footerPage: {
     fontFamily: PDF_FONT.body,
     fontSize: 7,
-    color: PDF_COLOR.footerInk,
+    color: PDF_COLOR.inkSoft,
   },
   continuedTag: {
     position: 'absolute',
@@ -554,7 +559,9 @@ export const SummaryCard = ({ label, text }) => (text ? (
 // (design-tasks-7 §1).
 const FOOTER_ICON_SIZE = 6.5;
 const footerIconStyle = { width: FOOTER_ICON_SIZE, height: FOOTER_ICON_SIZE, marginRight: 3 };
-const footerIconStroke = { stroke: PDF_COLOR.footerInk, strokeWidth: 2, fill: 'none' };
+// Icons track the footer text tone (inkSoft since design-tasks-9 §5) so the icon+link pairs stay
+// one visual unit.
+const footerIconStroke = { stroke: PDF_COLOR.inkSoft, strokeWidth: 2, fill: 'none' };
 
 const FooterGlobeIcon = () => (
   <Svg style={footerIconStyle} viewBox="0 0 24 24">
@@ -576,7 +583,7 @@ const FooterMailIcon = () => (
 const FooterTelegramIcon = () => (
   <Svg style={footerIconStyle} viewBox="0 0 448 512">
     <Path
-      fill={PDF_COLOR.footerInk}
+      fill={PDF_COLOR.inkSoft}
       d="M446.7 98.6l-67.6 318.8c-5.1 22.5-18.4 28.1-37.3 17.5l-103-75.9-49.7 47.8c-5.5 5.5-10.1 10.1-20.7 10.1l7.4-104.9 190.9-172.5c8.3-7.4-1.8-11.5-12.9-4.1L117.8 284 16.2 252.2c-22.1-6.9-22.5-22.1 4.6-32.7L418.2 66.4c18.4-6.9 34.5 4.1 28.5 32.2z"
     />
   </Svg>


### PR DESCRIPTION
- Lighten table grids: 0.5pt row hairlines, roomier light-table rows,
  no vertical divider before the EUR column (incl. totals row)
- More separation around the Breakdown heading (above and before the
  table header row)
- Tabular figures on the Amount Due card's Services/Credits/Subtotal/Tax
  values so decimals align
- Hairline seam between Breakdown and Amount Due (same docLine hairline),
  mirrored in Expected Expenses before the Payments blocks, grouped with
  the first block so the heading never strands at a page bottom
- Footer text/links/icons step up footerInk -> inkSoft, more air under
  the diamond rule, page bottom padding grown to match

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012G1kmKhLxuTUNkmwu4XHq9