### PR TITLE
Fix layout V2 label offset and toggle races

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1612,10 +1612,33 @@ const DocumentsPage = ({ isAdmin }) => {
   // fieldLine label controls: `labelHidden` toggles the label off without discarding its text/
   // width (so turning it back on needs no retyping - see the normalizer, documentsCatalogUtils.js),
   // `labelOffsetMm` nudges it vertically, independent of the shared named style.
-  const handleToggleLayoutV2LabelHidden = (docId, blockIndex) => applyLayoutV2BlocksChange(
-    docId,
-    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, labelHidden: !item.labelHidden } : item)),
-  );
+  const handleToggleLayoutV2LabelHidden = async (docId, blockIndex) => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    const block = template?.layoutV2?.blocks?.[blockIndex];
+    if (!block) return;
+    const labelHidden = !block.labelHidden;
+
+    // Apply this immediately so a nearby offset edit is based on the toggled state. Persist only
+    // the leaf value: a pending toggle can then never replace newer edits with a captured template.
+    updateTemplate(docId, current => ({
+      ...current,
+      layoutV2: {
+        ...current.layoutV2,
+        blocks: (current.layoutV2?.blocks || []).map((item, index) => (
+          index === blockIndex ? { ...item, labelHidden } : item
+        )),
+      },
+    }));
+    try {
+      await set(
+        ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}/layoutV2/blocks/${blockIndex}/labelHidden`),
+        labelHidden,
+      );
+    } catch (saveError) {
+      console.error('Unable to update the layoutV2 field label visibility', saveError);
+      toast.error('Could not save the change.');
+    }
+  };
 
   const setLayoutV2LabelOffset = (docId, blockIndex, raw) => {
     const parsed = parsePlainNumber(raw);

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -614,10 +614,12 @@ const LayoutV2FieldLine = ({ block }) => {
     <View style={{ marginTop: (block.marginTopMm || 0) * MM_TO_PT, marginBottom: (block.marginBottomMm || 0) * MM_TO_PT }}>
       <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
         {block.labelWidthMm ? (
-          // marginBottom nudges the label off the row's shared bottom edge (positive = up,
-          // negative = down) without moving the value/line it sits above - a purely cosmetic,
-          // per-block adjustment (spec: "пересувати лейбл по вертикалі").
-          <View style={{ width: block.labelWidthMm * MM_TO_PT, marginBottom: (block.labelOffsetMm || 0) * MM_TO_PT }}>
+          // Translate rather than adding margin: the offset is purely cosmetic and must not make
+          // Yoga resize this row (or move the value/underline and every following block).
+          <View style={{
+            width: block.labelWidthMm * MM_TO_PT,
+            transform: `translateY(${-(block.labelOffsetMm || 0) * MM_TO_PT}pt)`,
+          }}>
             {block.labelRuns ? (
               <Text style={layoutV2TextStyle(block.labelStyle)}>
                 {block.labelRuns.map((run, index) => (


### PR DESCRIPTION
### Motivation

- Ensure per-block label vertical adjustments do not affect the row layout or move the value/underline in generated PDFs. 
- Prevent a pending `labelHidden` persistence from overwriting newer local edits to adjacent layoutV2 fields.

### Description

- Replace the layout-affecting `marginBottom` on the label cell with a flow-neutral vertical translation in `LayoutV2FieldLine` so label offsets no longer change Yoga row height (`src/components/DocumentsPdfDocument.jsx`).
- Make `handleToggleLayoutV2LabelHidden` optimistic: read the current block, compute the new `labelHidden` value, update local state via `updateTemplate` immediately, and then persist only the leaf `layoutV2/blocks/<index>/labelHidden` path to Firebase while handling persistence errors (`src/components/DocumentsPage.jsx`).
- Add error handling and a toast on persistence failure so the optimistic update remains visible while failures are logged.

### Testing

- Ran unit/smoke tests with `CI=true npm test -- --runInBand src/components/DocumentsLayoutV2.test.js src/components/DocumentsRenderers.smoke.test.js`, which passed (2 suites, 37 tests).
- Ran linting with `npx eslint src/components/DocumentsPdfDocument.jsx src/components/DocumentsPage.jsx` and verified no blocking issues.
- Verified there are no `git diff --check` problems after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a662dad251c83268d7294061c676040)