### PR TITLE
Documents Builder: support surrogacy-agreement, surrogate-unmarried-declaration and surrogacy-program-rules templates

### DIFF
--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -14,6 +14,8 @@ import { database } from './config';
 import {
   DOCUMENTS_CASES_PATH,
   createChildRecord,
+  formatShortNameUk,
+  getMaternityHospitalDisplayName,
   normalizeIsoDate,
   removeEmptyCaseValues,
   toArray,
@@ -198,6 +200,14 @@ const DangerButton = styled(SmallButton)`
 // into the toast itself, same idea as DocumentsPage's describeStorageError for Storage failures.
 const describeSaveError = error => `${error?.code || error?.name || 'error'}: ${error?.message || String(error)}`.trim();
 
+// A notary select's option label - the short display name computed on the fly (never read from a
+// stored `short` field, which no longer exists - spec §5/§13), falling back to the full nominative
+// name, then the raw id for a record with no name at all.
+const notaryOptionLabel = notary => {
+  const nominative = notary?.name?.uk?.nominative || '';
+  return formatShortNameUk(nominative) || nominative || notary?.id || '';
+};
+
 const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelectedChildIdChange }) => {
   const selectedCase = catalog.cases.find(item => String(item.id) === String(caseId)) || null;
 
@@ -208,8 +218,9 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   // backend record whenever the selected case changes, saved back explicitly via their own Save
   // buttons, same pattern as the per-document format draft in Documents Builder.
   const [childbirthDraft, setChildbirthDraft] = useState({ maternityHospitalId: '', children: [] });
-  const [surrogacyAgreementDraft, setSurrogacyAgreementDraft] = useState({ number: { uk: '', en: '' }, date: '' });
+  const [surrogacyAgreementDraft, setSurrogacyAgreementDraft] = useState({ number: { uk: '', en: '' }, date: '', notaryId: '' });
   const [birthRegistrationDraft, setBirthRegistrationDraft] = useState({ statementDate: '', notaryId: '' });
+  const [maritalStatusDeclarationDraft, setMaritalStatusDeclarationDraft] = useState({ statementDate: '', notaryId: '' });
   const [embryoOwnershipDraft, setEmbryoOwnershipDraft] = useState({ shipmentPeriod: { uk: '', en: '' }, ivfDate: '' });
 
   useEffect(() => {
@@ -226,10 +237,15 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
         en: selectedCase?.documents?.surrogacyAgreement?.number?.en || '',
       },
       date: selectedCase?.documents?.surrogacyAgreement?.date || '',
+      notaryId: selectedCase?.documents?.surrogacyAgreement?.notaryId || '',
     });
     setBirthRegistrationDraft({
       statementDate: selectedCase?.documents?.birthRegistrationConsent?.statementDate || '',
       notaryId: selectedCase?.documents?.birthRegistrationConsent?.notaryId || '',
+    });
+    setMaritalStatusDeclarationDraft({
+      statementDate: selectedCase?.documents?.maritalStatusDeclaration?.statementDate || '',
+      notaryId: selectedCase?.documents?.maritalStatusDeclaration?.notaryId || '',
     });
     setEmbryoOwnershipDraft({
       shipmentPeriod: {
@@ -295,7 +311,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   };
 
   const updateSurrogacyAgreementField = (path, value) => setSurrogacyAgreementDraft(previous => {
-    if (path === 'date') return { ...previous, date: value };
+    if (path === 'date' || path === 'notaryId') return { ...previous, [path]: value };
     return { ...previous, number: { ...previous.number, [path]: value } };
   });
 
@@ -347,6 +363,33 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     } catch (saveError) {
       console.error('Unable to save the birth registration details', saveError);
       toast.error(`Could not save the birth registration details: ${describeSaveError(saveError)}`);
+    }
+  };
+
+  const updateMaritalStatusDeclarationField = (field, value) => setMaritalStatusDeclarationDraft(previous => ({ ...previous, [field]: value }));
+
+  // Never writes an empty `documents.maritalStatusDeclaration` service object - same rule as
+  // surrogacyAgreement/birthRegistrationConsent above.
+  const handleSaveMaritalStatusDeclaration = async () => {
+    if (!selectedCase) return;
+    const cleaned = removeEmptyCaseValues(maritalStatusDeclarationDraft);
+    const nextValue = Object.keys(cleaned).length ? cleaned : null;
+    try {
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/documents/maritalStatusDeclaration`), nextValue);
+      setCatalog(previous => ({
+        ...previous,
+        cases: previous.cases.map(item => {
+          if (String(item.id) !== String(selectedCase.id)) return item;
+          const documents = { ...(item.documents || {}) };
+          if (nextValue) documents.maritalStatusDeclaration = nextValue;
+          else delete documents.maritalStatusDeclaration;
+          return { ...item, documents };
+        }),
+      }));
+      toast.success('Marital status declaration details saved.');
+    } catch (saveError) {
+      console.error('Unable to save the marital status declaration details', saveError);
+      toast.error(`Could not save the marital status declaration details: ${describeSaveError(saveError)}`);
     }
   };
 
@@ -403,7 +446,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
             <option value="">— не обрано —</option>
             {catalog.parties.maternityHospitals.map(hospital => (
               <option key={hospital.id} value={String(hospital.id)}>
-                {hospital.shortName?.uk || hospital.name?.uk || hospital.id}
+                {getMaternityHospitalDisplayName(hospital) || hospital.id}
               </option>
             ))}
           </Select>
@@ -525,6 +568,17 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
             onChange={event => updateSurrogacyAgreementField('date', event.target.value)}
           />
         </Field>
+        <Field>
+          Нотаріус (договір)
+          <Select value={surrogacyAgreementDraft.notaryId || ''} onChange={event => updateSurrogacyAgreementField('notaryId', event.target.value)}>
+            <option value="">— не обрано —</option>
+            {catalog.parties.notaries.map(notary => (
+              <option key={notary.id} value={String(notary.id)}>
+                {notaryOptionLabel(notary)}
+              </option>
+            ))}
+          </Select>
+        </Field>
       </FieldGrid>
       <RowLine style={{ marginTop: 8 }}>
         <PrimaryMiniButton type="button" onClick={handleSaveSurrogacyAgreement}>
@@ -548,7 +602,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
             <option value="">— не обрано —</option>
             {catalog.parties.notaries.map(notary => (
               <option key={notary.id} value={String(notary.id)}>
-                {notary.name?.uk?.short || notary.name?.uk?.nominative || notary.id}
+                {notaryOptionLabel(notary)}
               </option>
             ))}
           </Select>
@@ -557,6 +611,37 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       <RowLine style={{ marginTop: 8 }}>
         <PrimaryMiniButton type="button" onClick={handleSaveBirthRegistration}>
           Save birth registration details
+        </PrimaryMiniButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Заява СМ про відсутність шлюбу</SectionSubhead>
+      <FieldGrid>
+        <Field>
+          Дата заяви (відсутність шлюбу)
+          <FieldInput
+            type="date"
+            value={maritalStatusDeclarationDraft.statementDate || ''}
+            onChange={event => updateMaritalStatusDeclarationField('statementDate', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Нотаріус (відсутність шлюбу)
+          <Select
+            value={maritalStatusDeclarationDraft.notaryId || ''}
+            onChange={event => updateMaritalStatusDeclarationField('notaryId', event.target.value)}
+          >
+            <option value="">— не обрано —</option>
+            {catalog.parties.notaries.map(notary => (
+              <option key={notary.id} value={String(notary.id)}>
+                {notaryOptionLabel(notary)}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      </FieldGrid>
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveMaritalStatusDeclaration}>
+          Save marital status declaration
         </PrimaryMiniButton>
       </RowLine>
 

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1319,6 +1319,10 @@ const DocumentsPage = ({ isAdmin }) => {
   // only meaningful for a template-kind field, since only the raw {{placeholder}} markup is ever
   // resolved against a case (an override is already-resolved final text - see buildGeneratedDocument).
   const [variablePickerOpen, setVariablePickerOpen] = useState(false);
+  // Which document the picker was opened for (spec §8: the picker's notary entry must resolve
+  // against that document's own notary, not a case-wide default) - state, not read off the ref
+  // during render, so the modal's context recomputes on the render the ref was set for.
+  const [variablePickerTemplateId, setVariablePickerTemplateId] = useState('');
   const pendingInsertRef = useRef(null);
 
   const openVariablePicker = () => {
@@ -1327,6 +1331,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const node = fieldNodesRef.current[fieldKey(active.docId, active.scope, active.langKey)];
     if (!node) return;
     pendingInsertRef.current = { ...active, start: node.selectionStart, end: node.selectionEnd };
+    setVariablePickerTemplateId(active.docId);
     setVariablePickerOpen(true);
   };
 
@@ -1603,7 +1608,12 @@ const DocumentsPage = ({ isAdmin }) => {
   // Editing children lives on the Parties page (CaseChildbirthTransactionEditor) - a twin case
   // only needs to say here which one this batch of documents resolves against.
   const selectedCaseChildren = toArray(selectedCase?.childbirth?.children);
+  // Case-level context, not scoped to any one document - used wherever a specific document's own
+  // notary doesn't matter (the completeness checklist, the logo preview, the fallback variable
+  // picker). A document that needs its own notary (spec §8: a case can use a different notary per
+  // document) resolves its own context via getContextForTemplate below instead.
   const caseContext = resolveCaseContext(catalog, selectedCaseId, { childId: selectedChildId });
+  const getContextForTemplate = templateId => resolveCaseContext(catalog, selectedCaseId, { childId: selectedChildId, templateId });
   // Every path referenced anywhere across the checked documents - used below to scope the
   // completeness checklist to what those specific documents actually need (spec 2026-07-24
   // follow-up: an early-stage document like a surrogacy agreement shouldn't warn about a birth
@@ -1653,11 +1663,19 @@ const DocumentsPage = ({ isAdmin }) => {
   const activeLogoVariant = selectedHasLogoToken
     ? getClinicLogo(clinicLogos, 'logo')
     : (selectedHasLogoLongToken ? getClinicLogo(clinicLogos, 'logo-long') : null);
+  // Each selected document resolves against its own context (spec §8: a case can use a different
+  // notary per document, so there is no single case-wide notary to validate every template
+  // against) - computed once here and reused below for both the unresolved-variables scan and the
+  // missing-notary check.
+  const selectedTemplateContexts = selectedTemplates.map(template => ({
+    template,
+    context: getContextForTemplate(template.id),
+  }));
   // Every unresolved {{path}} across the selected documents for the current case - shown as a
   // non-blocking warning and confirmed again right before a final export (spec §15).
-  const unresolvedVariables = caseContext
-    ? [...new Set(selectedTemplates.flatMap(template => validateDocumentTemplate(template, caseContext)))].sort()
-    : [];
+  const unresolvedVariables = [...new Set(selectedTemplateContexts.flatMap(({ template, context }) => (
+    context ? validateDocumentTemplate(template, context) : []
+  )))].sort();
   // A case with no partnerClinicId set (old cases, or one just cleared - spec §3) resolves
   // caseContext.partnerClinic to null, so every {{partnerClinic.*}} token in a selected template
   // shows up in unresolvedVariables like any other missing field - technically correct (never a
@@ -1666,9 +1684,18 @@ const DocumentsPage = ({ isAdmin }) => {
   // redundant per-field paths from the generic list.
   const missingPartnerClinic = Boolean(caseContext) && !caseContext.partnerClinic
     && unresolvedVariables.some(path => path.startsWith('partnerClinic.'));
-  const visibleUnresolvedVariables = missingPartnerClinic
-    ? unresolvedVariables.filter(path => !path.startsWith('partnerClinic.'))
-    : unresolvedVariables;
+  // Same idea for the notary (spec §8): a document that references {{notary...}} but whose own
+  // notaryId isn't set (or points at a deleted notary) never crashes - it just surfaces one clear
+  // message instead of a wall of unresolved notary.* paths.
+  const missingNotary = selectedTemplateContexts.some(({ template, context }) => (
+    Boolean(context) && !context.notary
+    && getTemplateReferencedPaths(template).some(path => path === 'notary' || path.startsWith('notary.'))
+  ));
+  const visibleUnresolvedVariables = unresolvedVariables.filter(path => {
+    if (missingPartnerClinic && path.startsWith('partnerClinic.')) return false;
+    if (missingNotary && (path === 'notary' || path.startsWith('notary.'))) return false;
+    return true;
+  });
   const isGenerateDisabled = loading || Boolean(error) || isGenerating || clinicLogoLoading || !selectedTemplates.length || !selectedCase;
 
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
@@ -1768,8 +1795,9 @@ const DocumentsPage = ({ isAdmin }) => {
   }, [readImageDimensions, clinicLogoStorageKey]);
 
   const prepareGeneration = () => {
-    const context = resolveCaseContext(catalog, selectedCaseId, { childId: selectedChildId });
-    const generated = selectedTemplates.map(template => buildGeneratedDocument(template, context));
+    // Each document resolves its own context (spec §8: per-document notary) rather than sharing
+    // one case-level context across every selected template.
+    const generated = selectedTemplates.map(template => buildGeneratedDocument(template, getContextForTemplate(template.id)));
     // Each document renders with the shared defaults merged with its own format overrides -
     // independent of whichever document (if any) the Format panel currently targets.
     const formattingByDoc = selectedTemplates.map(template => resolveEffectiveDocFormatting(formatting, template.format));
@@ -1798,6 +1826,9 @@ const DocumentsPage = ({ isAdmin }) => {
     const sections = [];
     if (missingPartnerClinic) {
       sections.push('Для цього документа не вибрана клініка-партнер.');
+    }
+    if (missingNotary) {
+      sections.push('Для цього документа не вибрано нотаріуса.');
     }
     if (visibleUnresolvedVariables.length) {
       sections.push(
@@ -2004,6 +2035,11 @@ const DocumentsPage = ({ isAdmin }) => {
                   Для цього документа не вибрана клініка-партнер.
                 </DocSubtitle>
               ) : null}
+              {missingNotary ? (
+                <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
+                  Для цього документа не вибрано нотаріуса.
+                </DocSubtitle>
+              ) : null}
               {visibleUnresolvedVariables.length ? (
                 <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
                   Не вдалося підставити: {visibleUnresolvedVariables.join(', ')}
@@ -2022,7 +2058,7 @@ const DocumentsPage = ({ isAdmin }) => {
                 const isSingle = !(showUk && showEn);
                 // Needed even while collapsed - the title input right in the row header (below)
                 // always shows/edits the resolved value once a case is selected.
-                const resolvedDoc = buildGeneratedDocument(template, caseContext);
+                const resolvedDoc = buildGeneratedDocument(template, getContextForTemplate(template.id));
                 // The per-paragraph indent slider's "inherit" default - this document's own
                 // effective first-line indent, same value generation actually renders with.
                 const docFormatting = resolveEffectiveDocFormatting(formatting, template.format);
@@ -2785,7 +2821,7 @@ const DocumentsPage = ({ isAdmin }) => {
       </Shell>
       {variablePickerOpen ? (
         <VariablePickerModal
-          context={caseContext}
+          context={variablePickerTemplateId ? getContextForTemplate(variablePickerTemplateId) : caseContext}
           onPick={handleInsertVariable}
           onClose={() => setVariablePickerOpen(false)}
         />

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -42,7 +42,7 @@ const buildParties = () => ({
   representatives: {},
   clinics: {},
   maternityHospitals: {
-    'hospital-1': { id: 'hospital-1', shortName: { uk: 'Пологовий будинок №1', en: '' } },
+    'hospital-1': { id: 'hospital-1', name: { uk: 'Пологовий будинок №1', en: '' } },
   },
   notaries: {
     'notary-1': { id: 'notary-1', name: { uk: { nominative: 'Нотаріус Іванова Іванівна', short: 'Іванова І.І.' } } },
@@ -93,9 +93,9 @@ describe('spec: Childbirth/Transaction case editor (Batch 18 §6), on Parties', 
 
     const hospitalSelect = await screen.findByLabelText('Пологовий будинок');
     expect(hospitalSelect).toHaveValue('hospital-1');
-    // shortName is a bilingual { uk, en } record (same shape as name/address on every other
-    // maternity hospital field) - rendering it as an <option> label must resolve to the uk string,
-    // not the object itself (which crashes React: "Objects are not valid as a React child").
+    // name is a bilingual { uk, en } record - rendering it as an <option> label must resolve to
+    // the uk string, not the object itself (which crashes React: "Objects are not valid as a
+    // React child"). There is no separate `shortName` field (spec: never stored).
     expect(screen.getByText('Пологовий будинок №1')).toBeInTheDocument();
     expect(screen.getByText('Дитина 1')).toBeInTheDocument();
     expect(screen.getByLabelText('Стать')).toHaveValue('female');

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -33,6 +33,7 @@ import {
   createEmptySurrogateMother,
   emptyDocumentsCatalog,
   findPartyReferences,
+  getMaternityHospitalDisplayName,
   getValueByPath,
   isPlainObject,
   makeCaseId,
@@ -470,7 +471,7 @@ const nameFormOf = value => {
 };
 
 const partyDisplayName = record => nameFormOf(record?.name) || record?.id;
-const maternityDisplayName = record => nameFormOf(record?.name) || nameFormOf(record?.shortName) || record?.id;
+const maternityDisplayName = record => getMaternityHospitalDisplayName(record) || record?.id;
 const coupleDisplayName = record => {
   const names = toArray(record?.partners).map(partner => nameFormOf(partner?.name)).filter(Boolean);
   return names.length ? names.join(' & ') : record?.id;
@@ -550,9 +551,7 @@ const CLINIC_FIELDS = [
   { label: 'License issued by (en)', path: 'license.issuedBy.en' },
   { label: 'Medical director (uk, nominative)', path: 'medicalDirector.name.uk.nominative' },
   { label: 'Medical director (uk, genitive)', path: 'medicalDirector.name.uk.genitive' },
-  { label: 'Medical director (uk, short)', path: 'medicalDirector.name.uk.short' },
   { label: 'Medical director (en, full)', path: 'medicalDirector.name.en.full' },
-  { label: 'Medical director (en, short)', path: 'medicalDirector.name.en.short' },
   { label: 'Director authority type (uk)', path: 'medicalDirector.authority.type.uk' },
   { label: 'Director authority type (en)', path: 'medicalDirector.authority.type.en' },
   { label: 'Director authority number', path: 'medicalDirector.authority.number' },
@@ -570,23 +569,24 @@ const PARTNER_CLINIC_FIELDS = [
   { label: 'Address (en)', path: 'address.en' },
 ];
 
+// `shortName` is never stored (spec §6) - the maternity hospital's display name is always its
+// full bilingual `name`, read via getMaternityHospitalDisplayName (see maternityDisplayName
+// below), never a hand-typed abbreviation.
 const MATERNITY_HOSPITAL_FIELDS = [
   { label: 'Name (uk)', path: 'name.uk' },
   { label: 'Name (en)', path: 'name.en' },
-  { label: 'Short name (uk)', path: 'shortName.uk' },
-  { label: 'Short name (en)', path: 'shortName.en' },
   { label: 'EDRPOU', path: 'edrpou' },
   { label: 'Address (uk)', path: 'address.uk' },
   { label: 'Address (en)', path: 'address.en' },
 ];
 
+// `name.uk.short`/`name.en.short` are computed at template-context build time
+// (enrichNameWithDerivedFields), never hand-typed here. `name.uk.instrumental` is exactly the
+// kind of one-off grammatical-case workaround field spec §13 forbids adding.
 const NOTARY_FIELDS = [
   { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
   { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
-  { label: 'Name (uk, short)', path: 'name.uk.short' },
-  { label: 'Name (uk, instrumental)', path: 'name.uk.instrumental' },
   { label: 'Name (en, full)', path: 'name.en.full' },
-  { label: 'Name (en, short)', path: 'name.en.short' },
   { label: 'Title (uk)', path: 'title.uk' },
   { label: 'Title (en)', path: 'title.en' },
   { label: 'City (uk)', path: 'city.uk' },

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -302,6 +302,32 @@ export const catalogTemplatesToBackend = catalog => (catalog.documents || []).re
   return byId;
 }, {});
 
+// Every key that only ever belongs in a runtime template context (short names, spelled-out/long
+// dates) and must never reach Firebase or a JSON export (spec §1/§11/§13). Kept as one shared
+// list so an export/serialization path can never drift from what the context builder actually
+// treats as derived.
+export const DERIVED_CONTEXT_FIELD_KEYS = [
+  'short', 'shortName', 'dateWords', 'statementDateWords', 'statementDateFormatted', 'dateDisplay', 'numberEn', 'wordsAfterArticle',
+];
+
+// Recursively strips every DERIVED_CONTEXT_FIELD_KEYS key out of a value before it's serialized
+// for export (spec §11: "Перед серіалізацією рекурсивно виключати похідні runtime-поля"). Source
+// data (catalog.cases/parties/documents straight from Firebase) never carries these keys in the
+// first place - this is a defensive final pass for whatever actually gets serialized, so an
+// export path can never accidentally leak an enrichment copy's derived fields even if one was
+// passed in by mistake. Never mutates its input.
+export const stripDerivedFields = value => {
+  if (Array.isArray(value)) return value.map(stripDerivedFields);
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => !DERIVED_CONTEXT_FIELD_KEYS.includes(key))
+        .map(([key, child]) => [key, stripDerivedFields(child)]),
+    );
+  }
+  return value;
+};
+
 // --- Case context + placeholders ------------------------------------------------------------
 
 const findById = (records, id) => (records || []).find(record => String(record?.id) === String(id)) || null;
@@ -476,6 +502,165 @@ export const formatEnglishDateWords = value => {
   return `${EN_DAY_ORDINALS[day]} of ${EN_MONTHS[month]}, ${year}`;
 };
 
+// --- Shared date-context builder (spec 2026-07-24 follow-up §4/§12) --------------------------
+// One generic pair of "date in words" / "date, long form" formatters, reused by every document
+// that needs a spelled-out signature date (surrogacyAgreement.dateWords,
+// maritalStatusDeclaration.statementDateWords/.statementDateFormatted, and - via
+// withDerivedDateFields below - birthRegistration.statementDateWords) instead of one bespoke
+// formatter per document. `formatDateWordsUk` is the same generic Ukrainian day/month/year ->
+// words converter as formatUkrainianDateWords (kept as a separate export only for symmetry with
+// its English counterpart's name).
+export const formatDateWordsUk = formatUkrainianDateWords;
+
+// English number (0-9999) in plain cardinal words - "two thousand twenty-five" for 2025, not the
+// colloquial paired-year reading ("twenty twenty-five") - a real generic number-to-words
+// converter, not a lookup table for one date.
+const EN_ONES_CARDINAL = {
+  1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 6: 'six', 7: 'seven', 8: 'eight', 9: 'nine',
+};
+const EN_TEENS_CARDINAL = {
+  10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen', 15: 'fifteen', 16: 'sixteen', 17: 'seventeen', 18: 'eighteen', 19: 'nineteen',
+};
+const EN_TENS_CARDINAL = {
+  2: 'twenty', 3: 'thirty', 4: 'forty', 5: 'fifty', 6: 'sixty', 7: 'seventy', 8: 'eighty', 9: 'ninety',
+};
+
+const threeDigitToEnglishCardinalWords = n => {
+  if (n === 0) return '';
+  const hundreds = Math.floor(n / 100);
+  const remainder = n % 100;
+  const parts = [];
+  if (hundreds) parts.push(`${EN_ONES_CARDINAL[hundreds]} hundred`);
+  if (remainder) {
+    if (remainder < 10) parts.push(EN_ONES_CARDINAL[remainder]);
+    else if (remainder < 20) parts.push(EN_TEENS_CARDINAL[remainder]);
+    else {
+      const tens = Math.floor(remainder / 10);
+      const ones = remainder % 10;
+      parts.push(ones ? `${EN_TENS_CARDINAL[tens]}-${EN_ONES_CARDINAL[ones]}` : EN_TENS_CARDINAL[tens]);
+    }
+  }
+  return parts.join(' ');
+};
+
+const yearToEnglishCardinalWords = year => {
+  const thousands = Math.floor(year / 1000);
+  const remainder = year % 1000;
+  const parts = [];
+  if (thousands) parts.push(`${EN_ONES_CARDINAL[thousands]} thousand`);
+  if (remainder) parts.push(threeDigitToEnglishCardinalWords(remainder));
+  return parts.join(' ');
+};
+
+const capitalizeWord = word => (word ? `${word[0].toUpperCase()}${word.slice(1)}` : word);
+
+// A spelled-out English date used by legal statements (e.g. "Fifth of September two thousand
+// twenty-five") - distinct from formatEnglishDateWords (used by the RATS birth-registration
+// statement, "eighteenth of May, 2026", kept unchanged for backward compatibility).
+export const formatDateWordsEn = value => {
+  if (!isIsoDate(value)) return '';
+  const [year, month, day] = String(value).trim().split('-').map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return '';
+  return `${capitalizeWord(EN_DAY_ORDINALS[day])} of ${EN_MONTHS[month]} ${yearToEnglishCardinalWords(year)}`;
+};
+
+// "DD MMMM YYYY року" / "DD Month YYYY" - the long (numeric day, spelled-out month) date form
+// legal statements show alongside the fully spelled-out one (spec: maritalStatusDeclaration /
+// surrogacyAgreement dates).
+export const formatDateLongUk = value => {
+  if (!isIsoDate(value)) return '';
+  const [year, month, day] = String(value).trim().split('-').map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return '';
+  return `${String(day).padStart(2, '0')} ${UK_MONTHS_GENITIVE[month]} ${year} року`;
+};
+
+export const formatDateLongEn = value => {
+  if (!isIsoDate(value)) return '';
+  const [year, month, day] = String(value).trim().split('-').map(Number);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return '';
+  return `${String(day).padStart(2, '0')} ${EN_MONTHS[month]} ${year}`;
+};
+
+// Shared date-context builder (spec §4/§12: "винести у спільний date-context builder... не
+// дублювати логіку окремо для кожного документа"): augments a case document sub-record (e.g.
+// `case.documents.surrogacyAgreement`) with its derived spelled-out/long date fields, computed
+// from one caller-named ISO date field - never mutates the source, never persisted back to
+// Firebase (see buildGeneratedDocument/resolveCaseContext - the result only ever lives in the
+// in-memory template context). `wordsUk`/`wordsEn` are overridable so a pre-existing document
+// (birthRegistration) can keep its own already-shipped English wording while every new document
+// gets the shared default.
+const withDerivedDateFields = (raw, {
+  dateField, wordsKey, longKey, wordsUk = formatDateWordsUk, wordsEn = formatDateWordsEn,
+}) => {
+  const source = isPlainObject(raw) ? raw : {};
+  const value = source[dateField] ?? '';
+  const next = { ...source };
+  if (wordsKey) next[wordsKey] = { uk: wordsUk(value), en: wordsEn(value) };
+  if (longKey) next[longKey] = { uk: formatDateLongUk(value), en: formatDateLongEn(value) };
+  return next;
+};
+
+// --- Short names + runtime name enrichment (spec §5/§13) --------------------------------------
+// A person's short display name ("Алексашина Ю.Б." / "L.V. Davyd") is always computed from the
+// full name at template-context build time, never stored - the JSON only ever carries the full
+// name (`name.uk.nominative`, `name.en.full`). Whitespace-tolerant, never throws: a missing or
+// malformed name simply resolves to ''.
+export const formatShortNameUk = fullName => {
+  const parts = String(fullName || '').trim().split(/\s+/).filter(Boolean);
+  if (parts.length < 2) return '';
+  const [surname, ...rest] = parts;
+  const initials = rest.map(part => `${part[0].toUpperCase()}.`).join('');
+  return `${surname} ${initials}`;
+};
+
+// English short form reverses the order (initials first): the source full name still carries the
+// surname first ("Davyd Liliia Volodymyrivna"), same as the Ukrainian nominative - only the
+// rendered short form's word order differs ("L.V. Davyd").
+export const formatShortNameEn = fullName => {
+  const parts = String(fullName || '').trim().split(/\s+/).filter(Boolean);
+  if (parts.length < 2) return '';
+  const [surname, ...rest] = parts;
+  const initials = rest.map(part => `${part[0].toUpperCase()}.`).join('');
+  return `${initials} ${surname}`;
+};
+
+// Adds a `short` field alongside whatever a person's `name` node already carries - `uk.short`
+// whenever `uk.nominative` is a real string, `en.short` only when `en` is itself an object
+// carrying `.full` (spec §5: a `name.en` stored as a plain string, e.g. the notary/wife/husband
+// shape `{ en: "Aleksashyna..." }`, is never restructured into an object - templates already read
+// it directly as `{{notary.name.en}}`). Never mutates the source object.
+export const enrichNameWithDerivedFields = name => {
+  if (!isPlainObject(name)) return name;
+  const result = { ...name };
+  const ukNominative = name.uk?.nominative;
+  if (isPlainObject(name.uk) && ukNominative) {
+    result.uk = { ...name.uk, short: formatShortNameUk(ukNominative) };
+  }
+  const enFull = typeof name.en?.full === 'string' ? name.en.full : null;
+  if (isPlainObject(name.en) && enFull) {
+    result.en = { ...name.en, short: formatShortNameEn(enFull) };
+  }
+  return result;
+};
+
+// Same enrichment, applied to a whole person/party record's `name` field - used for every
+// name-carrying context entity (wife/husband/surrogateMother/representative/notary, and the
+// clinic's medicalDirector) so `{{x.name.uk.short}}`/`{{x.name.en.short}}` always resolve without
+// a stored `short` field ever existing in Firebase. Null-safe: a record with no `name` (or no
+// record at all) passes through unchanged.
+const enrichPersonName = person => {
+  if (!isPlainObject(person) || !person.name) return person;
+  return { ...person, name: enrichNameWithDerivedFields(person.name) };
+};
+
+// The maternity hospital's display name used to read a stored `shortName` field (spec §6: no
+// longer created or persisted) - this is the safe replacement: the full bilingual name, uk
+// preferred, falling back to en, never an automatic legal-name abbreviation (that algorithm is
+// for personal names, not organizations).
+export const getMaternityHospitalDisplayName = maternityHospital => (
+  maternityHospital?.name?.uk || maternityHospital?.name?.en || ''
+);
+
 // --- Party record shapes (Parties page, batch 19 §1) --------------------------------------------
 // Canonical "blank record" for each party collection - the shape a freshly-added record starts
 // from, matching exactly what resolveCaseContext/fillPlaceholders already expect to find (spec
@@ -544,7 +729,9 @@ export const createEmptyClinic = () => ({
   },
   license: { number: '', date: '', issuedBy: { uk: '', en: '' } },
   medicalDirector: {
-    name: { uk: { nominative: '', genitive: '', short: '' }, en: { full: '', short: '' } },
+    // `uk.short`/`en.short` are never stored (spec §5/§13) - computed at template-context build
+    // time by enrichNameWithDerivedFields, from `uk.nominative`/`en.full` below.
+    name: { uk: { nominative: '', genitive: '' }, en: { full: '' } },
     authority: { type: { uk: '', en: '' }, number: '', date: '' },
   },
 });
@@ -559,21 +746,23 @@ export const createEmptyPartnerClinic = () => ({
   address: { uk: '', en: '' },
 });
 
+// `shortName` is never stored (spec §6) - use getMaternityHospitalDisplayName wherever the UI
+// used to read `maternityHospital.shortName.uk`.
 export const createEmptyMaternityHospital = () => ({
   id: makeRecordId('maternity-hospital'),
   name: { uk: '', en: '' },
-  shortName: { uk: '', en: '' },
   edrpou: '',
   address: { uk: '', en: '' },
 });
 
+// `uk.short`/`en.short` are never stored (spec §5/§13) - computed at template-context build time
+// by enrichNameWithDerivedFields. `uk.instrumental` (a one-off grammatical case for a single past
+// document) is exactly the kind of workaround field spec §13 forbids adding.
 export const createEmptyNotary = () => ({
   id: makeRecordId('notary'),
   name: {
-    uk: {
-      nominative: '', genitive: '', short: '', instrumental: '',
-    },
-    en: { full: '', short: '' },
+    uk: { nominative: '', genitive: '' },
+    en: { full: '' },
   },
   title: { uk: '', en: '' },
   city: { uk: '', en: '' },
@@ -635,7 +824,26 @@ export const removeEmptyCaseValues = value => {
   return value;
 };
 
-export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
+// Which case-document sub-record supplies the notary for a given template (spec §8): a case can
+// use a different notary for each document it produces (birth-registration statement, marital
+// status declaration, surrogacy agreement each carry their own `notaryId`), so there is no single
+// case-wide "the" notary. `documentKey: null` means the template never needs a notary at all
+// (surrogacy-program-rules). Exported so other call sites (validators, tests) share the same map
+// instead of re-deriving it.
+export const TEMPLATE_DOCUMENT_CONFIG = {
+  'birth-registration-surrogate-consent': { documentKey: 'birthRegistrationConsent' },
+  'surrogate-unmarried-declaration': { documentKey: 'maritalStatusDeclaration' },
+  'surrogacy-agreement': { documentKey: 'surrogacyAgreement' },
+  'surrogacy-program-rules': { documentKey: null },
+};
+
+// `templateId` picks which document's own `notaryId` resolves as `notary` (spec §8/§9) - omitted
+// (every pre-existing call site that only ever needed the birth-registration statement's notary),
+// it defaults to `birthRegistrationConsent` so nothing that already calls resolveCaseContext
+// without a templateId changes behavior. A templateId not listed in TEMPLATE_DOCUMENT_CONFIG (an
+// older template that never references `{{notary...}}`) simply resolves to no notary - harmless,
+// since nothing reads it.
+export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}) => {
   const rawCaseRecord = findById(catalog?.cases, caseId);
   if (!rawCaseRecord) return null;
   const caseRecord = normalizeCaseRecord(rawCaseRecord);
@@ -643,11 +851,12 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
 
   const couple = findById(catalog.parties.couples, relations.coupleId);
   const partners = toArray(couple?.partners);
-  const wife = partners.find(partner => partner?.role === 'wife') || partners[0] || null;
-  const husband = partners.find(partner => partner?.role === 'husband') || partners[1] || null;
+  const rawWife = partners.find(partner => partner?.role === 'wife') || partners[0] || null;
+  const rawHusband = partners.find(partner => partner?.role === 'husband') || partners[1] || null;
   const representatives = toArray(relations.representativeIds)
     .map(id => findById(catalog.parties.representatives, id))
-    .filter(Boolean);
+    .filter(Boolean)
+    .map(enrichPersonName);
 
   const childbirth = isPlainObject(caseRecord.childbirth) ? caseRecord.childbirth : {};
   const rawChildren = toArray(childbirth.children);
@@ -659,34 +868,68 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
   const medicalConclusion = isPlainObject(rawChild.medicalConclusion) ? rawChild.medicalConclusion : {};
 
   const documents = isPlainObject(caseRecord.documents) ? caseRecord.documents : {};
-  const surrogacyAgreement = isPlainObject(documents.surrogacyAgreement) ? documents.surrogacyAgreement : {};
-  const rawBirthRegistration = isPlainObject(documents.birthRegistrationConsent) ? documents.birthRegistrationConsent : {};
-  const statementDate = rawBirthRegistration.statementDate ?? '';
-  const birthRegistration = {
-    ...rawBirthRegistration,
-    statementDateWords: {
-      uk: formatUkrainianDateWords(statementDate),
-      en: formatEnglishDateWords(statementDate),
-    },
+
+  // birthRegistration keeps its already-shipped English wording (formatEnglishDateWords, e.g.
+  // "eighteenth of May, 2026") for backward compatibility; every new document uses the shared
+  // default formatters (withDerivedDateFields's own defaults).
+  const birthRegistration = withDerivedDateFields(documents.birthRegistrationConsent, {
+    dateField: 'statementDate',
+    wordsKey: 'statementDateWords',
+    wordsEn: formatEnglishDateWords,
+  });
+  const surrogacyAgreement = withDerivedDateFields(documents.surrogacyAgreement, {
+    dateField: 'date',
+    wordsKey: 'dateWords',
+  });
+  const maritalStatusDeclaration = withDerivedDateFields(documents.maritalStatusDeclaration, {
+    dateField: 'statementDate',
+    wordsKey: 'statementDateWords',
+    longKey: 'statementDateFormatted',
+  });
+
+  // Which document's notaryId is "the" notary for this render (spec §8) - defaults to the
+  // birth-registration statement so every existing caller (no templateId) keeps working exactly
+  // as before.
+  const notaryDocumentKey = templateId !== undefined
+    ? (TEMPLATE_DOCUMENT_CONFIG[templateId]?.documentKey ?? null)
+    : 'birthRegistrationConsent';
+  const notaryDocuments = {
+    birthRegistrationConsent: birthRegistration,
+    surrogacyAgreement,
+    maritalStatusDeclaration,
   };
+  const notaryId = notaryDocumentKey ? (notaryDocuments[notaryDocumentKey]?.notaryId ?? null) : null;
+  const notary = enrichPersonName(notaryId ? findById(catalog.parties.notaries, notaryId) : null);
+
   // The Ukrainian clinic (parties.clinics, relations.clinicId) runs the surrogacy program and signs
   // the documents; the partner clinic (parties.partnerClinics, relations.partnerClinicId) is the
   // separate foreign clinic embryos ship from - never the same collection, never a second "main"
-  // clinic. Both are null-safe: an old case with no partnerClinicId simply resolves to null rather
-  // than throwing, so a template referencing partnerClinic degrades to a visible warning instead of
-  // a crash (see getUnresolvedVariablePaths/fillPlaceholders).
+  // clinic. Both are null-safe: an old case with no partnerClinicId/clinicId simply resolves to
+  // null rather than throwing, so a template referencing it degrades to a visible warning instead
+  // of a crash (see getUnresolvedVariablePaths/fillPlaceholders) - e.g. a case with no clinicId at
+  // all (spec §2: case-kikawa has no clinic/maternity-hospital relations).
   const partnerClinic = relations.partnerClinicId
     ? findById(catalog.parties.partnerClinics, relations.partnerClinicId)
     : null;
+  const rawClinic = relations.clinicId ? findById(catalog.parties.clinics, relations.clinicId) : null;
+  const clinic = rawClinic ? {
+    ...rawClinic,
+    medicalDirector: rawClinic.medicalDirector ? {
+      ...rawClinic.medicalDirector,
+      name: enrichNameWithDerivedFields(rawClinic.medicalDirector.name),
+    } : rawClinic.medicalDirector,
+  } : null;
 
   return {
     case: caseRecord,
     relations,
     couple,
-    wife,
-    husband,
-    surrogateMother: findById(catalog.parties.surrogateMothers, relations.surrogateMotherId),
-    clinic: findById(catalog.parties.clinics, relations.clinicId),
+    wife: enrichPersonName(rawWife),
+    husband: enrichPersonName(rawHusband),
+    surrogateMother: enrichPersonName(relations.surrogateMotherId
+      ? findById(catalog.parties.surrogateMothers, relations.surrogateMotherId)
+      : null),
+    clinic,
     partnerClinic,
     representative: representatives[0] || null,
     representatives,
@@ -695,10 +938,13 @@ export const resolveCaseContext = (catalog, caseId, { childId } = {}) => {
     child: buildChildContext(rawChild),
     selectedChildId: rawChild?.id,
     medicalConclusion,
-    maternityHospital: findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId),
+    maternityHospital: childbirth.maternityHospitalId
+      ? findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId)
+      : null,
     surrogacyAgreement,
     birthRegistration,
-    notary: findById(catalog.parties.notaries, rawBirthRegistration.notaryId),
+    maritalStatusDeclaration,
+    notary,
   };
 };
 
@@ -1332,7 +1578,13 @@ export const findPartyReferences = (catalog, collection, id) => {
       case 'surrogateMothers': return String(relations.surrogateMotherId) === targetId;
       case 'representatives': return toArray(relations.representativeIds).some(repId => String(repId) === targetId);
       case 'maternityHospitals': return String(caseRecord.childbirth?.maternityHospitalId) === targetId;
-      case 'notaries': return String(caseRecord.documents?.birthRegistrationConsent?.notaryId) === targetId;
+      // A case can reference the same notary from up to three different documents (spec §8) -
+      // any one of them counts as a reference, not just the birth-registration statement.
+      case 'notaries': return [
+        caseRecord.documents?.birthRegistrationConsent?.notaryId,
+        caseRecord.documents?.surrogacyAgreement?.notaryId,
+        caseRecord.documents?.maritalStatusDeclaration?.notaryId,
+      ].some(notaryId => String(notaryId) === targetId);
       default: return false;
     }
   });

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -1,6 +1,8 @@
 import {
   DEFAULT_DOC_FORMATTING,
+  DERIVED_CONTEXT_FIELD_KEYS,
   DOCUMENT_LAYOUTS,
+  TEMPLATE_DOCUMENT_CONFIG,
   applyLogoLayoutAssignment,
   applyPlainTextEdit,
   buildVariablePickerGroups,
@@ -27,13 +29,21 @@ import {
   deepMergeRecords,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
+  enrichNameWithDerivedFields,
   fillPlaceholders,
   findPartyReferences,
+  formatDateLongEn,
+  formatDateLongUk,
+  formatDateWordsEn,
+  formatDateWordsUk,
   formatDocumentDate,
   formatEnglishDateWords,
   formatPassportNumber,
+  formatShortNameEn,
+  formatShortNameUk,
   formatUkrainianDateWords,
   getChildGenderForms,
+  getMaternityHospitalDisplayName,
   getClinicLogo,
   getEffectiveDocLayout,
   getEffectiveParagraphAlign,
@@ -72,6 +82,7 @@ import {
   serializeFormattedRuns,
   splitParagraphsIntoColumns,
   splitParagraphsIntoPages,
+  stripDerivedFields,
   TITLE_SCOPE,
   beforeTitleScope,
   getTemplateScopeText,
@@ -2675,5 +2686,366 @@ describe('spec: title is an ordinary centered paragraph, with the standard toolb
     const generated = buildGeneratedDocument(legacyTemplate, context);
     expect(generated.title.align).toBeUndefined(); // renderer's own default (Center) applies
     expect(generated.title.uk).toBe('Договір');
+  });
+});
+
+// spec (2026-07-24 follow-up): surrogacy-agreement / surrogate-unmarried-declaration /
+// surrogacy-program-rules templates, per-document notary resolution, runtime-only short
+// names/derived dates, and a null-safe context for a case with no clinic/maternity-hospital
+// relations at all (fictional stand-in for the real "no optional relations" case in the spec).
+describe('spec: short names (§5) - computed at template-context build time, never stored', () => {
+  it('formatShortNameUk: surname unchanged, one initial per remaining word', () => {
+    expect(formatShortNameUk('Алексашина Юлія Борисівна')).toBe('Алексашина Ю.Б.');
+    expect(formatShortNameUk('Давид Лілія Володимирівна')).toBe('Давид Л.В.');
+  });
+
+  it('formatShortNameUk handles a two-component name with a single initial', () => {
+    expect(formatShortNameUk('Іванов Іван')).toBe('Іванов І.');
+  });
+
+  it('formatShortNameUk tolerates extra/irregular whitespace without changing the result', () => {
+    expect(formatShortNameUk('  Алексашина   Юлія  Борисівна  ')).toBe('Алексашина Ю.Б.');
+  });
+
+  it('formatShortNameUk returns an empty string for missing/single-word/non-string input, never throws', () => {
+    expect(formatShortNameUk('')).toBe('');
+    expect(formatShortNameUk(undefined)).toBe('');
+    expect(formatShortNameUk(null)).toBe('');
+    expect(formatShortNameUk('Одне')).toBe('');
+  });
+
+  it('formatShortNameEn puts the initials first, surname last (source is still surname-first)', () => {
+    expect(formatShortNameEn('Davyd Liliia Volodymyrivna')).toBe('L.V. Davyd');
+  });
+
+  it('formatShortNameEn returns an empty string for missing/single-word input', () => {
+    expect(formatShortNameEn('')).toBe('');
+    expect(formatShortNameEn('Surname')).toBe('');
+  });
+
+  it('enrichNameWithDerivedFields adds uk.short from uk.nominative, without mutating the source', () => {
+    const name = { uk: { nominative: 'Алексашина Юлія Борисівна' }, en: 'Aleksashyna Yuliia Borysivna' };
+    const enriched = enrichNameWithDerivedFields(name);
+    expect(enriched.uk.short).toBe('Алексашина Ю.Б.');
+    // name.en stored as a plain string is never restructured into an object (spec §5: the
+    // notary/wife/husband shape) - no en.short is fabricated for it.
+    expect(enriched.en).toBe('Aleksashyna Yuliia Borysivna');
+    expect(name.uk.short).toBeUndefined(); // original untouched
+  });
+
+  it('enrichNameWithDerivedFields adds en.short only when en is an object carrying .full', () => {
+    const name = { uk: { nominative: 'Давид Лілія Володимирівна' }, en: { full: 'Davyd Liliia Volodymyrivna' } };
+    const enriched = enrichNameWithDerivedFields(name);
+    expect(enriched.uk.short).toBe('Давид Л.В.');
+    expect(enriched.en.short).toBe('L.V. Davyd');
+  });
+
+  it('enrichNameWithDerivedFields tolerates a missing/malformed name without throwing', () => {
+    expect(enrichNameWithDerivedFields(null)).toBeNull();
+    expect(enrichNameWithDerivedFields(undefined)).toBeUndefined();
+    expect(enrichNameWithDerivedFields({})).toEqual({});
+  });
+});
+
+describe('spec: generic date formatters (§4/§12/§14) - not hardcoded to one date', () => {
+  it('formatDateWordsUk (same algorithm as formatUkrainianDateWords)', () => {
+    expect(formatDateWordsUk('2025-09-05')).toBe("п'ятого вересня дві тисячі двадцять п'ятого року");
+  });
+
+  it('formatDateLongUk: DD MMMM YYYY року', () => {
+    expect(formatDateLongUk('2025-09-05')).toBe('05 вересня 2025 року');
+  });
+
+  it('formatDateLongEn: DD Month YYYY', () => {
+    expect(formatDateLongEn('2025-09-05')).toBe('05 September 2025');
+  });
+
+  it('formatDateWordsEn: capitalized ordinal + spelled-out year', () => {
+    expect(formatDateWordsEn('2025-09-05')).toBe('Fifth of September two thousand twenty-five');
+  });
+
+  it('handles a leap-year day (Feb 29)', () => {
+    expect(formatDateLongUk('2024-02-29')).toBe('29 лютого 2024 року');
+    expect(formatDateLongEn('2024-02-29')).toBe('29 February 2024');
+    expect(formatDateWordsUk('2024-02-29')).toBe("двадцять дев'ятого лютого дві тисячі двадцять четвертого року");
+    expect(formatDateWordsEn('2024-02-29')).toBe('Twenty-ninth of February two thousand twenty-four');
+  });
+
+  it('handles the first day of a month', () => {
+    expect(formatDateWordsUk('2025-01-01')).toBe("першого січня дві тисячі двадцять п'ятого року");
+    expect(formatDateWordsEn('2025-01-01')).toBe('First of January two thousand twenty-five');
+  });
+
+  it('handles the second day of a month', () => {
+    expect(formatDateLongUk('1988-09-02')).toBe('02 вересня 1988 року');
+    expect(formatDateLongEn('1988-09-02')).toBe('02 September 1988');
+  });
+
+  it('handles the last day of a 31-day month', () => {
+    expect(formatDateWordsUk('2025-01-31')).toBe("тридцять першого січня дві тисячі двадцять п'ятого року");
+    expect(formatDateWordsEn('2025-01-31')).toBe('Thirty-first of January two thousand twenty-five');
+  });
+
+  it('covers January, February, September and October', () => {
+    expect(formatDateLongUk('2025-01-15')).toContain('січня');
+    expect(formatDateLongUk('2025-02-15')).toContain('лютого');
+    expect(formatDateLongUk('2025-09-15')).toContain('вересня');
+    expect(formatDateLongUk('2025-10-15')).toContain('жовтня');
+    expect(formatDateLongEn('2025-01-15')).toContain('January');
+    expect(formatDateLongEn('2025-02-15')).toContain('February');
+    expect(formatDateLongEn('2025-09-15')).toContain('September');
+    expect(formatDateLongEn('2025-10-15')).toContain('October');
+  });
+
+  it('spells out years after 2000, not just a lookup for one year', () => {
+    expect(formatDateWordsEn('2001-01-01')).toBe('First of January two thousand one');
+    expect(formatDateWordsEn('2020-12-31')).toBe('Thirty-first of December two thousand twenty');
+    expect(formatDateWordsEn('2000-01-01')).toBe('First of January two thousand');
+  });
+
+  it('returns an empty string for an empty value, never throwing', () => {
+    [formatDateWordsUk, formatDateWordsEn, formatDateLongUk, formatDateLongEn].forEach(fn => {
+      expect(fn('')).toBe('');
+      expect(fn(undefined)).toBe('');
+      expect(fn(null)).toBe('');
+    });
+  });
+
+  it('returns an empty string for an invalid/non-ISO date, never throwing', () => {
+    [formatDateWordsUk, formatDateWordsEn, formatDateLongUk, formatDateLongEn].forEach(fn => {
+      expect(fn('not-a-date')).toBe('');
+      expect(fn('18/05/2026')).toBe('');
+      expect(fn('2025-13-01')).toBe(''); // month out of range
+      expect(fn('2025-02-30')).not.toBe(undefined); // out-of-range day: still never throws
+    });
+  });
+});
+
+describe('spec: getMaternityHospitalDisplayName (§6) - safe replacement for the removed shortName', () => {
+  it('prefers the Ukrainian name, falls back to English, then blank', () => {
+    expect(getMaternityHospitalDisplayName({ name: { uk: 'Пологовий будинок №1', en: 'Maternity Hospital 1' } })).toBe('Пологовий будинок №1');
+    expect(getMaternityHospitalDisplayName({ name: { uk: '', en: 'Maternity Hospital 1' } })).toBe('Maternity Hospital 1');
+    expect(getMaternityHospitalDisplayName({ name: { uk: '', en: '' } })).toBe('');
+    expect(getMaternityHospitalDisplayName(null)).toBe('');
+  });
+});
+
+describe('spec: stripDerivedFields (§11) - excludes runtime-only keys before any serialization', () => {
+  it('recursively drops every key in DERIVED_CONTEXT_FIELD_KEYS, keeping everything else', () => {
+    const value = {
+      surrogateMother: { name: { uk: { nominative: 'X', short: 'X.' }, en: { full: 'X', short: 'X' } } },
+      birthRegistration: { statementDate: '2026-05-18', statementDateWords: { uk: 'a', en: 'b' } },
+      maritalStatusDeclaration: { statementDate: '2025-09-05', statementDateFormatted: { uk: 'c' }, statementDateWords: { uk: 'd' } },
+      surrogacyAgreement: { date: '2025-09-05', dateWords: { uk: 'e' } },
+      passport: { number: 'TT2633446', numberEn: 'should-not-exist' },
+      maternityHospital: { name: { uk: 'X' }, shortName: { uk: 'Y' } },
+      wordsAfterArticle: 'z',
+      case: { documents: { surrogacyAgreement: { date: '2025-09-05', dateDisplay: '05.09.2025' } } },
+    };
+    const stripped = stripDerivedFields(value);
+    expect(stripped).toEqual({
+      surrogateMother: { name: { uk: { nominative: 'X' }, en: { full: 'X' } } },
+      birthRegistration: { statementDate: '2026-05-18' },
+      maritalStatusDeclaration: { statementDate: '2025-09-05' },
+      surrogacyAgreement: { date: '2025-09-05' },
+      passport: { number: 'TT2633446' },
+      maternityHospital: { name: { uk: 'X' } },
+      case: { documents: { surrogacyAgreement: { date: '2025-09-05' } } },
+    });
+  });
+
+  it('never mutates the input and passes arrays/scalars through', () => {
+    const value = { list: [{ short: 'x', keep: 1 }, { keep: 2 }], n: 5, s: 'text' };
+    const stripped = stripDerivedFields(value);
+    expect(stripped).toEqual({ list: [{ keep: 1 }, { keep: 2 }], n: 5, s: 'text' });
+    expect(value.list[0].short).toBe('x'); // original untouched
+  });
+});
+
+// Fictional stand-in for the real "surrogacy" case that has no clinic/maternity-hospital
+// relations at all - only a couple, a surrogate mother and one representative, plus the new
+// surrogacyAgreement/maritalStatusDeclaration document data (spec §2/§3/§8/§9).
+const noClinicCaseCatalog = (overrides = {}) => normalizeDocumentsCatalog(
+  {
+    couples: {
+      'couple-9': {
+        id: 'couple-9',
+        partners: [
+          { id: 'partner-9a', role: 'wife', name: { uk: { nominative: 'Приклад Марія Іванівна' }, en: 'Prykllad Mariia' } },
+          { id: 'partner-9b', role: 'husband', name: { uk: { nominative: 'Приклад Петро Іванович' }, en: 'Prykllad Petro' } },
+        ],
+        address: { uk: 'Тестова адреса', en: 'Test address' },
+      },
+    },
+    surrogateMothers: {
+      'surrogate-9': {
+        id: 'surrogate-9',
+        name: { uk: { nominative: 'Зразкова Оксана Василівна', genitive: 'Зразкової Оксани Василівни' }, en: 'Zrazkova Oksana' },
+        passport: { number: 'TT9999999' },
+      },
+    },
+    representatives: {
+      'representative-9': {
+        id: 'representative-9',
+        name: { uk: { nominative: 'Довірений Максим Олегович' }, en: 'Dovirenyi Maksym' },
+        address: { uk: 'Адреса представника' },
+      },
+    },
+    notaries: {
+      'notary-9': {
+        id: 'notary-9',
+        name: { uk: { nominative: 'Тестова Анна Петрівна' }, en: 'Aleksashyna Yuliia' },
+        title: { uk: 'приватний нотаріус' },
+        city: { uk: 'місто Київ' },
+      },
+    },
+  },
+  {},
+  {
+    'case-no-clinic': {
+      id: 'case-no-clinic',
+      relations: {
+        coupleId: 'couple-9', surrogateMotherId: 'surrogate-9', representativeIds: ['representative-9'],
+      },
+      documents: {
+        surrogacyAgreement: { date: '2025-09-05', notaryId: 'notary-9' },
+        maritalStatusDeclaration: { statementDate: '2025-09-05', notaryId: 'notary-9' },
+        ...overrides.documents,
+      },
+    },
+  },
+);
+
+describe('spec §2/§3: null-safe context for a case with no clinic/maternity-hospital relations at all', () => {
+  it('never throws, and resolves clinic/maternityHospital/partnerClinic to null', () => {
+    const catalog = noClinicCaseCatalog();
+    expect(() => resolveCaseContext(catalog, 'case-no-clinic')).not.toThrow();
+    const context = resolveCaseContext(catalog, 'case-no-clinic');
+    expect(context.clinic).toBeNull();
+    expect(context.maternityHospital).toBeNull();
+    expect(context.partnerClinic).toBeNull();
+    expect(context.wife.name.uk.nominative).toBe('Приклад Марія Іванівна');
+  });
+
+  it('a template referencing clinic/maternityHospital fields degrades to unresolved, never crashes', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic');
+    expect(fillPlaceholders('{{clinic.medicalDirector.name.uk.short}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+    expect(fillPlaceholders('{{maternityHospital.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+});
+
+describe('spec §8/§9: TEMPLATE_DOCUMENT_CONFIG - notary resolved per current document, not one case-wide default', () => {
+  it('exposes the documented mapping', () => {
+    expect(TEMPLATE_DOCUMENT_CONFIG['birth-registration-surrogate-consent']).toEqual({ documentKey: 'birthRegistrationConsent' });
+    expect(TEMPLATE_DOCUMENT_CONFIG['surrogate-unmarried-declaration']).toEqual({ documentKey: 'maritalStatusDeclaration' });
+    expect(TEMPLATE_DOCUMENT_CONFIG['surrogacy-agreement']).toEqual({ documentKey: 'surrogacyAgreement' });
+    expect(TEMPLATE_DOCUMENT_CONFIG['surrogacy-program-rules']).toEqual({ documentKey: null });
+  });
+
+  it('resolves notary from documents.surrogacyAgreement.notaryId for the surrogacy-agreement template', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic', { templateId: 'surrogacy-agreement' });
+    expect(context.notary.name.uk.nominative).toBe('Тестова Анна Петрівна');
+    expect(context.notary.name.uk.short).toBe('Тестова А.П.');
+  });
+
+  it('resolves notary from documents.maritalStatusDeclaration.notaryId for the surrogate-unmarried-declaration template', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic', { templateId: 'surrogate-unmarried-declaration' });
+    expect(context.notary.name.uk.nominative).toBe('Тестова Анна Петрівна');
+  });
+
+  it('a template with documentKey: null (surrogacy-program-rules) never resolves a notary', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic', { templateId: 'surrogacy-program-rules' });
+    expect(context.notary).toBeNull();
+  });
+
+  it('a case whose two documents use different notaries resolves each independently', () => {
+    const catalog = noClinicCaseCatalog();
+    catalog.parties.notaries.push({
+      id: 'notary-10',
+      name: { uk: { nominative: 'Другий Нотаріус Богданович' } },
+    });
+    catalog.cases[0].documents.maritalStatusDeclaration.notaryId = 'notary-10';
+
+    const agreementContext = resolveCaseContext(catalog, 'case-no-clinic', { templateId: 'surrogacy-agreement' });
+    const declarationContext = resolveCaseContext(catalog, 'case-no-clinic', { templateId: 'surrogate-unmarried-declaration' });
+    expect(agreementContext.notary.name.uk.nominative).toBe('Тестова Анна Петрівна');
+    expect(declarationContext.notary.name.uk.nominative).toBe('Другий Нотаріус Богданович');
+  });
+
+  it('omitting templateId keeps the old default (birthRegistrationConsent) for backward compatibility', () => {
+    const catalog = noClinicCaseCatalog({ documents: { birthRegistrationConsent: { notaryId: 'notary-9', statementDate: '2026-05-18' } } });
+    const context = resolveCaseContext(catalog, 'case-no-clinic');
+    expect(context.notary.name.uk.nominative).toBe('Тестова Анна Петрівна');
+  });
+
+  it('a templateId not in TEMPLATE_DOCUMENT_CONFIG never resolves a notary (harmless - unused by that template)', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic', { templateId: 'embryo-transfer-consent' });
+    expect(context.notary).toBeNull();
+  });
+});
+
+describe('spec §4/§9: surrogacyAgreement.dateWords + maritalStatusDeclaration derived date fields', () => {
+  it('surrogacyAgreement.dateWords.uk is derived from documents.surrogacyAgreement.date', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic');
+    expect(context.surrogacyAgreement.date).toBe('2025-09-05');
+    expect(context.surrogacyAgreement.dateWords.uk).toBe("п'ятого вересня дві тисячі двадцять п'ятого року");
+  });
+
+  it('maritalStatusDeclaration exposes statementDateFormatted and statementDateWords in both languages', () => {
+    const catalog = noClinicCaseCatalog();
+    const context = resolveCaseContext(catalog, 'case-no-clinic');
+    expect(context.maritalStatusDeclaration.statementDate).toBe('2025-09-05');
+    expect(context.maritalStatusDeclaration.statementDateFormatted.uk).toBe('05 вересня 2025 року');
+    expect(context.maritalStatusDeclaration.statementDateFormatted.en).toBe('05 September 2025');
+    expect(context.maritalStatusDeclaration.statementDateWords.uk).toBe("п'ятого вересня дві тисячі двадцять п'ятого року");
+    expect(context.maritalStatusDeclaration.statementDateWords.en).toBe('Fifth of September two thousand twenty-five');
+  });
+
+  it('a case with no surrogacyAgreement/maritalStatusDeclaration data resolves blank derived fields, never throwing', () => {
+    const catalog = noClinicCaseCatalog({ documents: { surrogacyAgreement: undefined, maritalStatusDeclaration: undefined } });
+    // normalizeDocumentsCatalog keeps whatever was actually passed; simulate a case with neither.
+    catalog.cases[0].documents = {};
+    const context = resolveCaseContext(catalog, 'case-no-clinic');
+    expect(context.surrogacyAgreement.dateWords).toEqual({ uk: '', en: '' });
+    expect(context.maritalStatusDeclaration.statementDateWords).toEqual({ uk: '', en: '' });
+    expect(context.maritalStatusDeclaration.statementDateFormatted).toEqual({ uk: '', en: '' });
+  });
+
+  it('these derived fields are never written back to Firebase (source records stay bare)', () => {
+    const catalog = noClinicCaseCatalog();
+    const rawCase = catalog.cases.find(item => item.id === 'case-no-clinic');
+    expect(rawCase.documents.surrogacyAgreement).toEqual({ date: '2025-09-05', notaryId: 'notary-9' });
+    expect(rawCase.documents.maritalStatusDeclaration).toEqual({ statementDate: '2025-09-05', notaryId: 'notary-9' });
+  });
+});
+
+describe('spec §5/§13: DERIVED_CONTEXT_FIELD_KEYS never created by createEmpty* factories', () => {
+  it('createEmptyNotary carries no short/instrumental field', () => {
+    const notary = createEmptyNotary();
+    expect(notary.name.uk.short).toBeUndefined();
+    expect(notary.name.uk.instrumental).toBeUndefined();
+    expect(notary.name.en.short).toBeUndefined();
+  });
+
+  it('createEmptyMaternityHospital carries no shortName field', () => {
+    expect(createEmptyMaternityHospital().shortName).toBeUndefined();
+  });
+
+  it('createEmptyClinic carries no medicalDirector.name short field', () => {
+    const clinic = createEmptyClinic();
+    expect(clinic.medicalDirector.name.uk.short).toBeUndefined();
+    expect(clinic.medicalDirector.name.en.short).toBeUndefined();
+  });
+
+  it('DERIVED_CONTEXT_FIELD_KEYS lists every forbidden persisted key from the spec', () => {
+    expect(DERIVED_CONTEXT_FIELD_KEYS).toEqual(expect.arrayContaining([
+      'short', 'shortName', 'dateWords', 'statementDateWords', 'statementDateFormatted', 'dateDisplay', 'numberEn', 'wordsAfterArticle',
+    ]));
   });
 });


### PR DESCRIPTION
Update the documentsBuilder catalog/context layer to work with the full (non-partial)
documentsBuilder export: short names, spelled-out dates and long-form dates are now
computed purely at template-context build time and never stored to Firebase or in any
"empty record" schema (createEmptyNotary/createEmptyMaternityHospital/createEmptyClinic
no longer carry short/shortName/instrumental fields).

- resolveCaseContext now resolves the active document's notary per-template via
  TEMPLATE_DOCUMENT_CONFIG (birth-registration statement, marital-status declaration and
  surrogacy agreement can each use a different notary) instead of one case-wide notary,
  and is null-safe for a case with no clinic/maternity-hospital/partner-clinic relations.
- Added generic formatShortNameUk/En, formatDateWordsEn, formatDateLongUk/En, and a
  shared withDerivedDateFields builder so surrogacyAgreement.dateWords and
  maritalStatusDeclaration.statementDateFormatted/statementDateWords reuse the same
  logic as the existing birthRegistration.statementDateWords instead of duplicating it.
- enrichNameWithDerivedFields adds `.short` to a person's name at context-build time
  without mutating stored records or restructuring a plain-string name.en.
- DocumentsPage.jsx now resolves each selected document against its own per-template
  context (unresolved-variables scan, generation, builder preview, variable picker) and
  surfaces a clear "notary not selected" warning alongside the existing partner-clinic one.
- CaseChildbirthTransactionEditor gained a notary field on the surrogacy agreement and a
  new "Заява СМ про відсутність шлюбу" section (date + notary), and reads the maternity
  hospital's display name from name.uk/en instead of a stored shortName.
- Added stripDerivedFields/DERIVED_CONTEXT_FIELD_KEYS to keep any future export path from
  leaking runtime-only fields.

Verified against the full uploaded documentsBuilder JSON (3 cases, 10 templates):
case-kikawa generates surrogacy-agreement, surrogate-unmarried-declaration (uk/en) and
surrogacy-program-rules with no leftover {{...}} tokens, correct notary short name,
correct spelled-out dates, and passport numbers preserved exactly (no transliteration).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Qgt12sZGH4HxNNBSTp4U9