### PR TITLE
Implement Batch 21 Documents Builder refinements + Parties read/edit modes

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -34,6 +34,7 @@ import {
   clinicLogoEntriesToBackend,
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
+  DEFAULT_BLOCK_WIDTH_PERCENT,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   getClinicLogo,
@@ -445,29 +446,22 @@ const ParagraphFieldColumn = styled.div`
   gap: 2px;
 `;
 
-// A plain <textarea> can never render partial bold/italic - Data mode edits the de-markup'd plain
-// text (spec §2), so pressing Bold/Italic on a selection changed the stored data with no visible
-// feedback at all in that box. This read-only preview (shown only once a paragraph actually has
-// formatting applied) renders the real bold/italic so the admin can confirm the toggle worked
-// without generating a PDF first.
-const FormattedPreviewLabel = styled.div`
-  margin-top: 3px;
-  font-size: 8.5px;
-  font-weight: 800;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--km-muted);
-`;
-
-const FormattedPreviewText = styled.div`
+// Text mode's live display (spec batch 21 §2/§9): renders the resolved text with bold/italic
+// already applied, in the exact spot the plain <textarea> used to sit - this *is* the Text-mode
+// editing surface (select a fragment, press Bold/Italic to change it right there), never a
+// secondary "preview" underneath a separate edit box that has to catch up with it.
+const TextModeDisplay = styled.div`
+  width: 100%;
+  min-height: 24px;
+  padding: 4px 0;
+  font-family: var(--km-font);
   font-size: 12.5px;
-  line-height: 1.45;
+  line-height: 1.4;
   color: var(--km-text);
-  padding: 2px 6px 4px;
   white-space: pre-wrap;
+  cursor: text;
+  user-select: text;
 `;
-
-const hasInlineFormatting = text => parseFormattedRuns(text).some(run => run.bold || run.italic);
 
 const FormattedRunsPreview = ({ text }) => (
   <>
@@ -480,6 +474,40 @@ const FormattedRunsPreview = ({ text }) => (
     })}
   </>
 );
+
+// Text mode has no textarea to read `.selectionStart`/`.selectionEnd` from - the display above is
+// plain rendered HTML, so Bold/Italic instead reads the browser's native Selection and walks the
+// container's text nodes to translate it into the same plain-text character offsets
+// toggleInlineFormat already expects (the same offsets a textarea would have given directly).
+const plainTextOffsetInContainer = (container, node, nodeOffset) => {
+  let offset = 0;
+  let found = false;
+  const walk = current => {
+    if (found) return;
+    if (current === node) {
+      offset += nodeOffset;
+      found = true;
+      return;
+    }
+    if (current.nodeType === Node.TEXT_NODE) {
+      offset += current.textContent.length;
+      return;
+    }
+    current.childNodes.forEach(walk);
+  };
+  Array.from(container.childNodes).forEach(walk);
+  return offset;
+};
+
+const getContainerSelectionOffsets = container => {
+  const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+  const range = selection.getRangeAt(0);
+  if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) return null;
+  const start = plainTextOffsetInContainer(container, range.startContainer, range.startOffset);
+  const end = plainTextOffsetInContainer(container, range.endContainer, range.endOffset);
+  return start === end ? null : { start: Math.min(start, end), end: Math.max(start, end) };
+};
 
 const FieldGrid = styled.div`
   display: grid;
@@ -615,13 +643,22 @@ const DocumentsPage = ({ isAdmin }) => {
   const [selectedDocIds, setSelectedDocIds] = useState({});
   const [layout, setLayout] = useState('two-column');
   const [expandedDocId, setExpandedDocId] = useState('');
-  // Per-row mode toggle: 'template' shows the raw {{placeholder}} markup and edits the shared
-  // template; 'text' shows the resolved value and edits it as a per-case override, with a
-  // formatted (bold/italic-applied) preview shown underneath whenever the text actually has
-  // inline formatting - there is no contentEditable/rich-text engine here, so the editing surface
-  // is still a plain textarea with selection-based Bold/Italic. Defaults to 'text' (what an admin
-  // filling in a specific case wants most of the time). Shared by paragraphs (`index` a number)
-  // and the title row (`index` the 'title' pseudo-index).
+  // Per-row mode, one cycling button instead of separate toggles (spec batch 21 §3/§9): 'template'
+  // shows the raw {{placeholder}} markup and edits the shared template; 'input' shows the resolved
+  // value as plain text and edits it as a per-case override (retype the wording, no formatting);
+  // 'text' shows that same resolved value with bold/italic already rendered in place and is the
+  // *only* mode Bold/Italic can be applied in - the wording itself isn't editable there (spec §9:
+  // "the paragraph's wording itself is not directly editable... the only action available is
+  // selecting a fragment and applying Bold"). Defaults to 'text'. Shared by the title row (scope
+  // TITLE_SCOPE) and every paragraph (scope paragraphScope(index)).
+  const PARAGRAPH_MODES = ['template', 'input', 'text'];
+  const nextParagraphMode = mode => PARAGRAPH_MODES[(PARAGRAPH_MODES.indexOf(mode) + 1) % PARAGRAPH_MODES.length];
+  const PARAGRAPH_MODE_ICON = { template: '{}', input: 'I', text: 'T' };
+  const PARAGRAPH_MODE_TITLE = {
+    template: 'Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.',
+    input: "Input mode - retyping this case's resolved wording. Tap to switch to Text mode.",
+    text: 'Text mode - select text and press Bold/Italic; wording isn\'t editable here. Tap to switch to Template mode.',
+  };
   const [paragraphModes, setParagraphModes] = useState({});
   const paragraphModeKey = (docId, index) => `${docId}#${index}`;
   const getParagraphMode = (docId, index) => paragraphModes[paragraphModeKey(docId, index)] || 'text';
@@ -845,6 +882,18 @@ const DocumentsPage = ({ isAdmin }) => {
       console.error('Unable to reset the paragraph indent', saveError);
       toast.error('Could not save the indent change.');
     }
+  };
+
+  // The signatory/applicant data block's draggable width handle (spec batch 21 §8: half-page-right
+  // layout, adjustable per document/template) - same drag-updates-locally/persists-on-release
+  // pattern as the paragraph indent slider above.
+  const handleBeforeTitleWidthChange = (docId, index, value) => {
+    updateTemplate(docId, template => ({
+      ...template,
+      beforeTitle: (template.beforeTitle || []).map((block, blockIndex) => (
+        blockIndex === index ? { ...block, width: value } : block
+      )),
+    }));
   };
 
   // The letterhead logo always renders before the title (spec: "лого відображай перед title") and
@@ -1090,12 +1139,16 @@ const DocumentsPage = ({ isAdmin }) => {
     if (!active) return;
     const node = fieldNodesRef.current[fieldKey(active.docId, active.scope, active.langKey)];
     if (!node) return;
-    const start = node.selectionStart;
-    const end = node.selectionEnd;
-    if (start === end) {
+    // Text mode's field is a plain rendered display, not a textarea (see getContainerSelectionOffsets)
+    // - every other mode still reads the native .selectionStart/.selectionEnd off the textarea node.
+    const offsets = active.kind === 'text-display'
+      ? getContainerSelectionOffsets(node)
+      : { start: node.selectionStart, end: node.selectionEnd };
+    if (!offsets || offsets.start === offsets.end) {
       toast.error('Select some text first.');
       return;
     }
+    const { start, end } = offsets;
     const { docId, scope, langKey } = active;
     if (active.kind === 'template') {
       const template = catalog.documents.find(item => String(item.id) === String(docId));
@@ -1178,7 +1231,7 @@ const DocumentsPage = ({ isAdmin }) => {
   // --- Deletes (always behind an explicit confirmation) ----------------------------------------
 
   const handleDeleteTemplate = async template => {
-    const name = template.title?.uk || template.title?.en || template.id;
+    const name = template.catalogName || template.title?.uk || template.title?.en || template.id;
     if (typeof window !== 'undefined' && !window.confirm(`Delete document "${name}" from the catalog?`)) return;
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${template.id}`), null);
@@ -1817,17 +1870,32 @@ const DocumentsPage = ({ isAdmin }) => {
                   : (getParagraphType((template.paragraphs || [])[0]) !== 'text'
                     ? ((template.paragraphs || [])[0]?.uk || (template.paragraphs || [])[0]?.en || '')
                     : '');
-                // The document name's own inline input (shown right in the row header, spec: "input
-                // мого улюбленого формату поруч з назвою документу") always edits the resolved
-                // per-case title once a case is selected - the same per-case override every other
-                // resolved-value field uses - falling back to the raw template title when there is
-                // no case yet (nothing to resolve against).
-                const titleEditsCase = Boolean(selectedCase);
-                const titleValue = langKey => (titleEditsCase ? resolvedDoc?.title?.[langKey] ?? '' : template.title?.[langKey] || '');
-                const onTitleChange = langKey => event => (titleEditsCase
-                  ? handleDataScopeChange(template.id, TITLE_SCOPE, langKey, event.target.value)
-                  : handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, event.target.value));
-                const onTitleBlur = () => (titleEditsCase ? persistDocOverride(template.id) : persistTemplate(template.id));
+                // The Documents-list entry name (spec batch 21 §6: "Заява СМ в РАЦС" is the
+                // catalog/list name, never the in-document title) - its own field, `catalogName`,
+                // completely separate from `template.title.*` (which only ever prints inside the
+                // document itself, see the Title block below and buildGeneratedDocument/the PDF+DOCX
+                // renderers, which read title.uk/title.en and nothing else). Legacy templates saved
+                // before this field existed fall back to the title text so the list doesn't go blank
+                // for them, but any edit here writes catalogName only - it never touches title.
+                const catalogNameValue = template.catalogName || template.title?.uk || template.title?.en || template.id;
+                const onCatalogNameChange = event => updateTemplate(template.id, current => ({ ...current, catalogName: event.target.value }));
+                const onCatalogNameBlur = () => persistTemplate(template.id);
+                // Title mode/state - same template/input/text cycle as paragraphs (see PARAGRAPH_MODES).
+                const titleMode = getParagraphMode(template.id, TITLE_SCOPE);
+                const titleIsTemplateMode = titleMode === 'template';
+                const titleIsInputMode = titleMode === 'input';
+                const titleCaseModeLocked = !titleIsTemplateMode && !selectedCase;
+                const titleRawValue = langKey => (titleIsTemplateMode ? (template.title?.[langKey] || '') : (resolvedDoc?.title?.[langKey] ?? ''));
+                const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleRawValue(langKey)));
+                const onTitleFieldChange = langKey => event => {
+                  if (titleIsTemplateMode) {
+                    handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, event.target.value);
+                  } else {
+                    const nextRaw = applyPlainTextEdit(titleRawValue(langKey), event.target.value);
+                    handleDataScopeChange(template.id, TITLE_SCOPE, langKey, nextRaw);
+                  }
+                };
+                const onTitleFieldBlur = () => (titleIsTemplateMode ? persistTemplate(template.id) : persistDocOverride(template.id));
                 return (
                   <DocRow key={template.id}>
                     <DocRowHead>
@@ -1845,12 +1913,12 @@ const DocumentsPage = ({ isAdmin }) => {
                         {isExpanded ? <FaChevronUp /> : <FaChevronDown />}
                       </DocTitleButton>
                       <AutoInlineTextarea
-                        value={titleValue('uk')}
-                        placeholder="Title (uk)"
-                        onChange={onTitleChange('uk')}
-                        onBlur={onTitleBlur}
+                        value={catalogNameValue}
+                        placeholder="Document name (Documents list)"
+                        onChange={onCatalogNameChange}
+                        onBlur={onCatalogNameBlur}
                         style={{ flex: 1, minWidth: 0, fontWeight: 600 }}
-                        title="Edit the document's title directly - the resolved value for the selected case, or the shared template title otherwise"
+                        title="The document's entry name in the Documents list - never printed inside the document itself (edit the printed title below, in the Title row)"
                       />
                       <DangerButton type="button" onClick={() => handleDeleteTemplate(template)} title="Delete document">
                         <FaTrash />
@@ -1883,7 +1951,6 @@ const DocumentsPage = ({ isAdmin }) => {
                               const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
                               const onChange = langKey => event => handleTemplateScopeChange(template.id, scope, langKey, event.target.value);
                               const onBlur = () => persistTemplate(template.id);
-                              const showPreview = langKey => hasInlineFormatting(rawValue(langKey));
                               return (
                                 <ParagraphEditorBlock key={`${template.id}-before-title-${index}`}>
                                   <ParagraphControlsRow>
@@ -1893,6 +1960,24 @@ const DocumentsPage = ({ isAdmin }) => {
                                       <SmallButton type="button" onMouseDown={preventSelectionLoss} onClick={openVariablePicker} title="Insert a variable"><FaCode /></SmallButton>
                                     </RowLine>
                                   </ParagraphControlsRow>
+                                  <RowLine style={{ marginTop: 2, marginBottom: 2 }}>
+                                    <DocSubtitle style={{ fontSize: 10, whiteSpace: 'nowrap' }}>Ширина блоку</DocSubtitle>
+                                    <RangeInput
+                                      type="range"
+                                      min={10}
+                                      max={100}
+                                      step={5}
+                                      value={block.width ?? DEFAULT_BLOCK_WIDTH_PERCENT}
+                                      onChange={event => handleBeforeTitleWidthChange(template.id, index, Number(event.target.value))}
+                                      onMouseUp={() => persistTemplate(template.id)}
+                                      onTouchEnd={() => persistTemplate(template.id)}
+                                      aria-label={`Ширина блоку ${index + 1}`}
+                                      title="Ширина блоку, вирівняного від середини сторінки до краю - перетягніть, щоб змінити"
+                                    />
+                                    <DocSubtitle style={{ fontSize: 10, minWidth: 32 }}>
+                                      {block.width ?? DEFAULT_BLOCK_WIDTH_PERCENT}%
+                                    </DocSubtitle>
+                                  </RowLine>
                                   <ParagraphPair $single={isSingle} $plain>
                                     {showUk ? (
                                       <ParagraphFieldColumn>
@@ -1904,12 +1989,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                           onChange={onChange('uk')}
                                           onBlur={onBlur}
                                         />
-                                        {showPreview('uk') ? (
-                                          <>
-                                            <FormattedPreviewLabel>Preview (bold/italic applied)</FormattedPreviewLabel>
-                                            <FormattedPreviewText><FormattedRunsPreview text={rawValue('uk')} /></FormattedPreviewText>
-                                          </>
-                                        ) : null}
                                       </ParagraphFieldColumn>
                                     ) : null}
                                     {showEn ? (
@@ -1922,12 +2001,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                           onChange={onChange('en')}
                                           onBlur={onBlur}
                                         />
-                                        {showPreview('en') ? (
-                                          <>
-                                            <FormattedPreviewLabel>Preview (bold/italic applied)</FormattedPreviewLabel>
-                                            <FormattedPreviewText><FormattedRunsPreview text={rawValue('en')} /></FormattedPreviewText>
-                                          </>
-                                        ) : null}
                                       </ParagraphFieldColumn>
                                     ) : null}
                                   </ParagraphPair>
@@ -1936,47 +2009,115 @@ const DocumentsPage = ({ isAdmin }) => {
                             })}
                           </>
                         ) : null}
-                        {showEn ? (
-                          // The header input above only edits the uk title (space is tight in a
-                          // single row); the en title is edited here instead, following whichever
-                          // mode the header is currently in (case selected -> this case's override;
-                          // no case yet -> the shared template) - one implicit mode for both halves
-                          // of the same title, never a separate toggle to fall out of sync with.
-                          <ParagraphEditorBlock>
-                            <ParagraphControlsRow>
-                              <DocSubtitle style={{ fontWeight: 700 }}>Title (en)</DocSubtitle>
-                              <RowLine style={{ gap: 6 }}>
-                                <SmallButton type="button" disabled={titleEditsCase && !selectedCase} {...formatButtonProps('bold')} title="Bold the selected text"><FaBold /></SmallButton>
-                                <SmallButton type="button" disabled={titleEditsCase && !selectedCase} {...formatButtonProps('italic')} title="Italicize the selected text"><FaItalic /></SmallButton>
-                                <SmallButton type="button" disabled={titleEditsCase} onMouseDown={preventSelectionLoss} onClick={openVariablePicker} title="Insert a variable"><FaCode /></SmallButton>
-                              </RowLine>
-                            </ParagraphControlsRow>
-                            <AutoInlineTextarea
-                              ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
-                              value={titleValue('en')}
-                              placeholder="Title (en)"
-                              onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleEditsCase ? 'override' : 'template')}
-                              onChange={onTitleChange('en')}
-                              onBlur={onTitleBlur}
-                            />
-                            {hasInlineFormatting(titleEditsCase ? (resolvedDoc?.title?.en || '') : (template.title?.en || '')) ? (
-                              <>
-                                <FormattedPreviewLabel>Preview (bold/italic applied)</FormattedPreviewLabel>
-                                <FormattedPreviewText>
-                                  <FormattedRunsPreview text={titleEditsCase ? (resolvedDoc?.title?.en || '') : (template.title?.en || '')} />
-                                </FormattedPreviewText>
-                              </>
-                            ) : null}
-                          </ParagraphEditorBlock>
-                        ) : null}
+                        {(() => {
+                          // Title (uk)/(en) always shown as a paired, symmetric row (spec batch 21
+                          // §5) - the exact same template/input/text cycle paragraphs use (spec §3/
+                          // §9), never a separate uk-in-the-header + en-below split. Printed inside
+                          // the document from title.uk/title.en only - never the catalogName above.
+                          const titleFieldKind = titleIsTemplateMode ? 'template' : (titleMode === 'input' ? 'override' : 'text-display');
+                          return (
+                            <ParagraphEditorBlock>
+                              <ParagraphControlsRow>
+                                <DocSubtitle style={{ fontWeight: 700 }}>Title</DocSubtitle>
+                                <RowLine style={{ gap: 6 }}>
+                                  <SmallButton
+                                    type="button"
+                                    onClick={() => setParagraphModeFor(template.id, TITLE_SCOPE, nextParagraphMode(titleMode))}
+                                    title={PARAGRAPH_MODE_TITLE[titleMode]}
+                                  >
+                                    {PARAGRAPH_MODE_ICON[titleMode]}
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={titleIsInputMode || titleCaseModeLocked}
+                                    {...formatButtonProps('bold')}
+                                    title="Bold the selected text"
+                                  >
+                                    <FaBold />
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={titleIsInputMode || titleCaseModeLocked}
+                                    {...formatButtonProps('italic')}
+                                    title="Italicize the selected text"
+                                  >
+                                    <FaItalic />
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={!titleIsTemplateMode}
+                                    onMouseDown={preventSelectionLoss}
+                                    onClick={openVariablePicker}
+                                    title="Insert a variable"
+                                  >
+                                    <FaCode />
+                                  </SmallButton>
+                                </RowLine>
+                              </ParagraphControlsRow>
+                              {titleCaseModeLocked ? (
+                                <DocSubtitle>Select a case first to edit its resolved values.</DocSubtitle>
+                              ) : null}
+                              <ParagraphPair $single={isSingle} $plain>
+                                {showUk ? (
+                                  <ParagraphFieldColumn>
+                                    {titleMode === 'text' ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
+                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={titleRawValue('uk')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
+                                        value={titleDisplayValue('uk')}
+                                        placeholder="Title (uk)"
+                                        readOnly={titleCaseModeLocked}
+                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind)}
+                                        onChange={onTitleFieldChange('uk')}
+                                        onBlur={onTitleFieldBlur}
+                                      />
+                                    )}
+                                  </ParagraphFieldColumn>
+                                ) : null}
+                                {showEn ? (
+                                  <ParagraphFieldColumn>
+                                    {titleMode === 'text' ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
+                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={titleRawValue('en')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
+                                        value={titleDisplayValue('en')}
+                                        placeholder="Title (en)"
+                                        readOnly={titleCaseModeLocked}
+                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind)}
+                                        onChange={onTitleFieldChange('en')}
+                                        onBlur={onTitleFieldBlur}
+                                      />
+                                    )}
+                                  </ParagraphFieldColumn>
+                                ) : null}
+                              </ParagraphPair>
+                            </ParagraphEditorBlock>
+                          );
+                        })()}
                         {(template.paragraphs || []).map((paragraph, index) => {
                           const scope = paragraphScope(index);
-                          // Per-paragraph mode: 'template' edits the shared {{placeholder}} markup;
-                          // 'text' edits this case's resolved-value override (Bold/Italic apply
-                          // there) - a formatted preview appears underneath only when the text
-                          // actually has inline formatting, never forced on.
+                          // Per-paragraph mode - see PARAGRAPH_MODES above for what each of
+                          // template/input/text means; Bold/Italic only ever act in template mode
+                          // (raw markers) or text mode (this case's override, applied live in place
+                          // - no separate preview to catch up, spec batch 21 §2).
                           const mode = getParagraphMode(template.id, scope);
                           const isTemplateMode = mode === 'template';
+                          const isInputMode = mode === 'input';
+                          const isTextMode = mode === 'text';
                           const caseModeLocked = !isTemplateMode && !selectedCase;
                           const rawValue = langKey => (isTemplateMode
                             ? paragraph?.[langKey] || ''
@@ -1991,7 +2132,7 @@ const DocumentsPage = ({ isAdmin }) => {
                             }
                           };
                           const onBlur = () => (isTemplateMode ? persistTemplate(template.id) : persistDocOverride(template.id));
-                          const showPreview = langKey => hasInlineFormatting(rawValue(langKey));
+                          const fieldKind = isTemplateMode ? 'template' : 'override';
                           return (
                             // Boxed together so it's unambiguous which paragraph the toolbar acts
                             // on: the +/mode-switch/Bold/Italic/Delete controls and the paragraph's
@@ -2003,30 +2144,19 @@ const DocumentsPage = ({ isAdmin }) => {
                                   onClick={() => handleInsertParagraph(template.id, index)}
                                   title="Insert a new custom paragraph above this one"
                                 >
-                                  <FaPlus /> Insert paragraph
+                                  <FaPlus />
                                 </SmallButton>
                                 <RowLine style={{ gap: 6 }}>
-                                  <ToggleGroup>
-                                    <ToggleOption
-                                      type="button"
-                                      $active={mode === 'template'}
-                                      onClick={() => setParagraphModeFor(template.id, scope, 'template')}
-                                      title="Raw {{placeholder}} markup - edits the shared template"
-                                    >
-                                      Template
-                                    </ToggleOption>
-                                    <ToggleOption
-                                      type="button"
-                                      $active={mode === 'text'}
-                                      onClick={() => setParagraphModeFor(template.id, scope, 'text')}
-                                      title="Resolved value - edits this case's override; select text to Bold/Italic it"
-                                    >
-                                      Text
-                                    </ToggleOption>
-                                  </ToggleGroup>
                                   <SmallButton
                                     type="button"
-                                    disabled={caseModeLocked}
+                                    onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
+                                    title={PARAGRAPH_MODE_TITLE[mode]}
+                                  >
+                                    {PARAGRAPH_MODE_ICON[mode]}
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={isInputMode || caseModeLocked}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2034,7 +2164,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={caseModeLocked}
+                                    disabled={isInputMode || caseModeLocked}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2091,44 +2221,48 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, scope, 'uk')}
-                                      value={displayValue('uk')}
-                                      placeholder="Paragraph (uk)"
-                                      readOnly={caseModeLocked}
-                                      onFocus={handleRichFieldFocus(template.id, scope, 'uk', isTemplateMode ? 'template' : 'override')}
-                                      onChange={onChange('uk')}
-                                      onBlur={onBlur}
-                                    />
-                                    {showPreview('uk') ? (
-                                      <>
-                                        <FormattedPreviewLabel>Preview (bold/italic applied)</FormattedPreviewLabel>
-                                        <FormattedPreviewText>
-                                          <FormattedRunsPreview text={rawValue('uk')} />
-                                        </FormattedPreviewText>
-                                      </>
-                                    ) : null}
+                                    {isTextMode ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={rawValue('uk')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        value={displayValue('uk')}
+                                        placeholder="Paragraph (uk)"
+                                        readOnly={caseModeLocked}
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
+                                        onChange={onChange('uk')}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, scope, 'en')}
-                                      value={displayValue('en')}
-                                      placeholder="Paragraph (en)"
-                                      readOnly={caseModeLocked}
-                                      onFocus={handleRichFieldFocus(template.id, scope, 'en', isTemplateMode ? 'template' : 'override')}
-                                      onChange={onChange('en')}
-                                      onBlur={onBlur}
-                                    />
-                                    {showPreview('en') ? (
-                                      <>
-                                        <FormattedPreviewLabel>Preview (bold/italic applied)</FormattedPreviewLabel>
-                                        <FormattedPreviewText>
-                                          <FormattedRunsPreview text={rawValue('en')} />
-                                        </FormattedPreviewText>
-                                      </>
-                                    ) : null}
+                                    {isTextMode ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={rawValue('en')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        value={displayValue('en')}
+                                        placeholder="Paragraph (en)"
+                                        readOnly={caseModeLocked}
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
+                                        onChange={onChange('en')}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                               </ParagraphPair>
@@ -2141,7 +2275,7 @@ const DocumentsPage = ({ isAdmin }) => {
                             onClick={() => handleInsertParagraph(template.id, (template.paragraphs || []).length)}
                             title="Append a new custom paragraph at the end of the document"
                           >
-                            <FaPlus /> Add paragraph at the end
+                            <FaPlus />
                           </SmallButton>
                         </ParagraphControlsRow>
                       </div>
@@ -2188,7 +2322,7 @@ const DocumentsPage = ({ isAdmin }) => {
                       <option value="">Format for: all documents (defaults)</option>
                       {orderedDocuments.map(template => (
                         <option key={template.id} value={String(template.id)}>
-                          Format for: {template.title?.uk || template.title?.en || template.id}
+                          Format for: {template.catalogName || template.title?.uk || template.title?.en || template.id}
                         </option>
                       ))}
                     </Select>

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -73,13 +73,13 @@ describe('spec: per-paragraph first-line indent slider', () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const indentedField = await screen.findByDisplayValue('Абзац з відступом.');
+    const indentedField = await screen.findByText('Абзац з відступом.');
     // eslint-disable-next-line testing-library/no-node-access
     const indentedBlock = indentedField.closest('.paragraph-editor-block');
     expect(within(indentedBlock).getByLabelText('Відступ абзацу 1')).toHaveValue('1');
     expect(within(indentedBlock).getByText('1.00 см')).toBeInTheDocument();
 
-    const plainField = screen.getByDisplayValue('Абзац без відступу.');
+    const plainField = screen.getByText('Абзац без відступу.');
     // eslint-disable-next-line testing-library/no-node-access
     const plainBlock = plainField.closest('.paragraph-editor-block');
     expect(within(plainBlock).getByLabelText('Відступ абзацу 2')).toHaveValue('0'); // document default
@@ -90,7 +90,7 @@ describe('spec: per-paragraph first-line indent slider', () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const plainField = await screen.findByDisplayValue('Абзац без відступу.');
+    const plainField = await screen.findByText('Абзац без відступу.');
     // eslint-disable-next-line testing-library/no-node-access
     const plainBlock = plainField.closest('.paragraph-editor-block');
     const slider = within(plainBlock).getByLabelText('Відступ абзацу 2');
@@ -116,7 +116,7 @@ describe('spec: per-paragraph first-line indent slider', () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const indentedField = await screen.findByDisplayValue('Абзац з відступом.');
+    const indentedField = await screen.findByText('Абзац з відступом.');
     // eslint-disable-next-line testing-library/no-node-access
     const indentedBlock = indentedField.closest('.paragraph-editor-block');
     fireEvent.click(within(indentedBlock).getByTitle('Скинути до відступу документа'));

--- a/src/components/DocumentsPage.richFormatting.test.js
+++ b/src/components/DocumentsPage.richFormatting.test.js
@@ -37,6 +37,22 @@ import { listStorageFolderFileNames } from './config';
 // eslint-disable-next-line import/first
 import DocumentsPage from './DocumentsPage';
 
+// Text mode's field is a plain rendered display, not a textarea (spec batch 21 §2 - the display
+// itself is the editing surface), so there's no `.setSelectionRange` to drive a selection through.
+// This mirrors what a real browser drag-select does: build a Range over the container's own text
+// node and install it as the document's selection, then fire the mouseUp/touchEnd the component
+// listens on to know a selection was just made in that field.
+const selectTextInContainer = (container, start, end) => {
+  // eslint-disable-next-line testing-library/no-node-access
+  const textNode = container.firstChild;
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
 beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
   get.mockImplementation(async path => {
@@ -74,23 +90,24 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    // Default mode is 'text' (spec batch 21 §9) - the field is the rendered display itself.
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    selectTextInContainer(field, 10, 15); // "текст"
+    fireEvent.mouseUp(field);
 
-    fireEvent.focus(textarea);
-    textarea.setSelectionRange(10, 15); // "текст"
-
-    // Bold/Italic now also appear on the Title (en) row above (spec: unified format across every
+    // Bold/Italic now also appear on the Title row above (spec: unified format across every
     // editable row) - scope the query to this paragraph's own boxed controls, same as a sighted
     // admin would click the toolbar right above this specific field.
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = textarea.closest('.paragraph-editor-block');
+    const paragraphBlock = field.closest('.paragraph-editor-block');
     const boldButton = within(paragraphBlock).getByTitle('Bold the selected text');
     fireEvent.click(boldButton);
 
     await waitFor(() => expect(set).toHaveBeenCalled());
     const [, payload] = set.mock.calls[set.mock.calls.length - 1];
     expect(payload.paragraphs[0].uk).toBe('Звичайний **текст** без форматування.');
-    expect(textarea.value).toBe('Звичайний текст без форматування.');
+    // The change is applied in place, right in the display - never a separate preview to catch up.
+    expect(await within(paragraphBlock).findByText('текст')).toBeInTheDocument();
   });
 
   it('also applies via touch (mobile), where preventing the selection-dismissing touchstart suppresses the synthetic click', async () => {
@@ -99,12 +116,12 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
-    fireEvent.focus(textarea);
-    textarea.setSelectionRange(10, 15); // "текст"
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    selectTextInContainer(field, 10, 15); // "текст"
+    fireEvent.touchEnd(field);
 
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = textarea.closest('.paragraph-editor-block');
+    const paragraphBlock = field.closest('.paragraph-editor-block');
     const italicButton = within(paragraphBlock).getByTitle('Italicize the selected text');
     // No fireEvent.click - mobile browsers won't synthesize one once touchstart's default is
     // prevented (exactly what the button needs to do to keep the selection alive), so the
@@ -131,13 +148,18 @@ describe('spec: per-paragraph template/text mode switch replaces the global togg
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    // Default mode ('text') shows the resolved value.
-    await screen.findByDisplayValue('Звичайний текст без форматування.');
+    // Default mode ('text') shows the resolved value as a rendered display, not a textarea.
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    // eslint-disable-next-line testing-library/no-node-access
+    const paragraphBlock = field.closest('.paragraph-editor-block');
 
-    const templateModeButton = screen.getByTitle('Raw {{placeholder}} markup - edits the shared template');
-    fireEvent.click(templateModeButton);
+    // One cycling button, not three separate ones (spec §3): text -> template is one tap.
+    const modeButton = within(paragraphBlock).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    );
+    fireEvent.click(modeButton);
 
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    const textarea = await within(paragraphBlock).findByDisplayValue('Звичайний текст без форматування.');
     fireEvent.change(textarea, { target: { value: 'Змінений шаблонний текст.' } });
     fireEvent.blur(textarea);
 
@@ -147,14 +169,19 @@ describe('spec: per-paragraph template/text mode switch replaces the global togg
     ));
   });
 
-  it('shows an inline-editable title input next to the document name', async () => {
+  it('shows an inline-editable Documents-list name next to the checkbox, separate from the in-document title', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     await screen.findByTitle('Edit paragraphs');
 
-    const titleInput = await screen.findByDisplayValue('Тест');
-    fireEvent.change(titleInput, { target: { value: 'Оновлена назва' } });
-    fireEvent.blur(titleInput);
+    // No catalogName saved yet, so the field falls back to showing the title text - but editing it
+    // writes catalogName only (spec batch 21 §6), never template.title.
+    const nameInput = await screen.findByDisplayValue('Тест');
+    fireEvent.change(nameInput, { target: { value: 'Оновлена назва' } });
+    fireEvent.blur(nameInput);
 
-    await waitFor(() => expect(set).toHaveBeenCalled());
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({ catalogName: 'Оновлена назва', title: expect.objectContaining({ uk: 'Тест' }) }),
+    ));
   });
 });

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -99,6 +99,30 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
       }),
     ));
   });
+
+  it('the width handle defaults to 50% and persists a dragged value on release (spec batch 21 §8)', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const textarea = await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = textarea.closest('.paragraph-editor-block');
+    const slider = within(block).getByLabelText('Ширина блоку 1');
+    expect(slider).toHaveValue('50');
+
+    fireEvent.change(slider, { target: { value: '75' } });
+    expect(within(block).getByText('75%')).toBeInTheDocument();
+    expect(set).not.toHaveBeenCalled(); // not yet released
+
+    fireEvent.mouseUp(slider);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        beforeTitle: [expect.objectContaining({ width: 75 })],
+      }),
+    ));
+  });
 });
 
 describe('spec: Bold/Italic also work on a paragraph while in Template mode', () => {
@@ -106,13 +130,18 @@ describe('spec: Bold/Italic also work on a paragraph while in Template mode', ()
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    fireEvent.click(screen.getByTitle('Raw {{placeholder}} markup - edits the shared template'));
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    // Default mode is 'text'; one tap of the cycling mode button goes straight to 'template'
+    // (spec §3: template -> input -> text -> template).
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = field.closest('.paragraph-editor-block');
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(block).findByDisplayValue('Звичайний текст без форматування.');
     fireEvent.focus(textarea);
     textarea.setSelectionRange(10, 15); // "текст"
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
     fireEvent.click(within(block).getByTitle('Bold the selected text'));
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(

--- a/src/components/DocumentsPage.variablePicker.test.js
+++ b/src/components/DocumentsPage.variablePicker.test.js
@@ -70,32 +70,41 @@ describe('spec: insert-variable button + modal', () => {
   it('is disabled outside Template mode and enabled once the paragraph is switched to Template mode', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-    const textarea = await screen.findByPlaceholderText('Paragraph (uk)');
+    const field = await screen.findByText('Я,');
     // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
+    const block = field.closest('.paragraph-editor-block');
 
     expect(within(block).getByTitle('Insert a variable')).toBeDisabled();
 
-    fireEvent.click(within(block).getByTitle('Raw {{placeholder}} markup - edits the shared template'));
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
     expect(within(block).getByTitle('Insert a variable')).toBeEnabled();
   });
 
-  it('opens the modal grouped into Пара/Сурогатна мати/Довірена особа/Клініка, showing the resolved value', async () => {
+  it('opens the modal grouped one-per-role (Дружина/Сурогатна мати/Довірена особа/...), showing the resolved value', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-    const textarea = await screen.findByPlaceholderText('Paragraph (uk)');
+    const field = await screen.findByText('Я,');
     // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
-    fireEvent.click(within(block).getByTitle('Raw {{placeholder}} markup - edits the shared template'));
+    const block = field.closest('.paragraph-editor-block');
+    // Default mode is 'text'; one tap of the cycling mode button goes straight to 'template'.
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(block).findByPlaceholderText('Paragraph (uk)');
     fireEvent.focus(textarea);
     textarea.setSelectionRange(3, 3);
 
     fireEvent.click(within(block).getByTitle('Insert a variable'));
 
-    expect(await screen.findByText('Пара')).toBeInTheDocument();
+    expect(await screen.findByText('Дружина')).toBeInTheDocument();
     expect(screen.getByText('Сурогатна мати')).toBeInTheDocument();
     expect(screen.getByText('Довірена особа')).toBeInTheDocument();
-    expect(screen.getByText('Клініка')).toBeInTheDocument();
+    // No clinic is linked, so it defaults into the Ukrainian group (empty); the foreign-clinic
+    // group's predicate fails entirely and it doesn't render at all.
+    expect(screen.getByText('Клініка — українська')).toBeInTheDocument();
+    expect(screen.queryByText('Клініка — іноземна')).not.toBeInTheDocument();
     // The picked wife's name is shown in its resolved final-format form, not the raw path.
     expect(screen.getByText('Кьогоку Ая')).toBeInTheDocument();
     expect(screen.queryByText('wife.name.uk.nominative')).not.toBeInTheDocument();
@@ -104,10 +113,14 @@ describe('spec: insert-variable button + modal', () => {
   it('clicking an item inserts {{path}} at the captured cursor position and persists to the template', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-    const textarea = await screen.findByPlaceholderText('Paragraph (uk)');
+    const field = await screen.findByText('Я,');
     // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
-    fireEvent.click(within(block).getByTitle('Raw {{placeholder}} markup - edits the shared template'));
+    const block = field.closest('.paragraph-editor-block');
+    // Default mode is 'text'; one tap of the cycling mode button goes straight to 'template'.
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(block).findByPlaceholderText('Paragraph (uk)');
     fireEvent.focus(textarea);
     textarea.setSelectionRange(3, 3); // right after "Я, "
 
@@ -121,22 +134,26 @@ describe('spec: insert-variable button + modal', () => {
       }),
     ));
     // The modal closes itself after a pick.
-    await waitFor(() => expect(screen.queryByText('Пара')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Дружина')).not.toBeInTheDocument());
   });
 
   it('locks page scroll while open and restores it on close (spec: modal scroll must never leak to the page)', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-    const textarea = await screen.findByPlaceholderText('Paragraph (uk)');
+    const field = await screen.findByText('Я,');
     // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
-    fireEvent.click(within(block).getByTitle('Raw {{placeholder}} markup - edits the shared template'));
+    const block = field.closest('.paragraph-editor-block');
+    // Default mode is 'text'; one tap of the cycling mode button goes straight to 'template'.
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(block).findByPlaceholderText('Paragraph (uk)');
     fireEvent.focus(textarea);
     textarea.setSelectionRange(3, 3);
 
     expect(document.body.style.overflow).not.toBe('hidden');
     fireEvent.click(within(block).getByTitle('Insert a variable'));
-    await screen.findByText('Пара');
+    await screen.findByText('Дружина');
     expect(document.body.style.overflow).toBe('hidden');
 
     fireEvent.click(screen.getByLabelText('Закрити'));
@@ -147,10 +164,14 @@ describe('spec: insert-variable button + modal', () => {
     jest.useFakeTimers({ advanceTimers: true });
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-    const textarea = await screen.findByPlaceholderText('Paragraph (uk)');
+    const field = await screen.findByText('Я,');
     // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
-    fireEvent.click(within(block).getByTitle('Raw {{placeholder}} markup - edits the shared template'));
+    const block = field.closest('.paragraph-editor-block');
+    // Default mode is 'text'; one tap of the cycling mode button goes straight to 'template'.
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(block).findByPlaceholderText('Paragraph (uk)');
     fireEvent.focus(textarea);
     textarea.setSelectionRange(3, 3);
     fireEvent.click(within(block).getByTitle('Insert a variable'));
@@ -170,17 +191,21 @@ describe('spec: insert-variable button + modal', () => {
   it('the × button and clicking the overlay both close the modal without inserting anything', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-    const textarea = await screen.findByPlaceholderText('Paragraph (uk)');
+    const field = await screen.findByText('Я,');
     // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
-    fireEvent.click(within(block).getByTitle('Raw {{placeholder}} markup - edits the shared template'));
+    const block = field.closest('.paragraph-editor-block');
+    // Default mode is 'text'; one tap of the cycling mode button goes straight to 'template'.
+    fireEvent.click(within(block).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(block).findByPlaceholderText('Paragraph (uk)');
     fireEvent.focus(textarea);
     textarea.setSelectionRange(3, 3);
 
     fireEvent.click(within(block).getByTitle('Insert a variable'));
     fireEvent.click(await screen.findByLabelText('Закрити'));
 
-    expect(screen.queryByText('Пара')).not.toBeInTheDocument();
+    expect(screen.queryByText('Дружина')).not.toBeInTheDocument();
     expect(set).not.toHaveBeenCalledWith('documentsBuilder/templates/doc-1', expect.anything());
   });
 });

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -198,17 +198,31 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
 // Free-standing text between the letterhead logo and the title (spec §14: "ЗА МІСЦЕМ ВИМОГИ" etc.)
 // - never merged into the paragraph list, so it always renders in this fixed position regardless of
 // how the body is edited. `align`/`bold` (spec §17) are resolved per block, not inferred from text.
+// `width` (spec batch 21 §8: the applicant/signatory data block is a *half-page-right* layout rule,
+// not just right-aligned text) constrains the block to that percentage of its column's width, still
+// pushed against whichever margin `align` names - a wide block wraps inside that strip instead of
+// spanning the full page width the way plain text-align would.
 const BeforeTitleBlock = ({ block, isBilingual, lang, cellStyles }) => {
   const runStyle = { textAlign: block.align, fontWeight: block.bold ? 700 : 400 };
+  const widthStyle = { width: `${block.width}%` };
+  const rowJustify = block.align === 'right' ? 'flex-end' : (block.align === 'center' ? 'center' : 'flex-start');
   if (isBilingual) {
     return (
       <View style={styles.row}>
-        <Text style={[cellStyles.beforeTitle, cellStyles.leftCell, runStyle]}><FormattedRuns text={block.uk} /></Text>
-        <Text style={[cellStyles.beforeTitle, cellStyles.rightCell, runStyle]}><FormattedRuns text={block.en} /></Text>
+        <View style={[cellStyles.leftCell, { flexDirection: 'row', justifyContent: rowJustify }]}>
+          <Text style={[cellStyles.beforeTitle, widthStyle, runStyle]}><FormattedRuns text={block.uk} /></Text>
+        </View>
+        <View style={[cellStyles.rightCell, { flexDirection: 'row', justifyContent: rowJustify }]}>
+          <Text style={[cellStyles.beforeTitle, widthStyle, runStyle]}><FormattedRuns text={block.en} /></Text>
+        </View>
       </View>
     );
   }
-  return <Text style={[cellStyles.beforeTitle, runStyle]}><FormattedRuns text={block[lang]} /></Text>;
+  return (
+    <View style={{ flexDirection: 'row', justifyContent: rowJustify }}>
+      <Text style={[cellStyles.beforeTitle, widthStyle, runStyle]}><FormattedRuns text={block[lang]} /></Text>
+    </View>
+  );
 };
 
 const BeforeTitleBlocks = ({ blocks, isBilingual, lang, cellStyles }) => (blocks || []).map((block, index) => (

--- a/src/components/DocumentsVariablePickerModal.jsx
+++ b/src/components/DocumentsVariablePickerModal.jsx
@@ -1,6 +1,7 @@
 // Insert-variable picker (spec: "поруч з курсивом кнопку... модальне вікно в якому можна обрати
-// змінні"): grouped into 4 blocks (Пара/Сурогатна мати/Довірена особа/Клініка, see
-// buildVariablePickerGroups). Every item shows its resolved final-format value ("дані відображай
+// змінні"): grouped one group per party role (see VARIABLE_PICKER_GROUPS in documentsCatalogUtils
+// for the current list - husband/wife/shared/surrogate mother/representative/clinic-by-kind).
+// Every item shows its resolved final-format value ("дані відображай
 // в фінальному форматі") - the technical {{path}} only surfaces on a long press/hold ("при довгому
 // тапі відображай технічні дані"), then a tap inserts it at the field's captured cursor position.
 import React, { useEffect, useRef, useState } from 'react';

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -69,6 +69,7 @@ const buildParties = () => ({
 
 const openCaseOne = async () => {
   render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+  fireEvent.click(await screen.findByTitle('Edit parties'));
   fireEvent.click(await screen.findByText('Cases'));
   fireEvent.click(await screen.findByText(/Testova Mariia/));
 };
@@ -83,6 +84,7 @@ beforeEach(() => {
   });
   set.mockResolvedValue(undefined);
   update.mockResolvedValue(undefined);
+  window.localStorage.clear(); // read/edit mode persists across reloads (spec §10) - not across tests
 });
 
 describe('spec: Childbirth/Transaction case editor (Batch 18 §6), on Parties', () => {

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaPlus, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaPen, FaPlus, FaTrash, FaUpload } from 'react-icons/fa';
 import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
@@ -19,6 +19,8 @@ import {
   DOCUMENTS_TEMPLATES_PATH,
   PARTY_COLLECTIONS,
   buildCaseLabel,
+  buildVariablePickerGroups,
+  CLINIC_KINDS,
   createEmptyCase,
   createEmptyClinic,
   createEmptyCouple,
@@ -36,6 +38,7 @@ import {
   normalizeDocumentsCatalog,
   orderRecordsByRecentIds,
   parseDocumentsTechnicalInput,
+  resolveCaseContext,
   resolveMergedRecordsForPersistence,
   toArray,
   upsertRecentId,
@@ -162,6 +165,40 @@ const StateCard = styled.div`
   border: 1px solid var(--km-border);
   color: var(--km-muted);
   font-size: 13px;
+`;
+
+// --- Read mode (spec batch 21 §10: Budget's view/edit pattern) ---------------------------------
+// Grouped one-per-role, same shape the variable picker already uses (buildVariablePickerGroups) -
+// a read-only rundown of exactly the one selected case's resolved data, never the full directory.
+
+const ReadGroupBlock = styled.div`
+  margin-top: 10px;
+`;
+
+const ReadRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  padding: 3px 2px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--km-border);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const ReadRowLabel = styled.span`
+  color: var(--km-muted);
+  font-family: monospace;
+  font-size: 10.5px;
+`;
+
+const ReadRowValue = styled.span`
+  color: var(--km-text);
+  font-weight: 600;
+  text-align: right;
 `;
 
 // --- Group panel + collapsed summary row (Beneficiary/Payer pattern from Invoice Builder) -------
@@ -352,8 +389,23 @@ const useFieldDraft = externalValue => {
   return [draft, setDraft, editingRef];
 };
 
-const RecordFieldInput = ({ label, value, type, onCommit }) => {
+const RecordFieldInput = ({ label, value, type, options, onCommit }) => {
   const [draft, setDraft, editingRef] = useFieldDraft(value || '');
+  if (type === 'select') {
+    return (
+      <Field>
+        {label}
+        <FieldInput
+          as="select"
+          value={draft}
+          aria-label={label}
+          onChange={event => { setDraft(event.target.value); onCommit(event.target.value); }}
+        >
+          {options.map(option => <option key={option} value={option}>{option}</option>)}
+        </FieldInput>
+      </Field>
+    );
+  }
   return (
     <Field>
       {label}
@@ -374,11 +426,12 @@ const RecordFieldInput = ({ label, value, type, onCommit }) => {
 
 const RecordFieldsGrid = ({ record, fieldDefs, onFieldChange }) => (
   <FieldGrid>
-    {fieldDefs.map(({ label, path, type }) => (
+    {fieldDefs.map(({ label, path, type, options }) => (
       <RecordFieldInput
         key={path}
         label={label}
         type={type}
+        options={options}
         value={getValueByPath(record, path)}
         onCommit={value => onFieldChange(path, value)}
       />
@@ -450,6 +503,7 @@ const REPRESENTATIVE_FIELDS = [
 ];
 
 const CLINIC_FIELDS = [
+  { label: 'Kind', path: 'kind', type: 'select', options: CLINIC_KINDS },
   { label: 'Name (uk)', path: 'name.uk' },
   { label: 'Name (en)', path: 'name.en' },
   { label: 'Legal name (uk)', path: 'legalName.uk' },
@@ -815,7 +869,7 @@ const RepresentativesSlot = ({ records, valueIds, onToggle }) => {
   );
 };
 
-const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen, onToggleGroup, recentIds, recordPartyUsage }) => {
+const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen, onToggleGroup, recentIds, recordPartyUsage, onSelectCase }) => {
   const cases = catalog.parties.cases;
   const orderedCouples = orderRecordsByRecentIds(catalog.parties.couples, recentIds.couples);
   const orderedClinics = orderRecordsByRecentIds(catalog.parties.clinics, recentIds.clinics);
@@ -829,6 +883,7 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
       await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}`), record);
       setCatalog(previous => ({ ...previous, parties: { ...previous.parties, cases: [...previous.parties.cases, record] } }));
       toggleRecord('cases', caseId, true);
+      onSelectCase(caseId);
       toast.success('Case created.');
     } catch (addError) {
       console.error('Unable to create case', addError);
@@ -892,7 +947,11 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
             const relations = caseRecord.relations || {};
             return (
               <RecordBlock key={caseRecord.id}>
-                <CompactSection onClick={() => toggleRecord('cases', caseRecord.id)} role="button" aria-expanded={expanded}>
+                <CompactSection
+                  onClick={() => { toggleRecord('cases', caseRecord.id); onSelectCase(caseRecord.id); }}
+                  role="button"
+                  aria-expanded={expanded}
+                >
                   <CompactInfo>
                     <CompactValue>{buildCaseLabel(catalog, caseRecord) || caseRecord.id}</CompactValue>
                   </CompactInfo>
@@ -1053,11 +1112,67 @@ const TechnicalSection = ({ catalog, setCatalog }) => {
   );
 };
 
+// Default read-mode view (spec batch 21 §10): the last-selected case's data only, grouped by role
+// exactly like the Documents Builder's variable picker (buildVariablePickerGroups reused as-is, so
+// the two stay in sync automatically as new party types/groups are added). "Create new case" sits
+// above the case data per spec; picking a different case (or creating one) updates the persisted
+// last-selected case, so switching into Edit mode and back never loses it.
+const CaseReadView = ({ catalog, selectedCaseId, onSelectCase, onCreateCase }) => {
+  const cases = catalog.parties.cases;
+  const selectedCase = cases.find(item => String(item.id) === String(selectedCaseId));
+  const context = selectedCase ? resolveCaseContext(catalog, selectedCase.id) : null;
+  const groups = context ? buildVariablePickerGroups(context) : [];
+
+  return (
+    <Panel>
+      <RowLine>
+        <SmallButton type="button" onClick={onCreateCase}><FaPlus /> Create new case</SmallButton>
+      </RowLine>
+      {cases.length ? (
+        <RowLine style={{ marginTop: 10 }}>
+          <Field style={{ flex: 1, minWidth: 200 }}>
+            Case
+            <FieldInput
+              as="select"
+              value={selectedCase ? selectedCase.id : ''}
+              onChange={event => onSelectCase(event.target.value)}
+            >
+              {!selectedCase ? <option value="">Select a case…</option> : null}
+              {cases.map(caseRecord => (
+                <option key={caseRecord.id} value={caseRecord.id}>{buildCaseLabel(catalog, caseRecord) || caseRecord.id}</option>
+              ))}
+            </FieldInput>
+          </Field>
+        </RowLine>
+      ) : (
+        <StateCard style={{ marginTop: 10 }}>No cases yet - create one above to see its data here.</StateCard>
+      )}
+      {selectedCase ? groups.map(group => (
+        <ReadGroupBlock key={group.label}>
+          <SectionSubhead>{group.label}</SectionSubhead>
+          {group.items.length
+            ? group.items.map(item => (
+              <ReadRow key={item.path}>
+                <ReadRowLabel>{item.path}</ReadRowLabel>
+                <ReadRowValue>{item.value}</ReadRowValue>
+              </ReadRow>
+            ))
+            : <CompactValue>No data</CompactValue>}
+        </ReadGroupBlock>
+      )) : null}
+    </Panel>
+  );
+};
+
 // --- Page ---------------------------------------------------------------------------------------
 
 const EMPTY_RECENT_IDS = {
   couples: [], clinics: [], surrogateMothers: [], representatives: [], notaries: [],
 };
+
+// Same view/edit pattern as the Budget page (spec batch 21 §10): read mode is the default, an
+// admin-only toggle unlocks editing, and the choice survives a reload via localStorage.
+const PARTIES_EDIT_MODE_STORAGE_KEY = 'parties:edit-mode';
 
 const PartiesPage = ({ isAdmin }) => {
   const isPartiesAdmin = Boolean(isAdmin) || isInvoiceBuilderUid(auth.currentUser?.uid) || (typeof window !== 'undefined'
@@ -1069,20 +1184,34 @@ const PartiesPage = ({ isAdmin }) => {
   const [error, setError] = useState('');
   const [openGroups, setOpenGroups] = useState({});
   const [expandedKeys, setExpandedKeys] = useState({});
+  const [isEditMode, setIsEditMode] = useState(() => (
+    typeof window !== 'undefined' && window.localStorage.getItem(PARTIES_EDIT_MODE_STORAGE_KEY) === '1'
+  ));
+  // The read view's "last-selected case" (spec §10) - loaded from the backend below, and never
+  // reset by switching modes, so it survives read <-> edit exactly like the selected case itself.
+  const [selectedCaseId, setSelectedCaseId] = useState('');
 
   const loadPartiesData = useCallback(async () => {
     setLoading(true);
     setError('');
     try {
-      const [partiesSnapshot, templatesSnapshot, settingsSnapshot] = await Promise.all([
+      const [partiesSnapshot, templatesSnapshot, settingsSnapshot, lastCaseSnapshot] = await Promise.all([
         get(ref(database, DOCUMENTS_PARTIES_PATH)),
         get(ref(database, DOCUMENTS_TEMPLATES_PATH)),
         get(ref(database, `${PARTIES_SETTINGS_PATH}/recentIds`)),
+        get(ref(database, `${PARTIES_SETTINGS_PATH}/lastCaseId`)),
       ]);
-      setCatalog(normalizeDocumentsCatalog(
+      const nextCatalog = normalizeDocumentsCatalog(
         partiesSnapshot.exists() ? partiesSnapshot.val() : null,
         templatesSnapshot.exists() ? templatesSnapshot.val() : null,
-      ));
+      );
+      setCatalog(nextCatalog);
+      const rawLastCaseId = lastCaseSnapshot.exists() ? String(lastCaseSnapshot.val()) : '';
+      // Falls back to the first case only when there's no persisted choice yet (or it no longer
+      // resolves to a real case) - never silently swaps out a case the admin deliberately picked.
+      setSelectedCaseId(nextCatalog.parties.cases.some(item => String(item.id) === rawLastCaseId)
+        ? rawLastCaseId
+        : (nextCatalog.parties.cases[0]?.id || ''));
       const rawRecentIds = settingsSnapshot.exists() ? settingsSnapshot.val() : null;
       setRecentIds({
         couples: toArray(rawRecentIds?.couples),
@@ -1124,6 +1253,48 @@ const PartiesPage = ({ isAdmin }) => {
     });
   };
 
+  // The read view's case selection (spec §10) - both picking a case in Read mode and expanding one
+  // in Edit mode's Cases group call this, so either surface always reflects the other.
+  const persistSelectedCase = id => {
+    setSelectedCaseId(id);
+    set(ref(database, `${PARTIES_SETTINGS_PATH}/lastCaseId`), id || null).catch(usageError => {
+      console.error('Unable to save the last-selected case', usageError);
+    });
+  };
+
+  // Read <-> edit never loses the selected case (spec §10) - selectedCaseId lives above both modes
+  // and neither mode switch touches it, so the same case is still there whichever way you toggle.
+  const enterEditModeOnCase = caseId => {
+    setIsEditMode(true);
+    if (typeof window !== 'undefined') window.localStorage.setItem(PARTIES_EDIT_MODE_STORAGE_KEY, '1');
+    setOpenGroups(previous => ({ ...previous, cases: true }));
+    toggleRecord('cases', caseId, true);
+  };
+
+  const handleToggleEditMode = () => {
+    const next = !isEditMode;
+    setIsEditMode(next);
+    if (typeof window !== 'undefined') window.localStorage.setItem(PARTIES_EDIT_MODE_STORAGE_KEY, next ? '1' : '0');
+  };
+
+  // "Create new case" sits above the read-mode case data (spec §10) - creates the record, selects
+  // it, and jumps into Edit mode with it already expanded so the admin can assign its parties right
+  // away via the full directory, per Batch 19's collapsible-groups design.
+  const handleCreateCaseFromReadView = async () => {
+    const caseId = makeCaseId();
+    const record = createEmptyCase({ caseId });
+    try {
+      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}`), record);
+      setCatalog(previous => ({ ...previous, parties: { ...previous.parties, cases: [...previous.parties.cases, record] } }));
+      persistSelectedCase(caseId);
+      enterEditModeOnCase(caseId);
+      toast.success('Case created.');
+    } catch (addError) {
+      console.error('Unable to create case', addError);
+      toast.error('Could not create the case.');
+    }
+  };
+
   if (!isPartiesAdmin) {
     return (
       <Page>
@@ -1143,6 +1314,9 @@ const PartiesPage = ({ isAdmin }) => {
             <Title>Parties</Title>
           </div>
           <HeaderActions>
+            <MiniButton type="button" onClick={handleToggleEditMode} aria-pressed={isEditMode} title={isEditMode ? 'Switch to read mode' : 'Edit parties'}>
+              <FaPen /> {isEditMode ? 'Read' : 'Edit'}
+            </MiniButton>
             <PageNavMenu />
           </HeaderActions>
         </Header>
@@ -1151,6 +1325,13 @@ const PartiesPage = ({ isAdmin }) => {
           <StateCard>Loading…</StateCard>
         ) : error ? (
           <StateCard>{error}</StateCard>
+        ) : !isEditMode ? (
+          <CaseReadView
+            catalog={catalog}
+            selectedCaseId={selectedCaseId}
+            onSelectCase={persistSelectedCase}
+            onCreateCase={handleCreateCaseFromReadView}
+          />
         ) : (
           <>
             <CouplesGroup
@@ -1240,6 +1421,7 @@ const PartiesPage = ({ isAdmin }) => {
               onToggleGroup={() => toggleGroup('cases')}
               recentIds={recentIds}
               recordPartyUsage={recordPartyUsage}
+              onSelectCase={persistSelectedCase}
             />
             <TechnicalSection catalog={catalog} setCatalog={setCatalog} />
           </>

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -67,11 +67,13 @@ beforeEach(() => {
   });
   set.mockResolvedValue(undefined);
   window.confirm = jest.fn(() => true);
+  window.localStorage.clear(); // read/edit mode persists across reloads (spec §10) - not across tests
 });
 
 describe('spec: Parties page', () => {
   it('renders every party-type group collapsed by default, with a record count', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
 
     expect(await screen.findByText('Couples')).toBeInTheDocument();
     expect(screen.getByText('Surrogate mothers')).toBeInTheDocument();
@@ -87,6 +89,7 @@ describe('spec: Parties page', () => {
 
   it('expanding a group reveals its records; expanding a record reveals its fields', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Clinics');
 
     fireEvent.click(screen.getByText('Clinics'));
@@ -99,6 +102,7 @@ describe('spec: Parties page', () => {
 
   it('editing a field on blur persists it additively to the record path', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Clinics');
     fireEvent.click(screen.getByText('Clinics'));
     fireEvent.click(await screen.findByText('Клініка Мрія'));
@@ -112,6 +116,7 @@ describe('spec: Parties page', () => {
 
   it('"Add" creates a new blank record and expands it', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Notaries');
     fireEvent.click(screen.getByText('Notaries'));
 
@@ -126,6 +131,7 @@ describe('spec: Parties page', () => {
 
   it('deleting a party referenced by a case includes the reference in the confirmation, but still deletes when confirmed', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Couples');
     fireEvent.click(screen.getByText('Couples'));
     fireEvent.click(await screen.findByText('Тестова Марія & Тестовий Петро'));
@@ -139,6 +145,7 @@ describe('spec: Parties page', () => {
   it('deleting a party skips the delete when the confirmation is declined', async () => {
     window.confirm = jest.fn(() => false);
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Notaries');
     fireEvent.click(screen.getByText('Clinics'));
     fireEvent.click(await screen.findByText('Клініка Мрія'));
@@ -151,6 +158,7 @@ describe('spec: Parties page', () => {
 
   it('a case relation slot picks from the existing records and persists the pick, most-recently-used tracked', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Cases');
     fireEvent.click(screen.getByText('Cases'));
     fireEvent.click(await screen.findByText('Testova Mariia & Testovyi Petro'));
@@ -164,10 +172,62 @@ describe('spec: Parties page', () => {
 
   it('renders the shared Childbirth/Transaction editor inside an expanded case', async () => {
     render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
     await screen.findByText('Cases');
     fireEvent.click(screen.getByText('Cases'));
     fireEvent.click(await screen.findByText('Testova Mariia & Testovyi Petro'));
 
     expect(await screen.findByText('Дані для заяви в РАЦС')).toBeInTheDocument();
+  });
+});
+
+describe('spec: Parties page read/edit modes (batch 21 §10, Budget page pattern)', () => {
+  it('defaults to read mode, showing only the last-selected case\'s grouped data, with "Create new case" above it', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+
+    // Read mode is the default - none of the always-editable directory groups render at all.
+    await screen.findByRole('button', { name: /create new case/i });
+    expect(screen.queryByText('Couples')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notaries')).not.toBeInTheDocument();
+
+    // No last-selected case was ever persisted, so it falls back to the only case in the catalog.
+    expect(screen.getByText('Тестова Марія')).toBeInTheDocument();
+    expect(screen.getByText('Дружина')).toBeInTheDocument();
+    expect(screen.getByText('Сурогатна мати')).toBeInTheDocument();
+  });
+
+  it('unlocks the full party directory (all records, all groups) only once switched into Edit mode', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByRole('button', { name: /create new case/i });
+
+    fireEvent.click(screen.getByTitle('Edit parties'));
+
+    expect(await screen.findByText('Couples')).toBeInTheDocument();
+    expect(screen.getByText('Surrogate mothers')).toBeInTheDocument();
+    expect(screen.getByText('Representatives')).toBeInTheDocument();
+    expect(screen.getByText('Clinics')).toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /create new case/i })).not.toBeInTheDocument();
+  });
+
+  it('switching from edit back to read mode does not lose the currently selected case', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    await screen.findByRole('button', { name: /create new case/i });
+    expect(screen.getByText('Тестова Марія')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Edit parties'));
+    await screen.findByText('Cases');
+    fireEvent.click(screen.getByTitle('Switch to read mode'));
+
+    await screen.findByRole('button', { name: /create new case/i });
+    expect(screen.getByText('Тестова Марія')).toBeInTheDocument();
+  });
+
+  it('picking a different case in the read view persists it as the last-selected case', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    const casePicker = await screen.findByLabelText('Case');
+    fireEvent.change(casePicker, { target: { value: 'case-1' } });
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/partiesSettings/lastCaseId', 'case-1'));
   });
 });

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -538,8 +538,15 @@ export const createEmptyRepresentative = () => ({
   powerOfAttorney: { date: '', apostille: '' },
 });
 
+// A clinic is either the foreign fertility clinic the intended parents came from, or the
+// Ukrainian clinic actually performing the surrogacy procedure (spec batch 21 §1: the variable
+// picker needs to offer these as two separate groups) - unset/legacy records default to
+// 'ukrainian' since that's the common case pre-dating this field.
+export const CLINIC_KINDS = ['foreign', 'ukrainian'];
+
 export const createEmptyClinic = () => ({
   id: makeRecordId('clinic'),
+  kind: 'ukrainian',
   name: { uk: '', en: '' },
   legalName: { uk: '', en: '' },
   medicalCenterName: { uk: '', en: '' },
@@ -1120,8 +1127,11 @@ export const allowsParagraphInternalBreak = (paragraph, allowPageBreaks) => {
   return longest > LONG_PARAGRAPH_CHAR_THRESHOLD;
 };
 
+// Never backfills a missing translation from the other language (spec batch 21 §4: a paragraph/
+// title with no `en` value must render empty, not silently show the `uk` text as if it were a
+// translation) - a requested language that isn't on the record resolves to '', full stop.
 const localizedText = (value, lang) => {
-  if (isPlainObject(value)) return String(value[lang] ?? value.uk ?? value.en ?? '');
+  if (isPlainObject(value)) return String(value[lang] ?? '');
   return String(value ?? '');
 };
 
@@ -1138,6 +1148,19 @@ const overriddenText = (override, langKey, fallback) => (
   typeof override?.[langKey] === 'string' ? override[langKey] : fallback
 );
 
+// A paragraph that starts with a variable - commonly a lowercase date-in-words - must still read
+// as a proper sentence (spec batch 21 §7). Applied here, at render time, on the resolved output
+// only - the stored template/override text is never rewritten. Idempotent (capitalizing an
+// already-capitalized letter is a no-op), and skips past any leading bold/italic markers so
+// `**сьогодні...` capitalizes "Сьогодні", not the marker itself.
+const capitalizeFirstLetter = text => {
+  const value = String(text || '');
+  const match = /^(\*+)?([\s\S])([\s\S]*)$/.exec(value);
+  if (!match) return value;
+  const [, markers, firstChar, rest] = match;
+  return `${markers || ''}${firstChar.toUpperCase()}${rest}`;
+};
+
 // --- beforeTitle blocks (batch 16 §14/§17) ---------------------------------------------------
 // Free-standing text rendered between the letterhead logo and the title (e.g. "ЗА МІСЦЕМ ВИМОГИ",
 // right-aligned and bold) - never merged into `paragraphs`, so it always renders in that fixed
@@ -1146,9 +1169,17 @@ const ALLOWED_BLOCK_ALIGNMENTS = ['left', 'right', 'center', 'justify'];
 
 export const normalizeBlockAlign = align => (ALLOWED_BLOCK_ALIGNMENTS.includes(align) ? align : 'left');
 
+// A block's width as a percentage of its column (spec batch 21 §8: the applicant/signatory data
+// block under "ЗА МІСЦЕМ ВИМОГИ" is a half-page-right layout rule - defaults to 50, i.e. half the
+// page, pushed against whichever margin `align` names). Never below 10 (unreadably narrow) or
+// above 100 (full width).
+export const DEFAULT_BLOCK_WIDTH_PERCENT = 50;
+export const normalizeBlockWidth = width => clampNumber(width, 10, 100, DEFAULT_BLOCK_WIDTH_PERCENT);
+
 const resolveBeforeTitleBlocks = (template, context) => toArray(template?.beforeTitle).map(block => ({
   align: normalizeBlockAlign(block?.align),
   bold: Boolean(block?.bold),
+  width: normalizeBlockWidth(block?.width),
   uk: fillPlaceholders(localizedText(block, 'uk'), context, 'uk'),
   en: fillPlaceholders(localizedText(block, 'en'), context, 'en'),
 }));
@@ -1272,8 +1303,8 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
         // one document-wide firstLineIndentCm can't express that). undefined = inherit the
         // document's own formatting.firstLineIndentCm, same as every paragraph did before this.
         indentCm: paragraph?.indentCm !== undefined ? clampNumber(paragraph.indentCm, 0, 5, undefined) : undefined,
-        uk: overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
-        en: overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
+        uk: capitalizeFirstLetter(overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk'))),
+        en: capitalizeFirstLetter(overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en'))),
       };
     }),
   };
@@ -1368,28 +1399,37 @@ export const collectContextLeafPaths = (value, prefix = '') => {
   if (Array.isArray(value)) return [];
   if (typeof value === 'object') {
     return Object.keys(value)
-      .filter(key => key !== 'id')
+      .filter(key => key !== 'id' && key !== 'kind')
       .flatMap(key => collectContextLeafPaths(value[key], prefix ? `${prefix}.${key}` : key));
   }
   return [];
 };
 
-// The 4 blocks the picker groups variables into (spec: "данні по парі (чоловік, дружина,
-// спільні), дані по СМ, дані по довіреній особі, дані по клініці" - one Клініка block, not split
-// by language). Each root is a top-level key already exposed by resolveCaseContext.
+// One group per role (spec batch 21 §1: "split the couple into its natural roles rather than one
+// combined block" - extend similarly as new party types are added, never regroup by "couple").
+// Each root is a top-level key already exposed by resolveCaseContext; `predicate` (when present)
+// filters the group in/out of a given context instead of picking a root - used to split the single
+// `clinic` root into its two kinds (see CLINIC_KINDS) without needing two separate context keys.
 export const VARIABLE_PICKER_GROUPS = [
-  { label: 'Пара', roots: ['wife', 'husband', 'couple'] },
+  { label: 'Чоловік', roots: ['husband'] },
+  { label: 'Дружина', roots: ['wife'] },
+  { label: 'Спільне', roots: ['couple', 'program'] },
   { label: 'Сурогатна мати', roots: ['surrogateMother'] },
   { label: 'Довірена особа', roots: ['representative'] },
-  { label: 'Клініка', roots: ['clinic'] },
+  { label: 'Клініка — іноземна', roots: ['clinic'], predicate: context => context?.clinic?.kind === 'foreign' },
+  { label: 'Клініка — українська', roots: ['clinic'], predicate: context => context?.clinic?.kind !== 'foreign' },
 ];
 
 // Builds the picker's grouped leaf list from a resolved case context (or any similarly-shaped
-// object, e.g. an example record when no case is selected yet).
-export const buildVariablePickerGroups = context => VARIABLE_PICKER_GROUPS.map(group => ({
-  label: group.label,
-  items: group.roots.flatMap(root => collectContextLeafPaths(context?.[root], root)),
-}));
+// object, e.g. an example record when no case is selected yet). A group with a predicate that
+// evaluates false for this context (e.g. the clinic kind that isn't this case's clinic) is
+// dropped entirely rather than shown empty.
+export const buildVariablePickerGroups = context => VARIABLE_PICKER_GROUPS
+  .filter(group => !group.predicate || group.predicate(context))
+  .map(group => ({
+    label: group.label,
+    items: group.roots.flatMap(root => collectContextLeafPaths(context?.[root], root)),
+  }));
 
 // Generic "most recently used first" ordering + upsert, shared by the case selector (spec §5) and
 // the Documents list (most recently downloaded templates float to the top): whatever isn't in the

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -1096,33 +1096,45 @@ describe('spec: insert-variable picker (collectContextLeafPaths / buildVariableP
     expect(leaves).toEqual([{ path: 'wife.role', value: 'wife' }]);
   });
 
-  it('buildVariablePickerGroups groups Пара/Сурогатна мати/Довірена особа/Клініка, spanning wife+husband+couple in one block', () => {
+  it('buildVariablePickerGroups groups by role (Чоловік/Дружина/Спільне/Сурогатна мати/Довірена особа/Клініка — split by kind), never a combined "couple" block', () => {
     const context = {
       wife: { name: { en: 'Kyogoku Aya' } },
       husband: { name: { en: 'Kyogoku Keigo' } },
       couple: { marriage: { certificateNumber: 'M-1' } },
+      program: { type: 'gestational' },
       surrogateMother: { name: { en: 'Molvinskykh Yuliia' } },
       representative: { name: { en: 'Koval Oleksandr' } },
-      clinic: { name: { en: 'Victoria' } },
+      clinic: { kind: 'ukrainian', name: { en: 'Victoria' } },
     };
     const groups = buildVariablePickerGroups(context);
-    expect(groups.map(g => g.label)).toEqual(['Пара', 'Сурогатна мати', 'Довірена особа', 'Клініка']);
+    expect(groups.map(g => g.label)).toEqual([
+      'Чоловік', 'Дружина', 'Спільне', 'Сурогатна мати', 'Довірена особа', 'Клініка — українська',
+    ]);
 
-    const pairGroup = groups.find(g => g.label === 'Пара');
-    expect(pairGroup.items).toEqual(expect.arrayContaining([
-      { path: 'wife.name.en', value: 'Kyogoku Aya' },
-      { path: 'husband.name.en', value: 'Kyogoku Keigo' },
+    expect(groups.find(g => g.label === 'Чоловік').items).toEqual([{ path: 'husband.name.en', value: 'Kyogoku Keigo' }]);
+    expect(groups.find(g => g.label === 'Дружина').items).toEqual([{ path: 'wife.name.en', value: 'Kyogoku Aya' }]);
+
+    const sharedGroup = groups.find(g => g.label === 'Спільне');
+    expect(sharedGroup.items).toEqual(expect.arrayContaining([
       { path: 'couple.marriage.certificateNumber', value: 'M-1' },
+      { path: 'program.type', value: 'gestational' },
     ]));
 
-    const clinicGroup = groups.find(g => g.label === 'Клініка');
+    const clinicGroup = groups.find(g => g.label === 'Клініка — українська');
     expect(clinicGroup.items).toEqual([{ path: 'clinic.name.en', value: 'Victoria' }]);
+    expect(groups.find(g => g.label === 'Клініка — іноземна')).toBeUndefined();
+  });
+
+  it('splits the clinic group by kind: a foreign clinic only ever shows under "Клініка — іноземна"', () => {
+    const groups = buildVariablePickerGroups({ clinic: { kind: 'foreign', name: { en: 'Victoria' } } });
+    expect(groups.find(g => g.label === 'Клініка — іноземна').items).toEqual([{ path: 'clinic.name.en', value: 'Victoria' }]);
+    expect(groups.find(g => g.label === 'Клініка — українська')).toBeUndefined();
   });
 
   it('tolerates a missing root (null context, or a group whose root is null/undefined) without throwing', () => {
     expect(() => buildVariablePickerGroups(null)).not.toThrow();
     expect(buildVariablePickerGroups(null).every(group => group.items.length === 0)).toBe(true);
-    expect(buildVariablePickerGroups({ wife: null }).find(g => g.label === 'Пара').items).toEqual([]);
+    expect(buildVariablePickerGroups({ wife: null }).find(g => g.label === 'Дружина').items).toEqual([]);
   });
 });
 
@@ -1647,6 +1659,21 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
       expect(generated.paragraphs.some(p => p.uk.includes('ЗА МІСЦЕМ ВИМОГИ'))).toBe(false);
     });
 
+    it('a beforeTitle block defaults to 50% width, clamped to a sane 10-100 range (§21 #8)', () => {
+      const template = {
+        id: 'doc-1',
+        title: { uk: 'Заява' },
+        beforeTitle: [
+          { uk: 'За місцем вимоги', align: 'right' },
+          { uk: 'Явне значення', align: 'right', width: 70 },
+          { uk: 'Замале', align: 'right', width: 2 },
+          { uk: 'Завелике', align: 'right', width: 500 },
+        ],
+      };
+      const generated = buildGeneratedDocument(template, {});
+      expect(generated.beforeTitle.map(block => block.width)).toEqual([50, 70, 10, 100]);
+    });
+
     it('a legacy template without languages/columns/beforeTitle keeps rendering under the page-wide layout unchanged (§21 #11)', () => {
       const legacyTemplate = { id: 'legacy', title: { uk: 'Договір', en: 'Agreement' }, paragraphs: [{ uk: 'Текст.', en: 'Text.' }] };
       const generated = buildGeneratedDocument(legacyTemplate, {});
@@ -1656,12 +1683,10 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
       expect(getEffectiveDocLayout(generated, 'two-column')).toBe('two-column');
     });
 
-    it('a missing `en` field never throws, undefined, or "null" (§21 #10) - localizedText falls back to the uk text', () => {
+    it('a missing `en` field renders empty - never undefined, "null", or backfilled from the uk text (§21 #4/#10)', () => {
       const generated = buildGeneratedDocument({ id: 'uk-only', title: { uk: 'Заява' }, beforeTitle: [{ uk: 'Блок' }], paragraphs: [{ uk: 'Текст.' }] }, {});
       [generated.title.en, generated.beforeTitle[0].en, generated.paragraphs[0].en].forEach(value => {
-        expect(value).not.toBeUndefined();
-        expect(value).not.toBe('undefined');
-        expect(value).not.toBe('null');
+        expect(value).toBe('');
       });
     });
   });
@@ -1994,7 +2019,40 @@ describe('spec: normalized case structure (batch 18)', () => {
     const context = resolveCaseContext(catalog, 'case-1');
     expect(() => buildGeneratedDocument(template, context)).not.toThrow();
     const generated = buildGeneratedDocument(template, context);
-    expect(generated.paragraphs[0].uk).toBe('дівчинка та хлопчик');
+    // Auto-capitalized at render time (§21 #7) - the paragraph starts with a variable that
+    // resolved lowercase ("дівчинка"), so it must still read as a proper sentence.
+    expect(generated.paragraphs[0].uk).toBe('Дівчинка та хлопчик');
+  });
+
+  it('capitalizes the first letter of a paragraph that starts lowercase, without mutating the stored template (§21 #7)', () => {
+    const template = {
+      id: 'doc-1',
+      title: { uk: 'Заява' },
+      paragraphs: [{ uk: 'п\'ятого травня дві тисячі... народилася дитина.', en: 'on the fifth of may... a child was born.' }],
+    };
+    const generated = buildGeneratedDocument(template, {});
+    expect(generated.paragraphs[0].uk).toBe('П\'ятого травня дві тисячі... народилася дитина.');
+    expect(generated.paragraphs[0].en).toBe('On the fifth of may... a child was born.');
+    // The stored template text itself is untouched - only the resolved/rendered output changes.
+    expect(template.paragraphs[0].uk).toBe('п\'ятого травня дві тисячі... народилася дитина.');
+  });
+
+  it('capitalizes past any leading bold/italic markers, never the marker character itself', () => {
+    const template = { id: 'doc-1', title: { uk: 'Заява' }, paragraphs: [{ uk: '**сьогодні** гарний день.' }] };
+    const generated = buildGeneratedDocument(template, {});
+    expect(generated.paragraphs[0].uk).toBe('**Сьогодні** гарний день.');
+  });
+
+  it('is idempotent and leaves an already-capitalized or non-letter-leading paragraph unchanged', () => {
+    const template = {
+      id: 'doc-1',
+      title: { uk: 'Заява' },
+      paragraphs: [{ uk: 'Вже з великої літери.' }, { uk: '5 травня відбулося.' }, { uk: '' }],
+    };
+    const generated = buildGeneratedDocument(template, {});
+    expect(generated.paragraphs[0].uk).toBe('Вже з великої літери.');
+    expect(generated.paragraphs[1].uk).toBe('5 травня відбулося.');
+    expect(generated.paragraphs[2].uk).toBe('');
   });
 
   it('an empty children array does not break the component (§19 #19)', () => {

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -146,11 +146,26 @@ export const buildDocumentsDocx = async ({
 
   // Free-standing text between the letterhead logo and the title (spec §14/§17: "ЗА МІСЦЕМ
   // ВИМОГИ" etc.) - `align`/`bold` are resolved per block, never inferred from the text itself.
-  const beforeTitleParagraph = (text, block) => new Paragraph({
-    alignment: alignmentForBlock(block.align),
-    spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
-    children: formattedTextRuns(text, { size: bodySize, baseBold: Boolean(block.bold) }),
-  });
+  // `width` (spec batch 21 §8: the applicant/signatory data block is a half-page-right layout rule,
+  // not just right-aligned text) is expressed as an indent that eats the complementary space, the
+  // same technique Word itself uses for a "float" - so a wide block wraps inside that narrower
+  // strip instead of spanning the full column the way plain alignment would. `containerWidthTwips`
+  // is whichever width this paragraph's own column actually has (the full page in the single-
+  // column flow, or one table cell's width in the bilingual layout).
+  const beforeTitleParagraph = (text, block, containerWidthTwips) => {
+    const complementTwips = Math.round(containerWidthTwips * (1 - (block.width ?? 50) / 100));
+    const indent = block.align === 'right'
+      ? { left: complementTwips }
+      : (block.align === 'left'
+        ? { right: complementTwips }
+        : { left: Math.round(complementTwips / 2), right: Math.round(complementTwips / 2) });
+    return new Paragraph({
+      alignment: alignmentForBlock(block.align),
+      spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
+      indent,
+      children: formattedTextRuns(text, { size: bodySize, baseBold: Boolean(block.bold) }),
+    });
+  };
 
   const twoColumnCellFromParagraph = (paragraphOrParagraphs, marginSide, showColumnDivider) => new TableCell({
     borders: showColumnDivider && marginSide === 'left' ? { ...noBorders, right: dividerBorder } : noBorders,
@@ -266,11 +281,11 @@ export const buildDocumentsDocx = async ({
     (doc.beforeTitle || []).forEach(block => {
       if (isBilingual) {
         children.push(twoColumnTable([[
-          beforeTitleParagraph(block.uk, block),
-          beforeTitleParagraph(block.en, block),
+          beforeTitleParagraph(block.uk, block, columnContentWidthTwips),
+          beforeTitleParagraph(block.en, block, columnContentWidthTwips),
         ]], true, showColumnDivider));
       } else {
-        children.push(beforeTitleParagraph(block[lang], block));
+        children.push(beforeTitleParagraph(block[lang], block, contentWidthTwips));
       }
     });
 


### PR DESCRIPTION
- Variable picker: split the couple block into Husband/Wife/Shared groups,
  and split Clinic into foreign/Ukrainian groups (new clinic.kind field)
- Removed the separate bold/italic preview; a new "text" mode renders the
  resolved text with formatting applied in place and is the edit surface
- Replaced the template/text toggle with a single cycling
  template -> input -> text mode button ({}/I/T icons), default "text"
- localizedText no longer backfills a missing translation from the other
  language - a missing en/uk renders empty
- Title (uk) and Title (en) are always shown as a paired, symmetric row
- Added a template.catalogName field, separate from title.uk/title.en, for
  the Documents-list entry name; renderers only ever read title.*
- Paragraphs are auto-capitalized at render time when they resolve to a
  leading lowercase letter, without mutating stored template text
- beforeTitle blocks gained a width field (default 50%) with a draggable
  handle, rendered as a half-page-right block in both PDF and DOCX output
- Insert-paragraph button is now a bare "+" icon
- Parties page now defaults to a read-only view of the last-selected case
  (grouped like the variable picker) with "Create new case" above it; an
  Edit toggle (Budget page pattern) unlocks the full party directory

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RboziEncSqhM5c22FC6hRA