### PR TITLE
Download each document as its own file; order the list by recent downloads

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -40,12 +40,14 @@ import {
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
   orderCasesByRecent,
+  orderRecordsByRecentIds,
   parseDocumentsTechnicalInput,
   pruneDocOverride,
   resolveCaseContext,
   resolveMergedRecordsForPersistence,
   shiftDocOverrideParagraphIndices,
   upsertRecentCaseId,
+  upsertRecentId,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
@@ -1080,7 +1082,10 @@ const DocumentsPage = ({ isAdmin }) => {
   // --- Generation --------------------------------------------------------------------------------
 
   const orderedCases = orderCasesByRecent(catalog.parties.cases, settings.recentCaseIds);
-  const selectedTemplates = catalog.documents.filter(template => selectedDocIds[template.id]);
+  // Most recently downloaded documents first (spec: "самі популярні документи мають бути вгорі") -
+  // whatever hasn't been downloaded yet keeps the catalog's own order, after every recent one.
+  const orderedDocuments = orderRecordsByRecentIds(catalog.documents, settings.recentDocIds);
+  const selectedTemplates = orderedDocuments.filter(template => selectedDocIds[template.id]);
   const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
   const caseContext = resolveCaseContext(catalog, selectedCaseId);
   // A logo only ever appears where a template declares one - via the dedicated `logo` field, or
@@ -1197,6 +1202,14 @@ const DocumentsPage = ({ isAdmin }) => {
     persistSettings({ recentCaseIds: upsertRecentCaseId(settings.recentCaseIds, selectedCaseId) });
   };
 
+  // Bumps every just-downloaded document to the front of the Documents list, in download order -
+  // the last one downloaded ends up first (spec: "документ, скачаний останнім" is the most
+  // popular), the rest keep whatever relative order they already had.
+  const rememberRecentDocs = docIds => {
+    const nextRecentDocIds = docIds.reduce((recent, docId) => upsertRecentId(recent, docId), settings.recentDocIds);
+    persistSettings({ recentDocIds: nextRecentDocIds });
+  };
+
   // A non-blocking warning is shown inline at all times (spec §15); the final export step still
   // asks for a confirmation so an admin never ships blanks without noticing.
   const confirmUnresolvedVariables = () => {
@@ -1207,6 +1220,14 @@ const DocumentsPage = ({ isAdmin }) => {
       + `${unresolvedVariables.map(path => `- ${path}`).join('\n')}\n\nЗгенерувати документ попри це?`,
     );
   };
+
+  const sleep = ms => new Promise(resolve => { setTimeout(resolve, ms); });
+
+  // Every checked document downloads as its own file (spec: "всі обрані документи ... мають бути
+  // окремими файлами") - never bundled into one combined multi-page PDF/multi-section DOCX. A
+  // short pause between saves keeps the browser from treating a fast run of downloads as a
+  // pop-up-style flood and silently blocking everything after the first.
+  const MULTI_DOWNLOAD_DELAY_MS = 300;
 
   const handleGeneratePdf = async () => {
     if (isGenerateDisabled) return;
@@ -1220,14 +1241,19 @@ const DocumentsPage = ({ isAdmin }) => {
       ]);
       documentsModule.ensureDocumentsPdfFontsRegistered();
       const DocumentsPdfDocument = documentsModule.default;
-      const blob = await pdf(React.createElement(DocumentsPdfDocument, {
-        documents: generated,
-        layout,
-        formatting: normalizedFormatting,
-        clinicLogos,
-      })).toBlob();
-      saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'pdf'));
+      for (let index = 0; index < generated.length; index += 1) {
+        const doc = generated[index];
+        const blob = await pdf(React.createElement(DocumentsPdfDocument, {
+          documents: [doc],
+          layout,
+          formatting: normalizedFormatting,
+          clinicLogos,
+        })).toBlob();
+        saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'pdf', doc));
+        if (index < generated.length - 1) await sleep(MULTI_DOWNLOAD_DELAY_MS);
+      }
       rememberRecentCase();
+      rememberRecentDocs(generated.map(doc => doc.id));
     } catch (generateError) {
       console.error('Unable to generate documents PDF', generateError);
       toast.error(isStaleChunkError(generateError) ? STALE_APP_MESSAGE : 'Could not generate the PDF.');
@@ -1243,14 +1269,19 @@ const DocumentsPage = ({ isAdmin }) => {
     try {
       const { generated, normalizedFormatting } = prepareGeneration();
       const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
-      const blob = await buildDocumentsDocx({
-        documents: generated,
-        layout,
-        formatting: normalizedFormatting,
-        clinicLogos,
-      });
-      saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'docx'));
+      for (let index = 0; index < generated.length; index += 1) {
+        const doc = generated[index];
+        const blob = await buildDocumentsDocx({
+          documents: [doc],
+          layout,
+          formatting: normalizedFormatting,
+          clinicLogos,
+        });
+        saveAs(blob, buildDocumentsFileName(catalog, selectedCase, layout, 'docx', doc));
+        if (index < generated.length - 1) await sleep(MULTI_DOWNLOAD_DELAY_MS);
+      }
       rememberRecentCase();
+      rememberRecentDocs(generated.map(doc => doc.id));
     } catch (generateError) {
       console.error('Unable to generate documents DOCX', generateError);
       toast.error(isStaleChunkError(generateError) ? STALE_APP_MESSAGE : 'Could not generate the Word file.');
@@ -1371,7 +1402,7 @@ const DocumentsPage = ({ isAdmin }) => {
               {!catalog.documents.length ? (
                 <DocSubtitle style={{ marginTop: 8 }}>No document templates yet — paste them in the technical field below.</DocSubtitle>
               ) : null}
-              {catalog.documents.map(template => {
+              {orderedDocuments.map(template => {
                 const isExpanded = expandedDocId === String(template.id);
                 const isDataMode = editMode === 'data';
                 // The builder view mirrors the selected layout mode (spec §1): both languages as

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -563,21 +563,27 @@ export const buildCaseLabel = (catalog, caseRecord) => {
   return parts.join(' — ') || String(caseRecord.id);
 };
 
-// Most recently used case first (spec §5), the rest keep catalog order.
-export const orderCasesByRecent = (cases, recentCaseIds) => {
-  const recent = toArray(recentCaseIds).map(String);
+// Generic "most recently used first" ordering + upsert, shared by the case selector (spec §5) and
+// the Documents list (most recently downloaded templates float to the top): whatever isn't in the
+// recent list yet keeps its original catalog order, appended after every recent record.
+export const orderRecordsByRecentIds = (records, recentIds) => {
+  const recent = toArray(recentIds).map(String);
   const rank = id => {
     const index = recent.indexOf(String(id));
     return index === -1 ? recent.length : index;
   };
-  return [...(cases || [])].sort((a, b) => rank(a.id) - rank(b.id));
+  return [...(records || [])].sort((a, b) => rank(a.id) - rank(b.id));
 };
 
-export const upsertRecentCaseId = (recentCaseIds, caseId) => {
-  if (!caseId) return toArray(recentCaseIds).map(String);
-  const id = String(caseId);
-  return [id, ...toArray(recentCaseIds).map(String).filter(existing => existing !== id)].slice(0, 20);
+export const upsertRecentId = (recentIds, id) => {
+  if (!id) return toArray(recentIds).map(String);
+  const strId = String(id);
+  return [strId, ...toArray(recentIds).map(String).filter(existing => existing !== strId)].slice(0, 20);
 };
+
+export const orderCasesByRecent = (cases, recentCaseIds) => orderRecordsByRecentIds(cases, recentCaseIds);
+
+export const upsertRecentCaseId = (recentCaseIds, caseId) => upsertRecentId(recentCaseIds, caseId);
 
 // --- Layouts + formatting settings ----------------------------------------------------------
 
@@ -664,7 +670,8 @@ export const normalizeDocFormatting = raw => {
   };
 };
 
-// The backend settings record stores formatting values and the recently-used case order.
+// The backend settings record stores formatting values, the recently-used case order, and the
+// recently-downloaded document template order (spec: "самі популярні документи мають бути вгорі").
 // Clinic logos are resolved from Storage at render time, not stored as URLs/data URLs here.
 export const normalizeDocumentsSettings = raw => {
   const source = isPlainObject(raw) ? raw : {};
@@ -672,16 +679,22 @@ export const normalizeDocumentsSettings = raw => {
     formatting: normalizeDocFormatting(source.formatting),
     clinicLogo: null,
     recentCaseIds: toArray(source.recentCaseIds).map(String),
+    recentDocIds: toArray(source.recentDocIds).map(String),
   };
 };
 
 // --- File naming ----------------------------------------------------------------------------
 
-export const buildDocumentsFileName = (catalog, caseRecord, layout, extension) => {
-  const label = buildCaseLabel(catalog, caseRecord)
-    .replace(/[^\p{L}\p{N}]+/gu, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 60) || 'Case';
+const slugifyFileNamePart = value => String(value || '')
+  .replace(/[^\p{L}\p{N}]+/gu, '_')
+  .replace(/^_+|_+$/g, '');
+
+// Every selected document downloads as its own file (spec: "всі обрані документи ... мають бути
+// окремими файлами") - `doc` (a single generated document, when provided) adds its own title to
+// the name so a batch download doesn't produce several identically-named files.
+export const buildDocumentsFileName = (catalog, caseRecord, layout, extension, doc = null) => {
+  const label = slugifyFileNamePart(buildCaseLabel(catalog, caseRecord)).slice(0, 60) || 'Case';
+  const docLabel = doc ? slugifyFileNamePart(doc.title?.uk || doc.title?.en || doc.id).slice(0, 60) : '';
   const langTag = layout === 'one-column-uk' ? 'UA' : layout === 'one-column-en' ? 'EN' : 'UA-EN';
   const today = new Date();
   const ymd = [
@@ -689,5 +702,6 @@ export const buildDocumentsFileName = (catalog, caseRecord, layout, extension) =
     String(today.getMonth() + 1).padStart(2, '0'),
     String(today.getDate()).padStart(2, '0'),
   ].join('-');
-  return `Documents_${label}_${langTag}_${ymd}.${extension}`;
+  const parts = ['Documents', label, docLabel, langTag, ymd].filter(Boolean);
+  return `${parts.join('_')}.${extension}`;
 };

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -2,6 +2,7 @@ import {
   DEFAULT_DOC_FORMATTING,
   applyLogoLayoutAssignment,
   buildCaseLabel,
+  buildDocumentsFileName,
   buildGeneratedDocument,
   clinicLogoEntriesToBackend,
   deepMergeRecords,
@@ -18,6 +19,7 @@ import {
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
   orderCasesByRecent,
+  orderRecordsByRecentIds,
   parseDocumentsTechnicalInput,
   pickLogoVariantForLayout,
   pruneDocOverride,
@@ -25,6 +27,7 @@ import {
   resolveMergedRecordsForPersistence,
   shiftDocOverrideParagraphIndices,
   upsertRecentCaseId,
+  upsertRecentId,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
@@ -500,12 +503,50 @@ describe('case selector helpers', () => {
   });
 });
 
+describe('spec: Documents list ordered by most recently downloaded', () => {
+  it('orderRecordsByRecentIds puts the most recently downloaded document first, same as cases', () => {
+    const documents = [{ id: 'doc-a' }, { id: 'doc-b' }, { id: 'doc-c' }];
+    expect(orderRecordsByRecentIds(documents, ['doc-c']).map(record => record.id)).toEqual(['doc-c', 'doc-a', 'doc-b']);
+    expect(orderRecordsByRecentIds(documents, []).map(record => record.id)).toEqual(['doc-a', 'doc-b', 'doc-c']);
+  });
+
+  it('the last document downloaded ends up first, even across several downloads', () => {
+    let recentDocIds = [];
+    recentDocIds = upsertRecentId(recentDocIds, 'doc-a');
+    recentDocIds = upsertRecentId(recentDocIds, 'doc-b');
+    // doc-a downloaded again, most recently of all - it should be back at the front.
+    recentDocIds = upsertRecentId(recentDocIds, 'doc-a');
+    expect(recentDocIds).toEqual(['doc-a', 'doc-b']);
+  });
+});
+
+describe('spec: every selected document downloads as its own separate file', () => {
+  it('includes the document title in the file name so a batch never collides on one name', () => {
+    const catalog = sampleCatalog();
+    const caseRecord = catalog.parties.cases[0];
+    const docA = { id: 'doc-a', title: { uk: 'Перший документ', en: 'First document' } };
+    const docB = { id: 'doc-b', title: { uk: 'Другий документ', en: 'Second document' } };
+    const nameA = buildDocumentsFileName(catalog, caseRecord, 'two-column', 'pdf', docA);
+    const nameB = buildDocumentsFileName(catalog, caseRecord, 'two-column', 'pdf', docB);
+    expect(nameA).not.toBe(nameB);
+    expect(nameA).toContain('Перший_документ');
+    expect(nameB).toContain('Другий_документ');
+  });
+
+  it('still produces a valid name when no specific document is given (batch-level fallback)', () => {
+    const catalog = sampleCatalog();
+    const caseRecord = catalog.parties.cases[0];
+    expect(buildDocumentsFileName(catalog, caseRecord, 'two-column', 'pdf')).toMatch(/^Documents_.+\.pdf$/);
+  });
+});
+
 describe('settings', () => {
   it('provides reference-document defaults', () => {
     const settings = normalizeDocumentsSettings(null);
     expect(settings.formatting).toEqual(DEFAULT_DOC_FORMATTING);
     expect(settings.clinicLogo).toBeNull();
     expect(settings.recentCaseIds).toEqual([]);
+    expect(settings.recentDocIds).toEqual([]);
   });
 
   it('clamps out-of-range formatting values and keeps valid ones', () => {


### PR DESCRIPTION
## Summary
- **Separate files per document**: checking several documents and downloading previously produced one combined multi-page PDF (or multi-section DOCX) for the whole batch. Now generates and saves one PDF/DOCX per selected document, each through its own render pass. `buildDocumentsFileName` now optionally takes the specific document so its title is part of the file name (a batch never collides on one name), and each PDF's page numbering restarts cleanly since the file only ever contains that one document to begin with. A short pause between saves keeps the browser from blocking a fast run of downloads.
- **Documents list ordered by recent downloads**: the list now surfaces the most recently downloaded templates at the top ("самі популярні документи мають бути вгорі"). Generalized `orderCasesByRecent`/`upsertRecentCaseId` into reusable `orderRecordsByRecentIds`/`upsertRecentId` (the case-specific names stay as thin wrappers, unchanged behavior/tests), and added `settings.recentDocIds`, updated after every PDF/DOCX download in save order — the last document downloaded ends up first.

## Test plan
- [x] New unit tests: `orderRecordsByRecentIds`/`upsertRecentId` generic MRU behavior, `buildDocumentsFileName` producing distinct per-document names (and a valid batch-level fallback), `normalizeDocumentsSettings` defaulting `recentDocIds` to `[]`.
- [x] Real-render PDF/DOCX smoke tests (including per-document page-numbering pagination) still pass.
- [x] `npm test` — no new failures beyond pre-existing unrelated ones.
- [x] `npm run build` — compiles clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6VYVG6G2TzzpTUZckJV7X)_