### PR TITLE
Allow inserting or removing a custom paragraph at any position

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaPencilAlt, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaPencilAlt, FaPlus, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFolderFileNames, uploadFileToStorageFolder } from './config';
@@ -44,6 +44,7 @@ import {
   pruneDocOverride,
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
+  shiftDocOverrideParagraphIndices,
   upsertRecentCaseId,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
@@ -387,6 +388,17 @@ const ParagraphPair = styled.div`
   }
 `;
 
+// Structural paragraph controls (insert a custom paragraph here / remove this one) - kept slim and
+// visually distinct from the text itself, and only shown in Template mode: a paragraph's position
+// is a template-level concept, not a per-case data value.
+const ParagraphControlsRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-top: 8px;
+`;
+
 const FieldGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -715,6 +727,61 @@ const DocumentsPage = ({ isAdmin }) => {
       ...template,
       title: { ...(template.title || {}), [langKey]: value },
     }));
+  };
+
+  // Inserting or removing a paragraph is a structural edit, not a text edit - persisted
+  // immediately (not deferred to blur, unlike the plain text fields above) and, since a
+  // paragraph's position is how per-case data-mode overrides key into it, reindexes every
+  // affected case's overrides in the same operation so an insert/remove at any position never
+  // silently misapplies an existing override to the wrong paragraph.
+  const applyParagraphStructureChange = async (docId, buildParagraphs, atIndex, delta) => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template) return;
+    const nextTemplate = { ...template, paragraphs: buildParagraphs(template.paragraphs || []) };
+    const shiftedByCaseId = catalog.parties.cases
+      .filter(caseRecord => caseRecord.docOverrides?.[docId])
+      .map(caseRecord => [caseRecord.id, shiftDocOverrideParagraphIndices(caseRecord.docOverrides[docId], atIndex, delta)]);
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      const partiesPatch = {};
+      shiftedByCaseId.forEach(([caseId, override]) => {
+        partiesPatch[`cases/${caseId}/docOverrides/${docId}`] = override;
+      });
+      if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+        parties: {
+          ...previous.parties,
+          cases: previous.parties.cases.map(caseRecord => {
+            const shifted = shiftedByCaseId.find(([caseId]) => caseId === caseRecord.id);
+            if (!shifted) return caseRecord;
+            return { ...caseRecord, docOverrides: { ...(caseRecord.docOverrides || {}), [docId]: shifted[1] } };
+          }),
+        },
+      }));
+    } catch (structureError) {
+      console.error('Unable to update the document paragraph structure', structureError);
+      toast.error('Could not save the paragraph change.');
+    }
+  };
+
+  // `atIndex` may equal paragraphs.length to append a new custom paragraph after the last one.
+  const handleInsertParagraph = (docId, atIndex) => applyParagraphStructureChange(
+    docId,
+    paragraphs => [...paragraphs.slice(0, atIndex), { uk: '', en: '' }, ...paragraphs.slice(atIndex)],
+    atIndex,
+    1,
+  );
+
+  const handleRemoveParagraph = (docId, atIndex) => {
+    if (typeof window !== 'undefined' && !window.confirm('Remove this paragraph?')) return;
+    applyParagraphStructureChange(
+      docId,
+      paragraphs => paragraphs.filter((_, index) => index !== atIndex),
+      atIndex,
+      -1,
+    );
   };
 
   const persistTemplate = async docId => {
@@ -1394,27 +1461,58 @@ const DocumentsPage = ({ isAdmin }) => {
                           ) : null}
                         </ParagraphPair>
                         {(template.paragraphs || []).map((paragraph, index) => (
-                          <ParagraphPair key={`${template.id}-p-${index}`} $single={isSingle}>
-                            {showUk ? (
-                              <AutoInlineTextarea
-                                value={paragraphValue(paragraph, index, 'uk')}
-                                placeholder="Paragraph (uk)"
-                                readOnly={dataEditLocked}
-                                onChange={onParagraphChange(index, 'uk')}
-                                onBlur={onFieldBlur}
-                              />
+                          <React.Fragment key={`${template.id}-p-${index}`}>
+                            {!isDataMode ? (
+                              <ParagraphControlsRow>
+                                <SmallButton
+                                  type="button"
+                                  onClick={() => handleInsertParagraph(template.id, index)}
+                                  title="Insert a new custom paragraph above this one"
+                                >
+                                  <FaPlus /> Insert paragraph
+                                </SmallButton>
+                                <DangerButton
+                                  type="button"
+                                  onClick={() => handleRemoveParagraph(template.id, index)}
+                                  title="Remove this paragraph"
+                                >
+                                  <FaTrash />
+                                </DangerButton>
+                              </ParagraphControlsRow>
                             ) : null}
-                            {showEn ? (
-                              <AutoInlineTextarea
-                                value={paragraphValue(paragraph, index, 'en')}
-                                placeholder="Paragraph (en)"
-                                readOnly={dataEditLocked}
-                                onChange={onParagraphChange(index, 'en')}
-                                onBlur={onFieldBlur}
-                              />
-                            ) : null}
-                          </ParagraphPair>
+                            <ParagraphPair $single={isSingle}>
+                              {showUk ? (
+                                <AutoInlineTextarea
+                                  value={paragraphValue(paragraph, index, 'uk')}
+                                  placeholder="Paragraph (uk)"
+                                  readOnly={dataEditLocked}
+                                  onChange={onParagraphChange(index, 'uk')}
+                                  onBlur={onFieldBlur}
+                                />
+                              ) : null}
+                              {showEn ? (
+                                <AutoInlineTextarea
+                                  value={paragraphValue(paragraph, index, 'en')}
+                                  placeholder="Paragraph (en)"
+                                  readOnly={dataEditLocked}
+                                  onChange={onParagraphChange(index, 'en')}
+                                  onBlur={onFieldBlur}
+                                />
+                              ) : null}
+                            </ParagraphPair>
+                          </React.Fragment>
                         ))}
+                        {!isDataMode ? (
+                          <ParagraphControlsRow style={{ justifyContent: 'flex-start' }}>
+                            <SmallButton
+                              type="button"
+                              onClick={() => handleInsertParagraph(template.id, (template.paragraphs || []).length)}
+                              title="Append a new custom paragraph at the end of the document"
+                            >
+                              <FaPlus /> Add paragraph at the end
+                            </SmallButton>
+                          </ParagraphControlsRow>
+                        ) : null}
                       </div>
                     ) : null}
                   </DocRow>

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -463,6 +463,25 @@ const overriddenText = (override, langKey, fallback) => (
   typeof override?.[langKey] === 'string' ? override[langKey] : fallback
 );
 
+// A custom paragraph can be inserted (or removed) at any position in a template (spec: "кастомний
+// абзац в будь-якому місці документу"). Because per-case data-mode overrides key into a template's
+// paragraphs by array index, a structural edit like that must reindex every existing override so
+// it keeps pointing at the same paragraph it always did - never silently drift onto the paragraph
+// that happens to now sit at that index. `delta` is +1 for an insertion, -1 for a removal; the
+// override entry that sat exactly at a removed index is dropped along with that paragraph.
+export const shiftDocOverrideParagraphIndices = (docOverride, atIndex, delta) => {
+  if (!isPlainObject(docOverride) || !docOverride.paragraphs) return docOverride;
+  const entries = Array.isArray(docOverride.paragraphs)
+    ? docOverride.paragraphs.map((value, index) => [index, value]).filter(([, value]) => value !== undefined)
+    : Object.entries(docOverride.paragraphs).map(([key, value]) => [Number(key), value]);
+  const nextParagraphs = {};
+  entries.forEach(([index, value]) => {
+    if (delta < 0 && index === atIndex) return;
+    nextParagraphs[index >= atIndex ? index + delta : index] = value;
+  });
+  return { ...docOverride, paragraphs: nextParagraphs };
+};
+
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
 // with every placeholder already substituted from the case context, then any per-case data-mode
 // overrides applied on top. Logo/logo-long paragraphs are never text-substituted or overridden -

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -23,6 +23,7 @@ import {
   pruneDocOverride,
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
+  shiftDocOverrideParagraphIndices,
   upsertRecentCaseId,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
@@ -331,6 +332,32 @@ describe('data-mode overrides', () => {
     const baseline = buildGeneratedDocument(catalog.documents[0], context);
     expect(pruneDocOverride({ title: { uk: baseline.title.uk } }, baseline)).toBeNull();
     expect(pruneDocOverride(null, baseline)).toBeNull();
+  });
+});
+
+describe('spec: inserting/removing a paragraph at any position reindexes existing overrides', () => {
+  it('shifts overrides at or after the insertion point up by one, keeping earlier ones untouched', () => {
+    const docOverride = { title: { en: 'Kept' }, paragraphs: { 0: { en: 'First' }, 2: { en: 'Third' } } };
+    const shifted = shiftDocOverrideParagraphIndices(docOverride, 1, 1);
+    expect(shifted.title).toEqual({ en: 'Kept' });
+    expect(shifted.paragraphs).toEqual({ 0: { en: 'First' }, 3: { en: 'Third' } });
+  });
+
+  it('shifts overrides after a removal down by one and drops the override at the removed index', () => {
+    const docOverride = { paragraphs: { 0: { en: 'First' }, 1: { en: 'Removed' }, 2: { en: 'Third' } } };
+    const shifted = shiftDocOverrideParagraphIndices(docOverride, 1, -1);
+    expect(shifted.paragraphs).toEqual({ 0: { en: 'First' }, 1: { en: 'Third' } });
+  });
+
+  it('handles the Firebase dense-array override shape the same way as the object shape', () => {
+    const docOverride = { paragraphs: [{ en: 'First' }, undefined, { en: 'Third' }] };
+    const shifted = shiftDocOverrideParagraphIndices(docOverride, 0, 1);
+    expect(shifted.paragraphs).toEqual({ 1: { en: 'First' }, 3: { en: 'Third' } });
+  });
+
+  it('leaves overrides without a doc-level paragraphs node untouched', () => {
+    expect(shiftDocOverrideParagraphIndices(null, 0, 1)).toBeNull();
+    expect(shiftDocOverrideParagraphIndices({ title: { en: 'Only title' } }, 0, 1)).toEqual({ title: { en: 'Only title' } });
   });
 });
 


### PR DESCRIPTION
## Summary
- The template editor could only edit the text of paragraphs that already existed — there was no way to add a brand-new custom paragraph anywhere in a document, or remove one.
- Added an "Insert paragraph" button above every paragraph (inserts before it — the button on the first paragraph inserts at the very start) plus one more after the last paragraph (to append at the end), and a remove button per paragraph. Both are shown only in Template mode, since a paragraph's position is a template-level concept, not per-case data.
- Since per-case data-mode overrides key into a template's paragraphs by array index (`docOverrides[docId].paragraphs[index]`), added `shiftDocOverrideParagraphIndices()` and reindex every affected case's overrides in the same operation an insert/remove performs — so a structural edit never silently misapplies an existing case's override text onto the wrong paragraph.

## Test plan
- [x] New unit tests for `shiftDocOverrideParagraphIndices`: shifting up on insert, shifting down + dropping the removed entry, the Firebase dense-array override shape, and no-op when there's nothing to shift.
- [x] `npm test` — no new failures beyond pre-existing unrelated ones.
- [x] `npm run build` — compiles clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6VYVG6G2TzzpTUZckJV7X)_