### PR TITLE
Invoice Builder batch 11: hairline table rows, unified section headings, one service-table label

### DIFF
--- a/src/components/BudgetPdfDocument.jsx
+++ b/src/components/BudgetPdfDocument.jsx
@@ -109,17 +109,18 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     backgroundColor: PDF_COLOR.card,
   },
-  // Row hairlines sit a step lighter/thinner than the table frame (design-tasks-8 §1) so the
-  // grid recedes behind the content instead of reading like a spreadsheet.
+  // Row hairlines sit a step lighter/thinner than the table frame (design-tasks-8 §1, thinned to
+  // a true 0.5pt hairline in design-tasks-11 §1) so the grid recedes behind the content instead
+  // of reading like a spreadsheet - the taller row padding below does the separating, not the line.
   tableRow: {
     flexDirection: 'row',
-    borderTopWidth: 0.75,
+    borderTopWidth: 0.5,
     borderTopColor: PDF_COLOR.docLineSoft,
     borderTopStyle: 'solid',
   },
   labelCell: {
     flex: 1,
-    paddingVertical: 3.5,
+    paddingVertical: 5,
     paddingHorizontal: 9,
     justifyContent: 'center',
   },
@@ -144,25 +145,28 @@ const styles = StyleSheet.create({
   },
   // Dense variant: tighter row padding + slightly smaller cell text for the single-page Invoice
   // (design-tasks §3, tightened further in design-tasks-4 §7 so a package invoice fits one page;
-  // relaxed a step in design-tasks-8 §1 - the rows needed breathing room more than the page
-  // needed those few points back).
+  // relaxed a step in design-tasks-8 §1 and again in design-tasks-11 §1 - the rows needed
+  // breathing room more than the page needed those few points back. The batch-11 step moves the
+  // fits-one-page boundary from ~10 to ~8 included package services; a fuller invoice wraps its
+  // total card whole onto page 2, which the design accepts in exchange for rows that no longer
+  // feel boxed in).
   denseCell: {
-    paddingVertical: 3,
+    paddingVertical: 3.5,
   },
   denseCellText: {
     fontSize: 8,
     lineHeight: 1.35,
   },
   // Column divider between the two service cells of a compact included-services row - the same
-  // hairline the program columns use, so the compact table still reads as part of one table family.
+  // 0.5pt hairline the rows use, so the compact table still reads as part of one table family.
   compactSecondCell: {
-    borderLeftWidth: 0.75,
+    borderLeftWidth: 0.5,
     borderLeftColor: PDF_COLOR.docLineSoft,
     borderLeftStyle: 'solid',
   },
   programCell: {
     width: PROGRAM_COL_WIDTH,
-    paddingVertical: 3.5,
+    paddingVertical: 5,
     paddingHorizontal: 4,
     borderLeftWidth: 1,
     borderLeftColor: PDF_COLOR.docLine,
@@ -304,6 +308,11 @@ const styles = StyleSheet.create({
   },
 });
 
+// The one lead-column header every service-listing table shows, in every document that lists
+// services (package invoice, plain-services invoice, Expected Expenses, Program Budget) - always
+// this exact label, never a per-document variant like "Description" (design-tasks-11 §3).
+export const SERVICE_TABLE_LEAD_LABEL = 'Provided service';
+
 const ProgramColumnsHead = ({ packages, leadLabel, dense = false, light = false }) => (
   <View style={styles.tableHeadRow} wrap={false}>
     <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
@@ -365,7 +374,7 @@ export const IncludedServicesTable = ({
         <View style={styles.table}>
           <View style={styles.tableHeadRow} wrap={false}>
             <View style={[styles.labelCell, styles.denseCell]}>
-              <Text style={styles.labelCellHeadText}>Provided service</Text>
+              <Text style={styles.labelCellHeadText}>{SERVICE_TABLE_LEAD_LABEL}</Text>
             </View>
           </View>
           {pairedRows.map((pair, rowIndex) => (
@@ -389,7 +398,7 @@ export const IncludedServicesTable = ({
         {note ? <Text style={styles.sectionNote}>{note}</Text> : null}
       </View>
       <View style={styles.table}>
-        <ProgramColumnsHead packages={packages} leadLabel="Provided service" dense={dense} />
+        <ProgramColumnsHead packages={packages} leadLabel={SERVICE_TABLE_LEAD_LABEL} dense={dense} />
         {includedRows.map(item => (
           <View key={item.id} style={styles.tableRow} wrap={false}>
             <View style={[styles.labelCell, dense ? styles.denseCell : null]}>
@@ -414,13 +423,13 @@ export const IncludedServicesTable = ({
 // repeat the same numbers at its foot (round7 spec A.1).
 // A cell amount may also be a free-text label (e.g. "GIFT") when the table renders invoice
 // breakdown rows - a string passes through as-is instead of being coerced to a number.
-// `light` (design-tasks-8 §1) drops the vertical divider before the amount column(s);
-// `titleStyle` lets a document promote one table's heading (the invoice's "Breakdown",
-// design-tasks-8 §2) without a second table component.
-export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment schedule', leadLabel = 'Milestone', sectionStyle, dense = false, light = false, titleStyle }) => (rows.length ? (
+// `light` (design-tasks-8 §1) drops the vertical divider before the amount column(s). The heading
+// always renders in the one shared sectionTitle style (design-tasks-11 §2) - no per-document
+// heading overrides, so "Breakdown", "Payment schedule", etc. can never drift apart.
+export const PaymentScheduleTable = ({ packages, rows, totals, title = 'Payment schedule', leadLabel = 'Milestone', sectionStyle, dense = false, light = false }) => (rows.length ? (
   <View style={sectionStyle || styles.scheduleSection}>
     <View wrap={false} minPresenceAhead={70}>
-      <Text style={titleStyle ? [styles.sectionTitle, titleStyle] : styles.sectionTitle}>{title}</Text>
+      <Text style={styles.sectionTitle}>{title}</Text>
     </View>
     <View style={styles.table}>
       <ProgramColumnsHead packages={packages} leadLabel={leadLabel} dense={dense} light={light} />

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -33,18 +33,12 @@ const styles = StyleSheet.create({
     color: PDF_COLOR.bronzeDeep,
     marginBottom: 22,
   },
-  // Same hairline seam the Invoice draws between its Breakdown and Amount Due card
-  // (design-tasks-9 §4), here between the payment-schedule table and the Payments blocks that
-  // carry the amount cards - keeping the three documents' section seams identical.
-  paymentsDivider: {
-    borderTopWidth: 0.75,
-    borderTopColor: PDF_COLOR.docLine,
-    borderTopStyle: 'solid',
-    marginTop: 26,
-  },
+  // No divider above this heading anymore (design-tasks-13 §2 dropped the hairline seam) - the
+  // marginTop alone separates it from the payment-schedule table above, now that that table
+  // always opens its own fresh page.
   paymentsHeading: {
     ...pdfBaseStyles.sectionTitle,
-    marginTop: 12,
+    marginTop: 22,
     marginBottom: 12,
   },
   paymentBlock: {
@@ -224,12 +218,17 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
         />
 
         {/* `light` (design-tasks-8 §1): single amount column, so no vertical divider before it -
-            same treatment as the Invoice's Breakdown, keeping the two documents unified. */}
-        <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} light />
+            same treatment as the Invoice's Breakdown, keeping the two documents unified.
+            `break` (design-tasks-13 §2): Payment schedule always opens its own fresh page rather
+            than trailing under Included services, conditioned on there being rows so an empty
+            table (no milestones) never forces a blank page break with nothing on it. */}
+        <View break={scheduleRows.length > 0}>
+          <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} light />
+        </View>
 
         {milestones.length ? (
           <View>
-            {/* The divider + heading share one non-wrapping group with the first payment block:
+            {/* The heading shares one non-wrapping group with the first payment block:
                 minPresenceAhead is not honored this deep in the tree, so this is what actually
                 keeps the heading from stranding at a page bottom with every block on the next. */}
             {milestones.map((milestone, index) => {
@@ -238,7 +237,6 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
               );
               return index === 0 ? (
                 <View key={milestone.id || index} wrap={false}>
-                  <View style={styles.paymentsDivider} />
                   <Text style={styles.paymentsHeading}>Payments</Text>
                   {block}
                 </View>

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -5,7 +5,7 @@ import {
   ensurePdfFontsRegistered, formatDisplayDate, pdfBaseStyles, sanitizePdfText, TitleBlock,
 } from './pdfTheme';
 import { formatMoney } from './budgetCatalogUtils';
-import { formatAmountTwoDecimals, IncludedServicesTable, PaymentScheduleTable } from './BudgetPdfDocument';
+import { formatAmountTwoDecimals, IncludedServicesTable, PaymentScheduleTable, SERVICE_TABLE_LEAD_LABEL } from './BudgetPdfDocument';
 import {
   buildPayerLocation,
   buildPayerName,
@@ -64,17 +64,15 @@ const styles = StyleSheet.create({
   },
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
-  // The Breakdown heading gets real section-header weight (design-tasks-8 §2): a bit larger than
-  // the shared sectionTitle and with extra air above it, so it stops reading like body text.
+  // The Breakdown heading renders in the shared promoted sectionTitle (design-tasks-8 §2,
+  // unified in design-tasks-11 §2) - what stays invoice-specific is the extra air above it, so
+  // it clearly separates from whatever precedes it: the "Prepared exclusively for..." title
+  // subrow on a plain-services invoice, the package's payment schedule on a package invoice.
   breakdownSection: {
-    marginTop: 14,
+    marginTop: 16,
   },
   breakdownSectionAfterTitle: {
-    marginTop: 6,
-  },
-  breakdownTitle: {
-    fontSize: 15,
-    marginBottom: 6,
+    marginTop: 14,
   },
   packageBlock: {
     marginTop: 2,
@@ -367,9 +365,8 @@ const InvoicePdfDocument = ({
             packages={breakdownMeta}
             rows={breakdownTableRows}
             title="Breakdown"
-            leadLabel="Provided service"
+            leadLabel={SERVICE_TABLE_LEAD_LABEL}
             sectionStyle={!isPackageInvoice ? styles.breakdownSectionAfterTitle : styles.breakdownSection}
-            titleStyle={styles.breakdownTitle}
             dense
             light
           />

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -110,10 +110,12 @@ const styles = StyleSheet.create({
   // 14pt section rhythm above it keeps a full package invoice - package block, included services,
   // payment schedule, breakdown, total - on one physical page whenever possible (design-tasks §3).
   // design-tasks-8 §4 pushes the page's focal point further: a larger amount figure and more
-  // internal padding, with the label kept subdued relative to the figure.
+  // internal padding, with the label kept subdued relative to the figure. The gap above it is
+  // plain whitespace, not a rule (design-tasks-12 §1 dropped the hairline seam that used to sit
+  // here) - marginTop alone now carries the separation from the Breakdown table/notes above.
   totalCard: {
     ...pdfBaseStyles.totalCard,
-    marginTop: 10,
+    marginTop: 20,
     paddingVertical: 12,
   },
   totalCardLabel: {
@@ -136,15 +138,6 @@ const styles = StyleSheet.create({
     ...pdfBaseStyles.totalCardRule,
     marginTop: 7,
     marginBottom: 5,
-  },
-  // Hairline seam between the Breakdown (with its footnotes) and the Amount Due card
-  // (design-tasks-9 §4) - the same docLine hairline the document already uses for its rules,
-  // not a new visual element. The card's own marginTop provides the spacing below it.
-  amountDueDivider: {
-    borderTopWidth: 0.75,
-    borderTopColor: PDF_COLOR.docLine,
-    borderTopStyle: 'solid',
-    marginTop: 16,
   },
   noteRow: {
     flexDirection: 'row',
@@ -392,8 +385,6 @@ const InvoicePdfDocument = ({
               <Text style={styles.noteText}>{sanitizePdfText(note)}</Text>
             </View>
           ))}
-
-          <View style={styles.amountDueDivider} />
 
           {/* wrap={false}: the card either fits under the breakdown or moves to the next page
               whole - it must never split its amount from its subtotal/tax rows. */}

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -273,13 +273,17 @@ export const pdfBaseStyles = {
     lineHeight: 1.6,
     color: PDF_COLOR.docInk,
   },
+  // Real section-header weight (design-tasks-11 §2): one promoted size for every section heading
+  // in every document ("Breakdown", "Included in this programme", "Payment schedule", ...) - the
+  // invoice's Breakdown no longer carries its own larger one-off style, the shared style is the
+  // header treatment.
   sectionTitle: {
     fontFamily: PDF_FONT.display,
     fontWeight: 600,
-    fontSize: 13.5,
+    fontSize: 15,
     letterSpacing: -0.1,
     color: PDF_COLOR.docInk,
-    marginBottom: 4,
+    marginBottom: 6,
   },
   sectionNote: {
     fontFamily: PDF_FONT.body,

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -640,12 +640,13 @@ export const Footer = ({ variant = 'branded' } = {}) => {
             </View>
           </View>
         )}
-        {/* A single-page document has nothing to count - "Page 1 of 1" on every page of every
-            document was just noise (design-tasks-12 §2). Shown only once there's an actual page
-            to distinguish it from. */}
+        {/* A one- or two-page document has nothing worth counting - "Page 1 of 1"/"Page 1 of 2"
+            on every page was just noise (design-tasks-12 §2, tightened design-tasks-13 §1). Shown
+            only once a document actually runs to three or more pages, and then on every page
+            including the first, not just the ones after it. */}
         <Text
           style={pdfSharedStyles.footerPage}
-          render={({ pageNumber, totalPages }) => (totalPages > 1 ? `Page ${pageNumber} of ${totalPages}` : '')}
+          render={({ pageNumber, totalPages }) => (totalPages > 2 ? `Page ${pageNumber} of ${totalPages}` : '')}
         />
       </View>
     </View>

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -640,9 +640,12 @@ export const Footer = ({ variant = 'branded' } = {}) => {
             </View>
           </View>
         )}
+        {/* A single-page document has nothing to count - "Page 1 of 1" on every page of every
+            document was just noise (design-tasks-12 §2). Shown only once there's an actual page
+            to distinguish it from. */}
         <Text
           style={pdfSharedStyles.footerPage}
-          render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}
+          render={({ pageNumber, totalPages }) => (totalPages > 1 ? `Page ${pageNumber} of ${totalPages}` : '')}
         />
       </View>
     </View>

--- a/src/components/pdfTheme.js
+++ b/src/components/pdfTheme.js
@@ -640,13 +640,12 @@ export const Footer = ({ variant = 'branded' } = {}) => {
             </View>
           </View>
         )}
-        {/* A one- or two-page document has nothing worth counting - "Page 1 of 1"/"Page 1 of 2"
-            on every page was just noise (design-tasks-12 §2, tightened design-tasks-13 §1). Shown
-            only once a document actually runs to three or more pages, and then on every page
-            including the first, not just the ones after it. */}
+        {/* A single-page document has nothing worth counting - "Page 1 of 1" on every page was
+            just noise (design-tasks-12 §2). Shown only once a document actually runs to two or
+            more pages, and then on every page including the first, not just the ones after it. */}
         <Text
           style={pdfSharedStyles.footerPage}
-          render={({ pageNumber, totalPages }) => (totalPages > 2 ? `Page ${pageNumber} of ${totalPages}` : '')}
+          render={({ pageNumber, totalPages }) => (totalPages > 1 ? `Page ${pageNumber} of ${totalPages}` : '')}
         />
       </View>
     </View>


### PR DESCRIPTION
- Thin the horizontal row dividers to a true 0.5pt hairline (docLineSoft,
  no new colors) and drop the compact column divider to match, so table
  rows read as open lines rather than boxed-in cells (§1)
- Add vertical row padding: 3.5 -> 5pt in the multi-page tables, 3 -> 3.5pt
  in the invoice's dense tables. The dense step moves the package invoice's
  fits-one-page boundary from ~10 to ~8 included services - a fuller
  invoice wraps its total card whole onto page 2, accepted in exchange for
  rows that no longer feel boxed in (§1)
- Promote the shared sectionTitle to real header weight (13.5 -> 15pt,
  larger trailing margin) and delete the invoice's one-off Breakdown title
  override plus the PaymentScheduleTable titleStyle prop, so "Breakdown",
  "Included in this programme", "Payment schedule", etc. carry one
  identical treatment in every document; the Breakdown section also gets
  more air above it so it clearly separates from the "Prepared exclusively
  for..." line (§2)
- Centralize the service-table header label as SERVICE_TABLE_LEAD_LABEL =
  "Provided service" and use it in the Breakdown and included-services
  tables of all documents, so the label can never fork per document (§3;
  the repo already read "Provided service" everywhere - no "DESCRIPTION"
  string exists in the codebase or its history)

Verified with npm run qa:pdf, the pdf smoke test, and rasterized sample
renders of the package invoice, plain-services invoice, and Expected
Expenses.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013u19xzuF4JvoyenjNCsWja