### PR TITLE
Documents Builder: support the new case.artProgram structure

### DIFF
--- a/src/components/CaseArtProgramEditor.jsx
+++ b/src/components/CaseArtProgramEditor.jsx
@@ -1,0 +1,734 @@
+// "Програма ДРТ" (case.artProgram editor) - the shared, once-only medical facts of a case's
+// fertility program: diagnosis/genetic material/attending physician, embryo shipments from a
+// partner clinic, and transfer attempts (each carrying its own hCG tests and ultrasounds). Every
+// document that references one of these events (embryoOwnershipStatement,
+// geneticAffinityCertificate, racssClinicLetter - edited in CaseChildbirthTransactionEditor) only
+// ever stores the id it points at, never a copy of the fact itself - editing an event here is
+// instantly reflected in every document that references it.
+//
+// Self-contained (same reasoning as CaseChildbirthTransactionEditor's own header comment): no
+// dependency on the host page's internals, so it drops into any --km-* scoped page as-is.
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import toast from 'react-hot-toast';
+import { ref, set } from 'firebase/database';
+import { FaPlus, FaTrash } from 'react-icons/fa';
+import { database } from './config';
+import {
+  DOCUMENTS_CASES_PATH,
+  formatShipmentOptionLabel,
+  normalizeIsoDate,
+  removeEmptyCaseValues,
+  toArray,
+} from './documentsCatalogUtils';
+
+const Section = styled.section`
+  background: var(--km-card);
+  border: 1px solid var(--km-border);
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 12px;
+`;
+
+const SectionHead = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  font-family: var(--km-font-display);
+  font-size: 15px;
+  letter-spacing: -0.01em;
+`;
+
+const SectionSubhead = styled.h3`
+  margin: 12px 0 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--km-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+`;
+
+const RowLine = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const Select = styled.select`
+  flex: 1;
+  min-width: 200px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 30px;
+  padding: 4px 8px;
+  font-size: 12.5px;
+  font-family: var(--km-font);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--km-border);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--km-accent);
+    background: var(--km-card);
+  }
+`;
+
+const DocRow = styled.div`
+  border: 1px solid var(--km-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-top: 8px;
+`;
+
+const NestedRow = styled(DocRow)`
+  background: var(--km-bg, transparent);
+  margin-left: 4px;
+`;
+
+const DocRowHead = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const DocSubtitle = styled.div`
+  color: var(--km-muted);
+  font-size: 11px;
+  font-weight: 400;
+`;
+
+const FieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+`;
+
+const Field = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--km-muted);
+`;
+
+const FieldInput = styled.input`
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 28px;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-family: var(--km-font);
+
+  &:hover {
+    border-color: var(--km-border);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--km-accent);
+    background: var(--km-card);
+  }
+`;
+
+const MiniButton = styled.button`
+  border: 1px solid var(--km-border);
+  background: var(--km-card);
+  color: var(--km-text);
+  border-radius: 6px;
+  min-height: 30px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-accent);
+    color: var(--km-accent);
+  }
+`;
+
+const PrimaryMiniButton = styled(MiniButton)`
+  border: none;
+  color: #fff;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+
+  &:hover:not(:disabled) {
+    color: #fff;
+    filter: brightness(1.05);
+  }
+`;
+
+const SmallButton = styled(MiniButton)`
+  min-height: 24px;
+  padding: 3px 9px;
+  font-size: 10.5px;
+  border-radius: 5px;
+`;
+
+const DangerButton = styled(SmallButton)`
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
+
+  &:hover:not(:disabled) {
+    border-color: var(--km-danger);
+    color: var(--km-danger);
+  }
+`;
+
+const describeSaveError = error => `${error?.code || error?.name || 'error'}: ${error?.message || String(error)}`.trim();
+
+// The next `<prefix>-N` id for a freshly-added row (spec §8: "ID створювати автоматично") - the
+// highest existing numeric suffix plus one, not just `items.length + 1`, so removing a middle row
+// and adding a new one never collides with a still-referenced id (a document elsewhere may still
+// point at "shipment-2" even after "shipment-1" was deleted).
+const nextSequentialId = (prefix, items) => {
+  const maxSuffix = (items || []).reduce((max, item) => {
+    const match = /-(\d+)$/.exec(String(item?.id || ''));
+    return match ? Math.max(max, Number(match[1])) : max;
+  }, 0);
+  return `${prefix}-${maxSuffix + 1}`;
+};
+
+const emptyArtProgramDraft = () => ({
+  medicalIndication: { diagnosis: { uk: '' } },
+  geneticMaterial: { oocyteSourcePartnerRole: '', spermSourcePartnerRole: '' },
+  medicalTeam: { physician: { name: { uk: { nominative: '' } } } },
+  embryoShipments: [],
+  transferAttempts: [],
+});
+
+const PARTNER_ROLE_OPTIONS = [
+  { value: '', label: '— не обрано —' },
+  { value: 'wife', label: 'дружина' },
+  { value: 'husband', label: 'чоловік' },
+  { value: 'donor', label: 'донор' },
+];
+
+const TRI_STATE_OPTIONS = [
+  { value: '', label: '— не вказано —' },
+  { value: 'true', label: 'так' },
+  { value: 'false', label: 'ні' },
+];
+
+// Firebase never stores these as arrays (spec §2/§12) - each list is converted back to a map keyed
+// by its own `id` right before the write, whatever order the draft happens to hold it in.
+const arrayToMap = items => (items || []).reduce((byId, item) => {
+  if (item?.id) byId[item.id] = item;
+  return byId;
+}, {});
+
+const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
+  const selectedCase = catalog.cases.find(item => String(item.id) === String(caseId)) || null;
+  const [draft, setDraft] = useState(emptyArtProgramDraft());
+
+  useEffect(() => {
+    const artProgram = selectedCase?.artProgram || {};
+    setDraft({
+      medicalIndication: { diagnosis: { uk: artProgram.medicalIndication?.diagnosis?.uk || '' } },
+      geneticMaterial: {
+        oocyteSourcePartnerRole: artProgram.geneticMaterial?.oocyteSourcePartnerRole || '',
+        spermSourcePartnerRole: artProgram.geneticMaterial?.spermSourcePartnerRole || '',
+      },
+      medicalTeam: {
+        physician: { name: { uk: { nominative: artProgram.medicalTeam?.physician?.name?.uk?.nominative || '' } } },
+      },
+      // toArray tolerates a Firebase map-with-gaps the same way every other reader in this app does
+      // (see documentsCatalogUtils.toArray) - never assumes the backend snapshot is a real Array.
+      embryoShipments: toArray(artProgram.embryoShipments),
+      transferAttempts: toArray(artProgram.transferAttempts).map(transfer => ({
+        ...transfer,
+        hcgTests: toArray(transfer.hcgTests),
+        ultrasounds: toArray(transfer.ultrasounds),
+      })),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [caseId]);
+
+  const updateDiagnosis = value => setDraft(previous => ({ ...previous, medicalIndication: { diagnosis: { uk: value } } }));
+  const updateGeneticMaterial = (field, value) => setDraft(previous => ({
+    ...previous,
+    geneticMaterial: { ...previous.geneticMaterial, [field]: value },
+  }));
+  const updatePhysicianName = value => setDraft(previous => ({
+    ...previous,
+    medicalTeam: { physician: { name: { uk: { nominative: value } } } },
+  }));
+
+  // --- Embryo shipments ------------------------------------------------------------------------
+
+  const addShipment = () => setDraft(previous => ({
+    ...previous,
+    embryoShipments: [...previous.embryoShipments, {
+      id: nextSequentialId('shipment', previous.embryoShipments),
+      sourceClinicId: '',
+      destinationClinicId: '',
+      ivfDate: '',
+      plannedPeriod: { startDate: '', endDate: '' },
+      receivedDate: '',
+    }],
+  }));
+
+  const removeShipment = shipmentId => setDraft(previous => ({
+    ...previous,
+    embryoShipments: previous.embryoShipments.filter(shipment => shipment.id !== shipmentId),
+  }));
+
+  const updateShipmentField = (shipmentId, field, value) => setDraft(previous => ({
+    ...previous,
+    embryoShipments: previous.embryoShipments.map(shipment => (shipment.id === shipmentId ? { ...shipment, [field]: value } : shipment)),
+  }));
+
+  // A migrated shipment may still carry `plannedPeriod.text` (spec §6) - preserved untouched here
+  // (spread first) since there's no input for it; only startDate/endDate are ever edited.
+  const updateShipmentPeriodField = (shipmentId, field, value) => setDraft(previous => ({
+    ...previous,
+    embryoShipments: previous.embryoShipments.map(shipment => (shipment.id === shipmentId
+      ? { ...shipment, plannedPeriod: { ...(shipment.plannedPeriod || {}), [field]: value } }
+      : shipment)),
+  }));
+
+  // --- Transfer attempts + nested hCG/ultrasound ------------------------------------------------
+
+  const addTransfer = () => setDraft(previous => ({
+    ...previous,
+    transferAttempts: [...previous.transferAttempts, {
+      id: nextSequentialId('transfer', previous.transferAttempts),
+      shipmentId: '',
+      date: '',
+      embryoCount: '',
+      embryoStage: '',
+      hcgTests: [],
+      ultrasounds: [],
+    }],
+  }));
+
+  const removeTransfer = transferId => setDraft(previous => ({
+    ...previous,
+    transferAttempts: previous.transferAttempts.filter(transfer => transfer.id !== transferId),
+  }));
+
+  const updateTransferField = (transferId, field, value) => setDraft(previous => ({
+    ...previous,
+    transferAttempts: previous.transferAttempts.map(transfer => (transfer.id === transferId ? { ...transfer, [field]: value } : transfer)),
+  }));
+
+  const updateTransferList = (transferId, listKey, updater) => setDraft(previous => ({
+    ...previous,
+    transferAttempts: previous.transferAttempts.map(transfer => (transfer.id === transferId
+      ? { ...transfer, [listKey]: updater(transfer[listKey]) }
+      : transfer)),
+  }));
+
+  const addHcgTest = transferId => updateTransferList(transferId, 'hcgTests', hcgTests => [...hcgTests, {
+    id: nextSequentialId('hcg', hcgTests), date: '', positive: '', value: '', unit: '',
+  }]);
+  const removeHcgTest = (transferId, hcgTestId) => updateTransferList(transferId, 'hcgTests', hcgTests => hcgTests.filter(item => item.id !== hcgTestId));
+  const updateHcgTestField = (transferId, hcgTestId, field, value) => updateTransferList(
+    transferId,
+    'hcgTests',
+    hcgTests => hcgTests.map(item => (item.id === hcgTestId ? { ...item, [field]: value } : item)),
+  );
+
+  const addUltrasound = transferId => updateTransferList(transferId, 'ultrasounds', ultrasounds => [...ultrasounds, {
+    id: nextSequentialId('ultrasound', ultrasounds), date: '', pregnancyConfirmed: '', fetusCount: '', gestationalAgeWeeks: { from: '', to: '' },
+  }]);
+  const removeUltrasound = (transferId, ultrasoundId) => updateTransferList(
+    transferId,
+    'ultrasounds',
+    ultrasounds => ultrasounds.filter(item => item.id !== ultrasoundId),
+  );
+  const updateUltrasoundField = (transferId, ultrasoundId, field, value) => updateTransferList(
+    transferId,
+    'ultrasounds',
+    ultrasounds => ultrasounds.map(item => (item.id === ultrasoundId ? { ...item, [field]: value } : item)),
+  );
+  const updateUltrasoundGestField = (transferId, ultrasoundId, field, value) => updateTransferList(
+    transferId,
+    'ultrasounds',
+    ultrasounds => ultrasounds.map(item => (item.id === ultrasoundId
+      ? { ...item, gestationalAgeWeeks: { ...(item.gestationalAgeWeeks || {}), [field]: value } }
+      : item)),
+  );
+
+  // --- Save --------------------------------------------------------------------------------------
+
+  const parseTriState = value => (value === 'true' ? true : (value === 'false' ? false : undefined));
+  const parseNumberOrBlank = value => (value === '' || value === undefined || value === null ? undefined : Number(value));
+
+  const handleSave = async () => {
+    if (!selectedCase) return;
+    const payload = {
+      medicalIndication: draft.medicalIndication,
+      geneticMaterial: draft.geneticMaterial,
+      medicalTeam: draft.medicalTeam,
+      embryoShipments: arrayToMap(draft.embryoShipments.map(shipment => ({
+        ...shipment,
+        ivfDate: normalizeIsoDate(shipment.ivfDate),
+        receivedDate: normalizeIsoDate(shipment.receivedDate),
+        plannedPeriod: {
+          ...(shipment.plannedPeriod || {}),
+          startDate: normalizeIsoDate(shipment.plannedPeriod?.startDate),
+          endDate: normalizeIsoDate(shipment.plannedPeriod?.endDate),
+        },
+      }))),
+      transferAttempts: arrayToMap(draft.transferAttempts.map(transfer => ({
+        ...transfer,
+        date: normalizeIsoDate(transfer.date),
+        embryoCount: parseNumberOrBlank(transfer.embryoCount),
+        hcgTests: arrayToMap(transfer.hcgTests.map(hcgTest => ({
+          ...hcgTest,
+          date: normalizeIsoDate(hcgTest.date),
+          positive: parseTriState(hcgTest.positive),
+          value: parseNumberOrBlank(hcgTest.value),
+        }))),
+        ultrasounds: arrayToMap(transfer.ultrasounds.map(ultrasound => ({
+          ...ultrasound,
+          date: normalizeIsoDate(ultrasound.date),
+          pregnancyConfirmed: parseTriState(ultrasound.pregnancyConfirmed),
+          fetusCount: parseNumberOrBlank(ultrasound.fetusCount),
+          gestationalAgeWeeks: {
+            from: parseNumberOrBlank(ultrasound.gestationalAgeWeeks?.from),
+            to: parseNumberOrBlank(ultrasound.gestationalAgeWeeks?.to),
+          },
+        }))),
+      }))),
+    };
+    const cleaned = removeEmptyCaseValues(payload);
+    const nextValue = Object.keys(cleaned).length ? cleaned : null;
+    try {
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/artProgram`), nextValue);
+      setCatalog(previous => ({
+        ...previous,
+        cases: previous.cases.map(item => {
+          if (String(item.id) !== String(selectedCase.id)) return item;
+          if (nextValue) return { ...item, artProgram: nextValue };
+          const { artProgram, ...rest } = item;
+          return rest;
+        }),
+      }));
+      toast.success('ART program details saved.');
+    } catch (saveError) {
+      console.error('Unable to save the ART program details', saveError);
+      toast.error(`Could not save the ART program details: ${describeSaveError(saveError)}`);
+    }
+  };
+
+  if (!selectedCase) return null;
+
+  return (
+    <Section>
+      <SectionHead>
+        <SectionTitle>Програма ДРТ</SectionTitle>
+      </SectionHead>
+
+      <SectionSubhead>Медичні дані</SectionSubhead>
+      <FieldGrid>
+        <Field style={{ gridColumn: '1 / -1' }}>
+          Діагноз
+          <FieldInput type="text" value={draft.medicalIndication.diagnosis.uk} onChange={event => updateDiagnosis(event.target.value)} />
+        </Field>
+        <Field>
+          Джерело яйцеклітин
+          <Select
+            value={draft.geneticMaterial.oocyteSourcePartnerRole}
+            onChange={event => updateGeneticMaterial('oocyteSourcePartnerRole', event.target.value)}
+          >
+            {PARTNER_ROLE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </Select>
+        </Field>
+        <Field>
+          Джерело сперматозоїдів
+          <Select
+            value={draft.geneticMaterial.spermSourcePartnerRole}
+            onChange={event => updateGeneticMaterial('spermSourcePartnerRole', event.target.value)}
+          >
+            {PARTNER_ROLE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </Select>
+        </Field>
+        <Field>
+          Лікар програми
+          <FieldInput
+            type="text"
+            value={draft.medicalTeam.physician.name.uk.nominative}
+            onChange={event => updatePhysicianName(event.target.value)}
+          />
+        </Field>
+      </FieldGrid>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Доставлення ембріонів</SectionSubhead>
+      {draft.embryoShipments.map((shipment, index) => (
+        <DocRow key={shipment.id}>
+          <DocRowHead>
+            <DocSubtitle style={{ fontWeight: 700 }}>{shipment.id || `Доставлення ${index + 1}`}</DocSubtitle>
+            <DangerButton type="button" onClick={() => removeShipment(shipment.id)} title="Remove this shipment">
+              <FaTrash />
+            </DangerButton>
+          </DocRowHead>
+          <FieldGrid>
+            <Field>
+              Клініка-відправник
+              <Select value={shipment.sourceClinicId || ''} onChange={event => updateShipmentField(shipment.id, 'sourceClinicId', event.target.value)}>
+                <option value="">— не обрано —</option>
+                {catalog.parties.partnerClinics.map(partnerClinic => (
+                  <option key={partnerClinic.id} value={String(partnerClinic.id)}>{partnerClinic.name?.uk || partnerClinic.id}</option>
+                ))}
+              </Select>
+            </Field>
+            <Field>
+              Клініка-отримувач
+              <Select
+                value={shipment.destinationClinicId || ''}
+                onChange={event => updateShipmentField(shipment.id, 'destinationClinicId', event.target.value)}
+              >
+                <option value="">— не обрано —</option>
+                {catalog.parties.clinics.map(clinic => (
+                  <option key={clinic.id} value={String(clinic.id)}>{clinic.name?.uk || clinic.medicalCenterName?.uk || clinic.id}</option>
+                ))}
+              </Select>
+            </Field>
+            <Field>
+              Дата ЗІВ
+              <FieldInput type="date" value={shipment.ivfDate || ''} onChange={event => updateShipmentField(shipment.id, 'ivfDate', event.target.value)} />
+            </Field>
+            <Field>
+              Запланований період — початок
+              <FieldInput
+                type="date"
+                value={shipment.plannedPeriod?.startDate || ''}
+                onChange={event => updateShipmentPeriodField(shipment.id, 'startDate', event.target.value)}
+              />
+            </Field>
+            <Field>
+              Запланований період — кінець
+              <FieldInput
+                type="date"
+                value={shipment.plannedPeriod?.endDate || ''}
+                onChange={event => updateShipmentPeriodField(shipment.id, 'endDate', event.target.value)}
+              />
+            </Field>
+            <Field>
+              Дата фактичного отримання
+              <FieldInput
+                type="date"
+                value={shipment.receivedDate || ''}
+                onChange={event => updateShipmentField(shipment.id, 'receivedDate', event.target.value)}
+              />
+            </Field>
+          </FieldGrid>
+          {shipment.plannedPeriod?.text?.uk || shipment.plannedPeriod?.text?.en ? (
+            <DocSubtitle style={{ marginTop: 6 }}>
+              Мігрований текстовий період: {shipment.plannedPeriod.text.uk || shipment.plannedPeriod.text.en}
+            </DocSubtitle>
+          ) : null}
+        </DocRow>
+      ))}
+      <RowLine style={{ marginTop: 8 }}>
+        <SmallButton type="button" onClick={addShipment}>
+          <FaPlus /> Add shipment
+        </SmallButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Спроби переносу</SectionSubhead>
+      {draft.transferAttempts.map((transfer, index) => (
+        <DocRow key={transfer.id}>
+          <DocRowHead>
+            <DocSubtitle style={{ fontWeight: 700 }}>{transfer.id || `Перенос ${index + 1}`}</DocSubtitle>
+            <DangerButton type="button" onClick={() => removeTransfer(transfer.id)} title="Remove this transfer attempt">
+              <FaTrash />
+            </DangerButton>
+          </DocRowHead>
+          <FieldGrid>
+            <Field>
+              Доставлення
+              <Select value={transfer.shipmentId || ''} onChange={event => updateTransferField(transfer.id, 'shipmentId', event.target.value)}>
+                <option value="">— не обрано —</option>
+                {draft.embryoShipments.map(shipment => (
+                  <option key={shipment.id} value={shipment.id}>
+                    {formatShipmentOptionLabel(shipment, catalog.parties) || shipment.id}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+            <Field>
+              Дата переносу
+              <FieldInput type="date" value={transfer.date || ''} onChange={event => updateTransferField(transfer.id, 'date', event.target.value)} />
+            </Field>
+            <Field>
+              Кількість ембріонів
+              <FieldInput
+                type="number"
+                min="0"
+                value={transfer.embryoCount ?? ''}
+                onChange={event => updateTransferField(transfer.id, 'embryoCount', event.target.value)}
+              />
+            </Field>
+            <Field>
+              Стадія ембріонів
+              <FieldInput
+                type="text"
+                list="art-embryo-stage-options"
+                placeholder="blastocyst"
+                value={transfer.embryoStage || ''}
+                onChange={event => updateTransferField(transfer.id, 'embryoStage', event.target.value)}
+              />
+            </Field>
+          </FieldGrid>
+
+          <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>Аналізи ХГЧ</SectionSubhead>
+          {transfer.hcgTests.map((hcgTest, hcgIndex) => (
+            <NestedRow key={hcgTest.id}>
+              <DocRowHead>
+                <DocSubtitle style={{ fontWeight: 700 }}>{hcgTest.id || `ХГЧ ${hcgIndex + 1}`}</DocSubtitle>
+                <DangerButton type="button" onClick={() => removeHcgTest(transfer.id, hcgTest.id)} title="Remove this hCG test">
+                  <FaTrash />
+                </DangerButton>
+              </DocRowHead>
+              <FieldGrid>
+                <Field>
+                  Дата
+                  <FieldInput
+                    type="date"
+                    value={hcgTest.date || ''}
+                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'date', event.target.value)}
+                  />
+                </Field>
+                <Field>
+                  Результат
+                  <Select
+                    value={hcgTest.positive === true ? 'true' : (hcgTest.positive === false ? 'false' : '')}
+                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'positive', event.target.value)}
+                  >
+                    {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                  </Select>
+                </Field>
+                <Field>
+                  Значення
+                  <FieldInput
+                    type="number"
+                    value={hcgTest.value ?? ''}
+                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'value', event.target.value)}
+                  />
+                </Field>
+                <Field>
+                  Одиниці вимірювання
+                  <FieldInput
+                    type="text"
+                    value={hcgTest.unit || ''}
+                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'unit', event.target.value)}
+                  />
+                </Field>
+              </FieldGrid>
+            </NestedRow>
+          ))}
+          <RowLine style={{ marginTop: 8 }}>
+            <SmallButton type="button" onClick={() => addHcgTest(transfer.id)}>
+              <FaPlus /> Add hCG test
+            </SmallButton>
+          </RowLine>
+
+          <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>УЗД</SectionSubhead>
+          {transfer.ultrasounds.map((ultrasound, ultrasoundIndex) => (
+            <NestedRow key={ultrasound.id}>
+              <DocRowHead>
+                <DocSubtitle style={{ fontWeight: 700 }}>{ultrasound.id || `УЗД ${ultrasoundIndex + 1}`}</DocSubtitle>
+                <DangerButton type="button" onClick={() => removeUltrasound(transfer.id, ultrasound.id)} title="Remove this ultrasound">
+                  <FaTrash />
+                </DangerButton>
+              </DocRowHead>
+              <FieldGrid>
+                <Field>
+                  Дата
+                  <FieldInput
+                    type="date"
+                    value={ultrasound.date || ''}
+                    onChange={event => updateUltrasoundField(transfer.id, ultrasound.id, 'date', event.target.value)}
+                  />
+                </Field>
+                <Field>
+                  Вагітність підтверджена
+                  <Select
+                    value={ultrasound.pregnancyConfirmed === true ? 'true' : (ultrasound.pregnancyConfirmed === false ? 'false' : '')}
+                    onChange={event => updateUltrasoundField(transfer.id, ultrasound.id, 'pregnancyConfirmed', event.target.value)}
+                  >
+                    {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                  </Select>
+                </Field>
+                <Field>
+                  Кількість плодів
+                  <FieldInput
+                    type="number"
+                    min="0"
+                    value={ultrasound.fetusCount ?? ''}
+                    onChange={event => updateUltrasoundField(transfer.id, ultrasound.id, 'fetusCount', event.target.value)}
+                  />
+                </Field>
+                <Field>
+                  Строк вагітності — від (тижнів)
+                  <FieldInput
+                    type="number"
+                    min="0"
+                    value={ultrasound.gestationalAgeWeeks?.from ?? ''}
+                    onChange={event => updateUltrasoundGestField(transfer.id, ultrasound.id, 'from', event.target.value)}
+                  />
+                </Field>
+                <Field>
+                  Строк вагітності — до (тижнів)
+                  <FieldInput
+                    type="number"
+                    min="0"
+                    value={ultrasound.gestationalAgeWeeks?.to ?? ''}
+                    onChange={event => updateUltrasoundGestField(transfer.id, ultrasound.id, 'to', event.target.value)}
+                  />
+                </Field>
+              </FieldGrid>
+            </NestedRow>
+          ))}
+          <RowLine style={{ marginTop: 8 }}>
+            <SmallButton type="button" onClick={() => addUltrasound(transfer.id)}>
+              <FaPlus /> Add ultrasound
+            </SmallButton>
+          </RowLine>
+        </DocRow>
+      ))}
+      <RowLine style={{ marginTop: 8 }}>
+        <SmallButton type="button" onClick={addTransfer}>
+          <FaPlus /> Add transfer attempt
+        </SmallButton>
+      </RowLine>
+
+      <datalist id="art-embryo-stage-options">
+        <option value="blastocyst" />
+      </datalist>
+
+      <RowLine style={{ marginTop: 14 }}>
+        <PrimaryMiniButton type="button" onClick={handleSave}>
+          Save ART program
+        </PrimaryMiniButton>
+      </RowLine>
+    </Section>
+  );
+};
+
+export default CaseArtProgramEditor;

--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -14,7 +14,11 @@ import { database } from './config';
 import {
   DOCUMENTS_CASES_PATH,
   createChildRecord,
+  formatHcgTestOptionLabel,
+  formatShipmentOptionLabel,
   formatShortNameUk,
+  formatTransferOptionLabel,
+  formatUltrasoundOptionLabel,
   getMaternityHospitalDisplayName,
   normalizeIsoDate,
   removeEmptyCaseValues,
@@ -225,7 +229,27 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   // No notaryId field - this appendix isn't itself notarized (see TEMPLATE_DOCUMENT_CONFIG's
   // usesNotary: false for surrogacy-agreement-appendix-1).
   const [surrogacyAgreementAppendix1Draft, setSurrogacyAgreementAppendix1Draft] = useState({ date: '' });
-  const [embryoOwnershipDraft, setEmbryoOwnershipDraft] = useState({ shipmentPeriod: { uk: '', en: '' }, ivfDate: '' });
+  // Spec §4/§14: a fresh pick always writes `shipmentId` (resolved against case.artProgram.
+  // embryoShipments); `legacyIvfDate`/`legacyShipmentPeriod` are read-only leftovers from a
+  // not-yet-migrated record, carried through unedited on save so simply opening/saving this editor
+  // (without touching the shipment dropdown) never destroys them.
+  const [embryoOwnershipDraft, setEmbryoOwnershipDraft] = useState({ shipmentId: '', legacyIvfDate: '', legacyShipmentPeriod: null });
+  const [geneticAffinityCertificateDraft, setGeneticAffinityCertificateDraft] = useState({
+    transferAttemptId: '', hcgTestId: '', ultrasoundId: '', issueDate: '', outgoingNumber: '',
+  });
+  const [racssClinicLetterDraft, setRacssClinicLetterDraft] = useState({ transferAttemptId: '', ultrasoundId: '' });
+  const [medicalServicesAgreementDraft, setMedicalServicesAgreementDraft] = useState({ date: '' });
+
+  // Every artProgram-referencing dropdown reads from the same source: the selected case's own
+  // shipments/transfer attempts (never converted to arrays for storage - see documentsCatalogUtils
+  // - only here, transiently, for rendering <option>s).
+  const artShipments = toArray(selectedCase?.artProgram?.embryoShipments);
+  const artTransferAttempts = toArray(selectedCase?.artProgram?.transferAttempts);
+  const certificateTransfer = artTransferAttempts.find(item => item.id === geneticAffinityCertificateDraft.transferAttemptId) || null;
+  const certificateHcgTests = toArray(certificateTransfer?.hcgTests);
+  const certificateUltrasounds = toArray(certificateTransfer?.ultrasounds);
+  const letterTransfer = artTransferAttempts.find(item => item.id === racssClinicLetterDraft.transferAttemptId) || null;
+  const letterUltrasounds = toArray(letterTransfer?.ultrasounds);
 
   useEffect(() => {
     // `childbirth.children` isn't guaranteed to be a real array - a case edited straight in the
@@ -259,13 +283,23 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       date: selectedCase?.documents?.surrogacyAgreementAppendix1?.date || '',
     });
     setEmbryoOwnershipDraft({
-      shipmentPeriod: {
-        uk: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod?.uk || '',
-        en: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod?.en || '',
-      },
-      // `<input type="date">` only ever shows/emits ISO - a still-legacy `DD.MM.YYYY` import (spec
-      // §6) has to be read into ISO here or the field would just render blank.
-      ivfDate: normalizeIsoDate(selectedCase?.documents?.embryoOwnershipStatement?.ivfDate || ''),
+      shipmentId: selectedCase?.documents?.embryoOwnershipStatement?.shipmentId || '',
+      legacyIvfDate: selectedCase?.documents?.embryoOwnershipStatement?.ivfDate || '',
+      legacyShipmentPeriod: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod || null,
+    });
+    setGeneticAffinityCertificateDraft({
+      transferAttemptId: selectedCase?.documents?.geneticAffinityCertificate?.transferAttemptId || '',
+      hcgTestId: selectedCase?.documents?.geneticAffinityCertificate?.hcgTestId || '',
+      ultrasoundId: selectedCase?.documents?.geneticAffinityCertificate?.ultrasoundId || '',
+      issueDate: selectedCase?.documents?.geneticAffinityCertificate?.issueDate || '',
+      outgoingNumber: selectedCase?.documents?.geneticAffinityCertificate?.outgoingNumber || '',
+    });
+    setRacssClinicLetterDraft({
+      transferAttemptId: selectedCase?.documents?.racssClinicLetter?.transferAttemptId || '',
+      ultrasoundId: selectedCase?.documents?.racssClinicLetter?.ultrasoundId || '',
+    });
+    setMedicalServicesAgreementDraft({
+      date: selectedCase?.documents?.medicalServicesAgreement?.date || '',
     });
     setSelectedChildId('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -458,39 +492,86 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     }
   };
 
-  const updateEmbryoOwnershipField = (path, value) => setEmbryoOwnershipDraft(previous => {
-    if (path === 'ivfDate') return { ...previous, ivfDate: value };
-    return { ...previous, shipmentPeriod: { ...previous.shipmentPeriod, [path]: value } };
-  });
+  const updateEmbryoOwnershipShipmentId = shipmentId => setEmbryoOwnershipDraft(previous => ({ ...previous, shipmentId }));
 
-  // Every save normalizes ivfDate to ISO (spec §6: "під час наступного збереження нормалізувати
-  // дату до ISO") - a no-op once the field is already ISO, since normalizeIsoDate is idempotent,
-  // and the source `<input type="date">` already only ever emits ISO itself.
-  const handleSaveEmbryoOwnership = async () => {
+  // A generic "save one document sub-record" helper, shared by every document below - each just
+  // supplies its own storage key and cleaned payload; never writes an empty `{}` service object,
+  // same rule every document editor in this file already follows.
+  const saveCaseDocument = async (storageKey, payload, successMessage, failureLabel) => {
     if (!selectedCase) return;
-    const cleaned = removeEmptyCaseValues({
-      shipmentPeriod: embryoOwnershipDraft.shipmentPeriod,
-      ivfDate: normalizeIsoDate(embryoOwnershipDraft.ivfDate),
-    });
+    const cleaned = removeEmptyCaseValues(payload);
     const nextValue = Object.keys(cleaned).length ? cleaned : null;
     try {
-      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/documents/embryoOwnershipStatement`), nextValue);
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/documents/${storageKey}`), nextValue);
       setCatalog(previous => ({
         ...previous,
         cases: previous.cases.map(item => {
           if (String(item.id) !== String(selectedCase.id)) return item;
           const documents = { ...(item.documents || {}) };
-          if (nextValue) documents.embryoOwnershipStatement = nextValue;
-          else delete documents.embryoOwnershipStatement;
+          if (nextValue) documents[storageKey] = nextValue;
+          else delete documents[storageKey];
           return { ...item, documents };
         }),
       }));
-      toast.success('Embryo ownership statement details saved.');
+      toast.success(successMessage);
     } catch (saveError) {
-      console.error('Unable to save the embryo ownership statement details', saveError);
-      toast.error(`Could not save the embryo ownership statement details: ${describeSaveError(saveError)}`);
+      console.error(`Unable to save ${failureLabel}`, saveError);
+      toast.error(`Could not save ${failureLabel}: ${describeSaveError(saveError)}`);
     }
   };
+
+  // Spec §14: a fresh save always writes shipmentId once the admin has actually picked one from
+  // the dropdown; only a case that's still untouched (no shipmentId chosen at all) keeps whatever
+  // legacy ivfDate/shipmentPeriod it already had, so simply opening and saving this editor never
+  // destroys not-yet-migrated data.
+  const handleSaveEmbryoOwnership = () => {
+    const payload = embryoOwnershipDraft.shipmentId
+      ? { shipmentId: embryoOwnershipDraft.shipmentId }
+      : {
+        ivfDate: normalizeIsoDate(embryoOwnershipDraft.legacyIvfDate),
+        shipmentPeriod: embryoOwnershipDraft.legacyShipmentPeriod,
+      };
+    return saveCaseDocument('embryoOwnershipStatement', payload, 'Embryo ownership statement details saved.', 'the embryo ownership statement details');
+  };
+
+  const updateGeneticAffinityCertificateField = (field, value) => setGeneticAffinityCertificateDraft(previous => {
+    // Picking a different transfer attempt invalidates whatever hCG test/ultrasound was selected
+    // from the previous one - they belong to a specific transfer, never shared across transfers.
+    if (field === 'transferAttemptId') return { ...previous, transferAttemptId: value, hcgTestId: '', ultrasoundId: '' };
+    return { ...previous, [field]: value };
+  });
+
+  const handleSaveGeneticAffinityCertificate = () => saveCaseDocument(
+    'geneticAffinityCertificate',
+    {
+      transferAttemptId: geneticAffinityCertificateDraft.transferAttemptId,
+      hcgTestId: geneticAffinityCertificateDraft.hcgTestId,
+      ultrasoundId: geneticAffinityCertificateDraft.ultrasoundId,
+      issueDate: normalizeIsoDate(geneticAffinityCertificateDraft.issueDate),
+      outgoingNumber: geneticAffinityCertificateDraft.outgoingNumber,
+    },
+    'Genetic affinity certificate details saved.',
+    'the genetic affinity certificate details',
+  );
+
+  const updateRacssClinicLetterField = (field, value) => setRacssClinicLetterDraft(previous => {
+    if (field === 'transferAttemptId') return { ...previous, transferAttemptId: value, ultrasoundId: '' };
+    return { ...previous, [field]: value };
+  });
+
+  const handleSaveRacssClinicLetter = () => saveCaseDocument(
+    'racssClinicLetter',
+    { transferAttemptId: racssClinicLetterDraft.transferAttemptId, ultrasoundId: racssClinicLetterDraft.ultrasoundId },
+    'RACSS clinic letter details saved.',
+    'the RACSS clinic letter details',
+  );
+
+  const handleSaveMedicalServicesAgreement = () => saveCaseDocument(
+    'medicalServicesAgreement',
+    { date: normalizeIsoDate(medicalServicesAgreementDraft.date) },
+    'Medical services agreement details saved.',
+    'the medical services agreement details',
+  );
 
   if (!selectedCase) return null;
 
@@ -758,36 +839,147 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
         </PrimaryMiniButton>
       </RowLine>
 
-      <SectionSubhead style={{ marginTop: 14 }}>Приналежність ембріонів</SectionSubhead>
+      <SectionSubhead style={{ marginTop: 14 }}>Заява про належність ембріонів</SectionSubhead>
+      <FieldGrid>
+        <Field style={{ flex: 1, minWidth: 220 }}>
+          Доставлення
+          <Select value={embryoOwnershipDraft.shipmentId || ''} onChange={event => updateEmbryoOwnershipShipmentId(event.target.value)}>
+            <option value="">— не обрано —</option>
+            {artShipments.map(shipment => (
+              <option key={shipment.id} value={shipment.id}>
+                {formatShipmentOptionLabel(shipment, catalog.parties) || shipment.id}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      </FieldGrid>
+      {!embryoOwnershipDraft.shipmentId && (embryoOwnershipDraft.legacyIvfDate || embryoOwnershipDraft.legacyShipmentPeriod?.uk) ? (
+        <DocSubtitle style={{ marginTop: 6 }}>
+          Мігровані дані (зберігаються без змін, поки не обрано доставлення):
+          {' '}{embryoOwnershipDraft.legacyShipmentPeriod?.uk || ''} {embryoOwnershipDraft.legacyIvfDate || ''}
+        </DocSubtitle>
+      ) : null}
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveEmbryoOwnership}>
+          Save embryo ownership statement details
+        </PrimaryMiniButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Довідка про генетичну спорідненість</SectionSubhead>
       <FieldGrid>
         <Field>
-          Період передачі ембріонів (укр)
-          <FieldInput
-            type="text"
-            value={embryoOwnershipDraft.shipmentPeriod.uk || ''}
-            onChange={event => updateEmbryoOwnershipField('uk', event.target.value)}
-          />
+          Спроба переносу (довідка)
+          <Select
+            value={geneticAffinityCertificateDraft.transferAttemptId || ''}
+            onChange={event => updateGeneticAffinityCertificateField('transferAttemptId', event.target.value)}
+          >
+            <option value="">— не обрано —</option>
+            {artTransferAttempts.map(transferAttempt => (
+              <option key={transferAttempt.id} value={transferAttempt.id}>
+                {formatTransferOptionLabel(transferAttempt) || transferAttempt.id}
+              </option>
+            ))}
+          </Select>
         </Field>
         <Field>
-          Період передачі ембріонів (eng)
-          <FieldInput
-            type="text"
-            value={embryoOwnershipDraft.shipmentPeriod.en || ''}
-            onChange={event => updateEmbryoOwnershipField('en', event.target.value)}
-          />
+          ХГЧ (довідка)
+          <Select
+            value={geneticAffinityCertificateDraft.hcgTestId || ''}
+            onChange={event => updateGeneticAffinityCertificateField('hcgTestId', event.target.value)}
+            disabled={!certificateTransfer}
+          >
+            <option value="">— не обрано —</option>
+            {certificateHcgTests.map(hcgTest => (
+              <option key={hcgTest.id} value={hcgTest.id}>{formatHcgTestOptionLabel(hcgTest) || hcgTest.id}</option>
+            ))}
+          </Select>
         </Field>
         <Field>
-          Дата програми ЗІВ
+          УЗД (довідка)
+          <Select
+            value={geneticAffinityCertificateDraft.ultrasoundId || ''}
+            onChange={event => updateGeneticAffinityCertificateField('ultrasoundId', event.target.value)}
+            disabled={!certificateTransfer}
+          >
+            <option value="">— не обрано —</option>
+            {certificateUltrasounds.map(ultrasound => (
+              <option key={ultrasound.id} value={ultrasound.id}>{formatUltrasoundOptionLabel(ultrasound) || ultrasound.id}</option>
+            ))}
+          </Select>
+        </Field>
+        <Field>
+          Дата видачі
           <FieldInput
             type="date"
-            value={embryoOwnershipDraft.ivfDate || ''}
-            onChange={event => updateEmbryoOwnershipField('ivfDate', event.target.value)}
+            value={geneticAffinityCertificateDraft.issueDate || ''}
+            onChange={event => updateGeneticAffinityCertificateField('issueDate', event.target.value)}
+          />
+        </Field>
+        <Field>
+          Вихідний номер
+          <FieldInput
+            type="text"
+            value={geneticAffinityCertificateDraft.outgoingNumber || ''}
+            onChange={event => updateGeneticAffinityCertificateField('outgoingNumber', event.target.value)}
           />
         </Field>
       </FieldGrid>
       <RowLine style={{ marginTop: 8 }}>
-        <PrimaryMiniButton type="button" onClick={handleSaveEmbryoOwnership}>
-          Save embryo ownership statement details
+        <PrimaryMiniButton type="button" onClick={handleSaveGeneticAffinityCertificate}>
+          Save genetic affinity certificate details
+        </PrimaryMiniButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Лист клініки до РАЦС</SectionSubhead>
+      <FieldGrid>
+        <Field>
+          Спроба переносу (лист РАЦС)
+          <Select
+            value={racssClinicLetterDraft.transferAttemptId || ''}
+            onChange={event => updateRacssClinicLetterField('transferAttemptId', event.target.value)}
+          >
+            <option value="">— не обрано —</option>
+            {artTransferAttempts.map(transferAttempt => (
+              <option key={transferAttempt.id} value={transferAttempt.id}>
+                {formatTransferOptionLabel(transferAttempt) || transferAttempt.id}
+              </option>
+            ))}
+          </Select>
+        </Field>
+        <Field>
+          УЗД (лист РАЦС)
+          <Select
+            value={racssClinicLetterDraft.ultrasoundId || ''}
+            onChange={event => updateRacssClinicLetterField('ultrasoundId', event.target.value)}
+            disabled={!letterTransfer}
+          >
+            <option value="">— не обрано —</option>
+            {letterUltrasounds.map(ultrasound => (
+              <option key={ultrasound.id} value={ultrasound.id}>{formatUltrasoundOptionLabel(ultrasound) || ultrasound.id}</option>
+            ))}
+          </Select>
+        </Field>
+      </FieldGrid>
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveRacssClinicLetter}>
+          Save RACSS clinic letter details
+        </PrimaryMiniButton>
+      </RowLine>
+
+      <SectionSubhead style={{ marginTop: 14 }}>Договір про медичні послуги</SectionSubhead>
+      <FieldGrid>
+        <Field>
+          Дата договору про медичні послуги
+          <FieldInput
+            type="date"
+            value={medicalServicesAgreementDraft.date || ''}
+            onChange={event => setMedicalServicesAgreementDraft({ date: event.target.value })}
+          />
+        </Field>
+      </FieldGrid>
+      <RowLine style={{ marginTop: 8 }}>
+        <PrimaryMiniButton type="button" onClick={handleSaveMedicalServicesAgreement}>
+          Save medical services agreement details
         </PrimaryMiniButton>
       </RowLine>
     </Section>

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -72,6 +72,7 @@ import {
   toggleRawInlineMarker,
   upsertRecentCaseId,
   upsertRecentId,
+  validateArtProgramReferences,
   validateBirthRegistrationCase,
   validateCaseRecord,
   validateDocumentTemplate,
@@ -1628,6 +1629,12 @@ const DocumentsPage = ({ isAdmin }) => {
   const referencesBirthDomain = referencesPathDomain([
     'child', 'children', 'medicalConclusion', 'birthRegistration', 'case.childbirth', 'case.documents.birthRegistrationConsent',
   ]);
+  // Same idea, scoped to the ART-program-referencing documents (spec §13/§15): a shipment/transfer/
+  // hCG/ultrasound id that no longer resolves gets its own specific message here instead of
+  // drowning in the generic unresolved-{{placeholder}} list below.
+  const referencesArtDomain = referencesPathDomain([
+    'embryoOwnershipStatement', 'geneticAffinityCertificate', 'racssClinicLetter', 'case.artProgram',
+  ]);
   // Which relation each base checklist issue actually gates on - an issue with no listed domain
   // (case.id) is always relevant; everything else only matters once a checked document references
   // that data at all.
@@ -1649,6 +1656,7 @@ const DocumentsPage = ({ isAdmin }) => {
     ? [...new Set([
       ...validateCaseRecord(selectedCase).filter(isChecklistIssueRelevant),
       ...(referencesBirthDomain ? validateBirthRegistrationCase(catalog, selectedCaseId) : []),
+      ...(referencesArtDomain ? validateArtProgramReferences(catalog, selectedCaseId) : []),
     ])]
     : [];
   // A logo only ever appears where a template declares one - via the dedicated `logo` field, or

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -13,6 +13,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
+import CaseArtProgramEditor from './CaseArtProgramEditor';
 import CaseChildbirthTransactionEditor from './CaseChildbirthTransactionEditor';
 import {
   DOCUMENTS_CASES_PATH,
@@ -1042,6 +1043,8 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
                       valueIds={relations.representativeIds}
                       onToggle={(repId, include) => handleToggleRepresentative(caseRecord, repId, include)}
                     />
+
+                    <CaseArtProgramEditor catalog={catalog} setCatalog={setCatalog} caseId={caseRecord.id} />
 
                     <CaseChildbirthTransactionEditor catalog={catalog} setCatalog={setCatalog} caseId={caseRecord.id} />
 

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -1,0 +1,642 @@
+// Unit + integration tests for the ART program (case.artProgram) support: resolvers, formatters,
+// the four document contexts that reference it (embryoOwnershipStatement, geneticAffinityCertificate,
+// racssClinicLetter, medicalServicesAgreement), and couple.marriage enrichment.
+//
+// All fixtures below are fictional - tests must never carry real client data (same rule as
+// documentsCatalogUtils.test.js).
+import {
+  DERIVED_CONTEXT_FIELD_KEYS,
+  MISSING_VALUE_PLACEHOLDER,
+  buildEmbryoOwnershipStatementContext,
+  buildGeneticAffinityCertificateContext,
+  buildMedicalServicesAgreementContext,
+  buildRacssClinicLetterContext,
+  deepMergeRecords,
+  enrichCoupleMarriage,
+  enrichHcgTestForTemplate,
+  enrichShipment,
+  enrichShipmentForTemplate,
+  enrichTransferForTemplate,
+  enrichUltrasoundForTemplate,
+  fillPlaceholders,
+  formatDateNumericUk,
+  formatDateRange,
+  formatEmbryoCountTextUk,
+  formatGestationalAgeText,
+  formatHcgTestOptionLabel,
+  formatPregnancyTypeTextUk,
+  formatShipmentOptionLabel,
+  formatShipmentPeriod,
+  formatTransferOptionLabel,
+  formatUltrasoundOptionLabel,
+  mergeDocumentsCatalog,
+  normalizeDocumentsCatalog,
+  parseDocumentsTechnicalInput,
+  resolveCaseContext,
+  resolveEmbryoStageLabel,
+  resolveHcgTest,
+  resolveShipment,
+  resolveTransferAttempt,
+  resolveUltrasound,
+  stripDerivedFields,
+  validateArtProgramReferences,
+  validateDocumentTemplate,
+} from './documentsCatalogUtils';
+
+// --- Fixtures ------------------------------------------------------------------------------
+
+const partnerClinic = {
+  id: 'partner-clinic-fixture',
+  name: { uk: 'Клініка Тестова', en: 'Test Clinic' },
+  country: { uk: 'Японія', en: 'Japan' },
+  address: { uk: 'Адреса', en: 'Address' },
+};
+
+const clinic = {
+  id: 'clinic-fixture',
+  name: { uk: 'МЦ Приклад', en: 'MC Example' },
+  legalName: { uk: 'ТОВ «Приклад»', en: 'Example LLC' },
+};
+
+const rawParties = {
+  clinics: { [clinic.id]: clinic },
+  partnerClinics: { [partnerClinic.id]: partnerClinic },
+};
+
+// enrichShipment (and everything built on it) reads `parties.clinics`/`parties.partnerClinics` as
+// arrays - the same normalized shape resolveCaseContext always passes it (catalog.parties from
+// normalizeDocumentsCatalog), never the raw id-keyed map a Firebase snapshot carries.
+const parties = normalizeDocumentsCatalog(rawParties, {}, {}).parties;
+
+// A case that uses the new startDate/endDate planned-period shape (spec: "Kikawa" scenario).
+const caseWithDateRangePeriod = {
+  id: 'case-daterange',
+  relations: { clinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  artProgram: {
+    medicalIndication: { diagnosis: { uk: 'Тестовий діагноз' } },
+    geneticMaterial: { oocyteSourcePartnerRole: 'wife', spermSourcePartnerRole: 'husband' },
+    medicalTeam: { physician: { name: { uk: { nominative: 'Тестова Лікарка Лікарівна' } } } },
+    embryoShipments: {
+      'shipment-1': {
+        id: 'shipment-1',
+        sourceClinicId: partnerClinic.id,
+        destinationClinicId: clinic.id,
+        ivfDate: '2021-08-17',
+        plannedPeriod: { startDate: '2026-01-01', endDate: '2026-02-01' },
+        receivedDate: '2025-08-27',
+      },
+    },
+    transferAttempts: {
+      'transfer-1': {
+        id: 'transfer-1',
+        shipmentId: 'shipment-1',
+        date: '2025-09-18',
+        embryoCount: 1,
+        embryoStage: 'blastocyst',
+        hcgTests: {
+          'hcg-1': { id: 'hcg-1', date: '2025-09-30', positive: true },
+        },
+        ultrasounds: {
+          'ultrasound-1': {
+            id: 'ultrasound-1', date: '2025-10-17', pregnancyConfirmed: true, fetusCount: 1, gestationalAgeWeeks: { from: 6, to: 7 },
+          },
+        },
+      },
+      'transfer-2': {
+        id: 'transfer-2',
+        shipmentId: 'shipment-1',
+        date: '2025-11-01',
+        embryoCount: 2,
+        embryoStage: 'blastocyst',
+        hcgTests: {
+          'hcg-2': { id: 'hcg-2', date: '2025-11-15', positive: false },
+        },
+        ultrasounds: {},
+      },
+    },
+  },
+  documents: {
+    embryoOwnershipStatement: { shipmentId: 'shipment-1' },
+    geneticAffinityCertificate: {
+      transferAttemptId: 'transfer-1', hcgTestId: 'hcg-1', ultrasoundId: 'ultrasound-1', issueDate: '2025-10-20', outgoingNumber: '42/1',
+    },
+    racssClinicLetter: { transferAttemptId: 'transfer-1', ultrasoundId: 'ultrasound-1' },
+    medicalServicesAgreement: { date: '2025-09-12' },
+  },
+};
+
+// A case that only ever carries the migrated freeform text period (spec: "Katsura" scenario).
+const caseWithTextPeriod = {
+  id: 'case-textperiod',
+  relations: { clinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  artProgram: {
+    embryoShipments: {
+      'shipment-1': {
+        id: 'shipment-1',
+        sourceClinicId: partnerClinic.id,
+        destinationClinicId: clinic.id,
+        ivfDate: '2021-08-17',
+        plannedPeriod: { text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } },
+      },
+    },
+  },
+  documents: {
+    embryoOwnershipStatement: { shipmentId: 'shipment-1' },
+  },
+};
+
+// A pre-artProgram case: no artProgram at all, and embryoOwnershipStatement still stored the old
+// way (spec §14 backward compatibility).
+const caseWithoutArtProgram = {
+  id: 'case-old',
+  relations: { clinicId: clinic.id },
+  documents: {
+    embryoOwnershipStatement: {
+      ivfDate: '2021-08-17',
+      shipmentPeriod: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' },
+    },
+  },
+};
+
+// Every document reference points at an id that doesn't exist (spec §13/§15).
+const caseWithBrokenReferences = {
+  id: 'case-broken',
+  relations: { clinicId: clinic.id },
+  artProgram: {
+    embryoShipments: {
+      'shipment-1': { id: 'shipment-1', sourceClinicId: partnerClinic.id, destinationClinicId: clinic.id },
+    },
+    transferAttempts: {
+      'transfer-1': {
+        id: 'transfer-1', shipmentId: 'shipment-1', date: '2025-09-18', hcgTests: {}, ultrasounds: {},
+      },
+    },
+  },
+  documents: {
+    embryoOwnershipStatement: { shipmentId: 'shipment-999' },
+    geneticAffinityCertificate: { transferAttemptId: 'transfer-999', hcgTestId: 'hcg-999', ultrasoundId: 'ultrasound-999' },
+    racssClinicLetter: { transferAttemptId: 'transfer-1', ultrasoundId: 'ultrasound-999' },
+  },
+};
+
+const buildCatalog = (...cases) => normalizeDocumentsCatalog(
+  rawParties,
+  {},
+  Object.fromEntries(cases.map(caseRecord => [caseRecord.id, caseRecord])),
+);
+
+// --- Resolvers -------------------------------------------------------------------------------
+
+describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferAttempt/resolveHcgTest/resolveUltrasound)', () => {
+  it('resolves an existing shipment/transferAttempt by id', () => {
+    const { artProgram } = caseWithDateRangePeriod;
+    expect(resolveShipment(caseWithDateRangePeriod, 'shipment-1')).toBe(artProgram.embryoShipments['shipment-1']);
+    expect(resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1')).toBe(artProgram.transferAttempts['transfer-1']);
+  });
+
+  it('resolves an existing hCG test/ultrasound from within its transfer attempt', () => {
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+    expect(resolveHcgTest(transfer, 'hcg-1')).toBe(transfer.hcgTests['hcg-1']);
+    expect(resolveUltrasound(transfer, 'ultrasound-1')).toBe(transfer.ultrasounds['ultrasound-1']);
+  });
+
+  it('never throws and returns null for a missing/unset id, a missing artProgram, or a missing case', () => {
+    expect(resolveShipment(null, 'shipment-1')).toBeNull();
+    expect(resolveShipment(caseWithDateRangePeriod, '')).toBeNull();
+    expect(resolveShipment(caseWithDateRangePeriod, undefined)).toBeNull();
+    expect(resolveShipment(caseWithoutArtProgram, 'shipment-1')).toBeNull();
+    expect(resolveShipment(caseWithDateRangePeriod, 'shipment-999')).toBeNull();
+    expect(resolveTransferAttempt(caseWithoutArtProgram, 'transfer-1')).toBeNull();
+    expect(resolveHcgTest(null, 'hcg-1')).toBeNull();
+    expect(resolveHcgTest({ hcgTests: {} }, 'hcg-1')).toBeNull();
+    expect(resolveUltrasound(null, 'ultrasound-1')).toBeNull();
+  });
+
+  it('a second transfer attempt never overwrites or shadows the first (independent lookup by id)', () => {
+    expect(resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1').embryoCount).toBe(1);
+    expect(resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-2').embryoCount).toBe(2);
+  });
+
+  it('enrichShipment attaches sourceClinic (partnerClinics) and destinationClinic (clinics), null-safe', () => {
+    const shipment = resolveShipment(caseWithDateRangePeriod, 'shipment-1');
+    const enriched = enrichShipment(shipment, parties);
+    expect(enriched.sourceClinic).toBe(partnerClinic);
+    expect(enriched.destinationClinic).toBe(clinic);
+    expect(enrichShipment(null, parties)).toBeNull();
+  });
+});
+
+// --- Formatters --------------------------------------------------------------------------------
+
+describe('spec §6: ART formatters', () => {
+  it('formatDateNumericUk formats an ISO date as DD.MM.YYYY, and blank/invalid input as \'\'', () => {
+    expect(formatDateNumericUk('2025-09-18')).toBe('18.09.2025');
+    expect(formatDateNumericUk('')).toBe('');
+    expect(formatDateNumericUk(undefined)).toBe('');
+    expect(formatDateNumericUk('not-a-date')).toBe('');
+  });
+
+  it('formatDateRange renders a numeric uk range and a long-form en range', () => {
+    expect(formatDateRange('2026-01-01', '2026-02-01', 'uk')).toBe('01.01.2026 – 01.02.2026');
+    expect(formatDateRange('2026-01-01', '2026-02-01', 'en')).toBe('01 January 2026 - 01 February 2026');
+  });
+
+  it('formatShipmentPeriod prefers startDate/endDate when present, falls back to the migrated text', () => {
+    expect(formatShipmentPeriod({ startDate: '2026-01-01', endDate: '2026-02-01' }, 'uk')).toBe('01.01.2026 – 01.02.2026');
+    expect(formatShipmentPeriod({ text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } }, 'uk')).toBe('квітні – травні 2026 року');
+    expect(formatShipmentPeriod({ text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } }, 'en')).toBe('April-May 2026');
+    expect(formatShipmentPeriod(null, 'uk')).toBe('');
+    expect(formatShipmentPeriod({}, 'uk')).toBe('');
+  });
+
+  it('resolveEmbryoStageLabel resolves a known code and degrades to blanks for an unknown one', () => {
+    expect(resolveEmbryoStageLabel('blastocyst')).toEqual({
+      uk: { nominative: 'бластоциста', genitive: 'бластоцисти' },
+      en: { nominative: 'blastocyst' },
+    });
+    expect(resolveEmbryoStageLabel('unknown-stage')).toEqual({ uk: { nominative: '', genitive: '' }, en: { nominative: '' } });
+    expect(resolveEmbryoStageLabel(undefined)).toEqual({ uk: { nominative: '', genitive: '' }, en: { nominative: '' } });
+  });
+
+  it('formatEmbryoCountTextUk matches every spec example exactly (cardinal + noun agreement)', () => {
+    expect(formatEmbryoCountTextUk(1)).toBe('один ембріон');
+    expect(formatEmbryoCountTextUk(2)).toBe('два ембріони');
+    expect(formatEmbryoCountTextUk(3)).toBe('три ембріони');
+    expect(formatEmbryoCountTextUk(5)).toBe("п'ять ембріонів");
+    expect(formatEmbryoCountTextUk(0)).toBe('');
+    expect(formatEmbryoCountTextUk(undefined)).toBe('');
+    expect(formatEmbryoCountTextUk(null)).toBe('');
+  });
+
+  it('formatGestationalAgeText renders a real 6-7 week range, and degrades to a single value or blank', () => {
+    expect(formatGestationalAgeText({ from: 6, to: 7 })).toBe('6–7 тижнів');
+    expect(formatGestationalAgeText({ from: 6, to: 6 })).toBe('6 тижнів');
+    expect(formatGestationalAgeText({ from: 1, to: 1 })).toBe('1 тиждень');
+    expect(formatGestationalAgeText({ from: 6 })).toBe('6 тижнів');
+    expect(formatGestationalAgeText({})).toBe('');
+    expect(formatGestationalAgeText(undefined)).toBe('');
+  });
+
+  it('formatPregnancyTypeTextUk is driven solely by fetusCount, never a stored source field', () => {
+    expect(formatPregnancyTypeTextUk(1)).toBe('одноплідна');
+    expect(formatPregnancyTypeTextUk(2)).toBe('двоплідна');
+    expect(formatPregnancyTypeTextUk(3)).toBe('триплідна');
+    expect(formatPregnancyTypeTextUk(4)).toBe('');
+    expect(formatPregnancyTypeTextUk(undefined)).toBe('');
+  });
+});
+
+// --- Template-ready enrichers ------------------------------------------------------------------
+
+describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enrichHcgTestForTemplate/enrichUltrasoundForTemplate', () => {
+  it('enrichShipmentForTemplate adds formatted date/period fields on top of the party-enriched shipment', () => {
+    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod, 'shipment-1'), parties);
+    const enriched = enrichShipmentForTemplate(shipment);
+    expect(enriched.ivfDateFormatted).toEqual({ uk: '17.08.2021', en: '17 August 2021' });
+    expect(enriched.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
+    expect(enriched.receivedDateFormatted.uk).toBe('27.08.2025');
+    expect(enriched.sourceClinic).toBe(partnerClinic);
+    expect(enrichShipmentForTemplate(null)).toBeNull();
+  });
+
+  it('enrichTransferForTemplate adds dateFormatted/embryoCountText/embryoStageLabel and nests the enriched shipment', () => {
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod, transfer.shipmentId), parties);
+    const enriched = enrichTransferForTemplate(transfer, shipment);
+    expect(enriched.dateFormatted.uk).toBe('18.09.2025');
+    expect(enriched.embryoCountText.uk).toBe('один ембріон');
+    expect(enriched.embryoStageLabel.uk.genitive).toBe('бластоцисти');
+    expect(enriched.shipment.sourceClinic).toBe(partnerClinic);
+    expect(enrichTransferForTemplate(null, shipment)).toBeNull();
+  });
+
+  it('enrichHcgTestForTemplate/enrichUltrasoundForTemplate add their own formatted fields, null-safe', () => {
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+    const hcgTest = enrichHcgTestForTemplate(resolveHcgTest(transfer, 'hcg-1'));
+    expect(hcgTest.dateFormatted.uk).toBe('30.09.2025');
+    expect(enrichHcgTestForTemplate(null)).toBeNull();
+
+    const ultrasound = enrichUltrasoundForTemplate(resolveUltrasound(transfer, 'ultrasound-1'));
+    expect(ultrasound.dateFormatted.uk).toBe('17.10.2025');
+    expect(ultrasound.gestationalAgeText.uk).toBe('6–7 тижнів');
+    expect(ultrasound.pregnancyTypeText.uk).toBe('одноплідна');
+    expect(enrichUltrasoundForTemplate(null)).toBeNull();
+  });
+});
+
+// --- Document contexts -------------------------------------------------------------------------
+
+describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityCertificate/racssClinicLetter/medicalServicesAgreement)', () => {
+  it('embryoOwnershipStatement resolves shipment via shipmentId (startDate/endDate case)', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, parties, caseWithDateRangePeriod.documents.embryoOwnershipStatement);
+    expect(context.shipment.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
+    expect(context.shipment.sourceClinic).toBe(partnerClinic);
+    expect(context.shipment.destinationClinic).toBe(clinic);
+  });
+
+  it('embryoOwnershipStatement resolves shipment via shipmentId (migrated text case)', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithTextPeriod, parties, caseWithTextPeriod.documents.embryoOwnershipStatement);
+    expect(context.shipment.plannedPeriodFormatted.uk).toBe('квітні – травні 2026 року');
+    expect(context.shipment.plannedPeriodFormatted.en).toBe('April-May 2026');
+  });
+
+  it('spec §14: falls back to legacy ivfDate/shipmentPeriod fields when no shipmentId is set, never throwing', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithoutArtProgram, parties, caseWithoutArtProgram.documents.embryoOwnershipStatement);
+    expect(context.shipment.ivfDateFormatted.uk).toBe('17.08.2021');
+    expect(context.shipment.plannedPeriodFormatted.uk).toBe('квітні – травні 2026 року');
+    expect(context.shipment.sourceClinic).toBeNull();
+  });
+
+  it('a case with neither a shipmentId nor legacy fields resolves shipment to null, never throwing', () => {
+    const context = buildEmbryoOwnershipStatementContext({ id: 'bare-case' }, parties, undefined);
+    expect(context.shipment).toBeNull();
+  });
+
+  it('geneticAffinityCertificate resolves transferAttempt/hcgTest/ultrasound by id and computes the print-only fallback fields', () => {
+    const context = buildGeneticAffinityCertificateContext(
+      caseWithDateRangePeriod,
+      parties,
+      caseWithDateRangePeriod.documents.geneticAffinityCertificate,
+    );
+    expect(context.transferAttempt.embryoCountText.uk).toBe('один ембріон');
+    expect(context.transferAttempt.shipment.sourceClinic).toBe(partnerClinic);
+    expect(context.hcgTest.dateFormatted.uk).toBe('30.09.2025');
+    expect(context.ultrasound.gestationalAgeText.uk).toBe('6–7 тижнів');
+    expect(context.issueDateOrBlank.uk).toBe('20.10.2025');
+    expect(context.outgoingNumberOrBlank).toBe('42/1');
+  });
+
+  it('geneticAffinityCertificate falls back to print-only blanks (never persisted) when issueDate/outgoingNumber are unset', () => {
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, { transferAttemptId: 'transfer-1' });
+    expect(context.issueDateOrBlank.uk).toBe('__.__.____');
+    expect(context.outgoingNumberOrBlank).toBe('______');
+  });
+
+  it('racssClinicLetter resolves its own transferAttempt/ultrasound independently of geneticAffinityCertificate', () => {
+    const context = buildRacssClinicLetterContext(caseWithDateRangePeriod, parties, caseWithDateRangePeriod.documents.racssClinicLetter);
+    expect(context.transferAttempt.shipment.receivedDateFormatted.uk).toBe('27.08.2025');
+    expect(context.ultrasound.dateFormatted.uk).toBe('17.10.2025');
+  });
+
+  it('medicalServicesAgreement computes dateFormatted in both languages, blank when unset', () => {
+    expect(buildMedicalServicesAgreementContext({ date: '2025-09-12' }).dateFormatted).toEqual({ uk: '12.09.2025', en: '12 September 2025' });
+    expect(buildMedicalServicesAgreementContext({}).dateFormatted).toEqual({ uk: '', en: '' });
+    expect(buildMedicalServicesAgreementContext(undefined).dateFormatted).toEqual({ uk: '', en: '' });
+  });
+});
+
+// --- couple.marriage enrichment -----------------------------------------------------------------
+
+describe('spec §10: couple.marriage dateFormatted/certificateDateFormatted, old fields kept', () => {
+  it('adds dateFormatted/certificateDateFormatted on top of the new date/certificateType/certificateIssuedBy shape', () => {
+    const couple = {
+      marriage: {
+        date: '2017-11-25',
+        certificateType: { uk: 'Витяг', en: 'Extract' },
+        certificateNumber: '00554629',
+        certificateDate: '2025-04-23',
+        certificateIssuedBy: { uk: 'Мером', en: 'Mayor' },
+      },
+    };
+    const enriched = enrichCoupleMarriage(couple);
+    expect(enriched.marriage.dateFormatted).toEqual({ uk: '25.11.2017', en: '25 November 2017' });
+    expect(enriched.marriage.certificateDateFormatted).toEqual({ uk: '23.04.2025', en: '23 April 2025' });
+    expect(enriched.marriage.certificateType).toEqual({ uk: 'Витяг', en: 'Extract' });
+  });
+
+  it('an old certificateNumber/certificateDate-only record keeps its fields and still gets certificateDateFormatted', () => {
+    const couple = { marriage: { certificateNumber: 'AB-123', certificateDate: '2020-11-22' } };
+    const enriched = enrichCoupleMarriage(couple);
+    expect(enriched.marriage.certificateNumber).toBe('AB-123');
+    expect(enriched.marriage.certificateDateFormatted.uk).toBe('22.11.2020');
+    expect(enriched.marriage.dateFormatted).toEqual({ uk: '', en: '' });
+  });
+
+  it('a couple with no marriage record, or no couple at all, passes through unchanged', () => {
+    expect(enrichCoupleMarriage({ address: { uk: 'Київ' } })).toEqual({ address: { uk: 'Київ' } });
+    expect(enrichCoupleMarriage(null)).toBeNull();
+    expect(enrichCoupleMarriage(undefined)).toBeUndefined();
+  });
+});
+
+// --- validateArtProgramReferences (spec §13/§15) -------------------------------------------------
+
+describe('spec §13/§15: validateArtProgramReferences reports specific, actionable messages', () => {
+  it('reports one message per broken reference, never a generic "field missing"', () => {
+    const catalog = buildCatalog(caseWithBrokenReferences);
+    const issues = validateArtProgramReferences(catalog, 'case-broken');
+    expect(issues).toContain('Не знайдено доставлення ембріонів shipment-999.');
+    expect(issues).toContain('Не знайдено спробу переносу transfer-999.');
+    expect(issues).toContain('Не знайдено УЗД ultrasound-999 у переносі transfer-1.');
+  });
+
+  it('a broken hcgTestId/ultrasoundId under a broken transferAttemptId is only reported once, via the transfer message', () => {
+    const catalog = buildCatalog(caseWithBrokenReferences);
+    const issues = validateArtProgramReferences(catalog, 'case-broken');
+    expect(issues.filter(issue => issue.includes('transfer-999')).length).toBe(1);
+  });
+
+  it('a fully-valid case reports no issues', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    expect(validateArtProgramReferences(catalog, 'case-daterange')).toEqual([]);
+  });
+
+  it('a missing case id resolves to no issues rather than throwing', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    expect(() => validateArtProgramReferences(catalog, 'does-not-exist')).not.toThrow();
+    expect(validateArtProgramReferences(catalog, 'does-not-exist')).toEqual([]);
+  });
+});
+
+// --- Dropdown option labels (spec §9) -------------------------------------------------------------
+
+describe('spec §9: human-readable dropdown labels, never a raw id', () => {
+  it('formats a shipment/transfer/hcgTest/ultrasound as the exact spec example shapes', () => {
+    const shipment = resolveShipment(caseWithDateRangePeriod, 'shipment-1');
+    expect(formatShipmentOptionLabel(shipment, parties)).toBe('Доставлення 27.08.2025 — Клініка Тестова');
+
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+    expect(formatTransferOptionLabel(transfer)).toBe('Перенос 18.09.2025 — один ембріон');
+
+    const hcgTest = resolveHcgTest(transfer, 'hcg-1');
+    expect(formatHcgTestOptionLabel(hcgTest)).toBe('ХГЧ 30.09.2025 — позитивний');
+
+    const ultrasound = resolveUltrasound(transfer, 'ultrasound-1');
+    expect(formatUltrasoundOptionLabel(ultrasound)).toBe('УЗД 17.10.2025 — 1 плід, 6–7 тижнів');
+  });
+
+  it('every label helper is null-safe', () => {
+    expect(formatShipmentOptionLabel(null, parties)).toBe('');
+    expect(formatTransferOptionLabel(null)).toBe('');
+    expect(formatHcgTestOptionLabel(null)).toBe('');
+    expect(formatUltrasoundOptionLabel(null)).toBe('');
+  });
+});
+
+// --- resolveCaseContext / fillPlaceholders integration ---------------------------------------
+
+describe('integration: resolveCaseContext wires every ART document context in, null-safe throughout', () => {
+  it('resolves embryoOwnershipStatement/geneticAffinityCertificate/racssClinicLetter/medicalServicesAgreement on the context', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const context = resolveCaseContext(catalog, 'case-daterange');
+    expect(fillPlaceholders('{{embryoOwnershipStatement.shipment.sourceClinic.name.uk}}', context, 'uk')).toBe('Клініка Тестова');
+    expect(fillPlaceholders('{{embryoOwnershipStatement.shipment.plannedPeriodFormatted.uk}}', context, 'uk')).toBe('01.01.2026 – 01.02.2026');
+    expect(fillPlaceholders('{{geneticAffinityCertificate.transferAttempt.dateFormatted.uk}}', context, 'uk')).toBe('18.09.2025');
+    expect(fillPlaceholders('{{geneticAffinityCertificate.transferAttempt.embryoStageLabel.uk.genitive}}', context, 'uk')).toBe('бластоцисти');
+    expect(fillPlaceholders('{{geneticAffinityCertificate.hcgTest.dateFormatted.uk}}', context, 'uk')).toBe('30.09.2025');
+    expect(fillPlaceholders('{{geneticAffinityCertificate.ultrasound.gestationalAgeText.uk}}', context, 'uk')).toBe('6–7 тижнів');
+    expect(fillPlaceholders('{{racssClinicLetter.transferAttempt.shipment.receivedDateFormatted.uk}}', context, 'uk')).toBe('27.08.2025');
+    expect(fillPlaceholders('{{medicalServicesAgreement.dateFormatted.uk}}', context, 'uk')).toBe('12.09.2025');
+    expect(fillPlaceholders('{{case.artProgram.medicalIndication.diagnosis.uk}}', context, 'uk')).toBe('Тестовий діагноз');
+  });
+
+  it('a template using every geneticAffinityCertificate/racssClinicLetter placeholder resolves with zero unresolved variables (spec: "не містить необроблених {{...}}")', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const context = resolveCaseContext(catalog, 'case-daterange');
+    const template = {
+      title: { uk: '' },
+      paragraphs: [
+        {
+          uk: [
+            '{{geneticAffinityCertificate.transferAttempt.dateFormatted.uk}}',
+            '{{geneticAffinityCertificate.transferAttempt.embryoCountText.uk}}',
+            '{{geneticAffinityCertificate.transferAttempt.embryoStageLabel.uk.genitive}}',
+            '{{geneticAffinityCertificate.transferAttempt.shipment.sourceClinic.name.uk}}',
+            '{{geneticAffinityCertificate.transferAttempt.shipment.receivedDateFormatted.uk}}',
+            '{{geneticAffinityCertificate.hcgTest.dateFormatted.uk}}',
+            '{{geneticAffinityCertificate.ultrasound.dateFormatted.uk}}',
+            '{{geneticAffinityCertificate.ultrasound.gestationalAgeText.uk}}',
+            '{{geneticAffinityCertificate.ultrasound.pregnancyTypeText.uk}}',
+            '{{geneticAffinityCertificate.issueDateOrBlank.uk}}',
+            '{{geneticAffinityCertificate.outgoingNumberOrBlank}}',
+            '{{racssClinicLetter.transferAttempt.shipment.receivedDateFormatted.uk}}',
+            '{{racssClinicLetter.ultrasound.dateFormatted.uk}}',
+          ].join(' '),
+        },
+      ],
+    };
+    expect(validateDocumentTemplate(template, context)).toEqual([]);
+  });
+
+  it('spec §8/§9: editing a shared transfer/ultrasound once is reflected simultaneously in geneticAffinityCertificate and racssClinicLetter', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const edited = deepMergeRecords(catalog.cases.find(item => item.id === 'case-daterange'), {
+      artProgram: { transferAttempts: { 'transfer-1': { date: '2026-03-03' } } },
+    });
+    const nextCatalog = { ...catalog, cases: catalog.cases.map(item => (item.id === 'case-daterange' ? edited : item)) };
+    const context = resolveCaseContext(nextCatalog, 'case-daterange');
+    expect(context.geneticAffinityCertificate.transferAttempt.dateFormatted.uk).toBe('03.03.2026');
+    expect(context.racssClinicLetter.transferAttempt.dateFormatted.uk).toBe('03.03.2026');
+  });
+
+  it('a case with no artProgram at all resolves every ART context to a non-throwing, mostly-null shape (no white screen)', () => {
+    const catalog = buildCatalog(caseWithoutArtProgram);
+    const context = resolveCaseContext(catalog, 'case-old');
+    expect(context.case.artProgram).toBeUndefined();
+    expect(context.geneticAffinityCertificate.transferAttempt).toBeNull();
+    expect(context.geneticAffinityCertificate.hcgTest).toBeNull();
+    expect(context.racssClinicLetter.transferAttempt).toBeNull();
+    expect(() => fillPlaceholders('{{geneticAffinityCertificate.transferAttempt.dateFormatted.uk}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{geneticAffinityCertificate.transferAttempt.dateFormatted.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+
+  it('a case with dangling reference ids resolves without throwing, and validateArtProgramReferences names the exact missing event', () => {
+    const catalog = buildCatalog(caseWithBrokenReferences);
+    const context = resolveCaseContext(catalog, 'case-broken');
+    expect(() => fillPlaceholders('{{embryoOwnershipStatement.shipment.sourceClinic.name.uk}}', context, 'uk')).not.toThrow();
+    expect(context.embryoOwnershipStatement.shipment).toBeNull();
+    expect(validateArtProgramReferences(catalog, 'case-broken').length).toBeGreaterThan(0);
+  });
+
+  it('hCG/ultrasound are selected strictly by id, not array order - picking the second test/scan of a transfer resolves the right one', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const context = resolveCaseContext(catalog, 'case-daterange', undefined);
+    // transfer-2 carries only hcg-2 (negative) - a document referencing it must never accidentally
+    // resolve transfer-1's hcg-1 (positive) instead.
+    const caseRecord = catalog.cases.find(item => item.id === 'case-daterange');
+    const built = buildGeneticAffinityCertificateContext(caseRecord, catalog.parties, { transferAttemptId: 'transfer-2', hcgTestId: 'hcg-2' });
+    expect(built.hcgTest.positive).toBe(false);
+    expect(built.hcgTest.dateFormatted.uk).toBe('15.11.2025');
+    expect(context).toBeTruthy(); // context built successfully above too
+  });
+});
+
+// --- Export / stripDerivedFields (spec §11/§12) -------------------------------------------------
+
+describe('spec §11/§12: ART-derived fields are never written back to Firebase', () => {
+  it('DERIVED_CONTEXT_FIELD_KEYS lists every runtime-only ART field named in the spec', () => {
+    ['plannedPeriodFormatted', 'ivfDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
+      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank']
+      .forEach(key => expect(DERIVED_CONTEXT_FIELD_KEYS).toContain(key));
+  });
+
+  it('stripDerivedFields removes every derived key from a resolved geneticAffinityCertificate/embryoOwnershipStatement context', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const context = resolveCaseContext(catalog, 'case-daterange');
+    const stripped = stripDerivedFields({
+      embryoOwnershipStatement: context.embryoOwnershipStatement,
+      geneticAffinityCertificate: context.geneticAffinityCertificate,
+      couple: context.couple,
+    });
+    const serialized = JSON.stringify(stripped);
+    DERIVED_CONTEXT_FIELD_KEYS.forEach(key => expect(serialized).not.toContain(`"${key}"`));
+  });
+
+  it('the source case record itself never gained any derived field just by being resolved (resolveCaseContext never mutates)', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const rawCase = catalog.cases.find(item => item.id === 'case-daterange');
+    const serialized = JSON.stringify(rawCase);
+    resolveCaseContext(catalog, 'case-daterange');
+    expect(JSON.stringify(rawCase)).toBe(serialized);
+  });
+});
+
+// --- Import/export round trip stays additive (spec §12) ------------------------------------------
+
+describe('spec §12: import/merge keeps embryoShipments/transferAttempts as maps and merges per-event', () => {
+  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog never converts embryoShipments/transferAttempts into arrays', () => {
+    const currentCatalog = buildCatalog(caseWithDateRangePeriod);
+    const pasted = parseDocumentsTechnicalInput(JSON.stringify({
+      cases: { 'case-daterange': { id: 'case-daterange', artProgram: { transferAttempts: { 'transfer-1': { date: '2026-04-04' } } } } },
+    }));
+    const { catalog: merged } = mergeDocumentsCatalog(currentCatalog, pasted);
+    const mergedCase = merged.cases.find(item => item.id === 'case-daterange');
+    expect(Array.isArray(mergedCase.artProgram.embryoShipments)).toBe(false);
+    expect(Array.isArray(mergedCase.artProgram.transferAttempts)).toBe(false);
+    // The edit to transfer-1 landed...
+    expect(mergedCase.artProgram.transferAttempts['transfer-1'].date).toBe('2026-04-04');
+    // ...without wiping transfer-2 or shipment-1, which the incoming payload never mentioned.
+    expect(mergedCase.artProgram.transferAttempts['transfer-2'].embryoCount).toBe(2);
+    expect(mergedCase.artProgram.embryoShipments['shipment-1'].id).toBe('shipment-1');
+  });
+
+  it('a deep merge of one hcgTest field never replaces its sibling hcgTests/ultrasounds on the same transfer', () => {
+    const currentCatalog = buildCatalog(caseWithDateRangePeriod);
+    const currentCase = currentCatalog.cases.find(item => item.id === 'case-daterange');
+    const merged = deepMergeRecords(currentCase, {
+      artProgram: { transferAttempts: { 'transfer-1': { hcgTests: { 'hcg-1': { positive: false } } } } },
+    });
+    expect(merged.artProgram.transferAttempts['transfer-1'].hcgTests['hcg-1'].positive).toBe(false);
+    expect(merged.artProgram.transferAttempts['transfer-1'].hcgTests['hcg-1'].date).toBe('2025-09-30');
+    expect(merged.artProgram.transferAttempts['transfer-1'].ultrasounds['ultrasound-1'].fetusCount).toBe(1);
+    expect(merged.artProgram.transferAttempts['transfer-2'].embryoCount).toBe(2);
+  });
+});
+
+// --- Optional passport fields (spec §10) ---------------------------------------------------------
+
+describe('spec §10: passport.type/countryCode are optional and never transliterated', () => {
+  it('resolves passport.type/countryCode when present, and degrades to missing (not a throw) when absent', () => {
+    const withTypeCode = { passport: { number: 'TS0299493', type: 'P', countryCode: 'JPN' } };
+    expect(fillPlaceholders('{{husband.passport.type}}', { husband: withTypeCode }, 'uk')).toBe('P');
+    expect(fillPlaceholders('{{husband.passport.countryCode}}', { husband: withTypeCode }, 'uk')).toBe('JPN');
+    const withoutTypeCode = { passport: { number: 'ME680736' } };
+    expect(() => fillPlaceholders('{{husband.passport.type}}', { husband: withoutTypeCode }, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{husband.passport.type}}', { husband: withoutTypeCode }, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  });
+
+  it('a passport number is never transliterated, only formatted with a space (spec §10)', () => {
+    const context = { husband: { passport: { number: 'TS0299493' } } };
+    expect(fillPlaceholders('{{husband.passport.number}}', context, 'uk')).toBe('TS 0299493');
+  });
+});

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -308,6 +308,10 @@ export const catalogTemplatesToBackend = catalog => (catalog.documents || []).re
 // treats as derived.
 export const DERIVED_CONTEXT_FIELD_KEYS = [
   'short', 'shortName', 'dateWords', 'dateFormatted', 'statementDateWords', 'statementDateFormatted', 'dateDisplay', 'numberEn', 'wordsAfterArticle',
+  // ART program document contexts (spec §4/§6/§12) - computed fresh from case.artProgram on every
+  // resolveCaseContext call, never written back to Firebase.
+  'plannedPeriodFormatted', 'ivfDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
+  'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
 ];
 
 // Recursively strips every DERIVED_CONTEXT_FIELD_KEYS key out of a value before it's serialized
@@ -898,6 +902,342 @@ export const TEMPLATE_DOCUMENT_CONFIG = {
 // so nothing that already calls resolveCaseContext without a templateId changes behavior.
 const DEFAULT_NOTARY_TEMPLATE_CONFIG = { documentKey: 'birthRegistrationConsent', usesNotary: true };
 
+// --- ART program (case.artProgram) - resolvers, formatters, document contexts ----------------
+// The medical facts of a case's fertility program (diagnosis, embryo shipments, transfer attempts,
+// hCG tests, ultrasounds) live once at `case.artProgram`, keyed by id (never converted to arrays -
+// spec §12). Every document that references one of these events (embryoOwnershipStatement,
+// geneticAffinityCertificate, racssClinicLetter) stores only the id(s) it points at
+// (shipmentId/transferAttemptId/hcgTestId/ultrasoundId); editing the underlying event once (e.g.
+// the transfer date) is instantly reflected in every document that references it, since none of
+// them ever copy the fact - they resolve it fresh every render.
+
+// Null-safe lookups (spec §3) - a missing/unset id, or an id that no longer exists (a document
+// still pointing at a deleted event), resolves to null rather than throwing, so a template that
+// references it degrades to a visible "missing" blank instead of a white screen.
+export const resolveShipment = (caseData, shipmentId) => {
+  if (!shipmentId) return null;
+  return caseData?.artProgram?.embryoShipments?.[shipmentId] ?? null;
+};
+
+export const resolveTransferAttempt = (caseData, transferAttemptId) => {
+  if (!transferAttemptId) return null;
+  return caseData?.artProgram?.transferAttempts?.[transferAttemptId] ?? null;
+};
+
+export const resolveHcgTest = (transferAttempt, hcgTestId) => {
+  if (!hcgTestId) return null;
+  return transferAttempt?.hcgTests?.[hcgTestId] ?? null;
+};
+
+export const resolveUltrasound = (transferAttempt, ultrasoundId) => {
+  if (!ultrasoundId) return null;
+  return transferAttempt?.ultrasounds?.[ultrasoundId] ?? null;
+};
+
+// A shipment on its own only carries clinic ids - never mutates the stored record, just layers the
+// resolved party records on top (spec §3).
+export const enrichShipment = (shipment, parties) => {
+  if (!shipment) return null;
+  return {
+    ...shipment,
+    sourceClinic: findById(parties?.partnerClinics, shipment.sourceClinicId) ?? null,
+    destinationClinic: findById(parties?.clinics, shipment.destinationClinicId) ?? null,
+  };
+};
+
+// "DD.MM.YYYY" - same rendering every other document date uses (formatDocumentDate is defined
+// further down this file; referencing it here is safe since it's only ever called once the whole
+// module has finished loading, same pattern as DOCUMENT_DATE_CONFIG's longUk/longEn above). Unlike
+// formatDocumentDate itself (a generic "format if it's a date, else pass the value through
+// unchanged" helper used on arbitrary placeholder leaves), this always resolves a blank/invalid
+// input to '' - consistent with formatDateLongEn/formatDateWordsUk/etc, so an ART formatted-date
+// field is never accidentally set to a raw ISO string or undefined.
+export const formatDateNumericUk = value => (isIsoDate(value) ? formatDocumentDate(value) : '');
+
+// A date range, spelled out long-form in English and numeric in Ukrainian - "01.01.2026 – 01.02.2026"
+// / "01 January 2026 - 01 February 2026". Used only when a shipment's plannedPeriod carries real
+// startDate/endDate values (the new shape) rather than a migrated freeform text (see
+// formatShipmentPeriod).
+export const formatDateRange = (startDate, endDate, locale) => {
+  if (locale === 'en') return `${formatDateLongEn(startDate)} - ${formatDateLongEn(endDate)}`;
+  return `${formatDateNumericUk(startDate)} – ${formatDateNumericUk(endDate)}`;
+};
+
+// Supports both plannedPeriod shapes (spec §6): the new startDate/endDate pair, or a migrated
+// freeform text kept verbatim per locale - never both computed and stored, this only ever reads
+// whichever shape is actually present.
+export const formatShipmentPeriod = (period, locale = 'uk') => {
+  if (period?.startDate && period?.endDate) return formatDateRange(period.startDate, period.endDate, locale);
+  return period?.text?.[locale] ?? '';
+};
+
+// The stored code (e.g. "blastocyst") never carries its own display label - this is the lookup
+// table, extendable with more stages without touching any resolver/formatter call site.
+export const EMBRYO_STAGE_LABELS = {
+  blastocyst: {
+    uk: { nominative: 'бластоциста', genitive: 'бластоцисти' },
+    en: { nominative: 'blastocyst' },
+  },
+};
+
+const EMPTY_EMBRYO_STAGE_LABEL = { uk: { nominative: '', genitive: '' }, en: { nominative: '' } };
+
+export const resolveEmbryoStageLabel = code => EMBRYO_STAGE_LABELS[code] || EMPTY_EMBRYO_STAGE_LABEL;
+
+// Generic Ukrainian one/few/many noun-form picker (1 -> one, 2-4 -> few, 5+ -> many, with the
+// standard 11-14 exception falling into "many") - shared by the embryo count and gestational-age/
+// fetus-count wording below instead of one bespoke mod-arithmetic block per noun.
+const ukPluralForm = (count, [one, few, many]) => {
+  const n = Math.abs(Math.trunc(Number(count) || 0));
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) return few;
+  return many;
+};
+
+const UK_EMBRYO_COUNT_CARDINALS = {
+  1: 'один', 2: 'два', 3: 'три', 4: 'чотири', 5: "п'ять", 6: 'шість', 7: 'сім', 8: 'вісім', 9: "дев'ять", 10: 'десять',
+};
+
+// "1 -> один ембріон", "2 -> два ембріони", "3 -> три ембріони", "5 -> п'ять ембріонів" (spec §6) -
+// a real cardinal-number + noun-agreement formatter, not a lookup table for the four spec examples.
+export const formatEmbryoCountTextUk = count => {
+  const n = Number(count);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  const word = UK_EMBRYO_COUNT_CARDINALS[n] || String(n);
+  return `${word} ${ukPluralForm(n, ['ембріон', 'ембріони', 'ембріонів'])}`;
+};
+
+// "6-7 тижнів" (a real range) or "6 тижнів" (a single value, either from/to alone) - spec §6 only
+// ever shows the range form, but a partially-filled ultrasound (only `from` recorded yet) should
+// still degrade to something readable rather than an empty string.
+export const formatGestationalAgeText = weeks => {
+  const from = weeks?.from;
+  const to = weeks?.to;
+  const hasFrom = from !== undefined && from !== null && from !== '';
+  const hasTo = to !== undefined && to !== null && to !== '';
+  if (hasFrom && hasTo && Number(from) !== Number(to)) return `${from}–${to} ${ukPluralForm(to, ['тиждень', 'тижні', 'тижнів'])}`;
+  const single = hasFrom ? from : (hasTo ? to : null);
+  if (single === null) return '';
+  return `${single} ${ukPluralForm(single, ['тиждень', 'тижні', 'тижнів'])}`;
+};
+
+const PREGNANCY_TYPE_LABELS_UK = { 1: 'одноплідна', 2: 'двоплідна', 3: 'триплідна' };
+
+// Determined solely by fetusCount (spec §6: "не створювати окреме source-поле pregnancyType") -
+// anything outside 1-3 (unset, 0, or an unusually high multiple) simply resolves to '', a blank in
+// the rendered document rather than a guessed label.
+export const formatPregnancyTypeTextUk = fetusCount => PREGNANCY_TYPE_LABELS_UK[Number(fetusCount)] || '';
+
+// Layers the formatted-for-template fields onto an already party-enriched shipment (see
+// enrichShipment) - the two are separate steps because embryoOwnershipStatement's legacy fallback
+// (spec §14) needs to synthesize just these formatted fields without a real shipment record to
+// enrich with parties.
+export const enrichShipmentForTemplate = shipment => {
+  if (!shipment) return null;
+  return {
+    ...shipment,
+    ivfDateFormatted: { uk: formatDateNumericUk(shipment.ivfDate), en: formatDateLongEn(shipment.ivfDate) },
+    plannedPeriodFormatted: { uk: formatShipmentPeriod(shipment.plannedPeriod, 'uk'), en: formatShipmentPeriod(shipment.plannedPeriod, 'en') },
+    receivedDateFormatted: { uk: formatDateNumericUk(shipment.receivedDate), en: formatDateLongEn(shipment.receivedDate) },
+  };
+};
+
+export const enrichTransferForTemplate = (transferAttempt, shipment) => {
+  if (!transferAttempt) return null;
+  return {
+    ...transferAttempt,
+    dateFormatted: { uk: formatDateNumericUk(transferAttempt.date), en: formatDateLongEn(transferAttempt.date) },
+    embryoCountText: { uk: formatEmbryoCountTextUk(transferAttempt.embryoCount) },
+    embryoStageLabel: resolveEmbryoStageLabel(transferAttempt.embryoStage),
+    shipment: enrichShipmentForTemplate(shipment),
+  };
+};
+
+export const enrichHcgTestForTemplate = hcgTest => {
+  if (!hcgTest) return null;
+  return {
+    ...hcgTest,
+    dateFormatted: { uk: formatDateNumericUk(hcgTest.date), en: formatDateLongEn(hcgTest.date) },
+  };
+};
+
+export const enrichUltrasoundForTemplate = ultrasound => {
+  if (!ultrasound) return null;
+  return {
+    ...ultrasound,
+    dateFormatted: { uk: formatDateNumericUk(ultrasound.date), en: formatDateLongEn(ultrasound.date) },
+    gestationalAgeText: { uk: formatGestationalAgeText(ultrasound.gestationalAgeWeeks) },
+    pregnancyTypeText: { uk: formatPregnancyTypeTextUk(ultrasound.fetusCount) },
+  };
+};
+
+// case.documents.embryoOwnershipStatement - spec §4. Backward compatible (spec §14): a case not
+// yet migrated off the old shape still carries `ivfDate`/`shipmentPeriod` directly on the document
+// instead of a shipmentId: those synthesize the same `.shipment.*` template fields the new shape
+// exposes, so an old template keeps rendering unchanged. A fresh save always writes shipmentId
+// (spec §14) - this fallback only ever reads what's already stored.
+export const buildEmbryoOwnershipStatementContext = (caseData, parties, ownershipData) => {
+  const data = isPlainObject(ownershipData) ? ownershipData : {};
+  const resolvedShipment = enrichShipmentForTemplate(enrichShipment(resolveShipment(caseData, data.shipmentId), parties));
+  const legacyShipment = !resolvedShipment && (data.ivfDate || data.shipmentPeriod) ? {
+    ivfDateFormatted: { uk: formatDateNumericUk(data.ivfDate), en: formatDateLongEn(data.ivfDate) },
+    plannedPeriodFormatted: { uk: data.shipmentPeriod?.uk || '', en: data.shipmentPeriod?.en || '' },
+    sourceClinic: null,
+    destinationClinic: null,
+  } : null;
+  return { ...data, shipment: resolvedShipment || legacyShipment };
+};
+
+// case.documents.geneticAffinityCertificate - spec §4.
+export const buildGeneticAffinityCertificateContext = (caseData, parties, certificateData) => {
+  const data = isPlainObject(certificateData) ? certificateData : {};
+  const transferAttempt = resolveTransferAttempt(caseData, data.transferAttemptId);
+  const shipment = enrichShipment(resolveShipment(caseData, transferAttempt?.shipmentId), parties);
+  return {
+    ...data,
+    transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
+    hcgTest: enrichHcgTestForTemplate(resolveHcgTest(transferAttempt, data.hcgTestId)),
+    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt, data.ultrasoundId)),
+    outgoingNumberOrBlank: data.outgoingNumber?.trim() || '______',
+    // A print-only blank, never persisted (spec §4) - a fully blank pattern rather than a
+    // hand-picked placeholder date, so it never silently doubles as a real value.
+    issueDateOrBlank: { uk: data.issueDate ? formatDateNumericUk(data.issueDate) : '__.__.____' },
+  };
+};
+
+// case.documents.racssClinicLetter - spec §4.
+export const buildRacssClinicLetterContext = (caseData, parties, letterData) => {
+  const data = isPlainObject(letterData) ? letterData : {};
+  const transferAttempt = resolveTransferAttempt(caseData, data.transferAttemptId);
+  const shipment = enrichShipment(resolveShipment(caseData, transferAttempt?.shipmentId), parties);
+  return {
+    ...data,
+    transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
+    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt, data.ultrasoundId)),
+  };
+};
+
+// case.documents.medicalServicesAgreement - spec §5.
+export const buildMedicalServicesAgreementContext = agreementData => {
+  const data = isPlainObject(agreementData) ? agreementData : {};
+  return {
+    ...data,
+    dateFormatted: {
+      uk: data.date ? formatDateNumericUk(data.date) : '',
+      en: data.date ? formatDateLongEn(data.date) : '',
+    },
+  };
+};
+
+// couple.marriage - spec §10: dateFormatted/certificateDateFormatted layered on top of whatever the
+// record already carries (old certificateNumber/certificateDate-only records, or the newer
+// date/certificateType/certificateIssuedBy shape) - never removes a field, never requires the new
+// ones to be present.
+export const enrichCoupleMarriage = couple => {
+  if (!isPlainObject(couple) || !isPlainObject(couple.marriage)) return couple;
+  const { marriage } = couple;
+  return {
+    ...couple,
+    marriage: {
+      ...marriage,
+      dateFormatted: { uk: marriage.date ? formatDateNumericUk(marriage.date) : '', en: marriage.date ? formatDateLongEn(marriage.date) : '' },
+      certificateDateFormatted: {
+        uk: marriage.certificateDate ? formatDateNumericUk(marriage.certificateDate) : '',
+        en: marriage.certificateDate ? formatDateLongEn(marriage.certificateDate) : '',
+      },
+    },
+  };
+};
+
+// Specific, actionable messages for a document reference that points at an event id that doesn't
+// exist (spec §13/§15) - deleted since the document was set up, mistyped on import, etc. Distinct
+// from the generic unresolved-{{placeholder}} warning (which would otherwise just list every
+// `geneticAffinityCertificate.transferAttempt.*` leaf as "missing" with no indication of why).
+export const validateArtProgramReferences = (catalog, caseId) => {
+  const rawCaseRecord = findById(catalog?.cases, caseId);
+  if (!rawCaseRecord) return [];
+  const caseRecord = normalizeCaseRecord(rawCaseRecord);
+  const documents = isPlainObject(caseRecord.documents) ? caseRecord.documents : {};
+  const issues = [];
+
+  const checkTransferAttempt = transferAttemptId => {
+    if (!transferAttemptId) return null;
+    const transferAttempt = resolveTransferAttempt(caseRecord, transferAttemptId);
+    if (!transferAttempt) issues.push(`Не знайдено спробу переносу ${transferAttemptId}.`);
+    return transferAttempt;
+  };
+
+  const ownership = documents.embryoOwnershipStatement;
+  if (ownership?.shipmentId && !resolveShipment(caseRecord, ownership.shipmentId)) {
+    issues.push(`Не знайдено доставлення ембріонів ${ownership.shipmentId}.`);
+  }
+
+  const certificate = documents.geneticAffinityCertificate;
+  if (certificate?.transferAttemptId || certificate?.hcgTestId || certificate?.ultrasoundId) {
+    const transferAttempt = checkTransferAttempt(certificate.transferAttemptId);
+    if (transferAttempt) {
+      if (certificate.hcgTestId && !resolveHcgTest(transferAttempt, certificate.hcgTestId)) {
+        issues.push(`Не знайдено аналіз ХГЧ ${certificate.hcgTestId} у переносі ${certificate.transferAttemptId}.`);
+      }
+      if (certificate.ultrasoundId && !resolveUltrasound(transferAttempt, certificate.ultrasoundId)) {
+        issues.push(`Не знайдено УЗД ${certificate.ultrasoundId} у переносі ${certificate.transferAttemptId}.`);
+      }
+    }
+  }
+
+  const letter = documents.racssClinicLetter;
+  if (letter?.transferAttemptId || letter?.ultrasoundId) {
+    const transferAttempt = checkTransferAttempt(letter.transferAttemptId);
+    if (transferAttempt && letter.ultrasoundId && !resolveUltrasound(transferAttempt, letter.ultrasoundId)) {
+      issues.push(`Не знайдено УЗД ${letter.ultrasoundId} у переносі ${letter.transferAttemptId}.`);
+    }
+  }
+
+  return issues;
+};
+
+// Human-readable dropdown labels (spec §9) - so an editor never makes the admin type/paste a raw
+// id: "Перенос 18.09.2025 — 1 ембріон", "Доставлення 27.08.2025 — Medical Park Shonan",
+// "ХГЧ 30.09.2025 — позитивний", "УЗД 17.10.2025 — 1 плід, 6–7 тижнів" - the label word and its
+// date are joined by a plain space, only the trailing detail is set off with an em dash.
+const joinOptionLabel = (label, dateText, details) => {
+  const prefix = [label, dateText].filter(Boolean).join(' ');
+  return [prefix, details].filter(Boolean).join(' — ');
+};
+
+export const formatShipmentOptionLabel = (shipment, parties) => {
+  if (!shipment) return '';
+  const enriched = enrichShipment(shipment, parties);
+  const clinicName = enriched?.sourceClinic?.name?.uk || enriched?.destinationClinic?.name?.uk || '';
+  const dateText = shipment.receivedDate ? formatDateNumericUk(shipment.receivedDate) : (shipment.ivfDate ? formatDateNumericUk(shipment.ivfDate) : '');
+  return joinOptionLabel('Доставлення', dateText, clinicName);
+};
+
+export const formatTransferOptionLabel = transferAttempt => {
+  if (!transferAttempt) return '';
+  const dateText = transferAttempt.date ? formatDateNumericUk(transferAttempt.date) : '';
+  const countText = transferAttempt.embryoCount ? formatEmbryoCountTextUk(transferAttempt.embryoCount) : '';
+  return joinOptionLabel('Перенос', dateText, countText);
+};
+
+export const formatHcgTestOptionLabel = hcgTest => {
+  if (!hcgTest) return '';
+  const dateText = hcgTest.date ? formatDateNumericUk(hcgTest.date) : '';
+  const resultText = hcgTest.positive === true ? 'позитивний' : (hcgTest.positive === false ? 'негативний' : '');
+  return joinOptionLabel('ХГЧ', dateText, resultText);
+};
+
+export const formatUltrasoundOptionLabel = ultrasound => {
+  if (!ultrasound) return '';
+  const dateText = ultrasound.date ? formatDateNumericUk(ultrasound.date) : '';
+  const fetusText = ultrasound.fetusCount ? `${ultrasound.fetusCount} ${ukPluralForm(ultrasound.fetusCount, ['плід', 'плоди', 'плодів'])}` : '';
+  const ageText = formatGestationalAgeText(ultrasound.gestationalAgeWeeks);
+  const details = [fetusText, ageText].filter(Boolean).join(', ');
+  return joinOptionLabel('УЗД', dateText, details);
+};
+
 export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}) => {
   const rawCaseRecord = findById(catalog?.cases, caseId);
   if (!rawCaseRecord) return null;
@@ -968,10 +1308,18 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
     } : rawClinic.medicalDirector,
   } : null;
 
+  // ART-program-referencing documents (spec §4/§7): each resolves its own referenced shipment/
+  // transfer/hcgTest/ultrasound fresh from `caseRecord.artProgram` on every call, so editing an
+  // event once (e.g. the transfer date) is reflected in every document that references it.
+  const embryoOwnershipStatement = buildEmbryoOwnershipStatementContext(caseRecord, catalog.parties, documents.embryoOwnershipStatement);
+  const geneticAffinityCertificate = buildGeneticAffinityCertificateContext(caseRecord, catalog.parties, documents.geneticAffinityCertificate);
+  const racssClinicLetter = buildRacssClinicLetterContext(caseRecord, catalog.parties, documents.racssClinicLetter);
+  const medicalServicesAgreement = buildMedicalServicesAgreementContext(documents.medicalServicesAgreement);
+
   return {
     case: caseRecord,
     relations,
-    couple,
+    couple: enrichCoupleMarriage(couple),
     wife: enrichPersonName(rawWife),
     husband: enrichPersonName(rawHusband),
     surrogateMother: enrichPersonName(relations.surrogateMotherId
@@ -994,6 +1342,10 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
     maritalStatusDeclaration,
     legalServicesDisclaimer,
     surrogacyAgreementAppendix1,
+    embryoOwnershipStatement,
+    geneticAffinityCertificate,
+    racssClinicLetter,
+    medicalServicesAgreement,
     notary,
   };
 };
@@ -1681,6 +2033,30 @@ export const VARIABLE_PICKER_GROUPS = [
   // embryos ship from (spec: embryo-ownership-statement document). Shown whenever one is selected
   // on the case; a case without a partnerClinicId simply doesn't offer this group.
   { label: 'Клініка-партнер', roots: ['partnerClinic'], predicate: context => Boolean(context?.partnerClinic) },
+  // ART program document contexts (spec §7) - each root is a top-level key resolveCaseContext
+  // already exposes. Shown only once the case actually carries that document's own service data
+  // (same idea as the partner-clinic group above) - an old case that never uses these documents at
+  // all shouldn't show four permanently-empty "Немає даних" groups in the picker.
+  {
+    label: 'Заява про належність ембріонів',
+    roots: ['embryoOwnershipStatement'],
+    predicate: context => Boolean(context?.case?.documents?.embryoOwnershipStatement),
+  },
+  {
+    label: 'Довідка про генетичну спорідненість',
+    roots: ['geneticAffinityCertificate'],
+    predicate: context => Boolean(context?.case?.documents?.geneticAffinityCertificate),
+  },
+  {
+    label: 'Лист клініки до РАЦС',
+    roots: ['racssClinicLetter'],
+    predicate: context => Boolean(context?.case?.documents?.racssClinicLetter),
+  },
+  {
+    label: 'Договір про медичні послуги',
+    roots: ['medicalServicesAgreement'],
+    predicate: context => Boolean(context?.case?.documents?.medicalServicesAgreement),
+  },
 ];
 
 // Builds the picker's grouped leaf list from a resolved case context (or any similarly-shaped


### PR DESCRIPTION
Adds resolvers, formatters, and document-context builders for the new
case.artProgram tree (medicalIndication/geneticMaterial/medicalTeam,
embryoShipments, transferAttempts with nested hcgTests/ultrasounds), and
wires them into resolveCaseContext for the embryoOwnershipStatement,
geneticAffinityCertificate, racssClinicLetter, and medicalServicesAgreement
documents. Every lookup is null-safe (missing/deleted references degrade to
a visible blank, never a white screen), and validateArtProgramReferences
reports the exact missing shipment/transfer/hCG test/ultrasound instead of
a generic warning.

Adds a case editor section ("Програма ДРТ") for the artProgram data itself,
and updates the document-reference editors (embryoOwnershipStatement now
picks a shipment; new editors for geneticAffinityCertificate,
racssClinicLetter, medicalServicesAgreement) with human-readable dropdowns
instead of raw ids. The pre-migration embryoOwnershipStatement shape
(ivfDate/shipmentPeriod) keeps resolving and is preserved on save until a
shipment is actually picked.

Firebase-persisted maps (embryoShipments/transferAttempts/hcgTests/
ultrasounds) are never converted to arrays, and every formatted/derived
field (dateFormatted, embryoCountText, embryoStageLabel, gestationalAgeText,
pregnancyTypeText, plannedPeriodFormatted, issueDateOrBlank,
outgoingNumberOrBlank, marriage.dateFormatted/certificateDateFormatted) is
computed at template-render time only, never written back to Firebase.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012vKtQzdm3itmWMaPWLYQJr