### PR TITLE
Fix document formatting offset and metadata handling

### DIFF
--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1471,9 +1471,10 @@ export const mapResolvedSelectionToRaw = (rawMarkup, context, lang, start, end) 
       resolvedCursor += length;
     }
     const resolvedToken = fillPlaceholders(token, context, lang);
-    segments.push({ rawStart: tokenOffset, rawEnd: tokenOffset + token.length, resolvedStart: resolvedCursor, resolvedEnd: resolvedCursor + resolvedToken.length, placeholder: true });
+    const resolvedLength = plainTextOf(resolvedToken).length;
+    segments.push({ rawStart: tokenOffset, rawEnd: tokenOffset + token.length, resolvedStart: resolvedCursor, resolvedEnd: resolvedCursor + resolvedLength, placeholder: true });
     rawCursor = tokenOffset + token.length;
-    resolvedCursor += resolvedToken.length;
+    resolvedCursor += resolvedLength;
     return token;
   });
   if (rawCursor < rawText.length) {
@@ -2330,16 +2331,24 @@ const splitLayoutV2RunsAtCuts = (runsWithOffsets, cuts) => {
   return result;
 };
 
-// Two runs merge only when both their bold (style) and italic (styleOverrides.fontStyle) state
-// match - either dimension differing keeps them apart, so toggling one never silently merges into
-// a neighbor that still differs in the other.
-const layoutV2RunFormatKey = run => `${run.style || ''}::${run.styleOverrides?.fontStyle || ''}`;
+// Offsets are temporary editing data; every other field is persisted run metadata and must match
+// before adjacent text can be combined. In particular, runs with the same bold/italic state can
+// still carry different colors, sizes, or other renderer overrides.
+const layoutV2RunMetadata = run => {
+  const metadata = { ...run };
+  delete metadata.text;
+  delete metadata.start;
+  delete metadata.end;
+  return metadata;
+};
+
+const layoutV2RunFormatKey = run => JSON.stringify(layoutV2RunMetadata(run));
 
 const mergeAdjacentLayoutV2Runs = runs => runs.reduce((merged, run) => {
   if (!run.text) return merged;
   const last = merged[merged.length - 1];
   if (last && layoutV2RunFormatKey(last) === layoutV2RunFormatKey(run)) last.text += run.text;
-  else merged.push({ text: run.text, style: run.style, styleOverrides: run.styleOverrides });
+  else merged.push({ text: run.text, ...layoutV2RunMetadata(run) });
   return merged;
 }, []);
 
@@ -2702,11 +2711,6 @@ export const parseFormattedRuns = text => {
     buffer = '';
   };
   for (let i = 0; i < str.length; i += 1) {
-    if (str[i] === '\\' && (str[i + 1] === '*' || str[i + 1] === '\\')) {
-      buffer += str[i + 1];
-      i += 1;
-      continue;
-    }
     if (str[i] === '*' && str[i + 1] === '*') {
       flush();
       bold = !bold;
@@ -2759,7 +2763,7 @@ export const serializeFormattedRuns = runs => {
       italic = true;
       openOrder.push('italic');
     }
-    out += String(run.text || '').replace(/\\/g, '\\\\').replace(/\*/g, '\\*');
+    out += String(run.text || '');
   });
   for (let i = openOrder.length - 1; i >= 0; i -= 1) {
     out += openOrder[i] === 'bold' ? BOLD_MARKER : ITALIC_MARKER;

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -1843,6 +1843,16 @@ describe('spec: layoutV2 paragraph full toolbar parity (Italic, markup round-tri
     });
   });
 
+  it('maps offsets using rendered placeholder text when its value contains formatting markers', () => {
+    const raw = 'Dear {{person.name}}, welcome home';
+    const context = { person: { name: 'A*B' } };
+    const resolved = plainTextOf(fillPlaceholders(raw, context, 'en'));
+    const start = resolved.indexOf('welcome');
+    expect(mapResolvedSelectionToRaw(raw, context, 'en', start, start + 7)).toEqual({
+      start: raw.indexOf('welcome'), end: raw.indexOf('welcome') + 7,
+    });
+  });
+
   it('keeps a selection inside a resolved value outside the raw placeholder token', () => {
     const raw = 'Dear {{person.name}}!';
     const context = { person: { name: 'Alexandria' } };
@@ -1863,11 +1873,23 @@ describe('spec: layoutV2 paragraph full toolbar parity (Italic, markup round-tri
     expect(Object.values(next.runs[0])).not.toContain(undefined);
   });
 
-  it('escapes literal asterisks in structured run text losslessly', () => {
-    const block = { type: 'richParagraph', runs: [{ text: 'Footnote * and \\ path', style: 'accent' }] };
-    const markup = layoutV2ParagraphMarkup(block);
-    expect(markup).toBe('Footnote \\* and \\\\ path');
-    expect(layoutV2ParagraphFromMarkup(block, markup).runs).toEqual(block.runs);
+  it('does not merge adjacent runs whose non-italic overrides differ', () => {
+    const block = {
+      type: 'richParagraph',
+      runs: [
+        { text: 'Red', style: 'accent', styleOverrides: { color: '#f00', fontSizePt: 12 } },
+        { text: 'Blue', style: 'accent', styleOverrides: { color: '#00f', fontSizePt: 14 } },
+      ],
+    };
+    expect(layoutV2ParagraphFromMarkup(block, layoutV2ParagraphMarkup(block)).runs).toEqual(block.runs);
+  });
+
+  it('keeps legacy backslashes literal instead of treating them as escapes', () => {
+    const raw = String.raw`UNC \\server and legacy \*value*`;
+    expect(plainTextOf(raw)).toBe(String.raw`UNC \\server and legacy \value`);
+    expect(parseFormattedRuns(String.raw`\\server`)).toEqual([
+      { text: String.raw`\\server`, bold: false, italic: false },
+    ]);
   });
 
   it('getTemplateScopeText/withTemplateScopeText dispatch a `lv2:<index>` scope to the block\'s markup, ignoring langKey', () => {


### PR DESCRIPTION
### Motivation

- Resolved-selection offsets could be mis-mapped when a substituted placeholder rendered to text containing formatting markers or escape sequences, causing later formatting to attach to the wrong raw characters. 
- Adjacent layout V2 runs that shared bold/italic state could still differ in persisted overrides (color/fontSize/etc) and were being merged incorrectly, losing metadata. 
- Legacy persisted text used literal backslashes and must not be interpreted as new escape syntax to avoid altering stored content.

### Description

- Use the rendered plain-text length (`plainTextOf(resolvedToken).length`) when mapping resolved placeholder segments in `mapResolvedSelectionToRaw` so offsets reflect the browser-visible text. 
- Replace the simple style/fontStyle comparison with a metadata-based key by computing `layoutV2RunMetadata` (drop `text`, `start`, `end`) and comparing `JSON.stringify(...)` to decide whether adjacent runs may merge, and preserve the full metadata on merged runs. 
- Stop treating `\\` and `\*` as escape sequences during parsing/serialization of inline markup so legacy backslashes remain literal. 
- Add regression tests that verify mapping with formatted placeholder values, that runs with differing non-italic overrides do not merge, and that legacy backslash content is preserved.

### Testing

- ✅ `CI=true npm test -- --runInBand src/components/documentsCatalogUtils.test.js` — unit suite passed (tests covering mappings and layoutV2 behaviors). 
- ✅ `CI=true npm test -- --runInBand src/components/documentsCatalogUtils.artProgram.test.js` — art-program-related tests passed. 
- ⚠️ `npx eslint src/components/documentsCatalogUtils.js src/components/documentsCatalogUtils.test.js` — completed with one pre-existing unused-variable warning but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66293c40ec832683656fcac388e48c)