### PR TITLE
Batch 12: tunable block spacing, per-column logos, conditional page numbers

### DIFF
--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -2,7 +2,8 @@
 // exports (Invoice/Budget/...), these documents reproduce the look of the reference statements
 // docx: Times-style serif (Tinos - metric-compatible with Times New Roman and
 // covering the full Ukrainian alphabet + №), justified paragraphs, an optional clinic logo
-// centered above the title, and either a single-language column or the uk|en two-column layout.
+// above the title (once, centered, in one-column mode; once per column in two-column mode),
+// and either a single-language column or the uk|en two-column layout.
 // Every metric (font sizes, margins, spacing, indent, header/footer) comes from the formatting
 // settings the user tunes on the page - nothing visual is hardcoded beyond the defaults.
 import React from 'react';
@@ -98,10 +99,12 @@ const DocumentsPdfDocument = ({
   const columnGap = formatting.columnGapCm * CM_TO_PT;
   const hasHeader = Boolean(formatting.headerText);
   const hasFooter = Boolean(formatting.footerText) || formatting.showPageNumbers;
-  // Spec §7: two-column pages share one compact logo at the tuned width; one-column pages get the
-  // long variant stretched across the full text width.
+  const isTwoColumn = layout === 'two-column';
+  // Batch 12 §2: two-column pages get the compact logo rendered twice, once above each column
+  // (superseding the earlier single shared logo); one-column pages keep the long variant
+  // stretched across the full text width.
   const contentWidth = A4_WIDTH_PT - marginLeft - marginRight;
-  const logoWidth = layout === 'two-column' ? formatting.logoWidthMm * MM_TO_PT : contentWidth;
+  const logoWidth = isTwoColumn ? formatting.logoWidthMm * MM_TO_PT : contentWidth;
 
   const cellStyles = StyleSheet.create({
     title: {
@@ -158,13 +161,24 @@ const DocumentsPdfDocument = ({
             </Text>
           ) : null}
           {formatting.showLogo && logoDataUrl ? (
-            <Image
-              src={logoDataUrl}
-              style={[styles.logo, {
-                width: logoWidth,
-                marginBottom: LOGO_BOTTOM_GAP_PT,
-              }]}
-            />
+            isTwoColumn ? (
+              <View style={[styles.row, { marginBottom: LOGO_BOTTOM_GAP_PT }]}>
+                <View style={cellStyles.leftCell}>
+                  <Image src={logoDataUrl} style={[styles.logo, { width: logoWidth }]} />
+                </View>
+                <View style={cellStyles.rightCell}>
+                  <Image src={logoDataUrl} style={[styles.logo, { width: logoWidth }]} />
+                </View>
+              </View>
+            ) : (
+              <Image
+                src={logoDataUrl}
+                style={[styles.logo, {
+                  width: logoWidth,
+                  marginBottom: LOGO_BOTTOM_GAP_PT,
+                }]}
+              />
+            )
           ) : null}
           <DocumentBlock doc={doc} layout={layout} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} />
           {hasFooter ? (
@@ -180,7 +194,10 @@ const DocumentsPdfDocument = ({
               {formatting.showPageNumbers ? (
                 <Text
                   style={{ fontSize: Math.max(7, formatting.fontSize - 2) }}
-                  render={({ pageNumber }) => `${pageNumber}`}
+                  // Batch 12 §3: nothing worth counting on a one-page export - shown only once the
+                  // export actually runs to two or more pages, then on every page including the
+                  // first (same rule as the branded PDFs' shared Footer in pdfTheme.js).
+                  render={({ pageNumber, totalPages }) => (totalPages > 1 ? `Page ${pageNumber} of ${totalPages}` : '')}
                 />
               ) : null}
             </View>

--- a/src/components/ExpectedExpensesPdfDocument.jsx
+++ b/src/components/ExpectedExpensesPdfDocument.jsx
@@ -21,9 +21,6 @@ const formatPercentValue = percent => (Number.isInteger(percent) ? String(percen
 
 const styles = StyleSheet.create({
   page: pdfBaseStyles.page,
-  section: {
-    marginTop: 26,
-  },
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
   forecastNotice: {
@@ -35,19 +32,21 @@ const styles = StyleSheet.create({
   },
   // No divider above this heading anymore (design-tasks-13 §2 dropped the hairline seam) - the
   // marginTop alone separates it from the payment-schedule table above, now that that table
-  // always opens its own fresh page.
+  // always opens its own fresh page. marginTop moved out to the Batch 12 §1 spacing prop (applied
+  // inline at the usage site) so the admin can tune it; this default (22) is unchanged when the
+  // Builder's Spacing panel is untouched.
   paymentsHeading: {
     ...pdfBaseStyles.sectionTitle,
-    marginTop: 22,
     marginBottom: 12,
   },
+  // marginBottom (the gap between consecutive Payment blocks) moved out to the Batch 12 §1 spacing
+  // prop, same as paymentsHeading above.
   paymentBlock: {
     borderWidth: 1,
     borderColor: PDF_COLOR.docLine,
     borderStyle: 'solid',
     borderRadius: 6,
     padding: 10,
-    marginBottom: 10,
   },
   paymentHeaderRow: {
     flexDirection: 'row',
@@ -109,13 +108,13 @@ const styles = StyleSheet.create({
 // every other row (SM deposits, catalog add-ons, gifts) as the same plain line, and the milestone's
 // own total. Never repeats the package name, included services, or payment schedule - those render
 // exactly once, above, in the shared programme-overview block.
-const PaymentBlock = ({ index, milestone, rows, currency }) => {
+const PaymentBlock = ({ index, milestone, rows, currency, gap }) => {
   const { scheduledRows, additionalRows } = splitScheduledRows(rows);
   const subtotal = computeMilestoneSubtotal(rows);
   const taxPercent = Number(milestone.taxPercent) || 0;
   const amountDue = computeMilestoneAmountDue(subtotal, taxPercent);
   return (
-    <View style={styles.paymentBlock} wrap={false}>
+    <View style={[styles.paymentBlock, { marginBottom: gap }]} wrap={false}>
       <View style={styles.paymentHeaderRow}>
         <Text style={styles.paymentTitle}>{sanitizePdfText(`Payment #${index + 1} — ${milestone.title}`)}</Text>
       </View>
@@ -157,8 +156,15 @@ const PaymentBlock = ({ index, milestone, rows, currency }) => {
 // two documents can never drift apart), followed by a compact "Payment #N" block per milestone.
 // Everything lives on one flowing, auto-paginating <Page>, so several compact payment blocks land
 // on the same physical page instead of each getting its own.
-const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate }) => {
+const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceContext, planDate, spacing = {} }) => {
   const caseTitle = buildCaseTitle(customers);
+  // Batch 12 §1: admin-tunable gaps between blocks (Documents Builder Format panel's spacing
+  // controls, lighter version). Each falls back to the exact value design-tasks tuned when the
+  // Builder's Spacing panel is untouched.
+  const aboveIncludedServicesGap = Number.isFinite(spacing.aboveIncludedServices) ? spacing.aboveIncludedServices : 26;
+  const abovePaymentScheduleGap = Number.isFinite(spacing.abovePaymentSchedule) ? spacing.abovePaymentSchedule : 23;
+  const abovePaymentsGap = Number.isFinite(spacing.abovePayments) ? spacing.abovePayments : 22;
+  const betweenPaymentsGap = Number.isFinite(spacing.betweenPayments) ? spacing.betweenPayments : 10;
   const payerName = buildPayerName(customers);
   const dateLabel = formatDisplayDate(planDate instanceof Date ? planDate : new Date(planDate || Date.now()));
   const programmeName = plan?.packageSnapshot?.name || 'Programme';
@@ -215,6 +221,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
           includedRows={includedRows}
           title="Included in this programme"
           note="Every item below is already covered by the programme fee."
+          sectionStyle={{ marginTop: aboveIncludedServicesGap }}
         />
 
         {/* `light` (design-tasks-8 §1): single amount column, so no vertical divider before it -
@@ -223,7 +230,7 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
             than trailing under Included services, conditioned on there being rows so an empty
             table (no milestones) never forces a blank page break with nothing on it. */}
         <View break={scheduleRows.length > 0}>
-          <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} light />
+          <PaymentScheduleTable packages={packagesMeta} rows={scheduleRows} light sectionStyle={{ marginTop: abovePaymentScheduleGap }} />
         </View>
 
         {milestones.length ? (
@@ -233,11 +240,11 @@ const ExpectedExpensesPdfDocument = ({ plan, customers, catalogItemsById, priceC
                 keeps the heading from stranding at a page bottom with every block on the next. */}
             {milestones.map((milestone, index) => {
               const block = (
-                <PaymentBlock index={index} milestone={milestone} rows={milestoneRows[index]} currency={currency} />
+                <PaymentBlock index={index} milestone={milestone} rows={milestoneRows[index]} currency={currency} gap={betweenPaymentsGap} />
               );
               return index === 0 ? (
                 <View key={milestone.id || index} wrap={false}>
-                  <Text style={styles.paymentsHeading}>Payments</Text>
+                  <Text style={[styles.paymentsHeading, { marginTop: abovePaymentsGap }]}>Payments</Text>
                   {block}
                 </View>
               ) : (

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -599,6 +599,36 @@ const useFieldDraft = externalValue => {
   return [draft, setDraft, editingRef];
 };
 
+// Batch 12 §1: one numeric "plain editable text" field for a block-spacing value - a lighter
+// version of the Documents Builder's Format panel, spacing-between-blocks only. A blank field
+// clears the override and falls back to the document's own tuned default (shown as the
+// placeholder), it is never coerced to 0.
+const SpacingField = ({ label, value, placeholder, onCommit }) => {
+  const [draft, setDraft, editingRef] = useFieldDraft(value === undefined || value === null ? '' : String(value));
+  return (
+    <FieldRow $align="center">
+      <FieldTag>{label}</FieldTag>
+      <AutoTextArea
+        as={PlainPriceBase}
+        $width="56px"
+        inputMode="decimal"
+        value={draft}
+        placeholder={placeholder}
+        aria-label={label}
+        onFocus={() => { editingRef.current = true; }}
+        onChange={event => setDraft(event.target.value)}
+        onBlur={() => {
+          editingRef.current = false;
+          const trimmed = draft.trim();
+          if (trimmed === '') { onCommit(undefined); return; }
+          const parsed = Number(trimmed.replace(',', '.'));
+          onCommit(Number.isFinite(parsed) ? parsed : undefined);
+        }}
+      />
+    </FieldRow>
+  );
+};
+
 const formatEuroPreview = formatEuroSmart;
 
 const getFormulaAwarePriceDraft = row => {
@@ -1970,6 +2000,14 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   const [beneficiaryExpanded, setBeneficiaryExpanded] = useState(false);
   const [payerExpanded, setPayerExpanded] = useState(false);
   const [issuedInvoicesOpen, setIssuedInvoicesOpen] = useState(false);
+  // Batch 12 §1: a lighter version of the Documents Builder's Format panel - spacing between
+  // document blocks only, nothing else (fonts/margins stay fixed). Session-local, not persisted:
+  // an unset field falls back to the document's own tuned default (see InvoicePdfDocument /
+  // ExpectedExpensesPdfDocument), so leaving this panel untouched never changes existing output.
+  const [invoiceSpacing, setInvoiceSpacing] = useState({});
+  const [invoiceSpacingExpanded, setInvoiceSpacingExpanded] = useState(false);
+  const [expectedExpensesSpacing, setExpectedExpensesSpacing] = useState({});
+  const [expectedExpensesSpacingExpanded, setExpectedExpensesSpacingExpanded] = useState(false);
   // round7 spec D: Expected Expenses is a standalone section of the Builder, not a step inside the
   // regular invoice-creation flow - a top-level tab keeps the two entirely separate on screen.
   const [activeTab, setActiveTab] = useState('invoice');
@@ -3097,6 +3135,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         catalogItemsById,
         priceContext,
         planDate: new Date(`${invoiceDateInput || getTodayYmd()}T00:00:00`),
+        spacing: expectedExpensesSpacing,
       };
       let blob;
       try {
@@ -3369,6 +3408,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
         generatePaymentDetails,
         includePackageInPdf: data.includePackageInPdf,
         includeScheduleInPdf: data.includeScheduleInPdf,
+        spacing: invoiceSpacing,
       };
 
       // @react-pdf/renderer's WASM layout engine can still be warming up on the
@@ -4088,6 +4128,45 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               {!data.notes.length ? <PanelNote style={{ margin: 0 }}>No notes yet.</PanelNote> : null}
             </Panel>
 
+            {/* Spacing (batch 12 §1): a lighter version of the Documents Builder's Format panel -
+                only the vertical gap between blocks (header/Breakdown/Amount due) is tunable here;
+                fonts, margins and everything else on the branded Invoice PDF stay fixed. */}
+            <Panel>
+              <CompactSection
+                $expanded={invoiceSpacingExpanded}
+                onClick={() => setInvoiceSpacingExpanded(current => !current)}
+                role="button"
+                aria-expanded={invoiceSpacingExpanded}
+              >
+                <CompactInfo>
+                  <CompactLabel>Spacing</CompactLabel>
+                  <CompactValue>
+                    {Object.values(invoiceSpacing).some(value => value !== undefined) ? 'Custom block spacing' : 'Default block spacing'}
+                  </CompactValue>
+                </CompactInfo>
+                <CompactChevron>{invoiceSpacingExpanded ? 'Hide ›' : 'Edit ›'}</CompactChevron>
+              </CompactSection>
+              {invoiceSpacingExpanded ? (
+                <>
+                  <PanelHeading>
+                    <H2>Spacing</H2>
+                  </PanelHeading>
+                  <SpacingField
+                    label="Above Breakdown (pt)"
+                    value={invoiceSpacing.aboveBreakdown}
+                    placeholder="auto"
+                    onCommit={value => setInvoiceSpacing(current => ({ ...current, aboveBreakdown: value }))}
+                  />
+                  <SpacingField
+                    label="Above Amount due (pt)"
+                    value={invoiceSpacing.aboveAmountDue}
+                    placeholder="20"
+                    onCommit={value => setInvoiceSpacing(current => ({ ...current, aboveAmountDue: value }))}
+                  />
+                </>
+              ) : null}
+            </Panel>
+
             {/* Issued Invoices (design-tasks-3 §7): a click-to-reveal block at the bottom of the
                 page - the same collapsed-summary pattern Beneficiary/Payer use - listing every
                 invoice ever generated for the active payer, read-only, newest first. */}
@@ -4374,6 +4453,57 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   ))}
                 </>
               )}
+            </Panel>
+
+            {/* Spacing (batch 12 §1): same lighter Format-panel pattern as the Invoice tab - only
+                the gap between programme sections/payments blocks is tunable, everything else on
+                the branded Expected Expenses PDF stays fixed. */}
+            <Panel>
+              <CompactSection
+                $expanded={expectedExpensesSpacingExpanded}
+                onClick={() => setExpectedExpensesSpacingExpanded(current => !current)}
+                role="button"
+                aria-expanded={expectedExpensesSpacingExpanded}
+              >
+                <CompactInfo>
+                  <CompactLabel>Spacing</CompactLabel>
+                  <CompactValue>
+                    {Object.values(expectedExpensesSpacing).some(value => value !== undefined) ? 'Custom block spacing' : 'Default block spacing'}
+                  </CompactValue>
+                </CompactInfo>
+                <CompactChevron>{expectedExpensesSpacingExpanded ? 'Hide ›' : 'Edit ›'}</CompactChevron>
+              </CompactSection>
+              {expectedExpensesSpacingExpanded ? (
+                <>
+                  <PanelHeading>
+                    <H2>Spacing</H2>
+                  </PanelHeading>
+                  <SpacingField
+                    label="Above included services (pt)"
+                    value={expectedExpensesSpacing.aboveIncludedServices}
+                    placeholder="26"
+                    onCommit={value => setExpectedExpensesSpacing(current => ({ ...current, aboveIncludedServices: value }))}
+                  />
+                  <SpacingField
+                    label="Above payment schedule (pt)"
+                    value={expectedExpensesSpacing.abovePaymentSchedule}
+                    placeholder="23"
+                    onCommit={value => setExpectedExpensesSpacing(current => ({ ...current, abovePaymentSchedule: value }))}
+                  />
+                  <SpacingField
+                    label="Above payments (pt)"
+                    value={expectedExpensesSpacing.abovePayments}
+                    placeholder="22"
+                    onCommit={value => setExpectedExpensesSpacing(current => ({ ...current, abovePayments: value }))}
+                  />
+                  <SpacingField
+                    label="Between payments (pt)"
+                    value={expectedExpensesSpacing.betweenPayments}
+                    placeholder="10"
+                    onCommit={value => setExpectedExpensesSpacing(current => ({ ...current, betweenPayments: value }))}
+                  />
+                </>
+              ) : null}
             </Panel>
               </>
             ) : null}

--- a/src/components/InvoicePdfDocument.jsx
+++ b/src/components/InvoicePdfDocument.jsx
@@ -64,17 +64,6 @@ const styles = StyleSheet.create({
   },
   sectionTitle: pdfBaseStyles.sectionTitle,
   sectionNote: pdfBaseStyles.sectionNote,
-  // The Breakdown heading renders in the shared promoted sectionTitle (design-tasks-8 §2, unified
-  // across every document's headings in design-tasks-11 §2 - no more per-document size override)
-  // - what stays invoice-specific is the extra air above it, opened up further in design-tasks-9
-  // §2 so it clearly separates from whatever precedes it: the "Prepared exclusively for..." title
-  // subrow on a plain-services invoice, the package's payment schedule on a package invoice.
-  breakdownSection: {
-    marginTop: 20,
-  },
-  breakdownSectionAfterTitle: {
-    marginTop: 14,
-  },
   packageBlock: {
     marginTop: 2,
   },
@@ -113,9 +102,10 @@ const styles = StyleSheet.create({
   // internal padding, with the label kept subdued relative to the figure. The gap above it is
   // plain whitespace, not a rule (design-tasks-12 §1 dropped the hairline seam that used to sit
   // here) - marginTop alone now carries the separation from the Breakdown table/notes above.
+  // marginTop moved out to the Batch 12 §1 spacing prop (applied inline at the usage site) so the
+  // admin can tune it; this default (20) is unchanged when the Builder's Spacing panel is untouched.
   totalCard: {
     ...pdfBaseStyles.totalCard,
-    marginTop: 20,
     paddingVertical: 12,
   },
   totalCardLabel: {
@@ -278,6 +268,7 @@ const InvoicePdfDocument = ({
   generatePaymentDetails = true,
   includePackageInPdf = true,
   includeScheduleInPdf = true,
+  spacing = {},
 }) => {
   const rows = resolveInvoiceServiceRows(invoiceServices, catalogItemsById, priceContext);
   const subtotal = computeInvoiceSubtotal(rows);
@@ -326,6 +317,14 @@ const InvoicePdfDocument = ({
     return [...acc, row];
   }, []);
   const isPackageInvoice = packageRows.length > 0;
+  // Batch 12 §1: admin-tunable gaps between blocks (Documents Builder Format panel's spacing
+  // controls, lighter version - just these two, everything else on the page stays fixed). Each
+  // falls back to the exact value design-tasks tuned when the Builder's Spacing panel is untouched
+  // - the "above Breakdown" default depends on whether a package block precedes it (20pt after a
+  // package, design-tasks-9 §2; 14pt directly under the title otherwise), same as before this was
+  // made tunable.
+  const aboveBreakdownGap = Number.isFinite(spacing.aboveBreakdown) ? spacing.aboveBreakdown : (isPackageInvoice ? 20 : 14);
+  const aboveAmountDueGap = Number.isFinite(spacing.aboveAmountDue) ? spacing.aboveAmountDue : 20;
   // A "% of package" row (a programme milestone share) and any custom/catalog service row share one
   // "Breakdown" table, one row style, one running numbering - splitting them into two headed
   // sections was the second-biggest source of clutter on this document (declutter spec §2).
@@ -369,7 +368,7 @@ const InvoicePdfDocument = ({
             rows={breakdownTableRows}
             title="Breakdown"
             leadLabel={SERVICE_TABLE_LEAD_LABEL}
-            sectionStyle={!isPackageInvoice ? styles.breakdownSectionAfterTitle : styles.breakdownSection}
+            sectionStyle={{ marginTop: aboveBreakdownGap }}
             dense
             light
           />
@@ -388,7 +387,7 @@ const InvoicePdfDocument = ({
 
           {/* wrap={false}: the card either fits under the breakdown or moves to the next page
               whole - it must never split its amount from its subtotal/tax rows. */}
-          <View style={styles.totalCard} wrap={false}>
+          <View style={[styles.totalCard, { marginTop: aboveAmountDueGap }]} wrap={false}>
             <Text style={styles.totalCardLabel}>Amount due</Text>
             <Text style={styles.totalCardAmount}>{formatMoneyTwoDecimals(amountDue)}</Text>
             {/* When how much is stated, so is when (design-tasks-8 §7): a concrete due date when

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -1,8 +1,9 @@
 // Word (.docx) renderer for the Documents page, mirroring DocumentsPdfDocument: same formatting
 // settings (Times New Roman, justified, tunable sizes/margins/spacing/header/footer), same
-// one-column / two-column layouts, same optional clinic logo above the title. The `docx` package
-// is imported dynamically by the caller-facing builder so the library only loads when a Word
-// export is actually requested.
+// one-column / two-column layouts, same optional clinic logo above the title (once, centered, in
+// one-column mode; once per column in two-column mode). The `docx` package is imported
+// dynamically by the caller-facing builder so the library only loads when a Word export is
+// actually requested.
 import { DEFAULT_DOC_FORMATTING } from './documentsCatalogUtils';
 
 const CM_TO_TWIP = 567;
@@ -65,7 +66,7 @@ export const buildDocumentsDocx = async ({
     children: [new TextRun({ text, bold: true, size: titleSize })],
   });
 
-  const twoColumnCell = (text, paragraphBuilder, marginSide) => new TableCell({
+  const twoColumnCellFromParagraph = (paragraph, marginSide) => new TableCell({
     borders: noBorders,
     width: { size: 50, type: WidthType.PERCENTAGE },
     verticalAlign: VerticalAlign.TOP,
@@ -75,8 +76,10 @@ export const buildDocumentsDocx = async ({
       left: marginSide === 'right' ? Math.round(gapTwips / 2) : 0,
       right: marginSide === 'left' ? Math.round(gapTwips / 2) : 0,
     },
-    children: [paragraphBuilder(text)],
+    children: [paragraph],
   });
+
+  const twoColumnCell = (text, paragraphBuilder, marginSide) => twoColumnCellFromParagraph(paragraphBuilder(text), marginSide);
 
   const twoColumnRow = (uk, en, paragraphBuilder) => new TableRow({
     children: [
@@ -91,9 +94,10 @@ export const buildDocumentsDocx = async ({
     if (formatting.showLogo && logo?.dataUrl) {
       const decoded = decodeLogoDataUrl(logo.dataUrl);
       if (decoded) {
-        // Spec §7: compact logo at the tuned width above the two-column layout, the long variant
-        // stretched to the full text width in one-column layouts. 10 pt (200 twips) below the
-        // logo matches the PDF's LOGO_BOTTOM_GAP_PT.
+        // Batch 12 §2: compact logo at the tuned width, rendered once per column in two-column
+        // layouts (superseding the earlier single shared logo) - the long variant still stretches
+        // to the full text width, once, in one-column layouts. 10 pt (200 twips) below the logo
+        // matches the PDF's LOGO_BOTTOM_GAP_PT.
         const contentWidthTwips = 11906
           - Math.round(formatting.marginLeftCm * CM_TO_TWIP)
           - Math.round(formatting.marginRightCm * CM_TO_TWIP);
@@ -101,7 +105,7 @@ export const buildDocumentsDocx = async ({
           ? Math.round(formatting.logoWidthMm * MM_TO_PX)
           : Math.round((contentWidthTwips / 1440) * 96);
         const ratio = logo.width && logo.height ? logo.height / logo.width : 0.25;
-        children.push(new Paragraph({
+        const logoParagraph = () => new Paragraph({
           alignment: AlignmentType.CENTER,
           spacing: { after: 200 },
           children: [new ImageRun({
@@ -109,7 +113,21 @@ export const buildDocumentsDocx = async ({
             type: decoded.type,
             transformation: { width: widthPx, height: Math.round(widthPx * ratio) },
           })],
-        }));
+        });
+        if (isTwoColumn) {
+          children.push(new Table({
+            width: { size: 100, type: WidthType.PERCENTAGE },
+            borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
+            rows: [new TableRow({
+              children: [
+                twoColumnCellFromParagraph(logoParagraph(), 'left'),
+                twoColumnCellFromParagraph(logoParagraph(), 'right'),
+              ],
+            })],
+          }));
+        } else {
+          children.push(logoParagraph());
+        }
       }
     }
 
@@ -140,13 +158,22 @@ export const buildDocumentsDocx = async ({
     }
     : undefined;
 
+  // Batch 12 §3: a Word document's real page count is only known once Word itself lays the
+  // content out, not at generation time - unlike the PDF renderer, which gets a real totalPages
+  // from @react-pdf. documents.length is the best available proxy: every generated statement
+  // opens its own section/page, so 2+ selected statements guarantees 2+ pages, and this keeps the
+  // same "nothing worth counting on a single page" rule the PDF applies exactly.
+  const showPageNumbers = formatting.showPageNumbers && documents.length > 1;
   const footerChildren = [];
-  if (formatting.footerText || formatting.showPageNumbers) {
+  if (formatting.footerText || showPageNumbers) {
     const runs = [];
     if (formatting.footerText) runs.push(new TextRun({ text: formatting.footerText, size: smallSize }));
-    if (formatting.showPageNumbers) {
+    if (showPageNumbers) {
       if (formatting.footerText) runs.push(new TextRun({ text: '   ', size: smallSize }));
+      runs.push(new TextRun({ text: 'Page ', size: smallSize }));
       runs.push(new TextRun({ children: [PageNumber.CURRENT], size: smallSize }));
+      runs.push(new TextRun({ text: ' of ', size: smallSize }));
+      runs.push(new TextRun({ children: [PageNumber.TOTAL_PAGES], size: smallSize }));
     }
     footerChildren.push(new Paragraph({
       alignment: formatting.footerText ? AlignmentType.LEFT : AlignmentType.CENTER,
@@ -170,6 +197,9 @@ export const buildDocumentsDocx = async ({
 
   // One section per document so every statement starts on a fresh page with its own header/footer.
   const doc = new Document({
+    // The PAGE/NUMPAGES fields above are computed by Word itself, not by this builder - without
+    // this, Word shows their last-cached value (0) until the user manually recalculates (F9).
+    features: showPageNumbers ? { updateFields: true } : undefined,
     styles: {
       default: {
         document: {


### PR DESCRIPTION
- Invoice/Expected Expenses builders get a lighter Spacing panel (Documents
  Builder Format panel pattern, spacing-only) with plain editable fields for
  the gaps above Breakdown/Amount due (Invoice) and above included
  services/payment schedule/payments plus between payment blocks (Expected
  Expenses). Untouched fields keep every current default exactly.
- Documents Builder: two-column mode now renders the clinic logo once per
  column (PDF and Word) instead of one shared centered logo; one-column mode
  is unchanged.
- Documents Builder PDF footer now hides the page count on a single-page
  export and shows "Page N of Total" on every page once it runs 2+ pages,
  matching the branded PDFs' existing rule. The Word export gets the same
  page count via real Word PAGE/NUMPAGES fields, shown once 2+ statements
  are selected (the best available proxy for page count before Word lays
  the document out) with updateFields so the numbers resolve on open.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DH42eNJ9cexwNnp1cTfovN