### PR TITLE
Documents Builder: implement layoutV2 renderer, fix Bold/Italic and Input mode, add missing data fields

### DIFF
--- a/src/components/DocumentsLayoutV2.test.js
+++ b/src/components/DocumentsLayoutV2.test.js
@@ -1,0 +1,242 @@
+// layoutV2 renderer (spec: "Оновити renderer documentsBuilder, щоб шаблон... рендерився за
+// структурою layoutV2") - covers the normalization step (buildGeneratedDocument/buildLayoutV2Document)
+// and both real render backends (PDF via @react-pdf/renderer, DOCX via docx), plus the 3
+// pre-delivery-review fixes: the surrogate mother's field never uppercases, formValue never
+// double-underlines (border only), and letterSpacingPt actually reaches both backends.
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { buildGeneratedDocument, isLayoutV2Template } from './documentsCatalogUtils';
+
+const toDataUri = file => {
+  const buf = fs.readFileSync(path.join(__dirname, '../../public/fonts', file));
+  return `data:font/ttf;base64,${buf.toString('base64')}`;
+};
+
+const TINY_PNG_DATA_URL = 'data:image/png;base64,'
+  + 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+const clinicLogos = [{ fileName: 'logo.png', dataUrl: TINY_PNG_DATA_URL, layout: '1col', width: 4, height: 1 }];
+
+// A minimal but structurally complete layoutV2 template - one of every block type, styled with
+// the same pre-delivery-review-corrected styleSheet as genetic-affinity-certificate.
+const layoutV2Template = () => ({
+  id: 'layout-v2-fixture',
+  catalogName: 'Test layoutV2 form',
+  logo: '{{logo}}',
+  languages: ['uk'],
+  rendererVersion: 2,
+  page: {
+    size: 'A4',
+    orientation: 'portrait',
+    widthMm: 210,
+    heightMm: 297,
+    marginsMm: {
+      top: 5, right: 15, bottom: 10, left: 15,
+    },
+  },
+  styleSheet: {
+    document: {
+      fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 400, lineHeight: 1, letterSpacingPt: -0.3,
+    },
+    letterheadContact: {
+      fontFamily: 'Times New Roman', fontSizePt: 9, fontWeight: 700, fontStyle: 'italic', align: 'right', letterSpacingPt: 0,
+    },
+    body: { fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 400, align: 'left' },
+    titleMain: {
+      fontFamily: 'Times New Roman', fontSizePt: 14, fontWeight: 700, align: 'center', letterSpacingPt: 0,
+    },
+    formValue: {
+      fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 700, textTransform: 'uppercase', align: 'center', letterSpacingPt: -0.3,
+    },
+    formValueMixedCase: {
+      fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 700, align: 'center', letterSpacingPt: -0.4,
+    },
+    formCaption: {
+      fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 400, align: 'center', letterSpacingPt: 0,
+    },
+    signatureLabel: { fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 400 },
+    signatureName: { fontFamily: 'Times New Roman', fontSizePt: 10, fontWeight: 400, align: 'center' },
+  },
+  layoutV2: {
+    contentWidthMm: 180,
+    renderLegacyContent: false,
+    blocks: [
+      {
+        type: 'letterhead',
+        heightMm: 18,
+        columnGapMm: 5,
+        bottomBorder: { widthPt: 3, color: '#000000' },
+        columns: [
+          { widthMm: 64.4, content: { type: 'image', source: '{{logo}}', widthMm: 64.4, heightMm: 17 } },
+          {
+            widthMm: 110.6,
+            content: {
+              type: 'stack', style: 'letterheadContact', horizontalAlign: 'right', lines: ['{{clinic.edrpou}}'],
+            },
+          },
+        ],
+      },
+      { type: 'paragraph', style: 'titleMain', text: 'ДОВІДКА' },
+      {
+        type: 'fieldLine',
+        style: 'body',
+        label: 'дружина',
+        labelWidthMm: 15,
+        value: '{{wife.name.uk.nominative}}',
+        valueStyle: 'formValue',
+        line: {
+          widthPt: 0.75, color: '#000000', fillBeforeValue: true, fillAfterValue: true,
+        },
+        caption: '(прізвище)',
+        captionStyle: 'formCaption',
+      },
+      {
+        type: 'fieldLine',
+        style: 'body',
+        value: '{{surrogateMother.name.uk.nominative}}',
+        valueStyle: 'formValueMixedCase',
+        line: {
+          widthPt: 0.75, color: '#000000', fillBeforeValue: true, fillAfterValue: true,
+        },
+        caption: '(прізвище)',
+        captionStyle: 'formCaption',
+      },
+      {
+        type: 'richParagraph',
+        style: 'body',
+        runs: [{ text: 'Діагноз: ' }, { text: '{{case.artProgram.medicalIndication.diagnosis.uk}}' }],
+      },
+      { type: 'spacer', heightMm: 5 },
+      {
+        type: 'signatureTable',
+        widthMm: 172.5,
+        columnWidthsMm: [80, 60, 32.5],
+        rows: [
+          [
+            { text: 'Лікар', style: 'signatureLabel' },
+            {
+              text: '{{clinic.medicalDirector.name.uk.nominative}}', style: 'signatureName', bottomBorder: { widthPt: 0.75, color: '#000000' },
+            },
+            { text: '', style: 'signatureName', bottomBorder: { widthPt: 0.75, color: '#000000' } },
+          ],
+          { type: 'spacerRow', heightMm: 5 },
+        ],
+      },
+      {
+        type: 'alignedBox', widthMm: 70, horizontalAlign: 'right', style: 'formCaption', lines: ['Додаток 18'],
+      },
+    ],
+  },
+});
+
+const context = {
+  logo: '{{logo}}',
+  wife: { name: { uk: { nominative: 'Кікава Харука' } } },
+  surrogateMother: { name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } } },
+  clinic: { edrpou: '35085030', medicalDirector: { name: { uk: { nominative: 'Пилип Юрій Юрійович' } } } },
+  case: { artProgram: { medicalIndication: { diagnosis: { uk: 'Безпліддя' } } } },
+};
+
+describe('layoutV2 normalization (buildGeneratedDocument)', () => {
+  it('flags a rendererVersion 2 template with layoutV2.blocks', () => {
+    expect(isLayoutV2Template(layoutV2Template())).toBe(true);
+  });
+
+  it('resolves placeholders and leaves no unresolved {{...}} anywhere in the tree', () => {
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    expect(resolved.layoutV2).toBeTruthy();
+    const serialized = JSON.stringify(resolved.layoutV2);
+    expect(serialized).not.toMatch(/\{\{[^}]+\}\}/);
+    expect(serialized).toContain('Кікава Харука');
+    expect(serialized).toContain('Молвінських Юлія Володимирівна');
+  });
+
+  // Pre-delivery review fix #1: the surrogate mother's field must not carry textTransform: uppercase.
+  it('gives the surrogate mother field formValueMixedCase (no uppercase), not formValue', () => {
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    const fieldLines = resolved.layoutV2.blocks.filter(block => block.type === 'fieldLine');
+    const wifeField = fieldLines.find(block => block.value === 'Кікава Харука');
+    const surrogateField = fieldLines.find(block => block.value === 'Молвінських Юлія Володимирівна');
+    expect(wifeField.valueStyle.textTransform).toBe('uppercase');
+    expect(surrogateField.valueStyle.textTransform).toBeUndefined();
+  });
+
+  // Pre-delivery review fix #3: formValue must never carry its own textDecoration - fieldLine's
+  // border-bottom (drawn by the renderer, not the style) is the only underline mechanism.
+  it('never sets textDecoration on formValue/formValueMixedCase (border-only underline)', () => {
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    resolved.layoutV2.blocks.filter(block => block.type === 'fieldLine').forEach(block => {
+      expect(block.valueStyle.textDecoration).toBeUndefined();
+    });
+  });
+
+  // Pre-delivery review fix #2: letterSpacingPt must survive normalization for both the compressed
+  // body style and the (more compressed) surrogate-mother field.
+  it('carries letterSpacingPt through to the normalized style', () => {
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    const title = resolved.layoutV2.blocks.find(block => block.type === 'paragraph' && block.text === 'ДОВІДКА');
+    expect(title.style.fontSizePt).toBe(14);
+    const surrogateField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Молвінських'));
+    expect(surrogateField.valueStyle.letterSpacingPt).toBe(-0.4);
+  });
+});
+
+describe('layoutV2 PDF renderer (real @react-pdf render)', () => {
+  it('renders a layoutV2 document without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+        { src: toDataUri('Tinos-Italic.ttf'), fontWeight: 400, fontStyle: 'italic' },
+        { src: toDataUri('Tinos-BoldItalic.ttf'), fontWeight: 700, fontStyle: 'italic' },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    const element = React.createElement(DocumentsPdfDocument, {
+      documents: [resolved],
+      layout: 'two-column',
+      clinicLogos,
+    });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
+});
+
+describe('layoutV2 DOCX builder (real docx Packer)', () => {
+  it('builds a .docx blob for a layoutV2 document without throwing', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    const blob = await buildDocumentsDocx({ documents: [resolved], layout: 'two-column', clinicLogos });
+    expect(blob.size).toBeGreaterThan(500);
+  }, 20000);
+
+  it('never emits <w:u/> underline on the formValue run - the border is the only line', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const resolved = buildGeneratedDocument(layoutV2Template(), context);
+    const blob = await buildDocumentsDocx({ documents: [resolved], layout: 'two-column', clinicLogos });
+    const arrayBuffer = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(blob);
+    });
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(Buffer.from(arrayBuffer));
+    const xml = await zip.file('word/document.xml').async('string');
+    expect(xml).toContain('КІКАВА ХАРУКА');
+    expect(xml).not.toContain('Молвінських'.toUpperCase());
+    expect(xml).toContain('Молвінських Юлія Володимирівна');
+  }, 20000);
+});

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaLock, FaPlus, FaSlidersH, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaMagic, FaPlus, FaSearch, FaSlidersH, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFolderFileNames, uploadFileToStorageFolder } from './config';
@@ -50,6 +50,7 @@ import {
   getTemplateScopeRecord,
   getTemplateScopeText,
   isBilingualLayout,
+  isLayoutV2Template,
   isOfficialFormStyle,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
@@ -249,6 +250,38 @@ const SectionTitle = styled.h2`
   font-family: var(--km-font-display);
   font-size: 15px;
   letter-spacing: -0.01em;
+`;
+
+const SearchInputWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 160px;
+  flex: 0 1 220px;
+  border: 1px solid var(--km-border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  color: var(--km-muted);
+  font-size: 12px;
+
+  &:focus-within {
+    border-color: var(--km-accent);
+    color: var(--km-text);
+  }
+`;
+
+const SearchInput = styled.input`
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--km-text);
+  font-size: 12px;
+  font-family: inherit;
+
+  &:focus {
+    outline: none;
+  }
 `;
 
 const StateCard = styled.div`
@@ -764,25 +797,32 @@ const DocumentsPage = ({ isAdmin }) => {
   // duplicated here) - this page only needs to know which one to resolve documents against.
   const [selectedChildId, setSelectedChildId] = useState('');
   const [selectedDocIds, setSelectedDocIds] = useState({});
+  // Quick filter for the Documents list below - matches the same label an admin already reads on
+  // each row (catalogName, falling back the same way the Format section's own dropdown does) so
+  // typing what's on screen always finds it. Never touches which documents are selected/generated -
+  // purely a display filter.
+  const [docSearchQuery, setDocSearchQuery] = useState('');
   const [layout, setLayout] = useState('two-column');
   const [expandedDocId, setExpandedDocId] = useState('');
   // Per-row mode, one cycling button instead of separate toggles: 'template' shows the raw
-  // {{placeholder}} markup and edits the shared template directly; 'input' shows the de-markup'd
-  // plain wording and edits that same shared template (retype the wording, no formatting, no case
-  // involved - templates are static and shared across every case, so there is nothing left to
-  // override); 'text' is a read-only preview resolved against the currently selected case (real
-  // values substituted, never a raw {{token}} - see resolvedValue/titleResolvedValue/
-  // beforeTitleResolvedValue below, all three built from the same resolvedDoc) and is the *only*
-  // mode Bold/Italic can be applied in, acting on the underlying raw markup even though the
-  // resolved wording is what's shown - the wording itself isn't editable there, only its
-  // formatting. Every row - title, every paragraph, every beforeTitle block alike - follows this
-  // identical mechanism, no row-specific exceptions.
+  // {{placeholder}} markup and edits the shared template directly; 'text' is a read-only preview
+  // resolved against the currently selected case (real values substituted, never a raw {{token}} -
+  // see resolvedValue/titleResolvedValue/beforeTitleResolvedValue below, all three built from the
+  // same resolvedDoc), where Bold/Italic act on the underlying raw markup even though the resolved
+  // wording is what's shown - the wording itself isn't editable there, only its formatting.
+  // 'input' shows that same resolved wording at rest (batch 2026-07-25: matches Text mode, never a
+  // raw {{token}}) but is still meant for retyping the plain wording - clicking into a field swaps
+  // it to an editable plain-text view (de-markup'd, `{{token}}`s intact) for that one field only,
+  // tracked by `activeFieldKey` since a ref alone can't drive the re-render. Bold/Italic apply in
+  // both Template and Text mode; only Input mode disables them (nothing raw is on screen there
+  // until a field is actually clicked into). Every row - title, every paragraph, every beforeTitle
+  // block alike - follows this identical mechanism, no row-specific exceptions.
   const PARAGRAPH_MODES = ['template', 'input', 'text'];
   const nextParagraphMode = mode => PARAGRAPH_MODES[(PARAGRAPH_MODES.indexOf(mode) + 1) % PARAGRAPH_MODES.length];
   const PARAGRAPH_MODE_ICON = { template: '{}', input: 'I', text: 'T' };
   const PARAGRAPH_MODE_TITLE = {
     template: 'Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.',
-    input: 'Input mode - retyping the shared wording as plain text. Tap to switch to Text mode.',
+    input: 'Input mode - shows the resolved wording (click it to retype as plain text). Tap to switch to Text mode.',
     text: 'Text mode - select text and press Bold/Italic; wording isn\'t editable here. Tap to switch to Template mode.',
   };
   const [paragraphModes, setParagraphModes] = useState({});
@@ -1244,6 +1284,12 @@ const DocumentsPage = ({ isAdmin }) => {
   const fieldNodesRef = useRef({});
   const activeFieldRef = useRef(null);
   const fieldKey = (docId, scope, langKey) => `${docId}#${scope}#${langKey}`;
+  // Input mode shows the resolved (final, case-substituted) wording at rest - same as Text mode -
+  // instead of the raw {{token}} markup, and swaps to the editable plain-text field only for
+  // whichever single field was last clicked into (batch 2026-07-25: "має показувати вже фінальну
+  // версію тексту... а не посилання в форматі {}"). `activeFieldRef` alone can't drive this (a ref
+  // mutation doesn't re-render), so this mirrors it into real state.
+  const [activeFieldKey, setActiveFieldKey] = useState('');
   const registerFieldNode = (docId, scope, langKey) => node => {
     fieldNodesRef.current[fieldKey(docId, scope, langKey)] = node;
   };
@@ -1251,6 +1297,7 @@ const DocumentsPage = ({ isAdmin }) => {
     activeFieldRef.current = {
       docId, scope, langKey, kind,
     };
+    setActiveFieldKey(fieldKey(docId, scope, langKey));
   };
 
   const preventSelectionLoss = event => event.preventDefault();
@@ -1356,28 +1403,48 @@ const DocumentsPage = ({ isAdmin }) => {
 
   // A template can pin its own languages/columns (batch 16 §15/§16, getEffectiveDocLayout) so it
   // always renders that way regardless of the page's UA/EN/UA+EN toggle - by design for documents
-  // that must always ship bilingual (e.g. a notarized declaration meant for a foreign clinic). That
-  // pin can currently only be set via the technical JSON paste, with no visible indicator on the
-  // document row - an admin who picks "UA · 1 column" for the whole case and still sees this one
-  // document preview bilingual has no way to tell it's an intentional per-document pin rather than
-  // a bug, or any way to clear it short of re-pasting JSON. This surfaces the pin as a small badge
-  // (below) and clears it here in one click - an immediate structural edit, same as the paragraph
-  // insert/remove above, not deferred to blur.
-  const handleClearDocLanguagePin = async docId => {
+  // that must always ship bilingual (e.g. a notarized declaration meant for a foreign clinic), or
+  // that flow a single language across 2 newspaper-style columns. Column count is edited directly
+  // on the document row (next to its delete button, same spot as the document formatting popover)
+  // instead of only being settable via the technical JSON paste - clicking the already-active
+  // column count clears the override so the document goes back to following whatever `languages`
+  // implies (or the page-wide selector, if `languages` isn't pinned either).
+  const DOC_COLUMN_OPTIONS = [1, 2];
+
+  const handleSetDocColumns = async (docId, columns) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const nextTemplate = { ...template };
-    delete nextTemplate.languages;
-    delete nextTemplate.columns;
+    if (template.columns === columns) delete nextTemplate.columns;
+    else nextTemplate.columns = columns;
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
       setCatalog(previous => ({
         ...previous,
         documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
       }));
-      toast.success('This document now follows the page\'s language/column selector.');
-    } catch (pinError) {
-      console.error('Unable to clear the document language pin', pinError);
+    } catch (columnsError) {
+      console.error('Unable to update the document column count', columnsError);
+      toast.error('Could not update the document.');
+    }
+  };
+
+  // A template carrying `layoutV2.blocks` can render two ways: the exact-layout engine
+  // (rendererVersion: 2, spec "Оновити renderer documentsBuilder") or the legacy paragraph
+  // renderer, useful for comparing the two before fully switching a document over. Only shown on a
+  // row that actually has layoutV2 data to switch to/from - every other document is unaffected.
+  const handleToggleLayoutV2 = async docId => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template) return;
+    const nextTemplate = { ...template, rendererVersion: template.rendererVersion === 2 ? 1 : 2 };
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+      }));
+    } catch (rendererError) {
+      console.error('Unable to switch the document renderer', rendererError);
       toast.error('Could not update the document.');
     }
   };
@@ -1643,6 +1710,14 @@ const DocumentsPage = ({ isAdmin }) => {
   // catalog's own order, after every recent one.
   const orderedDocuments = orderRecordsByRecentIds(catalog.documents, settings.recentDocIds);
   const selectedTemplates = orderedDocuments.filter(template => selectedDocIds[template.id]);
+  // The row list only (never the Format section's "Format for: ..." dropdown, which always has to
+  // offer every document regardless of what's currently filtered on screen).
+  const docSearchNeedle = docSearchQuery.trim().toLowerCase();
+  const visibleDocuments = docSearchNeedle
+    ? orderedDocuments.filter(template => (
+      String(template.catalogName || template.title?.uk || template.title?.en || template.id).toLowerCase().includes(docSearchNeedle)
+    ))
+    : orderedDocuments;
   const selectedCase = catalog.cases.find(item => String(item.id) === selectedCaseId) || null;
   // Editing children lives on the Parties page (CaseChildbirthTransactionEditor) - a twin case
   // only needs to say here which one this batch of documents resolves against.
@@ -2065,7 +2140,20 @@ const DocumentsPage = ({ isAdmin }) => {
             <Section>
               <SectionHead>
                 <SectionTitle>Documents</SectionTitle>
+                <SearchInputWrap>
+                  <FaSearch aria-hidden="true" />
+                  <SearchInput
+                    type="search"
+                    value={docSearchQuery}
+                    onChange={event => setDocSearchQuery(event.target.value)}
+                    placeholder="Search documents…"
+                    aria-label="Search documents"
+                  />
+                </SearchInputWrap>
               </SectionHead>
+              {docSearchNeedle && !visibleDocuments.length ? (
+                <DocSubtitle style={{ marginTop: 8 }}>No documents match &ldquo;{docSearchQuery.trim()}&rdquo;.</DocSubtitle>
+              ) : null}
               {activeLogoVariant?.dataUrl ? (
                 <DocLogoPreviewRow>
                   <LogoPreview
@@ -2094,7 +2182,7 @@ const DocumentsPage = ({ isAdmin }) => {
               {!catalog.documents.length ? (
                 <DocSubtitle style={{ marginTop: 8 }}>No document templates yet — paste them in the technical field below.</DocSubtitle>
               ) : null}
-              {orderedDocuments.map(template => {
+              {visibleDocuments.map(template => {
                 const isExpanded = expandedDocId === String(template.id);
                 // The builder view mirrors the selected layout mode (spec §1/§4): both languages as
                 // grouped pairs in bilingual mode, a single language otherwise (1 or 2 columns).
@@ -2108,13 +2196,6 @@ const DocumentsPage = ({ isAdmin }) => {
                 // The per-paragraph indent slider's "inherit" default - this document's own
                 // effective first-line indent, same value generation actually renders with.
                 const docFormatting = resolveEffectiveDocFormatting(formatting, template.format, template.documentStyle);
-                // See handleClearDocLanguagePin above - a template-level languages/columns pin
-                // makes this document ignore the page's UA/EN/UA+EN toggle entirely; surfaced as a
-                // badge on the row so that's visible instead of looking like a preview bug.
-                const pinnedLanguages = toArray(template.languages).map(String).filter(langValue => langValue === 'uk' || langValue === 'en');
-                const languagePinLabel = pinnedLanguages.length > 1
-                  ? 'UA+EN'
-                  : (pinnedLanguages.length === 1 ? `${pinnedLanguages[0] === 'en' ? 'EN' : 'UA'} · ${template.columns === 2 ? '2 col' : '1 col'}` : '');
                 // Whichever source is currently authoritative (the dedicated `logo` field, or a
                 // legacy leading paragraph) shown as one plain-text value the admin can type into
                 // directly - never a normalized re-serialization, so a mid-edit/invalid value
@@ -2144,6 +2225,7 @@ const DocumentsPage = ({ isAdmin }) => {
                 // exists), so Text mode is display-only here.
                 const titleMode = getParagraphMode(template.id, TITLE_SCOPE);
                 const titleIsTemplateMode = titleMode === 'template';
+                const titleIsInputMode = titleMode === 'input';
                 const titleRawValue = langKey => template.title?.[langKey] || '';
                 const titleResolvedValue = langKey => resolvedDoc?.title?.[langKey] ?? '';
                 const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleRawValue(langKey)));
@@ -2178,14 +2260,35 @@ const DocumentsPage = ({ isAdmin }) => {
                         style={{ flex: 1, minWidth: 0, fontWeight: 600 }}
                         title="The document's entry name in the Documents list - never printed inside the document itself (edit the printed title below, in the Title row)"
                       />
-                      {languagePinLabel ? (
+                      {/* Column count for this document - overrides the page-wide selector above
+                          once set (see handleSetDocColumns); tap the active option again to clear
+                          the override. */}
+                      <ToggleGroup>
+                        {DOC_COLUMN_OPTIONS.map(columnsOption => (
+                          <ToggleOption
+                            key={columnsOption}
+                            type="button"
+                            $active={template.columns === columnsOption}
+                            onClick={() => handleSetDocColumns(template.id, columnsOption)}
+                            title={`Render this document with ${columnsOption} column${columnsOption > 1 ? 's' : ''}, regardless of the page's selector above. Tap again to clear the override.`}
+                          >
+                            {columnsOption} col
+                          </ToggleOption>
+                        ))}
+                      </ToggleGroup>
+                      {/* Only a document that actually has layoutV2 blocks (spec: an exact-layout
+                          form like genetic-affinity-certificate) gets a switch between it and the
+                          legacy renderer - every other document never shows this. */}
+                      {template.layoutV2?.blocks ? (
                         <SmallButton
                           type="button"
-                          onClick={() => handleClearDocLanguagePin(template.id)}
-                          title={`This document is pinned to always render ${languagePinLabel}, ignoring the page's language/column selector above. Click to clear the pin so it follows the page selector instead.`}
-                          style={{ flex: '0 0 auto', width: 'auto', color: 'var(--km-accent)' }}
+                          onClick={() => handleToggleLayoutV2(template.id)}
+                          title={isLayoutV2Template(template)
+                            ? 'Rendering with the exact-layout engine (layoutV2). Click to switch back to the legacy paragraph renderer.'
+                            : 'Rendering with the legacy paragraph renderer. Click to switch to the exact-layout engine (layoutV2).'}
+                          style={{ flex: '0 0 auto', width: 'auto', color: isLayoutV2Template(template) ? 'var(--km-accent)' : undefined }}
                         >
-                          <FaLock /> {languagePinLabel}
+                          <FaMagic /> {isLayoutV2Template(template) ? 'layoutV2 on' : 'layoutV2 off'}
                         </SmallButton>
                       ) : null}
                       {/* §1.2: the document-level formatting defaults every non-overridden
@@ -2347,11 +2450,13 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    {isTextMode ? (
+                                    {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, 'uk')) ? (
                                       <TextModeDisplay
                                         ref={registerFieldNode(template.id, scope, 'uk')}
-                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'uk', 'text-display')}
+                                        onMouseUp={isTextMode ? handleRichFieldFocus(template.id, scope, 'uk', 'text-display') : undefined}
+                                        onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, scope, 'uk', 'text-display') : undefined}
+                                        onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, 'uk', fieldKind) : undefined}
+                                        title={isInputMode ? 'Click to edit the wording' : undefined}
                                       >
                                         <FormattedRunsPreview text={beforeTitleResolvedValue('uk')} />
                                       </TextModeDisplay>
@@ -2360,6 +2465,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         ref={registerFieldNode(template.id, scope, 'uk')}
                                         value={displayValue('uk')}
                                         placeholder="Before title (uk)"
+                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
                                         onChange={onChange('uk')}
                                         onBlur={onBlur}
@@ -2369,11 +2475,13 @@ const DocumentsPage = ({ isAdmin }) => {
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    {isTextMode ? (
+                                    {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, 'en')) ? (
                                       <TextModeDisplay
                                         ref={registerFieldNode(template.id, scope, 'en')}
-                                        onMouseUp={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
-                                        onTouchEnd={handleRichFieldFocus(template.id, scope, 'en', 'text-display')}
+                                        onMouseUp={isTextMode ? handleRichFieldFocus(template.id, scope, 'en', 'text-display') : undefined}
+                                        onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, scope, 'en', 'text-display') : undefined}
+                                        onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, 'en', fieldKind) : undefined}
+                                        title={isInputMode ? 'Click to edit the wording' : undefined}
                                       >
                                         <FormattedRunsPreview text={beforeTitleResolvedValue('en')} />
                                       </TextModeDisplay>
@@ -2382,6 +2490,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         ref={registerFieldNode(template.id, scope, 'en')}
                                         value={displayValue('en')}
                                         placeholder="Before title (en)"
+                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
                                         onChange={onChange('en')}
                                         onBlur={onBlur}
@@ -2442,7 +2551,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={!titleIsTemplateMode}
+                                    disabled={titleIsInputMode}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2450,7 +2559,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={!titleIsTemplateMode}
+                                    disabled={titleIsInputMode}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2497,8 +2606,11 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    {titleMode === 'text' ? (
-                                      <TextModeDisplay>
+                                    {titleMode === 'text' || (titleIsInputMode && activeFieldKey !== fieldKey(template.id, TITLE_SCOPE, 'uk')) ? (
+                                      <TextModeDisplay
+                                        onMouseDown={titleIsInputMode ? handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind) : undefined}
+                                        title={titleIsInputMode ? 'Click to edit the wording' : undefined}
+                                      >
                                         <FormattedRunsPreview text={titleResolvedValue('uk')} />
                                       </TextModeDisplay>
                                     ) : (
@@ -2506,6 +2618,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
                                         value={titleDisplayValue('uk')}
                                         placeholder="Title (uk)"
+                                        autoFocus={titleIsInputMode}
                                         onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind)}
                                         onChange={onTitleFieldChange('uk')}
                                         onBlur={onTitleFieldBlur}
@@ -2515,8 +2628,11 @@ const DocumentsPage = ({ isAdmin }) => {
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    {titleMode === 'text' ? (
-                                      <TextModeDisplay>
+                                    {titleMode === 'text' || (titleIsInputMode && activeFieldKey !== fieldKey(template.id, TITLE_SCOPE, 'en')) ? (
+                                      <TextModeDisplay
+                                        onMouseDown={titleIsInputMode ? handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind) : undefined}
+                                        title={titleIsInputMode ? 'Click to edit the wording' : undefined}
+                                      >
                                         <FormattedRunsPreview text={titleResolvedValue('en')} />
                                       </TextModeDisplay>
                                     ) : (
@@ -2524,6 +2640,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
                                         value={titleDisplayValue('en')}
                                         placeholder="Title (en)"
+                                        autoFocus={titleIsInputMode}
                                         onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind)}
                                         onChange={onTitleFieldChange('en')}
                                         onBlur={onTitleFieldBlur}
@@ -2545,6 +2662,7 @@ const DocumentsPage = ({ isAdmin }) => {
                           // stay editable for formatting.
                           const mode = getParagraphMode(template.id, scope);
                           const isTemplateMode = mode === 'template';
+                          const isInputMode = mode === 'input';
                           const isTextMode = mode === 'text';
                           const rawValue = langKey => paragraph?.[langKey] || '';
                           const resolvedValue = langKey => resolvedDoc?.paragraphs?.[index]?.[langKey] ?? '';
@@ -2583,7 +2701,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={!isTemplateMode}
+                                    disabled={isInputMode}
                                     {...formatButtonProps('bold')}
                                     title="Bold the selected text"
                                   >
@@ -2591,7 +2709,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                   </SmallButton>
                                   <SmallButton
                                     type="button"
-                                    disabled={!isTemplateMode}
+                                    disabled={isInputMode}
                                     {...formatButtonProps('italic')}
                                     title="Italicize the selected text"
                                   >
@@ -2646,8 +2764,11 @@ const DocumentsPage = ({ isAdmin }) => {
                               <ParagraphPair $single={isSingle} $plain>
                                 {showUk ? (
                                   <ParagraphFieldColumn>
-                                    {isTextMode ? (
-                                      <TextModeDisplay>
+                                    {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, 'uk')) ? (
+                                      <TextModeDisplay
+                                        onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, 'uk', fieldKind) : undefined}
+                                        title={isInputMode ? 'Click to edit the wording' : undefined}
+                                      >
                                         <FormattedRunsPreview text={resolvedValue('uk')} />
                                       </TextModeDisplay>
                                     ) : (
@@ -2655,6 +2776,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         ref={registerFieldNode(template.id, scope, 'uk')}
                                         value={displayValue('uk')}
                                         placeholder="Paragraph (uk)"
+                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
                                         onChange={onChange('uk')}
                                         onBlur={onBlur}
@@ -2664,8 +2786,11 @@ const DocumentsPage = ({ isAdmin }) => {
                                 ) : null}
                                 {showEn ? (
                                   <ParagraphFieldColumn>
-                                    {isTextMode ? (
-                                      <TextModeDisplay>
+                                    {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, 'en')) ? (
+                                      <TextModeDisplay
+                                        onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, 'en', fieldKind) : undefined}
+                                        title={isInputMode ? 'Click to edit the wording' : undefined}
+                                      >
                                         <FormattedRunsPreview text={resolvedValue('en')} />
                                       </TextModeDisplay>
                                     ) : (
@@ -2673,6 +2798,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         ref={registerFieldNode(template.id, scope, 'en')}
                                         value={displayValue('en')}
                                         placeholder="Paragraph (en)"
+                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
                                         onChange={onChange('en')}
                                         onBlur={onBlur}

--- a/src/components/DocumentsPage.richFormatting.test.js
+++ b/src/components/DocumentsPage.richFormatting.test.js
@@ -9,12 +9,12 @@
 //
 // Post-migration: the per-case "data mode" resolved-text override system is gone entirely, but
 // title/paragraph rows keep the same template/input/text mode cycle beforeTitle always had.
-// Template and Input both edit the shared markup directly - Bold/Italic only ever act in Template
-// mode now, on the raw `**`/`*` markers, and are never gated on whether a case is selected (there
-// is no per-case value involved at all). Text mode became a read-only preview resolved against
-// whichever case is currently selected (real values substituted, not raw {{tokens}}) - there is
-// nowhere left to persist a formatting edit made against resolved text, so Bold/Italic are simply
-// disabled there.
+// Template and Input both edit the shared markup directly, and are never gated on whether a case
+// is selected (there is no per-case value involved at all). Text mode is a read-only preview
+// resolved against whichever case is currently selected (real values substituted, not raw
+// {{tokens}}) - the wording itself isn't editable there, but Bold/Italic still act on the
+// underlying raw markup through it (same as beforeTitle already did), so Text mode is enabled for
+// formatting alongside Template mode; only Input mode (retyping the plain wording) disables it.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
@@ -145,7 +145,11 @@ describe('spec: selection-based bold/italic applies to the browser selection, no
 });
 
 describe('spec: Text mode is a read-only preview resolved against the selected case', () => {
-  it('disables Bold/Italic in Text mode - there is nowhere left to persist a formatting edit against resolved text', async () => {
+  // Bug fix (batch 2026-07-25): Bold/Italic used to be disabled outside Template mode entirely,
+  // even though Text mode's underlying raw markup is perfectly editable through it (exactly how
+  // beforeTitle rows already worked) - only Input mode (retyping the plain de-markup'd wording)
+  // has nowhere to persist a formatting edit, since there is no raw-markup surface left there.
+  it('leaves Bold/Italic enabled in Text mode (default), disabled only in Input mode', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     const expandButton = await screen.findByTitle('Edit paragraphs');
     fireEvent.click(expandButton);
@@ -153,6 +157,17 @@ describe('spec: Text mode is a read-only preview resolved against the selected c
     const field = await screen.findByText('Звичайний текст без форматування.');
     // eslint-disable-next-line testing-library/no-node-access
     const paragraphBlock = field.closest('.paragraph-editor-block');
+    // Default mode is 'text'.
+    expect(within(paragraphBlock).getByTitle('Bold the selected text')).not.toBeDisabled();
+    expect(within(paragraphBlock).getByTitle('Italicize the selected text')).not.toBeDisabled();
+
+    // Cycle text -> template -> input.
+    fireEvent.click(within(paragraphBlock).getByTitle(
+      "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.",
+    ));
+    fireEvent.click(within(paragraphBlock).getByTitle(
+      'Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.',
+    ));
     expect(within(paragraphBlock).getByTitle('Bold the selected text')).toBeDisabled();
     expect(within(paragraphBlock).getByTitle('Italicize the selected text')).toBeDisabled();
   });

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -180,10 +180,35 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
 
     // template -> input -> text: two taps of the shared mode-cycle button.
     fireEvent.click(within(block).getByTitle('Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.'));
-    fireEvent.click(within(block).getByTitle('Input mode - retyping the shared wording as plain text. Tap to switch to Text mode.'));
+    fireEvent.click(within(block).getByTitle('Input mode - shows the resolved wording (click it to retype as plain text). Tap to switch to Text mode.'));
 
     expect(await within(block).findByText('Сурогатна мати Сурогатна Матір')).toBeInTheDocument();
     expect(within(block).queryByText(/\{\{surrogateMother/)).not.toBeInTheDocument();
+  });
+
+  // Bug fix (batch 2026-07-25): Input mode used to show the raw {{token}} embedded in plain text
+  // at rest ("Input mode... а на посилання в форматі {}"), unlike Text mode which always showed
+  // the resolved wording. Input mode now shows the same resolved wording at rest, and only swaps
+  // to the editable plain-text field (still carrying the raw {{token}}, still de-markup'd) once
+  // that field is actually clicked into.
+  it('Input mode shows the resolved wording at rest (not a raw {{token}}), and swaps to the editable field once clicked', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const textarea = await screen.findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = textarea.closest('.paragraph-editor-block');
+
+    fireEvent.click(within(block).getByTitle('Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.'));
+
+    // At rest, Input mode shows the resolved wording, same as Text mode - never the raw token.
+    expect(await within(block).findByText('Сурогатна мати Сурогатна Матір')).toBeInTheDocument();
+    expect(within(block).queryByText(/\{\{surrogateMother/)).not.toBeInTheDocument();
+    expect(within(block).queryByDisplayValue(/.*/)).not.toBeInTheDocument();
+
+    // Clicking that resolved-text view swaps it to the editable de-markup'd field, raw token intact.
+    fireEvent.mouseDown(within(block).getByText('Сурогатна мати Сурогатна Матір'));
+    expect(await within(block).findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}')).toBeInTheDocument();
   });
 
   // Notarial layout standard §3.3 + batch 2026-07-23 B §1.3/§1.4: the signer-block offset is a

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -478,6 +478,248 @@ const PageFooter = ({ formatting, marginBottom, marginLeft, marginRight }) => {
   );
 };
 
+// --- layoutV2 (pixel-exact single-page forms, e.g. genetic-affinity-certificate) ---------------
+// Reads exactly the normalized tree buildLayoutV2Document produces (doc.layoutV2) - no formatting
+// prop, no bilingual/column layout, no header/footer text: a layoutV2 document is fully
+// self-describing (its own page/margins/styles), the same tree the DOCX builder reads too (spec
+// §8 - one engine, two mm/pt-aware backends).
+const layoutV2TextStyle = style => ({
+  fontFamily: 'Tinos',
+  fontSize: style?.fontSizePt,
+  fontWeight: style?.fontWeight,
+  fontStyle: style?.fontStyle,
+  lineHeight: style?.lineHeight,
+  color: style?.color,
+  textAlign: style?.align,
+  textDecoration: style?.textDecoration,
+  textTransform: style?.textTransform,
+  letterSpacing: style?.letterSpacingPt,
+});
+
+const LayoutV2Content = ({ content, clinicLogos }) => {
+  if (!content) return null;
+  if (content.type === 'image') {
+    const variant = content.logoToken ? getClinicLogo(clinicLogos, content.logoToken) : null;
+    const dataUrl = variant?.dataUrl || content.source;
+    if (!dataUrl) return null;
+    return (
+      <Image
+        src={dataUrl}
+        style={{
+          width: (content.widthMm || 0) * MM_TO_PT,
+          height: (content.heightMm || 0) * MM_TO_PT,
+          objectFit: content.fit || 'contain',
+          objectPosition: `${content.horizontalAlign || 'left'} ${content.verticalAlign || 'top'}`,
+        }}
+      />
+    );
+  }
+  if (content.type === 'stack') {
+    const align = content.horizontalAlign === 'right' ? 'flex-end' : (content.horizontalAlign === 'center' ? 'center' : 'flex-start');
+    return (
+      <View style={{ alignItems: align }}>
+        {content.lines.map((line, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Text key={index} style={layoutV2TextStyle(content.style)}>{line}</Text>
+        ))}
+      </View>
+    );
+  }
+  return null;
+};
+
+const LayoutV2Letterhead = ({ block, clinicLogos }) => (
+  <View
+    style={{
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      paddingBottom: (block.paddingBottomMm || 0) * MM_TO_PT,
+      borderBottomWidth: block.bottomBorder?.widthPt || 0,
+      borderBottomColor: block.bottomBorder?.color || '#000000',
+      marginBottom: (block.marginBottomMm || 0) * MM_TO_PT,
+    }}
+  >
+    {block.columns.map((column, index) => (
+      <View
+        // eslint-disable-next-line react/no-array-index-key
+        key={index}
+        style={{
+          width: (column.widthMm || 0) * MM_TO_PT,
+          marginRight: index < block.columns.length - 1 ? (block.columnGapMm || 0) * MM_TO_PT : 0,
+        }}
+      >
+        <LayoutV2Content content={column.content} clinicLogos={clinicLogos} />
+      </View>
+    ))}
+  </View>
+);
+
+const LayoutV2AlignedBox = ({ block }) => (
+  <View
+    style={{
+      width: (block.widthMm || 0) * MM_TO_PT,
+      alignSelf: block.horizontalAlign === 'right' ? 'flex-end' : (block.horizontalAlign === 'center' ? 'center' : 'flex-start'),
+      marginTop: (block.marginTopMm || 0) * MM_TO_PT,
+      marginBottom: (block.marginBottomMm || 0) * MM_TO_PT,
+    }}
+  >
+    {block.lines.map((line, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <Text key={index} style={[layoutV2TextStyle(block.style), { textAlign: 'left' }]}>{line}</Text>
+    ))}
+  </View>
+);
+
+const LayoutV2Paragraph = ({ block }) => (
+  <Text
+    style={[
+      layoutV2TextStyle(block.style),
+      { marginTop: (block.marginTopMm || 0) * MM_TO_PT, marginBottom: (block.marginBottomMm || 0) * MM_TO_PT },
+    ]}
+  >
+    {block.text || ' '}
+  </Text>
+);
+
+const LayoutV2RichParagraph = ({ block }) => (
+  <Text
+    style={{
+      ...layoutV2TextStyle(block.style),
+      marginTop: (block.marginTopMm || 0) * MM_TO_PT,
+      marginBottom: (block.marginBottomMm || 0) * MM_TO_PT,
+    }}
+  >
+    {block.runs.map((run, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <Text key={index} style={layoutV2TextStyle(run.style)}>{run.text}</Text>
+    ))}
+  </Text>
+);
+
+// The key element for matching the Word sample (spec §5.5): a label cell, then a flexible value
+// area whose "fill" segments before/after the value are borderBottom lines - the value itself
+// carries the same borderBottom, so the line reads as one continuous rule under label-to-margin
+// with the value sitting on it. Never a second underline mechanism (textDecoration) on the value
+// style itself - the border here is the only line (spec batch 2026-07-25, pre-delivery review §3).
+const LayoutV2FieldLine = ({ block }) => {
+  const lineWidthPt = block.line?.widthPt || 0;
+  const lineColor = block.line?.color || '#000000';
+  const lineStyle = { borderBottomWidth: lineWidthPt, borderBottomColor: lineColor };
+  return (
+    <View style={{ marginTop: (block.marginTopMm || 0) * MM_TO_PT, marginBottom: (block.marginBottomMm || 0) * MM_TO_PT }}>
+      <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+        {block.labelWidthMm ? (
+          <View style={{ width: block.labelWidthMm * MM_TO_PT }}>
+            {block.labelRuns ? (
+              <Text style={layoutV2TextStyle(block.labelStyle)}>
+                {block.labelRuns.map((run, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <Text key={index} style={layoutV2TextStyle(run.style)}>{run.text}</Text>
+                ))}
+              </Text>
+            ) : (
+              <Text style={layoutV2TextStyle(block.labelStyle)}>{block.label}</Text>
+            )}
+          </View>
+        ) : null}
+        <View style={{ flex: 1, flexDirection: 'row', alignItems: 'flex-end' }}>
+          {block.line?.fillBeforeValue ? <View style={[{ flex: 1, minWidth: 4 * MM_TO_PT }, lineStyle]} /> : null}
+          <Text style={[layoutV2TextStyle(block.valueStyle), lineStyle, { paddingHorizontal: 1 * MM_TO_PT }]}>
+            {block.value}
+          </Text>
+          {block.line?.fillAfterValue ? <View style={[{ flex: 1, minWidth: 4 * MM_TO_PT }, lineStyle]} /> : null}
+        </View>
+      </View>
+      {block.caption !== undefined ? (
+        <View style={{ flexDirection: 'row' }}>
+          {block.labelWidthMm ? <View style={{ width: block.labelWidthMm * MM_TO_PT }} /> : null}
+          <Text style={[layoutV2TextStyle(block.captionStyle), { flex: 1 }]}>{block.caption}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+const LayoutV2Spacer = ({ block }) => <View style={{ height: (block.heightMm || 0) * MM_TO_PT }} />;
+
+const LayoutV2SignatureTable = ({ block }) => (
+  <View
+    style={{
+      width: (block.widthMm || 0) * MM_TO_PT,
+      alignSelf: block.horizontalAlign === 'right' ? 'flex-end' : (block.horizontalAlign === 'center' ? 'center' : 'flex-start'),
+      marginTop: (block.marginTopMm || 0) * MM_TO_PT,
+      marginBottom: (block.marginBottomMm || 0) * MM_TO_PT,
+    }}
+  >
+    {block.rows.map((row, rowIndex) => (
+      row.type === 'spacerRow' ? (
+        // eslint-disable-next-line react/no-array-index-key
+        <View key={rowIndex} style={{ height: (row.heightMm || 0) * MM_TO_PT }} />
+      ) : (
+        // eslint-disable-next-line react/no-array-index-key
+        <View key={rowIndex} style={{ flexDirection: 'row' }}>
+          {row.map((cell, cellIndex) => (
+            <Text
+              // eslint-disable-next-line react/no-array-index-key
+              key={cellIndex}
+              style={{
+                ...layoutV2TextStyle(cell.style),
+                width: (block.columnWidthsMm[cellIndex] || 0) * MM_TO_PT,
+                borderBottomWidth: cell.bottomBorder?.widthPt || 0,
+                borderBottomColor: cell.bottomBorder?.color || '#000000',
+              }}
+            >
+              {cell.text || ' '}
+            </Text>
+          ))}
+        </View>
+      )
+    ))}
+  </View>
+);
+
+const LayoutV2Block = ({ block, clinicLogos }) => {
+  switch (block.type) {
+    case 'letterhead': return <LayoutV2Letterhead block={block} clinicLogos={clinicLogos} />;
+    case 'alignedBox': return <LayoutV2AlignedBox block={block} />;
+    case 'paragraph': return <LayoutV2Paragraph block={block} />;
+    case 'richParagraph': return <LayoutV2RichParagraph block={block} />;
+    case 'fieldLine': return <LayoutV2FieldLine block={block} />;
+    case 'spacer': return <LayoutV2Spacer block={block} />;
+    case 'signatureTable': return <LayoutV2SignatureTable block={block} />;
+    default: return null;
+  }
+};
+
+const renderLayoutV2DocumentPage = (doc, clinicLogos) => {
+  const page = doc.layoutV2.page || {};
+  const margins = page.marginsMm || {
+    top: 5, right: 15, bottom: 10, left: 15,
+  };
+  const widthPt = (page.widthMm || 210) * MM_TO_PT;
+  const heightPt = (page.heightMm || 297) * MM_TO_PT;
+  return (
+    <Page
+      key={doc.id}
+      size={{ width: widthPt, height: heightPt }}
+      style={{
+        paddingTop: margins.top * MM_TO_PT,
+        paddingRight: margins.right * MM_TO_PT,
+        paddingBottom: margins.bottom * MM_TO_PT,
+        paddingLeft: margins.left * MM_TO_PT,
+        fontFamily: 'Tinos',
+      }}
+    >
+      {doc.layoutV2.blocks.map((block, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <View key={index} wrap>
+          <LayoutV2Block block={block} clinicLogos={clinicLogos} />
+        </View>
+      ))}
+    </Page>
+  );
+};
+
 // `documents` - output of buildGeneratedDocument (placeholders already filled, logo paragraphs
 // tagged). Each document starts on its own page, like the separate statements in the reference
 // file; templates with `allowPageBreaks` (the long agreement) are free to spill onto further
@@ -658,6 +900,9 @@ const DocumentsPdfDocument = ({
   return (
     <Document>
       {documents.flatMap(doc => {
+        // A layoutV2 document is fully self-describing (its own page/margins/styles) and never
+        // follows the page-wide bilingual/column layout selector - see buildLayoutV2Document.
+        if (doc.layoutV2) return [renderLayoutV2DocumentPage(doc, effectiveClinicLogos)];
         const effectiveLayout = getEffectiveDocLayout(doc, layout);
         return isSingleLanguageTwoColumnLayout(effectiveLayout)
           ? renderSingleLanguagePages(doc, effectiveLayout)

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -487,6 +487,8 @@ const PARTNER_FIELDS = [
   { label: 'Birth date', path: 'birthDate', type: 'date' },
   { label: 'Citizenship (uk)', path: 'citizenship.uk' },
   { label: 'Citizenship (en)', path: 'citizenship.en' },
+  { label: 'Passport type', path: 'passport.type' },
+  { label: 'Passport country code', path: 'passport.countryCode' },
   { label: 'Passport number', path: 'passport.number' },
   { label: 'Passport issued by (uk)', path: 'passport.issuedBy.uk' },
   { label: 'Passport issued by (en)', path: 'passport.issuedBy.en' },
@@ -494,7 +496,12 @@ const PARTNER_FIELDS = [
 ];
 
 const MARRIAGE_AND_ADDRESS_FIELDS = [
+  { label: 'Marriage date', path: 'marriage.date', type: 'date' },
+  { label: 'Marriage certificate type (uk)', path: 'marriage.certificateType.uk' },
+  { label: 'Marriage certificate type (en)', path: 'marriage.certificateType.en' },
   { label: 'Marriage certificate number', path: 'marriage.certificateNumber' },
+  { label: 'Marriage certificate issued by (uk)', path: 'marriage.certificateIssuedBy.uk' },
+  { label: 'Marriage certificate issued by (en)', path: 'marriage.certificateIssuedBy.en' },
   { label: 'Marriage certificate date', path: 'marriage.certificateDate', type: 'date' },
   { label: 'Address (uk)', path: 'address.uk' },
   { label: 'Address (en)', path: 'address.en' },
@@ -532,6 +539,9 @@ const CLINIC_FIELDS = [
   { label: 'Kind', path: 'kind', type: 'select', options: CLINIC_KINDS },
   { label: 'Name (uk)', path: 'name.uk' },
   { label: 'Name (en)', path: 'name.en' },
+  // Locative Ukrainian form ("у клініці «Вікторія»") - optional, falls back to the plain
+  // nominative Name above when blank (see enrichShipment/withDeclinedNameFallback).
+  { label: 'Name (uk, locative "у ...")', path: 'nameLocative.uk' },
   { label: 'Legal name (uk)', path: 'legalName.uk' },
   { label: 'Legal name (en)', path: 'legalName.en' },
   { label: 'Medical center name (uk)', path: 'medicalCenterName.uk' },
@@ -569,6 +579,11 @@ const CLINIC_FIELDS = [
 const PARTNER_CLINIC_FIELDS = [
   { label: 'Name (uk)', path: 'name.uk' },
   { label: 'Name (en)', path: 'name.en' },
+  // Genitive Ukrainian form ("з клініки «Оті Юме»") - optional, falls back to the plain nominative
+  // Name above when blank (see enrichShipment/withDeclinedNameFallback).
+  { label: 'Name (uk, genitive "з ...")', path: 'nameGenitive.uk' },
+  { label: 'Country (uk)', path: 'country.uk' },
+  { label: 'Country (en)', path: 'country.en' },
   { label: 'Address (uk)', path: 'address.uk' },
   { label: 'Address (en)', path: 'address.en' },
 ];

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -220,8 +220,10 @@ describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferA
   it('enrichShipment attaches sourceClinic (partnerClinics) and destinationClinic (clinics), null-safe', () => {
     const shipment = resolveShipment(caseWithDateRangePeriod, 'shipment-1');
     const enriched = enrichShipment(shipment, parties);
-    expect(enriched.sourceClinic).toBe(partnerClinic);
-    expect(enriched.destinationClinic).toBe(clinic);
+    // enrichShipment layers a declined-name fallback onto the party record (spec batch 2026-07-25),
+    // so this is no longer the exact same object reference as the fixture - just the same party.
+    expect(enriched.sourceClinic.id).toBe(partnerClinic.id);
+    expect(enriched.destinationClinic.id).toBe(clinic.id);
     expect(enrichShipment(null, parties)).toBeNull();
   });
 });
@@ -295,7 +297,9 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
     expect(enriched.ivfDateFormatted).toEqual({ uk: '17.08.2021', en: '17 August 2021' });
     expect(enriched.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
     expect(enriched.receivedDateFormatted.uk).toBe('27.08.2025');
-    expect(enriched.sourceClinic).toBe(partnerClinic);
+    // enrichShipment layers a declined-name fallback onto the party record (spec batch 2026-07-25),
+    // so this is no longer the exact same object reference as `partnerClinic` - just the same party.
+    expect(enriched.sourceClinic.id).toBe(partnerClinic.id);
     expect(enrichShipmentForTemplate(null)).toBeNull();
   });
 
@@ -306,7 +310,7 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
     expect(enriched.dateFormatted.uk).toBe('18.09.2025');
     expect(enriched.embryoCountText.uk).toBe('один ембріон');
     expect(enriched.embryoStageLabel.uk.genitive).toBe('бластоцисти');
-    expect(enriched.shipment.sourceClinic).toBe(partnerClinic);
+    expect(enriched.shipment.sourceClinic.id).toBe(partnerClinic.id);
     expect(enrichTransferForTemplate(null, shipment)).toBeNull();
   });
 
@@ -330,8 +334,8 @@ describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityC
   it('embryoOwnershipStatement resolves shipment via shipmentId (startDate/endDate case)', () => {
     const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, parties, caseWithDateRangePeriod.documents.embryoOwnershipStatement);
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
-    expect(context.shipment.sourceClinic).toBe(partnerClinic);
-    expect(context.shipment.destinationClinic).toBe(clinic);
+    expect(context.shipment.sourceClinic.id).toBe(partnerClinic.id);
+    expect(context.shipment.destinationClinic.id).toBe(clinic.id);
   });
 
   it('embryoOwnershipStatement resolves shipment via shipmentId (migrated text case)', () => {
@@ -359,7 +363,7 @@ describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityC
       caseWithDateRangePeriod.documents.geneticAffinityCertificate,
     );
     expect(context.transferAttempt.embryoCountText.uk).toBe('один ембріон');
-    expect(context.transferAttempt.shipment.sourceClinic).toBe(partnerClinic);
+    expect(context.transferAttempt.shipment.sourceClinic.id).toBe(partnerClinic.id);
     expect(context.hcgTest.dateFormatted.uk).toBe('30.09.2025');
     expect(context.ultrasound.gestationalAgeText.uk).toBe('6–7 тижнів');
     expect(context.issueDateOrBlank.uk).toBe('20.10.2025');

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -681,13 +681,28 @@ export const createEmptyPartner = ({ role = '' } = {}) => ({
   name: { uk: { nominative: '', genitive: '' }, en: '' },
   birthDate: '',
   citizenship: { uk: '', en: '' },
-  passport: { number: '', issuedBy: { uk: '', en: '' }, issueDate: '' },
+  // `type`/`countryCode` (e.g. genetic-affinity-certificate's "паспорт: тип: ..., Код країни: ...")
+  // sit alongside the existing number/issuedBy/issueDate fields - optional, blank by default, never
+  // required by any other template that only ever read `passport.number`.
+  passport: {
+    type: '', countryCode: '', number: '', issuedBy: { uk: '', en: '' }, issueDate: '',
+  },
 });
 
 export const createEmptyCouple = () => ({
   id: makeRecordId('couple'),
   partners: [createEmptyPartner({ role: 'wife' }), createEmptyPartner({ role: 'husband' })],
-  marriage: { certificateNumber: '', certificateDate: '' },
+  // `date` (the marriage itself) is distinct from `certificateDate` (when the certificate was
+  // issued) - enrichCoupleMarriage above already reads both separately. `certificateType`/
+  // `certificateIssuedBy` are the newer bilingual fields that comment already anticipated; blank by
+  // default so older couples keep working unchanged until an admin fills them in.
+  marriage: {
+    date: '',
+    certificateType: { uk: '', en: '' },
+    certificateNumber: '',
+    certificateIssuedBy: { uk: '', en: '' },
+    certificateDate: '',
+  },
   address: { uk: '', en: '' },
 });
 
@@ -729,6 +744,11 @@ export const createEmptyClinic = () => ({
   id: makeRecordId('clinic'),
   kind: 'ukrainian',
   name: { uk: '', en: '' },
+  // The Ukrainian locative form of `name.uk` ("у клініці «Вікторія»", as opposed to the nominative
+  // "клініка «Вікторія»") - a document that names this clinic after "у" reads nameLocative.uk when
+  // filled in, falling back to the plain nominative name otherwise (see enrichShipment). Optional,
+  // never required by any template that only ever reads `name.uk`.
+  nameLocative: { uk: '', en: '' },
   legalName: { uk: '', en: '' },
   medicalCenterName: { uk: '', en: '' },
   address: { uk: '', en: '' },
@@ -756,6 +776,14 @@ export const createEmptyClinic = () => ({
 export const createEmptyPartnerClinic = () => ({
   id: makeRecordId('partner-clinic'),
   name: { uk: '', en: '' },
+  // The Ukrainian genitive form of `name.uk` ("з клініки «Оті Юме»", as opposed to the nominative
+  // "клініка «Оті Юме»") - a document that names this clinic after "з" reads nameGenitive.uk when
+  // filled in, falling back to the plain nominative name otherwise (see enrichShipment).
+  nameGenitive: { uk: '', en: '' },
+  // Country a shipment "from" this clinic is described as coming from (geneticAffinityCertificate's
+  // "з ..., Японія" - spec batch 2026-07-25). Optional, never required by any template that doesn't
+  // reference it.
+  country: { uk: '', en: '' },
   address: { uk: '', en: '' },
 });
 
@@ -934,14 +962,31 @@ export const resolveUltrasound = (transferAttempt, ultrasoundId) => {
   return transferAttempt?.ultrasounds?.[ultrasoundId] ?? null;
 };
 
+// A declined-form name field (nameGenitive on a partner clinic, nameLocative on a clinic) falls
+// back to the plain nominative `name` when the admin hasn't filled the grammatical variant in yet -
+// a document referencing "{{...sourceClinic.nameGenitive.uk}}" never renders blank just because
+// only the nominative name was ever entered (spec batch 2026-07-25: Ukrainian grammar after
+// "у"/"з" needs the clinic's name declined, not its bare nominative form).
+const withDeclinedNameFallback = (record, field) => {
+  if (!record) return record;
+  const declined = record[field] || {};
+  return {
+    ...record,
+    [field]: {
+      uk: declined.uk || record.name?.uk || '',
+      en: declined.en || record.name?.en || '',
+    },
+  };
+};
+
 // A shipment on its own only carries clinic ids - never mutates the stored record, just layers the
 // resolved party records on top (spec §3).
 export const enrichShipment = (shipment, parties) => {
   if (!shipment) return null;
   return {
     ...shipment,
-    sourceClinic: findById(parties?.partnerClinics, shipment.sourceClinicId) ?? null,
-    destinationClinic: findById(parties?.clinics, shipment.destinationClinicId) ?? null,
+    sourceClinic: withDeclinedNameFallback(findById(parties?.partnerClinics, shipment.sourceClinicId), 'nameGenitive'),
+    destinationClinic: withDeclinedNameFallback(findById(parties?.clinics, shipment.destinationClinicId), 'nameLocative'),
   };
 };
 
@@ -1889,6 +1934,169 @@ export const withTemplateScopeText = (template, scope, langKey, value) => {
   return template;
 };
 
+// --- layoutV2 (pixel-exact single-page forms, e.g. genetic-affinity-certificate) ---------------
+// A template opts in with `rendererVersion: 2` + a `layoutV2.blocks` array instead of the legacy
+// beforeTitle/title/paragraphs shape (spec: "Оновити renderer documentsBuilder"). Unlike the
+// legacy bilingual/two-column system, a layoutV2 document is always a single physical A4 sheet in
+// its own template.languages[0] - the page-wide UA/EN/UA+EN selector never applies to it (there is
+// no side-by-side column concept for a government form reproduced mm-for-mm). Preview, PDF and
+// DOCX all read this one normalized tree (spec §8) - only the mm/pt/twip unit conversion differs
+// per renderer, never the resolved content or style.
+export const isLayoutV2Template = template => template?.rendererVersion === 2 && Array.isArray(template?.layoutV2?.blocks);
+
+const LAYOUT_V2_STYLE_KEYS = [
+  'fontFamily', 'fontSizePt', 'fontWeight', 'fontStyle', 'lineHeight', 'color', 'align',
+  'spaceBeforePt', 'spaceAfterPt', 'textDecoration', 'textTransform', 'letterSpacingPt',
+];
+
+const pickLayoutV2StyleKeys = source => LAYOUT_V2_STYLE_KEYS.reduce((acc, key) => {
+  if (source && source[key] !== undefined) acc[key] = source[key];
+  return acc;
+}, {});
+
+export const resolveLayoutV2NamedStyle = (template, styleName) => (
+  styleName ? (template?.styleSheet?.[styleName] ?? {}) : {}
+);
+
+// block override -> named style -> document (spec §2/§7: a layoutV2 block never falls through to
+// template.format/global settings - it always names its own style, and `document` is the only
+// implicit base every named style inherits from).
+export const resolveLayoutV2Style = (template, styleName, overrides) => ({
+  ...pickLayoutV2StyleKeys(template?.styleSheet?.document),
+  ...pickLayoutV2StyleKeys(resolveLayoutV2NamedStyle(template, styleName)),
+  ...pickLayoutV2StyleKeys(overrides),
+});
+
+const resolveLayoutV2Text = (text, context, lang) => (text === undefined ? undefined : fillPlaceholders(text, context, lang));
+
+const resolveLayoutV2Runs = (runs, template, context, lang) => (runs || []).map(run => ({
+  text: resolveLayoutV2Text(run.text, context, lang) || '',
+  style: resolveLayoutV2Style(template, run.style, run.styleOverrides),
+}));
+
+// `{{logo}}`/`{{logo-long}}` are graphical tokens, never text-substituted (same convention as the
+// legacy renderer's getTemplateLogoType) - an `image` content block tags which clinic-logo variant
+// to draw instead of carrying a resolved data URL of its own.
+const LOGO_TOKEN_PATTERN = /^\{\{\s*(logo|logo-long)\s*\}\}$/;
+
+const normalizeLayoutV2Content = (content, template, context, lang) => {
+  if (!content) return null;
+  if (content.type === 'image') {
+    const logoMatch = LOGO_TOKEN_PATTERN.exec(String(content.source || '').trim());
+    return {
+      type: 'image',
+      logoToken: logoMatch ? logoMatch[1] : null,
+      source: logoMatch ? null : resolveLayoutV2Text(content.source, context, lang),
+      widthMm: content.widthMm,
+      heightMm: content.heightMm,
+      fit: content.fit,
+      horizontalAlign: content.horizontalAlign,
+      verticalAlign: content.verticalAlign,
+    };
+  }
+  if (content.type === 'stack') {
+    return {
+      type: 'stack',
+      style: resolveLayoutV2Style(template, content.style, content.styleOverrides),
+      horizontalAlign: content.horizontalAlign,
+      lines: (content.lines || []).map(line => resolveLayoutV2Text(line, context, lang)),
+    };
+  }
+  return { type: 'unknown', raw: content };
+};
+
+const normalizeLayoutV2Block = (block, template, context, lang) => {
+  const base = {
+    type: block?.type,
+    marginTopMm: block?.marginTopMm,
+    marginBottomMm: block?.marginBottomMm,
+  };
+  switch (block?.type) {
+    case 'letterhead':
+      return {
+        ...base,
+        heightMm: block.heightMm,
+        columnGapMm: block.columnGapMm,
+        bottomBorder: block.bottomBorder,
+        paddingBottomMm: block.paddingBottomMm,
+        columns: (block.columns || []).map(column => ({
+          widthMm: column.widthMm,
+          content: normalizeLayoutV2Content(column.content, template, context, lang),
+        })),
+      };
+    case 'alignedBox':
+      return {
+        ...base,
+        widthMm: block.widthMm,
+        horizontalAlign: block.horizontalAlign,
+        style: resolveLayoutV2Style(template, block.style, block.styleOverrides),
+        lines: (block.lines || []).map(line => resolveLayoutV2Text(line, context, lang)),
+      };
+    case 'paragraph':
+      return {
+        ...base,
+        style: resolveLayoutV2Style(template, block.style, block.styleOverrides),
+        text: resolveLayoutV2Text(block.text, context, lang) || '',
+      };
+    case 'richParagraph':
+      return {
+        ...base,
+        style: resolveLayoutV2Style(template, block.style, block.styleOverrides),
+        runs: resolveLayoutV2Runs(block.runs, template, context, lang),
+      };
+    case 'fieldLine':
+      return {
+        ...base,
+        label: block.label !== undefined ? resolveLayoutV2Text(block.label, context, lang) : undefined,
+        labelRuns: block.labelRuns ? resolveLayoutV2Runs(block.labelRuns, template, context, lang) : undefined,
+        labelWidthMm: block.labelWidthMm || 0,
+        labelStyle: resolveLayoutV2Style(template, block.style, block.styleOverrides),
+        value: resolveLayoutV2Text(block.value, context, lang) || '',
+        valueStyle: resolveLayoutV2Style(template, block.valueStyle, block.valueStyleOverrides),
+        line: block.line || {},
+        caption: block.caption !== undefined ? resolveLayoutV2Text(block.caption, context, lang) : undefined,
+        captionStyle: resolveLayoutV2Style(template, block.captionStyle, block.captionStyleOverrides),
+      };
+    case 'spacer':
+      return { ...base, heightMm: block.heightMm };
+    case 'signatureTable':
+      return {
+        ...base,
+        widthMm: block.widthMm,
+        horizontalAlign: block.horizontalAlign,
+        columnWidthsMm: block.columnWidthsMm || [],
+        cellPaddingMm: block.cellPaddingMm || 0,
+        rows: (block.rows || []).map(row => (
+          row?.type === 'spacerRow'
+            ? { type: 'spacerRow', heightMm: row.heightMm }
+            : (row || []).map(cell => ({
+              text: resolveLayoutV2Text(cell?.text, context, lang) || '',
+              style: resolveLayoutV2Style(template, cell?.style, cell?.styleOverrides),
+              bottomBorder: cell?.bottomBorder,
+            }))
+        )),
+      };
+    default:
+      // spec §9: an unknown block type never crashes the render - it's carried through as a
+      // diagnostic-only entry the renderers skip.
+      return { ...base, unknown: true };
+  }
+};
+
+// The single normalized tree preview/PDF/DOCX all read (spec §8) - `null` for any template that
+// isn't opted into layoutV2, so every caller can do `doc.layoutV2 &&` without a separate feature
+// check.
+export const buildLayoutV2Document = (template, context) => {
+  if (!isLayoutV2Template(template)) return null;
+  const lang = (resolveDocLanguages(template) || ['uk'])[0];
+  return {
+    lang,
+    page: template.page || null,
+    contentWidthMm: template.layoutV2.contentWidthMm,
+    blocks: template.layoutV2.blocks.map(block => normalizeLayoutV2Block(block, template, context, lang)),
+  };
+};
+
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
 // with every placeholder already substituted from the case context. Logo/logo-long paragraphs are
 // never text-substituted - they stay tagged for the renderer to draw a graphical block instead.
@@ -1908,6 +2116,12 @@ export const buildGeneratedDocument = (template, context) => {
     id: template.id,
     documentStyle: normalizeDocumentStyle(template?.documentStyle),
     allowPageBreaks: Boolean(template.allowPageBreaks),
+    // Non-null only for a `rendererVersion: 2` template (spec: "Не рендерити legacy та layoutV2
+    // одночасно") - every renderer checks this first and, when present, renders exclusively from
+    // it instead of the legacy fields below (which still resolve, harmlessly unused, since a
+    // template's own `layoutV2.renderLegacyContent` flag is the only source of truth for whether
+    // the legacy fields were ever meant to be read here).
+    layoutV2: buildLayoutV2Document(template, context),
     logo,
     languages,
     columns: resolveDocColumns(template, languages),

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -2675,11 +2675,18 @@ describe('spec: Parties page record shapes', () => {
     expect(createEmptyMaternityHospital().id).toMatch(/^maternity-hospital-/);
     expect(createEmptyNotary().id).toMatch(/^notary-/);
 
-    // A partner clinic is a deliberately simplified party type (spec §5) - just name/address, no
-    // EDRPOU/license/director/bank/logo the Ukrainian clinic record carries.
+    // A partner clinic is a deliberately simplified party type (spec §5) - just name/address (plus
+    // the genitive name form and shipment-origin country, spec batch 2026-07-25), no EDRPOU/
+    // license/director/bank/logo the Ukrainian clinic record carries.
     const partnerClinic = createEmptyPartnerClinic();
     expect(partnerClinic.id).toMatch(/^partner-clinic-/);
-    expect(partnerClinic).toEqual({ id: partnerClinic.id, name: { uk: '', en: '' }, address: { uk: '', en: '' } });
+    expect(partnerClinic).toEqual({
+      id: partnerClinic.id,
+      name: { uk: '', en: '' },
+      nameGenitive: { uk: '', en: '' },
+      country: { uk: '', en: '' },
+      address: { uk: '', en: '' },
+    });
 
     // Two calls never collide, same guarantee makeRecordId already gives createChildRecord.
     expect(createEmptyCouple().id).not.toBe(couple.id);

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -24,6 +24,7 @@ import {
 } from './documentsCatalogUtils';
 
 const CM_TO_TWIP = 567;
+const MM_TO_TWIP = 56.6929; // 1440 twips/inch / 25.4mm/inch
 const MM_TO_PX = 96 / 25.4; // docx ImageRun transformations are CSS pixels at 96dpi
 
 const halfPoints = pt => Math.round(pt * 2);
@@ -402,6 +403,266 @@ export const buildDocumentsDocx = async ({
     return children;
   };
 
+  // --- layoutV2 (pixel-exact single-page forms, e.g. genetic-affinity-certificate) -------------
+  // Reads exactly the normalized tree buildLayoutV2Document produces (doc.layoutV2) - the same
+  // tree the PDF renderer reads (spec §8), just converted to twips/eighths-of-a-point instead of
+  // react-pdf's pt. A layoutV2 document is fully self-describing (its own page/margins/styles) and
+  // gets its own section below - no shared header/footer, no bilingual/column layout.
+  const eighthsFromPt = pt => Math.round((pt || 0) * 8); // OOXML border size unit
+  const halfPointsV2 = pt => Math.round((pt || 0) * 2);
+  const applyTextTransform = (text, transform) => (
+    transform === 'uppercase' ? String(text || '').toLocaleUpperCase('uk-UA') : String(text || '')
+  );
+  const lineTwipsFor = style => Math.round((style?.lineHeight || 1) * 240);
+  const marginBeforeTwips = block => (block.marginTopMm !== undefined
+    ? Math.round(block.marginTopMm * MM_TO_TWIP)
+    : Math.round((block.style?.spaceBeforePt || 0) * 20));
+  const marginAfterTwips = block => (block.marginBottomMm !== undefined
+    ? Math.round(block.marginBottomMm * MM_TO_TWIP)
+    : Math.round((block.style?.spaceAfterPt || 0) * 20));
+
+  const layoutV2Alignment = align => {
+    if (align === 'right') return AlignmentType.RIGHT;
+    if (align === 'center') return AlignmentType.CENTER;
+    if (align === 'justify') return AlignmentType.JUSTIFIED;
+    return AlignmentType.LEFT;
+  };
+
+  // textTransform is applied to the run's text right here (spec §5.5: "лише візуально. Не
+  // змінювати значення в context/Firebase") - the normalized tree itself, and everything upstream
+  // of it, keeps the original case; only this TextRun's rendered characters are uppercased.
+  // letterSpacingPt maps straight onto `characterSpacing`, which docx (like the reference docx's
+  // own `<w:spacing>`) expects in twentieths of a point - the same unit fontSize halves into.
+  const layoutV2TextRun = (text, style) => new TextRun({
+    text: applyTextTransform(text, style?.textTransform),
+    font: style?.fontFamily || 'Times New Roman',
+    size: halfPointsV2(style?.fontSizePt) || bodySize,
+    bold: (style?.fontWeight || 400) >= 600,
+    italics: style?.fontStyle === 'italic',
+    underline: style?.textDecoration === 'underline' ? {} : undefined,
+    characterSpacing: style?.letterSpacingPt ? Math.round(style.letterSpacingPt * 20) : undefined,
+  });
+
+  const layoutV2Content = (content, clinicLogos) => {
+    if (!content) return [new Paragraph({ children: [] })];
+    if (content.type === 'image') {
+      const variant = content.logoToken ? getClinicLogo(clinicLogos, content.logoToken) : null;
+      const dataUrl = variant?.dataUrl || content.source;
+      const decoded = dataUrl ? decodeLogoDataUrl(dataUrl) : null;
+      if (!decoded) return [new Paragraph({ children: [] })];
+      const ratio = variant?.width && variant?.height
+        ? variant.height / variant.width
+        : ((content.heightMm && content.widthMm) ? content.heightMm / content.widthMm : 0.25);
+      const widthPx = Math.round((content.widthMm || 0) * MM_TO_PX);
+      return [new Paragraph({ spacing: { after: 0 }, children: [logoImageRun(decoded, widthPx, ratio)] })];
+    }
+    if (content.type === 'stack') {
+      const alignment = content.horizontalAlign === 'right'
+        ? AlignmentType.RIGHT
+        : (content.horizontalAlign === 'center' ? AlignmentType.CENTER : AlignmentType.LEFT);
+      return (content.lines || []).map(line => new Paragraph({
+        alignment,
+        spacing: { after: 0, line: lineTwipsFor(content.style), lineRule: 'auto' },
+        children: [layoutV2TextRun(line, content.style)],
+      }));
+    }
+    return [new Paragraph({ children: [] })];
+  };
+
+  // The bottom border draws as one continuous rule across the whole 180mm width (batch 2026-07-25):
+  // each cell of the single row carries its own bottom border, but adjoining table cells share the
+  // same edge in Word, so the two lines render as one - exactly how the reference docx's own
+  // multi-paragraph pBdr achieves the same visual line.
+  const layoutV2Letterhead = (block, clinicLogos) => {
+    const gapTwips = Math.round((block.columnGapMm || 0) * MM_TO_TWIP);
+    const colTwips = (block.columns || []).map(column => Math.round((column.widthMm || 0) * MM_TO_TWIP));
+    const borderSize = eighthsFromPt(block.bottomBorder?.widthPt);
+    const borderColor = (block.bottomBorder?.color || '#000000').replace('#', '');
+    const bottomBorder = borderSize ? { style: BorderStyle.SINGLE, size: borderSize, color: borderColor } : noBorder;
+    const cells = (block.columns || []).map((column, index) => {
+      const isLast = index === block.columns.length - 1;
+      return new TableCell({
+        borders: { ...noBorders, bottom: bottomBorder },
+        width: { size: colTwips[index] + (isLast ? 0 : gapTwips), type: WidthType.DXA },
+        margins: {
+          top: 0, bottom: 0, left: 0, right: isLast ? 0 : gapTwips,
+        },
+        children: layoutV2Content(column.content, clinicLogos),
+      });
+    });
+    return new Table({
+      width: { size: colTwips.reduce((sum, w) => sum + w, 0) + gapTwips * Math.max(0, cells.length - 1), type: WidthType.DXA },
+      columnWidths: cells.map((_, index) => colTwips[index] + (index < cells.length - 1 ? gapTwips : 0)),
+      borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
+      rows: [new TableRow({ children: cells })],
+    });
+  };
+
+  // A right-pushed, left-aligned block of text (spec §5.2, "Додаток 18") - simplest to reproduce
+  // as an ordinary paragraph indented from the left by (content width - box width), rather than a
+  // table: text still wraps within the box's own width and stays left-aligned inside it.
+  const layoutV2AlignedBox = (block, contentWidthTwips) => {
+    const boxWidthTwips = Math.round((block.widthMm || 0) * MM_TO_TWIP);
+    const pushTwips = block.horizontalAlign === 'right' ? Math.max(0, contentWidthTwips - boxWidthTwips) : 0;
+    const lines = block.lines || [];
+    return lines.map((line, index) => new Paragraph({
+      alignment: AlignmentType.LEFT,
+      indent: pushTwips ? { left: pushTwips } : undefined,
+      spacing: {
+        before: index === 0 ? marginBeforeTwips(block) : 0,
+        after: index === lines.length - 1 ? marginAfterTwips(block) : 0,
+        line: lineTwipsFor(block.style),
+        lineRule: 'auto',
+      },
+      children: [layoutV2TextRun(line, block.style)],
+    }));
+  };
+
+  const layoutV2Paragraph = block => new Paragraph({
+    alignment: layoutV2Alignment(block.style?.align),
+    spacing: {
+      before: marginBeforeTwips(block), after: marginAfterTwips(block), line: lineTwipsFor(block.style), lineRule: 'auto',
+    },
+    children: [layoutV2TextRun(block.text || '', block.style)],
+  });
+
+  const layoutV2RichParagraph = block => new Paragraph({
+    alignment: layoutV2Alignment(block.style?.align),
+    spacing: {
+      before: marginBeforeTwips(block), after: marginAfterTwips(block), line: lineTwipsFor(block.style), lineRule: 'auto',
+    },
+    children: (block.runs || []).map(run => layoutV2TextRun(run.text, run.style)),
+  });
+
+  // The key element for matching the Word sample (spec §5.5): label + value cells in one borderless
+  // row, the value cell's own bottom border drawing the fill-to-margin line the value sits on -
+  // never a second underline mechanism (textDecoration) on the value style itself (spec batch
+  // 2026-07-25, pre-delivery review §3). The caption is a second row so it can center under the
+  // value column alone, matching `.field-caption { margin-left: var(--label-width) }`.
+  const layoutV2FieldLine = (block, contentWidthTwips) => {
+    const labelTwips = Math.max(1, Math.round((block.labelWidthMm || 0) * MM_TO_TWIP));
+    const valueTwips = Math.max(1, contentWidthTwips - labelTwips);
+    const lineSize = eighthsFromPt(block.line?.widthPt);
+    const lineColor = (block.line?.color || '#000000').replace('#', '');
+    const lineBorder = lineSize ? { style: BorderStyle.SINGLE, size: lineSize, color: lineColor } : noBorder;
+    const labelParagraph = new Paragraph({
+      alignment: AlignmentType.LEFT,
+      spacing: { after: 0, line: lineTwipsFor(block.labelStyle), lineRule: 'auto' },
+      children: block.labelRuns
+        ? block.labelRuns.map(run => layoutV2TextRun(run.text, run.style))
+        : [layoutV2TextRun(block.label || '', block.labelStyle)],
+    });
+    const valueParagraph = new Paragraph({
+      alignment: layoutV2Alignment(block.valueStyle?.align),
+      spacing: { after: 0, line: lineTwipsFor(block.valueStyle), lineRule: 'auto' },
+      children: [layoutV2TextRun(block.value || '', block.valueStyle)],
+    });
+    const rows = [new TableRow({
+      children: [
+        new TableCell({ borders: noBorders, width: { size: labelTwips, type: WidthType.DXA }, children: block.labelWidthMm ? [labelParagraph] : [new Paragraph({ children: [] })] }),
+        new TableCell({ borders: { ...noBorders, bottom: lineBorder }, width: { size: valueTwips, type: WidthType.DXA }, children: [valueParagraph] }),
+      ],
+    })];
+    if (block.caption !== undefined) {
+      const captionParagraph = new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 0, line: lineTwipsFor(block.captionStyle), lineRule: 'auto' },
+        children: [layoutV2TextRun(block.caption, block.captionStyle)],
+      });
+      rows.push(new TableRow({
+        children: [
+          new TableCell({ borders: noBorders, width: { size: labelTwips, type: WidthType.DXA }, children: [new Paragraph({ children: [] })] }),
+          new TableCell({ borders: noBorders, width: { size: valueTwips, type: WidthType.DXA }, children: [captionParagraph] }),
+        ],
+      }));
+    }
+    return new Table({
+      width: { size: labelTwips + valueTwips, type: WidthType.DXA },
+      columnWidths: [labelTwips, valueTwips],
+      borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
+      rows,
+    });
+  };
+
+  const layoutV2SignatureTable = block => {
+    const colTwips = (block.columnWidthsMm || []).map(width => Math.round(width * MM_TO_TWIP));
+    const rows = (block.rows || []).map(row => {
+      if (row?.type === 'spacerRow') {
+        const heightTwips = Math.round((row.heightMm || 0) * MM_TO_TWIP);
+        return new TableRow({
+          children: colTwips.map(width => new TableCell({
+            borders: noBorders,
+            width: { size: width, type: WidthType.DXA },
+            children: [new Paragraph({ spacing: { before: heightTwips, after: 0 }, children: [] })],
+          })),
+        });
+      }
+      return new TableRow({
+        children: (row || []).map((cell, index) => new TableCell({
+          borders: {
+            ...noBorders,
+            bottom: cell?.bottomBorder
+              ? { style: BorderStyle.SINGLE, size: eighthsFromPt(cell.bottomBorder.widthPt), color: (cell.bottomBorder.color || '#000000').replace('#', '') }
+              : noBorder,
+          },
+          width: { size: colTwips[index] || 0, type: WidthType.DXA },
+          children: [new Paragraph({
+            alignment: layoutV2Alignment(cell?.style?.align),
+            spacing: { after: 0, line: lineTwipsFor(cell?.style), lineRule: 'auto' },
+            children: [layoutV2TextRun(cell?.text || '', cell?.style)],
+          })],
+        })),
+      });
+    });
+    return new Table({
+      width: { size: colTwips.reduce((sum, w) => sum + w, 0), type: WidthType.DXA },
+      columnWidths: colTwips,
+      borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
+      rows,
+    });
+  };
+
+  const layoutV2BlockChildren = (block, contentWidthTwips, clinicLogos) => {
+    switch (block.type) {
+      case 'letterhead': return [layoutV2Letterhead(block, clinicLogos)];
+      case 'alignedBox': return layoutV2AlignedBox(block, contentWidthTwips);
+      case 'paragraph': return [layoutV2Paragraph(block)];
+      case 'richParagraph': return [layoutV2RichParagraph(block)];
+      case 'fieldLine': return [layoutV2FieldLine(block, contentWidthTwips)];
+      case 'spacer': return [new Paragraph({ spacing: { before: Math.round((block.heightMm || 0) * MM_TO_TWIP), after: 0 }, children: [] })];
+      case 'signatureTable': return [layoutV2SignatureTable(block)];
+      default: return [];
+    }
+  };
+
+  const DEFAULT_LAYOUT_V2_MARGINS_MM = {
+    top: 5, right: 15, bottom: 10, left: 15,
+  };
+
+  const buildLayoutV2Children = doc => {
+    const page = doc.layoutV2.page || {};
+    const margins = page.marginsMm || DEFAULT_LAYOUT_V2_MARGINS_MM;
+    const widthTwips = Math.round((page.widthMm || 210) * MM_TO_TWIP);
+    const contentWidthTwips = widthTwips - Math.round(margins.left * MM_TO_TWIP) - Math.round(margins.right * MM_TO_TWIP);
+    return doc.layoutV2.blocks.flatMap(block => layoutV2BlockChildren(block, contentWidthTwips, effectiveClinicLogos));
+  };
+
+  const layoutV2PageSetup = doc => {
+    const page = doc.layoutV2.page || {};
+    const margins = page.marginsMm || DEFAULT_LAYOUT_V2_MARGINS_MM;
+    return {
+      page: {
+        size: { width: Math.round((page.widthMm || 210) * MM_TO_TWIP), height: Math.round((page.heightMm || 297) * MM_TO_TWIP) },
+        margin: {
+          top: Math.round(margins.top * MM_TO_TWIP),
+          right: Math.round(margins.right * MM_TO_TWIP),
+          bottom: Math.round(margins.bottom * MM_TO_TWIP),
+          left: Math.round(margins.left * MM_TO_TWIP),
+        },
+      },
+    };
+  };
+
   // An official-form document's letterhead logo lives in the page Header (batch 22 §1) instead of
   // the one-off body block every branded document uses - Word repeats a Header on every page of
   // its section automatically and reflows the body to start after it, so (unlike the PDF renderer)
@@ -491,7 +752,12 @@ export const buildDocumentsDocx = async ({
         },
       },
     },
-    sections: documents.map(generated => ({
+    sections: documents.map(generated => (generated.layoutV2 ? {
+      // A layoutV2 document is fully self-describing (its own page/margins/styles, spec §8) - no
+      // shared header/footer, no bilingual/column layout.
+      properties: layoutV2PageSetup(generated),
+      children: buildLayoutV2Children(generated),
+    } : {
       properties: pageSetup,
       headers: buildHeader(generated),
       footers: buildFooter(generated),


### PR DESCRIPTION
Implements the layoutV2 exact-layout rendering engine for genetic-affinity-certificate-style
government forms (rendererVersion: 2 + layoutV2.blocks), sharing one normalized tree between the
PDF renderer (DocumentsPdfDocument.jsx) and the DOCX builder (documentsDocxBuilder.js):
letterhead, alignedBox, paragraph, richParagraph, fieldLine, spacer and signatureTable blocks, mm/pt
page geometry, and a styleSheet resolver (block override -> named style -> document) including the
new letterSpacingPt property for the reference docx's measured character compression.

Also fixes several reported bugs/gaps in the Documents Builder:
- Bold/Italic were wrongly disabled outside Template mode on title/paragraph rows (only beforeTitle
  had it right) - now enabled in Text mode too, matching the documented design.
- Input mode showed a raw {{token}} embedded in plain text at rest; now shows the resolved wording
  (like Text mode) and only swaps to the editable de-markup'd field once clicked into.
- Clinic names used after "у"/"з" need Ukrainian locative/genitive forms, not the bare nominative -
  added nameLocative (clinic) / nameGenitive (partner clinic) with fallback to the nominative name.
- Added missing data fields with UI: passport type/countryCode, marriage date/certificateType/
  certificateIssuedBy, partner clinic country.
- Removed the bilingual-language-pin badge; column count is now a per-document toggle next to the
  delete button; added a per-document layoutV2 on/off switch and a Documents list search input.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XzPptZCtB6CRfasLyQrjkT