### PR TITLE
Documents: fix space/blank-line preservation, unify title with paragraphs, fix PDF preview

### DIFF
--- a/scripts/pdfQaCheck.js
+++ b/scripts/pdfQaCheck.js
@@ -516,6 +516,61 @@ async function checkDocuments() {
   } else if (Math.abs(actualDeltaPt - expectedDeltaPt) > 2) {
     fail(`Documents (indent regression): indentCm=2 should shift the paragraph ~${expectedDeltaPt.toFixed(1)}pt right, got ${actualDeltaPt.toFixed(1)}pt (indentCm is not being applied)`);
   }
+
+  // Batch 2026-07-23 C §1: a run of consecutive spaces must survive as one unbroken run at
+  // render time (substituted for non-breaking spaces so the PDF engine never treats it as
+  // collapsible/wrap-swallowable trailing whitespace) - glyph-level, so only pdfjs-dist (this
+  // plain-Node script, never Jest) can actually verify it.
+  const renderOnePage = async doc => {
+    const stream = await pdf(React.createElement(DocumentsPdfDocument, {
+      documents: [doc], layout: 'one-column-uk', formatting: DEFAULT_DOC_FORMATTING,
+    })).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      stream.on('data', c => chunks.push(c));
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    });
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    const pdfDoc = await pdfjsLib.getDocument({ data: new Uint8Array(Buffer.concat(chunks)) }).promise;
+    const page = await pdfDoc.getPage(1);
+    return page.getTextContent();
+  };
+
+  const spacesContent = await renderOnePage({
+    id: 'spaces-regression',
+    title: { uk: 'Т' },
+    paragraphs: [{ type: 'text', uk: 'Приватний нотаріус          Алексашина Юлія Борисівна' }],
+  });
+  const gapItem = spacesContent.items.find(item => /^\s+$/.test(item.str) && item.str.trim() === '');
+  if (!gapItem || gapItem.str.length !== 10) {
+    fail(`Documents (consecutive-spaces regression): expected one unbroken 10-character gap between "нотаріус" and "Алексашина", got ${gapItem ? `"${gapItem.str}" (length ${gapItem.str.length})` : 'no gap item at all'}`);
+  }
+
+  // Batch 2026-07-23 C §3: a trailing empty line inside a paragraph must render as a real blank
+  // line before the next paragraph, not collapse to nothing.
+  const withBlank = await renderOnePage({
+    id: 'trailing-blank-regression',
+    title: { uk: 'Т' },
+    paragraphs: [
+      { type: 'text', uk: 'ЗАЯВА\n' },
+      { type: 'text', uk: 'Наступний абзац.' },
+    ],
+  });
+  const withoutBlank = await renderOnePage({
+    id: 'no-blank-regression',
+    title: { uk: 'Т' },
+    paragraphs: [
+      { type: 'text', uk: 'ЗАЯВА' },
+      { type: 'text', uk: 'Наступний абзац.' },
+    ],
+  });
+  const yOf = (content, needle) => content.items.find(item => item.str.includes(needle))?.transform?.[5];
+  const gapWithBlank = (yOf(withBlank, 'ЗАЯВА') ?? 0) - (yOf(withBlank, 'Наступний абзац') ?? 0);
+  const gapNoBlank = (yOf(withoutBlank, 'ЗАЯВА') ?? 0) - (yOf(withoutBlank, 'Наступний абзац') ?? 0);
+  if (!(gapWithBlank > gapNoBlank * 1.5)) {
+    fail(`Documents (trailing-blank-line regression): a trailing "\\n" should add roughly one extra line of vertical space (got ${gapWithBlank.toFixed(1)}pt vs ${gapNoBlank.toFixed(1)}pt baseline) - the trailing blank line may be collapsing again`);
+  }
 }
 
 async function main() {

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -40,6 +40,7 @@ import {
   emptyDocumentsCatalog,
   getClinicLogo,
   getEffectiveParagraphAlign,
+  getEffectiveTitleAlign,
   getLayoutLang,
   getParagraphStyle,
   getParagraphType,
@@ -467,6 +468,15 @@ const TextModeDisplay = styled.div`
   white-space: pre-wrap;
   cursor: text;
   user-select: text;
+
+  /* A zero-width space after the content: with pre-wrap, a trailing newline the admin typed
+     creates no visible line box on its own (batch 2026-07-23 C §3 - the blank line "disappeared"
+     in this read-only Text mode while the textarea modes showed it), so this sentinel gives the
+     final empty line something to render. Pseudo-element content is not part of textContent, so
+     the selection-offset math (plainTextOffsetInContainer) is unaffected. */
+  &::after {
+    content: '\\200B';
+  }
 `;
 
 const FormattedRunsPreview = ({ text }) => (
@@ -1036,7 +1046,11 @@ const DocumentsPage = ({ isAdmin }) => {
     if (!template) return;
     const record = getTemplateScopeRecord(template, scope);
     if (!record) return;
-    const nextTemplate = withTemplateScopeStyle(template, scope, { align: nextParagraphAlign(getEffectiveParagraphAlign(record)) });
+    // The title's un-overridden default is Center (an ordinary centered paragraph, batch
+    // 2026-07-23 C §2), not the body-paragraph bold/justify default - the cycle order itself is
+    // identical.
+    const currentAlign = scope === TITLE_SCOPE ? getEffectiveTitleAlign(record) : getEffectiveParagraphAlign(record);
+    const nextTemplate = withTemplateScopeStyle(template, scope, { align: nextParagraphAlign(currentAlign) });
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
       setCatalog(previous => ({
@@ -1171,6 +1185,64 @@ const DocumentsPage = ({ isAdmin }) => {
     } catch (structureError) {
       console.error('Unable to remove the before-title block', structureError);
       toast.error('Could not save the change.');
+    }
+  };
+
+  // The title is an ordinary paragraph with the standard toolbar, including delete (batch
+  // 2026-07-23 C §2). Removing it drops the template's `title` key entirely (a direct structural
+  // write, like the paragraph/beforeTitle structure edits above) and also clears every case's
+  // per-case title override for this document - otherwise a stale override would "resurrect" the
+  // deleted title next time that case resolves the document.
+  const handleRemoveTitle = async docId => {
+    if (typeof window !== 'undefined' && !window.confirm('Remove the title?')) return;
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template) return;
+    const nextTemplate = { ...template };
+    delete nextTemplate.title;
+    const casesWithTitleOverride = catalog.parties.cases.filter(caseRecord => caseRecord.documents?.overrides?.[docId]?.title);
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      const partiesPatch = {};
+      casesWithTitleOverride.forEach(caseRecord => {
+        partiesPatch[`cases/${caseRecord.id}/documents/overrides/${docId}/title`] = null;
+      });
+      if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+        parties: {
+          ...previous.parties,
+          cases: previous.parties.cases.map(caseRecord => {
+            if (!caseRecord.documents?.overrides?.[docId]?.title) return caseRecord;
+            const { title: _removedTitle, ...restOverride } = caseRecord.documents.overrides[docId];
+            return {
+              ...caseRecord,
+              documents: { ...caseRecord.documents, overrides: { ...caseRecord.documents.overrides, [docId]: restOverride } },
+            };
+          }),
+        },
+      }));
+    } catch (structureError) {
+      console.error('Unable to remove the title', structureError);
+      toast.error('Could not remove the title.');
+    }
+  };
+
+  // The way back after a delete: an empty title record the admin can type into - without this a
+  // deleted title would be unrecoverable from the UI.
+  const handleAddTitle = async docId => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template || template.title != null) return;
+    const nextTemplate = { ...template, title: { uk: '', en: '' } };
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+      }));
+    } catch (structureError) {
+      console.error('Unable to add the title', structureError);
+      toast.error('Could not add the title.');
     }
   };
 
@@ -2342,7 +2414,24 @@ const DocumentsPage = ({ isAdmin }) => {
                           // §5) - the exact same template/input/text cycle paragraphs use (spec §3/
                           // §9), never a separate uk-in-the-header + en-below split. Printed inside
                           // the document from title.uk/title.en only - never the catalogName above.
+                          // Batch 2026-07-23 C §2: an ordinary paragraph with the full standard
+                          // toolbar - alignment cycle (default Center), formatting popover, delete.
+                          // A template whose title was deleted shows only a "+" to add it back.
+                          if (template.title == null) {
+                            return (
+                              <ParagraphControlsRow style={{ justifyContent: 'flex-start', marginTop: 10 }}>
+                                <SmallButton
+                                  type="button"
+                                  onClick={() => handleAddTitle(template.id)}
+                                  title="Add a title to this document"
+                                >
+                                  <FaPlus /> Title
+                                </SmallButton>
+                              </ParagraphControlsRow>
+                            );
+                          }
                           const titleFieldKind = titleIsTemplateMode ? 'template' : (titleMode === 'input' ? 'override' : 'text-display');
+                          const titleStyle = getParagraphStyle(template.title);
                           return (
                             <ParagraphEditorBlock>
                               <ParagraphControlsRow>
@@ -2380,6 +2469,33 @@ const DocumentsPage = ({ isAdmin }) => {
                                   >
                                     <FaCode />
                                   </SmallButton>
+                                  <AlignCycleButton
+                                    align={getEffectiveTitleAlign(template.title)}
+                                    onCycle={() => handleCycleAlign(template.id, TITLE_SCOPE)}
+                                  />
+                                  <FormatPopoverButton
+                                    open={openFormatKey === formatPopoverKey(template.id, TITLE_SCOPE)}
+                                    onToggle={() => toggleFormatPopover(template.id, TITLE_SCOPE)}
+                                    onClose={() => closeFormatPopover(template.id)}
+                                    buttonTitle="Title formatting - font size (pt); empty = inherit the document's title size"
+                                    fields={[
+                                      {
+                                        key: 'fontSize',
+                                        label: 'Font size (pt)',
+                                        value: titleStyle.fontSize !== undefined ? String(titleStyle.fontSize) : '',
+                                        placeholder: String(docFormatting.titleFontSize),
+                                        onApply: raw => setScopeStyleField(template.id, TITLE_SCOPE, 'fontSize', raw),
+                                        onFieldBlur: () => persistTemplate(template.id),
+                                      },
+                                    ]}
+                                  />
+                                  <DangerButton
+                                    type="button"
+                                    onClick={() => handleRemoveTitle(template.id)}
+                                    title="Remove the title"
+                                  >
+                                    <FaTrash />
+                                  </DangerButton>
                                 </RowLine>
                               </ParagraphControlsRow>
                               {titleCaseModeLocked ? (

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -80,6 +80,22 @@ const styles = StyleSheet.create({
   },
 });
 
+// Render-time-only text massaging (batch 2026-07-23 C §1/§3) - the stored template/override data
+// is never rewritten, both rules exist purely because of how the PDF layout engine treats
+// whitespace:
+// - A run of 2+ spaces becomes the same number of non-breaking spaces (U+00A0). The engine keeps
+//   interior space runs on an unbroken line, but a run that lands on a line-wrap boundary is
+//   swallowed as trailing whitespace - and these runs are deliberate (e.g. the physical gap for a
+//   notary's signature in "Приватний нотаріус         Алексашина"), so they must survive wrapping
+//   as one unbreakable block.
+// - A trailing newline gets one NBSP appended after it, because the engine silently drops the
+//   final empty line of a text block - a trailing blank line the admin typed must render as one
+//   full blank line, exactly like the editor and the Word export show it.
+export const toPdfRenderableText = text => {
+  const value = String(text ?? '').replace(/ {2,}/g, spaces => '\u00A0'.repeat(spaces.length));
+  return value.endsWith('\n') ? `${value}\u00A0` : value;
+};
+
 // Renders one piece of paragraph/title text as a run of nested <Text> spans so a bold/italic
 // fragment (spec §1: selection-based, not whole-paragraph) keeps its exact boundaries in the PDF -
 // react-pdf resolves each span's own font weight/style against the registered Tinos faces. A plain
@@ -93,7 +109,7 @@ const styles = StyleSheet.create({
 // date-in-words line, `**Підпис**...`): the leading nested <Text> ignored the parent's indent, so
 // exactly the bolded lines lost their 1.5 cm first-line indent - `firstLineIndent` re-states the
 // paragraph's own resolved indent on that leading run.
-const FormattedRuns = ({ text, firstLineIndent }) => parseFormattedRuns(text).map((run, index) => {
+const FormattedRuns = ({ text, firstLineIndent }) => parseFormattedRuns(toPdfRenderableText(text)).map((run, index) => {
   if (!run.bold && !run.italic) {
     // eslint-disable-next-line react/no-array-index-key
     return <React.Fragment key={index}>{run.text}</React.Fragment>;
@@ -218,18 +234,34 @@ const SingleLanguageColumns = ({ paragraphs, lang, cellStyles, allowPageBreaks, 
   );
 };
 
-const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) => (
-  <View style={{ marginBottom: titleGap }}>
-    {isBilingual ? (
-      <View style={styles.row}>
-        <Text style={[cellStyles.title, cellStyles.leftCell]}><FormattedRuns text={doc.title.uk} /></Text>
-        <Text style={[cellStyles.title, cellStyles.rightCell]}><FormattedRuns text={doc.title.en} /></Text>
-      </View>
-    ) : (
-      <Text style={cellStyles.title}><FormattedRuns text={doc.title[lang]} /></Text>
-    )}
-  </View>
-);
+// A block whose text is blank in both languages (an empty template row, or - for the title - a
+// deleted title) renders nothing.
+const isBlankBlockText = value => !String(value || '').trim();
+
+// The title is an ordinary centered paragraph (batch 2026-07-23 C §2): default alignment Center
+// (cellStyles.title), its own sparse align/fontSize overrides applied like any paragraph's, and a
+// document whose title was deleted (both languages resolve blank) renders no title block at all -
+// never an empty centered line plus its titleGap.
+const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) => {
+  const title = doc.title || {};
+  if (isBlankBlockText(title.uk) && isBlankBlockText(title.en)) return null;
+  const overrideStyles = [
+    title.align ? { textAlign: title.align } : undefined,
+    title.fontSize !== undefined ? { fontSize: title.fontSize } : undefined,
+  ];
+  return (
+    <View style={{ marginBottom: titleGap }}>
+      {isBilingual ? (
+        <View style={styles.row}>
+          <Text style={[cellStyles.title, cellStyles.leftCell, ...overrideStyles]}><FormattedRuns text={title.uk} /></Text>
+          <Text style={[cellStyles.title, cellStyles.rightCell, ...overrideStyles]}><FormattedRuns text={title.en} /></Text>
+        </View>
+      ) : (
+        <Text style={[cellStyles.title, ...overrideStyles]}><FormattedRuns text={title[lang]} /></Text>
+      )}
+    </View>
+  );
+};
 
 // The addressee/signer block between the letterhead logo and the title (notarial layout standard
 // §3.2, "ЗА МІСЦЕМ ВИМОГИ" + the signer data) - never merged into the paragraph list, so it always
@@ -241,7 +273,6 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
 // first-line indent. Consecutive blocks are separated by exactly one empty line (empty blocks in
 // the template collapse into that same separator), and one empty line follows the whole strip
 // before the title (structure §3.4).
-const isBlankBlockText = value => !String(value || '').trim();
 
 // An explicitly aligned block (the §1.5 alignment button, stored under the block's `style` key)
 // overrides the strip's notarial default: bold caption flush-left, regular data justified.

--- a/src/components/DocumentsPdfPreview.jsx
+++ b/src/components/DocumentsPdfPreview.jsx
@@ -193,8 +193,14 @@ const DocumentsPdfPreview = ({ doc, layout, formatting, clinicLogos }) => {
         setError('');
         setRenderedGeneration(generation);
       } catch (previewError) {
+        // Never a silent generic failure (batch 2026-07-23 C §4): the full exception goes to the
+        // console, and its one-line cause is appended to the on-screen error state - mobile
+        // admins have no devtools, so the visible message is the only diagnostic they can report.
         console.error('Unable to build the PDF preview', previewError);
-        if (generationRef.current === generation) setError('Не вдалося побудувати прев\'ю PDF.');
+        if (generationRef.current === generation) {
+          const cause = `${previewError?.name || 'Error'}: ${previewError?.message || String(previewError)}`;
+          setError(`Не вдалося побудувати прев'ю PDF. ${cause}`);
+        }
       } finally {
         if (generationRef.current === generation) setUpdating(false);
       }

--- a/src/components/DocumentsRenderers.smoke.test.js
+++ b/src/components/DocumentsRenderers.smoke.test.js
@@ -545,3 +545,135 @@ describe('Documents DOCX builder - notarial signer block layout', () => {
   }, 20000);
 });
 
+// Batch 2026-07-23 C: four Documents Builder fixes, verified against the real renderers. Reading
+// back exact glyph text/positions needs pdfjs-dist, which can't load under this sandbox's Jest
+// (see DocumentsPageNumbering.smoke.test.js's note on the same limitation) - the pixel-level
+// space/blank-line checks live in scripts/pdfQaCheck.js (plain Node, `npm run qa:pdf`) instead.
+// These tests cover the pure render-time helper directly, plus render-without-throwing for the
+// title-deletion crash-proofing.
+describe('Documents PDF renderer - toPdfRenderableText (batch 2026-07-23 C §1/§3)', () => {
+  it('turns a run of 2+ spaces into the same number of non-breaking spaces, leaving single spaces alone', async () => {
+    const { toPdfRenderableText } = await import('./DocumentsPdfDocument');
+    expect(toPdfRenderableText('A B')).toBe('A B'); // single space untouched
+    expect(toPdfRenderableText('A          B')).toBe(`A${' '.repeat(10)}B`);
+    expect(toPdfRenderableText('A  B   C')).toBe(`A${'  '}B${'   '}C`);
+  });
+
+  it('appends one non-breaking space after a trailing newline, so the empty last line keeps its height', async () => {
+    const { toPdfRenderableText } = await import('./DocumentsPdfDocument');
+    expect(toPdfRenderableText('ЗАЯВА\n')).toBe('ЗАЯВА\n ');
+    expect(toPdfRenderableText('ЗАЯВА')).toBe('ЗАЯВА'); // no trailing newline, no change
+    expect(toPdfRenderableText('ЗАЯВА\n\n')).toBe('ЗАЯВА\n\n '); // only one sentinel needed
+  });
+
+  it('never mutates the stored text - it only ever runs at render time on a copy', async () => {
+    const { toPdfRenderableText } = await import('./DocumentsPdfDocument');
+    const stored = 'Приватний нотаріус          Алексашина';
+    toPdfRenderableText(stored);
+    expect(stored).toBe('Приватний нотаріус          Алексашина'); // untouched
+  });
+
+  it('renders a document with multi-space runs and a trailing blank line without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const { DEFAULT_DOC_FORMATTING } = await import('./documentsCatalogUtils');
+    const doc = {
+      id: 'spaces-and-blank-doc',
+      title: { uk: 'Т' },
+      paragraphs: [
+        { type: 'text', uk: 'Приватний нотаріус          Алексашина Юлія Борисівна\n' },
+        { type: 'text', uk: 'Наступний абзац.' },
+      ],
+    };
+    const buffer = await pdf(React.createElement(documentsModule.default, {
+      documents: [doc], layout: 'one-column-uk', formatting: DEFAULT_DOC_FORMATTING,
+    })).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
+});
+
+describe('Documents renderers - title deletion never crashes (batch 2026-07-23 C §2)', () => {
+  const registerFonts = async Font => {
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+  };
+
+  it('PDF export renders a document whose title was deleted, with no title block and no throw', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    await registerFonts(Font);
+    const { buildGeneratedDocument, DEFAULT_DOC_FORMATTING } = await import('./documentsCatalogUtils');
+    const template = { id: 'no-title-doc', paragraphs: [{ uk: 'ONLY_BODY_TEXT', en: 'ONLY_BODY_TEXT' }] };
+    const generated = buildGeneratedDocument(template, {});
+    const buffer = await pdf(React.createElement(documentsModule.default, {
+      documents: [generated], layout: 'one-column-uk', formatting: DEFAULT_DOC_FORMATTING,
+    })).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
+
+  it('DOCX export renders a document whose title was deleted, with no title paragraph and no throw', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const { buildGeneratedDocument } = await import('./documentsCatalogUtils');
+    const template = { id: 'no-title-doc', paragraphs: [{ uk: 'ONLY_BODY_TEXT', en: 'ONLY_BODY_TEXT' }] };
+    const generated = buildGeneratedDocument(template, {});
+    const blob = await buildDocumentsDocx({ documents: [generated], layout: 'one-column-uk' });
+    expect(blob.size).toBeGreaterThan(300);
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const xml = await zip.file('word/document.xml').async('string');
+    expect(xml).toContain('ONLY_BODY_TEXT');
+    expect(xml).not.toContain('undefined');
+  }, 20000);
+
+  it('an old template stored with a plain {uk, en} title (no `style` key) still renders centered, unchanged', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    await registerFonts(Font);
+    const { buildGeneratedDocument, DEFAULT_DOC_FORMATTING } = await import('./documentsCatalogUtils');
+    const legacyTemplate = { id: 'legacy-doc', title: { uk: 'ЗАЯВА', en: 'STATEMENT' }, paragraphs: [{ uk: 'Тіло.', en: 'Body.' }] };
+    const generated = buildGeneratedDocument(legacyTemplate, {});
+    expect(generated.title.align).toBeUndefined();
+    const buffer = await pdf(React.createElement(documentsModule.default, {
+      documents: [generated], layout: 'one-column-uk', formatting: DEFAULT_DOC_FORMATTING,
+    })).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
+});

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1257,9 +1257,11 @@ export const nextParagraphAlign = align => {
 };
 
 // Scope-addressed style access, mirroring getTemplateScopeText/withTemplateScopeText: the same
-// alignment/formatting controls serve a beforeTitle block and a body paragraph through one pair
-// of helpers (the title has no per-row style, so TITLE_SCOPE deliberately resolves to nothing).
+// alignment/formatting controls serve the title, a beforeTitle block, and a body paragraph
+// through one pair of helpers (batch 2026-07-23 C §2: the title is an ordinary paragraph with the
+// standard toolbar, so TITLE_SCOPE resolves to the `title` record and its consolidated `style`).
 export const getTemplateScopeRecord = (template, scope) => {
+  if (scope === TITLE_SCOPE) return isPlainObject(template?.title) ? template.title : null;
   const beforeTitleMatch = /^beforeTitle:(\d+)$/.exec(scope);
   if (beforeTitleMatch) return toArray(template?.beforeTitle)[Number(beforeTitleMatch[1])] || null;
   const paragraphMatch = /^p:(\d+)$/.exec(scope);
@@ -1267,7 +1269,15 @@ export const getTemplateScopeRecord = (template, scope) => {
   return null;
 };
 
+// The title's effective alignment defaults to Center (batch 2026-07-23 C §2: an ordinary centered
+// paragraph), unlike body paragraphs whose default comes from their bold/heading status - an
+// explicit `style.align` set with the alignment button still wins, exactly like any paragraph.
+export const getEffectiveTitleAlign = titleRecord => getParagraphStyle(titleRecord).align ?? 'center';
+
 export const withTemplateScopeStyle = (template, scope, partialStyle) => {
+  if (scope === TITLE_SCOPE) {
+    return { ...template, title: withParagraphStyle(isPlainObject(template?.title) ? template.title : {}, partialStyle) };
+  }
   const beforeTitleMatch = /^beforeTitle:(\d+)$/.exec(scope);
   if (beforeTitleMatch) {
     const index = Number(beforeTitleMatch[1]);
@@ -1430,9 +1440,15 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
     columns: resolveDocColumns(template, languages),
     beforeTitle: resolveBeforeTitleBlocks(template, context),
     beforeTitleOffsetPercent: normalizeSignerBlockOffsetPercent(template?.beforeTitleOffsetPercent),
+    // The title is an ordinary centered paragraph (batch 2026-07-23 C §2): its own consolidated
+    // `style` resolves here the same way a body paragraph's does - sparse, undefined = inherit
+    // the document default (centered, titleFontSize). A template whose title was deleted simply
+    // resolves to empty strings; the renderers skip an all-blank title block entirely.
     title: {
       uk: overriddenText(override.title, 'uk', fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk')),
       en: overriddenText(override.title, 'en', fillPlaceholders(localizedText(template.title, 'en'), context, 'en')),
+      align: getParagraphStyle(template.title).align,
+      fontSize: getParagraphStyle(template.title).fontSize,
     },
     paragraphs: toArray(template.paragraphs).map((paragraph, index) => {
       const type = getParagraphType(paragraph);

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -36,6 +36,8 @@ import {
   getClinicLogo,
   getEffectiveDocLayout,
   getEffectiveParagraphAlign,
+  getEffectiveTitleAlign,
+  getTemplateScopeRecord,
   getLayoutColumnCount,
   getLayoutLang,
   getParagraphStyle,
@@ -2591,5 +2593,78 @@ describe('spec: Parties page record shapes', () => {
     expect(findPartyReferences(catalog, 'maternityHospitals', 'hospital-1')).toEqual([expect.stringContaining('case')]);
     expect(findPartyReferences(catalog, 'notaries', 'notary-1')).toEqual([expect.stringContaining('transaction "transaction-1"')]);
     expect(findPartyReferences(catalog, 'couples', 'nobody')).toEqual([]);
+  });
+});
+
+describe('spec: consecutive spaces are never normalized in storage (batch 2026-07-23 C §1)', () => {
+  it('parseDocumentsTechnicalInput keeps interior runs of spaces exactly as pasted', () => {
+    const incoming = parseDocumentsTechnicalInput(JSON.stringify({
+      documents: [{ id: 'doc-1', title: { uk: 'Т', en: 'T' }, paragraphs: [{ uk: 'Приватний нотаріус         Алексашина', en: '' }] }],
+    }));
+    expect(incoming.documents[0].paragraphs[0].uk).toBe('Приватний нотаріус         Алексашина');
+  });
+
+  it('normalizeDocumentsCatalog round-trips a run of spaces byte-for-byte, no collapse/trim', () => {
+    const catalog = normalizeDocumentsCatalog(null, {
+      'doc-1': { id: 'doc-1', title: { uk: 'Заява' }, paragraphs: [{ uk: 'A          B' }] },
+    });
+    expect(catalog.documents[0].paragraphs[0].uk).toBe('A          B');
+  });
+
+  it('buildGeneratedDocument never collapses spaces while filling placeholders', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = { id: 'doc-spaces', title: { uk: 'Т' }, paragraphs: [{ uk: 'A          {{wife.name.uk.nominative}}          B' }] };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.paragraphs[0].uk).toMatch(/^A {10}.*B$/);
+    expect(generated.paragraphs[0].uk).toContain('          ');
+  });
+});
+
+describe('spec: title is an ordinary centered paragraph, with the standard toolbar (batch 2026-07-23 C §2)', () => {
+  it('defaults to Center when no style override is set, same shape as any paragraph', () => {
+    expect(getEffectiveTitleAlign({ uk: 'ЗАЯВА', en: 'STATEMENT' })).toBe('center');
+    expect(getEffectiveTitleAlign({ uk: 'ЗАЯВА', style: { align: 'left' } })).toBe('left');
+  });
+
+  it('getTemplateScopeRecord/withTemplateScopeStyle address the title through the same scope key as a paragraph', () => {
+    const template = { id: 'doc-1', title: { uk: 'ЗАЯВА', en: 'STATEMENT' } };
+    expect(getTemplateScopeRecord(template, TITLE_SCOPE)).toEqual(template.title);
+    const next = withTemplateScopeStyle(template, TITLE_SCOPE, { align: 'left', fontSize: 20 });
+    expect(next.title).toEqual({ uk: 'ЗАЯВА', en: 'STATEMENT', style: { align: 'left', fontSize: 20 } });
+    expect(getEffectiveTitleAlign(next.title)).toBe('left');
+  });
+
+  it('buildGeneratedDocument resolves the title\'s own align/fontSize from its consolidated style, like a paragraph', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = { id: 'doc-1', title: { uk: 'ЗАЯВА', en: 'STATEMENT', style: { align: 'left', fontSize: 20 } }, paragraphs: [] };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.title).toMatchObject({ uk: 'ЗАЯВА', en: 'STATEMENT', align: 'left', fontSize: 20 });
+  });
+
+  it('a template with no title key resolves to a blank title, never throwing', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const template = { id: 'doc-no-title', paragraphs: [{ uk: 'Тіло документа.', en: 'Body.' }] };
+    const generated = buildGeneratedDocument(template, context);
+    expect(generated.title).toEqual({ uk: '', en: '' });
+    expect(generated.paragraphs).toHaveLength(1);
+  });
+
+  it('getTemplateScopeText/withTemplateScopeText tolerate a missing title record (deleted title)', () => {
+    const template = { id: 'doc-1', paragraphs: [] };
+    expect(getTemplateScopeText(template, TITLE_SCOPE, 'uk')).toBe('');
+    const next = withTemplateScopeText(template, TITLE_SCOPE, 'uk', 'Нова назва');
+    expect(next.title).toEqual({ uk: 'Нова назва' });
+  });
+
+  it('an old template stored with the pre-batch title shape (no `style` key) still resolves to Center, unchanged', () => {
+    const catalog = sampleCatalog();
+    const context = resolveCaseContext(catalog, 'case-1');
+    const legacyTemplate = { id: 'legacy-doc', title: { uk: 'Договір', en: 'Agreement' }, paragraphs: [] };
+    const generated = buildGeneratedDocument(legacyTemplate, context);
+    expect(generated.title.align).toBeUndefined(); // renderer's own default (Center) applies
+    expect(generated.title.uk).toBe('Договір');
   });
 });

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -146,11 +146,17 @@ export const buildDocumentsDocx = async ({
   };
 
   // Exactly the Format panel's paragraph spacing - no hidden minimum - so the Word output keeps
-  // the same title-to-body rhythm as the PDF and the reference statements.
-  const titleParagraph = text => new Paragraph({
-    alignment: AlignmentType.CENTER,
+  // the same title-to-body rhythm as the PDF and the reference statements. The title is an
+  // ordinary centered paragraph (batch 2026-07-23 C §2): Center is only its default - its own
+  // sparse align/fontSize (resolved by buildGeneratedDocument from the title's consolidated
+  // `style`) override it like any paragraph's.
+  const titleParagraph = (text, title = {}) => new Paragraph({
+    alignment: title.align ? alignmentForBlock(title.align) : AlignmentType.CENTER,
     spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
-    children: formattedTextRuns(text, { size: titleSize, baseBold: true }),
+    children: formattedTextRuns(text, {
+      size: title.fontSize !== undefined ? halfPoints(title.fontSize) : titleSize,
+      baseBold: true,
+    }),
   });
 
   // The addressee/signer block between the letterhead logo and the title (notarial layout
@@ -335,10 +341,15 @@ export const buildDocumentsDocx = async ({
       children.push(emptyLineParagraph());
     }
 
-    if (isBilingual) {
-      children.push(twoColumnTable([[titleParagraph(doc.title.uk), titleParagraph(doc.title.en)]], true, showColumnDivider));
-    } else {
-      children.push(titleParagraph(doc.title[lang]));
+    // A document whose title was deleted (both languages resolve blank) gets no title paragraph
+    // at all - deleting the title must never crash or leave an empty centered line (§2).
+    const title = doc.title || {};
+    if (!isBlankBlockText(title.uk) || !isBlankBlockText(title.en)) {
+      if (isBilingual) {
+        children.push(twoColumnTable([[titleParagraph(title.uk, title), titleParagraph(title.en, title)]], true, showColumnDivider));
+      } else {
+        children.push(titleParagraph(title[lang], title));
+      }
     }
 
     const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed');

--- a/src/components/documentsPdfPreviewEngine.js
+++ b/src/components/documentsPdfPreviewEngine.js
@@ -6,10 +6,27 @@
 // DocumentsPdfPreview).
 import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist';
 
-// webpack 5 (react-scripts 5) emits the worker as its own asset from this URL reference.
-GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
+// The worker must be spawned through webpack's own `new Worker(new URL(...))` compilation, not
+// referenced as a plain `new URL(...)` asset (batch 2026-07-23 C §4). The asset route let
+// react-scripts' babel pass rewrite the worker file while still emitting it as a raw standalone
+// file, leaving `import ... from "/абсолютний/шлях/node_modules/@babel/runtime/..."` build-machine
+// paths inside it - the browser then 404s those imports, the module worker never starts, and
+// pdf.js's fake-worker fallback dynamically imports the same broken file and fails too ("Setting
+// up fake worker failed"), killing every preview on the deployed site. Compiling it as a real
+// worker chunk bundles those helpers in, and the chunk URL resolves against the deployed public
+// path (the GitHub Pages /main/ sub-path) like any other chunk.
+const ensurePdfWorker = () => {
+  if (GlobalWorkerOptions.workerPort) return;
+  GlobalWorkerOptions.workerPort = new Worker(
+    new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url),
+    { type: 'module' },
+  );
+};
 
-export const loadPdfDocument = async data => getDocument({ data }).promise;
+export const loadPdfDocument = async data => {
+  ensurePdfWorker();
+  return getDocument({ data }).promise;
+};
 
 // Renders one page at the container's CSS width × devicePixelRatio (spec §4.1), so the preview is
 // the exported page's own rasterization at native screen density - not an HTML approximation.


### PR DESCRIPTION
- Preserve consecutive spaces end to end: no normalization existed in the
  save/load path already, but the PDF renderer now substitutes NBSPs for
  space runs at render time only, so a wrapped line never swallows a
  deliberate gap (e.g. a notary signature blank). Word already emitted
  xml:space="preserve" on every run.
- Title is now an ordinary paragraph: default Center alignment, the same
  unified toolbar (align cycle, formatting popover, delete), backward
  compatible with documents saved before this change. Deleting the title
  is crash-safe across the PDF/DOCX renderers, the preview, and every
  paragraph/override consumer, and can be re-added from the editor.
- A trailing empty line in a paragraph now renders as a real blank line in
  the editor's Text-mode display, the PDF, and the Word export (Word
  already handled it; the editor's CSS pre-wrap div and the PDF renderer
  did not).
- PDF preview: the pdf.js worker is now compiled as a real webpack worker
  chunk instead of referenced as a raw asset URL, fixing "Setting up fake
  worker failed" on the deployed GitHub Pages sub-path build. Preview
  failures now show the real exception message, not a generic phrase.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H4C1HkEzvVCiczqMioqxXX