### PR TITLE
Give layoutV2 paragraphs the full paragraph toolbar

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -2502,14 +2502,17 @@ const DocumentsPage = ({ isAdmin }) => {
                         style={{ flex: 1, minWidth: 0, fontWeight: 600 }}
                         title="The document's entry name in the Documents list - never printed inside the document itself (edit the printed title below, in the Title row)"
                       />
-                      {/* Column count + (for every document carrying layoutV2 blocks) the renderer
-                          switch, both in one settings popover (batch 23 §3) instead of
-                          always-visible buttons - column count overrides the page-wide selector
-                          above once set (see handleSetDocColumns); tap the active option again to
-                          clear it. Keep the renderer switch available even for layoutV2-only
-                          documents: an imported template or one disabled by an earlier version
-                          can have rendererVersion 1, and needs this control to recover exact-layout
-                          rendering instead of remaining stuck on its empty legacy fields. */}
+                      {/* Column count + renderer switch in one settings popover (batch 23 §3)
+                          instead of always-visible buttons - column count overrides the page-wide
+                          selector above once set (see handleSetDocColumns); tap the active option
+                          again to clear it. The renderer switch itself only ever shows when it's a
+                          real choice: either this document actually has legacy content to compare
+                          against, or its layoutV2 blocks exist but aren't currently active (an
+                          imported template, or one left on rendererVersion 1 by an earlier
+                          version) - shown so it can be recovered. A document that's already
+                          settled on layoutV2 with no legacy content at all (e.g.
+                          genetic-affinity-certificate) has no real "renderer" to switch to/from,
+                          so the control stays hidden for it instead of offering a fake choice. */}
                       <DocLayoutSettingsPopoverButton
                         open={openLayoutSettingsDocId === String(template.id)}
                         onToggle={() => toggleLayoutSettingsPopover(String(template.id))}
@@ -2517,7 +2520,7 @@ const DocumentsPage = ({ isAdmin }) => {
                         columnOptions={DOC_COLUMN_OPTIONS}
                         activeColumns={template.columns}
                         onSetColumns={columnsOption => handleSetDocColumns(template.id, columnsOption)}
-                        hasLayoutV2={Boolean(template.layoutV2?.blocks)}
+                        hasLayoutV2={Boolean(template.layoutV2?.blocks) && (hasLegacyDocContent || !isLayoutV2Template(template))}
                         layoutV2Active={isLayoutV2Template(template)}
                         onToggleLayoutV2={() => handleToggleLayoutV2(template.id)}
                       />

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -41,7 +41,9 @@ import {
   DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
+  fillPlaceholders,
   getClinicLogo,
+  getEffectiveLayoutV2BlockAlign,
   getEffectiveParagraphAlign,
   getEffectiveTitleAlign,
   getLayoutLang,
@@ -54,7 +56,7 @@ import {
   isBilingualLayout,
   isLayoutV2Template,
   isOfficialFormStyle,
-  layoutV2ParagraphRuns,
+  layoutV2Scope,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
   mergeDocumentsCatalog,
@@ -75,7 +77,6 @@ import {
   TITLE_SCOPE,
   toArray,
   toggleInlineFormat,
-  toggleLayoutV2ParagraphBold,
   toggleRawInlineMarker,
   upsertRecentCaseId,
   upsertRecentId,
@@ -571,18 +572,6 @@ const TextModeDisplay = styled.div`
     outline: none;
   }
 `;
-
-// layoutV2's {text, style} runs (batch 25 §3) - a run styled 'inlineEmphasis' renders bold, same
-// visual convention as FormattedRunsPreview's **markdown** runs below, just resolved from the
-// template's own named style instead of a markup character.
-const LayoutV2RunsPreview = ({ block }) => (
-  <>
-    {layoutV2ParagraphRuns(block).map((run, index) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <React.Fragment key={index}>{run.style === 'inlineEmphasis' ? <strong>{run.text}</strong> : run.text}</React.Fragment>
-    ))}
-  </>
-);
 
 const FormattedRunsPreview = ({ text }) => (
   <>
@@ -1546,33 +1535,24 @@ const DocumentsPage = ({ isAdmin }) => {
     await commitTemplateScopeText(docId, scope, langKey, nextRaw);
   };
 
-  // --- layoutV2 paragraph/richParagraph selection-based bold (batch 25 §3) -----------------------
-  // A layoutV2 block has no per-mode toolbar of its own (there is no per-case resolved view for it -
-  // a layoutV2 template is always edited as its own shared raw markup, same as legacy Template mode)
-  // - one Bold button per paragraph/richParagraph block, acting on whatever text is currently
-  // selected inside it (same native-Selection approach as Text mode's handleApplyInlineFormat,
-  // above, since this display is a rendered <div> too, not a textarea).
-  const layoutV2BlockNodesRef = useRef({});
-  const registerLayoutV2BlockNode = (docId, blockIndex) => node => {
-    layoutV2BlockNodesRef.current[`${docId}#${blockIndex}`] = node;
-  };
-  const handleLayoutV2BlockBold = async (docId, blockIndex) => {
-    const node = layoutV2BlockNodesRef.current[`${docId}#${blockIndex}`];
-    if (!node) return;
-    const offsets = getContainerSelectionOffsets(node);
-    if (!offsets) {
-      toast.error('Select some text first.');
-      return;
-    }
+  // --- layoutV2 paragraph/richParagraph full toolbar parity ---------------------------------------
+  // A layoutV2 paragraph/richParagraph block's raw content is just its own **bold**/*italic*
+  // markup string (layoutV2ParagraphMarkup/layoutV2ParagraphFromMarkup, documentsCatalogUtils.js) -
+  // addressed via a `lv2:<index>` scope (layoutV2Scope) that getTemplateScopeText/
+  // withTemplateScopeText already understand, exactly like `p:<index>`/`beforeTitle:<index>`/the
+  // title scope. That's what lets the mode cycle ({}/I/T), Bold/Italic, and Insert-variable buttons
+  // below reuse the very same generic handlers every other paragraph row already has
+  // (getParagraphMode/setParagraphModeFor, formatButtonProps, openVariablePicker,
+  // handleTemplateScopeChange/persistTemplate) with no bespoke layoutV2-only mechanism at all -
+  // only insert/delete/alignment/font-size need their own handlers below, since a layoutV2 block's
+  // `style` names a *shared* template style (resolveLayoutV2Style) rather than carrying its own
+  // inline style object the way a legacy paragraph's `style` does.
+  const applyLayoutV2BlocksChange = async (docId, buildBlocks) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
-    if (!template?.layoutV2?.blocks?.[blockIndex]) return;
-    const nextBlock = toggleLayoutV2ParagraphBold(template.layoutV2.blocks[blockIndex], offsets.start, offsets.end);
+    if (!template) return;
     const nextTemplate = {
       ...template,
-      layoutV2: {
-        ...template.layoutV2,
-        blocks: template.layoutV2.blocks.map((item, index) => (index === blockIndex ? nextBlock : item)),
-      },
+      layoutV2: { ...template.layoutV2, blocks: buildBlocks(template.layoutV2?.blocks || []) },
     };
     try {
       await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
@@ -1580,10 +1560,49 @@ const DocumentsPage = ({ isAdmin }) => {
         ...previous,
         documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
       }));
-    } catch (saveError) {
-      console.error('Unable to save the template change', saveError);
+    } catch (structureError) {
+      console.error('Unable to update the layoutV2 paragraph structure', structureError);
       toast.error('Could not save the change.');
     }
+  };
+
+  // `atIndex` may equal blocks.length to append a new paragraph after the last block.
+  const handleInsertLayoutV2Paragraph = (docId, atIndex) => applyLayoutV2BlocksChange(
+    docId,
+    blocks => [...blocks.slice(0, atIndex), { type: 'paragraph', style: 'body', text: '' }, ...blocks.slice(atIndex)],
+  );
+
+  const handleRemoveLayoutV2Block = (docId, atIndex) => {
+    if (typeof window !== 'undefined' && !window.confirm('Remove this paragraph?')) return;
+    applyLayoutV2BlocksChange(docId, blocks => blocks.filter((_, index) => index !== atIndex));
+  };
+
+  const handleCycleLayoutV2Align = (docId, blockIndex) => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    const block = template?.layoutV2?.blocks?.[blockIndex];
+    if (!block) return;
+    const nextAlign = nextParagraphAlign(getEffectiveLayoutV2BlockAlign(template, block));
+    applyLayoutV2BlocksChange(docId, blocks => blocks.map((item, index) => (
+      index === blockIndex ? { ...item, styleOverrides: { ...item.styleOverrides, align: nextAlign } } : item
+    )));
+  };
+
+  const setLayoutV2StyleOverrideField = (docId, blockIndex, styleKey, raw) => {
+    const parsed = parsePlainNumber(raw);
+    if (parsed === undefined) return;
+    updateTemplate(docId, template => ({
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: (template.layoutV2?.blocks || []).map((item, index) => {
+          if (index !== blockIndex) return item;
+          const nextOverrides = { ...item.styleOverrides };
+          if (parsed === null) delete nextOverrides[styleKey];
+          else nextOverrides[styleKey] = parsed;
+          return { ...item, styleOverrides: nextOverrides };
+        }),
+      },
+    }));
   };
 
   // Insert-variable modal (spec: "кнопка поруч з курсивом... модальне вікно... обрати змінні") -
@@ -2432,6 +2451,10 @@ const DocumentsPage = ({ isAdmin }) => {
                   || String(template.logo || '').trim(),
                 );
                 const isLayoutV2OnlyDoc = isLayoutV2Template(template) && !hasLegacyDocContent;
+                // A layoutV2 document always renders in its own single `languages[0]` (spec: never
+                // the page-wide bilingual/column selector) - its paragraph rows show one field,
+                // never a uk/en pair.
+                const layoutV2Lang = (Array.isArray(template.languages) && template.languages[0]) || 'uk';
                 // Needed even while collapsed - the title input right in the row header (below)
                 // always shows/edits the resolved value once a case is selected.
                 const resolvedDoc = buildGeneratedDocument(template, getContextForTemplate(template.id));
@@ -3105,43 +3128,151 @@ const DocumentsPage = ({ isAdmin }) => {
                         </ParagraphControlsRow>
                           </>
                         ) : null}
-                        {/* Paragraph/richParagraph blocks of a layoutV2 template (batch 25 §3):
-                            select a text fragment inside one of these blocks and press Bold to mark
-                            just that fragment 'inlineEmphasis' (configurable in the Style Editor).
-                            Only shown for a layoutV2 template, and only for its paragraph-shaped
-                            blocks - every other block type (letterhead, fieldLine, signatureTable,
-                            ...) has no free-text content to select. */}
+                        {/* Paragraph/richParagraph blocks of a layoutV2 template: the same toolbar
+                            every other paragraph row has (mode cycle, Bold, Italic, Insert-
+                            variable, alignment, formatting, insert/delete) - see
+                            applyLayoutV2BlocksChange and friends above for why this needs no
+                            bespoke editing mechanism of its own. Every other block type
+                            (letterhead, fieldLine, signatureTable, ...) has no free-text content
+                            to edit here at all. */}
                         {isLayoutV2Template(template) ? (
-                          <ParagraphEditorBlock>
-                            <ParagraphControlsRow>
-                              <DocSubtitle style={{ fontWeight: 700 }}>Paragraphs - select text, Bold the fragment</DocSubtitle>
-                            </ParagraphControlsRow>
-                            {template.layoutV2.blocks.map((block, blockIndex) => (
-                              (block?.type === 'paragraph' || block?.type === 'richParagraph') ? (
+                          <>
+                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Paragraphs</DocSubtitle>
+                            {template.layoutV2.blocks.map((block, blockIndex) => {
+                              if (block?.type !== 'paragraph' && block?.type !== 'richParagraph') return null;
+                              const scope = layoutV2Scope(blockIndex);
+                              const mode = getParagraphMode(template.id, scope);
+                              const isTemplateMode = mode === 'template';
+                              const isInputMode = mode === 'input';
+                              const isTextMode = mode === 'text';
+                              const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
+                              const resolvedValue = langKey => fillPlaceholders(rawValue(langKey), getContextForTemplate(template.id), langKey);
+                              const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(resolvedValue(langKey)));
+                              const onChange = langKey => event => {
+                                const nextRaw = isTemplateMode
+                                  ? event.target.value
+                                  : applyResolvedTextEdit(rawValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
+                                handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
+                              };
+                              const onBlur = () => persistTemplate(template.id);
+                              const fieldKind = isTemplateMode ? 'template' : 'input-plain';
+                              return (
                                 // eslint-disable-next-line react/no-array-index-key
-                                <ParagraphFieldColumn key={`${template.id}-lv2-${blockIndex}`} style={{ marginTop: 6 }}>
-                                  <RowLine style={{ gap: 6, marginBottom: 4 }}>
+                                <ParagraphEditorBlock key={`${template.id}-lv2-${blockIndex}`}>
+                                  <ParagraphControlsRow>
                                     <SmallButton
                                       type="button"
-                                      onMouseDown={preventSelectionLoss}
-                                      onTouchStart={preventSelectionLoss}
-                                      onTouchEnd={event => {
-                                        event.preventDefault();
-                                        handleLayoutV2BlockBold(template.id, blockIndex);
-                                      }}
-                                      onClick={() => handleLayoutV2BlockBold(template.id, blockIndex)}
-                                      title="Bold the selected text"
+                                      onClick={() => handleInsertLayoutV2Paragraph(template.id, blockIndex)}
+                                      title="Insert a new paragraph above this one"
                                     >
-                                      <FaBold />
+                                      <FaPlus />
                                     </SmallButton>
-                                  </RowLine>
-                                  <TextModeDisplay ref={registerLayoutV2BlockNode(template.id, blockIndex)}>
-                                    <LayoutV2RunsPreview block={block} />
-                                  </TextModeDisplay>
-                                </ParagraphFieldColumn>
-                              ) : null
-                            ))}
-                          </ParagraphEditorBlock>
+                                    <RowLine style={{ gap: 6 }}>
+                                      <SmallButton
+                                        type="button"
+                                        onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
+                                        title={PARAGRAPH_MODE_TITLE[mode]}
+                                      >
+                                        {PARAGRAPH_MODE_ICON[mode]}
+                                      </SmallButton>
+                                      <SmallButton
+                                        type="button"
+                                        disabled={isInputMode}
+                                        {...formatButtonProps('bold')}
+                                        title="Bold the selected text"
+                                      >
+                                        <FaBold />
+                                      </SmallButton>
+                                      <SmallButton
+                                        type="button"
+                                        disabled={isInputMode}
+                                        {...formatButtonProps('italic')}
+                                        title="Italicize the selected text"
+                                      >
+                                        <FaItalic />
+                                      </SmallButton>
+                                      <SmallButton
+                                        type="button"
+                                        disabled={!isTemplateMode}
+                                        onMouseDown={preventSelectionLoss}
+                                        onClick={openVariablePicker}
+                                        title="Insert a variable"
+                                      >
+                                        <FaCode />
+                                      </SmallButton>
+                                      <AlignCycleButton
+                                        align={getEffectiveLayoutV2BlockAlign(template, block)}
+                                        onCycle={() => handleCycleLayoutV2Align(template.id, blockIndex)}
+                                      />
+                                      <FormatPopoverButton
+                                        open={openFormatKey === formatPopoverKey(template.id, scope)}
+                                        onToggle={() => toggleFormatPopover(template.id, scope)}
+                                        onClose={() => closeFormatPopover(template.id)}
+                                        buttonTitle="Paragraph formatting - font size (pt); empty = inherit the template style"
+                                        fields={[
+                                          {
+                                            key: 'fontSizePt',
+                                            label: 'Font size (pt)',
+                                            value: block.styleOverrides?.fontSizePt !== undefined ? String(block.styleOverrides.fontSizePt) : '',
+                                            placeholder: '',
+                                            onApply: raw => setLayoutV2StyleOverrideField(template.id, blockIndex, 'fontSizePt', raw),
+                                            onFieldBlur: () => persistTemplate(template.id),
+                                          },
+                                        ]}
+                                      />
+                                      <DangerButton
+                                        type="button"
+                                        onClick={() => handleRemoveLayoutV2Block(template.id, blockIndex)}
+                                        title="Remove this paragraph"
+                                      >
+                                        <FaTrash />
+                                      </DangerButton>
+                                    </RowLine>
+                                  </ParagraphControlsRow>
+                                  <ParagraphFieldColumn>
+                                    {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, layoutV2Lang)) ? (
+                                      <TextModeDisplay
+                                        ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                        onMouseUp={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
+                                        onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
+                                        onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind) : undefined}
+                                        title={isInputMode ? 'Click to edit the wording' : undefined}
+                                      >
+                                        <FormattedRunsPreview text={resolvedValue(layoutV2Lang)} />
+                                      </TextModeDisplay>
+                                    ) : isInputMode ? (
+                                      <RichResolvedTextField
+                                        ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                        initialText={resolvedValue(layoutV2Lang)}
+                                        placeholder="Paragraph"
+                                        onPlainTextChange={nextPlain => onChange(layoutV2Lang)({ target: { value: nextPlain } })}
+                                        onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
+                                        onBlur={onBlur}
+                                      />
+                                    ) : (
+                                      <AutoInlineTextarea
+                                        ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                        value={displayValue(layoutV2Lang)}
+                                        placeholder="Paragraph"
+                                        onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
+                                        onChange={onChange(layoutV2Lang)}
+                                        onBlur={onBlur}
+                                      />
+                                    )}
+                                  </ParagraphFieldColumn>
+                                </ParagraphEditorBlock>
+                              );
+                            })}
+                            <ParagraphControlsRow style={{ justifyContent: 'flex-start' }}>
+                              <SmallButton
+                                type="button"
+                                onClick={() => handleInsertLayoutV2Paragraph(template.id, template.layoutV2.blocks.length)}
+                                title="Append a new paragraph at the end of the document"
+                              >
+                                <FaPlus />
+                              </SmallButton>
+                            </ParagraphControlsRow>
+                          </>
                         ) : null}
                         {/* Task 4: the document exactly as the exported PDF - same generation
                             pipeline, same props - as the last block of the document. */}

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
-  render, screen, fireEvent, waitFor,
+  render, screen, fireEvent, waitFor, within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -143,5 +143,51 @@ describe('spec: layoutV2 paragraph blocks - selection-based Bold (batch 25 §3)'
     await screen.findByText('Звичайний текст.');
 
     expect(screen.queryByText('Paragraphs - select text, Bold the fragment')).not.toBeInTheDocument();
+  });
+
+  // A layoutV2-only document (no legacy beforeTitle/title/paragraphs/logo, e.g.
+  // genetic-affinity-certificate) has no real second renderer to switch to/from - the "Exact
+  // layout" toggle is a fake choice for it and must stay hidden, unlike a document that either
+  // still has real legacy content or is stuck on rendererVersion 1 despite carrying layoutV2
+  // blocks (the recovery case the toggle exists for).
+  it('hides the renderer toggle for a settled layoutV2-only document, but keeps it for recovery', async () => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'settled-doc': {
+              id: 'settled-doc',
+              catalogName: 'Settled layoutV2-only doc',
+              rendererVersion: 2,
+              languages: ['uk'],
+              layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }] },
+            },
+            'stuck-doc': {
+              id: 'stuck-doc',
+              catalogName: 'Stuck on rendererVersion 1',
+              rendererVersion: 1,
+              languages: ['uk'],
+              layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }] },
+            },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const settledRowHead = (await screen.findByDisplayValue('Settled layoutV2-only doc')).closest('div');
+    fireEvent.click(within(settledRowHead).getByTitle(/Document layout settings/));
+    expect(screen.queryByText(/Exact layout/)).not.toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const stuckRowHead = (await screen.findByDisplayValue('Stuck on rendererVersion 1')).closest('div');
+    fireEvent.click(within(stuckRowHead).getByTitle(/Document layout settings/));
+    expect(await screen.findByText(/Exact layout/)).toBeInTheDocument();
   });
 });

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -1,10 +1,9 @@
-// Real-DOM regression test (batch 25 §3): a layoutV2 template previously had no way in the UI to
-// select a text fragment inside one of its `paragraph`/`richParagraph` blocks and bold just that
-// fragment - the Style Editor only edits whole named styles, and the legacy title/beforeTitle/
-// paragraphs editor only ever touches the legacy (non-layoutV2) fields. This drives a genuine
-// browser selection through the new per-block Bold button (mirroring the legacy Text-mode
-// mechanism, batch 17) to prove the wiring end to end, not just the pure toggleLayoutV2ParagraphBold
-// logic already covered in documentsCatalogUtils.test.js.
+// Real-DOM regression test: a layoutV2 template's paragraph/richParagraph blocks get the exact
+// same paragraph-row toolbar every other document already has (mode cycle, Bold, Italic,
+// Insert-variable, alignment, formatting, insert/delete) - not just a lone Bold button on a
+// read-only preview. See documentsCatalogUtils.js's layoutV2ParagraphMarkup/layoutV2ParagraphFromMarkup
+// and the `lv2:<index>` scope getTemplateScopeText/withTemplateScopeText understand, which is what
+// lets this reuse the entire existing paragraph editor instead of a bespoke layoutV2-only one.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
@@ -39,8 +38,7 @@ import { listStorageFolderFileNames } from './config';
 import DocumentsPage from './DocumentsPage';
 
 // Selects `text.slice(start, end)` of a single-text-node DOM element via a genuine browser
-// Selection/Range, the same object getContainerSelectionOffsets (used by both the legacy Text-mode
-// Bold button and this new layoutV2 one) reads from.
+// Selection/Range, the same object getContainerSelectionOffsets reads from.
 const selectTextNodeRange = (container, start, end) => {
   // Testing Library deliberately has no API for creating a browser Selection. Use a TreeWalker
   // for this small browser-API boundary rather than reaching through the rendered element with
@@ -53,6 +51,8 @@ const selectTextNodeRange = (container, start, end) => {
   selection.removeAllRanges();
   selection.addRange(range);
 };
+
+const TEXT_MODE_TITLE = "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.";
 
 beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
@@ -92,13 +92,16 @@ beforeEach(() => {
   listStorageFolderFileNames.mockResolvedValue([]);
 });
 
-describe('spec: layoutV2 paragraph blocks - selection-based Bold (batch 25 §3)', () => {
-  it('bolds only the selected fragment of a layoutV2 paragraph block, converting it to a richParagraph', async () => {
+describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () => {
+  it('bolds only the selected fragment in Text mode (default), converting it to a richParagraph', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const field = await screen.findByText('Hello world else');
     selectTextNodeRange(field, 6, 11); // "world"
+    // Text mode tracks the active field off a mouseup (the last event of a real drag-select), not
+    // a focus event - the read-only display is never focusable itself.
+    fireEvent.mouseUp(field);
 
     fireEvent.click(screen.getByTitle('Bold the selected text'));
 
@@ -123,6 +126,100 @@ describe('spec: layoutV2 paragraph blocks - selection-based Bold (batch 25 §3)'
     expect(await screen.findByText('world', { selector: 'strong' })).toBeInTheDocument();
   });
 
+  it('italicizes the selected fragment via Template mode, mapping to styleOverrides.fontStyle', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const field = await screen.findByText('Hello world else');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = field.closest('.paragraph-editor-block');
+    fireEvent.click(within(block).getByTitle(TEXT_MODE_TITLE));
+    const textarea = await within(block).findByPlaceholderText('Paragraph');
+    fireEvent.focus(textarea);
+    textarea.setSelectionRange(6, 11); // "world"
+
+    fireEvent.click(within(block).getByTitle('Italicize the selected text'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [{
+            type: 'richParagraph',
+            style: 'body',
+            runs: [
+              { text: 'Hello ', style: undefined, styleOverrides: undefined },
+              { text: 'world', style: undefined, styleOverrides: { fontStyle: 'italic' } },
+              { text: ' else', style: undefined, styleOverrides: undefined },
+            ],
+          }],
+        }),
+      }),
+    ));
+  });
+
+  it('inserts a new blank paragraph and removes it again, both via the standard +/trash buttons', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    const field = await screen.findByText('Hello world else');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = field.closest('.paragraph-editor-block');
+
+    fireEvent.click(within(block).getByTitle('Insert a new paragraph above this one'));
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            { type: 'paragraph', style: 'body', text: '' },
+            { type: 'paragraph', style: 'body', text: 'Hello world else' },
+          ],
+        }),
+      }),
+    ));
+
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    // "Hello world else" matches even before the re-render lands (it was already on screen pre-
+    // insert) - wait for the second row's own Delete button to actually exist first, so the block
+    // this test then clicks is the freshly re-rendered one, not a stale reference to the old row.
+    await waitFor(() => expect(screen.getAllByTitle('Remove this paragraph')).toHaveLength(2));
+    const secondField = screen.getByText('Hello world else');
+    // eslint-disable-next-line testing-library/no-node-access
+    const secondBlock = secondField.closest('.paragraph-editor-block');
+    fireEvent.click(within(secondBlock).getByTitle('Remove this paragraph'));
+    expect(confirmSpy).toHaveBeenCalled();
+    await waitFor(() => expect(set).toHaveBeenLastCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [{ type: 'paragraph', style: 'body', text: '' }],
+        }),
+      }),
+    ));
+    confirmSpy.mockRestore();
+  });
+
+  it('cycles alignment onto the block\'s own styleOverrides, never the shared named style', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    const field = await screen.findByText('Hello world else');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = field.closest('.paragraph-editor-block');
+
+    fireEvent.click(within(block).getByLabelText(/Вирівнювання: left/));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [{ type: 'paragraph', style: 'body', text: 'Hello world else', styleOverrides: { align: 'center' } }],
+        }),
+        // The shared named style itself is untouched - only this one block's override changed.
+        styleSheet: expect.objectContaining({ body: { fontFamily: 'Times New Roman', fontSizePt: 10 } }),
+      }),
+    ));
+  });
+
   it('does not show the layoutV2 paragraph section for a legacy (non-layoutV2) template', async () => {
     get.mockImplementation(async path => {
       if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
@@ -142,7 +239,7 @@ describe('spec: layoutV2 paragraph blocks - selection-based Bold (batch 25 §3)'
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
     await screen.findByText('Звичайний текст.');
 
-    expect(screen.queryByText('Paragraphs - select text, Bold the fragment')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Insert a new paragraph above this one')).not.toBeInTheDocument();
   });
 
   // A layoutV2-only document (no legacy beforeTitle/title/paragraphs/logo, e.g.

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1883,12 +1883,20 @@ export const TITLE_SCOPE = 'title';
 export const beforeTitleScope = index => `beforeTitle:${index}`;
 export const paragraphScope = index => `p:${index}`;
 
+// A `lv2:<index>` scope (layoutV2Scope) ignores langKey entirely - a layoutV2 paragraph/
+// richParagraph block is never bilingual (the whole template renders in its own single
+// `languages[0]`), so there is only ever one markup string to read/write, whichever langKey the
+// caller happens to pass.
+const layoutV2ScopeMatch = scope => /^lv2:(\d+)$/.exec(scope);
+
 export const getTemplateScopeText = (template, scope, langKey) => {
   if (scope === TITLE_SCOPE) return template?.title?.[langKey] || '';
   const beforeTitleMatch = /^beforeTitle:(\d+)$/.exec(scope);
   if (beforeTitleMatch) return template?.beforeTitle?.[Number(beforeTitleMatch[1])]?.[langKey] || '';
   const paragraphMatch = /^p:(\d+)$/.exec(scope);
   if (paragraphMatch) return template?.paragraphs?.[Number(paragraphMatch[1])]?.[langKey] || '';
+  const layoutV2Match = layoutV2ScopeMatch(scope);
+  if (layoutV2Match) return layoutV2ParagraphMarkup(template?.layoutV2?.blocks?.[Number(layoutV2Match[1])]);
   return '';
 };
 
@@ -1910,6 +1918,18 @@ export const withTemplateScopeText = (template, scope, langKey, value) => {
     return {
       ...template,
       paragraphs: (template.paragraphs || []).map((paragraph, i) => (i === index ? { ...paragraph, [langKey]: value } : paragraph)),
+    };
+  }
+  const layoutV2Match = layoutV2ScopeMatch(scope);
+  if (layoutV2Match) {
+    const index = Number(layoutV2Match[1]);
+    const blocks = template?.layoutV2?.blocks || [];
+    return {
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: blocks.map((block, i) => (i === index ? layoutV2ParagraphFromMarkup(block, value) : block)),
+      },
     };
   }
   return template;
@@ -2236,11 +2256,14 @@ export const findUnresolvedPlaceholders = layoutV2Doc => {
 // (the same shared markup every case sees, {{tokens}} included) - identical in spirit to Template
 // mode for legacy paragraphs, since a layoutV2 block has no per-case resolved-text editing mode.
 
-// A block's runs as one flat {text, style}[] list regardless of whether it's still a plain
-// `paragraph` (single implicit run, no style override) or already a `richParagraph`.
+// A block's runs as one flat {text, style, styleOverrides}[] list regardless of whether it's
+// still a plain `paragraph` (single implicit run, no style override) or already a `richParagraph`.
+// Bold is the 'inlineEmphasis' named style; italic (added alongside the full toolbar for layoutV2
+// paragraphs) is a plain `styleOverrides.fontStyle` instead of a named style, so it works on any
+// template regardless of whether its styleSheet defines one.
 export const layoutV2ParagraphRuns = block => (block?.type === 'richParagraph'
-  ? (block.runs || []).map(run => ({ text: String(run?.text || ''), style: run?.style }))
-  : [{ text: String(block?.text || ''), style: undefined }]);
+  ? (block.runs || []).map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }))
+  : [{ text: String(block?.text || ''), style: undefined, styleOverrides: undefined }]);
 
 export const layoutV2ParagraphPlainText = block => layoutV2ParagraphRuns(block).map(run => run.text).join('');
 
@@ -2265,7 +2288,7 @@ const splitLayoutV2RunsAtCuts = (runsWithOffsets, cuts) => {
     let offset = run.start;
     [...localCuts, run.end].forEach(cut => {
       result.push({
-        text: run.text.slice(offset - run.start, cut - run.start), style: run.style, start: offset, end: cut,
+        text: run.text.slice(offset - run.start, cut - run.start), style: run.style, styleOverrides: run.styleOverrides, start: offset, end: cut,
       });
       offset = cut;
     });
@@ -2273,20 +2296,27 @@ const splitLayoutV2RunsAtCuts = (runsWithOffsets, cuts) => {
   return result;
 };
 
+// Two runs merge only when both their bold (style) and italic (styleOverrides.fontStyle) state
+// match - either dimension differing keeps them apart, so toggling one never silently merges into
+// a neighbor that still differs in the other.
+const layoutV2RunFormatKey = run => `${run.style || ''}::${run.styleOverrides?.fontStyle || ''}`;
+
 const mergeAdjacentLayoutV2Runs = runs => runs.reduce((merged, run) => {
   if (!run.text) return merged;
   const last = merged[merged.length - 1];
-  if (last && last.style === run.style) last.text += run.text;
-  else merged.push({ text: run.text, style: run.style });
+  if (last && layoutV2RunFormatKey(last) === layoutV2RunFormatKey(run)) last.text += run.text;
+  else merged.push({ text: run.text, style: run.style, styleOverrides: run.styleOverrides });
   return merged;
 }, []);
+
+const isLayoutV2RunPlain = run => !run.style && !run.styleOverrides?.fontStyle;
 
 // MS Word toggle behavior (batch 17), same rule as toggleInlineFormat: if every run inside
 // [plainStart, plainEnd) is already 'inlineEmphasis', the whole selection loses it; otherwise the
 // whole selection gains it. Always returns a `richParagraph` (a plain `paragraph` block has no
 // runs of its own to hold a partial style yet) - collapsed back to a single-run `paragraph` when
-// the result ends up with no bold left anywhere, so an untouched/fully-unbolded block stays in its
-// simpler original shape instead of permanently upgrading.
+// the result ends up with no formatting left anywhere, so an untouched/fully-unformatted block
+// stays in its simpler original shape instead of permanently upgrading.
 export const toggleLayoutV2ParagraphBold = (block, plainStart, plainEnd) => {
   if (!(plainEnd > plainStart)) return block;
   const runs = withLayoutV2RunOffsets(layoutV2ParagraphRuns(block));
@@ -2296,13 +2326,71 @@ export const toggleLayoutV2ParagraphBold = (block, plainStart, plainEnd) => {
   const allBold = selected.length > 0 && selected.every(run => run.style === 'inlineEmphasis');
   const next = split.map(run => (within(run) ? { ...run, style: allBold ? undefined : 'inlineEmphasis' } : run));
   const mergedRuns = mergeAdjacentLayoutV2Runs(next);
-  if (mergedRuns.length <= 1 && !mergedRuns.some(run => run.style)) {
+  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
     return {
       ...block, type: 'paragraph', text: mergedRuns[0]?.text || '', runs: undefined,
     };
   }
   return { ...block, type: 'richParagraph', runs: mergedRuns, text: undefined };
 };
+
+// Same MS Word toggle rule as Bold, just flipping styleOverrides.fontStyle instead of the
+// 'inlineEmphasis' named style - independent of it, so a fragment can be bold, italic, or both.
+export const toggleLayoutV2ParagraphItalic = (block, plainStart, plainEnd) => {
+  if (!(plainEnd > plainStart)) return block;
+  const runs = withLayoutV2RunOffsets(layoutV2ParagraphRuns(block));
+  const split = splitLayoutV2RunsAtCuts(runs, [plainStart, plainEnd]);
+  const within = run => run.start >= plainStart && run.end <= plainEnd && run.end > run.start;
+  const selected = split.filter(within);
+  const allItalic = selected.length > 0 && selected.every(run => run.styleOverrides?.fontStyle === 'italic');
+  const next = split.map(run => (within(run)
+    ? { ...run, styleOverrides: allItalic ? undefined : { ...run.styleOverrides, fontStyle: 'italic' } }
+    : run));
+  const mergedRuns = mergeAdjacentLayoutV2Runs(next);
+  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
+    return {
+      ...block, type: 'paragraph', text: mergedRuns[0]?.text || '', runs: undefined,
+    };
+  }
+  return { ...block, type: 'richParagraph', runs: mergedRuns, text: undefined };
+};
+
+// --- layoutV2 paragraph full toolbar parity (mode cycle, Italic, Insert-variable) ---------------
+// The legacy paragraph/beforeTitle/title editor's whole toolbar (Template/Input/Text mode cycle,
+// Bold/Italic, Insert-variable) is built on one shared **bold**/*italic* markup string per row
+// (parseFormattedRuns/serializeFormattedRuns) addressed via getTemplateScopeText/
+// withTemplateScopeText. Converting a layoutV2 paragraph/richParagraph block to and from that same
+// markup shape lets a `lv2:<index>` scope (see layoutV2Scope) reuse that entire existing editor
+// unchanged, instead of duplicating a second toolbar/mode system just for layoutV2 blocks.
+export const layoutV2ParagraphMarkup = block => serializeFormattedRuns(layoutV2ParagraphRuns(block).map(run => ({
+  text: run.text,
+  bold: run.style === 'inlineEmphasis',
+  italic: run.styleOverrides?.fontStyle === 'italic',
+})));
+
+export const layoutV2ParagraphFromMarkup = (existingBlock, markup) => {
+  const runs = parseFormattedRuns(markup).map(run => ({
+    text: run.text,
+    style: run.bold ? 'inlineEmphasis' : undefined,
+    styleOverrides: run.italic ? { fontStyle: 'italic' } : undefined,
+  }));
+  if (runs.length <= 1 && runs.every(isLayoutV2RunPlain)) {
+    return {
+      ...existingBlock, type: 'paragraph', text: runs[0]?.text || '', runs: undefined,
+    };
+  }
+  return { ...existingBlock, type: 'richParagraph', runs, text: undefined };
+};
+
+// The scope key a layoutV2 paragraph/richParagraph block edits under (mirrors beforeTitleScope/
+// paragraphScope) - resolved by getTemplateScopeText/withTemplateScopeText below.
+export const layoutV2Scope = index => `lv2:${index}`;
+
+// The effective alignment a layoutV2 block renders with - unlike a legacy paragraph's own `style`
+// object, a layoutV2 block's `style` names a *shared* template style (resolveLayoutV2Style), so an
+// alignment override belongs on the block's own `styleOverrides` instead, never on the shared
+// named style every other block using it would also pick up.
+export const getEffectiveLayoutV2BlockAlign = (template, block) => resolveLayoutV2Style(template, block?.style, block?.styleOverrides).align || 'left';
 
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
 // with every placeholder already substituted from the case context. Logo/logo-long paragraphs are

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -99,7 +99,12 @@ import {
   toggleRawInlineMarker,
   layoutV2ParagraphRuns,
   layoutV2ParagraphPlainText,
+  layoutV2ParagraphMarkup,
+  layoutV2ParagraphFromMarkup,
+  layoutV2Scope,
+  getEffectiveLayoutV2BlockAlign,
   toggleLayoutV2ParagraphBold,
+  toggleLayoutV2ParagraphItalic,
   upsertRecentCaseId,
   upsertRecentId,
   validateBirthRegistrationCase,
@@ -1769,6 +1774,83 @@ describe('spec: layoutV2 paragraph/richParagraph selection-based bold (batch 25 
   it('is a no-op for a collapsed (empty) selection', () => {
     const block = { type: 'paragraph', text: 'Hello world' };
     expect(toggleLayoutV2ParagraphBold(block, 5, 5)).toBe(block);
+  });
+});
+
+describe('spec: layoutV2 paragraph full toolbar parity (Italic, markup round-trip, scope dispatch)', () => {
+  it('italicizes a plain-text range independently of bold, converting to a `richParagraph`', () => {
+    const block = { type: 'paragraph', style: 'body', text: 'Hello world else' };
+    const next = toggleLayoutV2ParagraphItalic(block, 6, 11); // "world"
+    expect(next.type).toBe('richParagraph');
+    expect(next.style).toBe('body');
+    expect(next.runs).toEqual([
+      { text: 'Hello ', style: undefined, styleOverrides: undefined },
+      { text: 'world', style: undefined, styleOverrides: { fontStyle: 'italic' } },
+      { text: ' else', style: undefined, styleOverrides: undefined },
+    ]);
+  });
+
+  it('bold and italic combine independently on the same fragment', () => {
+    const block = { type: 'paragraph', style: 'body', text: 'Hello world else' };
+    const bolded = toggleLayoutV2ParagraphBold(block, 6, 11);
+    const both = toggleLayoutV2ParagraphItalic(bolded, 6, 11);
+    const worldRun = both.runs.find(run => run.text === 'world');
+    expect(worldRun.style).toBe('inlineEmphasis');
+    expect(worldRun.styleOverrides).toEqual({ fontStyle: 'italic' });
+  });
+
+  it('pressing italic again removes it and collapses back to a plain `paragraph` when nothing else is formatted', () => {
+    const block = { type: 'paragraph', style: 'body', text: 'Hello world else' };
+    const italicized = toggleLayoutV2ParagraphItalic(block, 6, 11);
+    const plain = toggleLayoutV2ParagraphItalic(italicized, 6, 11);
+    expect(plain).toEqual({
+      type: 'paragraph', style: 'body', text: 'Hello world else', runs: undefined,
+    });
+  });
+
+  it('layoutV2ParagraphMarkup/layoutV2ParagraphFromMarkup round-trip through the same **/* markup every legacy paragraph uses', () => {
+    const block = {
+      type: 'richParagraph',
+      style: 'body',
+      runs: [
+        { text: 'Hello ', style: undefined },
+        { text: 'world', style: 'inlineEmphasis', styleOverrides: { fontStyle: 'italic' } },
+        { text: ' else', style: undefined },
+      ],
+    };
+    const markup = layoutV2ParagraphMarkup(block);
+    expect(markup).toBe('Hello ***world*** else');
+    const roundTripped = layoutV2ParagraphFromMarkup(block, markup);
+    expect(roundTripped.type).toBe('richParagraph');
+    expect(roundTripped.style).toBe('body'); // the block's own named style survives the round-trip
+    expect(roundTripped.runs).toEqual(block.runs);
+  });
+
+  it('layoutV2ParagraphFromMarkup collapses plain (no **/*) markup back to a simple `paragraph`', () => {
+    const existing = { type: 'richParagraph', style: 'body', runs: [{ text: 'x', style: 'inlineEmphasis' }] };
+    const next = layoutV2ParagraphFromMarkup(existing, 'Hello world');
+    expect(next).toEqual({ type: 'paragraph', style: 'body', text: 'Hello world', runs: undefined });
+  });
+
+  it('getTemplateScopeText/withTemplateScopeText dispatch a `lv2:<index>` scope to the block\'s markup, ignoring langKey', () => {
+    const template = {
+      layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }, { type: 'paragraph', style: 'title', text: 'World' }] },
+    };
+    const scope = layoutV2Scope(1);
+    expect(getTemplateScopeText(template, scope, 'uk')).toBe('World');
+    expect(getTemplateScopeText(template, scope, 'en')).toBe('World');
+    const next = withTemplateScopeText(template, scope, 'uk', '**World**');
+    expect(next.layoutV2.blocks[1]).toEqual({
+      type: 'richParagraph', style: 'title', text: undefined, runs: [{ text: 'World', style: 'inlineEmphasis', styleOverrides: undefined }],
+    });
+    expect(next.layoutV2.blocks[0]).toBe(template.layoutV2.blocks[0]); // untouched sibling block
+  });
+
+  it('getEffectiveLayoutV2BlockAlign reads the cascade (format/named style/styleOverrides), defaulting to left', () => {
+    const template = { format: {}, styleSheet: { title: { align: 'center' } } };
+    expect(getEffectiveLayoutV2BlockAlign(template, { style: 'title' })).toBe('center');
+    expect(getEffectiveLayoutV2BlockAlign(template, { style: 'title', styleOverrides: { align: 'right' } })).toBe('right');
+    expect(getEffectiveLayoutV2BlockAlign(template, { style: 'body' })).toBe('left');
   });
 });
 


### PR DESCRIPTION
## Summary
- layoutV2 paragraph/richParagraph blocks (e.g. genetic-affinity-certificate) previously had only a lone Bold button on a read-only preview - missing the mode cycle ({}/I/T), Italic, Insert-variable, insert/delete, and alignment/font-size controls every legacy paragraph row already has.
- `documentsCatalogUtils.js`: a layoutV2 block's raw content is now representable as the same `**bold**`/`*italic*` markup string every legacy paragraph uses (`layoutV2ParagraphMarkup`/`layoutV2ParagraphFromMarkup`), addressed via a new `lv2:<index>` scope that `getTemplateScopeText`/`withTemplateScopeText` understand alongside the existing title/beforeTitle/paragraph scopes. Italic is a plain `styleOverrides.fontStyle` (no named style needed), independent of Bold's existing `'inlineEmphasis'` named style.
- `DocumentsPage.jsx`: that scope dispatch lets a layoutV2 paragraph row reuse the entire existing paragraph editor (mode cycle, Bold/Italic, Insert-variable, resolved-text Input mode) unchanged - only insert/delete/alignment/font-size needed their own handlers, since a layoutV2 block's `style` names a shared template style rather than an inline style object.

## Test plan
- [x] `DocumentsPage.layoutV2ParagraphBold.test.js` - Bold (Text mode), Italic (Template mode), insert/remove paragraph, alignment cycle (writing to the block's own `styleOverrides`, never the shared named style), renderer-toggle visibility
- [x] `documentsCatalogUtils.test.js` - new unit tests for `toggleLayoutV2ParagraphItalic`, markup round-trip, `lv2:` scope dispatch, `getEffectiveLayoutV2BlockAlign`
- [x] All 450 Documents-related tests pass
- [x] `eslint` clean on touched files (one pre-existing unrelated warning)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014XPtYnTf2CEUDoSNoxbGxV)_