### PR TITLE
Add parties.transactions: a transaction pairs couple + surrogate mother + notary

### DIFF
--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -25,7 +25,7 @@ export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoSt
 export const legacyClinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const legacyClinicLogoStorageFilePath = (clinicId, fileName) => `${legacyClinicLogoStorageFolder(clinicId)}/${fileName}`;
 
-export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases', 'maternityHospitals', 'notaries'];
+export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases', 'maternityHospitals', 'notaries', 'transactions'];
 
 // mergeCollection derives an id prefix for un-identified incoming records by stripping a trailing
 // 's' off the collection name; 'notaries' isn't a simple plural ('notarys' would be wrong), so it
@@ -105,7 +105,7 @@ export const clinicLogoEntriesToBackend = variants => (variants || [])
 
 export const emptyDocumentsCatalog = () => ({
   parties: {
-    couples: [], surrogateMothers: [], representatives: [], clinics: [], cases: [], maternityHospitals: [], notaries: [],
+    couples: [], surrogateMothers: [], representatives: [], clinics: [], cases: [], maternityHospitals: [], notaries: [], transactions: [],
   },
   documents: [],
   clinicLogos: {},
@@ -515,7 +515,9 @@ export const createEmptyCase = ({ caseId, programId = '' } = {}) => ({
     agreement: { number: { uk: '', en: '' }, date: '' },
   },
   childbirth: { maternityHospitalId: '', children: [] },
-  registrations: { birth: { statementDate: '', notaryId: '' } },
+  // batch 19: the case only ever stores a transactionId - the actual notary/statementDate/
+  // registryNumber live on parties.transactions[transactionId] (see createTransaction).
+  registrations: { birth: { transactionId: '' } },
   documents: { overrides: {} },
 });
 
@@ -585,9 +587,56 @@ export const normalizeCaseRecord = (rawCase = {}) => {
   };
 };
 
+// --- Transactions (batch 19) -------------------------------------------------------------------
+// A transaction is one concrete combination of couple + surrogate mother + notary for a specific
+// legal act (e.g. the birth-registration surrogate-consent statement) - decoupled from the case's
+// current `relations` so a signed document keeps pointing at exactly who signed it even if the
+// case's relations were ever revisited later. The case only ever stores the transactionId; the
+// notary's own name/title/city live solely in `parties.notaries[notaryId]`, never copied in.
+export const createTransaction = ({
+  transactionId, caseId, type, coupleId, surrogateMotherId, notaryId, statementDate = '', registryNumber = '',
+}) => ({
+  id: transactionId,
+  type,
+  caseId,
+  coupleId,
+  surrogateMotherId,
+  notaryId,
+  statementDate,
+  registryNumber,
+});
+
+// `transactionType` guards against a stale/mistyped transactionId pointing at a transaction of a
+// different kind - resolves to null exactly like a missing transaction rather than silently
+// returning mismatched data.
+export const resolveTransaction = (catalog, caseRecord, transactionType) => {
+  const transactionId = caseRecord?.registrations?.birth?.transactionId;
+  const transaction = findById(catalog?.parties?.transactions, transactionId);
+  if (!transaction) return null;
+  if (transactionType && transaction.type !== transactionType) return null;
+  return transaction;
+};
+
+// Deleting a transaction (spec §14) never touches the couple/surrogate mother/notary records it
+// referenced - only the transaction itself and the transactionId reference(s) pointing at it.
+export const removeTransactionReferences = (catalog, transactionId) => ({
+  ...catalog,
+  parties: {
+    ...catalog.parties,
+    transactions: (catalog.parties.transactions || []).filter(item => String(item.id) !== String(transactionId)),
+    cases: (catalog.parties.cases || []).map(caseRecord => {
+      if (String(caseRecord.registrations?.birth?.transactionId) !== String(transactionId)) return caseRecord;
+      const { transactionId: _removed, ...restBirth } = caseRecord.registrations.birth;
+      return { ...caseRecord, registrations: { ...caseRecord.registrations, birth: restBirth } };
+    }),
+  },
+});
+
 // One case is one concrete relations combination (spec batch 18 §10); a case picked by programId
 // alone would be ambiguous (several cases can share a programId - see createEmptyCase) - the
 // currently-selected case is whatever the caller/UI passed as caseId, never an "active" flag.
+export const BIRTH_REGISTRATION_TRANSACTION_TYPE = 'birth-registration-surrogate-consent';
+
 export const resolveCaseContext = (catalog, caseId) => {
   const rawCaseRecord = findById(catalog?.parties?.cases, caseId);
   if (!rawCaseRecord) return null;
@@ -597,7 +646,16 @@ export const resolveCaseContext = (catalog, caseId) => {
   const caseRecord = normalizeCaseRecord(rawCaseRecord);
   const relations = caseRecord.relations;
 
-  const couple = findById(catalog.parties.couples, relations.coupleId);
+  const transaction = resolveTransaction(catalog, caseRecord, BIRTH_REGISTRATION_TRANSACTION_TYPE);
+  // A document tied to a specific transaction must use exactly that transaction's own couple/
+  // surrogate mother (spec §5: "не брати пару, СМ ... безпосередньо з інших блоків кейса"), never
+  // silently the case's current relations - but a case that hasn't reached that stage yet (no
+  // transaction created) still needs relations.coupleId/surrogateMotherId to resolve wife/husband/
+  // surrogateMother for every other document.
+  const coupleId = transaction?.coupleId || relations.coupleId;
+  const surrogateMotherId = transaction?.surrogateMotherId || relations.surrogateMotherId;
+
+  const couple = findById(catalog.parties.couples, coupleId);
   const partners = toArray(couple?.partners);
   const wife = partners.find(partner => partner?.role === 'wife') || partners[0] || null;
   const husband = partners.find(partner => partner?.role === 'husband') || partners[1] || null;
@@ -613,12 +671,20 @@ export const resolveCaseContext = (catalog, caseId) => {
   const rawChild = isPlainObject(rawChildren[0]) ? rawChildren[0] : {};
   const medicalConclusion = isPlainObject(rawChild.medicalConclusion) ? rawChild.medicalConclusion : {};
 
-  const rawBirthRegistration = isPlainObject(caseRecord.registrations?.birth) ? caseRecord.registrations.birth : {};
+  const rawBirth = isPlainObject(caseRecord.registrations?.birth) ? caseRecord.registrations.birth : {};
+  // Pre-batch-19 cases kept statementDate/notaryId directly on registrations.birth instead of
+  // pointing at a transaction - consulted only when there is no transaction yet, so a case that
+  // hasn't been migrated still resolves exactly as it did before (spec §16 is the rule for
+  // newly-authored data, not a forced rewrite of every existing case).
+  const statementDate = transaction?.statementDate ?? rawBirth.statementDate ?? '';
+  const notaryId = transaction?.notaryId ?? rawBirth.notaryId;
   const birthRegistration = {
-    ...rawBirthRegistration,
+    transactionId: rawBirth.transactionId,
+    statementDate,
+    registryNumber: transaction?.registryNumber ?? '',
     statementDateWords: {
-      uk: formatUkrainianDateWords(rawBirthRegistration.statementDate),
-      en: formatEnglishDateWords(rawBirthRegistration.statementDate),
+      uk: formatUkrainianDateWords(statementDate),
+      en: formatEnglishDateWords(statementDate),
     },
   };
 
@@ -627,10 +693,11 @@ export const resolveCaseContext = (catalog, caseId) => {
     programId: caseRecord.programId ?? '',
     relations,
     program: isPlainObject(caseRecord.program) ? caseRecord.program : {},
+    transaction,
     couple,
     wife,
     husband,
-    surrogateMother: findById(catalog.parties.surrogateMothers, relations.surrogateMotherId),
+    surrogateMother: findById(catalog.parties.surrogateMothers, surrogateMotherId),
     clinic: findById(catalog.parties.clinics, relations.clinicId),
     representative: representatives[0] || null,
     representatives,
@@ -640,7 +707,7 @@ export const resolveCaseContext = (catalog, caseId) => {
     medicalConclusion,
     maternityHospital: findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId),
     birthRegistration,
-    notary: findById(catalog.parties.notaries, rawBirthRegistration.notaryId),
+    notary: findById(catalog.parties.notaries, notaryId),
   };
 };
 
@@ -759,16 +826,57 @@ export const validateCaseRecord = rawCaseRecord => {
   requirePresent(caseRecord.relations?.surrogateMotherId, 'case.relations.surrogateMotherId');
   requirePresent(caseRecord.program?.type, 'case.program.type');
   if (!toArray(caseRecord.childbirth?.children).length) issues.push('case.childbirth.children');
-  if (isBlank(caseRecord.registrations?.birth?.statementDate) && isBlank(caseRecord.registrations?.birth?.notaryId)) {
+  // batch 19: registrations.birth normally carries only transactionId; the direct
+  // statementDate/notaryId fields are consulted too so a not-yet-migrated case isn't flagged.
+  if (isBlank(caseRecord.registrations?.birth?.transactionId)
+    && isBlank(caseRecord.registrations?.birth?.statementDate)
+    && isBlank(caseRecord.registrations?.birth?.notaryId)) {
     issues.push('case.registrations.birth');
   }
 
   return issues;
 };
 
+// A transaction's own checklist (spec batch 19 §17): couple/surrogate mother/notary presence AND
+// existence, plus a statement date - registryNumber may stay blank (it's fine to fill in by hand
+// after the document is signed).
+export const validateTransaction = (catalog, transactionId) => {
+  const transaction = findById(catalog?.parties?.transactions, transactionId);
+  if (!transaction) return ['transaction'];
+
+  const issues = [];
+  const isBlank = value => value === undefined || value === null || String(value).trim() === '';
+  const requirePresent = (value, path) => {
+    if (isBlank(value)) issues.push(path);
+  };
+
+  requirePresent(transaction.id, 'transaction.id');
+  requirePresent(transaction.type, 'transaction.type');
+  requirePresent(transaction.coupleId, 'transaction.coupleId');
+  requirePresent(transaction.surrogateMotherId, 'transaction.surrogateMotherId');
+  requirePresent(transaction.notaryId, 'transaction.notaryId');
+  requirePresent(transaction.statementDate, 'transaction.statementDate');
+
+  if (!isBlank(transaction.coupleId) && !findById(catalog?.parties?.couples, transaction.coupleId)) {
+    issues.push('transaction.coupleId (no matching couple)');
+  }
+  if (!isBlank(transaction.surrogateMotherId) && !findById(catalog?.parties?.surrogateMothers, transaction.surrogateMotherId)) {
+    issues.push('transaction.surrogateMotherId (no matching surrogate mother)');
+  }
+  if (!isBlank(transaction.notaryId) && !findById(catalog?.parties?.notaries, transaction.notaryId)) {
+    issues.push('transaction.notaryId (no matching notary)');
+  }
+  if (!isBlank(transaction.statementDate) && !isIsoDate(transaction.statementDate)) {
+    issues.push('transaction.statementDate (must be YYYY-MM-DD)');
+  }
+
+  return issues;
+};
+
 // The birth-registration surrogate-consent statement's own checklist (spec batch 16 §20; field
-// locations updated for the batch 18 case shape) - missing hospital/notary lookups and malformed
-// dates are reported the same way as a genuinely empty field.
+// locations updated for the batch 18 case shape, then again for the batch 19 transaction) -
+// missing hospital/notary/transaction lookups and malformed dates are reported the same way as a
+// genuinely empty field.
 export const validateBirthRegistrationCase = (catalog, caseId) => {
   const context = resolveCaseContext(catalog, caseId);
   if (!context) return ['case'];
@@ -780,7 +888,7 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
   };
 
   const {
-    childbirth, child, medicalConclusion, birthRegistration, surrogateMother, maternityHospital, notary,
+    childbirth, child, medicalConclusion, surrogateMother, maternityHospital,
   } = context;
 
   requirePresent(childbirth.maternityHospitalId, 'case.childbirth.maternityHospitalId');
@@ -789,8 +897,6 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
   requirePresent(child.birthPlace?.uk, 'case.childbirth.children[0].birthPlace.uk');
   requirePresent(medicalConclusion.number, 'case.childbirth.children[0].medicalConclusion.number');
   requirePresent(medicalConclusion.date, 'case.childbirth.children[0].medicalConclusion.date');
-  requirePresent(birthRegistration.statementDate, 'case.registrations.birth.statementDate');
-  requirePresent(birthRegistration.notaryId, 'case.registrations.birth.notaryId');
   requirePresent(surrogateMother?.taxId, 'surrogateMother.taxId');
   requirePresent(surrogateMother?.address?.uk, 'surrogateMother.address.uk');
 
@@ -803,14 +909,27 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
   if (!isBlank(medicalConclusion.date) && !isIsoDate(medicalConclusion.date)) {
     issues.push('case.childbirth.children[0].medicalConclusion.date (must be YYYY-MM-DD)');
   }
-  if (!isBlank(birthRegistration.statementDate) && !isIsoDate(birthRegistration.statementDate)) {
-    issues.push('case.registrations.birth.statementDate (must be YYYY-MM-DD)');
-  }
   if (!isBlank(childbirth.maternityHospitalId) && !maternityHospital) {
     issues.push('case.childbirth.maternityHospitalId (no matching maternity hospital)');
   }
-  if (!isBlank(birthRegistration.notaryId) && !notary) {
-    issues.push('case.registrations.birth.notaryId (no matching notary)');
+
+  const rawBirth = context.case.registrations?.birth || {};
+  if (rawBirth.transactionId) {
+    // The transaction is the source of truth (spec §17) - couple/surrogate mother/notary presence
+    // and existence are validated there, scoped to `transaction.*` paths.
+    issues.push(...validateTransaction(catalog, rawBirth.transactionId));
+  } else if (!isBlank(rawBirth.statementDate) || !isBlank(rawBirth.notaryId)) {
+    // Pre-batch-19 case still using the direct registrations.birth.{statementDate,notaryId} shape.
+    requirePresent(rawBirth.statementDate, 'case.registrations.birth.statementDate');
+    requirePresent(rawBirth.notaryId, 'case.registrations.birth.notaryId');
+    if (!isBlank(rawBirth.statementDate) && !isIsoDate(rawBirth.statementDate)) {
+      issues.push('case.registrations.birth.statementDate (must be YYYY-MM-DD)');
+    }
+    if (!isBlank(rawBirth.notaryId) && !context.notary) {
+      issues.push('case.registrations.birth.notaryId (no matching notary)');
+    }
+  } else {
+    issues.push('case.registrations.birth.transactionId');
   }
 
   return issues;

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -13,6 +13,7 @@ import {
   clinicLogoEntriesToBackend,
   createChildRecord,
   createEmptyCase,
+  createTransaction,
   deepMergeRecords,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
@@ -46,9 +47,11 @@ import {
   pickLogoVariantForLayout,
   plainTextOf,
   pruneDocOverride,
+  removeTransactionReferences,
   resolveCaseContext,
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
+  resolveTransaction,
   serializeFormattedRuns,
   shiftDocOverrideParagraphIndices,
   splitParagraphsIntoColumns,
@@ -59,6 +62,7 @@ import {
   validateBirthRegistrationCase,
   validateCaseRecord,
   validateDocumentTemplate,
+  validateTransaction,
 } from './documentsCatalogUtils';
 
 // All party fixtures below are fictional - tests must never carry real client data.
@@ -1467,6 +1471,9 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
         child: {}, medicalConclusion: {}, statementDate: '', notaryId: '',
       });
       const issues = validateBirthRegistrationCase(catalog, 'case-1');
+      // batch 19: with statementDate/notaryId both blank and no transactionId either, there is
+      // nothing at all to point at a transaction - reported as one missing reference rather than
+      // two separate blank-field paths.
       expect(issues).toEqual(expect.arrayContaining([
         'case.childbirth.maternityHospitalId',
         'case.childbirth.children[0].sex',
@@ -1474,8 +1481,7 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
         'case.childbirth.children[0].birthPlace.uk',
         'case.childbirth.children[0].medicalConclusion.number',
         'case.childbirth.children[0].medicalConclusion.date',
-        'case.registrations.birth.statementDate',
-        'case.registrations.birth.notaryId',
+        'case.registrations.birth.transactionId',
       ]));
     });
 
@@ -1902,5 +1908,235 @@ describe('spec: normalized case structure (batch 18)', () => {
     expect(first.id).not.toBe(second.id);
     expect(first.id).toMatch(/^child-/);
     expect(first).toMatchObject({ sex: '', birthDate: '', birthPlace: { uk: '', en: '' }, medicalConclusion: { number: '', date: '' } });
+  });
+});
+
+// A transaction is one concrete combination of couple + surrogate mother + notary for a specific
+// legal act (batch 19): decoupled from the case's current relations, so the birth-registration
+// statement uses exactly the participants recorded on its own transaction, not whatever the case's
+// relations happen to be right now. The couple/surrogate mother below are deliberately different
+// from the transaction's, to prove the document really reads through the transaction.
+describe('spec: transactions (batch 19)', () => {
+  const transactionCatalog = (transactionOverride = {}, birthOverride = {}) => normalizeDocumentsCatalog(
+    {
+      couples: {
+        'couple-1': {
+          id: 'couple-1',
+          partners: [
+            { id: 'w1', role: 'wife', name: { uk: { nominative: 'Кікава Харука' }, en: 'Kikawa Haruka' } },
+            { id: 'h1', role: 'husband', name: { uk: { nominative: 'Кікава Йосуке' }, en: 'Kikawa Yosuke' } },
+          ],
+        },
+        'couple-2': {
+          id: 'couple-2',
+          partners: [{ id: 'w2', role: 'wife', name: { uk: { nominative: 'Інша Дружина' } } }],
+        },
+      },
+      surrogateMothers: {
+        'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } }, taxId: '3411512481', address: { uk: 'Гайворон' } },
+        'surrogate-2': { id: 'surrogate-2', name: { uk: { nominative: 'Інша Сурогатна' } } },
+      },
+      notaries: {
+        'notary-1': {
+          id: 'notary-1',
+          name: { uk: { nominative: 'Алексашина Юлія Борисівна', genitive: 'Алексашиної Юлії Борисівни', short: 'Алексашина Ю.Б.' } },
+          title: { uk: 'приватний нотаріус Київського міського нотаріального округу' },
+          city: { uk: 'місто Київ, Україна' },
+        },
+      },
+      maternityHospitals: {},
+      transactions: {
+        'transaction-1': {
+          id: 'transaction-1',
+          type: 'birth-registration-surrogate-consent',
+          caseId: 'case-1',
+          coupleId: 'couple-1',
+          surrogateMotherId: 'surrogate-1',
+          notaryId: 'notary-1',
+          statementDate: '2026-05-18',
+          registryNumber: '',
+          ...transactionOverride,
+        },
+      },
+      cases: {
+        'case-1': {
+          id: 'case-1',
+          // Deliberately a different couple/surrogate mother than the transaction's, so a test
+          // failure here would mean the document fell back to case.relations instead.
+          relations: { coupleId: 'couple-2', surrogateMotherId: 'surrogate-2' },
+          childbirth: {
+            maternityHospitalId: '',
+            children: [{ id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } }],
+          },
+          registrations: { birth: { transactionId: 'transaction-1', ...birthOverride } },
+        },
+      },
+    },
+    {},
+  );
+
+  it('the transaction is resolved via case.registrations.birth.transactionId (§18 #1)', () => {
+    const catalog = transactionCatalog();
+    const caseRecord = catalog.parties.cases[0];
+    const transaction = resolveTransaction(catalog, caseRecord, 'birth-registration-surrogate-consent');
+    expect(transaction.id).toBe('transaction-1');
+    // A type mismatch resolves to null, same as a missing transaction.
+    expect(resolveTransaction(catalog, caseRecord, 'some-other-document')).toBeNull();
+  });
+
+  it('the couple is read via transaction.coupleId, not case.relations (§18 #2, §18 #12)', () => {
+    const context = resolveCaseContext(transactionCatalog(), 'case-1');
+    expect(context.wife.name.uk.nominative).toBe('Кікава Харука');
+    expect(context.husband.name.uk.nominative).toBe('Кікава Йосуке');
+  });
+
+  it('the surrogate mother is read via transaction.surrogateMotherId, not case.relations (§18 #3, §18 #12)', () => {
+    const context = resolveCaseContext(transactionCatalog(), 'case-1');
+    expect(context.surrogateMother.name.uk.nominative).toBe('Молвінських Юлія Володимирівна');
+  });
+
+  it('the notary is read via transaction.notaryId (§18 #4)', () => {
+    const context = resolveCaseContext(transactionCatalog(), 'case-1');
+    expect(context.notary.name.uk.nominative).toBe('Алексашина Юлія Борисівна');
+    expect(fillPlaceholders('{{notary.name.uk.short}}', context, 'uk')).toBe('Алексашина Ю.Б.');
+    expect(fillPlaceholders('{{notary.title.uk}}', context, 'uk')).toBe('приватний нотаріус Київського міського нотаріального округу');
+  });
+
+  it('the statement date is read from transaction.statementDate (§18 #5)', () => {
+    const context = resolveCaseContext(transactionCatalog(), 'case-1');
+    expect(fillPlaceholders('{{birthRegistration.statementDate}}', context, 'uk')).toBe('18.05.2026');
+    expect(fillPlaceholders('{{transaction.statementDate}}', context, 'uk')).toBe('18.05.2026');
+    expect(fillPlaceholders('{{birthRegistration.statementDateWords.uk}}', context, 'uk')).toBe('вісімнадцятого травня дві тисячі двадцять шостого року');
+  });
+
+  it('the registry number is read from transaction.registryNumber (§18 #6)', () => {
+    const context = resolveCaseContext(transactionCatalog({ registryNumber: '12345' }), 'case-1');
+    expect(fillPlaceholders('{{birthRegistration.registryNumber}}', context, 'uk')).toBe('12345');
+    expect(fillPlaceholders('{{transaction.registryNumber}}', context, 'uk')).toBe('12345');
+  });
+
+  it('an empty registryNumber leaves a blank line to fill in by hand, never undefined/null (§18 #7)', () => {
+    const context = resolveCaseContext(transactionCatalog(), 'case-1');
+    const rendered = fillPlaceholders('Зареєстровано в реєстрі за № {{birthRegistration.registryNumber}}', context, 'uk');
+    expect(rendered).toBe(`Зареєстровано в реєстрі за № ${MISSING_VALUE_PLACEHOLDER}`);
+    expect(rendered).not.toContain('undefined');
+    expect(rendered).not.toContain('null');
+  });
+
+  it('case.registrations.birth carries only transactionId, never a duplicated notaryId/statementDate (§18 #8)', () => {
+    const emptyCase = createEmptyCase({ caseId: 'case-9', programId: 'program-9' });
+    expect(Object.keys(emptyCase.registrations.birth)).toEqual(['transactionId']);
+    const catalog = transactionCatalog();
+    expect(Object.keys(catalog.parties.cases[0].registrations.birth)).toEqual(['transactionId']);
+  });
+
+  it('a transaction never carries status/draft/active fields (§18 #9)', () => {
+    const transaction = createTransaction({
+      transactionId: 'transaction-9', caseId: 'case-9', type: 'birth-registration-surrogate-consent', coupleId: 'couple-1', surrogateMotherId: 'surrogate-1', notaryId: 'notary-1',
+    });
+    ['status', 'draft', 'active', 'replaced', 'createdAt', 'updatedAt'].forEach(key => expect(transaction).not.toHaveProperty(key));
+    expect(Object.keys(transaction).sort()).toEqual(
+      ['id', 'type', 'caseId', 'coupleId', 'surrogateMotherId', 'notaryId', 'statementDate', 'registryNumber'].sort(),
+    );
+  });
+
+  it('changing the notary on a transaction never touches the notary record itself (§18 #10)', () => {
+    const catalog = transactionCatalog();
+    const originalNotaryName = catalog.parties.notaries.find(n => n.id === 'notary-1').name.uk.nominative;
+    const updatedTransaction = { ...catalog.parties.transactions[0], notaryId: 'notary-1' };
+    const updatedCatalog = {
+      ...catalog,
+      parties: {
+        ...catalog.parties,
+        transactions: catalog.parties.transactions.map(t => (t.id === updatedTransaction.id ? updatedTransaction : t)),
+      },
+    };
+    expect(updatedCatalog.parties.notaries.find(n => n.id === 'notary-1').name.uk.nominative).toBe(originalNotaryName);
+  });
+
+  it('removeTransactionReferences deletes only the transaction and its case reference, never the couple/surrogate mother/notary (§18 #11)', () => {
+    const catalog = transactionCatalog();
+    const updated = removeTransactionReferences(catalog, 'transaction-1');
+    expect(updated.parties.transactions).toHaveLength(0);
+    expect(updated.parties.cases[0].registrations.birth.transactionId).toBeUndefined();
+    expect(updated.parties.couples.find(c => c.id === 'couple-1')).toBeDefined();
+    expect(updated.parties.surrogateMothers.find(s => s.id === 'surrogate-1')).toBeDefined();
+    expect(updated.parties.notaries.find(n => n.id === 'notary-1')).toBeDefined();
+  });
+
+  it('the generated document uses the specific transaction\'s own participants (§18 #12)', () => {
+    const catalog = transactionCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = {
+      id: 'birth-registration-surrogate-consent',
+      title: { uk: 'З А Я В А' },
+      paragraphs: [{ uk: 'Я, {{surrogateMother.name.uk.nominative}}, за участі {{wife.name.uk.nominative}} та {{husband.name.uk.nominative}}, нотаріус {{notary.name.uk.nominative}}.' }],
+    };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.paragraphs[0].uk).toBe(
+      'Я, Молвінських Юлія Володимирівна, за участі Кікава Харука та Кікава Йосуке, нотаріус Алексашина Юлія Борисівна.',
+    );
+  });
+
+  it('a missing transactionId is reported as a validation warning, not a crash (§18 #13)', () => {
+    const catalog = transactionCatalog();
+    catalog.parties.cases[0].registrations.birth = {};
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.transaction).toBeNull();
+    expect(() => fillPlaceholders('{{notary.name.uk.nominative}}', context, 'uk')).not.toThrow();
+    expect(validateBirthRegistrationCase(catalog, 'case-1')).toContain('case.registrations.birth.transactionId');
+  });
+
+  it('an unresolvable notaryId on the transaction never crashes the preview (§18 #14)', () => {
+    const catalog = transactionCatalog({ notaryId: 'ghost-notary' });
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.notary).toBeNull();
+    expect(() => fillPlaceholders('{{notary.name.uk.nominative}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{notary.name.uk.nominative}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+    expect(validateTransaction(catalog, 'transaction-1')).toContain('transaction.notaryId (no matching notary)');
+  });
+
+  it('never leaks undefined/null/[object Object] into the generated statement (§18 #15)', () => {
+    const catalog = transactionCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = {
+      id: 'birth-registration-surrogate-consent',
+      title: { uk: 'З А Я В А' },
+      paragraphs: [{ uk: 'Зареєстровано в реєстрі за № {{birthRegistration.registryNumber}}, нотаріус {{notary.name.uk.short}}, {{notary.city.uk}}.' }],
+    };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.paragraphs[0].uk).not.toContain('undefined');
+    expect(generated.paragraphs[0].uk).not.toContain('null');
+    expect(generated.paragraphs[0].uk).not.toContain('[object Object]');
+  });
+
+  describe('validateTransaction', () => {
+    it('reports no issues for a fully-filled transaction', () => {
+      const catalog = transactionCatalog();
+      expect(validateTransaction(catalog, 'transaction-1')).toEqual([]);
+    });
+
+    it('flags every missing required field, but never registryNumber (empty is allowed)', () => {
+      const catalog = transactionCatalog({
+        type: '', coupleId: '', surrogateMotherId: '', notaryId: '', statementDate: '', registryNumber: '',
+      });
+      const issues = validateTransaction(catalog, 'transaction-1');
+      expect(issues).toEqual(expect.arrayContaining([
+        'transaction.type', 'transaction.coupleId', 'transaction.surrogateMotherId', 'transaction.notaryId', 'transaction.statementDate',
+      ]));
+      expect(issues).not.toContain('transaction.registryNumber');
+    });
+
+    it('flags an unresolvable coupleId/surrogateMotherId', () => {
+      const catalog = transactionCatalog({ coupleId: 'ghost-couple', surrogateMotherId: 'ghost-sm' });
+      const issues = validateTransaction(catalog, 'transaction-1');
+      expect(issues).toContain('transaction.coupleId (no matching couple)');
+      expect(issues).toContain('transaction.surrogateMotherId (no matching surrogate mother)');
+    });
+
+    it('flags a non-ISO statementDate', () => {
+      const catalog = transactionCatalog({ statementDate: '18.05.2026' });
+      expect(validateTransaction(catalog, 'transaction-1')).toContain('transaction.statementDate (must be YYYY-MM-DD)');
+    });
   });
 });


### PR DESCRIPTION
## Summary
A transaction is one concrete combination of couple + surrogate mother + notary for a specific legal act (e.g. the birth-registration surrogate-consent statement) - decoupled from the case's current relations, so a signed document keeps pointing at exactly who signed it. The case only ever stores the `transactionId`; the notary's own name/title/city live solely in `parties.notaries[notaryId]`, never copied into the transaction or the case.

- `createTransaction` builds the minimal record (`id`/`type`/`caseId`/`coupleId`/`surrogateMotherId`/`notaryId`/`statementDate`/`registryNumber`) - no `status`/`draft`/`active`/`createdAt`/`updatedAt`.
- `resolveTransaction` reads `case.registrations.birth.transactionId`, with an optional type guard so a stale/mistyped reference resolves to `null` exactly like a missing transaction rather than returning mismatched data.
- `removeTransactionReferences` deletes the transaction and clears the referencing case's `transactionId`, never touching the couple/surrogate mother/notary records it pointed at.
- `resolveCaseContext` now sources wife/husband/couple/surrogateMother from the transaction's own `coupleId`/`surrogateMotherId` (not `case.relations`) whenever a birth-registration transaction exists on the case, and notary/statementDate/registryNumber from the transaction too - so the document uses exactly the participants recorded on that specific legal act. Cases that haven't reached that stage yet (no transaction created) still resolve wife/husband/surrogateMother from `case.relations`, and a pre-batch-19 case that still carries `registrations.birth.{statementDate,notaryId}` directly keeps resolving exactly as before - both existing behaviors are unaffected.
- `createEmptyCase`'s `registrations.birth` now holds only `transactionId`, matching the target shape.
- `validateTransaction` checks the transaction's own required fields + couple/surrogate-mother/notary existence (`registryNumber` may stay blank). `validateBirthRegistrationCase` delegates to it when a `transactionId` is present, keeps the pre-batch-19 direct-field checks as a fallback, and flags a genuinely missing `transactionId` as its own warning.

## Test plan
- [x] 19 new tests: transaction resolved via `transactionId`, couple/surrogate mother/notary read via the transaction (not `case.relations`), statement date/registry number from the transaction, empty `registryNumber` leaves a fill-in-by-hand blank, `case.registrations.birth` carries only `transactionId`, a transaction never carries `status`/`draft`, changing a transaction's notary never touches the notary record, `removeTransactionReferences` never deletes the couple/surrogate mother/notary, the generated document uses the specific transaction's own participants, missing/unresolvable transaction or notary never crashes the preview, `validateTransaction` checklist.
- [x] Full Documents test suite (`documentsCatalogUtils.test.js`, `DocumentsRenderers.smoke.test.js`, `DocumentsPageNumbering.smoke.test.js`, `DocumentsPage.richFormatting.test.js`): 200/200 passing.
- [x] `eslint` clean on the changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DMTKizBC4vNqzMs15tjGup)_