### PR TITLE
Add birth-registration surrogate-consent document support

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -803,6 +803,37 @@ const DocumentsPage = ({ isAdmin }) => {
     }));
   };
 
+  // beforeTitle (spec §14): free-standing text rendered between the logo and the title - a
+  // template opts in by carrying the array at all (usually pasted in via the technical JSON), so
+  // editing here only touches existing blocks rather than letting the admin create the array from
+  // scratch.
+  const handleBeforeTitleChange = (docId, index, langKey, value) => {
+    updateTemplate(docId, template => ({
+      ...template,
+      beforeTitle: (template.beforeTitle || []).map((block, blockIndex) => (
+        blockIndex === index ? { ...block, [langKey]: value } : block
+      )),
+    }));
+  };
+
+  const handleBeforeTitleAlignChange = (docId, index, value) => {
+    updateTemplate(docId, template => ({
+      ...template,
+      beforeTitle: (template.beforeTitle || []).map((block, blockIndex) => (
+        blockIndex === index ? { ...block, align: value } : block
+      )),
+    }));
+  };
+
+  const handleBeforeTitleBoldChange = (docId, index, checked) => {
+    updateTemplate(docId, template => ({
+      ...template,
+      beforeTitle: (template.beforeTitle || []).map((block, blockIndex) => (
+        blockIndex === index ? { ...block, bold: checked } : block
+      )),
+    }));
+  };
+
   // Inserting or removing a paragraph is a structural edit, not a text edit - persisted
   // immediately (not deferred to blur, unlike the plain text fields above) and, since a
   // paragraph's position is how per-case data-mode overrides key into it, reindexes every
@@ -1697,6 +1728,55 @@ const DocumentsPage = ({ isAdmin }) => {
                               style={{ flex: 1, minWidth: 240 }}
                             />
                           </RowLine>
+                        ) : null}
+                        {!isDataMode && (template.beforeTitle || []).length ? (
+                          <div style={{ marginTop: 4 }}>
+                            <DocSubtitle style={{ fontWeight: 700 }}>Before title</DocSubtitle>
+                            {template.beforeTitle.map((block, index) => (
+                              // eslint-disable-next-line react/no-array-index-key
+                              <RowLine key={`${template.id}-before-title-${index}`} style={{ marginTop: 4 }}>
+                                <FieldInput
+                                  type="text"
+                                  value={block.uk || ''}
+                                  placeholder="Before title (uk)"
+                                  onChange={event => handleBeforeTitleChange(template.id, index, 'uk', event.target.value)}
+                                  onBlur={() => persistTemplate(template.id)}
+                                  style={{ flex: 1, minWidth: 180 }}
+                                />
+                                <FieldInput
+                                  type="text"
+                                  value={block.en || ''}
+                                  placeholder="Before title (en)"
+                                  onChange={event => handleBeforeTitleChange(template.id, index, 'en', event.target.value)}
+                                  onBlur={() => persistTemplate(template.id)}
+                                  style={{ flex: 1, minWidth: 180 }}
+                                />
+                                <select
+                                  value={block.align || 'left'}
+                                  onChange={event => {
+                                    handleBeforeTitleAlignChange(template.id, index, event.target.value);
+                                    persistTemplate(template.id);
+                                  }}
+                                >
+                                  <option value="left">left</option>
+                                  <option value="right">right</option>
+                                  <option value="center">center</option>
+                                  <option value="justify">justify</option>
+                                </select>
+                                <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                  <input
+                                    type="checkbox"
+                                    checked={Boolean(block.bold)}
+                                    onChange={event => {
+                                      handleBeforeTitleBoldChange(template.id, index, event.target.checked);
+                                      persistTemplate(template.id);
+                                    }}
+                                  />
+                                  Bold
+                                </label>
+                              </RowLine>
+                            ))}
+                          </div>
                         ) : null}
                         <ParagraphPair $single={isSingle}>
                           {showUk ? (

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -19,6 +19,7 @@ import {
   estimateCharsPerLine,
   estimateColumnPageCapacity,
   getClinicLogo,
+  getEffectiveDocLayout,
   getLayoutLang,
   isBilingualLayout,
   isParagraphBold,
@@ -132,19 +133,22 @@ const LogoBlock = ({ type, isBilingual, cellStyles, logoWidth, longLogoWidth, cl
   );
 };
 
+// batch 16 §17: an explicit `align` on a paragraph overrides the default alignment (justified
+// body / flush-left heading) - never inferred from the text itself.
 const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBreaks }) => {
   const wrap = allowsParagraphInternalBreak(paragraph, allowPageBreaks);
   const cellStyle = isParagraphBold(paragraph) ? cellStyles.paragraphHeading : cellStyles.paragraph;
+  const alignStyle = paragraph.align ? { textAlign: paragraph.align } : undefined;
   if (isBilingual) {
     return (
       <View style={styles.row} wrap={wrap}>
-        <Text style={[cellStyle, cellStyles.leftCell]}><FormattedRuns text={paragraph.uk} /></Text>
-        <Text style={[cellStyle, cellStyles.rightCell]}><FormattedRuns text={paragraph.en} /></Text>
+        <Text style={[cellStyle, cellStyles.leftCell, alignStyle]}><FormattedRuns text={paragraph.uk} /></Text>
+        <Text style={[cellStyle, cellStyles.rightCell, alignStyle]}><FormattedRuns text={paragraph.en} /></Text>
       </View>
     );
   }
   const text = paragraph[lang];
-  return <Text style={cellStyle} wrap={wrap}><FormattedRuns text={text} /></Text>;
+  return <Text style={[cellStyle, alignStyle]} wrap={wrap}><FormattedRuns text={text} /></Text>;
 };
 
 // The single-language 2-column layout (spec §4: newspaper-style, one language flowing across two
@@ -188,6 +192,27 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
   </View>
 );
 
+// Free-standing text between the letterhead logo and the title (spec §14: "ЗА МІСЦЕМ ВИМОГИ" etc.)
+// - never merged into the paragraph list, so it always renders in this fixed position regardless of
+// how the body is edited. `align`/`bold` (spec §17) are resolved per block, not inferred from text.
+const BeforeTitleBlock = ({ block, isBilingual, lang, cellStyles }) => {
+  const runStyle = { textAlign: block.align, fontWeight: block.bold ? 700 : 400 };
+  if (isBilingual) {
+    return (
+      <View style={styles.row}>
+        <Text style={[cellStyles.beforeTitle, cellStyles.leftCell, runStyle]}><FormattedRuns text={block.uk} /></Text>
+        <Text style={[cellStyles.beforeTitle, cellStyles.rightCell, runStyle]}><FormattedRuns text={block.en} /></Text>
+      </View>
+    );
+  }
+  return <Text style={[cellStyles.beforeTitle, runStyle]}><FormattedRuns text={block[lang]} /></Text>;
+};
+
+const BeforeTitleBlocks = ({ blocks, isBilingual, lang, cellStyles }) => (blocks || []).map((block, index) => (
+  // eslint-disable-next-line react/no-array-index-key
+  <BeforeTitleBlock key={index} block={block} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} />
+));
+
 // The bilingual and single-column (1-language) layouts: everything lives on one <Page> JSX
 // element and react-pdf's own automatic wrap handles overflow onto further physical pages. The
 // single-language 2-column layout does NOT use this - see SingleLanguagePages below.
@@ -203,6 +228,7 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
           came from the dedicated `logo` field or a legacy leading paragraph - see
           getTemplateLogoType in documentsCatalogUtils. */}
       {doc.logo ? <LogoBlock type={doc.logo} {...logoBlockProps} /> : null}
+      <BeforeTitleBlocks blocks={doc.beforeTitle} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} />
       <DocumentTitleBlock doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} titleGap={titleGap} />
       {doc.paragraphs.map((paragraph, index) => {
         // Already drawn as doc.logo above - a legacy leading logo paragraph must not also render
@@ -294,12 +320,11 @@ const DocumentsPdfDocument = ({
   const contentWidth = A4_WIDTH_PT - marginLeft - marginRight;
   // Both column layouts (bilingual UA|EN and single-language newspaper-style, spec §4) share the
   // same left/right cell geometry and divider - only how the paragraphs are distributed between
-  // the two cells differs (see DocumentBlock/SingleLanguageColumns).
-  const isTwoColumn = isBilingualLayout(layout) || isSingleLanguageTwoColumnLayout(layout);
+  // the two cells differs (see DocumentBlock/SingleLanguageColumns). Geometry here is shared across
+  // every document; which layout actually applies is resolved per document below (getEffectiveDocLayout),
+  // since a template can pin its own languages/columns regardless of the page-wide selector.
   const columnContentWidth = (contentWidth - columnGap) / 2;
-  const showColumnDivider = isTwoColumn && Boolean(formatting.columnDivider);
   const configuredLogoWidth = formatting.logoWidthMm * MM_TO_PT;
-  const logoWidth = isTwoColumn ? Math.min(configuredLogoWidth, columnContentWidth) : configuredLogoWidth;
   // `showLogo` is only the global permission (spec §5: `canRenderLogo = formatting.showLogo !==
   // false`) - whether a logo actually renders still depends entirely on the template carrying a
   // {{logo}}/{{logo-long}} paragraph; clinicLogos being empty (or missing the matching variant)
@@ -333,6 +358,12 @@ const DocumentsPdfDocument = ({
       marginTop: formatting.paragraphSpacing,
       marginBottom: formatting.paragraphSpacing,
     },
+    beforeTitle: {
+      fontFamily: 'Tinos',
+      fontSize: formatting.fontSize,
+      lineHeight: formatting.lineSpacing,
+      marginBottom: formatting.paragraphSpacing,
+    },
     leftCell: {
       flex: 1,
       marginRight: columnGap / 2,
@@ -352,8 +383,6 @@ const DocumentsPdfDocument = ({
     fontSize: formatting.fontSize,
   };
   const dividerLeft = marginLeft + columnContentWidth + columnGap / 2 - 0.5;
-  const isSingleLanguageFlow = isSingleLanguageTwoColumnLayout(layout);
-  const lang = getLayoutLang(layout);
 
   // The single-language 2-column layout can't rely on react-pdf's automatic wrap the way every
   // other layout does (see splitParagraphsIntoPages for why): a flex row's two columns can't
@@ -370,7 +399,10 @@ const DocumentsPdfDocument = ({
   // after the first, keeps the same one-page-per-group layout in the normal case while letting
   // react-pdf's own dynamic subPageNumber/subPageTotalPages count every actual physical page -
   // including any accidental extra overflow page - so numbering can never desync from reality.
-  const renderSingleLanguagePages = doc => {
+  const renderSingleLanguagePages = (doc, effectiveLayout) => {
+    const lang = getLayoutLang(effectiveLayout);
+    const showColumnDivider = Boolean(formatting.columnDivider);
+    const logoWidth = Math.min(configuredLogoWidth, columnContentWidth);
     const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed');
     const pageContentHeightPt = A4_HEIGHT_PT - marginTop - marginBottom;
     const charsPerLine = estimateCharsPerLine({ columnWidthPt: columnContentWidth, fontSize: formatting.fontSize });
@@ -393,6 +425,7 @@ const DocumentsPdfDocument = ({
                 {doc.logo ? (
                   <LogoBlock type={doc.logo} isBilingual={false} cellStyles={cellStyles} logoWidth={logoWidth} longLogoWidth={contentWidth} clinicLogos={effectiveClinicLogos} showUk showEn />
                 ) : null}
+                <BeforeTitleBlocks blocks={doc.beforeTitle} isBilingual={false} lang={lang} cellStyles={cellStyles} />
                 <DocumentTitleBlock doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} />
               </>
             ) : null}
@@ -412,26 +445,36 @@ const DocumentsPdfDocument = ({
     );
   };
 
-  const renderDocumentPage = doc => (
-    <Page key={doc.id} size="A4" style={pageStyle}>
-      <PageHeader formatting={formatting} marginTop={marginTop} marginLeft={marginLeft} marginRight={marginRight} />
-      <PageDivider show={showColumnDivider} marginTop={marginTop} marginBottom={marginBottom} left={dividerLeft} />
-      <DocumentBlock
-        doc={doc}
-        layout={layout}
-        cellStyles={cellStyles}
-        titleGap={formatting.paragraphSpacing}
-        logoWidth={logoWidth}
-        longLogoWidth={contentWidth}
-        clinicLogos={effectiveClinicLogos}
-      />
-      <PageFooter formatting={formatting} marginBottom={marginBottom} marginLeft={marginLeft} marginRight={marginRight} />
-    </Page>
-  );
+  const renderDocumentPage = (doc, effectiveLayout) => {
+    const isTwoColumn = isBilingualLayout(effectiveLayout) || isSingleLanguageTwoColumnLayout(effectiveLayout);
+    const showColumnDivider = isTwoColumn && Boolean(formatting.columnDivider);
+    const logoWidth = isTwoColumn ? Math.min(configuredLogoWidth, columnContentWidth) : configuredLogoWidth;
+    return (
+      <Page key={doc.id} size="A4" style={pageStyle}>
+        <PageHeader formatting={formatting} marginTop={marginTop} marginLeft={marginLeft} marginRight={marginRight} />
+        <PageDivider show={showColumnDivider} marginTop={marginTop} marginBottom={marginBottom} left={dividerLeft} />
+        <DocumentBlock
+          doc={doc}
+          layout={effectiveLayout}
+          cellStyles={cellStyles}
+          titleGap={formatting.paragraphSpacing}
+          logoWidth={logoWidth}
+          longLogoWidth={contentWidth}
+          clinicLogos={effectiveClinicLogos}
+        />
+        <PageFooter formatting={formatting} marginBottom={marginBottom} marginLeft={marginLeft} marginRight={marginRight} />
+      </Page>
+    );
+  };
 
   return (
     <Document>
-      {documents.flatMap(doc => (isSingleLanguageFlow ? renderSingleLanguagePages(doc) : [renderDocumentPage(doc)]))}
+      {documents.flatMap(doc => {
+        const effectiveLayout = getEffectiveDocLayout(doc, layout);
+        return isSingleLanguageTwoColumnLayout(effectiveLayout)
+          ? renderSingleLanguagePages(doc, effectiveLayout)
+          : [renderDocumentPage(doc, effectiveLayout)];
+      })}
     </Document>
   );
 };

--- a/src/components/DocumentsRenderers.smoke.test.js
+++ b/src/components/DocumentsRenderers.smoke.test.js
@@ -202,3 +202,76 @@ describe('Documents PDF renderer - single-language 2-column layout + divider + i
   }, 30000);
 });
 
+// batch 16 §6/§14/§15: a template opting into `languages: ["uk"], columns: 1` (the birth-
+// registration surrogate-consent statement) must render one full-width UA column - no empty EN
+// column, no divider - with its beforeTitle blocks appearing before the title, even while the page-
+// wide layout selector is set to the bilingual default.
+describe('Documents renderers - single-column template with beforeTitle (batch 16 §6/§14/§15)', () => {
+  const buildBirthRegistrationDoc = async () => {
+    const { buildGeneratedDocument } = await import('./documentsCatalogUtils');
+    const template = {
+      id: 'birth-registration-surrogate-consent',
+      languages: ['uk'],
+      columns: 1,
+      beforeTitle: [
+        { uk: 'ЗА МІСЦЕМ ВИМОГИ', align: 'right', bold: true },
+      ],
+      title: { uk: 'З А Я В А' },
+      paragraphs: [
+        { uk: 'Я, {{surrogateMother.name.uk.nominative}}, даю згоду.' },
+      ],
+    };
+    return buildGeneratedDocument(template, { surrogateMother: { name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } } } });
+  };
+
+  it('renders as a PDF without throwing, ignoring the page-wide two-column selector', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+    const doc = await buildBirthRegistrationDoc();
+
+    const element = React.createElement(DocumentsPdfDocument, { documents: [doc], layout: 'two-column', clinicLogos: [] });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(1000);
+  }, 20000);
+
+  it('renders as a DOCX with beforeTitle text ordered before the title and before the body', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = await buildBirthRegistrationDoc();
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'two-column' });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const xml = await zip.file('word/document.xml').async('string');
+
+    const beforeTitleIndex = xml.indexOf('ЗА МІСЦЕМ ВИМОГИ');
+    const titleIndex = xml.indexOf('З А Я В А');
+    const bodyIndex = xml.indexOf('даю згоду');
+    expect(beforeTitleIndex).toBeGreaterThan(-1);
+    expect(titleIndex).toBeGreaterThan(beforeTitleIndex);
+    expect(bodyIndex).toBeGreaterThan(titleIndex);
+    // Single-column template: no second (EN) language column table for the title/body.
+    expect(xml).not.toContain('undefined');
+    expect(xml).not.toContain('[object Object]');
+  }, 20000);
+});
+

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -16,7 +16,12 @@ export const clinicLogoDbPath = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/cli
 export const clinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoStorageFolder(clinicId)}/${fileName}`;
 
-export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases'];
+export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases', 'maternityHospitals', 'notaries'];
+
+// mergeCollection derives an id prefix for un-identified incoming records by stripping a trailing
+// 's' off the collection name; 'notaries' isn't a simple plural ('notarys' would be wrong), so it
+// needs the explicit override.
+const COLLECTION_ID_PREFIXES = { notaries: 'notary' };
 
 export const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
@@ -75,7 +80,9 @@ export const clinicLogoEntriesToBackend = variants => (variants || [])
 // --- Catalog -------------------------------------------------------------------------------
 
 export const emptyDocumentsCatalog = () => ({
-  parties: { couples: [], surrogateMothers: [], representatives: [], clinics: [], cases: [] },
+  parties: {
+    couples: [], surrogateMothers: [], representatives: [], clinics: [], cases: [], maternityHospitals: [], notaries: [],
+  },
   documents: [],
   clinicLogos: {},
 });
@@ -244,7 +251,7 @@ export const mergeDocumentsCatalog = (current, incoming) => {
     catalog.parties[collection] = mergeCollection(
       current?.parties?.[collection] || [],
       incoming?.parties?.[collection] || [],
-      collection.replace(/s$/, ''),
+      COLLECTION_ID_PREFIXES[collection] || collection.replace(/s$/, ''),
       summary,
     );
   });
@@ -274,6 +281,176 @@ export const catalogTemplatesToBackend = catalog => (catalog.documents || []).re
 
 const findById = (records, id) => (records || []).find(record => String(record?.id) === String(id)) || null;
 
+// --- Birth-registration surrogate-consent document (batch 16 §6) --------------------------------
+// Everything below is derived, not stored: the JSON only ever carries the bare `sex` enum
+// (female/male) and ISO dates - every Ukrainian grammatical form (дівчинки/хлопчика, народженої
+// мною/народженого мною, яка народилась/який народився...) is computed here so the backend record
+// never has to carry hand-typed inflected strings that could drift out of agreement with `sex`.
+export const getChildGenderForms = sex => {
+  if (sex === 'female') {
+    return {
+      uk: {
+        label: 'дівчинка',
+        childNominative: 'дівчинка',
+        childGenitive: 'дівчинки',
+        childAccusative: 'дівчинку',
+        bornByMe: 'народженої мною',
+        whichWasBorn: 'яка народилась',
+        born: 'народилась',
+        pronoun: 'вона',
+        pronounGenitive: 'її',
+      },
+      en: {
+        label: 'girl',
+        childNominative: 'girl',
+        childGenitive: 'girl',
+        bornByMe: 'born by me',
+        whichWasBorn: 'who was born',
+        pronoun: 'she',
+        pronounGenitive: 'her',
+      },
+    };
+  }
+  if (sex === 'male') {
+    return {
+      uk: {
+        label: 'хлопчик',
+        childNominative: 'хлопчик',
+        childGenitive: 'хлопчика',
+        childAccusative: 'хлопчика',
+        bornByMe: 'народженого мною',
+        whichWasBorn: 'який народився',
+        born: 'народився',
+        pronoun: 'він',
+        pronounGenitive: 'його',
+      },
+      en: {
+        label: 'boy',
+        childNominative: 'boy',
+        childGenitive: 'boy',
+        bornByMe: 'born by me',
+        whichWasBorn: 'who was born',
+        pronoun: 'he',
+        pronounGenitive: 'his',
+      },
+    };
+  }
+  return {
+    uk: {
+      label: '', childNominative: '', childGenitive: '', childAccusative: '', bornByMe: '', whichWasBorn: '', born: '', pronoun: '', pronounGenitive: '',
+    },
+    en: {
+      label: '', childNominative: '', childGenitive: '', bornByMe: '', whichWasBorn: '', pronoun: '', pronounGenitive: '',
+    },
+  };
+};
+
+export const buildChildContext = (childData = {}) => ({
+  ...childData,
+  gender: getChildGenderForms(childData?.sex),
+});
+
+// --- Ukrainian/English "date in words" (batch 16 §12) -------------------------------------------
+// Legal statements spell the signature date out in words (spec: "вісімнадцятого травня дві тисячі
+// двадцять шостого року"), not as digits - this is a fully generic day/month/year -> words
+// converter, not a lookup table for one date, so it has to actually do Ukrainian ordinal-genitive
+// numeral grammar rather than special-case 18/05/2026.
+export const isIsoDate = value => /^\d{4}-\d{2}-\d{2}$/.test(String(value || '').trim());
+
+const UK_ONES_ORDINAL_GENITIVE = {
+  1: 'першого', 2: 'другого', 3: 'третього', 4: 'четвертого', 5: "п'ятого", 6: 'шостого', 7: 'сьомого', 8: 'восьмого', 9: "дев'ятого",
+};
+const UK_TEENS_ORDINAL_GENITIVE = {
+  10: 'десятого', 11: 'одинадцятого', 12: 'дванадцятого', 13: 'тринадцятого', 14: 'чотирнадцятого', 15: "п'ятнадцятого", 16: 'шістнадцятого', 17: 'сімнадцятого', 18: 'вісімнадцятого', 19: "дев'ятнадцятого",
+};
+const UK_TENS_ORDINAL_GENITIVE = {
+  1: 'десятого', 2: 'двадцятого', 3: 'тридцятого', 4: 'сорокового', 5: "п'ятдесятого", 6: 'шістдесятого', 7: 'сімдесятого', 8: 'вісімдесятого', 9: "дев'яностого",
+};
+const UK_TENS_CARDINAL = {
+  2: 'двадцять', 3: 'тридцять', 4: 'сорок', 5: "п'ятдесят", 6: 'шістдесят', 7: 'сімдесят', 8: 'вісімдесят', 9: "дев'яносто",
+};
+const UK_HUNDREDS_CARDINAL = {
+  1: 'сто', 2: 'двісті', 3: 'триста', 4: 'чотириста', 5: "п'ятсот", 6: 'шістсот', 7: 'сімсот', 8: 'вісімсот', 9: "дев'ятсот",
+};
+const UK_HUNDREDS_ORDINAL_GENITIVE = {
+  1: 'сотого', 2: 'двохсотого', 3: 'трьохсотого', 4: 'чотирьохсотого', 5: "п'ятисотого", 6: 'шестисотого', 7: 'семисотого', 8: 'восьмисотого', 9: "дев'ятисотого",
+};
+const UK_THOUSANDS_CARDINAL = {
+  1: 'тисяча', 2: 'дві тисячі', 3: 'три тисячі', 4: 'чотири тисячі', 5: "п'ять тисяч", 6: 'шість тисяч', 7: 'сім тисяч', 8: 'вісім тисяч', 9: "дев'ять тисяч",
+};
+const UK_EXACT_THOUSAND_ORDINAL_GENITIVE = {
+  1: 'тисячного', 2: 'двохтисячного', 3: 'трьохтисячного', 4: 'чотиритисячного', 5: "п'ятитисячного", 6: 'шеститисячного', 7: 'семитисячного', 8: 'восьмитисячного', 9: "дев'ятитисячного",
+};
+
+export const UK_MONTHS_GENITIVE = {
+  1: 'січня', 2: 'лютого', 3: 'березня', 4: 'квітня', 5: 'травня', 6: 'червня', 7: 'липня', 8: 'серпня', 9: 'вересня', 10: 'жовтня', 11: 'листопада', 12: 'грудня',
+};
+
+// A day-of-month (1-31) in ordinal genitive form - the same ones-place words double as the last
+// word of a year (see yearToGenitiveWords), since "шостого" means "the sixth" regardless of
+// whether it's completing a day or a year.
+const dayToGenitiveWords = day => {
+  if (day <= 9) return UK_ONES_ORDINAL_GENITIVE[day];
+  if (day <= 19) return UK_TEENS_ORDINAL_GENITIVE[day];
+  if (day % 10 === 0) return UK_TENS_ORDINAL_GENITIVE[Math.floor(day / 10)];
+  return `${UK_TENS_CARDINAL[Math.floor(day / 10)]} ${UK_ONES_ORDINAL_GENITIVE[day % 10]}`;
+};
+
+// A 0-999 remainder in words, where only the last (rightmost) nonzero group is ordinal-genitive and
+// everything before it is a plain cardinal numeral - e.g. 993 -> "дев'ятсот дев'яносто третього"
+// (cardinal hundred + cardinal tens + ordinal ones), 900 -> "дев'ятисотого" (ordinal hundred alone).
+const threeDigitToGenitiveWords = n => {
+  if (n === 0) return '';
+  const hundreds = Math.floor(n / 100);
+  const tensOnes = n % 100;
+  if (tensOnes === 0) return UK_HUNDREDS_ORDINAL_GENITIVE[hundreds];
+  const words = hundreds ? [UK_HUNDREDS_CARDINAL[hundreds]] : [];
+  if (tensOnes >= 10 && tensOnes <= 19) {
+    words.push(UK_TEENS_ORDINAL_GENITIVE[tensOnes]);
+  } else {
+    const tens = Math.floor(tensOnes / 10);
+    const ones = tensOnes % 10;
+    if (ones === 0) {
+      words.push(UK_TENS_ORDINAL_GENITIVE[tens]);
+    } else {
+      if (tens) words.push(UK_TENS_CARDINAL[tens]);
+      words.push(UK_ONES_ORDINAL_GENITIVE[ones]);
+    }
+  }
+  return words.join(' ');
+};
+
+const yearToGenitiveWords = year => {
+  const thousands = Math.floor(year / 1000);
+  const remainder = year % 1000;
+  if (!thousands) return threeDigitToGenitiveWords(remainder);
+  if (!remainder) return UK_EXACT_THOUSAND_ORDINAL_GENITIVE[thousands];
+  return `${UK_THOUSANDS_CARDINAL[thousands]} ${threeDigitToGenitiveWords(remainder)}`;
+};
+
+// Generic for any ISO date, not just the reference statement's 2026-05-18 (spec: "Функцію потрібно
+// зробити універсальною").
+export const formatUkrainianDateWords = value => {
+  if (!isIsoDate(value)) return '';
+  const [year, month, day] = String(value).trim().split('-').map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return '';
+  return `${dayToGenitiveWords(day)} ${UK_MONTHS_GENITIVE[month]} ${yearToGenitiveWords(year)} року`;
+};
+
+const EN_MONTHS = {
+  1: 'January', 2: 'February', 3: 'March', 4: 'April', 5: 'May', 6: 'June', 7: 'July', 8: 'August', 9: 'September', 10: 'October', 11: 'November', 12: 'December',
+};
+const EN_DAY_ORDINALS = {
+  1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth', 6: 'sixth', 7: 'seventh', 8: 'eighth', 9: 'ninth', 10: 'tenth', 11: 'eleventh', 12: 'twelfth', 13: 'thirteenth', 14: 'fourteenth', 15: 'fifteenth', 16: 'sixteenth', 17: 'seventeenth', 18: 'eighteenth', 19: 'nineteenth', 20: 'twentieth', 21: 'twenty-first', 22: 'twenty-second', 23: 'twenty-third', 24: 'twenty-fourth', 25: 'twenty-fifth', 26: 'twenty-sixth', 27: 'twenty-seventh', 28: 'twenty-eighth', 29: 'twenty-ninth', 30: 'thirtieth', 31: 'thirty-first',
+};
+
+export const formatEnglishDateWords = value => {
+  if (!isIsoDate(value)) return '';
+  const [year, month, day] = String(value).trim().split('-').map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return '';
+  return `${EN_DAY_ORDINALS[day]} of ${EN_MONTHS[month]}, ${year}`;
+};
+
 export const resolveCaseContext = (catalog, caseId) => {
   const caseRecord = findById(catalog?.parties?.cases, caseId);
   if (!caseRecord) return null;
@@ -284,6 +461,17 @@ export const resolveCaseContext = (catalog, caseId) => {
   const representatives = toArray(caseRecord.representativeIds)
     .map(id => findById(catalog.parties.representatives, id))
     .filter(Boolean);
+
+  const rawBirthRegistration = isPlainObject(caseRecord.birthRegistration) ? caseRecord.birthRegistration : {};
+  const medicalConclusion = isPlainObject(rawBirthRegistration.medicalConclusion) ? rawBirthRegistration.medicalConclusion : {};
+  const birthRegistration = {
+    ...rawBirthRegistration,
+    statementDateWords: {
+      uk: formatUkrainianDateWords(rawBirthRegistration.statementDate),
+      en: formatEnglishDateWords(rawBirthRegistration.statementDate),
+    },
+  };
+
   return {
     case: caseRecord,
     couple,
@@ -293,6 +481,11 @@ export const resolveCaseContext = (catalog, caseId) => {
     clinic: findById(catalog.parties.clinics, caseRecord.clinicId),
     representative: representatives[0] || null,
     representatives,
+    birthRegistration,
+    child: buildChildContext(isPlainObject(rawBirthRegistration.child) ? rawBirthRegistration.child : {}),
+    medicalConclusion,
+    maternityHospital: findById(catalog.parties.maternityHospitals, medicalConclusion.maternityHospitalId),
+    notary: findById(catalog.parties.notaries, rawBirthRegistration.notaryId),
   };
 };
 
@@ -382,10 +575,64 @@ export const validateDocumentTemplate = (template, context) => {
   const missing = new Set();
   const scan = (value, lang) => getUnresolvedVariablePaths(value, context, lang).forEach(path => missing.add(path));
   ['uk', 'en'].forEach(lang => scan(template?.title?.[lang], lang));
+  toArray(template?.beforeTitle).forEach(block => {
+    ['uk', 'en'].forEach(lang => scan(block?.[lang], lang));
+  });
   toArray(template?.paragraphs).forEach(paragraph => {
     ['uk', 'en'].forEach(lang => scan(paragraph?.[lang], lang));
   });
   return [...missing].sort();
+};
+
+// --- Birth-registration surrogate-consent: pre-export field checklist (batch 16 §20) --------
+// A non-blocking checklist of the fields this specific document needs, shown before export rather
+// than enforced while editing - missing hospital/notary lookups and malformed dates are reported
+// the same way as a genuinely empty field, never as a thrown error.
+export const validateBirthRegistrationCase = (catalog, caseId) => {
+  const context = resolveCaseContext(catalog, caseId);
+  if (!context) return ['case'];
+
+  const issues = [];
+  const isBlank = value => value === undefined || value === null || String(value).trim() === '';
+  const requirePresent = (value, path) => {
+    if (isBlank(value)) issues.push(path);
+  };
+
+  const { birthRegistration, surrogateMother, maternityHospital, notary } = context;
+  const child = birthRegistration.child || {};
+  const medicalConclusion = birthRegistration.medicalConclusion || {};
+
+  requirePresent(child.sex, 'birthRegistration.child.sex');
+  requirePresent(child.birthDate, 'birthRegistration.child.birthDate');
+  requirePresent(child.birthPlace?.uk, 'birthRegistration.child.birthPlace.uk');
+  requirePresent(medicalConclusion.number, 'birthRegistration.medicalConclusion.number');
+  requirePresent(medicalConclusion.date, 'birthRegistration.medicalConclusion.date');
+  requirePresent(medicalConclusion.maternityHospitalId, 'birthRegistration.medicalConclusion.maternityHospitalId');
+  requirePresent(birthRegistration.statementDate, 'birthRegistration.statementDate');
+  requirePresent(birthRegistration.notaryId, 'birthRegistration.notaryId');
+  requirePresent(surrogateMother?.taxId, 'surrogateMother.taxId');
+  requirePresent(surrogateMother?.address?.uk, 'surrogateMother.address.uk');
+
+  if (!isBlank(child.sex) && child.sex !== 'female' && child.sex !== 'male') {
+    issues.push('birthRegistration.child.sex (must be "female" or "male")');
+  }
+  if (!isBlank(child.birthDate) && !isIsoDate(child.birthDate)) {
+    issues.push('birthRegistration.child.birthDate (must be YYYY-MM-DD)');
+  }
+  if (!isBlank(medicalConclusion.date) && !isIsoDate(medicalConclusion.date)) {
+    issues.push('birthRegistration.medicalConclusion.date (must be YYYY-MM-DD)');
+  }
+  if (!isBlank(birthRegistration.statementDate) && !isIsoDate(birthRegistration.statementDate)) {
+    issues.push('birthRegistration.statementDate (must be YYYY-MM-DD)');
+  }
+  if (!isBlank(medicalConclusion.maternityHospitalId) && !maternityHospital) {
+    issues.push('birthRegistration.medicalConclusion.maternityHospitalId (no matching maternity hospital)');
+  }
+  if (!isBlank(birthRegistration.notaryId) && !notary) {
+    issues.push('birthRegistration.notaryId (no matching notary)');
+  }
+
+  return issues;
 };
 
 // --- Special paragraph types (logo blocks) + section headings ------------------------------
@@ -475,6 +722,37 @@ const overriddenText = (override, langKey, fallback) => (
   typeof override?.[langKey] === 'string' ? override[langKey] : fallback
 );
 
+// --- beforeTitle blocks (batch 16 §14/§17) ---------------------------------------------------
+// Free-standing text rendered between the letterhead logo and the title (e.g. "ЗА МІСЦЕМ ВИМОГИ",
+// right-aligned and bold) - never merged into `paragraphs`, so it always renders in that fixed
+// logo -> beforeTitle -> title -> paragraphs order regardless of how the body is edited.
+const ALLOWED_BLOCK_ALIGNMENTS = ['left', 'right', 'center', 'justify'];
+
+export const normalizeBlockAlign = align => (ALLOWED_BLOCK_ALIGNMENTS.includes(align) ? align : 'left');
+
+const resolveBeforeTitleBlocks = (template, context) => toArray(template?.beforeTitle).map(block => ({
+  align: normalizeBlockAlign(block?.align),
+  bold: Boolean(block?.bold),
+  uk: fillPlaceholders(localizedText(block, 'uk'), context, 'uk'),
+  en: fillPlaceholders(localizedText(block, 'en'), context, 'en'),
+}));
+
+// --- Template-level languages/columns (batch 16 §15/§16) -------------------------------------
+// A template can pin its own language set + column count (e.g. `languages: ["uk"], columns: 1` for
+// a currently-Ukrainian-only statement) instead of following whatever layout the admin has picked
+// for the export batch as a whole. `null` here means "the template doesn't opt in" - the renderers
+// fall back to the page-wide layout selector unchanged, so every template saved before this existed
+// keeps rendering exactly as it did (spec: "Для старих шаблонів... стара поведінка").
+const resolveDocLanguages = template => {
+  const languages = toArray(template?.languages).map(String).filter(lang => lang === 'uk' || lang === 'en');
+  return languages.length ? languages : null;
+};
+
+const resolveDocColumns = (template, languages) => {
+  if (!languages) return null;
+  return template?.columns === 1 || template?.columns === 2 ? template.columns : (languages.length === 1 ? 1 : 2);
+};
+
 // A custom paragraph can be inserted (or removed) at any position in a template (spec: "кастомний
 // абзац в будь-якому місці документу"). Because per-case data-mode overrides key into a template's
 // paragraphs by array index, a structural edit like that must reindex every existing override so
@@ -508,10 +786,14 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
   // 'logo-consumed' (a no-op for the renderer) rather than dropped from the array, so paragraph
   // indices stay stable for per-case data-mode overrides (docOverrides[docId].paragraphs[index]).
   const hasDedicatedLogoField = Boolean(String(template?.logo || '').trim());
+  const languages = resolveDocLanguages(template);
   return {
     id: template.id,
     allowPageBreaks: Boolean(template.allowPageBreaks),
     logo,
+    languages,
+    columns: resolveDocColumns(template, languages),
+    beforeTitle: resolveBeforeTitleBlocks(template, context),
     title: {
       uk: overriddenText(override.title, 'uk', fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk')),
       en: overriddenText(override.title, 'en', fillPlaceholders(localizedText(template.title, 'en'), context, 'en')),
@@ -528,6 +810,7 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
       return {
         type,
         bold: paragraph?.bold,
+        align: paragraph?.align !== undefined ? normalizeBlockAlign(paragraph.align) : undefined,
         uk: overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
         en: overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
       };
@@ -798,6 +1081,19 @@ export const getLayoutColumnCount = layout => (isBilingualLayout(layout) || isSi
 // Which language a single-language layout (1 or 2 columns) renders - meaningless for the bilingual
 // layout, which always shows both.
 export const getLayoutLang = layout => (layout === 'one-column-en' || layout === 'two-column-en' ? 'en' : 'uk');
+
+// A document whose template pinned its own `languages`/`columns` (batch 16 §15/§16) renders with
+// that layout regardless of the page-wide selector - e.g. `languages: ["uk"], columns: 1` always
+// renders one full-width UA column, even while the admin has "UA + EN" selected for the rest of the
+// batch. A template that never set `languages` (doc.languages is null) simply defers to whatever
+// layout the page/export call passes in, so every pre-existing template is unaffected.
+export const getEffectiveDocLayout = (doc, fallbackLayout) => {
+  if (!doc?.languages?.length) return fallbackLayout;
+  const [firstLang] = doc.languages;
+  if (doc.languages.length > 1) return 'two-column';
+  const lang = firstLang === 'en' ? 'en' : 'uk';
+  return doc.columns === 2 ? `two-column-${lang}` : `one-column-${lang}`;
+};
 
 // Rough per-page-per-column character capacity for the single-language 2-column layout's manual
 // pagination (splitParagraphsIntoPages below). react-pdf has no native multi-column text flow: a

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -6,6 +6,7 @@ import {
   estimateColumnPageCapacity,
   estimateParagraphChars,
   buildCaseLabel,
+  buildChildContext,
   buildDocumentsFileName,
   buildGeneratedDocument,
   clinicLogoEntriesToBackend,
@@ -14,16 +15,22 @@ import {
   emptyDocumentsCatalog,
   fillPlaceholders,
   formatDocumentDate,
+  formatEnglishDateWords,
+  formatUkrainianDateWords,
+  getChildGenderForms,
   getClinicLogo,
+  getEffectiveDocLayout,
   getLayoutColumnCount,
   getLayoutLang,
   getParagraphType,
   getTemplateLogoType,
   getValueByPath,
   isBilingualLayout,
+  isIsoDate,
   isParagraphBold,
   isSectionHeading,
   isSingleLanguageTwoColumnLayout,
+  MISSING_VALUE_PLACEHOLDER,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -45,6 +52,7 @@ import {
   toggleInlineFormat,
   upsertRecentCaseId,
   upsertRecentId,
+  validateBirthRegistrationCase,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
@@ -1119,5 +1127,298 @@ describe('spec: per-document format overrides (batch 13 §5)', () => {
     const reference = normalizeDocFormatting({ fontSize: 10 });
     const working = normalizeDocFormatting({ fontSize: 10 });
     expect(diffDocFormattingOverrides(reference, working)).toEqual({});
+  });
+});
+
+// Fixture mirroring the reference statement (batch 16 §6): a surrogate mother's consent to the
+// birth registration of a child born for a Japanese couple, medical conclusion issued by a named
+// maternity hospital, signature witnessed by a named notary.
+const birthRegistrationCatalog = (birthRegistrationOverride = {}) => normalizeDocumentsCatalog(
+  {
+    couples: {
+      'couple-1': {
+        id: 'couple-1',
+        partners: [
+          {
+            id: 'wife-1', role: 'wife', name: { uk: { nominative: 'Кікава Харука' }, en: 'Kikawa Haruka' }, birthDate: '1988-12-03', citizenship: { uk: 'Японії', en: 'Japan' },
+          },
+          {
+            id: 'husband-1', role: 'husband', name: { uk: { nominative: 'Кікава Йосуке' }, en: 'Kikawa Yosuke' }, birthDate: '1988-09-02', citizenship: { uk: 'Японії', en: 'Japan' },
+          },
+        ],
+      },
+    },
+    surrogateMothers: {
+      'surrogate-1': {
+        id: 'surrogate-1',
+        name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } },
+        birthDate: '1993-05-27',
+        passport: { number: 'ЕВ409051', issueDate: '2016-04-28' },
+        taxId: '3411512481',
+        address: { uk: 'Кіровоградська область, місто Гайворон' },
+      },
+    },
+    maternityHospitals: {
+      'maternity-hospital-1': {
+        id: 'maternity-hospital-1',
+        name: { uk: 'КОМУНАЛЬНЕ НЕКОМЕРЦІЙНЕ ПІДПРИЄМСТВО "ПЕРИНАТАЛЬНИЙ ЦЕНТР М. КИЄВА"', en: '' },
+        edrpou: '22964365',
+      },
+    },
+    notaries: {
+      'notary-1': {
+        id: 'notary-1',
+        name: { uk: { nominative: 'Алексашина Ю.Б.', instrumental: 'Алексашиною Ю.Б.' } },
+        title: { uk: 'приватний нотаріус Київського міського нотаріального округу' },
+        city: { uk: 'місто Київ, Україна', en: 'Kyiv, Ukraine' },
+      },
+    },
+    cases: {
+      'case-1': {
+        id: 'case-1',
+        coupleId: 'couple-1',
+        surrogateMotherId: 'surrogate-1',
+        birthRegistration: {
+          child: { sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'місто Київ', en: 'Kyiv' } },
+          medicalConclusion: { number: '1234-7H6A-2T6C-CK24', date: '2026-05-16', maternityHospitalId: 'maternity-hospital-1' },
+          statementDate: '2026-05-18',
+          notaryId: 'notary-1',
+          ...birthRegistrationOverride,
+        },
+      },
+    },
+  },
+  {
+    'birth-registration-surrogate-consent': {
+      id: 'birth-registration-surrogate-consent',
+      languages: ['uk'],
+      columns: 1,
+      beforeTitle: [
+        { uk: 'ЗА МІСЦЕМ ВИМОГИ', align: 'right', bold: true },
+        { uk: 'Дані сурогатної матері: {{surrogateMother.name.uk.nominative}}', align: 'left' },
+      ],
+      title: { uk: 'З А Я В А' },
+      paragraphs: [
+        {
+          uk: 'Я, {{surrogateMother.name.uk.nominative}}, даю згоду на те, щоб батьками, '
+            + '{{child.gender.uk.bornByMe}} {{child.birthDate}} року {{child.gender.uk.whichWasBorn}} '
+            + '{{child.gender.uk.childGenitive}}, були записані генетичні батьки.',
+        },
+      ],
+    },
+  },
+);
+
+describe('spec: birth-registration surrogate-consent document (batch 16 §6)', () => {
+  describe('child gender grammar (§3/§4/§21 #1-4)', () => {
+    it('female: "народженої мною" + "дівчинки"', () => {
+      const forms = getChildGenderForms('female');
+      expect(forms.uk.bornByMe).toBe('народженої мною');
+      expect(forms.uk.childGenitive).toBe('дівчинки');
+    });
+
+    it('female: "яка народилась"', () => {
+      expect(getChildGenderForms('female').uk.whichWasBorn).toBe('яка народилась');
+    });
+
+    it('male: "народженого мною" + "хлопчика"', () => {
+      const forms = getChildGenderForms('male');
+      expect(forms.uk.bornByMe).toBe('народженого мною');
+      expect(forms.uk.childGenitive).toBe('хлопчика');
+    });
+
+    it('male: "який народився"', () => {
+      expect(getChildGenderForms('male').uk.whichWasBorn).toBe('який народився');
+    });
+
+    it('buildChildContext keeps the raw child fields alongside the derived gender forms', () => {
+      const child = buildChildContext({ sex: 'female', birthDate: '2026-05-16' });
+      expect(child.sex).toBe('female');
+      expect(child.birthDate).toBe('2026-05-16');
+      expect(child.gender.uk.label).toBe('дівчинка');
+      expect(child.gender.en.label).toBe('girl');
+    });
+
+    it('an unknown/missing sex resolves to blank grammar forms rather than throwing (§21 #14)', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog({ child: { birthDate: '2026-05-16' } }), 'case-1');
+      expect(context.child.gender.uk.label).toBe('');
+      expect(fillPlaceholders('{{child.gender.uk.label}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+    });
+  });
+
+  describe('maternity hospital + notary lookups (§7/§8, §21 #5-6/#12-13)', () => {
+    it('resolves the maternity hospital via medicalConclusion.maternityHospitalId', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog(), 'case-1');
+      expect(context.maternityHospital.edrpou).toBe('22964365');
+      expect(fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).toContain('ПЕРИНАТАЛЬНИЙ ЦЕНТР');
+    });
+
+    it('resolves the notary via birthRegistration.notaryId', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog(), 'case-1');
+      expect(context.notary.name.uk.nominative).toBe('Алексашина Ю.Б.');
+      expect(fillPlaceholders('{{notary.title.uk}}', context, 'uk')).toBe('приватний нотаріус Київського міського нотаріального округу');
+    });
+
+    it('an unresolvable maternityHospitalId never crashes - the variable is just unresolved', () => {
+      const catalog = birthRegistrationCatalog({ medicalConclusion: { number: 'X', date: '2026-05-16', maternityHospitalId: 'no-such-hospital' } });
+      const context = resolveCaseContext(catalog, 'case-1');
+      expect(context.maternityHospital).toBeNull();
+      expect(fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+    });
+
+    it('an unresolvable notaryId never crashes - the variable is just unresolved', () => {
+      const catalog = birthRegistrationCatalog({ notaryId: 'no-such-notary' });
+      const context = resolveCaseContext(catalog, 'case-1');
+      expect(context.notary).toBeNull();
+      expect(fillPlaceholders('{{notary.title.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+    });
+  });
+
+  describe('Ukrainian date-in-words (§12, §21 #7) - generic, not hardcoded to one date', () => {
+    it.each([
+      ['2026-05-18', 'вісімнадцятого травня дві тисячі двадцять шостого року'],
+      ['1993-05-27', 'двадцять сьомого травня тисяча дев\'ятсот дев\'яносто третього року'],
+      ['2020-06-10', 'десятого червня дві тисячі двадцятого року'],
+      ['2024-01-01', 'першого січня дві тисячі двадцять четвертого року'],
+      ['1988-09-02', 'другого вересня тисяча дев\'ятсот вісімдесят восьмого року'],
+    ])('%s -> %s', (iso, expected) => {
+      expect(formatUkrainianDateWords(iso)).toBe(expected);
+    });
+
+    it('returns an empty string for a non-ISO or invalid value rather than throwing', () => {
+      expect(formatUkrainianDateWords('')).toBe('');
+      expect(formatUkrainianDateWords('18/05/2026')).toBe('');
+      expect(formatUkrainianDateWords(undefined)).toBe('');
+      expect(isIsoDate('2026-05-18')).toBe(true);
+      expect(isIsoDate('2026-5-18')).toBe(false);
+    });
+
+    it('formatEnglishDateWords is generic across dates too', () => {
+      expect(formatEnglishDateWords('2026-05-18')).toBe('eighteenth of May, 2026');
+      expect(formatEnglishDateWords('1993-05-27')).toBe('twenty-seventh of May, 1993');
+    });
+  });
+
+  describe('birthRegistration context + statement date words', () => {
+    it('exposes birthRegistration.statementDateWords.uk derived from statementDate', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog(), 'case-1');
+      expect(context.birthRegistration.statementDateWords.uk).toBe('вісімнадцятого травня дві тисячі двадцять шостого року');
+      expect(fillPlaceholders('{{birthRegistration.statementDateWords.uk}}', context, 'uk')).toBe('вісімнадцятого травня дві тисячі двадцять шостого року');
+    });
+
+    it('renders child.birthDate as DD.MM.YYYY through the existing date formatter (§13)', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog(), 'case-1');
+      expect(fillPlaceholders('{{child.birthDate}}', context, 'uk')).toBe('16.05.2026');
+    });
+
+    it('exposes medicalConclusion.* directly, not just nested under birthRegistration', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog(), 'case-1');
+      expect(fillPlaceholders('{{medicalConclusion.number}}', context, 'uk')).toBe('1234-7H6A-2T6C-CK24');
+    });
+
+    it('resolves surrogateMother.taxId/address.uk and wife/husband.citizenship.uk via the generic path resolver (no code change needed, §9/§10)', () => {
+      const context = resolveCaseContext(birthRegistrationCatalog(), 'case-1');
+      expect(fillPlaceholders('{{surrogateMother.taxId}}', context, 'uk')).toBe('3411512481');
+      expect(fillPlaceholders('{{surrogateMother.address.uk}}', context, 'uk')).toBe('Кіровоградська область, місто Гайворон');
+      expect(fillPlaceholders('{{wife.citizenship.uk}}', context, 'uk')).toBe('Японії');
+      expect(fillPlaceholders('{{husband.citizenship.uk}}', context, 'uk')).toBe('Японії');
+    });
+  });
+
+  describe('pre-export validation (§20)', () => {
+    it('reports no issues for a fully-filled case', () => {
+      expect(validateBirthRegistrationCase(birthRegistrationCatalog(), 'case-1')).toEqual([]);
+    });
+
+    it('lists every missing required field without throwing', () => {
+      const catalog = birthRegistrationCatalog({
+        child: {}, medicalConclusion: {}, statementDate: '', notaryId: '',
+      });
+      const issues = validateBirthRegistrationCase(catalog, 'case-1');
+      expect(issues).toEqual(expect.arrayContaining([
+        'birthRegistration.child.sex',
+        'birthRegistration.child.birthDate',
+        'birthRegistration.child.birthPlace.uk',
+        'birthRegistration.medicalConclusion.number',
+        'birthRegistration.medicalConclusion.date',
+        'birthRegistration.medicalConclusion.maternityHospitalId',
+        'birthRegistration.statementDate',
+        'birthRegistration.notaryId',
+      ]));
+    });
+
+    it('flags an invalid sex value and a non-ISO date without blocking editing', () => {
+      const catalog = birthRegistrationCatalog({ child: { sex: 'other', birthDate: '16.05.2026', birthPlace: { uk: 'Київ' } } });
+      const issues = validateBirthRegistrationCase(catalog, 'case-1');
+      expect(issues).toContain('birthRegistration.child.sex (must be "female" or "male")');
+      expect(issues).toContain('birthRegistration.child.birthDate (must be YYYY-MM-DD)');
+    });
+
+    it('flags an unresolvable maternity hospital / notary id', () => {
+      const catalog = birthRegistrationCatalog({ notaryId: 'ghost-notary' });
+      const issues = validateBirthRegistrationCase(catalog, 'case-1');
+      expect(issues).toContain('birthRegistration.notaryId (no matching notary)');
+    });
+  });
+
+  describe('template-level languages/columns + beforeTitle (§14/§15/§16, §21 #8-11/#15)', () => {
+    it('a single-column template resolves to one-column-uk regardless of the page-wide layout (§21 #9)', () => {
+      const catalog = birthRegistrationCatalog();
+      const context = resolveCaseContext(catalog, 'case-1');
+      const generated = buildGeneratedDocument(catalog.documents[0], context);
+      expect(generated.languages).toEqual(['uk']);
+      expect(generated.columns).toBe(1);
+      expect(getEffectiveDocLayout(generated, 'two-column')).toBe('one-column-uk');
+    });
+
+    it('resolves beforeTitle blocks with placeholders filled and align/bold normalized, kept separate from paragraphs (§21 #8)', () => {
+      const catalog = birthRegistrationCatalog();
+      const context = resolveCaseContext(catalog, 'case-1');
+      const generated = buildGeneratedDocument(catalog.documents[0], context);
+      expect(generated.beforeTitle).toHaveLength(2);
+      expect(generated.beforeTitle[0]).toMatchObject({ uk: 'ЗА МІСЦЕМ ВИМОГИ', align: 'right', bold: true });
+      expect(generated.beforeTitle[1].uk).toBe('Дані сурогатної матері: Молвінських Юлія Володимирівна');
+      expect(generated.paragraphs.some(p => p.uk.includes('ЗА МІСЦЕМ ВИМОГИ'))).toBe(false);
+    });
+
+    it('a legacy template without languages/columns/beforeTitle keeps rendering under the page-wide layout unchanged (§21 #11)', () => {
+      const legacyTemplate = { id: 'legacy', title: { uk: 'Договір', en: 'Agreement' }, paragraphs: [{ uk: 'Текст.', en: 'Text.' }] };
+      const generated = buildGeneratedDocument(legacyTemplate, {});
+      expect(generated.languages).toBeNull();
+      expect(generated.columns).toBeNull();
+      expect(generated.beforeTitle).toEqual([]);
+      expect(getEffectiveDocLayout(generated, 'two-column')).toBe('two-column');
+    });
+
+    it('a missing `en` field never throws, undefined, or "null" (§21 #10) - localizedText falls back to the uk text', () => {
+      const generated = buildGeneratedDocument({ id: 'uk-only', title: { uk: 'Заява' }, beforeTitle: [{ uk: 'Блок' }], paragraphs: [{ uk: 'Текст.' }] }, {});
+      [generated.title.en, generated.beforeTitle[0].en, generated.paragraphs[0].en].forEach(value => {
+        expect(value).not.toBeUndefined();
+        expect(value).not.toBe('undefined');
+        expect(value).not.toBe('null');
+      });
+    });
+  });
+
+  describe('align/bold formatting on beforeTitle + paragraphs (§17, §21 #15)', () => {
+    it('an explicit paragraph.align overrides the default alignment', () => {
+      const generated = buildGeneratedDocument({
+        id: 'aligned',
+        title: { uk: 'Заява' },
+        paragraphs: [{ uk: 'Підпис', align: 'right' }, { uk: 'Звичайний абзац' }],
+      }, {});
+      expect(generated.paragraphs[0].align).toBe('right');
+      expect(generated.paragraphs[1].align).toBeUndefined();
+    });
+
+    it('an invalid align value normalizes to "left" rather than being passed through as-is', () => {
+      const generated = buildGeneratedDocument({
+        id: 'bad-align',
+        title: { uk: 'Заява' },
+        beforeTitle: [{ uk: 'Блок', align: 'diagonal' }],
+        paragraphs: [],
+      }, {});
+      expect(generated.beforeTitle[0].align).toBe('left');
+    });
   });
 });

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -11,6 +11,7 @@ import {
   DEFAULT_DOC_FORMATTING,
   allowsParagraphInternalBreak,
   getClinicLogo,
+  getEffectiveDocLayout,
   getLayoutLang,
   isBilingualLayout,
   isParagraphBold,
@@ -49,15 +50,11 @@ export const buildDocumentsDocx = async ({
     Paragraph, Table, TableCell, TableRow, TextRun, VerticalAlign, WidthType,
   } = docx;
 
-  const isBilingual = isBilingualLayout(layout);
-  const isSingleLanguageFlow = isSingleLanguageTwoColumnLayout(layout);
   // Both column layouts (bilingual UA|EN and single-language newspaper-style, spec §4) share the
   // same two-cell geometry/logo clamping - only how paragraphs are distributed between the two
-  // cells differs (see singleLanguageColumnsTable below).
-  const isTwoColumn = isBilingual || isSingleLanguageFlow;
-  const lang = getLayoutLang(layout);
-  const showUk = isBilingual || lang === 'uk';
-  const showEn = isBilingual || lang === 'en';
+  // cells differs (see singleLanguageColumnsTable below). Which layout actually applies is resolved
+  // per document below (getEffectiveDocLayout), since a template can pin its own languages/columns
+  // regardless of the page-wide selector (batch 16 §15/§16).
   const bodySize = halfPoints(formatting.fontSize);
   const titleSize = halfPoints(formatting.titleFontSize);
   const smallSize = halfPoints(Math.max(7, formatting.fontSize - 2));
@@ -75,7 +72,7 @@ export const buildDocumentsDocx = async ({
   // Off by default (spec §3): a hairline rule between the two columns, drawn as a single border on
   // the left cell only (the right cell stays borderless) so the table renders exactly one line at
   // the boundary instead of a doubled one. Same docLine hairline weight the PDF renderer uses.
-  const showColumnDivider = isTwoColumn && Boolean(formatting.columnDivider);
+  // Whether it actually applies is resolved per document (see showColumnDivider in buildDocChildren).
   const dividerBorder = { style: BorderStyle.SINGLE, size: 4, color: 'E6DCC7' };
 
   const contentWidthTwips = 11906
@@ -94,8 +91,17 @@ export const buildDocumentsDocx = async ({
     italics: run.italic,
   }));
 
-  const bodyParagraph = (text, { keepLines = true } = {}) => new Paragraph({
-    alignment: AlignmentType.JUSTIFIED,
+  // batch 16 §17: an explicit `align` on a paragraph (or beforeTitle block) overrides the default
+  // alignment (justified body / flush-left heading) - never inferred from the text itself.
+  const alignmentForBlock = align => {
+    if (align === 'right') return AlignmentType.RIGHT;
+    if (align === 'center') return AlignmentType.CENTER;
+    if (align === 'justify') return AlignmentType.JUSTIFIED;
+    return AlignmentType.LEFT;
+  };
+
+  const bodyParagraph = (text, { keepLines = true, alignmentOverride } = {}) => new Paragraph({
+    alignment: alignmentOverride || AlignmentType.JUSTIFIED,
     spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
     indent: firstLineTwips ? { firstLine: firstLineTwips } : undefined,
     keepLines,
@@ -104,17 +110,20 @@ export const buildDocumentsDocx = async ({
 
   // Short numbered section titles ("1. Предмет Договору") render bold, flush left, with extra
   // room above and kept with the paragraph that follows so a heading never ends a page alone.
-  const headingParagraph = text => new Paragraph({
-    alignment: AlignmentType.LEFT,
+  const headingParagraph = (text, alignmentOverride) => new Paragraph({
+    alignment: alignmentOverride || AlignmentType.LEFT,
     spacing: { before: afterTwips, after: afterTwips, line: lineTwips, lineRule: 'auto' },
     keepLines: true,
     keepNext: true,
     children: formattedTextRuns(text, { size: bodySize, baseBold: true }),
   });
 
-  const cellParagraph = (text, allowPageBreaks, paragraph) => (isParagraphBold(paragraph)
-    ? headingParagraph(text)
-    : bodyParagraph(text, { keepLines: !allowsParagraphInternalBreak(paragraph, allowPageBreaks) }));
+  const cellParagraph = (text, allowPageBreaks, paragraph) => {
+    const alignmentOverride = paragraph?.align ? alignmentForBlock(paragraph.align) : undefined;
+    return isParagraphBold(paragraph)
+      ? headingParagraph(text, alignmentOverride)
+      : bodyParagraph(text, { keepLines: !allowsParagraphInternalBreak(paragraph, allowPageBreaks), alignmentOverride });
+  };
 
   // Exactly the Format panel's paragraph spacing - no hidden minimum - so the Word output keeps
   // the same title-to-body rhythm as the PDF and the reference statements.
@@ -124,7 +133,15 @@ export const buildDocumentsDocx = async ({
     children: formattedTextRuns(text, { size: titleSize, baseBold: true }),
   });
 
-  const twoColumnCellFromParagraph = (paragraphOrParagraphs, marginSide) => new TableCell({
+  // Free-standing text between the letterhead logo and the title (spec §14/§17: "ЗА МІСЦЕМ
+  // ВИМОГИ" etc.) - `align`/`bold` are resolved per block, never inferred from the text itself.
+  const beforeTitleParagraph = (text, block) => new Paragraph({
+    alignment: alignmentForBlock(block.align),
+    spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
+    children: formattedTextRuns(text, { size: bodySize, baseBold: Boolean(block.bold) }),
+  });
+
+  const twoColumnCellFromParagraph = (paragraphOrParagraphs, marginSide, showColumnDivider) => new TableCell({
     borders: showColumnDivider && marginSide === 'left' ? { ...noBorders, right: dividerBorder } : noBorders,
     width: { size: 50, type: WidthType.PERCENTAGE },
     verticalAlign: VerticalAlign.TOP,
@@ -137,14 +154,14 @@ export const buildDocumentsDocx = async ({
     children: Array.isArray(paragraphOrParagraphs) ? paragraphOrParagraphs : [paragraphOrParagraphs],
   });
 
-  const twoColumnTable = (rows, cantSplit) => new Table({
+  const twoColumnTable = (rows, cantSplit, showColumnDivider = false) => new Table({
     width: { size: 100, type: WidthType.PERCENTAGE },
     borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
     rows: rows.map(([left, right]) => new TableRow({
       cantSplit,
       children: [
-        twoColumnCellFromParagraph(left, 'left'),
-        twoColumnCellFromParagraph(right, 'right'),
+        twoColumnCellFromParagraph(left, 'left', showColumnDivider),
+        twoColumnCellFromParagraph(right, 'right', showColumnDivider),
       ],
     })),
   });
@@ -156,18 +173,18 @@ export const buildDocumentsDocx = async ({
   // renderer (which has no native multi-column flow at all) and to keep the well-tested
   // per-document section/pagination model untouched, this uses the same up-front split into two
   // whole-paragraph groups as the PDF, laid out as a single borderless table row.
-  const singleLanguageColumnsTable = (paragraphs, allowPageBreaks) => {
+  const singleLanguageColumnsTable = (paragraphs, allowPageBreaks, lang, layoutCtx) => {
     const [leftParagraphs, rightParagraphs] = splitParagraphsIntoColumns(paragraphs, lang);
     const buildColumnChildren = columnParagraphs => columnParagraphs.flatMap(paragraph => (
-      paragraph.type && paragraph.type !== 'text' ? buildLogoBlock(paragraph.type) : [cellParagraph(paragraph[lang], allowPageBreaks, paragraph)]
+      paragraph.type && paragraph.type !== 'text' ? buildLogoBlock(paragraph.type, layoutCtx) : [cellParagraph(paragraph[lang], allowPageBreaks, paragraph)]
     ));
     return new Table({
       width: { size: 100, type: WidthType.PERCENTAGE },
       borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
       rows: [new TableRow({
         children: [
-          twoColumnCellFromParagraph(buildColumnChildren(leftParagraphs), 'left'),
-          twoColumnCellFromParagraph(buildColumnChildren(rightParagraphs), 'right'),
+          twoColumnCellFromParagraph(buildColumnChildren(leftParagraphs), 'left', layoutCtx.showColumnDivider),
+          twoColumnCellFromParagraph(buildColumnChildren(rightParagraphs), 'right', layoutCtx.showColumnDivider),
         ],
       })],
     });
@@ -187,7 +204,8 @@ export const buildDocumentsDocx = async ({
 
   // {{logo}}: a compact logo duplicated above each visible language column (or once, centered,
   // in a one-column export); {{logo-long}}: one shared full-width logo, never duplicated.
-  const buildLogoBlock = paragraphType => {
+  const buildLogoBlock = (paragraphType, layoutCtx) => {
+    const { isTwoColumn, showUk, showEn, showColumnDivider } = layoutCtx;
     const variantKind = paragraphType === 'logo-long' ? 'logo-long' : 'logo';
     const variant = getClinicLogo(effectiveClinicLogos, variantKind);
     if (!variant?.dataUrl) return [];
@@ -209,20 +227,44 @@ export const buildDocumentsDocx = async ({
       return [twoColumnTable([[
         logoParagraph(decoded, compactWidthPx, ratio),
         logoParagraph(decoded, compactWidthPx, ratio),
-      ]], true)];
+      ]], true, showColumnDivider)];
     }
     return [logoParagraph(decoded, compactWidthPx, ratio)];
   };
 
   const buildDocChildren = doc => {
+    const effectiveLayout = getEffectiveDocLayout(doc, layout);
+    const isBilingual = isBilingualLayout(effectiveLayout);
+    const isSingleLanguageFlow = isSingleLanguageTwoColumnLayout(effectiveLayout);
+    const isTwoColumn = isBilingual || isSingleLanguageFlow;
+    const lang = getLayoutLang(effectiveLayout);
+    const showUk = isBilingual || lang === 'uk';
+    const showEn = isBilingual || lang === 'en';
+    const showColumnDivider = isTwoColumn && Boolean(formatting.columnDivider);
+    const layoutCtx = {
+      isTwoColumn, showUk, showEn, showColumnDivider,
+    };
+
     const children = [];
 
     // The template's letterhead logo (doc.logo) always renders before the title, whether it came
     // from the dedicated `logo` field or a legacy leading paragraph - see getTemplateLogoType.
-    if (doc.logo) children.push(...buildLogoBlock(doc.logo));
+    if (doc.logo) children.push(...buildLogoBlock(doc.logo, layoutCtx));
+
+    // Free-standing text between the logo and the title (spec §14), never merged into the body.
+    (doc.beforeTitle || []).forEach(block => {
+      if (isBilingual) {
+        children.push(twoColumnTable([[
+          beforeTitleParagraph(block.uk, block),
+          beforeTitleParagraph(block.en, block),
+        ]], true, showColumnDivider));
+      } else {
+        children.push(beforeTitleParagraph(block[lang], block));
+      }
+    });
 
     if (isBilingual) {
-      children.push(twoColumnTable([[titleParagraph(doc.title.uk), titleParagraph(doc.title.en)]], true));
+      children.push(twoColumnTable([[titleParagraph(doc.title.uk), titleParagraph(doc.title.en)]], true, showColumnDivider));
     } else {
       children.push(titleParagraph(doc.title[lang]));
     }
@@ -233,13 +275,13 @@ export const buildDocumentsDocx = async ({
       // One shared table for the whole body (not one per paragraph, unlike the bilingual/1-column
       // branches below) - the newspaper-style column split is decided once, up front, across every
       // paragraph together (see splitParagraphsIntoColumns).
-      children.push(singleLanguageColumnsTable(bodyParagraphs, doc.allowPageBreaks));
+      children.push(singleLanguageColumnsTable(bodyParagraphs, doc.allowPageBreaks, lang, layoutCtx));
       return children;
     }
 
     bodyParagraphs.forEach(paragraph => {
       if (paragraph.type !== 'text') {
-        children.push(...buildLogoBlock(paragraph.type));
+        children.push(...buildLogoBlock(paragraph.type, layoutCtx));
         return;
       }
       if (isBilingual) {
@@ -247,7 +289,7 @@ export const buildDocumentsDocx = async ({
         children.push(twoColumnTable([[
           cellParagraph(paragraph.uk, doc.allowPageBreaks, paragraph),
           cellParagraph(paragraph.en, doc.allowPageBreaks, paragraph),
-        ]], cantSplit));
+        ]], cantSplit, showColumnDivider));
       } else {
         children.push(cellParagraph(paragraph[lang], doc.allowPageBreaks, paragraph));
       }


### PR DESCRIPTION
- New per-case birthRegistration node (child, medicalConclusion, statementDate,
  notaryId) plus maternityHospitals/notaries party collections, wired into the
  generic resolver: child.*, child.gender.uk/en.* (programmatic Ukrainian/English
  grammar for female/male), medicalConclusion.*, maternityHospital.*, notary.*,
  and birthRegistration.statementDateWords via a generic Ukrainian/English
  date-in-words formatter (any date, not just one hardcoded example). Existing
  fields like surrogateMother.taxId/address and wife/husband.citizenship resolve
  automatically through the already-generic path resolver.
- Missing maternity hospital/notary lookups resolve to null instead of crashing,
  and validateBirthRegistrationCase gives a non-blocking pre-export checklist.
- Templates can now carry beforeTitle blocks (rendered between the logo and the
  title, with per-block align/bold) and languages/columns (a template can force
  its own single-column single-language layout regardless of the page-wide
  layout selector); both the PDF and DOCX renderers resolve this per document,
  so legacy bilingual templates keep rendering exactly as before.
- Paragraphs also accept an explicit align override.
- Light admin-UI support for editing existing beforeTitle blocks in Template mode.