### PR TITLE
Documents Builder: fix Input mode bold loss on focus, add layoutV2 paragraph bold, cover Style Editor align/weight

### DIFF
--- a/src/components/DocumentStyleEditorPage.test.js
+++ b/src/components/DocumentStyleEditorPage.test.js
@@ -4,7 +4,9 @@
 // after confirming) - never a bulk clear of the whole styleSheet.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render, screen, fireEvent, waitFor, within,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('firebase/database', () => ({
@@ -123,6 +125,31 @@ describe('DocumentStyleEditorPage', () => {
       '__root__',
       { 'documentsBuilder/templates/genetic-affinity-certificate/styleSheet/titleMain/fontSizePt': null },
     ));
+  });
+
+  // Batch 25 §2 reaffirms batch 23/24's request for Align and Bold/font-weight controls on this
+  // page - both are already wired into every style group via LAYOUT_V2_STYLE_KEYS/PROPERTY_CONTROLS
+  // (documentsCatalogUtils.js / DocumentStyleEditorPage.jsx), so this pins that down as a concrete
+  // regression test rather than leaving it as something only visible by reading the source.
+  it('offers an Align select (left/center/right/justify) and a Font weight select in every style group', async () => {
+    mockGet();
+    render(<MemoryRouter><DocumentStyleEditorPage isAdmin /></MemoryRouter>);
+    await screen.findByText('Genetic affinity certificate');
+    fireEvent.click(await screen.findByText(/titleMain/));
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const alignRow = (await screen.findByText('Align')).closest('label');
+    const alignSelect = within(alignRow).getByRole('combobox');
+    expect(alignSelect).not.toBeDisabled();
+    expect(alignSelect).toHaveValue('center');
+    expect(Array.from(alignSelect.options).map(option => option.value)).toEqual(['left', 'center', 'right', 'justify']);
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const fontWeightRow = (await screen.findByText('Font weight')).closest('label');
+    const fontWeightSelect = within(fontWeightRow).getByRole('combobox');
+    expect(fontWeightSelect).not.toBeDisabled();
+    expect(fontWeightSelect).toHaveValue('700');
+    expect(Array.from(fontWeightSelect.options).map(option => option.value)).toEqual(['400', '500', '600', '700']);
   });
 
   it('asks for confirmation before resetting a whole group, and clears only that named style', async () => {

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -4,7 +4,9 @@
 // page-scoped --km-* palette override. Data lives on the backend under documentsBuilder/*:
 // parties + cases, paragraph templates, and a settings record (favourite formatting values +
 // recently used cases). Clinic logo files live directly in Firebase Storage by clinic id.
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
@@ -52,6 +54,7 @@ import {
   isBilingualLayout,
   isLayoutV2Template,
   isOfficialFormStyle,
+  layoutV2ParagraphRuns,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
   mergeDocumentsCatalog,
@@ -72,6 +75,7 @@ import {
   TITLE_SCOPE,
   toArray,
   toggleInlineFormat,
+  toggleLayoutV2ParagraphBold,
   toggleRawInlineMarker,
   upsertRecentCaseId,
   upsertRecentId,
@@ -557,7 +561,28 @@ const TextModeDisplay = styled.div`
   &::after {
     content: '\\200B';
   }
+
+  &[contenteditable]:empty::before {
+    content: attr(data-placeholder);
+    color: var(--km-muted);
+  }
+
+  &[contenteditable] {
+    outline: none;
+  }
 `;
+
+// layoutV2's {text, style} runs (batch 25 §3) - a run styled 'inlineEmphasis' renders bold, same
+// visual convention as FormattedRunsPreview's **markdown** runs below, just resolved from the
+// template's own named style instead of a markup character.
+const LayoutV2RunsPreview = ({ block }) => (
+  <>
+    {layoutV2ParagraphRuns(block).map((run, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <React.Fragment key={index}>{run.style === 'inlineEmphasis' ? <strong>{run.text}</strong> : run.text}</React.Fragment>
+    ))}
+  </>
+);
 
 const FormattedRunsPreview = ({ text }) => (
   <>
@@ -570,6 +595,48 @@ const FormattedRunsPreview = ({ text }) => (
     })}
   </>
 );
+
+// Input mode's focused view (bug fix, batch 25 §1): tapping into an already-bold resolved-text
+// field must keep showing that bold, not just the plain wording - only the ability to place a
+// cursor and type is being added on focus, nothing about the formatting already on screen should
+// change. A native <textarea> can never render <strong>/<em> at all, so this makes the very same
+// rich preview (FormattedRunsPreview, identical to the at-rest view directly above) the editable
+// surface itself via contentEditable, instead of swapping to a plain-text control on focus.
+// The rich children are captured once, from whatever was on screen at the moment of focusing, and
+// never re-rendered from props afterward - only the browser's own in-place DOM edits drive it past
+// that point, translated back up to plain text on every input event (mirroring the old textarea's
+// onChange; Input mode still never reformats via typing here, see handleApplyInlineFormat's
+// input-plain hard-stop).
+const RichResolvedTextField = React.forwardRef(({
+  initialText, placeholder, onPlainTextChange, onFocus, onBlur,
+}, forwardedRef) => {
+  const localRef = useRef(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const initialChildren = useMemo(() => <FormattedRunsPreview text={initialText} />, []);
+
+  useEffect(() => {
+    localRef.current?.focus();
+  }, []);
+
+  return (
+    <TextModeDisplay
+      ref={node => {
+        localRef.current = node;
+        if (typeof forwardedRef === 'function') forwardedRef(node);
+        else if (forwardedRef) forwardedRef.current = node;
+      }}
+      contentEditable
+      suppressContentEditableWarning
+      data-placeholder={placeholder}
+      onInput={() => onPlainTextChange(localRef.current?.innerText ?? '')}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
+      {initialChildren}
+    </TextModeDisplay>
+  );
+});
+RichResolvedTextField.displayName = 'RichResolvedTextField';
 
 // Text mode has no textarea to read `.selectionStart`/`.selectionEnd` from - the display above is
 // plain rendered HTML, so Bold/Italic instead reads the browser's native Selection and walks the
@@ -1477,6 +1544,46 @@ const DocumentsPage = ({ isAdmin }) => {
       ? toggleInlineFormat(currentRaw, start, end, attr)
       : toggleRawInlineMarker(currentRaw, start, end, attr);
     await commitTemplateScopeText(docId, scope, langKey, nextRaw);
+  };
+
+  // --- layoutV2 paragraph/richParagraph selection-based bold (batch 25 §3) -----------------------
+  // A layoutV2 block has no per-mode toolbar of its own (there is no per-case resolved view for it -
+  // a layoutV2 template is always edited as its own shared raw markup, same as legacy Template mode)
+  // - one Bold button per paragraph/richParagraph block, acting on whatever text is currently
+  // selected inside it (same native-Selection approach as Text mode's handleApplyInlineFormat,
+  // above, since this display is a rendered <div> too, not a textarea).
+  const layoutV2BlockNodesRef = useRef({});
+  const registerLayoutV2BlockNode = (docId, blockIndex) => node => {
+    layoutV2BlockNodesRef.current[`${docId}#${blockIndex}`] = node;
+  };
+  const handleLayoutV2BlockBold = async (docId, blockIndex) => {
+    const node = layoutV2BlockNodesRef.current[`${docId}#${blockIndex}`];
+    if (!node) return;
+    const offsets = getContainerSelectionOffsets(node);
+    if (!offsets) {
+      toast.error('Select some text first.');
+      return;
+    }
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    if (!template?.layoutV2?.blocks?.[blockIndex]) return;
+    const nextBlock = toggleLayoutV2ParagraphBold(template.layoutV2.blocks[blockIndex], offsets.start, offsets.end);
+    const nextTemplate = {
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: template.layoutV2.blocks.map((item, index) => (index === blockIndex ? nextBlock : item)),
+      },
+    };
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
+      }));
+    } catch (saveError) {
+      console.error('Unable to save the template change', saveError);
+      toast.error('Could not save the change.');
+    }
   };
 
   // Insert-variable modal (spec: "кнопка поруч з курсивом... модальне вікно... обрати змінні") -
@@ -2558,12 +2665,20 @@ const DocumentsPage = ({ isAdmin }) => {
                                       >
                                         <FormattedRunsPreview text={beforeTitleResolvedValue('uk')} />
                                       </TextModeDisplay>
+                                    ) : isInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        initialText={beforeTitleResolvedValue('uk')}
+                                        placeholder="Before title (uk)"
+                                        onPlainTextChange={nextPlain => onChange('uk')({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
+                                        onBlur={onBlur}
+                                      />
                                     ) : (
                                       <AutoInlineTextarea
                                         ref={registerFieldNode(template.id, scope, 'uk')}
                                         value={displayValue('uk')}
                                         placeholder="Before title (uk)"
-                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
                                         onChange={onChange('uk')}
                                         onBlur={onBlur}
@@ -2583,12 +2698,20 @@ const DocumentsPage = ({ isAdmin }) => {
                                       >
                                         <FormattedRunsPreview text={beforeTitleResolvedValue('en')} />
                                       </TextModeDisplay>
+                                    ) : isInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        initialText={beforeTitleResolvedValue('en')}
+                                        placeholder="Before title (en)"
+                                        onPlainTextChange={nextPlain => onChange('en')({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
+                                        onBlur={onBlur}
+                                      />
                                     ) : (
                                       <AutoInlineTextarea
                                         ref={registerFieldNode(template.id, scope, 'en')}
                                         value={displayValue('en')}
                                         placeholder="Before title (en)"
-                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
                                         onChange={onChange('en')}
                                         onBlur={onBlur}
@@ -2711,12 +2834,20 @@ const DocumentsPage = ({ isAdmin }) => {
                                       >
                                         <FormattedRunsPreview text={titleResolvedValue('uk')} />
                                       </TextModeDisplay>
+                                    ) : titleIsInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
+                                        initialText={titleResolvedValue('uk')}
+                                        placeholder="Title (uk)"
+                                        onPlainTextChange={nextPlain => onTitleFieldChange('uk')({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind)}
+                                        onBlur={onTitleFieldBlur}
+                                      />
                                     ) : (
                                       <AutoInlineTextarea
                                         ref={registerFieldNode(template.id, TITLE_SCOPE, 'uk')}
                                         value={titleDisplayValue('uk')}
                                         placeholder="Title (uk)"
-                                        autoFocus={titleIsInputMode}
                                         onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'uk', titleFieldKind)}
                                         onChange={onTitleFieldChange('uk')}
                                         onBlur={onTitleFieldBlur}
@@ -2733,12 +2864,20 @@ const DocumentsPage = ({ isAdmin }) => {
                                       >
                                         <FormattedRunsPreview text={titleResolvedValue('en')} />
                                       </TextModeDisplay>
+                                    ) : titleIsInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
+                                        initialText={titleResolvedValue('en')}
+                                        placeholder="Title (en)"
+                                        onPlainTextChange={nextPlain => onTitleFieldChange('en')({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind)}
+                                        onBlur={onTitleFieldBlur}
+                                      />
                                     ) : (
                                       <AutoInlineTextarea
                                         ref={registerFieldNode(template.id, TITLE_SCOPE, 'en')}
                                         value={titleDisplayValue('en')}
                                         placeholder="Title (en)"
-                                        autoFocus={titleIsInputMode}
                                         onFocus={handleRichFieldFocus(template.id, TITLE_SCOPE, 'en', titleFieldKind)}
                                         onChange={onTitleFieldChange('en')}
                                         onBlur={onTitleFieldBlur}
@@ -2869,12 +3008,20 @@ const DocumentsPage = ({ isAdmin }) => {
                                       >
                                         <FormattedRunsPreview text={resolvedValue('uk')} />
                                       </TextModeDisplay>
+                                    ) : isInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, scope, 'uk')}
+                                        initialText={resolvedValue('uk')}
+                                        placeholder="Paragraph (uk)"
+                                        onPlainTextChange={nextPlain => onChange('uk')({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
+                                        onBlur={onBlur}
+                                      />
                                     ) : (
                                       <AutoInlineTextarea
                                         ref={registerFieldNode(template.id, scope, 'uk')}
                                         value={displayValue('uk')}
                                         placeholder="Paragraph (uk)"
-                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'uk', fieldKind)}
                                         onChange={onChange('uk')}
                                         onBlur={onBlur}
@@ -2891,12 +3038,20 @@ const DocumentsPage = ({ isAdmin }) => {
                                       >
                                         <FormattedRunsPreview text={resolvedValue('en')} />
                                       </TextModeDisplay>
+                                    ) : isInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, scope, 'en')}
+                                        initialText={resolvedValue('en')}
+                                        placeholder="Paragraph (en)"
+                                        onPlainTextChange={nextPlain => onChange('en')({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
+                                        onBlur={onBlur}
+                                      />
                                     ) : (
                                       <AutoInlineTextarea
                                         ref={registerFieldNode(template.id, scope, 'en')}
                                         value={displayValue('en')}
                                         placeholder="Paragraph (en)"
-                                        autoFocus={isInputMode}
                                         onFocus={handleRichFieldFocus(template.id, scope, 'en', fieldKind)}
                                         onChange={onChange('en')}
                                         onBlur={onBlur}
@@ -2917,6 +3072,46 @@ const DocumentsPage = ({ isAdmin }) => {
                             <FaPlus />
                           </SmallButton>
                         </ParagraphControlsRow>
+                        {/* layoutV2 paragraph/richParagraph blocks (batch 25 §3) - a separate
+                            rendering/editing path from the legacy title/beforeTitle/paragraphs
+                            fields above, so it gets its own section: select a text fragment inside
+                            one of these blocks and press Bold to mark just that fragment
+                            'inlineEmphasis' (configurable in the Style Editor). Only shown for a
+                            layoutV2 template, and only for its paragraph-shaped blocks - every other
+                            block type (letterhead, fieldLine, signatureTable, ...) has no free-text
+                            content to select. */}
+                        {isLayoutV2Template(template) ? (
+                          <ParagraphEditorBlock>
+                            <ParagraphControlsRow>
+                              <DocSubtitle style={{ fontWeight: 700 }}>layoutV2 paragraphs - select text, Bold the fragment</DocSubtitle>
+                            </ParagraphControlsRow>
+                            {template.layoutV2.blocks.map((block, blockIndex) => (
+                              (block?.type === 'paragraph' || block?.type === 'richParagraph') ? (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <ParagraphFieldColumn key={`${template.id}-lv2-${blockIndex}`} style={{ marginTop: 6 }}>
+                                  <RowLine style={{ gap: 6, marginBottom: 4 }}>
+                                    <SmallButton
+                                      type="button"
+                                      onMouseDown={preventSelectionLoss}
+                                      onTouchStart={preventSelectionLoss}
+                                      onTouchEnd={event => {
+                                        event.preventDefault();
+                                        handleLayoutV2BlockBold(template.id, blockIndex);
+                                      }}
+                                      onClick={() => handleLayoutV2BlockBold(template.id, blockIndex)}
+                                      title="Bold the selected text"
+                                    >
+                                      <FaBold />
+                                    </SmallButton>
+                                  </RowLine>
+                                  <TextModeDisplay ref={registerLayoutV2BlockNode(template.id, blockIndex)}>
+                                    <LayoutV2RunsPreview block={block} />
+                                  </TextModeDisplay>
+                                </ParagraphFieldColumn>
+                              ) : null
+                            ))}
+                          </ParagraphEditorBlock>
+                        ) : null}
                         {/* Task 4: the document exactly as the exported PDF - same generation
                             pipeline, same props - as the last block of the document. */}
                         <DocumentsPdfPreview

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -1,0 +1,148 @@
+// Real-DOM regression test (batch 25 §3): a layoutV2 template previously had no way in the UI to
+// select a text fragment inside one of its `paragraph`/`richParagraph` blocks and bold just that
+// fragment - the Style Editor only edits whole named styles, and the legacy title/beforeTitle/
+// paragraphs editor only ever touches the legacy (non-layoutV2) fields. This drives a genuine
+// browser selection through the new per-block Bold button (mirroring the legacy Text-mode
+// mechanism, batch 17) to prove the wiring end to end, not just the pure toggleLayoutV2ParagraphBold
+// logic already covered in documentsCatalogUtils.test.js.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  render, screen, fireEvent, waitFor, within,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('firebase/database', () => ({
+  ref: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'test-admin' } },
+  database: {},
+  deleteStorageFile: jest.fn(),
+  getStorageFileDataUrl: jest.fn(),
+  listStorageFolderFileNames: jest.fn(),
+  uploadFileToStorageFolder: jest.fn(),
+}));
+
+jest.mock('utils/accessLevel', () => ({ isInvoiceBuilderUid: () => true }));
+jest.mock('utils/pdfImageEncoding', () => ({ reencodePdfImageDataUrl: jest.fn() }));
+
+// eslint-disable-next-line import/first
+import { ref, get, set } from 'firebase/database';
+// eslint-disable-next-line import/first
+import { listStorageFolderFileNames } from './config';
+// eslint-disable-next-line import/first
+import DocumentsPage from './DocumentsPage';
+
+// Selects `text.slice(start, end)` of a single-text-node DOM element via a genuine browser
+// Selection/Range, the same object getContainerSelectionOffsets (used by both the legacy Text-mode
+// Bold button and this new layoutV2 one) reads from.
+const selectTextNodeRange = (container, start, end) => {
+  const textNode = container.firstChild;
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
+beforeEach(() => {
+  ref.mockImplementation((_db, path) => path);
+  get.mockImplementation(async path => {
+    if (path === 'documentsBuilder/parties') {
+      return { exists: () => true, val: () => ({}) };
+    }
+    if (path === 'documentsBuilder/cases') {
+      return { exists: () => false, val: () => null };
+    }
+    if (path === 'documentsBuilder/templates') {
+      return {
+        exists: () => true,
+        val: () => ({
+          'doc-1': {
+            id: 'doc-1',
+            catalogName: 'Genetic affinity certificate',
+            rendererVersion: 2,
+            languages: ['uk'],
+            page: {
+              size: 'A4', widthMm: 210, heightMm: 297, marginsMm: {
+                top: 5, right: 15, bottom: 10, left: 15,
+              },
+            },
+            styleSheet: { body: { fontFamily: 'Times New Roman', fontSizePt: 10 } },
+            layoutV2: {
+              contentWidthMm: 180,
+              blocks: [{ type: 'paragraph', style: 'body', text: 'Hello world else' }],
+            },
+          },
+        }),
+      };
+    }
+    return { exists: () => false, val: () => null };
+  });
+  set.mockResolvedValue(undefined);
+  listStorageFolderFileNames.mockResolvedValue([]);
+});
+
+describe('spec: layoutV2 paragraph blocks - selection-based Bold (batch 25 §3)', () => {
+  it('bolds only the selected fragment of a layoutV2 paragraph block, converting it to a richParagraph', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const field = await screen.findByText('Hello world else');
+    // eslint-disable-next-line testing-library/no-node-access
+    const blockColumn = field.closest('.paragraph-editor-block');
+    selectTextNodeRange(field, 6, 11); // "world"
+
+    fireEvent.click(within(blockColumn).getByTitle('Bold the selected text'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [{
+            type: 'richParagraph',
+            style: 'body',
+            runs: [
+              { text: 'Hello ', style: undefined },
+              { text: 'world', style: 'inlineEmphasis' },
+              { text: ' else', style: undefined },
+            ],
+          }],
+        }),
+      }),
+    ));
+
+    // The bold fragment now renders as <strong>, right in place - no separate preview to catch up.
+    const boldFragment = await within(blockColumn).findByText('world');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(boldFragment.closest('strong')).toBeInTheDocument();
+  });
+
+  it('does not show the layoutV2 paragraph section for a legacy (non-layoutV2) template', async () => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'doc-1': { id: 'doc-1', title: { uk: 'Заява' }, paragraphs: [{ uk: 'Звичайний текст.' }] },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    await screen.findByText('Звичайний текст.');
+
+    expect(screen.queryByText('layoutV2 paragraphs - select text, Bold the fragment')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -205,11 +205,80 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     expect(within(block).queryByText(/\{\{surrogateMother/)).not.toBeInTheDocument();
     expect(within(block).queryByDisplayValue(/.*/)).not.toBeInTheDocument();
 
-    // Clicking that resolved-text view swaps it to an editable field showing that same resolved
-    // wording - not the raw {{token}} markup.
+    // Clicking that resolved-text view swaps it to an editable (contentEditable) view showing that
+    // same resolved wording - not the raw {{token}} markup, and not a plain <textarea> either (a
+    // native textarea can't preserve inline bold, see the batch 25 §1 test below).
     fireEvent.mouseDown(within(block).getByText('Сурогатна мати Сурогатна Матір'));
-    expect(await within(block).findByDisplayValue('Сурогатна мати Сурогатна Матір')).toBeInTheDocument();
+    const editable = await within(block).findByText('Сурогатна мати Сурогатна Матір');
+    expect(editable).toHaveAttribute('contenteditable', 'true');
     expect(within(block).queryByDisplayValue(/\{\{surrogateMother/)).not.toBeInTheDocument();
+  });
+
+  // Bug fix (batch 25 §1): tapping into an Input-mode field to place a cursor used to lose whatever
+  // inline bold formatting was already applied to that text (while correctly staying on the
+  // resolved wording, batch 24 §1's fix) - the field swapped to a plain <textarea>, which can never
+  // render <strong> at all. Focusing must only add the ability to place a cursor and edit; nothing
+  // about the formatting already on screen should change.
+  it('focusing an Input-mode field preserves inline bold already applied to the resolved text', async () => {
+    // A beforeTitle block whose raw markup already has "Сурогатна мати" bolded, so this test starts
+    // from a genuinely unfocused Input-mode row (no prior focus/selection needed to create the
+    // bold) - isolating the exact scenario the bug report describes.
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') {
+        return {
+          exists: () => true,
+          val: () => ({
+            couples: { 'couple-1': { id: 'couple-1', partners: [{ id: 'p1', role: 'wife', name: { uk: { nominative: 'Тестова Марія' }, en: 'Testova Mariia' } }] } },
+            surrogateMothers: { 'surrogate-1': { id: 'surrogate-1', name: { uk: { nominative: 'Сурогатна Матір' } } } },
+          }),
+        };
+      }
+      if (path === 'documentsBuilder/cases') {
+        return {
+          exists: () => true,
+          val: () => ({ 'case-1': { id: 'case-1', relations: { coupleId: 'couple-1', surrogateMotherId: 'surrogate-1' } } }),
+        };
+      }
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'doc-1': {
+              id: 'doc-1',
+              title: { uk: 'Заява', en: 'Statement' },
+              beforeTitle: [{ uk: '**Сурогатна мати** {{surrogateMother.name.uk.nominative}}', en: '', align: 'left' }],
+              paragraphs: [{ uk: 'Звичайний текст без форматування.', en: 'Plain text without formatting.' }],
+            },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const textarea = await screen.findByDisplayValue('**Сурогатна мати** {{surrogateMother.name.uk.nominative}}');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = textarea.closest('.paragraph-editor-block');
+
+    fireEvent.click(within(block).getByTitle('Template mode - editing the shared {{placeholder}} markup. Tap to switch to Input mode.'));
+
+    // At rest, Input mode shows the resolved wording with the bold already applied - nothing was
+    // focused/clicked yet.
+    const boldAtRest = await within(block).findByText('Сурогатна мати');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(boldAtRest.closest('strong')).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(boldAtRest.closest('[contenteditable]')).not.toBeInTheDocument();
+
+    // Tapping in to place a cursor must not strip that bold - only add editability.
+    fireEvent.mouseDown(boldAtRest);
+    const boldWhileEditing = await within(block).findByText('Сурогатна мати');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(boldWhileEditing.closest('strong')).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(boldWhileEditing.closest('[contenteditable]')).toBeInTheDocument();
   });
 
   // Notarial layout standard §3.3 + batch 2026-07-23 B §1.3/§1.4: the signer-block offset is a

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -2080,6 +2080,84 @@ export const buildLayoutV2Document = (template, context) => {
   };
 };
 
+// --- layoutV2 paragraph/richParagraph inline bold (batch 25 §3) --------------------------------
+// The legacy paragraph/beforeTitle/title editor already has a "select a fragment, press Bold"
+// mechanism (toggleInlineFormat, above) built on **markdown**-style runs; layoutV2's `paragraph`/
+// `richParagraph` blocks store runs as {text, style} instead (style names one of the template's
+// styleSheet entries, resolved by resolveLayoutV2Style), so bolding a fragment here means tagging
+// it with the 'inlineEmphasis' named style (already configurable in the Style Editor, batch 23 §4)
+// rather than writing a markup character. These operate on the block's raw, unresolved text/runs
+// (the same shared markup every case sees, {{tokens}} included) - identical in spirit to Template
+// mode for legacy paragraphs, since a layoutV2 block has no per-case resolved-text editing mode.
+
+// A block's runs as one flat {text, style}[] list regardless of whether it's still a plain
+// `paragraph` (single implicit run, no style override) or already a `richParagraph`.
+export const layoutV2ParagraphRuns = block => (block?.type === 'richParagraph'
+  ? (block.runs || []).map(run => ({ text: String(run?.text || ''), style: run?.style }))
+  : [{ text: String(block?.text || ''), style: undefined }]);
+
+export const layoutV2ParagraphPlainText = block => layoutV2ParagraphRuns(block).map(run => run.text).join('');
+
+const withLayoutV2RunOffsets = runs => {
+  let pos = 0;
+  return runs.map(run => {
+    const start = pos;
+    pos += run.text.length;
+    return { ...run, start, end: pos };
+  });
+};
+
+const splitLayoutV2RunsAtCuts = (runsWithOffsets, cuts) => {
+  const sortedCuts = [...new Set(cuts)].sort((a, b) => a - b);
+  const result = [];
+  runsWithOffsets.forEach(run => {
+    const localCuts = sortedCuts.filter(cut => cut > run.start && cut < run.end);
+    if (!localCuts.length) {
+      result.push(run);
+      return;
+    }
+    let offset = run.start;
+    [...localCuts, run.end].forEach(cut => {
+      result.push({
+        text: run.text.slice(offset - run.start, cut - run.start), style: run.style, start: offset, end: cut,
+      });
+      offset = cut;
+    });
+  });
+  return result;
+};
+
+const mergeAdjacentLayoutV2Runs = runs => runs.reduce((merged, run) => {
+  if (!run.text) return merged;
+  const last = merged[merged.length - 1];
+  if (last && last.style === run.style) last.text += run.text;
+  else merged.push({ text: run.text, style: run.style });
+  return merged;
+}, []);
+
+// MS Word toggle behavior (batch 17), same rule as toggleInlineFormat: if every run inside
+// [plainStart, plainEnd) is already 'inlineEmphasis', the whole selection loses it; otherwise the
+// whole selection gains it. Always returns a `richParagraph` (a plain `paragraph` block has no
+// runs of its own to hold a partial style yet) - collapsed back to a single-run `paragraph` when
+// the result ends up with no bold left anywhere, so an untouched/fully-unbolded block stays in its
+// simpler original shape instead of permanently upgrading.
+export const toggleLayoutV2ParagraphBold = (block, plainStart, plainEnd) => {
+  if (!(plainEnd > plainStart)) return block;
+  const runs = withLayoutV2RunOffsets(layoutV2ParagraphRuns(block));
+  const split = splitLayoutV2RunsAtCuts(runs, [plainStart, plainEnd]);
+  const within = run => run.start >= plainStart && run.end <= plainEnd && run.end > run.start;
+  const selected = split.filter(within);
+  const allBold = selected.length > 0 && selected.every(run => run.style === 'inlineEmphasis');
+  const next = split.map(run => (within(run) ? { ...run, style: allBold ? undefined : 'inlineEmphasis' } : run));
+  const mergedRuns = mergeAdjacentLayoutV2Runs(next);
+  if (mergedRuns.length <= 1 && !mergedRuns.some(run => run.style)) {
+    return {
+      ...block, type: 'paragraph', text: mergedRuns[0]?.text || '', runs: undefined,
+    };
+  }
+  return { ...block, type: 'richParagraph', runs: mergedRuns, text: undefined };
+};
+
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
 // with every placeholder already substituted from the case context. Logo/logo-long paragraphs are
 // never text-substituted - they stay tagged for the renderer to draw a graphical block instead.

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -97,6 +97,9 @@ import {
   withTemplateScopeText,
   toggleInlineFormat,
   toggleRawInlineMarker,
+  layoutV2ParagraphRuns,
+  layoutV2ParagraphPlainText,
+  toggleLayoutV2ParagraphBold,
   upsertRecentCaseId,
   upsertRecentId,
   validateBirthRegistrationCase,
@@ -1703,6 +1706,69 @@ describe('spec: selection-based inline bold/italic (batch 13 §1)', () => {
       { text: 'Hello ', bold: false, italic: false },
       { text: 'world', bold: true, italic: false },
     ]);
+  });
+});
+
+describe('spec: layoutV2 paragraph/richParagraph selection-based bold (batch 25 §3)', () => {
+  it('layoutV2ParagraphRuns/layoutV2ParagraphPlainText read a plain `paragraph` block as one unstyled run', () => {
+    const block = { type: 'paragraph', style: 'body', text: 'Hello world' };
+    expect(layoutV2ParagraphRuns(block)).toEqual([{ text: 'Hello world', style: undefined }]);
+    expect(layoutV2ParagraphPlainText(block)).toBe('Hello world');
+  });
+
+  it('bolds a plain-text range of a `paragraph` block, converting it to a `richParagraph`', () => {
+    const block = { type: 'paragraph', style: 'body', text: 'Hello world else' };
+    const next = toggleLayoutV2ParagraphBold(block, 6, 11); // "world"
+    expect(next.type).toBe('richParagraph');
+    expect(next.style).toBe('body'); // the paragraph's own named style is untouched
+    expect(next.text).toBeUndefined();
+    expect(next.runs).toEqual([
+      { text: 'Hello ', style: undefined },
+      { text: 'world', style: 'inlineEmphasis' },
+      { text: ' else', style: undefined },
+    ]);
+    expect(layoutV2ParagraphPlainText(next)).toBe('Hello world else');
+  });
+
+  it('pressing bold again on an already-bold selection removes it and collapses back to a plain `paragraph`', () => {
+    const block = { type: 'paragraph', style: 'body', text: 'Hello world else' };
+    const bolded = toggleLayoutV2ParagraphBold(block, 6, 11);
+    const unbolded = toggleLayoutV2ParagraphBold(bolded, 6, 11);
+    expect(unbolded).toEqual({
+      type: 'paragraph', style: 'body', text: 'Hello world else', runs: undefined,
+    });
+  });
+
+  it('a partially-bold selection becomes fully bold on the first press, not toggled per-run (MS Word behavior)', () => {
+    const block = { type: 'paragraph', text: 'Hello world else' };
+    const partiallyBold = toggleLayoutV2ParagraphBold(block, 6, 8); // "wo" -> bold
+    const fullyBold = toggleLayoutV2ParagraphBold(partiallyBold, 6, 11); // whole "world" selected
+    expect(layoutV2ParagraphRuns(fullyBold).find(run => run.text === 'world').style).toBe('inlineEmphasis');
+  });
+
+  it('bolds a fragment of an existing `richParagraph`, merging adjacent same-style runs', () => {
+    const block = {
+      type: 'richParagraph',
+      style: 'body',
+      runs: [
+        { text: 'Ільченко Вікторія Віталіївна', style: 'inlineEmphasis' },
+        { text: ', 18.07.1991 р.н.', style: undefined },
+      ],
+    };
+    // Extend the bold a few characters into the previously-unbolded run.
+    const plainText = layoutV2ParagraphPlainText(block);
+    const extendedEnd = plainText.indexOf(', 18') + ', 18'.length;
+    const next = toggleLayoutV2ParagraphBold(block, 0, extendedEnd);
+    expect(layoutV2ParagraphPlainText(next)).toBe(plainText);
+    expect(next.runs).toEqual([
+      { text: 'Ільченко Вікторія Віталіївна, 18', style: 'inlineEmphasis' },
+      { text: '.07.1991 р.н.', style: undefined },
+    ]);
+  });
+
+  it('is a no-op for a collapsed (empty) selection', () => {
+    const block = { type: 'paragraph', text: 'Hello world' };
+    expect(toggleLayoutV2ParagraphBold(block, 5, 5)).toBe(block);
   });
 });
 


### PR DESCRIPTION
- Batch 25 §1: focusing an Input-mode field to place a cursor no longer strips
  inline bold already applied to the resolved text. The focused view now
  renders the same rich (FormattedRunsPreview) markup as a contentEditable
  surface instead of swapping to a plain <textarea>, which could never show
  <strong>/<em> at all.
- Batch 25 §2: the Style Editor's Align and Font weight controls were already
  wired into every style group (LAYOUT_V2_STYLE_KEYS/PROPERTY_CONTROLS) - added
  a regression test pinning this down explicitly.
- Batch 25 §3: added a selection-based Bold mechanism for layoutV2
  paragraph/richParagraph blocks (documentsCatalogUtils.toggleLayoutV2ParagraphBold
  + a per-block Bold button in DocumentsPage), mirroring the legacy Text-mode
  MS-Word toggle behavior but tagging the selected fragment with the
  'inlineEmphasis' named style instead of a markdown marker.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mv4EgLX8HPnMsEEGeUGJJL