### PR TITLE
Documents: Text mode resolves beforeTitle against the case, same as title/paragraphs

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -767,10 +767,13 @@ const DocumentsPage = ({ isAdmin }) => {
   // {{placeholder}} markup and edits the shared template directly; 'input' shows the de-markup'd
   // plain wording and edits that same shared template (retype the wording, no formatting, no case
   // involved - templates are static and shared across every case, so there is nothing left to
-  // override); 'text' shows that markup rendered (bold/italic applied in place, placeholders still
-  // unresolved) and is the *only* mode Bold/Italic can be applied in - the wording itself isn't
-  // editable there, only its formatting. All three modes write straight to the template, exactly
-  // like beforeTitle rows always have - title/paragraph rows now follow the identical mechanism.
+  // override); 'text' is a read-only preview resolved against the currently selected case (real
+  // values substituted, never a raw {{token}} - see resolvedValue/titleResolvedValue/
+  // beforeTitleResolvedValue below, all three built from the same resolvedDoc) and is the *only*
+  // mode Bold/Italic can be applied in, acting on the underlying raw markup even though the
+  // resolved wording is what's shown - the wording itself isn't editable there, only its
+  // formatting. Every row - title, every paragraph, every beforeTitle block alike - follows this
+  // identical mechanism, no row-specific exceptions.
   const PARAGRAPH_MODES = ['template', 'input', 'text'];
   const nextParagraphMode = mode => PARAGRAPH_MODES[(PARAGRAPH_MODES.indexOf(mode) + 1) % PARAGRAPH_MODES.length];
   const PARAGRAPH_MODE_ICON = { template: '{}', input: 'I', text: 'T' };
@@ -2083,13 +2086,12 @@ const DocumentsPage = ({ isAdmin }) => {
                 const onCatalogNameBlur = () => persistTemplate(template.id);
                 // Title mode/state - same template/input/text cycle as every paragraph and
                 // beforeTitle block. Template and Input both edit the shared markup directly
-                // (never a per-case value). Text mode is a read-only preview of the paragraph
-                // resolved against the currently selected case - unlike beforeTitle (which has no
-                // case data to resolve against and always shows raw markup even in Text mode),
-                // the title/paragraph Text preview shows real substituted values so an admin can
-                // actually read it, not raw {{tokens}} - there is nowhere left to persist a Bold/
-                // Italic edit made against resolved text (that used to be a per-case override,
-                // which no longer exists), so Text mode is display-only here.
+                // (never a per-case value). Text mode is a read-only preview resolved against the
+                // currently selected case - same rule for the title, every paragraph, and every
+                // beforeTitle block alike, so an admin always reads real substituted values there,
+                // never a raw {{token}} - there is nowhere left to persist a Bold/Italic edit made
+                // against resolved text (that used to be a per-case override, which no longer
+                // exists), so Text mode is display-only here.
                 const titleMode = getParagraphMode(template.id, TITLE_SCOPE);
                 const titleIsTemplateMode = titleMode === 'template';
                 const titleRawValue = langKey => template.title?.[langKey] || '';
@@ -2189,6 +2191,11 @@ const DocumentsPage = ({ isAdmin }) => {
                           const isTextMode = mode === 'text';
                           const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
                           const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
+                          // Same rule as the title/paragraph rows below: Text mode shows the
+                          // resolved-against-the-current-case value (real names/dates), never the
+                          // raw {{token}} markup - resolveBeforeTitleBlocks already fills every
+                          // placeholder when building resolvedDoc, this just has to read it.
+                          const beforeTitleResolvedValue = langKey => resolvedDoc?.beforeTitle?.[index]?.[langKey] ?? '';
                           const onChange = langKey => event => {
                             const nextRaw = isTemplateMode
                               ? event.target.value
@@ -2286,7 +2293,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
                                         onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
                                       >
-                                        <FormattedRunsPreview text={rawValue('uk')} />
+                                        <FormattedRunsPreview text={beforeTitleResolvedValue('uk')} />
                                       </TextModeDisplay>
                                     ) : (
                                       <AutoInlineTextarea
@@ -2308,7 +2315,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
                                         onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
                                       >
-                                        <FormattedRunsPreview text={rawValue('en')} />
+                                        <FormattedRunsPreview text={beforeTitleResolvedValue('en')} />
                                       </TextModeDisplay>
                                     ) : (
                                       <AutoInlineTextarea

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -45,8 +45,17 @@ beforeEach(() => {
         val: () => ({
           couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } }] } },
           surrogateMothers: { 'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Сурогатна Матір' } } } },
-          cases: { 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' } } },
         }),
+      };
+    }
+    // Cases live at their own top-level path (DOCUMENTS_CASES_PATH), a sibling of `parties`, not
+    // nested under it - a case placed under `parties` here (as this fixture used to) is silently
+    // never loaded, so `selectedCaseId` stays unset and every case-resolved value falls back to
+    // the missing-value placeholder instead of the real data.
+    if (path === 'documentsBuilder/cases') {
+      return {
+        exists: () => true,
+        val: () => ({ 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' } } }),
       };
     }
     if (path === 'documentsBuilder/templates') {
@@ -155,6 +164,26 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
         beforeTitle: [expect.objectContaining({ uk: '**Сурогатна мати** {{surrogateMother.name.uk.nominative}}' })],
       }),
     ));
+  });
+
+  // Regression: Text mode used to render beforeTitle's raw `rawValue()` (unresolved {{tokens}})
+  // while the title/paragraph rows in the same mode already rendered `resolvedDoc`'s substituted
+  // values - same mode, same case selected, different result depending on row type. Text mode
+  // must resolve identically for every row (spec: "для всіх абзаців діє однакова логіка").
+  it('Text mode shows the beforeTitle text resolved against the selected case, not the raw {{token}} - same rule as title/paragraph rows', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const textarea = await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = textarea.closest('.paragraph-editor-block');
+
+    // template -> input -> text: two taps of the shared mode-cycle button.
+    fireEvent.click(within(block).getByTitle('Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.'));
+    fireEvent.click(within(block).getByTitle('Input mode - retyping the shared wording as plain text. Tap to switch to Text mode.'));
+
+    expect(await within(block).findByText('Сурогатна мати Сурогатна Матір')).toBeInTheDocument();
+    expect(within(block).queryByText(/\{\{surrogateMother/)).not.toBeInTheDocument();
   });
 
   // Notarial layout standard §3.3 + batch 2026-07-23 B §1.3/§1.4: the signer-block offset is a


### PR DESCRIPTION
## Summary
- beforeTitle blocks in Text (T) mode rendered the raw `{{token}}` markup, while the title and every paragraph row in the same mode already rendered `resolvedDoc`'s substituted real-case values. Same mode, same selected case, inconsistent result depending on row type.
- `resolveBeforeTitleBlocks` (documentsCatalogUtils.js) already fills every placeholder when building `resolvedDoc`; `DocumentsPage.jsx`'s beforeTitle Text-mode rendering just never read it.
- Text mode now shows real case data for beforeTitle blocks too — one identical rule for the title, every paragraph, and every beforeTitle block.
- Also fixes a latent test-fixture bug in `DocumentsPage.templateBoldItalic.test.js`: its case was nested under `documentsBuilder/parties` instead of the separate `documentsBuilder/cases` path, so it was silently never loaded.

## Test plan
- [x] `documentsCatalogUtils.test.js`, all `DocumentsPage.*.test.js`, `PartiesPage.*.test.js` pass (343 tests)
- [x] New regression test: beforeTitle Text mode resolves `{{surrogateMother.name.uk.nominative}}` to the real case value
- [x] `eslint` clean, production build compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Qgt12sZGH4HxNNBSTp4U9

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qgt12sZGH4HxNNBSTp4U9)_