### PR TITLE
Generalize documentsBuilder for the 5-template JSON: variable-driven logos, deep resolver, headings

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -32,17 +32,19 @@ import {
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
   emptyDocumentsCatalog,
+  getClinicLogo,
+  getParagraphType,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
   orderCasesByRecent,
   parseDocumentsTechnicalInput,
-  pickLogoVariantForLayout,
   pruneDocOverride,
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
   upsertRecentCaseId,
+  validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
 // Same stale-chunk detection as the Invoice Builder: a failed dynamic chunk means the deployed
@@ -52,11 +54,14 @@ const STALE_APP_MESSAGE = 'The app has been updated since this page was opened. 
 
 const MAX_LOGO_FILE_BYTES = 1024 * 1024;
 
-// The two layout tags a logo variant can be assigned to (one tap on the variant row); the column
-// mode selected at the top of the page then picks the matching variant automatically.
+// The two layout tags a logo variant can be assigned to (one tap on the variant row). Which
+// variant a document actually uses is decided by the template itself, not by the page's column
+// mode: a {{logo}} paragraph uses the '1col' variant (compact, duplicated above each visible
+// language column); a {{logo-long}} paragraph uses the '2col' variant (one shared full-width
+// logo, never duplicated). A template with neither token renders no logo at all.
 const LOGO_LAYOUT_OPTIONS = [
-  { tag: '2col', label: '2 col', title: 'Use this variant above the two-column (UA + EN) layout' },
-  { tag: '1col', label: '1 col', title: 'Use this variant full-width on the one-column (UA or EN) layouts' },
+  { tag: '1col', label: '{{logo}}', title: 'Use this variant for the {{logo}} token - compact, duplicated above each language column' },
+  { tag: '2col', label: '{{logo-long}}', title: 'Use this variant for the {{logo-long}} token - one shared full-width logo' },
 ];
 
 // Mobile admins can't easily reach the browser devtools console, so every Storage failure below
@@ -956,9 +961,25 @@ const DocumentsPage = ({ isAdmin }) => {
   const selectedTemplates = catalog.documents.filter(template => selectedDocIds[template.id]);
   const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
   const caseContext = resolveCaseContext(catalog, selectedCaseId);
-  // Exactly the variant PDF/Word generation will use for the selected column mode - shown as the
-  // live preview above the document list, so switching the mode swaps the logo immediately.
-  const activeLogoVariant = pickLogoVariantForLayout(clinicLogos, layout);
+  // A logo only ever appears where a template places a {{logo}}/{{logo-long}} paragraph (spec
+  // §5) - never automatically. `showLogo` is just the global permission gate.
+  const canRenderLogo = formatting.showLogo !== false;
+  const selectedHasLogoToken = canRenderLogo && selectedTemplates.some(
+    template => (template.paragraphs || []).some(paragraph => getParagraphType(paragraph) === 'logo'),
+  );
+  const selectedHasLogoLongToken = canRenderLogo && !selectedHasLogoToken && selectedTemplates.some(
+    template => (template.paragraphs || []).some(paragraph => getParagraphType(paragraph) === 'logo-long'),
+  );
+  // Live preview above the document list of whichever variant the selected documents will
+  // actually draw - or nothing, when none of them reference a logo token.
+  const activeLogoVariant = selectedHasLogoToken
+    ? getClinicLogo(clinicLogos, 'logo')
+    : (selectedHasLogoLongToken ? getClinicLogo(clinicLogos, 'logo-long') : null);
+  // Every unresolved {{path}} across the selected documents for the current case - shown as a
+  // non-blocking warning and confirmed again right before a final export (spec §15).
+  const unresolvedVariables = caseContext
+    ? [...new Set(selectedTemplates.flatMap(template => validateDocumentTemplate(template, caseContext)))].sort()
+    : [];
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || clinicLogoLoading || !selectedTemplates.length || !selectedCase;
 
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
@@ -968,7 +989,7 @@ const DocumentsPage = ({ isAdmin }) => {
   const clinicLogoStorageKey = `${logoClinicId}:${clinicLogoRefreshKey}`;
 
   // Fetch every stored logo variant of the selected clinic from Storage; the dimensions are what
-  // pickLogoVariantForLayout uses to tell compact from full-width variants.
+  // the PDF/DOCX renderers use to scale each {{logo}}/{{logo-long}} image proportionally.
   useEffect(() => {
     let cancelled = false;
     const [clinicId] = clinicLogoStorageKey.split(':');
@@ -1046,7 +1067,6 @@ const DocumentsPage = ({ isAdmin }) => {
     return {
       generated,
       normalizedFormatting: normalizeDocFormatting(formatting),
-      logoVariant: pickLogoVariantForLayout(clinicLogos, layout),
     };
   };
 
@@ -1054,11 +1074,23 @@ const DocumentsPage = ({ isAdmin }) => {
     persistSettings({ recentCaseIds: upsertRecentCaseId(settings.recentCaseIds, selectedCaseId) });
   };
 
+  // A non-blocking warning is shown inline at all times (spec §15); the final export step still
+  // asks for a confirmation so an admin never ships blanks without noticing.
+  const confirmUnresolvedVariables = () => {
+    if (!unresolvedVariables.length) return true;
+    if (typeof window === 'undefined') return true;
+    return window.confirm(
+      `Не вдалося підставити ${unresolvedVariables.length} змінн${unresolvedVariables.length === 1 ? 'у' : 'их'}:\n`
+      + `${unresolvedVariables.map(path => `- ${path}`).join('\n')}\n\nЗгенерувати документ попри це?`,
+    );
+  };
+
   const handleGeneratePdf = async () => {
     if (isGenerateDisabled) return;
+    if (!confirmUnresolvedVariables()) return;
     setIsGenerating(true);
     try {
-      const { generated, normalizedFormatting, logoVariant } = prepareGeneration();
+      const { generated, normalizedFormatting } = prepareGeneration();
       const [{ pdf }, documentsModule] = await Promise.all([
         import('@react-pdf/renderer'),
         import('./DocumentsPdfDocument'),
@@ -1069,7 +1101,7 @@ const DocumentsPage = ({ isAdmin }) => {
         documents: generated,
         layout,
         formatting: normalizedFormatting,
-        logoDataUrl: logoVariant?.dataUrl || null,
+        clinicLogos,
       })).toBlob();
       saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'pdf'));
       rememberRecentCase();
@@ -1083,15 +1115,16 @@ const DocumentsPage = ({ isAdmin }) => {
 
   const handleGenerateDocx = async () => {
     if (isGenerateDisabled) return;
+    if (!confirmUnresolvedVariables()) return;
     setIsGenerating(true);
     try {
-      const { generated, normalizedFormatting, logoVariant } = prepareGeneration();
+      const { generated, normalizedFormatting } = prepareGeneration();
       const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
       const blob = await buildDocumentsDocx({
         documents: generated,
         layout,
         formatting: normalizedFormatting,
-        logo: logoVariant,
+        clinicLogos,
       });
       saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'docx'));
       rememberRecentCase();
@@ -1197,15 +1230,20 @@ const DocumentsPage = ({ isAdmin }) => {
                   </ToggleOption>
                 </ToggleGroup>
               </SectionHead>
-              {formatting.showLogo && activeLogoVariant ? (
+              {activeLogoVariant?.dataUrl ? (
                 <DocLogoPreviewRow>
                   <LogoPreview
                     src={activeLogoVariant.dataUrl}
-                    alt="Clinic logo for the selected column mode"
-                    title="The logo variant the selected column mode will render (also used by PDF/Word generation)"
-                    style={layout === 'two-column' ? undefined : { width: '100%', maxWidth: '100%' }}
+                    alt="Clinic logo used by the selected document(s)"
+                    title="The logo variant the selected document(s) will render, based on their {{logo}}/{{logo-long}} tokens"
+                    style={selectedHasLogoLongToken ? { width: '100%', maxWidth: '100%' } : undefined}
                   />
                 </DocLogoPreviewRow>
+              ) : null}
+              {unresolvedVariables.length ? (
+                <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
+                  Не вдалося підставити: {unresolvedVariables.join(', ')}
+                </DocSubtitle>
               ) : null}
               {!catalog.documents.length ? (
                 <DocSubtitle style={{ marginTop: 8 }}>No document templates yet — paste them in the technical field below.</DocSubtitle>

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -1,14 +1,16 @@
 // PDF renderer for the Documents page's generated legal statements. Unlike the branded UKRCOM
 // exports (Invoice/Budget/...), these documents reproduce the look of the reference statements
 // docx: Times-style serif (Tinos - metric-compatible with Times New Roman and
-// covering the full Ukrainian alphabet + №), justified paragraphs, an optional clinic logo
-// above the title (once, centered, in one-column mode; once per column in two-column mode),
-// and either a single-language column or the uk|en two-column layout.
+// covering the full Ukrainian alphabet + №), justified paragraphs, and either a single-language
+// column or the uk|en two-column layout.
+// A clinic logo is never added automatically - it only appears where the template itself places
+// a {{logo}} (one compact logo above each visible language column) or {{logo-long}} (one shared
+// full-width logo) paragraph; see getParagraphType/getClinicLogo in documentsCatalogUtils.
 // Every metric (font sizes, margins, spacing, indent, header/footer) comes from the formatting
 // settings the user tunes on the page - nothing visual is hardcoded beyond the defaults.
 import React from 'react';
 import { Document, Font, Image, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
-import { DEFAULT_DOC_FORMATTING } from './documentsCatalogUtils';
+import { DEFAULT_DOC_FORMATTING, allowsParagraphInternalBreak, getClinicLogo, isSectionHeading } from './documentsCatalogUtils';
 
 const CM_TO_PT = 28.3465;
 const MM_TO_PT = 2.83465;
@@ -33,8 +35,8 @@ export const ensureDocumentsPdfFontsRegistered = () => {
   Font.registerHyphenationCallback(word => [word]);
 };
 
-// Word/PDF parity (spec §6): the gap under the clinic logo is the one fixed metric shared with
-// the DOCX builder (10 pt = 200 twips); everything else comes from the Format panel values.
+// Word/PDF parity: the gap under the clinic logo is the one fixed metric shared with the DOCX
+// builder (10 pt = 200 twips); everything else comes from the Format panel values.
 export const LOGO_BOTTOM_GAP_PT = 10;
 
 const A4_WIDTH_PT = 595.28;
@@ -57,9 +59,68 @@ const styles = StyleSheet.create({
   },
 });
 
-const DocumentBlock = ({ doc, layout, cellStyles, titleGap }) => {
+// A logo paragraph draws graphics, not text - it never goes through the title/paragraph text
+// styles and never picks up the template's paragraphSpacing/indent (spec §5).
+const LogoParagraph = ({ paragraph, isTwoColumn, cellStyles, logoWidth, longLogoWidth, clinicLogos, showUk, showEn }) => {
+  if (paragraph.type === 'logo-long') {
+    const variant = getClinicLogo(clinicLogos, 'logo-long');
+    if (!variant?.dataUrl) return null;
+    return (
+      <View style={{ marginBottom: LOGO_BOTTOM_GAP_PT, alignItems: 'center' }}>
+        <Image src={variant.dataUrl} style={[styles.logo, { width: longLogoWidth }]} />
+      </View>
+    );
+  }
+
+  // type === 'logo': one compact logo per visible column, same width, centered in each column.
+  const variant = getClinicLogo(clinicLogos, 'logo');
+  if (!variant?.dataUrl) return null;
+  if (isTwoColumn) {
+    return (
+      <View style={[styles.row, { marginBottom: LOGO_BOTTOM_GAP_PT }]}>
+        {showUk ? (
+          <View style={[cellStyles.leftCell, { alignItems: 'center' }]}>
+            <Image src={variant.dataUrl} style={[styles.logo, { width: logoWidth }]} />
+          </View>
+        ) : null}
+        {showEn ? (
+          <View style={[cellStyles.rightCell, { alignItems: 'center' }]}>
+            <Image src={variant.dataUrl} style={[styles.logo, { width: logoWidth }]} />
+          </View>
+        ) : null}
+      </View>
+    );
+  }
+  return (
+    <View style={{ marginBottom: LOGO_BOTTOM_GAP_PT, alignItems: 'center' }}>
+      <Image src={variant.dataUrl} style={[styles.logo, { width: logoWidth }]} />
+    </View>
+  );
+};
+
+const TextParagraph = ({ paragraph, isTwoColumn, lang, cellStyles, allowPageBreaks }) => {
+  const wrap = allowsParagraphInternalBreak(paragraph, allowPageBreaks);
+  const ukHeading = isSectionHeading(paragraph.uk);
+  const enHeading = isSectionHeading(paragraph.en);
+  const cellStyle = heading => (heading ? cellStyles.paragraphHeading : cellStyles.paragraph);
+  if (isTwoColumn) {
+    return (
+      <View style={styles.row} wrap={wrap}>
+        <Text style={[cellStyle(ukHeading), cellStyles.leftCell]}>{paragraph.uk}</Text>
+        <Text style={[cellStyle(enHeading), cellStyles.rightCell]}>{paragraph.en}</Text>
+      </View>
+    );
+  }
+  const text = paragraph[lang];
+  const heading = lang === 'en' ? enHeading : ukHeading;
+  return <Text style={cellStyle(heading)} wrap={wrap}>{text}</Text>;
+};
+
+const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoWidth, clinicLogos }) => {
   const isTwoColumn = layout === 'two-column';
   const lang = layout === 'one-column-en' ? 'en' : 'uk';
+  const showUk = layout !== 'one-column-en';
+  const showEn = layout !== 'one-column-uk';
   return (
     <View>
       <View style={{ marginBottom: titleGap }}>
@@ -72,25 +133,43 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap }) => {
           <Text style={cellStyles.title}>{doc.title[lang]}</Text>
         )}
       </View>
-      {doc.paragraphs.map((paragraph, index) => (isTwoColumn ? (
-        <View key={`p-${index}`} style={styles.row} wrap={false}>
-          <Text style={[cellStyles.paragraph, cellStyles.leftCell]}>{paragraph.uk}</Text>
-          <Text style={[cellStyles.paragraph, cellStyles.rightCell]}>{paragraph.en}</Text>
+      {doc.paragraphs.map((paragraph, index) => (
+        <View key={`p-${index}`} wrap>
+          {paragraph.type !== 'text' ? (
+            <LogoParagraph
+              paragraph={paragraph}
+              isTwoColumn={isTwoColumn}
+              cellStyles={cellStyles}
+              logoWidth={logoWidth}
+              longLogoWidth={longLogoWidth}
+              clinicLogos={clinicLogos}
+              showUk={showUk}
+              showEn={showEn}
+            />
+          ) : (
+            <TextParagraph
+              paragraph={paragraph}
+              isTwoColumn={isTwoColumn}
+              lang={lang}
+              cellStyles={cellStyles}
+              allowPageBreaks={doc.allowPageBreaks}
+            />
+          )}
         </View>
-      ) : (
-        <Text key={`p-${index}`} style={cellStyles.paragraph}>{paragraph[lang]}</Text>
-      )))}
+      ))}
     </View>
   );
 };
 
-// `documents` - output of buildGeneratedDocument (placeholders already filled). Each document
-// starts on its own page, like the separate statements in the reference file.
+// `documents` - output of buildGeneratedDocument (placeholders already filled, logo paragraphs
+// tagged). Each document starts on its own page, like the separate statements in the reference
+// file; templates with `allowPageBreaks` (the long agreement) are free to spill onto further
+// pages - nothing here constrains a document to a single page.
 const DocumentsPdfDocument = ({
   documents = [],
   layout = 'two-column',
   formatting = DEFAULT_DOC_FORMATTING,
-  logoDataUrl = null,
+  clinicLogos = [],
 }) => {
   const marginTop = formatting.marginTopCm * CM_TO_PT;
   const marginBottom = formatting.marginBottomCm * CM_TO_PT;
@@ -99,12 +178,14 @@ const DocumentsPdfDocument = ({
   const columnGap = formatting.columnGapCm * CM_TO_PT;
   const hasHeader = Boolean(formatting.headerText);
   const hasFooter = Boolean(formatting.footerText) || formatting.showPageNumbers;
-  const isTwoColumn = layout === 'two-column';
-  // Batch 12 §2: two-column pages get the compact logo rendered twice, once above each column
-  // (superseding the earlier single shared logo); one-column pages keep the long variant
-  // stretched across the full text width.
   const contentWidth = A4_WIDTH_PT - marginLeft - marginRight;
-  const logoWidth = isTwoColumn ? formatting.logoWidthMm * MM_TO_PT : contentWidth;
+  const logoWidth = formatting.logoWidthMm * MM_TO_PT;
+  // `showLogo` is only the global permission (spec §5: `canRenderLogo = formatting.showLogo !==
+  // false`) - whether a logo actually renders still depends entirely on the template carrying a
+  // {{logo}}/{{logo-long}} paragraph; clinicLogos being empty (or missing the matching variant)
+  // simply renders no image, never a broken document.
+  const canRenderLogo = formatting.showLogo !== false;
+  const effectiveClinicLogos = canRenderLogo ? clinicLogos : [];
 
   const cellStyles = StyleSheet.create({
     title: {
@@ -120,6 +201,16 @@ const DocumentsPdfDocument = ({
       textAlign: 'justify',
       lineHeight: formatting.lineSpacing,
       textIndent: formatting.firstLineIndentCm * CM_TO_PT,
+      marginBottom: formatting.paragraphSpacing,
+    },
+    paragraphHeading: {
+      fontFamily: 'Tinos',
+      fontWeight: 700,
+      fontSize: formatting.fontSize,
+      textAlign: 'left',
+      lineHeight: formatting.lineSpacing,
+      textIndent: 0,
+      marginTop: formatting.paragraphSpacing,
       marginBottom: formatting.paragraphSpacing,
     },
     leftCell: {
@@ -160,27 +251,15 @@ const DocumentsPdfDocument = ({
               {formatting.headerText}
             </Text>
           ) : null}
-          {formatting.showLogo && logoDataUrl ? (
-            isTwoColumn ? (
-              <View style={[styles.row, { marginBottom: LOGO_BOTTOM_GAP_PT }]}>
-                <View style={cellStyles.leftCell}>
-                  <Image src={logoDataUrl} style={[styles.logo, { width: logoWidth }]} />
-                </View>
-                <View style={cellStyles.rightCell}>
-                  <Image src={logoDataUrl} style={[styles.logo, { width: logoWidth }]} />
-                </View>
-              </View>
-            ) : (
-              <Image
-                src={logoDataUrl}
-                style={[styles.logo, {
-                  width: logoWidth,
-                  marginBottom: LOGO_BOTTOM_GAP_PT,
-                }]}
-              />
-            )
-          ) : null}
-          <DocumentBlock doc={doc} layout={layout} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} />
+          <DocumentBlock
+            doc={doc}
+            layout={layout}
+            cellStyles={cellStyles}
+            titleGap={formatting.paragraphSpacing}
+            logoWidth={logoWidth}
+            longLogoWidth={contentWidth}
+            clinicLogos={effectiveClinicLogos}
+          />
           {hasFooter ? (
             <View
               fixed
@@ -194,9 +273,9 @@ const DocumentsPdfDocument = ({
               {formatting.showPageNumbers ? (
                 <Text
                   style={{ fontSize: Math.max(7, formatting.fontSize - 2) }}
-                  // Batch 12 §3: nothing worth counting on a one-page export - shown only once the
-                  // export actually runs to two or more pages, then on every page including the
-                  // first (same rule as the branded PDFs' shared Footer in pdfTheme.js).
+                  // Nothing worth counting on a one-page export - shown only once the export
+                  // actually runs to two or more pages, then on every page including the first
+                  // (same rule as the branded PDFs' shared Footer in pdfTheme.js).
                   render={({ pageNumber, totalPages }) => (totalPages > 1 ? `Page ${pageNumber} of ${totalPages}` : '')}
                 />
               ) : null}

--- a/src/components/DocumentsRenderers.smoke.test.js
+++ b/src/components/DocumentsRenderers.smoke.test.js
@@ -1,0 +1,121 @@
+// End-to-end smoke test for the Documents PDF/DOCX renderers: builds two generated documents (one
+// with a {{logo}} paragraph and a short heading, one with neither) and actually renders them
+// through @react-pdf/renderer and docx, so a broken prop name or an invalid docx option (e.g.
+// keepLines/cantSplit) fails here instead of only showing up as a blank/broken export later.
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import React from 'react';
+import { buildGeneratedDocument, resolveCaseContext, normalizeDocumentsCatalog } from './documentsCatalogUtils';
+
+const toDataUri = file => {
+  const buf = fs.readFileSync(path.join(__dirname, '../../public/fonts', file));
+  return `data:font/ttf;base64,${buf.toString('base64')}`;
+};
+
+// A tiny 1x1 PNG, used as a stand-in clinic logo image.
+const TINY_PNG_DATA_URL = 'data:image/png;base64,'
+  + 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+const sampleCatalog = () => normalizeDocumentsCatalog(
+  {
+    couples: {
+      'couple-1': {
+        id: 'couple-1',
+        partners: [
+          { id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' }, birthDate: '1990-01-01' },
+          { id: 'p2', role: 'husband', name: { uk: { nominative: 'Тестовий Петро' }, en: 'Testovyi Petro' }, birthDate: '1989-03-03' },
+        ],
+        marriage: { certificateNumber: 'C-04', certificateDate: '2015-11-22' },
+        address: { uk: 'Тестове', en: 'Test City' },
+      },
+    },
+    clinics: {
+      'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка «Тест»', en: 'Clinic "Test"' }, legalName: { uk: 'ТОВ Тест', en: 'Test LLC' } },
+    },
+    cases: {
+      'case-1': { id: 'case-1', coupleId: 'couple-1', clinicId: 'clinic-1' },
+    },
+  },
+  {
+    'with-logo': {
+      id: 'with-logo',
+      title: { uk: 'Згода', en: 'Consent' },
+      allowPageBreaks: true,
+      paragraphs: [
+        { uk: '{{logo}}', en: '{{logo}}' },
+        { uk: '1. Предмет Договору', en: '1. Subject of the Agreement' },
+        { uk: 'Я, {{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.', en: 'I, {{wife.name.en}}, born {{wife.birthDate}}' },
+        { uk: '____________________ (підпис)', en: '____________________ (signature)' },
+      ],
+    },
+    'without-logo': {
+      id: 'without-logo',
+      title: { uk: 'Договір', en: 'Agreement' },
+      allowPageBreaks: true,
+      paragraphs: Array.from({ length: 30 }, (_, i) => ({
+        uk: `${i + 1}. Пункт номер ${i + 1}.`,
+        en: `${i + 1}. Clause number ${i + 1}.`,
+      })),
+    },
+  },
+);
+
+const clinicLogos = [
+  { fileName: 'square.png', dataUrl: TINY_PNG_DATA_URL, layout: '1col', width: 1, height: 1 },
+  { fileName: 'wide.png', dataUrl: TINY_PNG_DATA_URL, layout: '2col', width: 1, height: 1 },
+];
+
+const buildDocuments = () => {
+  const catalog = sampleCatalog();
+  const context = resolveCaseContext(catalog, 'case-1');
+  return catalog.documents.map(template => buildGeneratedDocument(template, context));
+};
+
+describe('Documents PDF renderer (real @react-pdf render)', () => {
+  it('renders a document with a {{logo}} block, a heading and a document without any logo, without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+
+    const DocumentsPdfDocument = documentsModule.default;
+    const documents = buildDocuments();
+    expect(documents).toHaveLength(2);
+
+    const element = React.createElement(DocumentsPdfDocument, {
+      documents,
+      layout: 'two-column',
+      clinicLogos,
+    });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    const out = Buffer.concat(chunks);
+    expect(out.length).toBeGreaterThan(1000);
+    fs.writeFileSync(path.join(os.tmpdir(), 'documents-pdf-smoke.pdf'), out);
+  }, 20000);
+});
+
+describe('Documents DOCX builder (real docx Packer)', () => {
+  it('builds a .docx blob for the same documents without throwing', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const documents = buildDocuments();
+    const blob = await buildDocumentsDocx({
+      documents,
+      layout: 'two-column',
+      clinicLogos,
+    });
+    expect(blob.size).toBeGreaterThan(500);
+  }, 20000);
+});

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -283,14 +283,23 @@ export const formatDocumentDate = value => {
 
 export const MISSING_VALUE_PLACEHOLDER = '__________';
 
+// Every {{...}} token in a template, e.g. {{wife.name.uk.nominative}}, {{logo}}, {{logo-long}}.
+// Deliberately permissive (any run of non-brace characters) so it also matches the two special
+// graphical tokens, which are not dotted paths.
+export const PLACEHOLDER_PATTERN = /\{\{\s*([^{}]+?)\s*\}\}/g;
+
+// Generic arbitrary-depth path walker - no assumption about how many levels a variable has
+// (spec: `clinic.medicalDirector.name.uk.genitive` must resolve exactly like a two-level path).
+export const getValueByPath = (source, path) => String(path).split('.').reduce((value, key) => {
+  if (value === null || value === undefined) return undefined;
+  return value[key];
+}, source);
+
 const resolvePlaceholderValue = (context, path, lang) => {
-  let value = context;
-  for (const segment of String(path).split('.')) {
-    if (value === undefined || value === null) return undefined;
-    value = value[segment];
-  }
+  let value = getValueByPath(context, path);
   // A path that stops at a bilingual node ({uk, en}) resolves to the requested language; one that
-  // stops at a cased-name node resolves to the nominative form.
+  // stops at a cased-name node resolves to the nominative form. These fallbacks only kick in when
+  // the path itself didn't already walk all the way down to a leaf.
   if (isPlainObject(value)) {
     if (value[lang] !== undefined) value = value[lang];
     else if (value.uk !== undefined) value = value.uk;
@@ -301,15 +310,104 @@ const resolvePlaceholderValue = (context, path, lang) => {
 };
 
 // Missing data renders as a fill-in-by-hand blank, matching how the reference statements leave
-// unknown values (dates, counts) as underscores - never as a leaked {{token}}.
+// unknown values (dates, counts) as underscores - never as a leaked {{token}} or the literal
+// strings "undefined"/"null". Unlike the bare {{token}} left in editor/template mode, this is the
+// resolved-for-export text; findUnresolvedVariables (below) is how callers warn about the same
+// paths before a final export.
 export const fillPlaceholders = (text, context, lang = 'uk') => String(text || '').replace(
-  /\{\{\s*([\w.]+)\s*\}\}/g,
-  (token, path) => {
+  PLACEHOLDER_PATTERN,
+  (token, rawPath) => {
+    const path = rawPath.trim();
+    if (path === 'logo' || path === 'logo-long') return token;
     const value = context ? resolvePlaceholderValue(context, path, lang) : undefined;
     const output = value === undefined || String(value).trim() === '' ? MISSING_VALUE_PLACEHOLDER : String(value);
     return output;
   },
 );
+
+// Spec-shaped helper kept alongside fillPlaceholders: a minimal resolver that only substitutes
+// values it can find and otherwise leaves the token untouched (used by the template/editor view,
+// where an unresolved {{path}} should stay visible rather than blank out).
+export const resolveTemplateText = (text, context) => {
+  if (typeof text !== 'string') return '';
+  return text.replace(PLACEHOLDER_PATTERN, (match, rawPath) => {
+    const path = rawPath.trim();
+    if (path === 'logo' || path === 'logo-long') return match;
+    const value = context ? getValueByPath(context, path) : undefined;
+    if (value === null || value === undefined) return match;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+    return match;
+  });
+};
+
+// Every path referenced by a piece of template text, excluding the two graphical tokens (spec
+// §15: logo/logo-long must never show up in an "unresolved variables" list).
+export const findUnresolvedVariables = text => [...String(text || '').matchAll(PLACEHOLDER_PATTERN)]
+  .map(match => match[1].trim())
+  .filter(path => path !== 'logo' && path !== 'logo-long');
+
+// Paths from findUnresolvedVariables that actually fail to resolve against the given context -
+// what the pre-export warning is built from.
+export const getUnresolvedVariablePaths = (text, context, lang = 'uk') => findUnresolvedVariables(text)
+  .filter(path => resolvePlaceholderValue(context, path, lang) === undefined);
+
+// Scans every uk/en title + paragraph of a template and returns the sorted, de-duplicated list of
+// variable paths that won't resolve against the given context. Used before a final PDF/DOCX
+// export to show a confirmation instead of silently shipping blanks.
+export const validateDocumentTemplate = (template, context) => {
+  const missing = new Set();
+  const scan = (value, lang) => getUnresolvedVariablePaths(value, context, lang).forEach(path => missing.add(path));
+  ['uk', 'en'].forEach(lang => scan(template?.title?.[lang], lang));
+  toArray(template?.paragraphs).forEach(paragraph => {
+    ['uk', 'en'].forEach(lang => scan(paragraph?.[lang], lang));
+  });
+  return [...missing].sort();
+};
+
+// --- Special paragraph types (logo blocks) + section headings ------------------------------
+
+// A paragraph whose only content (in either language) is a graphical token is not text - it's a
+// place to draw the clinic logo, and must never be run through fillPlaceholders/resolveTemplateText.
+export const getParagraphType = paragraph => {
+  const uk = String(paragraph?.uk || '').trim();
+  const en = String(paragraph?.en || '').trim();
+  if (uk === '{{logo-long}}' || en === '{{logo-long}}') return 'logo-long';
+  if (uk === '{{logo}}' || en === '{{logo}}') return 'logo';
+  return 'text';
+};
+
+// {{logo}} duplicates a compact, single-column-wide logo above each language column (tagged
+// '1col' - sized for one column); {{logo-long}} is one shared full-width logo spanning both
+// columns (tagged '2col'). `clinicAssets` accepts either the raw `{ logo: [...] }` shape or the
+// flat variants array directly (both appear in this codebase).
+export const getClinicLogo = (clinicAssets, variant) => {
+  const variants = Array.isArray(clinicAssets) ? clinicAssets : clinicAssets?.logo;
+  const expectedLayout = variant === 'logo-long' ? '2col' : '1col';
+  return toArray(variants).find(item => item?.layout === expectedLayout) ?? null;
+};
+
+// Short numbered section titles ("1. Предмет Договору") are bolded; long numbered clauses
+// ("1.1. Клініка зобов'язується...") are not - only a short heading-shaped paragraph qualifies.
+const SECTION_HEADING_PATTERN = /^\d+(?:\.\d+)*\.\s+\S+/;
+const SECTION_HEADING_MAX_LENGTH = 120;
+
+export const isSectionHeading = text => {
+  const trimmed = String(text || '').trim();
+  if (!trimmed || trimmed.length > SECTION_HEADING_MAX_LENGTH) return false;
+  return SECTION_HEADING_PATTERN.test(trimmed);
+};
+
+// A paragraph long enough that forcing it to stay on one page (break-inside: avoid / wrap=false)
+// would fight natural pagination - only relevant once the template opts into page breaks at all.
+const LONG_PARAGRAPH_CHAR_THRESHOLD = 1200;
+
+export const allowsParagraphInternalBreak = (paragraph, allowPageBreaks) => {
+  if (!allowPageBreaks) return false;
+  const longest = Math.max(String(paragraph?.uk || '').length, String(paragraph?.en || '').length);
+  return longest > LONG_PARAGRAPH_CHAR_THRESHOLD;
+};
 
 const localizedText = (value, lang) => {
   if (isPlainObject(value)) return String(value[lang] ?? value.uk ?? value.en ?? '');
@@ -331,18 +429,25 @@ const overriddenText = (override, langKey, fallback) => (
 
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
 // with every placeholder already substituted from the case context, then any per-case data-mode
-// overrides applied on top.
+// overrides applied on top. Logo/logo-long paragraphs are never text-substituted or overridden -
+// they stay tagged for the renderer to draw a graphical block instead (spec §5-§7).
 export const buildGeneratedDocument = (template, context, docOverride = null) => {
   const override = isPlainObject(docOverride) ? docOverride : {};
   return {
     id: template.id,
+    allowPageBreaks: Boolean(template.allowPageBreaks),
     title: {
       uk: overriddenText(override.title, 'uk', fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk')),
       en: overriddenText(override.title, 'en', fillPlaceholders(localizedText(template.title, 'en'), context, 'en')),
     },
     paragraphs: toArray(template.paragraphs).map((paragraph, index) => {
+      const type = getParagraphType(paragraph);
+      if (type !== 'text') {
+        return { type, uk: paragraph?.uk || '', en: paragraph?.en || '' };
+      }
       const paragraphOverride = overrideAt(override.paragraphs, index);
       return {
+        type,
         uk: overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
         en: overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
       };

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -8,6 +8,10 @@ import {
   emptyDocumentsCatalog,
   fillPlaceholders,
   formatDocumentDate,
+  getClinicLogo,
+  getParagraphType,
+  getValueByPath,
+  isSectionHeading,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -19,6 +23,7 @@ import {
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
   upsertRecentCaseId,
+  validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
 // All party fixtures below are fictional - tests must never carry real client data.
@@ -438,5 +443,233 @@ describe('settings', () => {
       clinicLogo: { dataUrl: 'data:image/png;base64,AAA', width: 620, height: 128 },
     });
     expect(settings.clinicLogo).toBeNull();
+  });
+});
+
+// Catalog carrying the full clinic detail shape (spec §2) plus a template exercising both
+// {{logo}}/{{logo-long}} tokens and a long section-heading-bearing agreement.
+const richCatalog = () => normalizeDocumentsCatalog(
+  {
+    couples: {
+      'couple-1': {
+        id: 'couple-1',
+        partners: [
+          {
+            id: 'patient-2', role: 'husband', name: { en: 'Testovyi Petro', uk: { nominative: 'Тестовий Петро' } }, birthDate: '1979-04-27',
+          },
+          {
+            id: 'patient-1', role: 'wife', name: { en: 'Testova Mariia', uk: { nominative: 'Тестова Марія' } }, birthDate: '1982-01-21',
+          },
+        ],
+        marriage: { certificateNumber: 'C-04', certificateDate: '2020-11-22' },
+        address: { uk: 'місто Тестове', en: 'Test City' },
+      },
+    },
+    representatives: {},
+    clinics: {
+      'clinic-1': {
+        id: 'clinic-1',
+        name: { uk: 'Клініка «Вікторія»', en: 'Clinic "Victoria"' },
+        legalName: { uk: 'ТОВ «Вікторія»', en: 'Victoria LLC' },
+        medicalCenterName: { uk: 'МЦ «Вікторія»', en: 'MC "Victoria"' },
+        address: { uk: 'Київ', en: 'Kyiv' },
+        phone: '+380440000000',
+        email: 'info@victoria.example',
+        edrpou: '35085030',
+        taxId: '350850326598',
+        vatCertificateNumber: '200107025',
+        bank: {
+          account: '26001014039074',
+          mfo: '380333',
+          name: { uk: 'Укрексімбанк', en: 'Ukreximbank' },
+          address: { uk: 'Київ, банк', en: 'Kyiv, bank' },
+        },
+        license: { number: 'АД №063736', date: '2012-09-28', issuedBy: { uk: 'МОЗ України', en: 'Ministry of Health' } },
+        medicalDirector: {
+          name: {
+            uk: { nominative: 'Давид Лілія Володимирівна', genitive: 'Давид Лілії Володимирівни', short: 'Давид Л.В.' },
+            en: { full: 'Davyd Liliia Volodymyrivna', short: 'L.V. Davyd' },
+          },
+          authority: { type: { uk: 'Наказ', en: 'Order' }, number: '064', date: '2021-12-31' },
+        },
+      },
+    },
+    cases: {
+      'case-1': { id: 'case-1', coupleId: 'couple-1', clinicId: 'clinic-1', representativeIds: [] },
+      clinics: { 'clinic-1': { logo: [{ file: 'square.jpg', layout: '1col' }, { file: 'wide.jpg', layout: '2col' }] } },
+    },
+  },
+  {
+    'embryo-transfer-consent': {
+      id: 'embryo-transfer-consent',
+      title: { uk: 'Згода', en: 'Consent' },
+      paragraphs: [
+        { uk: '{{logo}}', en: '{{logo}}' },
+        { uk: 'Я, {{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.', en: 'I, {{wife.name.en}}, born {{wife.birthDate}}' },
+        { uk: '{{clinic.medicalDirector.name.uk.genitive}}', en: '{{clinic.medicalDirector.name.en.full}}' },
+      ],
+    },
+  },
+);
+
+describe('spec: universal placeholder resolver', () => {
+  it('resolves an arbitrarily deep clinic.medicalDirector path (getValueByPath)', () => {
+    const context = resolveCaseContext(richCatalog(), 'case-1');
+    expect(getValueByPath(context, 'clinic.medicalDirector.name.uk.genitive')).toBe('Давид Лілії Володимирівни');
+    expect(fillPlaceholders('{{clinic.medicalDirector.name.uk.genitive}}', context, 'uk')).toBe('Давид Лілії Володимирівни');
+    expect(fillPlaceholders('{{clinic.medicalDirector.authority.date}}', context, 'uk')).toBe('31.12.2021');
+    expect(fillPlaceholders('{{clinic.bank.name.uk}}', context, 'uk')).toBe('Укрексімбанк');
+    expect(fillPlaceholders('{{clinic.license.issuedBy.en}}', context, 'en')).toBe('Ministry of Health');
+  });
+
+  it('formats an ISO date as DD.MM.YYYY', () => {
+    expect(formatDocumentDate('2024-02-08')).toBe('08.02.2024');
+  });
+
+  it('never turns a missing variable into the literal "undefined"/"null"/empty string', () => {
+    const context = resolveCaseContext(richCatalog(), 'case-1');
+    const output = fillPlaceholders('{{representative.powerOfAttorney.apostilleDate}}', context, 'uk');
+    expect(output).not.toBe('undefined');
+    expect(output).not.toBe('null');
+    expect(output.trim()).not.toBe('');
+    expect(output).toBe('__________');
+  });
+
+  it('lists genuinely unresolved variables without flagging logo/logo-long', () => {
+    const catalog = richCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = {
+      title: { uk: '{{logo}}', en: '' },
+      paragraphs: [
+        { uk: '{{representative.powerOfAttorney.apostilleDate}}', en: '{{representative.powerOfAttorney.apostilleDate}}' },
+        { uk: '{{logo-long}}', en: '{{logo-long}}' },
+      ],
+    };
+    // The fixture case has no representative at all, so this path never resolves.
+    expect(validateDocumentTemplate(template, context)).toEqual(['representative.powerOfAttorney.apostilleDate']);
+  });
+});
+
+describe('spec: logo paragraph type + clinic logo resolver', () => {
+  it('recognizes {{logo}} as a service block, never as text', () => {
+    expect(getParagraphType({ uk: '{{logo}}', en: '{{logo}}' })).toBe('logo');
+    expect(getParagraphType({ uk: '{{logo}}', en: '' })).toBe('logo');
+  });
+
+  it('recognizes {{logo-long}} distinctly from {{logo}}', () => {
+    expect(getParagraphType({ uk: '{{logo-long}}', en: '{{logo-long}}' })).toBe('logo-long');
+    expect(getParagraphType({ uk: 'Дата: ____________________', en: 'Date: ____________________' })).toBe('text');
+  });
+
+  it('maps {{logo}} to the 1col variant and {{logo-long}} to the 2col variant, never mixing them up', () => {
+    const variants = [
+      { file: 'square.jpg', dataUrl: 'data:1', layout: '1col' },
+      { file: 'wide.jpg', dataUrl: 'data:2', layout: '2col' },
+    ];
+    expect(getClinicLogo(variants, 'logo').file).toBe('square.jpg');
+    expect(getClinicLogo(variants, 'logo-long').file).toBe('wide.jpg');
+    // Also accepts the raw `{ logo: [...] }` shape.
+    expect(getClinicLogo({ logo: variants }, 'logo-long').file).toBe('wide.jpg');
+  });
+
+  it('returns null (never throws or fabricates a file name) when the matching variant is missing', () => {
+    expect(getClinicLogo([{ file: 'square.jpg', layout: '1col' }], 'logo-long')).toBeNull();
+    expect(getClinicLogo([], 'logo')).toBeNull();
+    expect(getClinicLogo(null, 'logo')).toBeNull();
+  });
+
+  it('a document without any logo token never gets a logo attached', () => {
+    const catalog = richCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const noLogoTemplate = {
+      id: 'medical-services-agreement',
+      title: { uk: 'Договір', en: 'Agreement' },
+      paragraphs: [{ uk: 'Текст без логотипу.', en: 'Text without a logo.' }],
+    };
+    const generated = buildGeneratedDocument(noLogoTemplate, context);
+    expect(generated.paragraphs.some(p => p.type === 'logo' || p.type === 'logo-long')).toBe(false);
+  });
+
+  it('tags a {{logo}} paragraph once per occurrence - a renderer never has to guess and never duplicates a logo-long block', () => {
+    const catalog = richCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const generated = buildGeneratedDocument(catalog.documents[0], context);
+    const logoParagraphs = generated.paragraphs.filter(p => p.type === 'logo');
+    expect(logoParagraphs).toHaveLength(1);
+    // The token itself is preserved (not blanked out by fillPlaceholders) for the renderer to act on.
+    expect(logoParagraphs[0].uk).toBe('{{logo}}');
+  });
+});
+
+describe('spec: section headings', () => {
+  it('flags a short numbered heading as bold-worthy', () => {
+    expect(isSectionHeading('1. Предмет Договору')).toBe(true);
+    expect(isSectionHeading('11. Реквізити та підписи сторін:')).toBe(true);
+  });
+
+  it('does not flag a long numbered clause as a heading', () => {
+    const longClause = '1.1. Клініка зобов\'язується надати Пацієнту медичні послуги у сфері застосування допоміжних репродуктивних технологій, відповідно до чинного законодавства України та ліцензії.';
+    expect(longClause.length).toBeGreaterThan(120);
+    expect(isSectionHeading(longClause)).toBe(false);
+  });
+
+  it('does not flag ordinary body text', () => {
+    expect(isSectionHeading('Дата: ____________________')).toBe(false);
+  });
+});
+
+describe('spec: long multi-page documents', () => {
+  it('renders every paragraph of a ~90-paragraph agreement without dropping any', () => {
+    const catalog = richCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const paragraphs = Array.from({ length: 90 }, (_, index) => ({
+      uk: `${index + 1}. Пункт договору номер ${index + 1}.`,
+      en: `${index + 1}. Agreement clause number ${index + 1}.`,
+    }));
+    const longTemplate = {
+      id: 'medical-services-agreement',
+      title: { uk: 'Договір', en: 'Agreement' },
+      allowPageBreaks: true,
+      paragraphs,
+    };
+    const generated = buildGeneratedDocument(longTemplate, context);
+    expect(generated.paragraphs).toHaveLength(90);
+    expect(generated.allowPageBreaks).toBe(true);
+    expect(generated.paragraphs[89].uk).toBe('90. Пункт договору номер 90.');
+  });
+});
+
+describe('spec: bilingual paragraph pairing stays in sync', () => {
+  it('keeps the uk/en text of one logical paragraph at the same array index', () => {
+    const catalog = richCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const generated = buildGeneratedDocument(catalog.documents[0], context);
+    // Index 1 in the fixture template is the wife paragraph - both languages describe the same
+    // person at the same position, never the uk half of one pair next to the en half of another.
+    expect(generated.paragraphs[1].uk).toContain('Тестова Марія');
+    expect(generated.paragraphs[1].en).toContain('Testova Mariia');
+  });
+});
+
+describe('spec: safe optional entities', () => {
+  it('finds partners by role even when the wife is not at index 0', () => {
+    // richCatalog() deliberately lists the husband before the wife.
+    const context = resolveCaseContext(richCatalog(), 'case-1');
+    expect(context.wife.name.uk.nominative).toBe('Тестова Марія');
+    expect(context.husband.name.uk.nominative).toBe('Тестовий Петро');
+  });
+
+  it('does not crash when the case has no surrogate mother, no representative and no clinic logo', () => {
+    const catalog = richCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.surrogateMother).toBeNull();
+    expect(context.representative).toBeNull();
+    expect(() => buildGeneratedDocument(catalog.documents[0], context)).not.toThrow();
+    const generated = buildGeneratedDocument(catalog.documents[0], context);
+    expect(generated.paragraphs[1].uk).toContain('Тестова Марія');
+  });
+
+  it('resolveCaseContext returns null for an unknown case instead of throwing', () => {
+    expect(resolveCaseContext(richCatalog(), 'no-such-case')).toBeNull();
   });
 });

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -1,10 +1,11 @@
 // Word (.docx) renderer for the Documents page, mirroring DocumentsPdfDocument: same formatting
 // settings (Times New Roman, justified, tunable sizes/margins/spacing/header/footer), same
-// one-column / two-column layouts, same optional clinic logo above the title (once, centered, in
-// one-column mode; once per column in two-column mode). The `docx` package is imported
-// dynamically by the caller-facing builder so the library only loads when a Word export is
-// actually requested.
-import { DEFAULT_DOC_FORMATTING } from './documentsCatalogUtils';
+// one-column / two-column layouts. A clinic logo is never added automatically - it only appears
+// where the template itself places a {{logo}} (compact, once per visible language column) or
+// {{logo-long}} (one shared full-width logo) paragraph; see getParagraphType/getClinicLogo in
+// documentsCatalogUtils. The `docx` package is imported dynamically by the caller-facing builder
+// so the library only loads when a Word export is actually requested.
+import { DEFAULT_DOC_FORMATTING, allowsParagraphInternalBreak, getClinicLogo, isSectionHeading } from './documentsCatalogUtils';
 
 const CM_TO_TWIP = 567;
 const MM_TO_PX = 96 / 25.4; // docx ImageRun transformations are CSS pixels at 96dpi
@@ -28,7 +29,7 @@ export const buildDocumentsDocx = async ({
   documents = [],
   layout = 'two-column',
   formatting = DEFAULT_DOC_FORMATTING,
-  logo = null,
+  clinicLogos = [],
 }) => {
   const docx = await import('docx');
   const {
@@ -37,6 +38,8 @@ export const buildDocumentsDocx = async ({
   } = docx;
 
   const isTwoColumn = layout === 'two-column';
+  const showUk = layout !== 'one-column-en';
+  const showEn = layout !== 'one-column-uk';
   const lang = layout === 'one-column-en' ? 'en' : 'uk';
   const bodySize = halfPoints(formatting.fontSize);
   const titleSize = halfPoints(formatting.titleFontSize);
@@ -45,24 +48,45 @@ export const buildDocumentsDocx = async ({
   const afterTwips = Math.round(formatting.paragraphSpacing * 20);
   const firstLineTwips = Math.round(formatting.firstLineIndentCm * CM_TO_TWIP);
   const gapTwips = Math.round(formatting.columnGapCm * CM_TO_TWIP);
+  // `showLogo` is only the global permission (spec §5) - whether a logo actually renders still
+  // depends entirely on the template carrying a {{logo}}/{{logo-long}} paragraph.
+  const canRenderLogo = formatting.showLogo !== false;
+  const effectiveClinicLogos = canRenderLogo ? clinicLogos : [];
 
   const noBorder = { style: BorderStyle.NONE, size: 0, color: 'FFFFFF' };
   const noBorders = { top: noBorder, bottom: noBorder, left: noBorder, right: noBorder };
 
-  const paragraphSpacing = { after: afterTwips, line: lineTwips, lineRule: 'auto' };
+  const contentWidthTwips = 11906
+    - Math.round(formatting.marginLeftCm * CM_TO_TWIP)
+    - Math.round(formatting.marginRightCm * CM_TO_TWIP);
 
-  const bodyParagraph = text => new Paragraph({
+  const bodyParagraph = (text, { keepLines = true } = {}) => new Paragraph({
     alignment: AlignmentType.JUSTIFIED,
-    spacing: paragraphSpacing,
+    spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
     indent: firstLineTwips ? { firstLine: firstLineTwips } : undefined,
+    keepLines,
     children: [new TextRun({ text, size: bodySize })],
   });
 
+  // Short numbered section titles ("1. Предмет Договору") render bold, flush left, with extra
+  // room above and kept with the paragraph that follows so a heading never ends a page alone.
+  const headingParagraph = text => new Paragraph({
+    alignment: AlignmentType.LEFT,
+    spacing: { before: afterTwips, after: afterTwips, line: lineTwips, lineRule: 'auto' },
+    keepLines: true,
+    keepNext: true,
+    children: [new TextRun({ text, bold: true, size: bodySize })],
+  });
+
+  const cellParagraph = (text, allowPageBreaks, paragraph) => (isSectionHeading(text)
+    ? headingParagraph(text)
+    : bodyParagraph(text, { keepLines: !allowsParagraphInternalBreak(paragraph, allowPageBreaks) }));
+
   // Exactly the Format panel's paragraph spacing - no hidden minimum - so the Word output keeps
-  // the same title-to-body rhythm as the PDF and the reference statements (spec §6).
+  // the same title-to-body rhythm as the PDF and the reference statements.
   const titleParagraph = text => new Paragraph({
     alignment: AlignmentType.CENTER,
-    spacing: paragraphSpacing,
+    spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
     children: [new TextRun({ text, bold: true, size: titleSize })],
   });
 
@@ -79,71 +103,79 @@ export const buildDocumentsDocx = async ({
     children: [paragraph],
   });
 
-  const twoColumnCell = (text, paragraphBuilder, marginSide) => twoColumnCellFromParagraph(paragraphBuilder(text), marginSide);
-
-  const twoColumnRow = (uk, en, paragraphBuilder) => new TableRow({
-    children: [
-      twoColumnCell(uk, paragraphBuilder, 'left'),
-      twoColumnCell(en, paragraphBuilder, 'right'),
-    ],
+  const twoColumnTable = (rows, cantSplit) => new Table({
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
+    rows: rows.map(([left, right]) => new TableRow({
+      cantSplit,
+      children: [
+        twoColumnCellFromParagraph(left, 'left'),
+        twoColumnCellFromParagraph(right, 'right'),
+      ],
+    })),
   });
+
+  const logoImageRun = (decoded, widthPx, ratio) => new ImageRun({
+    data: decoded.bytes,
+    type: decoded.type,
+    transformation: { width: widthPx, height: Math.round(widthPx * ratio) },
+  });
+
+  const logoParagraph = (decoded, widthPx, ratio) => new Paragraph({
+    alignment: AlignmentType.CENTER,
+    spacing: { after: 200 },
+    children: [logoImageRun(decoded, widthPx, ratio)],
+  });
+
+  // {{logo}}: a compact logo duplicated above each visible language column (or once, centered,
+  // in a one-column export); {{logo-long}}: one shared full-width logo, never duplicated.
+  const buildLogoBlock = paragraphType => {
+    const variantKind = paragraphType === 'logo-long' ? 'logo-long' : 'logo';
+    const variant = getClinicLogo(effectiveClinicLogos, variantKind);
+    if (!variant?.dataUrl) return [];
+    const decoded = decodeLogoDataUrl(variant.dataUrl);
+    if (!decoded) return [];
+    const ratio = variant.width && variant.height ? variant.height / variant.width : 0.25;
+
+    if (variantKind === 'logo-long') {
+      const widthPx = Math.round((contentWidthTwips / 1440) * 96);
+      return [logoParagraph(decoded, widthPx, ratio)];
+    }
+
+    const compactWidthPx = Math.round(formatting.logoWidthMm * MM_TO_PX);
+    if (isTwoColumn && showUk && showEn) {
+      return [twoColumnTable([[
+        logoParagraph(decoded, compactWidthPx, ratio),
+        logoParagraph(decoded, compactWidthPx, ratio),
+      ]], true)];
+    }
+    return [logoParagraph(decoded, compactWidthPx, ratio)];
+  };
 
   const buildDocChildren = doc => {
     const children = [];
 
-    if (formatting.showLogo && logo?.dataUrl) {
-      const decoded = decodeLogoDataUrl(logo.dataUrl);
-      if (decoded) {
-        // Batch 12 §2: compact logo at the tuned width, rendered once per column in two-column
-        // layouts (superseding the earlier single shared logo) - the long variant still stretches
-        // to the full text width, once, in one-column layouts. 10 pt (200 twips) below the logo
-        // matches the PDF's LOGO_BOTTOM_GAP_PT.
-        const contentWidthTwips = 11906
-          - Math.round(formatting.marginLeftCm * CM_TO_TWIP)
-          - Math.round(formatting.marginRightCm * CM_TO_TWIP);
-        const widthPx = isTwoColumn
-          ? Math.round(formatting.logoWidthMm * MM_TO_PX)
-          : Math.round((contentWidthTwips / 1440) * 96);
-        const ratio = logo.width && logo.height ? logo.height / logo.width : 0.25;
-        const logoParagraph = () => new Paragraph({
-          alignment: AlignmentType.CENTER,
-          spacing: { after: 200 },
-          children: [new ImageRun({
-            data: decoded.bytes,
-            type: decoded.type,
-            transformation: { width: widthPx, height: Math.round(widthPx * ratio) },
-          })],
-        });
-        if (isTwoColumn) {
-          children.push(new Table({
-            width: { size: 100, type: WidthType.PERCENTAGE },
-            borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
-            rows: [new TableRow({
-              children: [
-                twoColumnCellFromParagraph(logoParagraph(), 'left'),
-                twoColumnCellFromParagraph(logoParagraph(), 'right'),
-              ],
-            })],
-          }));
-        } else {
-          children.push(logoParagraph());
-        }
-      }
-    }
-
     if (isTwoColumn) {
-      children.push(new Table({
-        width: { size: 100, type: WidthType.PERCENTAGE },
-        borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
-        rows: [
-          twoColumnRow(doc.title.uk, doc.title.en, titleParagraph),
-          ...doc.paragraphs.map(paragraph => twoColumnRow(paragraph.uk, paragraph.en, bodyParagraph)),
-        ],
-      }));
+      children.push(twoColumnTable([[titleParagraph(doc.title.uk), titleParagraph(doc.title.en)]], true));
     } else {
       children.push(titleParagraph(doc.title[lang]));
-      doc.paragraphs.forEach(paragraph => children.push(bodyParagraph(paragraph[lang])));
     }
+
+    doc.paragraphs.forEach(paragraph => {
+      if (paragraph.type !== 'text') {
+        children.push(...buildLogoBlock(paragraph.type));
+        return;
+      }
+      if (isTwoColumn) {
+        const cantSplit = !allowsParagraphInternalBreak(paragraph, doc.allowPageBreaks);
+        children.push(twoColumnTable([[
+          cellParagraph(paragraph.uk, doc.allowPageBreaks, paragraph),
+          cellParagraph(paragraph.en, doc.allowPageBreaks, paragraph),
+        ]], cantSplit));
+      } else {
+        children.push(cellParagraph(paragraph[lang], doc.allowPageBreaks, paragraph));
+      }
+    });
     return children;
   };
 
@@ -158,18 +190,18 @@ export const buildDocumentsDocx = async ({
     }
     : undefined;
 
-  // Batch 12 §3: a Word document's real page count is only known once Word itself lays the
-  // content out, not at generation time - unlike the PDF renderer, which gets a real totalPages
-  // from @react-pdf. documents.length is the best available proxy: every generated statement
-  // opens its own section/page, so 2+ selected statements guarantees 2+ pages, and this keeps the
-  // same "nothing worth counting on a single page" rule the PDF applies exactly.
+  // A Word document's real page count is only known once Word itself lays the content out, not
+  // at generation time - unlike the PDF renderer, which gets a real totalPages from @react-pdf.
+  // documents.length is the best available proxy: every generated statement opens its own
+  // section/page, so 2+ selected statements guarantees 2+ pages, and this keeps the same "nothing
+  // worth counting on a single page" rule the PDF applies exactly.
   const showPageNumbers = formatting.showPageNumbers && documents.length > 1;
   const footerChildren = [];
   if (formatting.footerText || showPageNumbers) {
     const runs = [];
     if (formatting.footerText) runs.push(new TextRun({ text: formatting.footerText, size: smallSize }));
     if (showPageNumbers) {
-      if (formatting.footerText) runs.push(new TextRun({ text: '   ', size: smallSize }));
+      if (formatting.footerText) runs.push(new TextRun({ text: '   ', size: smallSize }));
       runs.push(new TextRun({ text: 'Page ', size: smallSize }));
       runs.push(new TextRun({ children: [PageNumber.CURRENT], size: smallSize }));
       runs.push(new TextRun({ text: ' of ', size: smallSize }));


### PR DESCRIPTION
- Add an arbitrary-depth placeholder resolver (getValueByPath/PLACEHOLDER_PATTERN) so any
  clinic.*/wife.*/representative.* path resolves regardless of nesting depth, plus
  findUnresolvedVariables/validateDocumentTemplate for a pre-export warning.
- Logo placement is now driven entirely by {{logo}}/{{logo-long}} paragraphs
  (getParagraphType/getClinicLogo) instead of an unconditional top-of-page image tied to the
  page's column layout; a template with neither token renders no logo.
- PDF and DOCX renderers draw logo blocks per paragraph, bold short numbered section headings
  (isSectionHeading), and allow long paragraphs to break across pages when a template sets
  allowPageBreaks instead of forcing every row to stay on one page.
- DocumentsPage now passes the full clinic logo variant list to the renderers, shows a live
  logo preview based on which token the selected documents use, and warns + confirms about
  unresolved variables before a final PDF/DOCX export.
- Add resolver/logo/heading/safety unit tests plus a real @react-pdf + docx render smoke test.