### PR TITLE
Preserve hidden letterhead logo geometry

### DIFF
--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -499,26 +499,32 @@ const layoutV2TextStyle = style => ({
 const LayoutV2Content = ({ content, clinicLogos }) => {
   if (!content) return null;
   if (content.type === 'image') {
-    // `hidden` skips the image but the column's own View (LayoutV2Letterhead) keeps its declared
-    // width regardless, so a sibling column never shifts (spec: "решта тексту ... не стрибала").
-    // offsetXMm/offsetYMm are plain margins on the image itself, inside that same fixed-width
-    // column - moving it never resizes/repositions the column box around it.
-    if (content.hidden) return null;
     const variant = content.logoToken ? getClinicLogo(clinicLogos, content.logoToken) : null;
     const dataUrl = variant?.dataUrl || content.source;
-    if (!dataUrl) return null;
+    // The wrapper owns the logo's footprint. Hiding (or temporarily lacking) the bitmap must not
+    // shorten the letterhead row, and absolute offsets must not enlarge or move its column.
     return (
-      <Image
-        src={dataUrl}
+      <View
         style={{
           width: (content.widthMm || 0) * MM_TO_PT,
           height: (content.heightMm || 0) * MM_TO_PT,
-          objectFit: content.fit || 'contain',
-          objectPosition: `${content.horizontalAlign || 'left'} ${content.verticalAlign || 'top'}`,
-          marginLeft: (content.offsetXMm || 0) * MM_TO_PT,
-          marginTop: (content.offsetYMm || 0) * MM_TO_PT,
         }}
-      />
+      >
+        {!content.hidden && dataUrl ? (
+          <Image
+            src={dataUrl}
+            style={{
+              position: 'absolute',
+              left: (content.offsetXMm || 0) * MM_TO_PT,
+              top: (content.offsetYMm || 0) * MM_TO_PT,
+              width: (content.widthMm || 0) * MM_TO_PT,
+              height: (content.heightMm || 0) * MM_TO_PT,
+              objectFit: content.fit || 'contain',
+              objectPosition: `${content.horizontalAlign || 'left'} ${content.verticalAlign || 'top'}`,
+            }}
+          />
+        ) : null}
+      </View>
     );
   }
   if (content.type === 'stack') {

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -51,7 +51,8 @@ export const buildDocumentsDocx = async ({
   const docx = await import('docx');
   const {
     AlignmentType, BorderStyle, Document, Footer, Header, ImageRun, Packer, PageNumber,
-    Paragraph, Table, TableCell, TableRow, TextRun, UnderlineType, VerticalAlign, WidthType,
+    HorizontalPositionRelativeFrom, Paragraph, Table, TableCell, TableLayoutType, TableRow,
+    TextRun, TextWrappingType, UnderlineType, VerticalAlign, VerticalPositionRelativeFrom, WidthType,
   } = docx;
 
   // Both column layouts (bilingual UA|EN and single-language newspaper-style, spec §4) share the
@@ -283,10 +284,11 @@ export const buildDocumentsDocx = async ({
     });
   };
 
-  const logoImageRun = (decoded, widthPx, ratio) => new ImageRun({
+  const logoImageRun = (decoded, widthPx, ratio, floating) => new ImageRun({
     data: decoded.bytes,
     type: decoded.type,
     transformation: { width: widthPx, height: Math.round(widthPx * ratio) },
+    floating,
   });
 
   const logoParagraph = (decoded, widthPx, ratio) => new Paragraph({
@@ -446,27 +448,25 @@ export const buildDocumentsDocx = async ({
   const layoutV2Content = (content, clinicLogos) => {
     if (!content) return [new Paragraph({ children: [] })];
     if (content.type === 'image') {
-      // `hidden` skips the image but still returns an empty paragraph - the column's own cell
-      // keeps its declared width regardless, so a sibling column never shifts (spec: "решта
-      // тексту ... не стрибала"). offsetXMm moves the image within its cell via a paragraph
-      // indent; offsetYMm approximates a downward nudge via spacing before (DOCX has no negative
-      // spacing, so a negative/"up" offset has no effect here - the PDF preview is authoritative
-      // for that direction).
-      if (content.hidden) return [new Paragraph({ children: [] })];
       const variant = content.logoToken ? getClinicLogo(clinicLogos, content.logoToken) : null;
       const dataUrl = variant?.dataUrl || content.source;
       const decoded = dataUrl ? decodeLogoDataUrl(dataUrl) : null;
-      if (!decoded) return [new Paragraph({ children: [] })];
       const ratio = variant?.width && variant?.height
         ? variant.height / variant.width
         : ((content.heightMm && content.widthMm) ? content.heightMm / content.widthMm : 0.25);
       const widthPx = Math.round((content.widthMm || 0) * MM_TO_PX);
       const offsetXTwips = Math.round((content.offsetXMm || 0) * MM_TO_TWIP);
-      const offsetYTwips = Math.max(0, Math.round((content.offsetYMm || 0) * MM_TO_TWIP));
+      const offsetYTwips = Math.round((content.offsetYMm || 0) * MM_TO_TWIP);
+      const heightTwips = Math.max(1, Math.round((content.heightMm || 0) * MM_TO_TWIP));
       return [new Paragraph({
-        spacing: { before: offsetYTwips, after: 0 },
-        indent: offsetXTwips ? { left: offsetXTwips } : undefined,
-        children: [logoImageRun(decoded, widthPx, ratio)],
+        // An exact-height anchor paragraph reserves the same row height with the image hidden.
+        // Floating offsets are visual only: unlike an indent, they never add to the cell width.
+        spacing: { after: 0, line: heightTwips, lineRule: 'exact' },
+        children: !content.hidden && decoded ? [logoImageRun(decoded, widthPx, ratio, {
+          horizontalPosition: { relative: HorizontalPositionRelativeFrom.CHARACTER, offset: offsetXTwips },
+          verticalPosition: { relative: VerticalPositionRelativeFrom.PARAGRAPH, offset: offsetYTwips },
+          wrap: { type: TextWrappingType.NONE },
+        })] : [],
       })];
     }
     if (content.type === 'stack') {
@@ -506,6 +506,7 @@ export const buildDocumentsDocx = async ({
     return new Table({
       width: { size: colTwips.reduce((sum, w) => sum + w, 0) + gapTwips * Math.max(0, cells.length - 1), type: WidthType.DXA },
       columnWidths: cells.map((_, index) => colTwips[index] + (index < cells.length - 1 ? gapTwips : 0)),
+      layout: TableLayoutType.FIXED,
       borders: { ...noBorders, insideHorizontal: noBorder, insideVertical: noBorder },
       rows: [new TableRow({ children: cells })],
     });


### PR DESCRIPTION
### Motivation
- Hiding a letterhead logo previously collapsed the row height in the PDF and DOCX outputs and allowed DOCX paragraph indents to widen the logo column, which shifted the neighboring contact column and moved the document divider. 
- The intent is to keep the logo cell’s declared geometry while hiding only the bitmap so the rest of the document remains stationary and offsets remain visual only.

### Description
- Reserve the logo footprint in the PDF by wrapping the image in a fixed-size `View` and absolutely positioning the `Image` inside it so `hidden` or missing bitmaps do not change row height (changes in `src/components/DocumentsPdfDocument.jsx`).
- Reserve the logo height in DOCX by emitting an exact-height anchor paragraph and render visible logos as floating `ImageRun`s so offsets use floating positioning rather than paragraph indenting (changes in `src/components/documentsDocxBuilder.js`).
- Prevent Word auto-fit from widening the logo column by forcing the letterhead table to use `TableLayoutType.FIXED` and import necessary `docx` enums for floating positioning (changes in `src/components/documentsDocxBuilder.js`).

### Testing
- Ran `CI=true npm test -- --runInBand src/components/DocumentsLayoutV2CleanTemplate.test.js`, which passed (19 tests passed), including real PDF rendering and DOCX blob generation tests. 
- Ran `npx eslint src/components/DocumentsPdfDocument.jsx src/components/documentsDocxBuilder.js` and `git diff --check` to verify no lint or diff issues were introduced. 
- Verified the new DOCX floating image usage and table layout do not regress the existing layoutV2 normalization and rendering tests referenced by `DocumentsLayoutV2CleanTemplate.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6642589e548326b1ffef2016568232)