### PR TITLE
Documents Builder: migrate to simplified cases/documents data model

### DIFF
--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -1,21 +1,20 @@
-// "Дані для заяви в РАЦС" (Childbirth + Transaction editor, Batch 18 §6 / Batch 19) - shared
-// between Documents Builder (editing a case while preparing to generate its documents) and the
-// Parties page (editing a case as part of assembling it), per the Parties spec: "reuse the ...
-// form structure ... rather than duplicating it". Self-contained: owns its own drafts, resets them
-// whenever the selected case changes, and persists additively to the same documentsBuilder/parties
-// tree either host page already reads/writes.
+// "Дані для заяви в РАЦС" (childbirth + documents editor) - shared between Documents Builder
+// (editing a case while preparing to generate its documents) and the Parties page (editing a case
+// as part of assembling it), so the form structure isn't duplicated. Self-contained: owns its own
+// drafts, resets them whenever the selected case changes, and persists additively to the
+// documentsBuilder/cases/{caseId} tree either host page already reads/writes. The case's
+// `documents` branch only ever holds structured input data (surrogacyAgreement, birth-registration
+// statement date/notary) - never a stored/overridden rendering of a document.
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
-import { ref, set, update } from 'firebase/database';
+import { ref, set } from 'firebase/database';
 import { FaPlus, FaTrash } from 'react-icons/fa';
 import { database } from './config';
 import {
-  BIRTH_REGISTRATION_TRANSACTION_TYPE,
-  DOCUMENTS_PARTIES_PATH,
+  DOCUMENTS_CASES_PATH,
   createChildRecord,
-  createTransaction,
-  makeTransactionId,
+  removeEmptyCaseValues,
   toArray,
 } from './documentsCatalogUtils';
 
@@ -193,33 +192,37 @@ const DangerButton = styled(SmallButton)`
 `;
 
 const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelectedChildIdChange }) => {
-  const selectedCase = catalog.parties.cases.find(item => String(item.id) === String(caseId)) || null;
+  const selectedCase = catalog.cases.find(item => String(item.id) === String(caseId)) || null;
 
   // Which of the selected case's childbirth.children[] documents are generated for ('' = default
   // to the first child - a case with just one child never needs this shown).
   const [selectedChildId, setSelectedChildId] = useState('');
-  // Local editable copies of the selected case's childbirth/transaction data - reset from the
+  // Local editable copies of the selected case's childbirth/documents data - reset from the
   // backend record whenever the selected case changes, saved back explicitly via their own Save
   // buttons, same pattern as the per-document format draft in Documents Builder.
   const [childbirthDraft, setChildbirthDraft] = useState({ maternityHospitalId: '', children: [] });
-  const [transactionDraft, setTransactionDraft] = useState({ statementDate: '', notaryId: '', registryNumber: '' });
+  const [surrogacyAgreementDraft, setSurrogacyAgreementDraft] = useState({ number: { uk: '', en: '' }, date: '' });
+  const [birthRegistrationDraft, setBirthRegistrationDraft] = useState({ statementDate: '', notaryId: '' });
 
   useEffect(() => {
-    // `childbirth.children` isn't re-validated by normalizeCaseRecord beyond "childbirth itself is
-    // an object" - a case saved before this editor existed (or edited straight in the Firebase
-    // console) can carry `children` as a Firebase gap-object instead of a real array, which crashed
-    // every `.map()` below with no error boundary to catch it (blank page).
+    // `childbirth.children` isn't guaranteed to be a real array - a case edited straight in the
+    // Firebase console can carry it as a gap-object, which crashed every `.map()` below with no
+    // error boundary to catch it (blank page).
     setChildbirthDraft({
       maternityHospitalId: selectedCase?.childbirth?.maternityHospitalId || '',
       children: toArray(selectedCase?.childbirth?.children),
     });
-    const transactionId = selectedCase?.registrations?.birth?.transactionId;
-    const existingTransaction = transactionId
-      ? catalog.parties.transactions.find(item => String(item.id) === String(transactionId))
-      : null;
-    setTransactionDraft(existingTransaction && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE
-      ? { statementDate: existingTransaction.statementDate || '', notaryId: existingTransaction.notaryId || '', registryNumber: existingTransaction.registryNumber || '' }
-      : { statementDate: '', notaryId: '', registryNumber: '' });
+    setSurrogacyAgreementDraft({
+      number: {
+        uk: selectedCase?.documents?.surrogacyAgreement?.number?.uk || '',
+        en: selectedCase?.documents?.surrogacyAgreement?.number?.en || '',
+      },
+      date: selectedCase?.documents?.surrogacyAgreement?.date || '',
+    });
+    setBirthRegistrationDraft({
+      statementDate: selectedCase?.documents?.birthRegistrationConsent?.statementDate || '',
+      notaryId: selectedCase?.documents?.birthRegistrationConsent?.notaryId || '',
+    });
     setSelectedChildId('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [caseId]);
@@ -260,15 +263,12 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   const handleSaveChildbirth = async () => {
     if (!selectedCase) return;
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${selectedCase.id}/childbirth`), childbirthDraft);
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/childbirth`), childbirthDraft);
       setCatalog(previous => ({
         ...previous,
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(item => (String(item.id) === String(selectedCase.id)
-            ? { ...item, childbirth: childbirthDraft }
-            : item)),
-        },
+        cases: previous.cases.map(item => (String(item.id) === String(selectedCase.id)
+          ? { ...item, childbirth: childbirthDraft }
+          : item)),
       }));
       toast.success('Childbirth details saved.');
     } catch (saveError) {
@@ -277,51 +277,59 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     }
   };
 
-  const updateTransactionField = (field, value) => setTransactionDraft(previous => ({ ...previous, [field]: value }));
+  const updateSurrogacyAgreementField = (path, value) => setSurrogacyAgreementDraft(previous => {
+    if (path === 'date') return { ...previous, date: value };
+    return { ...previous, number: { ...previous.number, [path]: value } };
+  });
 
-  // Creates the case's birth-registration-surrogate-consent transaction the first time this is
-  // saved, then only ever updates that same record afterward - a transaction keeps the couple/
-  // surrogate mother it was originally signed for (batch 19), so an update never re-pulls those
-  // ids from the case's current relations, only a brand-new transaction does.
-  const handleSaveTransaction = async () => {
+  const updateBirthRegistrationField = (field, value) => setBirthRegistrationDraft(previous => ({ ...previous, [field]: value }));
+
+  // Never writes an empty `documents.surrogacyAgreement`/`documents.birthRegistrationConsent`
+  // service object - clearing every field in a section and saving removes that node entirely
+  // instead of leaving `{}` behind.
+  const handleSaveSurrogacyAgreement = async () => {
     if (!selectedCase) return;
-    const existingTransactionId = selectedCase.registrations?.birth?.transactionId;
-    const existingTransaction = existingTransactionId
-      ? catalog.parties.transactions.find(item => String(item.id) === String(existingTransactionId))
-      : null;
-    const isReusableTransaction = Boolean(existingTransaction) && existingTransaction.type === BIRTH_REGISTRATION_TRANSACTION_TYPE;
-    const transactionId = isReusableTransaction ? existingTransaction.id : makeTransactionId();
-    const nextTransaction = createTransaction({
-      transactionId,
-      caseId: selectedCase.id,
-      type: BIRTH_REGISTRATION_TRANSACTION_TYPE,
-      coupleId: isReusableTransaction ? existingTransaction.coupleId : (selectedCase.relations?.coupleId || ''),
-      surrogateMotherId: isReusableTransaction ? existingTransaction.surrogateMotherId : (selectedCase.relations?.surrogateMotherId || ''),
-      notaryId: transactionDraft.notaryId,
-      statementDate: transactionDraft.statementDate,
-      registryNumber: transactionDraft.registryNumber,
-    });
+    const cleaned = removeEmptyCaseValues(surrogacyAgreementDraft);
+    const nextValue = Object.keys(cleaned).length ? cleaned : null;
     try {
-      await update(ref(database, DOCUMENTS_PARTIES_PATH), {
-        [`transactions/${transactionId}`]: nextTransaction,
-        [`cases/${selectedCase.id}/registrations/birth/transactionId`]: transactionId,
-      });
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/documents/surrogacyAgreement`), nextValue);
       setCatalog(previous => ({
         ...previous,
-        parties: {
-          ...previous.parties,
-          transactions: isReusableTransaction
-            ? previous.parties.transactions.map(item => (String(item.id) === transactionId ? nextTransaction : item))
-            : [...previous.parties.transactions, nextTransaction],
-          cases: previous.parties.cases.map(item => (String(item.id) === String(selectedCase.id)
-            ? { ...item, registrations: { ...(item.registrations || {}), birth: { ...(item.registrations?.birth || {}), transactionId } } }
-            : item)),
-        },
+        cases: previous.cases.map(item => {
+          if (String(item.id) !== String(selectedCase.id)) return item;
+          const documents = { ...(item.documents || {}) };
+          if (nextValue) documents.surrogacyAgreement = nextValue;
+          else delete documents.surrogacyAgreement;
+          return { ...item, documents };
+        }),
       }));
-      toast.success('Transaction saved.');
+      toast.success('Surrogacy agreement saved.');
     } catch (saveError) {
-      console.error('Unable to save the transaction', saveError);
-      toast.error('Could not save the transaction.');
+      console.error('Unable to save the surrogacy agreement', saveError);
+      toast.error('Could not save the surrogacy agreement.');
+    }
+  };
+
+  const handleSaveBirthRegistration = async () => {
+    if (!selectedCase) return;
+    const cleaned = removeEmptyCaseValues(birthRegistrationDraft);
+    const nextValue = Object.keys(cleaned).length ? cleaned : null;
+    try {
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/documents/birthRegistrationConsent`), nextValue);
+      setCatalog(previous => ({
+        ...previous,
+        cases: previous.cases.map(item => {
+          if (String(item.id) !== String(selectedCase.id)) return item;
+          const documents = { ...(item.documents || {}) };
+          if (nextValue) documents.birthRegistrationConsent = nextValue;
+          else delete documents.birthRegistrationConsent;
+          return { ...item, documents };
+        }),
+      }));
+      toast.success('Birth registration details saved.');
+    } catch (saveError) {
+      console.error('Unable to save the birth registration details', saveError);
+      toast.error('Could not save the birth registration details.');
     }
   };
 
@@ -440,19 +448,52 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
         </RowLine>
       ) : null}
 
-      <SectionSubhead style={{ marginTop: 14 }}>Заява до РАЦС (транзакція)</SectionSubhead>
+      <SectionSubhead style={{ marginTop: 14 }}>Договір сурогатного материнства</SectionSubhead>
+      <FieldGrid>
+        <Field>
+          Номер (укр)
+          <FieldInput
+            type="text"
+            value={surrogacyAgreementDraft.number.uk || ''}
+            onChange={event => updateSurrogacyAgreementField('uk', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Номер (eng)
+          <FieldInput
+            type="text"
+            value={surrogacyAgreementDraft.number.en || ''}
+            onChange={event => updateSurrogacyAgreementField('en', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Дата договору
+          <FieldInput
+            type="date"
+            value={surrogacyAgreementDraft.date || ''}
+            onChange={event => updateSurrogacyAgreementField('date', event.target.value)}
+          />
+        </Field>
+      </FieldGrid>
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveSurrogacyAgreement}>
+          Save surrogacy agreement
+        </PrimaryMiniButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Заява до РАЦС</SectionSubhead>
       <FieldGrid>
         <Field>
           Дата заяви
           <FieldInput
             type="date"
-            value={transactionDraft.statementDate || ''}
-            onChange={event => updateTransactionField('statementDate', event.target.value)}
+            value={birthRegistrationDraft.statementDate || ''}
+            onChange={event => updateBirthRegistrationField('statementDate', event.target.value)}
           />
         </Field>
         <Field>
           Нотаріус
-          <Select value={transactionDraft.notaryId || ''} onChange={event => updateTransactionField('notaryId', event.target.value)}>
+          <Select value={birthRegistrationDraft.notaryId || ''} onChange={event => updateBirthRegistrationField('notaryId', event.target.value)}>
             <option value="">— не обрано —</option>
             {catalog.parties.notaries.map(notary => (
               <option key={notary.id} value={String(notary.id)}>
@@ -461,18 +502,10 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
             ))}
           </Select>
         </Field>
-        <Field>
-          Номер реєстру
-          <FieldInput
-            type="text"
-            value={transactionDraft.registryNumber || ''}
-            onChange={event => updateTransactionField('registryNumber', event.target.value)}
-          />
-        </Field>
       </FieldGrid>
       <RowLine style={{ marginTop: 8 }}>
-        <PrimaryMiniButton type="button" onClick={handleSaveTransaction}>
-          Save transaction
+        <PrimaryMiniButton type="button" onClick={handleSaveBirthRegistration}>
+          Save birth registration details
         </PrimaryMiniButton>
       </RowLine>
     </Section>

--- a/src/components/DocumentsPage.childSelector.test.js
+++ b/src/components/DocumentsPage.childSelector.test.js
@@ -35,7 +35,7 @@ import { listStorageFolderFileNames } from './config';
 // eslint-disable-next-line import/first
 import DocumentsPage from './DocumentsPage';
 
-const buildParties = (children) => ({
+const buildParties = () => ({
   couples: {
     'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } }] },
   },
@@ -44,22 +44,20 @@ const buildParties = (children) => ({
     'hospital-1': { id: 'hospital-1', shortName: { uk: 'Пологовий будинок №1', en: '' } },
   },
   notaries: {},
-  transactions: {},
-  cases: {
-    'case-1': {
-      id: 'case-1',
-      relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
-      program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
-      childbirth: { maternityHospitalId: 'hospital-1', children },
-      registrations: { birth: { transactionId: '' } },
-      documents: { overrides: {} },
-    },
+});
+
+const buildCases = children => ({
+  'case-1': {
+    id: 'case-1',
+    relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
+    childbirth: { maternityHospitalId: 'hospital-1', children },
   },
 });
 
-const mockGet = parties => {
+const mockGet = children => {
   get.mockImplementation(async path => {
-    if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => parties };
+    if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => buildParties() };
+    if (path === 'documentsBuilder/cases') return { exists: () => true, val: () => buildCases(children) };
     if (path === 'documentsBuilder/templates') return { exists: () => false, val: () => null };
     return { exists: () => false, val: () => null };
   });
@@ -74,10 +72,10 @@ beforeEach(() => {
 
 describe('spec: РАЦС editor is not duplicated on Documents Builder', () => {
   it('never renders the childbirth/transaction editing form, even for a multi-child case', async () => {
-    mockGet(buildParties([
+    mockGet([
       { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
       { id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' } },
-    ]));
+    ]);
 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     await screen.findByText('Case');
@@ -89,10 +87,10 @@ describe('spec: РАЦС editor is not duplicated on Documents Builder', () => {
   });
 
   it('shows a plain child picker for a multi-child case, defaulting to the first child', async () => {
-    mockGet(buildParties([
+    mockGet([
       { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
       { id: 'child-2', sex: 'male', birthDate: '2026-05-17', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-17' } },
-    ]));
+    ]);
 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
 
@@ -103,9 +101,9 @@ describe('spec: РАЦС editor is not duplicated on Documents Builder', () => {
   });
 
   it('hides the child picker entirely for a single-child case', async () => {
-    mockGet(buildParties([
+    mockGet([
       { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
-    ]));
+    ]);
 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     await screen.findByText('Case');
@@ -117,8 +115,7 @@ describe('spec: РАЦС editor is not duplicated on Documents Builder', () => {
   // array (same hazard PartiesPage.caseEditor.test.js covers for the editor) - this page's own
   // read of it (toArray) must tolerate that too.
   it('does not crash when case.childbirth.children arrives as a Firebase gap-object', async () => {
-    const parties = buildParties({ 1: { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } } });
-    mockGet(parties);
+    mockGet({ 1: { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } } });
 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
 

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -20,6 +20,7 @@ import DocumentsPdfPreview from './DocumentsPdfPreview';
 import { useAutoResize } from '../hooks/useAutoResize';
 import {
   DEFAULT_DOC_FORMATTING,
+  DOCUMENTS_CASES_PATH,
   DOCUMENTS_PARTIES_PATH,
   DOCUMENTS_SETTINGS_PATH,
   DOCUMENTS_TEMPLATES_PATH,
@@ -61,11 +62,9 @@ import {
   parseDocumentsTechnicalInput,
   parseFormattedRuns,
   plainTextOf,
-  pruneDocOverride,
   resolveCaseContext,
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
-  shiftDocOverrideParagraphIndices,
   TITLE_SCOPE,
   toArray,
   toggleInlineFormat,
@@ -788,7 +787,6 @@ const DocumentsPage = ({ isAdmin }) => {
     || (String(scope).startsWith('beforeTitle') ? 'template' : 'text');
   const setParagraphModeFor = (docId, index, mode) => setParagraphModes(previous => ({ ...previous, [paragraphModeKey(docId, index)]: mode }));
   const [dirtyDocIds, setDirtyDocIds] = useState({});
-  const [dirtyOverrideDocIds, setDirtyOverrideDocIds] = useState({});
   const [technicalInput, setTechnicalInput] = useState('');
   const [isApplyingTechnical, setIsApplyingTechnical] = useState(false);
   const [formattingOpen, setFormattingOpen] = useState(false);
@@ -826,21 +824,23 @@ const DocumentsPage = ({ isAdmin }) => {
     setLoading(true);
     setError('');
     try {
-      const [partiesSnapshot, templatesSnapshot, settingsSnapshot] = await Promise.all([
+      const [partiesSnapshot, casesSnapshot, templatesSnapshot, settingsSnapshot] = await Promise.all([
         get(ref(database, DOCUMENTS_PARTIES_PATH)),
+        get(ref(database, DOCUMENTS_CASES_PATH)),
         get(ref(database, DOCUMENTS_TEMPLATES_PATH)),
         get(ref(database, DOCUMENTS_SETTINGS_PATH)),
       ]);
       const nextCatalog = normalizeDocumentsCatalog(
         partiesSnapshot.exists() ? partiesSnapshot.val() : null,
         templatesSnapshot.exists() ? templatesSnapshot.val() : null,
+        casesSnapshot.exists() ? casesSnapshot.val() : null,
       );
       const nextSettings = normalizeDocumentsSettings(settingsSnapshot.exists() ? settingsSnapshot.val() : null);
       setCatalog(nextCatalog);
       setSettings(nextSettings);
       // The favourite formatting values from the backend become the working values on load.
       setFormatting(nextSettings.formatting);
-      const orderedCases = orderCasesByRecent(nextCatalog.parties.cases, nextSettings.recentCaseIds);
+      const orderedCases = orderCasesByRecent(nextCatalog.cases, nextSettings.recentCaseIds);
       setSelectedCaseId(previous => (previous && orderedCases.some(item => String(item.id) === previous)
         ? previous
         : String(orderedCases[0]?.id || '')));
@@ -912,22 +912,27 @@ const DocumentsPage = ({ isAdmin }) => {
           partiesPatch[`${collection}/${mergedRecord.id}`] = mergedRecord;
         });
       });
+      const casesPatch = {};
+      resolveMergedRecordsForPersistence(catalog.cases, merged.cases, incoming.cases).forEach(mergedRecord => {
+        casesPatch[mergedRecord.id] = mergedRecord;
+      });
       const templatesPatch = {};
       resolveMergedRecordsForPersistence(catalog.documents, merged.documents, incoming.documents).forEach(mergedRecord => {
         templatesPatch[mergedRecord.id] = mergedRecord;
       });
       if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
+      if (Object.keys(casesPatch).length) await update(ref(database, DOCUMENTS_CASES_PATH), casesPatch);
       if (Object.keys(templatesPatch).length) await update(ref(database, DOCUMENTS_TEMPLATES_PATH), templatesPatch);
       // A full backend export also carries each clinic's {{logo}}/{{logo-long}} layout
-      // assignments (parties.cases.clinics) - written per clinic id so an uploaded export
-      // restores them instead of leaving every logo variant unassigned.
+      // assignments - written per clinic id so an uploaded export restores them instead of
+      // leaving every logo variant unassigned.
       const clinicIdsWithLogos = Object.keys(incoming.clinicLogos || {});
       await Promise.all(clinicIdsWithLogos.map(clinicId => set(
         ref(database, clinicLogoDbPath(clinicId)),
         merged.clinicLogos[clinicId],
       )));
       setCatalog(merged);
-      if (!selectedCaseId && merged.parties.cases.length) setSelectedCaseId(String(merged.parties.cases[0].id));
+      if (!selectedCaseId && merged.cases.length) setSelectedCaseId(String(merged.cases[0].id));
       setTechnicalInput('');
       const logoNote = clinicIdsWithLogos.length ? `, ${clinicIdsWithLogos.length} clinic logo assignment(s)` : '';
       toast.success(`Merged: ${summary.added} added, ${summary.updated} updated${logoNote}.`);
@@ -1089,38 +1094,16 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   // Inserting or removing a paragraph is a structural edit, not a text edit - persisted
-  // immediately (not deferred to blur, unlike the plain text fields above) and, since a
-  // paragraph's position is how per-case data-mode overrides key into it, reindexes every
-  // affected case's overrides in the same operation so an insert/remove at any position never
-  // silently misapplies an existing override to the wrong paragraph.
-  const applyParagraphStructureChange = async (docId, buildParagraphs, atIndex, delta) => {
+  // immediately (not deferred to blur, unlike the plain text fields above).
+  const applyParagraphStructureChange = async (docId, buildParagraphs) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const nextTemplate = { ...template, paragraphs: buildParagraphs(template.paragraphs || []) };
-    const shiftedByCaseId = catalog.parties.cases
-      .filter(caseRecord => caseRecord.documents?.overrides?.[docId])
-      .map(caseRecord => [caseRecord.id, shiftDocOverrideParagraphIndices(caseRecord.documents.overrides[docId], atIndex, delta)]);
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      const partiesPatch = {};
-      shiftedByCaseId.forEach(([caseId, override]) => {
-        partiesPatch[`cases/${caseId}/documents/overrides/${docId}`] = override;
-      });
-      if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
       setCatalog(previous => ({
         ...previous,
         documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(caseRecord => {
-            const shifted = shiftedByCaseId.find(([caseId]) => caseId === caseRecord.id);
-            if (!shifted) return caseRecord;
-            return {
-              ...caseRecord,
-              documents: { ...(caseRecord.documents || {}), overrides: { ...(caseRecord.documents?.overrides || {}), [docId]: shifted[1] } },
-            };
-          }),
-        },
       }));
     } catch (structureError) {
       console.error('Unable to update the document paragraph structure', structureError);
@@ -1132,8 +1115,6 @@ const DocumentsPage = ({ isAdmin }) => {
   const handleInsertParagraph = (docId, atIndex) => applyParagraphStructureChange(
     docId,
     paragraphs => [...paragraphs.slice(0, atIndex), { uk: '', en: '' }, ...paragraphs.slice(atIndex)],
-    atIndex,
-    1,
   );
 
   const handleRemoveParagraph = (docId, atIndex) => {
@@ -1141,8 +1122,6 @@ const DocumentsPage = ({ isAdmin }) => {
     applyParagraphStructureChange(
       docId,
       paragraphs => paragraphs.filter((_, index) => index !== atIndex),
-      atIndex,
-      -1,
     );
   };
 
@@ -1199,28 +1178,11 @@ const DocumentsPage = ({ isAdmin }) => {
     if (!template) return;
     const nextTemplate = { ...template };
     delete nextTemplate.title;
-    const casesWithTitleOverride = catalog.parties.cases.filter(caseRecord => caseRecord.documents?.overrides?.[docId]?.title);
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      const partiesPatch = {};
-      casesWithTitleOverride.forEach(caseRecord => {
-        partiesPatch[`cases/${caseRecord.id}/documents/overrides/${docId}/title`] = null;
-      });
-      if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
       setCatalog(previous => ({
         ...previous,
         documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(caseRecord => {
-            if (!caseRecord.documents?.overrides?.[docId]?.title) return caseRecord;
-            const { title: _removedTitle, ...restOverride } = caseRecord.documents.overrides[docId];
-            return {
-              ...caseRecord,
-              documents: { ...caseRecord.documents, overrides: { ...caseRecord.documents.overrides, [docId]: restOverride } },
-            };
-          }),
-        },
       }));
     } catch (structureError) {
       console.error('Unable to remove the title', structureError);
@@ -1264,93 +1226,14 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   // --- Data-mode editing (pencil "Data" mode, spec §2) ------------------------------------------
-  // Edits to the resolved text are kept per case as sparse overrides (case.documents.overrides[docId])
-  // so the shared template with its {{tokens}} stays untouched.
-
-  const updateCaseDocOverride = (docId, updater) => {
-    if (!selectedCaseId) return;
-    setCatalog(previous => ({
-      ...previous,
-      parties: {
-        ...previous.parties,
-        cases: previous.parties.cases.map(caseRecord => (String(caseRecord.id) === selectedCaseId
-          ? {
-            ...caseRecord,
-            documents: {
-              ...(caseRecord.documents || {}),
-              overrides: {
-                ...(caseRecord.documents?.overrides || {}),
-                [docId]: updater(caseRecord.documents?.overrides?.[docId] || {}),
-              },
-            },
-          }
-          : caseRecord)),
-      },
-    }));
-    setDirtyOverrideDocIds(previous => ({ ...previous, [docId]: true }));
-  };
-
-  // Shared by the title row and every paragraph row (spec: "єдиний формат, як параграфи") -
-  // beforeTitle has no override counterpart (see getTemplateScopeText), so it never calls this.
-  const handleDataScopeChange = (docId, scope, langKey, value) => {
-    updateCaseDocOverride(docId, override => (scope === TITLE_SCOPE
-      ? { ...override, title: { ...(override.title || {}), [langKey]: value } }
-      : {
-        ...override,
-        paragraphs: {
-          ...(override.paragraphs || {}),
-          [Number(scope.slice(2))]: { ...(override.paragraphs?.[Number(scope.slice(2))] || {}), [langKey]: value },
-        },
-      }));
-  };
-
-  const persistDocOverride = async docId => {
-    if (!dirtyOverrideDocIds[docId] || !selectedCaseId) return;
-    const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId);
-    const template = catalog.documents.find(item => String(item.id) === String(docId));
-    if (!caseRecord || !template) return;
-    // Only real deviations from the resolved template survive on the backend.
-    const baseline = buildGeneratedDocument(template, resolveCaseContext(catalog, selectedCaseId));
-    const pruned = pruneDocOverride(caseRecord.documents?.overrides?.[docId], baseline);
-    try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/documents/overrides/${docId}`), pruned);
-      setCatalog(previous => ({
-        ...previous,
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(item => {
-            if (String(item.id) !== String(caseRecord.id)) return item;
-            const overrides = { ...(item.documents?.overrides || {}) };
-            if (pruned) overrides[docId] = pruned;
-            else delete overrides[docId];
-            return {
-              ...item,
-              documents: { ...(item.documents || {}), overrides },
-            };
-          }),
-        },
-      }));
-      setDirtyOverrideDocIds(previous => {
-        const next = { ...previous };
-        delete next[docId];
-        return next;
-      });
-    } catch (saveError) {
-      console.error('Unable to save document data edits', saveError);
-      toast.error('Could not save the data edits.');
-    }
-  };
-
-  // --- Selection-based bold/italic + variable insertion (spec §1, §14/§17) -----------------------
+  // --- Selection-based bold/italic + variable insertion --------------------------------------
   // The Bold/Italic/Insert-variable toolbar buttons act on whichever row field currently holds the
   // browser text selection - tracked here rather than passed as props, since a toolbar click always
   // blurs the field first (selectionStart/End survive that, but focus itself moves to the button).
   // One `scope` key addresses any editable row (title / a beforeTitle block / a paragraph, see
-  // getTemplateScopeText) so the same toolbar and handlers serve all of them (spec: "єдиний
-  // формат, як параграфи"). `kind` says which text the field is actually showing/editing:
-  // 'template' - the shared raw {{placeholder}} markup (direct write to the template, no case
-  // needed - beforeTitle only ever has this kind, since it has no per-case override); 'override' -
-  // this case's resolved-value override (only meaningful once a case is selected).
+  // getTemplateScopeText) so the same toolbar and handlers serve all of them. Every row is always
+  // the shared raw {{placeholder}} markup - templates are static and shared across every case, so
+  // there is no per-case resolved-value editing layer.
 
   const fieldNodesRef = useRef({});
   const activeFieldRef = useRef(null);
@@ -1420,9 +1303,9 @@ const DocumentsPage = ({ isAdmin }) => {
     // Input mode's field never takes Bold/Italic (the buttons are disabled there) - hard-stop in
     // case a stale focus record from it is still the active field.
     if (active.kind === 'input-plain') return;
-    // beforeTitle rows have no per-case override layer, so their Text mode applies Bold/Italic
-    // straight onto the shared template markup (plain-text offsets via toggleInlineFormat) -
-    // unlike title/paragraph Text mode below, which writes this case's resolved-text override.
+    // beforeTitle rows have no template/text distinction in what they write - their Text mode
+    // applies Bold/Italic straight onto the shared template markup (plain-text offsets via
+    // toggleInlineFormat), exactly like Template mode does with raw offsets.
     if (active.kind === 'text-display' && /^beforeTitle:/.test(scope)) {
       const template = catalog.documents.find(item => String(item.id) === String(docId));
       if (!template) return;
@@ -1436,47 +1319,6 @@ const DocumentsPage = ({ isAdmin }) => {
       const currentRaw = getTemplateScopeText(template, scope, langKey);
       const nextRaw = toggleRawInlineMarker(currentRaw, start, end, attr);
       await commitTemplateScopeText(docId, scope, langKey, nextRaw);
-      return;
-    }
-    if (!selectedCaseId) return;
-    const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId);
-    const template = catalog.documents.find(item => String(item.id) === String(docId));
-    if (!caseRecord || !template) return;
-    const baseline = buildGeneratedDocument(template, resolveCaseContext(catalog, selectedCaseId));
-    const currentOverride = caseRecord.documents?.overrides?.[docId] || {};
-    const baselineText = scope === TITLE_SCOPE ? baseline.title?.[langKey] : baseline.paragraphs[Number(scope.slice(2))]?.[langKey];
-    const currentRaw = scope === TITLE_SCOPE
-      ? (currentOverride.title?.[langKey] ?? baselineText ?? '')
-      : (currentOverride.paragraphs?.[Number(scope.slice(2))]?.[langKey] ?? baselineText ?? '');
-    const nextRaw = toggleInlineFormat(currentRaw, start, end, attr);
-    const nextOverride = scope === TITLE_SCOPE
-      ? { ...currentOverride, title: { ...(currentOverride.title || {}), [langKey]: nextRaw } }
-      : {
-        ...currentOverride,
-        paragraphs: {
-          ...(currentOverride.paragraphs || {}),
-          [Number(scope.slice(2))]: { ...(currentOverride.paragraphs?.[Number(scope.slice(2))] || {}), [langKey]: nextRaw },
-        },
-      };
-    const pruned = pruneDocOverride(nextOverride, baseline);
-    try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}/documents/overrides/${docId}`), pruned);
-      setCatalog(previous => ({
-        ...previous,
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(item => {
-            if (String(item.id) !== String(caseRecord.id)) return item;
-            const overrides = { ...(item.documents?.overrides || {}) };
-            if (pruned) overrides[docId] = pruned;
-            else delete overrides[docId];
-            return { ...item, documents: { ...(item.documents || {}), overrides } };
-          }),
-        },
-      }));
-    } catch (formatError) {
-      console.error('Unable to save the inline formatting change', formatError);
-      toast.error('Could not save the formatting change.');
     }
   };
 
@@ -1532,17 +1374,14 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   const handleDeleteCase = async () => {
-    const caseRecord = catalog.parties.cases.find(item => String(item.id) === selectedCaseId);
+    const caseRecord = catalog.cases.find(item => String(item.id) === selectedCaseId);
     if (!caseRecord) return;
     const label = buildCaseLabel(catalog, caseRecord);
     if (typeof window !== 'undefined' && !window.confirm(`Delete case "${label}"? Party records stay in the catalog.`)) return;
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}`), null);
-      const remaining = catalog.parties.cases.filter(item => String(item.id) !== selectedCaseId);
-      setCatalog(previous => ({
-        ...previous,
-        parties: { ...previous.parties, cases: remaining },
-      }));
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${caseRecord.id}`), null);
+      const remaining = catalog.cases.filter(item => String(item.id) !== selectedCaseId);
+      setCatalog(previous => ({ ...previous, cases: remaining }));
       const nextRecent = settings.recentCaseIds.filter(id => id !== selectedCaseId);
       persistSettings({ recentCaseIds: nextRecent });
       const ordered = orderCasesByRecent(remaining, nextRecent);
@@ -1762,12 +1601,12 @@ const DocumentsPage = ({ isAdmin }) => {
 
   // --- Generation --------------------------------------------------------------------------------
 
-  const orderedCases = orderCasesByRecent(catalog.parties.cases, settings.recentCaseIds);
-  // Most recently downloaded documents first (spec: "самі популярні документи мають бути вгорі") -
-  // whatever hasn't been downloaded yet keeps the catalog's own order, after every recent one.
+  const orderedCases = orderCasesByRecent(catalog.cases, settings.recentCaseIds);
+  // Most recently downloaded documents first - whatever hasn't been downloaded yet keeps the
+  // catalog's own order, after every recent one.
   const orderedDocuments = orderRecordsByRecentIds(catalog.documents, settings.recentDocIds);
   const selectedTemplates = orderedDocuments.filter(template => selectedDocIds[template.id]);
-  const selectedCase = catalog.parties.cases.find(item => String(item.id) === selectedCaseId) || null;
+  const selectedCase = catalog.cases.find(item => String(item.id) === selectedCaseId) || null;
   // Editing children lives on the Parties page (CaseChildbirthTransactionEditor) - a twin case
   // only needs to say here which one this batch of documents resolves against.
   const selectedCaseChildren = toArray(selectedCase?.childbirth?.children);
@@ -1897,13 +1736,9 @@ const DocumentsPage = ({ isAdmin }) => {
 
   const prepareGeneration = () => {
     const context = resolveCaseContext(catalog, selectedCaseId, { childId: selectedChildId });
-    const generated = selectedTemplates.map(template => buildGeneratedDocument(
-      template,
-      context,
-      selectedCase?.documents?.overrides?.[template.id],
-    ));
-    // Each document renders with the shared defaults merged with its own format overrides (spec
-    // §5) - independent of whichever document (if any) the Format panel currently targets.
+    const generated = selectedTemplates.map(template => buildGeneratedDocument(template, context));
+    // Each document renders with the shared defaults merged with its own format overrides -
+    // independent of whichever document (if any) the Format panel currently targets.
     const formattingByDoc = selectedTemplates.map(template => resolveEffectiveDocFormatting(formatting, template.format));
     return {
       generated,
@@ -2137,7 +1972,7 @@ const DocumentsPage = ({ isAdmin }) => {
                 const isSingle = !(showUk && showEn);
                 // Needed even while collapsed - the title input right in the row header (below)
                 // always shows/edits the resolved value once a case is selected.
-                const resolvedDoc = buildGeneratedDocument(template, caseContext, selectedCase?.documents?.overrides?.[template.id]);
+                const resolvedDoc = buildGeneratedDocument(template, caseContext);
                 // The per-paragraph indent slider's "inherit" default - this document's own
                 // effective first-line indent, same value generation actually renders with.
                 const docFormatting = resolveEffectiveDocFormatting(formatting, template.format);
@@ -2160,22 +1995,11 @@ const DocumentsPage = ({ isAdmin }) => {
                 const catalogNameValue = template.catalogName || template.title?.uk || template.title?.en || template.id;
                 const onCatalogNameChange = event => updateTemplate(template.id, current => ({ ...current, catalogName: event.target.value }));
                 const onCatalogNameBlur = () => persistTemplate(template.id);
-                // Title mode/state - same template/input/text cycle as paragraphs (see PARAGRAPH_MODES).
-                const titleMode = getParagraphMode(template.id, TITLE_SCOPE);
-                const titleIsTemplateMode = titleMode === 'template';
-                const titleIsInputMode = titleMode === 'input';
-                const titleCaseModeLocked = !titleIsTemplateMode && !selectedCase;
-                const titleRawValue = langKey => (titleIsTemplateMode ? (template.title?.[langKey] || '') : (resolvedDoc?.title?.[langKey] ?? ''));
-                const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleRawValue(langKey)));
-                const onTitleFieldChange = langKey => event => {
-                  if (titleIsTemplateMode) {
-                    handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, event.target.value);
-                  } else {
-                    const nextRaw = applyPlainTextEdit(titleRawValue(langKey), event.target.value);
-                    handleDataScopeChange(template.id, TITLE_SCOPE, langKey, nextRaw);
-                  }
-                };
-                const onTitleFieldBlur = () => (titleIsTemplateMode ? persistTemplate(template.id) : persistDocOverride(template.id));
+                // The title is always edited as raw template markup - templates are static and
+                // shared across every case, so there is no per-case resolved-text mode anymore.
+                const titleRawValue = langKey => template.title?.[langKey] || '';
+                const onTitleFieldChange = langKey => event => handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, event.target.value);
+                const onTitleFieldBlur = () => persistTemplate(template.id);
                 return (
                   <DocRow key={template.id}>
                     <DocRowHead>
@@ -2410,13 +2234,14 @@ const DocumentsPage = ({ isAdmin }) => {
                           </SmallButton>
                         </ParagraphControlsRow>
                         {(() => {
-                          // Title (uk)/(en) always shown as a paired, symmetric row (spec batch 21
-                          // §5) - the exact same template/input/text cycle paragraphs use (spec §3/
-                          // §9), never a separate uk-in-the-header + en-below split. Printed inside
-                          // the document from title.uk/title.en only - never the catalogName above.
-                          // Batch 2026-07-23 C §2: an ordinary paragraph with the full standard
-                          // toolbar - alignment cycle (default Center), formatting popover, delete.
-                          // A template whose title was deleted shows only a "+" to add it back.
+                          // Title (uk)/(en) always shown as a paired, symmetric row, never a
+                          // separate uk-in-the-header + en-below split. Printed inside the document
+                          // from title.uk/title.en only - never the catalogName above. An ordinary
+                          // paragraph with the full standard toolbar - alignment cycle (default
+                          // Center), formatting popover, delete. A template whose title was deleted
+                          // shows only a "+" to add it back. Templates are static and shared across
+                          // every case, so the title is always edited as raw markup - there is no
+                          // per-case resolved-text mode.
                           if (template.title == null) {
                             return (
                               <ParagraphControlsRow style={{ justifyContent: 'flex-start', marginTop: 10 }}>
@@ -2430,7 +2255,6 @@ const DocumentsPage = ({ isAdmin }) => {
                               </ParagraphControlsRow>
                             );
                           }
-                          const titleFieldKind = titleIsTemplateMode ? 'template' : (titleMode === 'input' ? 'override' : 'text-display');
                           const titleStyle = getParagraphStyle(template.title);
                           return (
                             <ParagraphEditorBlock>
@@ -2439,14 +2263,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                 <RowLine style={{ gap: 6 }}>
                                   <SmallButton
                                     type="button"
-                                    onClick={() => setParagraphModeFor(template.id, TITLE_SCOPE, nextParagraphMode(titleMode))}
-                                    title={PARAGRAPH_MODE_TITLE[titleMode]}
-                                  >
-                                    {PARAGRAPH_MODE_ICON[titleMode]}
-                                  </SmallButton>
-                                  <SmallButton
-                                    type="button"
-                                    disabled={titleIsInputMode || titleCaseModeLocked}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2454,7 +2270,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={titleIsInputMode || titleCaseModeLocked}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2462,7 +2277,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={!titleIsTemplateMode}
                                     onMouseDown={preventSelectionLoss}
                                     onClick={openVariablePicker}
                                     title="Insert a variable"
@@ -2498,54 +2312,29 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </DangerButton>
                                 </RowLine>
                               </ParagraphControlsRow>
-                              {titleCaseModeLocked ? (
-                                <DocSubtitle>Select a case first to edit its resolved values.</DocSubtitle>
-                              ) : null}
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    {titleMode === 'text' ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
-                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={titleRawValue('uk')} />
-                                      </TextModeDisplay>
-                                    ) : (
-                                      <AutoInlineTextarea
-                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
-                                        value={titleDisplayValue('uk')}
-                                        placeholder="Title (uk)"
-                                        readOnly={titleCaseModeLocked}
-                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind)}
-                                        onChange={onTitleFieldChange('uk')}
-                                        onBlur={onTitleFieldBlur}
-                                      />
-                                    )}
+                                    <AutoInlineTextarea
+                                      ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
+                                      value={titleRawValue('uk')}
+                                      placeholder="Title (uk)"
+                                      onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'template')}
+                                      onChange={onTitleFieldChange('uk')}
+                                      onBlur={onTitleFieldBlur}
+                                    />
                                   </ParagraphFieldColumn>
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    {titleMode === 'text' ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
-                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={titleRawValue('en')} />
-                                      </TextModeDisplay>
-                                    ) : (
-                                      <AutoInlineTextarea
-                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
-                                        value={titleDisplayValue('en')}
-                                        placeholder="Title (en)"
-                                        readOnly={titleCaseModeLocked}
-                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind)}
-                                        onChange={onTitleFieldChange('en')}
-                                        onBlur={onTitleFieldBlur}
-                                      />
-                                    )}
+                                    <AutoInlineTextarea
+                                      ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
+                                      value={titleRawValue('en')}
+                                      placeholder="Title (en)"
+                                      onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'template')}
+                                      onChange={onTitleFieldChange('en')}
+                                      onBlur={onTitleFieldBlur}
+                                    />
                                   </ParagraphFieldColumn>
                                 ) : null}
                               </ParagraphPair>
@@ -2554,36 +2343,19 @@ const DocumentsPage = ({ isAdmin }) => {
                         })()}
                         {(template.paragraphs || []).map((paragraph, index) => {
                           const scope = paragraphScope(index);
-                          // Per-paragraph mode - see PARAGRAPH_MODES above for what each of
-                          // template/input/text means; Bold/Italic only ever act in template mode
-                          // (raw markers) or text mode (this case's override, applied live in place
-                          // - no separate preview to catch up, spec batch 21 §2).
-                          const mode = getParagraphMode(template.id, scope);
-                          const isTemplateMode = mode === 'template';
-                          const isInputMode = mode === 'input';
-                          const isTextMode = mode === 'text';
-                          const caseModeLocked = !isTemplateMode && !selectedCase;
-                          const rawValue = langKey => (isTemplateMode
-                            ? paragraph?.[langKey] || ''
-                            : resolvedDoc?.paragraphs?.[index]?.[langKey] ?? '');
-                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
-                          const onChange = langKey => event => {
-                            if (isTemplateMode) {
-                              handleTemplateScopeChange(template.id, scope, langKey, event.target.value);
-                            } else {
-                              const nextRaw = applyPlainTextEdit(rawValue(langKey), event.target.value);
-                              handleDataScopeChange(template.id, scope, langKey, nextRaw);
-                            }
-                          };
-                          const onBlur = () => (isTemplateMode ? persistTemplate(template.id) : persistDocOverride(template.id));
-                          const fieldKind = isTemplateMode ? 'template' : 'override';
-                          // This paragraph's own stored overrides, whichever backend shape they
-                          // are in (consolidated `style` key or legacy flat fields).
+                          // A paragraph is always edited as raw template markup - templates are
+                          // static and shared across every case, so there is no per-case
+                          // resolved-text mode (Bold/Italic act on the raw `**`/`*` markers).
+                          const rawValue = langKey => paragraph?.[langKey] || '';
+                          const onChange = langKey => event => handleTemplateScopeChange(template.id, scope, langKey, event.target.value);
+                          const onBlur = () => persistTemplate(template.id);
+                          // This paragraph's own stored style overrides, whichever backend shape
+                          // they are in (consolidated `style` key or legacy flat fields).
                           const paragraphStyle = getParagraphStyle(paragraph);
                           return (
                             // Boxed together so it's unambiguous which paragraph the toolbar acts
-                            // on: the +/mode-switch/Bold/Italic/Delete controls and the paragraph's
-                            // own text live inside the same visible border.
+                            // on: the +/Bold/Italic/Delete controls and the paragraph's own text
+                            // live inside the same visible border.
                             <ParagraphEditorBlock key={`${template.id}-p-${index}`}>
                               <ParagraphControlsRow>
                                 <SmallButton
@@ -2596,14 +2368,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                 <RowLine style={{ gap: 6 }}>
                                   <SmallButton
                                     type="button"
-                                    onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
-                                    title={PARAGRAPH_MODE_TITLE[mode]}
-                                  >
-                                    {PARAGRAPH_MODE_ICON[mode]}
-                                  </SmallButton>
-                                  <SmallButton
-                                    type="button"
-                                    disabled={isInputMode || caseModeLocked}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2611,7 +2375,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={isInputMode || caseModeLocked}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2619,7 +2382,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={!isTemplateMode}
                                     onMouseDown={preventSelectionLoss}
                                     onClick={openVariablePicker}
                                     title="Insert a variable"
@@ -2663,54 +2425,29 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </DangerButton>
                                 </RowLine>
                               </ParagraphControlsRow>
-                              {caseModeLocked ? (
-                                <DocSubtitle>Select a case first to edit its resolved values.</DocSubtitle>
-                              ) : null}
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    {isTextMode ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, scope, 'uk')}
-                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={rawValue('uk')} />
-                                      </TextModeDisplay>
-                                    ) : (
-                                      <AutoInlineTextarea
-                                        ref={registerFieldNode(template.id, scope, 'uk')}
-                                        value={displayValue('uk')}
-                                        placeholder="Paragraph (uk)"
-                                        readOnly={caseModeLocked}
-                                        onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
-                                        onChange={onChange('uk')}
-                                        onBlur={onBlur}
-                                      />
-                                    )}
+                                    <AutoInlineTextarea
+                                      ref={registerFieldNode(template.id, scope, 'uk')}
+                                      value={rawValue('uk')}
+                                      placeholder="Paragraph (uk)"
+                                      onFocus={handleRichFieldFocus(template.id, scope, 'uk', 'template')}
+                                      onChange={onChange('uk')}
+                                      onBlur={onBlur}
+                                    />
                                   </ParagraphFieldColumn>
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    {isTextMode ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, scope, 'en')}
-                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={rawValue('en')} />
-                                      </TextModeDisplay>
-                                    ) : (
-                                      <AutoInlineTextarea
-                                        ref={registerFieldNode(template.id, scope, 'en')}
-                                        value={displayValue('en')}
-                                        placeholder="Paragraph (en)"
-                                        readOnly={caseModeLocked}
-                                        onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
-                                        onChange={onChange('en')}
-                                        onBlur={onBlur}
-                                      />
-                                    )}
+                                    <AutoInlineTextarea
+                                      ref={registerFieldNode(template.id, scope, 'en')}
+                                      value={rawValue('en')}
+                                      placeholder="Paragraph (en)"
+                                      onFocus={handleRichFieldFocus(template.id, scope, 'en', 'template')}
+                                      onChange={onChange('en')}
+                                      onBlur={onBlur}
+                                    />
                                   </ParagraphFieldColumn>
                                 ) : null}
                               </ParagraphPair>

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -44,8 +44,13 @@ beforeEach(() => {
         exists: () => true,
         val: () => ({
           couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } }] } },
-          cases: { 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1' } } },
         }),
+      };
+    }
+    if (path === 'documentsBuilder/cases') {
+      return {
+        exists: () => true,
+        val: () => ({ 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1' } } }),
       };
     }
     if (path === 'documentsBuilder/templates') {

--- a/src/components/DocumentsPage.richFormatting.test.js
+++ b/src/components/DocumentsPage.richFormatting.test.js
@@ -6,6 +6,12 @@
 // NOTE: this project's Jest config sets `resetMocks: true`, which strips every mock's
 // implementation before each test - so the mock bodies below must be (re-)installed in
 // beforeEach, not just in the jest.mock(...) factory (which only runs once at hoist time).
+//
+// Post-migration (batch 2026-07-24): the per-case "data mode" resolved-text overrides on
+// title/paragraph rows are gone. A paragraph (and the title) is now always the raw
+// `{{placeholder}}` template markup - there is no mode-toggle button and no rendered
+// resolved-value display for these rows anymore, so Bold/Italic act directly on the textarea's
+// native selection and always persist to the shared template.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
@@ -37,22 +43,6 @@ import { listStorageFolderFileNames } from './config';
 // eslint-disable-next-line import/first
 import DocumentsPage from './DocumentsPage';
 
-// Text mode's field is a plain rendered display, not a textarea (spec batch 21 §2 - the display
-// itself is the editing surface), so there's no `.setSelectionRange` to drive a selection through.
-// This mirrors what a real browser drag-select does: build a Range over the container's own text
-// node and install it as the document's selection, then fire the mouseUp/touchEnd the component
-// listens on to know a selection was just made in that field.
-const selectTextInContainer = (container, start, end) => {
-  // eslint-disable-next-line testing-library/no-node-access
-  const textNode = container.firstChild;
-  const range = document.createRange();
-  range.setStart(textNode, start);
-  range.setEnd(textNode, end);
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-};
-
 beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
   get.mockImplementation(async path => {
@@ -61,7 +51,14 @@ beforeEach(() => {
         exists: () => true,
         val: () => ({
           couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } }] } },
-          cases: { 'case-1': { id: 'case-1', coupleId: 'couple-1' } },
+        }),
+      };
+    }
+    if (path === 'documentsBuilder/cases') {
+      return {
+        exists: () => true,
+        val: () => ({
+          'case-1': { id: 'case-1', relations: { coupleId: 'couple-1' } },
         }),
       };
     }
@@ -84,30 +81,33 @@ beforeEach(() => {
 });
 
 describe('spec: selection-based bold/italic applies to the browser selection, not the whole paragraph', () => {
-  it('bolds only the selected fragment of a Data-mode paragraph field', async () => {
+  it('bolds only the selected fragment of a paragraph field (raw template markup)', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
 
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    // Default mode is 'text' (spec batch 21 §9) - the field is the rendered display itself.
-    const field = await screen.findByText('Звичайний текст без форматування.');
-    selectTextInContainer(field, 10, 15); // "текст"
-    fireEvent.mouseUp(field);
+    // A paragraph is always the raw template textarea now - no mode to switch, no separate
+    // rendered display to select text in.
+    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    // eslint-disable-next-line testing-library/no-node-access
+    const paragraphBlock = textarea.closest('.paragraph-editor-block');
 
-    // Bold/Italic now also appear on the Title row above (spec: unified format across every
+    fireEvent.focus(textarea);
+    textarea.setSelectionRange(10, 15); // "текст"
+
+    // Bold/Italic also appear on the Title row above (spec: unified format across every
     // editable row) - scope the query to this paragraph's own boxed controls, same as a sighted
     // admin would click the toolbar right above this specific field.
-    // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = field.closest('.paragraph-editor-block');
     const boldButton = within(paragraphBlock).getByTitle('Bold the selected text');
     fireEvent.click(boldButton);
 
     await waitFor(() => expect(set).toHaveBeenCalled());
     const [, payload] = set.mock.calls[set.mock.calls.length - 1];
     expect(payload.paragraphs[0].uk).toBe('Звичайний **текст** без форматування.');
-    // The change is applied in place, right in the display - never a separate preview to catch up.
-    expect(await within(paragraphBlock).findByText('текст')).toBeInTheDocument();
+    // The change is applied in place, right in the raw markup textarea - never a separate
+    // preview to catch up.
+    expect(await within(paragraphBlock).findByDisplayValue('Звичайний **текст** без форматування.')).toBeInTheDocument();
   });
 
   it('also applies via touch (mobile), where preventing the selection-dismissing touchstart suppresses the synthetic click', async () => {
@@ -116,12 +116,13 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    const field = await screen.findByText('Звичайний текст без форматування.');
-    selectTextInContainer(field, 10, 15); // "текст"
-    fireEvent.touchEnd(field);
-
+    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = field.closest('.paragraph-editor-block');
+    const paragraphBlock = textarea.closest('.paragraph-editor-block');
+
+    fireEvent.focus(textarea);
+    textarea.setSelectionRange(10, 15); // "текст"
+
     const italicButton = within(paragraphBlock).getByTitle('Italicize the selected text');
     // No fireEvent.click - mobile browsers won't synthesize one once touchstart's default is
     // prevented (exactly what the button needs to do to keep the selection alive), so the
@@ -135,7 +136,7 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
   });
 });
 
-describe('spec: per-paragraph template/text mode switch replaces the global toggle', () => {
+describe('spec: title/paragraph rows have a single always-template editing surface', () => {
   it('does not render the old global Template/Data section toggle', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     await screen.findByTitle('Edit paragraphs');
@@ -143,23 +144,20 @@ describe('spec: per-paragraph template/text mode switch replaces the global togg
     expect(screen.queryByTitle('Edit the resolved values of the selected case directly')).not.toBeInTheDocument();
   });
 
-  it('switching one paragraph to Template mode edits and persists the shared template, not a per-case override', async () => {
+  it('editing a paragraph directly edits and persists the shared template, not a per-case override', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    // Default mode ('text') shows the resolved value as a rendered display, not a textarea.
-    const field = await screen.findByText('Звичайний текст без форматування.');
+    // Paragraphs no longer have a mode-toggle button (spec: raw {{placeholder}} markup is the
+    // only surface, shared across every case) - the textarea is already showing/editing it.
+    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = field.closest('.paragraph-editor-block');
-
-    // One cycling button, not three separate ones (spec §3): text -> template is one tap.
-    const modeButton = within(paragraphBlock).getByTitle(
+    const paragraphBlock = textarea.closest('.paragraph-editor-block');
+    expect(within(paragraphBlock).queryByTitle(
       "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
-    );
-    fireEvent.click(modeButton);
+    )).not.toBeInTheDocument();
 
-    const textarea = await within(paragraphBlock).findByDisplayValue('Звичайний текст без форматування.');
     fireEvent.change(textarea, { target: { value: 'Змінений шаблонний текст.' } });
     fireEvent.blur(textarea);
 

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -47,22 +47,19 @@ const buildParties = () => ({
   notaries: {
     'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Нотаріус Іванова Іванівна', short: 'Іванова І.І.' } } },
   },
-  transactions: {},
-  cases: {
-    'case-1': {
-      id: 'case-1',
-      relations: {
-        coupleId: 'couple-1', clinicId: '', surrogateMotherId: 'surrogate-1', representativeIds: [],
-      },
-      program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
-      childbirth: {
-        maternityHospitalId: 'hospital-1',
-        children: [{
-          id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ', en: 'Kyiv' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' },
-        }],
-      },
-      registrations: { birth: { transactionId: '' } },
-      documents: { overrides: {} },
+});
+
+const buildCases = () => ({
+  'case-1': {
+    id: 'case-1',
+    relations: {
+      coupleId: 'couple-1', clinicId: '', surrogateMotherId: 'surrogate-1', representativeIds: [],
+    },
+    childbirth: {
+      maternityHospitalId: 'hospital-1',
+      children: [{
+        id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ', en: 'Kyiv' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' },
+      }],
     },
   },
 });
@@ -79,6 +76,9 @@ beforeEach(() => {
   get.mockImplementation(async path => {
     if (path === 'documentsBuilder/parties') {
       return { exists: () => true, val: () => buildParties() };
+    }
+    if (path === 'documentsBuilder/cases') {
+      return { exists: () => true, val: () => buildCases() };
     }
     return { exists: () => false, val: () => null };
   });
@@ -135,7 +135,7 @@ describe('spec: Childbirth/Transaction case editor (Batch 18 §6), on Parties', 
     fireEvent.click(screen.getByRole('button', { name: /save childbirth details/i }));
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
-      'documentsBuilder/parties/cases/case-1/childbirth',
+      'documentsBuilder/cases/case-1/childbirth',
       expect.objectContaining({
         maternityHospitalId: 'hospital-1',
         children: [expect.objectContaining({ id: 'child-1', medicalConclusion: expect.objectContaining({ number: 'MC-99' }) })],
@@ -143,32 +143,35 @@ describe('spec: Childbirth/Transaction case editor (Batch 18 §6), on Parties', 
     ));
   });
 
-  it('"Save transaction" creates a birth-registration-surrogate-consent transaction and points the case at it', async () => {
+  it('"Save surrogacy agreement" persists the agreement number/date directly to case.documents.surrogacyAgreement', async () => {
     await openCaseOne();
     await screen.findByLabelText('Пологовий будинок');
 
+    fireEvent.change(screen.getByLabelText('Номер (укр)'), { target: { value: 'Д-1' } });
+    fireEvent.change(screen.getByLabelText('Дата договору'), { target: { value: '2026-05-01' } });
+    fireEvent.click(screen.getByRole('button', { name: /save surrogacy agreement/i }));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/cases/case-1/documents/surrogacyAgreement',
+      { number: { uk: 'Д-1' }, date: '2026-05-01' },
+    ));
+  });
+
+  it('"Save birth registration details" persists the statement date/notary directly to case.documents.birthRegistrationConsent, with no registry number field', async () => {
+    await openCaseOne();
+    await screen.findByLabelText('Пологовий будинок');
+
+    expect(screen.queryByLabelText('Номер реєстру')).not.toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText('Дата заяви'), { target: { value: '2026-05-18' } });
     fireEvent.change(screen.getByLabelText('Нотаріус'), { target: { value: 'notary-1' } });
-    fireEvent.change(screen.getByLabelText('Номер реєстру'), { target: { value: '12345' } });
-    fireEvent.click(screen.getByRole('button', { name: /save transaction/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save birth registration details/i }));
 
-    await waitFor(() => expect(update).toHaveBeenCalled());
-    const [path, payload] = update.mock.calls[update.mock.calls.length - 1];
-    expect(path).toBe('documentsBuilder/parties');
-    const transactionKey = Object.keys(payload).find(key => key.startsWith('transactions/'));
-    expect(transactionKey).toBeDefined();
-    const transactionId = transactionKey.split('/')[1];
-    expect(payload[transactionKey]).toEqual(expect.objectContaining({
-      id: transactionId,
-      type: 'birth-registration-surrogate-consent',
-      caseId: 'case-1',
-      coupleId: 'couple-1',
-      surrogateMotherId: 'surrogate-1',
-      notaryId: 'notary-1',
-      statementDate: '2026-05-18',
-      registryNumber: '12345',
-    }));
-    expect(payload['cases/case-1/registrations/birth/transactionId']).toBe(transactionId);
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/cases/case-1/documents/birthRegistrationConsent',
+      { statementDate: '2026-05-18', notaryId: 'notary-1' },
+    ));
+    expect(update).not.toHaveBeenCalled();
   });
 
   // Regression: Firebase RTDB silently turns a JS array into a `{"1": {...}}`-shaped plain object
@@ -178,12 +181,15 @@ describe('spec: Childbirth/Transaction case editor (Batch 18 §6), on Parties', 
   it('does not crash when a case.childbirth.children arrives as a Firebase gap-object instead of an array', async () => {
     get.mockImplementation(async path => {
       if (path === 'documentsBuilder/parties') {
-        const parties = buildParties();
+        return { exists: () => true, val: () => buildParties() };
+      }
+      if (path === 'documentsBuilder/cases') {
+        const cases = buildCases();
         // `.children` here is a plain-object field on the fixture, not a DOM node, but the
         // testing-library lint rule can't tell the two apart from the property name alone.
         // eslint-disable-next-line testing-library/no-node-access
-        parties.cases['case-1'].childbirth.children = { 1: parties.cases['case-1'].childbirth.children[0] };
-        return { exists: () => true, val: () => parties };
+        cases['case-1'].childbirth.children = { 1: cases['case-1'].childbirth.children[0] };
+        return { exists: () => true, val: () => cases };
       }
       return { exists: () => false, val: () => null };
     });

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -15,6 +15,7 @@ import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
 import CaseChildbirthTransactionEditor from './CaseChildbirthTransactionEditor';
 import {
+  DOCUMENTS_CASES_PATH,
   DOCUMENTS_PARTIES_PATH,
   DOCUMENTS_TEMPLATES_PATH,
   PARTY_COLLECTIONS,
@@ -561,14 +562,6 @@ const NOTARY_FIELDS = [
   { label: 'City (en)', path: 'city.en' },
 ];
 
-const PROGRAM_FIELDS = [
-  { label: 'Program ID', path: 'programId' },
-  { label: 'Program type', path: 'program.type' },
-  { label: 'Agreement number (uk)', path: 'program.agreement.number.uk' },
-  { label: 'Agreement number (en)', path: 'program.agreement.number.en' },
-  { label: 'Agreement date', path: 'program.agreement.date', type: 'date' },
-];
-
 // --- One party-type group (couples/surrogateMothers/representatives/clinics/maternityHospitals/
 // notaries) ---------------------------------------------------------------------------------------
 
@@ -870,7 +863,7 @@ const RepresentativesSlot = ({ records, valueIds, onToggle }) => {
 };
 
 const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen, onToggleGroup, recentIds, recordPartyUsage, onSelectCase }) => {
-  const cases = catalog.parties.cases;
+  const cases = catalog.cases;
   const orderedCouples = orderRecordsByRecentIds(catalog.parties.couples, recentIds.couples);
   const orderedClinics = orderRecordsByRecentIds(catalog.parties.clinics, recentIds.clinics);
   const orderedSurrogateMothers = orderRecordsByRecentIds(catalog.parties.surrogateMothers, recentIds.surrogateMothers);
@@ -880,8 +873,8 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
     const caseId = makeCaseId();
     const record = createEmptyCase({ caseId });
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}`), record);
-      setCatalog(previous => ({ ...previous, parties: { ...previous.parties, cases: [...previous.parties.cases, record] } }));
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${caseId}`), record);
+      setCatalog(previous => ({ ...previous, cases: [...previous.cases, record] }));
       toggleRecord('cases', caseId, true);
       onSelectCase(caseId);
       toast.success('Case created.');
@@ -892,15 +885,12 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
   };
 
   const updateCaseField = async (caseId, path, value) => {
-    const dbPath = `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}/${path.split('.').join('/')}`;
+    const dbPath = `${DOCUMENTS_CASES_PATH}/${caseId}/${path.split('.').join('/')}`;
     try {
       await set(ref(database, dbPath), value);
       setCatalog(previous => ({
         ...previous,
-        parties: {
-          ...previous.parties,
-          cases: previous.parties.cases.map(item => (String(item.id) === String(caseId) ? setValueAtPath(item, path, value) : item)),
-        },
+        cases: previous.cases.map(item => (String(item.id) === String(caseId) ? setValueAtPath(item, path, value) : item)),
       }));
     } catch (updateError) {
       console.error('Unable to save case field', updateError);
@@ -919,10 +909,10 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
     const label = buildCaseLabel(catalog, caseRecord) || caseRecord.id;
     if (typeof window !== 'undefined' && !window.confirm(`Delete case "${label}"? Party records stay in the catalog.`)) return;
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseRecord.id}`), null);
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${caseRecord.id}`), null);
       setCatalog(previous => ({
         ...previous,
-        parties: { ...previous.parties, cases: previous.parties.cases.filter(item => String(item.id) !== String(caseRecord.id)) },
+        cases: previous.cases.filter(item => String(item.id) !== String(caseRecord.id)),
       }));
       toast.success('Case deleted.');
     } catch (deleteError) {
@@ -987,9 +977,6 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
                       onToggle={(repId, include) => handleToggleRepresentative(caseRecord, repId, include)}
                     />
 
-                    <SectionSubhead>Program</SectionSubhead>
-                    <RecordFieldsGrid record={caseRecord} fieldDefs={PROGRAM_FIELDS} onFieldChange={(path, value) => updateCaseField(caseRecord.id, path, value)} />
-
                     <CaseChildbirthTransactionEditor catalog={catalog} setCatalog={setCatalog} caseId={caseRecord.id} />
 
                     <RowLine style={{ marginTop: 8 }}>
@@ -1044,11 +1031,16 @@ const TechnicalSection = ({ catalog, setCatalog }) => {
           partiesPatch[`${collection}/${mergedRecord.id}`] = mergedRecord;
         });
       });
+      const casesPatch = {};
+      resolveMergedRecordsForPersistence(catalog.cases, merged.cases, incoming.cases).forEach(mergedRecord => {
+        casesPatch[mergedRecord.id] = mergedRecord;
+      });
       const templatesPatch = {};
       resolveMergedRecordsForPersistence(catalog.documents, merged.documents, incoming.documents).forEach(mergedRecord => {
         templatesPatch[mergedRecord.id] = mergedRecord;
       });
       if (Object.keys(partiesPatch).length) await update(ref(database, DOCUMENTS_PARTIES_PATH), partiesPatch);
+      if (Object.keys(casesPatch).length) await update(ref(database, DOCUMENTS_CASES_PATH), casesPatch);
       if (Object.keys(templatesPatch).length) await update(ref(database, DOCUMENTS_TEMPLATES_PATH), templatesPatch);
       setCatalog(merged);
       setTechnicalInput('');
@@ -1118,7 +1110,7 @@ const TechnicalSection = ({ catalog, setCatalog }) => {
 // above the case data per spec; picking a different case (or creating one) updates the persisted
 // last-selected case, so switching into Edit mode and back never loses it.
 const CaseReadView = ({ catalog, selectedCaseId, onSelectCase, onCreateCase }) => {
-  const cases = catalog.parties.cases;
+  const cases = catalog.cases;
   const selectedCase = cases.find(item => String(item.id) === String(selectedCaseId));
   const context = selectedCase ? resolveCaseContext(catalog, selectedCase.id) : null;
   const groups = context ? buildVariablePickerGroups(context) : [];
@@ -1195,8 +1187,9 @@ const PartiesPage = ({ isAdmin }) => {
     setLoading(true);
     setError('');
     try {
-      const [partiesSnapshot, templatesSnapshot, settingsSnapshot, lastCaseSnapshot] = await Promise.all([
+      const [partiesSnapshot, casesSnapshot, templatesSnapshot, settingsSnapshot, lastCaseSnapshot] = await Promise.all([
         get(ref(database, DOCUMENTS_PARTIES_PATH)),
+        get(ref(database, DOCUMENTS_CASES_PATH)),
         get(ref(database, DOCUMENTS_TEMPLATES_PATH)),
         get(ref(database, `${PARTIES_SETTINGS_PATH}/recentIds`)),
         get(ref(database, `${PARTIES_SETTINGS_PATH}/lastCaseId`)),
@@ -1204,14 +1197,15 @@ const PartiesPage = ({ isAdmin }) => {
       const nextCatalog = normalizeDocumentsCatalog(
         partiesSnapshot.exists() ? partiesSnapshot.val() : null,
         templatesSnapshot.exists() ? templatesSnapshot.val() : null,
+        casesSnapshot.exists() ? casesSnapshot.val() : null,
       );
       setCatalog(nextCatalog);
       const rawLastCaseId = lastCaseSnapshot.exists() ? String(lastCaseSnapshot.val()) : '';
       // Falls back to the first case only when there's no persisted choice yet (or it no longer
       // resolves to a real case) - never silently swaps out a case the admin deliberately picked.
-      setSelectedCaseId(nextCatalog.parties.cases.some(item => String(item.id) === rawLastCaseId)
+      setSelectedCaseId(nextCatalog.cases.some(item => String(item.id) === rawLastCaseId)
         ? rawLastCaseId
-        : (nextCatalog.parties.cases[0]?.id || ''));
+        : (nextCatalog.cases[0]?.id || ''));
       const rawRecentIds = settingsSnapshot.exists() ? settingsSnapshot.val() : null;
       setRecentIds({
         couples: toArray(rawRecentIds?.couples),
@@ -1284,8 +1278,8 @@ const PartiesPage = ({ isAdmin }) => {
     const caseId = makeCaseId();
     const record = createEmptyCase({ caseId });
     try {
-      await set(ref(database, `${DOCUMENTS_PARTIES_PATH}/cases/${caseId}`), record);
-      setCatalog(previous => ({ ...previous, parties: { ...previous.parties, cases: [...previous.parties.cases, record] } }));
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${caseId}`), record);
+      setCatalog(previous => ({ ...previous, cases: [...previous.cases, record] }));
       persistSelectedCase(caseId);
       enterEditModeOnCase(caseId);
       toast.success('Case created.');

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -44,16 +44,13 @@ const buildParties = () => ({
   },
   maternityHospitals: {},
   notaries: {},
-  transactions: {},
-  cases: {
-    'case-1': {
-      id: 'case-1',
-      relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
-      program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
-      childbirth: { maternityHospitalId: '', children: [] },
-      registrations: { birth: { transactionId: '' } },
-      documents: { overrides: {} },
-    },
+});
+
+const buildCases = () => ({
+  'case-1': {
+    id: 'case-1',
+    relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
+    childbirth: { maternityHospitalId: '', children: [] },
   },
 });
 
@@ -61,6 +58,7 @@ beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
   get.mockImplementation(async path => {
     if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => buildParties() };
+    if (path === 'documentsBuilder/cases') return { exists: () => true, val: () => buildCases() };
     if (path === 'documentsBuilder/templates') return { exists: () => false, val: () => null };
     if (path === 'documentsBuilder/partiesSettings/recentIds') return { exists: () => false, val: () => null };
     return { exists: () => false, val: () => null };
@@ -166,7 +164,7 @@ describe('spec: Parties page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Clinic slot' }));
     fireEvent.click(await screen.findByText('Клініка Мрія'));
 
-    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/parties/cases/case-1/relations/clinicId', 'clinic-1'));
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/cases/case-1/relations/clinicId', 'clinic-1'));
     await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/partiesSettings/recentIds/clinics', ['clinic-1']));
   });
 

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -5,6 +5,7 @@
 // (favourite formatting values + recently-used cases).
 
 export const DOCUMENTS_PARTIES_PATH = 'documentsBuilder/parties';
+export const DOCUMENTS_CASES_PATH = 'documentsBuilder/cases';
 export const DOCUMENTS_TEMPLATES_PATH = 'documentsBuilder/templates';
 export const DOCUMENTS_SETTINGS_PATH = 'documentsBuilder/settings';
 
@@ -25,7 +26,7 @@ export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoSt
 export const legacyClinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const legacyClinicLogoStorageFilePath = (clinicId, fileName) => `${legacyClinicLogoStorageFolder(clinicId)}/${fileName}`;
 
-export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'cases', 'maternityHospitals', 'notaries', 'transactions'];
+export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'maternityHospitals', 'notaries'];
 
 // mergeCollection derives an id prefix for un-identified incoming records by stripping a trailing
 // 's' off the collection name; 'notaries' isn't a simple plural ('notarys' would be wrong), so it
@@ -108,53 +109,34 @@ export const clinicLogoEntriesToBackend = variants => (variants || [])
 // --- Catalog -------------------------------------------------------------------------------
 
 export const emptyDocumentsCatalog = () => ({
+  cases: [],
   parties: {
-    couples: [], surrogateMothers: [], representatives: [], clinics: [], cases: [], maternityHospitals: [], notaries: [], transactions: [],
+    couples: [], surrogateMothers: [], representatives: [], clinics: [], maternityHospitals: [], notaries: [],
   },
   documents: [],
   clinicLogos: {},
 });
 
 // Backend stores every collection keyed by record id (so merges/deletes touch single children);
-// this converts a raw snapshot (or a pasted array) back into ordered arrays for the UI.
-export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
+// this converts a raw snapshot (or a pasted array) back into ordered arrays for the UI. Cases live
+// at their own top-level `documentsBuilder/cases` path (sibling of `parties`/`templates`), so their
+// raw snapshot is passed in separately from the party collections.
+export const normalizeDocumentsCatalog = (rawParties, rawTemplates, rawCases) => {
   const catalog = emptyDocumentsCatalog();
   PARTY_COLLECTIONS.forEach(collection => {
-    let rawCollection = rawParties?.[collection];
-    // `parties/cases/clinics` was the pre-batch-17 clinic-logo file-name store, not a case record -
-    // it must never leak into the cases list, even though the canonical logo location has since
-    // moved onto the clinic record itself (see clinicLogoDbPath).
-    if (collection === 'cases' && isPlainObject(rawCollection)) {
-      const { clinics: _clinicLogos, ...caseRecords } = rawCollection;
-      rawCollection = caseRecords;
-    }
-    catalog.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
-    // Batch 18: every case is migrated to the new relations/program/childbirth/registrations/
-    // documents shape right at ingestion, so nothing downstream ever has to branch on which shape
-    // a given case record happens to carry.
-    if (collection === 'cases') catalog.parties.cases = catalog.parties.cases.map(normalizeCaseRecord);
+    catalog.parties[collection] = toRecordsWithIdFromKey(rawParties?.[collection]).filter(record => isPlainObject(record));
   });
+  catalog.cases = toRecordsWithIdFromKey(rawCases).filter(record => isPlainObject(record)).map(normalizeCaseRecord);
   // Same read-time migration idea as normalizeCaseRecord, for templates: per-paragraph styles
   // are consolidated under each paragraph's single `style` key right at ingestion, so nothing
   // downstream ever has to branch on which shape a stored paragraph happens to carry.
   catalog.documents = toRecordsWithIdFromKey(rawTemplates).filter(record => isPlainObject(record)).map(consolidateTemplateStyles);
-  // Primary (batch 17 §1/§2): a clinic's own `logo` field, alongside its name/legalName/etc. - a
-  // clinic is shared across many cases, so its logo was never really case-scoped to begin with.
+  // A clinic's own `logo` field, alongside its name/legalName/etc. - a clinic is shared across
+  // many cases, so its logo was never really case-scoped to begin with.
   catalog.parties.clinics.forEach(clinic => {
     const entries = normalizeClinicLogoEntries(clinic.logo);
     if (entries.length) catalog.clinicLogos[String(clinic.id)] = entries;
   });
-  // Legacy fallback (spec §8): pre-batch-17 exports kept the layout assignments on a sibling
-  // `parties/cases/clinics` node instead - only consulted for a clinic that doesn't already have
-  // its own `logo` field, so the new shape always wins once a clinic has been migrated.
-  const rawClinicLogos = rawParties?.cases?.clinics;
-  if (isPlainObject(rawClinicLogos)) {
-    Object.entries(rawClinicLogos).forEach(([clinicId, node]) => {
-      if (catalog.clinicLogos[clinicId]) return;
-      const entries = normalizeClinicLogoEntries(node?.logo);
-      if (entries.length) catalog.clinicLogos[clinicId] = entries;
-    });
-  }
   return catalog;
 };
 
@@ -162,10 +144,11 @@ export const normalizeDocumentsCatalog = (rawParties, rawTemplates) => {
 
 // Accepts three JSON shapes, so the exact file the backend exports (documentsBuilder/*) can be
 // pasted or uploaded as-is, with no manual reshaping:
-//   1. The full backend export: `{ parties: { couples, cases, ... }, templates: {...}, settings }`
-//      - i.e. `documentsBuilder/{parties,templates,settings}` dumped together, party collections
-//      one level deeper under `parties`, documents keyed by id under `templates`.
-//   2. The older technical-paste shape: `{ data: {...party collections...}, documents: [...] }`,
+//   1. The full backend export: `{ cases: {...}, parties: { couples, ... }, templates: {...}, settings }`
+//      - i.e. `documentsBuilder/{cases,parties,templates,settings}` dumped together, party
+//      collections one level deeper under `parties`, cases and documents each keyed by id at
+//      their own top level.
+//   2. The older technical-paste shape: `{ data: {...party collections, cases...}, documents: [...] }`,
 //      or top-level party collections without the `data` wrapper.
 //   3. Any partial mix of the two - `{ documents: [...] }` alone, `{ parties: {...} }` alone, etc.
 export const parseDocumentsTechnicalInput = rawText => {
@@ -192,45 +175,27 @@ export const parseDocumentsTechnicalInput = rawText => {
   // same as `parties`); the older technical-paste shape calls the same thing `documents` (an
   // array, also top-level) - both normalize the same way via toArray.
   const templatesSource = parsed.templates !== undefined ? parsed.templates : parsed.documents;
+  // Cases live at the top level (`cases`), sibling to `parties`/`templates`; a bare paste without
+  // the `parties` wrapper carries them at the same top level too.
+  const casesSource = dataRoot.cases !== undefined ? dataRoot.cases : dataSource.cases;
 
   const incoming = emptyDocumentsCatalog();
-  // Legacy (pre-batch-17) shape: `parties.cases.clinics` mirrored the clinic-logo layout
-  // assignments separately from the clinic record - it is not a case record, so it's carried aside
-  // here instead of being imported as a generated case; kept only as a fallback below.
-  let legacyClinicLogoNode = null;
   PARTY_COLLECTIONS.forEach(collection => {
-    let rawCollection = dataSource[collection];
-    if (collection === 'cases' && isPlainObject(rawCollection)) {
-      const { clinics: clinicLogoNode, ...caseRecords } = rawCollection;
-      rawCollection = caseRecords;
-      if (isPlainObject(clinicLogoNode)) legacyClinicLogoNode = clinicLogoNode;
-    }
-    incoming.parties[collection] = toRecordsWithIdFromKey(rawCollection).filter(record => isPlainObject(record));
-    // Batch 18: migrate every pasted case to the new relations/program/childbirth/registrations/
-    // documents shape right away, same as normalizeDocumentsCatalog.
-    if (collection === 'cases') incoming.parties.cases = incoming.parties.cases.map(normalizeCaseRecord);
+    incoming.parties[collection] = toRecordsWithIdFromKey(dataSource[collection]).filter(record => isPlainObject(record));
   });
+  incoming.cases = toRecordsWithIdFromKey(casesSource).filter(record => isPlainObject(record)).map(normalizeCaseRecord);
   // Pasted templates get the same style consolidation as normalizeDocumentsCatalog - a paragraph
   // row copied out of the backend (either shape) merges in with its full style intact.
   incoming.documents = toRecordsWithIdFromKey(templatesSource).filter(record => isPlainObject(record)).map(consolidateTemplateStyles);
 
-  // Primary (batch 17 §1/§2): each clinic's own `logo` field.
   incoming.parties.clinics.forEach(clinic => {
     const entries = normalizeClinicLogoEntries(clinic.logo);
     if (entries.length) incoming.clinicLogos[String(clinic.id)] = entries;
   });
-  // Legacy fallback (spec §8): only for a clinic not already covered by its own `logo` field above.
-  if (isPlainObject(legacyClinicLogoNode)) {
-    Object.entries(legacyClinicLogoNode).forEach(([clinicId, node]) => {
-      if (incoming.clinicLogos[clinicId]) return;
-      const entries = normalizeClinicLogoEntries(node?.logo);
-      if (entries.length) incoming.clinicLogos[clinicId] = entries;
-    });
-  }
 
   const hasParties = PARTY_COLLECTIONS.some(collection => incoming.parties[collection].length > 0);
   const hasClinicLogos = Object.keys(incoming.clinicLogos).length > 0;
-  if (!hasParties && incoming.documents.length === 0 && !hasClinicLogos) {
+  if (!hasParties && incoming.documents.length === 0 && incoming.cases.length === 0 && !hasClinicLogos) {
     throw new Error('No parties or documents found in the pasted JSON.');
   }
   return incoming;
@@ -309,6 +274,7 @@ export const mergeDocumentsCatalog = (current, incoming) => {
       summary,
     );
   });
+  catalog.cases = mergeCollection(current?.cases || [], incoming?.cases || [], 'case', summary);
   catalog.documents = mergeCollection(current?.documents || [], incoming?.documents || [], 'document', summary);
   // Clinic-logo layout assignments are a per-clinic snapshot (not per-field records), so an
   // incoming clinic's list simply replaces the existing one for that clinic id; every other
@@ -324,6 +290,11 @@ export const catalogPartiesToBackend = catalog => PARTY_COLLECTIONS.reduce((acc,
     return byId;
   }, {});
   return acc;
+}, {});
+
+export const catalogCasesToBackend = catalog => (catalog.cases || []).reduce((byId, record) => {
+  byId[record.id] = record;
+  return byId;
 }, {});
 
 export const catalogTemplatesToBackend = catalog => (catalog.documents || []).reduce((byId, record) => {
@@ -591,38 +562,27 @@ export const createEmptyNotary = () => ({
   city: { uk: '', en: '' },
 });
 
-// --- Case shape (batch 18) --------------------------------------------------------------------
-// One case is one concrete combination of couple + clinic + surrogate mother + representative(s)
-// (spec: "один case — це одна конкретна комбінація"); changing the clinic or surrogate mother means
-// creating a new case rather than mutating this one in place, so there is no active/replaced/from/to
-// history to track inside a single case record.
+// --- Case shape ------------------------------------------------------------------------------
+// One case is one concrete combination of couple + clinic + surrogate mother + representative(s);
+// changing the clinic or surrogate mother means creating a new case rather than mutating this one
+// in place, so there is no active/replaced/from/to history to track inside a single case record.
+// Every case in this Documents Builder is a surrogacy-program case - no `programType`/`program`
+// field distinguishes cases from one another. Templates are static (configured once in
+// `templates`); a document is always `static template + current case data + derived formatting
+// context` - never a stored snapshot, version, or per-case override of resolved text.
 
 // A fresh id for a brand-new case (Parties page "+ New case") - same generated shape as
-// makeTransactionId/createChildRecord's id.
+// createChildRecord's id.
 export const makeCaseId = () => makeRecordId('case');
 
-// A freshly-created case: every relation blank, ready for the admin to pick a couple/clinic/
-// surrogate mother/representatives - never pre-filled from another case (spec §14: no auto-copy).
-export const createEmptyCase = ({ caseId, programId = '' } = {}) => ({
-  id: caseId,
-  programId,
-  relations: {
-    coupleId: '', clinicId: '', surrogateMotherId: '', representativeIds: [],
-  },
-  program: {
-    type: 'surrogacy',
-    agreement: { number: { uk: '', en: '' }, date: '' },
-  },
-  childbirth: { maternityHospitalId: '', children: [] },
-  // batch 19: the case only ever stores a transactionId - the actual notary/statementDate/
-  // registryNumber live on parties.transactions[transactionId] (see createTransaction).
-  registrations: { birth: { transactionId: '' } },
-  documents: { overrides: {} },
-});
+// A freshly-created case carries only its id - `relations`/`childbirth`/`documents` are added
+// only once the admin actually enters that data, never pre-populated with empty placeholder
+// branches.
+export const createEmptyCase = ({ caseId } = {}) => ({ id: caseId });
 
-// A new child record for the childbirth.children editor (spec §13) - a stable generated id, never
-// the array index, since children can be reordered/removed independently of any document that
-// still references an earlier one by id.
+// A new child record for the childbirth.children editor - a stable generated id, never the array
+// index, since children can be reordered/removed independently of any document that still
+// references an earlier one by id.
 export const createChildRecord = () => ({
   id: makeRecordId('child'),
   sex: '',
@@ -631,136 +591,40 @@ export const createChildRecord = () => ({
   medicalConclusion: { number: '', date: '' },
 });
 
-// Migrates a pre-batch-18 case record (coupleId/clinicId/surrogateMotherId/representativeIds at the
-// top level, surrogacyAgreement, birthRegistration.{child,medicalConclusion.maternityHospitalId,
-// statementDate,notaryId}, docOverrides) onto the new shape - spec §16: a temporary read-time
-// normalizer, but once normalized the legacy top-level fields are dropped rather than carried
-// forward, so re-saving a migrated case never recreates them (spec: "не записувати назад старі
-// поля"). Idempotent: a case that already has `relations`/`program`/`childbirth`/`registrations`/
-// `documents` passes through those as-is.
-export const normalizeCaseRecord = (rawCase = {}) => {
-  const {
-    coupleId, clinicId, surrogateMotherId, representativeIds,
-    surrogacyAgreement, birthRegistration: legacyBirthRegistration, docOverrides,
-    ...rest
-  } = isPlainObject(rawCase) ? rawCase : {};
+// Idempotent pass-through: a case record is used as-is (relations/childbirth/documents are all
+// optional - missing branches are handled by the `?.` reads below, not backfilled here) so a case
+// saved before a given field existed never crashes the UI, and re-saving it never recreates a
+// branch nobody ever asked for.
+export const normalizeCaseRecord = rawCase => (isPlainObject(rawCase) ? rawCase : {});
 
-  const relations = isPlainObject(rest.relations) ? rest.relations : {
-    coupleId: coupleId ?? '',
-    clinicId: clinicId ?? '',
-    surrogateMotherId: surrogateMotherId ?? '',
-    representativeIds: Array.isArray(representativeIds) ? representativeIds : [],
-  };
-
-  const program = isPlainObject(rest.program) ? rest.program : {
-    type: 'surrogacy',
-    agreement: isPlainObject(surrogacyAgreement) ? surrogacyAgreement : { number: { uk: '', en: '' }, date: '' },
-  };
-
-  const legacyChild = isPlainObject(legacyBirthRegistration?.child) ? legacyBirthRegistration.child : null;
-  const legacyMedicalConclusion = isPlainObject(legacyBirthRegistration?.medicalConclusion) ? legacyBirthRegistration.medicalConclusion : {};
-  const childbirth = isPlainObject(rest.childbirth) ? rest.childbirth : {
-    maternityHospitalId: legacyMedicalConclusion.maternityHospitalId ?? '',
-    // maternityHospitalId moved up onto childbirth itself (shared by every child of one birth
-    // event) - never duplicated back onto the per-child medicalConclusion.
-    children: legacyChild ? [{
-      id: makeRecordId('child'),
-      ...legacyChild,
-      medicalConclusion: { number: legacyMedicalConclusion.number ?? '', date: legacyMedicalConclusion.date ?? '' },
-    }] : [],
-  };
-
-  const registrations = isPlainObject(rest.registrations) ? rest.registrations : {
-    birth: {
-      statementDate: legacyBirthRegistration?.statementDate ?? '',
-      notaryId: legacyBirthRegistration?.notaryId ?? '',
-    },
-  };
-
-  const documents = isPlainObject(rest.documents) ? rest.documents : {
-    overrides: isPlainObject(docOverrides) ? docOverrides : {},
-  };
-
-  return {
-    ...rest, relations, program, childbirth, registrations, documents,
-  };
+// Strips undefined/null/''-valued fields (and now-empty objects) out of a case form draft before
+// it's written to Firebase, so saving a case that has no documents data yet never creates empty
+// placeholder branches like `documents: { surrogacyAgreement: {} }`. Never applied to `templates` -
+// blank lines/strings there can be a deliberate part of a document.
+export const removeEmptyCaseValues = value => {
+  if (Array.isArray(value)) return value.map(removeEmptyCaseValues);
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .map(([key, child]) => [key, removeEmptyCaseValues(child)])
+        .filter(([, child]) => {
+          if (child === undefined || child === null || child === '') return false;
+          if (Array.isArray(child)) return true;
+          if (typeof child === 'object') return Object.keys(child).length > 0;
+          return true;
+        }),
+    );
+  }
+  return value;
 };
-
-// --- Transactions (batch 19) -------------------------------------------------------------------
-// A transaction is one concrete combination of couple + surrogate mother + notary for a specific
-// legal act (e.g. the birth-registration surrogate-consent statement) - decoupled from the case's
-// current `relations` so a signed document keeps pointing at exactly who signed it even if the
-// case's relations were ever revisited later. The case only ever stores the transactionId; the
-// notary's own name/title/city live solely in `parties.notaries[notaryId]`, never copied in.
-
-// A fresh id for a brand-new transaction record (the case editor form needs one the first time it
-// saves the Transaction section, since createTransaction itself takes the id rather than making
-// one - same generated shape as createChildRecord's id).
-export const makeTransactionId = () => makeRecordId('transaction');
-
-export const createTransaction = ({
-  transactionId, caseId, type, coupleId, surrogateMotherId, notaryId, statementDate = '', registryNumber = '',
-}) => ({
-  id: transactionId,
-  type,
-  caseId,
-  coupleId,
-  surrogateMotherId,
-  notaryId,
-  statementDate,
-  registryNumber,
-});
-
-// `transactionType` guards against a stale/mistyped transactionId pointing at a transaction of a
-// different kind - resolves to null exactly like a missing transaction rather than silently
-// returning mismatched data.
-export const resolveTransaction = (catalog, caseRecord, transactionType) => {
-  const transactionId = caseRecord?.registrations?.birth?.transactionId;
-  const transaction = findById(catalog?.parties?.transactions, transactionId);
-  if (!transaction) return null;
-  if (transactionType && transaction.type !== transactionType) return null;
-  return transaction;
-};
-
-// Deleting a transaction (spec §14) never touches the couple/surrogate mother/notary records it
-// referenced - only the transaction itself and the transactionId reference(s) pointing at it.
-export const removeTransactionReferences = (catalog, transactionId) => ({
-  ...catalog,
-  parties: {
-    ...catalog.parties,
-    transactions: (catalog.parties.transactions || []).filter(item => String(item.id) !== String(transactionId)),
-    cases: (catalog.parties.cases || []).map(caseRecord => {
-      if (String(caseRecord.registrations?.birth?.transactionId) !== String(transactionId)) return caseRecord;
-      const { transactionId: _removed, ...restBirth } = caseRecord.registrations.birth;
-      return { ...caseRecord, registrations: { ...caseRecord.registrations, birth: restBirth } };
-    }),
-  },
-});
-
-// One case is one concrete relations combination (spec batch 18 §10); a case picked by programId
-// alone would be ambiguous (several cases can share a programId - see createEmptyCase) - the
-// currently-selected case is whatever the caller/UI passed as caseId, never an "active" flag.
-export const BIRTH_REGISTRATION_TRANSACTION_TYPE = 'birth-registration-surrogate-consent';
 
 export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
-  const rawCaseRecord = findById(catalog?.parties?.cases, caseId);
+  const rawCaseRecord = findById(catalog?.cases, caseId);
   if (!rawCaseRecord) return null;
-  // Defensively re-normalized here too (idempotent) - a case can reach this function without
-  // having passed through normalizeDocumentsCatalog/parseDocumentsTechnicalInput first (e.g. a
-  // freshly created or duplicated case still held only in local UI state).
   const caseRecord = normalizeCaseRecord(rawCaseRecord);
-  const relations = caseRecord.relations;
+  const relations = isPlainObject(caseRecord.relations) ? caseRecord.relations : {};
 
-  const transaction = resolveTransaction(catalog, caseRecord, BIRTH_REGISTRATION_TRANSACTION_TYPE);
-  // A document tied to a specific transaction must use exactly that transaction's own couple/
-  // surrogate mother (spec §5: "не брати пару, СМ ... безпосередньо з інших блоків кейса"), never
-  // silently the case's current relations - but a case that hasn't reached that stage yet (no
-  // transaction created) still needs relations.coupleId/surrogateMotherId to resolve wife/husband/
-  // surrogateMother for every other document.
-  const coupleId = transaction?.coupleId || relations.coupleId;
-  const surrogateMotherId = transaction?.surrogateMotherId || relations.surrogateMotherId;
-
-  const couple = findById(catalog.parties.couples, coupleId);
+  const couple = findById(catalog.parties.couples, relations.coupleId);
   const partners = toArray(couple?.partners);
   const wife = partners.find(partner => partner?.role === 'wife') || partners[0] || null;
   const husband = partners.find(partner => partner?.role === 'husband') || partners[1] || null;
@@ -770,51 +634,32 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
 
   const childbirth = isPlainObject(caseRecord.childbirth) ? caseRecord.childbirth : {};
   const rawChildren = toArray(childbirth.children);
-  // The first child is the default fallback for single-child documents (spec §4: "не прив'язувати
-  // систему назавжди лише до children[0]") - a caller generating a document for a twin passes
-  // `childId` to pick a different one; `children` (every child, gender-computed) is exposed
-  // alongside it so the UI can offer a selector.
+  // The first child is the default fallback for single-child documents - a caller generating a
+  // document for a twin passes `childId` to pick a different one; `children` (every child,
+  // gender-computed) is exposed alongside it so the UI can offer a selector.
   const selectedRawChild = childId ? rawChildren.find(item => String(item?.id) === String(childId)) : null;
   const rawChild = isPlainObject(selectedRawChild) ? selectedRawChild : (isPlainObject(rawChildren[0]) ? rawChildren[0] : {});
   const medicalConclusion = isPlainObject(rawChild.medicalConclusion) ? rawChild.medicalConclusion : {};
 
-  const rawBirth = isPlainObject(caseRecord.registrations?.birth) ? caseRecord.registrations.birth : {};
-  // Pre-batch-19 cases kept statementDate/notaryId directly on registrations.birth instead of
-  // pointing at a transaction - consulted only when there is no transaction yet, so a case that
-  // hasn't been migrated still resolves exactly as it did before (spec §16 is the rule for
-  // newly-authored data, not a forced rewrite of every existing case).
-  const statementDate = transaction?.statementDate ?? rawBirth.statementDate ?? '';
-  const notaryId = transaction?.notaryId ?? rawBirth.notaryId;
+  const documents = isPlainObject(caseRecord.documents) ? caseRecord.documents : {};
+  const surrogacyAgreement = isPlainObject(documents.surrogacyAgreement) ? documents.surrogacyAgreement : {};
+  const rawBirthRegistration = isPlainObject(documents.birthRegistrationConsent) ? documents.birthRegistrationConsent : {};
+  const statementDate = rawBirthRegistration.statementDate ?? '';
   const birthRegistration = {
-    transactionId: rawBirth.transactionId,
-    statementDate,
-    registryNumber: transaction?.registryNumber ?? '',
+    ...rawBirthRegistration,
     statementDateWords: {
       uk: formatUkrainianDateWords(statementDate),
       en: formatEnglishDateWords(statementDate),
     },
   };
-  // `{{transaction.statementDateWords.uk/en}}` (spec batch 18 §3) needs the words form directly on
-  // the transaction itself, not only on the `birthRegistration` legacy-named alias above - derived
-  // here rather than stored, same as every other date-in-words field.
-  const transactionContext = transaction ? {
-    ...transaction,
-    statementDateWords: {
-      uk: formatUkrainianDateWords(transaction.statementDate),
-      en: formatEnglishDateWords(transaction.statementDate),
-    },
-  } : null;
 
   return {
     case: caseRecord,
-    programId: caseRecord.programId ?? '',
     relations,
-    program: isPlainObject(caseRecord.program) ? caseRecord.program : {},
-    transaction: transactionContext,
     couple,
     wife,
     husband,
-    surrogateMother: findById(catalog.parties.surrogateMothers, surrogateMotherId),
+    surrogateMother: findById(catalog.parties.surrogateMothers, relations.surrogateMotherId),
     clinic: findById(catalog.parties.clinics, relations.clinicId),
     representative: representatives[0] || null,
     representatives,
@@ -824,8 +669,9 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
     selectedChildId: rawChild?.id,
     medicalConclusion,
     maternityHospital: findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId),
+    surrogacyAgreement,
     birthRegistration,
-    notary: findById(catalog.parties.notaries, notaryId),
+    notary: findById(catalog.parties.notaries, rawBirthRegistration.notaryId),
   };
 };
 
@@ -938,63 +784,16 @@ export const validateCaseRecord = rawCaseRecord => {
   };
 
   requirePresent(caseRecord.id, 'case.id');
-  requirePresent(caseRecord.programId, 'case.programId');
   requirePresent(caseRecord.relations?.coupleId, 'case.relations.coupleId');
   requirePresent(caseRecord.relations?.clinicId, 'case.relations.clinicId');
   requirePresent(caseRecord.relations?.surrogateMotherId, 'case.relations.surrogateMotherId');
-  requirePresent(caseRecord.program?.type, 'case.program.type');
   if (!toArray(caseRecord.childbirth?.children).length) issues.push('case.childbirth.children');
-  // batch 19: registrations.birth normally carries only transactionId; the direct
-  // statementDate/notaryId fields are consulted too so a not-yet-migrated case isn't flagged.
-  if (isBlank(caseRecord.registrations?.birth?.transactionId)
-    && isBlank(caseRecord.registrations?.birth?.statementDate)
-    && isBlank(caseRecord.registrations?.birth?.notaryId)) {
-    issues.push('case.registrations.birth');
-  }
 
   return issues;
 };
 
-// A transaction's own checklist (spec batch 19 §17): couple/surrogate mother/notary presence AND
-// existence, plus a statement date - registryNumber may stay blank (it's fine to fill in by hand
-// after the document is signed).
-export const validateTransaction = (catalog, transactionId) => {
-  const transaction = findById(catalog?.parties?.transactions, transactionId);
-  if (!transaction) return ['transaction'];
-
-  const issues = [];
-  const isBlank = value => value === undefined || value === null || String(value).trim() === '';
-  const requirePresent = (value, path) => {
-    if (isBlank(value)) issues.push(path);
-  };
-
-  requirePresent(transaction.id, 'transaction.id');
-  requirePresent(transaction.type, 'transaction.type');
-  requirePresent(transaction.coupleId, 'transaction.coupleId');
-  requirePresent(transaction.surrogateMotherId, 'transaction.surrogateMotherId');
-  requirePresent(transaction.notaryId, 'transaction.notaryId');
-  requirePresent(transaction.statementDate, 'transaction.statementDate');
-
-  if (!isBlank(transaction.coupleId) && !findById(catalog?.parties?.couples, transaction.coupleId)) {
-    issues.push('transaction.coupleId (no matching couple)');
-  }
-  if (!isBlank(transaction.surrogateMotherId) && !findById(catalog?.parties?.surrogateMothers, transaction.surrogateMotherId)) {
-    issues.push('transaction.surrogateMotherId (no matching surrogate mother)');
-  }
-  if (!isBlank(transaction.notaryId) && !findById(catalog?.parties?.notaries, transaction.notaryId)) {
-    issues.push('transaction.notaryId (no matching notary)');
-  }
-  if (!isBlank(transaction.statementDate) && !isIsoDate(transaction.statementDate)) {
-    issues.push('transaction.statementDate (must be YYYY-MM-DD)');
-  }
-
-  return issues;
-};
-
-// The birth-registration surrogate-consent statement's own checklist (spec batch 16 §20; field
-// locations updated for the batch 18 case shape, then again for the batch 19 transaction) -
-// missing hospital/notary/transaction lookups and malformed dates are reported the same way as a
-// genuinely empty field.
+// The birth-registration surrogate-consent statement's own checklist - missing hospital/notary
+// lookups and malformed dates are reported the same way as a genuinely empty field.
 export const validateBirthRegistrationCase = (catalog, caseId) => {
   const context = resolveCaseContext(catalog, caseId);
   if (!context) return ['case'];
@@ -1006,7 +805,7 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
   };
 
   const {
-    childbirth, child, medicalConclusion, surrogateMother, maternityHospital,
+    childbirth, child, medicalConclusion, surrogateMother, maternityHospital, birthRegistration, notary,
   } = context;
 
   requirePresent(childbirth.maternityHospitalId, 'case.childbirth.maternityHospitalId');
@@ -1031,33 +830,13 @@ export const validateBirthRegistrationCase = (catalog, caseId) => {
     issues.push('case.childbirth.maternityHospitalId (no matching maternity hospital)');
   }
 
-  const rawBirth = context.case.registrations?.birth || {};
-  if (rawBirth.transactionId) {
-    const linkedTransaction = findById(catalog?.parties?.transactions, rawBirth.transactionId);
-    if (linkedTransaction && linkedTransaction.type !== BIRTH_REGISTRATION_TRANSACTION_TYPE) {
-      // A transactionId can point at a transaction of a different document type (spec §3: "Find the
-      // transaction with type: 'birth-registration-surrogate-consent'") - resolveCaseContext already
-      // treats this as no transaction at all (context.transaction is null), so flagging it here keeps
-      // this checklist from passing while every `transaction.*`/`notary.*` template variable is
-      // actually unresolved.
-      issues.push('case.registrations.birth.transactionId (transaction is not a birth-registration-surrogate-consent)');
-    } else {
-      // The transaction is the source of truth (spec §17) - couple/surrogate mother/notary presence
-      // and existence are validated there, scoped to `transaction.*` paths.
-      issues.push(...validateTransaction(catalog, rawBirth.transactionId));
-    }
-  } else if (!isBlank(rawBirth.statementDate) || !isBlank(rawBirth.notaryId)) {
-    // Pre-batch-19 case still using the direct registrations.birth.{statementDate,notaryId} shape.
-    requirePresent(rawBirth.statementDate, 'case.registrations.birth.statementDate');
-    requirePresent(rawBirth.notaryId, 'case.registrations.birth.notaryId');
-    if (!isBlank(rawBirth.statementDate) && !isIsoDate(rawBirth.statementDate)) {
-      issues.push('case.registrations.birth.statementDate (must be YYYY-MM-DD)');
-    }
-    if (!isBlank(rawBirth.notaryId) && !context.notary) {
-      issues.push('case.registrations.birth.notaryId (no matching notary)');
-    }
-  } else {
-    issues.push('case.registrations.birth.transactionId');
+  requirePresent(birthRegistration.statementDate, 'case.documents.birthRegistrationConsent.statementDate');
+  requirePresent(birthRegistration.notaryId, 'case.documents.birthRegistrationConsent.notaryId');
+  if (!isBlank(birthRegistration.statementDate) && !isIsoDate(birthRegistration.statementDate)) {
+    issues.push('case.documents.birthRegistrationConsent.statementDate (must be YYYY-MM-DD)');
+  }
+  if (!isBlank(birthRegistration.notaryId) && !notary) {
+    issues.push('case.documents.birthRegistrationConsent.notaryId (no matching notary)');
   }
 
   return issues;
@@ -1140,19 +919,6 @@ const localizedText = (value, lang) => {
   if (isPlainObject(value)) return String(value[lang] ?? '');
   return String(value ?? '');
 };
-
-// Data-mode edits (spec: the "pencil" Data mode) are stored per case as sparse overrides of the
-// resolved text: `case.docOverrides[docId] = { title: {uk,en}, paragraphs: { [index]: {uk,en} } }`.
-// Firebase may hand dense numeric-keyed nodes back as arrays, so both shapes are accepted.
-const overrideAt = (overrides, index) => {
-  if (Array.isArray(overrides)) return overrides[index];
-  if (isPlainObject(overrides)) return overrides[index] ?? overrides[String(index)];
-  return undefined;
-};
-
-const overriddenText = (override, langKey, fallback) => (
-  typeof override?.[langKey] === 'string' ? override[langKey] : fallback
-);
 
 // A paragraph that starts with a variable - commonly a lowercase date-in-words - must still read
 // as a proper sentence (spec batch 21 §7). Applied here, at render time, on the resolved output
@@ -1358,25 +1124,6 @@ const resolveDocColumns = (template, languages) => {
   return template?.columns === 1 || template?.columns === 2 ? template.columns : (languages.length === 1 ? 1 : 2);
 };
 
-// A custom paragraph can be inserted (or removed) at any position in a template (spec: "кастомний
-// абзац в будь-якому місці документу"). Because per-case data-mode overrides key into a template's
-// paragraphs by array index, a structural edit like that must reindex every existing override so
-// it keeps pointing at the same paragraph it always did - never silently drift onto the paragraph
-// that happens to now sit at that index. `delta` is +1 for an insertion, -1 for a removal; the
-// override entry that sat exactly at a removed index is dropped along with that paragraph.
-export const shiftDocOverrideParagraphIndices = (docOverride, atIndex, delta) => {
-  if (!isPlainObject(docOverride) || !docOverride.paragraphs) return docOverride;
-  const entries = Array.isArray(docOverride.paragraphs)
-    ? docOverride.paragraphs.map((value, index) => [index, value]).filter(([, value]) => value !== undefined)
-    : Object.entries(docOverride.paragraphs).map(([key, value]) => [Number(key), value]);
-  const nextParagraphs = {};
-  entries.forEach(([index, value]) => {
-    if (delta < 0 && index === atIndex) return;
-    nextParagraphs[index >= atIndex ? index + delta : index] = value;
-  });
-  return { ...docOverride, paragraphs: nextParagraphs };
-};
-
 // A row-editing "scope" identifies one editable raw-text slot on a template - the shared title,
 // one beforeTitle block, or one paragraph - so the Bold/Italic/Insert-variable toolbar can share
 // one pair of read/write helpers across all of them instead of one bespoke pair per element (spec:
@@ -1418,18 +1165,18 @@ export const withTemplateScopeText = (template, scope, langKey, value) => {
 };
 
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
-// with every placeholder already substituted from the case context, then any per-case data-mode
-// overrides applied on top. Logo/logo-long paragraphs are never text-substituted or overridden -
-// they stay tagged for the renderer to draw a graphical block instead (spec §5-§7). The template's
-// letterhead logo (`logo`, below) always renders before the title - see getTemplateLogoType.
-export const buildGeneratedDocument = (template, context, docOverride = null) => {
-  const override = isPlainObject(docOverride) ? docOverride : {};
+// with every placeholder already substituted from the case context. Logo/logo-long paragraphs are
+// never text-substituted - they stay tagged for the renderer to draw a graphical block instead.
+// The template's letterhead logo (`logo`, below) always renders before the title - see
+// getTemplateLogoType. Every render re-substitutes the template against the case's current data -
+// nothing generated is ever stored back onto the case or the template.
+export const buildGeneratedDocument = (template, context) => {
   const logo = getTemplateLogoType(template);
   // A legacy template embeds its logo as the first paragraph instead of the dedicated `logo`
   // field; once getTemplateLogoType has picked it up for the before-the-title block, that same
   // paragraph must not also render a second time in its old body position. It's tagged
   // 'logo-consumed' (a no-op for the renderer) rather than dropped from the array, so paragraph
-  // indices stay stable for per-case data-mode overrides (docOverrides[docId].paragraphs[index]).
+  // indices stay stable.
   const hasDedicatedLogoField = Boolean(String(template?.logo || '').trim());
   const languages = resolveDocLanguages(template);
   return {
@@ -1440,13 +1187,13 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
     columns: resolveDocColumns(template, languages),
     beforeTitle: resolveBeforeTitleBlocks(template, context),
     beforeTitleOffsetPercent: normalizeSignerBlockOffsetPercent(template?.beforeTitleOffsetPercent),
-    // The title is an ordinary centered paragraph (batch 2026-07-23 C §2): its own consolidated
-    // `style` resolves here the same way a body paragraph's does - sparse, undefined = inherit
-    // the document default (centered, titleFontSize). A template whose title was deleted simply
-    // resolves to empty strings; the renderers skip an all-blank title block entirely.
+    // The title is an ordinary centered paragraph: its own consolidated `style` resolves here the
+    // same way a body paragraph's does - sparse, undefined = inherit the document default
+    // (centered, titleFontSize). A template whose title was deleted simply resolves to empty
+    // strings; the renderers skip an all-blank title block entirely.
     title: {
-      uk: overriddenText(override.title, 'uk', fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk')),
-      en: overriddenText(override.title, 'en', fillPlaceholders(localizedText(template.title, 'en'), context, 'en')),
+      uk: fillPlaceholders(localizedText(template.title, 'uk'), context, 'uk'),
+      en: fillPlaceholders(localizedText(template.title, 'en'), context, 'en'),
       align: getParagraphStyle(template.title).align,
       fontSize: getParagraphStyle(template.title).fontSize,
     },
@@ -1458,12 +1205,10 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
       if (type !== 'text') {
         return { type, uk: paragraph?.uk || '', en: paragraph?.en || '' };
       }
-      const paragraphOverride = overrideAt(override.paragraphs, index);
       // Every visual override of this paragraph comes from its one consolidated `style` key (or
       // the legacy flat fields, see getParagraphStyle) - resolved here into flat fields for the
       // renderers. An absent key means "inherit the document's own formatting" (fontSize /
-      // firstLineIndentCm / default alignment), same as every paragraph did before overrides
-      // existed.
+      // firstLineIndentCm / default alignment).
       const style = getParagraphStyle(paragraph);
       return {
         type,
@@ -1471,43 +1216,18 @@ export const buildGeneratedDocument = (template, context, docOverride = null) =>
         align: style.align,
         indentCm: style.indentCm,
         fontSize: style.fontSize,
-        uk: capitalizeFirstLetter(overriddenText(paragraphOverride, 'uk', fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk'))),
-        en: capitalizeFirstLetter(overriddenText(paragraphOverride, 'en', fillPlaceholders(localizedText(paragraph, 'en'), context, 'en'))),
+        uk: capitalizeFirstLetter(fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
+        en: capitalizeFirstLetter(fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
       };
     }),
   };
-};
-
-// Drops override entries that match the resolved template text again, so the backend only keeps
-// real deviations. Returns null when nothing is left (the node can then be deleted).
-export const pruneDocOverride = (docOverride, baselineDoc) => {
-  if (!isPlainObject(docOverride) || !baselineDoc) return null;
-  const pruned = {};
-  const title = {};
-  ['uk', 'en'].forEach(langKey => {
-    const value = docOverride.title?.[langKey];
-    if (typeof value === 'string' && value !== baselineDoc.title?.[langKey]) title[langKey] = value;
-  });
-  if (Object.keys(title).length) pruned.title = title;
-  const paragraphs = {};
-  (baselineDoc.paragraphs || []).forEach((baseline, index) => {
-    const paragraphOverride = overrideAt(docOverride.paragraphs, index);
-    const entry = {};
-    ['uk', 'en'].forEach(langKey => {
-      const value = paragraphOverride?.[langKey];
-      if (typeof value === 'string' && value !== baseline?.[langKey]) entry[langKey] = value;
-    });
-    if (Object.keys(entry).length) paragraphs[index] = entry;
-  });
-  if (Object.keys(paragraphs).length) pruned.paragraphs = paragraphs;
-  return Object.keys(pruned).length ? pruned : null;
 };
 
 // --- Case selector --------------------------------------------------------------------------
 
 export const buildCaseLabel = (catalog, caseRecord) => {
   if (!caseRecord) return '';
-  const relations = normalizeCaseRecord(caseRecord).relations;
+  const relations = normalizeCaseRecord(caseRecord).relations || {};
   const couple = findById(catalog?.parties?.couples, relations.coupleId);
   const partners = toArray(couple?.partners);
   const coupleNames = partners
@@ -1520,13 +1240,12 @@ export const buildCaseLabel = (catalog, caseRecord) => {
   return parts.join(' — ') || String(caseRecord.id);
 };
 
-// Which cases/transactions currently point at a given party record (Parties page delete
-// confirmation, spec: "If a record is referenced by a case, the confirmation must say so") -
-// deletes are never blocked on this, only clearly labeled, same "sever the reference, never touch
-// the other record" spirit as removeTransactionReferences.
+// Which cases currently point at a given party record (Parties page delete confirmation) - deletes
+// are never blocked on this, only clearly labeled; the reference is severed, the other record (the
+// case) is never touched.
 export const findPartyReferences = (catalog, collection, id) => {
   const targetId = String(id);
-  const referencingCases = (catalog?.parties?.cases || []).filter(rawCase => {
+  const referencingCases = (catalog?.cases || []).filter(rawCase => {
     const caseRecord = normalizeCaseRecord(rawCase);
     const relations = caseRecord.relations || {};
     switch (collection) {
@@ -1535,22 +1254,12 @@ export const findPartyReferences = (catalog, collection, id) => {
       case 'surrogateMothers': return String(relations.surrogateMotherId) === targetId;
       case 'representatives': return toArray(relations.representativeIds).some(repId => String(repId) === targetId);
       case 'maternityHospitals': return String(caseRecord.childbirth?.maternityHospitalId) === targetId;
+      case 'notaries': return String(caseRecord.documents?.birthRegistrationConsent?.notaryId) === targetId;
       default: return false;
     }
   });
 
-  const referencingTransactions = ['couples', 'surrogateMothers', 'notaries'].includes(collection)
-    ? (catalog?.parties?.transactions || []).filter(transaction => {
-      if (collection === 'couples') return String(transaction.coupleId) === targetId;
-      if (collection === 'surrogateMothers') return String(transaction.surrogateMotherId) === targetId;
-      return String(transaction.notaryId) === targetId;
-    })
-    : [];
-
-  return [
-    ...referencingCases.map(caseRecord => `case "${buildCaseLabel(catalog, caseRecord) || caseRecord.id}"`),
-    ...referencingTransactions.map(transaction => `transaction "${transaction.id}"`),
-  ];
+  return referencingCases.map(caseRecord => `case "${buildCaseLabel(catalog, caseRecord) || caseRecord.id}"`);
 };
 
 // --- Insert-variable picker (spec: "модальне вікно в якому можна обрати змінні") --------------
@@ -1581,7 +1290,7 @@ export const collectContextLeafPaths = (value, prefix = '') => {
 export const VARIABLE_PICKER_GROUPS = [
   { label: 'Чоловік', roots: ['husband'] },
   { label: 'Дружина', roots: ['wife'] },
-  { label: 'Спільне', roots: ['couple', 'program'] },
+  { label: 'Спільне', roots: ['couple', 'surrogacyAgreement'] },
   { label: 'Сурогатна мати', roots: ['surrogateMother'] },
   { label: 'Довірена особа', roots: ['representative'] },
   { label: 'Клініка — іноземна', roots: ['clinic'], predicate: context => context?.clinic?.kind === 'foreign' },

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -23,7 +23,6 @@ import {
   createEmptyPartner,
   createEmptyRepresentative,
   createEmptySurrogateMother,
-  createTransaction,
   deepMergeRecords,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
@@ -62,14 +61,11 @@ import {
   parseFormattedRuns,
   pickLogoVariantForLayout,
   plainTextOf,
-  pruneDocOverride,
-  removeTransactionReferences,
+  removeEmptyCaseValues,
   resolveCaseContext,
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
-  resolveTransaction,
   serializeFormattedRuns,
-  shiftDocOverrideParagraphIndices,
   splitParagraphsIntoColumns,
   splitParagraphsIntoPages,
   TITLE_SCOPE,
@@ -86,7 +82,6 @@ import {
   validateBirthRegistrationCase,
   validateCaseRecord,
   validateDocumentTemplate,
-  validateTransaction,
 } from './documentsCatalogUtils';
 
 // All party fixtures below are fictional - tests must never carry real client data.
@@ -127,16 +122,6 @@ const sampleCatalog = () => normalizeDocumentsCatalog(
     clinics: {
       'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка «Мрія»', en: 'Clinic "Mriia"' } },
     },
-    cases: {
-      'case-1': {
-        id: 'case-1',
-        coupleId: 'couple-1',
-        surrogateMotherId: 'surrogate-mother-1',
-        clinicId: 'clinic-1',
-        representativeIds: ['representative-1'],
-        surrogacyAgreement: { number: { uk: 'без номера', en: 'without a number' } },
-      },
-    },
   },
   {
     'embryo-transfer-consent': {
@@ -145,6 +130,17 @@ const sampleCatalog = () => normalizeDocumentsCatalog(
       paragraphs: [
         { uk: 'Я, {{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.', en: 'I, {{wife.name.en}}, born {{wife.birthDate}}' },
       ],
+    },
+  },
+  {
+    'case-1': {
+      id: 'case-1',
+      relations: {
+        coupleId: 'couple-1', surrogateMotherId: 'surrogate-mother-1', clinicId: 'clinic-1', representativeIds: ['representative-1'],
+      },
+      documents: {
+        surrogacyAgreement: { number: { uk: 'без номера', en: 'without a number' } },
+      },
     },
   },
 );
@@ -156,7 +152,7 @@ describe('parseDocumentsTechnicalInput', () => {
       documents: [{ id: 'doc-9', title: { uk: 'Т', en: 'T' }, paragraphs: [] }],
     }));
     expect(parsed.parties.couples).toHaveLength(1);
-    expect(parsed.parties.cases[0].id).toBe('case-9');
+    expect(parsed.cases[0].id).toBe('case-9');
     expect(parsed.documents[0].id).toBe('doc-9');
   });
 
@@ -171,37 +167,24 @@ describe('parseDocumentsTechnicalInput', () => {
     expect(parsed.parties.clinics[0].id).toBe('clinic-2');
   });
 
-  it('strips exported clinic-logo nodes from parsed case records', () => {
-    const parsed = parseDocumentsTechnicalInput(JSON.stringify({
-      data: {
-        cases: {
-          'case-1': { id: 'case-1', clinicId: 'clinic-1' },
-          clinics: { 'clinic-1': { logo: ['square.jpg'] } },
-        },
-      },
-    }));
-    expect(parsed.parties.cases.map(record => record.id)).toEqual(['case-1']);
-  });
-
   it('rejects invalid or empty input', () => {
     expect(() => parseDocumentsTechnicalInput('')).toThrow(/Paste/);
     expect(() => parseDocumentsTechnicalInput('not json')).toThrow(/Invalid JSON/);
     expect(() => parseDocumentsTechnicalInput('{"foo": 1}')).toThrow(/No parties or documents/);
   });
 
-  // The backend's full documentsBuilder export (`{ parties, templates, settings }`, i.e.
-  // documentsBuilder/{parties,templates,settings} dumped together) previously produced nothing:
-  // party collections live one level deeper under `parties`, and templates are called `templates`
-  // (an id-keyed dict), not `documents` (an array).
-  it('parses the full backend export shape (parties.* nesting + id-keyed templates)', () => {
+  // The backend's full documentsBuilder export (`{ cases, parties, templates, settings }`, i.e.
+  // documentsBuilder/{cases,parties,templates,settings} dumped together) previously produced
+  // nothing: party collections live one level deeper under `parties`, cases and templates are each
+  // an id-keyed dict at the top level (templates is called `templates`, not `documents`).
+  it('parses the full backend export shape (parties.* nesting + top-level cases + id-keyed templates)', () => {
     const parsed = parseDocumentsTechnicalInput(JSON.stringify({
       parties: {
         couples: { 'couple-1': { id: 'couple-1', partners: [] } },
-        cases: {
-          'case-1': { id: 'case-1', clinicId: 'clinic-1' },
-          clinics: { 'clinic-1': { logo: [{ file: 'square.jpg', layout: '1col' }, { file: 'wide.jpg', layout: '2col' }] } },
-        },
-        clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
+        clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' }, logo: [{ file: 'square.jpg', layout: '1col' }, { file: 'wide.jpg', layout: '2col' }] } },
+      },
+      cases: {
+        'case-1': { id: 'case-1', relations: { clinicId: 'clinic-1' } },
       },
       settings: { formatting: { fontSize: 12 }, recentCaseIds: ['case-1'] },
       templates: {
@@ -210,7 +193,7 @@ describe('parseDocumentsTechnicalInput', () => {
       },
     }));
     expect(parsed.parties.couples.map(record => record.id)).toEqual(['couple-1']);
-    expect(parsed.parties.cases.map(record => record.id)).toEqual(['case-1']);
+    expect(parsed.cases.map(record => record.id)).toEqual(['case-1']);
     expect(parsed.parties.clinics.map(record => record.id)).toEqual(['clinic-1']);
     expect(parsed.documents.map(record => record.id)).toEqual(['embryo-transfer-consent', 'medical-services-agreement']);
     expect(parsed.clinicLogos['clinic-1']).toEqual([
@@ -219,48 +202,39 @@ describe('parseDocumentsTechnicalInput', () => {
     ]);
   });
 
-  // Bugfix regression: pasting `{ parties: { cases: { "case-1": { birthRegistration: {...} } } } }`
-  // straight from the Firebase console (no inner `id` field, only the object key) used to create a
-  // brand-new case with a random id instead of updating case-1, because toArray's Object.values()
-  // silently dropped the key and mergeCollection then had nothing to match against.
+  // Bugfix regression: pasting `{ cases: { "case-1": { relations: {...} } } }` straight from the
+  // Firebase console (no inner `id` field, only the object key) used to create a brand-new case
+  // with a random id instead of updating case-1, because toArray's Object.values() silently
+  // dropped the key and mergeCollection then had nothing to match against.
   it('recovers a record\'s id from its object key when the record itself carries no `id` field', () => {
     const parsed = parseDocumentsTechnicalInput(JSON.stringify({
-      parties: {
-        cases: {
-          'case-1': {
-            birthRegistration: {
-              child: { sex: 'female', birthDate: '2026-05-16' },
-              statementDate: '2026-05-18',
-              notaryId: 'notary-1',
-            },
-          },
+      cases: {
+        'case-1': {
+          documents: { birthRegistrationConsent: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
         },
       },
     }));
-    expect(parsed.parties.cases).toHaveLength(1);
-    expect(parsed.parties.cases[0].id).toBe('case-1');
-    // batch 18: the legacy top-level birthRegistration is migrated onto case.registrations.birth.
-    expect(parsed.parties.cases[0].registrations.birth.notaryId).toBe('notary-1');
+    expect(parsed.cases).toHaveLength(1);
+    expect(parsed.cases[0].id).toBe('case-1');
+    expect(parsed.cases[0].documents.birthRegistrationConsent.notaryId).toBe('notary-1');
   });
 
   it('merging that id-less paste into an existing catalog updates case-1 in place instead of creating a second case', () => {
-    const current = normalizeDocumentsCatalog({
-      cases: {
-        'case-1': {
-          id: 'case-1', coupleId: 'couple-1', surrogateMotherId: 'surrogate-1',
-        },
+    const current = normalizeDocumentsCatalog({}, {}, {
+      'case-1': {
+        id: 'case-1', relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' },
       },
-    }, {});
+    });
     const incoming = parseDocumentsTechnicalInput(JSON.stringify({
-      parties: { cases: { 'case-1': { birthRegistration: { statementDate: '2026-05-18', notaryId: 'notary-1' } } } },
+      cases: { 'case-1': { documents: { birthRegistrationConsent: { statementDate: '2026-05-18', notaryId: 'notary-1' } } } },
     }));
     const { catalog, summary } = mergeDocumentsCatalog(current, incoming);
-    expect(catalog.parties.cases).toHaveLength(1);
+    expect(catalog.cases).toHaveLength(1);
     expect(summary).toEqual({ added: 0, updated: 1 });
-    expect(catalog.parties.cases[0]).toMatchObject({
+    expect(catalog.cases[0]).toMatchObject({
       id: 'case-1',
       relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' },
-      registrations: { birth: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
+      documents: { birthRegistrationConsent: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
     });
   });
 
@@ -273,39 +247,15 @@ describe('parseDocumentsTechnicalInput', () => {
     expect(parsed.documents[0].id).toBe('doc-9');
   });
 
-  // batch 17 §1/§2/§8: parties.clinics[clinicId].logo is now the primary clinic-logo source when
-  // pasting technical input too (previously only normalizeDocumentsCatalog read it at all).
-  describe('clinic-logo priority (batch 17)', () => {
-    it('reads clinic.logo as the primary source for a pasted parties.clinics record', () => {
-      const parsed = parseDocumentsTechnicalInput(JSON.stringify({
-        parties: {
-          clinics: {
-            'clinic-1': { id: 'clinic-1', logo: [{ file: 'a.jpg', layout: '1col' }] },
-          },
+  it('reads clinic.logo as the clinic-logo source for a pasted parties.clinics record', () => {
+    const parsed = parseDocumentsTechnicalInput(JSON.stringify({
+      parties: {
+        clinics: {
+          'clinic-1': { id: 'clinic-1', logo: [{ file: 'a.jpg', layout: '1col' }] },
         },
-      }));
-      expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'a.jpg', layout: '1col' }]);
-    });
-
-    it('clinic.logo wins over a pasted legacy parties.cases.clinics node for the same clinic', () => {
-      const parsed = parseDocumentsTechnicalInput(JSON.stringify({
-        parties: {
-          clinics: { 'clinic-1': { id: 'clinic-1', logo: [{ file: 'current.jpg', layout: '1col' }] } },
-          cases: { clinics: { 'clinic-1': { logo: [{ file: 'stale.jpg', layout: '1col' }] } } },
-        },
-      }));
-      expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'current.jpg', layout: '1col' }]);
-    });
-
-    it('falls back to parties.cases.clinics only when the clinic record has no logo field of its own', () => {
-      const parsed = parseDocumentsTechnicalInput(JSON.stringify({
-        parties: {
-          clinics: { 'clinic-1': { id: 'clinic-1' } },
-          cases: { clinics: { 'clinic-1': { logo: [{ file: 'legacy.jpg', layout: '1col' }] } } },
-        },
-      }));
-      expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'legacy.jpg', layout: '1col' }]);
-    });
+      },
+    }));
+    expect(parsed.clinicLogos['clinic-1']).toEqual([{ file: 'a.jpg', layout: '1col' }]);
   });
 });
 
@@ -337,10 +287,10 @@ describe('mergeDocumentsCatalog', () => {
   it('supports arbitrary extra key/value pairs on records', () => {
     const current = sampleCatalog();
     const incoming = parseDocumentsTechnicalInput(JSON.stringify({
-      data: { cases: [{ id: 'case-1', embryoCount: 2, extra: { anything: 'goes' } }] },
+      cases: [{ id: 'case-1', embryoCount: 2, extra: { anything: 'goes' } }],
     }));
     const { catalog } = mergeDocumentsCatalog(current, incoming);
-    const caseRecord = catalog.parties.cases[0];
+    const caseRecord = catalog.cases[0];
     expect(caseRecord.embryoCount).toBe(2);
     expect(caseRecord.extra.anything).toBe('goes');
     expect(caseRecord.relations.coupleId).toBe('couple-1');
@@ -356,7 +306,7 @@ describe('mergeDocumentsCatalog', () => {
   it('merges incoming clinic logo layout assignments additively, keyed by clinic id', () => {
     const current = { ...emptyDocumentsCatalog(), clinicLogos: { 'clinic-old': [{ file: 'kept.jpg', layout: '1col' }] } };
     const incoming = parseDocumentsTechnicalInput(JSON.stringify({
-      parties: { cases: { clinics: { 'clinic-new': { logo: [{ file: 'new.jpg', layout: '2col' }] } } } },
+      parties: { clinics: { 'clinic-new': { id: 'clinic-new', logo: [{ file: 'new.jpg', layout: '2col' }] } } },
     }));
     const { catalog } = mergeDocumentsCatalog(current, incoming);
     expect(catalog.clinicLogos['clinic-old']).toEqual([{ file: 'kept.jpg', layout: '1col' }]);
@@ -408,8 +358,7 @@ describe('placeholders', () => {
     expect(fillPlaceholders('{{wife.name.uk.nominative}}', context, 'uk')).toBe('Тестова Марія');
     expect(fillPlaceholders('{{wife.name.uk.genitive}}', context, 'uk')).toBe('Тестової Марії');
     expect(fillPlaceholders('{{clinic.name.en}}', context, 'en')).toBe('Clinic "Mriia"');
-    // batch 18: case.surrogacyAgreement was migrated onto case.program.agreement.
-    expect(fillPlaceholders('{{case.program.agreement.number.uk}}', context, 'uk')).toBe('без номера');
+    expect(fillPlaceholders('{{surrogacyAgreement.number.uk}}', context, 'uk')).toBe('без номера');
   });
 
   it('falls back by language and to nominative when the path stops early', () => {
@@ -434,109 +383,24 @@ describe('placeholders', () => {
   });
 });
 
-describe('data-mode overrides', () => {
-  it('applies per-case overrides on top of the resolved template text', () => {
-    const catalog = sampleCatalog();
-    const context = resolveCaseContext(catalog, 'case-1');
-    const generated = buildGeneratedDocument(catalog.documents[0], context, {
-      title: { en: 'Edited consent' },
-      paragraphs: { 0: { uk: 'Відредагований абзац' } },
-    });
-    expect(generated.title.en).toBe('Edited consent');
-    expect(generated.title.uk).toBe('Згода');
-    expect(generated.paragraphs[0].uk).toBe('Відредагований абзац');
-    expect(generated.paragraphs[0].en).toBe('I, Testova Mariia, born 01.01.1990');
-  });
-
-  it('accepts array-shaped paragraph overrides (Firebase dense-node shape)', () => {
-    const catalog = sampleCatalog();
-    const context = resolveCaseContext(catalog, 'case-1');
-    const generated = buildGeneratedDocument(catalog.documents[0], context, {
-      paragraphs: [{ en: 'Array override' }],
-    });
-    expect(generated.paragraphs[0].en).toBe('Array override');
-  });
-
-  it('pruneDocOverride keeps only real deviations from the baseline', () => {
-    const catalog = sampleCatalog();
-    const context = resolveCaseContext(catalog, 'case-1');
-    const baseline = buildGeneratedDocument(catalog.documents[0], context);
-    const pruned = pruneDocOverride({
-      title: { uk: 'Згода', en: 'Edited consent' },
-      paragraphs: { 0: { uk: baseline.paragraphs[0].uk, en: 'Changed' } },
-    }, baseline);
-    expect(pruned).toEqual({ title: { en: 'Edited consent' }, paragraphs: { 0: { en: 'Changed' } } });
-  });
-
-  it('pruneDocOverride returns null when everything matches the baseline again', () => {
-    const catalog = sampleCatalog();
-    const context = resolveCaseContext(catalog, 'case-1');
-    const baseline = buildGeneratedDocument(catalog.documents[0], context);
-    expect(pruneDocOverride({ title: { uk: baseline.title.uk } }, baseline)).toBeNull();
-    expect(pruneDocOverride(null, baseline)).toBeNull();
-  });
-});
-
-describe('spec: inserting/removing a paragraph at any position reindexes existing overrides', () => {
-  it('shifts overrides at or after the insertion point up by one, keeping earlier ones untouched', () => {
-    const docOverride = { title: { en: 'Kept' }, paragraphs: { 0: { en: 'First' }, 2: { en: 'Third' } } };
-    const shifted = shiftDocOverrideParagraphIndices(docOverride, 1, 1);
-    expect(shifted.title).toEqual({ en: 'Kept' });
-    expect(shifted.paragraphs).toEqual({ 0: { en: 'First' }, 3: { en: 'Third' } });
-  });
-
-  it('shifts overrides after a removal down by one and drops the override at the removed index', () => {
-    const docOverride = { paragraphs: { 0: { en: 'First' }, 1: { en: 'Removed' }, 2: { en: 'Third' } } };
-    const shifted = shiftDocOverrideParagraphIndices(docOverride, 1, -1);
-    expect(shifted.paragraphs).toEqual({ 0: { en: 'First' }, 1: { en: 'Third' } });
-  });
-
-  it('handles the Firebase dense-array override shape the same way as the object shape', () => {
-    const docOverride = { paragraphs: [{ en: 'First' }, undefined, { en: 'Third' }] };
-    const shifted = shiftDocOverrideParagraphIndices(docOverride, 0, 1);
-    expect(shifted.paragraphs).toEqual({ 1: { en: 'First' }, 3: { en: 'Third' } });
-  });
-
-  it('leaves overrides without a doc-level paragraphs node untouched', () => {
-    expect(shiftDocOverrideParagraphIndices(null, 0, 1)).toBeNull();
-    expect(shiftDocOverrideParagraphIndices({ title: { en: 'Only title' } }, 0, 1)).toEqual({ title: { en: 'Only title' } });
-  });
-});
+// The per-case "data mode" resolved-text override system has been removed: a document is always
+// `static template + current case data`, generated fresh on every render - there is nothing left
+// to test here (buildGeneratedDocument no longer takes an override argument, and pruneDocOverride/
+// shiftDocOverrideParagraphIndices no longer exist).
 
 describe('clinic logos', () => {
-  // batch 17 §8: parties.cases.clinics is a legacy fallback now - only consulted for a clinic that
-  // doesn't already carry its own `logo` field.
-  it('reads legacy bare file names from parties/cases/clinics as unassigned entries (fallback only)', () => {
+  it('reads { file, layout } entries and drops unknown layout tags', () => {
     const catalog = normalizeDocumentsCatalog(
       {
-        clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
-        cases: {
-          'case-1': { id: 'case-1', clinicId: 'clinic-1' },
-          clinics: { 'clinic-1': { logo: ['a.jpg', 'b.png'] } },
-        },
-      },
-      null,
-    );
-    expect(catalog.clinicLogos['clinic-1']).toEqual([
-      { file: 'a.jpg', layout: '' },
-      { file: 'b.png', layout: '' },
-    ]);
-    expect(catalog.parties.cases.map(record => record.id)).toEqual(['case-1']);
-  });
-
-  it('reads { file, layout } entries and drops unknown layout tags (legacy fallback path)', () => {
-    const catalog = normalizeDocumentsCatalog(
-      {
-        cases: {
-          clinics: {
-            'clinic-1': {
-              logo: [
-                { file: 'square.jpg', layout: '2col' },
-                { file: 'wide.jpg', layout: '1col' },
-                { file: 'spare.jpg', layout: 'diagonal' },
-                'legacy.jpg',
-              ],
-            },
+        clinics: {
+          'clinic-1': {
+            id: 'clinic-1',
+            logo: [
+              { file: 'square.jpg', layout: '2col' },
+              { file: 'wide.jpg', layout: '1col' },
+              { file: 'spare.jpg', layout: 'diagonal' },
+              'legacy.jpg',
+            ],
           },
         },
       },
@@ -550,9 +414,7 @@ describe('clinic logos', () => {
     ]);
   });
 
-  // batch 17 §1/§2/§12: the clinic's own `logo` field is now the primary source - no
-  // `parties.cases.clinics` node is needed at all once a clinic carries it directly.
-  it('reads the logo directly from parties.clinics[clinicId].logo (primary, no cases.clinics needed)', () => {
+  it('reads the logo directly from parties.clinics[clinicId].logo', () => {
     const catalog = normalizeDocumentsCatalog(
       { clinics: { 'clinic-1': { id: 'clinic-1', logo: ['legacy.jpg'] } } },
       null,
@@ -560,28 +422,7 @@ describe('clinic logos', () => {
     expect(catalog.clinicLogos['clinic-1']).toEqual([{ file: 'legacy.jpg', layout: '' }]);
   });
 
-  it('parties.clinics[clinicId].logo wins over a stale parties.cases.clinics node for the same clinic (§12 #4)', () => {
-    const catalog = normalizeDocumentsCatalog(
-      {
-        clinics: {
-          'clinic-1': {
-            id: 'clinic-1',
-            logo: [{ file: 'current-1col.jpg', layout: '1col' }, { file: 'current-2col.jpg', layout: '2col' }],
-          },
-        },
-        cases: {
-          clinics: { 'clinic-1': { logo: [{ file: 'stale.jpg', layout: '1col' }] } },
-        },
-      },
-      null,
-    );
-    expect(catalog.clinicLogos['clinic-1']).toEqual([
-      { file: 'current-1col.jpg', layout: '1col' },
-      { file: 'current-2col.jpg', layout: '2col' },
-    ]);
-  });
-
-  it('resolveClinicLogo (getClinicLogo) reads {{logo}}/{{logo-long}} from parties.clinics[clinicId].logo (§12 #2/#3)', () => {
+  it('resolveClinicLogo (getClinicLogo) reads {{logo}}/{{logo-long}} from parties.clinics[clinicId].logo', () => {
     const catalog = normalizeDocumentsCatalog(
       {
         clinics: {
@@ -593,9 +434,9 @@ describe('clinic logos', () => {
             ],
           },
         },
-        cases: { 'case-1': { id: 'case-1', clinicId: 'clinic-1' } },
       },
       null,
+      { 'case-1': { id: 'case-1', relations: { clinicId: 'clinic-1' } } },
     );
     const context = resolveCaseContext(catalog, 'case-1');
     expect(getClinicLogo(catalog.clinicLogos[context.clinic.id], 'logo').file).toBe('1784230621524-mwe7prn3.jpg');
@@ -672,7 +513,7 @@ describe('clinic logos', () => {
 describe('case selector helpers', () => {
   it('builds a readable case label', () => {
     const catalog = sampleCatalog();
-    expect(buildCaseLabel(catalog, catalog.parties.cases[0]))
+    expect(buildCaseLabel(catalog, catalog.cases[0]))
       .toBe('Testova Mariia & Testovyi Petro — SM Prykladova Oksana');
   });
 
@@ -708,7 +549,7 @@ describe('spec: Documents list ordered by most recently downloaded', () => {
 describe('spec: every selected document downloads as its own separate file', () => {
   it('includes the document title in the file name so a batch never collides on one name', () => {
     const catalog = sampleCatalog();
-    const caseRecord = catalog.parties.cases[0];
+    const caseRecord = catalog.cases[0];
     const docA = { id: 'doc-a', title: { uk: 'Перший документ', en: 'First document' } };
     const docB = { id: 'doc-b', title: { uk: 'Другий документ', en: 'Second document' } };
     const nameA = buildDocumentsFileName(catalog, caseRecord, 'two-column', 'pdf', docA);
@@ -720,7 +561,7 @@ describe('spec: every selected document downloads as its own separate file', () 
 
   it('still produces a valid name when no specific document is given (batch-level fallback)', () => {
     const catalog = sampleCatalog();
-    const caseRecord = catalog.parties.cases[0];
+    const caseRecord = catalog.cases[0];
     expect(buildDocumentsFileName(catalog, caseRecord, 'two-column', 'pdf')).toMatch(/^Documents_.+\.pdf$/);
   });
 });
@@ -795,11 +636,8 @@ const richCatalog = () => normalizeDocumentsCatalog(
           },
           authority: { type: { uk: 'Наказ', en: 'Order' }, number: '064', date: '2021-12-31' },
         },
+        logo: [{ file: 'square.jpg', layout: '1col' }, { file: 'wide.jpg', layout: '2col' }],
       },
-    },
-    cases: {
-      'case-1': { id: 'case-1', coupleId: 'couple-1', clinicId: 'clinic-1', representativeIds: [] },
-      clinics: { 'clinic-1': { logo: [{ file: 'square.jpg', layout: '1col' }, { file: 'wide.jpg', layout: '2col' }] } },
     },
   },
   {
@@ -812,6 +650,9 @@ const richCatalog = () => normalizeDocumentsCatalog(
         { uk: '{{clinic.medicalDirector.name.uk.genitive}}', en: '{{clinic.medicalDirector.name.en.full}}' },
       ],
     },
+  },
+  {
+    'case-1': { id: 'case-1', relations: { coupleId: 'couple-1', clinicId: 'clinic-1', representativeIds: [] } },
   },
 );
 
@@ -1267,7 +1108,7 @@ describe('spec: insert-variable picker (collectContextLeafPaths / buildVariableP
       wife: { name: { en: 'Kyogoku Aya' } },
       husband: { name: { en: 'Kyogoku Keigo' } },
       couple: { marriage: { certificateNumber: 'M-1' } },
-      program: { type: 'gestational' },
+      surrogacyAgreement: { number: { en: 'without a number' } },
       surrogateMother: { name: { en: 'Molvinskykh Yuliia' } },
       representative: { name: { en: 'Koval Oleksandr' } },
       clinic: { kind: 'ukrainian', name: { en: 'Victoria' } },
@@ -1283,7 +1124,7 @@ describe('spec: insert-variable picker (collectContextLeafPaths / buildVariableP
     const sharedGroup = groups.find(g => g.label === 'Спільне');
     expect(sharedGroup.items).toEqual(expect.arrayContaining([
       { path: 'couple.marriage.certificateNumber', value: 'M-1' },
-      { path: 'program.type', value: 'gestational' },
+      { path: 'surrogacyAgreement.number.en', value: 'without a number' },
     ]));
 
     const clinicGroup = groups.find(g => g.label === 'Клініка — українська');
@@ -1575,81 +1416,91 @@ describe('spec: per-document format overrides (batch 13 §5)', () => {
 // Fixture mirroring the reference statement (batch 16 §6): a surrogate mother's consent to the
 // birth registration of a child born for a Japanese couple, medical conclusion issued by a named
 // maternity hospital, signature witnessed by a named notary.
-const birthRegistrationCatalog = (birthRegistrationOverride = {}) => normalizeDocumentsCatalog(
-  {
-    couples: {
-      'couple-1': {
-        id: 'couple-1',
-        partners: [
+const birthRegistrationCatalog = (birthRegistrationOverride = {}) => {
+  const defaults = {
+    child: { sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'місто Київ', en: 'Kyiv' } },
+    medicalConclusion: { number: '1234-7H6A-2T6C-CK24', date: '2026-05-16', maternityHospitalId: 'maternity-hospital-1' },
+    statementDate: '2026-05-18',
+    notaryId: 'notary-1',
+  };
+  // Flat wholesale replacement (same as the old flat `birthRegistration` shape): passing `child`
+  // or `medicalConclusion` replaces that whole sub-object, it never deep-merges into the default.
+  const merged = { ...defaults, ...birthRegistrationOverride };
+  const { maternityHospitalId, ...medicalConclusionFields } = merged.medicalConclusion;
+  const child = { id: 'child-1', ...merged.child, medicalConclusion: medicalConclusionFields };
+
+  return normalizeDocumentsCatalog(
+    {
+      couples: {
+        'couple-1': {
+          id: 'couple-1',
+          partners: [
+            {
+              id: 'wife-1', role: 'wife', name: { uk: { nominative: 'Кікава Харука' }, en: 'Kikawa Haruka' }, birthDate: '1988-12-03', citizenship: { uk: 'Японії', en: 'Japan' },
+            },
+            {
+              id: 'husband-1', role: 'husband', name: { uk: { nominative: 'Кікава Йосуке' }, en: 'Kikawa Yosuke' }, birthDate: '1988-09-02', citizenship: { uk: 'Японії', en: 'Japan' },
+            },
+          ],
+        },
+      },
+      surrogateMothers: {
+        'surrogate-1': {
+          id: 'surrogate-1',
+          name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } },
+          birthDate: '1993-05-27',
+          passport: { number: 'ЕВ409051', issueDate: '2016-04-28' },
+          taxId: '3411512481',
+          address: { uk: 'Кіровоградська область, місто Гайворон' },
+        },
+      },
+      maternityHospitals: {
+        'maternity-hospital-1': {
+          id: 'maternity-hospital-1',
+          name: { uk: 'КОМУНАЛЬНЕ НЕКОМЕРЦІЙНЕ ПІДПРИЄМСТВО "ПЕРИНАТАЛЬНИЙ ЦЕНТР М. КИЄВА"', en: '' },
+          edrpou: '22964365',
+        },
+      },
+      notaries: {
+        'notary-1': {
+          id: 'notary-1',
+          name: { uk: { nominative: 'Алексашина Ю.Б.', instrumental: 'Алексашиною Ю.Б.' } },
+          title: { uk: 'приватний нотаріус Київського міського нотаріального округу' },
+          city: { uk: 'місто Київ, Україна', en: 'Kyiv, Ukraine' },
+        },
+      },
+    },
+    {
+      'birth-registration-surrogate-consent': {
+        id: 'birth-registration-surrogate-consent',
+        languages: ['uk'],
+        columns: 1,
+        beforeTitle: [
+          { uk: 'ЗА МІСЦЕМ ВИМОГИ', align: 'right', bold: true },
+          { uk: 'Дані сурогатної матері: {{surrogateMother.name.uk.nominative}}', align: 'left' },
+        ],
+        title: { uk: 'З А Я В А' },
+        paragraphs: [
           {
-            id: 'wife-1', role: 'wife', name: { uk: { nominative: 'Кікава Харука' }, en: 'Kikawa Haruka' }, birthDate: '1988-12-03', citizenship: { uk: 'Японії', en: 'Japan' },
-          },
-          {
-            id: 'husband-1', role: 'husband', name: { uk: { nominative: 'Кікава Йосуке' }, en: 'Kikawa Yosuke' }, birthDate: '1988-09-02', citizenship: { uk: 'Японії', en: 'Japan' },
+            uk: 'Я, {{surrogateMother.name.uk.nominative}}, даю згоду на те, щоб батьками, '
+              + '{{child.gender.uk.bornByMe}} {{child.birthDate}} року {{child.gender.uk.whichWasBorn}} '
+              + '{{child.gender.uk.childGenitive}}, були записані генетичні батьки.',
           },
         ],
       },
     },
-    surrogateMothers: {
-      'surrogate-1': {
-        id: 'surrogate-1',
-        name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } },
-        birthDate: '1993-05-27',
-        passport: { number: 'ЕВ409051', issueDate: '2016-04-28' },
-        taxId: '3411512481',
-        address: { uk: 'Кіровоградська область, місто Гайворон' },
-      },
-    },
-    maternityHospitals: {
-      'maternity-hospital-1': {
-        id: 'maternity-hospital-1',
-        name: { uk: 'КОМУНАЛЬНЕ НЕКОМЕРЦІЙНЕ ПІДПРИЄМСТВО "ПЕРИНАТАЛЬНИЙ ЦЕНТР М. КИЄВА"', en: '' },
-        edrpou: '22964365',
-      },
-    },
-    notaries: {
-      'notary-1': {
-        id: 'notary-1',
-        name: { uk: { nominative: 'Алексашина Ю.Б.', instrumental: 'Алексашиною Ю.Б.' } },
-        title: { uk: 'приватний нотаріус Київського міського нотаріального округу' },
-        city: { uk: 'місто Київ, Україна', en: 'Kyiv, Ukraine' },
-      },
-    },
-    cases: {
+    {
       'case-1': {
         id: 'case-1',
-        coupleId: 'couple-1',
-        surrogateMotherId: 'surrogate-1',
-        birthRegistration: {
-          child: { sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'місто Київ', en: 'Kyiv' } },
-          medicalConclusion: { number: '1234-7H6A-2T6C-CK24', date: '2026-05-16', maternityHospitalId: 'maternity-hospital-1' },
-          statementDate: '2026-05-18',
-          notaryId: 'notary-1',
-          ...birthRegistrationOverride,
+        relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' },
+        childbirth: { maternityHospitalId, children: [child] },
+        documents: {
+          birthRegistrationConsent: { statementDate: merged.statementDate, notaryId: merged.notaryId },
         },
       },
     },
-  },
-  {
-    'birth-registration-surrogate-consent': {
-      id: 'birth-registration-surrogate-consent',
-      languages: ['uk'],
-      columns: 1,
-      beforeTitle: [
-        { uk: 'ЗА МІСЦЕМ ВИМОГИ', align: 'right', bold: true },
-        { uk: 'Дані сурогатної матері: {{surrogateMother.name.uk.nominative}}', align: 'left' },
-      ],
-      title: { uk: 'З А Я В А' },
-      paragraphs: [
-        {
-          uk: 'Я, {{surrogateMother.name.uk.nominative}}, даю згоду на те, щоб батьками, '
-            + '{{child.gender.uk.bornByMe}} {{child.birthDate}} року {{child.gender.uk.whichWasBorn}} '
-            + '{{child.gender.uk.childGenitive}}, були записані генетичні батьки.',
-        },
-      ],
-    },
-  },
-);
+  );
+};
 
 describe('spec: birth-registration surrogate-consent document (batch 16 §6)', () => {
   describe('child gender grammar (§3/§4/§21 #1-4)', () => {
@@ -1777,9 +1628,6 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
         child: {}, medicalConclusion: {}, statementDate: '', notaryId: '',
       });
       const issues = validateBirthRegistrationCase(catalog, 'case-1');
-      // batch 19: with statementDate/notaryId both blank and no transactionId either, there is
-      // nothing at all to point at a transaction - reported as one missing reference rather than
-      // two separate blank-field paths.
       expect(issues).toEqual(expect.arrayContaining([
         'case.childbirth.maternityHospitalId',
         'case.childbirth.children[0].sex',
@@ -1787,7 +1635,8 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
         'case.childbirth.children[0].birthPlace.uk',
         'case.childbirth.children[0].medicalConclusion.number',
         'case.childbirth.children[0].medicalConclusion.date',
-        'case.registrations.birth.transactionId',
+        'case.documents.birthRegistrationConsent.statementDate',
+        'case.documents.birthRegistrationConsent.notaryId',
       ]));
     });
 
@@ -1801,7 +1650,7 @@ describe('spec: birth-registration surrogate-consent document (batch 16 §6)', (
     it('flags an unresolvable maternity hospital / notary id', () => {
       const catalog = birthRegistrationCatalog({ notaryId: 'ghost-notary' });
       const issues = validateBirthRegistrationCase(catalog, 'case-1');
-      expect(issues).toContain('case.registrations.birth.notaryId (no matching notary)');
+      expect(issues).toContain('case.documents.birthRegistrationConsent.notaryId (no matching notary)');
     });
   });
 
@@ -1905,17 +1754,15 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
           address: { uk: 'місто Київ', en: 'Kyiv' },
         },
       },
-      cases: {
-        'case-1': {
-          id: 'case-1',
-          clinicId: 'clinic-1',
-          birthRegistration: {
-            medicalConclusion: { number: '1234-7H6A-2T6C-CK24', date: '2026-05-16', maternityHospitalId: 'maternity-hospital-1' },
-          },
-        },
-      },
     },
     {},
+    {
+      'case-1': {
+        id: 'case-1',
+        relations: { clinicId: 'clinic-1' },
+        childbirth: { maternityHospitalId: 'maternity-hospital-1' },
+      },
+    },
   );
 
   it('finds the clinic through case.clinicId, not a per-case node (§1, §12 #1)', () => {
@@ -1941,7 +1788,7 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
 
   it('an unknown clinicId resolves clinic to null without crashing (§10, §12 #8)', () => {
     const catalog = clinicAndHospitalCatalog();
-    catalog.parties.cases[0].relations.clinicId = 'no-such-clinic';
+    catalog.cases[0].relations.clinicId = 'no-such-clinic';
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.clinic).toBeNull();
     expect(() => fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).not.toThrow();
@@ -1950,7 +1797,7 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
 
   it('an unknown maternityHospitalId resolves maternityHospital to null without crashing (§10, §12 #9)', () => {
     const catalog = clinicAndHospitalCatalog();
-    catalog.parties.cases[0].childbirth.maternityHospitalId = 'ghost-hospital';
+    catalog.cases[0].childbirth.maternityHospitalId = 'ghost-hospital';
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.maternityHospital).toBeNull();
     expect(() => fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).not.toThrow();
@@ -1962,11 +1809,10 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
     expect(fillPlaceholders('{{clinic.medicalDirector.name.uk.genitive}}', context, 'uk')).toBe('Давид Лілії Володимирівни');
   });
 
-  it('persisting the catalog never re-creates parties.cases.clinics (§12 #12)', () => {
+  it('persisting the catalog never nests cases under parties (§12 #12)', () => {
     const catalog = clinicAndHospitalCatalog();
     const backend = catalogPartiesToBackend(catalog);
-    expect(backend.cases['case-1'].clinics).toBeUndefined();
-    expect(Object.values(backend.cases).some(record => record && record.clinics)).toBe(false);
+    expect(backend.cases).toBeUndefined();
     // The clinic record's own `logo` field is exactly what gets persisted - not a sibling node.
     expect(backend.clinics['clinic-1'].logo).toEqual([
       { file: '1784230621524-mwe7prn3.jpg', layout: '1col' },
@@ -1975,11 +1821,11 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
   });
 });
 
-// One case is one concrete relations combination (batch 18 §10): couple + clinic + surrogate
-// mother + representative(s). Changing the clinic or surrogate mother means creating a new case,
-// never mutating this one's relations in place - there is no active/replaced/from/to history.
-describe('spec: normalized case structure (batch 18)', () => {
-  const twoCasesOneProgramCatalog = () => normalizeDocumentsCatalog(
+// One case is one concrete relations combination: couple + clinic + surrogate mother +
+// representative(s). Changing the clinic or surrogate mother means creating a new case, never
+// mutating this one's relations in place - there is no active/replaced/from/to history.
+describe('spec: normalized case structure', () => {
+  const twoCasesCatalog = () => normalizeDocumentsCatalog(
     {
       couples: {
         'couple-1': {
@@ -2007,176 +1853,125 @@ describe('spec: normalized case structure (batch 18)', () => {
       notaries: {
         'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Нотаріус Один' } } },
       },
-      cases: {
-        'case-1': {
-          id: 'case-1',
-          programId: 'program-1',
-          relations: {
-            coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['representative-1'],
-          },
-          program: { type: 'surrogacy', agreement: { number: { uk: 'Договір №1', en: 'Agreement No.1' }, date: '2020-01-01' } },
-          childbirth: {
-            maternityHospitalId: 'maternity-hospital-1',
-            children: [
-              { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
-              { id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' } },
-            ],
-          },
-          registrations: { birth: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
-          documents: { overrides: { 'doc-1': { title: { uk: 'Перейменована заява' } } } },
-        },
-        'case-2': {
-          id: 'case-2',
-          programId: 'program-1',
-          relations: { coupleId: 'couple-1', clinicId: 'clinic-2', surrogateMotherId: 'surrogate-2', representativeIds: [] },
-          program: { type: 'surrogacy', agreement: { number: { uk: '', en: '' }, date: '' } },
-          childbirth: { maternityHospitalId: '', children: [] },
-          registrations: { birth: { statementDate: '', notaryId: '' } },
-          documents: { overrides: {} },
-        },
-      },
     },
     {},
+    {
+      'case-1': {
+        id: 'case-1',
+        relations: {
+          coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['representative-1'],
+        },
+        childbirth: {
+          maternityHospitalId: 'maternity-hospital-1',
+          children: [
+            { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
+            { id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' } },
+          ],
+        },
+        documents: {
+          surrogacyAgreement: { number: { uk: 'Договір №1', en: 'Agreement No.1' }, date: '2020-01-01' },
+          birthRegistrationConsent: { statementDate: '2026-05-18', notaryId: 'notary-1' },
+        },
+      },
+      'case-2': {
+        id: 'case-2',
+        relations: { coupleId: 'couple-1', clinicId: 'clinic-2', surrogateMotherId: 'surrogate-2', representativeIds: [] },
+      },
+    },
   );
 
-  it('finds the couple through case.relations.coupleId (§19 #1)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('finds the couple through case.relations.coupleId', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.wife.name.uk.nominative).toBe('Тестова Марія');
     expect(context.husband.name.uk.nominative).toBe('Тестовий Петро');
   });
 
-  it('finds the clinic through case.relations.clinicId (§19 #2)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('finds the clinic through case.relations.clinicId', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.clinic.name.uk).toBe('Клініка А');
   });
 
-  it('finds the surrogate mother through case.relations.surrogateMotherId (§19 #3)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('finds the surrogate mother through case.relations.surrogateMotherId', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.surrogateMother.name.uk.nominative).toBe('Сурогатна Одна');
   });
 
-  it('finds the representative through case.relations.representativeIds (§19 #4)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('finds the representative through case.relations.representativeIds', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.representative.name.uk.nominative).toBe('Представник Один');
   });
 
-  it('reads the agreement from case.program.agreement (§19 #5)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
-    expect(fillPlaceholders('{{case.program.type}}', context, 'uk')).toBe('surrogacy');
-    expect(fillPlaceholders('{{case.program.agreement.number.uk}}', context, 'uk')).toBe('Договір №1');
-    expect(fillPlaceholders('{{case.program.agreement.date}}', context, 'uk')).toBe('01.01.2020');
+  it('reads the surrogacy agreement from case.documents.surrogacyAgreement', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
+    expect(fillPlaceholders('{{surrogacyAgreement.number.uk}}', context, 'uk')).toBe('Договір №1');
+    expect(fillPlaceholders('{{surrogacyAgreement.date}}', context, 'uk')).toBe('01.01.2020');
   });
 
-  it('reads the maternity hospital from case.childbirth.maternityHospitalId (§19 #6)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('reads the maternity hospital from case.childbirth.maternityHospitalId', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.maternityHospital.edrpou).toBe('11111111');
   });
 
-  it('the first child lands in context.child (§19 #7)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('the first child lands in context.child', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.child.sex).toBe('female');
     expect(context.child.gender.uk.label).toBe('дівчинка');
   });
 
-  it('every child lands in context.children, gender-computed (§19 #8)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('every child lands in context.children, gender-computed', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.children).toHaveLength(2);
     expect(context.children[0].gender.uk.label).toBe('дівчинка');
     expect(context.children[1].gender.uk.label).toBe('хлопчик');
   });
 
-  it('medicalConclusion is read from the child, not the case (§19 #9)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('medicalConclusion is read from the child, not the case', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.medicalConclusion.number).toBe('MC-1');
   });
 
-  it('the birth registration is read from case.registrations.birth (§19 #10)', () => {
-    const context = resolveCaseContext(twoCasesOneProgramCatalog(), 'case-1');
+  it('the birth registration is read from case.documents.birthRegistrationConsent', () => {
+    const context = resolveCaseContext(twoCasesCatalog(), 'case-1');
     expect(context.birthRegistration.statementDate).toBe('2026-05-18');
     expect(context.notary.name.uk.nominative).toBe('Нотаріус Один');
   });
 
-  it('per-case document overrides are read from case.documents.overrides (§19 #11)', () => {
-    const catalog = twoCasesOneProgramCatalog();
-    const caseRecord = catalog.parties.cases.find(item => item.id === 'case-1');
-    const template = { id: 'doc-1', title: { uk: 'Заява' }, paragraphs: [] };
-    const generated = buildGeneratedDocument(template, resolveCaseContext(catalog, 'case-1'), caseRecord.documents.overrides['doc-1']);
-    expect(generated.title.uk).toBe('Перейменована заява');
-  });
-
-  it('two cases sharing a programId can have different surrogate mothers (§19 #12)', () => {
-    const catalog = twoCasesOneProgramCatalog();
+  it('two cases can have different surrogate mothers', () => {
+    const catalog = twoCasesCatalog();
     expect(resolveCaseContext(catalog, 'case-1').surrogateMother.id).toBe('surrogate-1');
     expect(resolveCaseContext(catalog, 'case-2').surrogateMother.id).toBe('surrogate-2');
   });
 
-  it('two cases sharing a programId can have different clinics (§19 #13)', () => {
-    const catalog = twoCasesOneProgramCatalog();
+  it('two cases can have different clinics', () => {
+    const catalog = twoCasesCatalog();
     expect(resolveCaseContext(catalog, 'case-1').clinic.id).toBe('clinic-1');
     expect(resolveCaseContext(catalog, 'case-2').clinic.id).toBe('clinic-2');
   });
 
-  it('no case carries an active/replaced/from/to status (§19 #14)', () => {
-    const empty = createEmptyCase({ caseId: 'case-9', programId: 'program-9' });
+  it('no case carries an active/replaced/from/to status', () => {
+    const empty = createEmptyCase({ caseId: 'case-9' });
+    expect(empty).toEqual({ id: 'case-9' });
     expect(empty).not.toHaveProperty('active');
     expect(empty).not.toHaveProperty('replaced');
     expect(empty).not.toHaveProperty('from');
     expect(empty).not.toHaveProperty('to');
   });
 
-  it('the caseId the caller picks determines the current relations combination, not an "active" flag (§19 #15)', () => {
-    const catalog = twoCasesOneProgramCatalog();
-    const programCases = catalog.parties.cases.filter(item => item.programId === 'program-1');
-    expect(programCases).toHaveLength(2);
-    expect(resolveCaseContext(catalog, programCases[1].id).clinic.id).toBe('clinic-2');
+  it('the caseId the caller picks determines the current relations combination, not an "active" flag', () => {
+    const catalog = twoCasesCatalog();
+    expect(catalog.cases).toHaveLength(2);
+    expect(resolveCaseContext(catalog, 'case-2').clinic.id).toBe('clinic-2');
   });
 
-  it('a legacy-shaped case can be normalized (§19 #16)', () => {
-    const legacy = {
-      id: 'case-legacy',
-      coupleId: 'couple-1',
-      clinicId: 'clinic-1',
-      surrogateMotherId: 'surrogate-1',
-      representativeIds: ['representative-1'],
-      surrogacyAgreement: { number: { uk: 'без номера', en: 'without a number' }, date: '' },
-      birthRegistration: {
-        child: { sex: 'male', birthDate: '2026-01-01', birthPlace: { uk: 'Львів' } },
-        medicalConclusion: { number: 'MC-9', date: '2026-01-01', maternityHospitalId: 'maternity-hospital-1' },
-        statementDate: '2026-01-05',
-        notaryId: 'notary-1',
-      },
-      docOverrides: { 'doc-1': { title: { uk: 'X' } } },
-    };
-    const normalized = normalizeCaseRecord(legacy);
-    expect(normalized.relations).toEqual({
-      coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['representative-1'],
-    });
-    expect(normalized.program.agreement.number.uk).toBe('без номера');
-    expect(normalized.childbirth.maternityHospitalId).toBe('maternity-hospital-1');
-    expect(normalized.childbirth.children).toHaveLength(1);
-    expect(normalized.childbirth.children[0].sex).toBe('male');
-    expect(normalized.childbirth.children[0].medicalConclusion).toEqual({ number: 'MC-9', date: '2026-01-01' });
-    expect(normalized.registrations.birth).toEqual({ statementDate: '2026-01-05', notaryId: 'notary-1' });
-    expect(normalized.documents.overrides).toEqual({ 'doc-1': { title: { uk: 'X' } } });
+  it('normalizeCaseRecord is an idempotent pass-through - no legacy migration, missing branches never crash', () => {
+    expect(normalizeCaseRecord({ id: 'case-bare' })).toEqual({ id: 'case-bare' });
+    expect(normalizeCaseRecord(null)).toEqual({});
+    const withData = { id: 'case-1', relations: { coupleId: 'couple-1' } };
+    expect(normalizeCaseRecord(withData)).toBe(withData);
   });
 
-  it('after normalizing, the legacy top-level fields are dropped, not carried forward (§19 #17)', () => {
-    const normalized = normalizeCaseRecord({
-      id: 'case-legacy',
-      coupleId: 'couple-1',
-      clinicId: 'clinic-1',
-      surrogateMotherId: 'surrogate-1',
-      representativeIds: ['representative-1'],
-      surrogacyAgreement: { number: { uk: 'без номера', en: '' }, date: '' },
-      birthRegistration: { statementDate: '2026-01-05', notaryId: 'notary-1' },
-      docOverrides: {},
-    });
-    ['coupleId', 'clinicId', 'surrogateMotherId', 'representativeIds', 'surrogacyAgreement', 'birthRegistration', 'docOverrides']
-      .forEach(legacyKey => expect(normalized).not.toHaveProperty(legacyKey));
-  });
-
-  it('a two-child array does not break the generated preview (§19 #18)', () => {
-    const catalog = twoCasesOneProgramCatalog();
+  it('a two-child array does not break the generated preview', () => {
+    const catalog = twoCasesCatalog();
     const template = {
       id: 'doc-1',
       title: { uk: 'Заява' },
@@ -2185,8 +1980,8 @@ describe('spec: normalized case structure (batch 18)', () => {
     const context = resolveCaseContext(catalog, 'case-1');
     expect(() => buildGeneratedDocument(template, context)).not.toThrow();
     const generated = buildGeneratedDocument(template, context);
-    // Auto-capitalized at render time (§21 #7) - the paragraph starts with a variable that
-    // resolved lowercase ("дівчинка"), so it must still read as a proper sentence.
+    // Auto-capitalized at render time - the paragraph starts with a variable that resolved
+    // lowercase ("дівчинка"), so it must still read as a proper sentence.
     expect(generated.paragraphs[0].uk).toBe('Дівчинка та хлопчик');
   });
 
@@ -2221,8 +2016,8 @@ describe('spec: normalized case structure (batch 18)', () => {
     expect(generated.paragraphs[2].uk).toBe('');
   });
 
-  it('an empty children array does not break the component (§19 #19)', () => {
-    const catalog = twoCasesOneProgramCatalog();
+  it('an empty children array does not break the component', () => {
+    const catalog = twoCasesCatalog();
     const context = resolveCaseContext(catalog, 'case-2');
     expect(context.children).toEqual([]);
     expect(context.child.sex).toBeUndefined();
@@ -2231,7 +2026,7 @@ describe('spec: normalized case structure (batch 18)', () => {
     expect(fillPlaceholders('{{child.birthDate}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
   });
 
-  it('the birth-registration surrogate-consent statement keeps generating correctly (§19 #20)', () => {
+  it('the birth-registration surrogate-consent statement keeps generating correctly', () => {
     const catalog = birthRegistrationCatalog();
     const context = resolveCaseContext(catalog, 'case-1');
     const generated = buildGeneratedDocument(catalog.documents[0], context);
@@ -2245,13 +2040,13 @@ describe('spec: normalized case structure (batch 18)', () => {
 
   it('validateCaseRecord reports the base checklist without throwing on a bare/empty case', () => {
     expect(validateCaseRecord({})).toEqual(expect.arrayContaining([
-      'case.id', 'case.programId', 'case.relations.coupleId', 'case.relations.clinicId',
-      'case.relations.surrogateMotherId', 'case.childbirth.children', 'case.registrations.birth',
+      'case.id', 'case.relations.coupleId', 'case.relations.clinicId',
+      'case.relations.surrogateMotherId', 'case.childbirth.children',
     ]));
-    expect(validateCaseRecord(createEmptyCase({ caseId: 'case-9', programId: 'program-9' }))).toEqual(expect.arrayContaining([
-      'case.relations.coupleId', 'case.relations.clinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children', 'case.registrations.birth',
+    expect(validateCaseRecord(createEmptyCase({ caseId: 'case-9' }))).toEqual(expect.arrayContaining([
+      'case.relations.coupleId', 'case.relations.clinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children',
     ]));
-    expect(validateCaseRecord(twoCasesOneProgramCatalog().parties.cases[0])).toEqual([]);
+    expect(validateCaseRecord(twoCasesCatalog().cases[0])).toEqual([]);
   });
 
   it('createChildRecord generates a stable id, never reusing an array index', () => {
@@ -2263,13 +2058,12 @@ describe('spec: normalized case structure (batch 18)', () => {
   });
 });
 
-// A transaction is one concrete combination of couple + surrogate mother + notary for a specific
-// legal act (batch 19): decoupled from the case's current relations, so the birth-registration
-// statement uses exactly the participants recorded on its own transaction, not whatever the case's
-// relations happen to be right now. The couple/surrogate mother below are deliberately different
-// from the transaction's, to prove the document really reads through the transaction.
-describe('spec: transactions (batch 19)', () => {
-  const transactionCatalog = (transactionOverride = {}, birthOverride = {}) => normalizeDocumentsCatalog(
+// Transactions have been removed entirely: the birth-registration statement's notary/statementDate
+// live directly on `case.documents.birthRegistrationConsent`, no indirection through a separate
+// transaction record - already covered by the "spec: normalized case structure" and "spec:
+// birth-registration surrogate-consent document" describe blocks above.
+describe('spec: multi-child case (twins)', () => {
+  const twinsCatalog = () => normalizeDocumentsCatalog(
     {
       couples: {
         'couple-1': {
@@ -2279,263 +2073,48 @@ describe('spec: transactions (batch 19)', () => {
             { id: 'h1', role: 'husband', name: { uk: { nominative: 'Кікава Йосуке' }, en: 'Kikawa Yosuke' } },
           ],
         },
-        'couple-2': {
-          id: 'couple-2',
-          partners: [{ id: 'w2', role: 'wife', name: { uk: { nominative: 'Інша Дружина' } } }],
-        },
       },
       surrogateMothers: {
-        'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } }, taxId: '3411512481', address: { uk: 'Гайворон' } },
-        'surrogate-2': { id: 'surrogate-2', name: { uk: { nominative: 'Інша Сурогатна' } } },
+        'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } } },
       },
       notaries: {
-        'notary-1': {
-          id: 'notary-1',
-          name: { uk: { nominative: 'Алексашина Юлія Борисівна', genitive: 'Алексашиної Юлії Борисівни', short: 'Алексашина Ю.Б.' } },
-          title: { uk: 'приватний нотаріус Київського міського нотаріального округу' },
-          city: { uk: 'місто Київ, Україна' },
-        },
-      },
-      maternityHospitals: {},
-      transactions: {
-        'transaction-1': {
-          id: 'transaction-1',
-          type: 'birth-registration-surrogate-consent',
-          caseId: 'case-1',
-          coupleId: 'couple-1',
-          surrogateMotherId: 'surrogate-1',
-          notaryId: 'notary-1',
-          statementDate: '2026-05-18',
-          registryNumber: '',
-          ...transactionOverride,
-        },
-      },
-      cases: {
-        'case-1': {
-          id: 'case-1',
-          // Deliberately a different couple/surrogate mother than the transaction's, so a test
-          // failure here would mean the document fell back to case.relations instead.
-          relations: { coupleId: 'couple-2', surrogateMotherId: 'surrogate-2' },
-          childbirth: {
-            maternityHospitalId: '',
-            children: [{ id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } }],
-          },
-          registrations: { birth: { transactionId: 'transaction-1', ...birthOverride } },
-        },
+        'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Алексашина Юлія Борисівна' } } },
       },
     },
     {},
+    {
+      'case-1': {
+        id: 'case-1',
+        relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' },
+        childbirth: {
+          children: [
+            { id: 'child-1', sex: 'female', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-1', date: '2026-05-16' } },
+            { id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' } },
+          ],
+        },
+        documents: { birthRegistrationConsent: { statementDate: '2026-05-18', notaryId: 'notary-1' } },
+      },
+    },
   );
 
-  it('the transaction is resolved via case.registrations.birth.transactionId (§18 #1)', () => {
-    const catalog = transactionCatalog();
-    const caseRecord = catalog.parties.cases[0];
-    const transaction = resolveTransaction(catalog, caseRecord, 'birth-registration-surrogate-consent');
-    expect(transaction.id).toBe('transaction-1');
-    // A type mismatch resolves to null, same as a missing transaction.
-    expect(resolveTransaction(catalog, caseRecord, 'some-other-document')).toBeNull();
+  it('defaults to the first child when no childId is given', () => {
+    const context = resolveCaseContext(twinsCatalog(), 'case-1');
+    expect(context.selectedChildId).toBe('child-1');
+    expect(context.child.sex).toBe('female');
+    expect(context.children).toHaveLength(2);
   });
 
-  it('the couple is read via transaction.coupleId, not case.relations (§18 #2, §18 #12)', () => {
-    const context = resolveCaseContext(transactionCatalog(), 'case-1');
-    expect(context.wife.name.uk.nominative).toBe('Кікава Харука');
-    expect(context.husband.name.uk.nominative).toBe('Кікава Йосуке');
+  it('selects the requested child by id, leaving the full children array untouched', () => {
+    const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'child-2' });
+    expect(context.selectedChildId).toBe('child-2');
+    expect(context.child.sex).toBe('male');
+    expect(context.medicalConclusion.number).toBe('MC-2');
+    expect(context.children.map(child => child.id)).toEqual(['child-1', 'child-2']);
   });
 
-  it('the surrogate mother is read via transaction.surrogateMotherId, not case.relations (§18 #3, §18 #12)', () => {
-    const context = resolveCaseContext(transactionCatalog(), 'case-1');
-    expect(context.surrogateMother.name.uk.nominative).toBe('Молвінських Юлія Володимирівна');
-  });
-
-  it('the notary is read via transaction.notaryId (§18 #4)', () => {
-    const context = resolveCaseContext(transactionCatalog(), 'case-1');
-    expect(context.notary.name.uk.nominative).toBe('Алексашина Юлія Борисівна');
-    expect(fillPlaceholders('{{notary.name.uk.short}}', context, 'uk')).toBe('Алексашина Ю.Б.');
-    expect(fillPlaceholders('{{notary.title.uk}}', context, 'uk')).toBe('приватний нотаріус Київського міського нотаріального округу');
-  });
-
-  it('the statement date is read from transaction.statementDate (§18 #5)', () => {
-    const context = resolveCaseContext(transactionCatalog(), 'case-1');
-    expect(fillPlaceholders('{{birthRegistration.statementDate}}', context, 'uk')).toBe('18.05.2026');
-    expect(fillPlaceholders('{{transaction.statementDate}}', context, 'uk')).toBe('18.05.2026');
-    expect(fillPlaceholders('{{birthRegistration.statementDateWords.uk}}', context, 'uk')).toBe('вісімнадцятого травня дві тисячі двадцять шостого року');
-  });
-
-  it('the registry number is read from transaction.registryNumber (§18 #6)', () => {
-    const context = resolveCaseContext(transactionCatalog({ registryNumber: '12345' }), 'case-1');
-    expect(fillPlaceholders('{{birthRegistration.registryNumber}}', context, 'uk')).toBe('12345');
-    expect(fillPlaceholders('{{transaction.registryNumber}}', context, 'uk')).toBe('12345');
-  });
-
-  it('an empty registryNumber leaves a blank line to fill in by hand, never undefined/null (§18 #7)', () => {
-    const context = resolveCaseContext(transactionCatalog(), 'case-1');
-    const rendered = fillPlaceholders('Зареєстровано в реєстрі за № {{birthRegistration.registryNumber}}', context, 'uk');
-    expect(rendered).toBe(`Зареєстровано в реєстрі за № ${MISSING_VALUE_PLACEHOLDER}`);
-    expect(rendered).not.toContain('undefined');
-    expect(rendered).not.toContain('null');
-  });
-
-  it('case.registrations.birth carries only transactionId, never a duplicated notaryId/statementDate (§18 #8)', () => {
-    const emptyCase = createEmptyCase({ caseId: 'case-9', programId: 'program-9' });
-    expect(Object.keys(emptyCase.registrations.birth)).toEqual(['transactionId']);
-    const catalog = transactionCatalog();
-    expect(Object.keys(catalog.parties.cases[0].registrations.birth)).toEqual(['transactionId']);
-  });
-
-  it('a transaction never carries status/draft/active fields (§18 #9)', () => {
-    const transaction = createTransaction({
-      transactionId: 'transaction-9', caseId: 'case-9', type: 'birth-registration-surrogate-consent', coupleId: 'couple-1', surrogateMotherId: 'surrogate-1', notaryId: 'notary-1',
-    });
-    ['status', 'draft', 'active', 'replaced', 'createdAt', 'updatedAt'].forEach(key => expect(transaction).not.toHaveProperty(key));
-    expect(Object.keys(transaction).sort()).toEqual(
-      ['id', 'type', 'caseId', 'coupleId', 'surrogateMotherId', 'notaryId', 'statementDate', 'registryNumber'].sort(),
-    );
-  });
-
-  it('changing the notary on a transaction never touches the notary record itself (§18 #10)', () => {
-    const catalog = transactionCatalog();
-    const originalNotaryName = catalog.parties.notaries.find(n => n.id === 'notary-1').name.uk.nominative;
-    const updatedTransaction = { ...catalog.parties.transactions[0], notaryId: 'notary-1' };
-    const updatedCatalog = {
-      ...catalog,
-      parties: {
-        ...catalog.parties,
-        transactions: catalog.parties.transactions.map(t => (t.id === updatedTransaction.id ? updatedTransaction : t)),
-      },
-    };
-    expect(updatedCatalog.parties.notaries.find(n => n.id === 'notary-1').name.uk.nominative).toBe(originalNotaryName);
-  });
-
-  it('removeTransactionReferences deletes only the transaction and its case reference, never the couple/surrogate mother/notary (§18 #11)', () => {
-    const catalog = transactionCatalog();
-    const updated = removeTransactionReferences(catalog, 'transaction-1');
-    expect(updated.parties.transactions).toHaveLength(0);
-    expect(updated.parties.cases[0].registrations.birth.transactionId).toBeUndefined();
-    expect(updated.parties.couples.find(c => c.id === 'couple-1')).toBeDefined();
-    expect(updated.parties.surrogateMothers.find(s => s.id === 'surrogate-1')).toBeDefined();
-    expect(updated.parties.notaries.find(n => n.id === 'notary-1')).toBeDefined();
-  });
-
-  it('the generated document uses the specific transaction\'s own participants (§18 #12)', () => {
-    const catalog = transactionCatalog();
-    const context = resolveCaseContext(catalog, 'case-1');
-    const template = {
-      id: 'birth-registration-surrogate-consent',
-      title: { uk: 'З А Я В А' },
-      paragraphs: [{ uk: 'Я, {{surrogateMother.name.uk.nominative}}, за участі {{wife.name.uk.nominative}} та {{husband.name.uk.nominative}}, нотаріус {{notary.name.uk.nominative}}.' }],
-    };
-    const generated = buildGeneratedDocument(template, context);
-    expect(generated.paragraphs[0].uk).toBe(
-      'Я, Молвінських Юлія Володимирівна, за участі Кікава Харука та Кікава Йосуке, нотаріус Алексашина Юлія Борисівна.',
-    );
-  });
-
-  it('a missing transactionId is reported as a validation warning, not a crash (§18 #13)', () => {
-    const catalog = transactionCatalog();
-    catalog.parties.cases[0].registrations.birth = {};
-    const context = resolveCaseContext(catalog, 'case-1');
-    expect(context.transaction).toBeNull();
-    expect(() => fillPlaceholders('{{notary.name.uk.nominative}}', context, 'uk')).not.toThrow();
-    expect(validateBirthRegistrationCase(catalog, 'case-1')).toContain('case.registrations.birth.transactionId');
-  });
-
-  it('an unresolvable notaryId on the transaction never crashes the preview (§18 #14)', () => {
-    const catalog = transactionCatalog({ notaryId: 'ghost-notary' });
-    const context = resolveCaseContext(catalog, 'case-1');
-    expect(context.notary).toBeNull();
-    expect(() => fillPlaceholders('{{notary.name.uk.nominative}}', context, 'uk')).not.toThrow();
-    expect(fillPlaceholders('{{notary.name.uk.nominative}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
-    expect(validateTransaction(catalog, 'transaction-1')).toContain('transaction.notaryId (no matching notary)');
-  });
-
-  it('never leaks undefined/null/[object Object] into the generated statement (§18 #15)', () => {
-    const catalog = transactionCatalog();
-    const context = resolveCaseContext(catalog, 'case-1');
-    const template = {
-      id: 'birth-registration-surrogate-consent',
-      title: { uk: 'З А Я В А' },
-      paragraphs: [{ uk: 'Зареєстровано в реєстрі за № {{birthRegistration.registryNumber}}, нотаріус {{notary.name.uk.short}}, {{notary.city.uk}}.' }],
-    };
-    const generated = buildGeneratedDocument(template, context);
-    expect(generated.paragraphs[0].uk).not.toContain('undefined');
-    expect(generated.paragraphs[0].uk).not.toContain('null');
-    expect(generated.paragraphs[0].uk).not.toContain('[object Object]');
-  });
-
-  describe('validateTransaction', () => {
-    it('reports no issues for a fully-filled transaction', () => {
-      const catalog = transactionCatalog();
-      expect(validateTransaction(catalog, 'transaction-1')).toEqual([]);
-    });
-
-    it('flags every missing required field, but never registryNumber (empty is allowed)', () => {
-      const catalog = transactionCatalog({
-        type: '', coupleId: '', surrogateMotherId: '', notaryId: '', statementDate: '', registryNumber: '',
-      });
-      const issues = validateTransaction(catalog, 'transaction-1');
-      expect(issues).toEqual(expect.arrayContaining([
-        'transaction.type', 'transaction.coupleId', 'transaction.surrogateMotherId', 'transaction.notaryId', 'transaction.statementDate',
-      ]));
-      expect(issues).not.toContain('transaction.registryNumber');
-    });
-
-    it('flags an unresolvable coupleId/surrogateMotherId', () => {
-      const catalog = transactionCatalog({ coupleId: 'ghost-couple', surrogateMotherId: 'ghost-sm' });
-      const issues = validateTransaction(catalog, 'transaction-1');
-      expect(issues).toContain('transaction.coupleId (no matching couple)');
-      expect(issues).toContain('transaction.surrogateMotherId (no matching surrogate mother)');
-    });
-
-    it('flags a non-ISO statementDate', () => {
-      const catalog = transactionCatalog({ statementDate: '18.05.2026' });
-      expect(validateTransaction(catalog, 'transaction-1')).toContain('transaction.statementDate (must be YYYY-MM-DD)');
-    });
-  });
-
-  it('exposes transaction.statementDateWords.uk/en directly on the transaction, not only via birthRegistration (Batch 18 §3)', () => {
-    const context = resolveCaseContext(transactionCatalog(), 'case-1');
-    expect(fillPlaceholders('{{transaction.statementDateWords.uk}}', context, 'uk')).toBe('вісімнадцятого травня дві тисячі двадцять шостого року');
-    expect(fillPlaceholders('{{transaction.statementDateWords.en}}', context, 'en')).toBe('eighteenth of May, 2026');
-  });
-
-  it('a transactionId pointing at a differently-typed transaction is treated as missing, not validated as-is (type-check fix)', () => {
-    const catalog = transactionCatalog({ type: 'some-other-document' });
-    const context = resolveCaseContext(catalog, 'case-1');
-    expect(context.transaction).toBeNull();
-    const issues = validateBirthRegistrationCase(catalog, 'case-1');
-    expect(issues).toContain('case.registrations.birth.transactionId (transaction is not a birth-registration-surrogate-consent)');
-    // Never falls through to reporting the wrongly-typed transaction's own fields as if it were valid.
-    expect(issues).not.toContain('transaction.notaryId');
-  });
-
-  describe('child selector (Batch 18 §2: twins)', () => {
-    const twinsCatalog = () => {
-      const catalog = transactionCatalog();
-      catalog.parties.cases[0].childbirth.children.push({
-        id: 'child-2', sex: 'male', birthDate: '2026-05-16', birthPlace: { uk: 'Київ' }, medicalConclusion: { number: 'MC-2', date: '2026-05-16' },
-      });
-      return catalog;
-    };
-
-    it('defaults to the first child when no childId is given', () => {
-      const context = resolveCaseContext(twinsCatalog(), 'case-1');
-      expect(context.selectedChildId).toBe('child-1');
-      expect(context.child.sex).toBe('female');
-      expect(context.children).toHaveLength(2);
-    });
-
-    it('selects the requested child by id, leaving the full children array untouched', () => {
-      const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'child-2' });
-      expect(context.selectedChildId).toBe('child-2');
-      expect(context.child.sex).toBe('male');
-      expect(context.medicalConclusion.number).toBe('MC-2');
-      expect(context.children.map(child => child.id)).toEqual(['child-1', 'child-2']);
-    });
-
-    it('an unresolvable childId falls back to the first child rather than crashing', () => {
-      const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'ghost-child' });
-      expect(context.selectedChildId).toBe('child-1');
-    });
+  it('an unresolvable childId falls back to the first child rather than crashing', () => {
+    const context = resolveCaseContext(twinsCatalog(), 'case-1', { childId: 'ghost-child' });
+    expect(context.selectedChildId).toBe('child-1');
   });
 });
 
@@ -2557,41 +2136,38 @@ describe('spec: Parties page record shapes', () => {
     expect(createEmptyMaternityHospital().id).toMatch(/^maternity-hospital-/);
     expect(createEmptyNotary().id).toMatch(/^notary-/);
 
-    // Two calls never collide, same guarantee makeRecordId already gives createChildRecord/createTransaction.
+    // Two calls never collide, same guarantee makeRecordId already gives createChildRecord.
     expect(createEmptyCouple().id).not.toBe(couple.id);
   });
 
-  it('findPartyReferences reports the cases/transactions pointing at a party, without deleting or blocking anything', () => {
-    const catalog = normalizeDocumentsCatalog({
-      couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { en: 'Jane Doe' } }] } },
-      clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
-      surrogateMothers: { 'surrogate-1': { id: 'surrogate-1', name: { en: 'Jane Roe' } } },
-      representatives: { 'rep-1': { id: 'rep-1' } },
-      notaries: { 'notary-1': { id: 'notary-1' } },
-      maternityHospitals: { 'hospital-1': { id: 'hospital-1' } },
-      cases: {
+  it('findPartyReferences reports the cases pointing at a party, without deleting or blocking anything', () => {
+    const catalog = normalizeDocumentsCatalog(
+      {
+        couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { en: 'Jane Doe' } }] } },
+        clinics: { 'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка' } } },
+        surrogateMothers: { 'surrogate-1': { id: 'surrogate-1', name: { en: 'Jane Roe' } } },
+        representatives: { 'rep-1': { id: 'rep-1' } },
+        notaries: { 'notary-1': { id: 'notary-1' } },
+        maternityHospitals: { 'hospital-1': { id: 'hospital-1' } },
+      },
+      {},
+      {
         'case-1': {
           id: 'case-1',
           relations: {
             coupleId: 'couple-1', clinicId: 'clinic-1', surrogateMotherId: 'surrogate-1', representativeIds: ['rep-1'],
           },
           childbirth: { maternityHospitalId: 'hospital-1', children: [] },
+          documents: { birthRegistrationConsent: { notaryId: 'notary-1' } },
         },
       },
-      transactions: {
-        'transaction-1': {
-          id: 'transaction-1', coupleId: 'couple-1', surrogateMotherId: 'surrogate-1', notaryId: 'notary-1',
-        },
-      },
-    });
+    );
 
-    expect(findPartyReferences(catalog, 'couples', 'couple-1')).toEqual([
-      expect.stringContaining('case'), expect.stringContaining('transaction "transaction-1"'),
-    ]);
+    expect(findPartyReferences(catalog, 'couples', 'couple-1')).toEqual([expect.stringContaining('case')]);
     expect(findPartyReferences(catalog, 'clinics', 'clinic-1')).toEqual([expect.stringContaining('case')]);
     expect(findPartyReferences(catalog, 'representatives', 'rep-1')).toEqual([expect.stringContaining('case')]);
     expect(findPartyReferences(catalog, 'maternityHospitals', 'hospital-1')).toEqual([expect.stringContaining('case')]);
-    expect(findPartyReferences(catalog, 'notaries', 'notary-1')).toEqual([expect.stringContaining('transaction "transaction-1"')]);
+    expect(findPartyReferences(catalog, 'notaries', 'notary-1')).toEqual([expect.stringContaining('case')]);
     expect(findPartyReferences(catalog, 'couples', 'nobody')).toEqual([]);
   });
 });


### PR DESCRIPTION
Move cases out of documentsBuilder/parties into their own top-level
documentsBuilder/cases path, and drop the transaction indirection and
per-case resolved-text override system entirely per the new schema.

- documentsCatalogUtils.js: cases live in catalog.cases (new
  DOCUMENTS_CASES_PATH), remove parties.transactions collection and all
  transaction helpers, simplify the case shape (no programId/program/
  registrations/documents.overrides), case.documents now holds
  surrogacyAgreement and birthRegistrationConsent directly,
  resolveCaseContext/buildGeneratedDocument/validateCaseRecord/
  validateBirthRegistrationCase/findPartyReferences/buildCaseLabel
  updated accordingly, add removeEmptyCaseValues helper.
- CaseChildbirthTransactionEditor.jsx: edit surrogacyAgreement and
  birthRegistrationConsent directly instead of a transaction record;
  drop the never-stored registryNumber field.
- PartiesPage.jsx: case CRUD writes to documentsBuilder/cases, drop the
  Program fields section (superseded by the editor above).
- DocumentsPage.jsx: load cases from the new path; remove the per-case
  "data mode" resolved-text override editing UI for title/paragraph
  rows (templates are static and shared across every case now) while
  keeping the beforeTitle block's template/input/text cycle intact.
- Update documentsCatalogUtils.test.js and the DocumentsPage/PartiesPage
  test suites to match.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GFTfNuRZL5uHk4rguDdKVy