### PR TITLE
Clamp two-column document logo widths

### DIFF
--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -184,7 +184,10 @@ const DocumentsPdfDocument = ({
   const hasHeader = Boolean(formatting.headerText);
   const hasFooter = Boolean(formatting.footerText) || formatting.showPageNumbers;
   const contentWidth = A4_WIDTH_PT - marginLeft - marginRight;
-  const logoWidth = formatting.logoWidthMm * MM_TO_PT;
+  const isTwoColumn = layout === 'two-column';
+  const columnContentWidth = (contentWidth - columnGap) / 2;
+  const configuredLogoWidth = formatting.logoWidthMm * MM_TO_PT;
+  const logoWidth = isTwoColumn ? Math.min(configuredLogoWidth, columnContentWidth) : configuredLogoWidth;
   // `showLogo` is only the global permission (spec §5: `canRenderLogo = formatting.showLogo !==
   // false`) - whether a logo actually renders still depends entirely on the template carrying a
   // {{logo}}/{{logo-long}} paragraph; clinicLogos being empty (or missing the matching variant)

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -61,6 +61,7 @@ export const buildDocumentsDocx = async ({
   const contentWidthTwips = 11906
     - Math.round(formatting.marginLeftCm * CM_TO_TWIP)
     - Math.round(formatting.marginRightCm * CM_TO_TWIP);
+  const columnContentWidthTwips = (contentWidthTwips - gapTwips) / 2;
 
   const bodyParagraph = (text, { keepLines = true } = {}) => new Paragraph({
     alignment: AlignmentType.JUSTIFIED,
@@ -144,7 +145,11 @@ export const buildDocumentsDocx = async ({
       return [logoParagraph(decoded, widthPx, ratio)];
     }
 
-    const compactWidthPx = Math.round(formatting.logoWidthMm * MM_TO_PX);
+    const configuredCompactWidthPx = Math.round(formatting.logoWidthMm * MM_TO_PX);
+    const columnContentWidthPx = Math.round((columnContentWidthTwips / 1440) * 96);
+    const compactWidthPx = isTwoColumn
+      ? Math.min(configuredCompactWidthPx, columnContentWidthPx)
+      : configuredCompactWidthPx;
     if (isTwoColumn && showUk && showEn) {
       return [twoColumnTable([[
         logoParagraph(decoded, compactWidthPx, ratio),


### PR DESCRIPTION
### Motivation
- Prevent duplicated compact logos in two-column documents from overlapping or spilling outside their language cell when the user-configured logo width exceeds the available per-column width.
- Keep long/full-width logos (`logo-long`) using the full content width while applying a per-column clamp only to compact/duplicated logos.

### Description
- In `src/components/DocumentsPdfDocument.jsx` compute `isTwoColumn`, `columnContentWidth` and `configuredLogoWidth`, and set `logoWidth` to `Math.min(configuredLogoWidth, columnContentWidth)` when in two-column mode to clamp per-column PDF logos.
- In `src/components/documentsDocxBuilder.js` add `columnContentWidthTwips` and compute a clamped `compactWidthPx` from `configuredCompactWidthPx` and `columnContentWidthPx`, preserving the existing full `contentWidthTwips` usage for `logo-long`.
- Reused existing formatting metrics (`columnGap`, margins, configured logo mm → px/pt conversions) and preserved behavior for one-column exports and long logos.
- Changes applied to two files: `DocumentsPdfDocument.jsx` and `documentsDocxBuilder.js`.

### Testing
- Ran `git diff --check` and it reported no issues (success).
- Ran `npm run lint:js -- src/components/DocumentsPdfDocument.jsx src/components/documentsDocxBuilder.js` and it completed (warnings from dependencies only).
- Ran `npm run build` and the project compiled successfully and produced a production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a6ab403208326a3f0046fd64a8aba)