### PR TITLE
Clamp two-column document logo width

### DIFF
--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -104,7 +104,10 @@ const DocumentsPdfDocument = ({
   // (superseding the earlier single shared logo); one-column pages keep the long variant
   // stretched across the full text width.
   const contentWidth = A4_WIDTH_PT - marginLeft - marginRight;
-  const logoWidth = isTwoColumn ? formatting.logoWidthMm * MM_TO_PT : contentWidth;
+  const columnWidth = Math.max(0, (contentWidth - columnGap) / 2);
+  const logoWidth = isTwoColumn
+    ? Math.min(formatting.logoWidthMm * MM_TO_PT, columnWidth)
+    : contentWidth;
 
   const cellStyles = StyleSheet.create({
     title: {

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -101,8 +101,9 @@ export const buildDocumentsDocx = async ({
         const contentWidthTwips = 11906
           - Math.round(formatting.marginLeftCm * CM_TO_TWIP)
           - Math.round(formatting.marginRightCm * CM_TO_TWIP);
+        const columnWidthTwips = Math.max(0, (contentWidthTwips - gapTwips) / 2);
         const widthPx = isTwoColumn
-          ? Math.round(formatting.logoWidthMm * MM_TO_PX)
+          ? Math.round(Math.min(formatting.logoWidthMm * MM_TO_PX, (columnWidthTwips / 1440) * 96))
           : Math.round((contentWidthTwips / 1440) * 96);
         const ratio = logo.width && logo.height ? logo.height / logo.width : 0.25;
         const logoParagraph = () => new Paragraph({


### PR DESCRIPTION
### Motivation
- Prevent duplicated logos in two-column document exports from overlapping or spilling outside their column when users set a logo width larger than the per-column space.
- Ensure PDF and DOCX outputs behave consistently by applying the same per-column width constraint for the compact (two-column) logo variant.
- Avoid negative/invalid column sizes when the page content width is small by guarding the computed column width.

### Description
- In `src/components/DocumentsPdfDocument.jsx` compute `columnWidth = Math.max(0, (contentWidth - columnGap) / 2)` and clamp the two-column `logoWidth` with `Math.min(formatting.logoWidthMm * MM_TO_PT, columnWidth)` while preserving full `contentWidth` in one-column mode.
- In `src/components/documentsDocxBuilder.js` compute `columnWidthTwips = Math.max(0, (contentWidthTwips - gapTwips) / 2)` and clamp the DOCX two-column image `widthPx` by taking the minimum of the configured logo width and the per-column width converted to pixels, while preserving full-content sizing for one-column exports.
- Changes are limited to the two files above and keep existing behavior for one-column layouts and the logo bottom gap alignment.

### Testing
- Ran `npm run lint:js -- src/components/DocumentsPdfDocument.jsx src/components/documentsDocxBuilder.js`, which completed successfully (warnings only).
- Ran `git diff --check`, which produced no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a1fb4f1dc83268f94bc024c44edf1)