### PR TITLE
Fix heading auto-bold matching sub-clauses; add a manual bold toggle

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaPencilAlt, FaPlus, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaBold, FaChevronDown, FaChevronUp, FaFilePdf, FaFileWord, FaHeart, FaPencilAlt, FaPlus, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFolderFileNames, uploadFileToStorageFolder } from './config';
@@ -35,6 +35,7 @@ import {
   getClinicLogo,
   getParagraphType,
   getTemplateLogoType,
+  isParagraphBold,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -195,6 +196,16 @@ const DangerButton = styled(SmallButton)`
     border-color: var(--km-danger);
     color: var(--km-danger);
   }
+`;
+
+// Highlighted while the paragraph currently renders bold (whether via auto-detection or an
+// explicit override), so the toggle's own state always matches what the exported document shows.
+const BoldToggleButton = styled(SmallButton)`
+  ${({ $active }) => ($active ? `
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+    background: var(--km-accent-light);
+  ` : '')}
 `;
 
 const Section = styled.section`
@@ -798,6 +809,32 @@ const DocumentsPage = ({ isAdmin }) => {
       atIndex,
       -1,
     );
+  };
+
+  // Auto-detection (isSectionHeading) can still be wrong for a case the admin spots visually -
+  // e.g. a numbered clause that happens to look heading-shaped. This sets an explicit override
+  // (true/false) directly on the paragraph, which always wins over auto-detection from then on.
+  // Persisted immediately, the same direct-write pattern as applyParagraphStructureChange (not the
+  // onChange/onBlur pattern used for text fields), since it's a single discrete click.
+  const handleToggleParagraphBold = async (docId, atIndex, nextBold) => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template) return;
+    const nextTemplate = {
+      ...template,
+      paragraphs: (template.paragraphs || []).map((paragraph, index) => (
+        index === atIndex ? { ...paragraph, bold: nextBold } : paragraph
+      )),
+    };
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+      }));
+    } catch (boldError) {
+      console.error('Unable to update the paragraph bold override', boldError);
+      toast.error('Could not save the bold change.');
+    }
   };
 
   const persistTemplate = async docId => {
@@ -1548,13 +1585,23 @@ const DocumentsPage = ({ isAdmin }) => {
                                 >
                                   <FaPlus /> Insert paragraph
                                 </SmallButton>
-                                <DangerButton
-                                  type="button"
-                                  onClick={() => handleRemoveParagraph(template.id, index)}
-                                  title="Remove this paragraph"
-                                >
-                                  <FaTrash />
-                                </DangerButton>
+                                <RowLine style={{ gap: 6 }}>
+                                  <BoldToggleButton
+                                    type="button"
+                                    $active={isParagraphBold(paragraph)}
+                                    onClick={() => handleToggleParagraphBold(template.id, index, !isParagraphBold(paragraph))}
+                                    title={isParagraphBold(paragraph) ? 'Remove bold from this paragraph' : 'Make this paragraph bold'}
+                                  >
+                                    <FaBold />
+                                  </BoldToggleButton>
+                                  <DangerButton
+                                    type="button"
+                                    onClick={() => handleRemoveParagraph(template.id, index)}
+                                    title="Remove this paragraph"
+                                  >
+                                    <FaTrash />
+                                  </DangerButton>
+                                </RowLine>
                               </ParagraphControlsRow>
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -12,7 +12,7 @@
 // settings the user tunes on the page - nothing visual is hardcoded beyond the defaults.
 import React from 'react';
 import { Document, Font, Image, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
-import { DEFAULT_DOC_FORMATTING, allowsParagraphInternalBreak, getClinicLogo, isSectionHeading } from './documentsCatalogUtils';
+import { DEFAULT_DOC_FORMATTING, allowsParagraphInternalBreak, getClinicLogo, isParagraphBold } from './documentsCatalogUtils';
 
 const CM_TO_PT = 28.3465;
 const MM_TO_PT = 2.83465;
@@ -104,20 +104,17 @@ const LogoBlock = ({ type, isTwoColumn, cellStyles, logoWidth, longLogoWidth, cl
 
 const TextParagraph = ({ paragraph, isTwoColumn, lang, cellStyles, allowPageBreaks }) => {
   const wrap = allowsParagraphInternalBreak(paragraph, allowPageBreaks);
-  const ukHeading = isSectionHeading(paragraph.uk);
-  const enHeading = isSectionHeading(paragraph.en);
-  const cellStyle = heading => (heading ? cellStyles.paragraphHeading : cellStyles.paragraph);
+  const cellStyle = isParagraphBold(paragraph) ? cellStyles.paragraphHeading : cellStyles.paragraph;
   if (isTwoColumn) {
     return (
       <View style={styles.row} wrap={wrap}>
-        <Text style={[cellStyle(ukHeading), cellStyles.leftCell]}>{paragraph.uk}</Text>
-        <Text style={[cellStyle(enHeading), cellStyles.rightCell]}>{paragraph.en}</Text>
+        <Text style={[cellStyle, cellStyles.leftCell]}>{paragraph.uk}</Text>
+        <Text style={[cellStyle, cellStyles.rightCell]}>{paragraph.en}</Text>
       </View>
     );
   }
   const text = paragraph[lang];
-  const heading = lang === 'en' ? enHeading : ukHeading;
-  return <Text style={cellStyle(heading)} wrap={wrap}>{text}</Text>;
+  return <Text style={cellStyle} wrap={wrap}>{text}</Text>;
 };
 
 const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoWidth, clinicLogos }) => {

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -424,15 +424,27 @@ export const getTemplateLogoType = template => {
   return legacyLeadingType === 'text' ? null : legacyLeadingType;
 };
 
-// Short numbered section titles ("1. Предмет Договору") are bolded; long numbered clauses
-// ("1.1. Клініка зобов'язується...") are not - only a short heading-shaped paragraph qualifies.
-const SECTION_HEADING_PATTERN = /^\d+(?:\.\d+)*\.\s+\S+/;
+// Short numbered section titles ("1. Предмет Договору") are bolded; numbered clauses of any
+// length ("5.4. Клініка надає...", "1.1. Клініка зобов'язується...") are never bolded, even when
+// short - only a single top-level number qualifies (no sub-level ".N" group after the first dot),
+// which is what actually distinguishes a section title from clause body text in these contracts.
+const SECTION_HEADING_PATTERN = /^\d+\.\s+\S+/;
 const SECTION_HEADING_MAX_LENGTH = 120;
 
 export const isSectionHeading = text => {
   const trimmed = String(text || '').trim();
   if (!trimmed || trimmed.length > SECTION_HEADING_MAX_LENGTH) return false;
   return SECTION_HEADING_PATTERN.test(trimmed);
+};
+
+// Auto-detection (above) can still be wrong for an edge case the admin spots visually; `bold` on
+// the paragraph itself (true/false) explicitly overrides it either way, undefined falls back to
+// isSectionHeading. Bold is a whole-paragraph property (both languages together), matching how
+// real section headings actually look in these bilingual documents.
+export const isParagraphBold = paragraph => {
+  if (paragraph?.bold === true) return true;
+  if (paragraph?.bold === false) return false;
+  return isSectionHeading(paragraph?.uk) || isSectionHeading(paragraph?.en);
 };
 
 // A paragraph long enough that forcing it to stay on one page (break-inside: avoid / wrap=false)
@@ -515,6 +527,7 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
       const paragraphOverride = overrideAt(override.paragraphs, index);
       return {
         type,
+        bold: paragraph?.bold,
         uk: overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
         en: overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
       };

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -13,6 +13,7 @@ import {
   getParagraphType,
   getTemplateLogoType,
   getValueByPath,
+  isParagraphBold,
   isSectionHeading,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
@@ -778,6 +779,43 @@ describe('spec: section headings', () => {
 
   it('does not flag ordinary body text', () => {
     expect(isSectionHeading('Дата: ____________________')).toBe(false);
+  });
+
+  // Regression: a short sub-clause (e.g. "5.4. ..." inside section "5") was previously matched by
+  // the same regex as a real top-level heading ("5. ...") because it only checked length, not
+  // numbering depth - bolding ordinary clause text in the exported document.
+  it('does not flag a short sub-clause as a heading just because it is short', () => {
+    const shortSubClause = '5.4. Клініка надає Пацієнту медичні послуги в межах сплачених сум.';
+    expect(shortSubClause.length).toBeLessThan(120);
+    expect(isSectionHeading(shortSubClause)).toBe(false);
+    expect(isSectionHeading('6.1. Протягом всього періоду дії даний Договір може бути достроково розірваний за згодою сторін.')).toBe(false);
+  });
+});
+
+describe('spec: manual bold override on a paragraph', () => {
+  it('falls back to auto-detection when bold is not explicitly set', () => {
+    expect(isParagraphBold({ uk: '1. Предмет Договору', en: '1. Subject' })).toBe(true);
+    expect(isParagraphBold({ uk: '5.4. Клініка надає...', en: '5.4. The Clinic provides...' })).toBe(false);
+  });
+
+  it('an explicit bold:false always wins, even over an auto-detected heading', () => {
+    expect(isParagraphBold({ uk: '1. Предмет Договору', en: '1. Subject', bold: false })).toBe(false);
+  });
+
+  it('an explicit bold:true always wins, even over ordinary body text', () => {
+    expect(isParagraphBold({ uk: 'Просто текст.', en: 'Just text.', bold: true })).toBe(true);
+  });
+
+  it('buildGeneratedDocument threads the bold override through to the generated paragraph', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = {
+      id: 'doc-with-bold',
+      title: { uk: 'Т', en: 'T' },
+      paragraphs: [{ uk: '5.4. Клініка надає...', en: '5.4. The Clinic provides...', bold: true }],
+    };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.paragraphs[0].bold).toBe(true);
   });
 });
 

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -7,7 +7,7 @@
 // title; see getTemplateLogoType/getClinicLogo in documentsCatalogUtils. The `docx` package is
 // imported dynamically by the caller-facing builder so the library only loads when a Word export
 // is actually requested.
-import { DEFAULT_DOC_FORMATTING, allowsParagraphInternalBreak, getClinicLogo, isSectionHeading } from './documentsCatalogUtils';
+import { DEFAULT_DOC_FORMATTING, allowsParagraphInternalBreak, getClinicLogo, isParagraphBold } from './documentsCatalogUtils';
 
 const CM_TO_TWIP = 567;
 const MM_TO_PX = 96 / 25.4; // docx ImageRun transformations are CSS pixels at 96dpi
@@ -81,7 +81,7 @@ export const buildDocumentsDocx = async ({
     children: [new TextRun({ text, bold: true, size: bodySize })],
   });
 
-  const cellParagraph = (text, allowPageBreaks, paragraph) => (isSectionHeading(text)
+  const cellParagraph = (text, allowPageBreaks, paragraph) => (isParagraphBold(paragraph)
     ? headingParagraph(text)
     : bodyParagraph(text, { keepLines: !allowsParagraphInternalBreak(paragraph, allowPageBreaks) }));
 


### PR DESCRIPTION
## Summary
- **Root cause fix**: `isSectionHeading`'s regex matched any `\d+(\.\d+)*\.` prefix, so a short sub-clause like "5.4. Клініка надає..." or "6.1. Протягом..." was indistinguishable from a real top-level heading like "5. Сума Договору" and got bolded in the exported PDF/DOCX even though it's ordinary clause text. Tightened the pattern to a single top-level number only (no sub-level `.N` group right after the first dot) — the actual distinguishing feature between a section title and clause body text in these contracts.
- **Manual override**: auto-detection can still be wrong for an edge case, so paragraphs now support an explicit `bold` field (true/false) that always wins over `isSectionHeading` either way — threaded through `buildGeneratedDocument` and read by both renderers via the new `isParagraphBold()`. A **Bold** toggle button next to the trash button in the template editor lets an admin correct any paragraph's bold state directly, in either direction.

## Test plan
- [x] New regression tests: `isSectionHeading` rejects short 5.4./6.1.-style sub-clauses (reproducing the exact reported bug) while still accepting real top-level headings; `isParagraphBold` respects explicit overrides in both directions and falls back to auto-detection; `buildGeneratedDocument` threads `bold` through.
- [x] Real-render PDF/DOCX smoke tests still pass.
- [x] `npm test` — no new failures beyond pre-existing unrelated ones.
- [x] `npm run lint:js` (same command the deploy workflow gates on) — clean.
- [x] `npm run build` — compiles clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6VYVG6G2TzzpTUZckJV7X)_