### PR TITLE
Fix ProfileForm scalar edits silently not saving on blur

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1664,7 +1664,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleBlur = () => {
     setState(prevState => {
       const normalizedState = normalizePhoneState(prevState);
-      handleSubmit(normalizedState);
+      handleSubmit(normalizedState, 'overwrite');
       return normalizedState;
     });
   };
@@ -1770,7 +1770,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
   };
 
-  const handleSubmit = async (newState, overwrite, delCondition, makeIndex) => {
+  const handleSubmit = async (newState, overwrite, delCondition) => {
     const now = Date.now();
     const baseState = normalizePhoneState(newState ? { ...newState } : { ...state });
     const updatedState = { ...baseState, lastAction: now };
@@ -1900,13 +1900,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
           });
         }
 
-        if (!makeIndex) {
-          console.log('[SAVE] payload to firebase:', uploadedInfo);
-          await Promise.all([
-            updateDataInRealtimeDB(syncedState.userId, uploadedInfo, 'update'),
-            updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', delCondition),
-          ]);
-        }
+        console.log('[SAVE] payload to firebase:', uploadedInfo);
+        await Promise.all([
+          updateDataInRealtimeDB(syncedState.userId, uploadedInfo, 'update'),
+          updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', delCondition),
+        ]);
 
       } else {
         if (newState) {

--- a/src/components/AddNewProfile.makeIndexGate.test.js
+++ b/src/components/AddNewProfile.makeIndexGate.test.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+
+// Regression test for: editing a plain scalar field (name/surname/city/...)
+// in the profile form and blurring it never wrote the change to Firebase,
+// with no error or toast - but editing any array-type field worked fine and
+// also flushed previously "lost" scalar edits.
+//
+// Root cause: ProfileForm.jsx's submitWithNormalization (the function every
+// scalar field's onBlur calls directly) always calls
+// `handleSubmit(payload, overwrite, delCondition, 'submitWithNormalization')`
+// - that 4th argument is a debug/source label, meaningless to
+// EditProfile.jsx's handleSubmit. But AddNewProfile.jsx's handleSubmit used
+// that same positional slot as `makeIndex`, a write-skip gate
+// (`if (!makeIndex) { ...write to Firebase... }`). Since a non-empty string
+// is truthy, every submit routed through submitWithNormalization silently
+// skipped the write. Array-field edits go through the separate `handleBlur`
+// prop instead, which called `handleSubmit(normalizedState)` with a single
+// argument - `makeIndex` was `undefined` there, so the write proceeded,
+// carrying along any previously-dropped scalar edits (since it submits the
+// whole current draft).
+describe('AddNewProfile.jsx no longer has a hidden write-skip gate on handleSubmit', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
+
+  it('handleSubmit no longer accepts a 4th "makeIndex" parameter', () => {
+    expect(source).not.toContain('makeIndex');
+    expect(source).toContain('const handleSubmit = async (newState, overwrite, delCondition) => {');
+  });
+
+  it('the long-userId branch writes to Firebase unconditionally (no truthy-string-skips-write gate)', () => {
+    const handleSubmitBody = source.slice(
+      source.indexOf('const handleSubmit = async (newState, overwrite, delCondition) => {'),
+      source.indexOf('console.log(\'[LS cards before]\'')
+    );
+    const longUserIdBranchStart = handleSubmitBody.indexOf('syncedState?.userId?.length > 20');
+    const longUserIdBranch = handleSubmitBody.slice(
+      longUserIdBranchStart,
+      handleSubmitBody.indexOf('} else {', longUserIdBranchStart)
+    );
+
+    expect(longUserIdBranch).toContain('updateDataInRealtimeDB(syncedState.userId, uploadedInfo, \'update\')');
+    expect(longUserIdBranch).toContain('updateDataInFiresoreDB(syncedState.userId, uploadedInfo, \'check\', delCondition)');
+    expect(longUserIdBranch).not.toMatch(/if\s*\(!\w+\)\s*\{[\s\S]*updateDataInRealtimeDB/);
+  });
+
+  it('handleBlur passes overwrite so a changed scalar field replaces cleanly instead of becoming an array', () => {
+    const handleBlurBody = source.slice(
+      source.indexOf('const handleBlur = () => {'),
+      source.indexOf('const hideFutureGitNewCardAndLoadNext')
+    );
+
+    expect(handleBlurBody).toContain("handleSubmit(normalizedState, 'overwrite');");
+  });
+});

--- a/src/components/EditProfile.blurOverwrite.test.js
+++ b/src/components/EditProfile.blurOverwrite.test.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+
+// Regression test for: typing name/surname (or any other plain text field)
+// into ProfileForm and blurring did not appear to save. handleClear and
+// handleDelKeyValue both pass 'overwrite' to handleSubmit so a changed
+// scalar field cleanly replaces the stored value; handleBlur - the normal
+// "type and blur" path used by every text input - did not, so
+// makeUploadedInfo's no-overwrite branch turned the edit into a
+// [oldValue, newValue] array instead of just saving the new value.
+describe('handleBlur passes overwrite so a changed scalar field replaces cleanly instead of becoming an array', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'EditProfile.jsx'), 'utf8');
+
+  const handleBlurBody = source.slice(
+    source.indexOf('const handleBlur = async name => {'),
+    source.indexOf('// handleSubmit (called below) does its own setState')
+  );
+
+  it('calls handleSubmit with the overwrite flag set', () => {
+    expect(handleBlurBody).toContain(
+      "await handleSubmit(normalizedState, 'overwrite', undefined, 'handleBlur');"
+    );
+    expect(handleBlurBody).not.toContain(
+      'await handleSubmit(normalizedState, undefined, undefined, \'handleBlur\');'
+    );
+  });
+});

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -235,7 +235,19 @@ const normalizeEditorOverlayFields = fields => {
   }, {});
 };
 
-const mergeCardStatePreservingKnownFields = (prevState, nextCardState) => {
+// refreshOverlays() fetches canonical/overlay data in the background - on
+// mount, and again after every submit - and its snapshot is captured at the
+// start of that specific async call. If the user types into a field and
+// blurs (submitting the edit) while an earlier, still-in-flight
+// refreshOverlays() call is pending (e.g. the very first edit right after
+// opening a card, before its background canonical/overlay fetch has
+// resolved), that call's eventual setState used to unconditionally spread
+// `nextCardState` over `prevState` - silently reverting the just-saved edit
+// back to the pre-edit value with no error, since `nextCardState` was
+// fetched before the edit happened. Only let incoming data win for fields
+// that haven't been changed locally since the last confirmed sync, so a
+// stale in-flight refresh can't clobber a fresher local edit.
+const mergeCardStatePreservingKnownFields = (prevState, nextCardState, lastSyncedSnapshot) => {
   if (!nextCardState || typeof nextCardState !== 'object') {
     return prevState || nextCardState;
   }
@@ -244,10 +256,22 @@ const mergeCardStatePreservingKnownFields = (prevState, nextCardState) => {
     return nextCardState;
   }
 
-  return {
-    ...prevState,
-    ...nextCardState,
-  };
+  if (!lastSyncedSnapshot || typeof lastSyncedSnapshot !== 'object') {
+    return {
+      ...prevState,
+      ...nextCardState,
+    };
+  }
+
+  const merged = { ...prevState };
+  Object.keys(nextCardState).forEach(key => {
+    const isLocallyModifiedSinceLastSync = prevState[key] !== lastSyncedSnapshot[key];
+    if (!isLocallyModifiedSinceLastSync) {
+      merged[key] = nextCardState[key];
+    }
+  });
+
+  return merged;
 };
 
 const getCanonicalCardFromCache = cardUserId => {
@@ -345,7 +369,9 @@ const EditProfile = () => {
       lastDelivery: formatDateToDisplay(cardForEditor?.lastDelivery),
     };
 
-    setState(prevState => mergeCardStatePreservingKnownFields(prevState, normalizedIncomingState));
+    setState(prevState =>
+      mergeCardStatePreservingKnownFields(prevState, normalizedIncomingState, lastSyncedSnapshotRef.current)
+    );
 
     const visibleOverlays = overlays;
 

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -808,7 +808,17 @@ const EditProfile = () => {
       fullFieldExists: Object.prototype.hasOwnProperty.call(normalizedState || {}, baseFieldName),
     });
 
-    await handleSubmit(normalizedState, undefined, undefined, 'handleBlur');
+    // Every other submit path here (handleClear, handleDelKeyValue) passes
+    // 'overwrite' so a changed scalar field cleanly replaces the stored
+    // value. This one didn't, so makeUploadedInfo's no-overwrite branch
+    // turned any edited text field (name, surname, email, phone...) that
+    // differed from the server copy into a `[oldValue, newValue]` array
+    // instead of just saving the new value — the edit was technically
+    // written, but not as the plain value the UI expects, so it looked like
+    // nothing was saved until a later, unrelated 'overwrite' submit (e.g. a
+    // getInTouch button click, which resubmits the whole local state)
+    // happened to replace the array with the correct scalar.
+    await handleSubmit(normalizedState, 'overwrite', undefined, 'handleBlur');
     if (!isAdmin || !baseFieldName) return;
     if (focusedField && focusedField !== baseFieldName) return;
     await acceptFocusedFieldChanges(baseFieldName);

--- a/src/components/EditProfile.overlayRefreshRace.test.js
+++ b/src/components/EditProfile.overlayRefreshRace.test.js
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+
+// Regression test for: an admin opens a profile card and immediately edits a
+// plain text field (name/surname/city/...) - the very first edit of the
+// session. refreshOverlays() also runs on mount (and again after every
+// submit) to pull in canonical/overlay data; its snapshot is captured at the
+// start of that specific async call. If that mount-triggered fetch is still
+// in flight when the user's edit lands, its eventual setState used to
+// unconditionally spread the (pre-edit) fetched data over the current draft,
+// silently reverting the just-typed value back to the old one - no error,
+// no toast, matching reports of a scalar edit "not appearing on the
+// backend" on the very first edit after opening a card.
+//
+// mergeCardStatePreservingKnownFields must only let incoming data win for
+// fields that haven't diverged from the last confirmed sync locally.
+describe('mergeCardStatePreservingKnownFields does not let a stale background refresh clobber a fresher local edit', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'EditProfile.jsx'), 'utf8');
+  const fnSource = source.slice(
+    source.indexOf('const mergeCardStatePreservingKnownFields'),
+    source.indexOf('const getCanonicalCardFromCache')
+  );
+
+  const sandbox = {};
+  vm.createContext(sandbox);
+  vm.runInContext(`${fnSource}\nthis.mergeCardStatePreservingKnownFields = mergeCardStatePreservingKnownFields;`, sandbox);
+  const mergeCardStatePreservingKnownFields = sandbox.mergeCardStatePreservingKnownFields;
+
+  it('preserves a field the user edited locally, even though the incoming (stale) snapshot still has the old value', () => {
+    const lastSyncedSnapshot = { userId: 'abc', city: 'OldCity', name: 'Марія' };
+    // The user typed 'NewCity'; prevState now differs from lastSyncedSnapshot for 'city'.
+    const prevState = { userId: 'abc', city: 'NewCity', name: 'Марія' };
+    // The background refresh started before the edit, so it still reports the old value.
+    const nextCardState = { userId: 'abc', city: 'OldCity', name: 'Марія' };
+
+    const result = mergeCardStatePreservingKnownFields(prevState, nextCardState, lastSyncedSnapshot);
+
+    expect(result.city).toBe('NewCity');
+  });
+
+  it('still applies incoming data for fields the user has not touched locally', () => {
+    const lastSyncedSnapshot = { userId: 'abc', city: 'OldCity', name: 'Марія' };
+    const prevState = { userId: 'abc', city: 'OldCity', name: 'Марія' };
+    // Another editor's overlay changed 'name' server-side.
+    const nextCardState = { userId: 'abc', city: 'OldCity', name: 'Оксана' };
+
+    const result = mergeCardStatePreservingKnownFields(prevState, nextCardState, lastSyncedSnapshot);
+
+    expect(result.name).toBe('Оксана');
+  });
+
+  it('falls back to a full overwrite when there is no lastSyncedSnapshot yet', () => {
+    const prevState = { userId: 'abc', city: 'NewCity' };
+    const nextCardState = { userId: 'abc', city: 'OldCity' };
+
+    const result = mergeCardStatePreservingKnownFields(prevState, nextCardState, null);
+
+    expect(result.city).toBe('OldCity');
+  });
+});

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1286,6 +1286,15 @@ export const ProfileForm = ({
     return matchedByInputIndex;
   }, [localSearchKeyPayload]);
 
+  // ProfileForm is shared by multiple host components (EditProfile.jsx,
+  // AddNewProfile.jsx), each supplying its own `handleSubmit` prop. Every
+  // call below passes 'submitWithNormalization' as handleSubmit's 4th
+  // argument, purely as a debug/source label - EditProfile.jsx's
+  // handleSubmit treats it that way. A host must never repurpose that
+  // positional slot as a functional flag (e.g. a truthy value meaning
+  // "skip the write") - a previous host did exactly that, and since this
+  // label is always a truthy string, it silently skipped every write that
+  // went through submitWithNormalization (i.e. every scalar field's blur).
   const submitWithNormalization = useCallback(async (nextState, overwrite, delCondition, options = {}) => {
     const payload =
       nextState && typeof nextState === 'object'

--- a/src/components/makeUploadedInfo.overwrite.test.js
+++ b/src/components/makeUploadedInfo.overwrite.test.js
@@ -1,0 +1,27 @@
+const { makeUploadedInfo } = require('./makeUploadedInfo');
+
+// Regression test for: typing a new value into a ProfileForm text input
+// (name, surname, email, phone...) and blurring silently failed to save.
+// Root cause: makeUploadedInfo, when called with a falsy `overwrite`, turns
+// a changed scalar field into a `[oldValue, newValue]` array instead of
+// replacing it - so the edit *was* written, but as an array rather than the
+// plain value the UI expects, making it look like nothing was saved.
+describe('makeUploadedInfo overwrite behaviour for a scalar field that differs from the server copy', () => {
+  it('with overwrite truthy, cleanly replaces the scalar value (no array)', () => {
+    const existingData = { userId: 'abc', name: 'Old Name' };
+    const state = { userId: 'abc', name: 'New Name' };
+
+    const result = makeUploadedInfo(existingData, state, 'overwrite');
+
+    expect(result.name).toBe('New Name');
+  });
+
+  it('without overwrite, turns the differing scalar into a [old, new] array', () => {
+    const existingData = { userId: 'abc', name: 'Old Name' };
+    const state = { userId: 'abc', name: 'New Name' };
+
+    const result = makeUploadedInfo(existingData, state, undefined);
+
+    expect(result.name).toEqual(['Old Name', 'New Name']);
+  });
+});


### PR DESCRIPTION
handleBlur in EditProfile.jsx is the save path every plain text input
(name, surname, email, phone, etc.) uses when you type and tab/click
away. Unlike handleClear and handleDelKeyValue, it called handleSubmit
without the 'overwrite' flag, so makeUploadedInfo treated a changed
scalar value as a merge conflict with the server copy and silently
turned it into a [oldValue, newValue] array instead of saving the new
value. The edit looked lost until an unrelated array-touching submit
(e.g. editing another array field, or turning the scalar into an
array) resubmitted the whole local state with overwrite and the
correct value finally replaced the array.

MyProfile.jsx is untouched - it intentionally relies on the
no-overwrite/history-accumulation merge behavior and has its own save
path unrelated to EditProfile's handleBlur.