### PR TITLE
Fix rapid-delete race in renderAllFields (AddNewProfile.jsx + EditProfile.jsx)

### DIFF
--- a/src/components/AddNewProfile.deletionRace.test.js
+++ b/src/components/AddNewProfile.deletionRace.test.js
@@ -1,0 +1,152 @@
+import fs from 'fs';
+import path from 'path';
+
+// Regression test for: deleting several fields in quick succession via
+// renderAllFields could resurrect an earlier-deleted field and ship it back
+// to the backend - only the last deletion in a rapid burst would stick.
+// Root cause (two compounding bugs, ported fix from EditProfile.jsx):
+//  1) handleClear/handleDelKeyValue used to call handleSubmit (which does its
+//     own setState + fires an unawaited network write) *from inside* the
+//     setState(prevState => ...) updater callback, and captured the computed
+//     newState via a variable assigned inside that same callback. React only
+//     runs a setState updater synchronously via an internal, unguaranteed
+//     "eager state" optimization, which stops applying once another update
+//     is already pending on the fiber - not guaranteed once handleSubmit's
+//     own setState call schedules one immediately afterward. The fix reads
+//     and writes a plain ref (liveFieldsRef) with ordinary synchronous JS
+//     instead, which has no such scheduling ambiguity.
+//  2) handleSubmit had no write serialization and no delete-only minimal
+//     payload: concurrent calls' fetch+merge+write could land on the backend
+//     in any order, and even a pure deletion went through the full
+//     makeUploadedInfo merge, whose frozen local snapshot could resurrect a
+//     sibling field a different, faster-completing call had already deleted.
+describe('handleClear/handleDelKeyValue read/write liveFieldsRef synchronously instead of capturing via a setState updater', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
+
+  const extractFnBody = (startMarker, endMarker) => {
+    const start = source.indexOf(startMarker);
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf(endMarker, start);
+    expect(end).toBeGreaterThan(start);
+    return source.slice(start, end);
+  };
+
+  it('handleClear reads liveFieldsRef.current directly, writes it back, then calls handleSubmit', () => {
+    const fnBody = extractFnBody(
+      'const handleClear = (fieldName, idx) => {',
+      'const handleDelKeyValue = fieldName => {'
+    );
+
+    expect(fnBody).not.toMatch(/setState\(\s*prev(State)?\s*=>/);
+    expect(fnBody).toContain('const prevState = liveFieldsRef.current;');
+    expect(fnBody.indexOf('liveFieldsRef.current = newState;')).toBeLessThan(
+      fnBody.indexOf('setState(newState);')
+    );
+    expect(fnBody).toContain("handleSubmit(newState, 'overwrite', delCondition);");
+  });
+
+  it('handleDelKeyValue reads liveFieldsRef.current directly, writes it back, then calls handleSubmit', () => {
+    const fnBody = extractFnBody(
+      'const handleDelKeyValue = fieldName => {',
+      'const [isEmailVerified, setIsEmailVerified] = useState(false);'
+    );
+
+    expect(fnBody).not.toMatch(/setState\(\s*prev(State)?\s*=>/);
+    expect(fnBody).toContain('const prevState = liveFieldsRef.current;');
+    expect(fnBody.indexOf('liveFieldsRef.current = newState;')).toBeLessThan(
+      fnBody.indexOf('setState(newState);')
+    );
+    expect(fnBody).toContain(
+      "handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });"
+    );
+  });
+
+  it('handleSubmit keeps liveFieldsRef in sync with its own optimistic setState(optimisticCard) call', () => {
+    const fnBody = extractFnBody(
+      'const handleSubmit = (newState, overwrite, delCondition) => {',
+      'const handleExit = async () => {'
+    );
+
+    expect(fnBody.indexOf('liveFieldsRef.current = optimisticCard;')).toBeLessThan(
+      fnBody.indexOf('setState(optimisticCard, {')
+    );
+  });
+});
+
+describe("remoteUpdate is serialized through enqueueProfileSync and sends a minimal null-only payload for pure field deletions", () => {
+  const source = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
+  const remoteUpdateBody = source.slice(
+    source.indexOf('async function remoteUpdate('),
+    source.indexOf('const enqueueProfileSync = params => {')
+  );
+
+  it('derives deleteOnlyKeys from the accumulated deletedKeys, not just this call\'s own delCondition', () => {
+    expect(remoteUpdateBody).toContain(
+      "const deleteOnlyKeys = delCondition\n      ? (deletedKeys || []).filter(key => key && key !== 'userId')\n      : [];"
+    );
+    expect(remoteUpdateBody).toContain('const isDeleteOnlySubmit = deleteOnlyKeys.length > 0;');
+  });
+
+  it('long-userId delete-only branch writes only nulls (filtered by isUsersAllowedField) + lastAction, never touching makeUploadedInfo', () => {
+    const longBranch = remoteUpdateBody.slice(
+      remoteUpdateBody.indexOf("if (syncedState?.userId?.length > 20) {"),
+      remoteUpdateBody.indexOf('} else {\n      if (isDeleteOnlySubmit) {')
+    );
+    const deleteBranch = longBranch.slice(
+      longBranch.indexOf('if (isDeleteOnlySubmit) {'),
+      longBranch.indexOf('} else {')
+    );
+
+    expect(deleteBranch).toContain('const deletePayload = { lastAction: syncedState.lastAction };');
+    expect(deleteBranch).toContain('.filter(key => isUsersAllowedField(key))');
+    expect(deleteBranch).toContain('deletePayload[key] = null;');
+    expect(deleteBranch).not.toContain('makeUploadedInfo(');
+    expect(deleteBranch).toContain(
+      "await Promise.all([\n          updateDataInRealtimeDB(syncedState.userId, deletePayload, 'update'),\n          updateDataInFiresoreDB(syncedState.userId, deletePayload, 'check', delCondition),\n        ]);"
+    );
+  });
+
+  it('short-userId delete-only branch writes a minimal deletePayload with no skipIndexing argument', () => {
+    const shortBranch = remoteUpdateBody.slice(
+      remoteUpdateBody.indexOf("} else {\n      if (isDeleteOnlySubmit) {")
+    );
+    const deleteBranch = shortBranch.slice(
+      shortBranch.indexOf('if (isDeleteOnlySubmit) {'),
+      shortBranch.indexOf('} else if (hasNewState) {')
+    );
+
+    expect(deleteBranch).toContain('const deletePayload = { lastAction: syncedState.lastAction };');
+    expect(deleteBranch).toContain(
+      "await updateDataInNewUsersRTDB(syncedState.userId, deletePayload, 'update');"
+    );
+  });
+
+  it('non-admin overlay write happens inside remoteUpdate, not inline in handleSubmit', () => {
+    expect(remoteUpdateBody).toContain('if (!isAdmin) {');
+    expect(remoteUpdateBody).toContain('saveOverlayForUserCard(');
+
+    const handleSubmitBody = source.slice(
+      source.indexOf('const handleSubmit = (newState, overwrite, delCondition) => {'),
+      source.indexOf('const handleExit = async () => {')
+    );
+    expect(handleSubmitBody).not.toContain('saveOverlayForUserCard(');
+  });
+
+  it('every write is chained onto syncQueueRef so submissions execute in strict order', () => {
+    const enqueueBody = source.slice(
+      source.indexOf('const enqueueProfileSync = params => {'),
+      source.indexOf('const handleSubmit = (newState, overwrite, delCondition) => {')
+    );
+
+    expect(enqueueBody).toContain('syncQueueRef.current');
+    expect(enqueueBody).toContain('.then(runSync)');
+  });
+});
+
+describe('handleBlur is left untouched by this fix (separate, pre-existing hazard)', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
+
+  it('still calls handleSubmit(normalizedState, baseFieldName) unchanged', () => {
+    expect(source).toContain('handleSubmit(normalizedState, baseFieldName);');
+  });
+});

--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1084,6 +1084,49 @@ const normalizeExcelPhone = rawPhone => {
   return phone;
 };
 
+const normalizeDeletedKeys = (...sources) => {
+  const deleted = new Set();
+
+  sources.forEach(source => {
+    if (!source) return;
+
+    if (Array.isArray(source)) {
+      source.forEach(key => {
+        if (key && key !== 'userId') deleted.add(String(key));
+      });
+      return;
+    }
+
+    if (source instanceof Set) {
+      source.forEach(key => {
+        if (key && key !== 'userId') deleted.add(String(key));
+      });
+      return;
+    }
+
+    if (typeof source === 'object') {
+      Object.keys(source).forEach(key => {
+        if (key && key !== 'userId') deleted.add(String(key));
+      });
+    }
+  });
+
+  return [...deleted];
+};
+
+const hasOwn = (object, key) =>
+  Object.prototype.hasOwnProperty.call(object || {}, key);
+
+const applyDeletedKeysToPayload = (payload, deletedKeys = []) => {
+  deletedKeys.forEach(key => {
+    if (key && key !== 'userId') {
+      payload[key] = null;
+    }
+  });
+
+  return payload;
+};
+
 export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const cloneProfileState = useCallback(profileState => JSON.parse(JSON.stringify(profileState || {})), []);
   const toComparableHistoryState = useCallback(profileState => {
@@ -1448,6 +1491,23 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const profileFetchRequestRef = useRef(0);
   const backendInitialLoadUserIdsRef = useRef(new Set());
   const latestProfileSnapshotRef = useRef(state);
+  // Deletion handlers below must read/write this synchronously (plain JS,
+  // never inside a setState updater function) instead of capturing a value
+  // out of a functional setState callback: React only runs that callback
+  // synchronously via an internal, unguaranteed "eager state" optimization,
+  // which stops applying once another update is already pending on this
+  // fiber - easily true here since handleSubmit immediately does its own
+  // setState right after. `latestProfileSnapshotRef` above doesn't help
+  // either, since it's only ever written from inside that same kind of
+  // functional updater (see the setState wrapper below).
+  const liveFieldsRef = useRef(state);
+  // Accumulated, not-yet-confirmed deleted field names for the currently
+  // open profile - lets a queued write reinforce an earlier, still-in-flight
+  // deletion even if this call's own delCondition is a different field.
+  const pendingDeletedKeysRef = useRef(new Set());
+  // Serializes the actual backend writes so they land in submission order,
+  // regardless of how fast each call's own fetch/merge happens to resolve.
+  const syncQueueRef = useRef(Promise.resolve());
   const logProfileSnapshotUpdate = useCallback((source, payload = {}) => {
     const entry = {
       source,
@@ -1771,7 +1831,255 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     });
   };
 
-  const handleSubmit = async (newState, overwrite, delCondition) => {
+  // The actual network write, run one at a time (see enqueueProfileSync)
+  // rather than concurrently: several rapid deletions used to each do their
+  // own unserialized fetch+merge+write, so whichever finished last could
+  // resurrect fields a faster-finishing sibling call had already deleted,
+  // regardless of the order the user actually clicked delete in.
+  async function remoteUpdate({
+    syncedState,
+    overwrite,
+    delCondition,
+    deletedKeys,
+    optimisticCard,
+    hasNewState,
+    formattedLastDelivery,
+  }) {
+    if (!isAdmin) {
+      if (!syncedState?.userId) {
+        toast.error('Немає userId для збереження правки');
+        return;
+      }
+
+      const canonical = await getCanonicalCard(syncedState.userId);
+      const overlayFields = buildOverlayFromDraft(canonical, syncedState);
+      await saveOverlayForUserCard({
+        editorUserId: auth.currentUser?.uid,
+        cardUserId: syncedState.userId,
+        fields: overlayFields,
+      });
+      return;
+    }
+
+    let existingData = null;
+    if (syncedState?.userId) {
+      try {
+        existingData = await fetchUserById(syncedState.userId);
+      } catch (fetchError) {
+        const details = fetchError?.message || String(fetchError);
+        console.error('Submit: failed to fetch existing user before save', fetchError);
+        toast.error(`Збереження: не вдалося прочитати поточні дані (${details})`);
+        existingData = null;
+      }
+    }
+
+    if (syncedState?.userId) {
+      try {
+        const isUsersCollectionId = syncedState.userId.length > 20;
+        const searchKeySyncTasks = [
+          syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState),
+        ];
+        if (isUsersCollectionId) {
+          searchKeySyncTasks.push(
+            syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState, {
+              rootPath: 'searchKey/users',
+            })
+          );
+        }
+
+        await Promise.all([
+          syncUserSearchIdIndex(syncedState.userId, existingData || {}, syncedState),
+          ...searchKeySyncTasks,
+        ]);
+      } catch (indexError) {
+        const details = indexError?.message || String(indexError);
+        console.error('Submit: search index sync failed, continuing with save', indexError);
+        toast.error(`Індексація не виконана (${details}), продовжуємо збереження`);
+      }
+    }
+    refillGitAfterGetInTouchChange(optimisticCard, existingData);
+
+    console.log('[SAVE] userId:', syncedState.userId);
+
+    // A submit whose sole purpose is deleting field(s) gets a minimal,
+    // targeted null-only payload instead of going through makeUploadedInfo's
+    // full-profile merge. That merge rebuilds the payload from a
+    // locally-captured snapshot merged against a freshly fetched server
+    // copy — when several deletions fire in quick succession, a later
+    // call's merge could re-include a field an earlier, still-in-flight
+    // call already deleted, resurrecting it. A payload containing nothing
+    // but explicit nulls for the accumulated deletedKeys (so an earlier,
+    // not-yet-confirmed deletion gets reinforced too) can never resurrect
+    // anything, because it never carries any other field's value.
+    const deleteOnlyKeys = delCondition
+      ? (deletedKeys || []).filter(key => key && key !== 'userId')
+      : [];
+    const isDeleteOnlySubmit = deleteOnlyKeys.length > 0;
+
+    if (syncedState?.userId?.length > 20) {
+
+      if (isDeleteOnlySubmit) {
+        const deletePayload = { lastAction: syncedState.lastAction };
+        deleteOnlyKeys
+          .filter(key => isUsersAllowedField(key))
+          .forEach(key => {
+            deletePayload[key] = null;
+          });
+
+        console.log('[SAVE] payload to firebase:', deletePayload);
+        await Promise.all([
+          updateDataInRealtimeDB(syncedState.userId, deletePayload, 'update'),
+          updateDataInFiresoreDB(syncedState.userId, deletePayload, 'check', delCondition),
+        ]);
+      } else {
+        const cleanedState = sanitizeTechnicalPayload(pickUsersAllowedFields(syncedState));
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            if (key !== 'userId' && isUsersAllowedField(key)) {
+              delete cleanedState[key];
+            }
+          });
+        }
+
+        const sanitizedExistingData = sanitizeTechnicalPayload(pickUsersAllowedFields(existingData || {}));
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            if (key !== 'userId' && isUsersAllowedField(key)) {
+              delete sanitizedExistingData[key];
+            }
+          });
+        }
+
+        const uploadedInfo = applyDeletedKeysToPayload(
+          makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite),
+          deletedKeys
+        );
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            if (isUsersAllowedField(key)) {
+              uploadedInfo[key] = null;
+            }
+          });
+        }
+
+        console.log('[SAVE] payload to firebase:', uploadedInfo);
+        await Promise.all([
+          updateDataInRealtimeDB(syncedState.userId, uploadedInfo, 'update'),
+          updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', delCondition),
+        ]);
+      }
+
+    } else {
+      if (isDeleteOnlySubmit) {
+        const deletePayload = { lastAction: syncedState.lastAction };
+        deleteOnlyKeys.forEach(key => {
+          deletePayload[key] = null;
+        });
+        console.log('[SAVE] payload to firebase:', deletePayload);
+        await updateDataInNewUsersRTDB(syncedState.userId, deletePayload, 'update');
+      } else if (hasNewState) {
+        const newStateWithDelivery = applyDeletedKeysToPayload(
+          sanitizeNewUsersPayload({ ...syncedState }),
+          deletedKeys
+        );
+
+        if (formattedLastDelivery) {
+          newStateWithDelivery.lastDelivery = formattedLastDelivery;
+        } else {
+          delete newStateWithDelivery.lastDelivery;
+        }
+        if (delCondition) {
+          Object.keys(delCondition).forEach(key => {
+            newStateWithDelivery[key] = null;
+          });
+        }
+        console.log('[SAVE] payload to firebase:', newStateWithDelivery);
+        await updateDataInNewUsersRTDB(
+          syncedState.userId,
+          newStateWithDelivery,
+          'update'
+        );
+      } else {
+        const cleanedNewUsersState = applyDeletedKeysToPayload(
+          sanitizeNewUsersPayload(syncedState),
+          deletedKeys
+        );
+        console.log('[SAVE] payload to firebase:', cleanedNewUsersState);
+        await updateDataInNewUsersRTDB(syncedState.userId, cleanedNewUsersState, 'update');
+      }
+    }
+  }
+
+  // Chains every write onto the same promise so they execute strictly in
+  // submission order, regardless of how fast each call's own fetch/merge
+  // happens to resolve - the actual fix for the deletion-order race.
+  const enqueueProfileSync = params => {
+    const { syncedState, saveRequestId, localSaveVersion, removeKeys, deletedKeys } = params;
+
+    const runSync = async () => {
+      try {
+        await remoteUpdate(params);
+
+        if (!isAdmin) {
+          return;
+        }
+
+        console.log('[LS cards before]', getLocalStorageCardsDebugSnapshot());
+        const currentUserId = String((latestProfileSnapshotRef.current || {}).userId || '');
+        const isStaleSaveResponse =
+          profileSaveRequestRef.current !== saveRequestId ||
+          profileSnapshotVersionRef.current !== localSaveVersion ||
+          currentUserId !== String(syncedState.userId || '');
+
+        if (isStaleSaveResponse) {
+          logProfileSnapshotUpdate('saveResponse', {
+            caller: 'handleSubmit:finish',
+            requestId: saveRequestId,
+            userId: syncedState.userId,
+            localSaveVersion,
+            currentVersion: profileSnapshotVersionRef.current,
+            currentUserId,
+            applied: false,
+            reason: 'stale-save-response-local-snapshot-is-newer',
+          });
+          return;
+        }
+
+        deletedKeys.forEach(key => pendingDeletedKeysRef.current.delete(key));
+
+        const savedCachedCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
+        cacheFetchedUsers({ [syncedState.userId]: savedCachedCard }, cacheLoad2Users, filters);
+        liveFieldsRef.current = savedCachedCard;
+        setState(savedCachedCard, {
+          source: 'saveResponse',
+          caller: 'handleSubmit:finish',
+          reason: 'background-save-confirmed-current-snapshot',
+        });
+        setUsers(prev => {
+          if (!prev || !Object.prototype.hasOwnProperty.call(prev, syncedState.userId)) {
+            return prev;
+          }
+          return { ...prev, [syncedState.userId]: savedCachedCard };
+        });
+        console.log('[LS cards after]', getLocalStorageCardsDebugSnapshot());
+      } catch (submitError) {
+        const details = submitError?.message || String(submitError);
+        console.error('Submit failed', submitError);
+        toast.error(`Збереження не виконано: ${details}`);
+      }
+    };
+
+    const queuedSync = syncQueueRef.current
+      .catch(error => {
+        console.error('Previous profile sync failed', error);
+      })
+      .then(runSync);
+
+    syncQueueRef.current = queuedSync.catch(() => {});
+    return queuedSync;
+  };
+
+  const handleSubmit = (newState, overwrite, delCondition) => {
     const now = Date.now();
     const baseState = normalizePhoneState(newState ? { ...newState } : { ...state });
     const updatedState = { ...baseState, lastAction: now };
@@ -1792,187 +2100,65 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     registerHistorySnapshot(syncedState);
 
-    try {
-      if (!isAdmin) {
-        if (!syncedState?.userId) {
-          toast.error('Немає userId для збереження правки');
-          return;
-        }
+    const hasNewState = Boolean(newState);
 
-        const canonical = await getCanonicalCard(syncedState.userId);
-        const overlayFields = buildOverlayFromDraft(canonical, syncedState);
-        await saveOverlayForUserCard({
-          editorUserId: auth.currentUser?.uid,
-          cardUserId: syncedState.userId,
-          fields: overlayFields,
-        });
-        return;
-      }
-
-      // Optimistically update the only full-card cache and UI state before syncing with server.
-      const removeKeys = delCondition ? Object.keys(delCondition) : [];
-      const optimisticCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
-      const localSaveVersion = profileSnapshotVersionRef.current + 1;
-      setState(optimisticCard, {
-        source: 'userChange',
-        caller: 'handleSubmit:optimistic-update',
-        reason: 'optimistic-local-save-start',
+    if (!isAdmin) {
+      return enqueueProfileSync({
+        syncedState,
+        overwrite,
+        delCondition,
+        deletedKeys: [],
+        optimisticCard: syncedState,
+        removeKeys: [],
+        hasNewState,
+        formattedLastDelivery,
       });
-      logProfileSnapshotUpdate('saveResponse', {
-        caller: 'handleSubmit:start',
-        requestId: saveRequestId,
-        userId: syncedState.userId,
-        applied: true,
-        reason: 'background-save-started-local-is-source-of-truth',
-      });
-      cacheFetchedUsers({ [syncedState.userId]: optimisticCard }, cacheLoad2Users, filters);
-      const gitNewCardHidden = hideFutureGitNewCardAndLoadNext(optimisticCard);
-      const offlineCardHidden = hideOfflineCardAndLoadNext(optimisticCard);
-      if (!gitNewCardHidden && !offlineCardHidden) {
-        setUsers(prev => ({ ...prev, [syncedState.userId]: optimisticCard }));
-      }
-
-      let existingData = null;
-      if (syncedState?.userId) {
-        try {
-          existingData = await fetchUserById(syncedState.userId);
-        } catch (fetchError) {
-          const details = fetchError?.message || String(fetchError);
-          console.error('Submit: failed to fetch existing user before save', fetchError);
-          toast.error(`Збереження: не вдалося прочитати поточні дані (${details})`);
-          existingData = null;
-        }
-      }
-
-      if (syncedState?.userId) {
-        try {
-          const isUsersCollectionId = syncedState.userId.length > 20;
-          const searchKeySyncTasks = [
-            syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState),
-          ];
-          if (isUsersCollectionId) {
-            searchKeySyncTasks.push(
-              syncUserSearchKeyIndex(syncedState.userId, existingData || {}, syncedState, {
-                rootPath: 'searchKey/users',
-              })
-            );
-          }
-
-          await Promise.all([
-            syncUserSearchIdIndex(syncedState.userId, existingData || {}, syncedState),
-            ...searchKeySyncTasks,
-          ]);
-        } catch (indexError) {
-          const details = indexError?.message || String(indexError);
-          console.error('Submit: search index sync failed, continuing with save', indexError);
-          toast.error(`Індексація не виконана (${details}), продовжуємо збереження`);
-        }
-      }
-      refillGitAfterGetInTouchChange(optimisticCard, existingData);
-
-      console.log('[SAVE] userId:', syncedState.userId);
-
-      if (syncedState?.userId?.length > 20) {
-
-        const cleanedState = sanitizeTechnicalPayload(pickUsersAllowedFields(syncedState));
-        if (delCondition) {
-          Object.keys(delCondition).forEach(key => {
-            if (key !== 'userId' && isUsersAllowedField(key)) {
-              delete cleanedState[key];
-            }
-          });
-        }
-
-        const sanitizedExistingData = sanitizeTechnicalPayload(pickUsersAllowedFields(existingData || {}));
-        if (delCondition) {
-          Object.keys(delCondition).forEach(key => {
-            if (key !== 'userId' && isUsersAllowedField(key)) {
-              delete sanitizedExistingData[key];
-            }
-          });
-        }
-
-        const uploadedInfo = makeUploadedInfo(sanitizedExistingData, cleanedState, overwrite);
-        if (delCondition) {
-          Object.keys(delCondition).forEach(key => {
-            if (isUsersAllowedField(key)) {
-              uploadedInfo[key] = null;
-            }
-          });
-        }
-
-        console.log('[SAVE] payload to firebase:', uploadedInfo);
-        await Promise.all([
-          updateDataInRealtimeDB(syncedState.userId, uploadedInfo, 'update'),
-          updateDataInFiresoreDB(syncedState.userId, uploadedInfo, 'check', delCondition),
-        ]);
-
-      } else {
-        if (newState) {
-          const newStateWithDelivery = sanitizeNewUsersPayload({ ...syncedState });
-
-          if (formattedLastDelivery) {
-            newStateWithDelivery.lastDelivery = formattedLastDelivery;
-          } else {
-            delete newStateWithDelivery.lastDelivery;
-          }
-          if (delCondition) {
-            Object.keys(delCondition).forEach(key => {
-              newStateWithDelivery[key] = null;
-            });
-          }
-          console.log('[SAVE] payload to firebase:', newStateWithDelivery);
-          await updateDataInNewUsersRTDB(
-            syncedState.userId,
-            newStateWithDelivery,
-            'update'
-          );
-        } else {
-          const cleanedNewUsersState = sanitizeNewUsersPayload(syncedState);
-          console.log('[SAVE] payload to firebase:', cleanedNewUsersState);
-          await updateDataInNewUsersRTDB(syncedState.userId, cleanedNewUsersState, 'update');
-        }
-      }
-      console.log('[LS cards before]', getLocalStorageCardsDebugSnapshot());
-      const currentUserId = String((latestProfileSnapshotRef.current || {}).userId || '');
-      const isStaleSaveResponse =
-        profileSaveRequestRef.current !== saveRequestId ||
-        profileSnapshotVersionRef.current !== localSaveVersion ||
-        currentUserId !== String(syncedState.userId || '');
-
-      if (isStaleSaveResponse) {
-        logProfileSnapshotUpdate('saveResponse', {
-          caller: 'handleSubmit:finish',
-          requestId: saveRequestId,
-          userId: syncedState.userId,
-          localSaveVersion,
-          currentVersion: profileSnapshotVersionRef.current,
-          currentUserId,
-          applied: false,
-          reason: 'stale-save-response-local-snapshot-is-newer',
-        });
-        return;
-      }
-
-      const savedCachedCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
-      cacheFetchedUsers({ [syncedState.userId]: savedCachedCard }, cacheLoad2Users, filters);
-      setState(savedCachedCard, {
-        source: 'saveResponse',
-        caller: 'handleSubmit:finish',
-        reason: 'background-save-confirmed-current-snapshot',
-      });
-      setUsers(prev => {
-        if (!prev || !Object.prototype.hasOwnProperty.call(prev, syncedState.userId)) {
-          return prev;
-        }
-        return { ...prev, [syncedState.userId]: savedCachedCard };
-      });
-      console.log('[LS cards after]', getLocalStorageCardsDebugSnapshot());
-    } catch (submitError) {
-      const details = submitError?.message || String(submitError);
-      console.error('Submit failed', submitError);
-      toast.error(`Збереження не виконано: ${details}`);
     }
+
+    // Optimistically update the only full-card cache and UI state before syncing with server.
+    const removeKeys = normalizeDeletedKeys(delCondition);
+    pendingDeletedKeysRef.current.forEach(key => {
+      if (hasOwn(syncedState, key) && !removeKeys.includes(key)) {
+        pendingDeletedKeysRef.current.delete(key);
+      }
+    });
+    removeKeys.forEach(key => pendingDeletedKeysRef.current.add(key));
+    const deletedKeys = normalizeDeletedKeys(pendingDeletedKeysRef.current, removeKeys);
+
+    const optimisticCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
+    const localSaveVersion = profileSnapshotVersionRef.current + 1;
+    liveFieldsRef.current = optimisticCard;
+    setState(optimisticCard, {
+      source: 'userChange',
+      caller: 'handleSubmit:optimistic-update',
+      reason: 'optimistic-local-save-start',
+    });
+    logProfileSnapshotUpdate('saveResponse', {
+      caller: 'handleSubmit:start',
+      requestId: saveRequestId,
+      userId: syncedState.userId,
+      applied: true,
+      reason: 'background-save-started-local-is-source-of-truth',
+    });
+    cacheFetchedUsers({ [syncedState.userId]: optimisticCard }, cacheLoad2Users, filters);
+    const gitNewCardHidden = hideFutureGitNewCardAndLoadNext(optimisticCard);
+    const offlineCardHidden = hideOfflineCardAndLoadNext(optimisticCard);
+    if (!gitNewCardHidden && !offlineCardHidden) {
+      setUsers(prev => ({ ...prev, [syncedState.userId]: optimisticCard }));
+    }
+
+    return enqueueProfileSync({
+      syncedState,
+      overwrite,
+      delCondition,
+      deletedKeys,
+      optimisticCard,
+      removeKeys,
+      saveRequestId,
+      localSaveVersion,
+      hasNewState,
+      formattedLastDelivery,
+    });
   };
 
   const handleExit = async () => {
@@ -2069,58 +2255,61 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   //   setState(prevState => ({ ...prevState, [fieldName]: '' }));
   // };
 
+  // Reads/writes liveFieldsRef with plain synchronous JS instead of
+  // capturing a value out of a setState functional updater: React only runs
+  // that updater synchronously via an internal, unguaranteed "eager state"
+  // optimization, which stops applying once another update is already
+  // pending on this fiber - easily true here since handleSubmit immediately
+  // does its own setState right after. Reading/writing a ref has no such
+  // scheduling ambiguity, so each rapid click deterministically builds on
+  // the previous click's result.
   const handleClear = (fieldName, idx) => {
-    setState(prevState => {
-      const isArray = Array.isArray(prevState[fieldName]);
-      const applyDelLikeRemoval = deletedValue => {
-        const nextState = { ...prevState };
-        delete nextState[fieldName];
-        handleSubmit(nextState, 'overwrite', { [fieldName]: deletedValue });
-        return nextState;
-      };
+    const prevState = liveFieldsRef.current;
+    const isArray = Array.isArray(prevState[fieldName]);
+    const newState = { ...prevState };
+    let delCondition;
 
-      const newState = { ...prevState };
+    if (isArray) {
+      const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
+      const removedValue = prevState[fieldName][idx];
+      const normalizedFilteredArray = filteredArray.filter(
+        value => !(typeof value === 'string' && value.trim() === '')
+      );
 
-      if (isArray) {
-        const filteredArray = prevState[fieldName].filter((_, i) => i !== idx);
-        const removedValue = prevState[fieldName][idx];
-        const normalizedFilteredArray = filteredArray.filter(
-          value => !(typeof value === 'string' && value.trim() === '')
-        );
-
-        if (normalizedFilteredArray.length === 0) {
-          return applyDelLikeRemoval(removedValue);
-        } else if (normalizedFilteredArray.length === 1) {
-          newState[fieldName] = normalizedFilteredArray[0];
-        } else {
-          newState[fieldName] = normalizedFilteredArray;
-        }
-        handleSubmit(newState, 'overwrite');
-        return newState;
+      if (normalizedFilteredArray.length === 0) {
+        delete newState[fieldName];
+        delCondition = { [fieldName]: removedValue };
+      } else if (normalizedFilteredArray.length === 1) {
+        newState[fieldName] = normalizedFilteredArray[0];
       } else {
-        const removedValue = prevState[fieldName];
-        return applyDelLikeRemoval(removedValue);
+        newState[fieldName] = normalizedFilteredArray;
       }
-    });
+    } else {
+      const removedValue = prevState[fieldName];
+      delete newState[fieldName];
+      delCondition = { [fieldName]: removedValue };
+    }
+
+    liveFieldsRef.current = newState;
+    setState(newState);
+
+    if (delCondition) {
+      pendingDeletedKeysRef.current.add(fieldName);
+    }
+    handleSubmit(newState, 'overwrite', delCondition);
   };
 
   const handleDelKeyValue = fieldName => {
-    setState(prevState => {
-      // Створюємо копію попереднього стану
-      const newState = { ...prevState };
+    const prevState = liveFieldsRef.current;
+    const newState = { ...prevState };
+    const deletedValue = newState[fieldName];
+    delete newState[fieldName];
 
-      const deletedValue = newState[fieldName];
+    liveFieldsRef.current = newState;
+    setState(newState);
 
-      // Видаляємо ключ з нового стану
-      delete newState[fieldName];
-
-
-      // Встановлюємо значення 'del_key' для видалення
-      //  newState[fieldName] = 'del_key';
-
-      handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
-      return newState; // Повертаємо оновлений стан
-    });
+    pendingDeletedKeysRef.current.add(fieldName);
+    handleSubmit(newState, 'overwrite', { [fieldName]: deletedValue });
   };
 
   const [isEmailVerified, setIsEmailVerified] = useState(false);
@@ -2706,6 +2895,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
     localStorage.removeItem(EDIT_PROFILE_USER_ID_KEY);
   }, [state?.userId, EDIT_PROFILE_USER_ID_KEY]);
+
+  useEffect(() => {
+    liveFieldsRef.current = state;
+  }, [state]);
+
+  // AddNewProfile is a single persistent instance that can switch which
+  // profile is "open" (state.userId) without unmounting - clear accumulated
+  // not-yet-confirmed deletions from the previous profile so they can never
+  // leak into a different profile's delete-only payload.
+  useEffect(() => {
+    pendingDeletedKeysRef.current.clear();
+  }, [state.userId]);
 
   useEffect(() => {
     if (!searchBarQueryActive) return;

--- a/src/components/AddNewProfile.makeIndexGate.test.js
+++ b/src/components/AddNewProfile.makeIndexGate.test.js
@@ -24,18 +24,21 @@ describe('AddNewProfile.jsx no longer has a hidden write-skip gate on handleSubm
 
   it('handleSubmit no longer accepts a 4th "makeIndex" parameter', () => {
     expect(source).not.toContain('makeIndex');
-    expect(source).toContain('const handleSubmit = async (newState, overwrite, delCondition) => {');
+    expect(source).toContain('const handleSubmit = (newState, overwrite, delCondition) => {');
   });
 
   it('the long-userId branch writes to Firebase unconditionally (no truthy-string-skips-write gate)', () => {
-    const handleSubmitBody = source.slice(
-      source.indexOf('const handleSubmit = async (newState, overwrite, delCondition) => {'),
-      source.indexOf('console.log(\'[LS cards before]\'')
+    // The actual network write moved from handleSubmit into remoteUpdate
+    // (see AddNewProfile.deletionRace.test.js for that refactor), so this
+    // now checks remoteUpdate's non-delete-only long-userId sub-branch.
+    const remoteUpdateBody = source.slice(
+      source.indexOf('async function remoteUpdate('),
+      source.indexOf('const enqueueProfileSync = params => {')
     );
-    const longUserIdBranchStart = handleSubmitBody.indexOf('syncedState?.userId?.length > 20');
-    const longUserIdBranch = handleSubmitBody.slice(
+    const longUserIdBranchStart = remoteUpdateBody.indexOf('syncedState?.userId?.length > 20');
+    const longUserIdBranch = remoteUpdateBody.slice(
       longUserIdBranchStart,
-      handleSubmitBody.indexOf('} else {', longUserIdBranchStart)
+      remoteUpdateBody.indexOf('} else {\n      if (isDeleteOnlySubmit) {', longUserIdBranchStart)
     );
 
     expect(longUserIdBranch).toContain('updateDataInRealtimeDB(syncedState.userId, uploadedInfo, \'update\')');

--- a/src/components/EditProfile.deletionRace.test.js
+++ b/src/components/EditProfile.deletionRace.test.js
@@ -3,56 +3,72 @@ import path from 'path';
 
 // Regression test for: deleting several fields in quick succession could
 // resurrect an earlier-deleted field and ship it back to the backend.
-// Root cause: handleClear/handleDelKeyValue called handleSubmit (which does
-// its own setState + enqueues the network write) *from inside* the
-// setState(prev => ...) updater callback. Nested/side-effecting setState
-// calls interleave unpredictably once several deletions queue up before any
-// of them commit, so a stale newState snapshot could win and get re-synced.
-describe('handleClear/handleDelKeyValue no longer call handleSubmit inside a setState updater', () => {
+// Root cause (two compounding bugs, fixed independently):
+//  1) handleClear/handleDelKeyValue used to call handleSubmit (which does its
+//     own setState + enqueues the network write) *from inside* the
+//     setState(prev => ...) updater callback - nested/side-effecting setState
+//     calls interleave unpredictably once several deletions queue up.
+//  2) Even after moving handleSubmit outside the updater, capturing the
+//     computed value via a `let captured...` variable assigned inside a
+//     setState functional updater still isn't safe: React only runs that
+//     updater synchronously (before setState() returns) via an internal
+//     "eager state" optimization, and only when no other update is already
+//     pending on the fiber - not guaranteed once handleSubmit's own setState
+//     call schedules one immediately afterward. So the fix reads and writes a
+//     plain ref (liveFieldsRef) with ordinary synchronous JS instead of
+//     depending on setState's callback ever running before the next
+//     statement.
+describe('handleClear/handleDelKeyValue read/write liveFieldsRef synchronously instead of capturing via a setState updater', () => {
   const source = fs.readFileSync(path.join(__dirname, 'EditProfile.jsx'), 'utf8');
 
-  const extractUpdaterBody = (fnBody, updaterStartMarker) => {
-    const start = fnBody.indexOf(updaterStartMarker);
+  const extractFnBody = (startMarker, endMarker) => {
+    const start = source.indexOf(startMarker);
     expect(start).toBeGreaterThan(-1);
-    const closeMarker = '\n      return newState;\n    });';
-    const end = fnBody.indexOf(closeMarker, start);
+    const end = source.indexOf(endMarker, start);
     expect(end).toBeGreaterThan(start);
-    return {
-      updaterBody: fnBody.slice(start, end),
-      afterUpdater: fnBody.slice(end + closeMarker.length),
-    };
+    return source.slice(start, end);
   };
 
-  it('handleClear computes newState via a pure functional setState updater, then calls handleSubmit afterwards', () => {
-    const fnBody = source.slice(
-      source.indexOf('const handleClear = (fieldName, idx) => {'),
-      source.indexOf('const handleDelKeyValue = fieldName => {')
+  it('handleClear reads liveFieldsRef.current directly, writes it back, then calls handleSubmit', () => {
+    const fnBody = extractFnBody(
+      'const handleClear = (fieldName, idx) => {',
+      'const handleDelKeyValue = fieldName => {'
     );
-    const { updaterBody, afterUpdater } = extractUpdaterBody(fnBody, 'setState(prev => {');
 
-    expect(updaterBody).not.toContain('handleSubmit(');
-    expect(afterUpdater).toContain(
+    expect(fnBody).not.toMatch(/setState\(\s*prev(State)?\s*=>/);
+    expect(fnBody).toContain('const prev = liveFieldsRef.current;');
+    expect(fnBody.indexOf('liveFieldsRef.current = capturedNewState;')).toBeLessThan(
+      fnBody.indexOf('setState(capturedNewState);')
+    );
+    expect(fnBody).toContain(
       "handleSubmit(capturedNewState, 'overwrite', capturedDelCondition, 'handleClear')"
     );
   });
 
-  it('handleDelKeyValue computes newState via a pure functional setState updater, then calls handleSubmit afterwards', () => {
-    const fnBody = source.slice(
-      source.indexOf('const handleDelKeyValue = fieldName => {'),
-      source.indexOf('const persistCanonicalByRules = async mergedCard => {')
+  it('handleDelKeyValue reads liveFieldsRef.current directly, writes it back, then calls handleSubmit', () => {
+    const fnBody = extractFnBody(
+      'const handleDelKeyValue = fieldName => {',
+      'const persistCanonicalByRules = async mergedCard => {'
     );
-    const updaterStart = fnBody.indexOf('setState(prev => {');
-    expect(updaterStart).toBeGreaterThan(-1);
-    const closeMarker = '\n      return newState;\n    });';
-    const updaterEnd = fnBody.indexOf(closeMarker, updaterStart);
-    expect(updaterEnd).toBeGreaterThan(updaterStart);
 
-    const updaterBody = fnBody.slice(updaterStart, updaterEnd);
-    const afterUpdater = fnBody.slice(updaterEnd + closeMarker.length);
+    expect(fnBody).not.toMatch(/setState\(\s*prev(State)?\s*=>/);
+    expect(fnBody).toContain('const prev = liveFieldsRef.current;');
+    expect(fnBody.indexOf('liveFieldsRef.current = capturedNewState;')).toBeLessThan(
+      fnBody.indexOf('setState(capturedNewState);')
+    );
+    expect(fnBody).toContain(
+      "handleSubmit(capturedNewState, 'overwrite', { [fieldName]: capturedDeletedValue });"
+    );
+  });
 
-    expect(updaterBody).not.toContain('handleSubmit(');
-    expect(afterUpdater).toContain(
-      "handleSubmit(capturedNewState, 'overwrite', { [fieldName]: capturedDeletedValue })"
+  it('handleSubmit keeps liveFieldsRef in sync with its own optimistic setState(updatedState) call', () => {
+    const fnBody = extractFnBody(
+      'const handleSubmit = async (newState, overwrite, delCondition, submitSource) => {',
+      'const handleFieldFocus = fieldName => {'
+    );
+
+    expect(fnBody.indexOf('liveFieldsRef.current = updatedState;')).toBeLessThan(
+      fnBody.indexOf('setState(updatedState);')
     );
   });
 });

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -303,6 +303,18 @@ const EditProfile = () => {
   const lastSyncedSnapshotRef = useRef(prepareSyncedSnapshot(state || {}));
   const syncedSnapshotVersionRef = useRef(0);
   const overlayRefreshSequenceRef = useRef(0);
+  // Deletion handlers below must read/write this synchronously (plain JS,
+  // never inside a setState updater function) rather than rely on React's
+  // "eager state" optimization actually running that updater before the next
+  // rapid click. That optimization only fires when no other update is
+  // already pending on this fiber - which isn't guaranteed once handleSubmit
+  // immediately does its own setState right after - so a stale/undefined
+  // captured snapshot could otherwise be submitted for the 2nd+ rapid delete.
+  const liveFieldsRef = useRef(state);
+
+  useEffect(() => {
+    liveFieldsRef.current = state;
+  }, [state]);
 
 
   const refreshOverlays = useCallback(async () => {
@@ -799,6 +811,7 @@ const EditProfile = () => {
       setIsOverlayResolved(false);
     }
 
+    liveFieldsRef.current = updatedState;
     setState(updatedState);
 
     const removeKeys = normalizeDeletedKeys(delCondition);
@@ -897,15 +910,14 @@ const EditProfile = () => {
   // handleSubmit (called below) does its own setState and enqueues the actual
   // network write, so it must never run *inside* a setState updater callback —
   // nested/side-effecting setState calls interleave unpredictably once several
-  // deletions fire in quick succession (React can invoke an updater more than
-  // once, e.g. StrictMode's double-invoke check), and a stale `newState` from
-  // a re-run updater could silently win, resurrecting a field a later click
-  // already deleted and shipping it back to the backend on the next sync.
-  // Still use the functional setState form to compute newState — that's what
-  // guarantees each click sees the previous click's deletion even when React
-  // batches several updates before committing — but only *capture* the result
-  // via a plain local variable; call handleSubmit afterwards, as a normal
-  // top-level call once setState has returned.
+  // deletions fire in quick succession. Relying on setState's functional form
+  // to compute newState doesn't fix this either: React only runs that updater
+  // synchronously via an internal "eager state" optimization, and only when
+  // no other update is already pending on this fiber - not guaranteed once
+  // handleSubmit's own setState schedules one right after. So instead of
+  // capturing a value out of a setState callback, read/write liveFieldsRef
+  // directly with plain synchronous JS - that has no scheduling ambiguity, so
+  // each rapid click deterministically builds on the previous click's result.
   const handleClear = (fieldName, idx) => {
     debugProfileSave('handleClear:start', {
       fieldName,
@@ -919,56 +931,53 @@ const EditProfile = () => {
       deletingFieldsRef.current.add(fieldName);
     }
 
-    let capturedNewState;
-    let capturedDelCondition;
+    const prev = liveFieldsRef.current;
+    const newState = { ...prev };
+    let removedValue;
+    const currentValue = prev[fieldName];
 
-    setState(prev => {
-      const newState = { ...prev };
-      let removedValue;
-      const currentValue = prev[fieldName];
+    if (hasIndex) {
+      const sourceArray = Array.isArray(currentValue)
+        ? currentValue
+        : (currentValue !== undefined && currentValue !== null ? [currentValue] : []);
 
-      if (hasIndex) {
-        const sourceArray = Array.isArray(currentValue)
-          ? currentValue
-          : (currentValue !== undefined && currentValue !== null ? [currentValue] : []);
+      const filtered = sourceArray.filter((_, i) => i !== idx);
+      removedValue = sourceArray[idx];
 
-        const filtered = sourceArray.filter((_, i) => i !== idx);
-        removedValue = sourceArray[idx];
+      if (filtered.length > 1) {
+        newState[fieldName] = filtered;
+      } else if (filtered.length === 1 && filtered[0] !== '') {
+        newState[fieldName] = filtered[0];
+      } else {
+        delete newState[fieldName];
+      }
+    } else {
+      const isArray = Array.isArray(currentValue);
 
-        if (filtered.length > 1) {
-          newState[fieldName] = filtered;
-        } else if (filtered.length === 1 && filtered[0] !== '') {
+      if (isArray) {
+        const filtered = currentValue.filter((_, i) => i !== idx);
+        removedValue = currentValue[idx];
+
+        if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
+          delete newState[fieldName];
+        } else if (filtered.length === 1) {
           newState[fieldName] = filtered[0];
         } else {
-          delete newState[fieldName];
+          newState[fieldName] = filtered;
         }
       } else {
-        const isArray = Array.isArray(currentValue);
-
-        if (isArray) {
-          const filtered = currentValue.filter((_, i) => i !== idx);
-          removedValue = currentValue[idx];
-
-          if (filtered.length === 0 || (filtered.length === 1 && filtered[0] === '')) {
-            delete newState[fieldName];
-          } else if (filtered.length === 1) {
-            newState[fieldName] = filtered[0];
-          } else {
-            newState[fieldName] = filtered;
-          }
-        } else {
-          removedValue = currentValue;
-          delete newState[fieldName];
-        }
+        removedValue = currentValue;
+        delete newState[fieldName];
       }
+    }
 
-      capturedNewState = newState;
-      capturedDelCondition = Object.prototype.hasOwnProperty.call(newState, fieldName)
-        ? undefined
-        : { [fieldName]: removedValue };
+    const capturedNewState = newState;
+    const capturedDelCondition = Object.prototype.hasOwnProperty.call(newState, fieldName)
+      ? undefined
+      : { [fieldName]: removedValue };
 
-      return newState;
-    });
+    liveFieldsRef.current = capturedNewState;
+    setState(capturedNewState);
 
     debugProfileSave('handleClear:computed', {
       fieldName,
@@ -993,16 +1002,14 @@ const EditProfile = () => {
   };
 
   const handleDelKeyValue = fieldName => {
-    let capturedNewState;
-    let capturedDeletedValue;
+    const prev = liveFieldsRef.current;
+    const newState = { ...prev };
+    const capturedDeletedValue = newState[fieldName];
+    delete newState[fieldName];
+    const capturedNewState = newState;
 
-    setState(prev => {
-      const newState = { ...prev };
-      capturedDeletedValue = newState[fieldName];
-      delete newState[fieldName];
-      capturedNewState = newState;
-      return newState;
-    });
+    liveFieldsRef.current = capturedNewState;
+    setState(capturedNewState);
 
     pendingDeletedKeysRef.current.add(fieldName);
     handleSubmit(capturedNewState, 'overwrite', { [fieldName]: capturedDeletedValue });


### PR DESCRIPTION
Deleting several fields in quick succession could resurrect earlier
deletions on the backend, keeping only the last one. Two compounding
causes:

1. handleClear/handleDelKeyValue captured the computed next-state via a
   variable assigned inside a setState functional updater, then called
   handleSubmit right after. That only works if React runs the updater
   synchronously before setState() returns, which is an internal,
   unguaranteed optimization that stops applying once another update is
   already pending on the fiber - easily true here since handleSubmit
   immediately issues its own setState. Both files now read/write a plain
   liveFieldsRef synchronously instead, removing the dependency on React's
   scheduling behavior.

2. AddNewProfile.jsx's handleSubmit had no write serialization and no
   delete-only minimal payload, so concurrent submits' fetch+merge+write
   could land on the backend out of order, and even a pure deletion went
   through the full profile merge, which could resurrect a sibling field a
   different, faster-completing call had already deleted. Ported
   EditProfile.jsx's syncQueueRef serialization and delete-only payload
   pattern into a new remoteUpdate/enqueueProfileSync split.

Updated EditProfile.deletionRace.test.js and AddNewProfile.makeIndexGate.test.js
for the new shapes, and added AddNewProfile.deletionRace.test.js.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GrxFAGM7VuVqnbmcZVgi6V