### PR TITLE
Fix scalar and owned-field user collection merges

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -30,6 +30,7 @@ import { normalizePhoneState } from './inputValidations';
 import toast from 'react-hot-toast';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
+import { NEW_USERS_OWNED_FIELDS } from 'utils/mergeUserCollections';
 import {
   acceptOverlayForUserCard,
   applyOverlayToCard,
@@ -454,7 +455,7 @@ const EditProfile = () => {
       };
     }
 
-    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
+    const fieldsForNewUsersOnly = NEW_USERS_OWNED_FIELDS;
     const ppTechnicalInputFields = newUsersMirrorFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
     const isMainProfileField = key => commonFields.includes(key) || !fieldsForNewUsersOnly.includes(key);
@@ -877,7 +878,7 @@ const EditProfile = () => {
   };
 
   const persistCanonicalByRules = async mergedCard => {
-    const fieldsForNewUsersOnly = ['role', 'lastCycle', 'myComment', 'writer', 'cycleStatus', 'stimulationSchedule'];
+    const fieldsForNewUsersOnly = NEW_USERS_OWNED_FIELDS;
     const ppTechnicalInputFields = newUsersMirrorFieldNames;
     const commonFields = ['lastAction', 'lastLogin2', 'getInTouch', 'lastDelivery', 'ownKids', 'cycleStatus', 'stimulationSchedule'];
 

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -22,11 +22,8 @@ describe('newUsers/users merge behaviour', () => {
     expect(mergeUserFieldValue(['a', ''], ['x'])).toEqual(['x', 'a', '']);
   });
 
-  it('mergeUserFieldValue combines a scalar conflict into [newUsers, users] so nothing is lost', () => {
-    expect(mergeUserFieldValue('fresh-from-users', 'stale-from-newUsers')).toEqual([
-      'stale-from-newUsers',
-      'fresh-from-users',
-    ]);
+  it('mergeUserFieldValue preserves scalar schema and users ownership on a conflict', () => {
+    expect(mergeUserFieldValue('fresh-from-users', 'stale-from-newUsers')).toBe('fresh-from-users');
   });
 
   it('mergeUserFieldValue returns the plain value when both sides already agree', () => {
@@ -38,12 +35,16 @@ describe('newUsers/users merge behaviour', () => {
     expect(mergeUserFieldValue('onlyInUsers', undefined)).toBe('onlyInUsers');
   });
 
-  it('mergeUserCollectionData does not drop fields that only exist in newUsers, and keeps users last on conflicts', () => {
+  it('mergeUserCollectionData preserves scalars and honors newUsers-owned fields', () => {
     const merged = mergeUserCollectionData(
       { surname: 'FreshSurname' },
       { role: 'writer', surname: 'StaleSurname' }
     );
-    expect(merged).toEqual({ surname: ['StaleSurname', 'FreshSurname'], role: 'writer' });
+    expect(merged).toEqual({ surname: 'FreshSurname', role: 'writer' });
+    expect(mergeUserCollectionData(
+      { role: 'stale-role', lastCycle: 'stale-cycle' },
+      { role: 'writer', lastCycle: 'fresh-cycle' }
+    )).toEqual({ role: 'writer', lastCycle: 'fresh-cycle' });
   });
 
   it('fetchUsersByIds merges users/newUsers per field instead of overwriting one side wholesale', () => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2759,10 +2759,12 @@ const sanitizeUploadedInfoPhones = uploadedInfo => {
 // щойно записане в users, той самий ключ у "newUsers" — це застарілий дублікат
 // ще з часів подвійного запису, і саме він спричиняв баг з перезатиранням
 // свіжих даних під час мерджу колекцій. Видаляємо його з newUsers, але лише
-// після того, як перечитали users і переконались, що значення там дійсно є —
-// щоб не вийшло, що дані зникли з newUsers, а в users так і не з'явились.
-const pruneMigratedFieldsFromNewUsers = async (userId, fieldNames) => {
-  const candidateFields = [...new Set((fieldNames || []).filter(
+// після того, як перечитали users і переконались, що значення там дійсно є.
+// Для успішного null-запису відсутність ключа в users якраз підтверджує його
+// видалення, тому такий ключ також треба прибрати зі старої копії newUsers.
+const pruneMigratedFieldsFromNewUsers = async (userId, writtenFields) => {
+  const fieldValues = writtenFields || {};
+  const candidateFields = [...new Set(Object.keys(fieldValues).filter(
     field => field && field !== 'userId' && !transientUserDataKeys.includes(field)
   ))];
   if (!candidateFields.length) return;
@@ -2772,7 +2774,7 @@ const pruneMigratedFieldsFromNewUsers = async (userId, fieldNames) => {
       get(ref2(database, `newUsers/${userId}`)),
       get(ref2(database, `users/${userId}`)),
     ]);
-    if (!newUsersSnap.exists() || !usersSnap.exists()) return;
+    if (!newUsersSnap.exists()) return;
 
     const newUsersData = newUsersSnap.val() || {};
     const usersData = usersSnap.val() || {};
@@ -2781,7 +2783,8 @@ const pruneMigratedFieldsFromNewUsers = async (userId, fieldNames) => {
     candidateFields.forEach(field => {
       const presentInNewUsers = Object.prototype.hasOwnProperty.call(newUsersData, field);
       const confirmedInUsers = Object.prototype.hasOwnProperty.call(usersData, field);
-      if (presentInNewUsers && confirmedInUsers) {
+      const confirmedDeletion = fieldValues[field] === null;
+      if (presentInNewUsers && (confirmedInUsers || confirmedDeletion)) {
         updates[`newUsers/${userId}/${field}`] = null;
       }
     });
@@ -2807,7 +2810,7 @@ export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) =>
     }
 
     if (String(userId || '').length > 20) {
-      await pruneMigratedFieldsFromNewUsers(userId, Object.keys(cleanedUploadedInfo));
+      await pruneMigratedFieldsFromNewUsers(userId, cleanedUploadedInfo);
     }
   } catch (error) {
     console.error(

--- a/src/components/config.pruneNewUsersOnMigration.test.js
+++ b/src/components/config.pruneNewUsersOnMigration.test.js
@@ -22,10 +22,11 @@ describe('cleaning up migrated fields from newUsers after a users write', () => 
     expect(updateDataInRealtimeDBBody).toContain("String(userId || '').length > 20");
   });
 
-  it('never deletes a newUsers field unless the same field is confirmed present in users', () => {
+  it('deletes a duplicate after a users write or a successful null deletion', () => {
     expect(pruneFnBody).toContain("Object.prototype.hasOwnProperty.call(newUsersData, field)");
     expect(pruneFnBody).toContain("Object.prototype.hasOwnProperty.call(usersData, field)");
-    expect(pruneFnBody).toContain('if (presentInNewUsers && confirmedInUsers)');
+    expect(pruneFnBody).toContain('const confirmedDeletion = fieldValues[field] === null');
+    expect(pruneFnBody).toContain('if (presentInNewUsers && (confirmedInUsers || confirmedDeletion))');
   });
 
   it('re-reads both collections instead of trusting the in-memory payload', () => {

--- a/src/utils/mergeUserCollections.js
+++ b/src/utils/mergeUserCollections.js
@@ -1,6 +1,17 @@
 const isPlainObject = value =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
+// Ці поля редагуються та зберігаються в newUsers навіть для мігрованих карток.
+// Єдиний список не дає правилам запису й читання колекцій розійтися.
+export const NEW_USERS_OWNED_FIELDS = [
+  'role',
+  'lastCycle',
+  'myComment',
+  'writer',
+  'cycleStatus',
+  'stimulationSchedule',
+];
+
 // Firebase RTDB зберігає "діряві" масиви як об'єкти з числовими ключами,
 // тож той самий список-поле може прийти з однієї колекції масивом,
 // а з іншої — об'єктом. Приводимо обидва варіанти до списку значень.
@@ -37,11 +48,8 @@ const dedupeKeepingLastOccurrence = values => {
 };
 
 // primaryValue/secondaryValue — значення того самого поля з "users" (primary)
-// та "newUsers" (secondary). Коли значення відрізняються, результат — список,
-// де дані з "newUsers" стоять першими (піднімаються вгору), а дані з "users" —
-// завжди останніми, оскільки саме users містить те, що фінально зберіг
-// користувач, і саме останній елемент списку показується звичайному
-// користувачу. Вкладені (не список-подібні) об'єкти зливаються по ключах.
+// та "newUsers" (secondary). Об'єднуємо лише справжні списки; скалярне поле
+// мусить зберігати свою схему й брати значення зі своєї колекції-власника.
 export const mergeUserFieldValue = (primaryValue, secondaryValue) => {
   if (primaryValue === undefined) return secondaryValue;
   if (secondaryValue === undefined) return primaryValue;
@@ -60,9 +68,7 @@ export const mergeUserFieldValue = (primaryValue, secondaryValue) => {
 
   if (primaryValue === secondaryValue) return primaryValue;
 
-  // Скалярні значення, що справді відрізняються: нічого не втрачаємо —
-  // newUsers-значення йде першим, users-значення лишається останнім.
-  return [secondaryValue, primaryValue];
+  return primaryValue;
 };
 
 // Зливає дані картки з "users" (primaryData) та "newUsers" (secondaryData) по кожному
@@ -73,7 +79,11 @@ export const mergeUserCollectionData = (primaryData = {}, secondaryData = {}) =>
   const keys = new Set([...Object.keys(primary), ...Object.keys(secondary)]);
   const merged = {};
   keys.forEach(key => {
-    merged[key] = mergeUserFieldValue(primary[key], secondary[key]);
+    // Для collection-specific полів newUsers є канонічним джерелом. Зокрема,
+    // не дозволяємо старій копії з users скасувати щойно збережене значення.
+    merged[key] = NEW_USERS_OWNED_FIELDS.includes(key) && secondary[key] !== undefined
+      ? secondary[key]
+      : mergeUserFieldValue(primary[key], secondary[key]);
   });
   return merged;
 };


### PR DESCRIPTION
### Motivation
- Prevent listification of scalar-only fields when `users` and `newUsers` disagree to avoid breaking downstream consumers that expect scalars.
- Ensure fields intentionally owned by `newUsers` (e.g. `role`, `lastCycle`, `myComment`, `writer`) are honored as the canonical source for those fields.
- Allow explicit deletions (successful `null` writes) to remove stale replicas from `newUsers` so user-initiated clears are not unintentionally restored.

### Description
- Added `NEW_USERS_OWNED_FIELDS` to `src/utils/mergeUserCollections.js` and centralized ownership rules. 
- Updated `mergeUserFieldValue` to preserve scalar schema (return the `users`/primary scalar) and continue unioning/deduplicating only genuine list-like fields.
- Updated `mergeUserCollectionData` to prefer `newUsers` values for fields listed in `NEW_USERS_OWNED_FIELDS` when present, otherwise defer to `mergeUserFieldValue`.
- Replaced inline `newUsers`-owned field lists in `src/components/EditProfile.jsx` with the shared `NEW_USERS_OWNED_FIELDS` constant.
- Changed `pruneMigratedFieldsFromNewUsers` in `src/components/config.js` to accept the actual write payload, derive candidate fields from that payload, treat `fieldValues[field] === null` as a confirmed deletion, and prune stale `newUsers` copies when appropriate.
- Updated regression tests in `src/components/config.fetchUsersByIds.test.js` and `src/components/config.pruneNewUsersOnMigration.test.js` to reflect scalar-preservation, collection ownership, and deletion cleanup behavior.

### Testing
- Ran unit tests: `CI=true npm test -- --runInBand src/components/config.fetchUsersByIds.test.js src/components/config.pruneNewUsersOnMigration.test.js`, result: 2 test suites, 20 tests passed. 
- Ran lint: `npm run lint:js -- --quiet` with no reported issues.
- Verified updated tests exercise scalar conflict handling, `newUsers` ownership, and prune-on-null logic and they passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66767e61788326ae7bf039d04c9933)