### PR TITLE
Fix layoutV2 paragraph formatting round trips

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -57,6 +57,7 @@ import {
   isLayoutV2Template,
   isOfficialFormStyle,
   layoutV2Scope,
+  mapResolvedSelectionToRaw,
   legacyClinicLogoStorageFilePath,
   legacyClinicLogoStorageFolder,
   mergeDocumentsCatalog,
@@ -1518,7 +1519,7 @@ const DocumentsPage = ({ isAdmin }) => {
       toast.error('Select some text first.');
       return;
     }
-    const { start, end } = offsets;
+    let { start, end } = offsets;
     const { docId, scope, langKey } = active;
     // Input mode's field never takes Bold/Italic (the buttons are disabled there) - hard-stop in
     // case a stale focus record from it is still the active field.
@@ -1526,6 +1527,9 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const currentRaw = getTemplateScopeText(template, scope, langKey);
+    if (active.kind === 'text-display') {
+      ({ start, end } = mapResolvedSelectionToRaw(currentRaw, getContextForTemplate(docId), langKey, start, end));
+    }
     // Every row (title, paragraph, beforeTitle) writes straight to the shared template - Text
     // mode's field is the rendered display (plain-text offsets via toggleInlineFormat), Template
     // mode's field is the raw markup itself (raw offsets via toggleRawInlineMarker).

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1456,6 +1456,40 @@ export const fillPlaceholders = (text, context, lang = 'uk') => String(text || '
   },
 );
 
+// Text mode renders substituted placeholders, while formatting is stored against the unresolved
+// template text. Map display offsets back through those variable-sized substitutions so a range
+// after (or touching) a placeholder can never put formatting markers inside its {{token}}.
+export const mapResolvedSelectionToRaw = (rawMarkup, context, lang, start, end) => {
+  const rawText = plainTextOf(rawMarkup);
+  let rawCursor = 0;
+  let resolvedCursor = 0;
+  const segments = [];
+  rawText.replace(PLACEHOLDER_PATTERN, (token, rawPath, tokenOffset) => {
+    if (tokenOffset > rawCursor) {
+      const length = tokenOffset - rawCursor;
+      segments.push({ rawStart: rawCursor, rawEnd: tokenOffset, resolvedStart: resolvedCursor, resolvedEnd: resolvedCursor + length, placeholder: false });
+      resolvedCursor += length;
+    }
+    const resolvedToken = fillPlaceholders(token, context, lang);
+    segments.push({ rawStart: tokenOffset, rawEnd: tokenOffset + token.length, resolvedStart: resolvedCursor, resolvedEnd: resolvedCursor + resolvedToken.length, placeholder: true });
+    rawCursor = tokenOffset + token.length;
+    resolvedCursor += resolvedToken.length;
+    return token;
+  });
+  if (rawCursor < rawText.length) {
+    segments.push({ rawStart: rawCursor, rawEnd: rawText.length, resolvedStart: resolvedCursor, resolvedEnd: resolvedCursor + rawText.length - rawCursor, placeholder: false });
+  }
+  const mapOffset = (offset, isEnd) => {
+    const segment = segments.find(item => offset >= item.resolvedStart && offset <= item.resolvedEnd);
+    if (!segment) return rawText.length;
+    if (!segment.placeholder) return segment.rawStart + Math.min(offset - segment.resolvedStart, segment.rawEnd - segment.rawStart);
+    if (offset === segment.resolvedStart) return segment.rawStart;
+    if (offset === segment.resolvedEnd) return segment.rawEnd;
+    return isEnd ? segment.rawEnd : segment.rawStart;
+  };
+  return { start: mapOffset(start, false), end: mapOffset(end, true) };
+};
+
 // Spec-shaped helper kept alongside fillPlaceholders: a minimal resolver that only substitutes
 // values it can find and otherwise leaves the token untouched (used by the template/editor view,
 // where an unresolved {{path}} should stay visible rather than blank out).
@@ -2369,17 +2403,58 @@ export const layoutV2ParagraphMarkup = block => serializeFormattedRuns(layoutV2P
 })));
 
 export const layoutV2ParagraphFromMarkup = (existingBlock, markup) => {
-  const runs = parseFormattedRuns(markup).map(run => ({
-    text: run.text,
-    style: run.bold ? 'inlineEmphasis' : undefined,
-    styleOverrides: run.italic ? { fontStyle: 'italic' } : undefined,
-  }));
-  if (runs.length <= 1 && runs.every(isLayoutV2RunPlain)) {
-    return {
-      ...existingBlock, type: 'paragraph', text: runs[0]?.text || '', runs: undefined,
-    };
+  const previousRuns = layoutV2ParagraphRuns(existingBlock);
+  const previousText = previousRuns.map(run => run.text).join('');
+  const parsedRuns = parseFormattedRuns(markup);
+  const nextText = parsedRuns.map(run => run.text).join('');
+  let prefixLength = 0;
+  while (prefixLength < previousText.length && prefixLength < nextText.length && previousText[prefixLength] === nextText[prefixLength]) prefixLength += 1;
+  let suffixLength = 0;
+  while (suffixLength < previousText.length - prefixLength && suffixLength < nextText.length - prefixLength
+    && previousText[previousText.length - 1 - suffixLength] === nextText[nextText.length - 1 - suffixLength]) suffixLength += 1;
+  const previousAt = offset => {
+    if (offset === null) return null;
+    let cursor = 0;
+    return previousRuns.find(run => {
+      const contains = offset >= cursor && offset < cursor + run.text.length;
+      cursor += run.text.length;
+      return contains;
+    });
+  };
+  const oldOffsetFor = offset => {
+    if (offset < prefixLength) return offset;
+    if (offset >= nextText.length - suffixLength) return previousText.length - (nextText.length - offset);
+    return null;
+  };
+  const runs = [];
+  let nextOffset = 0;
+  parsedRuns.forEach(parsedRun => {
+    let pieceStart = 0;
+    while (pieceStart < parsedRun.text.length) {
+      const oldOffset = oldOffsetFor(nextOffset + pieceStart);
+      const previous = oldOffset === null ? null : previousAt(oldOffset);
+      let pieceEnd = pieceStart + 1;
+      while (pieceEnd < parsedRun.text.length && previousAt(oldOffsetFor(nextOffset + pieceEnd)) === previous) pieceEnd += 1;
+      const styleOverrides = { ...(previous?.styleOverrides || {}) };
+      if (parsedRun.italic) styleOverrides.fontStyle = 'italic';
+      else delete styleOverrides.fontStyle;
+      const nextRun = { ...(previous || {}), text: parsedRun.text.slice(pieceStart, pieceEnd) };
+      if (parsedRun.bold) nextRun.style = 'inlineEmphasis';
+      else if (nextRun.style === 'inlineEmphasis') delete nextRun.style;
+      if (Object.keys(styleOverrides).length) nextRun.styleOverrides = styleOverrides;
+      else delete nextRun.styleOverrides;
+      runs.push(nextRun);
+      pieceStart = pieceEnd;
+    }
+    nextOffset += parsedRun.text.length;
+  });
+  const mergedRuns = mergeAdjacentLayoutV2Runs(runs);
+  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
+    const { runs: ignoredRuns, ...plainBlock } = existingBlock;
+    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
   }
-  return { ...existingBlock, type: 'richParagraph', runs, text: undefined };
+  const { text: ignoredText, ...richBlock } = existingBlock;
+  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
 };
 
 // The scope key a layoutV2 paragraph/richParagraph block edits under (mirrors beforeTitleScope/
@@ -2627,6 +2702,11 @@ export const parseFormattedRuns = text => {
     buffer = '';
   };
   for (let i = 0; i < str.length; i += 1) {
+    if (str[i] === '\\' && (str[i + 1] === '*' || str[i + 1] === '\\')) {
+      buffer += str[i + 1];
+      i += 1;
+      continue;
+    }
     if (str[i] === '*' && str[i + 1] === '*') {
       flush();
       bold = !bold;
@@ -2648,7 +2728,7 @@ export const parseFormattedRuns = text => {
 // consecutive runs (and closes whatever is still open at the end) - the inverse of
 // parseFormattedRuns. Markers are closed in the reverse of the order they were opened (like
 // properly-nested Markdown/HTML) purely for readability of the hand-edited Template-mode source -
-// parseFormattedRuns itself doesn't care about nesting order, since `**`/`_` are independent toggles.
+// parseFormattedRuns itself doesn't care about nesting order, since `**`/`*` are independent toggles.
 export const serializeFormattedRuns = runs => {
   let out = '';
   let bold = false;
@@ -2679,7 +2759,7 @@ export const serializeFormattedRuns = runs => {
       italic = true;
       openOrder.push('italic');
     }
-    out += run.text;
+    out += String(run.text || '').replace(/\\/g, '\\\\').replace(/\*/g, '\\*');
   });
   for (let i = openOrder.length - 1; i >= 0; i -= 1) {
     out += openOrder[i] === 'bold' ? BOLD_MARKER : ITALIC_MARKER;

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -101,6 +101,7 @@ import {
   layoutV2ParagraphPlainText,
   layoutV2ParagraphMarkup,
   layoutV2ParagraphFromMarkup,
+  mapResolvedSelectionToRaw,
   layoutV2Scope,
   getEffectiveLayoutV2BlockAlign,
   toggleLayoutV2ParagraphBold,
@@ -1830,6 +1831,43 @@ describe('spec: layoutV2 paragraph full toolbar parity (Italic, markup round-tri
     const existing = { type: 'richParagraph', style: 'body', runs: [{ text: 'x', style: 'inlineEmphasis' }] };
     const next = layoutV2ParagraphFromMarkup(existing, 'Hello world');
     expect(next).toEqual({ type: 'paragraph', style: 'body', text: 'Hello world', runs: undefined });
+  });
+
+  it('maps Text-mode offsets after a resolved placeholder back to unresolved offsets', () => {
+    const raw = 'Dear {{person.name}}, welcome home';
+    const context = { person: { name: 'Alexandria' } };
+    const resolved = plainTextOf(fillPlaceholders(raw, context, 'en'));
+    const start = resolved.indexOf('welcome');
+    expect(mapResolvedSelectionToRaw(raw, context, 'en', start, start + 7)).toEqual({
+      start: raw.indexOf('welcome'), end: raw.indexOf('welcome') + 7,
+    });
+  });
+
+  it('keeps a selection inside a resolved value outside the raw placeholder token', () => {
+    const raw = 'Dear {{person.name}}!';
+    const context = { person: { name: 'Alexandria' } };
+    expect(mapResolvedSelectionToRaw(raw, context, 'en', 7, 10)).toEqual({
+      start: raw.indexOf('{{'), end: raw.indexOf('}}') + 2,
+    });
+  });
+
+  it('preserves custom run metadata and emits no undefined Firebase values', () => {
+    const block = {
+      type: 'richParagraph',
+      style: 'body',
+      runs: [{ text: 'Colored', style: 'accent', styleOverrides: { color: '#f00', fontSizePt: 14 } }],
+    };
+    const next = layoutV2ParagraphFromMarkup(block, layoutV2ParagraphMarkup(block));
+    expect(next.runs).toEqual(block.runs);
+    expect(JSON.stringify(next)).not.toContain('undefined');
+    expect(Object.values(next.runs[0])).not.toContain(undefined);
+  });
+
+  it('escapes literal asterisks in structured run text losslessly', () => {
+    const block = { type: 'richParagraph', runs: [{ text: 'Footnote * and \\ path', style: 'accent' }] };
+    const markup = layoutV2ParagraphMarkup(block);
+    expect(markup).toBe('Footnote \\* and \\\\ path');
+    expect(layoutV2ParagraphFromMarkup(block, markup).runs).toEqual(block.runs);
   });
 
   it('getTemplateScopeText/withTemplateScopeText dispatch a `lv2:<index>` scope to the block\'s markup, ignoring langKey', () => {


### PR DESCRIPTION
### Motivation
- Text-mode selections after placeholder substitution could apply formatting to the wrong raw characters because resolved values have different lengths than their `{{token}}`s. 
- Converting layoutV2 runs to/from the legacy **/* markup lost or zeroed custom run metadata and wrote `undefined` fields that fail Firebase persistence. 
- Literal markup characters (asterisks, backslashes) in run text were treated as formatting markers and lost on round-trip. 

### Description
- Added `mapResolvedSelectionToRaw(rawMarkup, context, lang, start, end)` to translate display offsets in resolved Text mode back to the original unresolved template offsets. 
- Wired the mapping into the editor flow so `handleApplyInlineFormat` in `DocumentsPage.jsx` translates `text-display` selections before applying `toggleInlineFormat`. 
- Reworked `layoutV2ParagraphFromMarkup` to reconstruct runs by reusing unchanged run metadata where possible, merge adjacent runs via `mergeAdjacentLayoutV2Runs`, and avoid persisting `undefined` properties (emit sparse shapes instead). 
- Updated `parseFormattedRuns` / `serializeFormattedRuns` to escape and unescape literal `*` and `\` so structured run text round-trips losslessly. 
- Added regression tests covering placeholder-offset mapping, token-boundary protection, preservation of custom run metadata and sparse Firebase-safe shapes, and literal marker character handling. 

### Testing
- Ran unit tests: `CI=true npm test -- --runInBand src/components/documentsCatalogUtils.test.js src/components/DocumentsPage.layoutV2ParagraphBold.test.js`, and all tests passed (`309` tests passed). 
- Ran linting: `npm run lint:js -- --quiet`, which completed without errors. 
- Verified diffs and repository state with `git diff --check` and `git status --short` during the change cycle; changes were committed for the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6622cde69c8326b386e00e96fac041)