### PR TITLE
Fix Documents page blank-screen crash: normalize case.childbirth.children to an array

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -13,6 +13,7 @@ import FlowManager from './FlowManager';
 import BudgetPage from './BudgetPage';
 import InvoiceBuilderPage from './InvoiceBuilderPage';
 import DocumentsPage from './DocumentsPage';
+import PartiesPage from './PartiesPage';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth, fetchUserById } from './config';
 import { resolveAccess } from 'utils/accessLevel';
@@ -106,6 +107,7 @@ export const App = () => {
       {isAdmin && <Route path="/budget" element={<BudgetPage isAdmin={isAdmin} />} />}
       {canAccessInvoices && <Route path="/invoices" element={<InvoiceBuilderPage isAdmin={canAccessInvoices} />} />}
       {canAccessInvoices && <Route path="/documents" element={<DocumentsPage isAdmin={canAccessInvoices} />} />}
+      {canAccessInvoices && <Route path="/parties" element={<PartiesPage isAdmin={canAccessInvoices} />} />}
       <Route path="/policy" element={<PrivacyPolicy />} />
     </Routes>
   );

--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -1,0 +1,482 @@
+// "Дані для заяви в РАЦС" (Childbirth + Transaction editor, Batch 18 §6 / Batch 19) - shared
+// between Documents Builder (editing a case while preparing to generate its documents) and the
+// Parties page (editing a case as part of assembling it), per the Parties spec: "reuse the ...
+// form structure ... rather than duplicating it". Self-contained: owns its own drafts, resets them
+// whenever the selected case changes, and persists additively to the same documentsBuilder/parties
+// tree either host page already reads/writes.
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import toast from 'react-hot-toast';
+import { ref, set, update } from 'firebase/database';
+import { FaPlus, FaTrash } from 'react-icons/fa';
+import { database } from './config';
+import {
+  BIRTH_REGISTRATION_TRANSACTION_TYPE,
+  DOCUMENTS_PARTIES_PATH,
+  createChildRecord,
+  createTransaction,
+  makeTransactionId,
+  toArray,
+} from './documentsCatalogUtils';
+
+// Self-contained styled primitives (DocumentsPage's Section/FieldGrid idiom - see design-tasks
+// notes there) rather than importing DocumentsPage's, so this component has no dependency on that
+// page's internals and can be dropped into any --km-* scoped page (Documents, Parties) as-is.
+const Section = styled.section`
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 12px;
+`;
+
+const SectionHead = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  font-family: var(--km-font-display);
+  font-size: 15px;
+  letter-spacing: -0.01em;
+`;
+
+const SectionSubhead = styled.h3`
+  margin: 12px 0 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--km-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+`;
+
+const RowLine = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const Select = styled.select`
+  flex: 1;
+  min-width: 200px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 30px;
+  padding: 4px 8px;
+  font-size: 12.5px;
+  font-family: var(--km-font);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--km-border);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--km-accent);
+    background: var(--km-card);
+  }
+`;
+
+const DocRow = styled.div`
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-top: 8px;
+`;
+
+const DocRowHead = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const DocSubtitle = styled.div`
+  color: var(--km-muted);
+  font-size: 11px;
+  font-weight: 400;
+`;
+
+const FieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+`;
+
+const Field = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--km-muted);
+`;
+
+const FieldInput = styled.input`
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 28px;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-family: var(--km-font);
+
+  &:hover {
+    border-color: var(--km-border);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--km-accent);
+    background: var(--km-card);
+  }
+`;
+
+const MiniButton = styled.button`
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 30px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+`;
+
+const PrimaryMiniButton = styled(MiniButton)`
+  border: none;
+  color: #fff;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+
+  &:hover:not(:disabled) {
+    color: #fff;
+    filter: brightness(1.05);
+  }
+`;
+
+const SmallButton = styled(MiniButton)`
+  min-height: 24px;
+  padding: 3px 9px;
+  font-size: 10.5px;
+  border-radius: 5px;
+`;
+
+const DangerButton = styled(SmallButton)`
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-danger);
+    color: var(--km-danger);
+  }
+`;
+
+const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelectedChildIdChange }) => {
+  const selectedCase = catalog.parties.cases.find(item => String(item.id) === String(caseId)) || null;
+
+  // Which of the selected case's childbirth.children[] documents are generated for ('' = default
+  // to the first child - a case with just one child never needs this shown).
+  const [selectedChildId, setSelectedChildId] = useState('');
+  // Local editable copies of the selected case's childbirth/transaction data - reset from the
+  // backend record whenever the selected case changes, saved back explicitly via their own Save
+  // buttons, same pattern as the per-document format draft in Documents Builder.
+  const [childbirthDraft, setChildbirthDraft] = useState({ maternityHospitalId: '', children: [] });
+  const [transactionDraft, setTransactionDraft] = useState({ statementDate: '', notaryId: '', registryNumber: '' });
+
+  useEffect(() => {
+    // `childbirth.children` isn't re-validated by normalizeCaseRecord beyond "childbirth itself is
+    // an object" - a case saved before this editor existed (or edited straight in the Firebase
+    // console) can carry `children` as a Firebase gap-object instead of a real array, which crashed
+    // every `.map()` below with no error boundary to catch it (blank page).
+    setChildbirthDraft({
+      maternityHospitalId: selectedCase?.childbirth?.maternityHospitalId || '',
+      children: toArray(selectedCase?.childbirth?.children),
+    });
+    const transactionId = selectedCase?.registrations?.birth?.transactionId;
+    const existingTransaction = transactionId
+      ? catalog.parties.transactions.find(item => String(item.id) === String(transactionId))
+      : null;
+    setTransactionDraft(existingTransaction && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE
+      ? { statementDate: existingTransaction.statementDate || '', notaryId: existingTransaction.notaryId || '', registryNumber: existingTransaction.registryNumber || '' }
+      : { statementDate: '', notaryId: '', registryNumber: '' });
+    setSelectedChildId('');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [caseId]);
+
+  useEffect(() => {
+    onSelectedChildIdChange?.(selectedChildId);
+  }, [selectedChildId, onSelectedChildIdChange]);
+
+  const updateChildbirthField = (field, value) => setChildbirthDraft(previous => ({ ...previous, [field]: value }));
+
+  const updateChildField = (childId, field, value) => setChildbirthDraft(previous => ({
+    ...previous,
+    children: previous.children.map(child => (child.id === childId ? { ...child, [field]: value } : child)),
+  }));
+
+  const updateChildNestedField = (childId, group, field, value) => setChildbirthDraft(previous => ({
+    ...previous,
+    children: previous.children.map(child => (child.id === childId
+      ? { ...child, [group]: { ...(child[group] || {}), [field]: value } }
+      : child)),
+  }));
+
+  const handleAddChild = () => setChildbirthDraft(previous => ({
+    ...previous,
+    children: [...previous.children, createChildRecord()],
+  }));
+
+  // Removing the currently-selected child falls back to the default (first child) rather than
+  // pointing the document generator at an id that no longer exists.
+  const handleRemoveChild = childId => {
+    setChildbirthDraft(previous => ({
+      ...previous,
+      children: previous.children.filter(child => child.id !== childId),
+    }));
+    setSelectedChildId(previous => (previous === childId ? '' : previous));
+  };
+
+  const handleSaveChildbirth = async () => {
+    if (!selectedCase) return;
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${selectedCase.id}/childbirth`), childbirthDraft);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          cases: previous.parties.cases.map(item => (String(item.id) === String(selectedCase.id)
+            ? { ...item, childbirth: childbirthDraft }
+            : item)),
+        },
+      }));
+      toast.success('Childbirth details saved.');
+    } catch (saveError) {
+      console.error('Unable to save childbirth details', saveError);
+      toast.error('Could not save the childbirth details.');
+    }
+  };
+
+  const updateTransactionField = (field, value) => setTransactionDraft(previous => ({ ...previous, [field]: value }));
+
+  // Creates the case's birth-registration-surrogate-consent transaction the first time this is
+  // saved, then only ever updates that same record afterward - a transaction keeps the couple/
+  // surrogate mother it was originally signed for (batch 19), so an update never re-pulls those
+  // ids from the case's current relations, only a brand-new transaction does.
+  const handleSaveTransaction = async () => {
+    if (!selectedCase) return;
+    const existingTransactionId = selectedCase.registrations?.birth?.transactionId;
+    const existingTransaction = existingTransactionId
+      ? catalog.parties.transactions.find(item => String(item.id) === String(existingTransactionId))
+      : null;
+    const isReusableTransaction = Boolean(existingTransaction) && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE;
+    const transactionId = isReusableTransaction ? existingTransaction.id : makeTransactionId();
+    const nextTransaction = createTransaction({
+      transactionId,
+      caseId: selectedCase.id,
+      type: BIRTH_REGISTRATION_TRANSACTION_TYPE,
+      coupleId: isReusableTransaction ? existingTransaction.coupleId : (selectedCase.relations?.coupleId || ''),
+      surrogateMotherId: isReusableTransaction ? existingTransaction.surrogateMotherId : (selectedCase.relations?.surrogateMotherId || ''),
+      notaryId: transactionDraft.notaryId,
+      statementDate: transactionDraft.statementDate,
+      registryNumber: transactionDraft.registryNumber,
+    });
+    try {
+      await update(ref(database, DOCUMENTS_PARTIES_PATH), {
+        [`transactions/${transactionId}`]: nextTransaction,
+        [`cases/${selectedCase.id}/registrations/birth/transactionId`]: transactionId,
+      });
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          transactions: isReusableTransaction
+            ? previous.parties.transactions.map(item => (String(item.id) === transactionId ? nextTransaction : item))
+            : [...previous.parties.transactions, nextTransaction],
+          cases: previous.parties.cases.map(item => (String(item.id) === String(selectedCase.id)
+            ? { ...item, registrations: { ...(item.registrations || {}), birth: { ...(item.registrations?.birth || {}), transactionId } } }
+            : item)),
+        },
+      }));
+      toast.success('Transaction saved.');
+    } catch (saveError) {
+      console.error('Unable to save the transaction', saveError);
+      toast.error('Could not save the transaction.');
+    }
+  };
+
+  if (!selectedCase) return null;
+
+  return (
+    <Section>
+      <SectionHead>
+        <SectionTitle>Дані для заяви в РАЦС</SectionTitle>
+      </SectionHead>
+
+      <SectionSubhead>Пологи</SectionSubhead>
+      <RowLine style={{ marginTop: 6 }}>
+        <Field style={{ flex: 1, minWidth: 220 }}>
+          Пологовий будинок
+          <Select
+            value={childbirthDraft.maternityHospitalId || ''}
+            onChange={event => updateChildbirthField('maternityHospitalId', event.target.value)}
+          >
+            <option value="">— не обрано —</option>
+            {catalog.parties.maternityHospitals.map(hospital => (
+              <option key={hospital.id} value={String(hospital.id)}>
+                {hospital.shortName || hospital.name?.uk || hospital.id}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      </RowLine>
+
+      {childbirthDraft.children.map((child, childIndex) => (
+        <DocRow key={child.id}>
+          <DocRowHead>
+            <DocSubtitle style={{ fontWeight: 700 }}>Дитина {childIndex + 1}</DocSubtitle>
+            <DangerButton
+              type="button"
+              onClick={() => handleRemoveChild(child.id)}
+              title="Remove this child"
+            >
+              <FaTrash />
+            </DangerButton>
+          </DocRowHead>
+          <FieldGrid>
+            <Field>
+              Стать
+              <Select value={child.sex || ''} onChange={event => updateChildField(child.id, 'sex', event.target.value)}>
+                <option value="">— не обрано —</option>
+                <option value="female">жіноча</option>
+                <option value="male">чоловіча</option>
+              </Select>
+            </Field>
+            <Field>
+              Дата народження
+              <FieldInput
+                type="date"
+                value={child.birthDate || ''}
+                onChange={event => updateChildField(child.id, 'birthDate', event.target.value)}
+              />
+            </Field>
+            <Field>
+              Місце народження (укр)
+              <FieldInput
+                type="text"
+                value={child.birthPlace?.uk || ''}
+                onChange={event => updateChildNestedField(child.id, 'birthPlace', 'uk', event.target.value)}
+              />
+            </Field>
+            <Field>
+              Місце народження (eng)
+              <FieldInput
+                type="text"
+                value={child.birthPlace?.en || ''}
+                onChange={event => updateChildNestedField(child.id, 'birthPlace', 'en', event.target.value)}
+              />
+            </Field>
+            <Field>
+              № медичного висновку
+              <FieldInput
+                type="text"
+                value={child.medicalConclusion?.number || ''}
+                onChange={event => updateChildNestedField(child.id, 'medicalConclusion', 'number', event.target.value)}
+              />
+            </Field>
+            <Field>
+              Дата медичного висновку
+              <FieldInput
+                type="date"
+                value={child.medicalConclusion?.date || ''}
+                onChange={event => updateChildNestedField(child.id, 'medicalConclusion', 'date', event.target.value)}
+              />
+            </Field>
+          </FieldGrid>
+        </DocRow>
+      ))}
+
+      <RowLine style={{ marginTop: 8 }}>
+        <SmallButton type="button" onClick={handleAddChild}>
+          <FaPlus /> Add child
+        </SmallButton>
+        <PrimaryMiniButton type="button" onClick={handleSaveChildbirth}>
+          Save childbirth details
+        </PrimaryMiniButton>
+      </RowLine>
+
+      {childbirthDraft.children.length > 1 ? (
+        <RowLine style={{ marginTop: 10 }}>
+          <Field style={{ flex: 1, minWidth: 220 }}>
+            Дитина для документа
+            <Select value={selectedChildId} onChange={event => setSelectedChildId(event.target.value)}>
+              {childbirthDraft.children.map((child, childIndex) => (
+                <option key={child.id} value={child.id}>
+                  Дитина {childIndex + 1}{child.sex ? ` (${child.sex === 'female' ? 'дівчинка' : 'хлопчик'})` : ''}
+                </option>
+              ))}
+            </Select>
+          </Field>
+        </RowLine>
+      ) : null}
+
+      <SectionSubhead style={{ marginTop: 14 }}>Заява до РАЦС (транзакція)</SectionSubhead>
+      <FieldGrid>
+        <Field>
+          Дата заяви
+          <FieldInput
+            type="date"
+            value={transactionDraft.statementDate || ''}
+            onChange={event => updateTransactionField('statementDate', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Нотаріус
+          <Select value={transactionDraft.notaryId || ''} onChange={event => updateTransactionField('notaryId', event.target.value)}>
+            <option value="">— не обрано —</option>
+            {catalog.parties.notaries.map(notary => (
+              <option key={notary.id} value={String(notary.id)}>
+                {notary.name?.uk?.short || notary.name?.uk?.nominative || notary.id}
+              </option>
+            ))}
+          </Select>
+        </Field>
+        <Field>
+          Номер реєстру
+          <FieldInput
+            type="text"
+            value={transactionDraft.registryNumber || ''}
+            onChange={event => updateTransactionField('registryNumber', event.target.value)}
+          />
+        </Field>
+      </FieldGrid>
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveTransaction}>
+          Save transaction
+        </PrimaryMiniButton>
+      </RowLine>
+    </Section>
+  );
+};
+
+export default CaseChildbirthTransactionEditor;

--- a/src/components/DocumentsPage.caseEditor.test.js
+++ b/src/components/DocumentsPage.caseEditor.test.js
@@ -163,4 +163,29 @@ describe('spec: Childbirth/Transaction case editor (Batch 18 §6)', () => {
     }));
     expect(payload[`cases/case-1/registrations/birth/transactionId`]).toBe(transactionId);
   });
+
+  // Regression: Firebase RTDB silently turns a JS array into a `{"1": {...}}`-shaped plain object
+  // once a child has ever been removed by key rather than re-set as a dense array (or the case was
+  // edited straight in the Firebase console) - `childbirthDraft.children.map(...)` then threw
+  // "children.map is not a function" with no error boundary to catch it, blanking the whole page.
+  it('does not crash when a case.childbirth.children arrives as a Firebase gap-object instead of an array', async () => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') {
+        const parties = buildParties();
+        // `.children` here is a plain-object field on the fixture, not a DOM node, but the
+        // testing-library lint rule can't tell the two apart from the property name alone.
+        // eslint-disable-next-line testing-library/no-node-access
+        parties.cases['case-1'].childbirth.children = { 1: parties.cases['case-1'].childbirth.children[0] };
+        return { exists: () => true, val: () => parties };
+      }
+      if (path === 'documentsBuilder/templates') return { exists: () => false, val: () => null };
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+
+    expect(await screen.findByLabelText('Пологовий будинок')).toHaveValue('hospital-1');
+    expect(screen.getByText('Дитина 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Стать')).toHaveValue('female');
+  });
 });

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -59,6 +59,7 @@ import {
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
   shiftDocOverrideParagraphIndices,
+  toArray,
   toggleInlineFormat,
   upsertRecentCaseId,
   upsertRecentId,
@@ -694,7 +695,14 @@ const DocumentsPage = ({ isAdmin }) => {
   // carries a previous case's in-progress edits over onto the newly selected one.
   useEffect(() => {
     const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
-    setChildbirthDraft(caseRecord?.childbirth || { maternityHospitalId: '', children: [] });
+    // `childbirth.children` isn't re-validated by normalizeCaseRecord beyond "childbirth itself is
+    // an object" - a case saved before this editor existed (or edited straight in the Firebase
+    // console) can carry `children` as a Firebase gap-object instead of a real array, which crashed
+    // every `.map()` below with no error boundary to catch it (blank page, spec bug report).
+    setChildbirthDraft({
+      maternityHospitalId: caseRecord?.childbirth?.maternityHospitalId || '',
+      children: toArray(caseRecord?.childbirth?.children),
+    });
     const transactionId = caseRecord?.registrations?.birth?.transactionId;
     const existingTransaction = transactionId
       ? catalog.parties.transactions.find(item => String(item.id) === String(transactionId))

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -15,9 +15,9 @@ import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFo
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
+import CaseChildbirthTransactionEditor from './CaseChildbirthTransactionEditor';
 import { useAutoResize } from '../hooks/useAutoResize';
 import {
-  BIRTH_REGISTRATION_TRANSACTION_TYPE,
   DEFAULT_DOC_FORMATTING,
   DOCUMENTS_PARTIES_PATH,
   DOCUMENTS_SETTINGS_PATH,
@@ -33,8 +33,6 @@ import {
   clinicLogoEntriesToBackend,
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
-  createChildRecord,
-  createTransaction,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   getClinicLogo,
@@ -44,7 +42,6 @@ import {
   isBilingualLayout,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
-  makeTransactionId,
   mergeDocumentsCatalog,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -59,7 +56,6 @@ import {
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
   shiftDocOverrideParagraphIndices,
-  toArray,
   toggleInlineFormat,
   upsertRecentCaseId,
   upsertRecentId,
@@ -235,15 +231,6 @@ const SectionTitle = styled.h2`
   font-family: var(--km-font-display);
   font-size: 15px;
   letter-spacing: -0.01em;
-`;
-
-const SectionSubhead = styled.h3`
-  margin: 12px 0 0;
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--km-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
 `;
 
 const StateCard = styled.div`
@@ -601,12 +588,9 @@ const DocumentsPage = ({ isAdmin }) => {
   const [selectedCaseId, setSelectedCaseId] = useState('');
   // Which of the selected case's childbirth.children[] documents are generated for ('' = default
   // to the first child, spec Batch 18 §2 - a case with just one child never needs this shown).
+  // Owned here (not inside CaseChildbirthTransactionEditor) because prepareGeneration/caseContext
+  // below need to read it too - the editor just reports changes via onSelectedChildIdChange.
   const [selectedChildId, setSelectedChildId] = useState('');
-  // Local editable copies of the selected case's childbirth/transaction data (Batch 18 §6, "Дані
-  // для заяви в РАЦС") - reset from the backend record whenever the selected case changes, saved
-  // back explicitly via their own Save buttons, same pattern as the per-document format draft.
-  const [childbirthDraft, setChildbirthDraft] = useState({ maternityHospitalId: '', children: [] });
-  const [transactionDraft, setTransactionDraft] = useState({ statementDate: '', notaryId: '', registryNumber: '' });
   const [selectedDocIds, setSelectedDocIds] = useState({});
   const [layout, setLayout] = useState('two-column');
   const [expandedDocId, setExpandedDocId] = useState('');
@@ -690,29 +674,6 @@ const DocumentsPage = ({ isAdmin }) => {
   useEffect(() => {
     loadDocumentsData();
   }, [loadDocumentsData]);
-
-  // Reload the Childbirth/Transaction editor drafts whenever the selected case changes - never
-  // carries a previous case's in-progress edits over onto the newly selected one.
-  useEffect(() => {
-    const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
-    // `childbirth.children` isn't re-validated by normalizeCaseRecord beyond "childbirth itself is
-    // an object" - a case saved before this editor existed (or edited straight in the Firebase
-    // console) can carry `children` as a Firebase gap-object instead of a real array, which crashed
-    // every `.map()` below with no error boundary to catch it (blank page, spec bug report).
-    setChildbirthDraft({
-      maternityHospitalId: caseRecord?.childbirth?.maternityHospitalId || '',
-      children: toArray(caseRecord?.childbirth?.children),
-    });
-    const transactionId = caseRecord?.registrations?.birth?.transactionId;
-    const existingTransaction = transactionId
-      ? catalog.parties.transactions.find(item => String(item.id) === String(transactionId))
-      : null;
-    setTransactionDraft(existingTransaction && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE
-      ? { statementDate: existingTransaction.statementDate || '', notaryId: existingTransaction.notaryId || '', registryNumber: existingTransaction.registryNumber || '' }
-      : { statementDate: '', notaryId: '', registryNumber: '' });
-    setSelectedChildId('');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedCaseId]);
 
   // Warm the lazy PDF/DOCX chunks while this build is still deployed (see isStaleChunkError).
   useEffect(() => {
@@ -1174,108 +1135,6 @@ const DocumentsPage = ({ isAdmin }) => {
     } catch (deleteError) {
       console.error('Unable to delete case', deleteError);
       toast.error('Could not delete the case.');
-    }
-  };
-
-  // --- Childbirth + Transaction editor ("Дані для заяви в РАЦС", Batch 18 §6) --------------------
-  // Regrouped to match the actual backend shape: the maternity hospital + per-child birth details
-  // live under childbirth, while the notary/statementDate/registryNumber for the birth-registration
-  // surrogate-consent statement live on its own transaction record (batch 19).
-
-  const updateChildbirthField = (field, value) => setChildbirthDraft(previous => ({ ...previous, [field]: value }));
-
-  const updateChildField = (childId, field, value) => setChildbirthDraft(previous => ({
-    ...previous,
-    children: (previous.children || []).map(child => (child.id === childId ? { ...child, [field]: value } : child)),
-  }));
-
-  const updateChildNestedField = (childId, group, field, value) => setChildbirthDraft(previous => ({
-    ...previous,
-    children: (previous.children || []).map(child => (child.id === childId
-      ? { ...child, [group]: { ...(child[group] || {}), [field]: value } }
-      : child)),
-  }));
-
-  const handleAddChild = () => setChildbirthDraft(previous => ({
-    ...previous,
-    children: [...(previous.children || []), createChildRecord()],
-  }));
-
-  // Removing the currently-selected child falls back to the default (first child) rather than
-  // pointing the document generator at an id that no longer exists.
-  const handleRemoveChild = childId => {
-    setChildbirthDraft(previous => ({
-      ...previous,
-      children: (previous.children || []).filter(child => child.id !== childId),
-    }));
-    setSelectedChildId(previous => (previous === childId ? '' : previous));
-  };
-
-  const handleSaveChildbirth = async () => {
-    if (!selectedCase) return;
-    try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${selectedCase.id}/childbirth`), childbirthDraft);
-      setCatalog(previous => ({
-        ...previous,
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(item => (String(item.id) === selectedCaseId
-            ? { ...item, childbirth: childbirthDraft }
-            : item)),
-        },
-      }));
-      toast.success('Childbirth details saved.');
-    } catch (saveError) {
-      console.error('Unable to save childbirth details', saveError);
-      toast.error('Could not save the childbirth details.');
-    }
-  };
-
-  const updateTransactionField = (field, value) => setTransactionDraft(previous => ({ ...previous, [field]: value }));
-
-  // Creates the case's birth-registration-surrogate-consent transaction the first time this is
-  // saved, then only ever updates that same record afterward - a transaction keeps the couple/
-  // surrogate mother it was originally signed for (batch 19), so an update never re-pulls those
-  // ids from the case's current relations, only a brand-new transaction does.
-  const handleSaveTransaction = async () => {
-    if (!selectedCase) return;
-    const existingTransactionId = selectedCase.registrations?.birth?.transactionId;
-    const existingTransaction = existingTransactionId
-      ? catalog.parties.transactions.find(item => String(item.id) === String(existingTransactionId))
-      : null;
-    const isReusableTransaction = Boolean(existingTransaction) && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE;
-    const transactionId = isReusableTransaction ? existingTransaction.id : makeTransactionId();
-    const nextTransaction = createTransaction({
-      transactionId,
-      caseId: selectedCase.id,
-      type: BIRTH_REGISTRATION_TRANSACTION_TYPE,
-      coupleId: isReusableTransaction ? existingTransaction.coupleId : (selectedCase.relations?.coupleId || ''),
-      surrogateMotherId: isReusableTransaction ? existingTransaction.surrogateMotherId : (selectedCase.relations?.surrogateMotherId || ''),
-      notaryId: transactionDraft.notaryId,
-      statementDate: transactionDraft.statementDate,
-      registryNumber: transactionDraft.registryNumber,
-    });
-    try {
-      await update(ref(database, DOCUMENTS_PARTIES_PATH), {
-        [`transactions/${transactionId}`]: nextTransaction,
-        [`cases/${selectedCase.id}/registrations/birth/transactionId`]: transactionId,
-      });
-      setCatalog(previous => ({
-        ...previous,
-        parties: {
-          ...previous.parties,
-          transactions: isReusableTransaction
-            ? previous.parties.transactions.map(item => (String(item.id) === transactionId ? nextTransaction : item))
-            : [...previous.parties.transactions, nextTransaction],
-          cases: previous.parties.cases.map(item => (String(item.id) === selectedCaseId
-            ? { ...item, registrations: { ...(item.registrations || {}), birth: { ...(item.registrations?.birth || {}), transactionId } } }
-            : item)),
-        },
-      }));
-      toast.success('Transaction saved.');
-    } catch (saveError) {
-      console.error('Unable to save the transaction', saveError);
-      toast.error('Could not save the transaction.');
     }
   };
 
@@ -1812,156 +1671,12 @@ const DocumentsPage = ({ isAdmin }) => {
               ) : null}
             </Section>
 
-            {selectedCase ? (
-              <Section>
-                <SectionHead>
-                  <SectionTitle>Дані для заяви в РАЦС</SectionTitle>
-                </SectionHead>
-
-                <SectionSubhead>Пологи</SectionSubhead>
-                <RowLine style={{ marginTop: 6 }}>
-                  <Field style={{ flex: 1, minWidth: 220 }}>
-                    Пологовий будинок
-                    <Select
-                      value={childbirthDraft.maternityHospitalId || ''}
-                      onChange={event => updateChildbirthField('maternityHospitalId', event.target.value)}
-                    >
-                      <option value="">— не обрано —</option>
-                      {catalog.parties.maternityHospitals.map(hospital => (
-                        <option key={hospital.id} value={String(hospital.id)}>
-                          {hospital.shortName || hospital.name?.uk || hospital.id}
-                        </option>
-                      ))}
-                    </Select>
-                  </Field>
-                </RowLine>
-
-                {(childbirthDraft.children || []).map((child, childIndex) => (
-                  <DocRow key={child.id}>
-                    <DocRowHead>
-                      <DocSubtitle style={{ fontWeight: 700 }}>Дитина {childIndex + 1}</DocSubtitle>
-                      <DangerButton
-                        type="button"
-                        onClick={() => handleRemoveChild(child.id)}
-                        title="Remove this child"
-                      >
-                        <FaTrash />
-                      </DangerButton>
-                    </DocRowHead>
-                    <FieldGrid>
-                      <Field>
-                        Стать
-                        <Select value={child.sex || ''} onChange={event => updateChildField(child.id, 'sex', event.target.value)}>
-                          <option value="">— не обрано —</option>
-                          <option value="female">жіноча</option>
-                          <option value="male">чоловіча</option>
-                        </Select>
-                      </Field>
-                      <Field>
-                        Дата народження
-                        <FieldInput
-                          type="date"
-                          value={child.birthDate || ''}
-                          onChange={event => updateChildField(child.id, 'birthDate', event.target.value)}
-                        />
-                      </Field>
-                      <Field>
-                        Місце народження (укр)
-                        <FieldInput
-                          type="text"
-                          value={child.birthPlace?.uk || ''}
-                          onChange={event => updateChildNestedField(child.id, 'birthPlace', 'uk', event.target.value)}
-                        />
-                      </Field>
-                      <Field>
-                        Місце народження (eng)
-                        <FieldInput
-                          type="text"
-                          value={child.birthPlace?.en || ''}
-                          onChange={event => updateChildNestedField(child.id, 'birthPlace', 'en', event.target.value)}
-                        />
-                      </Field>
-                      <Field>
-                        № медичного висновку
-                        <FieldInput
-                          type="text"
-                          value={child.medicalConclusion?.number || ''}
-                          onChange={event => updateChildNestedField(child.id, 'medicalConclusion', 'number', event.target.value)}
-                        />
-                      </Field>
-                      <Field>
-                        Дата медичного висновку
-                        <FieldInput
-                          type="date"
-                          value={child.medicalConclusion?.date || ''}
-                          onChange={event => updateChildNestedField(child.id, 'medicalConclusion', 'date', event.target.value)}
-                        />
-                      </Field>
-                    </FieldGrid>
-                  </DocRow>
-                ))}
-
-                <RowLine style={{ marginTop: 8 }}>
-                  <SmallButton type="button" onClick={handleAddChild}>
-                    <FaPlus /> Add child
-                  </SmallButton>
-                  <PrimaryMiniButton type="button" onClick={handleSaveChildbirth}>
-                    Save childbirth details
-                  </PrimaryMiniButton>
-                </RowLine>
-
-                {(childbirthDraft.children || []).length > 1 ? (
-                  <RowLine style={{ marginTop: 10 }}>
-                    <Field style={{ flex: 1, minWidth: 220 }}>
-                      Дитина для документа
-                      <Select value={selectedChildId} onChange={event => setSelectedChildId(event.target.value)}>
-                        {(childbirthDraft.children || []).map((child, childIndex) => (
-                          <option key={child.id} value={child.id}>
-                            Дитина {childIndex + 1}{child.sex ? ` (${child.sex === 'female' ? 'дівчинка' : 'хлопчик'})` : ''}
-                          </option>
-                        ))}
-                      </Select>
-                    </Field>
-                  </RowLine>
-                ) : null}
-
-                <SectionSubhead style={{ marginTop: 14 }}>Заява до РАЦС (транзакція)</SectionSubhead>
-                <FieldGrid>
-                  <Field>
-                    Дата заяви
-                    <FieldInput
-                      type="date"
-                      value={transactionDraft.statementDate || ''}
-                      onChange={event => updateTransactionField('statementDate', event.target.value)}
-                    />
-                  </Field>
-                  <Field>
-                    Нотаріус
-                    <Select value={transactionDraft.notaryId || ''} onChange={event => updateTransactionField('notaryId', event.target.value)}>
-                      <option value="">— не обрано —</option>
-                      {catalog.parties.notaries.map(notary => (
-                        <option key={notary.id} value={String(notary.id)}>
-                          {notary.name?.uk?.short || notary.name?.uk?.nominative || notary.id}
-                        </option>
-                      ))}
-                    </Select>
-                  </Field>
-                  <Field>
-                    Номер реєстру
-                    <FieldInput
-                      type="text"
-                      value={transactionDraft.registryNumber || ''}
-                      onChange={event => updateTransactionField('registryNumber', event.target.value)}
-                    />
-                  </Field>
-                </FieldGrid>
-                <RowLine style={{ marginTop: 8 }}>
-                  <PrimaryMiniButton type="button" onClick={handleSaveTransaction}>
-                    Save transaction
-                  </PrimaryMiniButton>
-                </RowLine>
-              </Section>
-            ) : null}
+            <CaseChildbirthTransactionEditor
+              catalog={catalog}
+              setCatalog={setCatalog}
+              caseId={selectedCaseId}
+              onSelectedChildIdChange={setSelectedChildId}
+            />
 
             <Section>
               <SectionHead>

--- a/src/components/PageNavMenu.jsx
+++ b/src/components/PageNavMenu.jsx
@@ -9,6 +9,7 @@ const NAV_LINKS = [
   { path: '/documents', label: 'Documents' },
   { path: '/invoices', label: 'Invoice' },
   { path: '/budget', label: 'Budget' },
+  { path: '/parties', label: 'Parties' },
 ];
 
 const Wrap = styled.div`

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -1,0 +1,1252 @@
+// Parties - the single admin page to view and edit every party record (couples, surrogate
+// mothers, representatives, clinics, maternity hospitals, notaries) and assemble them into cases.
+// Third sibling of Invoice Builder / Documents Builder: same React + Firebase approach, same
+// page-scoped --km-* palette, reachable from the shared PageNavMenu. Reads/writes the exact same
+// documentsBuilder/parties tree Documents Builder already owns - this page is the manual-editing
+// counterpart to that page's JSON paste-and-parse path, not a separate data store.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import toast from 'react-hot-toast';
+import { get, ref, set, update } from 'firebase/database';
+import { FaPlus, FaTrash, FaUpload } from 'react-icons/fa';
+import designTokens from '../data/designTokens.json';
+import { auth, database } from './config';
+import { isInvoiceBuilderUid } from 'utils/accessLevel';
+import PageNavMenu from './PageNavMenu';
+import CaseChildbirthTransactionEditor from './CaseChildbirthTransactionEditor';
+import {
+  DOCUMENTS_PARTIES_PATH,
+  DOCUMENTS_TEMPLATES_PATH,
+  PARTY_COLLECTIONS,
+  buildCaseLabel,
+  createEmptyCase,
+  createEmptyClinic,
+  createEmptyCouple,
+  createEmptyMaternityHospital,
+  createEmptyNotary,
+  createEmptyPartner,
+  createEmptyRepresentative,
+  createEmptySurrogateMother,
+  emptyDocumentsCatalog,
+  findPartyReferences,
+  getValueByPath,
+  isPlainObject,
+  makeCaseId,
+  mergeDocumentsCatalog,
+  normalizeDocumentsCatalog,
+  orderRecordsByRecentIds,
+  parseDocumentsTechnicalInput,
+  resolveMergedRecordsForPersistence,
+  toArray,
+  upsertRecentId,
+} from './documentsCatalogUtils';
+
+const PARTIES_SETTINGS_PATH = 'documentsBuilder/partiesSettings';
+
+// --- Layout shell (same skeleton/palette as Invoice Builder & Documents Builder) ----------------
+
+const Page = styled.main`
+  --km-bg: #EFE9DD;
+  --km-card: ${designTokens.color.paper};
+  --km-text: ${designTokens.color.docInk};
+  --km-muted: ${designTokens.color.inkSoft};
+  --km-border: ${designTokens.color.docLine};
+  --km-accent: ${designTokens.color.bronze};
+  --km-accent-mid: #C6A671;
+  --km-accent-light: rgba(162, 121, 63, 0.12);
+  --km-danger: #B3523F;
+  --km-danger-border: rgba(179, 82, 63, 0.35);
+  --km-font: 'Inter', sans-serif;
+  --km-font-display: 'Fraunces', serif;
+
+  min-height: 100vh;
+  background: var(--km-bg);
+  color: var(--km-text);
+  padding: 16px 12px 72px;
+  font-family: var(--km-font);
+  font-size: 13px;
+`;
+
+const Shell = styled.div`
+  width: min(100%, 880px);
+  margin: 0 auto;
+`;
+
+const Header = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+
+  @media (max-width: 560px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;
+
+const Eyebrow = styled.div`
+  color: var(--km-accent);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  margin-bottom: 2px;
+  text-transform: uppercase;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  font-family: var(--km-font-display);
+  font-size: clamp(20px, 4vw, 27px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+`;
+
+const HeaderActions = styled.div`
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+
+  @media (max-width: 560px) {
+    width: 100%;
+    justify-content: flex-start;
+  }
+`;
+
+const MiniButton = styled.button`
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 30px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+`;
+
+const SmallButton = styled(MiniButton)`
+  min-height: 24px;
+  padding: 3px 9px;
+  font-size: 10.5px;
+  border-radius: 5px;
+`;
+
+const DangerButton = styled(SmallButton)`
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-danger);
+    color: var(--km-danger);
+  }
+`;
+
+const StateCard = styled.div`
+  padding: 20px;
+  border-radius: 10px;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  color: var(--km-muted);
+  font-size: 13px;
+`;
+
+// --- Group panel + collapsed summary row (Beneficiary/Payer pattern from Invoice Builder) -------
+// Collapsed by default; header shows a count. Each record inside is itself a collapsed row that
+// expands to its editable fields - same two-level "tap to expand" interaction throughout.
+
+const Panel = styled.section`
+  margin-top: 10px;
+  border: 1px solid var(--km-border);
+  border-radius: 10px;
+  background: var(--km-card);
+  padding: 12px 14px;
+`;
+
+const CompactSection = styled.div`
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  background: var(--km-bg);
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+`;
+
+const CompactInfo = styled.div`
+  flex: 1 1 auto;
+  min-width: 0;
+`;
+
+const CompactLabel = styled.div`
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--km-accent);
+`;
+
+const CompactValue = styled.div`
+  margin-top: 2px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--km-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const CompactChevron = styled.span`
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--km-accent);
+`;
+
+const RecordBlock = styled.div`
+  margin-top: 8px;
+`;
+
+const RecordBody = styled.div`
+  margin-top: 6px;
+  padding: 8px 10px 10px;
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  background: var(--km-card);
+`;
+
+const SectionSubhead = styled.h3`
+  margin: 10px 0 0;
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--km-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+
+  &:first-child {
+    margin-top: 0;
+  }
+`;
+
+const RowLine = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+// Plain-text convention: every field reads as editable text - borderless/background-free until
+// hovered or focused (same rule the case editor's own Field/FieldInput already follow).
+const FieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+const Field = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--km-muted);
+`;
+
+const FieldInput = styled.input`
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 28px;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-family: var(--km-font);
+
+  &:hover {
+    border-color: var(--km-border);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--km-accent);
+    background: var(--km-card);
+  }
+`;
+
+const PickerList = styled.div`
+  margin-top: 6px;
+  max-height: 190px;
+  overflow-y: auto;
+  display: grid;
+  gap: 4px;
+`;
+
+const PickerButton = styled.button`
+  border: 1px solid ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-border)')};
+  background: ${({ $active }) => ($active ? 'var(--km-accent-light)' : 'var(--km-card)')};
+  color: ${({ $active }) => ($active ? 'var(--km-accent)' : 'var(--km-text)')};
+  border-radius: 8px;
+  padding: 6px 9px;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+`;
+
+const TechnicalTextarea = styled.textarea`
+  width: 100%;
+  min-height: 120px;
+  margin-top: 8px;
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  background: var(--km-bg);
+  color: var(--km-text);
+  font-family: 'SFMono-Regular', Menlo, monospace;
+  font-size: 11.5px;
+  padding: 8px;
+  resize: vertical;
+`;
+
+// --- Path-based field helpers ---------------------------------------------------------------
+// Every record editor below is driven off a small `{ label, path, type }` list plus these two
+// generic helpers, rather than one bespoke component per field - the six party types differ only
+// in which fields they carry, never in how a field is read, drafted, or committed.
+
+const setValueAtPath = (obj, path, value) => {
+  const [key, ...rest] = String(path).split('.');
+  if (!rest.length) return { ...obj, [key]: value };
+  const child = isPlainObject(obj?.[key]) ? obj[key] : {};
+  return { ...obj, [key]: setValueAtPath(child, rest.join('.'), value) };
+};
+
+// Resyncs from the backend value on every change, unless the field currently has focus (so an
+// in-progress keystroke never gets clobbered by a re-render triggered by an unrelated commit) -
+// same guard the Invoice Builder's plain fields use.
+const useFieldDraft = externalValue => {
+  const [draft, setDraft] = useState(externalValue ?? '');
+  const editingRef = useRef(false);
+  useEffect(() => {
+    if (!editingRef.current) setDraft(externalValue ?? '');
+  }, [externalValue]);
+  return [draft, setDraft, editingRef];
+};
+
+const RecordFieldInput = ({ label, value, type, onCommit }) => {
+  const [draft, setDraft, editingRef] = useFieldDraft(value || '');
+  return (
+    <Field>
+      {label}
+      <FieldInput
+        type={type || 'text'}
+        value={draft}
+        aria-label={label}
+        onFocus={() => { editingRef.current = true; }}
+        onChange={event => setDraft(event.target.value)}
+        onBlur={() => {
+          editingRef.current = false;
+          if (draft !== (value || '')) onCommit(draft);
+        }}
+      />
+    </Field>
+  );
+};
+
+const RecordFieldsGrid = ({ record, fieldDefs, onFieldChange }) => (
+  <FieldGrid>
+    {fieldDefs.map(({ label, path, type }) => (
+      <RecordFieldInput
+        key={path}
+        label={label}
+        type={type}
+        value={getValueByPath(record, path)}
+        onCommit={value => onFieldChange(path, value)}
+      />
+    ))}
+  </FieldGrid>
+);
+
+// --- Display names (collapsed-row summary text) ----------------------------------------------
+
+const nameFormOf = value => {
+  if (isPlainObject(value)) {
+    if (typeof value.uk === 'string' && value.uk) return value.uk;
+    if (isPlainObject(value.uk)) return value.uk.nominative || value.uk.short || '';
+    if (typeof value.en === 'string' && value.en) return value.en;
+    if (isPlainObject(value.en)) return value.en.full || value.en.short || '';
+    return '';
+  }
+  return value || '';
+};
+
+const partyDisplayName = record => nameFormOf(record?.name) || record?.id;
+const maternityDisplayName = record => nameFormOf(record?.name) || nameFormOf(record?.shortName) || record?.id;
+const coupleDisplayName = record => {
+  const names = toArray(record?.partners).map(partner => nameFormOf(partner?.name)).filter(Boolean);
+  return names.length ? names.join(' & ') : record?.id;
+};
+
+// --- Field definitions per party type ----------------------------------------------------------
+
+const PARTNER_FIELDS = [
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
+  { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
+  { label: 'Name (en)', path: 'name.en' },
+  { label: 'Birth date', path: 'birthDate', type: 'date' },
+  { label: 'Citizenship (uk)', path: 'citizenship.uk' },
+  { label: 'Citizenship (en)', path: 'citizenship.en' },
+  { label: 'Passport number', path: 'passport.number' },
+  { label: 'Passport issued by (uk)', path: 'passport.issuedBy.uk' },
+  { label: 'Passport issued by (en)', path: 'passport.issuedBy.en' },
+  { label: 'Passport issue date', path: 'passport.issueDate', type: 'date' },
+];
+
+const MARRIAGE_AND_ADDRESS_FIELDS = [
+  { label: 'Marriage certificate number', path: 'marriage.certificateNumber' },
+  { label: 'Marriage certificate date', path: 'marriage.certificateDate', type: 'date' },
+  { label: 'Address (uk)', path: 'address.uk' },
+  { label: 'Address (en)', path: 'address.en' },
+];
+
+const SURROGATE_MOTHER_FIELDS = [
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
+  { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
+  { label: 'Name (en)', path: 'name.en' },
+  { label: 'Birth date', path: 'birthDate', type: 'date' },
+  { label: 'Passport number', path: 'passport.number' },
+  { label: 'Passport issue date', path: 'passport.issueDate', type: 'date' },
+  { label: 'Tax ID', path: 'taxId' },
+  { label: 'Address (uk)', path: 'address.uk' },
+  { label: 'Address (en)', path: 'address.en' },
+];
+
+const REPRESENTATIVE_FIELDS = [
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
+  { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
+  { label: 'Name (en)', path: 'name.en' },
+  { label: 'Passport number', path: 'passport.number' },
+  { label: 'Power of attorney date', path: 'powerOfAttorney.date', type: 'date' },
+  { label: 'Power of attorney apostille', path: 'powerOfAttorney.apostille' },
+];
+
+const CLINIC_FIELDS = [
+  { label: 'Name (uk)', path: 'name.uk' },
+  { label: 'Name (en)', path: 'name.en' },
+  { label: 'Legal name (uk)', path: 'legalName.uk' },
+  { label: 'Legal name (en)', path: 'legalName.en' },
+  { label: 'Medical center name (uk)', path: 'medicalCenterName.uk' },
+  { label: 'Medical center name (en)', path: 'medicalCenterName.en' },
+  { label: 'Address (uk)', path: 'address.uk' },
+  { label: 'Address (en)', path: 'address.en' },
+  { label: 'Phone', path: 'phone' },
+  { label: 'Email', path: 'email' },
+  { label: 'EDRPOU', path: 'edrpou' },
+  { label: 'Tax ID', path: 'taxId' },
+  { label: 'VAT certificate number', path: 'vatCertificateNumber' },
+  { label: 'Bank account', path: 'bank.account' },
+  { label: 'Bank MFO', path: 'bank.mfo' },
+  { label: 'Bank name (uk)', path: 'bank.name.uk' },
+  { label: 'Bank name (en)', path: 'bank.name.en' },
+  { label: 'Bank address (uk)', path: 'bank.address.uk' },
+  { label: 'Bank address (en)', path: 'bank.address.en' },
+  { label: 'License number', path: 'license.number' },
+  { label: 'License date', path: 'license.date', type: 'date' },
+  { label: 'License issued by (uk)', path: 'license.issuedBy.uk' },
+  { label: 'License issued by (en)', path: 'license.issuedBy.en' },
+  { label: 'Medical director (uk, nominative)', path: 'medicalDirector.name.uk.nominative' },
+  { label: 'Medical director (uk, genitive)', path: 'medicalDirector.name.uk.genitive' },
+  { label: 'Medical director (uk, short)', path: 'medicalDirector.name.uk.short' },
+  { label: 'Medical director (en, full)', path: 'medicalDirector.name.en.full' },
+  { label: 'Medical director (en, short)', path: 'medicalDirector.name.en.short' },
+  { label: 'Director authority type (uk)', path: 'medicalDirector.authority.type.uk' },
+  { label: 'Director authority type (en)', path: 'medicalDirector.authority.type.en' },
+  { label: 'Director authority number', path: 'medicalDirector.authority.number' },
+  { label: 'Director authority date', path: 'medicalDirector.authority.date', type: 'date' },
+];
+
+const MATERNITY_HOSPITAL_FIELDS = [
+  { label: 'Name (uk)', path: 'name.uk' },
+  { label: 'Name (en)', path: 'name.en' },
+  { label: 'Short name (uk)', path: 'shortName.uk' },
+  { label: 'Short name (en)', path: 'shortName.en' },
+  { label: 'EDRPOU', path: 'edrpou' },
+  { label: 'Address (uk)', path: 'address.uk' },
+  { label: 'Address (en)', path: 'address.en' },
+];
+
+const NOTARY_FIELDS = [
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
+  { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
+  { label: 'Name (uk, short)', path: 'name.uk.short' },
+  { label: 'Name (uk, instrumental)', path: 'name.uk.instrumental' },
+  { label: 'Name (en, full)', path: 'name.en.full' },
+  { label: 'Name (en, short)', path: 'name.en.short' },
+  { label: 'Title (uk)', path: 'title.uk' },
+  { label: 'Title (en)', path: 'title.en' },
+  { label: 'City (uk)', path: 'city.uk' },
+  { label: 'City (en)', path: 'city.en' },
+];
+
+const PROGRAM_FIELDS = [
+  { label: 'Program ID', path: 'programId' },
+  { label: 'Program type', path: 'program.type' },
+  { label: 'Agreement number (uk)', path: 'program.agreement.number.uk' },
+  { label: 'Agreement number (en)', path: 'program.agreement.number.en' },
+  { label: 'Agreement date', path: 'program.agreement.date', type: 'date' },
+];
+
+// --- One party-type group (couples/surrogateMothers/representatives/clinics/maternityHospitals/
+// notaries) ---------------------------------------------------------------------------------------
+
+const SimplePartyGroup = ({
+  title, collection, records, fieldDefs, displayName, createEmpty, catalog, setCatalog, expandedKeys, toggleRecord, groupOpen, onToggleGroup,
+}) => {
+  const handleAdd = async () => {
+    const record = createEmpty();
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/${collection}/${record.id}`), record);
+      setCatalog(previous => ({
+        ...previous,
+        parties: { ...previous.parties, [collection]: [...previous.parties[collection], record] },
+      }));
+      toggleRecord(collection, record.id, true);
+      toast.success('Added.');
+    } catch (addError) {
+      console.error(`Unable to add ${collection} record`, addError);
+      toast.error('Could not add the record.');
+    }
+  };
+
+  const handleFieldChange = async (record, path, value) => {
+    const dbPath = `${DOCUMENTS_PARTIES_PATH}/${collection}/${record.id}/${path.split('.').join('/')}`;
+    try {
+      await set(ref(database, dbPath), value);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          [collection]: previous.parties[collection].map(item => (
+            String(item.id) === String(record.id) ? setValueAtPath(item, path, value) : item
+          )),
+        },
+      }));
+    } catch (updateError) {
+      console.error(`Unable to save ${collection} field`, updateError);
+      toast.error('Could not save.');
+    }
+  };
+
+  const handleDelete = async record => {
+    const references = findPartyReferences(catalog, collection, record.id);
+    const label = displayName(record) || record.id;
+    const suffix = references.length ? ` Used in ${references.join(', ')}.` : '';
+    if (typeof window !== 'undefined' && !window.confirm(`Delete "${label}"?${suffix}`)) return;
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/${collection}/${record.id}`), null);
+      setCatalog(previous => ({
+        ...previous,
+        parties: { ...previous.parties, [collection]: previous.parties[collection].filter(item => String(item.id) !== String(record.id)) },
+      }));
+      toast.success('Deleted.');
+    } catch (deleteError) {
+      console.error(`Unable to delete ${collection} record`, deleteError);
+      toast.error('Could not delete.');
+    }
+  };
+
+  return (
+    <Panel>
+      <CompactSection onClick={onToggleGroup} role="button" aria-expanded={groupOpen}>
+        <CompactInfo>
+          <CompactLabel>{title}</CompactLabel>
+          <CompactValue>{records.length} record{records.length === 1 ? '' : 's'}</CompactValue>
+        </CompactInfo>
+        <CompactChevron>{groupOpen ? 'Hide ›' : 'Show ›'}</CompactChevron>
+      </CompactSection>
+      {groupOpen ? (
+        <>
+          {records.map(record => {
+            const expanded = Boolean(expandedKeys[`${collection}:${record.id}`]);
+            return (
+              <RecordBlock key={record.id}>
+                <CompactSection onClick={() => toggleRecord(collection, record.id)} role="button" aria-expanded={expanded}>
+                  <CompactInfo>
+                    <CompactValue>{displayName(record) || record.id}</CompactValue>
+                  </CompactInfo>
+                  <CompactChevron>{expanded ? 'Hide ›' : 'Edit ›'}</CompactChevron>
+                </CompactSection>
+                {expanded ? (
+                  <RecordBody>
+                    <RecordFieldsGrid record={record} fieldDefs={fieldDefs} onFieldChange={(path, value) => handleFieldChange(record, path, value)} />
+                    <RowLine style={{ marginTop: 8 }}>
+                      <DangerButton type="button" onClick={() => handleDelete(record)}>
+                        <FaTrash /> Delete
+                      </DangerButton>
+                    </RowLine>
+                  </RecordBody>
+                ) : null}
+              </RecordBlock>
+            );
+          })}
+          <RowLine style={{ marginTop: 10 }}>
+            <SmallButton type="button" onClick={handleAdd}>
+              <FaPlus /> Add
+            </SmallButton>
+          </RowLine>
+        </>
+      ) : null}
+    </Panel>
+  );
+};
+
+// --- Couples group (partners[wife/husband] special-cased, plus marriage/address) ----------------
+
+const CouplesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen, onToggleGroup }) => {
+  const collection = 'couples';
+  const records = catalog.parties.couples;
+
+  const handleAdd = async () => {
+    const record = createEmptyCouple();
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/couples/${record.id}`), record);
+      setCatalog(previous => ({ ...previous, parties: { ...previous.parties, couples: [...previous.parties.couples, record] } }));
+      toggleRecord(collection, record.id, true);
+      toast.success('Added.');
+    } catch (addError) {
+      console.error('Unable to add couple', addError);
+      toast.error('Could not add the record.');
+    }
+  };
+
+  const handlePartnerFieldChange = async (couple, role, path, value) => {
+    const partners = toArray(couple.partners);
+    const index = partners.findIndex(partner => partner.role === role);
+    const basePartner = index === -1 ? createEmptyPartner({ role }) : partners[index];
+    const nextPartner = setValueAtPath(basePartner, path, value);
+    const nextPartners = index === -1 ? [...partners, nextPartner] : partners.map((partner, i) => (i === index ? nextPartner : partner));
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/couples/${couple.id}/partners`), nextPartners);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          couples: previous.parties.couples.map(item => (String(item.id) === String(couple.id) ? { ...item, partners: nextPartners } : item)),
+        },
+      }));
+    } catch (updateError) {
+      console.error('Unable to save partner field', updateError);
+      toast.error('Could not save.');
+    }
+  };
+
+  const handleFieldChange = async (couple, path, value) => {
+    const dbPath = `${DOCUMENTS_PARTIES_PATH}/couples/${couple.id}/${path.split('.').join('/')}`;
+    try {
+      await set(ref(database, dbPath), value);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          couples: previous.parties.couples.map(item => (String(item.id) === String(couple.id) ? setValueAtPath(item, path, value) : item)),
+        },
+      }));
+    } catch (updateError) {
+      console.error('Unable to save couple field', updateError);
+      toast.error('Could not save.');
+    }
+  };
+
+  const handleDelete = async couple => {
+    const references = findPartyReferences(catalog, collection, couple.id);
+    const label = coupleDisplayName(couple);
+    const suffix = references.length ? ` Used in ${references.join(', ')}.` : '';
+    if (typeof window !== 'undefined' && !window.confirm(`Delete "${label}"?${suffix}`)) return;
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/couples/${couple.id}`), null);
+      setCatalog(previous => ({
+        ...previous,
+        parties: { ...previous.parties, couples: previous.parties.couples.filter(item => String(item.id) !== String(couple.id)) },
+      }));
+      toast.success('Deleted.');
+    } catch (deleteError) {
+      console.error('Unable to delete couple', deleteError);
+      toast.error('Could not delete.');
+    }
+  };
+
+  return (
+    <Panel>
+      <CompactSection onClick={onToggleGroup} role="button" aria-expanded={groupOpen}>
+        <CompactInfo>
+          <CompactLabel>Couples</CompactLabel>
+          <CompactValue>{records.length} record{records.length === 1 ? '' : 's'}</CompactValue>
+        </CompactInfo>
+        <CompactChevron>{groupOpen ? 'Hide ›' : 'Show ›'}</CompactChevron>
+      </CompactSection>
+      {groupOpen ? (
+        <>
+          {records.map(couple => {
+            const expanded = Boolean(expandedKeys[`${collection}:${couple.id}`]);
+            const partners = toArray(couple.partners);
+            const wife = partners.find(partner => partner.role === 'wife') || createEmptyPartner({ role: 'wife' });
+            const husband = partners.find(partner => partner.role === 'husband') || createEmptyPartner({ role: 'husband' });
+            return (
+              <RecordBlock key={couple.id}>
+                <CompactSection onClick={() => toggleRecord(collection, couple.id)} role="button" aria-expanded={expanded}>
+                  <CompactInfo>
+                    <CompactValue>{coupleDisplayName(couple)}</CompactValue>
+                  </CompactInfo>
+                  <CompactChevron>{expanded ? 'Hide ›' : 'Edit ›'}</CompactChevron>
+                </CompactSection>
+                {expanded ? (
+                  <RecordBody>
+                    <SectionSubhead>Wife</SectionSubhead>
+                    <RecordFieldsGrid record={wife} fieldDefs={PARTNER_FIELDS} onFieldChange={(path, value) => handlePartnerFieldChange(couple, 'wife', path, value)} />
+                    <SectionSubhead>Husband</SectionSubhead>
+                    <RecordFieldsGrid record={husband} fieldDefs={PARTNER_FIELDS} onFieldChange={(path, value) => handlePartnerFieldChange(couple, 'husband', path, value)} />
+                    <SectionSubhead>Marriage &amp; address</SectionSubhead>
+                    <RecordFieldsGrid record={couple} fieldDefs={MARRIAGE_AND_ADDRESS_FIELDS} onFieldChange={(path, value) => handleFieldChange(couple, path, value)} />
+                    <RowLine style={{ marginTop: 8 }}>
+                      <DangerButton type="button" onClick={() => handleDelete(couple)}>
+                        <FaTrash /> Delete
+                      </DangerButton>
+                    </RowLine>
+                  </RecordBody>
+                ) : null}
+              </RecordBlock>
+            );
+          })}
+          <RowLine style={{ marginTop: 10 }}>
+            <SmallButton type="button" onClick={handleAdd}>
+              <FaPlus /> Add
+            </SmallButton>
+          </RowLine>
+        </>
+      ) : null}
+    </Panel>
+  );
+};
+
+// --- Cases group (the assembly layer) -----------------------------------------------------------
+
+// A relation slot (Couple / Clinic / Surrogate mother): shows the currently linked party, tap to
+// pick from the existing records of that type, most-recently-used first - same "pick from saved
+// variants" interaction as the Invoice Builder's Beneficiary/Payer picker, generalized here to
+// every relation a case can hold.
+const RelationSlot = ({ label, records, valueId, displayName, onPick }) => {
+  const [open, setOpen] = useState(false);
+  const current = records.find(record => String(record.id) === String(valueId));
+  return (
+    <div style={{ marginTop: 6 }}>
+      <CompactSection onClick={() => setOpen(previous => !previous)} role="button" aria-expanded={open} aria-label={`${label} slot`}>
+        <CompactInfo>
+          <CompactLabel>{label}</CompactLabel>
+          <CompactValue>{current ? displayName(current) : '— not set —'}</CompactValue>
+        </CompactInfo>
+        <CompactChevron>{open ? 'Hide ›' : 'Pick ›'}</CompactChevron>
+      </CompactSection>
+      {open ? (
+        <PickerList>
+          <PickerButton type="button" onClick={() => { onPick(''); setOpen(false); }}>— None —</PickerButton>
+          {records.map(record => (
+            <PickerButton
+              key={record.id}
+              type="button"
+              $active={String(record.id) === String(valueId)}
+              onClick={() => { onPick(record.id); setOpen(false); }}
+            >
+              {displayName(record) || record.id}
+            </PickerButton>
+          ))}
+        </PickerList>
+      ) : null}
+    </div>
+  );
+};
+
+// Representatives is the one multi-value relation (relations.representativeIds[]) - same MRU
+// picker shell as RelationSlot, but each row toggles membership instead of replacing a single id.
+const RepresentativesSlot = ({ records, valueIds, onToggle }) => {
+  const [open, setOpen] = useState(false);
+  const selected = toArray(valueIds).map(String);
+  const selectedRecords = records.filter(record => selected.includes(String(record.id)));
+  return (
+    <div style={{ marginTop: 6 }}>
+      <CompactSection onClick={() => setOpen(previous => !previous)} role="button" aria-expanded={open}>
+        <CompactInfo>
+          <CompactLabel>Representatives</CompactLabel>
+          <CompactValue>{selectedRecords.length ? selectedRecords.map(partyDisplayName).join(', ') : '— none —'}</CompactValue>
+        </CompactInfo>
+        <CompactChevron>{open ? 'Hide ›' : 'Pick ›'}</CompactChevron>
+      </CompactSection>
+      {open ? (
+        <PickerList>
+          {records.map(record => {
+            const isSelected = selected.includes(String(record.id));
+            return (
+              <PickerButton key={record.id} type="button" $active={isSelected} onClick={() => onToggle(record.id, !isSelected)}>
+                {isSelected ? '✓ ' : ''}{partyDisplayName(record) || record.id}
+              </PickerButton>
+            );
+          })}
+        </PickerList>
+      ) : null}
+    </div>
+  );
+};
+
+const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen, onToggleGroup, recentIds, recordPartyUsage }) => {
+  const cases = catalog.parties.cases;
+  const orderedCouples = orderRecordsByRecentIds(catalog.parties.couples, recentIds.couples);
+  const orderedClinics = orderRecordsByRecentIds(catalog.parties.clinics, recentIds.clinics);
+  const orderedSurrogateMothers = orderRecordsByRecentIds(catalog.parties.surrogateMothers, recentIds.surrogateMothers);
+  const orderedRepresentatives = orderRecordsByRecentIds(catalog.parties.representatives, recentIds.representatives);
+
+  const handleAddCase = async () => {
+    const caseId = makeCaseId();
+    const record = createEmptyCase({ caseId });
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}`), record);
+      setCatalog(previous => ({ ...previous, parties: { ...previous.parties, cases: [...previous.parties.cases, record] } }));
+      toggleRecord('cases', caseId, true);
+      toast.success('Case created.');
+    } catch (addError) {
+      console.error('Unable to create case', addError);
+      toast.error('Could not create the case.');
+    }
+  };
+
+  const updateCaseField = async (caseId, path, value) => {
+    const dbPath = `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}/${path.split('.').join('/')}`;
+    try {
+      await set(ref(database, dbPath), value);
+      setCatalog(previous => ({
+        ...previous,
+        parties: {
+          ...previous.parties,
+          cases: previous.parties.cases.map(item => (String(item.id) === String(caseId) ? setValueAtPath(item, path, value) : item)),
+        },
+      }));
+    } catch (updateError) {
+      console.error('Unable to save case field', updateError);
+      toast.error('Could not save.');
+    }
+  };
+
+  const handleToggleRepresentative = (caseRecord, repId, include) => {
+    const current = toArray(caseRecord.relations?.representativeIds).map(String);
+    const next = include ? [...current, String(repId)] : current.filter(id => id !== String(repId));
+    updateCaseField(caseRecord.id, 'relations.representativeIds', next);
+    if (include) recordPartyUsage('representatives', repId);
+  };
+
+  const handleDeleteCase = async caseRecord => {
+    const label = buildCaseLabel(catalog, caseRecord) || caseRecord.id;
+    if (typeof window !== 'undefined' && !window.confirm(`Delete case "${label}"? Party records stay in the catalog.`)) return;
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}`), null);
+      setCatalog(previous => ({
+        ...previous,
+        parties: { ...previous.parties, cases: previous.parties.cases.filter(item => String(item.id) !== String(caseRecord.id)) },
+      }));
+      toast.success('Case deleted.');
+    } catch (deleteError) {
+      console.error('Unable to delete case', deleteError);
+      toast.error('Could not delete the case.');
+    }
+  };
+
+  return (
+    <Panel>
+      <CompactSection onClick={onToggleGroup} role="button" aria-expanded={groupOpen}>
+        <CompactInfo>
+          <CompactLabel>Cases</CompactLabel>
+          <CompactValue>{cases.length} record{cases.length === 1 ? '' : 's'}</CompactValue>
+        </CompactInfo>
+        <CompactChevron>{groupOpen ? 'Hide ›' : 'Show ›'}</CompactChevron>
+      </CompactSection>
+      {groupOpen ? (
+        <>
+          {cases.map(caseRecord => {
+            const expanded = Boolean(expandedKeys[`cases:${caseRecord.id}`]);
+            const relations = caseRecord.relations || {};
+            return (
+              <RecordBlock key={caseRecord.id}>
+                <CompactSection onClick={() => toggleRecord('cases', caseRecord.id)} role="button" aria-expanded={expanded}>
+                  <CompactInfo>
+                    <CompactValue>{buildCaseLabel(catalog, caseRecord) || caseRecord.id}</CompactValue>
+                  </CompactInfo>
+                  <CompactChevron>{expanded ? 'Hide ›' : 'Edit ›'}</CompactChevron>
+                </CompactSection>
+                {expanded ? (
+                  <RecordBody>
+                    <SectionSubhead>Relations</SectionSubhead>
+                    <RelationSlot
+                      label="Couple"
+                      records={orderedCouples}
+                      valueId={relations.coupleId}
+                      displayName={coupleDisplayName}
+                      onPick={id => { updateCaseField(caseRecord.id, 'relations.coupleId', id); recordPartyUsage('couples', id); }}
+                    />
+                    <RelationSlot
+                      label="Clinic"
+                      records={orderedClinics}
+                      valueId={relations.clinicId}
+                      displayName={partyDisplayName}
+                      onPick={id => { updateCaseField(caseRecord.id, 'relations.clinicId', id); recordPartyUsage('clinics', id); }}
+                    />
+                    <RelationSlot
+                      label="Surrogate mother"
+                      records={orderedSurrogateMothers}
+                      valueId={relations.surrogateMotherId}
+                      displayName={partyDisplayName}
+                      onPick={id => { updateCaseField(caseRecord.id, 'relations.surrogateMotherId', id); recordPartyUsage('surrogateMothers', id); }}
+                    />
+                    <RepresentativesSlot
+                      records={orderedRepresentatives}
+                      valueIds={relations.representativeIds}
+                      onToggle={(repId, include) => handleToggleRepresentative(caseRecord, repId, include)}
+                    />
+
+                    <SectionSubhead>Program</SectionSubhead>
+                    <RecordFieldsGrid record={caseRecord} fieldDefs={PROGRAM_FIELDS} onFieldChange={(path, value) => updateCaseField(caseRecord.id, path, value)} />
+
+                    <CaseChildbirthTransactionEditor catalog={catalog} setCatalog={setCatalog} caseId={caseRecord.id} />
+
+                    <RowLine style={{ marginTop: 8 }}>
+                      <DangerButton type="button" onClick={() => handleDeleteCase(caseRecord)}>
+                        <FaTrash /> Delete case
+                      </DangerButton>
+                    </RowLine>
+                  </RecordBody>
+                ) : null}
+              </RecordBlock>
+            );
+          })}
+          <RowLine style={{ marginTop: 10 }}>
+            <SmallButton type="button" onClick={handleAddCase}>
+              <FaPlus /> New case
+            </SmallButton>
+          </RowLine>
+        </>
+      ) : null}
+    </Panel>
+  );
+};
+
+// --- Technical input (paste-and-parse), same additive multi-location merge Documents Builder
+// already uses - the manual editors above and this JSON path both write to the same tree. -------
+
+const TechnicalSection = ({ catalog, setCatalog }) => {
+  const [technicalInput, setTechnicalInput] = useState('');
+  const [isApplying, setIsApplying] = useState(false);
+  const [open, setOpen] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const applyTechnical = async overrideText => {
+    const sourceText = typeof overrideText === 'string' ? overrideText : technicalInput;
+    let incoming;
+    try {
+      incoming = parseDocumentsTechnicalInput(sourceText);
+    } catch (parseError) {
+      toast.error(parseError.message);
+      return;
+    }
+    setIsApplying(true);
+    try {
+      const { catalog: merged, summary } = mergeDocumentsCatalog(catalog, incoming);
+      const partiesPatch = {};
+      PARTY_COLLECTIONS.forEach(collection => {
+        resolveMergedRecordsForPersistence(
+          catalog.parties[collection],
+          merged.parties[collection],
+          incoming.parties[collection],
+        ).forEach(mergedRecord => {
+          partiesPatch[`${collection}/${mergedRecord.id}`] = mergedRecord;
+        });
+      });
+      const templatesPatch = {};
+      resolveMergedRecordsForPersistence(catalog.documents, merged.documents, incoming.documents).forEach(mergedRecord => {
+        templatesPatch[mergedRecord.id] = mergedRecord;
+      });
+      if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
+      if (Object.keys(templatesPatch).length) await update(ref(database, DOCUMENTS_TEMPLATES_PATH), templatesPatch);
+      setCatalog(merged);
+      setTechnicalInput('');
+      toast.success(`Merged: ${summary.added} added, ${summary.updated} updated.`);
+    } catch (applyError) {
+      console.error('Unable to merge parties data', applyError);
+      toast.error('Could not save the parsed data to the backend.');
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const handleFileChange = event => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : '';
+      applyTechnical(text);
+    };
+    reader.onerror = () => toast.error('Could not read the file.');
+    reader.readAsText(file);
+  };
+
+  return (
+    <Panel>
+      <CompactSection onClick={() => setOpen(previous => !previous)} role="button" aria-expanded={open}>
+        <CompactInfo>
+          <CompactLabel>Technical</CompactLabel>
+          <CompactValue>Paste or upload JSON</CompactValue>
+        </CompactInfo>
+        <CompactChevron>{open ? 'Hide ›' : 'Show ›'}</CompactChevron>
+      </CompactSection>
+      {open ? (
+        <>
+          <RowLine style={{ marginTop: 8 }}>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json,.json"
+              style={{ display: 'none' }}
+              onChange={handleFileChange}
+            />
+            <SmallButton type="button" onClick={() => fileInputRef.current?.click()} disabled={isApplying}>
+              <FaUpload /> {isApplying ? 'Merging…' : 'Upload file'}
+            </SmallButton>
+            <SmallButton type="button" onClick={() => applyTechnical()} disabled={isApplying || !technicalInput.trim()}>
+              {isApplying ? 'Merging…' : 'Parse & merge'}
+            </SmallButton>
+          </RowLine>
+          <TechnicalTextarea
+            value={technicalInput}
+            onChange={event => setTechnicalInput(event.target.value)}
+            placeholder='Paste the exported documentsBuilder JSON here ({"parties": {...}} or bare party collections) - records are merged additively, nothing is wiped.'
+            spellCheck={false}
+          />
+        </>
+      ) : null}
+    </Panel>
+  );
+};
+
+// --- Page ---------------------------------------------------------------------------------------
+
+const EMPTY_RECENT_IDS = {
+  couples: [], clinics: [], surrogateMothers: [], representatives: [], notaries: [],
+};
+
+const PartiesPage = ({ isAdmin }) => {
+  const isPartiesAdmin = Boolean(isAdmin) || isInvoiceBuilderUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
+    && new URLSearchParams(window.location.search).get('admin') === '1');
+
+  const [catalog, setCatalog] = useState(() => emptyDocumentsCatalog());
+  const [recentIds, setRecentIds] = useState(EMPTY_RECENT_IDS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [openGroups, setOpenGroups] = useState({});
+  const [expandedKeys, setExpandedKeys] = useState({});
+
+  const loadPartiesData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [partiesSnapshot, templatesSnapshot, settingsSnapshot] = await Promise.all([
+        get(ref(database, DOCUMENTS_PARTIES_PATH)),
+        get(ref(database, DOCUMENTS_TEMPLATES_PATH)),
+        get(ref(database, `${PARTIES_SETTINGS_PATH}/recentIds`)),
+      ]);
+      setCatalog(normalizeDocumentsCatalog(
+        partiesSnapshot.exists() ? partiesSnapshot.val() : null,
+        templatesSnapshot.exists() ? templatesSnapshot.val() : null,
+      ));
+      const rawRecentIds = settingsSnapshot.exists() ? settingsSnapshot.val() : null;
+      setRecentIds({
+        couples: toArray(rawRecentIds?.couples),
+        clinics: toArray(rawRecentIds?.clinics),
+        surrogateMothers: toArray(rawRecentIds?.surrogateMothers),
+        representatives: toArray(rawRecentIds?.representatives),
+        notaries: toArray(rawRecentIds?.notaries),
+      });
+    } catch (loadError) {
+      console.error('Unable to load parties data', loadError);
+      setError('Parties data is not available right now.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPartiesData();
+  }, [loadPartiesData]);
+
+  const toggleGroup = key => setOpenGroups(previous => ({ ...previous, [key]: !previous[key] }));
+
+  const toggleRecord = (collection, id, forceOpen) => {
+    const key = `${collection}:${id}`;
+    setExpandedKeys(previous => ({ ...previous, [key]: forceOpen !== undefined ? forceOpen : !previous[key] }));
+  };
+
+  // Most-recently-used-first ordering for the Cases relation-slot pickers (spec: "consistent with
+  // the party-selector MRU rule elsewhere") - persisted the same way Documents Builder already
+  // persists recentCaseIds/recentDocIds, so the order survives a reload.
+  const recordPartyUsage = (collection, id) => {
+    if (!id) return;
+    setRecentIds(previous => {
+      const nextForCollection = upsertRecentId(previous[collection], id);
+      set(ref(database, `${PARTIES_SETTINGS_PATH}/recentIds/${collection}`), nextForCollection).catch(usageError => {
+        console.error(`Unable to save recent ${collection} usage`, usageError);
+      });
+      return { ...previous, [collection]: nextForCollection };
+    });
+  };
+
+  if (!isPartiesAdmin) {
+    return (
+      <Page>
+        <Shell>
+          <StateCard>This page is only available to admins.</StateCard>
+        </Shell>
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <Shell>
+        <Header>
+          <div>
+            <Eyebrow>Admin only</Eyebrow>
+            <Title>Parties</Title>
+          </div>
+          <HeaderActions>
+            <PageNavMenu />
+          </HeaderActions>
+        </Header>
+
+        {loading ? (
+          <StateCard>Loading…</StateCard>
+        ) : error ? (
+          <StateCard>{error}</StateCard>
+        ) : (
+          <>
+            <CouplesGroup
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.couples)}
+              onToggleGroup={() => toggleGroup('couples')}
+            />
+            <SimplePartyGroup
+              title="Surrogate mothers"
+              collection="surrogateMothers"
+              records={catalog.parties.surrogateMothers}
+              fieldDefs={SURROGATE_MOTHER_FIELDS}
+              displayName={partyDisplayName}
+              createEmpty={createEmptySurrogateMother}
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.surrogateMothers)}
+              onToggleGroup={() => toggleGroup('surrogateMothers')}
+            />
+            <SimplePartyGroup
+              title="Representatives"
+              collection="representatives"
+              records={catalog.parties.representatives}
+              fieldDefs={REPRESENTATIVE_FIELDS}
+              displayName={partyDisplayName}
+              createEmpty={createEmptyRepresentative}
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.representatives)}
+              onToggleGroup={() => toggleGroup('representatives')}
+            />
+            <SimplePartyGroup
+              title="Clinics"
+              collection="clinics"
+              records={catalog.parties.clinics}
+              fieldDefs={CLINIC_FIELDS}
+              displayName={partyDisplayName}
+              createEmpty={createEmptyClinic}
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.clinics)}
+              onToggleGroup={() => toggleGroup('clinics')}
+            />
+            <SimplePartyGroup
+              title="Maternity hospitals"
+              collection="maternityHospitals"
+              records={catalog.parties.maternityHospitals}
+              fieldDefs={MATERNITY_HOSPITAL_FIELDS}
+              displayName={maternityDisplayName}
+              createEmpty={createEmptyMaternityHospital}
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.maternityHospitals)}
+              onToggleGroup={() => toggleGroup('maternityHospitals')}
+            />
+            <SimplePartyGroup
+              title="Notaries"
+              collection="notaries"
+              records={catalog.parties.notaries}
+              fieldDefs={NOTARY_FIELDS}
+              displayName={partyDisplayName}
+              createEmpty={createEmptyNotary}
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.notaries)}
+              onToggleGroup={() => toggleGroup('notaries')}
+            />
+            <CasesGroup
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.cases)}
+              onToggleGroup={() => toggleGroup('cases')}
+              recentIds={recentIds}
+              recordPartyUsage={recordPartyUsage}
+            />
+            <TechnicalSection catalog={catalog} setCatalog={setCatalog} />
+          </>
+        )}
+      </Shell>
+    </Page>
+  );
+};
+
+export default PartiesPage;

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -1,0 +1,173 @@
+// Smoke test for the Parties page: mounts the real component (Firebase mocked out) and drives the
+// collapse/expand -> edit -> collapse interaction, the reference-checked delete confirmation, and
+// a case's relation-slot picker, to catch wiring bugs a pure-logic test can't see.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('firebase/database', () => ({
+  ref: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'test-admin' } },
+  database: {},
+}));
+
+jest.mock('utils/accessLevel', () => ({ isInvoiceBuilderUid: () => true }));
+
+// eslint-disable-next-line import/first
+import { ref, get, set } from 'firebase/database';
+// eslint-disable-next-line import/first
+import PartiesPage from './PartiesPage';
+
+const buildParties = () => ({
+  couples: {
+    'couple-1': {
+      id: 'couple-1',
+      partners: [
+        { id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } },
+        { id: 'p2', role: 'husband', name: { uk: { nominative: 'Тестовий Петро' }, en: 'Testovyi Petro' } },
+      ],
+    },
+  },
+  surrogateMothers: {
+    'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Сурогатна Матір' } }, taxId: '1234567890' },
+  },
+  representatives: {},
+  clinics: {
+    'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка Мрія' } },
+  },
+  maternityHospitals: {},
+  notaries: {},
+  transactions: {},
+  cases: {
+    'case-1': {
+      id: 'case-1',
+      relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
+      program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
+      childbirth: { maternityHospitalId: '', children: [] },
+      registrations: { birth: { transactionId: '' } },
+      documents: { overrides: {} },
+    },
+  },
+});
+
+beforeEach(() => {
+  ref.mockImplementation((_db, path) => path);
+  get.mockImplementation(async path => {
+    if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => buildParties() };
+    if (path === 'documentsBuilder/templates') return { exists: () => false, val: () => null };
+    if (path === 'documentsBuilder/partiesSettings/recentIds') return { exists: () => false, val: () => null };
+    return { exists: () => false, val: () => null };
+  });
+  set.mockResolvedValue(undefined);
+  window.confirm = jest.fn(() => true);
+});
+
+describe('spec: Parties page', () => {
+  it('renders every party-type group collapsed by default, with a record count', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+
+    expect(await screen.findByText('Couples')).toBeInTheDocument();
+    expect(screen.getByText('Surrogate mothers')).toBeInTheDocument();
+    expect(screen.getByText('Representatives')).toBeInTheDocument();
+    expect(screen.getByText('Clinics')).toBeInTheDocument();
+    expect(screen.getByText('Maternity hospitals')).toBeInTheDocument();
+    expect(screen.getByText('Notaries')).toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+
+    // Couples has 1 record, but its own row is not rendered until the group is expanded.
+    expect(screen.queryByText('Тестова Марія & Тестовий Петро')).not.toBeInTheDocument();
+  });
+
+  it('expanding a group reveals its records; expanding a record reveals its fields', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Clinics');
+
+    fireEvent.click(screen.getByText('Clinics'));
+    const clinicRow = await screen.findByText('Клініка Мрія');
+    expect(screen.queryByLabelText('Name (uk)')).not.toBeInTheDocument();
+
+    fireEvent.click(clinicRow);
+    expect(await screen.findByLabelText('Name (uk)')).toHaveValue('Клініка Мрія');
+  });
+
+  it('editing a field on blur persists it additively to the record path', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Clinics');
+    fireEvent.click(screen.getByText('Clinics'));
+    fireEvent.click(await screen.findByText('Клініка Мрія'));
+
+    const emailField = await screen.findByLabelText('Email');
+    fireEvent.change(emailField, { target: { value: 'info@mriia.example' } });
+    fireEvent.blur(emailField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/parties/clinics/clinic-1/email', 'info@mriia.example'));
+  });
+
+  it('"Add" creates a new blank record and expands it', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Notaries');
+    fireEvent.click(screen.getByText('Notaries'));
+
+    fireEvent.click(await screen.findByRole('button', { name: /add/i }));
+
+    await waitFor(() => expect(set).toHaveBeenCalled());
+    const [path, record] = set.mock.calls[set.mock.calls.length - 1];
+    expect(path).toMatch(/^documentsBuilder\/parties\/notaries\/notary-/);
+    expect(record.id).toBe(path.split('/').pop());
+    expect(await screen.findByLabelText('Title (uk)')).toBeInTheDocument();
+  });
+
+  it('deleting a party referenced by a case includes the reference in the confirmation, but still deletes when confirmed', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Couples');
+    fireEvent.click(screen.getByText('Couples'));
+    fireEvent.click(await screen.findByText('Тестова Марія & Тестовий Петро'));
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('Used in case'));
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/parties/couples/couple-1', null));
+  });
+
+  it('deleting a party skips the delete when the confirmation is declined', async () => {
+    window.confirm = jest.fn(() => false);
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Notaries');
+    fireEvent.click(screen.getByText('Clinics'));
+    fireEvent.click(await screen.findByText('Клініка Мрія'));
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalledWith('documentsBuilder/parties/clinics/clinic-1', null);
+  });
+
+  it('a case relation slot picks from the existing records and persists the pick, most-recently-used tracked', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Cases');
+    fireEvent.click(screen.getByText('Cases'));
+    fireEvent.click(await screen.findByText('Testova Mariia & Testovyi Petro'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clinic slot' }));
+    fireEvent.click(await screen.findByText('Клініка Мрія'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/parties/cases/case-1/relations/clinicId', 'clinic-1'));
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/partiesSettings/recentIds/clinics', ['clinic-1']));
+  });
+
+  it('renders the shared Childbirth/Transaction editor inside an expanded case', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Cases');
+    fireEvent.click(screen.getByText('Cases'));
+    fireEvent.click(await screen.findByText('Testova Mariia & Testovyi Petro'));
+
+    expect(await screen.findByText('Дані для заяви в РАЦС')).toBeInTheDocument();
+  });
+});

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -500,11 +500,94 @@ export const formatEnglishDateWords = value => {
   return `${EN_DAY_ORDINALS[day]} of ${EN_MONTHS[month]}, ${year}`;
 };
 
+// --- Party record shapes (Parties page, batch 19 §1) --------------------------------------------
+// Canonical "blank record" for each party collection - the shape a freshly-added record starts
+// from, matching exactly what resolveCaseContext/fillPlaceholders already expect to find (spec
+// §9/§10/§3/§5 fixtures in documentsCatalogUtils.test.js), so a record created here never needs a
+// follow-up migration the way legacy pasted data sometimes does.
+
+export const createEmptyPartner = ({ role = '' } = {}) => ({
+  id: makeRecordId('partner'),
+  role,
+  name: { uk: { nominative: '', genitive: '' }, en: '' },
+  birthDate: '',
+  citizenship: { uk: '', en: '' },
+  passport: { number: '', issuedBy: { uk: '', en: '' }, issueDate: '' },
+});
+
+export const createEmptyCouple = () => ({
+  id: makeRecordId('couple'),
+  partners: [createEmptyPartner({ role: 'wife' }), createEmptyPartner({ role: 'husband' })],
+  marriage: { certificateNumber: '', certificateDate: '' },
+  address: { uk: '', en: '' },
+});
+
+export const createEmptySurrogateMother = () => ({
+  id: makeRecordId('surrogate-mother'),
+  name: { uk: { nominative: '', genitive: '' }, en: '' },
+  birthDate: '',
+  passport: { number: '', issueDate: '' },
+  taxId: '',
+  address: { uk: '', en: '' },
+});
+
+export const createEmptyRepresentative = () => ({
+  id: makeRecordId('representative'),
+  name: { uk: { nominative: '', genitive: '' }, en: '' },
+  passport: { number: '' },
+  powerOfAttorney: { date: '', apostille: '' },
+});
+
+export const createEmptyClinic = () => ({
+  id: makeRecordId('clinic'),
+  name: { uk: '', en: '' },
+  legalName: { uk: '', en: '' },
+  medicalCenterName: { uk: '', en: '' },
+  address: { uk: '', en: '' },
+  phone: '',
+  email: '',
+  edrpou: '',
+  taxId: '',
+  vatCertificateNumber: '',
+  bank: {
+    account: '', mfo: '', name: { uk: '', en: '' }, address: { uk: '', en: '' },
+  },
+  license: { number: '', date: '', issuedBy: { uk: '', en: '' } },
+  medicalDirector: {
+    name: { uk: { nominative: '', genitive: '', short: '' }, en: { full: '', short: '' } },
+    authority: { type: { uk: '', en: '' }, number: '', date: '' },
+  },
+});
+
+export const createEmptyMaternityHospital = () => ({
+  id: makeRecordId('maternity-hospital'),
+  name: { uk: '', en: '' },
+  shortName: { uk: '', en: '' },
+  edrpou: '',
+  address: { uk: '', en: '' },
+});
+
+export const createEmptyNotary = () => ({
+  id: makeRecordId('notary'),
+  name: {
+    uk: {
+      nominative: '', genitive: '', short: '', instrumental: '',
+    },
+    en: { full: '', short: '' },
+  },
+  title: { uk: '', en: '' },
+  city: { uk: '', en: '' },
+});
+
 // --- Case shape (batch 18) --------------------------------------------------------------------
 // One case is one concrete combination of couple + clinic + surrogate mother + representative(s)
 // (spec: "один case — це одна конкретна комбінація"); changing the clinic or surrogate mother means
 // creating a new case rather than mutating this one in place, so there is no active/replaced/from/to
 // history to track inside a single case record.
+
+// A fresh id for a brand-new case (Parties page "+ New case") - same generated shape as
+// makeTransactionId/createChildRecord's id.
+export const makeCaseId = () => makeRecordId('case');
 
 // A freshly-created case: every relation blank, ready for the admin to pick a couple/clinic/
 // surrogate mother/representatives - never pre-filled from another case (spec §14: no auto-copy).
@@ -1191,6 +1274,39 @@ export const buildCaseLabel = (catalog, caseRecord) => {
   const surrogateName = localizedText(surrogate?.name, 'en');
   const parts = [coupleNames, surrogateName ? `SM ${surrogateName}` : ''].filter(Boolean);
   return parts.join(' — ') || String(caseRecord.id);
+};
+
+// Which cases/transactions currently point at a given party record (Parties page delete
+// confirmation, spec: "If a record is referenced by a case, the confirmation must say so") -
+// deletes are never blocked on this, only clearly labeled, same "sever the reference, never touch
+// the other record" spirit as removeTransactionReferences.
+export const findPartyReferences = (catalog, collection, id) => {
+  const targetId = String(id);
+  const referencingCases = (catalog?.parties?.cases || []).filter(rawCase => {
+    const caseRecord = normalizeCaseRecord(rawCase);
+    const relations = caseRecord.relations || {};
+    switch (collection) {
+      case 'couples': return String(relations.coupleId) === targetId;
+      case 'clinics': return String(relations.clinicId) === targetId;
+      case 'surrogateMothers': return String(relations.surrogateMotherId) === targetId;
+      case 'representatives': return toArray(relations.representativeIds).some(repId => String(repId) === targetId);
+      case 'maternityHospitals': return String(caseRecord.childbirth?.maternityHospitalId) === targetId;
+      default: return false;
+    }
+  });
+
+  const referencingTransactions = ['couples', 'surrogateMothers', 'notaries'].includes(collection)
+    ? (catalog?.parties?.transactions || []).filter(transaction => {
+      if (collection === 'couples') return String(transaction.coupleId) === targetId;
+      if (collection === 'surrogateMothers') return String(transaction.surrogateMotherId) === targetId;
+      return String(transaction.notaryId) === targetId;
+    })
+    : [];
+
+  return [
+    ...referencingCases.map(caseRecord => `case "${buildCaseLabel(catalog, caseRecord) || caseRecord.id}"`),
+    ...referencingTransactions.map(transaction => `transaction "${transaction.id}"`),
+  ];
 };
 
 // Generic "most recently used first" ordering + upsert, shared by the case selector (spec §5) and

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -34,7 +34,11 @@ const COLLECTION_ID_PREFIXES = { notaries: 'notary' };
 
 export const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
-const toArray = value => {
+// Firebase RTDB silently turns a JS array into a plain `{"0": ..., "2": ...}` object once it has
+// ever been written with a gap (e.g. a record removed by key rather than re-set as a dense array),
+// so any array read back from the backend has to tolerate that shape - never assume `.val()` gives
+// back a real Array just because it was one when last saved.
+export const toArray = value => {
   if (Array.isArray(value)) return value.filter(Boolean);
   if (isPlainObject(value)) return Object.values(value).filter(Boolean);
   return [];

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -13,11 +13,19 @@ import {
   clinicLogoEntriesToBackend,
   createChildRecord,
   createEmptyCase,
+  createEmptyClinic,
+  createEmptyCouple,
+  createEmptyMaternityHospital,
+  createEmptyNotary,
+  createEmptyPartner,
+  createEmptyRepresentative,
+  createEmptySurrogateMother,
   createTransaction,
   deepMergeRecords,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   fillPlaceholders,
+  findPartyReferences,
   formatDocumentDate,
   formatEnglishDateWords,
   formatUkrainianDateWords,
@@ -2184,5 +2192,62 @@ describe('spec: transactions (batch 19)', () => {
       const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'ghost-child' });
       expect(context.selectedChildId).toBe('child-1');
     });
+  });
+});
+
+// spec: Parties page (batch 19) - canonical blank records + reference-check for deletes.
+describe('spec: Parties page record shapes', () => {
+  it('creates blank couple/surrogateMother/representative/clinic/maternityHospital/notary records with a stable id and no undefined fields', () => {
+    const couple = createEmptyCouple();
+    expect(couple.id).toMatch(/^couple-/);
+    expect(couple.partners.map(partner => partner.role)).toEqual(['wife', 'husband']);
+    expect(couple.partners.every(partner => partner.name.uk.nominative === '')).toBe(true);
+
+    const partner = createEmptyPartner({ role: 'wife' });
+    expect(partner.role).toBe('wife');
+    expect(partner.id).toMatch(/^partner-/);
+
+    expect(createEmptySurrogateMother().id).toMatch(/^surrogate-mother-/);
+    expect(createEmptyRepresentative().id).toMatch(/^representative-/);
+    expect(createEmptyClinic().id).toMatch(/^clinic-/);
+    expect(createEmptyMaternityHospital().id).toMatch(/^maternity-hospital-/);
+    expect(createEmptyNotary().id).toMatch(/^notary-/);
+
+    // Two calls never collide, same guarantee makeRecordId already gives createChildRecord/createTransaction.
+    expect(createEmptyCouple().id).not.toBe(couple.id);
+  });
+
+  it('findPartyReferences reports the cases/transactions pointing at a party, without deleting or blocking anything', () => {
+    const catalog = normalizeDocumentsCatalog({
+      couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { en: 'Jane Doe' } }] } },
+      clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
+      surrogateMothers: { 'surrogate-1': { id: 'surrogate-1', name: { en: 'Jane Roe' } } },
+      representatives: { 'rep-1': { id: 'rep-1' } },
+      notaries: { 'notary-1': { id: 'notary-1' } },
+      maternityHospitals: { 'hospital-1': { id: 'hospital-1' } },
+      cases: {
+        'case-1': {
+          id: 'case-1',
+          relations: {
+            coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['rep-1'],
+          },
+          childbirth: { maternityHospitalId: 'hospital-1', children: [] },
+        },
+      },
+      transactions: {
+        'transaction-1': {
+          id: 'transaction-1', coupleId: 'couple-1', surrogateMotherId: 'surrogate-1', notaryId: 'notary-1',
+        },
+      },
+    });
+
+    expect(findPartyReferences(catalog, 'couples', 'couple-1')).toEqual([
+      expect.stringContaining('case'), expect.stringContaining('transaction "transaction-1"'),
+    ]);
+    expect(findPartyReferences(catalog, 'clinics', 'clinic-1')).toEqual([expect.stringContaining('case')]);
+    expect(findPartyReferences(catalog, 'representatives', 'rep-1')).toEqual([expect.stringContaining('case')]);
+    expect(findPartyReferences(catalog, 'maternityHospitals', 'hospital-1')).toEqual([expect.stringContaining('case')]);
+    expect(findPartyReferences(catalog, 'notaries', 'notary-1')).toEqual([expect.stringContaining('transaction "transaction-1"')]);
+    expect(findPartyReferences(catalog, 'couples', 'nobody')).toEqual([]);
   });
 });


### PR DESCRIPTION
Firebase RTDB silently turns a JS array into a gap-keyed plain object
(e.g. {"1": {...}}) once a child has ever been removed by key rather than
re-set as a dense array, or a case was edited straight in the Firebase
console. The Batch 18 childbirth/transaction editor read that field
straight off the backend into childbirthDraft.children and called .map()
on it directly, throwing "children.map is not a function" with no error
boundary anywhere in the app to catch it - the whole page unmounted to a
blank screen on load, since a case auto-selects as soon as the catalog
loads.

Export the existing toArray() helper (already used by resolveCaseContext
for the same field) and use it to normalize childbirth.children the one
place the editor's draft state is established, so every downstream
map/filter/spread on it is safe.