### PR TITLE
Normalize case records onto relations/program/childbirth/registrations/documents

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -846,13 +846,13 @@ const DocumentsPage = ({ isAdmin }) => {
     if (!template) return;
     const nextTemplate = { ...template, paragraphs: buildParagraphs(template.paragraphs || []) };
     const shiftedByCaseId = catalog.parties.cases
-      .filter(caseRecord => caseRecord.docOverrides?.[docId])
-      .map(caseRecord => [caseRecord.id, shiftDocOverrideParagraphIndices(caseRecord.docOverrides[docId], atIndex, delta)]);
+      .filter(caseRecord => caseRecord.documents?.overrides?.[docId])
+      .map(caseRecord => [caseRecord.id, shiftDocOverrideParagraphIndices(caseRecord.documents.overrides[docId], atIndex, delta)]);
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
       const partiesPatch = {};
       shiftedByCaseId.forEach(([caseId, override]) => {
-        partiesPatch[`cases/${caseId}/docOverrides/${docId}`] = override;
+        partiesPatch[`cases/${caseId}/documents/overrides/${docId}`] = override;
       });
       if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
       setCatalog(previous => ({
@@ -863,7 +863,10 @@ const DocumentsPage = ({ isAdmin }) => {
           cases: previous.parties.cases.map(caseRecord => {
             const shifted = shiftedByCaseId.find(([caseId]) => caseId === caseRecord.id);
             if (!shifted) return caseRecord;
-            return { ...caseRecord, docOverrides: { ...(caseRecord.docOverrides || {}), [docId]: shifted[1] } };
+            return {
+              ...caseRecord,
+              documents: { ...(caseRecord.documents || {}), overrides: { ...(caseRecord.documents?.overrides || {}), [docId]: shifted[1] } },
+            };
           }),
         },
       }));
@@ -909,7 +912,7 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   // --- Data-mode editing (pencil "Data" mode, spec §2) ------------------------------------------
-  // Edits to the resolved text are kept per case as sparse overrides (case.docOverrides[docId])
+  // Edits to the resolved text are kept per case as sparse overrides (case.documents.overrides[docId])
   // so the shared template with its {{tokens}} stays untouched.
 
   const updateCaseDocOverride = (docId, updater) => {
@@ -921,9 +924,12 @@ const DocumentsPage = ({ isAdmin }) => {
         cases: previous.parties.cases.map(caseRecord => (String(caseRecord.id) === selectedCaseId
           ? {
             ...caseRecord,
-            docOverrides: {
-              ...(caseRecord.docOverrides || {}),
-              [docId]: updater(caseRecord.docOverrides?.[docId] || {}),
+            documents: {
+              ...(caseRecord.documents || {}),
+              overrides: {
+                ...(caseRecord.documents?.overrides || {}),
+                [docId]: updater(caseRecord.documents?.overrides?.[docId] || {}),
+              },
             },
           }
           : caseRecord)),
@@ -956,21 +962,21 @@ const DocumentsPage = ({ isAdmin }) => {
     if (!caseRecord || !template) return;
     // Only real deviations from the resolved template survive on the backend.
     const baseline = buildGeneratedDocument(template, resolveCaseContext(catalog, selectedCaseId));
-    const pruned = pruneDocOverride(caseRecord.docOverrides?.[docId], baseline);
+    const pruned = pruneDocOverride(caseRecord.documents?.overrides?.[docId], baseline);
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/docOverrides/${docId}`), pruned);
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/documents/overrides/${docId}`), pruned);
       setCatalog(previous => ({
         ...previous,
         parties: {
           ...previous.parties,
           cases: previous.parties.cases.map(item => {
             if (String(item.id) !== String(caseRecord.id)) return item;
-            const docOverrides = { ...(item.docOverrides || {}) };
-            if (pruned) docOverrides[docId] = pruned;
-            else delete docOverrides[docId];
+            const overrides = { ...(item.documents?.overrides || {}) };
+            if (pruned) overrides[docId] = pruned;
+            else delete overrides[docId];
             return {
               ...item,
-              docOverrides: Object.keys(docOverrides).length ? docOverrides : undefined,
+              documents: { ...(item.documents || {}), overrides },
             };
           }),
         },
@@ -1037,7 +1043,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!caseRecord || !template) return;
     const baseline = buildGeneratedDocument(template, resolveCaseContext(catalog, selectedCaseId));
-    const currentOverride = caseRecord.docOverrides?.[docId] || {};
+    const currentOverride = caseRecord.documents?.overrides?.[docId] || {};
     const currentRaw = currentOverride.paragraphs?.[index]?.[langKey] ?? baseline.paragraphs[index]?.[langKey] ?? '';
     const nextRaw = toggleInlineFormat(currentRaw, start, end, attr);
     const nextOverride = {
@@ -1049,17 +1055,17 @@ const DocumentsPage = ({ isAdmin }) => {
     };
     const pruned = pruneDocOverride(nextOverride, baseline);
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/docOverrides/${docId}`), pruned);
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/documents/overrides/${docId}`), pruned);
       setCatalog(previous => ({
         ...previous,
         parties: {
           ...previous.parties,
           cases: previous.parties.cases.map(item => {
             if (String(item.id) !== String(caseRecord.id)) return item;
-            const docOverrides = { ...(item.docOverrides || {}) };
-            if (pruned) docOverrides[docId] = pruned;
-            else delete docOverrides[docId];
-            return { ...item, docOverrides: Object.keys(docOverrides).length ? docOverrides : undefined };
+            const overrides = { ...(item.documents?.overrides || {}) };
+            if (pruned) overrides[docId] = pruned;
+            else delete overrides[docId];
+            return { ...item, documents: { ...(item.documents || {}), overrides } };
           }),
         },
       }));
@@ -1140,7 +1146,7 @@ const DocumentsPage = ({ isAdmin }) => {
           return;
         }
 
-        const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
+        const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
         if (!clinicId) {
           toast.error('Select a case with a clinic before uploading the logo.');
           return;
@@ -1208,7 +1214,7 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   const handleAssignLogoLayout = async (fileName, layoutTag) => {
-    const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
+    const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
     if (!clinicId) return;
     const previousVariants = clinicLogos;
     const nextVariants = applyLogoLayoutAssignment(previousVariants, fileName, layoutTag);
@@ -1224,7 +1230,7 @@ const DocumentsPage = ({ isAdmin }) => {
 
   const handleRemoveLogoVariant = async fileName => {
     if (typeof window !== 'undefined' && !window.confirm('Remove this clinic logo variant from the backend?')) return;
-    const clinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
+    const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
     if (!clinicId) return;
     // A variant loaded via the legacy Storage-folder fallback still physically lives there.
     const isLegacyVariant = Boolean(clinicLogos.find(variant => variant.fileName === fileName)?.legacyFolder);
@@ -1355,7 +1361,7 @@ const DocumentsPage = ({ isAdmin }) => {
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
   // source of truth here, so logos uploaded through the app or Firebase Console are discovered
   // without relying on a Realtime Database filename mirror.
-  const logoClinicId = selectedCase?.clinicId ? String(selectedCase.clinicId) : '';
+  const logoClinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
   const clinicLogoStorageKey = `${logoClinicId}:${clinicLogoRefreshKey}`;
 
   // Fetch every stored logo variant of the selected clinic from Storage; the dimensions are what
@@ -1453,7 +1459,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const generated = selectedTemplates.map(template => buildGeneratedDocument(
       template,
       context,
-      selectedCase?.docOverrides?.[template.id],
+      selectedCase?.documents?.overrides?.[template.id],
     ));
     // Each document renders with the shared defaults merged with its own format overrides (spec
     // §5) - independent of whichever document (if any) the Format panel currently targets.
@@ -1678,7 +1684,7 @@ const DocumentsPage = ({ isAdmin }) => {
                 const showEn = isBilingual || getLayoutLang(layout) === 'en';
                 const isSingle = !(showUk && showEn);
                 const resolvedDoc = isExpanded && isDataMode
-                  ? buildGeneratedDocument(template, caseContext, selectedCase?.docOverrides?.[template.id])
+                  ? buildGeneratedDocument(template, caseContext, selectedCase?.documents?.overrides?.[template.id])
                   : null;
                 // Whichever source is currently authoritative (the dedicated `logo` field, or a
                 // legacy leading paragraph) shown as one plain-text value the admin can type into

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -125,6 +125,10 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
       rawCollection = caseRecords;
     }
     catalog.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
+    // Batch 18: every case is migrated to the new relations/program/childbirth/registrations/
+    // documents shape right at ingestion, so nothing downstream ever has to branch on which shape
+    // a given case record happens to carry.
+    if (collection === 'cases') catalog.parties.cases = catalog.parties.cases.map(normalizeCaseRecord);
   });
   catalog.documents = toRecordsWithIdFromKey(rawTemplates).filter(record => isPlainObject(record));
   // Primary (batch 17 §1/§2): a clinic's own `logo` field, alongside its name/legalName/etc. - a
@@ -195,6 +199,9 @@ export const parseDocumentsTechnicalInput = rawText => {
       if (isPlainObject(clinicLogoNode)) legacyClinicLogoNode = clinicLogoNode;
     }
     incoming.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
+    // Batch 18: migrate every pasted case to the new relations/program/childbirth/registrations/
+    // documents shape right away, same as normalizeDocumentsCatalog.
+    if (collection === 'cases') incoming.parties.cases = incoming.parties.cases.map(normalizeCaseRecord);
   });
   incoming.documents = toRecordsWithIdFromKey(templatesSource).filter(record => isPlainObject(record));
 
@@ -489,19 +496,124 @@ export const formatEnglishDateWords = value => {
   return `${EN_DAY_ORDINALS[day]} of ${EN_MONTHS[month]}, ${year}`;
 };
 
+// --- Case shape (batch 18) --------------------------------------------------------------------
+// One case is one concrete combination of couple + clinic + surrogate mother + representative(s)
+// (spec: "один case — це одна конкретна комбінація"); changing the clinic or surrogate mother means
+// creating a new case rather than mutating this one in place, so there is no active/replaced/from/to
+// history to track inside a single case record.
+
+// A freshly-created case: every relation blank, ready for the admin to pick a couple/clinic/
+// surrogate mother/representatives - never pre-filled from another case (spec §14: no auto-copy).
+export const createEmptyCase = ({ caseId, programId = '' } = {}) => ({
+  id: caseId,
+  programId,
+  relations: {
+    coupleId: '', clinicId: '', surrogateMotherId: '', representativeIds: [],
+  },
+  program: {
+    type: 'surrogacy',
+    agreement: { number: { uk: '', en: '' }, date: '' },
+  },
+  childbirth: { maternityHospitalId: '', children: [] },
+  registrations: { birth: { statementDate: '', notaryId: '' } },
+  documents: { overrides: {} },
+});
+
+// A new child record for the childbirth.children editor (spec §13) - a stable generated id, never
+// the array index, since children can be reordered/removed independently of any document that
+// still references an earlier one by id.
+export const createChildRecord = () => ({
+  id: makeRecordId('child'),
+  sex: '',
+  birthDate: '',
+  birthPlace: { uk: '', en: '' },
+  medicalConclusion: { number: '', date: '' },
+});
+
+// Migrates a pre-batch-18 case record (coupleId/clinicId/surrogateMotherId/representativeIds at the
+// top level, surrogacyAgreement, birthRegistration.{child,medicalConclusion.maternityHospitalId,
+// statementDate,notaryId}, docOverrides) onto the new shape - spec §16: a temporary read-time
+// normalizer, but once normalized the legacy top-level fields are dropped rather than carried
+// forward, so re-saving a migrated case never recreates them (spec: "не записувати назад старі
+// поля"). Idempotent: a case that already has `relations`/`program`/`childbirth`/`registrations`/
+// `documents` passes through those as-is.
+export const normalizeCaseRecord = (rawCase = {}) => {
+  const {
+    coupleId, clinicId, surrogateMotherId, representativeIds,
+    surrogacyAgreement, birthRegistration: legacyBirthRegistration, docOverrides,
+    ...rest
+  } = isPlainObject(rawCase) ? rawCase : {};
+
+  const relations = isPlainObject(rest.relations) ? rest.relations : {
+    coupleId: coupleId ?? '',
+    clinicId: clinicId ?? '',
+    surrogateMotherId: surrogateMotherId ?? '',
+    representativeIds: Array.isArray(representativeIds) ? representativeIds : [],
+  };
+
+  const program = isPlainObject(rest.program) ? rest.program : {
+    type: 'surrogacy',
+    agreement: isPlainObject(surrogacyAgreement) ? surrogacyAgreement : { number: { uk: '', en: '' }, date: '' },
+  };
+
+  const legacyChild = isPlainObject(legacyBirthRegistration?.child) ? legacyBirthRegistration.child : null;
+  const legacyMedicalConclusion = isPlainObject(legacyBirthRegistration?.medicalConclusion) ? legacyBirthRegistration.medicalConclusion : {};
+  const childbirth = isPlainObject(rest.childbirth) ? rest.childbirth : {
+    maternityHospitalId: legacyMedicalConclusion.maternityHospitalId ?? '',
+    // maternityHospitalId moved up onto childbirth itself (shared by every child of one birth
+    // event) - never duplicated back onto the per-child medicalConclusion.
+    children: legacyChild ? [{
+      id: makeRecordId('child'),
+      ...legacyChild,
+      medicalConclusion: { number: legacyMedicalConclusion.number ?? '', date: legacyMedicalConclusion.date ?? '' },
+    }] : [],
+  };
+
+  const registrations = isPlainObject(rest.registrations) ? rest.registrations : {
+    birth: {
+      statementDate: legacyBirthRegistration?.statementDate ?? '',
+      notaryId: legacyBirthRegistration?.notaryId ?? '',
+    },
+  };
+
+  const documents = isPlainObject(rest.documents) ? rest.documents : {
+    overrides: isPlainObject(docOverrides) ? docOverrides : {},
+  };
+
+  return {
+    ...rest, relations, program, childbirth, registrations, documents,
+  };
+};
+
+// One case is one concrete relations combination (spec batch 18 §10); a case picked by programId
+// alone would be ambiguous (several cases can share a programId - see createEmptyCase) - the
+// currently-selected case is whatever the caller/UI passed as caseId, never an "active" flag.
 export const resolveCaseContext = (catalog, caseId) => {
-  const caseRecord = findById(catalog?.parties?.cases, caseId);
-  if (!caseRecord) return null;
-  const couple = findById(catalog.parties.couples, caseRecord.coupleId);
+  const rawCaseRecord = findById(catalog?.parties?.cases, caseId);
+  if (!rawCaseRecord) return null;
+  // Defensively re-normalized here too (idempotent) - a case can reach this function without
+  // having passed through normalizeDocumentsCatalog/parseDocumentsTechnicalInput first (e.g. a
+  // freshly created or duplicated case still held only in local UI state).
+  const caseRecord = normalizeCaseRecord(rawCaseRecord);
+  const relations = caseRecord.relations;
+
+  const couple = findById(catalog.parties.couples, relations.coupleId);
   const partners = toArray(couple?.partners);
   const wife = partners.find(partner => partner?.role === 'wife') || partners[0] || null;
   const husband = partners.find(partner => partner?.role === 'husband') || partners[1] || null;
-  const representatives = toArray(caseRecord.representativeIds)
+  const representatives = toArray(relations.representativeIds)
     .map(id => findById(catalog.parties.representatives, id))
     .filter(Boolean);
 
-  const rawBirthRegistration = isPlainObject(caseRecord.birthRegistration) ? caseRecord.birthRegistration : {};
-  const medicalConclusion = isPlainObject(rawBirthRegistration.medicalConclusion) ? rawBirthRegistration.medicalConclusion : {};
+  const childbirth = isPlainObject(caseRecord.childbirth) ? caseRecord.childbirth : {};
+  const rawChildren = toArray(childbirth.children);
+  // The first child is the current fallback for single-child documents (spec §4: "не прив'язувати
+  // систему назавжди лише до children[0]") - `children` (every child, gender-computed) is exposed
+  // alongside it so a future multi-child template isn't blocked on this shape.
+  const rawChild = isPlainObject(rawChildren[0]) ? rawChildren[0] : {};
+  const medicalConclusion = isPlainObject(rawChild.medicalConclusion) ? rawChild.medicalConclusion : {};
+
+  const rawBirthRegistration = isPlainObject(caseRecord.registrations?.birth) ? caseRecord.registrations.birth : {};
   const birthRegistration = {
     ...rawBirthRegistration,
     statementDateWords: {
@@ -512,17 +624,22 @@ export const resolveCaseContext = (catalog, caseId) => {
 
   return {
     case: caseRecord,
+    programId: caseRecord.programId ?? '',
+    relations,
+    program: isPlainObject(caseRecord.program) ? caseRecord.program : {},
     couple,
     wife,
     husband,
-    surrogateMother: findById(catalog.parties.surrogateMothers, caseRecord.surrogateMotherId),
-    clinic: findById(catalog.parties.clinics, caseRecord.clinicId),
+    surrogateMother: findById(catalog.parties.surrogateMothers, relations.surrogateMotherId),
+    clinic: findById(catalog.parties.clinics, relations.clinicId),
     representative: representatives[0] || null,
     representatives,
-    birthRegistration,
-    child: buildChildContext(isPlainObject(rawBirthRegistration.child) ? rawBirthRegistration.child : {}),
+    childbirth,
+    children: rawChildren.map(buildChildContext),
+    child: buildChildContext(rawChild),
     medicalConclusion,
-    maternityHospital: findById(catalog.parties.maternityHospitals, medicalConclusion.maternityHospitalId),
+    maternityHospital: findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId),
+    birthRegistration,
     notary: findById(catalog.parties.notaries, rawBirthRegistration.notaryId),
   };
 };
@@ -622,10 +739,36 @@ export const validateDocumentTemplate = (template, context) => {
   return [...missing].sort();
 };
 
-// --- Birth-registration surrogate-consent: pre-export field checklist (batch 16 §20) --------
-// A non-blocking checklist of the fields this specific document needs, shown before export rather
-// than enforced while editing - missing hospital/notary lookups and malformed dates are reported
-// the same way as a genuinely empty field, never as a thrown error.
+// --- Case completeness checklists (batch 18 §18) --------------------------------------------
+// Non-blocking checklists shown before saving/exporting rather than enforced while editing -
+// missing data is reported the same way as a genuinely empty field, never as a thrown error.
+
+// The base checklist any case should satisfy, independent of which documents it's used for.
+export const validateCaseRecord = rawCaseRecord => {
+  const caseRecord = normalizeCaseRecord(rawCaseRecord);
+  const issues = [];
+  const isBlank = value => value === undefined || value === null || String(value).trim() === '';
+  const requirePresent = (value, path) => {
+    if (isBlank(value)) issues.push(path);
+  };
+
+  requirePresent(caseRecord.id, 'case.id');
+  requirePresent(caseRecord.programId, 'case.programId');
+  requirePresent(caseRecord.relations?.coupleId, 'case.relations.coupleId');
+  requirePresent(caseRecord.relations?.clinicId, 'case.relations.clinicId');
+  requirePresent(caseRecord.relations?.surrogateMotherId, 'case.relations.surrogateMotherId');
+  requirePresent(caseRecord.program?.type, 'case.program.type');
+  if (!toArray(caseRecord.childbirth?.children).length) issues.push('case.childbirth.children');
+  if (isBlank(caseRecord.registrations?.birth?.statementDate) && isBlank(caseRecord.registrations?.birth?.notaryId)) {
+    issues.push('case.registrations.birth');
+  }
+
+  return issues;
+};
+
+// The birth-registration surrogate-consent statement's own checklist (spec batch 16 §20; field
+// locations updated for the batch 18 case shape) - missing hospital/notary lookups and malformed
+// dates are reported the same way as a genuinely empty field.
 export const validateBirthRegistrationCase = (catalog, caseId) => {
   const context = resolveCaseContext(catalog, caseId);
   if (!context) return ['case'];
@@ -636,38 +779,38 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
     if (isBlank(value)) issues.push(path);
   };
 
-  const { birthRegistration, surrogateMother, maternityHospital, notary } = context;
-  const child = birthRegistration.child || {};
-  const medicalConclusion = birthRegistration.medicalConclusion || {};
+  const {
+    childbirth, child, medicalConclusion, birthRegistration, surrogateMother, maternityHospital, notary,
+  } = context;
 
-  requirePresent(child.sex, 'birthRegistration.child.sex');
-  requirePresent(child.birthDate, 'birthRegistration.child.birthDate');
-  requirePresent(child.birthPlace?.uk, 'birthRegistration.child.birthPlace.uk');
-  requirePresent(medicalConclusion.number, 'birthRegistration.medicalConclusion.number');
-  requirePresent(medicalConclusion.date, 'birthRegistration.medicalConclusion.date');
-  requirePresent(medicalConclusion.maternityHospitalId, 'birthRegistration.medicalConclusion.maternityHospitalId');
-  requirePresent(birthRegistration.statementDate, 'birthRegistration.statementDate');
-  requirePresent(birthRegistration.notaryId, 'birthRegistration.notaryId');
+  requirePresent(childbirth.maternityHospitalId, 'case.childbirth.maternityHospitalId');
+  requirePresent(child.sex, 'case.childbirth.children[0].sex');
+  requirePresent(child.birthDate, 'case.childbirth.children[0].birthDate');
+  requirePresent(child.birthPlace?.uk, 'case.childbirth.children[0].birthPlace.uk');
+  requirePresent(medicalConclusion.number, 'case.childbirth.children[0].medicalConclusion.number');
+  requirePresent(medicalConclusion.date, 'case.childbirth.children[0].medicalConclusion.date');
+  requirePresent(birthRegistration.statementDate, 'case.registrations.birth.statementDate');
+  requirePresent(birthRegistration.notaryId, 'case.registrations.birth.notaryId');
   requirePresent(surrogateMother?.taxId, 'surrogateMother.taxId');
   requirePresent(surrogateMother?.address?.uk, 'surrogateMother.address.uk');
 
   if (!isBlank(child.sex) && child.sex !== 'female' && child.sex !== 'male') {
-    issues.push('birthRegistration.child.sex (must be "female" or "male")');
+    issues.push('case.childbirth.children[0].sex (must be "female" or "male")');
   }
   if (!isBlank(child.birthDate) && !isIsoDate(child.birthDate)) {
-    issues.push('birthRegistration.child.birthDate (must be YYYY-MM-DD)');
+    issues.push('case.childbirth.children[0].birthDate (must be YYYY-MM-DD)');
   }
   if (!isBlank(medicalConclusion.date) && !isIsoDate(medicalConclusion.date)) {
-    issues.push('birthRegistration.medicalConclusion.date (must be YYYY-MM-DD)');
+    issues.push('case.childbirth.children[0].medicalConclusion.date (must be YYYY-MM-DD)');
   }
   if (!isBlank(birthRegistration.statementDate) && !isIsoDate(birthRegistration.statementDate)) {
-    issues.push('birthRegistration.statementDate (must be YYYY-MM-DD)');
+    issues.push('case.registrations.birth.statementDate (must be YYYY-MM-DD)');
   }
-  if (!isBlank(medicalConclusion.maternityHospitalId) && !maternityHospital) {
-    issues.push('birthRegistration.medicalConclusion.maternityHospitalId (no matching maternity hospital)');
+  if (!isBlank(childbirth.maternityHospitalId) && !maternityHospital) {
+    issues.push('case.childbirth.maternityHospitalId (no matching maternity hospital)');
   }
   if (!isBlank(birthRegistration.notaryId) && !notary) {
-    issues.push('birthRegistration.notaryId (no matching notary)');
+    issues.push('case.registrations.birth.notaryId (no matching notary)');
   }
 
   return issues;
@@ -885,13 +1028,14 @@ export const pruneDocOverride = (docOverride, baselineDoc) => {
 
 export const buildCaseLabel = (catalog, caseRecord) => {
   if (!caseRecord) return '';
-  const couple = findById(catalog?.parties?.couples, caseRecord.coupleId);
+  const relations = normalizeCaseRecord(caseRecord).relations;
+  const couple = findById(catalog?.parties?.couples, relations.coupleId);
   const partners = toArray(couple?.partners);
   const coupleNames = partners
     .map(partner => localizedText(partner?.name, 'en') || localizedText(partner?.name?.uk, 'uk'))
     .filter(Boolean)
     .join(' & ');
-  const surrogate = findById(catalog?.parties?.surrogateMothers, caseRecord.surrogateMotherId);
+  const surrogate = findById(catalog?.parties?.surrogateMothers, relations.surrogateMotherId);
   const surrogateName = localizedText(surrogate?.name, 'en');
   const parts = [coupleNames, surrogateName ? `SM ${surrogateName}` : ''].filter(Boolean);
   return parts.join(' — ') || String(caseRecord.id);

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -11,6 +11,8 @@ import {
   buildGeneratedDocument,
   catalogPartiesToBackend,
   clinicLogoEntriesToBackend,
+  createChildRecord,
+  createEmptyCase,
   deepMergeRecords,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
@@ -33,6 +35,7 @@ import {
   isSingleLanguageTwoColumnLayout,
   MISSING_VALUE_PLACEHOLDER,
   mergeDocumentsCatalog,
+  normalizeCaseRecord,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
@@ -54,6 +57,7 @@ import {
   upsertRecentCaseId,
   upsertRecentId,
   validateBirthRegistrationCase,
+  validateCaseRecord,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
@@ -207,7 +211,8 @@ describe('parseDocumentsTechnicalInput', () => {
     }));
     expect(parsed.parties.cases).toHaveLength(1);
     expect(parsed.parties.cases[0].id).toBe('case-1');
-    expect(parsed.parties.cases[0].birthRegistration.notaryId).toBe('notary-1');
+    // batch 18: the legacy top-level birthRegistration is migrated onto case.registrations.birth.
+    expect(parsed.parties.cases[0].registrations.birth.notaryId).toBe('notary-1');
   });
 
   it('merging that id-less paste into an existing catalog updates case-1 in place instead of creating a second case', () => {
@@ -226,9 +231,8 @@ describe('parseDocumentsTechnicalInput', () => {
     expect(summary).toEqual({ added: 0, updated: 1 });
     expect(catalog.parties.cases[0]).toMatchObject({
       id: 'case-1',
-      coupleId: 'couple-1',
-      surrogateMotherId: 'surrogate-1',
-      birthRegistration: { statementDate: '2026-05-18', notaryId: 'notary-1' },
+      relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' },
+      registrations: { birth: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
     });
   });
 
@@ -311,7 +315,7 @@ describe('mergeDocumentsCatalog', () => {
     const caseRecord = catalog.parties.cases[0];
     expect(caseRecord.embryoCount).toBe(2);
     expect(caseRecord.extra.anything).toBe('goes');
-    expect(caseRecord.coupleId).toBe('couple-1');
+    expect(caseRecord.relations.coupleId).toBe('couple-1');
   });
 
   it('generates ids for records pasted without one', () => {
@@ -376,7 +380,8 @@ describe('placeholders', () => {
     expect(fillPlaceholders('{{wife.name.uk.nominative}}', context, 'uk')).toBe('Тестова Марія');
     expect(fillPlaceholders('{{wife.name.uk.genitive}}', context, 'uk')).toBe('Тестової Марії');
     expect(fillPlaceholders('{{clinic.name.en}}', context, 'en')).toBe('Clinic "Mriia"');
-    expect(fillPlaceholders('{{case.surrogacyAgreement.number.uk}}', context, 'uk')).toBe('без номера');
+    // batch 18: case.surrogacyAgreement was migrated onto case.program.agreement.
+    expect(fillPlaceholders('{{case.program.agreement.number.uk}}', context, 'uk')).toBe('без номера');
   });
 
   it('falls back by language and to nominative when the path stops early', () => {
@@ -1463,28 +1468,28 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
       });
       const issues = validateBirthRegistrationCase(catalog, 'case-1');
       expect(issues).toEqual(expect.arrayContaining([
-        'birthRegistration.child.sex',
-        'birthRegistration.child.birthDate',
-        'birthRegistration.child.birthPlace.uk',
-        'birthRegistration.medicalConclusion.number',
-        'birthRegistration.medicalConclusion.date',
-        'birthRegistration.medicalConclusion.maternityHospitalId',
-        'birthRegistration.statementDate',
-        'birthRegistration.notaryId',
+        'case.childbirth.maternityHospitalId',
+        'case.childbirth.children[0].sex',
+        'case.childbirth.children[0].birthDate',
+        'case.childbirth.children[0].birthPlace.uk',
+        'case.childbirth.children[0].medicalConclusion.number',
+        'case.childbirth.children[0].medicalConclusion.date',
+        'case.registrations.birth.statementDate',
+        'case.registrations.birth.notaryId',
       ]));
     });
 
     it('flags an invalid sex value and a non-ISO date without blocking editing', () => {
       const catalog = birthRegistrationCatalog({ child: { sex: 'other', birthDate: '16.05.2026', birthPlace: { uk: 'Київ' } } });
       const issues = validateBirthRegistrationCase(catalog, 'case-1');
-      expect(issues).toContain('birthRegistration.child.sex (must be "female" or "male")');
-      expect(issues).toContain('birthRegistration.child.birthDate (must be YYYY-MM-DD)');
+      expect(issues).toContain('case.childbirth.children[0].sex (must be "female" or "male")');
+      expect(issues).toContain('case.childbirth.children[0].birthDate (must be YYYY-MM-DD)');
     });
 
     it('flags an unresolvable maternity hospital / notary id', () => {
       const catalog = birthRegistrationCatalog({ notaryId: 'ghost-notary' });
       const issues = validateBirthRegistrationCase(catalog, 'case-1');
-      expect(issues).toContain('birthRegistration.notaryId (no matching notary)');
+      expect(issues).toContain('case.registrations.birth.notaryId (no matching notary)');
     });
   });
 
@@ -1611,7 +1616,7 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
 
   it('an unknown clinicId resolves clinic to null without crashing (§10, §12 #8)', () => {
     const catalog = clinicAndHospitalCatalog();
-    catalog.parties.cases[0].clinicId = 'no-such-clinic';
+    catalog.parties.cases[0].relations.clinicId = 'no-such-clinic';
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.clinic).toBeNull();
     expect(() => fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).not.toThrow();
@@ -1620,7 +1625,7 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
 
   it('an unknown maternityHospitalId resolves maternityHospital to null without crashing (§10, §12 #9)', () => {
     const catalog = clinicAndHospitalCatalog();
-    catalog.parties.cases[0].birthRegistration.medicalConclusion.maternityHospitalId = 'ghost-hospital';
+    catalog.parties.cases[0].childbirth.maternityHospitalId = 'ghost-hospital';
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.maternityHospital).toBeNull();
     expect(() => fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).not.toThrow();
@@ -1642,5 +1647,260 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
       { file: '1784230621524-mwe7prn3.jpg', layout: '1col' },
       { file: '1784230642891-qzlngjn1.jpg', layout: '2col' },
     ]);
+  });
+});
+
+// One case is one concrete relations combination (batch 18 §10): couple + clinic + surrogate
+// mother + representative(s). Changing the clinic or surrogate mother means creating a new case,
+// never mutating this one's relations in place - there is no active/replaced/from/to history.
+describe('spec: normalized case structure (batch 18)', () => {
+  const twoCasesOneProgramCatalog = () => normalizeDocumentsCatalog(
+    {
+      couples: {
+        'couple-1': {
+          id: 'couple-1',
+          partners: [
+            { id: 'w1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } },
+            { id: 'h1', role: 'husband', name: { uk: { nominative: 'Тестовий Петро' }, en: 'Testovyi Petro' } },
+          ],
+        },
+      },
+      clinics: {
+        'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка А' } },
+        'clinic-2': { id: 'clinic-2', name: { uk: 'Клініка Б' } },
+      },
+      surrogateMothers: {
+        'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Сурогатна Одна' } } },
+        'surrogate-2': { id: 'surrogate-2', name: { uk: { nominative: 'Сурогатна Два' } } },
+      },
+      representatives: {
+        'representative-1': { id: 'representative-1', name: { uk: { nominative: 'Представник Один' } } },
+      },
+      maternityHospitals: {
+        'maternity-hospital-1': { id: 'maternity-hospital-1', name: { uk: 'Пологовий 1' }, edrpou: '11111111' },
+      },
+      notaries: {
+        'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Нотаріус Один' } } },
+      },
+      cases: {
+        'case-1': {
+          id: 'case-1',
+          programId: 'program-1',
+          relations: {
+            coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['representative-1'],
+          },
+          program: { type: 'surrogacy', agreement: { number: { uk: 'Договір №1', en: 'Agreement No.1' }, date: '2020-01-01' } },
+          childbirth: {
+            maternityHospitalId: 'maternity-hospital-1',
+            children: [
+              { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
+              { id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' } },
+            ],
+          },
+          registrations: { birth: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
+          documents: { overrides: { 'doc-1': { title: { uk: 'Перейменована заява' } } } },
+        },
+        'case-2': {
+          id: 'case-2',
+          programId: 'program-1',
+          relations: { coupleId: 'couple-1', clinicId: 'clinic-2', surrogateMotherId: 'surrogate-2', representativeIds: [] },
+          program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
+          childbirth: { maternityHospitalId: '', children: [] },
+          registrations: { birth: { statementDate: '', notaryId: '' } },
+          documents: { overrides: {} },
+        },
+      },
+    },
+    {},
+  );
+
+  it('finds the couple through case.relations.coupleId (§19 #1)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.wife.name.uk.nominative).toBe('Тестова Марія');
+    expect(context.husband.name.uk.nominative).toBe('Тестовий Петро');
+  });
+
+  it('finds the clinic through case.relations.clinicId (§19 #2)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.clinic.name.uk).toBe('Клініка А');
+  });
+
+  it('finds the surrogate mother through case.relations.surrogateMotherId (§19 #3)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.surrogateMother.name.uk.nominative).toBe('Сурогатна Одна');
+  });
+
+  it('finds the representative through case.relations.representativeIds (§19 #4)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.representative.name.uk.nominative).toBe('Представник Один');
+  });
+
+  it('reads the agreement from case.program.agreement (§19 #5)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(fillPlaceholders('{{case.program.type}}', context, 'uk')).toBe('surrogacy');
+    expect(fillPlaceholders('{{case.program.agreement.number.uk}}', context, 'uk')).toBe('Договір №1');
+    expect(fillPlaceholders('{{case.program.agreement.date}}', context, 'uk')).toBe('01.01.2020');
+  });
+
+  it('reads the maternity hospital from case.childbirth.maternityHospitalId (§19 #6)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.maternityHospital.edrpou).toBe('11111111');
+  });
+
+  it('the first child lands in context.child (§19 #7)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.child.sex).toBe('female');
+    expect(context.child.gender.uk.label).toBe('дівчинка');
+  });
+
+  it('every child lands in context.children, gender-computed (§19 #8)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.children).toHaveLength(2);
+    expect(context.children[0].gender.uk.label).toBe('дівчинка');
+    expect(context.children[1].gender.uk.label).toBe('хлопчик');
+  });
+
+  it('medicalConclusion is read from the child, not the case (§19 #9)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.medicalConclusion.number).toBe('MC-1');
+  });
+
+  it('the birth registration is read from case.registrations.birth (§19 #10)', () => {
+    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+    expect(context.birthRegistration.statementDate).toBe('2026-05-18');
+    expect(context.notary.name.uk.nominative).toBe('Нотаріус Один');
+  });
+
+  it('per-case document overrides are read from case.documents.overrides (§19 #11)', () => {
+    const catalog = twoCasesOneProgramCatalog();
+    const caseRecord = catalog.parties.cases.find(item => item.id === 'case-1');
+    const template = { id: 'doc-1', title: { uk: 'Заява' }, paragraphs: [] };
+    const generated = buildGeneratedDocument(template, resolveCaseContext(catalog, 'case-1'), caseRecord.documents.overrides['doc-1']);
+    expect(generated.title.uk).toBe('Перейменована заява');
+  });
+
+  it('two cases sharing a programId can have different surrogate mothers (§19 #12)', () => {
+    const catalog = twoCasesOneProgramCatalog();
+    expect(resolveCaseContext(catalog, 'case-1').surrogateMother.id).toBe('surrogate-1');
+    expect(resolveCaseContext(catalog, 'case-2').surrogateMother.id).toBe('surrogate-2');
+  });
+
+  it('two cases sharing a programId can have different clinics (§19 #13)', () => {
+    const catalog = twoCasesOneProgramCatalog();
+    expect(resolveCaseContext(catalog, 'case-1').clinic.id).toBe('clinic-1');
+    expect(resolveCaseContext(catalog, 'case-2').clinic.id).toBe('clinic-2');
+  });
+
+  it('no case carries an active/replaced/from/to status (§19 #14)', () => {
+    const empty = createEmptyCase({ caseId: 'case-9', programId: 'program-9' });
+    expect(empty).not.toHaveProperty('active');
+    expect(empty).not.toHaveProperty('replaced');
+    expect(empty).not.toHaveProperty('from');
+    expect(empty).not.toHaveProperty('to');
+  });
+
+  it('the caseId the caller picks determines the current relations combination, not an "active" flag (§19 #15)', () => {
+    const catalog = twoCasesOneProgramCatalog();
+    const programCases = catalog.parties.cases.filter(item => item.programId === 'program-1');
+    expect(programCases).toHaveLength(2);
+    expect(resolveCaseContext(catalog, programCases[1].id).clinic.id).toBe('clinic-2');
+  });
+
+  it('a legacy-shaped case can be normalized (§19 #16)', () => {
+    const legacy = {
+      id: 'case-legacy',
+      coupleId: 'couple-1',
+      clinicId: 'clinic-1',
+      surrogateMotherId: 'surrogate-1',
+      representativeIds: ['representative-1'],
+      surrogacyAgreement: { number: { uk: 'без номера', en: 'without a number' }, date: '' },
+      birthRegistration: {
+        child: { sex: 'male', birthDate: '2026-01-01', birthPlace: { uk: 'Львів' } },
+        medicalConclusion: { number: 'MC-9', date: '2026-01-01', maternityHospitalId: 'maternity-hospital-1' },
+        statementDate: '2026-01-05',
+        notaryId: 'notary-1',
+      },
+      docOverrides: { 'doc-1': { title: { uk: 'X' } } },
+    };
+    const normalized = normalizeCaseRecord(legacy);
+    expect(normalized.relations).toEqual({
+      coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['representative-1'],
+    });
+    expect(normalized.program.agreement.number.uk).toBe('без номера');
+    expect(normalized.childbirth.maternityHospitalId).toBe('maternity-hospital-1');
+    expect(normalized.childbirth.children).toHaveLength(1);
+    expect(normalized.childbirth.children[0].sex).toBe('male');
+    expect(normalized.childbirth.children[0].medicalConclusion).toEqual({ number: 'MC-9', date: '2026-01-01' });
+    expect(normalized.registrations.birth).toEqual({ statementDate: '2026-01-05', notaryId: 'notary-1' });
+    expect(normalized.documents.overrides).toEqual({ 'doc-1': { title: { uk: 'X' } } });
+  });
+
+  it('after normalizing, the legacy top-level fields are dropped, not carried forward (§19 #17)', () => {
+    const normalized = normalizeCaseRecord({
+      id: 'case-legacy',
+      coupleId: 'couple-1',
+      clinicId: 'clinic-1',
+      surrogateMotherId: 'surrogate-1',
+      representativeIds: ['representative-1'],
+      surrogacyAgreement: { number: { uk: 'без номера', en: '' }, date: '' },
+      birthRegistration: { statementDate: '2026-01-05', notaryId: 'notary-1' },
+      docOverrides: {},
+    });
+    ['coupleId', 'clinicId', 'surrogateMotherId', 'representativeIds', 'surrogacyAgreement', 'birthRegistration', 'docOverrides']
+      .forEach(legacyKey => expect(normalized).not.toHaveProperty(legacyKey));
+  });
+
+  it('a two-child array does not break the generated preview (§19 #18)', () => {
+    const catalog = twoCasesOneProgramCatalog();
+    const template = {
+      id: 'doc-1',
+      title: { uk: 'Заява' },
+      paragraphs: [{ uk: '{{children.0.gender.uk.label}} та {{children.1.gender.uk.label}}' }],
+    };
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(() => buildGeneratedDocument(template, context)).not.toThrow();
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.paragraphs[0].uk).toBe('дівчинка та хлопчик');
+  });
+
+  it('an empty children array does not break the component (§19 #19)', () => {
+    const catalog = twoCasesOneProgramCatalog();
+    const context = resolveCaseContext(catalog, 'case-2');
+    expect(context.children).toEqual([]);
+    expect(context.child.sex).toBeUndefined();
+    expect(context.child.gender.uk.label).toBe('');
+    expect(() => fillPlaceholders('{{child.birthDate}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{child.birthDate}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+
+  it('the birth-registration surrogate-consent statement keeps generating correctly (§19 #20)', () => {
+    const catalog = birthRegistrationCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const generated = buildGeneratedDocument(catalog.documents[0], context);
+    expect(generated.paragraphs[0].uk).toContain('народженої мною 16.05.2026 року');
+    expect(generated.paragraphs[0].uk).toContain('яка народилась');
+    expect(generated.paragraphs[0].uk).not.toContain('undefined');
+    expect(generated.paragraphs[0].uk).not.toContain('null');
+    expect(generated.paragraphs[0].uk).not.toContain('[object Object]');
+    expect(validateBirthRegistrationCase(catalog, 'case-1')).toEqual([]);
+  });
+
+  it('validateCaseRecord reports the base checklist without throwing on a bare/empty case', () => {
+    expect(validateCaseRecord({})).toEqual(expect.arrayContaining([
+      'case.id', 'case.programId', 'case.relations.coupleId', 'case.relations.clinicId',
+      'case.relations.surrogateMotherId', 'case.childbirth.children', 'case.registrations.birth',
+    ]));
+    expect(validateCaseRecord(createEmptyCase({ caseId: 'case-9', programId: 'program-9' }))).toEqual(expect.arrayContaining([
+      'case.relations.coupleId', 'case.relations.clinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children', 'case.registrations.birth',
+    ]));
+    expect(validateCaseRecord(twoCasesOneProgramCatalog().parties.cases[0])).toEqual([]);
+  });
+
+  it('createChildRecord generates a stable id, never reusing an array index', () => {
+    const first = createChildRecord();
+    const second = createChildRecord();
+    expect(first.id).not.toBe(second.id);
+    expect(first.id).toMatch(/^child-/);
+    expect(first).toMatchObject({ sex: '', birthDate: '', birthPlace: { uk: '', en: '' }, medicalConclusion: { number: '', date: '' } });
   });
 });


### PR DESCRIPTION
## Summary
One case is now one concrete combination of couple + clinic + surrogate mother + representative(s); changing the clinic or surrogate mother means creating a new case rather than mutating an existing one in place, so there's no active/replaced/from/to history to track.

- `normalizeCaseRecord` migrates a pre-batch-18 case (top-level `coupleId`/`clinicId`/`surrogateMotherId`/`representativeIds`, `surrogacyAgreement`, `birthRegistration.{child,medicalConclusion,statementDate,notaryId}`, `docOverrides`) onto the new shape (`relations`, `program.agreement`, `childbirth.{maternityHospitalId,children[]}`, `registrations.birth`, `documents.overrides`), dropping the legacy top-level fields rather than carrying them forward so a re-saved case never recreates them. Wired into both `normalizeDocumentsCatalog` and `parseDocumentsTechnicalInput` so every case is migrated at ingestion.
- `resolveCaseContext` now reads couple/clinic/surrogateMother/representative(s) via `case.relations`, the agreement via `case.program`, the maternity hospital via `case.childbirth.maternityHospitalId`, the (first) child and medical conclusion via `case.childbirth.children`, and birth registration/notary via `case.registrations.birth` - exposing both `child` (first, for single-child documents) and `children` (every child, gender-computed) so a future multi-child template isn't blocked on this shape. Existing template variables (`{{wife.*}}`, `{{clinic.*}}`, `{{child.*}}`, `{{medicalConclusion.*}}`, `{{birthRegistration.*}}`, `{{notary.*}}`) keep resolving unchanged.
- `validateBirthRegistrationCase`'s field locations updated to match (maternity hospital id moved from `medicalConclusion` onto `childbirth` itself); added `validateCaseRecord` for the base case-completeness checklist.
- Added `createEmptyCase` (a fresh case's starting skeleton - never auto-copies another case's relations) and `createChildRecord` (stable generated child id, never an array index).
- `DocumentsPage.jsx`: clinic-logo Storage/DB paths now key off `case.relations.clinicId`; per-case document overrides read/write `case.documents.overrides` (both in-memory and the Firebase path) instead of `case.docOverrides`.

## Test plan
- [x] 22 new tests: relations/program/childbirth/registrations/documents resolution, multiple cases sharing a `programId` with different clinics/surrogate mothers, legacy-case normalization (and that legacy fields are dropped after normalizing), two-child and empty-children arrays don't crash, the birth-registration statement keeps generating correctly.
- [x] Full Documents test suite (`documentsCatalogUtils.test.js`, `DocumentsRenderers.smoke.test.js`, `DocumentsPageNumbering.smoke.test.js`, `DocumentsPage.richFormatting.test.js`): 181/181 passing.
- [x] `eslint` clean on the changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DMTKizBC4vNqzMs15tjGup)_