### PR TITLE
Fix stale profile refreshes and scope blur overwrites

### DIFF
--- a/src/components/AddNewProfile.blurOverwrite.test.js
+++ b/src/components/AddNewProfile.blurOverwrite.test.js
@@ -1,0 +1,32 @@
+import { makeUploadedInfo } from './makeUploadedInfo';
+
+describe('AddNewProfile field-scoped blur overwrite', () => {
+  it('overwrites only the field that blurred', () => {
+    const existingData = {
+      name: 'Remote name',
+      phone: '111',
+      tags: ['remote'],
+    };
+    const staleDraft = {
+      name: 'Stale local name',
+      phone: '222',
+      tags: ['local'],
+    };
+
+    const uploadedInfo = makeUploadedInfo(existingData, staleDraft, 'tags');
+
+    expect(uploadedInfo.name).toEqual(['Remote name', 'Stale local name']);
+    expect(uploadedInfo.phone).toEqual(['111', '222']);
+    expect(uploadedInfo.tags).toEqual(['local']);
+  });
+
+  it('keeps full overwrite behavior for existing callers', () => {
+    const uploadedInfo = makeUploadedInfo(
+      { name: 'Old name', phone: '111' },
+      { name: 'New name', phone: '222' },
+      'overwrite'
+    );
+
+    expect(uploadedInfo).toMatchObject({ name: 'New name', phone: '222' });
+  });
+});

--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1661,10 +1661,11 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     isMountedRef.current = false;
   }, []);
 
-  const handleBlur = () => {
+  const handleBlur = name => {
+    const baseFieldName = String(name || '').replace(/-\d+$/, '');
     setState(prevState => {
       const normalizedState = normalizePhoneState(prevState);
-      handleSubmit(normalizedState, 'overwrite');
+      handleSubmit(normalizedState, baseFieldName);
       return normalizedState;
     });
   };

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -300,10 +300,18 @@ const EditProfile = () => {
   const [deletedOverlayFields, setDeletedOverlayFields] = useState([]);
   const [focusedField, setFocusedField] = useState('');
   const [isOverlayResolved, setIsOverlayResolved] = useState(isAdminUid(auth.currentUser?.uid));
+  const lastSyncedSnapshotRef = useRef(prepareSyncedSnapshot(state || {}));
+  const syncedSnapshotVersionRef = useRef(0);
+  const overlayRefreshSequenceRef = useRef(0);
 
 
   const refreshOverlays = useCallback(async () => {
     if (!userId) return;
+
+    const refreshSequence = overlayRefreshSequenceRef.current + 1;
+    overlayRefreshSequenceRef.current = refreshSequence;
+    const snapshotVersionAtStart = syncedSnapshotVersionRef.current;
+    const syncedSnapshotAtStart = lastSyncedSnapshotRef.current;
 
     if (!isAdmin && currentUid) {
       setIsOverlayResolved(false);
@@ -340,6 +348,16 @@ const EditProfile = () => {
       return;
     }
 
+    // A save (or a newer refresh) that completed while these reads were in
+    // flight owns the newer baseline. Applying this response against that
+    // mutable baseline could reintroduce values fetched before the save.
+    if (
+      refreshSequence !== overlayRefreshSequenceRef.current ||
+      snapshotVersionAtStart !== syncedSnapshotVersionRef.current
+    ) {
+      return;
+    }
+
     const hasMeaningfulValue = value => {
       if (value === null || value === undefined) return false;
       if (typeof value === 'string') return value.trim() !== '';
@@ -369,9 +387,31 @@ const EditProfile = () => {
       lastDelivery: formatDateToDisplay(cardForEditor?.lastDelivery),
     };
 
-    setState(prevState =>
-      mergeCardStatePreservingKnownFields(prevState, normalizedIncomingState, lastSyncedSnapshotRef.current)
-    );
+    setState(prevState => {
+      if (
+        refreshSequence !== overlayRefreshSequenceRef.current ||
+        snapshotVersionAtStart !== syncedSnapshotVersionRef.current
+      ) {
+        return prevState;
+      }
+
+      const mergedState = mergeCardStatePreservingKnownFields(
+        prevState,
+        normalizedIncomingState,
+        syncedSnapshotAtStart
+      );
+      const advancedSnapshot = { ...syncedSnapshotAtStart };
+
+      Object.keys(normalizedIncomingState).forEach(key => {
+        if (prevState?.[key] === syncedSnapshotAtStart?.[key]) {
+          advancedSnapshot[key] = normalizedIncomingState[key];
+        }
+      });
+
+      lastSyncedSnapshotRef.current = prepareSyncedSnapshot(advancedSnapshot);
+      syncedSnapshotVersionRef.current += 1;
+      return mergedState;
+    });
 
     const visibleOverlays = overlays;
 
@@ -417,7 +457,6 @@ const EditProfile = () => {
 
   const deletingFieldsRef = useRef(new Set());
   const pendingDeletedKeysRef = useRef(new Set());
-  const lastSyncedSnapshotRef = useRef(prepareSyncedSnapshot(state || {}));
   const syncQueueRef = useRef(Promise.resolve());
   const activeSyncCountRef = useRef(0);
   const submitSequenceRef = useRef(0);
@@ -613,6 +652,7 @@ const EditProfile = () => {
       }
 
       lastSyncedSnapshotRef.current = finalSnapshot;
+      syncedSnapshotVersionRef.current += 1;
       deletedKeys.forEach(key => pendingDeletedKeysRef.current.delete(key));
 
       if (submitSeq === submitSequenceRef.current) {
@@ -660,6 +700,8 @@ const EditProfile = () => {
     const cachedCard = getCard(userId) || location.state || null;
     setState(cachedCard);
     lastSyncedSnapshotRef.current = prepareSyncedSnapshot(cachedCard || {});
+    syncedSnapshotVersionRef.current += 1;
+    overlayRefreshSequenceRef.current += 1;
     pendingDeletedKeysRef.current.clear();
     syncQueueRef.current = Promise.resolve();
     activeSyncCountRef.current = 0;
@@ -689,6 +731,7 @@ const EditProfile = () => {
             : { userId };
         setState(formatted);
         lastSyncedSnapshotRef.current = prepareSyncedSnapshot(formatted);
+        syncedSnapshotVersionRef.current += 1;
         updateCachedUser(formatted);
         setDataSource('backend');
       } catch (error) {
@@ -716,6 +759,7 @@ const EditProfile = () => {
       setState(prev => (prev && prev.userId === userId ? { ...prev, myComment } : prev));
       if (lastSyncedSnapshotRef.current) {
         lastSyncedSnapshotRef.current = { ...lastSyncedSnapshotRef.current, myComment };
+        syncedSnapshotVersionRef.current += 1;
       }
     })();
 

--- a/src/components/EditProfile.overlayRefreshRace.test.js
+++ b/src/components/EditProfile.overlayRefreshRace.test.js
@@ -50,6 +50,23 @@ describe('mergeCardStatePreservingKnownFields does not let a stale background re
     expect(result.name).toBe('Оксана');
   });
 
+  it('can apply consecutive remote changes when the accepted value advances the baseline', () => {
+    const firstBaseline = { userId: 'abc', name: 'Марія' };
+    const firstResult = mergeCardStatePreservingKnownFields(
+      { userId: 'abc', name: 'Марія' },
+      { userId: 'abc', name: 'Оксана' },
+      firstBaseline
+    );
+
+    const secondResult = mergeCardStatePreservingKnownFields(
+      firstResult,
+      { userId: 'abc', name: 'Ірина' },
+      { ...firstBaseline, name: 'Оксана' }
+    );
+
+    expect(secondResult.name).toBe('Ірина');
+  });
+
   it('falls back to a full overwrite when there is no lastSyncedSnapshot yet', () => {
     const prevState = { userId: 'abc', city: 'NewCity' };
     const nextCardState = { userId: 'abc', city: 'OldCity' };

--- a/src/components/makeUploadedInfo.js
+++ b/src/components/makeUploadedInfo.js
@@ -57,6 +57,7 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
   let uploadedInfo = { ...existingData };
 
   for (const field in state) {
+    const shouldOverwriteField = overwrite === 'overwrite' || overwrite === field;
     if (field.startsWith('device')) {
       continue;
     }
@@ -79,7 +80,7 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
     ) {
       if (Array.isArray(existingData[field])) {
         console.log('ExistingData на сервері є масивом');
-        if (overwrite && !Array.isArray(state[field])) {
+        if (shouldOverwriteField && !Array.isArray(state[field])) {
           console.log('Якщо масив має лише одне значення, зберігаємо його як ключ-значення');
           uploadedInfo[field] = state[field];
         } else if (Array.isArray(state[field])) {
@@ -95,10 +96,10 @@ export const makeUploadedInfo = (existingData, state, overwrite) => {
             updatedField.push(state[field]);
             uploadedInfo[field] = dedupeArrayDeep(updatedField);
           }
-        }else if (overwrite && state[field]===''&& !Array.isArray(existingData[field])){
+      }else if (shouldOverwriteField && state[field]===''&& !Array.isArray(existingData[field])){
         console.log('Якщо це не масиви', state[field], existingData[field]);
         uploadedInfo[field] = '';
-      } else if (overwrite && state[field] !== '' && !Array.isArray(state[field]) && !Array.isArray(existingData[field])){
+      } else if (shouldOverwriteField && state[field] !== '' && !Array.isArray(state[field]) && !Array.isArray(existingData[field])){
         console.log('Якщо ЕxistingData не масив та state не масив і його треба перезаписати', state[field], existingData[field]);
         uploadedInfo[field] = state[field];
       } else if (existingData[field]===''){


### PR DESCRIPTION
### Motivation

- Prevent background overlay refreshes that started before a local save from silently reverting fresher local edits. 
- Ensure a refresh that legitimately advanced untouched fields updates the local synchronization baseline so later remote updates still apply. 
- Scope blur-triggered overwrites to the single field that blurred instead of forcing a full-profile overwrite.

### Description

- Capture an overlay refresh sequence and a synced-snapshot version at the start of `refreshOverlays()` and discard any refresh response whose sequence or baseline version is obsolete. 
- Use the captured baseline snapshot when merging incoming card data via `mergeCardStatePreservingKnownFields()` and advance `lastSyncedSnapshotRef` for fields accepted from a refresh so subsequent remote changes can continue applying. 
- Increment the synced-snapshot version whenever `lastSyncedSnapshotRef` is updated (after saves, initial loads, or applied refreshes). 
- Change `AddNewProfile` `handleBlur` to compute the base field name and pass that field name to `handleSubmit()` instead of the `'overwrite'` sentinel. 
- Extend `makeUploadedInfo` so `overwrite` may be the literal field name (or `'overwrite'`) and only that field is treated as overwrite when a field-scoped blur is requested. 
- Add regression tests: a consecutive-refresh test in `EditProfile.overlayRefreshRace.test.js` and field-scoped blur tests in `AddNewProfile.blurOverwrite.test.js` to cover the new behaviors.

### Testing

- Ran unit tests: `CI=true npm test -- --runInBand src/components/EditProfile.overlayRefreshRace.test.js src/components/AddNewProfile.blurOverwrite.test.js src/components/EditProfile.blurOverwrite.test.js` and all suites passed (3 suites, 7 tests passed). 
- Ran linter: `npx eslint src/components/EditProfile.jsx src/components/AddNewProfile.jsx src/components/makeUploadedInfo.js src/components/EditProfile.overlayRefreshRace.test.js src/components/AddNewProfile.blurOverwrite.test.js` with no blocking errors. 
- Verified diffs and trivial repository checks with `git diff --check` and `git status --short` showing a clean commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a685acaedf48326af5e5f17719d2d1f)