### PR TITLE
Replace fieldLine label controls with clinic logo controls

### DIFF
--- a/src/components/DocumentsLayoutV2CleanTemplate.test.js
+++ b/src/components/DocumentsLayoutV2CleanTemplate.test.js
@@ -477,29 +477,32 @@ describe('clean layoutV2 template - normalization (buildGeneratedDocument)', () 
     });
   });
 
-  it('fieldLine labelHidden collapses the label column without discarding the underlying label/labelWidthMm', () => {
+  it('letterhead image `hidden` collapses without discarding widthMm/heightMm/etc, the column keeps its own widthMm', () => {
     const template = cleanTemplate();
-    const wifeField = template.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.label === 'дружина');
-    wifeField.labelHidden = true;
+    const letterhead = template.layoutV2.blocks.find(block => block.type === 'letterhead');
+    letterhead.columns[0].content.hidden = true;
     const resolved = buildGeneratedDocument(template, fullContext());
-    const resolvedField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Кікава'));
-    expect(resolvedField.label).toBeUndefined();
-    expect(resolvedField.labelWidthMm).toBe(0);
-    // Turning it back off (the admin's own undo) needs no retyping - the source template's own
-    // label/labelWidthMm were never touched.
-    expect(wifeField.label).toBe('дружина');
-    expect(wifeField.labelWidthMm).toBe(15);
+    const resolvedLetterhead = resolved.layoutV2.blocks.find(block => block.type === 'letterhead');
+    expect(resolvedLetterhead.columns[0].content.hidden).toBe(true);
+    // The column's own widthMm is untouched - the clinic contact column beside it never shifts.
+    expect(resolvedLetterhead.columns[0].widthMm).toBe(64.4);
+    expect(resolvedLetterhead.columns[1].widthMm).toBe(110.6);
+    // The source template's own widthMm/heightMm were never touched - turning it back on needs no
+    // re-entering.
+    expect(letterhead.columns[0].content.widthMm).toBe(64.4);
+    expect(letterhead.columns[0].content.heightMm).toBe(17);
   });
 
-  it('fieldLine labelOffsetMm passes through as a plain number, defaulting to 0', () => {
+  it('letterhead image offsetXMm/offsetYMm pass through as plain numbers, defaulting to 0', () => {
     const template = cleanTemplate();
-    const wifeField = template.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.label === 'дружина');
-    wifeField.labelOffsetMm = 1.5;
+    const letterhead = template.layoutV2.blocks.find(block => block.type === 'letterhead');
+    letterhead.columns[0].content.offsetXMm = 3;
+    letterhead.columns[0].content.offsetYMm = -2;
     const resolved = buildGeneratedDocument(template, fullContext());
-    const resolvedField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Кікава'));
-    expect(resolvedField.labelOffsetMm).toBe(1.5);
-    const otherField = resolved.layoutV2.blocks.find(block => block.type === 'fieldLine' && block.value.startsWith('Молвінських'));
-    expect(otherField.labelOffsetMm).toBe(0);
+    const resolvedContent = resolved.layoutV2.blocks.find(block => block.type === 'letterhead').columns[0].content;
+    expect(resolvedContent.offsetXMm).toBe(3);
+    expect(resolvedContent.offsetYMm).toBe(-2);
+    expect(resolvedContent.widthMm).toBe(64.4); // the offset never changes the image's own size
   });
 
   it('resolves signatureTable cell bottomBorderStyle and computes the table width from columnWidthsMm', () => {

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1609,24 +1609,49 @@ const DocumentsPage = ({ isAdmin }) => {
     }));
   };
 
-  // fieldLine label controls: `labelHidden` toggles the label off without discarding its text/
-  // width (so turning it back on needs no retyping - see the normalizer, documentsCatalogUtils.js),
-  // `labelOffsetMm` nudges it vertically, independent of the shared named style.
-  const handleToggleLayoutV2LabelHidden = (docId, blockIndex) => applyLayoutV2BlocksChange(
+  // Clinic logo controls (letterhead image column): `hidden` toggles the logo off without
+  // discarding its geometry (turning it back on needs no re-entering widthMm/heightMm/etc.);
+  // offsetXMm/offsetYMm nudge it within its own column - never the column's own widthMm, so
+  // neighboring columns (the clinic contact block) never shift when the logo moves. Every
+  // letterhead column is addressed as [blockIndex, columnIndex] since a template could have more
+  // than one letterhead (or more than one image column) in principle.
+  const applyLayoutV2ImageContentChange = (docId, blockIndex, columnIndex, updateContent) => applyLayoutV2BlocksChange(
     docId,
-    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, labelHidden: !item.labelHidden } : item)),
+    blocks => blocks.map((item, index) => {
+      if (index !== blockIndex || item.type !== 'letterhead') return item;
+      return {
+        ...item,
+        columns: (item.columns || []).map((column, colIndex) => (
+          colIndex !== columnIndex ? column : { ...column, content: updateContent(column.content) }
+        )),
+      };
+    }),
   );
 
-  const setLayoutV2LabelOffset = (docId, blockIndex, raw) => {
+  const handleToggleLayoutV2LogoHidden = (docId, blockIndex, columnIndex) => applyLayoutV2ImageContentChange(
+    docId, blockIndex, columnIndex, content => ({ ...content, hidden: !content.hidden }),
+  );
+
+  const setLayoutV2LogoOffset = (docId, blockIndex, columnIndex, axisKey, raw) => {
     const parsed = parsePlainNumber(raw);
     if (parsed === undefined) return;
     updateTemplate(docId, template => ({
       ...template,
       layoutV2: {
         ...template.layoutV2,
-        blocks: (template.layoutV2?.blocks || []).map((item, index) => (
-          index === blockIndex ? { ...item, labelOffsetMm: parsed === null ? undefined : parsed } : item
-        )),
+        blocks: (template.layoutV2?.blocks || []).map((item, index) => {
+          if (index !== blockIndex || item.type !== 'letterhead') return item;
+          return {
+            ...item,
+            columns: (item.columns || []).map((column, colIndex) => {
+              if (colIndex !== columnIndex) return column;
+              const nextContent = { ...column.content };
+              if (parsed === null) delete nextContent[axisKey];
+              else nextContent[axisKey] = parsed;
+              return { ...column, content: nextContent };
+            }),
+          };
+        }),
       },
     }));
   };
@@ -3300,42 +3325,51 @@ const DocumentsPage = ({ isAdmin }) => {
                             </ParagraphControlsRow>
                           </>
                         ) : null}
-                        {/* fieldLine labels (e.g. "дружина", "та чоловік"): a per-block "Show
-                            label" toggle - hides it without discarding its text/width, so turning
-                            it back on needs no retyping - plus a vertical offset (mm, positive =
-                            up) independent of the shared named style, matching every other
-                            layoutV2 block's own styleOverrides convention. */}
+                        {/* Clinic logo (letterhead image column): a "Show logo" toggle - hides it
+                            without discarding its widthMm/heightMm/etc, so turning it back on
+                            needs no re-entering - plus horizontal/vertical offsets (mm) that move
+                            the logo image within its own fixed-width column, never the column's
+                            own widthMm. Every column (image or not) keeps its declared width
+                            regardless of the logo's offset, so the clinic contact block beside it
+                            never shifts when the logo moves (spec: "решта тексту ... не стрибала"). */}
                         {isLayoutV2Template(template) ? (
                           <>
-                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Field labels</DocSubtitle>
+                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Clinic logo</DocSubtitle>
                             {template.layoutV2.blocks.map((block, blockIndex) => {
-                              if (block?.type !== 'fieldLine') return null;
-                              const labelPreview = block.label || (block.labelRuns || []).map(run => run.text).join('') || '(no label)';
-                              return (
-                                // eslint-disable-next-line react/no-array-index-key
-                                <ParagraphEditorBlock key={`${template.id}-lv2-label-${blockIndex}`}>
-                                  <RowLine style={{ gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
-                                    <span style={{ fontSize: 12.5, opacity: block.labelHidden ? 0.5 : 1, flex: '1 1 140px' }}>
-                                      {labelPreview}
-                                    </span>
-                                    <CheckLine>
-                                      <input
-                                        type="checkbox"
-                                        checked={!block.labelHidden}
-                                        onChange={() => handleToggleLayoutV2LabelHidden(template.id, blockIndex)}
+                              if (block?.type !== 'letterhead') return null;
+                              return (block.columns || []).map((column, columnIndex) => {
+                                if (column?.content?.type !== 'image') return null;
+                                const { content } = column;
+                                return (
+                                  // eslint-disable-next-line react/no-array-index-key
+                                  <ParagraphEditorBlock key={`${template.id}-lv2-logo-${blockIndex}-${columnIndex}`}>
+                                    <RowLine style={{ gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                                      <CheckLine>
+                                        <input
+                                          type="checkbox"
+                                          checked={!content.hidden}
+                                          onChange={() => handleToggleLayoutV2LogoHidden(template.id, blockIndex, columnIndex)}
+                                        />
+                                        Show logo
+                                      </CheckLine>
+                                      <PlainNumberField
+                                        label="Horizontal offset (mm, + = right)"
+                                        initialValue={content.offsetXMm !== undefined ? String(content.offsetXMm) : ''}
+                                        placeholder="0"
+                                        onApply={raw => setLayoutV2LogoOffset(template.id, blockIndex, columnIndex, 'offsetXMm', raw)}
+                                        onFieldBlur={() => persistTemplate(template.id)}
                                       />
-                                      Show label
-                                    </CheckLine>
-                                    <PlainNumberField
-                                      label="Vertical offset (mm, + = up)"
-                                      initialValue={block.labelOffsetMm !== undefined ? String(block.labelOffsetMm) : ''}
-                                      placeholder="0"
-                                      onApply={raw => setLayoutV2LabelOffset(template.id, blockIndex, raw)}
-                                      onFieldBlur={() => persistTemplate(template.id)}
-                                    />
-                                  </RowLine>
-                                </ParagraphEditorBlock>
-                              );
+                                      <PlainNumberField
+                                        label="Vertical offset (mm, + = down)"
+                                        initialValue={content.offsetYMm !== undefined ? String(content.offsetYMm) : ''}
+                                        placeholder="0"
+                                        onApply={raw => setLayoutV2LogoOffset(template.id, blockIndex, columnIndex, 'offsetYMm', raw)}
+                                        onFieldBlur={() => persistTemplate(template.id)}
+                                      />
+                                    </RowLine>
+                                  </ParagraphEditorBlock>
+                                );
+                              });
                             })}
                           </>
                         ) : null}

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -220,7 +220,7 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     ));
   });
 
-  it('toggles a fieldLine label off/on and sets its vertical offset, without touching label text/width', async () => {
+  it('toggles the clinic logo off/on and sets its horizontal/vertical offset, without touching the column widths', async () => {
     get.mockImplementation(async path => {
       if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
       if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
@@ -235,7 +235,12 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
               languages: ['uk'],
               layoutV2: {
                 blocks: [{
-                  type: 'fieldLine', style: 'body', label: 'дружина', labelWidthMm: 15, value: 'X', valueStyle: 'formValue',
+                  type: 'letterhead',
+                  columnGapMm: 5,
+                  columns: [
+                    { widthMm: 64.4, content: { type: 'image', source: '{{logo}}', widthMm: 64.4, heightMm: 17 } },
+                    { widthMm: 110.6, content: { type: 'stack', lines: ['contact'] } },
+                  ],
                 }],
               },
             },
@@ -248,31 +253,42 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const labelPreview = await screen.findByText('дружина');
+    const logoCheckbox = await screen.findByRole('checkbox', { name: 'Show logo' });
     // eslint-disable-next-line testing-library/no-node-access
-    const labelBlock = labelPreview.closest('.paragraph-editor-block');
-    fireEvent.click(within(labelBlock).getByRole('checkbox', { name: 'Show label' }));
+    const logoBlock = logoCheckbox.closest('.paragraph-editor-block');
+    fireEvent.click(logoCheckbox);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({
         layoutV2: expect.objectContaining({
-          blocks: [{
-            type: 'fieldLine', style: 'body', label: 'дружина', labelWidthMm: 15, value: 'X', valueStyle: 'formValue', labelHidden: true,
-          }],
+          blocks: [expect.objectContaining({
+            columns: [
+              expect.objectContaining({ widthMm: 64.4, content: expect.objectContaining({ widthMm: 64.4, heightMm: 17, hidden: true }) }),
+              expect.objectContaining({ widthMm: 110.6 }),
+            ],
+          })],
         }),
       }),
     ));
 
-    const offsetField = within(labelBlock).getByLabelText('Vertical offset (mm, + = up)');
-    fireEvent.change(offsetField, { target: { value: '2' } });
-    fireEvent.blur(offsetField);
+    const xField = within(logoBlock).getByLabelText('Horizontal offset (mm, + = right)');
+    fireEvent.change(xField, { target: { value: '3' } });
+    fireEvent.blur(xField);
+    const yField = within(logoBlock).getByLabelText('Vertical offset (mm, + = down)');
+    fireEvent.change(yField, { target: { value: '-2' } });
+    fireEvent.blur(yField);
 
     await waitFor(() => expect(set).toHaveBeenLastCalledWith(
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({
         layoutV2: expect.objectContaining({
-          blocks: [expect.objectContaining({ label: 'дружина', labelWidthMm: 15, labelOffsetMm: 2 })],
+          blocks: [expect.objectContaining({
+            columns: [
+              expect.objectContaining({ widthMm: 64.4, content: expect.objectContaining({ offsetXMm: 3, offsetYMm: -2 }) }),
+              expect.objectContaining({ widthMm: 110.6 }),
+            ],
+          })],
         }),
       }),
     ));

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -499,6 +499,11 @@ const layoutV2TextStyle = style => ({
 const LayoutV2Content = ({ content, clinicLogos }) => {
   if (!content) return null;
   if (content.type === 'image') {
+    // `hidden` skips the image but the column's own View (LayoutV2Letterhead) keeps its declared
+    // width regardless, so a sibling column never shifts (spec: "решта тексту ... не стрибала").
+    // offsetXMm/offsetYMm are plain margins on the image itself, inside that same fixed-width
+    // column - moving it never resizes/repositions the column box around it.
+    if (content.hidden) return null;
     const variant = content.logoToken ? getClinicLogo(clinicLogos, content.logoToken) : null;
     const dataUrl = variant?.dataUrl || content.source;
     if (!dataUrl) return null;
@@ -510,6 +515,8 @@ const LayoutV2Content = ({ content, clinicLogos }) => {
           height: (content.heightMm || 0) * MM_TO_PT,
           objectFit: content.fit || 'contain',
           objectPosition: `${content.horizontalAlign || 'left'} ${content.verticalAlign || 'top'}`,
+          marginLeft: (content.offsetXMm || 0) * MM_TO_PT,
+          marginTop: (content.offsetYMm || 0) * MM_TO_PT,
         }}
       />
     );
@@ -614,10 +621,7 @@ const LayoutV2FieldLine = ({ block }) => {
     <View style={{ marginTop: (block.marginTopMm || 0) * MM_TO_PT, marginBottom: (block.marginBottomMm || 0) * MM_TO_PT }}>
       <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
         {block.labelWidthMm ? (
-          // marginBottom nudges the label off the row's shared bottom edge (positive = up,
-          // negative = down) without moving the value/line it sits above - a purely cosmetic,
-          // per-block adjustment (spec: "пересувати лейбл по вертикалі").
-          <View style={{ width: block.labelWidthMm * MM_TO_PT, marginBottom: (block.labelOffsetMm || 0) * MM_TO_PT }}>
+          <View style={{ width: block.labelWidthMm * MM_TO_PT }}>
             {block.labelRuns ? (
               <Text style={layoutV2TextStyle(block.labelStyle)}>
                 {block.labelRuns.map((run, index) => (

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -2067,8 +2067,13 @@ const normalizeLayoutV2Content = (content, template, context, lang) => {
   if (!content) return null;
   if (content.type === 'image') {
     const logoMatch = LOGO_TOKEN_PATTERN.exec(String(content.source || '').trim());
+    // `hidden` toggles the logo off without discarding its widthMm/heightMm/etc (turning it back
+    // on needs no re-entering); offsetXMm/offsetYMm nudge it within its own column - never the
+    // column's own widthMm, so a sibling column (the clinic contact block) never shifts when the
+    // logo moves (spec: "решта тексту ... не стрибала").
     return {
       type: 'image',
+      hidden: Boolean(content.hidden),
       logoToken: logoMatch ? logoMatch[1] : null,
       source: logoMatch ? null : resolveLayoutV2Text(content.source, context, lang),
       widthMm: content.widthMm,
@@ -2076,6 +2081,8 @@ const normalizeLayoutV2Content = (content, template, context, lang) => {
       fit: content.fit,
       horizontalAlign: content.horizontalAlign,
       verticalAlign: content.verticalAlign,
+      offsetXMm: content.offsetXMm || 0,
+      offsetYMm: content.offsetYMm || 0,
     };
   }
   if (content.type === 'stack') {
@@ -2129,19 +2136,11 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
         runs: resolveLayoutV2Runs(block.runs, template, context, lang),
       };
     case 'fieldLine':
-      // `labelHidden` toggles the label off without discarding its text/width - so re-enabling it
-      // (the admin's own undo) needs no retyping. Collapsing labelWidthMm to 0 alongside it is what
-      // actually removes the label's reserved column, the same way omitting labelWidthMm entirely
-      // already does for a field that never had one (see the fieldLine spec: "не вимагати повного
-      // об'єкта").
       return {
         ...base,
-        label: !block.labelHidden && block.label !== undefined ? resolveLayoutV2Text(block.label, context, lang) : undefined,
-        labelRuns: !block.labelHidden && block.labelRuns ? resolveLayoutV2Runs(block.labelRuns, template, context, lang) : undefined,
-        labelWidthMm: block.labelHidden ? 0 : (block.labelWidthMm || 0),
-        // Positive = nudge the label up off the value's baseline, negative = down - a purely
-        // cosmetic per-block adjustment, independent of the shared named style.
-        labelOffsetMm: block.labelOffsetMm || 0,
+        label: block.label !== undefined ? resolveLayoutV2Text(block.label, context, lang) : undefined,
+        labelRuns: block.labelRuns ? resolveLayoutV2Runs(block.labelRuns, template, context, lang) : undefined,
+        labelWidthMm: block.labelWidthMm || 0,
         labelStyle: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         value: resolveLayoutV2Text(block.value, context, lang) || '',
         valueStyle: resolveLayoutV2Style(template, block.valueStyle, block.valueStyleOverrides),

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -433,11 +433,7 @@ export const buildDocumentsDocx = async ({
   // of it, keeps the original case; only this TextRun's rendered characters are uppercased.
   // letterSpacingPt maps straight onto `characterSpacing`, which docx (like the reference docx's
   // own `<w:spacing>`) expects in twentieths of a point - the same unit fontSize halves into.
-  // `extra` merges in run properties layoutV2TextRun doesn't otherwise expose - currently just
-  // fieldLine's label `position` (see layoutV2FieldLine), OOXML's own raise/lower-the-baseline
-  // property, which shifts text vertically without touching paragraph/cell layout at all - the
-  // DOCX analog of the PDF renderer's marginBottom nudge on the label's View.
-  const layoutV2TextRun = (text, style, extra) => new TextRun({
+  const layoutV2TextRun = (text, style) => new TextRun({
     text: applyTextTransform(text, style?.textTransform),
     font: style?.fontFamily || 'Times New Roman',
     size: halfPointsV2(style?.fontSizePt) || bodySize,
@@ -445,12 +441,18 @@ export const buildDocumentsDocx = async ({
     italics: style?.fontStyle === 'italic',
     underline: style?.textDecoration === 'underline' ? {} : undefined,
     characterSpacing: style?.letterSpacingPt ? Math.round(style.letterSpacingPt * 20) : undefined,
-    ...extra,
   });
 
   const layoutV2Content = (content, clinicLogos) => {
     if (!content) return [new Paragraph({ children: [] })];
     if (content.type === 'image') {
+      // `hidden` skips the image but still returns an empty paragraph - the column's own cell
+      // keeps its declared width regardless, so a sibling column never shifts (spec: "решта
+      // тексту ... не стрибала"). offsetXMm moves the image within its cell via a paragraph
+      // indent; offsetYMm approximates a downward nudge via spacing before (DOCX has no negative
+      // spacing, so a negative/"up" offset has no effect here - the PDF preview is authoritative
+      // for that direction).
+      if (content.hidden) return [new Paragraph({ children: [] })];
       const variant = content.logoToken ? getClinicLogo(clinicLogos, content.logoToken) : null;
       const dataUrl = variant?.dataUrl || content.source;
       const decoded = dataUrl ? decodeLogoDataUrl(dataUrl) : null;
@@ -459,7 +461,13 @@ export const buildDocumentsDocx = async ({
         ? variant.height / variant.width
         : ((content.heightMm && content.widthMm) ? content.heightMm / content.widthMm : 0.25);
       const widthPx = Math.round((content.widthMm || 0) * MM_TO_PX);
-      return [new Paragraph({ spacing: { after: 0 }, children: [logoImageRun(decoded, widthPx, ratio)] })];
+      const offsetXTwips = Math.round((content.offsetXMm || 0) * MM_TO_TWIP);
+      const offsetYTwips = Math.max(0, Math.round((content.offsetYMm || 0) * MM_TO_TWIP));
+      return [new Paragraph({
+        spacing: { before: offsetYTwips, after: 0 },
+        indent: offsetXTwips ? { left: offsetXTwips } : undefined,
+        children: [logoImageRun(decoded, widthPx, ratio)],
+      })];
     }
     if (content.type === 'stack') {
       const alignment = content.horizontalAlign === 'right'
@@ -552,16 +560,12 @@ export const buildDocumentsDocx = async ({
     const lineSize = eighthsFromPt(block.line?.widthPt);
     const lineColor = (block.line?.color || '#000000').replace('#', '');
     const lineBorder = lineSize ? { style: BorderStyle.SINGLE, size: lineSize, color: lineColor } : noBorder;
-    // Twentieths-of-a-point (OOXML's own unit for `position`) from mm - positive raises the label
-    // off the row, negative lowers it, same sign convention as the PDF renderer's marginBottom.
-    const labelPositionHalfPoints = block.labelOffsetMm ? Math.round((block.labelOffsetMm * MM_TO_TWIP) / 10) : undefined;
-    const labelRunExtra = labelPositionHalfPoints ? { position: String(labelPositionHalfPoints) } : undefined;
     const labelParagraph = new Paragraph({
       alignment: AlignmentType.LEFT,
       spacing: { after: 0, line: lineTwipsFor(block.labelStyle), lineRule: 'auto' },
       children: block.labelRuns
-        ? block.labelRuns.map(run => layoutV2TextRun(run.text, run.style, labelRunExtra))
-        : [layoutV2TextRun(block.label || '', block.labelStyle, labelRunExtra)],
+        ? block.labelRuns.map(run => layoutV2TextRun(run.text, run.style))
+        : [layoutV2TextRun(block.label || '', block.labelStyle)],
     });
     const valueParagraph = new Paragraph({
       alignment: layoutV2Alignment(block.valueStyle?.align),


### PR DESCRIPTION
## Summary
The previous PR misread "лейбл клініки" as a fieldLine's label text (e.g. "дружина") - it actually meant the clinic **logo** in the letterhead. This PR:
- Removes the "Field labels" section and its `labelHidden`/`labelOffsetMm` plumbing entirely.
- Adds the actually-requested controls on the letterhead's logo image instead:
  - **Show logo** toggle (`hidden`) - hides the logo without discarding its `widthMm`/`heightMm`/etc, so turning it back on needs no re-entering.
  - **Horizontal/vertical offset** fields (`offsetXMm`/`offsetYMm`, mm) that move the logo within its own column via a plain margin (PDF) / paragraph indent+spacing (DOCX best-effort) - never the column's own `widthMm`, so the clinic contact block beside it never shifts when the logo moves (the actual ask: "решта тексту ... не стрибала").

## Test plan
- [x] `DocumentsLayoutV2CleanTemplate.test.js` - `hidden`/`offsetXMm`/`offsetYMm` normalization, confirming column widths stay untouched
- [x] `DocumentsPage.layoutV2ParagraphBold.test.js` - toggling "Show logo" and setting both offsets end-to-end
- [x] All 478 Documents/Parties-related tests pass
- [x] `eslint` clean, no leftover `labelHidden`/`labelOffsetMm` references

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014XPtYnTf2CEUDoSNoxbGxV)_