### PR TITLE
Preserve transparency for re-encoded clinic logos

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -934,7 +934,7 @@ const DocumentsPage = ({ isAdmin }) => {
           // Same re-encode the surrogate mother profile PDF export applies to uploaded photos:
           // @react-pdf/renderer only reliably embeds baseline JPEG/PNG, so a progressive JPEG or
           // EXIF-rotated logo can fail to appear in the generated PDF with no error.
-          const dataUrl = await reencodePdfImageDataUrl(rawDataUrl);
+          const dataUrl = await reencodePdfImageDataUrl(rawDataUrl, { preserveTransparency: true });
           const dimensions = await readImageDimensions(dataUrl);
           return { fileName, dataUrl, ...dimensions };
         } catch (loadLogoError) {

--- a/src/utils/pdfImageEncoding.js
+++ b/src/utils/pdfImageEncoding.js
@@ -1,10 +1,18 @@
+const canvasContainsTransparency = (ctx, width, height) => {
+  const { data } = ctx.getImageData(0, 0, width, height);
+  for (let index = 3; index < data.length; index += 4) {
+    if (data[index] < 255) return true;
+  }
+  return false;
+};
+
 // @react-pdf/renderer only reliably embeds baseline JPEG/PNG; re-encoding an uploaded image
 // through a canvas normalizes progressive JPEGs, unusual PNG color modes, and EXIF-rotated
 // photos that would otherwise render as a blank page (or not render at all) in the PDF, with
 // no error surfaced. This is the same fix the surrogate mother profile PDF export uses for
 // uploaded user photos (see smallCard/renderTopBlock.js) - shared here so any other data-URL
 // image about to be embedded in a PDF (e.g. the Documents Builder clinic logo) gets it too.
-export const reencodePdfImageDataUrl = src => new Promise(resolve => {
+export const reencodePdfImageDataUrl = (src, { preserveTransparency = false } = {}) => new Promise(resolve => {
   if (typeof window === 'undefined' || typeof window.Image !== 'function' || typeof document === 'undefined') {
     resolve(src);
     return;
@@ -25,7 +33,8 @@ export const reencodePdfImageDataUrl = src => new Promise(resolve => {
       canvas.height = height;
       const ctx = canvas.getContext('2d');
       ctx.drawImage(img, 0, 0, width, height);
-      resolve(canvas.toDataURL('image/jpeg', 0.92));
+      const hasTransparency = preserveTransparency && canvasContainsTransparency(ctx, width, height);
+      resolve(hasTransparency ? canvas.toDataURL('image/png') : canvas.toDataURL('image/jpeg', 0.92));
     } catch (error) {
       console.error('Unable to re-encode PDF image', error);
       resolve(src);


### PR DESCRIPTION
### Motivation
- Prevent uploaded PNG clinic logos with alpha from being flattened to opaque boxes when re-encoded for PDF/DOCX generation. 
- Keep the existing canvas-based normalization for problematic JPEG/PNG files while adding an opt-in path to preserve transparency.

### Description
- Add `canvasContainsTransparency` to detect alpha pixels in a canvas image. 
- Change `reencodePdfImageDataUrl` to accept an options object (`{ preserveTransparency = false }`) and emit `image/png` when transparency is present, otherwise emit `image/jpeg` as before. 
- Update `DocumentsPage.jsx` to call `reencodePdfImageDataUrl(rawDataUrl, { preserveTransparency: true })` for fetched clinic logos so transparent logos retain alpha on reload and in generated outputs.

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runTestsByPath src/components/documentsCatalogUtils.test.js`, and all tests passed (29 passed). 
- Ran the linter with `npm run lint:js -- src/utils/pdfImageEncoding.js src/components/DocumentsPage.jsx`, which completed with non-fatal warnings about a dependency but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591e3b4b9c83269473d1c9d04816c6)