### PR TITLE
Fix MyProfile authentication state transitions

### DIFF
--- a/src/components/MyProfile.accountIsolation.test.js
+++ b/src/components/MyProfile.accountIsolation.test.js
@@ -54,4 +54,21 @@ describe('MyProfile account isolation', () => {
     expect(source).toContain("editedFieldsRef.current = new Set();");
     expect(source).toContain('auth.currentUser?.uid !== targetUserId');
   });
+
+  it('clears a local draft before exposing an initially authenticated profile', () => {
+    expect(source).toContain('const hasLocalProfileState = Object.keys(stateRef.current || {}).length > 0;');
+    expect(source).toContain('activeAuthUidRef.current !== uid && (activeAuthUidRef.current || hasLocalProfileState)');
+  });
+
+  it('explicitly reloads an existing account after sign-in', () => {
+    expect(existingAccountBranch).toContain('await loadAuthenticatedProfile(userCredential.user.uid)');
+  });
+
+  it('flushes queued autosaves before invalidating the logout session', () => {
+    const logoutBody = source.slice(
+      source.indexOf('const handleExit = async () => {'),
+      source.indexOf('const dotsMenu = () => (')
+    );
+    expect(logoutBody.indexOf('await saveQueueRef.current')).toBeLessThan(logoutBody.indexOf('resetAuthenticatedProfileState();'));
+  });
 });

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -452,7 +452,7 @@ export const MyProfile = () => {
     }
   }, []);
 
-  const normalizeProfileData = (data = {}) => Object.entries(data).reduce((acc, [key, value]) => {
+  const normalizeProfileData = useCallback((data = {}) => Object.entries(data).reduce((acc, [key, value]) => {
     if (key === 'password') {
       return acc;
     }
@@ -469,9 +469,9 @@ export const MyProfile = () => {
 
     acc[key] = value;
     return acc;
-  }, {});
+  }, {}), []);
 
-  const mergeLoadedProfileData = (loadedData, uid) => {
+  const mergeLoadedProfileData = useCallback((loadedData, uid) => {
     setState(prevState => {
       const protectedFields = editedFieldsRef.current;
       const nextState = { userRole: 'ed', ...loadedData, userId: uid };
@@ -485,7 +485,31 @@ export const MyProfile = () => {
       stateRef.current = nextState;
       return nextState;
     });
-  };
+  }, []);
+
+  const loadAuthenticatedProfile = useCallback(async (uid, shouldApply = () => true) => {
+    latestFetchUidRef.current = uid;
+    setUserId(uid);
+
+    try {
+      const { existingData } = await fetchUserData(uid);
+
+      if (!shouldApply() || latestFetchUidRef.current !== uid) {
+        return false;
+      }
+
+      mergeLoadedProfileData(normalizeProfileData(existingData || {}), uid);
+      return true;
+    } catch (error) {
+      console.warn('Failed to load MyProfile profile data.', error);
+      if (!shouldApply() || latestFetchUidRef.current !== uid) {
+        return false;
+      }
+      setUserId('');
+      restoreLocalDraft();
+      return false;
+    }
+  }, [mergeLoadedProfileData, normalizeProfileData, restoreLocalDraft]);
 
   const updateFieldValue = (name, value, field) => {
     const updatedValue = inputUpdateValue(value, field);
@@ -557,36 +581,19 @@ export const MyProfile = () => {
       }
 
       const uid = user.uid;
-      if (activeAuthUidRef.current && activeAuthUidRef.current !== uid) {
+      const hasLocalProfileState = Object.keys(stateRef.current || {}).length > 0;
+      if (activeAuthUidRef.current !== uid && (activeAuthUidRef.current || hasLocalProfileState)) {
         resetAuthenticatedProfileState();
       }
       activeAuthUidRef.current = uid;
-      latestFetchUidRef.current = uid;
-      setUserId(uid);
-
-      try {
-        const { existingData } = await fetchUserData(uid);
-
-        if (!isMounted || latestFetchUidRef.current !== uid) {
-          return;
-        }
-
-        mergeLoadedProfileData(normalizeProfileData(existingData || {}), uid);
-      } catch (error) {
-        console.warn('Failed to load MyProfile profile data.', error);
-        if (!isMounted || latestFetchUidRef.current !== uid) {
-          return;
-        }
-        setUserId('');
-        restoreLocalDraft();
-      }
+      await loadAuthenticatedProfile(uid, () => isMounted);
     });
 
     return () => {
       isMounted = false;
       unsubscribe();
     };
-  }, [resetAuthenticatedProfileState, restoreLocalDraft]);
+  }, [loadAuthenticatedProfile, resetAuthenticatedProfileState, restoreLocalDraft]);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async user => {
@@ -602,6 +609,9 @@ export const MyProfile = () => {
   }, [state.areTermsConfirmed, hasAgreed]);
 
   const handleExit = async () => {
+    await saveQueueRef.current.catch(error => {
+      console.warn('Failed to finish MyProfile autosave before logout.', error);
+    });
     resetAuthenticatedProfileState();
     await signOut(auth);
     localStorage.removeItem('isLoggedIn');
@@ -806,6 +816,7 @@ export const MyProfile = () => {
       const methods = await fetchSignInMethodsForEmail(auth, normalizedEmail);
       let userCredential;
       let uploadedInfo;
+      let authenticatedProfileLoaded = true;
       const { password: _password, userId: _userId, ...draftProfileData } = stateRef.current;
 
       if (methods.length > 0) {
@@ -816,6 +827,7 @@ export const MyProfile = () => {
         setUserId(userCredential.user.uid);
         uploadedInfo = buildAuthSessionPayload({ todayDays, todayDash });
         await persistUserProfile(userCredential.user.uid, uploadedInfo, 'update');
+        authenticatedProfileLoaded = await loadAuthenticatedProfile(userCredential.user.uid);
       } else {
         userCredential = await createUserWithEmailAndPassword(auth, normalizedEmail, password);
         await sendEmailVerification(userCredential.user);
@@ -833,7 +845,9 @@ export const MyProfile = () => {
       markAuthSession({ email: normalizedEmail, userId: userCredential.user.uid });
 
       setHasAgreed(true);
-      setUserId(userCredential.user.uid);
+      if (authenticatedProfileLoaded) {
+        setUserId(userCredential.user.uid);
+      }
       setMissing({});
       if (methods.length === 0) {
         const nextState = {


### PR DESCRIPTION
### Motivation

- Prevent local unscoped drafts from being accidentally saved to an authenticated account when the page mounts with an already-authenticated user.  
- Ensure signing in with the same account explicitly reloads the authenticated profile so the UI is not left with an empty editable profile.  
- Avoid silently discarding a just-edited field when the user logs out immediately after a blur by flushing pending autosaves before invalidating session state.

### Description

- Introduce `loadAuthenticatedProfile(uid, shouldApply)` to centralize fetching, normalizing, and merging an authenticated account while rejecting stale/unmounted requests.  
- Convert `normalizeProfileData` and `mergeLoadedProfileData` to `useCallback` and reuse them from the new loader.  
- Treat the first authenticated callback as an identity transition when a local draft exists by checking `hasLocalProfileState` and calling `resetAuthenticatedProfileState()` when appropriate.  
- After sign-in into an existing account, explicitly call `loadAuthenticatedProfile(...)` and only set `userId` when the profile load completes, and await `saveQueueRef.current` in `handleExit` to flush pending autosaves before clearing state.  
- Add regression tests that assert draft isolation, same-account reload behavior, and autosave flush-before-logout in `src/components/MyProfile.accountIsolation.test.js`.

### Testing

- ✅ `git diff --check` (no whitespace or patch errors).  
- ✅ `CI=true npm test -- --runInBand src/components/MyProfile.accountIsolation.test.js src/components/MyProfile.fieldHistoryAccumulation.test.js` — both suites passed (2 suites, 10 tests).  
- ✅ `npm run lint:js -- --quiet` (lint passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68c64bbd4c8326a47ace7a65aa0e1c)