### PR TITLE
Normalize clinic logo storage under parties.clinics + maternityHospitals wiring

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -39,6 +39,8 @@ import {
   getParagraphType,
   getTemplateLogoType,
   isBilingualLayout,
+  legacyClinicLogoStorageFilePath,
+  legacyClinicLogoStorageFolder,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -1224,8 +1226,12 @@ const DocumentsPage = ({ isAdmin }) => {
     if (typeof window !== 'undefined' && !window.confirm('Remove this clinic logo variant from the backend?')) return;
     const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
     if (!clinicId) return;
+    // A variant loaded via the legacy Storage-folder fallback still physically lives there.
+    const isLegacyVariant = Boolean(clinicLogos.find(variant => variant.fileName === fileName)?.legacyFolder);
     try {
-      await deleteStorageFile(clinicLogoStorageFilePath(clinicId, fileName));
+      await deleteStorageFile(isLegacyVariant
+        ? legacyClinicLogoStorageFilePath(clinicId, fileName)
+        : clinicLogoStorageFilePath(clinicId, fileName));
       const remaining = clinicLogos.filter(variant => variant.fileName !== fileName);
       setClinicLogos(remaining);
       setClinicLogoRefreshKey(previous => previous + 1);
@@ -1369,15 +1375,33 @@ const DocumentsPage = ({ isAdmin }) => {
     setClinicLogoLoading(true);
     const loadVariants = async () => {
       let fileNames = [];
+      let activeFolder = clinicLogoStorageFolder(clinicId);
+      let usingLegacyFolder = false;
       try {
-        fileNames = await listStorageFolderFileNames(clinicLogoStorageFolder(clinicId));
+        fileNames = await listStorageFolderFileNames(activeFolder);
       } catch (listError) {
-        console.error('[ClinicLogo] Unable to list', clinicLogoStorageFolder(clinicId), listError);
+        console.error('[ClinicLogo] Unable to list', activeFolder, listError);
         if (!cancelled) {
           setClinicLogoError(`Could not list the clinic logo Storage folder - ${describeStorageError(listError)}`);
           setClinicLogoLoading(false);
         }
         return;
+      }
+      // Batch 17 §1/§2/§8: the canonical Storage folder moved from parties/cases/clinics/{id}/logo
+      // to parties/clinics/{id}/logo - a clinic that hasn't been re-uploaded under the new path yet
+      // still has its files at the old one, so fall back to reading (never writing) there.
+      if (!fileNames.length) {
+        const legacyFolder = legacyClinicLogoStorageFolder(clinicId);
+        try {
+          const legacyFileNames = await listStorageFolderFileNames(legacyFolder);
+          if (legacyFileNames.length) {
+            fileNames = legacyFileNames;
+            activeFolder = legacyFolder;
+            usingLegacyFolder = true;
+          }
+        } catch (legacyListError) {
+          console.error('[ClinicLogo] Unable to list legacy folder', legacyFolder, legacyListError);
+        }
       }
       if (cancelled) return;
       if (!fileNames.length) {
@@ -1391,16 +1415,19 @@ const DocumentsPage = ({ isAdmin }) => {
       const layoutFor = fileName => assignments.find(entry => entry.file === fileName)?.layout || '';
       const results = await Promise.all(fileNames.map(async fileName => {
         try {
-          const rawDataUrl = await getStorageFileDataUrl(clinicLogoStorageFilePath(clinicId, fileName));
+          const filePath = usingLegacyFolder
+            ? legacyClinicLogoStorageFilePath(clinicId, fileName)
+            : clinicLogoStorageFilePath(clinicId, fileName);
+          const rawDataUrl = await getStorageFileDataUrl(filePath);
           if (!rawDataUrl) return { fileName, error: 'empty response from Storage' };
           // Same re-encode the surrogate mother profile PDF export applies to uploaded photos:
           // @react-pdf/renderer only reliably embeds baseline JPEG/PNG, so a progressive JPEG or
           // EXIF-rotated logo can fail to appear in the generated PDF with no error.
           const dataUrl = await reencodePdfImageDataUrl(rawDataUrl, { preserveTransparency: true });
           const dimensions = await readImageDimensions(dataUrl);
-          return { fileName, variant: { fileName, dataUrl, layout: layoutFor(fileName), ...dimensions } };
+          return { fileName, variant: { fileName, dataUrl, layout: layoutFor(fileName), legacyFolder: usingLegacyFolder, ...dimensions } };
         } catch (loadLogoError) {
-          console.error('[ClinicLogo] Unable to load', fileName, 'from', clinicLogoStorageFolder(clinicId), loadLogoError);
+          console.error('[ClinicLogo] Unable to load', fileName, 'from', activeFolder, loadLogoError);
           return { fileName, error: describeStorageError(loadLogoError) };
         }
       }));

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -8,13 +8,22 @@ export const DOCUMENTS_PARTIES_PATH = 'documentsBuilder/parties';
 export const DOCUMENTS_TEMPLATES_PATH = 'documentsBuilder/templates';
 export const DOCUMENTS_SETTINGS_PATH = 'documentsBuilder/settings';
 
-// Clinic-logo paths. The Storage folder holds the image files themselves (and is listed directly
-// as the source of truth for which variants exist); the Realtime Database node at the same path
-// holds the per-variant layout assignments as `{ file, layout }` entries (legacy nodes stored
-// bare filenames - both shapes are normalized by normalizeClinicLogoEntries).
-export const clinicLogoDbPath = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
-export const clinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
+// Clinic-logo paths (batch 17 §1/§2: normalized under the clinic record itself, not a sibling
+// `cases.clinics` node - a clinic is shared across many cases, so its logo was never really
+// case-scoped). The Storage folder holds the image files themselves (and is listed directly as
+// the source of truth for which variants exist); the Realtime Database node at the same path holds
+// the per-variant layout assignments as `{ file, layout }` entries (legacy nodes stored bare
+// filenames - both shapes are normalized by normalizeClinicLogoEntries). Writing here writes
+// exactly the clinic record's own `logo` field, leaving every other clinic field untouched.
+export const clinicLogoDbPath = clinicId => `${DOCUMENTS_PARTIES_PATH}/clinics/${clinicId}/logo`;
+export const clinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/clinics/${clinicId}/logo`;
 export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoStorageFolder(clinicId)}/${fileName}`;
+
+// Pre-batch-17 Storage location - kept only as a temporary read fallback while older clinics still
+// have their files there (spec §8); never written to again. Delete once every clinic's logo has
+// been re-uploaded under the new path above.
+export const legacyClinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
+export const legacyClinicLogoStorageFilePath = (clinicId, fileName) => `${legacyClinicLogoStorageFolder(clinicId)}/${fileName}`;
 
 export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases', 'maternityHospitals', 'notaries'];
 
@@ -108,8 +117,9 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
   const catalog = emptyDocumentsCatalog();
   PARTY_COLLECTIONS.forEach(collection => {
     let rawCollection = rawParties?.[collection];
-    // `parties/cases/clinics` is the clinic-logo file-name store (see clinicLogoDbPath), not a
-    // case record - it must never leak into the cases list.
+    // `parties/cases/clinics` was the pre-batch-17 clinic-logo file-name store, not a case record -
+    // it must never leak into the cases list, even though the canonical logo location has since
+    // moved onto the clinic record itself (see clinicLogoDbPath).
     if (collection === 'cases' && isPlainObject(rawCollection)) {
       const { clinics: _clinicLogos, ...caseRecords } = rawCollection;
       rawCollection = caseRecords;
@@ -117,20 +127,23 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
     catalog.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
   });
   catalog.documents = toRecordsWithIdFromKey(rawTemplates).filter(record => isPlainObject(record));
+  // Primary (batch 17 §1/§2): a clinic's own `logo` field, alongside its name/legalName/etc. - a
+  // clinic is shared across many cases, so its logo was never really case-scoped to begin with.
+  catalog.parties.clinics.forEach(clinic => {
+    const entries = normalizeClinicLogoEntries(clinic.logo);
+    if (entries.length) catalog.clinicLogos[String(clinic.id)] = entries;
+  });
+  // Legacy fallback (spec §8): pre-batch-17 exports kept the layout assignments on a sibling
+  // `parties/cases/clinics` node instead - only consulted for a clinic that doesn't already have
+  // its own `logo` field, so the new shape always wins once a clinic has been migrated.
   const rawClinicLogos = rawParties?.cases?.clinics;
   if (isPlainObject(rawClinicLogos)) {
     Object.entries(rawClinicLogos).forEach(([clinicId, node]) => {
+      if (catalog.clinicLogos[clinicId]) return;
       const entries = normalizeClinicLogoEntries(node?.logo);
       if (entries.length) catalog.clinicLogos[clinicId] = entries;
     });
   }
-  // Legacy fallback: earlier builds kept the file names on the clinic record itself.
-  catalog.parties.clinics.forEach(clinic => {
-    if (!catalog.clinicLogos[String(clinic.id)] && Array.isArray(clinic.logo)) {
-      const entries = normalizeClinicLogoEntries(clinic.logo);
-      if (entries.length) catalog.clinicLogos[String(clinic.id)] = entries;
-    }
-  });
   return catalog;
 };
 
@@ -170,24 +183,34 @@ export const parseDocumentsTechnicalInput = rawText => {
   const templatesSource = parsed.templates !== undefined ? parsed.templates : parsed.documents;
 
   const incoming = emptyDocumentsCatalog();
+  // Legacy (pre-batch-17) shape: `parties.cases.clinics` mirrored the clinic-logo layout
+  // assignments separately from the clinic record - it is not a case record, so it's carried aside
+  // here instead of being imported as a generated case; kept only as a fallback below.
+  let legacyClinicLogoNode = null;
   PARTY_COLLECTIONS.forEach(collection => {
     let rawCollection = dataSource[collection];
-    // Backend exports include `cases.clinics` for clinic-logo layout assignments; it mirrors the
-    // Realtime Database storage path and is not a case record - carried into incoming.clinicLogos
-    // instead of being imported as a generated case.
     if (collection === 'cases' && isPlainObject(rawCollection)) {
       const { clinics: clinicLogoNode, ...caseRecords } = rawCollection;
       rawCollection = caseRecords;
-      if (isPlainObject(clinicLogoNode)) {
-        Object.entries(clinicLogoNode).forEach(([clinicId, node]) => {
-          const entries = normalizeClinicLogoEntries(node?.logo);
-          if (entries.length) incoming.clinicLogos[clinicId] = entries;
-        });
-      }
+      if (isPlainObject(clinicLogoNode)) legacyClinicLogoNode = clinicLogoNode;
     }
     incoming.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
   });
   incoming.documents = toRecordsWithIdFromKey(templatesSource).filter(record => isPlainObject(record));
+
+  // Primary (batch 17 §1/§2): each clinic's own `logo` field.
+  incoming.parties.clinics.forEach(clinic => {
+    const entries = normalizeClinicLogoEntries(clinic.logo);
+    if (entries.length) incoming.clinicLogos[String(clinic.id)] = entries;
+  });
+  // Legacy fallback (spec §8): only for a clinic not already covered by its own `logo` field above.
+  if (isPlainObject(legacyClinicLogoNode)) {
+    Object.entries(legacyClinicLogoNode).forEach(([clinicId, node]) => {
+      if (incoming.clinicLogos[clinicId]) return;
+      const entries = normalizeClinicLogoEntries(node?.logo);
+      if (entries.length) incoming.clinicLogos[clinicId] = entries;
+    });
+  }
 
   const hasParties = PARTY_COLLECTIONS.some(collection => incoming.parties[collection].length > 0);
   const hasClinicLogos = Object.keys(incoming.clinicLogos).length > 0;

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -9,6 +9,7 @@ import {
   buildChildContext,
   buildDocumentsFileName,
   buildGeneratedDocument,
+  catalogPartiesToBackend,
   clinicLogoEntriesToBackend,
   deepMergeRecords,
   diffDocFormattingOverrides,
@@ -239,6 +240,41 @@ describe('parseDocumentsTechnicalInput', () => {
     expect(parsed.parties.clinics[0].id).toBe('clinic-9');
     expect(parsed.documents[0].id).toBe('doc-9');
   });
+
+  // batch 17 §1/§2/§8: parties.clinics[clinicId].logo is now the primary clinic-logo source when
+  // pasting technical input too (previously only normalizeDocumentsCatalog read it at all).
+  describe('clinic-logo priority (batch 17)', () => {
+    it('reads clinic.logo as the primary source for a pasted parties.clinics record', () => {
+      const parsed = parseDocumentsTechnicalInput(JSON.stringify({
+        parties: {
+          clinics: {
+            'clinic-1': { id: 'clinic-1', logo: [{ file: 'a.jpg', layout: '1col' }] },
+          },
+        },
+      }));
+      expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'a.jpg', layout: '1col' }]);
+    });
+
+    it('clinic.logo wins over a pasted legacy parties.cases.clinics node for the same clinic', () => {
+      const parsed = parseDocumentsTechnicalInput(JSON.stringify({
+        parties: {
+          clinics: { 'clinic-1': { id: 'clinic-1', logo: [{ file: 'current.jpg', layout: '1col' }] } },
+          cases: { clinics: { 'clinic-1': { logo: [{ file: 'stale.jpg', layout: '1col' }] } } },
+        },
+      }));
+      expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'current.jpg', layout: '1col' }]);
+    });
+
+    it('falls back to parties.cases.clinics only when the clinic record has no logo field of its own', () => {
+      const parsed = parseDocumentsTechnicalInput(JSON.stringify({
+        parties: {
+          clinics: { 'clinic-1': { id: 'clinic-1' } },
+          cases: { clinics: { 'clinic-1': { logo: [{ file: 'legacy.jpg', layout: '1col' }] } } },
+        },
+      }));
+      expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'legacy.jpg', layout: '1col' }]);
+    });
+  });
 });
 
 describe('mergeDocumentsCatalog', () => {
@@ -435,7 +471,9 @@ describe('spec: inserting/removing a paragraph at any position reindexes existin
 });
 
 describe('clinic logos', () => {
-  it('reads legacy bare file names from parties/cases/clinics as unassigned entries', () => {
+  // batch 17 §8: parties.cases.clinics is a legacy fallback now - only consulted for a clinic that
+  // doesn't already carry its own `logo` field.
+  it('reads legacy bare file names from parties/cases/clinics as unassigned entries (fallback only)', () => {
     const catalog = normalizeDocumentsCatalog(
       {
         clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
@@ -453,7 +491,7 @@ describe('clinic logos', () => {
     expect(catalog.parties.cases.map(record => record.id)).toEqual(['case-1']);
   });
 
-  it('reads { file, layout } entries and drops unknown layout tags', () => {
+  it('reads { file, layout } entries and drops unknown layout tags (legacy fallback path)', () => {
     const catalog = normalizeDocumentsCatalog(
       {
         cases: {
@@ -479,12 +517,56 @@ describe('clinic logos', () => {
     ]);
   });
 
-  it('falls back to legacy file names stored on the clinic record', () => {
+  // batch 17 §1/§2/§12: the clinic's own `logo` field is now the primary source - no
+  // `parties.cases.clinics` node is needed at all once a clinic carries it directly.
+  it('reads the logo directly from parties.clinics[clinicId].logo (primary, no cases.clinics needed)', () => {
     const catalog = normalizeDocumentsCatalog(
       { clinics: { 'clinic-1': { id: 'clinic-1', logo: ['legacy.jpg'] } } },
       null,
     );
     expect(catalog.clinicLogos['clinic-1']).toEqual([{ file: 'legacy.jpg', layout: '' }]);
+  });
+
+  it('parties.clinics[clinicId].logo wins over a stale parties.cases.clinics node for the same clinic (§12 #4)', () => {
+    const catalog = normalizeDocumentsCatalog(
+      {
+        clinics: {
+          'clinic-1': {
+            id: 'clinic-1',
+            logo: [{ file: 'current-1col.jpg', layout: '1col' }, { file: 'current-2col.jpg', layout: '2col' }],
+          },
+        },
+        cases: {
+          clinics: { 'clinic-1': { logo: [{ file: 'stale.jpg', layout: '1col' }] } },
+        },
+      },
+      null,
+    );
+    expect(catalog.clinicLogos['clinic-1']).toEqual([
+      { file: 'current-1col.jpg', layout: '1col' },
+      { file: 'current-2col.jpg', layout: '2col' },
+    ]);
+  });
+
+  it('resolveClinicLogo (getClinicLogo) reads {{logo}}/{{logo-long}} from parties.clinics[clinicId].logo (§12 #2/#3)', () => {
+    const catalog = normalizeDocumentsCatalog(
+      {
+        clinics: {
+          'clinic-1': {
+            id: 'clinic-1',
+            logo: [
+              { file: '1784230621524-mwe7prn3.jpg', layout: '1col' },
+              { file: '1784230642891-qzlngjn1.jpg', layout: '2col' },
+            ],
+          },
+        },
+        cases: { 'case-1': { id: 'case-1', clinicId: 'clinic-1' } },
+      },
+      null,
+    );
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(getClinicLogo(catalog.clinicLogos[context.clinic.id], 'logo').file).toBe('1784230621524-mwe7prn3.jpg');
+    expect(getClinicLogo(catalog.clinicLogos[context.clinic.id], 'logo-long').file).toBe('1784230642891-qzlngjn1.jpg');
   });
 
   it('picks the variant assigned to the selected column mode', () => {
@@ -1465,5 +1547,100 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
       }, {});
       expect(generated.beforeTitle[0].align).toBe('left');
     });
+  });
+});
+
+// Normalized structure (batch 17): the clinic's logo lives on the clinic record itself
+// (parties.clinics[clinicId].logo), never on a caseId - and a case only ever stores clinicId /
+// maternityHospitalId references, never the party data itself.
+describe('spec: normalized clinic + maternityHospital structure (batch 17)', () => {
+  const clinicAndHospitalCatalog = () => normalizeDocumentsCatalog(
+    {
+      clinics: {
+        'clinic-1': {
+          id: 'clinic-1',
+          name: { uk: 'Клініка генетики репродукції «Вікторія»', en: 'Reproductive Genetics Clinic "Victoria"' },
+          logo: [
+            { file: '1784230621524-mwe7prn3.jpg', layout: '1col' },
+            { file: '1784230642891-qzlngjn1.jpg', layout: '2col' },
+          ],
+        },
+      },
+      maternityHospitals: {
+        'maternity-hospital-1': {
+          id: 'maternity-hospital-1',
+          name: { uk: 'КОМУНАЛЬНЕ НЕКОМЕРЦІЙНЕ ПІДПРИЄМСТВО "ПЕРИНАТАЛЬНИЙ ЦЕНТР М. КИЄВА"', en: '' },
+          shortName: { uk: 'Перинатальний центр м. Києва', en: '' },
+          edrpou: '22964365',
+          address: { uk: 'місто Київ', en: 'Kyiv' },
+        },
+      },
+      cases: {
+        'case-1': {
+          id: 'case-1',
+          clinicId: 'clinic-1',
+          birthRegistration: {
+            medicalConclusion: { number: '1234-7H6A-2T6C-CK24', date: '2026-05-16', maternityHospitalId: 'maternity-hospital-1' },
+          },
+        },
+      },
+    },
+    {},
+  );
+
+  it('finds the clinic through case.clinicId, not a per-case node (§1, §12 #1)', () => {
+    const context = resolveCaseContext(clinicAndHospitalCatalog(), 'case-1');
+    expect(context.clinic.id).toBe('clinic-1');
+    expect(fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).toBe('Клініка генетики репродукції «Вікторія»');
+  });
+
+  it('resolveClinicLogo picks the 1col/2col variant from parties.clinics[clinicId].logo, not tied to caseId (§2, §12 #2/#3)', () => {
+    const catalog = clinicAndHospitalCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const clinicLogos = catalog.clinicLogos[context.clinic.id];
+    expect(getClinicLogo(clinicLogos, 'logo').file).toBe('1784230621524-mwe7prn3.jpg');
+    expect(getClinicLogo(clinicLogos, 'logo-long').file).toBe('1784230642891-qzlngjn1.jpg');
+  });
+
+  it('exposes maternityHospital.shortName/address/edrpou through the generic resolver, no dedicated code (§3/§5)', () => {
+    const context = resolveCaseContext(clinicAndHospitalCatalog(), 'case-1');
+    expect(fillPlaceholders('{{maternityHospital.shortName.uk}}', context, 'uk')).toBe('Перинатальний центр м. Києва');
+    expect(fillPlaceholders('{{maternityHospital.address.uk}}', context, 'uk')).toBe('місто Київ');
+    expect(fillPlaceholders('{{maternityHospital.edrpou}}', context, 'uk')).toBe('22964365');
+  });
+
+  it('an unknown clinicId resolves clinic to null without crashing (§10, §12 #8)', () => {
+    const catalog = clinicAndHospitalCatalog();
+    catalog.parties.cases[0].clinicId = 'no-such-clinic';
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.clinic).toBeNull();
+    expect(() => fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+
+  it('an unknown maternityHospitalId resolves maternityHospital to null without crashing (§10, §12 #9)', () => {
+    const catalog = clinicAndHospitalCatalog();
+    catalog.parties.cases[0].birthRegistration.medicalConclusion.maternityHospitalId = 'ghost-hospital';
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.maternityHospital).toBeNull();
+    expect(() => fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+
+  it('old clinic.* variables keep working unchanged (§12 #11)', () => {
+    const context = resolveCaseContext(richCatalog(), 'case-1');
+    expect(fillPlaceholders('{{clinic.medicalDirector.name.uk.genitive}}', context, 'uk')).toBe('Давид Лілії Володимирівни');
+  });
+
+  it('persisting the catalog never re-creates parties.cases.clinics (§12 #12)', () => {
+    const catalog = clinicAndHospitalCatalog();
+    const backend = catalogPartiesToBackend(catalog);
+    expect(backend.cases['case-1'].clinics).toBeUndefined();
+    expect(Object.values(backend.cases).some(record => record && record.clinics)).toBe(false);
+    // The clinic record's own `logo` field is exactly what gets persisted - not a sibling node.
+    expect(backend.clinics['clinic-1'].logo).toEqual([
+      { file: '1784230621524-mwe7prn3.jpg', layout: '1col' },
+      { file: '1784230642891-qzlngjn1.jpg', layout: '2col' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Clinic logo is now read primarily from `parties.clinics[clinicId].logo` (alongside `name`/`legalName`/etc.), not the old sibling `parties.cases.clinics` node - a clinic is shared across many cases, so its logo was never really case-scoped. `parties.cases.clinics` is kept as a temporary read-only fallback for clinics not yet migrated (both `normalizeDocumentsCatalog` and `parseDocumentsTechnicalInput`).
- `clinicLogoDbPath`/`clinicLogoStorageFolder` now point at `parties/clinics/{id}/logo`; the old `parties/cases/clinics/{id}/logo` Storage folder is still consulted as a read-only fallback so already-uploaded logos keep resolving until each clinic is re-saved under the new path. New uploads always go to the new path.
- `maternityHospitals` (added in a prior batch) is confirmed/tested to resolve `shortName`/`address`/`edrpou` through the existing generic path resolver, with a missing clinic or maternity hospital resolving to `null` instead of crashing.

## Test plan
- [x] New tests: clinic-logo priority flip (clinic.logo wins, cases.clinics is fallback-only) in both `normalizeDocumentsCatalog` and `parseDocumentsTechnicalInput`.
- [x] New tests: `{{logo}}`/`{{logo-long}}` resolve off `parties.clinics[clinicId].logo`, not tied to a caseId.
- [x] New tests: unknown `clinicId` / `maternityHospitalId` resolve to `null` without throwing.
- [x] New test: persisting the catalog never re-creates `parties.cases.clinics`.
- [x] Regression: old `clinic.*` template variables still resolve unchanged.
- [x] Full Documents test suite (`documentsCatalogUtils.test.js`, `DocumentsRenderers.smoke.test.js`, `DocumentsPageNumbering.smoke.test.js`, `DocumentsPage.richFormatting.test.js`): 159/159 passing.
- [x] `eslint` clean on the changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DMTKizBC4vNqzMs15tjGup)_