### PR TITLE
Close Batch 18 schema-alignment gaps: child selector, transaction.statementDateWords, and the childbirth/transaction case editor

### DIFF
--- a/src/components/DocumentsPage.caseEditor.test.js
+++ b/src/components/DocumentsPage.caseEditor.test.js
@@ -1,0 +1,166 @@
+// Real-DOM regression test for the Childbirth/Transaction case editor ("Дані для заяви в РАЦС",
+// Batch 18 §6): mounts the actual DocumentsPage component (Firebase mocked out) and drives the
+// maternity hospital/child/transaction fields through real form controls, to catch wiring bugs
+// the pure-logic tests in documentsCatalogUtils.test.js can't see.
+//
+// NOTE: this project's Jest config sets `resetMocks: true`, so mock bodies must be (re-)installed
+// in beforeEach rather than only in the jest.mock(...) factory.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('firebase/database', () => ({
+  ref: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'test-admin' } },
+  database: {},
+  deleteStorageFile: jest.fn(),
+  getStorageFileDataUrl: jest.fn(),
+  listStorageFolderFileNames: jest.fn(),
+  uploadFileToStorageFolder: jest.fn(),
+}));
+
+jest.mock('utils/accessLevel', () => ({ isInvoiceBuilderUid: () => true }));
+jest.mock('utils/pdfImageEncoding', () => ({ reencodePdfImageDataUrl: jest.fn() }));
+
+// eslint-disable-next-line import/first
+import { ref, get, set, update } from 'firebase/database';
+// eslint-disable-next-line import/first
+import { listStorageFolderFileNames } from './config';
+// eslint-disable-next-line import/first
+import DocumentsPage from './DocumentsPage';
+
+const buildParties = () => ({
+  couples: {
+    'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } }] },
+  },
+  surrogateMothers: {
+    'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Сурогатна Матір' } }, taxId: '1234567890', address: { uk: 'Київ' } },
+  },
+  maternityHospitals: {
+    'hospital-1': { id: 'hospital-1', shortName: 'Пологовий будинок №1' },
+  },
+  notaries: {
+    'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Нотаріус Іванова Іванівна', short: 'Іванова І.І.' } } },
+  },
+  transactions: {},
+  cases: {
+    'case-1': {
+      id: 'case-1',
+      relations: {
+        coupleId: 'couple-1', clinicId: '', surrogateMotherId: 'surrogate-1', representativeIds: [],
+      },
+      program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
+      childbirth: {
+        maternityHospitalId: 'hospital-1',
+        children: [{
+          id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ', en: 'Kyiv' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' },
+        }],
+      },
+      registrations: { birth: { transactionId: '' } },
+      documents: { overrides: {} },
+    },
+  },
+});
+
+beforeEach(() => {
+  ref.mockImplementation((_db, path) => path);
+  get.mockImplementation(async path => {
+    if (path === 'documentsBuilder/parties') {
+      return { exists: () => true, val: () => buildParties() };
+    }
+    if (path === 'documentsBuilder/templates') {
+      return { exists: () => false, val: () => null };
+    }
+    return { exists: () => false, val: () => null };
+  });
+  set.mockResolvedValue(undefined);
+  update.mockResolvedValue(undefined);
+  listStorageFolderFileNames.mockResolvedValue([]);
+});
+
+describe('spec: Childbirth/Transaction case editor (Batch 18 §6)', () => {
+  it('renders the maternity hospital select and the single child, without a child selector', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+
+    expect(await screen.findByLabelText('Пологовий будинок')).toHaveValue('hospital-1');
+    expect(screen.getByText('Дитина 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Стать')).toHaveValue('female');
+    expect(screen.queryByLabelText('Дитина для документа')).not.toBeInTheDocument();
+  });
+
+  it('"Add child" adds a second child card and reveals the child selector for the document', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    await screen.findByLabelText('Пологовий будинок');
+
+    fireEvent.click(screen.getByRole('button', { name: /add child/i }));
+
+    expect(screen.getAllByText('Дитина 2').length).toBeGreaterThan(0);
+    expect(await screen.findByLabelText('Дитина для документа')).toBeInTheDocument();
+  });
+
+  it('removing a child drops its card and the selector again if only one remains', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    await screen.findByLabelText('Пологовий будинок');
+
+    fireEvent.click(screen.getByRole('button', { name: /add child/i }));
+    expect(screen.getAllByText('Дитина 2').length).toBeGreaterThan(0);
+
+    const removeButtons = screen.getAllByTitle('Remove this child');
+    fireEvent.click(removeButtons[removeButtons.length - 1]);
+
+    expect(screen.queryByText('Дитина 2')).not.toBeInTheDocument();
+    expect(screen.queryAllByText('Дитина 2')).toHaveLength(0);
+    expect(screen.queryByLabelText('Дитина для документа')).not.toBeInTheDocument();
+  });
+
+  it('"Save childbirth details" persists the edited hospital/child fields to case.childbirth', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    await screen.findByLabelText('Пологовий будинок');
+
+    fireEvent.change(screen.getByLabelText('№ медичного висновку'), { target: { value: 'MC-99' } });
+    fireEvent.click(screen.getByRole('button', { name: /save childbirth details/i }));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/parties/cases/case-1/childbirth',
+      expect.objectContaining({
+        maternityHospitalId: 'hospital-1',
+        children: [expect.objectContaining({ id: 'child-1', medicalConclusion: expect.objectContaining({ number: 'MC-99' }) })],
+      }),
+    ));
+  });
+
+  it('"Save transaction" creates a birth-registration-surrogate-consent transaction and points the case at it', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    await screen.findByLabelText('Пологовий будинок');
+
+    fireEvent.change(screen.getByLabelText('Дата заяви'), { target: { value: '2026-05-18' } });
+    fireEvent.change(screen.getByLabelText('Нотаріус'), { target: { value: 'notary-1' } });
+    fireEvent.change(screen.getByLabelText('Номер реєстру'), { target: { value: '12345' } });
+    fireEvent.click(screen.getByRole('button', { name: /save transaction/i }));
+
+    await waitFor(() => expect(update).toHaveBeenCalled());
+    const [path, payload] = update.mock.calls[update.mock.calls.length - 1];
+    expect(path).toBe('documentsBuilder/parties');
+    const transactionKey = Object.keys(payload).find(key => key.startsWith('transactions/'));
+    expect(transactionKey).toBeDefined();
+    const transactionId = transactionKey.split('/')[1];
+    expect(payload[transactionKey]).toEqual(expect.objectContaining({
+      id: transactionId,
+      type: 'birth-registration-surrogate-consent',
+      caseId: 'case-1',
+      coupleId: 'couple-1',
+      surrogateMotherId: 'surrogate-1',
+      notaryId: 'notary-1',
+      statementDate: '2026-05-18',
+      registryNumber: '12345',
+    }));
+    expect(payload[`cases/case-1/registrations/birth/transactionId`]).toBe(transactionId);
+  });
+});

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -17,6 +17,7 @@ import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
 import { useAutoResize } from '../hooks/useAutoResize';
 import {
+  BIRTH_REGISTRATION_TRANSACTION_TYPE,
   DEFAULT_DOC_FORMATTING,
   DOCUMENTS_PARTIES_PATH,
   DOCUMENTS_SETTINGS_PATH,
@@ -32,6 +33,8 @@ import {
   clinicLogoEntriesToBackend,
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
+  createChildRecord,
+  createTransaction,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   getClinicLogo,
@@ -41,6 +44,7 @@ import {
   isBilingualLayout,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
+  makeTransactionId,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -58,6 +62,8 @@ import {
   toggleInlineFormat,
   upsertRecentCaseId,
   upsertRecentId,
+  validateBirthRegistrationCase,
+  validateCaseRecord,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
@@ -228,6 +234,15 @@ const SectionTitle = styled.h2`
   font-family: var(--km-font-display);
   font-size: 15px;
   letter-spacing: -0.01em;
+`;
+
+const SectionSubhead = styled.h3`
+  margin: 12px 0 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--km-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 `;
 
 const StateCard = styled.div`
@@ -583,6 +598,14 @@ const DocumentsPage = ({ isAdmin }) => {
   const [settings, setSettings] = useState(() => normalizeDocumentsSettings(null));
   const [formatting, setFormatting] = useState(DEFAULT_DOC_FORMATTING);
   const [selectedCaseId, setSelectedCaseId] = useState('');
+  // Which of the selected case's childbirth.children[] documents are generated for ('' = default
+  // to the first child, spec Batch 18 §2 - a case with just one child never needs this shown).
+  const [selectedChildId, setSelectedChildId] = useState('');
+  // Local editable copies of the selected case's childbirth/transaction data (Batch 18 §6, "Дані
+  // для заяви в РАЦС") - reset from the backend record whenever the selected case changes, saved
+  // back explicitly via their own Save buttons, same pattern as the per-document format draft.
+  const [childbirthDraft, setChildbirthDraft] = useState({ maternityHospitalId: '', children: [] });
+  const [transactionDraft, setTransactionDraft] = useState({ statementDate: '', notaryId: '', registryNumber: '' });
   const [selectedDocIds, setSelectedDocIds] = useState({});
   const [layout, setLayout] = useState('two-column');
   const [expandedDocId, setExpandedDocId] = useState('');
@@ -666,6 +689,22 @@ const DocumentsPage = ({ isAdmin }) => {
   useEffect(() => {
     loadDocumentsData();
   }, [loadDocumentsData]);
+
+  // Reload the Childbirth/Transaction editor drafts whenever the selected case changes - never
+  // carries a previous case's in-progress edits over onto the newly selected one.
+  useEffect(() => {
+    const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
+    setChildbirthDraft(caseRecord?.childbirth || { maternityHospitalId: '', children: [] });
+    const transactionId = caseRecord?.registrations?.birth?.transactionId;
+    const existingTransaction = transactionId
+      ? catalog.parties.transactions.find(item => String(item.id) === String(transactionId))
+      : null;
+    setTransactionDraft(existingTransaction && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE
+      ? { statementDate: existingTransaction.statementDate || '', notaryId: existingTransaction.notaryId || '', registryNumber: existingTransaction.registryNumber || '' }
+      : { statementDate: '', notaryId: '', registryNumber: '' });
+    setSelectedChildId('');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCaseId]);
 
   // Warm the lazy PDF/DOCX chunks while this build is still deployed (see isStaleChunkError).
   useEffect(() => {
@@ -1130,6 +1169,108 @@ const DocumentsPage = ({ isAdmin }) => {
     }
   };
 
+  // --- Childbirth + Transaction editor ("Дані для заяви в РАЦС", Batch 18 §6) --------------------
+  // Regrouped to match the actual backend shape: the maternity hospital + per-child birth details
+  // live under childbirth, while the notary/statementDate/registryNumber for the birth-registration
+  // surrogate-consent statement live on its own transaction record (batch 19).
+
+  const updateChildbirthField = (field, value) => setChildbirthDraft(previous => ({ ...previous, [field]: value }));
+
+  const updateChildField = (childId, field, value) => setChildbirthDraft(previous => ({
+    ...previous,
+    children: (previous.children || []).map(child => (child.id === childId ? { ...child, [field]: value } : child)),
+  }));
+
+  const updateChildNestedField = (childId, group, field, value) => setChildbirthDraft(previous => ({
+    ...previous,
+    children: (previous.children || []).map(child => (child.id === childId
+      ? { ...child, [group]: { ...(child[group] || {}), [field]: value } }
+      : child)),
+  }));
+
+  const handleAddChild = () => setChildbirthDraft(previous => ({
+    ...previous,
+    children: [...(previous.children || []), createChildRecord()],
+  }));
+
+  // Removing the currently-selected child falls back to the default (first child) rather than
+  // pointing the document generator at an id that no longer exists.
+  const handleRemoveChild = childId => {
+    setChildbirthDraft(previous => ({
+      ...previous,
+      children: (previous.children || []).filter(child => child.id !== childId),
+    }));
+    setSelectedChildId(previous => (previous === childId ? '' : previous));
+  };
+
+  const handleSaveChildbirth = async () => {
+    if (!selectedCase) return;
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${selectedCase.id}/childbirth`), childbirthDraft);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          cases: previous.parties.cases.map(item => (String(item.id) === selectedCaseId
+            ? { ...item, childbirth: childbirthDraft }
+            : item)),
+        },
+      }));
+      toast.success('Childbirth details saved.');
+    } catch (saveError) {
+      console.error('Unable to save childbirth details', saveError);
+      toast.error('Could not save the childbirth details.');
+    }
+  };
+
+  const updateTransactionField = (field, value) => setTransactionDraft(previous => ({ ...previous, [field]: value }));
+
+  // Creates the case's birth-registration-surrogate-consent transaction the first time this is
+  // saved, then only ever updates that same record afterward - a transaction keeps the couple/
+  // surrogate mother it was originally signed for (batch 19), so an update never re-pulls those
+  // ids from the case's current relations, only a brand-new transaction does.
+  const handleSaveTransaction = async () => {
+    if (!selectedCase) return;
+    const existingTransactionId = selectedCase.registrations?.birth?.transactionId;
+    const existingTransaction = existingTransactionId
+      ? catalog.parties.transactions.find(item => String(item.id) === String(existingTransactionId))
+      : null;
+    const isReusableTransaction = Boolean(existingTransaction) && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE;
+    const transactionId = isReusableTransaction ? existingTransaction.id : makeTransactionId();
+    const nextTransaction = createTransaction({
+      transactionId,
+      caseId: selectedCase.id,
+      type: BIRTH_REGISTRATION_TRANSACTION_TYPE,
+      coupleId: isReusableTransaction ? existingTransaction.coupleId : (selectedCase.relations?.coupleId || ''),
+      surrogateMotherId: isReusableTransaction ? existingTransaction.surrogateMotherId : (selectedCase.relations?.surrogateMotherId || ''),
+      notaryId: transactionDraft.notaryId,
+      statementDate: transactionDraft.statementDate,
+      registryNumber: transactionDraft.registryNumber,
+    });
+    try {
+      await update(ref(database, DOCUMENTS_PARTIES_PATH), {
+        [`transactions/${transactionId}`]: nextTransaction,
+        [`cases/${selectedCase.id}/registrations/birth/transactionId`]: transactionId,
+      });
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          transactions: isReusableTransaction
+            ? previous.parties.transactions.map(item => (String(item.id) === transactionId ? nextTransaction : item))
+            : [...previous.parties.transactions, nextTransaction],
+          cases: previous.parties.cases.map(item => (String(item.id) === selectedCaseId
+            ? { ...item, registrations: { ...(item.registrations || {}), birth: { ...(item.registrations?.birth || {}), transactionId } } }
+            : item)),
+        },
+      }));
+      toast.success('Transaction saved.');
+    } catch (saveError) {
+      console.error('Unable to save the transaction', saveError);
+      toast.error('Could not save the transaction.');
+    }
+  };
+
   // --- Clinic logo ------------------------------------------------------------------------------
 
   const handleLogoFileChange = event => {
@@ -1344,7 +1485,12 @@ const DocumentsPage = ({ isAdmin }) => {
   const orderedDocuments = orderRecordsByRecentIds(catalog.documents, settings.recentDocIds);
   const selectedTemplates = orderedDocuments.filter(template => selectedDocIds[template.id]);
   const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
-  const caseContext = resolveCaseContext(catalog, selectedCaseId);
+  const caseContext = resolveCaseContext(catalog, selectedCaseId, { childId: selectedChildId });
+  // Pre-export completeness checklist (Batch 18 §5) - non-blocking while editing, listed before
+  // export alongside the unresolved-variable warning; missing lookups never crash resolution.
+  const caseChecklistIssues = selectedCaseId
+    ? [...new Set([...validateCaseRecord(selectedCase), ...validateBirthRegistrationCase(catalog, selectedCaseId)])]
+    : [];
   // A logo only ever appears where a template declares one - via the dedicated `logo` field, or
   // a legacy leading paragraph (spec §5) - never automatically. `showLogo` is just the global
   // permission gate.
@@ -1464,7 +1610,7 @@ const DocumentsPage = ({ isAdmin }) => {
   }, [readImageDimensions, clinicLogoStorageKey]);
 
   const prepareGeneration = () => {
-    const context = resolveCaseContext(catalog, selectedCaseId);
+    const context = resolveCaseContext(catalog, selectedCaseId, { childId: selectedChildId });
     const generated = selectedTemplates.map(template => buildGeneratedDocument(
       template,
       context,
@@ -1491,15 +1637,25 @@ const DocumentsPage = ({ isAdmin }) => {
     persistSettings({ recentDocIds: nextRecentDocIds });
   };
 
-  // A non-blocking warning is shown inline at all times (spec §15); the final export step still
-  // asks for a confirmation so an admin never ships blanks without noticing.
+  // Non-blocking warnings are shown inline at all times (spec §15; checklist per Batch 18 §5); the
+  // final export step still asks for a confirmation so an admin never ships blanks without noticing.
   const confirmUnresolvedVariables = () => {
-    if (!unresolvedVariables.length) return true;
     if (typeof window === 'undefined') return true;
-    return window.confirm(
-      `Не вдалося підставити ${unresolvedVariables.length} змінн${unresolvedVariables.length === 1 ? 'у' : 'их'}:\n`
-      + `${unresolvedVariables.map(path => `- ${path}`).join('\n')}\n\nЗгенерувати документ попри це?`,
-    );
+    const sections = [];
+    if (unresolvedVariables.length) {
+      sections.push(
+        `Не вдалося підставити ${unresolvedVariables.length} змінн${unresolvedVariables.length === 1 ? 'у' : 'их'}:\n`
+        + `${unresolvedVariables.map(path => `- ${path}`).join('\n')}`,
+      );
+    }
+    if (caseChecklistIssues.length) {
+      sections.push(
+        `Незаповнені обов'язкові поля кейса (${caseChecklistIssues.length}):\n`
+        + `${caseChecklistIssues.map(path => `- ${path}`).join('\n')}`,
+      );
+    }
+    if (!sections.length) return true;
+    return window.confirm(`${sections.join('\n\n')}\n\nЗгенерувати документ попри це?`);
   };
 
   const sleep = ms => new Promise(resolve => { setTimeout(resolve, ms); });
@@ -1641,7 +1797,163 @@ const DocumentsPage = ({ isAdmin }) => {
                   <FaTrash /> Delete case
                 </DangerButton>
               </RowLine>
+              {caseChecklistIssues.length ? (
+                <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
+                  Незаповнені обов'язкові поля: {caseChecklistIssues.join(', ')}
+                </DocSubtitle>
+              ) : null}
             </Section>
+
+            {selectedCase ? (
+              <Section>
+                <SectionHead>
+                  <SectionTitle>Дані для заяви в РАЦС</SectionTitle>
+                </SectionHead>
+
+                <SectionSubhead>Пологи</SectionSubhead>
+                <RowLine style={{ marginTop: 6 }}>
+                  <Field style={{ flex: 1, minWidth: 220 }}>
+                    Пологовий будинок
+                    <Select
+                      value={childbirthDraft.maternityHospitalId || ''}
+                      onChange={event => updateChildbirthField('maternityHospitalId', event.target.value)}
+                    >
+                      <option value="">— не обрано —</option>
+                      {catalog.parties.maternityHospitals.map(hospital => (
+                        <option key={hospital.id} value={String(hospital.id)}>
+                          {hospital.shortName || hospital.name?.uk || hospital.id}
+                        </option>
+                      ))}
+                    </Select>
+                  </Field>
+                </RowLine>
+
+                {(childbirthDraft.children || []).map((child, childIndex) => (
+                  <DocRow key={child.id}>
+                    <DocRowHead>
+                      <DocSubtitle style={{ fontWeight: 700 }}>Дитина {childIndex + 1}</DocSubtitle>
+                      <DangerButton
+                        type="button"
+                        onClick={() => handleRemoveChild(child.id)}
+                        title="Remove this child"
+                      >
+                        <FaTrash />
+                      </DangerButton>
+                    </DocRowHead>
+                    <FieldGrid>
+                      <Field>
+                        Стать
+                        <Select value={child.sex || ''} onChange={event => updateChildField(child.id, 'sex', event.target.value)}>
+                          <option value="">— не обрано —</option>
+                          <option value="female">жіноча</option>
+                          <option value="male">чоловіча</option>
+                        </Select>
+                      </Field>
+                      <Field>
+                        Дата народження
+                        <FieldInput
+                          type="date"
+                          value={child.birthDate || ''}
+                          onChange={event => updateChildField(child.id, 'birthDate', event.target.value)}
+                        />
+                      </Field>
+                      <Field>
+                        Місце народження (укр)
+                        <FieldInput
+                          type="text"
+                          value={child.birthPlace?.uk || ''}
+                          onChange={event => updateChildNestedField(child.id, 'birthPlace', 'uk', event.target.value)}
+                        />
+                      </Field>
+                      <Field>
+                        Місце народження (eng)
+                        <FieldInput
+                          type="text"
+                          value={child.birthPlace?.en || ''}
+                          onChange={event => updateChildNestedField(child.id, 'birthPlace', 'en', event.target.value)}
+                        />
+                      </Field>
+                      <Field>
+                        № медичного висновку
+                        <FieldInput
+                          type="text"
+                          value={child.medicalConclusion?.number || ''}
+                          onChange={event => updateChildNestedField(child.id, 'medicalConclusion', 'number', event.target.value)}
+                        />
+                      </Field>
+                      <Field>
+                        Дата медичного висновку
+                        <FieldInput
+                          type="date"
+                          value={child.medicalConclusion?.date || ''}
+                          onChange={event => updateChildNestedField(child.id, 'medicalConclusion', 'date', event.target.value)}
+                        />
+                      </Field>
+                    </FieldGrid>
+                  </DocRow>
+                ))}
+
+                <RowLine style={{ marginTop: 8 }}>
+                  <SmallButton type="button" onClick={handleAddChild}>
+                    <FaPlus /> Add child
+                  </SmallButton>
+                  <PrimaryMiniButton type="button" onClick={handleSaveChildbirth}>
+                    Save childbirth details
+                  </PrimaryMiniButton>
+                </RowLine>
+
+                {(childbirthDraft.children || []).length > 1 ? (
+                  <RowLine style={{ marginTop: 10 }}>
+                    <Field style={{ flex: 1, minWidth: 220 }}>
+                      Дитина для документа
+                      <Select value={selectedChildId} onChange={event => setSelectedChildId(event.target.value)}>
+                        {(childbirthDraft.children || []).map((child, childIndex) => (
+                          <option key={child.id} value={child.id}>
+                            Дитина {childIndex + 1}{child.sex ? ` (${child.sex === 'female' ? 'дівчинка' : 'хлопчик'})` : ''}
+                          </option>
+                        ))}
+                      </Select>
+                    </Field>
+                  </RowLine>
+                ) : null}
+
+                <SectionSubhead style={{ marginTop: 14 }}>Заява до РАЦС (транзакція)</SectionSubhead>
+                <FieldGrid>
+                  <Field>
+                    Дата заяви
+                    <FieldInput
+                      type="date"
+                      value={transactionDraft.statementDate || ''}
+                      onChange={event => updateTransactionField('statementDate', event.target.value)}
+                    />
+                  </Field>
+                  <Field>
+                    Нотаріус
+                    <Select value={transactionDraft.notaryId || ''} onChange={event => updateTransactionField('notaryId', event.target.value)}>
+                      <option value="">— не обрано —</option>
+                      {catalog.parties.notaries.map(notary => (
+                        <option key={notary.id} value={String(notary.id)}>
+                          {notary.name?.uk?.short || notary.name?.uk?.nominative || notary.id}
+                        </option>
+                      ))}
+                    </Select>
+                  </Field>
+                  <Field>
+                    Номер реєстру
+                    <FieldInput
+                      type="text"
+                      value={transactionDraft.registryNumber || ''}
+                      onChange={event => updateTransactionField('registryNumber', event.target.value)}
+                    />
+                  </Field>
+                </FieldGrid>
+                <RowLine style={{ marginTop: 8 }}>
+                  <PrimaryMiniButton type="button" onClick={handleSaveTransaction}>
+                    Save transaction
+                  </PrimaryMiniButton>
+                </RowLine>
+              </Section>
+            ) : null}
 
             <Section>
               <SectionHead>

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -593,6 +593,12 @@ export const normalizeCaseRecord = (rawCase = {}) => {
 // current `relations` so a signed document keeps pointing at exactly who signed it even if the
 // case's relations were ever revisited later. The case only ever stores the transactionId; the
 // notary's own name/title/city live solely in `parties.notaries[notaryId]`, never copied in.
+
+// A fresh id for a brand-new transaction record (the case editor form needs one the first time it
+// saves the Transaction section, since createTransaction itself takes the id rather than making
+// one - same generated shape as createChildRecord's id).
+export const makeTransactionId = () => makeRecordId('transaction');
+
 export const createTransaction = ({
   transactionId, caseId, type, coupleId, surrogateMotherId, notaryId, statementDate = '', registryNumber = '',
 }) => ({
@@ -637,7 +643,7 @@ export const removeTransactionReferences = (catalog, transactionId) => ({
 // currently-selected case is whatever the caller/UI passed as caseId, never an "active" flag.
 export const BIRTH_REGISTRATION_TRANSACTION_TYPE = 'birth-registration-surrogate-consent';
 
-export const resolveCaseContext = (catalog, caseId) => {
+export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
   const rawCaseRecord = findById(catalog?.parties?.cases, caseId);
   if (!rawCaseRecord) return null;
   // Defensively re-normalized here too (idempotent) - a case can reach this function without
@@ -665,10 +671,12 @@ export const resolveCaseContext = (catalog, caseId) => {
 
   const childbirth = isPlainObject(caseRecord.childbirth) ? caseRecord.childbirth : {};
   const rawChildren = toArray(childbirth.children);
-  // The first child is the current fallback for single-child documents (spec §4: "не прив'язувати
-  // систему назавжди лише до children[0]") - `children` (every child, gender-computed) is exposed
-  // alongside it so a future multi-child template isn't blocked on this shape.
-  const rawChild = isPlainObject(rawChildren[0]) ? rawChildren[0] : {};
+  // The first child is the default fallback for single-child documents (spec §4: "не прив'язувати
+  // систему назавжди лише до children[0]") - a caller generating a document for a twin passes
+  // `childId` to pick a different one; `children` (every child, gender-computed) is exposed
+  // alongside it so the UI can offer a selector.
+  const selectedRawChild = childId ? rawChildren.find(item => String(item?.id) === String(childId)) : null;
+  const rawChild = isPlainObject(selectedRawChild) ? selectedRawChild : (isPlainObject(rawChildren[0]) ? rawChildren[0] : {});
   const medicalConclusion = isPlainObject(rawChild.medicalConclusion) ? rawChild.medicalConclusion : {};
 
   const rawBirth = isPlainObject(caseRecord.registrations?.birth) ? caseRecord.registrations.birth : {};
@@ -687,13 +695,23 @@ export const resolveCaseContext = (catalog, caseId) => {
       en: formatEnglishDateWords(statementDate),
     },
   };
+  // `{{transaction.statementDateWords.uk/en}}` (spec batch 18 §3) needs the words form directly on
+  // the transaction itself, not only on the `birthRegistration` legacy-named alias above - derived
+  // here rather than stored, same as every other date-in-words field.
+  const transactionContext = transaction ? {
+    ...transaction,
+    statementDateWords: {
+      uk: formatUkrainianDateWords(transaction.statementDate),
+      en: formatEnglishDateWords(transaction.statementDate),
+    },
+  } : null;
 
   return {
     case: caseRecord,
     programId: caseRecord.programId ?? '',
     relations,
     program: isPlainObject(caseRecord.program) ? caseRecord.program : {},
-    transaction,
+    transaction: transactionContext,
     couple,
     wife,
     husband,
@@ -704,6 +722,7 @@ export const resolveCaseContext = (catalog, caseId) => {
     childbirth,
     children: rawChildren.map(buildChildContext),
     child: buildChildContext(rawChild),
+    selectedChildId: rawChild?.id,
     medicalConclusion,
     maternityHospital: findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId),
     birthRegistration,
@@ -915,9 +934,19 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
 
   const rawBirth = context.case.registrations?.birth || {};
   if (rawBirth.transactionId) {
-    // The transaction is the source of truth (spec §17) - couple/surrogate mother/notary presence
-    // and existence are validated there, scoped to `transaction.*` paths.
-    issues.push(...validateTransaction(catalog, rawBirth.transactionId));
+    const linkedTransaction = findById(catalog?.parties?.transactions, rawBirth.transactionId);
+    if (linkedTransaction && linkedTransaction.type !== BIRTH_REGISTRATION_TRANSACTION_TYPE) {
+      // A transactionId can point at a transaction of a different document type (spec §3: "Find the
+      // transaction with type: 'birth-registration-surrogate-consent'") - resolveCaseContext already
+      // treats this as no transaction at all (context.transaction is null), so flagging it here keeps
+      // this checklist from passing while every `transaction.*`/`notary.*` template variable is
+      // actually unresolved.
+      issues.push('case.registrations.birth.transactionId (transaction is not a birth-registration-surrogate-consent)');
+    } else {
+      // The transaction is the source of truth (spec §17) - couple/surrogate mother/notary presence
+      // and existence are validated there, scoped to `transaction.*` paths.
+      issues.push(...validateTransaction(catalog, rawBirth.transactionId));
+    }
   } else if (!isBlank(rawBirth.statementDate) || !isBlank(rawBirth.notaryId)) {
     // Pre-batch-19 case still using the direct registrations.birth.{statementDate,notaryId} shape.
     requirePresent(rawBirth.statementDate, 'case.registrations.birth.statementDate');

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -2139,4 +2139,50 @@ describe('spec: transactions (batch 19)', () => {
       expect(validateTransaction(catalog, 'transaction-1')).toContain('transaction.statementDate (must be YYYY-MM-DD)');
     });
   });
+
+  it('exposes transaction.statementDateWords.uk/en directly on the transaction, not only via birthRegistration (Batch 18 §3)', () => {
+    const context = resolveCaseContext(transactionCatalog(), 'case-1');
+    expect(fillPlaceholders('{{transaction.statementDateWords.uk}}', context, 'uk')).toBe('вісімнадцятого травня дві тисячі двадцять шостого року');
+    expect(fillPlaceholders('{{transaction.statementDateWords.en}}', context, 'en')).toBe('eighteenth of May, 2026');
+  });
+
+  it('a transactionId pointing at a differently-typed transaction is treated as missing, not validated as-is (type-check fix)', () => {
+    const catalog = transactionCatalog({ type: 'some-other-document' });
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.transaction).toBeNull();
+    const issues = validateBirthRegistrationCase(catalog, 'case-1');
+    expect(issues).toContain('case.registrations.birth.transactionId (transaction is not a birth-registration-surrogate-consent)');
+    // Never falls through to reporting the wrongly-typed transaction's own fields as if it were valid.
+    expect(issues).not.toContain('transaction.notaryId');
+  });
+
+  describe('child selector (Batch 18 §2: twins)', () => {
+    const twinsCatalog = () => {
+      const catalog = transactionCatalog();
+      catalog.parties.cases[0].childbirth.children.push({
+        id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' },
+      });
+      return catalog;
+    };
+
+    it('defaults to the first child when no childId is given', () => {
+      const context = resolveCaseContext(twinsCatalog(), 'case-1');
+      expect(context.selectedChildId).toBe('child-1');
+      expect(context.child.sex).toBe('female');
+      expect(context.children).toHaveLength(2);
+    });
+
+    it('selects the requested child by id, leaving the full children array untouched', () => {
+      const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'child-2' });
+      expect(context.selectedChildId).toBe('child-2');
+      expect(context.child.sex).toBe('male');
+      expect(context.medicalConclusion.number).toBe('MC-2');
+      expect(context.children.map(child => child.id)).toEqual(['child-1', 'child-2']);
+    });
+
+    it('an unresolvable childId falls back to the first child rather than crashing', () => {
+      const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'ghost-child' });
+      expect(context.selectedChildId).toBe('child-1');
+    });
+  });
 });


### PR DESCRIPTION
The resolver/validation logic already followed the case.childbirth.children[]/
transactions shape from prior batches, but a few addendum items were still
open: resolveCaseContext had no way to pick a non-first child for twins,
{{transaction.statementDateWords.uk/en}} only existed under the legacy
birthRegistration alias, and validateBirthRegistrationCase would validate a
wrongly-typed transaction as if it were a valid birth-registration-surrogate-
consent one. Also add the missing case editor UI ("Дані для заяви в РАЦС"):
a Childbirth section (maternity hospital select + per-child sex/birthDate/
birthPlace/medicalConclusion blocks, +Add child, a child selector once a case
has twins) and a Transaction section (statement date, notary select, registry
number), plus wire the existing pre-export completeness checklist into the
UI's non-blocking warnings and export confirmation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AxsMokJspXc2wP8LwS4Kb6