### PR TITLE
Documents Builder: add partner clinic + embryo ownership statement document

### DIFF
--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -14,6 +14,7 @@ import { database } from './config';
 import {
   DOCUMENTS_CASES_PATH,
   createChildRecord,
+  normalizeIsoDate,
   removeEmptyCaseValues,
   toArray,
 } from './documentsCatalogUtils';
@@ -203,6 +204,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   const [childbirthDraft, setChildbirthDraft] = useState({ maternityHospitalId: '', children: [] });
   const [surrogacyAgreementDraft, setSurrogacyAgreementDraft] = useState({ number: { uk: '', en: '' }, date: '' });
   const [birthRegistrationDraft, setBirthRegistrationDraft] = useState({ statementDate: '', notaryId: '' });
+  const [embryoOwnershipDraft, setEmbryoOwnershipDraft] = useState({ shipmentPeriod: { uk: '', en: '' }, ivfDate: '' });
 
   useEffect(() => {
     // `childbirth.children` isn't guaranteed to be a real array - a case edited straight in the
@@ -222,6 +224,15 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     setBirthRegistrationDraft({
       statementDate: selectedCase?.documents?.birthRegistrationConsent?.statementDate || '',
       notaryId: selectedCase?.documents?.birthRegistrationConsent?.notaryId || '',
+    });
+    setEmbryoOwnershipDraft({
+      shipmentPeriod: {
+        uk: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod?.uk || '',
+        en: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod?.en || '',
+      },
+      // `<input type="date">` only ever shows/emits ISO - a still-legacy `DD.MM.YYYY` import (spec
+      // §6) has to be read into ISO here or the field would just render blank.
+      ivfDate: normalizeIsoDate(selectedCase?.documents?.embryoOwnershipStatement?.ivfDate || ''),
     });
     setSelectedChildId('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -330,6 +341,40 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     } catch (saveError) {
       console.error('Unable to save the birth registration details', saveError);
       toast.error('Could not save the birth registration details.');
+    }
+  };
+
+  const updateEmbryoOwnershipField = (path, value) => setEmbryoOwnershipDraft(previous => {
+    if (path === 'ivfDate') return { ...previous, ivfDate: value };
+    return { ...previous, shipmentPeriod: { ...previous.shipmentPeriod, [path]: value } };
+  });
+
+  // Every save normalizes ivfDate to ISO (spec §6: "під час наступного збереження нормалізувати
+  // дату до ISO") - a no-op once the field is already ISO, since normalizeIsoDate is idempotent,
+  // and the source `<input type="date">` already only ever emits ISO itself.
+  const handleSaveEmbryoOwnership = async () => {
+    if (!selectedCase) return;
+    const cleaned = removeEmptyCaseValues({
+      shipmentPeriod: embryoOwnershipDraft.shipmentPeriod,
+      ivfDate: normalizeIsoDate(embryoOwnershipDraft.ivfDate),
+    });
+    const nextValue = Object.keys(cleaned).length ? cleaned : null;
+    try {
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/documents/embryoOwnershipStatement`), nextValue);
+      setCatalog(previous => ({
+        ...previous,
+        cases: previous.cases.map(item => {
+          if (String(item.id) !== String(selectedCase.id)) return item;
+          const documents = { ...(item.documents || {}) };
+          if (nextValue) documents.embryoOwnershipStatement = nextValue;
+          else delete documents.embryoOwnershipStatement;
+          return { ...item, documents };
+        }),
+      }));
+      toast.success('Embryo ownership statement details saved.');
+    } catch (saveError) {
+      console.error('Unable to save the embryo ownership statement details', saveError);
+      toast.error('Could not save the embryo ownership statement details.');
     }
   };
 
@@ -506,6 +551,39 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       <RowLine style={{ marginTop: 8 }}>
         <PrimaryMiniButton type="button" onClick={handleSaveBirthRegistration}>
           Save birth registration details
+        </PrimaryMiniButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Приналежність ембріонів</SectionSubhead>
+      <FieldGrid>
+        <Field>
+          Період передачі ембріонів (укр)
+          <FieldInput
+            type="text"
+            value={embryoOwnershipDraft.shipmentPeriod.uk || ''}
+            onChange={event => updateEmbryoOwnershipField('uk', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Період передачі ембріонів (eng)
+          <FieldInput
+            type="text"
+            value={embryoOwnershipDraft.shipmentPeriod.en || ''}
+            onChange={event => updateEmbryoOwnershipField('en', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Дата програми ЗІВ
+          <FieldInput
+            type="date"
+            value={embryoOwnershipDraft.ivfDate || ''}
+            onChange={event => updateEmbryoOwnershipField('ivfDate', event.target.value)}
+          />
+        </Field>
+      </FieldGrid>
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveEmbryoOwnership}>
+          Save embryo ownership statement details
         </PrimaryMiniButton>
       </RowLine>
     </Section>

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1628,6 +1628,17 @@ const DocumentsPage = ({ isAdmin }) => {
   const unresolvedVariables = caseContext
     ? [...new Set(selectedTemplates.flatMap(template => validateDocumentTemplate(template, caseContext)))].sort()
     : [];
+  // A case with no partnerClinicId set (old cases, or one just cleared - spec §3) resolves
+  // caseContext.partnerClinic to null, so every {{partnerClinic.*}} token in a selected template
+  // shows up in unresolvedVariables like any other missing field - technically correct (never a
+  // leaked {{token}}, never a crash) but "partnerClinic.name.uk, partnerClinic.address.uk, ..." is
+  // not a useful message on its own. Surface the actual cause instead, once, and drop the
+  // redundant per-field paths from the generic list.
+  const missingPartnerClinic = Boolean(caseContext) && !caseContext.partnerClinic
+    && unresolvedVariables.some(path => path.startsWith('partnerClinic.'));
+  const visibleUnresolvedVariables = missingPartnerClinic
+    ? unresolvedVariables.filter(path => !path.startsWith('partnerClinic.'))
+    : unresolvedVariables;
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || clinicLogoLoading || !selectedTemplates.length || !selectedCase;
 
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
@@ -1755,10 +1766,13 @@ const DocumentsPage = ({ isAdmin }) => {
   const confirmUnresolvedVariables = () => {
     if (typeof window === 'undefined') return true;
     const sections = [];
-    if (unresolvedVariables.length) {
+    if (missingPartnerClinic) {
+      sections.push('Для цього документа не вибрана клініка-партнер.');
+    }
+    if (visibleUnresolvedVariables.length) {
       sections.push(
-        `Не вдалося підставити ${unresolvedVariables.length} змінн${unresolvedVariables.length === 1 ? 'у' : 'их'}:\n`
-        + `${unresolvedVariables.map(path => `- ${path}`).join('\n')}`,
+        `Не вдалося підставити ${visibleUnresolvedVariables.length} змінн${visibleUnresolvedVariables.length === 1 ? 'у' : 'их'}:\n`
+        + `${visibleUnresolvedVariables.map(path => `- ${path}`).join('\n')}`,
       );
     }
     if (caseChecklistIssues.length) {
@@ -1946,9 +1960,14 @@ const DocumentsPage = ({ isAdmin }) => {
                   />
                 </DocLogoPreviewRow>
               ) : null}
-              {unresolvedVariables.length ? (
+              {missingPartnerClinic ? (
                 <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
-                  Не вдалося підставити: {unresolvedVariables.join(', ')}
+                  Для цього документа не вибрана клініка-партнер.
+                </DocSubtitle>
+              ) : null}
+              {visibleUnresolvedVariables.length ? (
+                <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
+                  Не вдалося підставити: {visibleUnresolvedVariables.join(', ')}
                 </DocSubtitle>
               ) : null}
               {!catalog.documents.length ? (

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -24,6 +24,7 @@ import {
   CLINIC_KINDS,
   createEmptyCase,
   createEmptyClinic,
+  createEmptyPartnerClinic,
   createEmptyCouple,
   createEmptyMaternityHospital,
   createEmptyNotary,
@@ -378,6 +379,21 @@ const setValueAtPath = (obj, path, value) => {
   return { ...obj, [key]: setValueAtPath(child, rest.join('.'), value) };
 };
 
+// Firebase RTDB removes a node when it's written as `null`; this is the local-state twin of that
+// (spec §4: clearing partnerClinicId must delete the key, never leave a `''` sitting in
+// `relations` - an empty string is a value, and would still resolve as a "clinic selected" ID).
+const deleteValueAtPath = (obj, path) => {
+  const [key, ...rest] = String(path).split('.');
+  if (!isPlainObject(obj)) return obj;
+  if (!rest.length) {
+    const next = { ...obj };
+    delete next[key];
+    return next;
+  }
+  if (!isPlainObject(obj[key])) return obj;
+  return { ...obj, [key]: deleteValueAtPath(obj[key], rest.join('.')) };
+};
+
 // Resyncs from the backend value on every change, unless the field currently has focus (so an
 // in-progress keystroke never gets clobbered by a re-render triggered by an unrelated commit) -
 // same guard the Invoice Builder's plain fields use.
@@ -499,8 +515,12 @@ const REPRESENTATIVE_FIELDS = [
   { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
   { label: 'Name (en)', path: 'name.en' },
   { label: 'Passport number', path: 'passport.number' },
+  { label: 'Passport issued by (uk)', path: 'passport.issuedBy.uk' },
+  { label: 'Passport issued by (en)', path: 'passport.issuedBy.en' },
+  { label: 'Passport issue date', path: 'passport.issueDate', type: 'date' },
   { label: 'Power of attorney date', path: 'powerOfAttorney.date', type: 'date' },
   { label: 'Power of attorney apostille', path: 'powerOfAttorney.apostille' },
+  { label: 'Power of attorney apostille date', path: 'powerOfAttorney.apostilleDate', type: 'date' },
 ];
 
 const CLINIC_FIELDS = [
@@ -537,6 +557,17 @@ const CLINIC_FIELDS = [
   { label: 'Director authority type (en)', path: 'medicalDirector.authority.type.en' },
   { label: 'Director authority number', path: 'medicalDirector.authority.number' },
   { label: 'Director authority date', path: 'medicalDirector.authority.date', type: 'date' },
+];
+
+// A partner clinic is deliberately a simplified party type (spec §5): just the two bilingual
+// fields a static document needs to name and address it by - never the Ukrainian clinic's
+// EDRPOU/license/director/bank/logo fields, which don't apply to a clinic that never signs
+// anything itself.
+const PARTNER_CLINIC_FIELDS = [
+  { label: 'Name (uk)', path: 'name.uk' },
+  { label: 'Name (en)', path: 'name.en' },
+  { label: 'Address (uk)', path: 'address.uk' },
+  { label: 'Address (en)', path: 'address.en' },
 ];
 
 const MATERNITY_HOSPITAL_FIELDS = [
@@ -866,6 +897,7 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
   const cases = catalog.cases;
   const orderedCouples = orderRecordsByRecentIds(catalog.parties.couples, recentIds.couples);
   const orderedClinics = orderRecordsByRecentIds(catalog.parties.clinics, recentIds.clinics);
+  const orderedPartnerClinics = orderRecordsByRecentIds(catalog.parties.partnerClinics, recentIds.partnerClinics);
   const orderedSurrogateMothers = orderRecordsByRecentIds(catalog.parties.surrogateMothers, recentIds.surrogateMothers);
   const orderedRepresentatives = orderRecordsByRecentIds(catalog.parties.representatives, recentIds.representatives);
 
@@ -894,6 +926,23 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
       }));
     } catch (updateError) {
       console.error('Unable to save case field', updateError);
+      toast.error('Could not save.');
+    }
+  };
+
+  // Same dbPath convention as updateCaseField, but writes `null` so Firebase actually removes the
+  // node - used when a relation slot is cleared back to "— None —" (spec §4: partnerClinicId must
+  // never be persisted as an empty string).
+  const removeCaseField = async (caseId, path) => {
+    const dbPath = `${DOCUMENTS_CASES_PATH}/${caseId}/${path.split('.').join('/')}`;
+    try {
+      await set(ref(database, dbPath), null);
+      setCatalog(previous => ({
+        ...previous,
+        cases: previous.cases.map(item => (String(item.id) === String(caseId) ? deleteValueAtPath(item, path) : item)),
+      }));
+    } catch (updateError) {
+      console.error('Unable to clear case field', updateError);
       toast.error('Could not save.');
     }
   };
@@ -963,6 +1012,20 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
                       valueId={relations.clinicId}
                       displayName={partyDisplayName}
                       onPick={id => { updateCaseField(caseRecord.id, 'relations.clinicId', id); recordPartyUsage('clinics', id); }}
+                    />
+                    <RelationSlot
+                      label="Partner clinic"
+                      records={orderedPartnerClinics}
+                      valueId={relations.partnerClinicId}
+                      displayName={partyDisplayName}
+                      onPick={id => {
+                        if (id) {
+                          updateCaseField(caseRecord.id, 'relations.partnerClinicId', id);
+                          recordPartyUsage('partnerClinics', id);
+                        } else {
+                          removeCaseField(caseRecord.id, 'relations.partnerClinicId');
+                        }
+                      }}
                     />
                     <RelationSlot
                       label="Surrogate mother"
@@ -1159,7 +1222,7 @@ const CaseReadView = ({ catalog, selectedCaseId, onSelectCase, onCreateCase }) =
 // --- Page ---------------------------------------------------------------------------------------
 
 const EMPTY_RECENT_IDS = {
-  couples: [], clinics: [], surrogateMothers: [], representatives: [], notaries: [],
+  couples: [], clinics: [], partnerClinics: [], surrogateMothers: [], representatives: [], notaries: [],
 };
 
 // Same view/edit pattern as the Budget page (spec batch 21 §10): read mode is the default, an
@@ -1210,6 +1273,7 @@ const PartiesPage = ({ isAdmin }) => {
       setRecentIds({
         couples: toArray(rawRecentIds?.couples),
         clinics: toArray(rawRecentIds?.clinics),
+        partnerClinics: toArray(rawRecentIds?.partnerClinics),
         surrogateMothers: toArray(rawRecentIds?.surrogateMothers),
         representatives: toArray(rawRecentIds?.representatives),
         notaries: toArray(rawRecentIds?.notaries),
@@ -1377,6 +1441,20 @@ const PartiesPage = ({ isAdmin }) => {
               toggleRecord={toggleRecord}
               groupOpen={Boolean(openGroups.clinics)}
               onToggleGroup={() => toggleGroup('clinics')}
+            />
+            <SimplePartyGroup
+              title="Partner clinics"
+              collection="partnerClinics"
+              records={catalog.parties.partnerClinics}
+              fieldDefs={PARTNER_CLINIC_FIELDS}
+              displayName={partyDisplayName}
+              createEmpty={createEmptyPartnerClinic}
+              catalog={catalog}
+              setCatalog={setCatalog}
+              expandedKeys={expandedKeys}
+              toggleRecord={toggleRecord}
+              groupOpen={Boolean(openGroups.partnerClinics)}
+              onToggleGroup={() => toggleGroup('partnerClinics')}
             />
             <SimplePartyGroup
               title="Maternity hospitals"

--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
-import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaFileInvoiceDollar, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
+import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaFileInvoiceDollar, FaFileAlt, FaAddressBook, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
 import { MdPersonAddAlt1 } from 'react-icons/md';
 import { VerifyEmail } from './VerifyEmail';
 import { useAppSettings } from 'hooks/useAppSettings';
@@ -221,6 +221,8 @@ export const ProfileDotsMenu = ({
     ...(isAdmin ? [{ path: '/flow', label: 'Flow', icon: <FaProjectDiagram /> }] : []),
     ...(isAdmin ? [{ path: '/budget', label: 'Budget', description: 'Program budget and other expenses', icon: <FaEuroSign /> }] : []),
     ...(isAdmin ? [{ path: '/invoices', label: 'Invoices', description: 'Create and export client invoices', icon: <FaFileInvoiceDollar /> }] : []),
+    ...(isAdmin ? [{ path: '/documents', label: 'Documents', description: 'Generate case documents from templates', icon: <FaFileAlt /> }] : []),
+    ...(isAdmin ? [{ path: '/parties', label: 'Parties', description: 'Manage clinics, couples and other case parties', icon: <FaAddressBook /> }] : []),
   ];
 
   return (

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -26,12 +26,12 @@ export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoSt
 export const legacyClinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const legacyClinicLogoStorageFilePath = (clinicId, fileName) => `${legacyClinicLogoStorageFolder(clinicId)}/${fileName}`;
 
-export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'maternityHospitals', 'notaries'];
+export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'partnerClinics', 'maternityHospitals', 'notaries'];
 
 // mergeCollection derives an id prefix for un-identified incoming records by stripping a trailing
 // 's' off the collection name; 'notaries' isn't a simple plural ('notarys' would be wrong), so it
 // needs the explicit override.
-const COLLECTION_ID_PREFIXES = { notaries: 'notary' };
+const COLLECTION_ID_PREFIXES = { notaries: 'notary', partnerClinics: 'partner-clinic' };
 
 export const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
@@ -111,7 +111,7 @@ export const clinicLogoEntriesToBackend = variants => (variants || [])
 export const emptyDocumentsCatalog = () => ({
   cases: [],
   parties: {
-    couples: [], surrogateMothers: [], representatives: [], clinics: [], maternityHospitals: [], notaries: [],
+    couples: [], surrogateMothers: [], representatives: [], clinics: [], partnerClinics: [], maternityHospitals: [], notaries: [],
   },
   documents: [],
   clinicLogos: {},
@@ -510,8 +510,15 @@ export const createEmptySurrogateMother = () => ({
 export const createEmptyRepresentative = () => ({
   id: makeRecordId('representative'),
   name: { uk: { nominative: '', genitive: '' }, en: '' },
-  passport: { number: '' },
-  powerOfAttorney: { date: '', apostille: '' },
+  passport: {
+    number: '', issuedBy: { uk: '', en: '' }, issueDate: '',
+  },
+  // `apostille` (legacy, freeform) is kept for whatever already reads it; `apostilleDate` is the
+  // discrete date a signature block needs (spec batch 2026-07-24 §10) - a separate field, not a
+  // rename, so no existing template silently loses its value.
+  powerOfAttorney: {
+    date: '', apostille: '', apostilleDate: '',
+  },
 });
 
 // A clinic is either the foreign fertility clinic the intended parents came from, or the
@@ -540,6 +547,16 @@ export const createEmptyClinic = () => ({
     name: { uk: { nominative: '', genitive: '', short: '' }, en: { full: '', short: '' } },
     authority: { type: { uk: '', en: '' }, number: '', date: '' },
   },
+});
+
+// A partner clinic is the foreign clinic embryos ship from - a distinct, deliberately simplified
+// party type from the Ukrainian `clinics` collection (which performs the surrogacy program itself
+// and carries a full legal/banking profile): no EDRPOU, license, director, bank details, or logo,
+// just the name and address a static document needs to reference it by.
+export const createEmptyPartnerClinic = () => ({
+  id: makeRecordId('partner-clinic'),
+  name: { uk: '', en: '' },
+  address: { uk: '', en: '' },
 });
 
 export const createEmptyMaternityHospital = () => ({
@@ -652,6 +669,15 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
       en: formatEnglishDateWords(statementDate),
     },
   };
+  // The Ukrainian clinic (parties.clinics, relations.clinicId) runs the surrogacy program and signs
+  // the documents; the partner clinic (parties.partnerClinics, relations.partnerClinicId) is the
+  // separate foreign clinic embryos ship from - never the same collection, never a second "main"
+  // clinic. Both are null-safe: an old case with no partnerClinicId simply resolves to null rather
+  // than throwing, so a template referencing partnerClinic degrades to a visible warning instead of
+  // a crash (see getUnresolvedVariablePaths/fillPlaceholders).
+  const partnerClinic = relations.partnerClinicId
+    ? findById(catalog.parties.partnerClinics, relations.partnerClinicId)
+    : null;
 
   return {
     case: caseRecord,
@@ -661,6 +687,7 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
     husband,
     surrogateMother: findById(catalog.parties.surrogateMothers, relations.surrogateMotherId),
     clinic: findById(catalog.parties.clinics, relations.clinicId),
+    partnerClinic,
     representative: representatives[0] || null,
     representatives,
     childbirth,
@@ -682,6 +709,22 @@ export const formatDocumentDate = value => {
   return `${match[3]}.${match[2]}.${match[1]}`;
 };
 
+// Read/write compatibility for a date field that's supposed to be stored as ISO (`ivfDate`): a
+// pre-prepared import may still carry the display form `DD.MM.YYYY` (spec §6) - this reads either
+// shape and always resolves to ISO, so fillPlaceholders' own ISO -> DD.MM.YYYY formatting
+// (formatDocumentDate) renders it correctly regardless of which shape happened to be stored. The
+// case editor calls this again on every save (see CaseChildbirthTransactionEditor's ivfDate
+// commit) so the backend is normalized to ISO from the next save onward; this is only a
+// compatibility shim for what's already stored, never a second source of truth.
+export const normalizeIsoDate = value => {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return '';
+  if (isIsoDate(trimmed)) return trimmed;
+  const match = /^(\d{2})\.(\d{2})\.(\d{4})$/.exec(trimmed);
+  if (match) return `${match[3]}-${match[2]}-${match[1]}`;
+  return trimmed;
+};
+
 export const MISSING_VALUE_PLACEHOLDER = '__________';
 
 // Every {{...}} token in a template, e.g. {{wife.name.uk.nominative}}, {{logo}}, {{logo-long}}.
@@ -696,6 +739,18 @@ export const getValueByPath = (source, path) => String(path).split('.').reduce((
   return value[key];
 }, source);
 
+// A passport number is stored compact ("ME680736"); every legal document that shows one wants a
+// space between the two-letter series and the digits ("ME 680736"). One shared formatter, applied
+// wherever a `...passport.number` path resolves (see resolvePlaceholderValue below), so no
+// template has to hand-write "серія {{...}} № ..." and risk duplicating a series/number split the
+// formatter already does (spec batch 2026-07-24 §10).
+export const formatPassportNumber = value => {
+  const trimmed = String(value || '').trim();
+  const match = /^([A-Za-zА-Яа-яЄЇІЄїієЇ]{1,3})\s*(\d+)$/.exec(trimmed);
+  if (!match) return trimmed;
+  return `${match[1].toUpperCase()} ${match[2]}`;
+};
+
 const resolvePlaceholderValue = (context, path, lang) => {
   let value = getValueByPath(context, path);
   // A path that stops at a bilingual node ({uk, en}) resolves to the requested language; one that
@@ -707,7 +762,8 @@ const resolvePlaceholderValue = (context, path, lang) => {
   }
   if (isPlainObject(value) && value.nominative !== undefined) value = value.nominative;
   if (value === undefined || value === null || isPlainObject(value) || Array.isArray(value)) return undefined;
-  return formatDocumentDate(value);
+  const formatted = formatDocumentDate(value);
+  return path.endsWith('passport.number') ? formatPassportNumber(formatted) : formatted;
 };
 
 // Missing data renders as a fill-in-by-hand blank, matching how the reference statements leave
@@ -1251,6 +1307,7 @@ export const findPartyReferences = (catalog, collection, id) => {
     switch (collection) {
       case 'couples': return String(relations.coupleId) === targetId;
       case 'clinics': return String(relations.clinicId) === targetId;
+      case 'partnerClinics': return String(relations.partnerClinicId) === targetId;
       case 'surrogateMothers': return String(relations.surrogateMotherId) === targetId;
       case 'representatives': return toArray(relations.representativeIds).some(repId => String(repId) === targetId);
       case 'maternityHospitals': return String(caseRecord.childbirth?.maternityHospitalId) === targetId;
@@ -1295,6 +1352,11 @@ export const VARIABLE_PICKER_GROUPS = [
   { label: 'Довірена особа', roots: ['representative'] },
   { label: 'Клініка — іноземна', roots: ['clinic'], predicate: context => context?.clinic?.kind === 'foreign' },
   { label: 'Клініка — українська', roots: ['clinic'], predicate: context => context?.clinic?.kind !== 'foreign' },
+  // Distinct from the `clinic` groups above: the partner clinic (parties.partnerClinics) is never
+  // the case's own `clinic` record under a different kind - it's the separate foreign clinic
+  // embryos ship from (spec: embryo-ownership-statement document). Shown whenever one is selected
+  // on the case; a case without a partnerClinicId simply doesn't offer this group.
+  { label: 'Клініка-партнер', roots: ['partnerClinic'], predicate: context => Boolean(context?.partnerClinic) },
 ];
 
 // Builds the picker's grouped leaf list from a resolved case context (or any similarly-shaped

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -21,6 +21,7 @@ import {
   createEmptyMaternityHospital,
   createEmptyNotary,
   createEmptyPartner,
+  createEmptyPartnerClinic,
   createEmptyRepresentative,
   createEmptySurrogateMother,
   deepMergeRecords,
@@ -30,6 +31,7 @@ import {
   findPartyReferences,
   formatDocumentDate,
   formatEnglishDateWords,
+  formatPassportNumber,
   formatUkrainianDateWords,
   getChildGenderForms,
   getClinicLogo,
@@ -55,6 +57,7 @@ import {
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
+  normalizeIsoDate,
   orderCasesByRecent,
   orderRecordsByRecentIds,
   parseDocumentsTechnicalInput,
@@ -336,6 +339,68 @@ describe('mergeDocumentsCatalog', () => {
     expect(clinicPatchRecord.name.en).toBe('Generated Clinic');
     expect(templatePatchRecord.id).toMatch(/^document-/);
     expect(templatePatchRecord.title.en).toBe('No id');
+  });
+
+  // Spec (batch 2026-07-24) §11: importing `{"cases":{"case-1":{"relations":{"partnerClinicId":...}}}}`
+  // must never wipe clinicId/coupleId/surrogateMotherId/representativeIds already on that case -
+  // the merge into `relations` (and `documents`) has to be a deep, additive, field-by-field merge,
+  // exactly like every other nested case branch.
+  it('adding partnerClinicId via Parse & merge never wipes the case\'s existing relations (spec §11)', () => {
+    const current = { ...emptyDocumentsCatalog() };
+    current.cases = [{
+      id: 'case-1',
+      relations: {
+        clinicId: 'clinic-1', coupleId: 'couple-2', surrogateMotherId: 'surrogate-mother-2', representativeIds: ['representative-1'],
+      },
+    }];
+    const incoming = parseDocumentsTechnicalInput(JSON.stringify({
+      cases: { 'case-1': { relations: { partnerClinicId: 'partner-clinic-1' } } },
+    }));
+    const { catalog } = mergeDocumentsCatalog(current, incoming);
+    const mergedCase = catalog.cases[0];
+    expect(mergedCase.relations).toEqual({
+      clinicId: 'clinic-1',
+      coupleId: 'couple-2',
+      surrogateMotherId: 'surrogate-mother-2',
+      representativeIds: ['representative-1'],
+      partnerClinicId: 'partner-clinic-1',
+    });
+  });
+
+  it('merges parties.partnerClinics, cases.*.documents.embryoOwnershipStatement and templates.embryo-ownership-statement additively (spec §11)', () => {
+    const current = sampleCatalog();
+    const incoming = parseDocumentsTechnicalInput(JSON.stringify({
+      parties: {
+        partnerClinics: {
+          'partner-clinic-1': {
+            id: 'partner-clinic-1',
+            name: { uk: 'Клініка Оті Юме у м. Нагоя', en: 'Ochi Yume Clinic Nagoya' },
+            address: { uk: 'Нагоя', en: 'Nagoya' },
+          },
+        },
+      },
+      cases: {
+        'case-1': { relations: { partnerClinicId: 'partner-clinic-1' }, documents: { embryoOwnershipStatement: { ivfDate: '2021-08-17' } } },
+      },
+      templates: {
+        'embryo-ownership-statement': { id: 'embryo-ownership-statement', title: { uk: 'Щодо приналежності ембріонів', en: 'Regarding ownership of embryos' } },
+      },
+    }));
+    const { catalog } = mergeDocumentsCatalog(current, incoming);
+
+    expect(catalog.parties.partnerClinics.map(record => record.id)).toEqual(['partner-clinic-1']);
+    // Every party collection that wasn't touched by this import stays exactly as it was.
+    expect(catalog.parties.clinics.map(record => record.id)).toEqual(['clinic-1']);
+    expect(catalog.parties.couples.map(record => record.id)).toEqual(['couple-1']);
+
+    const mergedCase = catalog.cases.find(record => record.id === 'case-1');
+    expect(mergedCase.relations.coupleId).toBe('couple-1');
+    expect(mergedCase.relations.partnerClinicId).toBe('partner-clinic-1');
+    expect(mergedCase.documents.embryoOwnershipStatement.ivfDate).toBe('2021-08-17');
+
+    expect(catalog.documents.some(record => record.id === 'embryo-ownership-statement')).toBe(true);
+    // The pre-existing template survives the import untouched.
+    expect(catalog.documents.some(record => record.id === 'embryo-transfer-consent')).toBe(true);
   });
 });
 
@@ -691,6 +756,340 @@ describe('spec: universal placeholder resolver', () => {
     };
     // The fixture case has no representative at all, so this path never resolves.
     expect(validateDocumentTemplate(template, context)).toEqual(['representative.powerOfAttorney.apostilleDate']);
+  });
+});
+
+// --- spec (batch 2026-07-24): partner clinic + embryo ownership statement document -------------
+// The Ukrainian clinic (parties.clinics, case.relations.clinicId) runs the surrogacy program; the
+// partner clinic (parties.partnerClinics, case.relations.partnerClinicId) is a distinct, foreign,
+// deliberately simplified party - the clinic embryos ship from. Both must resolve independently on
+// the same case, and a case without a partnerClinicId must degrade gracefully, never crash.
+const partnerClinicCatalog = ({ withPartnerClinic = true, ivfDate = '2021-08-17' } = {}) => normalizeDocumentsCatalog(
+  {
+    clinics: {
+      'clinic-1': {
+        id: 'clinic-1',
+        medicalCenterName: { uk: 'МЦ «Надія»', en: 'MC "Nadiya"' },
+        legalName: { uk: 'ТОВ «Надія»', en: 'Nadiya LLC' },
+      },
+    },
+    partnerClinics: {
+      'partner-clinic-1': {
+        id: 'partner-clinic-1',
+        name: { uk: 'Клініка Оті Юме у м. Нагоя', en: 'Ochi Yume Clinic Nagoya' },
+        address: {
+          uk: 'Хісая Парксайд Будівля 8F, 3-19-12 Маруноуті, округ Нака, місто Нагоя, префектура Айті',
+          en: 'Hisaya Parkside Building 8F, 3-19-12 Marunouchi, Naka-ku, Nagoya City, Aichi Prefecture',
+        },
+      },
+    },
+    representatives: {
+      'representative-1': {
+        id: 'representative-1',
+        name: { uk: { nominative: 'Тестовий Тест Тестович' }, en: 'Testovyi Test' },
+        passport: { number: 'ME680736', issuedBy: { uk: 'ДМС України', en: 'SMS of Ukraine' }, issueDate: '2019-05-06' },
+        powerOfAttorney: { date: '2026-01-10', apostilleDate: '2026-01-15' },
+      },
+    },
+  },
+  {},
+  {
+    'case-1': {
+      id: 'case-1',
+      relations: {
+        clinicId: 'clinic-1',
+        ...(withPartnerClinic ? { partnerClinicId: 'partner-clinic-1' } : {}),
+        representativeIds: ['representative-1'],
+      },
+      documents: {
+        embryoOwnershipStatement: {
+          shipmentPeriod: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' },
+          ivfDate,
+        },
+      },
+    },
+  },
+);
+
+describe('spec: partner clinic is a distinct party type from the Ukrainian clinic', () => {
+  it('resolves context.partnerClinic from parties.partnerClinics via relations.partnerClinicId, independent of context.clinic', () => {
+    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    expect(context.clinic.id).toBe('clinic-1');
+    expect(context.partnerClinic.id).toBe('partner-clinic-1');
+    expect(fillPlaceholders('{{partnerClinic.name.uk}}', context, 'uk')).toBe('Клініка Оті Юме у м. Нагоя');
+    expect(fillPlaceholders('{{partnerClinic.name.en}}', context, 'en')).toBe('Ochi Yume Clinic Nagoya');
+    expect(fillPlaceholders('{{partnerClinic.address.uk}}', context, 'uk')).toContain('Нагоя');
+  });
+
+  it('resolves context.partnerClinic to null (not undefined, not a throw) when the case has no partnerClinicId (old cases)', () => {
+    const context = resolveCaseContext(partnerClinicCatalog({ withPartnerClinic: false }), 'case-1');
+    expect(context.partnerClinic).toBeNull();
+    expect(() => fillPlaceholders('{{partnerClinic.name.uk}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{partnerClinic.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+
+  it('flags {{partnerClinic.*}} as unresolved only when no partner clinic is selected, never when one is', () => {
+    const template = { title: { uk: '', en: '' }, paragraphs: [{ uk: '{{partnerClinic.name.uk}}', en: '{{partnerClinic.name.en}}' }] };
+    const withClinic = resolveCaseContext(partnerClinicCatalog({ withPartnerClinic: true }), 'case-1');
+    const withoutClinic = resolveCaseContext(partnerClinicCatalog({ withPartnerClinic: false }), 'case-1');
+    expect(validateDocumentTemplate(template, withClinic)).toEqual([]);
+    expect(validateDocumentTemplate(template, withoutClinic)).toEqual(['partnerClinic.name.en', 'partnerClinic.name.uk']);
+  });
+
+  it('deleting/never-setting partnerClinicId never disturbs clinicId/coupleId/etc on the same case (null-safe, additive)', () => {
+    const catalog = partnerClinicCatalog({ withPartnerClinic: false });
+    const context = resolveCaseContext(catalog, 'case-1');
+    expect(context.clinic.id).toBe('clinic-1');
+    expect(context.representatives).toHaveLength(1);
+  });
+});
+
+describe('spec: case.documents.embryoOwnershipStatement resolves through the existing `case` root', () => {
+  it('resolves shipmentPeriod.uk/en directly, no derived context field needed', () => {
+    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.shipmentPeriod.uk}}', context, 'uk')).toBe('квітні – травні 2026 року');
+    expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.shipmentPeriod.en}}', context, 'en')).toBe('April-May 2026');
+  });
+
+  it('formats an ISO-stored ivfDate as DD.MM.YYYY, same as every other document date', () => {
+    const context = resolveCaseContext(partnerClinicCatalog({ ivfDate: '2021-08-17' }), 'case-1');
+    expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.ivfDate}}', context, 'uk')).toBe('17.08.2021');
+  });
+
+  it('still renders a legacy DD.MM.YYYY-stored ivfDate correctly (read-time compatibility, spec §6)', () => {
+    const context = resolveCaseContext(partnerClinicCatalog({ ivfDate: '17.08.2021' }), 'case-1');
+    expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.ivfDate}}', context, 'uk')).toBe('17.08.2021');
+  });
+
+  it('normalizeIsoDate converts DD.MM.YYYY to ISO and is a no-op on ISO/empty input (used by the case editor on save)', () => {
+    expect(normalizeIsoDate('17.08.2021')).toBe('2021-08-17');
+    expect(normalizeIsoDate('2021-08-17')).toBe('2021-08-17');
+    expect(normalizeIsoDate('')).toBe('');
+    expect(normalizeIsoDate(undefined)).toBe('');
+  });
+});
+
+describe('spec: clinic name for the new document is medicalCenterName, not clinic.name', () => {
+  it('resolves clinic.medicalCenterName.uk/en for a clinic record that never set clinic.name', () => {
+    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    expect(context.clinic.name).toBeUndefined();
+    expect(fillPlaceholders('{{clinic.medicalCenterName.uk}}', context, 'uk')).toBe('МЦ «Надія»');
+    expect(fillPlaceholders('{{clinic.medicalCenterName.en}}', context, 'en')).toBe('MC "Nadiya"');
+  });
+
+  it('flags {{clinic.name.uk}} as unresolved when the real clinic record never populated `name` (spec §12)', () => {
+    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    const template = { title: { uk: '', en: '' }, paragraphs: [{ uk: '{{clinic.name.uk}}', en: '' }] };
+    expect(validateDocumentTemplate(template, context)).toEqual(['clinic.name.uk']);
+  });
+});
+
+describe('spec: representative passport/power-of-attorney fields + centralized passport-number formatting (§10)', () => {
+  it('resolves the extended representative.passport.issuedBy/issueDate and powerOfAttorney.apostilleDate fields', () => {
+    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    expect(fillPlaceholders('{{representative.passport.issuedBy.uk}}', context, 'uk')).toBe('ДМС України');
+    expect(fillPlaceholders('{{representative.passport.issuedBy.en}}', context, 'en')).toBe('SMS of Ukraine');
+    expect(fillPlaceholders('{{representative.passport.issueDate}}', context, 'uk')).toBe('06.05.2019');
+    expect(fillPlaceholders('{{representative.powerOfAttorney.apostilleDate}}', context, 'uk')).toBe('15.01.2026');
+  });
+
+  it('formatPassportNumber inserts one space between the series letters and the digits, uppercased', () => {
+    expect(formatPassportNumber('ME680736')).toBe('ME 680736');
+    expect(formatPassportNumber('me680736')).toBe('ME 680736');
+    expect(formatPassportNumber('ME 680736')).toBe('ME 680736');
+    expect(formatPassportNumber('')).toBe('');
+  });
+
+  it('fillPlaceholders formats representative.passport.number through the centralized formatter automatically', () => {
+    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    expect(fillPlaceholders('{{representative.passport.number}}', context, 'uk')).toBe('ME 680736');
+  });
+});
+
+// --- spec (batch 2026-07-24) §7-13: the "Щодо приналежності ембріонів" / "Regarding ownership of
+// embryos" template - registered the same way every other template is (a plain data record with
+// id `embryo-ownership-statement`, no dedicated rendering code), and exercised end-to-end here
+// against a Japanese-partner-clinic case shaped like the spec's own example (fictional data only).
+const EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE = {
+  id: 'embryo-ownership-statement',
+  title: { uk: 'Щодо приналежності ембріонів', en: 'Regarding ownership of embryos' },
+  logo: '{{logo}}',
+  paragraphs: [
+    {
+      uk: 'Ми, {{wife.name.uk.nominative}}, громадянка {{wife.citizenship.uk}}, паспорт № {{wife.passport.number}}, '
+        + 'виданий {{wife.passport.issuedBy.uk}} {{wife.passport.issueDate}}, та {{husband.name.uk.nominative}}, '
+        + 'громадянин {{husband.citizenship.uk}}, паспорт № {{husband.passport.number}}, виданий {{husband.passport.issuedBy.uk}} '
+        + '{{husband.passport.issueDate}}, спільно заявляємо таке:',
+      en: 'We, {{wife.name.en}}, a citizen of {{wife.citizenship.en}}, passport No. {{wife.passport.number}}, '
+        + 'issued on {{wife.passport.issueDate}}, by {{wife.passport.issuedBy.en}}, and {{husband.name.en}}, '
+        + 'a citizen of {{husband.citizenship.en}}, passport No. {{husband.passport.number}}, issued on '
+        + '{{husband.passport.issueDate}}, by {{husband.passport.issuedBy.en}}, jointly declare as follows:',
+    },
+    {
+      uk: 'У результаті проведення програми запліднення in vitro (ЗІВ) від {{case.documents.embryoOwnershipStatement.ivfDate}} '
+        + 'у клініці {{partnerClinic.name.uk}} (адреса: {{partnerClinic.address.uk}}), нами як генетичними батьками отримано '
+        + 'ембріони, що належать виключно нам.',
+      en: 'As a result of the in vitro fertilization (IVF) program dated {{case.documents.embryoOwnershipStatement.ivfDate}} '
+        + 'at {{partnerClinic.name.en}} (address: {{partnerClinic.address.en}}), embryos were obtained that belong '
+        + 'exclusively to us as the genetic parents.',
+    },
+    {
+      uk: 'Зазначені ембріони підлягають передачі (транспортуванню) у {{case.documents.embryoOwnershipStatement.shipmentPeriod.uk}} '
+        + 'до {{clinic.medicalCenterName.uk}} для подальшого використання в межах програми сурогатного материнства.',
+      en: 'The said embryos shall be transferred (shipped) in {{case.documents.embryoOwnershipStatement.shipmentPeriod.en}} '
+        + 'to {{clinic.medicalCenterName.en}} for further use within the surrogacy program.',
+    },
+    {
+      uk: 'Ми не заперечуємо проти такої передачі, транспортування та подальшого використання зазначених ембріонів і '
+        + 'підтверджуємо, що жодна третя особа не має щодо них жодних прав.',
+      en: 'We have no objection to such transfer, transportation and further use of the said embryos and confirm that '
+        + 'no third party has any rights to them.',
+    },
+    {
+      uk: 'Від нашого імені та в наших інтересах діє {{representative.name.uk.nominative}} на підставі довіреності від '
+        + '{{representative.powerOfAttorney.date}}, апостильованої {{representative.powerOfAttorney.apostilleDate}}, '
+        + 'паспорт № {{representative.passport.number}}, виданий {{representative.passport.issuedBy.uk}} {{representative.passport.issueDate}}.',
+      en: 'On our behalf and in our interests acts {{representative.name.en}}, under a power of attorney dated '
+        + '{{representative.powerOfAttorney.date}}, apostilled on {{representative.powerOfAttorney.apostilleDate}}, '
+        + 'passport No. {{representative.passport.number}}, issued on {{representative.passport.issueDate}}, by '
+        + '{{representative.passport.issuedBy.en}}.',
+    },
+    {
+      uk: 'Підпис представника: _________________ {{representative.name.uk.nominative}}',
+      en: 'Representative’s signature: _________________ {{representative.name.en}}',
+    },
+  ],
+};
+
+const katsuraStyleCatalog = () => normalizeDocumentsCatalog(
+  {
+    couples: {
+      'couple-2': {
+        id: 'couple-2',
+        partners: [
+          {
+            id: 'wife-2', role: 'wife', name: { uk: { nominative: 'Кацура Юкі' }, en: 'Katsura Yuki' }, citizenship: { uk: 'Японії', en: 'Japan' }, passport: { number: 'TZ1234567', issuedBy: { uk: 'Міністерством закордонних справ Японії', en: 'Ministry of Foreign Affairs of Japan' }, issueDate: '2018-03-12' },
+          },
+          {
+            id: 'husband-2', role: 'husband', name: { uk: { nominative: 'Кацура Хіро' }, en: 'Katsura Hiro' }, citizenship: { uk: 'Японії', en: 'Japan' }, passport: { number: 'TZ7654321', issuedBy: { uk: 'Міністерством закордонних справ Японії', en: 'Ministry of Foreign Affairs of Japan' }, issueDate: '2018-03-12' },
+          },
+        ],
+      },
+    },
+    surrogateMothers: { 'surrogate-mother-2': { id: 'surrogate-mother-2', name: { uk: { nominative: 'Тестова Тест Тестівна' } } } },
+    representatives: {
+      'representative-1': {
+        id: 'representative-1',
+        name: { uk: { nominative: 'Тестовий Тест Тестович' }, en: 'Testovyi Test' },
+        passport: { number: 'ME680736', issuedBy: { uk: 'ДМС України', en: 'SMS of Ukraine' }, issueDate: '2019-05-06' },
+        powerOfAttorney: { date: '2026-01-10', apostilleDate: '2026-01-15' },
+      },
+    },
+    clinics: {
+      'clinic-1': {
+        id: 'clinic-1',
+        medicalCenterName: { uk: 'МЦ «Надія»', en: 'MC "Nadiya"' },
+        legalName: { uk: 'ТОВ «Надія»', en: 'Nadiya LLC' },
+      },
+    },
+    partnerClinics: {
+      'partner-clinic-1': {
+        id: 'partner-clinic-1',
+        name: { uk: 'Клініка Оті Юме у м. Нагоя', en: 'Ochi Yume Clinic Nagoya' },
+        address: {
+          uk: 'Хісая Парксайд Будівля 8F, 3-19-12 Маруноуті, округ Нака, місто Нагоя, префектура Айті',
+          en: 'Hisaya Parkside Building 8F, 3-19-12 Marunouchi, Naka-ku, Nagoya City, Aichi Prefecture',
+        },
+      },
+    },
+  },
+  { 'embryo-ownership-statement': EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE },
+  {
+    'case-mrry82h1-bws4eb': {
+      id: 'case-mrry82h1-bws4eb',
+      relations: {
+        clinicId: 'clinic-1',
+        partnerClinicId: 'partner-clinic-1',
+        coupleId: 'couple-2',
+        surrogateMotherId: 'surrogate-mother-2',
+        representativeIds: ['representative-1'],
+      },
+      documents: {
+        embryoOwnershipStatement: {
+          shipmentPeriod: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' },
+          ivfDate: '2021-08-17',
+        },
+      },
+    },
+  },
+);
+
+describe('spec: embryo-ownership-statement template (batch 2026-07-24 §7-13)', () => {
+  it('is a plain data template - registered, listed and rendered the same generic way as any other template, no dedicated rendering code', () => {
+    const catalog = katsuraStyleCatalog();
+    expect(catalog.documents.find(doc => doc.id === 'embryo-ownership-statement')).toBeTruthy();
+  });
+
+  it('renders every paragraph in both languages with no leftover {{...}} tokens (spec §14 checklist #7)', () => {
+    const catalog = katsuraStyleCatalog();
+    const context = resolveCaseContext(catalog, 'case-mrry82h1-bws4eb');
+    const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
+    expect(generated.title.uk).toBe('Щодо приналежності ембріонів');
+    expect(generated.title.en).toBe('Regarding ownership of embryos');
+    generated.paragraphs.forEach(paragraph => {
+      expect(paragraph.uk).not.toMatch(/\{\{|}}/);
+      expect(paragraph.en).not.toMatch(/\{\{|}}/);
+    });
+    expect(validateDocumentTemplate(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context)).toEqual([]);
+  });
+
+  it('never duplicates the country after the passport-issuing authority (spec §9, §14 checklist #8)', () => {
+    const catalog = katsuraStyleCatalog();
+    const context = resolveCaseContext(catalog, 'case-mrry82h1-bws4eb');
+    const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
+    const [firstParagraph] = generated.paragraphs;
+    expect(firstParagraph.uk).toContain('виданий Міністерством закордонних справ Японії 12.03.2018');
+    expect(firstParagraph.uk).not.toContain('Японії Японії');
+    expect(firstParagraph.en).toContain('issued on 12.03.2018, by Ministry of Foreign Affairs of Japan');
+  });
+
+  it('uses clinic.medicalCenterName (not the nonexistent clinic.name) for the Ukrainian clinic (spec §8, §14 checklist #9)', () => {
+    const catalog = katsuraStyleCatalog();
+    const context = resolveCaseContext(catalog, 'case-mrry82h1-bws4eb');
+    const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
+    const shipmentParagraph = generated.paragraphs[2];
+    expect(shipmentParagraph.uk).toContain('МЦ «Надія»');
+    expect(shipmentParagraph.en).toContain('MC "Nadiya"');
+  });
+
+  it('resolves the Japanese partner clinic name/address independently of the Ukrainian clinic (spec §4)', () => {
+    const catalog = katsuraStyleCatalog();
+    const context = resolveCaseContext(catalog, 'case-mrry82h1-bws4eb');
+    const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
+    const ivfParagraph = generated.paragraphs[1];
+    expect(ivfParagraph.uk).toContain('Клініка Оті Юме у м. Нагоя');
+    expect(ivfParagraph.uk).toContain('17.08.2021');
+    expect(ivfParagraph.en).toContain('Ochi Yume Clinic Nagoya');
+  });
+
+  it('degrades to a clear warning, never a leaked {{partnerClinic...}} token, when the case has no partner clinic selected (spec §3, §14 checklist #10)', () => {
+    const catalog = katsuraStyleCatalog();
+    const caseWithoutPartnerClinic = {
+      ...catalog.cases[0],
+      relations: { ...catalog.cases[0].relations, partnerClinicId: undefined },
+    };
+    delete caseWithoutPartnerClinic.relations.partnerClinicId;
+    const catalogWithoutPartnerClinic = { ...catalog, cases: [caseWithoutPartnerClinic] };
+    const context = resolveCaseContext(catalogWithoutPartnerClinic, 'case-mrry82h1-bws4eb');
+    expect(context.partnerClinic).toBeNull();
+    const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
+    generated.paragraphs.forEach(paragraph => {
+      expect(paragraph.uk).not.toMatch(/\{\{|}}/);
+      expect(paragraph.en).not.toMatch(/\{\{|}}/);
+    });
+    expect(validateDocumentTemplate(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context)).toEqual(
+      expect.arrayContaining(['partnerClinic.address.uk', 'partnerClinic.name.uk']),
+    );
   });
 });
 
@@ -2135,6 +2534,12 @@ describe('spec: Parties page record shapes', () => {
     expect(createEmptyClinic().id).toMatch(/^clinic-/);
     expect(createEmptyMaternityHospital().id).toMatch(/^maternity-hospital-/);
     expect(createEmptyNotary().id).toMatch(/^notary-/);
+
+    // A partner clinic is a deliberately simplified party type (spec §5) - just name/address, no
+    // EDRPOU/license/director/bank/logo the Ukrainian clinic record carries.
+    const partnerClinic = createEmptyPartnerClinic();
+    expect(partnerClinic.id).toMatch(/^partner-clinic-/);
+    expect(partnerClinic).toEqual({ id: partnerClinic.id, name: { uk: '', en: '' }, address: { uk: '', en: '' } });
 
     // Two calls never collide, same guarantee makeRecordId already gives createChildRecord.
     expect(createEmptyCouple().id).not.toBe(couple.id);


### PR DESCRIPTION
Adds a distinct parties.partnerClinics collection (kept separate from the
Ukrainian clinics collection) with a case-level relations.partnerClinicId,
wires it into resolveCaseContext as context.partnerClinic (null-safe), and
surfaces it in the Parties case editor and the variable picker.

Extends the case editor with shipmentPeriod/ivfDate fields for
case.documents.embryoOwnershipStatement (ISO-normalized on save, with
read-time DD.MM.YYYY compatibility), extends the representative party
record with passport.issuedBy/issueDate and powerOfAttorney.apostilleDate,
and adds a centralized passport-number formatter.

DocumentsPage now shows a dedicated "no partner clinic selected" warning
instead of a generic unresolved-variable list. Parse & merge already
supported the new branches additively via the existing PARTY_COLLECTIONS-
driven merge; added regression tests locking that in. Adds Documents and
Parties links to the profile's main navigation menu, alongside the
existing Invoices/Budget links.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H46NoLosfuiBNFbMogzKNE