### PR TITLE
Documents Builder: fix Input mode focus bug, collapse transfer attempts to one record

### DIFF
--- a/src/components/CaseArtProgramEditor.jsx
+++ b/src/components/CaseArtProgramEditor.jsx
@@ -211,12 +211,18 @@ const nextSequentialId = (prefix, items) => {
   return `${prefix}-${maxSuffix + 1}`;
 };
 
+// One transfer attempt per case (batch 24 §2) - only the successful attempt's data ever matters
+// once the program is underway, so this is a single record, not a log of attempts.
+const emptyTransferAttempt = () => ({
+  shipmentId: '', date: '', embryoCount: '', embryoStage: '', hcgTests: [], ultrasounds: [],
+});
+
 const emptyArtProgramDraft = () => ({
   medicalIndication: { diagnosis: { uk: '' } },
   geneticMaterial: { oocyteSourcePartnerRole: '', spermSourcePartnerRole: '' },
   medicalTeam: { physician: { name: { uk: { nominative: '' } } } },
   embryoShipments: [],
-  transferAttempts: [],
+  transferAttempt: emptyTransferAttempt(),
 });
 
 const PARTNER_ROLE_OPTIONS = [
@@ -257,11 +263,12 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
       // toArray tolerates a Firebase map-with-gaps the same way every other reader in this app does
       // (see documentsCatalogUtils.toArray) - never assumes the backend snapshot is a real Array.
       embryoShipments: toArray(artProgram.embryoShipments),
-      transferAttempts: toArray(artProgram.transferAttempts).map(transfer => ({
-        ...transfer,
-        hcgTests: toArray(transfer.hcgTests),
-        ultrasounds: toArray(transfer.ultrasounds),
-      })),
+      transferAttempt: {
+        ...emptyTransferAttempt(),
+        ...artProgram.transferAttempt,
+        hcgTests: toArray(artProgram.transferAttempt?.hcgTests),
+        ultrasounds: toArray(artProgram.transferAttempt?.ultrasounds),
+      },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [caseId]);
@@ -309,63 +316,39 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
       : shipment)),
   }));
 
-  // --- Transfer attempts + nested hCG/ultrasound ------------------------------------------------
+  // --- The one transfer attempt + its nested hCG tests/ultrasounds ------------------------------
 
-  const addTransfer = () => setDraft(previous => ({
+  const updateTransferField = (field, value) => setDraft(previous => ({
     ...previous,
-    transferAttempts: [...previous.transferAttempts, {
-      id: nextSequentialId('transfer', previous.transferAttempts),
-      shipmentId: '',
-      date: '',
-      embryoCount: '',
-      embryoStage: '',
-      hcgTests: [],
-      ultrasounds: [],
-    }],
+    transferAttempt: { ...previous.transferAttempt, [field]: value },
   }));
 
-  const removeTransfer = transferId => setDraft(previous => ({
+  const updateTransferList = (listKey, updater) => setDraft(previous => ({
     ...previous,
-    transferAttempts: previous.transferAttempts.filter(transfer => transfer.id !== transferId),
+    transferAttempt: { ...previous.transferAttempt, [listKey]: updater(previous.transferAttempt[listKey]) },
   }));
 
-  const updateTransferField = (transferId, field, value) => setDraft(previous => ({
-    ...previous,
-    transferAttempts: previous.transferAttempts.map(transfer => (transfer.id === transferId ? { ...transfer, [field]: value } : transfer)),
-  }));
-
-  const updateTransferList = (transferId, listKey, updater) => setDraft(previous => ({
-    ...previous,
-    transferAttempts: previous.transferAttempts.map(transfer => (transfer.id === transferId
-      ? { ...transfer, [listKey]: updater(transfer[listKey]) }
-      : transfer)),
-  }));
-
-  const addHcgTest = transferId => updateTransferList(transferId, 'hcgTests', hcgTests => [...hcgTests, {
+  const addHcgTest = () => updateTransferList('hcgTests', hcgTests => [...hcgTests, {
     id: nextSequentialId('hcg', hcgTests), date: '', positive: '', value: '', unit: '',
   }]);
-  const removeHcgTest = (transferId, hcgTestId) => updateTransferList(transferId, 'hcgTests', hcgTests => hcgTests.filter(item => item.id !== hcgTestId));
-  const updateHcgTestField = (transferId, hcgTestId, field, value) => updateTransferList(
-    transferId,
+  const removeHcgTest = hcgTestId => updateTransferList('hcgTests', hcgTests => hcgTests.filter(item => item.id !== hcgTestId));
+  const updateHcgTestField = (hcgTestId, field, value) => updateTransferList(
     'hcgTests',
     hcgTests => hcgTests.map(item => (item.id === hcgTestId ? { ...item, [field]: value } : item)),
   );
 
-  const addUltrasound = transferId => updateTransferList(transferId, 'ultrasounds', ultrasounds => [...ultrasounds, {
+  const addUltrasound = () => updateTransferList('ultrasounds', ultrasounds => [...ultrasounds, {
     id: nextSequentialId('ultrasound', ultrasounds), date: '', pregnancyConfirmed: '', fetusCount: '', gestationalAgeWeeks: { from: '', to: '' },
   }]);
-  const removeUltrasound = (transferId, ultrasoundId) => updateTransferList(
-    transferId,
+  const removeUltrasound = ultrasoundId => updateTransferList(
     'ultrasounds',
     ultrasounds => ultrasounds.filter(item => item.id !== ultrasoundId),
   );
-  const updateUltrasoundField = (transferId, ultrasoundId, field, value) => updateTransferList(
-    transferId,
+  const updateUltrasoundField = (ultrasoundId, field, value) => updateTransferList(
     'ultrasounds',
     ultrasounds => ultrasounds.map(item => (item.id === ultrasoundId ? { ...item, [field]: value } : item)),
   );
-  const updateUltrasoundGestField = (transferId, ultrasoundId, field, value) => updateTransferList(
-    transferId,
+  const updateUltrasoundGestField = (ultrasoundId, field, value) => updateTransferList(
     'ultrasounds',
     ultrasounds => ultrasounds.map(item => (item.id === ultrasoundId
       ? { ...item, gestationalAgeWeeks: { ...(item.gestationalAgeWeeks || {}), [field]: value } }
@@ -393,17 +376,17 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
           endDate: normalizeIsoDate(shipment.plannedPeriod?.endDate),
         },
       }))),
-      transferAttempts: arrayToMap(draft.transferAttempts.map(transfer => ({
-        ...transfer,
-        date: normalizeIsoDate(transfer.date),
-        embryoCount: parseNumberOrBlank(transfer.embryoCount),
-        hcgTests: arrayToMap(transfer.hcgTests.map(hcgTest => ({
+      transferAttempt: {
+        ...draft.transferAttempt,
+        date: normalizeIsoDate(draft.transferAttempt.date),
+        embryoCount: parseNumberOrBlank(draft.transferAttempt.embryoCount),
+        hcgTests: arrayToMap(draft.transferAttempt.hcgTests.map(hcgTest => ({
           ...hcgTest,
           date: normalizeIsoDate(hcgTest.date),
           positive: parseTriState(hcgTest.positive),
           value: parseNumberOrBlank(hcgTest.value),
         }))),
-        ultrasounds: arrayToMap(transfer.ultrasounds.map(ultrasound => ({
+        ultrasounds: arrayToMap(draft.transferAttempt.ultrasounds.map(ultrasound => ({
           ...ultrasound,
           date: normalizeIsoDate(ultrasound.date),
           pregnancyConfirmed: parseTriState(ultrasound.pregnancyConfirmed),
@@ -413,7 +396,7 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
             to: parseNumberOrBlank(ultrasound.gestationalAgeWeeks?.to),
           },
         }))),
-      }))),
+      },
     };
     const cleaned = removeEmptyCaseValues(payload);
     const nextValue = Object.keys(cleaned).length ? cleaned : null;
@@ -550,173 +533,162 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
         </SmallButton>
       </RowLine>
 
-      <SectionSubhead style={{ marginTop: 14 }}>Спроби переносу</SectionSubhead>
-      {draft.transferAttempts.map((transfer, index) => (
-        <DocRow key={transfer.id}>
-          <DocRowHead>
-            <DocSubtitle style={{ fontWeight: 700 }}>{transfer.id || `Перенос ${index + 1}`}</DocSubtitle>
-            <DangerButton type="button" onClick={() => removeTransfer(transfer.id)} title="Remove this transfer attempt">
-              <FaTrash />
-            </DangerButton>
-          </DocRowHead>
-          <FieldGrid>
-            <Field>
-              Доставлення
-              <Select value={transfer.shipmentId || ''} onChange={event => updateTransferField(transfer.id, 'shipmentId', event.target.value)}>
-                <option value="">— не обрано —</option>
-                {draft.embryoShipments.map(shipment => (
-                  <option key={shipment.id} value={shipment.id}>
-                    {formatShipmentOptionLabel(shipment, catalog.parties) || shipment.id}
-                  </option>
-                ))}
-              </Select>
-            </Field>
-            <Field>
-              Дата переносу
-              <FieldInput type="date" value={transfer.date || ''} onChange={event => updateTransferField(transfer.id, 'date', event.target.value)} />
-            </Field>
-            <Field>
-              Кількість ембріонів
-              <FieldInput
-                type="number"
-                min="0"
-                value={transfer.embryoCount ?? ''}
-                onChange={event => updateTransferField(transfer.id, 'embryoCount', event.target.value)}
-              />
-            </Field>
-            <Field>
-              Стадія ембріонів
-              <FieldInput
-                type="text"
-                list="art-embryo-stage-options"
-                placeholder="blastocyst"
-                value={transfer.embryoStage || ''}
-                onChange={event => updateTransferField(transfer.id, 'embryoStage', event.target.value)}
-              />
-            </Field>
-          </FieldGrid>
+      {/* One record only (batch 24 §2) - the successful transfer attempt's data, filled in once its
+          outcome is known. No add/remove: this is an edit form for that one record, not a list. */}
+      <SectionSubhead style={{ marginTop: 14 }}>Спроба переносу</SectionSubhead>
+      <DocRow>
+        <FieldGrid>
+          <Field>
+            Доставлення
+            <Select value={draft.transferAttempt.shipmentId || ''} onChange={event => updateTransferField('shipmentId', event.target.value)}>
+              <option value="">— не обрано —</option>
+              {draft.embryoShipments.map(shipment => (
+                <option key={shipment.id} value={shipment.id}>
+                  {formatShipmentOptionLabel(shipment, catalog.parties) || shipment.id}
+                </option>
+              ))}
+            </Select>
+          </Field>
+          <Field>
+            Дата переносу
+            <FieldInput type="date" value={draft.transferAttempt.date || ''} onChange={event => updateTransferField('date', event.target.value)} />
+          </Field>
+          <Field>
+            Кількість ембріонів
+            <FieldInput
+              type="number"
+              min="0"
+              value={draft.transferAttempt.embryoCount ?? ''}
+              onChange={event => updateTransferField('embryoCount', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Стадія ембріонів
+            <FieldInput
+              type="text"
+              list="art-embryo-stage-options"
+              placeholder="blastocyst"
+              value={draft.transferAttempt.embryoStage || ''}
+              onChange={event => updateTransferField('embryoStage', event.target.value)}
+            />
+          </Field>
+        </FieldGrid>
 
-          <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>Аналізи ХГЧ</SectionSubhead>
-          {transfer.hcgTests.map((hcgTest, hcgIndex) => (
-            <NestedRow key={hcgTest.id}>
-              <DocRowHead>
-                <DocSubtitle style={{ fontWeight: 700 }}>{hcgTest.id || `ХГЧ ${hcgIndex + 1}`}</DocSubtitle>
-                <DangerButton type="button" onClick={() => removeHcgTest(transfer.id, hcgTest.id)} title="Remove this hCG test">
-                  <FaTrash />
-                </DangerButton>
-              </DocRowHead>
-              <FieldGrid>
-                <Field>
-                  Дата
-                  <FieldInput
-                    type="date"
-                    value={hcgTest.date || ''}
-                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'date', event.target.value)}
-                  />
-                </Field>
-                <Field>
-                  Результат
-                  <Select
-                    value={hcgTest.positive === true ? 'true' : (hcgTest.positive === false ? 'false' : '')}
-                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'positive', event.target.value)}
-                  >
-                    {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-                  </Select>
-                </Field>
-                <Field>
-                  Значення
-                  <FieldInput
-                    type="number"
-                    value={hcgTest.value ?? ''}
-                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'value', event.target.value)}
-                  />
-                </Field>
-                <Field>
-                  Одиниці вимірювання
-                  <FieldInput
-                    type="text"
-                    value={hcgTest.unit || ''}
-                    onChange={event => updateHcgTestField(transfer.id, hcgTest.id, 'unit', event.target.value)}
-                  />
-                </Field>
-              </FieldGrid>
-            </NestedRow>
-          ))}
-          <RowLine style={{ marginTop: 8 }}>
-            <SmallButton type="button" onClick={() => addHcgTest(transfer.id)}>
-              <FaPlus /> Add hCG test
-            </SmallButton>
-          </RowLine>
+        <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>Аналізи ХГЧ</SectionSubhead>
+        {draft.transferAttempt.hcgTests.map((hcgTest, hcgIndex) => (
+          <NestedRow key={hcgTest.id}>
+            <DocRowHead>
+              <DocSubtitle style={{ fontWeight: 700 }}>{hcgTest.id || `ХГЧ ${hcgIndex + 1}`}</DocSubtitle>
+              <DangerButton type="button" onClick={() => removeHcgTest(hcgTest.id)} title="Remove this hCG test">
+                <FaTrash />
+              </DangerButton>
+            </DocRowHead>
+            <FieldGrid>
+              <Field>
+                Дата
+                <FieldInput
+                  type="date"
+                  value={hcgTest.date || ''}
+                  onChange={event => updateHcgTestField(hcgTest.id, 'date', event.target.value)}
+                />
+              </Field>
+              <Field>
+                Результат
+                <Select
+                  value={hcgTest.positive === true ? 'true' : (hcgTest.positive === false ? 'false' : '')}
+                  onChange={event => updateHcgTestField(hcgTest.id, 'positive', event.target.value)}
+                >
+                  {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </Select>
+              </Field>
+              <Field>
+                Значення
+                <FieldInput
+                  type="number"
+                  value={hcgTest.value ?? ''}
+                  onChange={event => updateHcgTestField(hcgTest.id, 'value', event.target.value)}
+                />
+              </Field>
+              <Field>
+                Одиниці вимірювання
+                <FieldInput
+                  type="text"
+                  value={hcgTest.unit || ''}
+                  onChange={event => updateHcgTestField(hcgTest.id, 'unit', event.target.value)}
+                />
+              </Field>
+            </FieldGrid>
+          </NestedRow>
+        ))}
+        <RowLine style={{ marginTop: 8 }}>
+          <SmallButton type="button" onClick={addHcgTest}>
+            <FaPlus /> Add hCG test
+          </SmallButton>
+        </RowLine>
 
-          <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>УЗД</SectionSubhead>
-          {transfer.ultrasounds.map((ultrasound, ultrasoundIndex) => (
-            <NestedRow key={ultrasound.id}>
-              <DocRowHead>
-                <DocSubtitle style={{ fontWeight: 700 }}>{ultrasound.id || `УЗД ${ultrasoundIndex + 1}`}</DocSubtitle>
-                <DangerButton type="button" onClick={() => removeUltrasound(transfer.id, ultrasound.id)} title="Remove this ultrasound">
-                  <FaTrash />
-                </DangerButton>
-              </DocRowHead>
-              <FieldGrid>
-                <Field>
-                  Дата
-                  <FieldInput
-                    type="date"
-                    value={ultrasound.date || ''}
-                    onChange={event => updateUltrasoundField(transfer.id, ultrasound.id, 'date', event.target.value)}
-                  />
-                </Field>
-                <Field>
-                  Вагітність підтверджена
-                  <Select
-                    value={ultrasound.pregnancyConfirmed === true ? 'true' : (ultrasound.pregnancyConfirmed === false ? 'false' : '')}
-                    onChange={event => updateUltrasoundField(transfer.id, ultrasound.id, 'pregnancyConfirmed', event.target.value)}
-                  >
-                    {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-                  </Select>
-                </Field>
-                <Field>
-                  Кількість плодів
-                  <FieldInput
-                    type="number"
-                    min="0"
-                    value={ultrasound.fetusCount ?? ''}
-                    onChange={event => updateUltrasoundField(transfer.id, ultrasound.id, 'fetusCount', event.target.value)}
-                  />
-                </Field>
-                <Field>
-                  Строк вагітності — від (тижнів)
-                  <FieldInput
-                    type="number"
-                    min="0"
-                    value={ultrasound.gestationalAgeWeeks?.from ?? ''}
-                    onChange={event => updateUltrasoundGestField(transfer.id, ultrasound.id, 'from', event.target.value)}
-                  />
-                </Field>
-                <Field>
-                  Строк вагітності — до (тижнів)
-                  <FieldInput
-                    type="number"
-                    min="0"
-                    value={ultrasound.gestationalAgeWeeks?.to ?? ''}
-                    onChange={event => updateUltrasoundGestField(transfer.id, ultrasound.id, 'to', event.target.value)}
-                  />
-                </Field>
-              </FieldGrid>
-            </NestedRow>
-          ))}
-          <RowLine style={{ marginTop: 8 }}>
-            <SmallButton type="button" onClick={() => addUltrasound(transfer.id)}>
-              <FaPlus /> Add ultrasound
-            </SmallButton>
-          </RowLine>
-        </DocRow>
-      ))}
-      <RowLine style={{ marginTop: 8 }}>
-        <SmallButton type="button" onClick={addTransfer}>
-          <FaPlus /> Add transfer attempt
-        </SmallButton>
-      </RowLine>
+        <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>УЗД</SectionSubhead>
+        {draft.transferAttempt.ultrasounds.map((ultrasound, ultrasoundIndex) => (
+          <NestedRow key={ultrasound.id}>
+            <DocRowHead>
+              <DocSubtitle style={{ fontWeight: 700 }}>{ultrasound.id || `УЗД ${ultrasoundIndex + 1}`}</DocSubtitle>
+              <DangerButton type="button" onClick={() => removeUltrasound(ultrasound.id)} title="Remove this ultrasound">
+                <FaTrash />
+              </DangerButton>
+            </DocRowHead>
+            <FieldGrid>
+              <Field>
+                Дата
+                <FieldInput
+                  type="date"
+                  value={ultrasound.date || ''}
+                  onChange={event => updateUltrasoundField(ultrasound.id, 'date', event.target.value)}
+                />
+              </Field>
+              <Field>
+                Вагітність підтверджена
+                <Select
+                  value={ultrasound.pregnancyConfirmed === true ? 'true' : (ultrasound.pregnancyConfirmed === false ? 'false' : '')}
+                  onChange={event => updateUltrasoundField(ultrasound.id, 'pregnancyConfirmed', event.target.value)}
+                >
+                  {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </Select>
+              </Field>
+              <Field>
+                Кількість плодів
+                <FieldInput
+                  type="number"
+                  min="0"
+                  value={ultrasound.fetusCount ?? ''}
+                  onChange={event => updateUltrasoundField(ultrasound.id, 'fetusCount', event.target.value)}
+                />
+              </Field>
+              <Field>
+                Строк вагітності — від (тижнів)
+                <FieldInput
+                  type="number"
+                  min="0"
+                  value={ultrasound.gestationalAgeWeeks?.from ?? ''}
+                  onChange={event => updateUltrasoundGestField(ultrasound.id, 'from', event.target.value)}
+                />
+              </Field>
+              <Field>
+                Строк вагітності — до (тижнів)
+                <FieldInput
+                  type="number"
+                  min="0"
+                  value={ultrasound.gestationalAgeWeeks?.to ?? ''}
+                  onChange={event => updateUltrasoundGestField(ultrasound.id, 'to', event.target.value)}
+                />
+              </Field>
+            </FieldGrid>
+          </NestedRow>
+        ))}
+        <RowLine style={{ marginTop: 8 }}>
+          <SmallButton type="button" onClick={addUltrasound}>
+            <FaPlus /> Add ultrasound
+          </SmallButton>
+        </RowLine>
+      </DocRow>
 
       <datalist id="art-embryo-stage-options">
         <option value="blastocyst" />

--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -17,7 +17,6 @@ import {
   formatHcgTestOptionLabel,
   formatShipmentOptionLabel,
   formatShortNameUk,
-  formatTransferOptionLabel,
   formatUltrasoundOptionLabel,
   getMaternityHospitalDisplayName,
   normalizeIsoDate,
@@ -235,21 +234,20 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   // (without touching the shipment dropdown) never destroys them.
   const [embryoOwnershipDraft, setEmbryoOwnershipDraft] = useState({ shipmentId: '', legacyIvfDate: '', legacyShipmentPeriod: null });
   const [geneticAffinityCertificateDraft, setGeneticAffinityCertificateDraft] = useState({
-    transferAttemptId: '', hcgTestId: '', ultrasoundId: '', issueDate: '', outgoingNumber: '',
+    hcgTestId: '', ultrasoundId: '', issueDate: '', outgoingNumber: '',
   });
-  const [racssClinicLetterDraft, setRacssClinicLetterDraft] = useState({ transferAttemptId: '', ultrasoundId: '' });
+  const [racssClinicLetterDraft, setRacssClinicLetterDraft] = useState({ ultrasoundId: '' });
   const [medicalServicesAgreementDraft, setMedicalServicesAgreementDraft] = useState({ date: '' });
 
   // Every artProgram-referencing dropdown reads from the same source: the selected case's own
-  // shipments/transfer attempts (never converted to arrays for storage - see documentsCatalogUtils
-  // - only here, transiently, for rendering <option>s).
+  // shipments/transfer attempt (never converted to arrays for storage - see documentsCatalogUtils -
+  // only here, transiently, for rendering <option>s). There is only ever one transfer attempt
+  // (batch 24 §2), so its hCG tests/ultrasounds are the only thing still picked by id.
   const artShipments = toArray(selectedCase?.artProgram?.embryoShipments);
-  const artTransferAttempts = toArray(selectedCase?.artProgram?.transferAttempts);
-  const certificateTransfer = artTransferAttempts.find(item => item.id === geneticAffinityCertificateDraft.transferAttemptId) || null;
-  const certificateHcgTests = toArray(certificateTransfer?.hcgTests);
-  const certificateUltrasounds = toArray(certificateTransfer?.ultrasounds);
-  const letterTransfer = artTransferAttempts.find(item => item.id === racssClinicLetterDraft.transferAttemptId) || null;
-  const letterUltrasounds = toArray(letterTransfer?.ultrasounds);
+  const artTransferAttempt = selectedCase?.artProgram?.transferAttempt || null;
+  const certificateHcgTests = toArray(artTransferAttempt?.hcgTests);
+  const certificateUltrasounds = toArray(artTransferAttempt?.ultrasounds);
+  const letterUltrasounds = toArray(artTransferAttempt?.ultrasounds);
 
   useEffect(() => {
     // `childbirth.children` isn't guaranteed to be a real array - a case edited straight in the
@@ -288,14 +286,12 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       legacyShipmentPeriod: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod || null,
     });
     setGeneticAffinityCertificateDraft({
-      transferAttemptId: selectedCase?.documents?.geneticAffinityCertificate?.transferAttemptId || '',
       hcgTestId: selectedCase?.documents?.geneticAffinityCertificate?.hcgTestId || '',
       ultrasoundId: selectedCase?.documents?.geneticAffinityCertificate?.ultrasoundId || '',
       issueDate: selectedCase?.documents?.geneticAffinityCertificate?.issueDate || '',
       outgoingNumber: selectedCase?.documents?.geneticAffinityCertificate?.outgoingNumber || '',
     });
     setRacssClinicLetterDraft({
-      transferAttemptId: selectedCase?.documents?.racssClinicLetter?.transferAttemptId || '',
       ultrasoundId: selectedCase?.documents?.racssClinicLetter?.ultrasoundId || '',
     });
     setMedicalServicesAgreementDraft({
@@ -534,17 +530,11 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     return saveCaseDocument('embryoOwnershipStatement', payload, 'Embryo ownership statement details saved.', 'the embryo ownership statement details');
   };
 
-  const updateGeneticAffinityCertificateField = (field, value) => setGeneticAffinityCertificateDraft(previous => {
-    // Picking a different transfer attempt invalidates whatever hCG test/ultrasound was selected
-    // from the previous one - they belong to a specific transfer, never shared across transfers.
-    if (field === 'transferAttemptId') return { ...previous, transferAttemptId: value, hcgTestId: '', ultrasoundId: '' };
-    return { ...previous, [field]: value };
-  });
+  const updateGeneticAffinityCertificateField = (field, value) => setGeneticAffinityCertificateDraft(previous => ({ ...previous, [field]: value }));
 
   const handleSaveGeneticAffinityCertificate = () => saveCaseDocument(
     'geneticAffinityCertificate',
     {
-      transferAttemptId: geneticAffinityCertificateDraft.transferAttemptId,
       hcgTestId: geneticAffinityCertificateDraft.hcgTestId,
       ultrasoundId: geneticAffinityCertificateDraft.ultrasoundId,
       issueDate: normalizeIsoDate(geneticAffinityCertificateDraft.issueDate),
@@ -554,14 +544,11 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     'the genetic affinity certificate details',
   );
 
-  const updateRacssClinicLetterField = (field, value) => setRacssClinicLetterDraft(previous => {
-    if (field === 'transferAttemptId') return { ...previous, transferAttemptId: value, ultrasoundId: '' };
-    return { ...previous, [field]: value };
-  });
+  const updateRacssClinicLetterField = (field, value) => setRacssClinicLetterDraft(previous => ({ ...previous, [field]: value }));
 
   const handleSaveRacssClinicLetter = () => saveCaseDocument(
     'racssClinicLetter',
-    { transferAttemptId: racssClinicLetterDraft.transferAttemptId, ultrasoundId: racssClinicLetterDraft.ultrasoundId },
+    { ultrasoundId: racssClinicLetterDraft.ultrasoundId },
     'RACSS clinic letter details saved.',
     'the RACSS clinic letter details',
   );
@@ -868,25 +855,11 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       <SectionSubhead style={{ marginTop: 14 }}>Довідка про генетичну спорідненість</SectionSubhead>
       <FieldGrid>
         <Field>
-          Спроба переносу (довідка)
-          <Select
-            value={geneticAffinityCertificateDraft.transferAttemptId || ''}
-            onChange={event => updateGeneticAffinityCertificateField('transferAttemptId', event.target.value)}
-          >
-            <option value="">— не обрано —</option>
-            {artTransferAttempts.map(transferAttempt => (
-              <option key={transferAttempt.id} value={transferAttempt.id}>
-                {formatTransferOptionLabel(transferAttempt) || transferAttempt.id}
-              </option>
-            ))}
-          </Select>
-        </Field>
-        <Field>
           ХГЧ (довідка)
           <Select
             value={geneticAffinityCertificateDraft.hcgTestId || ''}
             onChange={event => updateGeneticAffinityCertificateField('hcgTestId', event.target.value)}
-            disabled={!certificateTransfer}
+            disabled={!artTransferAttempt}
           >
             <option value="">— не обрано —</option>
             {certificateHcgTests.map(hcgTest => (
@@ -899,7 +872,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
           <Select
             value={geneticAffinityCertificateDraft.ultrasoundId || ''}
             onChange={event => updateGeneticAffinityCertificateField('ultrasoundId', event.target.value)}
-            disabled={!certificateTransfer}
+            disabled={!artTransferAttempt}
           >
             <option value="">— не обрано —</option>
             {certificateUltrasounds.map(ultrasound => (
@@ -933,25 +906,11 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       <SectionSubhead style={{ marginTop: 14 }}>Лист клініки до РАЦС</SectionSubhead>
       <FieldGrid>
         <Field>
-          Спроба переносу (лист РАЦС)
-          <Select
-            value={racssClinicLetterDraft.transferAttemptId || ''}
-            onChange={event => updateRacssClinicLetterField('transferAttemptId', event.target.value)}
-          >
-            <option value="">— не обрано —</option>
-            {artTransferAttempts.map(transferAttempt => (
-              <option key={transferAttempt.id} value={transferAttempt.id}>
-                {formatTransferOptionLabel(transferAttempt) || transferAttempt.id}
-              </option>
-            ))}
-          </Select>
-        </Field>
-        <Field>
           УЗД (лист РАЦС)
           <Select
             value={racssClinicLetterDraft.ultrasoundId || ''}
             onChange={event => updateRacssClinicLetterField('ultrasoundId', event.target.value)}
-            disabled={!letterTransfer}
+            disabled={!artTransferAttempt}
           >
             <option value="">— не обрано —</option>
             {letterUltrasounds.map(ultrasound => (

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -27,7 +27,7 @@ import {
   DOCUMENT_LAYOUTS,
   PARTY_COLLECTIONS,
   applyLogoLayoutAssignment,
-  applyPlainTextEdit,
+  applyResolvedTextEdit,
   beforeTitleScope,
   buildCaseLabel,
   buildDocumentsFileName,
@@ -913,19 +913,21 @@ const DocumentsPage = ({ isAdmin }) => {
   // see resolvedValue/titleResolvedValue/beforeTitleResolvedValue below, all three built from the
   // same resolvedDoc), where Bold/Italic act on the underlying raw markup even though the resolved
   // wording is what's shown - the wording itself isn't editable there, only its formatting.
-  // 'input' shows that same resolved wording at rest (batch 2026-07-25: matches Text mode, never a
-  // raw {{token}}) but is still meant for retyping the plain wording - clicking into a field swaps
-  // it to an editable plain-text view (de-markup'd, `{{token}}`s intact) for that one field only,
-  // tracked by `activeFieldKey` since a ref alone can't drive the re-render. Bold/Italic apply in
-  // both Template and Text mode; only Input mode disables them (nothing raw is on screen there
-  // until a field is actually clicked into). Every row - title, every paragraph, every beforeTitle
-  // block alike - follows this identical mechanism, no row-specific exceptions.
+  // 'input' shows that same resolved wording at rest (matches Text mode, never a raw {{token}}) and
+  // keeps showing it once a field is clicked into (batch 24 §1) - the field just becomes an
+  // editable plain-text view of the resolved wording for that one field only, tracked by
+  // `activeFieldKey` since a ref alone can't drive the re-render. Typing there edits the resolved
+  // text directly; applyResolvedTextEdit translates that edit back onto the shared raw markup
+  // (baking in a substituted value as literal text if the edit actually reached into one). Only
+  // switching to Template mode ever shows the raw {{token}} markup. Bold/Italic apply in both
+  // Template and Text mode; only Input mode disables them. Every row - title, every paragraph,
+  // every beforeTitle block alike - follows this identical mechanism, no row-specific exceptions.
   const PARAGRAPH_MODES = ['template', 'input', 'text'];
   const nextParagraphMode = mode => PARAGRAPH_MODES[(PARAGRAPH_MODES.indexOf(mode) + 1) % PARAGRAPH_MODES.length];
   const PARAGRAPH_MODE_ICON = { template: '{}', input: 'I', text: 'T' };
   const PARAGRAPH_MODE_TITLE = {
     template: 'Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.',
-    input: 'Input mode - shows the resolved wording (click it to retype as plain text). Tap to switch to Text mode.',
+    input: 'Input mode - shows the resolved wording, editable in place. Tap to switch to Text mode.',
     text: 'Text mode - select text and press Bold/Italic; wording isn\'t editable here. Tap to switch to Template mode.',
   };
   const [paragraphModes, setParagraphModes] = useState({});
@@ -1394,10 +1396,10 @@ const DocumentsPage = ({ isAdmin }) => {
   const activeFieldRef = useRef(null);
   const fieldKey = (docId, scope, langKey) => `${docId}#${scope}#${langKey}`;
   // Input mode shows the resolved (final, case-substituted) wording at rest - same as Text mode -
-  // instead of the raw {{token}} markup, and swaps to the editable plain-text field only for
-  // whichever single field was last clicked into (batch 2026-07-25: "має показувати вже фінальну
-  // версію тексту... а не посилання в форматі {}"). `activeFieldRef` alone can't drive this (a ref
-  // mutation doesn't re-render), so this mirrors it into real state.
+  // instead of the raw {{token}} markup, and swaps to an editable field showing that same resolved
+  // wording (never the raw markup, batch 24 §1) for whichever single field was last clicked into.
+  // `activeFieldRef` alone can't drive this (a ref mutation doesn't re-render), so this mirrors it
+  // into real state.
   const [activeFieldKey, setActiveFieldKey] = useState('');
   const registerFieldNode = (docId, scope, langKey) => node => {
     fieldNodesRef.current[fieldKey(docId, scope, langKey)] = node;
@@ -2339,11 +2341,11 @@ const DocumentsPage = ({ isAdmin }) => {
                 const titleIsInputMode = titleMode === 'input';
                 const titleRawValue = langKey => template.title?.[langKey] || '';
                 const titleResolvedValue = langKey => resolvedDoc?.title?.[langKey] ?? '';
-                const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleRawValue(langKey)));
+                const titleDisplayValue = langKey => (titleIsTemplateMode ? titleRawValue(langKey) : plainTextOf(titleResolvedValue(langKey)));
                 const onTitleFieldChange = langKey => event => {
                   const nextRaw = titleIsTemplateMode
                     ? event.target.value
-                    : applyPlainTextEdit(titleRawValue(langKey), event.target.value);
+                    : applyResolvedTextEdit(titleRawValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
                   handleTemplateScopeChange(template.id, TITLE_SCOPE, langKey, nextRaw);
                 };
                 const onTitleFieldBlur = () => persistTemplate(template.id);
@@ -2448,16 +2450,17 @@ const DocumentsPage = ({ isAdmin }) => {
                           const isInputMode = mode === 'input';
                           const isTextMode = mode === 'text';
                           const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
-                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
-                          // Same rule as the title/paragraph rows below: Text mode shows the
-                          // resolved-against-the-current-case value (real names/dates), never the
-                          // raw {{token}} markup - resolveBeforeTitleBlocks already fills every
-                          // placeholder when building resolvedDoc, this just has to read it.
+                          // Same rule as the title/paragraph rows below: both Text mode and a
+                          // focused Input mode field show the resolved-against-the-current-case
+                          // value (real names/dates), never the raw {{token}} markup -
+                          // resolveBeforeTitleBlocks already fills every placeholder when building
+                          // resolvedDoc, this just has to read it (batch 24 §1).
                           const beforeTitleResolvedValue = langKey => resolvedDoc?.beforeTitle?.[index]?.[langKey] ?? '';
+                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(beforeTitleResolvedValue(langKey)));
                           const onChange = langKey => event => {
                             const nextRaw = isTemplateMode
                               ? event.target.value
-                              : applyPlainTextEdit(rawValue(langKey), event.target.value);
+                              : applyResolvedTextEdit(rawValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
                             handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
                           };
                           const onBlur = () => persistTemplate(template.id);
@@ -2761,11 +2764,11 @@ const DocumentsPage = ({ isAdmin }) => {
                           const isTextMode = mode === 'text';
                           const rawValue = langKey => paragraph?.[langKey] || '';
                           const resolvedValue = langKey => resolvedDoc?.paragraphs?.[index]?.[langKey] ?? '';
-                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(rawValue(langKey)));
+                          const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(resolvedValue(langKey)));
                           const onChange = langKey => event => {
                             const nextRaw = isTemplateMode
                               ? event.target.value
-                              : applyPlainTextEdit(rawValue(langKey), event.target.value);
+                              : applyResolvedTextEdit(rawValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
                             handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
                           };
                           const onBlur = () => persistTemplate(template.id);

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -180,18 +180,17 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
 
     // template -> input -> text: two taps of the shared mode-cycle button.
     fireEvent.click(within(block).getByTitle('Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.'));
-    fireEvent.click(within(block).getByTitle('Input mode - shows the resolved wording (click it to retype as plain text). Tap to switch to Text mode.'));
+    fireEvent.click(within(block).getByTitle('Input mode - shows the resolved wording, editable in place. Tap to switch to Text mode.'));
 
     expect(await within(block).findByText('Сурогатна мати Сурогатна Матір')).toBeInTheDocument();
     expect(within(block).queryByText(/\{\{surrogateMother/)).not.toBeInTheDocument();
   });
 
-  // Bug fix (batch 2026-07-25): Input mode used to show the raw {{token}} embedded in plain text
-  // at rest ("Input mode... а на посилання в форматі {}"), unlike Text mode which always showed
-  // the resolved wording. Input mode now shows the same resolved wording at rest, and only swaps
-  // to the editable plain-text field (still carrying the raw {{token}}, still de-markup'd) once
-  // that field is actually clicked into.
-  it('Input mode shows the resolved wording at rest (not a raw {{token}}), and swaps to the editable field once clicked', async () => {
+  // Bug fix (batch 24 §1): focusing an Input-mode field used to revert it to the raw {{token}}
+  // markup ("focus/tap handler for input mode must not re-render from the template source").
+  // Input mode now shows the resolved wording both at rest and once a field is focused - only
+  // switching to Template mode ever shows the raw {{token}} syntax.
+  it('Input mode shows the resolved wording at rest, and keeps showing it (now editable) once clicked - never reverting to raw {{token}}', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
@@ -206,9 +205,11 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     expect(within(block).queryByText(/\{\{surrogateMother/)).not.toBeInTheDocument();
     expect(within(block).queryByDisplayValue(/.*/)).not.toBeInTheDocument();
 
-    // Clicking that resolved-text view swaps it to the editable de-markup'd field, raw token intact.
+    // Clicking that resolved-text view swaps it to an editable field showing that same resolved
+    // wording - not the raw {{token}} markup.
     fireEvent.mouseDown(within(block).getByText('Сурогатна мати Сурогатна Матір'));
-    expect(await within(block).findByDisplayValue('Сурогатна мати {{surrogateMother.name.uk.nominative}}')).toBeInTheDocument();
+    expect(await within(block).findByDisplayValue('Сурогатна мати Сурогатна Матір')).toBeInTheDocument();
+    expect(within(block).queryByDisplayValue(/\{\{surrogateMother/)).not.toBeInTheDocument();
   });
 
   // Notarial layout standard §3.3 + batch 2026-07-23 B §1.3/§1.4: the signer-block offset is a

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -27,7 +27,6 @@ import {
   formatPregnancyTypeTextUk,
   formatShipmentOptionLabel,
   formatShipmentPeriod,
-  formatTransferOptionLabel,
   formatUltrasoundOptionLabel,
   mergeDocumentsCatalog,
   normalizeDocumentsCatalog,
@@ -86,41 +85,30 @@ const caseWithDateRangePeriod = {
         receivedDate: '2025-08-27',
       },
     },
-    transferAttempts: {
-      'transfer-1': {
-        id: 'transfer-1',
-        shipmentId: 'shipment-1',
-        date: '2025-09-18',
-        embryoCount: 1,
-        embryoStage: 'blastocyst',
-        hcgTests: {
-          'hcg-1': { id: 'hcg-1', date: '2025-09-30', positive: true },
-        },
-        ultrasounds: {
-          'ultrasound-1': {
-            id: 'ultrasound-1', date: '2025-10-17', pregnancyConfirmed: true, fetusCount: 1, gestationalAgeWeeks: { from: 6, to: 7 },
-          },
-        },
+    // batch 24 §2: a single transfer attempt object, not a log of attempts - only the one
+    // successful attempt's data ever matters once the program is underway.
+    transferAttempt: {
+      shipmentId: 'shipment-1',
+      date: '2025-09-18',
+      embryoCount: 1,
+      embryoStage: 'blastocyst',
+      hcgTests: {
+        'hcg-1': { id: 'hcg-1', date: '2025-09-30', positive: true },
+        'hcg-2': { id: 'hcg-2', date: '2025-11-15', positive: false },
       },
-      'transfer-2': {
-        id: 'transfer-2',
-        shipmentId: 'shipment-1',
-        date: '2025-11-01',
-        embryoCount: 2,
-        embryoStage: 'blastocyst',
-        hcgTests: {
-          'hcg-2': { id: 'hcg-2', date: '2025-11-15', positive: false },
+      ultrasounds: {
+        'ultrasound-1': {
+          id: 'ultrasound-1', date: '2025-10-17', pregnancyConfirmed: true, fetusCount: 1, gestationalAgeWeeks: { from: 6, to: 7 },
         },
-        ultrasounds: {},
       },
     },
   },
   documents: {
     embryoOwnershipStatement: { shipmentId: 'shipment-1' },
     geneticAffinityCertificate: {
-      transferAttemptId: 'transfer-1', hcgTestId: 'hcg-1', ultrasoundId: 'ultrasound-1', issueDate: '2025-10-20', outgoingNumber: '42/1',
+      hcgTestId: 'hcg-1', ultrasoundId: 'ultrasound-1', issueDate: '2025-10-20', outgoingNumber: '42/1',
     },
-    racssClinicLetter: { transferAttemptId: 'transfer-1', ultrasoundId: 'ultrasound-1' },
+    racssClinicLetter: { ultrasoundId: 'ultrasound-1' },
     medicalServicesAgreement: { date: '2025-09-12' },
   },
 };
@@ -166,16 +154,14 @@ const caseWithBrokenReferences = {
     embryoShipments: {
       'shipment-1': { id: 'shipment-1', sourceClinicId: partnerClinic.id, destinationClinicId: clinic.id },
     },
-    transferAttempts: {
-      'transfer-1': {
-        id: 'transfer-1', shipmentId: 'shipment-1', date: '2025-09-18', hcgTests: {}, ultrasounds: {},
-      },
+    transferAttempt: {
+      shipmentId: 'shipment-1', date: '2025-09-18', hcgTests: {}, ultrasounds: {},
     },
   },
   documents: {
     embryoOwnershipStatement: { shipmentId: 'shipment-999' },
-    geneticAffinityCertificate: { transferAttemptId: 'transfer-999', hcgTestId: 'hcg-999', ultrasoundId: 'ultrasound-999' },
-    racssClinicLetter: { transferAttemptId: 'transfer-1', ultrasoundId: 'ultrasound-999' },
+    geneticAffinityCertificate: { hcgTestId: 'hcg-999', ultrasoundId: 'ultrasound-999' },
+    racssClinicLetter: { ultrasoundId: 'ultrasound-999' },
   },
 };
 
@@ -188,14 +174,14 @@ const buildCatalog = (...cases) => normalizeDocumentsCatalog(
 // --- Resolvers -------------------------------------------------------------------------------
 
 describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferAttempt/resolveHcgTest/resolveUltrasound)', () => {
-  it('resolves an existing shipment/transferAttempt by id', () => {
+  it('resolves an existing shipment by id, and the case\'s one transfer attempt (no id needed, batch 24 §2)', () => {
     const { artProgram } = caseWithDateRangePeriod;
     expect(resolveShipment(caseWithDateRangePeriod, 'shipment-1')).toBe(artProgram.embryoShipments['shipment-1']);
-    expect(resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1')).toBe(artProgram.transferAttempts['transfer-1']);
+    expect(resolveTransferAttempt(caseWithDateRangePeriod)).toBe(artProgram.transferAttempt);
   });
 
-  it('resolves an existing hCG test/ultrasound from within its transfer attempt', () => {
-    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+  it('resolves an existing hCG test/ultrasound from within the transfer attempt', () => {
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
     expect(resolveHcgTest(transfer, 'hcg-1')).toBe(transfer.hcgTests['hcg-1']);
     expect(resolveUltrasound(transfer, 'ultrasound-1')).toBe(transfer.ultrasounds['ultrasound-1']);
   });
@@ -206,15 +192,17 @@ describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferA
     expect(resolveShipment(caseWithDateRangePeriod, undefined)).toBeNull();
     expect(resolveShipment(caseWithoutArtProgram, 'shipment-1')).toBeNull();
     expect(resolveShipment(caseWithDateRangePeriod, 'shipment-999')).toBeNull();
-    expect(resolveTransferAttempt(caseWithoutArtProgram, 'transfer-1')).toBeNull();
+    expect(resolveTransferAttempt(caseWithoutArtProgram)).toBeNull();
+    expect(resolveTransferAttempt(null)).toBeNull();
     expect(resolveHcgTest(null, 'hcg-1')).toBeNull();
     expect(resolveHcgTest({ hcgTests: {} }, 'hcg-1')).toBeNull();
     expect(resolveUltrasound(null, 'ultrasound-1')).toBeNull();
   });
 
-  it('a second transfer attempt never overwrites or shadows the first (independent lookup by id)', () => {
-    expect(resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1').embryoCount).toBe(1);
-    expect(resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-2').embryoCount).toBe(2);
+  it('a second hCG test never overwrites or shadows the first (independent lookup by id within the one transfer attempt)', () => {
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
+    expect(resolveHcgTest(transfer, 'hcg-1').positive).toBe(true);
+    expect(resolveHcgTest(transfer, 'hcg-2').positive).toBe(false);
   });
 
   it('enrichShipment attaches sourceClinic (partnerClinics) and destinationClinic (clinics), null-safe', () => {
@@ -304,7 +292,7 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
   });
 
   it('enrichTransferForTemplate adds dateFormatted/embryoCountText/embryoStageLabel and nests the enriched shipment', () => {
-    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
     const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod, transfer.shipmentId), parties);
     const enriched = enrichTransferForTemplate(transfer, shipment);
     expect(enriched.dateFormatted.uk).toBe('18.09.2025');
@@ -315,7 +303,7 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
   });
 
   it('enrichHcgTestForTemplate/enrichUltrasoundForTemplate add their own formatted fields, null-safe', () => {
-    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
     const hcgTest = enrichHcgTestForTemplate(resolveHcgTest(transfer, 'hcg-1'));
     expect(hcgTest.dateFormatted.uk).toBe('30.09.2025');
     expect(enrichHcgTestForTemplate(null)).toBeNull();
@@ -371,7 +359,7 @@ describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityC
   });
 
   it('geneticAffinityCertificate falls back to print-only blanks (never persisted) when issueDate/outgoingNumber are unset', () => {
-    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, { transferAttemptId: 'transfer-1' });
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
     expect(context.issueDateOrBlank.uk).toBe('__.__.____');
     expect(context.outgoingNumberOrBlank).toBe('______');
   });
@@ -430,14 +418,8 @@ describe('spec §13/§15: validateArtProgramReferences reports specific, actiona
     const catalog = buildCatalog(caseWithBrokenReferences);
     const issues = validateArtProgramReferences(catalog, 'case-broken');
     expect(issues).toContain('Не знайдено доставлення ембріонів shipment-999.');
-    expect(issues).toContain('Не знайдено спробу переносу transfer-999.');
-    expect(issues).toContain('Не знайдено УЗД ultrasound-999 у переносі transfer-1.');
-  });
-
-  it('a broken hcgTestId/ultrasoundId under a broken transferAttemptId is only reported once, via the transfer message', () => {
-    const catalog = buildCatalog(caseWithBrokenReferences);
-    const issues = validateArtProgramReferences(catalog, 'case-broken');
-    expect(issues.filter(issue => issue.includes('transfer-999')).length).toBe(1);
+    expect(issues).toContain('Не знайдено аналіз ХГЧ hcg-999.');
+    expect(issues).toContain('Не знайдено УЗД ultrasound-999.');
   });
 
   it('a fully-valid case reports no issues', () => {
@@ -455,12 +437,11 @@ describe('spec §13/§15: validateArtProgramReferences reports specific, actiona
 // --- Dropdown option labels (spec §9) -------------------------------------------------------------
 
 describe('spec §9: human-readable dropdown labels, never a raw id', () => {
-  it('formats a shipment/transfer/hcgTest/ultrasound as the exact spec example shapes', () => {
+  it('formats a shipment/hcgTest/ultrasound as the exact spec example shapes', () => {
     const shipment = resolveShipment(caseWithDateRangePeriod, 'shipment-1');
     expect(formatShipmentOptionLabel(shipment, parties)).toBe('Доставлення 27.08.2025 — Клініка Тестова');
 
-    const transfer = resolveTransferAttempt(caseWithDateRangePeriod, 'transfer-1');
-    expect(formatTransferOptionLabel(transfer)).toBe('Перенос 18.09.2025 — один ембріон');
+    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
 
     const hcgTest = resolveHcgTest(transfer, 'hcg-1');
     expect(formatHcgTestOptionLabel(hcgTest)).toBe('ХГЧ 30.09.2025 — позитивний');
@@ -471,7 +452,6 @@ describe('spec §9: human-readable dropdown labels, never a raw id', () => {
 
   it('every label helper is null-safe', () => {
     expect(formatShipmentOptionLabel(null, parties)).toBe('');
-    expect(formatTransferOptionLabel(null)).toBe('');
     expect(formatHcgTestOptionLabel(null)).toBe('');
     expect(formatUltrasoundOptionLabel(null)).toBe('');
   });
@@ -522,10 +502,10 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(validateDocumentTemplate(template, context)).toEqual([]);
   });
 
-  it('spec §8/§9: editing a shared transfer/ultrasound once is reflected simultaneously in geneticAffinityCertificate and racssClinicLetter', () => {
+  it('spec §8/§9: editing the shared transfer attempt/ultrasound once is reflected simultaneously in geneticAffinityCertificate and racssClinicLetter', () => {
     const catalog = buildCatalog(caseWithDateRangePeriod);
     const edited = deepMergeRecords(catalog.cases.find(item => item.id === 'case-daterange'), {
-      artProgram: { transferAttempts: { 'transfer-1': { date: '2026-03-03' } } },
+      artProgram: { transferAttempt: { date: '2026-03-03' } },
     });
     const nextCatalog = { ...catalog, cases: catalog.cases.map(item => (item.id === 'case-daterange' ? edited : item)) };
     const context = resolveCaseContext(nextCatalog, 'case-daterange');
@@ -552,13 +532,13 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(validateArtProgramReferences(catalog, 'case-broken').length).toBeGreaterThan(0);
   });
 
-  it('hCG/ultrasound are selected strictly by id, not array order - picking the second test/scan of a transfer resolves the right one', () => {
+  it('hCG/ultrasound are selected strictly by id, not object order - picking hcg-2 resolves it, not hcg-1', () => {
     const catalog = buildCatalog(caseWithDateRangePeriod);
     const context = resolveCaseContext(catalog, 'case-daterange', undefined);
-    // transfer-2 carries only hcg-2 (negative) - a document referencing it must never accidentally
-    // resolve transfer-1's hcg-1 (positive) instead.
+    // hcg-2 (negative) is a second test on the same transfer attempt as hcg-1 (positive) - a
+    // document referencing it must never accidentally resolve hcg-1 instead.
     const caseRecord = catalog.cases.find(item => item.id === 'case-daterange');
-    const built = buildGeneticAffinityCertificateContext(caseRecord, catalog.parties, { transferAttemptId: 'transfer-2', hcgTestId: 'hcg-2' });
+    const built = buildGeneticAffinityCertificateContext(caseRecord, catalog.parties, { hcgTestId: 'hcg-2' });
     expect(built.hcgTest.positive).toBe(false);
     expect(built.hcgTest.dateFormatted.uk).toBe('15.11.2025');
     expect(context).toBeTruthy(); // context built successfully above too
@@ -597,33 +577,32 @@ describe('spec §11/§12: ART-derived fields are never written back to Firebase'
 
 // --- Import/export round trip stays additive (spec §12) ------------------------------------------
 
-describe('spec §12: import/merge keeps embryoShipments/transferAttempts as maps and merges per-event', () => {
-  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog never converts embryoShipments/transferAttempts into arrays', () => {
+describe('spec §12: import/merge keeps embryoShipments/hcgTests/ultrasounds as maps, transferAttempt as one object', () => {
+  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog never converts embryoShipments into arrays, and merges the one transferAttempt in place', () => {
     const currentCatalog = buildCatalog(caseWithDateRangePeriod);
     const pasted = parseDocumentsTechnicalInput(JSON.stringify({
-      cases: { 'case-daterange': { id: 'case-daterange', artProgram: { transferAttempts: { 'transfer-1': { date: '2026-04-04' } } } } },
+      cases: { 'case-daterange': { id: 'case-daterange', artProgram: { transferAttempt: { date: '2026-04-04' } } } },
     }));
     const { catalog: merged } = mergeDocumentsCatalog(currentCatalog, pasted);
     const mergedCase = merged.cases.find(item => item.id === 'case-daterange');
     expect(Array.isArray(mergedCase.artProgram.embryoShipments)).toBe(false);
-    expect(Array.isArray(mergedCase.artProgram.transferAttempts)).toBe(false);
-    // The edit to transfer-1 landed...
-    expect(mergedCase.artProgram.transferAttempts['transfer-1'].date).toBe('2026-04-04');
-    // ...without wiping transfer-2 or shipment-1, which the incoming payload never mentioned.
-    expect(mergedCase.artProgram.transferAttempts['transfer-2'].embryoCount).toBe(2);
+    // The edit landed...
+    expect(mergedCase.artProgram.transferAttempt.date).toBe('2026-04-04');
+    // ...without wiping embryoCount or shipment-1, which the incoming payload never mentioned.
+    expect(mergedCase.artProgram.transferAttempt.embryoCount).toBe(1);
     expect(mergedCase.artProgram.embryoShipments['shipment-1'].id).toBe('shipment-1');
   });
 
-  it('a deep merge of one hcgTest field never replaces its sibling hcgTests/ultrasounds on the same transfer', () => {
+  it('a deep merge of one hcgTest field never replaces its sibling hcgTests/ultrasounds on the transfer attempt', () => {
     const currentCatalog = buildCatalog(caseWithDateRangePeriod);
     const currentCase = currentCatalog.cases.find(item => item.id === 'case-daterange');
     const merged = deepMergeRecords(currentCase, {
-      artProgram: { transferAttempts: { 'transfer-1': { hcgTests: { 'hcg-1': { positive: false } } } } },
+      artProgram: { transferAttempt: { hcgTests: { 'hcg-1': { positive: false } } } },
     });
-    expect(merged.artProgram.transferAttempts['transfer-1'].hcgTests['hcg-1'].positive).toBe(false);
-    expect(merged.artProgram.transferAttempts['transfer-1'].hcgTests['hcg-1'].date).toBe('2025-09-30');
-    expect(merged.artProgram.transferAttempts['transfer-1'].ultrasounds['ultrasound-1'].fetusCount).toBe(1);
-    expect(merged.artProgram.transferAttempts['transfer-2'].embryoCount).toBe(2);
+    expect(merged.artProgram.transferAttempt.hcgTests['hcg-1'].positive).toBe(false);
+    expect(merged.artProgram.transferAttempt.hcgTests['hcg-1'].date).toBe('2025-09-30');
+    expect(merged.artProgram.transferAttempt.ultrasounds['ultrasound-1'].fetusCount).toBe(1);
+    expect(merged.artProgram.transferAttempt.hcgTests['hcg-2'].positive).toBe(false);
   });
 });
 

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -931,13 +931,16 @@ export const TEMPLATE_DOCUMENT_CONFIG = {
 const DEFAULT_NOTARY_TEMPLATE_CONFIG = { documentKey: 'birthRegistrationConsent', usesNotary: true };
 
 // --- ART program (case.artProgram) - resolvers, formatters, document contexts ----------------
-// The medical facts of a case's fertility program (diagnosis, embryo shipments, transfer attempts,
-// hCG tests, ultrasounds) live once at `case.artProgram`, keyed by id (never converted to arrays -
-// spec §12). Every document that references one of these events (embryoOwnershipStatement,
+// The medical facts of a case's fertility program (diagnosis, embryo shipments, the one successful
+// transfer attempt, its hCG tests, its ultrasounds) live once at `case.artProgram`. Embryo
+// shipments and a transfer attempt's own hCG tests/ultrasounds stay keyed by id (never converted to
+// arrays - spec §12); the transfer attempt itself is a single object, not a log of attempts (batch
+// 24 §2 - only the one successful attempt ever matters once the program is underway). Every
+// document that references one of these events (embryoOwnershipStatement,
 // geneticAffinityCertificate, racssClinicLetter) stores only the id(s) it points at
-// (shipmentId/transferAttemptId/hcgTestId/ultrasoundId); editing the underlying event once (e.g.
-// the transfer date) is instantly reflected in every document that references it, since none of
-// them ever copy the fact - they resolve it fresh every render.
+// (shipmentId/hcgTestId/ultrasoundId); editing the underlying event once (e.g. the transfer date)
+// is instantly reflected in every document that references it, since none of them ever copy the
+// fact - they resolve it fresh every render.
 
 // Null-safe lookups (spec §3) - a missing/unset id, or an id that no longer exists (a document
 // still pointing at a deleted event), resolves to null rather than throwing, so a template that
@@ -947,10 +950,7 @@ export const resolveShipment = (caseData, shipmentId) => {
   return caseData?.artProgram?.embryoShipments?.[shipmentId] ?? null;
 };
 
-export const resolveTransferAttempt = (caseData, transferAttemptId) => {
-  if (!transferAttemptId) return null;
-  return caseData?.artProgram?.transferAttempts?.[transferAttemptId] ?? null;
-};
+export const resolveTransferAttempt = caseData => caseData?.artProgram?.transferAttempt ?? null;
 
 export const resolveHcgTest = (transferAttempt, hcgTestId) => {
   if (!hcgTestId) return null;
@@ -1135,10 +1135,12 @@ export const buildEmbryoOwnershipStatementContext = (caseData, parties, ownershi
   return { ...data, shipment: resolvedShipment || legacyShipment };
 };
 
-// case.documents.geneticAffinityCertificate - spec §4.
+// case.documents.geneticAffinityCertificate - spec §4. There is only ever one transfer attempt
+// (batch 24 §2), so it never needs an id of its own - only which of its hCG tests/ultrasounds this
+// certificate cites is still a choice (hcgTestId/ultrasoundId).
 export const buildGeneticAffinityCertificateContext = (caseData, parties, certificateData) => {
   const data = isPlainObject(certificateData) ? certificateData : {};
-  const transferAttempt = resolveTransferAttempt(caseData, data.transferAttemptId);
+  const transferAttempt = resolveTransferAttempt(caseData);
   const shipment = enrichShipment(resolveShipment(caseData, transferAttempt?.shipmentId), parties);
   return {
     ...data,
@@ -1152,10 +1154,10 @@ export const buildGeneticAffinityCertificateContext = (caseData, parties, certif
   };
 };
 
-// case.documents.racssClinicLetter - spec §4.
+// case.documents.racssClinicLetter - spec §4. Same single-transfer-attempt rule as above.
 export const buildRacssClinicLetterContext = (caseData, parties, letterData) => {
   const data = isPlainObject(letterData) ? letterData : {};
-  const transferAttempt = resolveTransferAttempt(caseData, data.transferAttemptId);
+  const transferAttempt = resolveTransferAttempt(caseData);
   const shipment = enrichShipment(resolveShipment(caseData, transferAttempt?.shipmentId), parties);
   return {
     ...data,
@@ -1206,13 +1208,7 @@ export const validateArtProgramReferences = (catalog, caseId) => {
   const caseRecord = normalizeCaseRecord(rawCaseRecord);
   const documents = isPlainObject(caseRecord.documents) ? caseRecord.documents : {};
   const issues = [];
-
-  const checkTransferAttempt = transferAttemptId => {
-    if (!transferAttemptId) return null;
-    const transferAttempt = resolveTransferAttempt(caseRecord, transferAttemptId);
-    if (!transferAttempt) issues.push(`Не знайдено спробу переносу ${transferAttemptId}.`);
-    return transferAttempt;
-  };
+  const transferAttempt = resolveTransferAttempt(caseRecord);
 
   const ownership = documents.embryoOwnershipStatement;
   if (ownership?.shipmentId && !resolveShipment(caseRecord, ownership.shipmentId)) {
@@ -1220,24 +1216,16 @@ export const validateArtProgramReferences = (catalog, caseId) => {
   }
 
   const certificate = documents.geneticAffinityCertificate;
-  if (certificate?.transferAttemptId || certificate?.hcgTestId || certificate?.ultrasoundId) {
-    const transferAttempt = checkTransferAttempt(certificate.transferAttemptId);
-    if (transferAttempt) {
-      if (certificate.hcgTestId && !resolveHcgTest(transferAttempt, certificate.hcgTestId)) {
-        issues.push(`Не знайдено аналіз ХГЧ ${certificate.hcgTestId} у переносі ${certificate.transferAttemptId}.`);
-      }
-      if (certificate.ultrasoundId && !resolveUltrasound(transferAttempt, certificate.ultrasoundId)) {
-        issues.push(`Не знайдено УЗД ${certificate.ultrasoundId} у переносі ${certificate.transferAttemptId}.`);
-      }
-    }
+  if (certificate?.hcgTestId && !resolveHcgTest(transferAttempt, certificate.hcgTestId)) {
+    issues.push(`Не знайдено аналіз ХГЧ ${certificate.hcgTestId}.`);
+  }
+  if (certificate?.ultrasoundId && !resolveUltrasound(transferAttempt, certificate.ultrasoundId)) {
+    issues.push(`Не знайдено УЗД ${certificate.ultrasoundId}.`);
   }
 
   const letter = documents.racssClinicLetter;
-  if (letter?.transferAttemptId || letter?.ultrasoundId) {
-    const transferAttempt = checkTransferAttempt(letter.transferAttemptId);
-    if (transferAttempt && letter.ultrasoundId && !resolveUltrasound(transferAttempt, letter.ultrasoundId)) {
-      issues.push(`Не знайдено УЗД ${letter.ultrasoundId} у переносі ${letter.transferAttemptId}.`);
-    }
+  if (letter?.ultrasoundId && !resolveUltrasound(transferAttempt, letter.ultrasoundId)) {
+    issues.push(`Не знайдено УЗД ${letter.ultrasoundId}.`);
   }
 
   return issues;
@@ -1258,13 +1246,6 @@ export const formatShipmentOptionLabel = (shipment, parties) => {
   const clinicName = enriched?.sourceClinic?.name?.uk || enriched?.destinationClinic?.name?.uk || '';
   const dateText = shipment.receivedDate ? formatDateNumericUk(shipment.receivedDate) : (shipment.ivfDate ? formatDateNumericUk(shipment.ivfDate) : '');
   return joinOptionLabel('Доставлення', dateText, clinicName);
-};
-
-export const formatTransferOptionLabel = transferAttempt => {
-  if (!transferAttempt) return '';
-  const dateText = transferAttempt.date ? formatDateNumericUk(transferAttempt.date) : '';
-  const countText = transferAttempt.embryoCount ? formatEmbryoCountTextUk(transferAttempt.embryoCount) : '';
-  return joinOptionLabel('Перенос', dateText, countText);
 };
 
 export const formatHcgTestOptionLabel = hcgTest => {
@@ -2530,6 +2511,101 @@ export const applyPlainTextEdit = (rawText, newPlainValue) => {
     ? [{ text: inserted, bold: Boolean(inheritFrom?.bold), italic: Boolean(inheritFrom?.italic) }]
     : [];
   return serializeFormattedRuns(mergeAdjacentRuns([...before, ...insertedRun, ...after]));
+};
+
+// --- Input mode: editing the resolved (case-substituted) wording directly -------------------
+// Input mode shows the resolved wording at rest and, per batch 24 §1, must keep showing it once a
+// field is focused too - never falling back to the raw {{token}} markup an admin never asked to
+// see. Since the underlying template stays the shared raw markup (case-agnostic), an edit made
+// against the resolved text has to be translated back onto that raw string. buildResolvedTextSegments
+// walks the raw plain text (markers already stripped, see plainTextOf) once, alternating literal
+// spans (which map 1:1 onto their resolved counterpart) and {{token}} spans (replaced by their
+// resolved value, almost always a different length) - recording both sides' offsets so an edit's
+// position can be translated between them.
+const buildResolvedTextSegments = (rawPlainText, context, lang) => {
+  const raw = String(rawPlainText || '');
+  const segments = [];
+  let rawPos = 0;
+  let resolvedPos = 0;
+  const pattern = new RegExp(PLACEHOLDER_PATTERN.source, 'g');
+  let match = pattern.exec(raw);
+  while (match) {
+    if (match.index > rawPos) {
+      const literal = raw.slice(rawPos, match.index);
+      segments.push({
+        token: false, rawStart: rawPos, rawEnd: match.index, resolvedStart: resolvedPos, resolvedEnd: resolvedPos + literal.length, text: literal,
+      });
+      resolvedPos += literal.length;
+    }
+    const path = match[1].trim();
+    const rawTokenEnd = match.index + match[0].length;
+    let resolvedText;
+    if (path === 'logo' || path === 'logo-long') {
+      resolvedText = match[0];
+    } else {
+      const value = context ? resolvePlaceholderValue(context, path, lang) : undefined;
+      resolvedText = value === undefined || String(value).trim() === '' ? MISSING_VALUE_PLACEHOLDER : String(value);
+    }
+    segments.push({
+      token: true, rawStart: match.index, rawEnd: rawTokenEnd, resolvedStart: resolvedPos, resolvedEnd: resolvedPos + resolvedText.length, text: resolvedText,
+    });
+    resolvedPos += resolvedText.length;
+    rawPos = rawTokenEnd;
+    match = pattern.exec(raw);
+  }
+  if (rawPos < raw.length || !segments.length) {
+    const literal = raw.slice(rawPos);
+    segments.push({
+      token: false, rawStart: rawPos, rawEnd: raw.length, resolvedStart: resolvedPos, resolvedEnd: resolvedPos + literal.length, text: literal,
+    });
+  }
+  return segments;
+};
+
+// Translates an edit made against the resolved wording (Input mode's focused field) back onto the
+// raw template markup, so the shared {{token}}s an admin never touched stay exactly as they were.
+// Mirrors applyPlainTextEdit's diff-the-single-changed-region approach, but the changed region is
+// first "snapped" outward to the nearest segment boundary whenever it lands inside a token's
+// resolved span - i.e. typing over part of a substituted name/date bakes that whole value in as
+// literal wording instead of corrupting the {{token}} it came from.
+export const applyResolvedTextEdit = (rawText, context, lang, newResolvedValue) => {
+  const raw = String(rawText || '');
+  const rawPlain = plainTextOf(raw);
+  const segments = buildResolvedTextSegments(rawPlain, context, lang);
+  const oldResolvedPlain = segments.map(segment => segment.text).join('');
+  const nextResolvedPlain = String(newResolvedValue || '');
+  if (oldResolvedPlain === nextResolvedPlain) return raw;
+
+  const maxCommonStart = Math.min(oldResolvedPlain.length, nextResolvedPlain.length);
+  let start = 0;
+  while (start < maxCommonStart && oldResolvedPlain[start] === nextResolvedPlain[start]) start += 1;
+  let oldEnd = oldResolvedPlain.length;
+  let newEnd = nextResolvedPlain.length;
+  while (oldEnd > start && newEnd > start && oldResolvedPlain[oldEnd - 1] === nextResolvedPlain[newEnd - 1]) {
+    oldEnd -= 1;
+    newEnd -= 1;
+  }
+
+  // Snap the changed region outward so it never ends inside a token's resolved span - editing into
+  // a substituted value bakes that whole value in as literal text rather than corrupting the token.
+  const enclosingToken = pos => segments.find(segment => segment.token && pos > segment.resolvedStart && pos < segment.resolvedEnd);
+  const startToken = enclosingToken(start);
+  const snappedStart = startToken ? startToken.resolvedStart : start;
+  const endToken = enclosingToken(oldEnd);
+  const snappedOldEnd = endToken ? endToken.resolvedEnd : oldEnd;
+  const snappedNewEnd = newEnd + (snappedOldEnd - oldEnd);
+  const insertedText = nextResolvedPlain.slice(snappedStart, snappedNewEnd);
+
+  const toRawPos = pos => {
+    const exact = segments.find(segment => pos === segment.resolvedStart || pos === segment.resolvedEnd);
+    if (exact) return pos === exact.resolvedStart ? exact.rawStart : exact.rawEnd;
+    const inside = segments.find(segment => !segment.token && pos > segment.resolvedStart && pos < segment.resolvedEnd);
+    return inside ? inside.rawStart + (pos - inside.resolvedStart) : rawPlain.length;
+  };
+  const rawStart = toRawPos(snappedStart);
+  const rawOldEnd = toRawPos(snappedOldEnd);
+  const nextRawPlain = `${rawPlain.slice(0, rawStart)}${insertedText}${rawPlain.slice(rawOldEnd)}`;
+  return applyPlainTextEdit(raw, nextRawPlain);
 };
 
 // --- Layouts + formatting settings ----------------------------------------------------------

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -5,6 +5,7 @@ import {
   TEMPLATE_DOCUMENT_CONFIG,
   applyLogoLayoutAssignment,
   applyPlainTextEdit,
+  applyResolvedTextEdit,
   buildVariablePickerGroups,
   collectContextLeafPaths,
   estimateColumnPageCapacity,
@@ -1702,6 +1703,49 @@ describe('spec: selection-based inline bold/italic (batch 13 §1)', () => {
       { text: 'Hello ', bold: false, italic: false },
       { text: 'world', bold: true, italic: false },
     ]);
+  });
+});
+
+describe('spec: applyResolvedTextEdit (batch 24 §1 - editing Input mode\'s resolved wording)', () => {
+  const context = { wife: { name: { uk: { nominative: 'Іванова Марія' } } } };
+
+  it('an edit entirely outside any token maps straight back onto the surrounding raw text, token untouched', () => {
+    const raw = 'Дорога {{wife.name.uk.nominative}}, вітаю';
+    const resolved = 'Дорога Іванова Марія, вітаю';
+    const nextResolved = resolved.replace('вітаю', 'вітаємо');
+    const nextRaw = applyResolvedTextEdit(raw, context, 'uk', nextResolved);
+    expect(nextRaw).toBe('Дорога {{wife.name.uk.nominative}}, вітаємо');
+  });
+
+  it('an edit inserted right before a token leaves the token intact', () => {
+    const raw = '{{wife.name.uk.nominative}} вітає всіх';
+    const resolved = 'Іванова Марія вітає всіх';
+    const nextResolved = `Шановна ${resolved}`;
+    const nextRaw = applyResolvedTextEdit(raw, context, 'uk', nextResolved);
+    expect(nextRaw).toBe('Шановна {{wife.name.uk.nominative}} вітає всіх');
+  });
+
+  it('an edit reaching into the substituted value bakes that value in as literal text', () => {
+    const raw = 'Шановна {{wife.name.uk.nominative}}!';
+    const resolved = 'Шановна Іванова Марія!';
+    // Admin retypes the surname portion of the resolved name directly.
+    const nextResolved = resolved.replace('Іванова', 'Петрова');
+    const nextRaw = applyResolvedTextEdit(raw, context, 'uk', nextResolved);
+    expect(nextRaw).toBe('Шановна Петрова Марія!');
+  });
+
+  it('round-trips back to a no-op when the resolved text is unchanged', () => {
+    const raw = 'Дорога {{wife.name.uk.nominative}}';
+    const resolved = 'Дорога Іванова Марія';
+    expect(applyResolvedTextEdit(raw, context, 'uk', resolved)).toBe(raw);
+  });
+
+  it('preserves bold/italic markup on the untouched portion of the raw text', () => {
+    const raw = '**Шановна** {{wife.name.uk.nominative}}, дякуємо';
+    const resolved = 'Шановна Іванова Марія, дякуємо';
+    const nextResolved = resolved.replace('дякуємо', 'вітаємо');
+    const nextRaw = applyResolvedTextEdit(raw, context, 'uk', nextResolved);
+    expect(nextRaw).toBe('**Шановна** {{wife.name.uk.nominative}}, вітаємо');
   });
 });
 


### PR DESCRIPTION
Input mode's focused field now keeps showing the resolved (case-substituted)
wording instead of reverting to raw {{token}} markup - applyResolvedTextEdit
translates an edit made against the resolved text back onto the shared raw
template, baking in a substituted value as literal text if the edit reaches
into one.

case.artProgram.transferAttempts (a keyed collection of multiple attempts)
is now a single transferAttempt object, since only the one successful
attempt's data ever matters once a program is underway. Updated the ART
program editor, the genetic-affinity-certificate/RACSS-letter resolvers and
context builders, and the childbirth transaction editor's document drafts
accordingly.

Style Editor's align/fontWeight controls were already implemented and
tested (batch 23) - verified, no change needed.