### PR TITLE
Fix Flow FX equivalent display for negative positions

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -34,7 +34,9 @@ import {
   clinicLogoEntriesToBackend,
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
-  DEFAULT_BLOCK_WIDTH_PERCENT,
+  DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
+  SIGNER_BLOCK_OFFSET_MIN_PERCENT,
+  SIGNER_BLOCK_OFFSET_MAX_PERCENT,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   getClinicLogo,
@@ -884,16 +886,12 @@ const DocumentsPage = ({ isAdmin }) => {
     }
   };
 
-  // The signatory/applicant data block's draggable width handle (spec batch 21 §8: half-page-right
-  // layout, adjustable per document/template) - same drag-updates-locally/persists-on-release
-  // pattern as the paragraph indent slider above.
-  const handleBeforeTitleWidthChange = (docId, index, value) => {
-    updateTemplate(docId, template => ({
-      ...template,
-      beforeTitle: (template.beforeTitle || []).map((block, blockIndex) => (
-        blockIndex === index ? { ...block, width: value } : block
-      )),
-    }));
+  // The addressee/signer block's draggable left-offset handle (notarial layout standard §3.3):
+  // one handle for the whole block, persisted per document as a single number
+  // (beforeTitleOffsetPercent) that both the PDF and Word exports read - same
+  // drag-updates-locally/persists-on-release pattern as the paragraph indent slider above.
+  const handleSignerBlockOffsetChange = (docId, value) => {
+    updateTemplate(docId, template => ({ ...template, beforeTitleOffsetPercent: value }));
   };
 
   // The letterhead logo always renders before the title (spec: "лого відображай перед title") and
@@ -1980,6 +1978,34 @@ const DocumentsPage = ({ isAdmin }) => {
                           />
                         </ParagraphEditorBlock>
                         <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Before title</DocSubtitle>
+                        {(template.beforeTitle || []).length ? (() => {
+                          // Notarial layout standard §3.3: one draggable left-offset handle for
+                          // the whole addressee/signer block (30-65% of the text width, default
+                          // 8.5 cm), persisted per document as a single number that both the PDF
+                          // and Word exports read.
+                          const offsetPercent = template.beforeTitleOffsetPercent ?? DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT;
+                          const textWidthCm = 21 - docFormatting.marginLeftCm - docFormatting.marginRightCm;
+                          return (
+                            <RowLine style={{ marginTop: 2, marginBottom: 2 }}>
+                              <DocSubtitle style={{ fontSize: 10, whiteSpace: 'nowrap' }}>Відступ блоку зліва</DocSubtitle>
+                              <RangeInput
+                                type="range"
+                                min={SIGNER_BLOCK_OFFSET_MIN_PERCENT}
+                                max={SIGNER_BLOCK_OFFSET_MAX_PERCENT}
+                                step={0.1}
+                                value={offsetPercent}
+                                onChange={event => handleSignerBlockOffsetChange(template.id, Number(event.target.value))}
+                                onMouseUp={() => persistTemplate(template.id)}
+                                onTouchEnd={() => persistTemplate(template.id)}
+                                aria-label="Відступ блоку підписанта"
+                                title="Лівий відступ блоку адресата/підписанта - перетягніть, щоб змінити"
+                              />
+                              <DocSubtitle style={{ fontSize: 10, minWidth: 90 }}>
+                                {`${offsetPercent.toFixed(1)}% (≈${(textWidthCm * offsetPercent / 100).toFixed(1)} см)`}
+                              </DocSubtitle>
+                            </RowLine>
+                          );
+                        })() : null}
                         {(template.beforeTitle || []).map((block, index) => {
                           const scope = beforeTitleScope(index);
                           // beforeTitle has no per-case override (see getTemplateScopeText) -
@@ -2016,24 +2042,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </DangerButton>
                                 </RowLine>
                               </ParagraphControlsRow>
-                              <RowLine style={{ marginTop: 2, marginBottom: 2 }}>
-                                <DocSubtitle style={{ fontSize: 10, whiteSpace: 'nowrap' }}>Ширина блоку</DocSubtitle>
-                                <RangeInput
-                                  type="range"
-                                  min={10}
-                                  max={100}
-                                  step={5}
-                                  value={block.width ?? DEFAULT_BLOCK_WIDTH_PERCENT}
-                                  onChange={event => handleBeforeTitleWidthChange(template.id, index, Number(event.target.value))}
-                                  onMouseUp={() => persistTemplate(template.id)}
-                                  onTouchEnd={() => persistTemplate(template.id)}
-                                  aria-label={`Ширина блоку ${index + 1}`}
-                                  title="Ширина блоку, вирівняного від середини сторінки до краю - перетягніть, щоб змінити"
-                                />
-                                <DocSubtitle style={{ fontSize: 10, minWidth: 32 }}>
-                                  {block.width ?? DEFAULT_BLOCK_WIDTH_PERCENT}%
-                                </DocSubtitle>
-                              </RowLine>
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -82,7 +82,7 @@ describe('spec: per-paragraph first-line indent slider', () => {
     const plainField = screen.getByText('Абзац без відступу.');
     // eslint-disable-next-line testing-library/no-node-access
     const plainBlock = plainField.closest('.paragraph-editor-block');
-    expect(within(plainBlock).getByLabelText('Відступ абзацу 2')).toHaveValue('0'); // document default
+    expect(within(plainBlock).getByLabelText('Відступ абзацу 2')).toHaveValue('1.5'); // document default (notarial standard §3.1)
     expect(within(plainBlock).queryByTitle('Скинути до відступу документа')).not.toBeInTheDocument();
   });
 
@@ -130,7 +130,7 @@ describe('spec: per-paragraph first-line indent slider', () => {
         ],
       }),
     ));
-    await waitFor(() => expect(within(indentedBlock).getByLabelText('Відступ абзацу 1')).toHaveValue('0'));
+    await waitFor(() => expect(within(indentedBlock).getByLabelText('Відступ абзацу 1')).toHaveValue('1.5'));
     expect(within(indentedBlock).queryByTitle('Скинути до відступу документа')).not.toBeInTheDocument();
   });
 });

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -155,27 +155,26 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     ));
   });
 
-  it('the width handle defaults to 50% and persists a dragged value on release (spec batch 21 §8)', async () => {
+  // Notarial layout standard §3.3: the signer block gets one left-offset handle for the whole
+  // block (30-65% of the text width, default ≈47% = 8.5 cm), persisted per document as a single
+  // beforeTitleOffsetPercent field - not the old per-block width slider.
+  it('the signer-block offset handle defaults to 8.5 cm (≈47%) and persists a dragged value on release', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const textarea = await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
-    // eslint-disable-next-line testing-library/no-node-access
-    const block = textarea.closest('.paragraph-editor-block');
-    const slider = within(block).getByLabelText('Ширина блоку 1');
-    expect(slider).toHaveValue('50');
+    await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
+    const slider = screen.getByLabelText('Відступ блоку підписанта');
+    expect(slider).toHaveValue('47.2');
 
-    fireEvent.change(slider, { target: { value: '75' } });
-    expect(within(block).getByText('75%')).toBeInTheDocument();
+    fireEvent.change(slider, { target: { value: '60' } });
+    expect(screen.getByText('60.0% (≈10.8 см)')).toBeInTheDocument();
     expect(set).not.toHaveBeenCalled(); // not yet released
 
     fireEvent.mouseUp(slider);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
-      expect.objectContaining({
-        beforeTitle: [expect.objectContaining({ width: 75 })],
-      }),
+      expect.objectContaining({ beforeTitleOffsetPercent: 60 }),
     ));
   });
 });

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -24,6 +24,7 @@ import {
   isBilingualLayout,
   isParagraphBold,
   isSingleLanguageTwoColumnLayout,
+  normalizeSignerBlockOffsetPercent,
   parseFormattedRuns,
   splitParagraphsIntoColumns,
   splitParagraphsIntoPages,
@@ -87,15 +88,26 @@ const styles = StyleSheet.create({
 // from the exact instance that owns the text, never inherited into a nested <Text> child, so
 // wrapping every run - even a whole plain paragraph with no bold/italic at all - silently broke
 // indentCm (spec batch 21 §8/per-paragraph indent): the parent's indent was set, but the text that
-// actually needed it always lived one level too deep to see it.
-const FormattedRuns = ({ text }) => parseFormattedRuns(text).map((run, index) => {
+// actually needed it always lived one level too deep to see it. The same one-level-too-deep trap
+// applies to a paragraph that *starts* with a formatted run (the notarial standard's bold
+// date-in-words line, `**Підпис**...`): the leading nested <Text> ignored the parent's indent, so
+// exactly the bolded lines lost their 1.5 cm first-line indent - `firstLineIndent` re-states the
+// paragraph's own resolved indent on that leading run.
+const FormattedRuns = ({ text, firstLineIndent }) => parseFormattedRuns(text).map((run, index) => {
   if (!run.bold && !run.italic) {
     // eslint-disable-next-line react/no-array-index-key
     return <React.Fragment key={index}>{run.text}</React.Fragment>;
   }
   return (
-    // eslint-disable-next-line react/no-array-index-key
-    <Text key={index} style={{ fontWeight: run.bold ? 700 : undefined, fontStyle: run.italic ? 'italic' : undefined }}>
+    <Text
+      // eslint-disable-next-line react/no-array-index-key
+      key={index}
+      style={{
+        fontWeight: run.bold ? 700 : undefined,
+        fontStyle: run.italic ? 'italic' : undefined,
+        ...(index === 0 && firstLineIndent ? { textIndent: firstLineIndent } : {}),
+      }}
+    >
       {run.text}
     </Text>
   );
@@ -154,16 +166,24 @@ const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBrea
   const cellStyle = isParagraphBold(paragraph) ? cellStyles.paragraphHeading : cellStyles.paragraph;
   const alignStyle = paragraph.align ? { textAlign: paragraph.align } : undefined;
   const indentStyle = paragraph.indentCm !== undefined ? { textIndent: paragraph.indentCm * CM_TO_PT } : undefined;
+  // The indent this paragraph actually resolves to, re-applied to a leading bold/italic run
+  // (see FormattedRuns) since react-pdf never inherits textIndent into a nested <Text>.
+  const firstLineIndent = indentStyle ? indentStyle.textIndent : (cellStyle.textIndent || 0);
+  // An empty template paragraph is an explicit empty line (the notarial standard separates its
+  // blocks only with those) - it must keep one line's height, not collapse to nothing the way an
+  // empty <Text> does.
+  const lineOf = value => (String(value || '').trim()
+    ? <FormattedRuns text={value} firstLineIndent={firstLineIndent} />
+    : ' ');
   if (isBilingual) {
     return (
       <View style={styles.row} wrap={wrap}>
-        <Text style={[cellStyle, cellStyles.leftCell, alignStyle, indentStyle]}><FormattedRuns text={paragraph.uk} /></Text>
-        <Text style={[cellStyle, cellStyles.rightCell, alignStyle, indentStyle]}><FormattedRuns text={paragraph.en} /></Text>
+        <Text style={[cellStyle, cellStyles.leftCell, alignStyle, indentStyle]}>{lineOf(paragraph.uk)}</Text>
+        <Text style={[cellStyle, cellStyles.rightCell, alignStyle, indentStyle]}>{lineOf(paragraph.en)}</Text>
       </View>
     );
   }
-  const text = paragraph[lang];
-  return <Text style={[cellStyle, alignStyle, indentStyle]} wrap={wrap}><FormattedRuns text={text} /></Text>;
+  return <Text style={[cellStyle, alignStyle, indentStyle]} wrap={wrap}>{lineOf(paragraph[lang])}</Text>;
 };
 
 // The single-language 2-column layout (spec §4: newspaper-style, one language flowing across two
@@ -207,40 +227,63 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
   </View>
 );
 
-// Free-standing text between the letterhead logo and the title (spec §14: "ЗА МІСЦЕМ ВИМОГИ" etc.)
-// - never merged into the paragraph list, so it always renders in this fixed position regardless of
-// how the body is edited. `align`/`bold` (spec §17) are resolved per block, not inferred from text.
-// `width` (spec batch 21 §8: the applicant/signatory data block is a *half-page-right* layout rule,
-// not just right-aligned text) constrains the block to that percentage of its column's width, still
-// pushed against whichever margin `align` names - a wide block wraps inside that strip instead of
-// spanning the full page width the way plain text-align would.
-const BeforeTitleBlock = ({ block, isBilingual, lang, cellStyles }) => {
-  const runStyle = { textAlign: block.align, fontWeight: block.bold ? 700 : 400 };
-  const widthStyle = { width: `${block.width}%` };
-  const rowJustify = block.align === 'right' ? 'flex-end' : (block.align === 'center' ? 'center' : 'flex-start');
-  if (isBilingual) {
-    return (
-      <View style={styles.row}>
-        <View style={[cellStyles.leftCell, { flexDirection: 'row', justifyContent: rowJustify }]}>
-          <Text style={[cellStyles.beforeTitle, widthStyle, runStyle]}><FormattedRuns text={block.uk} /></Text>
-        </View>
-        <View style={[cellStyles.rightCell, { flexDirection: 'row', justifyContent: rowJustify }]}>
-          <Text style={[cellStyles.beforeTitle, widthStyle, runStyle]}><FormattedRuns text={block.en} /></Text>
-        </View>
-      </View>
-    );
-  }
+// The addressee/signer block between the letterhead logo and the title (notarial layout standard
+// §3.2, "ЗА МІСЦЕМ ВИМОГИ" + the signer data) - never merged into the paragraph list, so it always
+// renders in this fixed position regardless of how the body is edited. The whole group occupies
+// one strip from the document's stored left offset (beforeTitleOffsetPercent, default 8.5 cm of
+// the 18 cm text width) to the right margin - the PDF equivalent of the borderless 2-column layout
+// table the reference file uses. Inside the strip a bold block (the caption) sits flush with the
+// strip's left edge; a regular block (the signer data) is justified; neither ever carries a
+// first-line indent. Consecutive blocks are separated by exactly one empty line (empty blocks in
+// the template collapse into that same separator), and one empty line follows the whole strip
+// before the title (structure §3.4).
+const isBlankBlockText = value => !String(value || '').trim();
+
+const SignerBlockLine = ({ block, langKey, cellStyles }) => (
+  <Text style={[cellStyles.beforeTitle, block.bold ? { textAlign: 'left', fontWeight: 700 } : { textAlign: 'justify' }]}>
+    <FormattedRuns text={block[langKey]} />
+  </Text>
+);
+
+const BlankLine = ({ cellStyles }) => <Text style={cellStyles.beforeTitle}> </Text>;
+
+const SignerBlockStrip = ({ blocks, offsetPercent, langKey, cellStyles }) => (
+  <View style={styles.row}>
+    <View style={{ width: `${offsetPercent}%` }} />
+    <View style={{ flex: 1 }}>
+      {blocks.map((block, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <React.Fragment key={index}>
+          {index > 0 ? <BlankLine cellStyles={cellStyles} /> : null}
+          <SignerBlockLine block={block} langKey={langKey} cellStyles={cellStyles} />
+        </React.Fragment>
+      ))}
+    </View>
+  </View>
+);
+
+const BeforeTitleBlocks = ({ doc, isBilingual, lang, cellStyles }) => {
+  const blocks = (doc.beforeTitle || []).filter(block => !isBlankBlockText(block.uk) || !isBlankBlockText(block.en));
+  if (!blocks.length) return null;
+  const offsetPercent = normalizeSignerBlockOffsetPercent(doc.beforeTitleOffsetPercent);
   return (
-    <View style={{ flexDirection: 'row', justifyContent: rowJustify }}>
-      <Text style={[cellStyles.beforeTitle, widthStyle, runStyle]}><FormattedRuns text={block[lang]} /></Text>
+    <View>
+      {isBilingual ? (
+        <View style={styles.row}>
+          <View style={cellStyles.leftCell}>
+            <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey="uk" cellStyles={cellStyles} />
+          </View>
+          <View style={cellStyles.rightCell}>
+            <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey="en" cellStyles={cellStyles} />
+          </View>
+        </View>
+      ) : (
+        <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey={lang} cellStyles={cellStyles} />
+      )}
+      <BlankLine cellStyles={cellStyles} />
     </View>
   );
 };
-
-const BeforeTitleBlocks = ({ blocks, isBilingual, lang, cellStyles }) => (blocks || []).map((block, index) => (
-  // eslint-disable-next-line react/no-array-index-key
-  <BeforeTitleBlock key={index} block={block} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} />
-));
 
 // The bilingual and single-column (1-language) layouts: everything lives on one <Page> JSX
 // element and react-pdf's own automatic wrap handles overflow onto further physical pages. The
@@ -257,7 +300,7 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
           came from the dedicated `logo` field or a legacy leading paragraph - see
           getTemplateLogoType in documentsCatalogUtils. */}
       {doc.logo ? <LogoBlock type={doc.logo} {...logoBlockProps} /> : null}
-      <BeforeTitleBlocks blocks={doc.beforeTitle} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} />
+      <BeforeTitleBlocks doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} />
       <DocumentTitleBlock doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} titleGap={titleGap} />
       {doc.paragraphs.map((paragraph, index) => {
         // Already drawn as doc.logo above - a legacy leading logo paragraph must not also render
@@ -454,7 +497,7 @@ const DocumentsPdfDocument = ({
                 {doc.logo ? (
                   <LogoBlock type={doc.logo} isBilingual={false} cellStyles={cellStyles} logoWidth={logoWidth} longLogoWidth={contentWidth} clinicLogos={effectiveClinicLogos} showUk showEn />
                 ) : null}
-                <BeforeTitleBlocks blocks={doc.beforeTitle} isBilingual={false} lang={lang} cellStyles={cellStyles} />
+                <BeforeTitleBlocks doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} />
                 <DocumentTitleBlock doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} />
               </>
             ) : null}

--- a/src/components/DocumentsRenderers.smoke.test.js
+++ b/src/components/DocumentsRenderers.smoke.test.js
@@ -343,3 +343,95 @@ describe('Documents renderers - single-column template with beforeTitle (batch 1
   }, 20000);
 });
 
+// Notarial layout standard (§3.2/§3.3): the addressee/signer block renders as a borderless
+// 2-column layout table - column 1 empty (the stored left offset, default 8.5 cm of the 18 cm
+// text width), column 2 holding the bold caption and the justified signer data with one empty
+// line between them - and both exports honour the per-document beforeTitleOffsetPercent field.
+describe('Documents DOCX builder - notarial signer block layout', () => {
+  const extractXml = async blob => {
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    return zip.file('word/document.xml').async('string');
+  };
+
+  const buildSignerDoc = async offsetPercent => {
+    const { buildGeneratedDocument } = await import('./documentsCatalogUtils');
+    const template = {
+      id: 'zayava-racs',
+      languages: ['uk'],
+      columns: 1,
+      ...(offsetPercent !== undefined ? { beforeTitleOffsetPercent: offsetPercent } : {}),
+      beforeTitle: [
+        { uk: 'ЗА МІСЦЕМ ВИМОГИ', bold: true },
+        { uk: '**Молвінських Юлія Володимирівна**, 27.05.1993 року народження, паспорт серії ЕВ409051.' },
+      ],
+      title: { uk: 'З А Я В А' },
+      paragraphs: [{ uk: 'Я, **Молвінських Юлія Володимирівна**, даю згоду.' }],
+    };
+    return buildGeneratedDocument(template, {});
+  };
+
+  it('renders the signer block as a borderless table with the default 8.5 cm offset column', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = await buildSignerDoc(undefined);
+    // Default text width with the standard 1.5 cm margins: 11906 - 851 - 851 = 10204 twips;
+    // default offset 47.2% of it = 4816 twips ≈ the reference file's 4820-twip empty column.
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'two-column' });
+    const xml = await extractXml(blob);
+
+    expect(xml).toContain('<w:tbl>');
+    expect(xml).toContain('w:w="4816"');
+    // The caption is bold; the signer block table precedes the title.
+    expect(xml).toMatch(/<w:b\/>[\s\S]*?<w:t[^>]*>ЗА МІСЦЕМ ВИМОГИ<\/w:t>/);
+    expect(xml.indexOf('<w:tbl>')).toBeLessThan(xml.indexOf('З А Я В А'));
+    // The inline **bold** name inside the data paragraph stays a real bold run, no markup leak.
+    expect(xml).not.toContain('**');
+  }, 20000);
+
+  it('uses the stored per-document offset for the empty column width', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = await buildSignerDoc(60);
+    expect(doc.beforeTitleOffsetPercent).toBe(60);
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'two-column' });
+    const xml = await extractXml(blob);
+    // 60% of the 10204-twip text width.
+    expect(xml).toContain('w:w="6122"');
+  }, 20000);
+
+  it('clamps an out-of-range stored offset into the 30-65% band', async () => {
+    const doc = await buildSignerDoc(90);
+    expect(doc.beforeTitleOffsetPercent).toBe(65);
+  });
+
+  it('renders the signer block in the PDF without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+    const doc = await buildSignerDoc(undefined);
+
+    const element = React.createElement(DocumentsPdfDocument, { documents: [doc], layout: 'two-column', clinicLogos: [] });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(1000);
+  }, 20000);
+});
+

--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -560,7 +560,8 @@ const formatCategorySum = value => {
 
 const formatCurrencyValue = value => {
   if (!Number.isFinite(value)) return '0';
-  return value.toFixed(2).replace(/\.?0+$/, '');
+  const formatted = value.toFixed(2).replace(/\.?0+$/, '');
+  return formatted === '-0' ? '0' : formatted;
 };
 
 const normalizeCustomUsdRate = value => {
@@ -628,7 +629,7 @@ const getFlowRatesForRow = ({
   };
 };
 
-const calculateFlowRowCurrencyAmount = ({
+export const calculateFlowRowCurrencyAmount = ({
   row,
   currency = 'usd',
   exchangeRateMode,
@@ -650,7 +651,7 @@ const calculateFlowRowCurrencyAmount = ({
   }
 
   const storedAmount = toAmountNumber(currency === 'eur' ? row.amountEur : row.amountUsd);
-  return storedAmount > 0 ? storedAmount : 0;
+  return storedAmount;
 };
 
 const makeFlowCurrencyFormulaResolver = rates => name => {
@@ -2077,7 +2078,7 @@ export const FlowManager = ({ ownerId }) => {
                               historicalRatesByDate,
                               customUsdRate,
                             });
-                            return amountUsd > 0 ? ` / ${formatCurrencyValue(amountUsd)} $` : '';
+                            return amountUsd !== 0 ? ` / ${formatCurrencyValue(amountUsd)} $` : '';
                           })()}
                         </EventText>
                         <ChangeCategoryBtn

--- a/src/components/FlowManager.test.jsx
+++ b/src/components/FlowManager.test.jsx
@@ -16,7 +16,11 @@ jest.mock('./config', () => ({
   updateFlowEntry: jest.fn(),
 }));
 
-const { flattenFlowEntriesFromBackend, parseFlowEntryLine } = require('./FlowManager');
+const {
+  calculateFlowRowCurrencyAmount,
+  flattenFlowEntriesFromBackend,
+  parseFlowEntryLine,
+} = require('./FlowManager');
 
 describe('parseFlowEntryLine', () => {
   it('keeps dollar-only formulas as a persistable USD formula amount', () => {
@@ -62,5 +66,35 @@ describe('parseFlowEntryLine', () => {
       amount: '=100÷EUR',
       description: 'coffee',
     });
+  });
+});
+
+describe('calculateFlowRowCurrencyAmount', () => {
+  const { resolveFlowExchangeRatesForMode } = require('./config');
+
+  it('converts negative amounts the same way as positive ones', () => {
+    resolveFlowExchangeRatesForMode.mockReturnValue({ usd: 40, eur: 44 });
+    const options = {
+      currency: 'usd',
+      exchangeRateMode: 'mono',
+      exchangeRates: { usd: 40, eur: 44 },
+      historicalRatesByDate: {},
+      customUsdRate: '',
+    };
+    expect(calculateFlowRowCurrencyAmount({ ...options, row: { amount: '500' } })).toBe(12.5);
+    expect(calculateFlowRowCurrencyAmount({ ...options, row: { amount: '-500' } })).toBe(-12.5);
+  });
+
+  it('keeps stored negative currency amounts when no rate is available', () => {
+    resolveFlowExchangeRatesForMode.mockReturnValue(null);
+    const options = {
+      currency: 'usd',
+      exchangeRateMode: 'mono',
+      exchangeRates: null,
+      historicalRatesByDate: {},
+      customUsdRate: '',
+    };
+    expect(calculateFlowRowCurrencyAmount({ ...options, row: { amount: '-500', amountUsd: '-12.5' } })).toBe(-12.5);
+    expect(calculateFlowRowCurrencyAmount({ ...options, row: { amount: '500', amountUsd: '12.5' } })).toBe(12.5);
   });
 });

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -26,7 +26,7 @@ import { filterOutMedicationPhotos } from '../utils/photoFilters';
 import { convertDriveLinkToImage } from '../utils/convertDriveLinkToImage';
 import { getCurrentDate } from './foramtDate';
 import toast from 'react-hot-toast';
-import { getCard, incrementMatchingLoadStat, removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
+import { clearEmptySearchQueryCache, getCard, incrementMatchingLoadStat, removeCard, setIdsForQuery, normalizeQueryKey } from '../utils/cardIndex';
 import { updateCard } from '../utils/cardsStorage';
 import { parseUkTriggerQuery } from '../utils/parseUkTrigger';
 import { getCacheKey } from '../utils/cache';
@@ -2084,6 +2084,8 @@ export const makeNewUser = async (searchedValue, rawQuery = '') => {
     await update(searchIdRef, searchIdUpdates);
   }
 
+  clearEmptySearchQueryCache();
+
   return {
     userId: newUserId,
     ...newUser,
@@ -2885,6 +2887,8 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
         console.error('Error updating lastLogin2 in users:', e);
       }
     }
+
+    clearEmptySearchQueryCache();
   } catch (error) {
     console.error('Сталася помилка під час збереження даних в Realtime Database3:', error);
     throw error;
@@ -7336,6 +7340,7 @@ export const removeCardAndSearchId = async userId => {
     console.log(`Картка користувача видалена з newUsers: ${userId}`);
 
     removeCard(userId);
+    clearEmptySearchQueryCache();
 
     if (deletedFields.length) {
       toast.success(`Видалені дані:\n${deletedFields.join('\n')}`, {

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1176,6 +1176,21 @@ export const normalizeBlockAlign = align => (ALLOWED_BLOCK_ALIGNMENTS.includes(a
 export const DEFAULT_BLOCK_WIDTH_PERCENT = 50;
 export const normalizeBlockWidth = width => clampNumber(width, 10, 100, DEFAULT_BLOCK_WIDTH_PERCENT);
 
+// The addressee/signer block's left offset (notarial layout standard): the whole beforeTitle
+// group renders as one strip from this offset to the right margin, in both the PDF and Word
+// exports. Stored per document as a single number - percent of the text width, so the same value
+// holds whatever margins the Format panel sets. The default matches the notarial reference file:
+// 8.5 cm of the standard 18.0 cm text width (the 4820-twip empty column of its layout table).
+export const DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT = 47.2;
+export const SIGNER_BLOCK_OFFSET_MIN_PERCENT = 30;
+export const SIGNER_BLOCK_OFFSET_MAX_PERCENT = 65;
+export const normalizeSignerBlockOffsetPercent = value => clampNumber(
+  value,
+  SIGNER_BLOCK_OFFSET_MIN_PERCENT,
+  SIGNER_BLOCK_OFFSET_MAX_PERCENT,
+  DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
+);
+
 const resolveBeforeTitleBlocks = (template, context) => toArray(template?.beforeTitle).map(block => ({
   align: normalizeBlockAlign(block?.align),
   bold: Boolean(block?.bold),
@@ -1281,6 +1296,7 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
     languages,
     columns: resolveDocColumns(template, languages),
     beforeTitle: resolveBeforeTitleBlocks(template, context),
+    beforeTitleOffsetPercent: normalizeSignerBlockOffsetPercent(template?.beforeTitleOffsetPercent),
     title: {
       uk: overriddenText(override.title, 'uk', fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk')),
       en: overriddenText(override.title, 'en', fillPlaceholders(localizedText(template.title, 'en'), context, 'en')),
@@ -1804,19 +1820,21 @@ export const pickLogoVariantForLayout = (logoVariants, layout) => {
   }, null);
 };
 
-// Defaults mirror the reference statements docx: Times ~10pt body / 11pt bold titles,
-// single line spacing, zero after-paragraph spacing, A4 with 1.2/1.5/1.2/2.0 cm margins and a
-// ~5.5 cm wide clinic logo centered above the title.
+// Defaults mirror the notarial layout standard measured from the reference statements docx:
+// Times New Roman 12 pt everywhere (the title is the same size as the body), single line spacing,
+// zero after-paragraph spacing (blocks are separated only by explicit empty lines), a 1.5 cm
+// first-line indent on body paragraphs, and A4 with 2.0 (top) / 1.5 / 1.0 (bottom) / 1.5 cm
+// margins - an 18.0 cm text width. The clinic logo stays ~5.5 cm wide, centered above the title.
 export const DEFAULT_DOC_FORMATTING = {
-  fontSize: 10,
-  titleFontSize: 11,
+  fontSize: 12,
+  titleFontSize: 12,
   lineSpacing: 1,
   paragraphSpacing: 0,
-  firstLineIndentCm: 0,
-  marginTopCm: 1.2,
+  firstLineIndentCm: 1.5,
+  marginTopCm: 2,
   marginRightCm: 1.5,
-  marginBottomCm: 1.2,
-  marginLeftCm: 2,
+  marginBottomCm: 1,
+  marginLeftCm: 1.5,
   columnGapCm: 0.5,
   logoWidthMm: 55,
   showLogo: true,

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -16,6 +16,7 @@ import {
   isBilingualLayout,
   isParagraphBold,
   isSingleLanguageTwoColumnLayout,
+  normalizeSignerBlockOffsetPercent,
   parseFormattedRuns,
   splitParagraphsIntoColumns,
 } from './documentsCatalogUtils';
@@ -144,26 +145,54 @@ export const buildDocumentsDocx = async ({
     children: formattedTextRuns(text, { size: titleSize, baseBold: true }),
   });
 
-  // Free-standing text between the letterhead logo and the title (spec §14/§17: "ЗА МІСЦЕМ
-  // ВИМОГИ" etc.) - `align`/`bold` are resolved per block, never inferred from the text itself.
-  // `width` (spec batch 21 §8: the applicant/signatory data block is a half-page-right layout rule,
-  // not just right-aligned text) is expressed as an indent that eats the complementary space, the
-  // same technique Word itself uses for a "float" - so a wide block wraps inside that narrower
-  // strip instead of spanning the full column the way plain alignment would. `containerWidthTwips`
-  // is whichever width this paragraph's own column actually has (the full page in the single-
-  // column flow, or one table cell's width in the bilingual layout).
-  const beforeTitleParagraph = (text, block, containerWidthTwips) => {
-    const complementTwips = Math.round(containerWidthTwips * (1 - (block.width ?? 50) / 100));
-    const indent = block.align === 'right'
-      ? { left: complementTwips }
-      : (block.align === 'left'
-        ? { right: complementTwips }
-        : { left: Math.round(complementTwips / 2), right: Math.round(complementTwips / 2) });
-    return new Paragraph({
-      alignment: alignmentForBlock(block.align),
-      spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
-      indent,
-      children: formattedTextRuns(text, { size: bodySize, baseBold: Boolean(block.bold) }),
+  // The addressee/signer block between the letterhead logo and the title (notarial layout
+  // standard §3.2: "ЗА МІСЦЕМ ВИМОГИ" + the signer data). Implemented exactly the way the
+  // reference notarial file does it: a borderless 2-column table across the full width of its
+  // container - column 1 empty (the left offset, default 8.5 cm), column 2 holding every
+  // beforeTitle block. Inside the block a bold paragraph (the caption) aligns to the block's left
+  // edge; a regular one (the signer data) is justified; neither ever carries a first-line indent.
+  // Consecutive blocks are separated by exactly one empty line (empty blocks in the template
+  // collapse into that same separator). `containerWidthTwips` is whichever width this block's own
+  // column actually has (the full page in the single-column flow, or one table cell's width in
+  // the bilingual layout).
+  const isBlankBlockText = value => !String(value || '').trim();
+
+  const emptyLineParagraph = () => new Paragraph({
+    spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
+    children: [new TextRun({ text: '', size: bodySize })],
+  });
+
+  const signerBlockParagraph = (text, block) => new Paragraph({
+    alignment: block.bold ? AlignmentType.LEFT : AlignmentType.JUSTIFIED,
+    spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
+    children: formattedTextRuns(text, { size: bodySize, baseBold: Boolean(block.bold) }),
+  });
+
+  const signerBlockTable = (blocks, langKey, containerWidthTwips, offsetPercent) => {
+    const offsetTwips = Math.round(containerWidthTwips * (offsetPercent / 100));
+    const blockWidthTwips = Math.max(1, Math.round(containerWidthTwips) - offsetTwips);
+    const cellChildren = blocks.flatMap((block, index) => [
+      ...(index > 0 ? [emptyLineParagraph()] : []),
+      signerBlockParagraph(block[langKey], block),
+    ]);
+    return new Table({
+      width: { size: offsetTwips + blockWidthTwips, type: WidthType.DXA },
+      columnWidths: [offsetTwips, blockWidthTwips],
+      borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
+      rows: [new TableRow({
+        children: [
+          new TableCell({
+            borders: noBorders,
+            width: { size: offsetTwips, type: WidthType.DXA },
+            children: [new Paragraph({ spacing: { after: 0, line: lineTwips, lineRule: 'auto' }, children: [] })],
+          }),
+          new TableCell({
+            borders: noBorders,
+            width: { size: blockWidthTwips, type: WidthType.DXA },
+            children: cellChildren,
+          }),
+        ],
+      })],
     });
   };
 
@@ -277,17 +306,21 @@ export const buildDocumentsDocx = async ({
     // from the dedicated `logo` field or a legacy leading paragraph - see getTemplateLogoType.
     if (doc.logo) children.push(...buildLogoBlock(doc.logo, layoutCtx));
 
-    // Free-standing text between the logo and the title (spec §14), never merged into the body.
-    (doc.beforeTitle || []).forEach(block => {
+    // The addressee/signer block between the logo and the title (§3.2), never merged into the
+    // body. One empty line separates the whole block from the title that follows (§3.4).
+    const signerBlocks = (doc.beforeTitle || []).filter(block => !isBlankBlockText(block.uk) || !isBlankBlockText(block.en));
+    if (signerBlocks.length) {
+      const offsetPercent = normalizeSignerBlockOffsetPercent(doc.beforeTitleOffsetPercent);
       if (isBilingual) {
         children.push(twoColumnTable([[
-          beforeTitleParagraph(block.uk, block, columnContentWidthTwips),
-          beforeTitleParagraph(block.en, block, columnContentWidthTwips),
+          signerBlockTable(signerBlocks, 'uk', columnContentWidthTwips, offsetPercent),
+          signerBlockTable(signerBlocks, 'en', columnContentWidthTwips, offsetPercent),
         ]], true, showColumnDivider));
       } else {
-        children.push(beforeTitleParagraph(block[lang], block, contentWidthTwips));
+        children.push(signerBlockTable(signerBlocks, lang, contentWidthTwips, offsetPercent));
       }
-    });
+      children.push(emptyLineParagraph());
+    }
 
     if (isBilingual) {
       children.push(twoColumnTable([[titleParagraph(doc.title.uk), titleParagraph(doc.title.en)]], true, showColumnDivider));

--- a/src/utils/__tests__/cardIndex.test.js
+++ b/src/utils/__tests__/cardIndex.test.js
@@ -6,6 +6,8 @@ describe('cardIndex queries', () => {
     getCard,
     removeCard,
     serializeQueryFilters,
+    clearEmptySearchQueryCache,
+    getQueryEntry,
   } = require('../cardIndex');
   const { updateCard } = require('../cardsStorage');
 
@@ -38,6 +40,23 @@ describe('cardIndex queries', () => {
     removeCard('userId01');
     expect(getCard('userId01')).toBeNull();
     expect(getIdsByQuery('test')).toEqual([]);
+  });
+
+  it('clears cached empty search results but keeps other entries', () => {
+    updateCard('userId01', { name: 'A' });
+    setIdsForQuery('cards:search:name=іванова', [], { isNegativeHit: true });
+    setIdsForQuery('cards:search:name=петрова', ['userId01']);
+    setIdsForQuery('favorite', []);
+
+    expect(getQueryEntry('cards:search:name=іванова').isNegativeHit).toBe(true);
+
+    const removed = clearEmptySearchQueryCache();
+
+    expect(removed).toBe(1);
+    expect(getQueryEntry('cards:search:name=іванова').cachedAt).toBe(0);
+    expect(getQueryEntry('cards:search:name=іванова').isNegativeHit).toBe(false);
+    expect(getIdsByQuery('cards:search:name=петрова')).toEqual(['userId01']);
+    expect(getQueryEntry('favorite').cachedAt).toBeGreaterThan(0);
   });
 
   it('serializes filters with stable ordering', () => {

--- a/src/utils/cardIndex.js
+++ b/src/utils/cardIndex.js
@@ -444,6 +444,26 @@ export const setIdsForQuery = (queryKey, ids, options = {}) => {
   logMatchingCacheDebug('query ids cache save', { key, idsCount: nextIds.length, isNegativeHit });
 };
 
+const SEARCH_QUERY_CACHE_PREFIX = 'cards:search';
+
+// Drops cached search entries with no ids (negative "not found" hits) so a
+// freshly created or updated profile becomes findable without a page reload.
+export const clearEmptySearchQueryCache = () => {
+  const queries = loadQueries();
+  const staleKeys = Object.keys(queries).filter(key => {
+    if (!key.startsWith(SEARCH_QUERY_CACHE_PREFIX)) return false;
+    const ids = Array.isArray(queries[key]?.ids) ? queries[key].ids : [];
+    return ids.length === 0;
+  });
+  if (staleKeys.length === 0) return 0;
+  staleKeys.forEach(key => {
+    delete queries[key];
+  });
+  saveQueries(queries);
+  logMatchingCacheDebug('cleared empty search query cache entries', { count: staleKeys.length });
+  return staleKeys.length;
+};
+
 export const getIndexIdsByQuery = (queryKey, options = {}) => {
   const {
     ttlMs = MATCHING_INDEX_TTL_MS,


### PR DESCRIPTION
Negative amounts were hidden by amount > 0 guards in the row equivalent
display and in the stored-amount fallback of calculateFlowRowCurrencyAmount.
Negative positions now convert and display identically to positive ones,
with the minus sign preserved, and flow into category totals.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LHPuDj5y2XmVXiDj1Gy2gn