### PR TITLE
Hide the renderer toggle for settled layoutV2-only documents

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -2502,14 +2502,17 @@ const DocumentsPage = ({ isAdmin }) => {
                         style={{ flex: 1, minWidth: 0, fontWeight: 600 }}
                         title="The document's entry name in the Documents list - never printed inside the document itself (edit the printed title below, in the Title row)"
                       />
-                      {/* Column count + (for every document carrying layoutV2 blocks) the renderer
-                          switch, both in one settings popover (batch 23 §3) instead of
-                          always-visible buttons - column count overrides the page-wide selector
-                          above once set (see handleSetDocColumns); tap the active option again to
-                          clear it. Keep the renderer switch available even for layoutV2-only
-                          documents: an imported template or one disabled by an earlier version
-                          can have rendererVersion 1, and needs this control to recover exact-layout
-                          rendering instead of remaining stuck on its empty legacy fields. */}
+                      {/* Column count + renderer switch in one settings popover (batch 23 §3)
+                          instead of always-visible buttons - column count overrides the page-wide
+                          selector above once set (see handleSetDocColumns); tap the active option
+                          again to clear it. The renderer switch itself only ever shows when it's a
+                          real choice: either this document actually has legacy content to compare
+                          against, or its layoutV2 blocks exist but aren't currently active (an
+                          imported template, or one left on rendererVersion 1 by an earlier
+                          version) - shown so it can be recovered. A document that's already
+                          settled on layoutV2 with no legacy content at all (e.g.
+                          genetic-affinity-certificate) has no real "renderer" to switch to/from,
+                          so the control stays hidden for it instead of offering a fake choice. */}
                       <DocLayoutSettingsPopoverButton
                         open={openLayoutSettingsDocId === String(template.id)}
                         onToggle={() => toggleLayoutSettingsPopover(String(template.id))}
@@ -2517,7 +2520,7 @@ const DocumentsPage = ({ isAdmin }) => {
                         columnOptions={DOC_COLUMN_OPTIONS}
                         activeColumns={template.columns}
                         onSetColumns={columnsOption => handleSetDocColumns(template.id, columnsOption)}
-                        hasLayoutV2={Boolean(template.layoutV2?.blocks)}
+                        hasLayoutV2={Boolean(template.layoutV2?.blocks) && (hasLegacyDocContent || !isLayoutV2Template(template))}
                         layoutV2Active={isLayoutV2Template(template)}
                         onToggleLayoutV2={() => handleToggleLayoutV2(template.id)}
                       />

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
-  render, screen, fireEvent, waitFor,
+  render, screen, fireEvent, waitFor, within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -143,5 +143,51 @@ describe('spec: layoutV2 paragraph blocks - selection-based Bold (batch 25 §3)'
     await screen.findByText('Звичайний текст.');
 
     expect(screen.queryByText('Paragraphs - select text, Bold the fragment')).not.toBeInTheDocument();
+  });
+
+  // A layoutV2-only document (no legacy beforeTitle/title/paragraphs/logo, e.g.
+  // genetic-affinity-certificate) has no real second renderer to switch to/from - the "Exact
+  // layout" toggle is a fake choice for it and must stay hidden, unlike a document that either
+  // still has real legacy content or is stuck on rendererVersion 1 despite carrying layoutV2
+  // blocks (the recovery case the toggle exists for).
+  it('hides the renderer toggle for a settled layoutV2-only document, but keeps it for recovery', async () => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'settled-doc': {
+              id: 'settled-doc',
+              catalogName: 'Settled layoutV2-only doc',
+              rendererVersion: 2,
+              languages: ['uk'],
+              layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }] },
+            },
+            'stuck-doc': {
+              id: 'stuck-doc',
+              catalogName: 'Stuck on rendererVersion 1',
+              rendererVersion: 1,
+              languages: ['uk'],
+              layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }] },
+            },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const settledRowHead = (await screen.findByDisplayValue('Settled layoutV2-only doc')).closest('div');
+    fireEvent.click(within(settledRowHead).getByTitle(/Document layout settings/));
+    expect(screen.queryByText(/Exact layout/)).not.toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const stuckRowHead = (await screen.findByDisplayValue('Stuck on rendererVersion 1')).closest('div');
+    fireEvent.click(within(stuckRowHead).getByTitle(/Document layout settings/));
+    expect(await screen.findByText(/Exact layout/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- PR #2837 restored the "Exact layout on/off" renderer-switch popover for every document carrying layoutV2 blocks, to preserve a recovery path for a template stuck on `rendererVersion: 1`. That also brought back a fake "choice" for a document like `genetic-affinity-certificate`, which has no legacy content at all and is already rendering via layoutV2.
- Reconciled both needs: the toggle now shows only when it's a real choice - either the document has actual legacy content to compare its two renderings against, or its layoutV2 blocks exist but aren't currently active (the recovery case the toggle was restored for). A document already settled on layoutV2 with no legacy content keeps the toggle hidden, so there's no more "layoutV2"/"exact layout" wording shown for it at all.

## Test plan
- [x] New test: `DocumentsPage.layoutV2ParagraphBold.test.js` - toggle hidden for a settled layoutV2-only doc, shown for one stuck on `rendererVersion: 1`
- [x] All 440 Documents-related tests pass
- [x] `eslint` clean on touched files

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014XPtYnTf2CEUDoSNoxbGxV)_