### PR TITLE
Use Testing Library queries in style editor tests

### DIFF
--- a/src/components/DocumentStyleEditorPage.test.js
+++ b/src/components/DocumentStyleEditorPage.test.js
@@ -102,9 +102,8 @@ describe('DocumentStyleEditorPage', () => {
     render(<MemoryRouter><DocumentStyleEditorPage isAdmin /></MemoryRouter>);
     await screen.findByText('Genetic affinity certificate');
     fireEvent.click(await screen.findByText(/titleMain/));
-    const lineHeightRow = (await screen.findByText('Line height')).closest('label');
-    const checkbox = lineHeightRow.querySelector('input[type="checkbox"]');
-    expect(checkbox.checked).toBe(false);
+    const checkbox = await screen.findByRole('checkbox', { name: 'Line height' });
+    expect(checkbox).not.toBeChecked();
     fireEvent.click(checkbox);
     await waitFor(() => expect(update).toHaveBeenCalledWith(
       '__root__',
@@ -117,9 +116,8 @@ describe('DocumentStyleEditorPage', () => {
     render(<MemoryRouter><DocumentStyleEditorPage isAdmin /></MemoryRouter>);
     await screen.findByText('Genetic affinity certificate');
     fireEvent.click(await screen.findByText(/titleMain/));
-    const fontSizeRow = (await screen.findByText('Font size (pt)')).closest('label');
-    const checkbox = fontSizeRow.querySelector('input[type="checkbox"]');
-    expect(checkbox.checked).toBe(true);
+    const checkbox = await screen.findByRole('checkbox', { name: /^Font size \(pt\)/ });
+    expect(checkbox).toBeChecked();
     fireEvent.click(checkbox);
     await waitFor(() => expect(update).toHaveBeenCalledWith(
       '__root__',


### PR DESCRIPTION
### Motivation
- Improve test robustness and accessibility by removing direct DOM traversal and preferring Testing Library queries for checkbox elements.

### Description
- Replace `querySelector`/`.closest` DOM access with `findByRole('checkbox', { name: ... })` for the `Line height` and `Font size (pt)` rows.
- Replace direct reads of the `.checked` property with jest-dom matchers `toBeChecked` and `not.toBeChecked`.
- Use a regex name matcher for the `Font size (pt)` checkbox to tolerate appended annotation text in the label.

### Testing
- Ran `CI=true npm test -- --runInBand --watchAll=false src/components/DocumentStyleEditorPage.test.js` and all tests passed.
- Ran `npx eslint src/components/DocumentStyleEditorPage.test.js` with no reported errors.
- Ran `git diff --check` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6594da7d7c8326ae193d3e4fbe587b)