### PR TITLE
Fix technical-paste merge creating a duplicate case when id is only the object key

### DIFF
--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -33,6 +33,21 @@ const toArray = value => {
 
 const makeRecordId = prefix => `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
+// Every collection is stored keyed by record id (catalogPartiesToBackend/catalogTemplatesToBackend
+// duplicate that id inside the record too, e.g. `cases/case-1/id: "case-1"`) - a hand-written
+// technical-input paste, or a partial edit straight in the Firebase console, can easily carry a
+// record under its correct key but without that inner `id` field, relying on the key alone. Plain
+// toArray (Object.values) would silently drop that key, and mergeCollection would then treat the
+// record as brand new (no `id` to match against an existing one) instead of updating case-1/etc in
+// place - this recovers the key as a fallback `id` first, never overriding one the record already has.
+const toRecordsWithIdFromKey = raw => {
+  if (Array.isArray(raw)) return raw.filter(Boolean);
+  if (!isPlainObject(raw)) return [];
+  return Object.entries(raw)
+    .filter(([, record]) => Boolean(record))
+    .map(([key, record]) => (isPlainObject(record) && record.id === undefined ? { ...record, id: key } : record));
+};
+
 // --- Clinic logo variants --------------------------------------------------------------------
 
 // The column mode selected at the top of the page is the flag that decides which logo variant is
@@ -99,9 +114,9 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
       const { clinics: _clinicLogos, ...caseRecords } = rawCollection;
       rawCollection = caseRecords;
     }
-    catalog.parties[collection] = toArray(rawCollection).filter(record => isPlainObject(record));
+    catalog.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
   });
-  catalog.documents = toArray(rawTemplates).filter(record => isPlainObject(record));
+  catalog.documents = toRecordsWithIdFromKey(rawTemplates).filter(record => isPlainObject(record));
   const rawClinicLogos = rawParties?.cases?.clinics;
   if (isPlainObject(rawClinicLogos)) {
     Object.entries(rawClinicLogos).forEach(([clinicId, node]) => {
@@ -170,9 +185,9 @@ export const parseDocumentsTechnicalInput = rawText => {
         });
       }
     }
-    incoming.parties[collection] = toArray(rawCollection).filter(record => isPlainObject(record));
+    incoming.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
   });
-  incoming.documents = toArray(templatesSource).filter(record => isPlainObject(record));
+  incoming.documents = toRecordsWithIdFromKey(templatesSource).filter(record => isPlainObject(record));
 
   const hasParties = PARTY_COLLECTIONS.some(collection => incoming.parties[collection].length > 0);
   const hasClinicLogos = Object.keys(incoming.clinicLogos).length > 0;

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -186,6 +186,51 @@ describe('parseDocumentsTechnicalInput', () => {
     ]);
   });
 
+  // Bugfix regression: pasting `{ parties: { cases: { "case-1": { birthRegistration: {...} } } } }`
+  // straight from the Firebase console (no inner `id` field, only the object key) used to create a
+  // brand-new case with a random id instead of updating case-1, because toArray's Object.values()
+  // silently dropped the key and mergeCollection then had nothing to match against.
+  it('recovers a record\'s id from its object key when the record itself carries no `id` field', () => {
+    const parsed = parseDocumentsTechnicalInput(JSON.stringify({
+      parties: {
+        cases: {
+          'case-1': {
+            birthRegistration: {
+              child: { sex: 'female', birthDate: '2026-05-16' },
+              statementDate: '2026-05-18',
+              notaryId: 'notary-1',
+            },
+          },
+        },
+      },
+    }));
+    expect(parsed.parties.cases).toHaveLength(1);
+    expect(parsed.parties.cases[0].id).toBe('case-1');
+    expect(parsed.parties.cases[0].birthRegistration.notaryId).toBe('notary-1');
+  });
+
+  it('merging that id-less paste into an existing catalog updates case-1 in place instead of creating a second case', () => {
+    const current = normalizeDocumentsCatalog({
+      cases: {
+        'case-1': {
+          id: 'case-1', coupleId: 'couple-1', surrogateMotherId: 'surrogate-1',
+        },
+      },
+    }, {});
+    const incoming = parseDocumentsTechnicalInput(JSON.stringify({
+      parties: { cases: { 'case-1': { birthRegistration: { statementDate: '2026-05-18', notaryId: 'notary-1' } } } },
+    }));
+    const { catalog, summary } = mergeDocumentsCatalog(current, incoming);
+    expect(catalog.parties.cases).toHaveLength(1);
+    expect(summary).toEqual({ added: 0, updated: 1 });
+    expect(catalog.parties.cases[0]).toMatchObject({
+      id: 'case-1',
+      coupleId: 'couple-1',
+      surrogateMotherId: 'surrogate-1',
+      birthRegistration: { statementDate: '2026-05-18', notaryId: 'notary-1' },
+    });
+  });
+
   it('also accepts the full export shape wrapped in a markdown fence', () => {
     const parsed = parseDocumentsTechnicalInput(`\`\`\`json\n${JSON.stringify({
       parties: { clinics: { 'clinic-9': { id: 'clinic-9' } } },


### PR DESCRIPTION
## Summary
- Pasting a Documents technical-input JSON straight from the Firebase console (e.g. `parties.cases.case-1.birthRegistration = {...}` with no inner `id` field on the record, only the object key) created a brand-new case instead of updating `case-1`.
- Root cause: converting an id-keyed collection object to an array used a plain `Object.values(...)`, which drops the key entirely - `mergeCollection` then had no `id` to match against the existing record, so it generated a fresh random id.
- Fix: `toRecordsWithIdFromKey` recovers the object key as a fallback `id` (only when the record doesn't already carry one) before the party-collection/template arrays are built, in both `normalizeDocumentsCatalog` and `parseDocumentsTechnicalInput`.

## Test plan
- [x] New regression test: parsing an id-less, key-only case record resolves `id` from the key.
- [x] New regression test: merging that paste into an existing catalog updates the existing case in place (`added: 0, updated: 1`) instead of creating a second case.
- [x] Full Documents test suite (`documentsCatalogUtils.test.js`, `DocumentsRenderers.smoke.test.js`, `DocumentsPageNumbering.smoke.test.js`, `DocumentsPage.richFormatting.test.js`) passes: 147/147.
- [x] `eslint` clean on the changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DMTKizBC4vNqzMs15tjGup)_