### PR TITLE
Remove duplicate renderer-toggle test in DocumentsPage layoutV2 paragraph tests

### DIFF
--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -288,49 +288,4 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     expect(await screen.findByText(/Exact layout/)).toBeInTheDocument();
   });
 
-  // A layoutV2-only document (no legacy beforeTitle/title/paragraphs/logo, e.g.
-  // genetic-affinity-certificate) has no real second renderer to switch to/from - the "Exact
-  // layout" toggle is a fake choice for it and must stay hidden, unlike a document that either
-  // still has real legacy content or is stuck on rendererVersion 1 despite carrying layoutV2
-  // blocks (the recovery case the toggle exists for).
-  it('hides the renderer toggle for a settled layoutV2-only document, but keeps it for recovery', async () => {
-    get.mockImplementation(async path => {
-      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
-      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
-      if (path === 'documentsBuilder/templates') {
-        return {
-          exists: () => true,
-          val: () => ({
-            'settled-doc': {
-              id: 'settled-doc',
-              catalogName: 'Settled layoutV2-only doc',
-              rendererVersion: 2,
-              languages: ['uk'],
-              layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }] },
-            },
-            'stuck-doc': {
-              id: 'stuck-doc',
-              catalogName: 'Stuck on rendererVersion 1',
-              rendererVersion: 1,
-              languages: ['uk'],
-              layoutV2: { blocks: [{ type: 'paragraph', style: 'body', text: 'Hello' }] },
-            },
-          }),
-        };
-      }
-      return { exists: () => false, val: () => null };
-    });
-
-    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
-
-    // eslint-disable-next-line testing-library/no-node-access
-    const settledRowHead = (await screen.findByDisplayValue('Settled layoutV2-only doc')).closest('div');
-    fireEvent.click(within(settledRowHead).getByTitle(/Document layout settings/));
-    expect(screen.queryByText(/Exact layout/)).not.toBeInTheDocument();
-
-    // eslint-disable-next-line testing-library/no-node-access
-    const stuckRowHead = (await screen.findByDisplayValue('Stuck on rendererVersion 1')).closest('div');
-    fireEvent.click(within(stuckRowHead).getByTitle(/Document layout settings/));
-    expect(await screen.findByText(/Exact layout/)).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
### Motivation
- Remove a duplicated `it` block that used the same test title inside the same `describe` scope, which created redundant test code and risked confusion in test output.
- Preserve the original regression coverage for settled layoutV2 documents and the renderer-version recovery case while eliminating redundancy.

### Description
- Deleted the duplicated `it('hides the renderer toggle for a settled layoutV2-only document, but keeps it for recovery', ...)` test block from `src/components/DocumentsPage.layoutV2ParagraphBold.test.js` to keep a single authoritative test for this behavior.
- Kept all other layoutV2 paragraph toolbar tests intact and unchanged so the spec coverage remains the same.

### Testing
- Ran the unit test suite for the file with `CI=true npm test -- --runInBand --watchAll=false src/components/DocumentsPage.layoutV2ParagraphBold.test.js`, and all tests passed (`6 passed`).
- Ran linting with `npx eslint src/components/DocumentsPage.layoutV2ParagraphBold.test.js` with no blocking errors reported.
- Ran `git diff --check` to ensure no whitespace or diff errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a661f61f6108326ac0f519b8f9bdfc2)