### PR TITLE
Fix documentsBuilder crash on maternity hospitals with a filled shortName

### DIFF
--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -344,7 +344,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
             <option value="">— не обрано —</option>
             {catalog.parties.maternityHospitals.map(hospital => (
               <option key={hospital.id} value={String(hospital.id)}>
-                {hospital.shortName || hospital.name?.uk || hospital.id}
+                {hospital.shortName?.uk || hospital.name?.uk || hospital.id}
               </option>
             ))}
           </Select>

--- a/src/components/DocumentsPage.caseEditor.test.js
+++ b/src/components/DocumentsPage.caseEditor.test.js
@@ -44,7 +44,7 @@ const buildParties = () => ({
     'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Сурогатна Матір' } }, taxId: '1234567890', address: { uk: 'Київ' } },
   },
   maternityHospitals: {
-    'hospital-1': { id: 'hospital-1', shortName: 'Пологовий будинок №1' },
+    'hospital-1': { id: 'hospital-1', shortName: { uk: 'Пологовий будинок №1', en: '' } },
   },
   notaries: {
     'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Нотаріус Іванова Іванівна', short: 'Іванова І.І.' } } },
@@ -89,7 +89,12 @@ describe('spec: Childbirth/Transaction case editor (Batch 18 §6)', () => {
   it('renders the maternity hospital select and the single child, without a child selector', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
 
-    expect(await screen.findByLabelText('Пологовий будинок')).toHaveValue('hospital-1');
+    const hospitalSelect = await screen.findByLabelText('Пологовий будинок');
+    expect(hospitalSelect).toHaveValue('hospital-1');
+    // shortName is a bilingual { uk, en } record (same shape as name/address on every other
+    // maternity hospital field) - rendering it as an <option> label must resolve to the uk string,
+    // not the object itself (which crashes React: "Objects are not valid as a React child").
+    expect(screen.getByText('Пологовий будинок №1')).toBeInTheDocument();
     expect(screen.getByText('Дитина 1')).toBeInTheDocument();
     expect(screen.getByLabelText('Стать')).toHaveValue('female');
     expect(screen.queryByLabelText('Дитина для документа')).not.toBeInTheDocument();


### PR DESCRIPTION
maternityHospital.shortName is a bilingual { uk, en } record everywhere
else in the schema (documentsCatalogUtils.js, PartiesPage.jsx), but the
Childbirth/Transaction editor's hospital <option> rendered the raw
shortName object instead of shortName.uk. Any case whose backend data
had a real shortName (e.g. real production exports) crashed React with
"Objects are not valid as a React child" the moment Documents Builder
mounted the case editor.