### PR TITLE
Documents: restore template/input/text mode cycle for title and paragraphs

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -762,27 +762,26 @@ const DocumentsPage = ({ isAdmin }) => {
   const [selectedDocIds, setSelectedDocIds] = useState({});
   const [layout, setLayout] = useState('two-column');
   const [expandedDocId, setExpandedDocId] = useState('');
-  // Per-row mode, one cycling button instead of separate toggles (spec batch 21 §3/§9): 'template'
-  // shows the raw {{placeholder}} markup and edits the shared template; 'input' shows the resolved
-  // value as plain text and edits it as a per-case override (retype the wording, no formatting);
-  // 'text' shows that same resolved value with bold/italic already rendered in place and is the
-  // *only* mode Bold/Italic can be applied in - the wording itself isn't editable there (spec §9:
-  // "the paragraph's wording itself is not directly editable... the only action available is
-  // selecting a fragment and applying Bold"). Defaults to 'text'. Shared by the title row (scope
-  // TITLE_SCOPE) and every paragraph (scope paragraphScope(index)).
+  // Per-row mode, one cycling button instead of separate toggles: 'template' shows the raw
+  // {{placeholder}} markup and edits the shared template directly; 'input' shows the de-markup'd
+  // plain wording and edits that same shared template (retype the wording, no formatting, no case
+  // involved - templates are static and shared across every case, so there is nothing left to
+  // override); 'text' shows that markup rendered (bold/italic applied in place, placeholders still
+  // unresolved) and is the *only* mode Bold/Italic can be applied in - the wording itself isn't
+  // editable there, only its formatting. All three modes write straight to the template, exactly
+  // like beforeTitle rows always have - title/paragraph rows now follow the identical mechanism.
   const PARAGRAPH_MODES = ['template', 'input', 'text'];
   const nextParagraphMode = mode => PARAGRAPH_MODES[(PARAGRAPH_MODES.indexOf(mode) + 1) % PARAGRAPH_MODES.length];
   const PARAGRAPH_MODE_ICON = { template: '{}', input: 'I', text: 'T' };
   const PARAGRAPH_MODE_TITLE = {
     template: 'Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.',
-    input: "Input mode - retyping this case's resolved wording. Tap to switch to Text mode.",
+    input: 'Input mode - retyping the shared wording as plain text. Tap to switch to Text mode.',
     text: 'Text mode - select text and press Bold/Italic; wording isn\'t editable here. Tap to switch to Template mode.',
   };
   const [paragraphModes, setParagraphModes] = useState({});
   const paragraphModeKey = (docId, index) => `${docId}#${index}`;
-  // beforeTitle rows carry the same mode cycle (Task 2: identical toolbars) but default to
-  // 'template' - they have no per-case override layer, so raw markup is their canonical surface
-  // and what every admin edited there before the modes were unified.
+  // beforeTitle rows default to 'template'; title/paragraph rows default to 'text' - same defaults
+  // every row has always had, now just backed by the same template-only mechanism throughout.
   const getParagraphMode = (docId, scope) => paragraphModes[paragraphModeKey(docId, scope)]
     || (String(scope).startsWith('beforeTitle') ? 'template' : 'text');
   const setParagraphModeFor = (docId, index, mode) => setParagraphModes(previous => ({ ...previous, [paragraphModeKey(docId, index)]: mode }));
@@ -1303,23 +1302,16 @@ const DocumentsPage = ({ isAdmin }) => {
     // Input mode's field never takes Bold/Italic (the buttons are disabled there) - hard-stop in
     // case a stale focus record from it is still the active field.
     if (active.kind === 'input-plain') return;
-    // beforeTitle rows have no template/text distinction in what they write - their Text mode
-    // applies Bold/Italic straight onto the shared template markup (plain-text offsets via
-    // toggleInlineFormat), exactly like Template mode does with raw offsets.
-    if (active.kind === 'text-display' && /^beforeTitle:/.test(scope)) {
-      const template = catalog.documents.find(item => String(item.id) === String(docId));
-      if (!template) return;
-      const currentRaw = getTemplateScopeText(template, scope, langKey);
-      await commitTemplateScopeText(docId, scope, langKey, toggleInlineFormat(currentRaw, start, end, attr));
-      return;
-    }
-    if (active.kind === 'template') {
-      const template = catalog.documents.find(item => String(item.id) === String(docId));
-      if (!template) return;
-      const currentRaw = getTemplateScopeText(template, scope, langKey);
-      const nextRaw = toggleRawInlineMarker(currentRaw, start, end, attr);
-      await commitTemplateScopeText(docId, scope, langKey, nextRaw);
-    }
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template) return;
+    const currentRaw = getTemplateScopeText(template, scope, langKey);
+    // Every row (title, paragraph, beforeTitle) writes straight to the shared template - Text
+    // mode's field is the rendered display (plain-text offsets via toggleInlineFormat), Template
+    // mode's field is the raw markup itself (raw offsets via toggleRawInlineMarker).
+    const nextRaw = active.kind === 'text-display'
+      ? toggleInlineFormat(currentRaw, start, end, attr)
+      : toggleRawInlineMarker(currentRaw, start, end, attr);
+    await commitTemplateScopeText(docId, scope, langKey, nextRaw);
   };
 
   // Insert-variable modal (spec: "кнопка поруч з курсивом... модальне вікно... обрати змінні") -
@@ -1995,10 +1987,19 @@ const DocumentsPage = ({ isAdmin }) => {
                 const catalogNameValue = template.catalogName || template.title?.uk || template.title?.en || template.id;
                 const onCatalogNameChange = event => updateTemplate(template.id, current => ({ ...current, catalogName: event.target.value }));
                 const onCatalogNameBlur = () => persistTemplate(template.id);
-                // The title is always edited as raw template markup - templates are static and
-                // shared across every case, so there is no per-case resolved-text mode anymore.
+                // Title mode/state - same template/input/text cycle as every paragraph and
+                // beforeTitle block; always writes to the shared template, never a per-case value.
+                const titleMode = getParagraphMode(template.id, TITLE_SCOPE);
+                const titleIsTemplateMode = titleMode === 'template';
+                const titleIsInputMode = titleMode === 'input';
                 const titleRawValue = langKey => template.title?.[langKey] || '';
-                const onTitleFieldChange = langKey => event => handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, event.target.value);
+                const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleRawValue(langKey)));
+                const onTitleFieldChange = langKey => event => {
+                  const nextRaw = titleIsTemplateMode
+                    ? event.target.value
+                    : applyPlainTextEdit(titleRawValue(langKey), event.target.value);
+                  handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, nextRaw);
+                };
                 const onTitleFieldBlur = () => persistTemplate(template.id);
                 return (
                   <DocRow key={template.id}>
@@ -2255,6 +2256,7 @@ const DocumentsPage = ({ isAdmin }) => {
                               </ParagraphControlsRow>
                             );
                           }
+                          const titleFieldKind = titleIsTemplateMode ? 'template' : (titleIsInputMode ? 'input-plain' : 'text-display');
                           const titleStyle = getParagraphStyle(template.title);
                           return (
                             <ParagraphEditorBlock>
@@ -2263,6 +2265,14 @@ const DocumentsPage = ({ isAdmin }) => {
                                 <RowLine style={{ gap: 6 }}>
                                   <SmallButton
                                     type="button"
+                                    onClick={() => setParagraphModeFor(template.id, TITLE_SCOPE, nextParagraphMode(titleMode))}
+                                    title={PARAGRAPH_MODE_TITLE[titleMode]}
+                                  >
+                                    {PARAGRAPH_MODE_ICON[titleMode]}
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={titleIsInputMode}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2270,6 +2280,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
+                                    disabled={titleIsInputMode}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2277,6 +2288,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
+                                    disabled={!titleIsTemplateMode}
                                     onMouseDown={preventSelectionLoss}
                                     onClick={openVariablePicker}
                                     title="Insert a variable"
@@ -2315,26 +2327,46 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
-                                      value={titleRawValue('uk')}
-                                      placeholder="Title (uk)"
-                                      onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'template')}
-                                      onChange={onTitleFieldChange('uk')}
-                                      onBlur={onTitleFieldBlur}
-                                    />
+                                    {titleMode === 'text' ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
+                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={titleRawValue('uk')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
+                                        value={titleDisplayValue('uk')}
+                                        placeholder="Title (uk)"
+                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind)}
+                                        onChange={onTitleFieldChange('uk')}
+                                        onBlur={onTitleFieldBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
-                                      value={titleRawValue('en')}
-                                      placeholder="Title (en)"
-                                      onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'template')}
-                                      onChange={onTitleFieldChange('en')}
-                                      onBlur={onTitleFieldBlur}
-                                    />
+                                    {titleMode === 'text' ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
+                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={titleRawValue('en')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
+                                        value={titleDisplayValue('en')}
+                                        placeholder="Title (en)"
+                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind)}
+                                        onChange={onTitleFieldChange('en')}
+                                        onBlur={onTitleFieldBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                               </ParagraphPair>
@@ -2343,19 +2375,31 @@ const DocumentsPage = ({ isAdmin }) => {
                         })()}
                         {(template.paragraphs || []).map((paragraph, index) => {
                           const scope = paragraphScope(index);
-                          // A paragraph is always edited as raw template markup - templates are
-                          // static and shared across every case, so there is no per-case
-                          // resolved-text mode (Bold/Italic act on the raw `**`/`*` markers).
+                          // Same template/input/text mode cycle as beforeTitle - always writes to
+                          // the shared template, never a per-case value (Bold/Italic only ever act
+                          // in Template mode, on the raw markers, or Text mode, on the rendered
+                          // display).
+                          const mode = getParagraphMode(template.id, scope);
+                          const isTemplateMode = mode === 'template';
+                          const isInputMode = mode === 'input';
+                          const isTextMode = mode === 'text';
                           const rawValue = langKey => paragraph?.[langKey] || '';
-                          const onChange = langKey => event => handleTemplateScopeChange(template.id, scope, langKey, event.target.value);
+                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
+                          const onChange = langKey => event => {
+                            const nextRaw = isTemplateMode
+                              ? event.target.value
+                              : applyPlainTextEdit(rawValue(langKey), event.target.value);
+                            handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
+                          };
                           const onBlur = () => persistTemplate(template.id);
+                          const fieldKind = isTemplateMode ? 'template' : (isInputMode ? 'input-plain' : 'text-display');
                           // This paragraph's own stored style overrides, whichever backend shape
                           // they are in (consolidated `style` key or legacy flat fields).
                           const paragraphStyle = getParagraphStyle(paragraph);
                           return (
                             // Boxed together so it's unambiguous which paragraph the toolbar acts
-                            // on: the +/Bold/Italic/Delete controls and the paragraph's own text
-                            // live inside the same visible border.
+                            // on: the +/mode-switch/Bold/Italic/Delete controls and the paragraph's
+                            // own text live inside the same visible border.
                             <ParagraphEditorBlock key={`${template.id}-p-${index}`}>
                               <ParagraphControlsRow>
                                 <SmallButton
@@ -2368,6 +2412,14 @@ const DocumentsPage = ({ isAdmin }) => {
                                 <RowLine style={{ gap: 6 }}>
                                   <SmallButton
                                     type="button"
+                                    onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
+                                    title={PARAGRAPH_MODE_TITLE[mode]}
+                                  >
+                                    {PARAGRAPH_MODE_ICON[mode]}
+                                  </SmallButton>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={isInputMode}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2375,6 +2427,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
+                                    disabled={isInputMode}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2382,6 +2435,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
+                                    disabled={!isTemplateMode}
                                     onMouseDown={preventSelectionLoss}
                                     onClick={openVariablePicker}
                                     title="Insert a variable"
@@ -2428,26 +2482,46 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, scope, 'uk')}
-                                      value={rawValue('uk')}
-                                      placeholder="Paragraph (uk)"
-                                      onFocus={handleRichFieldFocus(template.id, scope, 'uk', 'template')}
-                                      onChange={onChange('uk')}
-                                      onBlur={onBlur}
-                                    />
+                                    {isTextMode ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={rawValue('uk')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        value={displayValue('uk')}
+                                        placeholder="Paragraph (uk)"
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
+                                        onChange={onChange('uk')}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    <AutoInlineTextarea
-                                      ref={registerFieldNode(template.id, scope, 'en')}
-                                      value={rawValue('en')}
-                                      placeholder="Paragraph (en)"
-                                      onFocus={handleRichFieldFocus(template.id, scope, 'en', 'template')}
-                                      onChange={onChange('en')}
-                                      onBlur={onBlur}
-                                    />
+                                    {isTextMode ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                      >
+                                        <FormattedRunsPreview text={rawValue('en')} />
+                                      </TextModeDisplay>
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        value={displayValue('en')}
+                                        placeholder="Paragraph (en)"
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
+                                        onChange={onChange('en')}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
                                   </ParagraphFieldColumn>
                                 ) : null}
                               </ParagraphPair>

--- a/src/components/DocumentsPage.richFormatting.test.js
+++ b/src/components/DocumentsPage.richFormatting.test.js
@@ -1,17 +1,17 @@
-// Real-DOM regression test for the selection-based Bold/Italic feature (batch 13 §1): mounts the
-// actual DocumentsPage component (Firebase mocked out) and drives a genuine browser textarea
-// selection through the Bold button, to catch any wiring bug independent of mobile-specific touch
-// quirks (this is the actual React component, not just the pure logic it calls).
+// Real-DOM regression test for the selection-based Bold/Italic feature: mounts the actual
+// DocumentsPage component (Firebase mocked out) and drives a genuine browser selection through
+// the Bold button, to catch any wiring bug independent of mobile-specific touch quirks (this is
+// the actual React component, not just the pure logic it calls).
 //
 // NOTE: this project's Jest config sets `resetMocks: true`, which strips every mock's
 // implementation before each test - so the mock bodies below must be (re-)installed in
 // beforeEach, not just in the jest.mock(...) factory (which only runs once at hoist time).
 //
-// Post-migration (batch 2026-07-24): the per-case "data mode" resolved-text overrides on
-// title/paragraph rows are gone. A paragraph (and the title) is now always the raw
-// `{{placeholder}}` template markup - there is no mode-toggle button and no rendered
-// resolved-value display for these rows anymore, so Bold/Italic act directly on the textarea's
-// native selection and always persist to the shared template.
+// Post-migration: the per-case "data mode" resolved-text override system is gone entirely - the
+// title/paragraph/beforeTitle rows all share one mechanism now (the same template/input/text mode
+// cycle beforeTitle always had), and every mode writes straight to the shared template. There is
+// no case dependency left in this toolbar: Bold/Italic on a Text-mode row is never gated on
+// whether a case is selected, since there is no per-case value to edit anymore.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
@@ -43,6 +43,22 @@ import { listStorageFolderFileNames } from './config';
 // eslint-disable-next-line import/first
 import DocumentsPage from './DocumentsPage';
 
+// Text mode's field is a plain rendered display, not a textarea (the display itself is the
+// editing surface), so there's no `.setSelectionRange` to drive a selection through. This mirrors
+// what a real browser drag-select does: build a Range over the container's own text node and
+// install it as the document's selection, then fire the mouseUp/touchEnd the component listens on
+// to know a selection was just made in that field.
+const selectTextInContainer = (container, start, end) => {
+  // eslint-disable-next-line testing-library/no-node-access
+  const textNode = container.firstChild;
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
 beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
   get.mockImplementation(async path => {
@@ -55,12 +71,7 @@ beforeEach(() => {
       };
     }
     if (path === 'documentsBuilder/cases') {
-      return {
-        exists: () => true,
-        val: () => ({
-          'case-1': { id: 'case-1', relations: { coupleId: 'couple-1' } },
-        }),
-      };
+      return { exists: () => false, val: () => null };
     }
     if (path === 'documentsBuilder/templates') {
       return {
@@ -81,33 +92,33 @@ beforeEach(() => {
 });
 
 describe('spec: selection-based bold/italic applies to the browser selection, not the whole paragraph', () => {
-  it('bolds only the selected fragment of a paragraph field (raw template markup)', async () => {
+  it('bolds only the selected fragment of a Text-mode paragraph field, with no case selected', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
 
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    // A paragraph is always the raw template textarea now - no mode to switch, no separate
-    // rendered display to select text in.
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    // Default mode is 'text' - the field is the rendered display itself. No case exists in this
+    // fixture at all, proving Bold/Italic here never depend on a case being selected.
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    selectTextInContainer(field, 10, 15); // "текст"
+    fireEvent.mouseUp(field);
+
+    // Bold/Italic also appear on the Title row above (unified toolbar across every editable row)
+    // - scope the query to this paragraph's own boxed controls, same as a sighted admin would
+    // click the toolbar right above this specific field.
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = textarea.closest('.paragraph-editor-block');
-
-    fireEvent.focus(textarea);
-    textarea.setSelectionRange(10, 15); // "текст"
-
-    // Bold/Italic also appear on the Title row above (spec: unified format across every
-    // editable row) - scope the query to this paragraph's own boxed controls, same as a sighted
-    // admin would click the toolbar right above this specific field.
+    const paragraphBlock = field.closest('.paragraph-editor-block');
     const boldButton = within(paragraphBlock).getByTitle('Bold the selected text');
     fireEvent.click(boldButton);
 
-    await waitFor(() => expect(set).toHaveBeenCalled());
-    const [, payload] = set.mock.calls[set.mock.calls.length - 1];
-    expect(payload.paragraphs[0].uk).toBe('Звичайний **текст** без форматування.');
-    // The change is applied in place, right in the raw markup textarea - never a separate
-    // preview to catch up.
-    expect(await within(paragraphBlock).findByDisplayValue('Звичайний **текст** без форматування.')).toBeInTheDocument();
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({ paragraphs: [expect.objectContaining({ uk: 'Звичайний **текст** без форматування.' })] }),
+    ));
+    // The change is applied in place, right in the display - never a separate preview to catch up,
+    // and never written to a per-case override path.
+    expect(await within(paragraphBlock).findByText('текст')).toBeInTheDocument();
   });
 
   it('also applies via touch (mobile), where preventing the selection-dismissing touchstart suppresses the synthetic click', async () => {
@@ -116,13 +127,12 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    selectTextInContainer(field, 10, 15); // "текст"
+    fireEvent.touchEnd(field);
+
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = textarea.closest('.paragraph-editor-block');
-
-    fireEvent.focus(textarea);
-    textarea.setSelectionRange(10, 15); // "текст"
-
+    const paragraphBlock = field.closest('.paragraph-editor-block');
     const italicButton = within(paragraphBlock).getByTitle('Italicize the selected text');
     // No fireEvent.click - mobile browsers won't synthesize one once touchstart's default is
     // prevented (exactly what the button needs to do to keep the selection alive), so the
@@ -130,13 +140,14 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
     fireEvent.touchStart(italicButton);
     fireEvent.touchEnd(italicButton);
 
-    await waitFor(() => expect(set).toHaveBeenCalled());
-    const [, payload] = set.mock.calls[set.mock.calls.length - 1];
-    expect(payload.paragraphs[0].uk).toBe('Звичайний *текст* без форматування.');
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({ paragraphs: [expect.objectContaining({ uk: 'Звичайний *текст* без форматування.' })] }),
+    ));
   });
 });
 
-describe('spec: title/paragraph rows have a single always-template editing surface', () => {
+describe('spec: per-row template/input/text mode cycle replaces the old global toggle', () => {
   it('does not render the old global Template/Data section toggle', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     await screen.findByTitle('Edit paragraphs');
@@ -144,20 +155,23 @@ describe('spec: title/paragraph rows have a single always-template editing surfa
     expect(screen.queryByTitle('Edit the resolved values of the selected case directly')).not.toBeInTheDocument();
   });
 
-  it('editing a paragraph directly edits and persists the shared template, not a per-case override', async () => {
+  it('switching a paragraph to Template mode edits and persists the shared template directly, with no case needed', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    // Paragraphs no longer have a mode-toggle button (spec: raw {{placeholder}} markup is the
-    // only surface, shared across every case) - the textarea is already showing/editing it.
-    const textarea = await screen.findByDisplayValue('Звичайний текст без форматування.');
+    // Default mode ('text') shows the raw template text as a rendered display, not a textarea.
+    const field = await screen.findByText('Звичайний текст без форматування.');
     // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = textarea.closest('.paragraph-editor-block');
-    expect(within(paragraphBlock).queryByTitle(
-      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
-    )).not.toBeInTheDocument();
+    const paragraphBlock = field.closest('.paragraph-editor-block');
 
+    // One cycling button, not three separate ones: text -> template is one tap.
+    const modeButton = within(paragraphBlock).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    );
+    fireEvent.click(modeButton);
+
+    const textarea = await within(paragraphBlock).findByDisplayValue('Звичайний текст без форматування.');
     fireEvent.change(textarea, { target: { value: 'Змінений шаблонний текст.' } });
     fireEvent.blur(textarea);
 
@@ -172,7 +186,7 @@ describe('spec: title/paragraph rows have a single always-template editing surfa
     await screen.findByTitle('Edit paragraphs');
 
     // No catalogName saved yet, so the field falls back to showing the title text - but editing it
-    // writes catalogName only (spec batch 21 §6), never template.title.
+    // writes catalogName only, never template.title.
     const nameInput = await screen.findByDisplayValue('Тест');
     fireEvent.change(nameInput, { target: { value: 'Оновлена назва' } });
     fireEvent.blur(nameInput);

--- a/src/components/DocumentsPage.variablePicker.test.js
+++ b/src/components/DocumentsPage.variablePicker.test.js
@@ -44,8 +44,13 @@ beforeEach(() => {
         exists: () => true,
         val: () => ({
           couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Кьогоку Ая' }, en: 'Kyogoku Aya' } }] } },
-          cases: { 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1' } } },
         }),
+      };
+    }
+    if (path === 'documentsBuilder/cases') {
+      return {
+        exists: () => true,
+        val: () => ({ 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1' } } }),
       };
     }
     if (path === 'documentsBuilder/templates') {


### PR DESCRIPTION
## Summary
- Follow-up to the documentsBuilder cases/documents data-model migration (previously merged in #2820).
- The migration had dropped the mode-toggle button and plain-text editing from title/paragraph rows entirely, since the per-case override system they used to write to was removed. This regressed the editing UX to a single always-raw-markup textarea, inconsistent with `beforeTitle` rows.
- Extends `beforeTitle`'s existing mechanism (the same `template`/`input`/`text` cycle, but always writing straight to the shared template, never a per-case value) to title and paragraph rows too, so every editable row now behaves identically.
- Simplifies `handleApplyInlineFormat` accordingly — Bold/Italic on any row's Text-mode display applies to the raw template text, with no more case-selection dependency anywhere in this toolbar.

## Test plan
- [x] `documentsCatalogUtils.test.js` — 198/198 passing
- [x] `DocumentsPage.*` and `PartiesPage.*` suites — 364/364 passing (full documentsBuilder-related suite)
- [x] `DocumentsRenderers.smoke.test.js`, `__pdfSmoke.test.js` — passing
- [x] Confirmed remaining unrelated failures (`dplStorage`, `Matching.sharedReactions`, etc.) pre-exist on `main` and are unaffected by this change

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GFTfNuRZL5uHk4rguDdKVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFTfNuRZL5uHk4rguDdKVy)_