### PR TITLE
Documents: Text mode shows resolved values, not raw {{tokens}}

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1988,11 +1988,18 @@ const DocumentsPage = ({ isAdmin }) => {
                 const onCatalogNameChange = event => updateTemplate(template.id, current => ({ ...current, catalogName: event.target.value }));
                 const onCatalogNameBlur = () => persistTemplate(template.id);
                 // Title mode/state - same template/input/text cycle as every paragraph and
-                // beforeTitle block; always writes to the shared template, never a per-case value.
+                // beforeTitle block. Template and Input both edit the shared markup directly
+                // (never a per-case value). Text mode is a read-only preview of the paragraph
+                // resolved against the currently selected case - unlike beforeTitle (which has no
+                // case data to resolve against and always shows raw markup even in Text mode),
+                // the title/paragraph Text preview shows real substituted values so an admin can
+                // actually read it, not raw {{tokens}} - there is nowhere left to persist a Bold/
+                // Italic edit made against resolved text (that used to be a per-case override,
+                // which no longer exists), so Text mode is display-only here.
                 const titleMode = getParagraphMode(template.id, TITLE_SCOPE);
                 const titleIsTemplateMode = titleMode === 'template';
-                const titleIsInputMode = titleMode === 'input';
                 const titleRawValue = langKey => template.title?.[langKey] || '';
+                const titleResolvedValue = langKey => resolvedDoc?.title?.[langKey] ?? '';
                 const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleRawValue(langKey)));
                 const onTitleFieldChange = langKey => event => {
                   const nextRaw = titleIsTemplateMode
@@ -2256,7 +2263,9 @@ const DocumentsPage = ({ isAdmin }) => {
                               </ParagraphControlsRow>
                             );
                           }
-                          const titleFieldKind = titleIsTemplateMode ? 'template' : (titleIsInputMode ? 'input-plain' : 'text-display');
+                          // Only reaches an AutoInlineTextarea in Template/Input mode - Text mode
+                          // renders the read-only TextModeDisplay below instead.
+                          const titleFieldKind = titleIsTemplateMode ? 'template' : 'input-plain';
                           const titleStyle = getParagraphStyle(template.title);
                           return (
                             <ParagraphEditorBlock>
@@ -2272,7 +2281,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={titleIsInputMode}
+                                    disabled={!titleIsTemplateMode}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2280,7 +2289,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={titleIsInputMode}
+                                    disabled={!titleIsTemplateMode}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2328,12 +2337,8 @@ const DocumentsPage = ({ isAdmin }) => {
                                 {showUk ? (
                                   <ParagraphFieldColumn>
                                     {titleMode === 'text' ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
-                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={titleRawValue('uk')} />
+                                      <TextModeDisplay>
+                                        <FormattedRunsPreview text={titleResolvedValue('uk')} />
                                       </TextModeDisplay>
                                     ) : (
                                       <AutoInlineTextarea
@@ -2350,12 +2355,8 @@ const DocumentsPage = ({ isAdmin }) => {
                                 {showEn ? (
                                   <ParagraphFieldColumn>
                                     {titleMode === 'text' ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
-                                        onMouseUp={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={titleRawValue('en')} />
+                                      <TextModeDisplay>
+                                        <FormattedRunsPreview text={titleResolvedValue('en')} />
                                       </TextModeDisplay>
                                     ) : (
                                       <AutoInlineTextarea
@@ -2375,15 +2376,17 @@ const DocumentsPage = ({ isAdmin }) => {
                         })()}
                         {(template.paragraphs || []).map((paragraph, index) => {
                           const scope = paragraphScope(index);
-                          // Same template/input/text mode cycle as beforeTitle - always writes to
-                          // the shared template, never a per-case value (Bold/Italic only ever act
-                          // in Template mode, on the raw markers, or Text mode, on the rendered
-                          // display).
+                          // Same template/input/text mode cycle as beforeTitle - Template and
+                          // Input both edit the shared markup directly. Text mode is a read-only
+                          // preview resolved against the selected case (real values substituted,
+                          // not raw {{tokens}}) - there is nowhere left to persist a Bold/Italic
+                          // edit made against resolved text, so only Template mode's raw markers
+                          // stay editable for formatting.
                           const mode = getParagraphMode(template.id, scope);
                           const isTemplateMode = mode === 'template';
-                          const isInputMode = mode === 'input';
                           const isTextMode = mode === 'text';
                           const rawValue = langKey => paragraph?.[langKey] || '';
+                          const resolvedValue = langKey => resolvedDoc?.paragraphs?.[index]?.[langKey] ?? '';
                           const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
                           const onChange = langKey => event => {
                             const nextRaw = isTemplateMode
@@ -2392,7 +2395,7 @@ const DocumentsPage = ({ isAdmin }) => {
                             handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
                           };
                           const onBlur = () => persistTemplate(template.id);
-                          const fieldKind = isTemplateMode ? 'template' : (isInputMode ? 'input-plain' : 'text-display');
+                          const fieldKind = isTemplateMode ? 'template' : 'input-plain';
                           // This paragraph's own stored style overrides, whichever backend shape
                           // they are in (consolidated `style` key or legacy flat fields).
                           const paragraphStyle = getParagraphStyle(paragraph);
@@ -2419,7 +2422,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={isInputMode}
+                                    disabled={!isTemplateMode}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2427,7 +2430,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={isInputMode}
+                                    disabled={!isTemplateMode}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2483,12 +2486,8 @@ const DocumentsPage = ({ isAdmin }) => {
                                 {showUk ? (
                                   <ParagraphFieldColumn>
                                     {isTextMode ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, scope, 'uk')}
-                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={rawValue('uk')} />
+                                      <TextModeDisplay>
+                                        <FormattedRunsPreview text={resolvedValue('uk')} />
                                       </TextModeDisplay>
                                     ) : (
                                       <AutoInlineTextarea
@@ -2505,12 +2504,8 @@ const DocumentsPage = ({ isAdmin }) => {
                                 {showEn ? (
                                   <ParagraphFieldColumn>
                                     {isTextMode ? (
-                                      <TextModeDisplay
-                                        ref={registerFieldNode(template.id, scope, 'en')}
-                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
-                                      >
-                                        <FormattedRunsPreview text={rawValue('en')} />
+                                      <TextModeDisplay>
+                                        <FormattedRunsPreview text={resolvedValue('en')} />
                                       </TextModeDisplay>
                                     ) : (
                                       <AutoInlineTextarea

--- a/src/components/DocumentsPage.richFormatting.test.js
+++ b/src/components/DocumentsPage.richFormatting.test.js
@@ -7,11 +7,14 @@
 // implementation before each test - so the mock bodies below must be (re-)installed in
 // beforeEach, not just in the jest.mock(...) factory (which only runs once at hoist time).
 //
-// Post-migration: the per-case "data mode" resolved-text override system is gone entirely - the
-// title/paragraph/beforeTitle rows all share one mechanism now (the same template/input/text mode
-// cycle beforeTitle always had), and every mode writes straight to the shared template. There is
-// no case dependency left in this toolbar: Bold/Italic on a Text-mode row is never gated on
-// whether a case is selected, since there is no per-case value to edit anymore.
+// Post-migration: the per-case "data mode" resolved-text override system is gone entirely, but
+// title/paragraph rows keep the same template/input/text mode cycle beforeTitle always had.
+// Template and Input both edit the shared markup directly - Bold/Italic only ever act in Template
+// mode now, on the raw `**`/`*` markers, and are never gated on whether a case is selected (there
+// is no per-case value involved at all). Text mode became a read-only preview resolved against
+// whichever case is currently selected (real values substituted, not raw {{tokens}}) - there is
+// nowhere left to persist a formatting edit made against resolved text, so Bold/Italic are simply
+// disabled there.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
@@ -42,22 +45,6 @@ import { ref, get, set } from 'firebase/database';
 import { listStorageFolderFileNames } from './config';
 // eslint-disable-next-line import/first
 import DocumentsPage from './DocumentsPage';
-
-// Text mode's field is a plain rendered display, not a textarea (the display itself is the
-// editing surface), so there's no `.setSelectionRange` to drive a selection through. This mirrors
-// what a real browser drag-select does: build a Range over the container's own text node and
-// install it as the document's selection, then fire the mouseUp/touchEnd the component listens on
-// to know a selection was just made in that field.
-const selectTextInContainer = (container, start, end) => {
-  // eslint-disable-next-line testing-library/no-node-access
-  const textNode = container.firstChild;
-  const range = document.createRange();
-  range.setStart(textNode, start);
-  range.setEnd(textNode, end);
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-};
 
 beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
@@ -92,23 +79,29 @@ beforeEach(() => {
 });
 
 describe('spec: selection-based bold/italic applies to the browser selection, not the whole paragraph', () => {
-  it('bolds only the selected fragment of a Text-mode paragraph field, with no case selected', async () => {
+  it('bolds only the selected fragment of a Template-mode paragraph field, with no case selected', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
 
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
 
-    // Default mode is 'text' - the field is the rendered display itself. No case exists in this
-    // fixture at all, proving Bold/Italic here never depend on a case being selected.
+    // Default mode is 'text' (a read-only resolved preview - there's nowhere left to persist a
+    // formatting edit made against resolved text, since per-case overrides no longer exist), so
+    // switch to Template mode first to reach the editable raw-markup textarea.
     const field = await screen.findByText('Звичайний текст без форматування.');
-    selectTextInContainer(field, 10, 15); // "текст"
-    fireEvent.mouseUp(field);
+    // eslint-disable-next-line testing-library/no-node-access
+    const paragraphBlock = field.closest('.paragraph-editor-block');
+    fireEvent.click(within(paragraphBlock).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(paragraphBlock).findByDisplayValue('Звичайний текст без форматування.');
+    fireEvent.focus(textarea);
+    textarea.setSelectionRange(10, 15); // "текст"
 
     // Bold/Italic also appear on the Title row above (unified toolbar across every editable row)
     // - scope the query to this paragraph's own boxed controls, same as a sighted admin would
-    // click the toolbar right above this specific field.
-    // eslint-disable-next-line testing-library/no-node-access
-    const paragraphBlock = field.closest('.paragraph-editor-block');
+    // click the toolbar right above this specific field. No case exists in this fixture at all,
+    // proving Bold/Italic here never depend on a case being selected.
     const boldButton = within(paragraphBlock).getByTitle('Bold the selected text');
     fireEvent.click(boldButton);
 
@@ -116,9 +109,9 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({ paragraphs: [expect.objectContaining({ uk: 'Звичайний **текст** без форматування.' })] }),
     ));
-    // The change is applied in place, right in the display - never a separate preview to catch up,
-    // and never written to a per-case override path.
-    expect(await within(paragraphBlock).findByText('текст')).toBeInTheDocument();
+    // The change is applied in place, right in the raw-markup textarea - never a separate preview
+    // to catch up, and never written to a per-case override path.
+    expect(await within(paragraphBlock).findByDisplayValue('Звичайний **текст** без форматування.')).toBeInTheDocument();
   });
 
   it('also applies via touch (mobile), where preventing the selection-dismissing touchstart suppresses the synthetic click', async () => {
@@ -128,11 +121,15 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
     fireEvent.click(expandButton);
 
     const field = await screen.findByText('Звичайний текст без форматування.');
-    selectTextInContainer(field, 10, 15); // "текст"
-    fireEvent.touchEnd(field);
-
     // eslint-disable-next-line testing-library/no-node-access
     const paragraphBlock = field.closest('.paragraph-editor-block');
+    fireEvent.click(within(paragraphBlock).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    const textarea = await within(paragraphBlock).findByDisplayValue('Звичайний текст без форматування.');
+    fireEvent.focus(textarea);
+    textarea.setSelectionRange(10, 15); // "текст"
+
     const italicButton = within(paragraphBlock).getByTitle('Italicize the selected text');
     // No fireEvent.click - mobile browsers won't synthesize one once touchstart's default is
     // prevented (exactly what the button needs to do to keep the selection alive), so the
@@ -144,6 +141,20 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({ paragraphs: [expect.objectContaining({ uk: 'Звичайний *текст* без форматування.' })] }),
     ));
+  });
+});
+
+describe('spec: Text mode is a read-only preview resolved against the selected case', () => {
+  it('disables Bold/Italic in Text mode - there is nowhere left to persist a formatting edit against resolved text', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    const expandButton = await screen.findByTitle('Edit paragraphs');
+    fireEvent.click(expandButton);
+
+    const field = await screen.findByText('Звичайний текст без форматування.');
+    // eslint-disable-next-line testing-library/no-node-access
+    const paragraphBlock = field.closest('.paragraph-editor-block');
+    expect(within(paragraphBlock).getByTitle('Bold the selected text')).toBeDisabled();
+    expect(within(paragraphBlock).getByTitle('Italicize the selected text')).toBeDisabled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Follow-up to #2821 (mode-cycle restoration).
- Title/paragraph Text mode was showing raw `{{placeholder}}` markup (copied from beforeTitle's mechanism), but beforeTitle never had case data to resolve against - title/paragraph Text mode always showed the case-resolved preview before the override system was removed.
- Text mode now renders the paragraph/title resolved against the selected case (real values substituted), so it reads like the actual document instead of showing template syntax.
- Since there is nowhere left to persist a Bold/Italic edit made against resolved text, Bold/Italic/Insert-variable are now only enabled in Template mode for title/paragraph rows — Text mode is a read-only preview there. `beforeTitle` is unaffected (it never resolved case data, so it keeps editing raw markup in every mode, same as always).

## Test plan
- [x] `documentsCatalogUtils.test.js`, `DocumentsPage.*`, `PartiesPage.*` — 365/365 passing
- [x] Manually verified via a throwaway RTL reproduction that a paragraph with `{{notary.city.uk}}, {{birthRegistration.statementDateWords.uk}}.` now renders as `"Місто Київ, Україна, двадцять другого липня дві тисячі двадцять шостого року."` in Text mode when a case is selected, with Bold/Italic disabled there

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GFTfNuRZL5uHk4rguDdKVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFTfNuRZL5uHk4rguDdKVy)_