### PR TITLE
Documents Builder: add official-form documentStyle for government forms

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaPlus, FaSlidersH, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaLock, FaPlus, FaSlidersH, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFolderFileNames, uploadFileToStorageFolder } from './config';
@@ -50,6 +50,7 @@ import {
   getTemplateScopeRecord,
   getTemplateScopeText,
   isBilingualLayout,
+  isOfficialFormStyle,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
   mergeDocumentsCatalog,
@@ -57,6 +58,7 @@ import {
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
+  OFFICIAL_FORM_FORMATTING,
   orderCasesByRecent,
   orderRecordsByRecentIds,
   paragraphScope,
@@ -1352,6 +1354,34 @@ const DocumentsPage = ({ isAdmin }) => {
     await commitTemplateScopeText(docId, scope, langKey, nextRaw);
   };
 
+  // A template can pin its own languages/columns (batch 16 §15/§16, getEffectiveDocLayout) so it
+  // always renders that way regardless of the page's UA/EN/UA+EN toggle - by design for documents
+  // that must always ship bilingual (e.g. a notarized declaration meant for a foreign clinic). That
+  // pin can currently only be set via the technical JSON paste, with no visible indicator on the
+  // document row - an admin who picks "UA · 1 column" for the whole case and still sees this one
+  // document preview bilingual has no way to tell it's an intentional per-document pin rather than
+  // a bug, or any way to clear it short of re-pasting JSON. This surfaces the pin as a small badge
+  // (below) and clears it here in one click - an immediate structural edit, same as the paragraph
+  // insert/remove above, not deferred to blur.
+  const handleClearDocLanguagePin = async docId => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template) return;
+    const nextTemplate = { ...template };
+    delete nextTemplate.languages;
+    delete nextTemplate.columns;
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+      }));
+      toast.success('This document now follows the page\'s language/column selector.');
+    } catch (pinError) {
+      console.error('Unable to clear the document language pin', pinError);
+      toast.error('Could not update the document.');
+    }
+  };
+
   // --- Deletes (always behind an explicit confirmation) ----------------------------------------
 
   const handleDeleteTemplate = async template => {
@@ -1538,7 +1568,7 @@ const DocumentsPage = ({ isAdmin }) => {
       return;
     }
     const template = catalog.documents.find(item => String(item.id) === nextDocId);
-    setDocFormatDraft(resolveEffectiveDocFormatting(formatting, template?.format));
+    setDocFormatDraft(resolveEffectiveDocFormatting(formatting, template?.format, template?.documentStyle));
   };
 
   const handleSaveFavouriteFormatting = async () => {
@@ -1555,7 +1585,12 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === formatDocId);
     if (!template) return;
     const normalizedDraft = normalizeDocFormatting(docFormatDraft || formatting);
-    const overrides = diffDocFormattingOverrides(formatting, normalizedDraft);
+    // An official-form document's own overrides are diffed against its OFFICIAL_FORM_FORMATTING
+    // baseline, not the shared branded favourites - otherwise every one of that baseline's values
+    // would be written out as a redundant per-document override the moment the admin opens this
+    // document in the Format panel (see resolveEffectiveDocFormatting).
+    const referenceFormatting = isOfficialFormStyle(template) ? OFFICIAL_FORM_FORMATTING : formatting;
+    const overrides = diffDocFormattingOverrides(referenceFormatting, normalizedDraft);
     const nextTemplate = { ...template };
     if (Object.keys(overrides).length) nextTemplate.format = overrides;
     else delete nextTemplate.format;
@@ -1811,7 +1846,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const generated = selectedTemplates.map(template => buildGeneratedDocument(template, getContextForTemplate(template.id)));
     // Each document renders with the shared defaults merged with its own format overrides -
     // independent of whichever document (if any) the Format panel currently targets.
-    const formattingByDoc = selectedTemplates.map(template => resolveEffectiveDocFormatting(formatting, template.format));
+    const formattingByDoc = selectedTemplates.map(template => resolveEffectiveDocFormatting(formatting, template.format, template.documentStyle));
     return {
       generated,
       formattingByDoc,
@@ -2072,7 +2107,14 @@ const DocumentsPage = ({ isAdmin }) => {
                 const resolvedDoc = buildGeneratedDocument(template, getContextForTemplate(template.id));
                 // The per-paragraph indent slider's "inherit" default - this document's own
                 // effective first-line indent, same value generation actually renders with.
-                const docFormatting = resolveEffectiveDocFormatting(formatting, template.format);
+                const docFormatting = resolveEffectiveDocFormatting(formatting, template.format, template.documentStyle);
+                // See handleClearDocLanguagePin above - a template-level languages/columns pin
+                // makes this document ignore the page's UA/EN/UA+EN toggle entirely; surfaced as a
+                // badge on the row so that's visible instead of looking like a preview bug.
+                const pinnedLanguages = toArray(template.languages).map(String).filter(langValue => langValue === 'uk' || langValue === 'en');
+                const languagePinLabel = pinnedLanguages.length > 1
+                  ? 'UA+EN'
+                  : (pinnedLanguages.length === 1 ? `${pinnedLanguages[0] === 'en' ? 'EN' : 'UA'} · ${template.columns === 2 ? '2 col' : '1 col'}` : '');
                 // Whichever source is currently authoritative (the dedicated `logo` field, or a
                 // legacy leading paragraph) shown as one plain-text value the admin can type into
                 // directly - never a normalized re-serialization, so a mid-edit/invalid value
@@ -2136,6 +2178,16 @@ const DocumentsPage = ({ isAdmin }) => {
                         style={{ flex: 1, minWidth: 0, fontWeight: 600 }}
                         title="The document's entry name in the Documents list - never printed inside the document itself (edit the printed title below, in the Title row)"
                       />
+                      {languagePinLabel ? (
+                        <SmallButton
+                          type="button"
+                          onClick={() => handleClearDocLanguagePin(template.id)}
+                          title={`This document is pinned to always render ${languagePinLabel}, ignoring the page's language/column selector above. Click to clear the pin so it follows the page selector instead.`}
+                          style={{ flex: '0 0 auto', width: 'auto', color: 'var(--km-accent)' }}
+                        >
+                          <FaLock /> {languagePinLabel}
+                        </SmallButton>
+                      ) : null}
                       {/* §1.2: the document-level formatting defaults every non-overridden
                           paragraph inherits - edited here, next to the delete button. */}
                       <FormatPopoverButton

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -22,10 +22,12 @@ import {
   getEffectiveDocLayout,
   getLayoutLang,
   isBilingualLayout,
+  isOfficialFormStyle,
   isParagraphBold,
   isSingleLanguageTwoColumnLayout,
   normalizeSignerBlockOffsetPercent,
   parseFormattedRuns,
+  splitBlankFieldRuns,
   splitParagraphsIntoColumns,
   splitParagraphsIntoPages,
 } from './documentsCatalogUtils';
@@ -114,25 +116,34 @@ export const toPdfRenderableText = text => {
 // date-in-words line, `**Підпис**...`): the leading nested <Text> ignored the parent's indent, so
 // exactly the bolded lines lost their 1.5 cm first-line indent - `firstLineIndent` re-states the
 // paragraph's own resolved indent on that leading run.
-const FormattedRuns = ({ text, firstLineIndent }) => parseFormattedRuns(toPdfRenderableText(text)).map((run, index) => {
-  if (!run.bold && !run.italic) {
-    // eslint-disable-next-line react/no-array-index-key
-    return <React.Fragment key={index}>{run.text}</React.Fragment>;
-  }
-  return (
-    <Text
+// `blankFields` (official-form documents only, batch 22 §1) additionally splits each run at its
+// underscore stretches so a government form's typed "__________" fill-in line draws as an
+// underlined run of non-breaking spaces instead of literal underscore glyphs - see
+// splitBlankFieldRuns. Every other document leaves its underscores exactly as typed.
+const FormattedRuns = ({ text, firstLineIndent, blankFields }) => {
+  const runs = parseFormattedRuns(toPdfRenderableText(text));
+  const renderRuns = blankFields ? splitBlankFieldRuns(runs) : runs;
+  return renderRuns.map((run, index) => {
+    if (!run.bold && !run.italic && !run.blank) {
       // eslint-disable-next-line react/no-array-index-key
-      key={index}
-      style={{
-        fontWeight: run.bold ? 700 : undefined,
-        fontStyle: run.italic ? 'italic' : undefined,
-        ...(index === 0 && firstLineIndent ? { textIndent: firstLineIndent } : {}),
-      }}
-    >
-      {run.text}
-    </Text>
-  );
-});
+      return <React.Fragment key={index}>{run.text}</React.Fragment>;
+    }
+    return (
+      <Text
+        // eslint-disable-next-line react/no-array-index-key
+        key={index}
+        style={{
+          fontWeight: run.bold ? 700 : undefined,
+          fontStyle: run.italic ? 'italic' : undefined,
+          textDecoration: run.blank ? 'underline' : undefined,
+          ...(index === 0 && firstLineIndent ? { textIndent: firstLineIndent } : {}),
+        }}
+      >
+        {run.blank ? ' '.repeat(run.text.length) : run.text}
+      </Text>
+    );
+  });
+};
 
 // A logo block draws graphics, not text - it never goes through the title/paragraph text styles
 // and never picks up the template's paragraphSpacing/indent (spec §5). `type` is 'logo' or
@@ -184,7 +195,7 @@ const LogoBlock = ({ type, isBilingual, cellStyles, logoWidth, longLogoWidth, cl
 // `fontSize` (batch 2026-07-23 B §1.1: a per-paragraph pt override of the document's font size)
 // work the same way - undefined leaves cellStyle's own document-wide value in place. All three
 // arrive already resolved from the paragraph's consolidated `style` key (buildGeneratedDocument).
-const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBreaks }) => {
+const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBreaks, blankFields }) => {
   const wrap = allowsParagraphInternalBreak(paragraph, allowPageBreaks);
   const cellStyle = isParagraphBold(paragraph) ? cellStyles.paragraphHeading : cellStyles.paragraph;
   const alignStyle = paragraph.align ? { textAlign: paragraph.align } : undefined;
@@ -201,7 +212,7 @@ const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBrea
   // zero width - and zero height along with it. A non-breaking space has real (if narrow) glyph
   // width, so justification has something to keep and the line renders at its full height.
   const lineOf = value => (String(value || '').trim()
-    ? <FormattedRuns text={value} firstLineIndent={firstLineIndent} />
+    ? <FormattedRuns text={value} firstLineIndent={firstLineIndent} blankFields={blankFields} />
     : ' ');
   if (isBilingual) {
     return (
@@ -220,7 +231,7 @@ const TextParagraph = ({ paragraph, isBilingual, lang, cellStyles, allowPageBrea
 // groups, each stacked in its own column. That is an approximation of true reflow (a single very
 // long paragraph can't itself be split across the columns), the same atomic-paragraph limit the
 // bilingual layout already lives with.
-const SingleLanguageColumns = ({ paragraphs, lang, cellStyles, allowPageBreaks, logoWidth, clinicLogos, charsPerLine }) => {
+const SingleLanguageColumns = ({ paragraphs, lang, cellStyles, allowPageBreaks, logoWidth, clinicLogos, charsPerLine, blankFields }) => {
   const [leftParagraphs, rightParagraphs] = splitParagraphsIntoColumns(paragraphs, lang, charsPerLine);
   const renderColumn = columnParagraphs => columnParagraphs.map((paragraph, index) => (
     // eslint-disable-next-line react/no-array-index-key
@@ -230,7 +241,7 @@ const SingleLanguageColumns = ({ paragraphs, lang, cellStyles, allowPageBreaks, 
         // compact and long variants are sized to fit the column, not the full page.
         <LogoBlock type={paragraph.type} isBilingual={false} cellStyles={cellStyles} logoWidth={logoWidth} longLogoWidth={logoWidth} clinicLogos={clinicLogos} showUk showEn />
       ) : (
-        <TextParagraph paragraph={paragraph} isBilingual={false} lang={lang} cellStyles={cellStyles} allowPageBreaks={allowPageBreaks} />
+        <TextParagraph paragraph={paragraph} isBilingual={false} lang={lang} cellStyles={cellStyles} allowPageBreaks={allowPageBreaks} blankFields={blankFields} />
       )}
     </View>
   ));
@@ -250,7 +261,7 @@ const isBlankBlockText = value => !String(value || '').trim();
 // (cellStyles.title), its own sparse align/fontSize overrides applied like any paragraph's, and a
 // document whose title was deleted (both languages resolve blank) renders no title block at all -
 // never an empty centered line plus its titleGap.
-const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) => {
+const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap, blankFields }) => {
   const title = doc.title || {};
   if (isBlankBlockText(title.uk) && isBlankBlockText(title.en)) return null;
   const overrideStyles = [
@@ -261,11 +272,11 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
     <View style={{ marginBottom: titleGap }}>
       {isBilingual ? (
         <View style={styles.row}>
-          <Text style={[cellStyles.title, cellStyles.leftCell, ...overrideStyles]}><FormattedRuns text={title.uk} /></Text>
-          <Text style={[cellStyles.title, cellStyles.rightCell, ...overrideStyles]}><FormattedRuns text={title.en} /></Text>
+          <Text style={[cellStyles.title, cellStyles.leftCell, ...overrideStyles]}><FormattedRuns text={title.uk} blankFields={blankFields} /></Text>
+          <Text style={[cellStyles.title, cellStyles.rightCell, ...overrideStyles]}><FormattedRuns text={title.en} blankFields={blankFields} /></Text>
         </View>
       ) : (
-        <Text style={[cellStyles.title, ...overrideStyles]}><FormattedRuns text={title[lang]} /></Text>
+        <Text style={[cellStyles.title, ...overrideStyles]}><FormattedRuns text={title[lang]} blankFields={blankFields} /></Text>
       )}
     </View>
   );
@@ -284,7 +295,7 @@ const DocumentTitleBlock = ({ doc, isBilingual, lang, cellStyles, titleGap }) =>
 
 // An explicitly aligned block (the §1.5 alignment button, stored under the block's `style` key)
 // overrides the strip's notarial default: bold caption flush-left, regular data justified.
-const SignerBlockLine = ({ block, langKey, cellStyles }) => (
+const SignerBlockLine = ({ block, langKey, cellStyles, blankFields }) => (
   <Text
     style={[
       cellStyles.beforeTitle,
@@ -293,13 +304,13 @@ const SignerBlockLine = ({ block, langKey, cellStyles }) => (
       block.fontSize !== undefined ? { fontSize: block.fontSize } : undefined,
     ]}
   >
-    <FormattedRuns text={block[langKey]} />
+    <FormattedRuns text={block[langKey]} blankFields={blankFields} />
   </Text>
 );
 
 const BlankLine = ({ cellStyles }) => <Text style={cellStyles.beforeTitle}> </Text>;
 
-const SignerBlockStrip = ({ blocks, offsetPercent, langKey, cellStyles }) => (
+const SignerBlockStrip = ({ blocks, offsetPercent, langKey, cellStyles, blankFields }) => (
   <View style={styles.row}>
     <View style={{ width: `${offsetPercent}%` }} />
     <View style={{ flex: 1 }}>
@@ -307,14 +318,14 @@ const SignerBlockStrip = ({ blocks, offsetPercent, langKey, cellStyles }) => (
         // eslint-disable-next-line react/no-array-index-key
         <React.Fragment key={index}>
           {index > 0 ? <BlankLine cellStyles={cellStyles} /> : null}
-          <SignerBlockLine block={block} langKey={langKey} cellStyles={cellStyles} />
+          <SignerBlockLine block={block} langKey={langKey} cellStyles={cellStyles} blankFields={blankFields} />
         </React.Fragment>
       ))}
     </View>
   </View>
 );
 
-const BeforeTitleBlocks = ({ doc, isBilingual, lang, cellStyles }) => {
+const BeforeTitleBlocks = ({ doc, isBilingual, lang, cellStyles, blankFields }) => {
   const blocks = (doc.beforeTitle || []).filter(block => !isBlankBlockText(block.uk) || !isBlankBlockText(block.en));
   if (!blocks.length) return null;
   const offsetPercent = normalizeSignerBlockOffsetPercent(doc.beforeTitleOffsetPercent);
@@ -323,10 +334,10 @@ const BeforeTitleBlocks = ({ doc, isBilingual, lang, cellStyles }) => {
       {isBilingual ? (
         <View style={styles.row}>
           <View style={cellStyles.leftCell}>
-            <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey="uk" cellStyles={cellStyles} />
+            <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey="uk" cellStyles={cellStyles} blankFields={blankFields} />
           </View>
           <View style={cellStyles.rightCell}>
-            <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey="en" cellStyles={cellStyles} />
+            <SignerBlockStrip blocks={blocks} offsetPercent={offsetPercent} langKey="en" cellStyles={cellStyles} blankFields={blankFields} />
           </View>
         </View>
       ) : (
@@ -346,14 +357,18 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
   const showUk = isBilingual || lang === 'uk';
   const showEn = isBilingual || lang === 'en';
   const logoBlockProps = { isBilingual, cellStyles, logoWidth, longLogoWidth, clinicLogos, showUk, showEn };
+  // An official-form document (batch 22 §1) draws its logo in the repeating page header instead
+  // (see HeaderLogo/renderDocumentPage) - never again here as a one-off body block.
+  const blankFields = isOfficialFormStyle(doc);
+  const showBodyLogo = doc.logo && !blankFields;
   return (
     <View>
       {/* The template's letterhead logo (doc.logo) always renders before the title, whether it
           came from the dedicated `logo` field or a legacy leading paragraph - see
           getTemplateLogoType in documentsCatalogUtils. */}
-      {doc.logo ? <LogoBlock type={doc.logo} {...logoBlockProps} /> : null}
-      <BeforeTitleBlocks doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} />
-      <DocumentTitleBlock doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} titleGap={titleGap} />
+      {showBodyLogo ? <LogoBlock type={doc.logo} {...logoBlockProps} /> : null}
+      <BeforeTitleBlocks doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} blankFields={blankFields} />
+      <DocumentTitleBlock doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} titleGap={titleGap} blankFields={blankFields} />
       {doc.paragraphs.map((paragraph, index) => {
         // Already drawn as doc.logo above - a legacy leading logo paragraph must not also render
         // a second time in its old body position.
@@ -369,6 +384,7 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
                 lang={lang}
                 cellStyles={cellStyles}
                 allowPageBreaks={doc.allowPageBreaks}
+                blankFields={blankFields}
               />
             )}
           </View>
@@ -376,6 +392,42 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
       })}
     </View>
   );
+};
+
+// batch 22 §1: an official-form document's letterhead logo repeats in a small page header instead
+// of a one-off body block - meaningfully different from the branded doc.logo body block above once
+// a form runs past one page (a government form's crest should stay identifiable on every page, not
+// just the first). `fixed` redraws it at the same top-left position on every physical page; the
+// caller reserves real space for it in the page's own top padding (see headerLogoReserve in
+// renderDocumentPage/renderSingleLanguagePages) so body content never starts underneath it.
+const resolveLogoAspectRatio = variant => (variant?.width && variant?.height ? variant.height / variant.width : 0.28);
+
+const HeaderLogo = ({ doc, clinicLogos, widthPt, marginLeft, marginTop }) => {
+  if (!doc.logo) return null;
+  const variant = getClinicLogo(clinicLogos, doc.logo);
+  if (!variant?.dataUrl) return null;
+  return (
+    <Image
+      fixed
+      src={variant.dataUrl}
+      style={{
+        position: 'absolute', top: marginTop, left: marginLeft, width: widthPt,
+      }}
+    />
+  );
+};
+
+const OFFICIAL_FORM_HEADER_LOGO_GAP_PT = 6;
+
+// How much extra top padding an official-form page needs to reserve so its repeating HeaderLogo
+// never overlaps the body content that starts right after it - 0 for every branded document (its
+// logo stays a normal one-off body block, drawn in flow) and for an official-form document with no
+// logo token at all.
+const resolveHeaderLogoReserve = (doc, clinicLogos, widthPt) => {
+  if (!isOfficialFormStyle(doc) || !doc.logo) return 0;
+  const variant = getClinicLogo(clinicLogos, doc.logo);
+  if (!variant?.dataUrl) return 0;
+  return widthPt * resolveLogoAspectRatio(variant) + OFFICIAL_FORM_HEADER_LOGO_GAP_PT;
 };
 
 const PageHeader = ({ formatting, marginTop, marginLeft, marginRight }) => (!formatting.headerText ? null : (
@@ -527,8 +579,11 @@ const DocumentsPdfDocument = ({
     const lang = getLayoutLang(effectiveLayout);
     const showColumnDivider = Boolean(formatting.columnDivider);
     const logoWidth = Math.min(configuredLogoWidth, columnContentWidth);
+    const blankFields = isOfficialFormStyle(doc);
+    const headerLogoReserve = resolveHeaderLogoReserve(doc, effectiveClinicLogos, logoWidth);
+    const pageStyleForDoc = headerLogoReserve ? { ...pageStyle, paddingTop: marginTop + headerLogoReserve } : pageStyle;
     const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed');
-    const pageContentHeightPt = A4_HEIGHT_PT - marginTop - marginBottom;
+    const pageContentHeightPt = A4_HEIGHT_PT - marginTop - headerLogoReserve - marginBottom;
     const charsPerLine = estimateCharsPerLine({ columnWidthPt: columnContentWidth, fontSize: formatting.fontSize });
     const capacity = estimateColumnPageCapacity({
       columnWidthPt: columnContentWidth,
@@ -538,19 +593,22 @@ const DocumentsPdfDocument = ({
     });
     const pageGroups = splitParagraphsIntoPages(bodyParagraphs, lang, capacity, charsPerLine);
     return (
-      <Page key={doc.id} size="A4" style={pageStyle}>
+      <Page key={doc.id} size="A4" style={pageStyleForDoc}>
         <PageHeader formatting={formatting} marginTop={marginTop} marginLeft={marginLeft} marginRight={marginRight} />
+        {headerLogoReserve ? (
+          <HeaderLogo doc={doc} clinicLogos={effectiveClinicLogos} widthPt={logoWidth} marginLeft={marginLeft} marginTop={marginTop} />
+        ) : null}
         <PageDivider show={showColumnDivider} marginTop={marginTop} marginBottom={marginBottom} left={dividerLeft} />
         {pageGroups.map((pageParagraphs, pageIndex) => (
           // eslint-disable-next-line react/no-array-index-key
           <View key={pageIndex} break={pageIndex > 0}>
             {pageIndex === 0 ? (
               <>
-                {doc.logo ? (
+                {doc.logo && !headerLogoReserve ? (
                   <LogoBlock type={doc.logo} isBilingual={false} cellStyles={cellStyles} logoWidth={logoWidth} longLogoWidth={contentWidth} clinicLogos={effectiveClinicLogos} showUk showEn />
                 ) : null}
-                <BeforeTitleBlocks doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} />
-                <DocumentTitleBlock doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} />
+                <BeforeTitleBlocks doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} blankFields={blankFields} />
+                <DocumentTitleBlock doc={doc} isBilingual={false} lang={lang} cellStyles={cellStyles} titleGap={formatting.paragraphSpacing} blankFields={blankFields} />
               </>
             ) : null}
             <SingleLanguageColumns
@@ -561,6 +619,7 @@ const DocumentsPdfDocument = ({
               logoWidth={logoWidth}
               clinicLogos={effectiveClinicLogos}
               charsPerLine={charsPerLine}
+              blankFields={blankFields}
             />
           </View>
         ))}
@@ -573,9 +632,14 @@ const DocumentsPdfDocument = ({
     const isTwoColumn = isBilingualLayout(effectiveLayout) || isSingleLanguageTwoColumnLayout(effectiveLayout);
     const showColumnDivider = isTwoColumn && Boolean(formatting.columnDivider);
     const logoWidth = isTwoColumn ? Math.min(configuredLogoWidth, columnContentWidth) : configuredLogoWidth;
+    const headerLogoReserve = resolveHeaderLogoReserve(doc, effectiveClinicLogos, logoWidth);
+    const pageStyleForDoc = headerLogoReserve ? { ...pageStyle, paddingTop: marginTop + headerLogoReserve } : pageStyle;
     return (
-      <Page key={doc.id} size="A4" style={pageStyle}>
+      <Page key={doc.id} size="A4" style={pageStyleForDoc}>
         <PageHeader formatting={formatting} marginTop={marginTop} marginLeft={marginLeft} marginRight={marginRight} />
+        {headerLogoReserve ? (
+          <HeaderLogo doc={doc} clinicLogos={effectiveClinicLogos} widthPt={logoWidth} marginLeft={marginLeft} marginTop={marginTop} />
+        ) : null}
         <PageDivider show={showColumnDivider} marginTop={marginTop} marginBottom={marginBottom} left={dividerLeft} />
         <DocumentBlock
           doc={doc}

--- a/src/components/DocumentsRenderers.smoke.test.js
+++ b/src/components/DocumentsRenderers.smoke.test.js
@@ -615,6 +615,127 @@ describe('Documents PDF renderer - toPdfRenderableText (batch 2026-07-23 C §1/�
   }, 20000);
 });
 
+// batch 22 §1: an official-form document (documentStyle: 'official-form', e.g. Додаток 18) must
+// replicate a government form's look - its underscore blank fields render underlined instead of
+// literal, and its letterhead logo moves into the page Header instead of the body block every
+// branded document uses. A branded (default) document must render byte-for-byte the same as before
+// this feature existed - proven by the untouched suites above; this block only covers the new
+// official-form-gated behavior.
+describe('Documents renderers - official-form documentStyle (batch 22 §1)', () => {
+  const clinicLogoVariants = [
+    { fileName: 'square.png', dataUrl: TINY_PNG_DATA_URL, layout: '1col', width: 10, height: 4 },
+  ];
+
+  const officialFormDoc = async () => {
+    const { buildGeneratedDocument } = await import('./documentsCatalogUtils');
+    const template = {
+      id: 'genetic-affinity-certificate',
+      documentStyle: 'official-form',
+      logo: '{{logo}}',
+      languages: ['uk'],
+      columns: 1,
+      title: { uk: 'ДОВІДКА' },
+      paragraphs: [
+        { uk: 'паспорт: тип: __________, Код країни: __________, № TM 0250875' },
+      ],
+    };
+    return buildGeneratedDocument(template, {});
+  };
+
+  it('buildGeneratedDocument carries documentStyle onto the generated doc', async () => {
+    const doc = await officialFormDoc();
+    expect(doc.documentStyle).toBe('official-form');
+  });
+
+  it('DOCX: renders the blank field underlined with non-breaking spaces, never the literal underscores', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = await officialFormDoc();
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'two-column', clinicLogos: clinicLogoVariants });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const xml = await zip.file('word/document.xml').async('string');
+    expect(xml).not.toContain('__________');
+    expect(xml).toMatch(/<w:u w:val="single"\/>/);
+    expect(xml).toContain('Код країни:');
+  }, 20000);
+
+  it('DOCX: draws the letterhead logo in the page Header, not as a body paragraph before the title', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const doc = await officialFormDoc();
+    const blob = await buildDocumentsDocx({ documents: [doc], layout: 'two-column', clinicLogos: clinicLogoVariants });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const documentXml = await zip.file('word/document.xml').async('string');
+    const headerFiles = Object.keys(zip.files).filter(name => /^word\/header\d*\.xml$/.test(name));
+    expect(headerFiles.length).toBeGreaterThan(0);
+    const headerXml = await zip.file(headerFiles[0]).async('string');
+    expect(headerXml).toContain('<w:drawing>');
+    // The body itself carries no drawing before the title - only the header does.
+    expect(documentXml.indexOf('<w:drawing>') === -1 || documentXml.indexOf('<w:drawing>') > documentXml.indexOf('ДОВІДКА')).toBe(true);
+  }, 20000);
+
+  it('a branded document (documentStyle absent) keeps rendering its logo as a body block, never in the Header', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const { buildGeneratedDocument } = await import('./documentsCatalogUtils');
+    const brandedDoc = buildGeneratedDocument({
+      id: 'branded-doc', logo: '{{logo}}', title: { uk: 'Т' }, paragraphs: [{ uk: '____' }],
+    }, {});
+    const blob = await buildDocumentsDocx({ documents: [brandedDoc], layout: 'one-column-uk', clinicLogos: clinicLogoVariants });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const documentXml = await zip.file('word/document.xml').async('string');
+    expect(documentXml).toContain('<w:drawing>');
+    // Underscores stay literal for a branded document - the blank-field rendering is official-form only.
+    expect(documentXml).toContain('____');
+  }, 20000);
+
+  it('PDF: renders an official-form document with a logo and blank fields without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+    const doc = await officialFormDoc();
+    const { DEFAULT_DOC_FORMATTING, OFFICIAL_FORM_FORMATTING, normalizeDocFormatting } = await import('./documentsCatalogUtils');
+    const formatting = normalizeDocFormatting({ ...DEFAULT_DOC_FORMATTING, ...OFFICIAL_FORM_FORMATTING });
+    const element = React.createElement(DocumentsPdfDocument, {
+      documents: [doc], layout: 'two-column', formatting, clinicLogos: clinicLogoVariants,
+    });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
+});
+
 describe('Documents renderers - title deletion never crashes (batch 2026-07-23 C §2)', () => {
   const registerFonts = async Font => {
     Font.register({

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1906,6 +1906,7 @@ export const buildGeneratedDocument = (template, context) => {
   const languages = resolveDocLanguages(template);
   return {
     id: template.id,
+    documentStyle: normalizeDocumentStyle(template?.documentStyle),
     allowPageBreaks: Boolean(template.allowPageBreaks),
     logo,
     languages,
@@ -2176,6 +2177,32 @@ export const serializeFormattedRuns = runs => {
   }
   return out;
 };
+
+// --- Blank fill-in fields (official-form documents, batch 22 §1) ----------------------------
+// A Ukrainian government form's blank line ("паспорт: тип: __________, Код країни: __________")
+// is typed as a run of underscores in the template text, the same way it was authored in the
+// reference docx - but a printed government form never shows literal underscore glyphs, it shows
+// an underlined blank space. This never touches how the underscores are typed/stored (still plain
+// `_` characters, so Data/Template mode round-trip unchanged); it only splits an already-formatted
+// run (parseFormattedRuns' output) at its underscore stretches, tagging each stretch `blank: true`,
+// so the PDF/DOCX renderers can draw that stretch as an underlined run of non-breaking spaces
+// instead of underscore characters - the renderer decides whether to actually do that (gated to
+// isOfficialFormStyle, batch 22 §1) so every other, non-official-form document keeps showing its
+// underscores exactly as before.
+const BLANK_FIELD_PATTERN = /_{2,}/g;
+
+export const splitBlankFieldRuns = runs => (runs || []).flatMap(run => {
+  const text = String(run.text || '');
+  const segments = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(BLANK_FIELD_PATTERN)) {
+    if (match.index > lastIndex) segments.push({ ...run, text: text.slice(lastIndex, match.index), blank: false });
+    segments.push({ ...run, text: match[0], blank: true });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length || !segments.length) segments.push({ ...run, text: text.slice(lastIndex), blank: false });
+  return segments;
+});
 
 // The text an admin actually reads/types in Data mode - the same string with every formatting
 // marker stripped out (Template mode shows the raw markup instead, spec §2).
@@ -2475,6 +2502,44 @@ const clampNumber = (value, min, max, fallback) => {
   return Math.min(max, Math.max(min, number));
 };
 
+// --- Document style classes (batch 22 §1) ---------------------------------------------------
+// Every template historically rendered with the one shared notarial layout above (the "branded"
+// class, tuned for consent letters/agreements). An official regulatory form (e.g. Додаток 18) has
+// to visually replicate a government template instead - tighter margins, a smaller dense body, no
+// paragraph gap beyond the reference's own empty lines - regardless of whatever the admin's shared
+// Format-panel favourites happen to be set to for the rest of the catalog. `documentStyle` is a
+// template-level flag (default 'branded', the untouched pre-existing behavior) picked up by
+// resolveEffectiveDocFormatting below; unrecognized/missing values always fall back to 'branded' so
+// every template saved before this existed keeps rendering exactly as it did.
+export const DOCUMENT_STYLES = ['branded', 'official-form'];
+
+export const normalizeDocumentStyle = value => (DOCUMENT_STYLES.includes(value) ? value : 'branded');
+
+export const isOfficialFormStyle = doc => normalizeDocumentStyle(doc?.documentStyle) === 'official-form';
+
+// Measured directly from the reference Додаток 18 docx's own XML (batch 22): pgMar top/right/
+// bottom/left = 284/851/567/851 twips = 0.5/1.5/1.0/1.5 cm, single line spacing, no after-paragraph
+// spacing (blocks separated only by explicit empty lines, same convention as the branded default),
+// a dense form body size and a 14 pt bold centered title.
+export const OFFICIAL_FORM_FORMATTING = {
+  fontSize: 10,
+  titleFontSize: 14,
+  lineSpacing: 1,
+  paragraphSpacing: 0,
+  firstLineIndentCm: 1,
+  marginTopCm: 0.5,
+  marginRightCm: 1.5,
+  marginBottomCm: 1,
+  marginLeftCm: 1.5,
+  columnGapCm: DEFAULT_DOC_FORMATTING.columnGapCm,
+  logoWidthMm: DEFAULT_DOC_FORMATTING.logoWidthMm,
+  showLogo: DEFAULT_DOC_FORMATTING.showLogo,
+  headerText: DEFAULT_DOC_FORMATTING.headerText,
+  footerText: DEFAULT_DOC_FORMATTING.footerText,
+  showPageNumbers: DEFAULT_DOC_FORMATTING.showPageNumbers,
+  columnDivider: DEFAULT_DOC_FORMATTING.columnDivider,
+};
+
 export const normalizeDocFormatting = raw => {
   const source = isPlainObject(raw) ? raw : {};
   return {
@@ -2506,11 +2571,15 @@ export const normalizeDocFormatting = raw => {
 // (default/favourite) formatting - an empty/absent field means "use the defaults as-is". Merging
 // is a flat shallow overlay since every DEFAULT_DOC_FORMATTING key is itself a scalar.
 
-// The formatting a document actually renders with: the shared reference settings with that
-// document's own overrides layered on top, then re-clamped/validated the same way any formatting
-// value is.
-export const resolveEffectiveDocFormatting = (referenceFormatting, docFormatOverride) => normalizeDocFormatting({
-  ...referenceFormatting,
+// The formatting a document actually renders with: an official-form document (batch 22 §1) starts
+// from the fixed OFFICIAL_FORM_FORMATTING baseline instead of the shared admin-tunable reference,
+// so it never inherits the branded catalog's margins/sizes just because the Format panel's
+// favourites happen to be set a certain way - a branded document (the default, `documentStyle`
+// absent/'branded') keeps starting from the shared reference exactly as before. Either way, that
+// document's own `format` overrides still layer on top, so an official-form template can still be
+// fine-tuned per document through the same panel.
+export const resolveEffectiveDocFormatting = (referenceFormatting, docFormatOverride, documentStyle) => normalizeDocFormatting({
+  ...(normalizeDocumentStyle(documentStyle) === 'official-form' ? OFFICIAL_FORM_FORMATTING : referenceFormatting),
   ...(isPlainObject(docFormatOverride) ? docFormatOverride : {}),
 });
 

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -58,6 +58,7 @@ import {
   getValueByPath,
   isBilingualLayout,
   isIsoDate,
+  isOfficialFormStyle,
   isParagraphBold,
   isSectionHeading,
   isSingleLanguageTwoColumnLayout,
@@ -68,7 +69,9 @@ import {
   normalizeDocFormatting,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
+  normalizeDocumentStyle,
   normalizeIsoDate,
+  OFFICIAL_FORM_FORMATTING,
   orderCasesByRecent,
   orderRecordsByRecentIds,
   parseDocumentsTechnicalInput,
@@ -80,6 +83,7 @@ import {
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
   serializeFormattedRuns,
+  splitBlankFieldRuns,
   splitParagraphsIntoColumns,
   splitParagraphsIntoPages,
   stripDerivedFields,
@@ -1848,6 +1852,100 @@ describe('spec: per-document format overrides (batch 13 §5)', () => {
     const reference = normalizeDocFormatting({ fontSize: 10 });
     const working = normalizeDocFormatting({ fontSize: 10 });
     expect(diffDocFormattingOverrides(reference, working)).toEqual({});
+  });
+});
+
+// batch 22 §1: official-form documents (e.g. Додаток 18) must visually replicate a government
+// template - tighter margins, a smaller dense body, no branded-catalog styling - regardless of
+// whatever the admin's shared Format-panel favourites happen to be set to.
+describe('spec: official-form documentStyle (batch 22 §1)', () => {
+  it('normalizeDocumentStyle defaults every unrecognized/missing value to "branded"', () => {
+    expect(normalizeDocumentStyle(undefined)).toBe('branded');
+    expect(normalizeDocumentStyle('')).toBe('branded');
+    expect(normalizeDocumentStyle('something-else')).toBe('branded');
+    expect(normalizeDocumentStyle('official-form')).toBe('official-form');
+  });
+
+  it('isOfficialFormStyle reads a generated doc\'s documentStyle field', () => {
+    expect(isOfficialFormStyle({ documentStyle: 'official-form' })).toBe(true);
+    expect(isOfficialFormStyle({ documentStyle: 'branded' })).toBe(false);
+    expect(isOfficialFormStyle({})).toBe(false);
+    expect(isOfficialFormStyle(undefined)).toBe(false);
+  });
+
+  it('resolveEffectiveDocFormatting starts an official-form document from OFFICIAL_FORM_FORMATTING, never the branded reference', () => {
+    const brandedReference = normalizeDocFormatting({ fontSize: 12, marginTopCm: 2 });
+    const effective = resolveEffectiveDocFormatting(brandedReference, undefined, 'official-form');
+    expect(effective).toEqual(normalizeDocFormatting(OFFICIAL_FORM_FORMATTING));
+    expect(effective.fontSize).toBe(10);
+    expect(effective.titleFontSize).toBe(14);
+    expect(effective.marginTopCm).toBe(0.5);
+    expect(effective.marginRightCm).toBe(1.5);
+    expect(effective.marginBottomCm).toBe(1);
+    expect(effective.marginLeftCm).toBe(1.5);
+    expect(effective.paragraphSpacing).toBe(0);
+    expect(effective.lineSpacing).toBe(1);
+  });
+
+  it('resolveEffectiveDocFormatting still layers a document\'s own format override on top of the official-form baseline', () => {
+    const brandedReference = normalizeDocFormatting({ fontSize: 12 });
+    const effective = resolveEffectiveDocFormatting(brandedReference, { fontSize: 9 }, 'official-form');
+    expect(effective.fontSize).toBe(9);
+    expect(effective.marginTopCm).toBe(0.5);
+  });
+
+  it('a branded (default) document is unaffected - still starts from the shared reference formatting', () => {
+    const brandedReference = normalizeDocFormatting({ fontSize: 12, marginTopCm: 2 });
+    expect(resolveEffectiveDocFormatting(brandedReference, undefined, undefined)).toEqual(brandedReference);
+    expect(resolveEffectiveDocFormatting(brandedReference, undefined, 'branded')).toEqual(brandedReference);
+  });
+
+  it('buildGeneratedDocument carries the template\'s documentStyle through onto the generated doc', () => {
+    const context = { case: {} };
+    expect(buildGeneratedDocument({ id: 'x', documentStyle: 'official-form', title: {}, paragraphs: [] }, context).documentStyle).toBe('official-form');
+    expect(buildGeneratedDocument({ id: 'x', title: {}, paragraphs: [] }, context).documentStyle).toBe('branded');
+    expect(buildGeneratedDocument({ id: 'x', documentStyle: 'nonsense', title: {}, paragraphs: [] }, context).documentStyle).toBe('branded');
+  });
+});
+
+// batch 22 §1: a government form's blank fill-in line ("паспорт: тип: __________") is typed as a
+// run of underscores, same as in the reference docx - splitBlankFieldRuns is what lets the PDF/DOCX
+// renderers draw that stretch as an underlined blank instead of literal underscore glyphs, gated to
+// official-form documents only (see DocumentsPdfDocument/documentsDocxBuilder).
+describe('spec: blank fill-in fields (batch 22 §1)', () => {
+  it('splits a run of 2+ underscores out of a plain run as its own blank segment', () => {
+    const runs = parseFormattedRuns('Код країни: __________, № TM');
+    const result = splitBlankFieldRuns(runs);
+    expect(result.map(run => [run.text, Boolean(run.blank)])).toEqual([
+      ['Код країни: ', false],
+      ['__________', true],
+      [', № TM', false],
+    ]);
+  });
+
+  it('never splits a single underscore (not a blank-field token)', () => {
+    const runs = parseFormattedRuns('file_name stays intact');
+    expect(splitBlankFieldRuns(runs)).toEqual([{ text: 'file_name stays intact', bold: false, italic: false, blank: false }]);
+  });
+
+  it('preserves the bold/italic flags of the run a blank segment was split out of', () => {
+    const runs = parseFormattedRuns('**Підпис ___**');
+    const result = splitBlankFieldRuns(runs);
+    expect(result).toEqual([
+      { text: 'Підпис ', bold: true, italic: false, blank: false },
+      { text: '___', bold: true, italic: false, blank: true },
+    ]);
+  });
+
+  it('handles multiple blank stretches and a run that is entirely a blank stretch', () => {
+    expect(splitBlankFieldRuns(parseFormattedRuns('__ and __')).map(run => run.blank)).toEqual([true, false, true]);
+    expect(splitBlankFieldRuns(parseFormattedRuns('____')).map(run => run.blank)).toEqual([true]);
+  });
+
+  it('leaves ordinary text with no underscores as a single non-blank segment', () => {
+    expect(splitBlankFieldRuns(parseFormattedRuns('ordinary text'))).toEqual([
+      { text: 'ordinary text', bold: false, italic: false, blank: false },
+    ]);
   });
 });
 

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -14,10 +14,12 @@ import {
   getEffectiveDocLayout,
   getLayoutLang,
   isBilingualLayout,
+  isOfficialFormStyle,
   isParagraphBold,
   isSingleLanguageTwoColumnLayout,
   normalizeSignerBlockOffsetPercent,
   parseFormattedRuns,
+  splitBlankFieldRuns,
   splitParagraphsIntoColumns,
 } from './documentsCatalogUtils';
 
@@ -48,7 +50,7 @@ export const buildDocumentsDocx = async ({
   const docx = await import('docx');
   const {
     AlignmentType, BorderStyle, Document, Footer, Header, ImageRun, Packer, PageNumber,
-    Paragraph, Table, TableCell, TableRow, TextRun, VerticalAlign, WidthType,
+    Paragraph, Table, TableCell, TableRow, TextRun, UnderlineType, VerticalAlign, WidthType,
   } = docx;
 
   // Both column layouts (bilingual UA|EN and single-language newspaper-style, spec §4) share the
@@ -88,13 +90,26 @@ export const buildDocumentsDocx = async ({
   // <w:br/> line breaks (batch 2026-07-23 B §3: an empty line inside a paragraph - consecutive
   // breaks - must survive into the Word output as a full blank line, never be silently dropped
   // by a TextRun that doesn't understand "\n").
-  const formattedTextRuns = (text, { size, baseBold = false } = {}) => parseFormattedRuns(text).flatMap(run => String(run.text).split('\n').map((segment, segmentIndex) => new TextRun({
-    text: segment,
-    size,
-    bold: baseBold || run.bold,
-    italics: run.italic,
-    ...(segmentIndex > 0 ? { break: 1 } : {}),
-  })));
+  // `blankFields` (official-form documents only, batch 22 §1) additionally splits each run at its
+  // underscore stretches (see splitBlankFieldRuns) so a government form's typed "__________"
+  // fill-in line renders as an underlined run of non-breaking spaces instead of literal underscore
+  // characters - the PDF renderer does the same, gated the same way. Every other document leaves
+  // its underscores exactly as typed.
+  const formattedTextRuns = (text, { size, baseBold = false, blankFields = false } = {}) => {
+    const runs = parseFormattedRuns(text);
+    const renderRuns = blankFields ? splitBlankFieldRuns(runs) : runs;
+    return renderRuns.flatMap(run => {
+      const runText = run.blank ? ' '.repeat(run.text.length) : String(run.text);
+      return runText.split('\n').map((segment, segmentIndex) => new TextRun({
+        text: segment,
+        size,
+        bold: baseBold || run.bold,
+        italics: run.italic,
+        underline: run.blank ? { type: UnderlineType.SINGLE } : undefined,
+        ...(segmentIndex > 0 ? { break: 1 } : {}),
+      }));
+    });
+  };
 
   // batch 16 §17: an explicit `align` on a paragraph (or beforeTitle block) overrides the default
   // alignment (justified body / flush-left heading) - never inferred from the text itself.
@@ -105,7 +120,7 @@ export const buildDocumentsDocx = async ({
     return AlignmentType.LEFT;
   };
 
-  const bodyParagraph = (text, { keepLines = true, alignmentOverride, indentTwipsOverride, sizeOverride } = {}) => {
+  const bodyParagraph = (text, { keepLines = true, alignmentOverride, indentTwipsOverride, sizeOverride, blankFields = false } = {}) => {
     // Per-paragraph first-line indent (spec: the reference notarial statement indents only its
     // opening declaration, not the signature/registration lines after it) - undefined falls back
     // to the document-wide firstLineTwips, same as every paragraph did before this existed.
@@ -115,33 +130,34 @@ export const buildDocumentsDocx = async ({
       spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
       indent: firstLine ? { firstLine } : undefined,
       keepLines,
-      children: formattedTextRuns(text, { size: sizeOverride ?? bodySize }),
+      children: formattedTextRuns(text, { size: sizeOverride ?? bodySize, blankFields }),
     });
   };
 
   // Short numbered section titles ("1. Предмет Договору") render bold, flush left, with extra
   // room above and kept with the paragraph that follows so a heading never ends a page alone.
-  const headingParagraph = (text, alignmentOverride, sizeOverride) => new Paragraph({
+  const headingParagraph = (text, alignmentOverride, sizeOverride, blankFields = false) => new Paragraph({
     alignment: alignmentOverride || AlignmentType.LEFT,
     spacing: { before: afterTwips, after: afterTwips, line: lineTwips, lineRule: 'auto' },
     keepLines: true,
     keepNext: true,
-    children: formattedTextRuns(text, { size: sizeOverride ?? bodySize, baseBold: true }),
+    children: formattedTextRuns(text, { size: sizeOverride ?? bodySize, baseBold: true, blankFields }),
   });
 
-  const cellParagraph = (text, allowPageBreaks, paragraph) => {
+  const cellParagraph = (text, allowPageBreaks, paragraph, blankFields = false) => {
     // align/indentCm/fontSize arrive already resolved from the paragraph's consolidated `style`
     // key (buildGeneratedDocument) - undefined means "inherit the document-wide value".
     const alignmentOverride = paragraph?.align ? alignmentForBlock(paragraph.align) : undefined;
     const indentTwipsOverride = paragraph?.indentCm !== undefined ? Math.round(paragraph.indentCm * CM_TO_TWIP) : undefined;
     const sizeOverride = paragraph?.fontSize !== undefined ? halfPoints(paragraph.fontSize) : undefined;
     return isParagraphBold(paragraph)
-      ? headingParagraph(text, alignmentOverride, sizeOverride)
+      ? headingParagraph(text, alignmentOverride, sizeOverride, blankFields)
       : bodyParagraph(text, {
         keepLines: !allowsParagraphInternalBreak(paragraph, allowPageBreaks),
         alignmentOverride,
         indentTwipsOverride,
         sizeOverride,
+        blankFields,
       });
   };
 
@@ -150,12 +166,13 @@ export const buildDocumentsDocx = async ({
   // ordinary centered paragraph (batch 2026-07-23 C §2): Center is only its default - its own
   // sparse align/fontSize (resolved by buildGeneratedDocument from the title's consolidated
   // `style`) override it like any paragraph's.
-  const titleParagraph = (text, title = {}) => new Paragraph({
+  const titleParagraph = (text, title = {}, blankFields = false) => new Paragraph({
     alignment: title.align ? alignmentForBlock(title.align) : AlignmentType.CENTER,
     spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
     children: formattedTextRuns(text, {
       size: title.fontSize !== undefined ? halfPoints(title.fontSize) : titleSize,
       baseBold: true,
+      blankFields,
     }),
   });
 
@@ -178,21 +195,22 @@ export const buildDocumentsDocx = async ({
 
   // An explicitly aligned block (the §1.5 alignment button, stored under the block's `style`
   // key) overrides the strip's notarial default: bold caption flush-left, regular data justified.
-  const signerBlockParagraph = (text, block) => new Paragraph({
+  const signerBlockParagraph = (text, block, blankFields = false) => new Paragraph({
     alignment: block.align ? alignmentForBlock(block.align) : (block.bold ? AlignmentType.LEFT : AlignmentType.JUSTIFIED),
     spacing: { after: afterTwips, line: lineTwips, lineRule: 'auto' },
     children: formattedTextRuns(text, {
       size: block.fontSize !== undefined ? halfPoints(block.fontSize) : bodySize,
       baseBold: Boolean(block.bold),
+      blankFields,
     }),
   });
 
-  const signerBlockTable = (blocks, langKey, containerWidthTwips, offsetPercent) => {
+  const signerBlockTable = (blocks, langKey, containerWidthTwips, offsetPercent, blankFields = false) => {
     const offsetTwips = Math.round(containerWidthTwips * (offsetPercent / 100));
     const blockWidthTwips = Math.max(1, Math.round(containerWidthTwips) - offsetTwips);
     const cellChildren = blocks.flatMap((block, index) => [
       ...(index > 0 ? [emptyLineParagraph()] : []),
-      signerBlockParagraph(block[langKey], block),
+      signerBlockParagraph(block[langKey], block, blankFields),
     ]);
     return new Table({
       width: { size: offsetTwips + blockWidthTwips, type: WidthType.DXA },
@@ -250,7 +268,7 @@ export const buildDocumentsDocx = async ({
   const singleLanguageColumnsTable = (paragraphs, allowPageBreaks, lang, layoutCtx) => {
     const [leftParagraphs, rightParagraphs] = splitParagraphsIntoColumns(paragraphs, lang);
     const buildColumnChildren = columnParagraphs => columnParagraphs.flatMap(paragraph => (
-      paragraph.type && paragraph.type !== 'text' ? buildLogoBlock(paragraph.type, layoutCtx) : [cellParagraph(paragraph[lang], allowPageBreaks, paragraph)]
+      paragraph.type && paragraph.type !== 'text' ? buildLogoBlock(paragraph.type, layoutCtx) : [cellParagraph(paragraph[lang], allowPageBreaks, paragraph, layoutCtx.blankFields)]
     ));
     return new Table({
       width: { size: 100, type: WidthType.PERCENTAGE },
@@ -315,15 +333,19 @@ export const buildDocumentsDocx = async ({
     const showUk = isBilingual || lang === 'uk';
     const showEn = isBilingual || lang === 'en';
     const showColumnDivider = isTwoColumn && Boolean(formatting.columnDivider);
+    // An official-form document (batch 22 §1) draws its logo in the page Header instead (see
+    // buildHeader below) - never again here as a one-off body block - and its underscore blank
+    // fields render underlined, not literal.
+    const blankFields = isOfficialFormStyle(doc);
     const layoutCtx = {
-      isTwoColumn, showUk, showEn, showColumnDivider,
+      isTwoColumn, showUk, showEn, showColumnDivider, blankFields,
     };
 
     const children = [];
 
     // The template's letterhead logo (doc.logo) always renders before the title, whether it came
     // from the dedicated `logo` field or a legacy leading paragraph - see getTemplateLogoType.
-    if (doc.logo) children.push(...buildLogoBlock(doc.logo, layoutCtx));
+    if (doc.logo && !blankFields) children.push(...buildLogoBlock(doc.logo, layoutCtx));
 
     // The addressee/signer block between the logo and the title (§3.2), never merged into the
     // body. One empty line separates the whole block from the title that follows (§3.4).
@@ -332,11 +354,11 @@ export const buildDocumentsDocx = async ({
       const offsetPercent = normalizeSignerBlockOffsetPercent(doc.beforeTitleOffsetPercent);
       if (isBilingual) {
         children.push(twoColumnTable([[
-          signerBlockTable(signerBlocks, 'uk', columnContentWidthTwips, offsetPercent),
-          signerBlockTable(signerBlocks, 'en', columnContentWidthTwips, offsetPercent),
+          signerBlockTable(signerBlocks, 'uk', columnContentWidthTwips, offsetPercent, blankFields),
+          signerBlockTable(signerBlocks, 'en', columnContentWidthTwips, offsetPercent, blankFields),
         ]], true, showColumnDivider));
       } else {
-        children.push(signerBlockTable(signerBlocks, lang, contentWidthTwips, offsetPercent));
+        children.push(signerBlockTable(signerBlocks, lang, contentWidthTwips, offsetPercent, blankFields));
       }
       children.push(emptyLineParagraph());
     }
@@ -346,9 +368,9 @@ export const buildDocumentsDocx = async ({
     const title = doc.title || {};
     if (!isBlankBlockText(title.uk) || !isBlankBlockText(title.en)) {
       if (isBilingual) {
-        children.push(twoColumnTable([[titleParagraph(title.uk, title), titleParagraph(title.en, title)]], true, showColumnDivider));
+        children.push(twoColumnTable([[titleParagraph(title.uk, title, blankFields), titleParagraph(title.en, title, blankFields)]], true, showColumnDivider));
       } else {
-        children.push(titleParagraph(title[lang], title));
+        children.push(titleParagraph(title[lang], title, blankFields));
       }
     }
 
@@ -370,26 +392,44 @@ export const buildDocumentsDocx = async ({
       if (isBilingual) {
         const cantSplit = !allowsParagraphInternalBreak(paragraph, doc.allowPageBreaks);
         children.push(twoColumnTable([[
-          cellParagraph(paragraph.uk, doc.allowPageBreaks, paragraph),
-          cellParagraph(paragraph.en, doc.allowPageBreaks, paragraph),
+          cellParagraph(paragraph.uk, doc.allowPageBreaks, paragraph, blankFields),
+          cellParagraph(paragraph.en, doc.allowPageBreaks, paragraph, blankFields),
         ]], cantSplit, showColumnDivider));
       } else {
-        children.push(cellParagraph(paragraph[lang], doc.allowPageBreaks, paragraph));
+        children.push(cellParagraph(paragraph[lang], doc.allowPageBreaks, paragraph, blankFields));
       }
     });
     return children;
   };
 
-  const headers = formatting.headerText
-    ? {
-      default: new Header({
-        children: [new Paragraph({
-          alignment: AlignmentType.CENTER,
-          children: [new TextRun({ text: formatting.headerText, size: smallSize })],
-        })],
-      }),
+  // An official-form document's letterhead logo lives in the page Header (batch 22 §1) instead of
+  // the one-off body block every branded document uses - Word repeats a Header on every page of
+  // its section automatically and reflows the body to start after it, so (unlike the PDF renderer)
+  // no manual space reservation is needed here. `formatting.headerText` still applies to every
+  // document the same way it always did, stacked below the logo when both are present.
+  const buildHeader = doc => {
+    const children = [];
+    if (isOfficialFormStyle(doc) && doc.logo) {
+      const variant = getClinicLogo(effectiveClinicLogos, doc.logo);
+      const decoded = variant?.dataUrl ? decodeLogoDataUrl(variant.dataUrl) : null;
+      if (decoded) {
+        const ratio = variant.width && variant.height ? variant.height / variant.width : 0.28;
+        const widthPx = Math.round(formatting.logoWidthMm * MM_TO_PX);
+        children.push(new Paragraph({
+          alignment: AlignmentType.LEFT,
+          spacing: { after: 80 },
+          children: [logoImageRun(decoded, widthPx, ratio)],
+        }));
+      }
     }
-    : undefined;
+    if (formatting.headerText) {
+      children.push(new Paragraph({
+        alignment: AlignmentType.CENTER,
+        children: [new TextRun({ text: formatting.headerText, size: smallSize })],
+      }));
+    }
+    return children.length ? { default: new Header({ children }) } : undefined;
+  };
 
   // One section per document (below), each with its own w:pgNumType/@start="1" (pageNumbers.start
   // in pageSetup) so Word's PAGE field restarts at 1 for every document instead of counting
@@ -453,7 +493,7 @@ export const buildDocumentsDocx = async ({
     },
     sections: documents.map(generated => ({
       properties: pageSetup,
-      headers,
+      headers: buildHeader(generated),
       footers: buildFooter(generated),
       children: buildDocChildren(generated),
     })),


### PR DESCRIPTION
Додаток 18 (ДОВІДКА про генетичну спорідненість) and future forms like it
need to visually replicate the government template - tight margins, dense
Times New Roman body, underlined blank fill-in fields - regardless of the
branded catalog's shared Format panel settings.

- documentStyle: 'official-form' on a template forces its effective
  formatting to start from OFFICIAL_FORM_FORMATTING (0.5/1.5/1/1.5 cm
  margins, 10pt body, 14pt title, single spacing) instead of the shared
  branded reference, while still allowing a per-document override on top.
- A run of 2+ underscores in an official-form document's text renders as
  an underlined run of non-breaking spaces in both PDF and Word output,
  instead of literal underscore glyphs - splitBlankFieldRuns never touches
  how the text is stored, only how it's drawn.
- The letterhead logo of an official-form document moves into a small,
  page-repeating header instead of the one-off body block every branded
  document uses.
- Every branded (default) document is unaffected - proven by the existing
  suites passing unchanged plus new regression coverage.

Also surfaces a per-template language/column pin (batch 16 §15/§16) as a
small lock badge on the Documents list row: a template can already pin
itself to always render bilingual regardless of the page's UA/EN/UA+EN
selector, but that was invisible and unexplained on the row, which read as
a preview bug. The badge shows the pin and clears it in one click.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WY2EqJcLCSxDHGWNVYtfmf