### PR TITLE
Fix Parties read-view text overflow, add fieldLine label controls

### DIFF
--- a/src/components/DocumentsLayoutV2CleanTemplate.test.js
+++ b/src/components/DocumentsLayoutV2CleanTemplate.test.js
@@ -477,6 +477,31 @@ describe('clean layoutV2 template - normalization (buildGeneratedDocument)', () 
     });
   });
 
+  it('fieldLine labelHidden collapses the label column without discarding the underlying label/labelWidthMm', () => {
+    const template = cleanTemplate();
+    const wifeField = template.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.label === 'дружина');
+    wifeField.labelHidden = true;
+    const resolved = buildGeneratedDocument(template, fullContext());
+    const resolvedField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Кікава'));
+    expect(resolvedField.label).toBeUndefined();
+    expect(resolvedField.labelWidthMm).toBe(0);
+    // Turning it back off (the admin's own undo) needs no retyping - the source template's own
+    // label/labelWidthMm were never touched.
+    expect(wifeField.label).toBe('дружина');
+    expect(wifeField.labelWidthMm).toBe(15);
+  });
+
+  it('fieldLine labelOffsetMm passes through as a plain number, defaulting to 0', () => {
+    const template = cleanTemplate();
+    const wifeField = template.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.label === 'дружина');
+    wifeField.labelOffsetMm = 1.5;
+    const resolved = buildGeneratedDocument(template, fullContext());
+    const resolvedField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Кікава'));
+    expect(resolvedField.labelOffsetMm).toBe(1.5);
+    const otherField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Молвінських'));
+    expect(otherField.labelOffsetMm).toBe(0);
+  });
+
   it('resolves signatureTable cell bottomBorderStyle and computes the table width from columnWidthsMm', () => {
     const resolved = buildGeneratedDocument(cleanTemplate(), fullContext());
     const table = resolved.layoutV2.blocks.find(block => block.type === 'signatureTable');

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1609,6 +1609,28 @@ const DocumentsPage = ({ isAdmin }) => {
     }));
   };
 
+  // fieldLine label controls: `labelHidden` toggles the label off without discarding its text/
+  // width (so turning it back on needs no retyping - see the normalizer, documentsCatalogUtils.js),
+  // `labelOffsetMm` nudges it vertically, independent of the shared named style.
+  const handleToggleLayoutV2LabelHidden = (docId, blockIndex) => applyLayoutV2BlocksChange(
+    docId,
+    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, labelHidden: !item.labelHidden } : item)),
+  );
+
+  const setLayoutV2LabelOffset = (docId, blockIndex, raw) => {
+    const parsed = parsePlainNumber(raw);
+    if (parsed === undefined) return;
+    updateTemplate(docId, template => ({
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: (template.layoutV2?.blocks || []).map((item, index) => (
+          index === blockIndex ? { ...item, labelOffsetMm: parsed === null ? undefined : parsed } : item
+        )),
+      },
+    }));
+  };
+
   // Insert-variable modal (spec: "кнопка поруч з курсивом... модальне вікно... обрати змінні") -
   // only meaningful for a template-kind field, since only the raw {{placeholder}} markup is ever
   // resolved against a case (an override is already-resolved final text - see buildGeneratedDocument).
@@ -3276,6 +3298,45 @@ const DocumentsPage = ({ isAdmin }) => {
                                 <FaPlus />
                               </SmallButton>
                             </ParagraphControlsRow>
+                          </>
+                        ) : null}
+                        {/* fieldLine labels (e.g. "дружина", "та чоловік"): a per-block "Show
+                            label" toggle - hides it without discarding its text/width, so turning
+                            it back on needs no retyping - plus a vertical offset (mm, positive =
+                            up) independent of the shared named style, matching every other
+                            layoutV2 block's own styleOverrides convention. */}
+                        {isLayoutV2Template(template) ? (
+                          <>
+                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Field labels</DocSubtitle>
+                            {template.layoutV2.blocks.map((block, blockIndex) => {
+                              if (block?.type !== 'fieldLine') return null;
+                              const labelPreview = block.label || (block.labelRuns || []).map(run => run.text).join('') || '(no label)';
+                              return (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <ParagraphEditorBlock key={`${template.id}-lv2-label-${blockIndex}`}>
+                                  <RowLine style={{ gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                                    <span style={{ fontSize: 12.5, opacity: block.labelHidden ? 0.5 : 1, flex: '1 1 140px' }}>
+                                      {labelPreview}
+                                    </span>
+                                    <CheckLine>
+                                      <input
+                                        type="checkbox"
+                                        checked={!block.labelHidden}
+                                        onChange={() => handleToggleLayoutV2LabelHidden(template.id, blockIndex)}
+                                      />
+                                      Show label
+                                    </CheckLine>
+                                    <PlainNumberField
+                                      label="Vertical offset (mm, + = up)"
+                                      initialValue={block.labelOffsetMm !== undefined ? String(block.labelOffsetMm) : ''}
+                                      placeholder="0"
+                                      onApply={raw => setLayoutV2LabelOffset(template.id, blockIndex, raw)}
+                                      onFieldBlur={() => persistTemplate(template.id)}
+                                    />
+                                  </RowLine>
+                                </ParagraphEditorBlock>
+                              );
+                            })}
                           </>
                         ) : null}
                         {/* Task 4: the document exactly as the exported PDF - same generation

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -220,6 +220,64 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     ));
   });
 
+  it('toggles a fieldLine label off/on and sets its vertical offset, without touching label text/width', async () => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'doc-1': {
+              id: 'doc-1',
+              catalogName: 'Genetic affinity certificate',
+              rendererVersion: 2,
+              languages: ['uk'],
+              layoutV2: {
+                blocks: [{
+                  type: 'fieldLine', style: 'body', label: 'дружина', labelWidthMm: 15, value: 'X', valueStyle: 'formValue',
+                }],
+              },
+            },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const labelPreview = await screen.findByText('дружина');
+    // eslint-disable-next-line testing-library/no-node-access
+    const labelBlock = labelPreview.closest('.paragraph-editor-block');
+    fireEvent.click(within(labelBlock).getByRole('checkbox', { name: 'Show label' }));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [{
+            type: 'fieldLine', style: 'body', label: 'дружина', labelWidthMm: 15, value: 'X', valueStyle: 'formValue', labelHidden: true,
+          }],
+        }),
+      }),
+    ));
+
+    const offsetField = within(labelBlock).getByLabelText('Vertical offset (mm, + = up)');
+    fireEvent.change(offsetField, { target: { value: '2' } });
+    fireEvent.blur(offsetField);
+
+    await waitFor(() => expect(set).toHaveBeenLastCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [expect.objectContaining({ label: 'дружина', labelWidthMm: 15, labelOffsetMm: 2 })],
+        }),
+      }),
+    ));
+  });
+
   it('does not show the layoutV2 paragraph section for a legacy (non-layoutV2) template', async () => {
     get.mockImplementation(async path => {
       if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -614,7 +614,10 @@ const LayoutV2FieldLine = ({ block }) => {
     <View style={{ marginTop: (block.marginTopMm || 0) * MM_TO_PT, marginBottom: (block.marginBottomMm || 0) * MM_TO_PT }}>
       <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
         {block.labelWidthMm ? (
-          <View style={{ width: block.labelWidthMm * MM_TO_PT }}>
+          // marginBottom nudges the label off the row's shared bottom edge (positive = up,
+          // negative = down) without moving the value/line it sits above - a purely cosmetic,
+          // per-block adjustment (spec: "пересувати лейбл по вертикалі").
+          <View style={{ width: block.labelWidthMm * MM_TO_PT, marginBottom: (block.labelOffsetMm || 0) * MM_TO_PT }}>
             {block.labelRuns ? (
               <Text style={layoutV2TextStyle(block.labelStyle)}>
                 {block.labelRuns.map((run, index) => (

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -179,10 +179,15 @@ const ReadGroupBlock = styled.div`
   margin-top: 10px;
 `;
 
+// A grid (not flex-with-space-between) so each column gets a fixed, wrappable share of the row's
+// width regardless of content length - a flex row with no min-width/flex-basis on its children lets
+// a long unbroken path eat all the available width, leaving the value almost none to wrap into
+// (the bug: a long value like "Ministry of Health of Ukraine" wrapping one word per line, spilling
+// well past where the row visually ends).
 const ReadRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  align-items: start;
   gap: 10px;
   padding: 3px 2px;
   font-size: 12px;
@@ -194,12 +199,16 @@ const ReadRow = styled.div`
 `;
 
 const ReadRowLabel = styled.span`
+  min-width: 0;
+  overflow-wrap: anywhere;
   color: var(--km-muted);
   font-family: monospace;
   font-size: 10.5px;
 `;
 
 const ReadRowValue = styled.span`
+  min-width: 0;
+  overflow-wrap: anywhere;
   color: var(--km-text);
   font-weight: 600;
   text-align: right;

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -2128,11 +2128,19 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
         runs: resolveLayoutV2Runs(block.runs, template, context, lang),
       };
     case 'fieldLine':
+      // `labelHidden` toggles the label off without discarding its text/width - so re-enabling it
+      // (the admin's own undo) needs no retyping. Collapsing labelWidthMm to 0 alongside it is what
+      // actually removes the label's reserved column, the same way omitting labelWidthMm entirely
+      // already does for a field that never had one (see the fieldLine spec: "не вимагати повного
+      // об'єкта").
       return {
         ...base,
-        label: block.label !== undefined ? resolveLayoutV2Text(block.label, context, lang) : undefined,
-        labelRuns: block.labelRuns ? resolveLayoutV2Runs(block.labelRuns, template, context, lang) : undefined,
-        labelWidthMm: block.labelWidthMm || 0,
+        label: !block.labelHidden && block.label !== undefined ? resolveLayoutV2Text(block.label, context, lang) : undefined,
+        labelRuns: !block.labelHidden && block.labelRuns ? resolveLayoutV2Runs(block.labelRuns, template, context, lang) : undefined,
+        labelWidthMm: block.labelHidden ? 0 : (block.labelWidthMm || 0),
+        // Positive = nudge the label up off the value's baseline, negative = down - a purely
+        // cosmetic per-block adjustment, independent of the shared named style.
+        labelOffsetMm: block.labelOffsetMm || 0,
         labelStyle: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         value: resolveLayoutV2Text(block.value, context, lang) || '',
         valueStyle: resolveLayoutV2Style(template, block.valueStyle, block.valueStyleOverrides),

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -433,7 +433,11 @@ export const buildDocumentsDocx = async ({
   // of it, keeps the original case; only this TextRun's rendered characters are uppercased.
   // letterSpacingPt maps straight onto `characterSpacing`, which docx (like the reference docx's
   // own `<w:spacing>`) expects in twentieths of a point - the same unit fontSize halves into.
-  const layoutV2TextRun = (text, style) => new TextRun({
+  // `extra` merges in run properties layoutV2TextRun doesn't otherwise expose - currently just
+  // fieldLine's label `position` (see layoutV2FieldLine), OOXML's own raise/lower-the-baseline
+  // property, which shifts text vertically without touching paragraph/cell layout at all - the
+  // DOCX analog of the PDF renderer's marginBottom nudge on the label's View.
+  const layoutV2TextRun = (text, style, extra) => new TextRun({
     text: applyTextTransform(text, style?.textTransform),
     font: style?.fontFamily || 'Times New Roman',
     size: halfPointsV2(style?.fontSizePt) || bodySize,
@@ -441,6 +445,7 @@ export const buildDocumentsDocx = async ({
     italics: style?.fontStyle === 'italic',
     underline: style?.textDecoration === 'underline' ? {} : undefined,
     characterSpacing: style?.letterSpacingPt ? Math.round(style.letterSpacingPt * 20) : undefined,
+    ...extra,
   });
 
   const layoutV2Content = (content, clinicLogos) => {
@@ -547,12 +552,16 @@ export const buildDocumentsDocx = async ({
     const lineSize = eighthsFromPt(block.line?.widthPt);
     const lineColor = (block.line?.color || '#000000').replace('#', '');
     const lineBorder = lineSize ? { style: BorderStyle.SINGLE, size: lineSize, color: lineColor } : noBorder;
+    // Twentieths-of-a-point (OOXML's own unit for `position`) from mm - positive raises the label
+    // off the row, negative lowers it, same sign convention as the PDF renderer's marginBottom.
+    const labelPositionHalfPoints = block.labelOffsetMm ? Math.round((block.labelOffsetMm * MM_TO_TWIP) / 10) : undefined;
+    const labelRunExtra = labelPositionHalfPoints ? { position: String(labelPositionHalfPoints) } : undefined;
     const labelParagraph = new Paragraph({
       alignment: AlignmentType.LEFT,
       spacing: { after: 0, line: lineTwipsFor(block.labelStyle), lineRule: 'auto' },
       children: block.labelRuns
-        ? block.labelRuns.map(run => layoutV2TextRun(run.text, run.style))
-        : [layoutV2TextRun(block.label || '', block.labelStyle)],
+        ? block.labelRuns.map(run => layoutV2TextRun(run.text, run.style, labelRunExtra))
+        : [layoutV2TextRun(block.label || '', block.labelStyle, labelRunExtra)],
     });
     const valueParagraph = new Paragraph({
       alignment: layoutV2Alignment(block.valueStyle?.align),


### PR DESCRIPTION
## Summary
- **Parties page bug**: the read-mode `ReadRow` (path/value list) was a flex row with no `min-width`/flex-basis on its children - a long monospace path could eat nearly all the row's width, leaving the value almost none to wrap into (visible as e.g. "Ministry of Health of Ukraine" wrapping one word per line, spilling past where the row visually ends). Switched to a two-column grid with `min-width: 0` + `overflow-wrap: anywhere` on both columns, so each gets a fixed, wrappable share of the row regardless of content length.
- **fieldLine label controls**: genetic-affinity-certificate's field labels ("дружина", "та чоловік", ...) had no editing UI at all. Added a "Field labels" section per layoutV2 document with:
  - a "Show label" toggle (`labelHidden`) - hides the label without discarding its text/width, so turning it back on needs no retyping
  - a vertical offset field (`labelOffsetMm`, mm, + = up), independent of the shared named style - applied as a margin nudge on the label's own View in the PDF renderer, approximated via OOXML's `position` run property in the DOCX builder (raises/lowers text without touching cell/paragraph layout)

Rebased onto the latest `main`, which had picked up another session's fix for layoutV2 paragraph formatting round-trips (`mapResolvedSelectionToRaw`, run-metadata-preserving `layoutV2ParagraphFromMarkup`) in the meantime - no conflicts, all tests green together.

## Test plan
- [x] `DocumentsLayoutV2CleanTemplate.test.js` - `labelHidden`/`labelOffsetMm` normalization
- [x] `DocumentsPage.layoutV2ParagraphBold.test.js` - toggling the label checkbox and setting the offset field end-to-end
- [x] All 476 Documents/Parties-related tests pass
- [x] `eslint` clean on touched files

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014XPtYnTf2CEUDoSNoxbGxV)_