### PR TITLE
Support the cleaned layoutV2 template shape for genetic-affinity-certificate

### DIFF
--- a/src/components/DocumentStyleEditorPage.jsx
+++ b/src/components/DocumentStyleEditorPage.jsx
@@ -39,6 +39,7 @@ import {
   resolveCaseContext,
   resolveLayoutV2Style,
   upsertRecentCaseId,
+  validateLayoutV2Template,
 } from './documentsCatalogUtils';
 
 // --- Layout shell (same skeleton/palette as Invoice Builder, Documents Builder & Parties) -------
@@ -306,11 +307,13 @@ const PROPERTY_LABELS = {
 };
 
 // One property row: a checkbox that says whether this property is overridden at all, plus its
-// control (disabled, showing the effective/inherited value as a hint, while off).
+// control (disabled, showing the effective/inherited value as a hint, while off). `controls`/
+// `labels` default to the layoutV2 text-style maps but are swappable (see LineStyleGroup below,
+// which reuses this same row for lineStyles' widthPt/color/fill* properties).
 const StylePropertyRow = ({
-  property, rawValue, effectiveValue, onSet, onDelete,
+  property, rawValue, effectiveValue, onSet, onDelete, controls = PROPERTY_CONTROLS, labels = PROPERTY_LABELS,
 }) => {
-  const control = PROPERTY_CONTROLS[property];
+  const control = controls[property];
   const isOn = rawValue !== undefined;
   const [draft, setDraft] = useState(rawValue !== undefined ? String(rawValue) : '');
   useEffect(() => {
@@ -331,8 +334,15 @@ const StylePropertyRow = ({
         checked={isOn}
         onChange={event => (event.target.checked ? onSet(effectiveValue !== undefined ? effectiveValue : control.seed) : onDelete())}
       />
-      <PropertyLabel>{PROPERTY_LABELS[property] || property}</PropertyLabel>
-      {control.type === 'select' ? (
+      <PropertyLabel>{labels[property] || property}</PropertyLabel>
+      {control.type === 'boolean' ? (
+        <input
+          type="checkbox"
+          disabled={!isOn}
+          checked={isOn ? Boolean(rawValue) : Boolean(effectiveValue ?? control.seed)}
+          onChange={event => onSet(event.target.checked)}
+        />
+      ) : control.type === 'select' ? (
         <PropertySelect
           disabled={!isOn}
           value={isOn ? String(rawValue) : String(effectiveValue ?? control.seed)}
@@ -396,6 +406,46 @@ const StyleGroup = ({
   );
 };
 
+// The document's base style (clean layoutV2 template spec §2/§3: `template.format`, the layer
+// every named style/block sits on top of - never a required `styleSheet.document`). Same
+// collapsible-group shape as StyleGroup, just backed by `format/<property>` instead of
+// `styleSheet/<styleName>/<property>`.
+const FormatGroup = ({
+  template, onSetProperty, onDeleteProperty, onResetGroup,
+}) => {
+  const [open, setOpen] = useState(false);
+  const rawStyle = template.format || {};
+  const effectiveStyle = resolveLayoutV2Style(template, undefined, {});
+  const hasOverrides = Object.keys(rawStyle).length > 0;
+  return (
+    <GroupCard>
+      <GroupHead type="button" onClick={() => setOpen(previous => !previous)}>
+        <span>format (base style){hasOverrides ? ` (${Object.keys(rawStyle).length})` : ''}</span>
+        {open ? <FaChevronUp /> : <FaChevronDown />}
+      </GroupHead>
+      {open ? (
+        <GroupBody>
+          {LAYOUT_V2_STYLE_KEYS.map(property => (
+            <StylePropertyRow
+              key={property}
+              property={property}
+              rawValue={rawStyle[property]}
+              effectiveValue={effectiveStyle[property]}
+              onSet={value => onSetProperty(property, value)}
+              onDelete={() => onDeleteProperty(property)}
+            />
+          ))}
+          {hasOverrides ? (
+            <div>
+              <DangerLink type="button" onClick={onResetGroup}>Reset format to default</DangerLink>
+            </div>
+          ) : null}
+        </GroupBody>
+      ) : null}
+    </GroupCard>
+  );
+};
+
 const PAGE_GEOMETRY_MARGIN_SIDES = ['top', 'right', 'bottom', 'left'];
 const PAGE_SIZE_OPTIONS = ['A4', 'Letter'];
 
@@ -444,6 +494,69 @@ const PageGeometryGroup = ({ template, onSetPageField, onDeletePageField }) => {
               />
             </PropertyRow>
           ))}
+        </GroupBody>
+      ) : null}
+    </GroupCard>
+  );
+};
+
+// Known line-style names a genetic-affinity-certificate-family template is expected to carry (spec
+// §4) - shown even when a template's own `lineStyles` doesn't (yet) have that key, same pattern as
+// KNOWN_LAYOUT_V2_STYLE_NAMES/styleNamesFor above.
+const KNOWN_LINE_STYLE_NAMES = ['letterheadDivider', 'formLine', 'signatureLine'];
+
+const lineStyleNamesFor = template => [...new Set([
+  ...KNOWN_LINE_STYLE_NAMES,
+  ...Object.keys(template?.lineStyles || {}),
+])];
+
+const LINE_STYLE_PROPERTY_CONTROLS = {
+  widthPt: { seed: 0.75, type: 'number' },
+  color: { seed: '#000000', type: 'text' },
+  fillBeforeValue: { seed: true, type: 'boolean' },
+  fillAfterValue: { seed: true, type: 'boolean' },
+};
+
+const LINE_STYLE_PROPERTY_LABELS = {
+  widthPt: 'Width (pt)',
+  color: 'Color',
+  fillBeforeValue: 'Fill before value',
+  fillAfterValue: 'Fill after value',
+};
+
+// One collapsible group per named line style (spec §4/§15: "editing lineStyles"), same non-
+// destructive per-leaf writes as StyleGroup/PageGeometryGroup, just under `lineStyles.<name>.*`.
+const LineStyleGroup = ({
+  styleName, template, onSetProperty, onDeleteProperty, onResetGroup,
+}) => {
+  const [open, setOpen] = useState(false);
+  const rawStyle = template.lineStyles?.[styleName] || {};
+  const hasOverrides = Object.keys(rawStyle).length > 0;
+  return (
+    <GroupCard>
+      <GroupHead type="button" onClick={() => setOpen(previous => !previous)}>
+        <span>{styleName}{hasOverrides ? ` (${Object.keys(rawStyle).length})` : ''}</span>
+        {open ? <FaChevronUp /> : <FaChevronDown />}
+      </GroupHead>
+      {open ? (
+        <GroupBody>
+          {Object.keys(LINE_STYLE_PROPERTY_CONTROLS).map(property => (
+            <StylePropertyRow
+              key={property}
+              property={property}
+              rawValue={rawStyle[property]}
+              effectiveValue={undefined}
+              controls={LINE_STYLE_PROPERTY_CONTROLS}
+              labels={LINE_STYLE_PROPERTY_LABELS}
+              onSet={value => onSetProperty(styleName, property, value)}
+              onDelete={() => onDeleteProperty(styleName, property)}
+            />
+          ))}
+          {hasOverrides ? (
+            <div>
+              <DangerLink type="button" onClick={() => onResetGroup(styleName)}>Reset this whole line style to default</DangerLink>
+            </div>
+          ) : null}
         </GroupBody>
       ) : null}
     </GroupCard>
@@ -561,6 +674,59 @@ const DocumentStyleEditorPage = ({ isAdmin }) => {
     });
   };
 
+  // Base `format` (spec §2/§3) - same per-leaf write pattern as styleSheet, just at the template's
+  // own top-level `format` key instead of `styleSheet/<styleName>`.
+  const handleSetFormatProperty = (property, value) => {
+    if (!selectedTemplate) return;
+    writeTemplateLeaf(selectedTemplate.id, `format/${property}`, value, template => ({
+      ...template,
+      format: { ...template.format, [property]: value },
+    }));
+  };
+
+  const handleDeleteFormatProperty = property => {
+    if (!selectedTemplate) return;
+    writeTemplateLeaf(selectedTemplate.id, `format/${property}`, undefined, template => {
+      const nextFormat = { ...template.format };
+      delete nextFormat[property];
+      return { ...template, format: nextFormat };
+    });
+  };
+
+  const handleResetFormat = () => {
+    if (!selectedTemplate) return;
+    if (typeof window !== 'undefined' && !window.confirm('Reset the base format to default?')) return;
+    writeTemplateLeaf(selectedTemplate.id, 'format', undefined, template => ({ ...template, format: {} }));
+  };
+
+  // lineStyles (spec §4/§15) - same per-leaf write pattern as styleSheet, under `lineStyles.<name>`.
+  const handleSetLineStyleProperty = (styleName, property, value) => {
+    if (!selectedTemplate) return;
+    writeTemplateLeaf(selectedTemplate.id, `lineStyles/${styleName}/${property}`, value, template => ({
+      ...template,
+      lineStyles: { ...template.lineStyles, [styleName]: { ...template.lineStyles?.[styleName], [property]: value } },
+    }));
+  };
+
+  const handleDeleteLineStyleProperty = (styleName, property) => {
+    if (!selectedTemplate) return;
+    writeTemplateLeaf(selectedTemplate.id, `lineStyles/${styleName}/${property}`, undefined, template => {
+      const nextStyle = { ...template.lineStyles?.[styleName] };
+      delete nextStyle[property];
+      return { ...template, lineStyles: { ...template.lineStyles, [styleName]: nextStyle } };
+    });
+  };
+
+  const handleResetLineStyleGroup = styleName => {
+    if (!selectedTemplate) return;
+    if (typeof window !== 'undefined' && !window.confirm(`Reset every "${styleName}" line style override to default?`)) return;
+    writeTemplateLeaf(selectedTemplate.id, `lineStyles/${styleName}`, undefined, template => {
+      const nextLineStyles = { ...template.lineStyles };
+      delete nextLineStyles[styleName];
+      return { ...template, lineStyles: nextLineStyles };
+    });
+  };
+
   const handleSetPageField = (fieldPath, value) => {
     if (!selectedTemplate) return;
     writeTemplateLeaf(selectedTemplate.id, `page/${fieldPath}`, value, template => {
@@ -588,6 +754,10 @@ const DocumentStyleEditorPage = ({ isAdmin }) => {
   const previewDoc = selectedTemplate
     ? buildGeneratedDocument(selectedTemplate, resolveCaseContext(catalog, selectedCaseId, { templateId: selectedTemplate.id }) || {})
     : null;
+
+  // Best-effort diagnostics (spec §17): unknown style/lineStyle/bottomBorderStyle references,
+  // columns overflowing the page's content width, etc. - never blocks editing, just surfaced.
+  const validation = selectedTemplate ? validateLayoutV2Template(selectedTemplate) : { errors: [], warnings: [] };
 
   if (!isStyleEditorAdmin) {
     return (
@@ -645,9 +815,23 @@ const DocumentStyleEditorPage = ({ isAdmin }) => {
               ) : null}
             </Section>
 
+            {selectedTemplate && (validation.errors.length || validation.warnings.length) ? (
+              <Section>
+                <SectionTitle>Validation</SectionTitle>
+                {validation.errors.map(message => <StateCard key={message} style={{ marginBottom: 6, color: 'var(--km-danger)' }}>{message}</StateCard>)}
+                {validation.warnings.map(message => <StateCard key={message} style={{ marginBottom: 6 }}>{message}</StateCard>)}
+              </Section>
+            ) : null}
+
             {selectedTemplate ? (
               <Section>
                 <SectionTitle>Styles</SectionTitle>
+                <FormatGroup
+                  template={selectedTemplate}
+                  onSetProperty={handleSetFormatProperty}
+                  onDeleteProperty={handleDeleteFormatProperty}
+                  onResetGroup={handleResetFormat}
+                />
                 {styleNamesFor(selectedTemplate).map(styleName => (
                   <StyleGroup
                     key={styleName}
@@ -663,6 +847,22 @@ const DocumentStyleEditorPage = ({ isAdmin }) => {
                   onSetPageField={handleSetPageField}
                   onDeletePageField={handleDeletePageField}
                 />
+              </Section>
+            ) : null}
+
+            {selectedTemplate ? (
+              <Section>
+                <SectionTitle>Line styles</SectionTitle>
+                {lineStyleNamesFor(selectedTemplate).map(styleName => (
+                  <LineStyleGroup
+                    key={styleName}
+                    styleName={styleName}
+                    template={selectedTemplate}
+                    onSetProperty={handleSetLineStyleProperty}
+                    onDeleteProperty={handleDeleteLineStyleProperty}
+                    onResetGroup={handleResetLineStyleGroup}
+                  />
+                ))}
               </Section>
             ) : null}
 

--- a/src/components/DocumentsLayoutV2CleanTemplate.test.js
+++ b/src/components/DocumentsLayoutV2CleanTemplate.test.js
@@ -1,0 +1,541 @@
+// Clean layoutV2 template support (spec: "підтримка очищеного layoutV2 для довідки про генетичну
+// спорідненість") - the fixture below is the actual genetic-affinity-certificate-clean-layout-v2.json
+// template: no legacy fields (beforeTitle/title/paragraphs/logo/columns), a `format` base style
+// instead of a required `styleSheet.document`, `lineStyles` + block-level `lineStyle`/
+// `bottomBorderStyle` references instead of inline `line`/`bottomBorder` objects, and no stored
+// page.widthMm/heightMm/layoutV2.contentWidthMm/signatureTable.widthMm - every derived geometry
+// value is computed by the renderer.
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import {
+  buildGeneratedDocument,
+  findUnresolvedPlaceholders,
+  getPageGeometry,
+  getSignatureTableWidthMm,
+  isLayoutV2Template,
+  resolveLayoutV2Style,
+  resolveLineStyle,
+  validateLayoutV2Template,
+} from './documentsCatalogUtils';
+
+const toDataUri = file => {
+  const buf = fs.readFileSync(path.join(__dirname, '../../public/fonts', file));
+  return `data:font/ttf;base64,${buf.toString('base64')}`;
+};
+
+// The exact clean template JSON (genetic-affinity-certificate-clean-layout-v2.json) - a fresh deep
+// clone per call so no test can mutate another's fixture.
+const CLEAN_TEMPLATE_JSON = {
+  id: 'genetic-affinity-certificate',
+  catalogName: 'Довідка про генетичну спорідненість',
+  rendererVersion: 2,
+  languages: ['uk'],
+  allowPageBreaks: true,
+  page: {
+    size: 'A4',
+    orientation: 'portrait',
+    marginsMm: {
+      top: 5, right: 15, bottom: 10, left: 15,
+    },
+    headerDistanceMm: 0,
+    footerDistanceMm: 0,
+  },
+  format: {
+    fontFamily: 'Times New Roman',
+    fontSizePt: 11,
+    lineHeight: 1,
+    paragraphSpacingBeforePt: 0,
+    paragraphSpacingAfterPt: 0,
+    showPageNumbers: false,
+  },
+  styleSheet: {
+    body: { align: 'left' },
+    bodyJustify: { align: 'justify' },
+    title: { fontSizePt: 14, fontWeight: 700, align: 'center' },
+    appendixReference: { fontSizePt: 10, align: 'left' },
+    formCaption: { fontSizePt: 10, align: 'center' },
+    formValue: { fontWeight: 700, textTransform: 'uppercase', align: 'center' },
+    inlineEmphasis: { fontWeight: 700, textDecoration: 'underline' },
+    letterheadContact: {
+      fontSizePt: 9, fontWeight: 700, fontStyle: 'italic', align: 'right',
+    },
+    signatureName: { align: 'center' },
+    signatureCaption: { align: 'center' },
+  },
+  lineStyles: {
+    letterheadDivider: { style: 'solid', widthPt: 3, color: '#000000' },
+    formLine: {
+      style: 'solid', widthPt: 0.75, color: '#000000', fillBeforeValue: true, fillAfterValue: true,
+    },
+    signatureLine: { style: 'solid', widthPt: 0.75, color: '#000000' },
+  },
+  layoutV2: {
+    renderLegacyContent: false,
+    blocks: [
+      {
+        columnGapMm: 5,
+        columns: [
+          {
+            content: {
+              fit: 'contain', heightMm: 17, horizontalAlign: 'left', source: '{{logo}}', type: 'image', verticalAlign: 'top', widthMm: 64.4,
+            },
+            widthMm: 64.4,
+          },
+          {
+            content: {
+              horizontalAlign: 'right',
+              lines: [
+                '{{clinic.address.uk}}',
+                'Код ЄДРПОУ {{clinic.edrpou}}, ІПН {{clinic.taxId}}, Свідоцтво ПДВ №{{clinic.vatCertificateNumber}}',
+                'тел.: {{clinic.phone}}',
+              ],
+              style: 'letterheadContact',
+              type: 'stack',
+            },
+            widthMm: 110.6,
+          },
+        ],
+        heightMm: 18,
+        paddingBottomMm: 1,
+        type: 'letterhead',
+        bottomBorderStyle: 'letterheadDivider',
+      },
+      {
+        marginBottomMm: 5,
+        marginTopMm: 4,
+        style: 'body',
+        text: 'Вих. № {{geneticAffinityCertificate.outgoingNumberOrBlank}} від {{geneticAffinityCertificate.issueDateOrBlank.uk}} року',
+        type: 'paragraph',
+      },
+      {
+        horizontalAlign: 'right',
+        lines: [
+          'Додаток 18',
+          'до Порядку застосування допоміжних',
+          'репродуктивних технологій в Україні',
+          '(пункт 6.9 розділу VI)',
+        ],
+        marginBottomMm: 6,
+        style: 'appendixReference',
+        type: 'alignedBox',
+        widthMm: 70,
+      },
+      { style: 'title', text: 'ДОВІДКА', type: 'paragraph' },
+      {
+        marginBottomMm: 1, style: 'title', text: 'про генетичну спорідненість батьків (матері чи батька) з плодом', type: 'paragraph',
+      },
+      { style: 'body', text: 'Подружжя:', type: 'paragraph' },
+      {
+        caption: '(прізвище, ім’я, по батькові, рік народження)',
+        captionStyle: 'formCaption',
+        label: 'дружина',
+        labelWidthMm: 15,
+        marginBottomMm: 0.5,
+        style: 'body',
+        type: 'fieldLine',
+        value: '{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,',
+        valueStyle: 'formValue',
+        lineStyle: 'formLine',
+      },
+      {
+        marginBottomMm: 2.5,
+        style: 'body',
+        text: 'паспорт: тип: {{wife.passport.type}}, Код країни: {{wife.passport.countryCode}}, № {{wife.passport.number}} виданий {{wife.passport.issuedBy.uk}} від {{wife.passport.issueDate}} року,',
+        type: 'paragraph',
+      },
+      {
+        caption: '(прізвище, ім’я, по батькові, рік народження)',
+        captionStyle: 'formCaption',
+        label: 'та чоловік',
+        labelWidthMm: 23,
+        marginBottomMm: 0.5,
+        style: 'body',
+        type: 'fieldLine',
+        value: '{{husband.name.uk.nominative}}, {{husband.birthDate}} р.н.,',
+        valueStyle: 'formValue',
+        lineStyle: 'formLine',
+      },
+      {
+        marginBottomMm: 3,
+        style: 'body',
+        text: 'паспорт: тип: {{husband.passport.type}}, Код країни: {{husband.passport.countryCode}}, № {{husband.passport.number}}, виданий {{husband.passport.issuedBy.uk}} від {{husband.passport.issueDate}} року,',
+        type: 'paragraph',
+      },
+      {
+        marginBottomMm: 3,
+        style: 'bodyJustify',
+        text: 'які перебувають у зареєстрованому шлюбі від {{couple.marriage.dateFormatted.uk}} року, {{couple.marriage.certificateType.uk}} № {{couple.marriage.certificateNumber}}, виданий {{couple.marriage.certificateIssuedBy.uk}} від {{couple.marriage.certificateDateFormatted.uk}} року, звернулися в заклад охорони здоров\'я.',
+        type: 'paragraph',
+      },
+      {
+        marginBottomMm: 3, style: 'body', text: 'Після обстеження встановлено діагноз: {{case.artProgram.medicalIndication.diagnosis.uk}}', type: 'paragraph',
+      },
+      {
+        runs: [
+          { text: 'У зв’язку з неможливістю виношування вагітності було проведено програму ДРТ з перенесенням ' },
+          { style: 'inlineEmphasis', text: 'ембріона' },
+          { text: '/ембріонів, доставленого {{geneticAffinityCertificate.transferAttempt.shipment.receivedDateFormatted.uk}} року у {{geneticAffinityCertificate.transferAttempt.shipment.destinationClinic.name.uk}} з {{geneticAffinityCertificate.transferAttempt.shipment.sourceClinic.name.uk}}, {{geneticAffinityCertificate.transferAttempt.shipment.sourceClinic.country.uk}}, на стадії {{geneticAffinityCertificate.transferAttempt.embryoStageLabel.uk.genitive}}, після відтаювання, у порожнину матки сурогатної матері' },
+        ],
+        style: 'bodyJustify',
+        type: 'richParagraph',
+      },
+      {
+        caption: '(прізвище, ім’я, по батькові, рік народження)',
+        captionStyle: 'formCaption',
+        marginBottomMm: 0.5,
+        style: 'body',
+        type: 'fieldLine',
+        value: '{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,',
+        valueStyle: 'formValue',
+        lineStyle: 'formLine',
+      },
+      {
+        style: 'body', text: 'паспорт: серії {{surrogateMother.passport.number}} виданий {{surrogateMother.passport.issuedBy.uk}} від {{surrogateMother.passport.issueDate}} року.', type: 'paragraph',
+      },
+      {
+        caption: '(прізвище, ініціали дружини / код донора)',
+        captionStyle: 'formCaption',
+        label: 'У лікувальній програмі ДРТ використано яйцеклітини',
+        labelWidthMm: 91,
+        style: 'body',
+        type: 'fieldLine',
+        value: '{{wife.name.uk.nominative}}',
+        valueStyle: 'formValue',
+        lineStyle: 'formLine',
+      },
+      {
+        caption: '(прізвище, ініціали / код донора)',
+        captionStyle: 'formCaption',
+        labelRuns: [
+          { style: 'inlineEmphasis', text: 'та' },
+          { text: '/або сперматозоїди' },
+        ],
+        labelWidthMm: 44,
+        style: 'body',
+        type: 'fieldLine',
+        value: '{{husband.name.uk.nominative}}',
+        valueStyle: 'formValue',
+        lineStyle: 'formLine',
+      },
+      {
+        style: 'body', text: 'Перенесення ембріона у порожнину матки сурогатної матері відбулось {{geneticAffinityCertificate.transferAttempt.dateFormatted.uk}} року.', type: 'paragraph',
+      },
+      {
+        style: 'body', text: 'Перенесено {{geneticAffinityCertificate.transferAttempt.embryoCountText.uk}} на стадії {{geneticAffinityCertificate.transferAttempt.embryoStageLabel.uk.genitive}}.', type: 'paragraph',
+      },
+      {
+        style: 'formCaption', text: '(кількість, стадія розвитку, в тому числі кріоконсервованих)', type: 'paragraph',
+      },
+      {
+        style: 'body', text: 'Факт вагітності при дослідженні ХГ в крові встановлено {{geneticAffinityCertificate.hcgTest.dateFormatted.uk}} року.', type: 'paragraph',
+      },
+      {
+        style: 'body', text: 'На УЗД факт вагітності, кількість плодів та строк вагітності підтверджено {{geneticAffinityCertificate.ultrasound.dateFormatted.uk}} року – вагітність {{geneticAffinityCertificate.ultrasound.gestationalAgeText.uk}}, {{geneticAffinityCertificate.ultrasound.pregnancyTypeText.uk}}.', type: 'paragraph',
+      },
+      {
+        runs: [
+          { text: 'Має місце генетична спорідненість батьків з ' },
+          { style: 'inlineEmphasis', text: 'плодом' },
+          { text: '/плодами.' },
+        ],
+        style: 'body',
+        type: 'richParagraph',
+      },
+      { heightMm: 12, type: 'spacer' },
+      {
+        border: 'none',
+        cellPaddingMm: 0,
+        columnWidthsMm: [80, 60, 32.5],
+        horizontalAlign: 'left',
+        rows: [
+          [
+            { style: 'body', text: 'Лікар' },
+            {
+              style: 'signatureName', text: '{{case.artProgram.medicalTeam.physician.name.uk.nominative}}', bottomBorderStyle: 'signatureLine',
+            },
+            { style: 'signatureName', text: '', bottomBorderStyle: 'signatureLine' },
+          ],
+          [
+            { text: '' },
+            { style: 'signatureCaption', text: '(прізвище, ім’я, по батькові)' },
+            { style: 'signatureCaption', text: '(підпис)' },
+          ],
+          { heightMm: 5, type: 'spacerRow' },
+          [
+            { style: 'body', text: 'Керівник закладу охорони здоров’я' },
+            {
+              style: 'signatureName', text: '{{clinic.medicalDirector.name.uk.nominative}}', bottomBorderStyle: 'signatureLine',
+            },
+            { style: 'signatureName', text: '', bottomBorderStyle: 'signatureLine' },
+          ],
+          [
+            { text: '' },
+            { style: 'signatureCaption', text: '(прізвище, ім’я, по батькові)' },
+            { style: 'signatureCaption', text: '(підпис)' },
+          ],
+        ],
+        type: 'signatureTable',
+      },
+      {
+        marginTopMm: 5, style: 'body', text: '{{geneticAffinityCertificate.issueDateOrBlank.uk}} року', type: 'paragraph',
+      },
+      { marginTopMm: 4, style: 'body', text: 'М.П.', type: 'paragraph' },
+    ],
+  },
+};
+
+const cleanTemplate = () => JSON.parse(JSON.stringify(CLEAN_TEMPLATE_JSON));
+
+const TINY_PNG_DATA_URL = 'data:image/png;base64,'
+  + 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+const clinicLogos = [{ fileName: 'logo.png', dataUrl: TINY_PNG_DATA_URL, layout: '1col', width: 4, height: 1 }];
+
+// Full context - every placeholder path the template actually references.
+const fullContext = () => ({
+  logo: '{{logo}}',
+  wife: {
+    name: { uk: { nominative: 'Кікава Харука' } },
+    birthDate: '01.01.1990',
+    passport: {
+      type: 'Р', countryCode: 'JPN', number: 'TS0299493', issuedBy: { uk: 'Міністерством закордонних справ' }, issueDate: '06.04.2018',
+    },
+  },
+  husband: {
+    name: { uk: { nominative: 'Кікава Йосуке' } },
+    birthDate: '02.02.1988',
+    passport: {
+      type: 'Р', countryCode: 'JPN', number: 'TT2633446', issuedBy: { uk: 'Міністерством закордонних справ' }, issueDate: '11.01.2023',
+    },
+  },
+  surrogateMother: {
+    name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } },
+    birthDate: '27.05.1993',
+    passport: { number: 'ЕВ 409051', issuedBy: { uk: 'Гайворонським РС УДМС України в Кіровоградській області' }, issueDate: '28.04.2016' },
+  },
+  couple: {
+    marriage: {
+      dateFormatted: { uk: '25.11.2017' },
+      certificateType: { uk: 'Витяг з сімейного реєстру' },
+      certificateNumber: '00554629',
+      certificateIssuedBy: { uk: 'Мером району Кіта' },
+      certificateDateFormatted: { uk: '25.11.2017' },
+    },
+  },
+  clinic: {
+    address: { uk: 'м. Київ, вул. Тестова, 1' },
+    edrpou: '35085030',
+    taxId: '350850326598',
+    vatCertificateNumber: '200107025',
+    phone: '(044) 425-52-77',
+    medicalDirector: { name: { uk: { nominative: 'Пилип Юрій Юрійович' } } },
+  },
+  case: {
+    artProgram: {
+      medicalIndication: { diagnosis: { uk: 'Непліддя І. Матковий фактор.' } },
+      medicalTeam: { physician: { name: { uk: { nominative: 'Тестовий Лікар Лікарович' } } } },
+    },
+  },
+  geneticAffinityCertificate: {
+    outgoingNumberOrBlank: '123',
+    issueDateOrBlank: { uk: '15.05.2026' },
+    transferAttempt: {
+      dateFormatted: { uk: '18.09.2025' },
+      embryoCountText: { uk: 'один ембріон' },
+      embryoStageLabel: { uk: { genitive: 'бластоцисти' } },
+      shipment: {
+        receivedDateFormatted: { uk: '27.08.2025' },
+        destinationClinic: { name: { uk: 'Клініка призначення' } },
+        sourceClinic: { name: { uk: 'Клініка джерело' }, country: { uk: 'Японія' } },
+      },
+    },
+    hcgTest: { dateFormatted: { uk: '30.09.2025' } },
+    ultrasound: {
+      dateFormatted: { uk: '17.10.2025' }, gestationalAgeText: { uk: '6-7 тижнів' }, pregnancyTypeText: { uk: 'одноплідна' },
+    },
+  },
+});
+
+describe('clean layoutV2 template - geometry/lineStyles/style-cascade unit tests', () => {
+  it('getPageGeometry derives contentWidthMm from size/orientation/marginsMm, never a stored value', () => {
+    const geometry = getPageGeometry(cleanTemplate());
+    expect(geometry.widthMm).toBe(210);
+    expect(geometry.heightMm).toBe(297);
+    expect(geometry.margins).toEqual({
+      top: 5, right: 15, bottom: 10, left: 15,
+    });
+    expect(geometry.contentWidthMm).toBe(180);
+  });
+
+  it('getPageGeometry never requires page.widthMm/heightMm/contentWidthMm on the template', () => {
+    const template = cleanTemplate();
+    expect(template.page.widthMm).toBeUndefined();
+    expect(template.page.heightMm).toBeUndefined();
+    expect(template.layoutV2.contentWidthMm).toBeUndefined();
+  });
+
+  it('getSignatureTableWidthMm sums columnWidthsMm - never requires a stored widthMm', () => {
+    expect(getSignatureTableWidthMm({ columnWidthsMm: [80, 60, 32.5] })).toBe(172.5);
+    const signatureBlock = cleanTemplate().layoutV2.blocks.find(block => block.type === 'signatureTable');
+    expect(signatureBlock.widthMm).toBeUndefined();
+    expect(getSignatureTableWidthMm(signatureBlock)).toBe(172.5);
+  });
+
+  it('resolveLineStyle reads a named entry from lineStyles, null for an unknown/absent name', () => {
+    const template = cleanTemplate();
+    expect(resolveLineStyle(template, 'formLine')).toEqual({
+      style: 'solid', widthPt: 0.75, color: '#000000', fillBeforeValue: true, fillAfterValue: true,
+    });
+    expect(resolveLineStyle(template, 'letterheadDivider')).toEqual({ style: 'solid', widthPt: 3, color: '#000000' });
+    expect(resolveLineStyle(template, 'doesNotExist')).toBeNull();
+    expect(resolveLineStyle(template, undefined)).toBeNull();
+  });
+
+  it('resolveLayoutV2Style cascades format -> named style -> styleOverrides, never requiring styleSheet.document', () => {
+    const template = cleanTemplate();
+    expect(template.styleSheet.document).toBeUndefined();
+    // "body" only overrides align - fontFamily/fontSizePt/lineHeight must still come from `format`.
+    const bodyStyle = resolveLayoutV2Style(template, 'body', {});
+    expect(bodyStyle.fontFamily).toBe('Times New Roman');
+    expect(bodyStyle.fontSizePt).toBe(11);
+    expect(bodyStyle.lineHeight).toBe(1);
+    expect(bodyStyle.align).toBe('left');
+    // named style wins over format when both set a key.
+    const titleStyle = resolveLayoutV2Style(template, 'title', {});
+    expect(titleStyle.fontSizePt).toBe(14);
+    expect(titleStyle.fontFamily).toBe('Times New Roman'); // still inherited from format
+    // an explicit block override wins over the named style.
+    const overridden = resolveLayoutV2Style(template, 'title', { fontSizePt: 20 });
+    expect(overridden.fontSizePt).toBe(20);
+  });
+
+  it('validateLayoutV2Template reports no errors/warnings for a well-formed clean template', () => {
+    const { errors, warnings } = validateLayoutV2Template(cleanTemplate());
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('validateLayoutV2Template flags an unknown named style, lineStyle, bottomBorderStyle and block type', () => {
+    const template = cleanTemplate();
+    template.layoutV2.blocks.push({ type: 'paragraph', style: 'noSuchStyle', text: 'x' });
+    template.layoutV2.blocks.push({
+      type: 'fieldLine', style: 'body', value: 'x', lineStyle: 'noSuchLine',
+    });
+    template.layoutV2.blocks[0].bottomBorderStyle = 'noSuchBorder';
+    template.layoutV2.blocks.push({ type: 'somethingWeird' });
+    const { warnings } = validateLayoutV2Template(template);
+    expect(warnings.some(message => message.includes('noSuchStyle'))).toBe(true);
+    expect(warnings.some(message => message.includes('noSuchLine'))).toBe(true);
+    expect(warnings.some(message => message.includes('noSuchBorder'))).toBe(true);
+    expect(warnings.some(message => message.includes('somethingWeird'))).toBe(true);
+  });
+
+  it('validateLayoutV2Template flags letterhead/signatureTable columns that overflow the content width', () => {
+    const template = cleanTemplate();
+    const letterhead = template.layoutV2.blocks.find(block => block.type === 'letterhead');
+    letterhead.columns[1].widthMm = 200;
+    const { warnings } = validateLayoutV2Template(template);
+    expect(warnings.some(message => message.includes('Letterhead columns'))).toBe(true);
+  });
+});
+
+describe('clean layoutV2 template - normalization (buildGeneratedDocument)', () => {
+  it('flags the clean template as layoutV2 and normalizes without throwing', () => {
+    expect(isLayoutV2Template(cleanTemplate())).toBe(true);
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    expect(resolved.layoutV2).toBeTruthy();
+    expect(resolved.layoutV2.blocks).toHaveLength(cleanTemplate().layoutV2.blocks.length);
+  });
+
+  it('computes page geometry (widthMm/heightMm/marginsMm/contentWidthMm) - never reads a stored value', () => {
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    expect(resolved.layoutV2.page.widthMm).toBe(210);
+    expect(resolved.layoutV2.page.heightMm).toBe(297);
+    expect(resolved.layoutV2.page.marginsMm).toEqual({
+      top: 5, right: 15, bottom: 10, left: 15,
+    });
+    expect(resolved.layoutV2.contentWidthMm).toBe(180);
+  });
+
+  it('resolves the letterhead bottomBorderStyle into a concrete border, without mutating the template', () => {
+    const template = cleanTemplate();
+    const resolved = buildGeneratedDocument(template, fullContext());
+    const letterhead = resolved.layoutV2.blocks.find(block => block.type === 'letterhead');
+    expect(letterhead.bottomBorder).toEqual({ style: 'solid', widthPt: 3, color: '#000000' });
+    // The source template's own block never gets a resolved copy written back onto it.
+    expect(cleanTemplate().layoutV2.blocks[0].bottomBorder).toBeUndefined();
+  });
+
+  it('resolves every fieldLine\'s lineStyle into a concrete line object (fillBeforeValue/fillAfterValue included)', () => {
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    const fieldLines = resolved.layoutV2.blocks.filter(block => block.type === 'fieldLine');
+    expect(fieldLines.length).toBeGreaterThan(0);
+    fieldLines.forEach(block => {
+      expect(block.line).toEqual({
+        style: 'solid', widthPt: 0.75, color: '#000000', fillBeforeValue: true, fillAfterValue: true,
+      });
+    });
+  });
+
+  it('resolves signatureTable cell bottomBorderStyle and computes the table width from columnWidthsMm', () => {
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    const table = resolved.layoutV2.blocks.find(block => block.type === 'signatureTable');
+    expect(table.widthMm).toBe(172.5);
+    const physicianNameCell = table.rows.flat().find(cell => cell?.text?.includes('Тестовий Лікар'));
+    expect(physicianNameCell.bottomBorder).toEqual({ style: 'solid', widthPt: 0.75, color: '#000000' });
+    // The caption row's cells never asked for a bottomBorderStyle - they must stay borderless.
+    const captionCell = table.rows.flat().find(cell => cell?.text === '(підпис)');
+    expect(captionCell.bottomBorder).toBeFalsy();
+  });
+
+  it('leaves no unresolved {{...}} placeholders anywhere in the normalized tree', () => {
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    expect(findUnresolvedPlaceholders(resolved.layoutV2)).toEqual([]);
+  });
+
+  it('never introduces legacy template fields (beforeTitle/title/paragraphs/logo/columns) into layoutV2 itself', () => {
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    expect(resolved.layoutV2.beforeTitle).toBeUndefined();
+    expect(resolved.layoutV2.title).toBeUndefined();
+    expect(resolved.layoutV2.paragraphs).toBeUndefined();
+    expect(resolved.layoutV2.logo).toBeUndefined();
+    expect(resolved.layoutV2.columns).toBeUndefined();
+  });
+});
+
+describe('clean layoutV2 template - real render backends', () => {
+  it('renders the clean template to a PDF without throwing', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [
+        { src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 },
+        { src: toDataUri('Tinos-Bold.ttf'), fontWeight: 700 },
+        { src: toDataUri('Tinos-Italic.ttf'), fontWeight: 400, fontStyle: 'italic' },
+        { src: toDataUri('Tinos-BoldItalic.ttf'), fontWeight: 700, fontStyle: 'italic' },
+      ],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    const element = React.createElement(DocumentsPdfDocument, {
+      documents: [resolved], layout: 'two-column', clinicLogos,
+    });
+    const buffer = await pdf(element).toBuffer();
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+      buffer.on('data', chunk => chunks.push(chunk));
+      buffer.on('end', resolve);
+      buffer.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(500);
+  }, 20000);
+
+  it('builds a .docx blob for the clean template without throwing', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
+    const blob = await buildDocumentsDocx({ documents: [resolved], layout: 'two-column', clinicLogos });
+    expect(blob.size).toBeGreaterThan(500);
+  }, 20000);
+});

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1853,7 +1853,7 @@ const DocumentsPage = ({ isAdmin }) => {
       return;
     }
     const template = catalog.documents.find(item => String(item.id) === nextDocId);
-    setDocFormatDraft(resolveEffectiveDocFormatting(formatting, template?.format, template?.documentStyle));
+    setDocFormatDraft(resolveEffectiveDocFormatting(formatting, isLayoutV2Template(template) ? undefined : template?.format, template?.documentStyle));
   };
 
   const handleSaveFavouriteFormatting = async () => {
@@ -1868,7 +1868,9 @@ const DocumentsPage = ({ isAdmin }) => {
   // persisting a redundant copy (spec §5).
   const handleSaveDocFormatOverride = async () => {
     const template = catalog.documents.find(item => String(item.id) === formatDocId);
-    if (!template) return;
+    // A layoutV2 document's `format` is its own base style (spec §2/§3), never the legacy
+    // DEFAULT_DOC_FORMATTING override shape - never let this path write into it.
+    if (!template || isLayoutV2Template(template)) return;
     const normalizedDraft = normalizeDocFormatting(docFormatDraft || formatting);
     // An official-form document's own overrides are diffed against its OFFICIAL_FORM_FORMATTING
     // baseline, not the shared branded favourites - otherwise every one of that baseline's values
@@ -1928,6 +1930,12 @@ const DocumentsPage = ({ isAdmin }) => {
   // catalog's own order, after every recent one.
   const orderedDocuments = orderRecordsByRecentIds(catalog.documents, settings.recentDocIds);
   const selectedTemplates = orderedDocuments.filter(template => selectedDocIds[template.id]);
+  // A layoutV2 document is fully self-describing (its own `format`/styleSheet/lineStyles, spec
+  // §2/§3) and never reads the legacy per-document format override at all - offering it in this
+  // picker would let "Save for this document" overwrite that clean base style with the unrelated
+  // DEFAULT_DOC_FORMATTING shape (fontSize/marginTopCm/...) the legacy renderer expects there.
+  // Style Editor is where a layoutV2 document's own format/styles are edited instead.
+  const formatOverrideEligibleDocuments = orderedDocuments.filter(template => !isLayoutV2Template(template));
   // The row list only (never the Format section's "Format for: ..." dropdown, which always has to
   // offer every document regardless of what's currently filtered on screen).
   const docSearchNeedle = docSearchQuery.trim().toLowerCase();
@@ -3162,7 +3170,7 @@ const DocumentsPage = ({ isAdmin }) => {
                   <RowLine style={{ marginTop: 8 }}>
                     <Select value={formatDocId} onChange={event => handleFormatDocChange(event.target.value)}>
                       <option value="">Format for: all documents (defaults)</option>
-                      {orderedDocuments.map(template => (
+                      {formatOverrideEligibleDocuments.map(template => (
                         <option key={template.id} value={String(template.id)}>
                           Format for: {template.catalogName || template.title?.uk || template.title?.en || template.id}
                         </option>

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1941,14 +1941,60 @@ export const resolveLayoutV2NamedStyle = (template, styleName) => (
   styleName ? (template?.styleSheet?.[styleName] ?? {}) : {}
 );
 
-// block override -> named style -> document (spec §2/§7: a layoutV2 block never falls through to
-// template.format/global settings - it always names its own style, and `document` is the only
-// implicit base every named style inherits from).
+// block override -> named style -> template.format (clean layoutV2 template spec §2/§3: the base
+// style is the template's own `format` - never a required `styleSheet.document` entry, and never
+// the page-wide Format-panel settings, which a layoutV2 document never inherits at all). A template
+// that never sets `format` simply starts every block from {}, exactly like one whose named style
+// already covers everything itself.
 export const resolveLayoutV2Style = (template, styleName, overrides) => ({
-  ...pickLayoutV2StyleKeys(template?.styleSheet?.document),
+  ...pickLayoutV2StyleKeys(template?.format),
   ...pickLayoutV2StyleKeys(resolveLayoutV2NamedStyle(template, styleName)),
   ...pickLayoutV2StyleKeys(overrides),
 });
+
+// --- Page geometry (clean layoutV2 template spec §5/§6) ---------------------------------------
+// A clean template carries only `page.size`/`page.orientation`/`page.marginsMm` - never its own
+// widthMm/heightMm/contentWidthMm, which are always derivable and would otherwise just be a second
+// copy that could drift from the size/orientation actually selected.
+export const PAGE_SIZES_MM = {
+  A4: {
+    portrait: { width: 210, height: 297 },
+    landscape: { width: 297, height: 210 },
+  },
+};
+
+export const getPageGeometry = template => {
+  const page = template?.page ?? {};
+  const orientation = page.orientation === 'landscape' ? 'landscape' : 'portrait';
+  const size = PAGE_SIZES_MM[page.size] ? page.size : 'A4';
+  const dimensions = PAGE_SIZES_MM[size][orientation];
+  const margins = {
+    top: page?.marginsMm?.top ?? 0,
+    right: page?.marginsMm?.right ?? 0,
+    bottom: page?.marginsMm?.bottom ?? 0,
+    left: page?.marginsMm?.left ?? 0,
+  };
+  return {
+    widthMm: dimensions.width,
+    heightMm: dimensions.height,
+    margins,
+    contentWidthMm: dimensions.width - margins.left - margins.right,
+  };
+};
+
+// --- lineStyles (clean layoutV2 template spec §4) ----------------------------------------------
+// Repeated line/border parameters (letterhead divider, form-field underline, signature-cell rule)
+// live once under `lineStyles`, named by a block's own `lineStyle`/`bottomBorderStyle` - resolved
+// into a concrete object only in the normalized render tree, never written back onto the template.
+export const resolveLineStyle = (template, styleName) => {
+  if (!styleName) return null;
+  return template?.lineStyles?.[styleName] ?? null;
+};
+
+// A signatureTable's own width is always the sum of its columns - never a stored `widthMm` that
+// could drift from the columns actually defined.
+export const getSignatureTableWidthMm = block => (block?.columnWidthsMm || [])
+  .reduce((sum, width) => sum + (Number(width) || 0), 0);
 
 const resolveLayoutV2Text = (text, context, lang) => (text === undefined ? undefined : fillPlaceholders(text, context, lang));
 
@@ -2000,7 +2046,7 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
         ...base,
         heightMm: block.heightMm,
         columnGapMm: block.columnGapMm,
-        bottomBorder: block.bottomBorder,
+        bottomBorder: block.bottomBorder ?? resolveLineStyle(template, block.bottomBorderStyle),
         paddingBottomMm: block.paddingBottomMm,
         columns: (block.columns || []).map(column => ({
           widthMm: column.widthMm,
@@ -2036,7 +2082,9 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
         labelStyle: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         value: resolveLayoutV2Text(block.value, context, lang) || '',
         valueStyle: resolveLayoutV2Style(template, block.valueStyle, block.valueStyleOverrides),
-        line: block.line || {},
+        // Both formats supported (spec §4/§16): an old inline `line` object wins if present, a new
+        // template names its border via `lineStyle` into the shared `lineStyles` map instead.
+        line: block.line ?? resolveLineStyle(template, block.lineStyle) ?? {},
         caption: block.caption !== undefined ? resolveLayoutV2Text(block.caption, context, lang) : undefined,
         captionStyle: resolveLayoutV2Style(template, block.captionStyle, block.captionStyleOverrides),
       };
@@ -2045,7 +2093,9 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
     case 'signatureTable':
       return {
         ...base,
-        widthMm: block.widthMm,
+        // A clean template never stores its own widthMm (spec §5/§10) - it's always the sum of
+        // columnWidthsMm; an old template's explicit widthMm (if any) still wins.
+        widthMm: block.widthMm ?? getSignatureTableWidthMm(block),
         horizontalAlign: block.horizontalAlign,
         columnWidthsMm: block.columnWidthsMm || [],
         cellPaddingMm: block.cellPaddingMm || 0,
@@ -2055,13 +2105,14 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
             : (row || []).map(cell => ({
               text: resolveLayoutV2Text(cell?.text, context, lang) || '',
               style: resolveLayoutV2Style(template, cell?.style, cell?.styleOverrides),
-              bottomBorder: cell?.bottomBorder,
+              bottomBorder: cell?.bottomBorder ?? resolveLineStyle(template, cell?.bottomBorderStyle),
             }))
         )),
       };
     default:
-      // spec §9: an unknown block type never crashes the render - it's carried through as a
-      // diagnostic-only entry the renderers skip.
+      // spec §7/§9: an unknown block type never crashes the render - it's carried through as a
+      // diagnostic-only entry the renderers skip, with a console warning for whoever authored it.
+      console.warn(`Unknown layoutV2 block type: ${block?.type}`);
       return { ...base, unknown: true };
   }
 };
@@ -2072,12 +2123,107 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
 export const buildLayoutV2Document = (template, context) => {
   if (!isLayoutV2Template(template)) return null;
   const lang = (resolveDocLanguages(template) || ['uk'])[0];
+  // Geometry is always derived (spec §5/§6) - a clean template's `page` never carries its own
+  // widthMm/heightMm/contentWidthMm, so getPageGeometry computes them from size/orientation/margins
+  // every render; an old template's explicit page.marginsMm still drives the same computation.
+  const geometry = getPageGeometry(template);
   return {
     lang,
-    page: template.page || null,
-    contentWidthMm: template.layoutV2.contentWidthMm,
+    page: {
+      ...(template.page || {}),
+      widthMm: geometry.widthMm,
+      heightMm: geometry.heightMm,
+      marginsMm: geometry.margins,
+    },
+    contentWidthMm: geometry.contentWidthMm,
     blocks: template.layoutV2.blocks.map(block => normalizeLayoutV2Block(block, template, context, lang)),
   };
+};
+
+// --- Validation (clean layoutV2 template spec §17) ---------------------------------------------
+// Best-effort diagnostics for a layoutV2 template - never thrown, always a { errors, warnings }
+// list an editor surface can show. A missing/unknown reference always falls back gracefully in the
+// renderers/normalizer themselves (undefined style, no border, etc.) - this only flags it for
+// whoever is authoring the template.
+const LAYOUT_V2_KNOWN_BLOCK_TYPES = ['letterhead', 'paragraph', 'alignedBox', 'richParagraph', 'fieldLine', 'spacer', 'signatureTable'];
+
+export const validateLayoutV2Template = template => {
+  const errors = [];
+  const warnings = [];
+  if (template?.rendererVersion !== 2) return { errors, warnings };
+  if (!Array.isArray(template?.layoutV2?.blocks)) {
+    errors.push('layoutV2.blocks is missing or is not an array.');
+    return { errors, warnings };
+  }
+
+  const geometry = getPageGeometry(template);
+  const styleNames = new Set(Object.keys(template?.styleSheet || {}));
+  const lineStyleNames = new Set(Object.keys(template?.lineStyles || {}));
+
+  const checkStyle = (styleName, where) => {
+    if (styleName && !styleNames.has(styleName)) warnings.push(`Unknown named style "${styleName}" (${where}).`);
+  };
+  const checkLineStyle = (styleName, where) => {
+    if (styleName && !lineStyleNames.has(styleName)) warnings.push(`Unknown lineStyle "${styleName}" (${where}).`);
+  };
+  const checkBottomBorderStyle = (styleName, where) => {
+    if (styleName && !lineStyleNames.has(styleName)) warnings.push(`Unknown bottomBorderStyle "${styleName}" (${where}).`);
+  };
+
+  template.layoutV2.blocks.forEach((block, index) => {
+    const where = `block[${index}] (${block?.type})`;
+    if (!LAYOUT_V2_KNOWN_BLOCK_TYPES.includes(block?.type)) {
+      warnings.push(`Unknown block type "${block?.type}" (${where}).`);
+      return;
+    }
+    if (block.type === 'letterhead') {
+      checkBottomBorderStyle(block.bottomBorderStyle, where);
+      const columnsWidthMm = (block.columns || []).reduce((sum, column) => sum + (Number(column.widthMm) || 0), 0)
+        + (Number(block.columnGapMm) || 0) * Math.max(0, (block.columns || []).length - 1);
+      if (columnsWidthMm > geometry.contentWidthMm) {
+        warnings.push(`Letterhead columns (${columnsWidthMm}mm) exceed the content width (${geometry.contentWidthMm}mm).`);
+      }
+      (block.columns || []).forEach(column => {
+        if (column?.content?.type === 'stack') checkStyle(column.content.style, where);
+      });
+    }
+    if (block.type === 'paragraph' || block.type === 'alignedBox') {
+      checkStyle(block.style, where);
+    }
+    if (block.type === 'richParagraph') {
+      (block.runs || []).forEach(run => checkStyle(run.style, where));
+    }
+    if (block.type === 'fieldLine') {
+      checkStyle(block.style, where);
+      checkStyle(block.valueStyle, where);
+      checkStyle(block.captionStyle, where);
+      checkLineStyle(block.lineStyle, where);
+    }
+    if (block.type === 'signatureTable') {
+      const tableWidthMm = getSignatureTableWidthMm(block);
+      if (tableWidthMm > geometry.contentWidthMm) {
+        warnings.push(`signatureTable columns (${tableWidthMm}mm) exceed the content width (${geometry.contentWidthMm}mm).`);
+      }
+      (block.rows || []).forEach(row => {
+        if (row?.type === 'spacerRow') return;
+        (row || []).forEach(cell => {
+          checkStyle(cell?.style, where);
+          checkBottomBorderStyle(cell?.bottomBorderStyle, where);
+        });
+      });
+    }
+  });
+
+  return { errors, warnings };
+};
+
+// Leftover `{{...}}` anywhere in an already-resolved layoutV2 render tree (buildLayoutV2Document's
+// output) means some placeholder in the template has no matching context value (spec §17/§18) -
+// returns the distinct unresolved tokens found, empty when everything resolved cleanly.
+export const findUnresolvedPlaceholders = layoutV2Doc => {
+  if (!layoutV2Doc) return [];
+  const serialized = JSON.stringify(layoutV2Doc);
+  return [...new Set(serialized.match(/\{\{[^}]+\}\}/g) || [])];
 };
 
 // --- layoutV2 paragraph/richParagraph inline bold (batch 25 §3) --------------------------------


### PR DESCRIPTION
layoutV2 now works from the trimmed template JSON directly: a base `format`
style (styleSheet.document is no longer required), named `lineStyles` resolved
via block-level `lineStyle`/`bottomBorderStyle` (with the old inline
line/bottomBorder objects still honored for backward compatibility), and all
page/table geometry (page size, content width, signature-table width) derived
at render time instead of read from stored widthMm/heightMm/contentWidthMm
fields. Adds validateLayoutV2Template/findUnresolvedPlaceholders diagnostics,
Style Editor groups for editing `format` and `lineStyles`, and fixes a latent
bug where the legacy per-document Format panel could overwrite a layoutV2
template's clean `format` field with incompatible legacy keys.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014XPtYnTf2CEUDoSNoxbGxV