### PR TITLE
Edit the logo as free {{logo}} text; box each paragraph with its controls

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -378,7 +378,7 @@ const ParagraphPair = styled.div`
   grid-template-columns: ${({ $single }) => ($single ? '1fr' : '1fr 1fr')};
   gap: 6px;
   margin-top: 6px;
-  ${({ $single }) => ($single ? '' : `
+  ${({ $single, $plain }) => ($single || $plain ? '' : `
     border: 1px solid var(--km-border);
     border-radius: 8px;
     padding: 4px 6px;
@@ -398,7 +398,18 @@ const ParagraphControlsRow = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 6px;
-  margin-top: 8px;
+  margin-bottom: 4px;
+`;
+
+// Encloses one paragraph's controls (Insert/Remove) together with its own text, in one visible
+// border - so which paragraph a button acts on is never ambiguous, regardless of whether the
+// two-column ParagraphPair below would otherwise draw its own (now suppressed via $plain) border.
+const ParagraphEditorBlock = styled.div`
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  padding: 6px 8px 8px;
+  margin-top: 10px;
+  background: rgba(162, 121, 63, 0.025);
 `;
 
 const FieldGrid = styled.div`
@@ -702,10 +713,13 @@ const DocumentsPage = ({ isAdmin }) => {
     }));
   };
 
-  // The letterhead logo always renders before the title (spec: "лого відображай перед title").
-  // Current templates carry it as a dedicated `logo` field; older ones still have it embedded as
-  // the first paragraph. Editing keeps whichever shape the template is already using instead of
-  // introducing a second, conflicting source of truth.
+  // The letterhead logo always renders before the title (spec: "лого відображай перед title") and
+  // is edited as plain text (spec: "додай його як посилання {{logo}} ... щоб я зміг вручну його
+  // правити") - a free-text field the admin types {{logo}} / {{logo-long}} into directly, or
+  // clears to remove the logo, rather than picking from a constrained list. Current templates
+  // carry it as a dedicated `logo` field; older ones still have it embedded as the first
+  // paragraph. Editing keeps whichever shape the template is already using instead of introducing
+  // a second, conflicting source of truth.
   const handleLogoFieldChange = (docId, value) => {
     const token = value || '';
     updateTemplate(docId, template => {
@@ -1413,6 +1427,15 @@ const DocumentsPage = ({ isAdmin }) => {
                 const resolvedDoc = isExpanded && isDataMode
                   ? buildGeneratedDocument(template, caseContext, selectedCase?.docOverrides?.[template.id])
                   : null;
+                // Whichever source is currently authoritative (the dedicated `logo` field, or a
+                // legacy leading paragraph) shown as one plain-text value the admin can type into
+                // directly - never a normalized re-serialization, so a mid-edit/invalid value
+                // isn't silently rewritten out from under them.
+                const logoFieldValue = String(template.logo || '').trim()
+                  ? template.logo
+                  : (getParagraphType((template.paragraphs || [])[0]) !== 'text'
+                    ? ((template.paragraphs || [])[0]?.uk || (template.paragraphs || [])[0]?.en || '')
+                    : '');
                 const titleValue = langKey => (isDataMode ? resolvedDoc?.title?.[langKey] ?? '' : template.title?.[langKey] || '');
                 const paragraphValue = (paragraph, index, langKey) => (isDataMode
                   ? resolvedDoc?.paragraphs?.[index]?.[langKey] ?? ''
@@ -1459,16 +1482,14 @@ const DocumentsPage = ({ isAdmin }) => {
                         {!isDataMode ? (
                           <RowLine style={{ marginTop: 4 }}>
                             <DocSubtitle style={{ fontWeight: 700 }}>Logo (before title)</DocSubtitle>
-                            <Select
-                              value={getTemplateLogoType(template) || ''}
+                            <FieldInput
+                              type="text"
+                              value={logoFieldValue}
+                              placeholder="{{logo}} or {{logo-long}} - empty for no logo"
                               onChange={event => handleLogoFieldChange(template.id, event.target.value)}
                               onBlur={() => persistTemplate(template.id)}
-                              style={{ flex: 'unset', minWidth: 240 }}
-                            >
-                              <option value="">No logo</option>
-                              <option value="logo">{'{{logo}}'} — compact, one per language column</option>
-                              <option value="logo-long">{'{{logo-long}}'} — one shared full-width logo</option>
-                            </Select>
+                              style={{ flex: 1, minWidth: 240 }}
+                            />
                           </RowLine>
                         ) : null}
                         <ParagraphPair $single={isSingle}>
@@ -1492,26 +1513,8 @@ const DocumentsPage = ({ isAdmin }) => {
                           ) : null}
                         </ParagraphPair>
                         {(template.paragraphs || []).map((paragraph, index) => (
-                          <React.Fragment key={`${template.id}-p-${index}`}>
-                            {!isDataMode ? (
-                              <ParagraphControlsRow>
-                                <SmallButton
-                                  type="button"
-                                  onClick={() => handleInsertParagraph(template.id, index)}
-                                  title="Insert a new custom paragraph above this one"
-                                >
-                                  <FaPlus /> Insert paragraph
-                                </SmallButton>
-                                <DangerButton
-                                  type="button"
-                                  onClick={() => handleRemoveParagraph(template.id, index)}
-                                  title="Remove this paragraph"
-                                >
-                                  <FaTrash />
-                                </DangerButton>
-                              </ParagraphControlsRow>
-                            ) : null}
-                            <ParagraphPair $single={isSingle}>
+                          isDataMode ? (
+                            <ParagraphPair key={`${template.id}-p-${index}`} $single={isSingle}>
                               {showUk ? (
                                 <AutoInlineTextarea
                                   value={paragraphValue(paragraph, index, 'uk')}
@@ -1531,7 +1534,48 @@ const DocumentsPage = ({ isAdmin }) => {
                                 />
                               ) : null}
                             </ParagraphPair>
-                          </React.Fragment>
+                          ) : (
+                            // Boxed together so it's unambiguous which paragraph "Insert"/"Remove"
+                            // act on: both controls and the paragraph's own text live inside the
+                            // same visible border (spec: "щоб було зрозуміло ... до якого абзацу
+                            // відноситься").
+                            <ParagraphEditorBlock key={`${template.id}-p-${index}`}>
+                              <ParagraphControlsRow>
+                                <SmallButton
+                                  type="button"
+                                  onClick={() => handleInsertParagraph(template.id, index)}
+                                  title="Insert a new custom paragraph above this one"
+                                >
+                                  <FaPlus /> Insert paragraph
+                                </SmallButton>
+                                <DangerButton
+                                  type="button"
+                                  onClick={() => handleRemoveParagraph(template.id, index)}
+                                  title="Remove this paragraph"
+                                >
+                                  <FaTrash />
+                                </DangerButton>
+                              </ParagraphControlsRow>
+                              <ParagraphPair $single={isSingle} $plain>
+                                {showUk ? (
+                                  <AutoInlineTextarea
+                                    value={paragraphValue(paragraph, index, 'uk')}
+                                    placeholder="Paragraph (uk)"
+                                    onChange={onParagraphChange(index, 'uk')}
+                                    onBlur={onFieldBlur}
+                                  />
+                                ) : null}
+                                {showEn ? (
+                                  <AutoInlineTextarea
+                                    value={paragraphValue(paragraph, index, 'en')}
+                                    placeholder="Paragraph (en)"
+                                    onChange={onParagraphChange(index, 'en')}
+                                    onBlur={onFieldBlur}
+                                  />
+                                ) : null}
+                              </ParagraphPair>
+                            </ParagraphEditorBlock>
+                          )
                         ))}
                         {!isDataMode ? (
                           <ParagraphControlsRow style={{ justifyContent: 'flex-start' }}>

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -727,6 +727,14 @@ describe('spec: template.logo field renders before the title', () => {
     expect(getTemplateLogoType({ paragraphs: [] })).toBeNull();
   });
 
+  // The logo field is edited as free text (spec: manually typing {{logo}}), so it must require the
+  // literal token including braces - a bare "logo" (e.g. from a stray write that stripped the
+  // braces) is not a graphical token and must never render a logo silently by accident.
+  it('requires the literal {{logo}}/{{logo-long}} token - a bare word does not count', () => {
+    expect(getTemplateLogoType({ logo: 'logo', paragraphs: [] })).toBeNull();
+    expect(getTemplateLogoType({ logo: 'logo-long', paragraphs: [] })).toBeNull();
+  });
+
   it('falls back to a legacy leading paragraph when there is no dedicated field', () => {
     expect(getTemplateLogoType({ paragraphs: [{ uk: '{{logo}}', en: '{{logo}}' }] })).toBe('logo');
     expect(getTemplateLogoType({ paragraphs: [{ uk: 'Body text.', en: 'Body text.' }] })).toBeNull();


### PR DESCRIPTION
## Summary
- **Logo field: fixed a real bug, switched to free-text editing.** The Logo field was a `<select>` whose option values were the bare words `logo`/`logo-long` (no braces); `handleLogoFieldChange` stored that raw value straight into `template.logo`, but `getTemplateLogoType` only recognizes the literal `{{logo}}`/`{{logo-long}}` tokens — so picking an option from the dropdown silently saved a value that never actually rendered a logo. Replaced it with a plain text input the admin types the token into directly (or clears, to remove the logo), bound to whichever source (the dedicated field or a legacy leading paragraph) is currently authoritative for that template.
- **Paragraph controls: now visually boxed.** Each paragraph's own text is wrapped together with its "Insert paragraph"/remove controls in one bordered block, so which paragraph those buttons act on is no longer ambiguous — previously the controls row and the paragraph pair had near-identical spacing above and below it, making it unclear whether a button belonged to the paragraph before or after it.

## Test plan
- [x] New regression test: `getTemplateLogoType` rejects a bare `"logo"`/`"logo-long"` string (proving the exact bug the dropdown used to trigger).
- [x] `npm test` — no new failures beyond pre-existing unrelated ones.
- [x] `npm run lint:js` (same command the deploy workflow gates on) — clean.
- [x] `npm run build` — compiles clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6VYVG6G2TzzpTUZckJV7X)_