### PR TITLE
Migrate comments to comments/{ownerId}/{cardId} flat structure

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -113,7 +113,7 @@ import {
   sanitizeTechnicalPayload,
 } from './formFields';
 import { PAGE_SIZE, database } from './config';
-import { get as firebaseGet, push, ref } from 'firebase/database';
+import { get as firebaseGet, ref } from 'firebase/database';
 import {
   getBackendDownloadToastsEnabled,
   setBackendDownloadToastsEnabled,
@@ -1662,7 +1662,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         const commentsJson = { [EXCEL_COMMENTS_OWNER_ID]: {} };
         const dislikesJson = { [EXCEL_COMMENTS_OWNER_ID]: {} };
         const todayTimestamp = Date.now();
-        const commentsOwnerRef = ref(database, `multiData/comments/${EXCEL_COMMENTS_OWNER_ID}`);
 
         dataRows.forEach((row, index) => {
           const rowArray = Array.isArray(row) ? row : [];
@@ -1682,14 +1681,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             ...(phone ? { phone } : {}),
           };
 
-          const commentId = push(commentsOwnerRef).key || `comment-${userId}`;
-
-          commentsJson[EXCEL_COMMENTS_OWNER_ID][commentId] = {
-            authorId: EXCEL_COMMENTS_OWNER_ID,
-            cardId: userId,
-            lastAction: todayTimestamp,
-            text: commentText,
-          };
+          if (commentText) {
+            commentsJson[EXCEL_COMMENTS_OWNER_ID][userId] = {
+              text: commentText,
+              updatedAt: todayTimestamp,
+            };
+          }
 
           dislikesJson[EXCEL_COMMENTS_OWNER_ID][userId] = true;
         });

--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -755,7 +755,7 @@ const EditProfile = () => {
   }, [state, userId]);
 
   // myComment no longer lives on the card itself — it's a per-admin note
-  // in multiData/comments (setUserComment/fetchUserComment). Once the card is
+  // in comments/{ownerId}/{cardId} (setUserComment/fetchUserComment). Once the card is
   // loaded, overlay the current admin's own comment onto state.myComment so
   // the existing ProfileForm textarea keeps working exactly as before, and
   // mirror it into lastSyncedSnapshotRef so remoteUpdate's change-detection
@@ -767,7 +767,7 @@ const EditProfile = () => {
     (async () => {
       const existing = await fetchUserComment(currentUid, userId);
       if (cancelled) return;
-      const myComment = existing.length ? existing[0].text : '';
+      const myComment = existing?.text || '';
       setState(prev => (prev && prev.userId === userId ? { ...prev, myComment } : prev));
       if (lastSyncedSnapshotRef.current) {
         lastSyncedSnapshotRef.current = { ...lastSyncedSnapshotRef.current, myComment };

--- a/src/components/EditProfile.myCommentPersonalization.test.js
+++ b/src/components/EditProfile.myCommentPersonalization.test.js
@@ -9,7 +9,7 @@ describe('EditProfile treats myComment as the current admin\'s personal note', (
     expect(source).toContain('saveMyCardComment,');
   });
 
-  it('seeds state.myComment from the current admin\'s own multiData/comments entry on load', () => {
+  it('seeds state.myComment from the current admin\'s own comments/{ownerId}/{cardId} entry on load', () => {
     const seedEffectBody = source.slice(
       source.indexOf("if (!userId || !currentUid || !isAdmin || !dataSource) return;"),
       source.indexOf('}, [userId, currentUid, isAdmin, dataSource]);')

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -81,7 +81,7 @@ import {
   filterMain,
   searchUsersOnly,
   fetchUserComments,
-  setUserComment,
+  saveMyCardComment,
   fetchUsersByIds,
   database,
   auth,
@@ -1936,14 +1936,13 @@ const Matching = () => {
     fetchedEntries.forEach(({ owner, comments: ownerComments = {}, requestedIds = [] }) => {
       nextStore[owner] = { ...(nextStore[owner] || {}) };
       requestedIds.forEach(id => {
-        const serverComments = ownerComments?.[id] || [];
-        const newestServer = [...serverComments].sort((a, b) => (b.lastAction || 0) - (a.lastAction || 0))[0];
+        const serverComment = ownerComments?.[id] || null;
         const local = nextStore[owner][id];
-        if (shouldUseServerComment(newestServer, local)) {
+        if (shouldUseServerComment(serverComment, local)) {
           nextStore[owner][id] = {
-            ...newestServer,
-            text: String(newestServer.text || ''),
-            lastAction: newestServer.lastAction || Date.now(),
+            ...serverComment,
+            text: String(serverComment.text || ''),
+            lastAction: serverComment.lastAction || Date.now(),
             cachedAt: Date.now(),
           };
         } else if (local) {
@@ -2034,7 +2033,7 @@ const Matching = () => {
               paths: accessOwnerIds.map(sharedOwnerId => ({
                 favorites: `multiData/favorites/${sharedOwnerId}`,
                 dislikes: `multiData/dislikes/${sharedOwnerId}`,
-                comments: `multiData/comments/${sharedOwnerId}`,
+                comments: `comments/${sharedOwnerId}`,
               })),
             });
             setMultiDataOwnerIds(resolvedOwnerIds);
@@ -5865,7 +5864,7 @@ const Matching = () => {
                       onCommentBlur={async () => {
                         if (auth.currentUser) {
                           const text = comments[user.userId] || '';
-                          const res = await setUserComment(user.userId, text, ownerId);
+                          const res = await saveMyCardComment(user.userId, text, ownerId);
                           setLocalComment(ownerId, user.userId, text, res?.lastAction);
                         }
                       }}

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1070,6 +1070,9 @@ export const fetchCycleUsersData = async (
   }
 };
 
+// Особистий коментар адміна до картки — comments/{ownerId}/{cardId} = { text, updatedAt }.
+// Рівно один запис на пару ownerId+cardId: повторне збереження оновлює його
+// (set), а не створює новий запис із випадковим ключем (push() не використовується).
 export const setUserComment = async (cardId, text, ownerId) => {
   try {
     const user = auth.currentUser;
@@ -1080,62 +1083,43 @@ export const setUserComment = async (cardId, text, ownerId) => {
       throw new Error('cardId і text обовʼязкові');
     }
     const commentsOwnerId = ownerId || user.uid;
-    const commentsRef = ref2(database, `multiData/comments/${commentsOwnerId}`);
-    const q = query(commentsRef, orderByChild('cardId'), equalTo(cardId));
-    const snap = await get(q);
-    const lastAction = Date.now();
-    if (snap.exists()) {
-      const key = Object.keys(snap.val())[0];
-      await set(ref2(database, `multiData/comments/${commentsOwnerId}/${key}`), {
-        cardId,
-        text,
-        authorId: commentsOwnerId,
-        lastAction,
-      });
-      return { commentId: key, lastAction };
-    }
-    const newRef = push(commentsRef);
-    await set(newRef, { cardId, text, authorId: commentsOwnerId, lastAction });
-    return { commentId: newRef.key, lastAction };
+    const updatedAt = Date.now();
+    await set(ref2(database, `comments/${commentsOwnerId}/${cardId}`), { text, updatedAt });
+    return { lastAction: updatedAt };
   } catch (error) {
     console.error('Error setting comment:', error);
     return null;
   }
 };
 
-export const updateCommentByOwner = async ({ ownerId, commentId, cardId, text }) => {
+export const updateCommentByOwner = async ({ ownerId, cardId, text }) => {
   try {
     const user = auth.currentUser;
     if (!user) {
       throw new Error('User not authenticated');
     }
-    if (!ownerId || !commentId || !cardId || typeof text !== 'string') {
-      throw new Error('ownerId, commentId, cardId і text обовʼязкові');
+    if (!ownerId || !cardId || typeof text !== 'string') {
+      throw new Error('ownerId, cardId і text обовʼязкові');
     }
-    const lastAction = Date.now();
-    await set(ref2(database, `multiData/comments/${ownerId}/${commentId}`), {
-      cardId,
-      text,
-      authorId: ownerId,
-      lastAction,
-    });
-    return { commentId, lastAction, ownerId };
+    const updatedAt = Date.now();
+    await set(ref2(database, `comments/${ownerId}/${cardId}`), { text, updatedAt });
+    return { lastAction: updatedAt, ownerId };
   } catch (error) {
     console.error('Error updating comment by owner:', error);
     return null;
   }
 };
 
-export const deleteCommentByOwner = async ({ ownerId, commentId }) => {
+export const deleteCommentByOwner = async ({ ownerId, cardId }) => {
   try {
     const user = auth.currentUser;
     if (!user) {
       throw new Error('User not authenticated');
     }
-    if (!ownerId || !commentId) {
-      throw new Error('ownerId і commentId обовʼязкові');
+    if (!ownerId || !cardId) {
+      throw new Error('ownerId і cardId обовʼязкові');
     }
-    await remove(ref2(database, `multiData/comments/${ownerId}/${commentId}`));
+    await remove(ref2(database, `comments/${ownerId}/${cardId}`));
     return true;
   } catch (error) {
     console.error('Error deleting comment by owner:', error);
@@ -1145,35 +1129,28 @@ export const deleteCommentByOwner = async ({ ownerId, commentId }) => {
 
 export const fetchUserComment = async (ownerId, cardId) => {
   try {
-    const q = query(
-      ref2(database, `multiData/comments/${ownerId}`),
-      orderByChild('cardId'),
-      equalTo(cardId)
-    );
-    const snap = await get(q);
-    if (!snap.exists()) return [];
-    return Object.entries(snap.val()).map(([commentId, value]) => ({
-      commentId,
-      cardId: value.cardId,
-      text: value.text,
-      lastAction: value.lastAction || 0,
-    }));
+    if (!ownerId || !cardId) return null;
+    const snap = await get(ref2(database, `comments/${ownerId}/${cardId}`));
+    if (!snap.exists()) return null;
+    const value = snap.val();
+    return {
+      text: typeof value?.text === 'string' ? value.text : '',
+      lastAction: typeof value?.updatedAt === 'number' ? value.updatedAt : 0,
+    };
   } catch (error) {
     console.error('Error fetching comment:', error);
-    return [];
+    return null;
   }
 };
 
 // Зберігає (або, для порожнього тексту, видаляє) особистий коментар поточного
-// адміна до картки в multiData/comments — замінює старий підхід "писати прямо
+// адміна до картки в comments/{ownerId}/{cardId} — замінює старий підхід "писати прямо
 // в поле myComment на картці".
 export const saveMyCardComment = async (cardId, text, ownerId) => {
   const trimmed = (text || '').trim();
   if (!trimmed) {
-    const existing = await fetchUserComment(ownerId, cardId);
-    await Promise.all(
-      existing.map(({ commentId }) => deleteCommentByOwner({ ownerId, commentId }))
-    );
+    const commentsOwnerId = ownerId || auth.currentUser?.uid;
+    await deleteCommentByOwner({ ownerId: commentsOwnerId, cardId });
     return null;
   }
   return setUserComment(cardId, text, ownerId);
@@ -1182,22 +1159,18 @@ export const saveMyCardComment = async (cardId, text, ownerId) => {
 export const fetchUserComments = async (ownerId, cardIds = []) => {
   try {
     incrementMatchingLoadStat('commentsReads', Array.isArray(cardIds) ? cardIds.length : 0);
-    const commentsRef = ref2(database, `multiData/comments/${ownerId}`);
-    const snaps = await Promise.all(
-      cardIds.map(cardId =>
-        get(query(commentsRef, orderByChild('cardId'), equalTo(cardId)))
-      )
-    );
+    if (!ownerId || !Array.isArray(cardIds) || !cardIds.length) return {};
+    const snap = await get(ref2(database, `comments/${ownerId}`));
+    if (!snap.exists()) return {};
+    const ownerComments = snap.val() || {};
     const result = {};
-    snaps.forEach((snap, idx) => {
-      if (snap.exists()) {
-        const arr = Object.entries(snap.val()).map(([commentId, val]) => ({
-          commentId,
-          text: val.text || '',
-          lastAction: val.lastAction || 0,
-        }));
-        result[cardIds[idx]] = arr;
-      }
+    cardIds.forEach(cardId => {
+      const value = ownerComments[cardId];
+      if (!value || typeof value !== 'object') return;
+      result[cardId] = {
+        text: typeof value.text === 'string' ? value.text : '',
+        lastAction: typeof value.updatedAt === 'number' ? value.updatedAt : 0,
+      };
     });
     return result;
   } catch (error) {
@@ -1209,28 +1182,21 @@ export const fetchUserComments = async (ownerId, cardIds = []) => {
 export const fetchAllCommentsByCardId = async cardId => {
   try {
     if (!cardId) return [];
-    const snap = await get(ref2(database, 'multiData/comments'));
+    const snap = await get(ref2(database, 'comments'));
     if (!snap.exists()) return [];
 
-    const normalizedCardId = String(cardId).trim().toLowerCase();
     const result = [];
 
     Object.entries(snap.val() || {}).forEach(([ownerId, ownerComments]) => {
       if (!ownerComments || typeof ownerComments !== 'object') return;
-      Object.entries(ownerComments).forEach(([commentId, value]) => {
-        if (!value || typeof value !== 'object') return;
-        const candidateCardId = String(value.cardId || '').trim().toLowerCase();
-        if (candidateCardId !== normalizedCardId) return;
-        const text = String(value.text || '').trim();
-        if (!text) return;
-        result.push({
-          ownerId,
-          commentId,
-          cardId: value.cardId || cardId,
-          text,
-          authorId: value.authorId || ownerId,
-          lastAction: value.lastAction || 0,
-        });
+      const value = ownerComments[cardId];
+      if (!value || typeof value !== 'object') return;
+      const text = String(value.text || '').trim();
+      if (!text) return;
+      result.push({
+        ownerId,
+        text,
+        lastAction: typeof value.updatedAt === 'number' ? value.updatedAt : 0,
       });
     });
 
@@ -2715,7 +2681,7 @@ const removeUndefined = obj => {
 
 // Ключі, які ніколи не мають лишатись записаними на самій картці users/newUsers:
 // клієнтські кеш-мітки (транзитні за природою) та 'myComment', яке мігрувало в
-// окреме сховище multiData/comments (per-адмін коментарі, config.js: setUserComment
+// окреме сховище comments/{ownerId}/{cardId} (per-адмін коментарі, config.js: setUserComment
 // / fetchUserComment). Останнє тут не тому, що воно транзитне, а тому, що для
 // нього тепер є власне джерело правди — картка більше не повинна його дублювати.
 const transientUserDataKeys = [

--- a/src/components/config.myCommentMigration.test.js
+++ b/src/components/config.myCommentMigration.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('myComment moves off the card into multiData/comments (per-admin)', () => {
+describe('myComment moves off the card into comments/{ownerId}/{cardId} (per-admin)', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
 
   it('strips myComment from every users/newUsers write and actively deletes it on updates', () => {
@@ -12,13 +12,33 @@ describe('myComment moves off the card into multiData/comments (per-admin)', () 
     expect(transientKeysBody).toContain("'myComment',");
   });
 
-  it('exposes a saveMyCardComment helper that writes to multiData/comments and deletes when text is empty', () => {
+  it('writes comments directly to comments/{ownerId}/{cardId} without push() or a commentId', () => {
+    const fnBody = source.slice(
+      source.indexOf('export const setUserComment'),
+      source.indexOf('export const updateCommentByOwner')
+    );
+    expect(fnBody).toContain('comments/${commentsOwnerId}/${cardId}');
+    expect(fnBody).not.toContain('push(');
+    expect(fnBody).not.toContain('orderByChild');
+    expect(fnBody).not.toContain('authorId');
+  });
+
+  it('exposes a saveMyCardComment helper that writes via setUserComment and deletes when text is empty', () => {
     const fnBody = source.slice(
       source.indexOf('export const saveMyCardComment'),
       source.indexOf('export const fetchUserComments')
     );
-    expect(fnBody).toContain('fetchUserComment(ownerId, cardId)');
-    expect(fnBody).toContain('deleteCommentByOwner({ ownerId, commentId })');
+    expect(fnBody).toContain('deleteCommentByOwner({ ownerId: commentsOwnerId, cardId })');
     expect(fnBody).toContain('return setUserComment(cardId, text, ownerId);');
+  });
+
+  it('reads a single comment straight from comments/{ownerId}/{cardId}, without orderByChild/equalTo', () => {
+    const fnBody = source.slice(
+      source.indexOf('export const fetchUserComment '),
+      source.indexOf('export const saveMyCardComment')
+    );
+    expect(fnBody).toContain('comments/${ownerId}/${cardId}');
+    expect(fnBody).not.toContain('orderByChild');
+    expect(fnBody).not.toContain('equalTo');
   });
 });

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -3,7 +3,7 @@ import { useAutoResize } from '../../hooks/useAutoResize';
 import { auth, fetchUserComment, saveMyCardComment } from '../config';
 
 // Персональний коментар поточного адміна до картки — зберігається в
-// multiData/comments/{ownerId}, а не прямо в самій картці (users/newUsers).
+// comments/{ownerId}/{cardId}, а не прямо в самій картці (users/newUsers).
 export const FieldComment = ({ userData }) => {
   const textareaRef = useRef(null);
   const [text, setText] = useState('');
@@ -18,7 +18,7 @@ export const FieldComment = ({ userData }) => {
 
     fetchUserComment(ownerId, cardId).then(existing => {
       if (cancelled) return;
-      setText(existing.length ? existing[0].text : '');
+      setText(existing?.text || '');
     });
 
     return () => {

--- a/src/components/smallCard/FieldComment.test.js
+++ b/src/components/smallCard/FieldComment.test.js
@@ -14,11 +14,11 @@ describe('FieldComment', () => {
   beforeEach(() => {
     fetchUserComment.mockReset();
     saveMyCardComment.mockReset();
-    fetchUserComment.mockResolvedValue([]);
+    fetchUserComment.mockResolvedValue(null);
   });
 
   it("loads the current admin's own comment for this card, not a card field", async () => {
-    fetchUserComment.mockResolvedValue([{ commentId: 'c1', text: 'my private note' }]);
+    fetchUserComment.mockResolvedValue({ text: 'my private note', updatedAt: 123 });
 
     render(<FieldComment userData={{ userId: 'user-1', myComment: 'legacy card value' }} />);
 
@@ -39,7 +39,7 @@ describe('FieldComment', () => {
   });
 
   it('clearing the comment persists an empty value', async () => {
-    fetchUserComment.mockResolvedValue([{ commentId: 'c1', text: 'existing' }]);
+    fetchUserComment.mockResolvedValue({ text: 'existing', updatedAt: 123 });
     render(<FieldComment userData={{ userId: 'user-1' }} />);
 
     const clearButton = await screen.findByLabelText('Очистити коментар');

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1322,9 +1322,9 @@ export const TopBlock = ({
       source: 'local',
     }));
     const fromBackend = backendMultiComments.map(item => ({
-      commentId: item.commentId,
+      commentId: item.ownerId || '',
       text: item.text,
-      authorId: item.authorId || item.ownerId || '',
+      authorId: item.ownerId || '',
       ownerId: item.ownerId || '',
       source: 'backend',
       lastAction: Number(item.lastAction) || 0,
@@ -1598,10 +1598,9 @@ export const TopBlock = ({
     }
 
     let result = null;
-    if (selectedComment?.ownerId && selectedComment?.commentId) {
+    if (selectedComment?.ownerId) {
       result = await updateCommentByOwner({
         ownerId: selectedComment.ownerId,
-        commentId: selectedComment.commentId,
         cardId: cardData.userId,
         text: prepared,
       });
@@ -1614,7 +1613,7 @@ export const TopBlock = ({
     }
     setBackendMultiComments(prev =>
       prev.map(item =>
-        item.commentId === targetCommentId && (item.ownerId || '') === (selectedComment?.ownerId || '')
+        (item.ownerId || '') === (selectedComment?.ownerId || '')
           ? { ...item, text: prepared, lastAction: result.lastAction || Date.now() }
           : item
       )
@@ -1625,20 +1624,20 @@ export const TopBlock = ({
   };
 
   const handleDeleteComment = async comment => {
-    if (!isAdmin || !comment?.ownerId || !comment?.commentId) {
+    if (!isAdmin || !comment?.ownerId) {
       toast.error('Видалення недоступне');
       return;
     }
     const isDeleted = await deleteCommentByOwner({
       ownerId: comment.ownerId,
-      commentId: comment.commentId,
+      cardId: cardData.userId,
     });
     if (!isDeleted) {
       toast.error('Не вдалося видалити коментар');
       return;
     }
     setBackendMultiComments(prev =>
-      prev.filter(item => !(item.commentId === comment.commentId && item.ownerId === comment.ownerId))
+      prev.filter(item => item.ownerId !== comment.ownerId)
     );
     toast.success('Коментар видалено');
   };


### PR DESCRIPTION
Comments now live at comments/{ownerId}/{cardId} = { text, updatedAt }
instead of multiData/comments/{ownerId}/{commentId} with pushed keys
and authorId/cardId/lastAction fields. Since cardId is now the record
key, reads/writes go straight to the deterministic path instead of
push()/orderByChild('cardId')/equalTo() queries, and each owner can
have at most one comment per card (set() replaces the old record,
remove() drops it when the text is cleared).

Updates config.js's setUserComment/updateCommentByOwner/
deleteCommentByOwner/fetchUserComment/saveMyCardComment/
fetchUserComments/fetchAllCommentsByCardId plus every caller
(FieldComment, EditProfile, Matching, renderTopBlock's multiData
comment admin UI, AddNewProfile's Excel comment export) and the
tests asserting the old push/orderByChild-based implementation.