### PR TITLE
Documents: consolidate per-paragraph styles under one backend style key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "file-saver": "^2.0.5",
         "firebase": "^10.12.3",
         "nanoid": "^4.0.0",
+        "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
         "react-dom": "^18.1.0",
         "react-hot-toast": "2.4.0",
@@ -3495,7 +3496,7 @@
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
       "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "workspaces": [
         "e2e/*"
@@ -12551,7 +12552,7 @@
         "url": "https://github.com/sponsors/mehmet-kozan"
       }
     },
-    "node_modules/pdfjs-dist": {
+    "node_modules/pdf-parse/node_modules/pdfjs-dist": {
       "version": "5.4.296",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
       "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
@@ -12562,6 +12563,18 @@
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "^0.1.80"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
       }
     },
     "node_modules/performance-now": {
@@ -19842,7 +19855,7 @@
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
       "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@napi-rs/canvas-android-arm64": "0.1.80",
         "@napi-rs/canvas-darwin-arm64": "0.1.80",
@@ -26408,15 +26421,25 @@
       "requires": {
         "@napi-rs/canvas": "0.1.80",
         "pdfjs-dist": "5.4.296"
+      },
+      "dependencies": {
+        "pdfjs-dist": {
+          "version": "5.4.296",
+          "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+          "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+          "dev": true,
+          "requires": {
+            "@napi-rs/canvas": "^0.1.80"
+          }
+        }
       }
     },
     "pdfjs-dist": {
-      "version": "5.4.296",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
-      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
-      "dev": true,
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
       "requires": {
-        "@napi-rs/canvas": "^0.1.80"
+        "@napi-rs/canvas": "^0.1.65"
       }
     },
     "performance-now": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "file-saver": "^2.0.5",
     "firebase": "^10.12.3",
     "nanoid": "^4.0.0",
+    "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",
     "react-dom": "^18.1.0",
     "react-hot-toast": "2.4.0",

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaBold, FaChevronDown, FaChevronUp, FaCode, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaPlus, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaPlus, FaSlidersH, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFolderFileNames, uploadFileToStorageFolder } from './config';
@@ -16,6 +16,7 @@ import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
 import VariablePickerModal from './DocumentsVariablePickerModal';
+import DocumentsPdfPreview from './DocumentsPdfPreview';
 import { useAutoResize } from '../hooks/useAutoResize';
 import {
   DEFAULT_DOC_FORMATTING,
@@ -35,20 +36,21 @@ import {
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
   DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
-  SIGNER_BLOCK_OFFSET_MIN_PERCENT,
-  SIGNER_BLOCK_OFFSET_MAX_PERCENT,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   getClinicLogo,
+  getEffectiveParagraphAlign,
   getLayoutLang,
   getParagraphStyle,
   getParagraphType,
   getTemplateLogoType,
+  getTemplateScopeRecord,
   getTemplateScopeText,
   isBilingualLayout,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
   mergeDocumentsCatalog,
+  nextParagraphAlign,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
@@ -72,7 +74,7 @@ import {
   validateBirthRegistrationCase,
   validateCaseRecord,
   validateDocumentTemplate,
-  withParagraphStyle,
+  withTemplateScopeStyle,
   withTemplateScopeText,
 } from './documentsCatalogUtils';
 
@@ -559,15 +561,119 @@ const CheckLine = styled.label`
   cursor: pointer;
 `;
 
-// Per-paragraph first-line indent (spec: "додай можливість їх совати") - a real draggable slider,
-// not a number box, so "move it" is literal.
-const RangeInput = styled.input`
-  flex: 1;
-  min-width: 90px;
-  max-width: 160px;
-  accent-color: var(--km-accent);
-  cursor: pointer;
+// --- Formatting popovers (batch 2026-07-23 B §1.2/§1.3/§1.4) ---------------------------------
+// The numeric plain-text fields in these popovers are the ONLY way to set the document defaults,
+// the per-paragraph overrides, and the before-title block offset - every slider is gone (§1.4).
+// Values apply live as typed; the popover closes on outside click or Esc, no OK/Apply buttons.
+
+const PopoverAnchor = styled.span`
+  position: relative;
+  display: inline-flex;
 `;
+
+const PopoverCard = styled.div`
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  min-width: 180px;
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  box-shadow: 0 8px 20px rgba(60, 42, 16, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+// Inheritance display (§1.3): an empty field shows the inherited value as the ghost placeholder;
+// typing a number sets the override, clearing the field removes it - no separate reset control.
+// The draft is local so partially-typed values ("1.", "0,7") are never rewritten mid-keystroke by
+// the parsed state they commit into.
+const PlainNumberField = ({ label, initialValue, placeholder, onApply, onFieldBlur }) => {
+  const [draft, setDraft] = useState(initialValue);
+  return (
+    <Field>
+      {label}
+      <FieldInput
+        type="text"
+        inputMode="decimal"
+        value={draft}
+        placeholder={placeholder}
+        onChange={event => {
+          setDraft(event.target.value);
+          onApply(event.target.value);
+        }}
+        onBlur={onFieldBlur}
+      />
+    </Field>
+  );
+};
+
+// One trigger button + its popover, sharing a boundary node so an outside-click close never
+// races the trigger's own toggle click.
+const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields }) => {
+  const anchorRef = useRef(null);
+  useEffect(() => {
+    if (!open) return undefined;
+    const handlePointerDown = event => {
+      if (anchorRef.current && !anchorRef.current.contains(event.target)) onClose();
+    };
+    const handleKeyDown = event => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+  return (
+    <PopoverAnchor ref={anchorRef}>
+      <SmallButton type="button" onClick={onToggle} title={buttonTitle}>
+        <FaSlidersH />
+      </SmallButton>
+      {open ? (
+        <PopoverCard>
+          {fields.map(field => (
+            <PlainNumberField
+              key={field.key}
+              label={field.label}
+              initialValue={field.value}
+              placeholder={field.placeholder}
+              onApply={field.onApply}
+              onFieldBlur={field.onFieldBlur}
+            />
+          ))}
+        </PopoverCard>
+      ) : null}
+    </PopoverAnchor>
+  );
+};
+
+// The §1.5 alignment button: its icon always shows the paragraph's current effective alignment;
+// each click cycles Left → Center → Right → Justify → Left (MS Word whole-paragraph behavior).
+const ALIGN_ICONS = {
+  left: FaAlignLeft, center: FaAlignCenter, right: FaAlignRight, justify: FaAlignJustify,
+};
+
+const AlignCycleButton = ({ align, onCycle }) => {
+  const Icon = ALIGN_ICONS[align] || FaAlignLeft;
+  return (
+    <SmallButton
+      type="button"
+      onClick={onCycle}
+      aria-label={`Вирівнювання: ${align}`}
+      title={`Alignment: ${align}. Tap to cycle Left → Center → Right → Justify.`}
+    >
+      <Icon />
+    </SmallButton>
+  );
+};
 
 const LogoPreview = styled.img`
   max-width: 220px;
@@ -665,7 +771,11 @@ const DocumentsPage = ({ isAdmin }) => {
   };
   const [paragraphModes, setParagraphModes] = useState({});
   const paragraphModeKey = (docId, index) => `${docId}#${index}`;
-  const getParagraphMode = (docId, index) => paragraphModes[paragraphModeKey(docId, index)] || 'text';
+  // beforeTitle rows carry the same mode cycle (Task 2: identical toolbars) but default to
+  // 'template' - they have no per-case override layer, so raw markup is their canonical surface
+  // and what every admin edited there before the modes were unified.
+  const getParagraphMode = (docId, scope) => paragraphModes[paragraphModeKey(docId, scope)]
+    || (String(scope).startsWith('beforeTitle') ? 'template' : 'text');
   const setParagraphModeFor = (docId, index, mode) => setParagraphModes(previous => ({ ...previous, [paragraphModeKey(docId, index)]: mode }));
   const [dirtyDocIds, setDirtyDocIds] = useState({});
   const [dirtyOverrideDocIds, setDirtyOverrideDocIds] = useState({});
@@ -854,48 +964,89 @@ const DocumentsPage = ({ isAdmin }) => {
     updateTemplate(docId, template => withTemplateScopeText(template, scope, langKey, value));
   };
 
-  // Per-paragraph first-line indent (spec: "відступи теж повтори, додай можливість їх совати" -
-  // the reference notarial statement indents only its opening declaration, not the signature/
-  // registration lines after it, so one document-wide value can't express it). `value === null`
-  // clears the override, falling back to the document's own firstLineIndentCm again. Dragging the
-  // slider updates local state per tick (persisted on release, like every text field's onBlur);
-  // the reset button below is a single discrete click, so it writes directly instead - same
-  // stale-closure hazard applyParagraphStructureChange's own comment explains. The value lives
-  // under the paragraph's single consolidated `style` key on the backend (withParagraphStyle),
-  // together with every other per-paragraph style.
-  const withParagraphIndent = (template, index, value) => ({
-    ...template,
-    paragraphs: (template.paragraphs || []).map((paragraph, paragraphIndex) => (
-      paragraphIndex === index ? withParagraphStyle(paragraph, { indentCm: value }) : paragraph
-    )),
-  });
-
-  const handleParagraphIndentChange = (docId, index, value) => {
-    updateTemplate(docId, template => withParagraphIndent(template, index, value));
+  // --- Formatting popovers + alignment (batch 2026-07-23 B §1.2/§1.3/§1.5) --------------------
+  // One popover open at a time, addressed as `${docId}#doc` (document defaults, §1.2) or
+  // `${docId}#<scope>` (a paragraph's or beforeTitle block's own overrides, §1.3). Values apply
+  // live as typed via updateTemplate (state), and persist on field blur / popover close through
+  // the same dirty-flag persistTemplate every text field already uses.
+  const [openFormatKey, setOpenFormatKey] = useState('');
+  const formatPopoverKey = (docId, scope) => `${docId}#${scope || 'doc'}`;
+  const toggleFormatPopover = (docId, scope) => {
+    const key = formatPopoverKey(docId, scope);
+    // Switching straight from one popover to another still flushes the first one's edits.
+    if (openFormatKey && openFormatKey !== key) persistTemplate(openFormatKey.split('#')[0]);
+    setOpenFormatKey(openFormatKey === key ? '' : key);
+  };
+  const closeFormatPopover = docId => {
+    setOpenFormatKey('');
+    persistTemplate(docId);
   };
 
-  const resetParagraphIndent = async (docId, index) => {
+  // '' clears the value (null), a parseable number applies, anything mid-typing/unparseable is
+  // ignored until it becomes a number ("1." and "0,7" both already parse).
+  const parsePlainNumber = raw => {
+    const text = String(raw ?? '').trim().replace(',', '.');
+    if (!text) return null;
+    const value = Number(text);
+    return Number.isFinite(value) ? value : undefined;
+  };
+
+  // §1.2: the document defaults (font size / first-line indent) every non-overridden paragraph
+  // inherits - stored in the template's existing sparse `format` override field, and dropped from
+  // it when cleared or dialed back to the shared reference value (nothing redundant persists).
+  const setDocFormatField = (docId, field, raw) => {
+    const parsed = parsePlainNumber(raw);
+    if (parsed === undefined) return;
+    updateTemplate(docId, template => {
+      const format = { ...(template.format || {}) };
+      if (parsed === null || parsed === formatting[field]) delete format[field];
+      else format[field] = parsed;
+      const next = { ...template };
+      if (Object.keys(format).length) next.format = format;
+      else delete next.format;
+      return next;
+    });
+  };
+
+  // §1.3: a paragraph's (or beforeTitle block's) own override, kept under its consolidated
+  // `style` key - clearing the field (null) removes the key and the row inherits again.
+  const setScopeStyleField = (docId, scope, styleKey, raw) => {
+    const parsed = parsePlainNumber(raw);
+    if (parsed === undefined) return;
+    updateTemplate(docId, template => withTemplateScopeStyle(template, scope, { [styleKey]: parsed }));
+  };
+
+  // §1.3: for the before-title block the popover's "indent" field is the whole block's offset in
+  // percent (notarial layout standard §3.3) - one number per document, '' restores the default.
+  const setBeforeTitleOffset = (docId, raw) => {
+    const parsed = parsePlainNumber(raw);
+    if (parsed === undefined) return;
+    updateTemplate(docId, template => {
+      const next = { ...template };
+      if (parsed === null) delete next.beforeTitleOffsetPercent;
+      else next.beforeTitleOffsetPercent = parsed;
+      return next;
+    });
+  };
+
+  // §1.5: one click = the next alignment state, written straight to the backend (a discrete
+  // click, so it uses the direct-set pattern applyParagraphStructureChange's comment explains).
+  const handleCycleAlign = async (docId, scope) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
-    const nextTemplate = withParagraphIndent(template, index, null);
+    const record = getTemplateScopeRecord(template, scope);
+    if (!record) return;
+    const nextTemplate = withTemplateScopeStyle(template, scope, { align: nextParagraphAlign(getEffectiveParagraphAlign(record)) });
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
       setCatalog(previous => ({
         ...previous,
         documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
       }));
-    } catch (saveError) {
-      console.error('Unable to reset the paragraph indent', saveError);
-      toast.error('Could not save the indent change.');
+    } catch (alignError) {
+      console.error('Unable to save the alignment change', alignError);
+      toast.error('Could not save the alignment change.');
     }
-  };
-
-  // The addressee/signer block's draggable left-offset handle (notarial layout standard §3.3):
-  // one handle for the whole block, persisted per document as a single number
-  // (beforeTitleOffsetPercent) that both the PDF and Word exports read - same
-  // drag-updates-locally/persists-on-release pattern as the paragraph indent slider above.
-  const handleSignerBlockOffsetChange = (docId, value) => {
-    updateTemplate(docId, template => ({ ...template, beforeTitleOffsetPercent: value }));
   };
 
   // The letterhead logo always renders before the title (spec: "лого відображай перед title") and
@@ -1194,6 +1345,19 @@ const DocumentsPage = ({ isAdmin }) => {
     }
     const { start, end } = offsets;
     const { docId, scope, langKey } = active;
+    // Input mode's field never takes Bold/Italic (the buttons are disabled there) - hard-stop in
+    // case a stale focus record from it is still the active field.
+    if (active.kind === 'input-plain') return;
+    // beforeTitle rows have no per-case override layer, so their Text mode applies Bold/Italic
+    // straight onto the shared template markup (plain-text offsets via toggleInlineFormat) -
+    // unlike title/paragraph Text mode below, which writes this case's resolved-text override.
+    if (active.kind === 'text-display' && /^beforeTitle:/.test(scope)) {
+      const template = catalog.documents.find(item => String(item.id) === String(docId));
+      if (!template) return;
+      const currentRaw = getTemplateScopeText(template, scope, langKey);
+      await commitTemplateScopeText(docId, scope, langKey, toggleInlineFormat(currentRaw, start, end, attr));
+      return;
+    }
     if (active.kind === 'template') {
       const template = catalog.documents.find(item => String(item.id) === String(docId));
       if (!template) return;
@@ -1964,6 +2128,32 @@ const DocumentsPage = ({ isAdmin }) => {
                         style={{ flex: 1, minWidth: 0, fontWeight: 600 }}
                         title="The document's entry name in the Documents list - never printed inside the document itself (edit the printed title below, in the Title row)"
                       />
+                      {/* §1.2: the document-level formatting defaults every non-overridden
+                          paragraph inherits - edited here, next to the delete button. */}
+                      <FormatPopoverButton
+                        open={openFormatKey === formatPopoverKey(template.id, '')}
+                        onToggle={() => toggleFormatPopover(template.id, '')}
+                        onClose={() => closeFormatPopover(template.id)}
+                        buttonTitle="Document formatting - font size (pt) and first-line indent (cm) inherited by all paragraphs"
+                        fields={[
+                          {
+                            key: 'fontSize',
+                            label: 'Font size (pt)',
+                            value: template.format?.fontSize !== undefined ? String(template.format.fontSize) : '',
+                            placeholder: String(formatting.fontSize),
+                            onApply: raw => setDocFormatField(template.id, 'fontSize', raw),
+                            onFieldBlur: () => persistTemplate(template.id),
+                          },
+                          {
+                            key: 'firstLineIndentCm',
+                            label: 'First line indent (cm)',
+                            value: template.format?.firstLineIndentCm !== undefined ? String(template.format.firstLineIndentCm) : '',
+                            placeholder: formatting.firstLineIndentCm.toFixed(1),
+                            onApply: raw => setDocFormatField(template.id, 'firstLineIndentCm', raw),
+                            onFieldBlur: () => persistTemplate(template.id),
+                          },
+                        ]}
+                      />
                       <DangerButton type="button" onClick={() => handleDeleteTemplate(template)} title="Delete document">
                         <FaTrash />
                       </DangerButton>
@@ -1984,47 +2174,31 @@ const DocumentsPage = ({ isAdmin }) => {
                           />
                         </ParagraphEditorBlock>
                         <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Before title</DocSubtitle>
-                        {(template.beforeTitle || []).length ? (() => {
-                          // Notarial layout standard §3.3: one draggable left-offset handle for
-                          // the whole addressee/signer block (30-65% of the text width, default
-                          // 8.5 cm), persisted per document as a single number that both the PDF
-                          // and Word exports read.
-                          const offsetPercent = template.beforeTitleOffsetPercent ?? DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT;
-                          const textWidthCm = 21 - docFormatting.marginLeftCm - docFormatting.marginRightCm;
-                          return (
-                            <RowLine style={{ marginTop: 2, marginBottom: 2 }}>
-                              <DocSubtitle style={{ fontSize: 10, whiteSpace: 'nowrap' }}>Відступ блоку зліва</DocSubtitle>
-                              <RangeInput
-                                type="range"
-                                min={SIGNER_BLOCK_OFFSET_MIN_PERCENT}
-                                max={SIGNER_BLOCK_OFFSET_MAX_PERCENT}
-                                step={0.1}
-                                value={offsetPercent}
-                                onChange={event => handleSignerBlockOffsetChange(template.id, Number(event.target.value))}
-                                onMouseUp={() => persistTemplate(template.id)}
-                                onTouchEnd={() => persistTemplate(template.id)}
-                                aria-label="Відступ блоку підписанта"
-                                title="Лівий відступ блоку адресата/підписанта - перетягніть, щоб змінити"
-                              />
-                              <DocSubtitle style={{ fontSize: 10, minWidth: 90 }}>
-                                {`${offsetPercent.toFixed(1)}% (≈${(textWidthCm * offsetPercent / 100).toFixed(1)} см)`}
-                              </DocSubtitle>
-                            </RowLine>
-                          );
-                        })() : null}
                         {(template.beforeTitle || []).map((block, index) => {
                           const scope = beforeTitleScope(index);
-                          // beforeTitle has no per-case override (see getTemplateScopeText) -
-                          // always the shared template's raw markup, position hardcoded by the
-                          // template itself (spec: "дані які зліва - їх положення хардкодь"),
-                          // never an admin-facing align/bold picker, and never the template/input/
-                          // text mode cycle paragraphs get (spec batch 21 follow-up: "вони немають
-                          // кнопки {}") - there's nothing to cycle to since it's always this one
-                          // raw-markup surface. Otherwise the same toolbar, same positions, as a
-                          // paragraph row: +, Bold, Italic, Insert-variable, Remove.
+                          // Task 2: the identical toolbar every paragraph row has - the same
+                          // {}/I/T mode cycle, Bold, Italic, Insert-variable, alignment (§1.5),
+                          // formatting (§1.3), delete - no block-specific exceptions. beforeTitle
+                          // still has no per-case override layer (see getTemplateScopeText), so
+                          // all three modes read/write the shared template text: 'template' edits
+                          // the raw markup, 'input' retypes the de-markup'd wording, 'text'
+                          // applies Bold/Italic to a selection in place. In the formatting
+                          // popover the block's "indent" field is the whole signer block's offset
+                          // in percent (§1.3, notarial layout standard §3.3).
+                          const mode = getParagraphMode(template.id, scope);
+                          const isTemplateMode = mode === 'template';
+                          const isInputMode = mode === 'input';
+                          const isTextMode = mode === 'text';
                           const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
-                          const onChange = langKey => event => handleTemplateScopeChange(template.id, scope, langKey, event.target.value);
+                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
+                          const onChange = langKey => event => {
+                            const nextRaw = isTemplateMode
+                              ? event.target.value
+                              : applyPlainTextEdit(rawValue(langKey), event.target.value);
+                            handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
+                          };
                           const onBlur = () => persistTemplate(template.id);
+                          const fieldKind = isTemplateMode ? 'template' : 'input-plain';
                           return (
                             <ParagraphEditorBlock key={`${template.id}-before-title-${index}`}>
                               <ParagraphControlsRow>
@@ -2036,9 +2210,66 @@ const DocumentsPage = ({ isAdmin }) => {
                                   <FaPlus />
                                 </SmallButton>
                                 <RowLine style={{ gap: 6 }}>
-                                  <SmallButton type="button" {...formatButtonProps('bold')} title="Bold the selected text"><FaBold /></SmallButton>
-                                  <SmallButton type="button" {...formatButtonProps('italic')} title="Italicize the selected text"><FaItalic /></SmallButton>
-                                  <SmallButton type="button" onMouseDown={preventSelectionLoss} onClick={openVariablePicker} title="Insert a variable"><FaCode /></SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
+                                    title={PARAGRAPH_MODE_TITLE[mode]}
+                                  >
+                                    {PARAGRAPH_MODE_ICON[mode]}
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={isInputMode}
+                                    {...formatButtonProps('bold')}
+                                    title="Bold the selected text"
+                                  >
+                                    <FaBold />
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={isInputMode}
+                                    {...formatButtonProps('italic')}
+                                    title="Italicize the selected text"
+                                  >
+                                    <FaItalic />
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={!isTemplateMode}
+                                    onMouseDown={preventSelectionLoss}
+                                    onClick={openVariablePicker}
+                                    title="Insert a variable"
+                                  >
+                                    <FaCode />
+                                  </SmallButton>
+                                  <AlignCycleButton
+                                    align={getEffectiveParagraphAlign(block)}
+                                    onCycle={() => handleCycleAlign(template.id, scope)}
+                                  />
+                                  <FormatPopoverButton
+                                    open={openFormatKey === formatPopoverKey(template.id, scope)}
+                                    onToggle={() => toggleFormatPopover(template.id, scope)}
+                                    onClose={() => closeFormatPopover(template.id)}
+                                    buttonTitle="Block formatting - font size (pt) and the signer block's offset (%)"
+                                    fields={[
+                                      {
+                                        key: 'fontSize',
+                                        label: 'Font size (pt)',
+                                        value: getParagraphStyle(block).fontSize !== undefined ? String(getParagraphStyle(block).fontSize) : '',
+                                        placeholder: String(docFormatting.fontSize),
+                                        onApply: raw => setScopeStyleField(template.id, scope, 'fontSize', raw),
+                                        onFieldBlur: () => persistTemplate(template.id),
+                                      },
+                                      {
+                                        key: 'offsetPercent',
+                                        label: 'Offset (%)',
+                                        value: template.beforeTitleOffsetPercent !== undefined ? String(template.beforeTitleOffsetPercent) : '',
+                                        placeholder: DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT.toFixed(1),
+                                        onApply: raw => setBeforeTitleOffset(template.id, raw),
+                                        onFieldBlur: () => persistTemplate(template.id),
+                                      },
+                                    ]}
+                                  />
                                   <DangerButton
                                     type="button"
                                     onClick={() => handleRemoveBeforeTitle(template.id, index)}
@@ -2051,26 +2282,46 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, scope, 'uk')}
-                                      value={rawValue('uk')}
-                                      placeholder="Before title (uk)"
-                                      onFocus={handleRichFieldFocus(template.id, scope, 'uk', 'template')}
-                                      onChange={onChange('uk')}
-                                      onBlur={onBlur}
-                                    />
+                                    {isTextMode ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={rawValue('uk')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        value={displayValue('uk')}
+                                        placeholder="Before title (uk)"
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
+                                        onChange={onChange('uk')}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, scope, 'en')}
-                                      value={rawValue('en')}
-                                      placeholder="Before title (en)"
-                                      onFocus={handleRichFieldFocus(template.id, scope, 'en', 'template')}
-                                      onChange={onChange('en')}
-                                      onBlur={onBlur}
-                                    />
+                                    {isTextMode ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={rawValue('en')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        value={displayValue('en')}
+                                        placeholder="Before title (en)"
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
+                                        onChange={onChange('en')}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                               </ParagraphPair>
@@ -2210,9 +2461,9 @@ const DocumentsPage = ({ isAdmin }) => {
                           };
                           const onBlur = () => (isTemplateMode ? persistTemplate(template.id) : persistDocOverride(template.id));
                           const fieldKind = isTemplateMode ? 'template' : 'override';
-                          // This paragraph's own stored indent override, whichever backend shape
-                          // it's in (consolidated `style` key or legacy flat field).
-                          const paragraphIndentCm = getParagraphStyle(paragraph).indentCm;
+                          // This paragraph's own stored overrides, whichever backend shape they
+                          // are in (consolidated `style` key or legacy flat fields).
+                          const paragraphStyle = getParagraphStyle(paragraph);
                           return (
                             // Boxed together so it's unambiguous which paragraph the toolbar acts
                             // on: the +/mode-switch/Bold/Italic/Delete controls and the paragraph's
@@ -2259,6 +2510,34 @@ const DocumentsPage = ({ isAdmin }) => {
                                   >
                                     <FaCode />
                                   </SmallButton>
+                                  <AlignCycleButton
+                                    align={getEffectiveParagraphAlign(paragraph)}
+                                    onCycle={() => handleCycleAlign(template.id, scope)}
+                                  />
+                                  <FormatPopoverButton
+                                    open={openFormatKey === formatPopoverKey(template.id, scope)}
+                                    onToggle={() => toggleFormatPopover(template.id, scope)}
+                                    onClose={() => closeFormatPopover(template.id)}
+                                    buttonTitle="Paragraph formatting - font size (pt) and first-line indent (cm); empty = inherit the document value"
+                                    fields={[
+                                      {
+                                        key: 'fontSize',
+                                        label: 'Font size (pt)',
+                                        value: paragraphStyle.fontSize !== undefined ? String(paragraphStyle.fontSize) : '',
+                                        placeholder: String(docFormatting.fontSize),
+                                        onApply: raw => setScopeStyleField(template.id, scope, 'fontSize', raw),
+                                        onFieldBlur: () => persistTemplate(template.id),
+                                      },
+                                      {
+                                        key: 'indentCm',
+                                        label: 'First line indent (cm)',
+                                        value: paragraphStyle.indentCm !== undefined ? String(paragraphStyle.indentCm) : '',
+                                        placeholder: docFormatting.firstLineIndentCm.toFixed(1),
+                                        onApply: raw => setScopeStyleField(template.id, scope, 'indentCm', raw),
+                                        onFieldBlur: () => persistTemplate(template.id),
+                                      },
+                                    ]}
+                                  />
                                   <DangerButton
                                     type="button"
                                     onClick={() => handleRemoveParagraph(template.id, index)}
@@ -2268,33 +2547,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </DangerButton>
                                 </RowLine>
                               </ParagraphControlsRow>
-                              <RowLine style={{ marginTop: 2, marginBottom: 2 }}>
-                                <DocSubtitle style={{ fontSize: 10, whiteSpace: 'nowrap' }}>Відступ</DocSubtitle>
-                                <RangeInput
-                                  type="range"
-                                  min={0}
-                                  max={5}
-                                  step={0.05}
-                                  value={paragraphIndentCm ?? docFormatting.firstLineIndentCm}
-                                  onChange={event => handleParagraphIndentChange(template.id, index, Number(event.target.value))}
-                                  onMouseUp={() => persistTemplate(template.id)}
-                                  onTouchEnd={() => persistTemplate(template.id)}
-                                  aria-label={`Відступ абзацу ${index + 1}`}
-                                  title="Перший рядок абзацу - перетягніть, щоб змінити відступ"
-                                />
-                                <DocSubtitle style={{ fontSize: 10, minWidth: 40 }}>
-                                  {(paragraphIndentCm ?? docFormatting.firstLineIndentCm).toFixed(2)} см
-                                </DocSubtitle>
-                                {paragraphIndentCm !== undefined ? (
-                                  <SmallButton
-                                    type="button"
-                                    onClick={() => resetParagraphIndent(template.id, index)}
-                                    title="Скинути до відступу документа"
-                                  >
-                                    ×
-                                  </SmallButton>
-                                ) : null}
-                              </RowLine>
                               {caseModeLocked ? (
                                 <DocSubtitle>Select a case first to edit its resolved values.</DocSubtitle>
                               ) : null}
@@ -2358,6 +2610,14 @@ const DocumentsPage = ({ isAdmin }) => {
                             <FaPlus />
                           </SmallButton>
                         </ParagraphControlsRow>
+                        {/* Task 4: the document exactly as the exported PDF - same generation
+                            pipeline, same props - as the last block of the document. */}
+                        <DocumentsPdfPreview
+                          doc={resolvedDoc}
+                          layout={layout}
+                          formatting={docFormatting}
+                          clinicLogos={clinicLogos}
+                        />
                       </div>
                     ) : null}
                   </DocRow>

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -41,6 +41,7 @@ import {
   emptyDocumentsCatalog,
   getClinicLogo,
   getLayoutLang,
+  getParagraphStyle,
   getParagraphType,
   getTemplateLogoType,
   getTemplateScopeText,
@@ -71,6 +72,7 @@ import {
   validateBirthRegistrationCase,
   validateCaseRecord,
   validateDocumentTemplate,
+  withParagraphStyle,
   withTemplateScopeText,
 } from './documentsCatalogUtils';
 
@@ -858,11 +860,13 @@ const DocumentsPage = ({ isAdmin }) => {
   // clears the override, falling back to the document's own firstLineIndentCm again. Dragging the
   // slider updates local state per tick (persisted on release, like every text field's onBlur);
   // the reset button below is a single discrete click, so it writes directly instead - same
-  // stale-closure hazard applyParagraphStructureChange's own comment explains.
+  // stale-closure hazard applyParagraphStructureChange's own comment explains. The value lives
+  // under the paragraph's single consolidated `style` key on the backend (withParagraphStyle),
+  // together with every other per-paragraph style.
   const withParagraphIndent = (template, index, value) => ({
     ...template,
     paragraphs: (template.paragraphs || []).map((paragraph, paragraphIndex) => (
-      paragraphIndex === index ? { ...paragraph, indentCm: value === null ? undefined : value } : paragraph
+      paragraphIndex === index ? withParagraphStyle(paragraph, { indentCm: value }) : paragraph
     )),
   });
 
@@ -983,10 +987,12 @@ const DocumentsPage = ({ isAdmin }) => {
   const handleInsertBeforeTitle = async (docId, atIndex) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
+    // A fresh block stores no style at all (batch 2026-07-23 B §1.1: nothing redundant) - it
+    // inherits every default; anything set later lands under its consolidated `style` key.
     const blocks = template.beforeTitle || [];
     const nextTemplate = {
       ...template,
-      beforeTitle: [...blocks.slice(0, atIndex), { uk: '', en: '', align: 'left' }, ...blocks.slice(atIndex)],
+      beforeTitle: [...blocks.slice(0, atIndex), { uk: '', en: '' }, ...blocks.slice(atIndex)],
     };
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
@@ -2204,6 +2210,9 @@ const DocumentsPage = ({ isAdmin }) => {
                           };
                           const onBlur = () => (isTemplateMode ? persistTemplate(template.id) : persistDocOverride(template.id));
                           const fieldKind = isTemplateMode ? 'template' : 'override';
+                          // This paragraph's own stored indent override, whichever backend shape
+                          // it's in (consolidated `style` key or legacy flat field).
+                          const paragraphIndentCm = getParagraphStyle(paragraph).indentCm;
                           return (
                             // Boxed together so it's unambiguous which paragraph the toolbar acts
                             // on: the +/mode-switch/Bold/Italic/Delete controls and the paragraph's
@@ -2266,7 +2275,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   min={0}
                                   max={5}
                                   step={0.05}
-                                  value={paragraph?.indentCm ?? docFormatting.firstLineIndentCm}
+                                  value={paragraphIndentCm ?? docFormatting.firstLineIndentCm}
                                   onChange={event => handleParagraphIndentChange(template.id, index, Number(event.target.value))}
                                   onMouseUp={() => persistTemplate(template.id)}
                                   onTouchEnd={() => persistTemplate(template.id)}
@@ -2274,9 +2283,9 @@ const DocumentsPage = ({ isAdmin }) => {
                                   title="Перший рядок абзацу - перетягніть, щоб змінити відступ"
                                 />
                                 <DocSubtitle style={{ fontSize: 10, minWidth: 40 }}>
-                                  {(paragraph?.indentCm ?? docFormatting.firstLineIndentCm).toFixed(2)} см
+                                  {(paragraphIndentCm ?? docFormatting.firstLineIndentCm).toFixed(2)} см
                                 </DocSubtitle>
-                                {paragraph?.indentCm !== undefined ? (
+                                {paragraphIndentCm !== undefined ? (
                                   <SmallButton
                                     type="button"
                                     onClick={() => resetParagraphIndent(template.id, index)}

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -1,7 +1,8 @@
-// Real-DOM regression test for the per-paragraph first-line indent slider (spec: "відступи теж
-// повтори, додай можливість їх совати" - the reference notarial statement indents only its
-// opening declaration, not the paragraphs after it, and the admin needs a draggable control to
-// set that per paragraph, not a single document-wide value).
+// Real-DOM regression test for the per-paragraph formatting popover (batch 2026-07-23 B §1.3/
+// §1.4): font size + first-line indent are numeric plain-text fields in a popover opened from the
+// paragraph toolbar - the old draggable slider is gone. An empty field shows the inherited
+// document value as a ghost placeholder; typing sets the override (stored under the paragraph's
+// single `style` key), clearing the field removes it - no separate reset control.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
@@ -68,38 +69,47 @@ beforeEach(() => {
   listStorageFolderFileNames.mockResolvedValue([]);
 });
 
-describe('spec: per-paragraph first-line indent slider', () => {
-  it('shows each paragraph\'s own indent value, defaulting to the document-wide setting when unset', async () => {
+const PARAGRAPH_FORMAT_TITLE = 'Paragraph formatting - font size (pt) and first-line indent (cm); empty = inherit the document value';
+
+const openParagraphPopover = async paragraphText => {
+  const field = await screen.findByText(paragraphText);
+  // eslint-disable-next-line testing-library/no-node-access
+  const block = field.closest('.paragraph-editor-block');
+  fireEvent.click(within(block).getByTitle(PARAGRAPH_FORMAT_TITLE));
+  return block;
+};
+
+describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', () => {
+  it('renders no range slider for indents or the signer-block offset', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-
-    const indentedField = await screen.findByText('Абзац з відступом.');
-    // eslint-disable-next-line testing-library/no-node-access
-    const indentedBlock = indentedField.closest('.paragraph-editor-block');
-    expect(within(indentedBlock).getByLabelText('Відступ абзацу 1')).toHaveValue('1');
-    expect(within(indentedBlock).getByText('1.00 см')).toBeInTheDocument();
-
-    const plainField = screen.getByText('Абзац без відступу.');
-    // eslint-disable-next-line testing-library/no-node-access
-    const plainBlock = plainField.closest('.paragraph-editor-block');
-    expect(within(plainBlock).getByLabelText('Відступ абзацу 2')).toHaveValue('1.5'); // document default (notarial standard §3.1)
-    expect(within(plainBlock).queryByTitle('Скинути до відступу документа')).not.toBeInTheDocument();
+    await screen.findByText('Абзац з відступом.');
+    expect(screen.queryAllByRole('slider')).toHaveLength(0);
   });
 
-  it('dragging the slider updates the value live and persists the whole template on release', async () => {
+  it('shows the stored override, and the inherited document value only as a ghost placeholder', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const plainField = await screen.findByText('Абзац без відступу.');
-    // eslint-disable-next-line testing-library/no-node-access
-    const plainBlock = plainField.closest('.paragraph-editor-block');
-    const slider = within(plainBlock).getByLabelText('Відступ абзацу 2');
+    const indentedBlock = await openParagraphPopover('Абзац з відступом.');
+    const indentField = within(indentedBlock).getByLabelText('First line indent (cm)');
+    expect(indentField).toHaveValue('1');
 
-    fireEvent.change(slider, { target: { value: '2.5' } });
-    expect(within(plainBlock).getByText('2.50 см')).toBeInTheDocument();
-    expect(set).not.toHaveBeenCalled(); // not yet released
+    fireEvent.click(within(indentedBlock).getByTitle(PARAGRAPH_FORMAT_TITLE)); // close the first popover
+    const plainBlock = await openParagraphPopover('Абзац без відступу.');
+    const inheritedField = within(plainBlock).getByLabelText('First line indent (cm)');
+    expect(inheritedField).toHaveValue('');
+    expect(inheritedField).toHaveAttribute('placeholder', '1.5'); // notarial standard §3.1 default
+  });
 
-    fireEvent.mouseUp(slider);
+  it('typing an indent sets the override under the paragraph `style` key and persists on blur', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const plainBlock = await openParagraphPopover('Абзац без відступу.');
+    const indentField = within(plainBlock).getByLabelText('First line indent (cm)');
+    fireEvent.change(indentField, { target: { value: '2.5' } });
+    fireEvent.blur(indentField);
 
     // All per-paragraph styles persist together under each paragraph's single `style` key - the
     // legacy flat indentCm the first paragraph was loaded with is consolidated on the same write.
@@ -116,14 +126,14 @@ describe('spec: per-paragraph first-line indent slider', () => {
     expect(persistedTemplate.paragraphs.some(paragraph => 'indentCm' in paragraph)).toBe(false);
   });
 
-  it('the reset button clears the override back to the document default and persists immediately', async () => {
+  it('clearing the field removes the override (back to inheriting) - no separate reset control', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const indentedField = await screen.findByText('Абзац з відступом.');
-    // eslint-disable-next-line testing-library/no-node-access
-    const indentedBlock = indentedField.closest('.paragraph-editor-block');
-    fireEvent.click(within(indentedBlock).getByTitle('Скинути до відступу документа'));
+    const indentedBlock = await openParagraphPopover('Абзац з відступом.');
+    const indentField = within(indentedBlock).getByLabelText('First line indent (cm)');
+    fireEvent.change(indentField, { target: { value: '' } });
+    fireEvent.blur(indentField);
 
     // Clearing the only style drops the paragraph's `style` key entirely - nothing redundant
     // stays behind on the backend record.
@@ -136,7 +146,88 @@ describe('spec: per-paragraph first-line indent slider', () => {
         ],
       }),
     ));
-    await waitFor(() => expect(within(indentedBlock).getByLabelText('Відступ абзацу 1')).toHaveValue('1.5'));
-    expect(within(indentedBlock).queryByTitle('Скинути до відступу документа')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Скинути до відступу документа')).not.toBeInTheDocument();
+  });
+
+  it('a per-paragraph font size persists under the same `style` key as the indent', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const indentedBlock = await openParagraphPopover('Абзац з відступом.');
+    const sizeField = within(indentedBlock).getByLabelText('Font size (pt)');
+    expect(sizeField).toHaveValue('');
+    expect(sizeField).toHaveAttribute('placeholder', '12');
+    fireEvent.change(sizeField, { target: { value: '10' } });
+    fireEvent.blur(sizeField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        paragraphs: [
+          expect.objectContaining({ style: { indentCm: 1, fontSize: 10 } }),
+          expect.anything(),
+        ],
+      }),
+    ));
+  });
+});
+
+describe('spec: document-level formatting popover in the header row (§1.2)', () => {
+  it('stores typed defaults as the document\'s sparse format overrides, cleared field = shared value', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    await screen.findByText('Абзац з відступом.');
+
+    fireEvent.click(screen.getByTitle('Document formatting - font size (pt) and first-line indent (cm) inherited by all paragraphs'));
+    const sizeField = screen.getByLabelText('Font size (pt)');
+    expect(sizeField).toHaveValue('');
+    expect(sizeField).toHaveAttribute('placeholder', '12'); // the shared reference default
+    fireEvent.change(sizeField, { target: { value: '14' } });
+    fireEvent.blur(sizeField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({ format: { fontSize: 14 } }),
+    ));
+  });
+});
+
+describe('spec: one alignment button per paragraph, MS Word cycle (§1.5)', () => {
+  it('shows the effective alignment (justify for body text) and one click stores the next state', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const field = await screen.findByText('Абзац без відступу.');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = field.closest('.paragraph-editor-block');
+    const alignButton = within(block).getByLabelText('Вирівнювання: justify');
+
+    fireEvent.click(alignButton); // Justify → Left (the cycle wraps around)
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        paragraphs: [
+          expect.anything(),
+          expect.objectContaining({ style: { align: 'left' } }),
+        ],
+      }),
+    ));
+    await within(block).findByLabelText('Вирівнювання: left');
+  });
+});
+
+describe('spec: PDF-true preview block (Task 4)', () => {
+  it('renders a collapsible preview block as the last block of the expanded document', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    await screen.findByText('Абзац з відступом.');
+
+    expect(screen.getByText('PDF preview')).toBeInTheDocument();
+    // Default expanded (spec §4.2) - the collapse control is showing.
+    expect(screen.getByTitle('Collapse the PDF preview')).toBeInTheDocument();
+    // Lazy: nothing generated until the block is actually visible (no IntersectionObserver in
+    // jsdom, so it stays in the not-yet-visible state).
+    expect(screen.getByText('Прев\'ю згенерується, щойно блок буде видно.')).toBeInTheDocument();
   });
 });

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -101,15 +101,19 @@ describe('spec: per-paragraph first-line indent slider', () => {
 
     fireEvent.mouseUp(slider);
 
+    // All per-paragraph styles persist together under each paragraph's single `style` key - the
+    // legacy flat indentCm the first paragraph was loaded with is consolidated on the same write.
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({
         paragraphs: [
-          expect.objectContaining({ indentCm: 1 }),
-          expect.objectContaining({ indentCm: 2.5 }),
+          expect.objectContaining({ style: { indentCm: 1 } }),
+          expect.objectContaining({ style: { indentCm: 2.5 } }),
         ],
       }),
     ));
+    const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
+    expect(persistedTemplate.paragraphs.some(paragraph => 'indentCm' in paragraph)).toBe(false);
   });
 
   it('the reset button clears the override back to the document default and persists immediately', async () => {
@@ -121,11 +125,13 @@ describe('spec: per-paragraph first-line indent slider', () => {
     const indentedBlock = indentedField.closest('.paragraph-editor-block');
     fireEvent.click(within(indentedBlock).getByTitle('Скинути до відступу документа'));
 
+    // Clearing the only style drops the paragraph's `style` key entirely - nothing redundant
+    // stays behind on the backend record.
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({
         paragraphs: [
-          expect.objectContaining({ indentCm: undefined }),
+          expect.not.objectContaining({ style: expect.anything() }),
           expect.anything(),
         ],
       }),

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -81,7 +81,7 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     expect(screen.queryByText('Bold')).not.toBeInTheDocument();
   });
 
-  it('has the same +/Bold/Italic/Insert-variable/Remove buttons as a paragraph row, but no template/input/text mode button (spec follow-up)', async () => {
+  it('exposes the identical paragraph-row button set, including the {}/I/T mode cycle, alignment and formatting (Task 2)', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
@@ -94,10 +94,12 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     expect(within(block).getByTitle('Italicize the selected text')).toBeInTheDocument();
     expect(within(block).getByTitle('Insert a variable')).toBeInTheDocument();
     expect(within(block).getByTitle('Remove this block')).toBeInTheDocument();
-    // No template/input/text mode cycle - beforeTitle always edits the raw markup directly.
-    expect(within(block).queryByText('{}')).not.toBeInTheDocument();
-    expect(within(block).queryByText('I')).not.toBeInTheDocument();
-    expect(within(block).queryByText('T')).not.toBeInTheDocument();
+    // The same {}/I/T mode cycle as a paragraph row (Task 2: no block-specific exceptions);
+    // beforeTitle starts in template mode since raw markup is its canonical surface.
+    expect(within(block).getByText('{}')).toBeInTheDocument();
+    // §1.5 alignment button + §1.3 formatting popover button complete the unified set.
+    expect(within(block).getByLabelText(/Вирівнювання:/)).toBeInTheDocument();
+    expect(within(block).getByTitle("Block formatting - font size (pt) and the signer block's offset (%)")).toBeInTheDocument();
   });
 
   it('"+" inserts a new block above this one, persisted straight to the template', async () => {
@@ -155,22 +157,25 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     ));
   });
 
-  // Notarial layout standard §3.3: the signer block gets one left-offset handle for the whole
-  // block (30-65% of the text width, default ≈47% = 8.5 cm), persisted per document as a single
-  // beforeTitleOffsetPercent field - not the old per-block width slider.
-  it('the signer-block offset handle defaults to 8.5 cm (≈47%) and persists a dragged value on release', async () => {
+  // Notarial layout standard §3.3 + batch 2026-07-23 B §1.3/§1.4: the signer-block offset is a
+  // numeric plain-text percent field in the block's formatting popover (default ≈47.2% = 8.5 cm)
+  // - the old draggable handle is gone.
+  it('the signer-block offset is edited as a number in % in the formatting popover, no slider', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
-    const slider = screen.getByLabelText('Відступ блоку підписанта');
-    expect(slider).toHaveValue('47.2');
+    const textarea = await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = textarea.closest('.paragraph-editor-block');
+    expect(screen.queryAllByRole('slider')).toHaveLength(0);
 
-    fireEvent.change(slider, { target: { value: '60' } });
-    expect(screen.getByText('60.0% (≈10.8 см)')).toBeInTheDocument();
-    expect(set).not.toHaveBeenCalled(); // not yet released
+    fireEvent.click(within(block).getByTitle("Block formatting - font size (pt) and the signer block's offset (%)"));
+    const offsetField = within(block).getByLabelText('Offset (%)');
+    expect(offsetField).toHaveValue('');
+    expect(offsetField).toHaveAttribute('placeholder', '47.2'); // 8.5 cm of the 18 cm text width
 
-    fireEvent.mouseUp(slider);
+    fireEvent.change(offsetField, { target: { value: '60' } });
+    fireEvent.blur(offsetField);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -243,11 +243,14 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
 // before the title (structure §3.4).
 const isBlankBlockText = value => !String(value || '').trim();
 
+// An explicitly aligned block (the §1.5 alignment button, stored under the block's `style` key)
+// overrides the strip's notarial default: bold caption flush-left, regular data justified.
 const SignerBlockLine = ({ block, langKey, cellStyles }) => (
   <Text
     style={[
       cellStyles.beforeTitle,
-      block.bold ? { textAlign: 'left', fontWeight: 700 } : { textAlign: 'justify' },
+      block.bold ? { fontWeight: 700 } : undefined,
+      { textAlign: block.align || (block.bold ? 'left' : 'justify') },
       block.fontSize !== undefined ? { fontSize: block.fontSize } : undefined,
     ]}
   >

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -159,13 +159,17 @@ const LogoBlock = ({ type, isBilingual, cellStyles, logoWidth, longLogoWidth, cl
 
 // batch 16 §17: an explicit `align` on a paragraph overrides the default alignment (justified
 // body / flush-left heading) - never inferred from the text itself. `indentCm` (spec: the
-// reference notarial statement indents only its opening declaration, not every paragraph) works
-// the same way - undefined leaves cellStyle's own document-wide firstLineIndentCm in place.
+// reference notarial statement indents only its opening declaration, not every paragraph) and
+// `fontSize` (batch 2026-07-23 B §1.1: a per-paragraph pt override of the document's font size)
+// work the same way - undefined leaves cellStyle's own document-wide value in place. All three
+// arrive already resolved from the paragraph's consolidated `style` key (buildGeneratedDocument).
 const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBreaks }) => {
   const wrap = allowsParagraphInternalBreak(paragraph, allowPageBreaks);
   const cellStyle = isParagraphBold(paragraph) ? cellStyles.paragraphHeading : cellStyles.paragraph;
   const alignStyle = paragraph.align ? { textAlign: paragraph.align } : undefined;
   const indentStyle = paragraph.indentCm !== undefined ? { textIndent: paragraph.indentCm * CM_TO_PT } : undefined;
+  // lineHeight in the cell styles is a unitless multiplier, so it scales with this automatically.
+  const sizeStyle = paragraph.fontSize !== undefined ? { fontSize: paragraph.fontSize } : undefined;
   // The indent this paragraph actually resolves to, re-applied to a leading bold/italic run
   // (see FormattedRuns) since react-pdf never inherits textIndent into a nested <Text>.
   const firstLineIndent = indentStyle ? indentStyle.textIndent : (cellStyle.textIndent || 0);
@@ -178,12 +182,12 @@ const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBrea
   if (isBilingual) {
     return (
       <View style={styles.row} wrap={wrap}>
-        <Text style={[cellStyle, cellStyles.leftCell, alignStyle, indentStyle]}>{lineOf(paragraph.uk)}</Text>
-        <Text style={[cellStyle, cellStyles.rightCell, alignStyle, indentStyle]}>{lineOf(paragraph.en)}</Text>
+        <Text style={[cellStyle, cellStyles.leftCell, alignStyle, indentStyle, sizeStyle]}>{lineOf(paragraph.uk)}</Text>
+        <Text style={[cellStyle, cellStyles.rightCell, alignStyle, indentStyle, sizeStyle]}>{lineOf(paragraph.en)}</Text>
       </View>
     );
   }
-  return <Text style={[cellStyle, alignStyle, indentStyle]} wrap={wrap}>{lineOf(paragraph[lang])}</Text>;
+  return <Text style={[cellStyle, alignStyle, indentStyle, sizeStyle]} wrap={wrap}>{lineOf(paragraph[lang])}</Text>;
 };
 
 // The single-language 2-column layout (spec §4: newspaper-style, one language flowing across two
@@ -240,7 +244,13 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
 const isBlankBlockText = value => !String(value || '').trim();
 
 const SignerBlockLine = ({ block, langKey, cellStyles }) => (
-  <Text style={[cellStyles.beforeTitle, block.bold ? { textAlign: 'left', fontWeight: 700 } : { textAlign: 'justify' }]}>
+  <Text
+    style={[
+      cellStyles.beforeTitle,
+      block.bold ? { textAlign: 'left', fontWeight: 700 } : { textAlign: 'justify' },
+      block.fontSize !== undefined ? { fontSize: block.fontSize } : undefined,
+    ]}
+  >
     <FormattedRuns text={block[langKey]} />
   </Text>
 );

--- a/src/components/DocumentsPdfPreview.jsx
+++ b/src/components/DocumentsPdfPreview.jsx
@@ -1,0 +1,291 @@
+// PDF-true preview under each document (batch 2026-07-23 B §4): runs the exact PDF generation
+// pipeline the export button uses (same component, same props, same data - real PDF bytes), then
+// rasterizes the pages via pdf.js at container width × devicePixelRatio. Never an HTML/CSS
+// approximation - if this differs from the exported file, the preview is wrong, not the file.
+// Multiple pages present as a horizontal one-page-per-view carousel (swipe + arrows, a laconic
+// "1 / N" counter, no autoplay, no thumbnails); a single page renders with no carousel chrome.
+// Regeneration is debounced ~500 ms and the previous render stays visible while a new one is
+// prepared - only a subtle updating badge, never a flicker to blank.
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { FaChevronDown, FaChevronLeft, FaChevronRight, FaChevronUp } from 'react-icons/fa';
+
+const PreviewBlock = styled.div.attrs({ className: 'pdf-preview-block' })`
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  padding: 6px 8px 8px;
+  margin-top: 10px;
+  background: rgba(162, 121, 63, 0.025);
+`;
+
+const PreviewHead = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
+const PreviewTitle = styled.div`
+  color: var(--km-muted);
+  font-size: 10.5px;
+  font-weight: 700;
+`;
+
+const PreviewHeadControls = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const UpdatingBadge = styled.span`
+  color: var(--km-muted);
+  font-size: 10px;
+  font-weight: 600;
+`;
+
+const ChromeButton = styled.button`
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
+  border-radius: 5px;
+  min-height: 24px;
+  min-width: 26px;
+  padding: 3px 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+`;
+
+// touch-action pan-y keeps vertical page scrolling native while horizontal swipes drive the
+// carousel.
+const PageViewport = styled.div`
+  margin-top: 6px;
+  touch-action: pan-y;
+
+  canvas {
+    display: block;
+    width: 100%;
+    border: 1px solid var(--km-border);
+    border-radius: 4px;
+    background: #fff;
+  }
+`;
+
+const CarouselRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 6px;
+`;
+
+const PageCounter = styled.span`
+  color: var(--km-muted);
+  font-size: 10.5px;
+  font-weight: 700;
+  min-width: 44px;
+  text-align: center;
+`;
+
+const PreviewHint = styled.div`
+  color: var(--km-muted);
+  font-size: 11px;
+  padding: 8px 0 2px;
+`;
+
+const SWIPE_THRESHOLD_PX = 40;
+const REGENERATE_DEBOUNCE_MS = 500;
+
+const DocumentsPdfPreview = ({ doc, layout, formatting, clinicLogos }) => {
+  // Collapsible like the page's other blocks, default expanded (spec §4.2).
+  const [expanded, setExpanded] = useState(true);
+  // Lazy: nothing is generated until the block has actually been on screen (spec §4.2). Without
+  // IntersectionObserver (jsdom/tests) the preview simply stays un-generated.
+  const [visible, setVisible] = useState(false);
+  const [pageCount, setPageCount] = useState(0);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [updating, setUpdating] = useState(false);
+  const [error, setError] = useState('');
+  // Bumped when a freshly generated document is ready, so the page-render effect redraws the
+  // current page even when pageIndex itself didn't change.
+  const [renderedGeneration, setRenderedGeneration] = useState(0);
+
+  const containerRef = useRef(null);
+  const canvasRef = useRef(null);
+  const pdfDocumentRef = useRef(null);
+  const generationRef = useRef(0);
+  const touchStartXRef = useRef(null);
+  // Read by the debounced generator at fire time, so the payload is always the latest one even
+  // though the effect below is keyed only on the cheap signature string.
+  const payloadRef = useRef(null);
+  payloadRef.current = {
+    doc, layout, formatting, clinicLogos,
+  };
+
+  // Cheap change signature (spec §4.3: regenerate on any data or formatting change). Logo data
+  // URLs can be near a megabyte, so variants participate by name + layout assignment only.
+  const signature = useMemo(
+    () => JSON.stringify([doc, layout, formatting, (clinicLogos || []).map(variant => `${variant.fileName}:${variant.layout}`)]),
+    [doc, layout, formatting, clinicLogos],
+  );
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return undefined;
+    const node = containerRef.current;
+    if (!node) return undefined;
+    const observer = new IntersectionObserver(entries => {
+      if (entries.some(entry => entry.isIntersecting)) setVisible(true);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  // Release the pdf.js document when the preview unmounts.
+  useEffect(() => () => {
+    generationRef.current += 1;
+    pdfDocumentRef.current?.destroy?.();
+    pdfDocumentRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (!expanded || !visible) return undefined;
+    const generation = generationRef.current + 1;
+    generationRef.current = generation;
+    setUpdating(true);
+    const timer = setTimeout(async () => {
+      try {
+        const payload = payloadRef.current;
+        const [{ pdf }, documentsModule, engine] = await Promise.all([
+          import('@react-pdf/renderer'),
+          import('./DocumentsPdfDocument'),
+          import('./documentsPdfPreviewEngine'),
+        ]);
+        documentsModule.ensureDocumentsPdfFontsRegistered();
+        // Exactly the export call (see handleGeneratePdf): one document, the same resolved doc /
+        // layout / per-document formatting / clinic logos.
+        const blob = await pdf(React.createElement(documentsModule.default, {
+          documents: [payload.doc],
+          layout: payload.layout,
+          formatting: payload.formatting,
+          clinicLogos: payload.clinicLogos,
+        })).toBlob();
+        if (generationRef.current !== generation) return;
+        const nextPdfDocument = await engine.loadPdfDocument(await blob.arrayBuffer());
+        if (generationRef.current !== generation) {
+          nextPdfDocument.destroy?.();
+          return;
+        }
+        // The old document (and its canvas render) stays up until this exact moment - swapping
+        // here is what makes regeneration flicker-free.
+        pdfDocumentRef.current?.destroy?.();
+        pdfDocumentRef.current = nextPdfDocument;
+        setPageCount(nextPdfDocument.numPages);
+        setPageIndex(previous => Math.min(previous, nextPdfDocument.numPages - 1));
+        setError('');
+        setRenderedGeneration(generation);
+      } catch (previewError) {
+        console.error('Unable to build the PDF preview', previewError);
+        if (generationRef.current === generation) setError('Не вдалося побудувати прев\'ю PDF.');
+      } finally {
+        if (generationRef.current === generation) setUpdating(false);
+      }
+    }, REGENERATE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [signature, expanded, visible]);
+
+  // Draws the current page of the current document onto the one visible canvas.
+  useEffect(() => {
+    const pdfDocument = pdfDocumentRef.current;
+    const canvas = canvasRef.current;
+    if (!renderedGeneration || !pdfDocument || !canvas) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const engine = await import('./documentsPdfPreviewEngine');
+        if (cancelled) return;
+        const cssWidth = containerRef.current?.clientWidth || 600;
+        await engine.renderPdfPageToCanvas(
+          pdfDocument,
+          pageIndex + 1,
+          canvas,
+          cssWidth,
+          (typeof window !== 'undefined' && window.devicePixelRatio) || 1,
+        );
+      } catch (renderError) {
+        if (!cancelled) console.error('Unable to draw the PDF preview page', renderError);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [renderedGeneration, pageIndex]);
+
+  const stepPage = delta => setPageIndex(previous => Math.min(Math.max(previous + delta, 0), Math.max(pageCount - 1, 0)));
+
+  const handleTouchStart = event => {
+    touchStartXRef.current = event.touches[0]?.clientX ?? null;
+  };
+
+  const handleTouchEnd = event => {
+    const startX = touchStartXRef.current;
+    touchStartXRef.current = null;
+    if (startX === null || pageCount < 2) return;
+    const deltaX = (event.changedTouches[0]?.clientX ?? startX) - startX;
+    if (Math.abs(deltaX) >= SWIPE_THRESHOLD_PX) stepPage(deltaX < 0 ? 1 : -1);
+  };
+
+  return (
+    <PreviewBlock ref={containerRef}>
+      <PreviewHead>
+        <PreviewTitle>PDF preview</PreviewTitle>
+        <PreviewHeadControls>
+          {updating ? <UpdatingBadge>Оновлення…</UpdatingBadge> : null}
+          <ChromeButton
+            type="button"
+            onClick={() => setExpanded(previous => !previous)}
+            title={expanded ? 'Collapse the PDF preview' : 'Expand the PDF preview'}
+          >
+            {expanded ? <FaChevronUp /> : <FaChevronDown />}
+          </ChromeButton>
+        </PreviewHeadControls>
+      </PreviewHead>
+      {expanded ? (
+        <>
+          {error ? <PreviewHint>{error}</PreviewHint> : null}
+          {!error && !pageCount ? (
+            <PreviewHint>{visible ? 'Прев\'ю генерується…' : 'Прев\'ю згенерується, щойно блок буде видно.'}</PreviewHint>
+          ) : null}
+          <PageViewport
+            style={pageCount ? undefined : { display: 'none' }}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+          >
+            <canvas ref={canvasRef} aria-label="Прев'ю сторінки PDF" />
+          </PageViewport>
+          {pageCount > 1 ? (
+            <CarouselRow>
+              <ChromeButton type="button" onClick={() => stepPage(-1)} disabled={pageIndex === 0} title="Попередня сторінка">
+                <FaChevronLeft />
+              </ChromeButton>
+              <PageCounter>{`${pageIndex + 1} / ${pageCount}`}</PageCounter>
+              <ChromeButton type="button" onClick={() => stepPage(1)} disabled={pageIndex === pageCount - 1} title="Наступна сторінка">
+                <FaChevronRight />
+              </ChromeButton>
+            </CarouselRow>
+          ) : null}
+        </>
+      ) : null}
+    </PreviewBlock>
+  );
+};
+
+export default DocumentsPdfPreview;

--- a/src/components/DocumentsRenderers.smoke.test.js
+++ b/src/components/DocumentsRenderers.smoke.test.js
@@ -215,6 +215,116 @@ describe('Documents DOCX builder (real docx Packer)', () => {
     const indentCount = (xml.match(/w:firstLine="567"/g) || []).length;
     expect(indentCount).toBe(1);
   }, 20000);
+
+  // batch 2026-07-23 B §3: empty lines separate the notarial blocks and must survive into the
+  // Word output - an in-paragraph blank line ("\n\n") as two real <w:br/> line breaks, an empty
+  // paragraph as its own full-height paragraph, never silently dropped by a TextRun that
+  // doesn't understand "\n".
+  it('preserves an in-paragraph blank line as real <w:br/> breaks in the Word output', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = {
+      id: 'blank-lines-doc',
+      allowPageBreaks: false,
+      logo: null,
+      title: { uk: 'Тест', en: 'Test' },
+      paragraphs: [
+        { type: 'text', uk: 'Перший рядок.\n\nПісля порожнього рядка.', en: 'First line.\n\nAfter the blank line.' },
+        { type: 'text', uk: '', en: '' },
+        { type: 'text', uk: 'Останній абзац.', en: 'Last paragraph.' },
+      ],
+    };
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'one-column-uk' });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const xml = await zip.file('word/document.xml').async('string');
+    // "\n\n" = two explicit line breaks = one full blank line at the current line height.
+    const breakCount = (xml.match(/<w:br\/>/g) || []).length;
+    expect(breakCount).toBe(2);
+    // The text on both sides of the blank line is still there, un-merged.
+    expect(xml).toContain('Перший рядок.');
+    expect(xml).toContain('Після порожнього рядка.');
+  }, 20000);
+
+  // batch 2026-07-23 B §1.1/§1.6: a per-paragraph fontSize override (stored under the paragraph's
+  // one `style` key, resolved flat by buildGeneratedDocument) must reach the Word output as that
+  // paragraph's own run size, leaving every other paragraph at the document default.
+  it('renders a per-paragraph fontSize override as that paragraph\'s own run size', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = {
+      id: 'font-size-doc',
+      allowPageBreaks: false,
+      logo: null,
+      title: { uk: 'Тест', en: 'Test' },
+      paragraphs: [
+        { type: 'text', uk: 'Дрібний абзац.', en: 'Small paragraph.', fontSize: 10 },
+        { type: 'text', uk: 'Звичайний абзац.', en: 'Normal paragraph.' },
+      ],
+    };
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'one-column-uk' });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const xml = await zip.file('word/document.xml').async('string');
+    // 10 pt = 20 half-points, only on the overridden paragraph's run.
+    expect(xml).toMatch(/<w:sz w:val="20"\/>[\s\S]*?<w:t[^>]*>Дрібний абзац.<\/w:t>/);
+    expect(xml).toMatch(/<w:t[^>]*>Звичайний абзац.<\/w:t>/);
+  }, 20000);
+});
+
+// batch 2026-07-23 B §1.6/§3: the PDF renderer must accept the same per-paragraph style
+// resolution (fontSize/align/indent) and blank-line content the Word builder does.
+describe('Documents PDF renderer - per-paragraph styles + blank lines', () => {
+  it('renders fontSize/align overrides and in-paragraph blank lines without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+
+    const doc = {
+      id: 'styled-doc',
+      allowPageBreaks: false,
+      logo: null,
+      title: { uk: 'Тест', en: 'Test' },
+      beforeTitle: [{ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: 'TO WHOM IT MAY CONCERN', bold: true, align: 'right', fontSize: 11 }],
+      paragraphs: [
+        { type: 'text', uk: 'Дрібний і по центру.', en: 'Small and centered.', fontSize: 9, align: 'center' },
+        { type: 'text', uk: 'Перший рядок.\n\nПісля порожнього рядка.', en: 'First.\n\nAfter blank.' },
+        { type: 'text', uk: '', en: '' },
+        { type: 'text', uk: 'Останній абзац.', en: 'Last paragraph.' },
+      ],
+    };
+    const element = React.createElement(DocumentsPdfDocument, {
+      documents: [doc],
+      layout: 'two-column',
+      clinicLogos: [],
+    });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
 });
 
 describe('Documents PDF renderer - single-language 2-column layout + divider + inline formatting (batch 13 §1/§3/§4)', () => {

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -134,7 +134,10 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
     // a given case record happens to carry.
     if (collection === 'cases') catalog.parties.cases = catalog.parties.cases.map(normalizeCaseRecord);
   });
-  catalog.documents = toRecordsWithIdFromKey(rawTemplates).filter(record => isPlainObject(record));
+  // Same read-time migration idea as normalizeCaseRecord, for templates: per-paragraph styles
+  // are consolidated under each paragraph's single `style` key right at ingestion, so nothing
+  // downstream ever has to branch on which shape a stored paragraph happens to carry.
+  catalog.documents = toRecordsWithIdFromKey(rawTemplates).filter(record => isPlainObject(record)).map(consolidateTemplateStyles);
   // Primary (batch 17 §1/§2): a clinic's own `logo` field, alongside its name/legalName/etc. - a
   // clinic is shared across many cases, so its logo was never really case-scoped to begin with.
   catalog.parties.clinics.forEach(clinic => {
@@ -207,7 +210,9 @@ export const parseDocumentsTechnicalInput = rawText => {
     // documents shape right away, same as normalizeDocumentsCatalog.
     if (collection === 'cases') incoming.parties.cases = incoming.parties.cases.map(normalizeCaseRecord);
   });
-  incoming.documents = toRecordsWithIdFromKey(templatesSource).filter(record => isPlainObject(record));
+  // Pasted templates get the same style consolidation as normalizeDocumentsCatalog - a paragraph
+  // row copied out of the backend (either shape) merges in with its full style intact.
+  incoming.documents = toRecordsWithIdFromKey(templatesSource).filter(record => isPlainObject(record)).map(consolidateTemplateStyles);
 
   // Primary (batch 17 §1/§2): each clinic's own `logo` field.
   incoming.parties.clinics.forEach(clinic => {
@@ -1107,13 +1112,14 @@ export const isSectionHeading = text => {
   return SECTION_HEADING_PATTERN.test(trimmed);
 };
 
-// Auto-detection (above) can still be wrong for an edge case the admin spots visually; `bold` on
-// the paragraph itself (true/false) explicitly overrides it either way, undefined falls back to
+// Auto-detection (above) can still be wrong for an edge case the admin spots visually; an
+// explicit bold on the paragraph (true/false, under its consolidated `style` key or the legacy
+// flat field - see getParagraphStyle) overrides it either way, undefined falls back to
 // isSectionHeading. Bold is a whole-paragraph property (both languages together), matching how
 // real section headings actually look in these bilingual documents.
 export const isParagraphBold = paragraph => {
-  if (paragraph?.bold === true) return true;
-  if (paragraph?.bold === false) return false;
+  const { bold } = getParagraphStyle(paragraph);
+  if (bold !== undefined) return bold;
   return isSectionHeading(paragraph?.uk) || isSectionHeading(paragraph?.en);
 };
 
@@ -1176,6 +1182,79 @@ export const normalizeBlockAlign = align => (ALLOWED_BLOCK_ALIGNMENTS.includes(a
 export const DEFAULT_BLOCK_WIDTH_PERCENT = 50;
 export const normalizeBlockWidth = width => clampNumber(width, 10, 100, DEFAULT_BLOCK_WIDTH_PERCENT);
 
+// --- Consolidated per-paragraph styles (batch 2026-07-23 B §1.1) -----------------------------
+// Everything visual one paragraph (or beforeTitle block) carries lives together under its single
+// `style` key on the backend record: `{ fontSize?, indentCm?, align?, bold?, width? }` - only the
+// keys the admin actually set, so a paragraph without a key inherits the document default and
+// nothing redundant is stored. One key for all of it means a whole paragraph row copied on the
+// backend and pasted into another document brings every style with it, and a parser never has to
+// hunt for scattered flat fields. Legacy records stored the same values flat on the record
+// (bold/align/indentCm/width) - those are still read (a `style` entry wins per field), and every
+// write path re-consolidates them under `style` via withParagraphStyle.
+export const PARAGRAPH_STYLE_KEYS = ['fontSize', 'indentCm', 'align', 'bold', 'width'];
+
+// Per-field validation, shared by reads and writes: an invalid/cleared value normalizes to
+// undefined (= the key is absent, the paragraph inherits), never to a silently-substituted
+// default that would then be persisted as if the admin had set it.
+const normalizeStyleValue = (key, value) => {
+  if (value === undefined || value === null) return undefined;
+  switch (key) {
+    case 'fontSize': return clampNumber(value, 6, 32, undefined);
+    case 'indentCm': return clampNumber(value, 0, 5, undefined);
+    case 'align': return ALLOWED_BLOCK_ALIGNMENTS.includes(value) ? value : undefined;
+    case 'bold': return Boolean(value);
+    case 'width': return clampNumber(value, 10, 100, undefined);
+    default: return undefined;
+  }
+};
+
+// The normalized sparse style of a paragraph/beforeTitle block, whichever shape the record is in.
+export const getParagraphStyle = record => {
+  const consolidated = isPlainObject(record?.style) ? record.style : {};
+  const style = {};
+  PARAGRAPH_STYLE_KEYS.forEach(key => {
+    const raw = consolidated[key] !== undefined ? consolidated[key] : record?.[key];
+    const value = normalizeStyleValue(key, raw);
+    if (value !== undefined) style[key] = value;
+  });
+  return style;
+};
+
+// The record with `partial` merged into its consolidated style: a null/undefined value clears
+// that key (the paragraph inherits the document default again), an empty result drops the `style`
+// key entirely, and any legacy flat style fields are stripped - so from the first write onward
+// the consolidated key is the record's single style source of truth.
+export const withParagraphStyle = (record, partial = {}) => {
+  const style = getParagraphStyle(record);
+  Object.keys(partial || {}).forEach(key => {
+    if (!PARAGRAPH_STYLE_KEYS.includes(key)) return;
+    const value = normalizeStyleValue(key, partial[key]);
+    if (value === undefined) delete style[key];
+    else style[key] = value;
+  });
+  const rest = { ...record };
+  delete rest.style;
+  PARAGRAPH_STYLE_KEYS.forEach(key => {
+    delete rest[key];
+  });
+  return Object.keys(style).length ? { ...rest, style } : rest;
+};
+
+// Read-time migration for one template (idempotent, same spirit as normalizeCaseRecord): every
+// paragraph and beforeTitle block re-expressed with its styles consolidated under `style`, so the
+// next persist writes the new shape without a separate migration pass.
+export const consolidateTemplateStyles = template => {
+  if (!isPlainObject(template)) return template;
+  const next = { ...template };
+  if (template.paragraphs !== undefined) {
+    next.paragraphs = toArray(template.paragraphs).map(paragraph => (isPlainObject(paragraph) ? withParagraphStyle(paragraph) : paragraph));
+  }
+  if (template.beforeTitle !== undefined) {
+    next.beforeTitle = toArray(template.beforeTitle).map(block => (isPlainObject(block) ? withParagraphStyle(block) : block));
+  }
+  return next;
+};
+
 // The addressee/signer block's left offset (notarial layout standard): the whole beforeTitle
 // group renders as one strip from this offset to the right margin, in both the PDF and Word
 // exports. Stored per document as a single number - percent of the text width, so the same value
@@ -1191,13 +1270,17 @@ export const normalizeSignerBlockOffsetPercent = value => clampNumber(
   DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
 );
 
-const resolveBeforeTitleBlocks = (template, context) => toArray(template?.beforeTitle).map(block => ({
-  align: normalizeBlockAlign(block?.align),
-  bold: Boolean(block?.bold),
-  width: normalizeBlockWidth(block?.width),
-  uk: fillPlaceholders(localizedText(block, 'uk'), context, 'uk'),
-  en: fillPlaceholders(localizedText(block, 'en'), context, 'en'),
-}));
+const resolveBeforeTitleBlocks = (template, context) => toArray(template?.beforeTitle).map(block => {
+  const style = getParagraphStyle(block);
+  return {
+    align: normalizeBlockAlign(style.align),
+    bold: Boolean(style.bold),
+    width: normalizeBlockWidth(style.width),
+    fontSize: style.fontSize,
+    uk: fillPlaceholders(localizedText(block, 'uk'), context, 'uk'),
+    en: fillPlaceholders(localizedText(block, 'en'), context, 'en'),
+  };
+});
 
 // --- Template-level languages/columns (batch 16 §15/§16) -------------------------------------
 // A template can pin its own language set + column count (e.g. `languages: ["uk"], columns: 1` for
@@ -1310,15 +1393,18 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
         return { type, uk: paragraph?.uk || '', en: paragraph?.en || '' };
       }
       const paragraphOverride = overrideAt(override.paragraphs, index);
+      // Every visual override of this paragraph comes from its one consolidated `style` key (or
+      // the legacy flat fields, see getParagraphStyle) - resolved here into flat fields for the
+      // renderers. An absent key means "inherit the document's own formatting" (fontSize /
+      // firstLineIndentCm / default alignment), same as every paragraph did before overrides
+      // existed.
+      const style = getParagraphStyle(paragraph);
       return {
         type,
-        bold: paragraph?.bold,
-        align: paragraph?.align !== undefined ? normalizeBlockAlign(paragraph.align) : undefined,
-        // Per-paragraph first-line indent override (spec: the reference notarial statement
-        // indents its opening declaration but not the signature/registration lines that follow -
-        // one document-wide firstLineIndentCm can't express that). undefined = inherit the
-        // document's own formatting.firstLineIndentCm, same as every paragraph did before this.
-        indentCm: paragraph?.indentCm !== undefined ? clampNumber(paragraph.indentCm, 0, 5, undefined) : undefined,
+        bold: style.bold,
+        align: style.align,
+        indentCm: style.indentCm,
+        fontSize: style.fontSize,
         uk: capitalizeFirstLetter(overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk'))),
         en: capitalizeFirstLetter(overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en'))),
       };

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1240,6 +1240,53 @@ export const withParagraphStyle = (record, partial = {}) => {
   return Object.keys(style).length ? { ...rest, style } : rest;
 };
 
+// One alignment button per paragraph toolbar, MS Word logic (batch 2026-07-23 B §1.5): each
+// click cycles to the next state, and Justify is in the cycle because the Заява's body/notary
+// blocks are justified per the notarial standard - without it one click would make justify
+// unreachable. The effective alignment (what the button's icon shows and what a never-clicked
+// paragraph renders with) is the stored override or the paragraph's type default: flush-left for
+// a bold/heading paragraph, justified body text otherwise - exactly what the renderers do.
+export const PARAGRAPH_ALIGN_CYCLE = ['left', 'center', 'right', 'justify'];
+
+export const getEffectiveParagraphAlign = record => getParagraphStyle(record).align
+  ?? (isParagraphBold(record) ? 'left' : 'justify');
+
+export const nextParagraphAlign = align => {
+  const index = PARAGRAPH_ALIGN_CYCLE.indexOf(align);
+  return PARAGRAPH_ALIGN_CYCLE[(index + 1) % PARAGRAPH_ALIGN_CYCLE.length];
+};
+
+// Scope-addressed style access, mirroring getTemplateScopeText/withTemplateScopeText: the same
+// alignment/formatting controls serve a beforeTitle block and a body paragraph through one pair
+// of helpers (the title has no per-row style, so TITLE_SCOPE deliberately resolves to nothing).
+export const getTemplateScopeRecord = (template, scope) => {
+  const beforeTitleMatch = /^beforeTitle:(\d+)$/.exec(scope);
+  if (beforeTitleMatch) return toArray(template?.beforeTitle)[Number(beforeTitleMatch[1])] || null;
+  const paragraphMatch = /^p:(\d+)$/.exec(scope);
+  if (paragraphMatch) return toArray(template?.paragraphs)[Number(paragraphMatch[1])] || null;
+  return null;
+};
+
+export const withTemplateScopeStyle = (template, scope, partialStyle) => {
+  const beforeTitleMatch = /^beforeTitle:(\d+)$/.exec(scope);
+  if (beforeTitleMatch) {
+    const index = Number(beforeTitleMatch[1]);
+    return {
+      ...template,
+      beforeTitle: toArray(template?.beforeTitle).map((block, i) => (i === index ? withParagraphStyle(block, partialStyle) : block)),
+    };
+  }
+  const paragraphMatch = /^p:(\d+)$/.exec(scope);
+  if (paragraphMatch) {
+    const index = Number(paragraphMatch[1]);
+    return {
+      ...template,
+      paragraphs: toArray(template?.paragraphs).map((paragraph, i) => (i === index ? withParagraphStyle(paragraph, partialStyle) : paragraph)),
+    };
+  }
+  return template;
+};
+
 // Read-time migration for one template (idempotent, same spirit as normalizeCaseRecord): every
 // paragraph and beforeTitle block re-expressed with its styles consolidated under `style`, so the
 // next persist writes the new shape without a separate migration pass.
@@ -1270,10 +1317,13 @@ export const normalizeSignerBlockOffsetPercent = value => clampNumber(
   DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
 );
 
+// `align` stays sparse here (undefined = never set): the signer-strip renderers fall back to
+// their own notarial default (bold caption flush-left, regular data justified), so only an
+// explicitly aligned block - stored or set with the alignment button (§1.5) - deviates from it.
 const resolveBeforeTitleBlocks = (template, context) => toArray(template?.beforeTitle).map(block => {
   const style = getParagraphStyle(block);
   return {
-    align: normalizeBlockAlign(style.align),
+    align: style.align,
     bold: Boolean(style.bold),
     width: normalizeBlockWidth(style.width),
     fontSize: style.fontSize,

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -35,6 +35,7 @@ import {
   getChildGenderForms,
   getClinicLogo,
   getEffectiveDocLayout,
+  getEffectiveParagraphAlign,
   getLayoutColumnCount,
   getLayoutLang,
   getParagraphStyle,
@@ -48,6 +49,7 @@ import {
   isSingleLanguageTwoColumnLayout,
   MISSING_VALUE_PLACEHOLDER,
   mergeDocumentsCatalog,
+  nextParagraphAlign,
   normalizeCaseRecord,
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
@@ -73,6 +75,7 @@ import {
   getTemplateScopeText,
   paragraphScope,
   withParagraphStyle,
+  withTemplateScopeStyle,
   withTemplateScopeText,
   toggleInlineFormat,
   toggleRawInlineMarker,
@@ -1113,6 +1116,67 @@ describe('spec: per-paragraph styles consolidated under one `style` key (batch 2
   });
 });
 
+describe('spec: alignment button cycle, MS Word logic (batch 2026-07-23 B §1.5)', () => {
+  it('cycles Left → Center → Right → Justify → Left', () => {
+    expect(nextParagraphAlign('left')).toBe('center');
+    expect(nextParagraphAlign('center')).toBe('right');
+    expect(nextParagraphAlign('right')).toBe('justify');
+    expect(nextParagraphAlign('justify')).toBe('left');
+  });
+
+  it('effective alignment is the stored override, else the type default: justified body, flush-left heading', () => {
+    expect(getEffectiveParagraphAlign({ uk: 'Звичайний абзац.', en: 'Body text.' })).toBe('justify');
+    expect(getEffectiveParagraphAlign({ uk: '1. Предмет Договору', en: '1. Subject' })).toBe('left'); // auto-detected heading
+    expect(getEffectiveParagraphAlign({ uk: 'Звичайний абзац.', en: 'Body text.', style: { align: 'center' } })).toBe('center');
+    expect(getEffectiveParagraphAlign({ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: '', style: { bold: true } })).toBe('left');
+  });
+
+  it('withTemplateScopeStyle writes a paragraph\'s or beforeTitle block\'s style through one scope key', () => {
+    const template = {
+      id: 'doc-1',
+      beforeTitle: [{ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: '' }],
+      paragraphs: [{ uk: 'Абзац.', en: 'Paragraph.' }, { uk: 'Інший.', en: 'Other.' }],
+    };
+    const withParagraphAlign = withTemplateScopeStyle(template, paragraphScope(1), { align: 'right' });
+    expect(withParagraphAlign.paragraphs[1]).toEqual({ uk: 'Інший.', en: 'Other.', style: { align: 'right' } });
+    expect(withParagraphAlign.paragraphs[0]).toEqual(template.paragraphs[0]);
+    const withBlockAlign = withTemplateScopeStyle(template, beforeTitleScope(0), { align: 'center' });
+    expect(withBlockAlign.beforeTitle[0]).toEqual({ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: '', style: { align: 'center' } });
+  });
+});
+
+describe('spec: empty lines are never stripped (batch 2026-07-23 B §3)', () => {
+  it('buildGeneratedDocument keeps in-paragraph blank lines and fully empty paragraphs verbatim', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = {
+      id: 'doc-blank-lines',
+      title: { uk: 'Т', en: 'T' },
+      paragraphs: [
+        { uk: 'Перший рядок.\n\nПісля порожнього рядка.', en: 'First line.\n\nAfter the blank line.' },
+        { uk: '', en: '' },
+        { uk: 'Останній абзац.', en: 'Last paragraph.' },
+      ],
+    };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.paragraphs).toHaveLength(3);
+    expect(generated.paragraphs[0].uk).toBe('Перший рядок.\n\nПісля порожнього рядка.');
+    expect(generated.paragraphs[1].uk).toBe('');
+    expect(generated.paragraphs[2].uk).toBe('Останній абзац.');
+  });
+
+  it('a trailing empty line inside a paragraph survives the catalog normalization round-trip', () => {
+    const catalog = normalizeDocumentsCatalog(null, {
+      'doc-1': {
+        id: 'doc-1',
+        title: { uk: 'Заява', en: 'Statement' },
+        paragraphs: [{ uk: 'Текст абзацу.\n', en: 'Paragraph text.\n' }],
+      },
+    });
+    expect(catalog.documents[0].paragraphs[0].uk).toBe('Текст абзацу.\n');
+  });
+});
+
 describe('spec: long multi-page documents', () => {
   it('renders every paragraph of a ~90-paragraph agreement without dropping any', () => {
     const catalog = richCatalog();
@@ -1802,14 +1866,14 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
       expect(generated.paragraphs[1].align).toBeUndefined();
     });
 
-    it('an invalid align value normalizes to "left" rather than being passed through as-is', () => {
+    it('an invalid align value is dropped (the block falls back to the renderers\' notarial default) rather than passed through as-is', () => {
       const generated = buildGeneratedDocument({
         id: 'bad-align',
         title: { uk: 'Заява' },
         beforeTitle: [{ uk: 'Блок', align: 'diagonal' }],
         paragraphs: [],
       }, {});
-      expect(generated.beforeTitle[0].align).toBe('left');
+      expect(generated.beforeTitle[0].align).toBeUndefined();
     });
   });
 });

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -13,6 +13,7 @@ import {
   buildGeneratedDocument,
   catalogPartiesToBackend,
   clinicLogoEntriesToBackend,
+  consolidateTemplateStyles,
   createChildRecord,
   createEmptyCase,
   createEmptyClinic,
@@ -36,6 +37,7 @@ import {
   getEffectiveDocLayout,
   getLayoutColumnCount,
   getLayoutLang,
+  getParagraphStyle,
   getParagraphType,
   getTemplateLogoType,
   getValueByPath,
@@ -70,6 +72,7 @@ import {
   beforeTitleScope,
   getTemplateScopeText,
   paragraphScope,
+  withParagraphStyle,
   withTemplateScopeText,
   toggleInlineFormat,
   toggleRawInlineMarker,
@@ -1010,6 +1013,103 @@ describe('spec: manual bold override on a paragraph', () => {
     expect(generated.paragraphs[0].indentCm).toBe(1.25);
     expect(generated.paragraphs[1].indentCm).toBeUndefined();
     expect(generated.paragraphs[2].indentCm).toBe(5); // clamped to the same 0-5 range as firstLineIndentCm
+  });
+});
+
+describe('spec: per-paragraph styles consolidated under one `style` key (batch 2026-07-23 B §1.1)', () => {
+  it('getParagraphStyle lifts legacy flat fields into the one normalized style object', () => {
+    expect(getParagraphStyle({ uk: 'Текст', en: 'Text', bold: true, align: 'center', indentCm: 1.25 }))
+      .toEqual({ bold: true, align: 'center', indentCm: 1.25 });
+  });
+
+  it('getParagraphStyle reads the consolidated `style` key, which wins per field over a leftover flat field', () => {
+    const paragraph = { uk: 'Текст', en: 'Text', indentCm: 3, style: { indentCm: 0.5, fontSize: 10 } };
+    expect(getParagraphStyle(paragraph)).toEqual({ indentCm: 0.5, fontSize: 10 });
+  });
+
+  it('getParagraphStyle drops invalid values instead of substituting defaults, and clamps numeric ones', () => {
+    expect(getParagraphStyle({ style: { align: 'diagonal', fontSize: 500, indentCm: -3 } }))
+      .toEqual({ fontSize: 32, indentCm: 0 });
+    expect(getParagraphStyle({ uk: 'Без стилів', en: 'No styles' })).toEqual({});
+  });
+
+  it('withParagraphStyle merges new values into `style`, stripping the legacy flat fields on the same write', () => {
+    const paragraph = { uk: 'Текст', en: 'Text', bold: true, indentCm: 1 };
+    expect(withParagraphStyle(paragraph, { fontSize: 10 }))
+      .toEqual({ uk: 'Текст', en: 'Text', style: { bold: true, indentCm: 1, fontSize: 10 } });
+  });
+
+  it('withParagraphStyle clears a key with null, and drops the `style` key entirely once nothing is left', () => {
+    const paragraph = { uk: 'Текст', en: 'Text', style: { indentCm: 2 } };
+    expect(withParagraphStyle(paragraph, { indentCm: null })).toEqual({ uk: 'Текст', en: 'Text' });
+  });
+
+  it('consolidateTemplateStyles migrates every paragraph and beforeTitle block at read time, idempotently', () => {
+    const template = {
+      id: 'doc-1',
+      title: { uk: 'Заява', en: 'Statement' },
+      beforeTitle: [{ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: '', align: 'right', bold: true, width: 70 }],
+      paragraphs: [
+        { uk: 'Абзац.', en: 'Paragraph.', indentCm: 1.25, align: 'center' },
+        { uk: 'Без стилів.', en: 'Unstyled.' },
+      ],
+    };
+    const consolidated = consolidateTemplateStyles(template);
+    expect(consolidated.beforeTitle[0]).toEqual({ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: '', style: { align: 'right', bold: true, width: 70 } });
+    expect(consolidated.paragraphs[0]).toEqual({ uk: 'Абзац.', en: 'Paragraph.', style: { indentCm: 1.25, align: 'center' } });
+    expect(consolidated.paragraphs[1]).toEqual({ uk: 'Без стилів.', en: 'Unstyled.' });
+    expect(consolidateTemplateStyles(consolidated)).toEqual(consolidated);
+  });
+
+  it('normalizeDocumentsCatalog consolidates stored templates right at ingestion', () => {
+    const catalog = normalizeDocumentsCatalog(null, {
+      'doc-1': {
+        id: 'doc-1',
+        title: { uk: 'Заява', en: 'Statement' },
+        paragraphs: [{ uk: 'Абзац.', en: 'Paragraph.', bold: false, indentCm: 2 }],
+      },
+    });
+    expect(catalog.documents[0].paragraphs[0]).toEqual({ uk: 'Абзац.', en: 'Paragraph.', style: { bold: false, indentCm: 2 } });
+  });
+
+  it('a whole paragraph row copied into another document carries every style with it (the copy-paste guarantee)', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const styledParagraph = {
+      uk: 'Скопійований абзац.',
+      en: 'Copied paragraph.',
+      style: { fontSize: 10, indentCm: 0.75, align: 'right', bold: true },
+    };
+    const generateWithin = templateId => buildGeneratedDocument(
+      { id: templateId, title: { uk: 'Т', en: 'T' }, paragraphs: [styledParagraph] },
+      context,
+    ).paragraphs[0];
+    const inSource = generateWithin('doc-source');
+    const inTarget = generateWithin('doc-target');
+    ['fontSize', 'indentCm', 'align', 'bold'].forEach(key => {
+      expect(inSource[key]).toEqual(styledParagraph.style[key]);
+      expect(inTarget[key]).toEqual(styledParagraph.style[key]);
+    });
+  });
+
+  it('buildGeneratedDocument threads a per-paragraph fontSize through, clamped, and resolves beforeTitle styles from the one key', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = {
+      id: 'doc-with-style',
+      title: { uk: 'Т', en: 'T' },
+      beforeTitle: [{ uk: 'ЗА МІСЦЕМ ВИМОГИ', en: '', style: { align: 'right', bold: true, fontSize: 11 } }],
+      paragraphs: [
+        { uk: 'Дрібний абзац.', en: 'Small paragraph.', style: { fontSize: 9 } },
+        { uk: 'Завеликий кегль.', en: 'Oversized font.', style: { fontSize: 500 } },
+        { uk: 'Успадкований кегль.', en: 'Inherited font.' },
+      ],
+    };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.beforeTitle[0]).toMatchObject({ align: 'right', bold: true, fontSize: 11 });
+    expect(generated.paragraphs[0].fontSize).toBe(9);
+    expect(generated.paragraphs[1].fontSize).toBe(32); // clamped
+    expect(generated.paragraphs[2].fontSize).toBeUndefined();
   });
 });
 

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -84,13 +84,17 @@ export const buildDocumentsDocx = async ({
   // Splits `text` on its bold/italic markup (spec §1: selection-based, not whole-paragraph) into
   // the TextRuns Word needs to render each fragment's own weight/style; `baseBold` is for a
   // heading/title paragraph that's already bold throughout (an inline-italic fragment inside it
-  // still needs its own run to pick up the italic flag).
-  const formattedTextRuns = (text, { size, baseBold = false } = {}) => parseFormattedRuns(text).map(run => new TextRun({
-    text: run.text,
+  // still needs its own run to pick up the italic flag). Embedded newlines become explicit
+  // <w:br/> line breaks (batch 2026-07-23 B §3: an empty line inside a paragraph - consecutive
+  // breaks - must survive into the Word output as a full blank line, never be silently dropped
+  // by a TextRun that doesn't understand "\n").
+  const formattedTextRuns = (text, { size, baseBold = false } = {}) => parseFormattedRuns(text).flatMap(run => String(run.text).split('\n').map((segment, segmentIndex) => new TextRun({
+    text: segment,
     size,
     bold: baseBold || run.bold,
     italics: run.italic,
-  }));
+    ...(segmentIndex > 0 ? { break: 1 } : {}),
+  })));
 
   // batch 16 §17: an explicit `align` on a paragraph (or beforeTitle block) overrides the default
   // alignment (justified body / flush-left heading) - never inferred from the text itself.
@@ -166,8 +170,10 @@ export const buildDocumentsDocx = async ({
     children: [new TextRun({ text: '', size: bodySize })],
   });
 
+  // An explicitly aligned block (the §1.5 alignment button, stored under the block's `style`
+  // key) overrides the strip's notarial default: bold caption flush-left, regular data justified.
   const signerBlockParagraph = (text, block) => new Paragraph({
-    alignment: block.bold ? AlignmentType.LEFT : AlignmentType.JUSTIFIED,
+    alignment: block.align ? alignmentForBlock(block.align) : (block.bold ? AlignmentType.LEFT : AlignmentType.JUSTIFIED),
     spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
     children: formattedTextRuns(text, {
       size: block.fontSize !== undefined ? halfPoints(block.fontSize) : bodySize,

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -101,7 +101,7 @@ export const buildDocumentsDocx = async ({
     return AlignmentType.LEFT;
   };
 
-  const bodyParagraph = (text, { keepLines = true, alignmentOverride, indentTwipsOverride } = {}) => {
+  const bodyParagraph = (text, { keepLines = true, alignmentOverride, indentTwipsOverride, sizeOverride } = {}) => {
     // Per-paragraph first-line indent (spec: the reference notarial statement indents only its
     // opening declaration, not the signature/registration lines after it) - undefined falls back
     // to the document-wide firstLineTwips, same as every paragraph did before this existed.
@@ -111,29 +111,33 @@ export const buildDocumentsDocx = async ({
       spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
       indent: firstLine ? { firstLine } : undefined,
       keepLines,
-      children: formattedTextRuns(text, { size: bodySize }),
+      children: formattedTextRuns(text, { size: sizeOverride ?? bodySize }),
     });
   };
 
   // Short numbered section titles ("1. Предмет Договору") render bold, flush left, with extra
   // room above and kept with the paragraph that follows so a heading never ends a page alone.
-  const headingParagraph = (text, alignmentOverride) => new Paragraph({
+  const headingParagraph = (text, alignmentOverride, sizeOverride) => new Paragraph({
     alignment: alignmentOverride || AlignmentType.LEFT,
     spacing: { before: afterTwips, after: afterTwips, line: lineTwips, lineRule: 'auto' },
     keepLines: true,
     keepNext: true,
-    children: formattedTextRuns(text, { size: bodySize, baseBold: true }),
+    children: formattedTextRuns(text, { size: sizeOverride ?? bodySize, baseBold: true }),
   });
 
   const cellParagraph = (text, allowPageBreaks, paragraph) => {
+    // align/indentCm/fontSize arrive already resolved from the paragraph's consolidated `style`
+    // key (buildGeneratedDocument) - undefined means "inherit the document-wide value".
     const alignmentOverride = paragraph?.align ? alignmentForBlock(paragraph.align) : undefined;
     const indentTwipsOverride = paragraph?.indentCm !== undefined ? Math.round(paragraph.indentCm * CM_TO_TWIP) : undefined;
+    const sizeOverride = paragraph?.fontSize !== undefined ? halfPoints(paragraph.fontSize) : undefined;
     return isParagraphBold(paragraph)
-      ? headingParagraph(text, alignmentOverride)
+      ? headingParagraph(text, alignmentOverride, sizeOverride)
       : bodyParagraph(text, {
         keepLines: !allowsParagraphInternalBreak(paragraph, allowPageBreaks),
         alignmentOverride,
         indentTwipsOverride,
+        sizeOverride,
       });
   };
 
@@ -165,7 +169,10 @@ export const buildDocumentsDocx = async ({
   const signerBlockParagraph = (text, block) => new Paragraph({
     alignment: block.bold ? AlignmentType.LEFT : AlignmentType.JUSTIFIED,
     spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
-    children: formattedTextRuns(text, { size: bodySize, baseBold: Boolean(block.bold) }),
+    children: formattedTextRuns(text, {
+      size: block.fontSize !== undefined ? halfPoints(block.fontSize) : bodySize,
+      baseBold: Boolean(block.bold),
+    }),
   });
 
   const signerBlockTable = (blocks, langKey, containerWidthTwips, offsetPercent) => {

--- a/src/components/documentsPdfPreviewEngine.js
+++ b/src/components/documentsPdfPreviewEngine.js
@@ -1,0 +1,26 @@
+// pdf.js glue for the Documents page's PDF-true preview (batch 2026-07-23 B §4): takes the real
+// exported-PDF bytes and rasterizes single pages onto a canvas. Kept in its own module - imported
+// only dynamically, from the preview component's effects - because pdfjs-dist is an ESM-heavy
+// package whose worker URL needs `import.meta`, which must never be parsed by the jest/babel test
+// pipeline (the preview never generates under jsdom anyway - see the IntersectionObserver gate in
+// DocumentsPdfPreview).
+import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist';
+
+// webpack 5 (react-scripts 5) emits the worker as its own asset from this URL reference.
+GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
+
+export const loadPdfDocument = async data => getDocument({ data }).promise;
+
+// Renders one page at the container's CSS width × devicePixelRatio (spec §4.1), so the preview is
+// the exported page's own rasterization at native screen density - not an HTML approximation.
+export const renderPdfPageToCanvas = async (pdfDocument, pageNumber, canvas, cssWidth, devicePixelRatio = 1) => {
+  const page = await pdfDocument.getPage(pageNumber);
+  const baseViewport = page.getViewport({ scale: 1 });
+  const scale = (cssWidth / baseViewport.width) * devicePixelRatio;
+  const viewport = page.getViewport({ scale });
+  canvas.width = Math.floor(viewport.width);
+  canvas.height = Math.floor(viewport.height);
+  canvas.style.width = `${cssWidth}px`;
+  canvas.style.height = `${Math.floor(viewport.height / devicePixelRatio)}px`;
+  await page.render({ canvasContext: canvas.getContext('2d'), viewport }).promise;
+};


### PR DESCRIPTION
Every visual property a paragraph or beforeTitle block carries (fontSize,
indentCm, align, bold, width) now lives together under the record's single
sparse style key on the backend, so a whole paragraph row copied into
another document brings all of its styles along and parsing never has to
hunt for scattered flat fields. Legacy flat fields are still read (a style
entry wins per field) and are re-consolidated at catalog/technical-input
ingestion and on every write. Per-paragraph fontSize overrides now thread
through buildGeneratedDocument into both the PDF and Word exports.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sm1URvhKVFt9ktnUZWkggW