### PR TITLE
Documents Builder: negative logo offsets, unified logo block, save-error diagnostics, single-shipment model (batch 26 §1-5)

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -6610,6 +6610,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       <InnerContainer>
         {isLoggedIn && (
           <TopButtons>
+            {/* Batch 26 §11: the "⋮" menu first, matching every other UKRCOM admin page's header
+                (PageNavMenu is always the first action button there). */}
+            <DotsButton
+              aria-label="Відкрити меню профілю"
+              onClick={() => {
+                setShowInfoModal('dotsMenu');
+              }}
+            >
+              ⋮
+            </DotsButton>
             {state.userId && (
               <>
                 <EditActionButton
@@ -6692,14 +6702,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               📦
               <DownloadSizeToastStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</DownloadSizeToastStatus>
             </DownloadSizeToastToggleButton>
-            <DotsButton
-              aria-label="Відкрити меню профілю"
-              onClick={() => {
-                setShowInfoModal('dotsMenu');
-              }}
-            >
-              ⋮
-            </DotsButton>
           </TopButtons>
         )}
 

--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -866,7 +866,11 @@ const SaveModalActionTitle = styled.strong`
 
 
 const PROFILE_RESTORE_LOG_PREFIX = '[ProfileRestore]';
-const MATCHING_DEBUG_LOG_MODE_KEY = 'matchingDebugLogMode';
+// Batch 26 §8: whether ProfileForm/TopBlock show their backend-navigation arrows (the ones that
+// jump a field straight to where it's stored in Firebase) - off by default, so the profile-card
+// edit page stays uncluttered until an admin actually needs to inspect the backend, and persisted
+// so the choice survives a reload the same way the other toolbar toggles here do.
+const PROFILE_FORM_EXTENDED_MODE_KEY = 'profileFormExtendedMode';
 const LOAD_DEBUG_LOG_PREFIX = '[AddNewProfileLoad]';
 const CONTACT_EXPORT_LOG_PREFIX = '[ContactsExport]';
 const CONTACT_EXPORT_DEBUG_USER_ID = '-Ots_t0kim8mWxe7BT_P';
@@ -1240,10 +1244,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const searchListIsolationRef = useRef(Boolean((search || '').trim()));
   const [isExcelImporting, setIsExcelImporting] = useState(false);
   const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
-  const [matchingDebugLogMode, setMatchingDebugLogMode] = useState(() => (
-    typeof localStorage !== 'undefined' && localStorage.getItem(MATCHING_DEBUG_LOG_MODE_KEY) === 'file'
-      ? 'file'
-      : 'console'
+  const [extendedMode, setExtendedMode] = useState(() => (
+    typeof localStorage !== 'undefined' && localStorage.getItem(PROFILE_FORM_EXTENDED_MODE_KEY) === 'true'
   ));
   const excelImportInputRef = useRef(null);
   const [showSearchKeyIndexPanel, setShowSearchKeyIndexPanel] = useState(false);
@@ -1612,24 +1614,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     console.log(LOAD_DEBUG_LOG_PREFIX, step, entry);
     return entry;
   }, []);
-
-  const downloadMatchingDebugLogs = useCallback(() => {
-    if (typeof window === 'undefined') return 0;
-
-    const logs = Array.isArray(window.__MATCHING_DEBUG_LOGS)
-      ? window.__MATCHING_DEBUG_LOGS
-      : [];
-
-    downloadJsonFile(`matching-debug-${buildJsonDownloadStamp()}.json`, {
-      userAgent: window.navigator?.userAgent || '',
-      url: window.location?.href || '',
-      timestamp: new Date().toISOString(),
-      logsCount: logs.length,
-      logs,
-    });
-
-    return logs.length;
-  }, [downloadJsonFile]);
 
   const handleExcelProfilesUpload = useCallback(
     async event => {
@@ -6144,30 +6128,12 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const handleDownloadSizeToastsToggle = () => {
     setDownloadSizeToastsEnabled(prev => !prev);
   };
-  const handleMatchingDebugLogModeToggle = () => {
-    const nextMode = matchingDebugLogMode === 'file' ? 'console' : 'file';
-    const downloadedLogsCount = matchingDebugLogMode === 'file'
-      ? downloadMatchingDebugLogs()
-      : null;
-
-    if (typeof window !== 'undefined') {
-      window.__MATCHING_DEBUG_LOG_MODE = nextMode;
-      if (nextMode === 'file') window.__MATCHING_DEBUG_LOGS = [];
-      window.dispatchEvent(new CustomEvent('matchingDebugLogModeChange', {
-        detail: { mode: nextMode },
-      }));
-    }
-
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(MATCHING_DEBUG_LOG_MODE_KEY, nextMode);
-    }
-
-    setMatchingDebugLogMode(nextMode);
-    toast.success(
-      nextMode === 'file'
-        ? 'Режим file-логів Matching увімкнено.'
-        : `Режим console-логів Matching увімкнено. Log-файл завантажено (${downloadedLogsCount || 0}).`
-    );
+  const handleExtendedModeToggle = () => {
+    setExtendedMode(prev => {
+      const next = !prev;
+      if (typeof localStorage !== 'undefined') localStorage.setItem(PROFILE_FORM_EXTENDED_MODE_KEY, String(next));
+      return next;
+    });
   };
 
   const fieldsToRender = getFieldsToRender(state);
@@ -6698,6 +6664,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
             )}
             <DownloadSizeToastToggleButton
               type="button"
+              $active={extendedMode}
+              aria-pressed={extendedMode}
+              title={extendedMode ? 'Сховати стрілки переходу до backend на полях' : 'Показати стрілки переходу до backend на полях'}
+              aria-label={extendedMode ? 'Сховати стрілки переходу до backend на полях' : 'Показати стрілки переходу до backend на полях'}
+              onClick={handleExtendedModeToggle}
+            >
+              🧭
+              <DownloadSizeToastStatus>{extendedMode ? 'EXT' : 'STD'}</DownloadSizeToastStatus>
+            </DownloadSizeToastToggleButton>
+            <DownloadSizeToastToggleButton
+              type="button"
               $active={downloadSizeToastsEnabled}
               aria-pressed={downloadSizeToastsEnabled}
               title={
@@ -6715,19 +6692,6 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               📦
               <DownloadSizeToastStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</DownloadSizeToastStatus>
             </DownloadSizeToastToggleButton>
-            {isAdmin && (
-              <DownloadSizeToastToggleButton
-                type="button"
-                $active={matchingDebugLogMode === 'file'}
-                aria-pressed={matchingDebugLogMode === 'file'}
-                title={matchingDebugLogMode === 'file' ? 'Перемкнути логи Matching у консоль' : 'Перемкнути логи Matching у файл'}
-                aria-label={matchingDebugLogMode === 'file' ? 'Перемкнути логи Matching у консоль' : 'Перемкнути логи Matching у файл'}
-                onClick={handleMatchingDebugLogModeToggle}
-              >
-                🧾
-                <DownloadSizeToastStatus>{matchingDebugLogMode === 'file' ? 'FILE' : 'LOG'}</DownloadSizeToastStatus>
-              </DownloadSizeToastToggleButton>
-            )}
             <DotsButton
               aria-label="Відкрити меню профілю"
               onClick={() => {
@@ -6877,6 +6841,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 setState={setState}
                 setUserIdToDelete={setUserIdToDelete}
                 isFromListOfUsers={false}
+                extendedMode={extendedMode}
                 favoriteUsers={favoriteUsersData}
                 setFavoriteUsers={setFavoriteUsersData}
                 dislikeUsers={dislikeUsersData}
@@ -6973,6 +6938,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               handleDelKeyValue={handleDelKeyValue}
               dataSource={profileSource}
               isAdmin={isAdmin}
+              extendedMode={extendedMode}
             />
           </>
         ) : (

--- a/src/components/CaseArtProgramEditor.jsx
+++ b/src/components/CaseArtProgramEditor.jsx
@@ -1,10 +1,12 @@
 // "Програма ДРТ" (case.artProgram editor) - the shared, once-only medical facts of a case's
-// fertility program: diagnosis/genetic material/attending physician, embryo shipments from a
-// partner clinic, and transfer attempts (each carrying its own hCG tests and ultrasounds). Every
-// document that references one of these events (embryoOwnershipStatement,
-// geneticAffinityCertificate, racssClinicLetter - edited in CaseChildbirthTransactionEditor) only
+// fertility program: diagnosis/genetic material/attending physician, the one embryo shipment from
+// the case's one partner clinic (batch 26 §5, stored at relations.shipment - "one case = one
+// partner clinic = one shipment"), and the transfer attempt (carrying its own hCG tests and
+// ultrasounds). Every document that references the transfer attempt's hCG tests/ultrasounds
+// (geneticAffinityCertificate, racssClinicLetter - edited in CaseChildbirthTransactionEditor) only
 // ever stores the id it points at, never a copy of the fact itself - editing an event here is
-// instantly reflected in every document that references it.
+// instantly reflected in every document that references it. The shipment itself needs no id at
+// all any more - every document just resolves the case's one shipment directly.
 //
 // Self-contained (same reasoning as CaseChildbirthTransactionEditor's own header comment): no
 // dependency on the host page's internals, so it drops into any --km-* scoped page as-is.
@@ -16,7 +18,6 @@ import { FaPlus, FaTrash } from 'react-icons/fa';
 import { database } from './config';
 import {
   DOCUMENTS_CASES_PATH,
-  formatShipmentOptionLabel,
   normalizeIsoDate,
   removeEmptyCaseValues,
   toArray,
@@ -212,16 +213,24 @@ const nextSequentialId = (prefix, items) => {
 };
 
 // One transfer attempt per case (batch 24 §2) - only the successful attempt's data ever matters
-// once the program is underway, so this is a single record, not a log of attempts.
+// once the program is underway, so this is a single record, not a log of attempts. It references
+// no shipment id of its own any more (batch 26 §5) - there is only ever the case's one shipment.
 const emptyTransferAttempt = () => ({
-  shipmentId: '', date: '', embryoCount: '', embryoStage: '', hcgTests: [], ultrasounds: [],
+  date: '', embryoCount: '', embryoStage: '', hcgTests: [], ultrasounds: [],
+});
+
+// One shipment per case (batch 26 §5: "one case = one partner clinic = one shipment" - a case that
+// ever needs a second shipment is a second case, not a second entry here), stored directly under
+// the case's relations rather than in a shipmentId-addressed list, so no document referencing it
+// can ever point at the wrong (or no) entry.
+const emptyShipment = () => ({
+  sourceClinicId: '', destinationClinicId: '', ivfDate: '', plannedPeriod: { startDate: '', endDate: '' }, receivedDate: '',
 });
 
 const emptyArtProgramDraft = () => ({
   medicalIndication: { diagnosis: { uk: '' } },
   geneticMaterial: { oocyteSourcePartnerRole: '', spermSourcePartnerRole: '' },
   medicalTeam: { physician: { name: { uk: { nominative: '' } } } },
-  embryoShipments: [],
   transferAttempt: emptyTransferAttempt(),
 });
 
@@ -248,6 +257,9 @@ const arrayToMap = items => (items || []).reduce((byId, item) => {
 const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
   const selectedCase = catalog.cases.find(item => String(item.id) === String(caseId)) || null;
   const [draft, setDraft] = useState(emptyArtProgramDraft());
+  // The case's one shipment (batch 26 §5) lives at relations.shipment, a separate backend path from
+  // artProgram - its own draft/save, same pattern the format-override draft elsewhere uses.
+  const [shipmentDraft, setShipmentDraft] = useState(emptyShipment());
 
   useEffect(() => {
     const artProgram = selectedCase?.artProgram || {};
@@ -260,14 +272,19 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
       medicalTeam: {
         physician: { name: { uk: { nominative: artProgram.medicalTeam?.physician?.name?.uk?.nominative || '' } } },
       },
-      // toArray tolerates a Firebase map-with-gaps the same way every other reader in this app does
-      // (see documentsCatalogUtils.toArray) - never assumes the backend snapshot is a real Array.
-      embryoShipments: toArray(artProgram.embryoShipments),
       transferAttempt: {
         ...emptyTransferAttempt(),
         ...artProgram.transferAttempt,
         hcgTests: toArray(artProgram.transferAttempt?.hcgTests),
         ultrasounds: toArray(artProgram.transferAttempt?.ultrasounds),
+      },
+    });
+    setShipmentDraft({
+      ...emptyShipment(),
+      ...(selectedCase?.relations?.shipment || {}),
+      plannedPeriod: {
+        ...emptyShipment().plannedPeriod,
+        ...(selectedCase?.relations?.shipment?.plannedPeriod || {}),
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -283,38 +300,48 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
     medicalTeam: { physician: { name: { uk: { nominative: value } } } },
   }));
 
-  // --- Embryo shipments ------------------------------------------------------------------------
+  // --- The one embryo shipment (batch 26 §5) --------------------------------------------------
 
-  const addShipment = () => setDraft(previous => ({
-    ...previous,
-    embryoShipments: [...previous.embryoShipments, {
-      id: nextSequentialId('shipment', previous.embryoShipments),
-      sourceClinicId: '',
-      destinationClinicId: '',
-      ivfDate: '',
-      plannedPeriod: { startDate: '', endDate: '' },
-      receivedDate: '',
-    }],
-  }));
-
-  const removeShipment = shipmentId => setDraft(previous => ({
-    ...previous,
-    embryoShipments: previous.embryoShipments.filter(shipment => shipment.id !== shipmentId),
-  }));
-
-  const updateShipmentField = (shipmentId, field, value) => setDraft(previous => ({
-    ...previous,
-    embryoShipments: previous.embryoShipments.map(shipment => (shipment.id === shipmentId ? { ...shipment, [field]: value } : shipment)),
-  }));
+  const updateShipmentField = (field, value) => setShipmentDraft(previous => ({ ...previous, [field]: value }));
 
   // A migrated shipment may still carry `plannedPeriod.text` (spec §6) - preserved untouched here
   // (spread first) since there's no input for it; only startDate/endDate are ever edited.
-  const updateShipmentPeriodField = (shipmentId, field, value) => setDraft(previous => ({
+  const updateShipmentPeriodField = (field, value) => setShipmentDraft(previous => ({
     ...previous,
-    embryoShipments: previous.embryoShipments.map(shipment => (shipment.id === shipmentId
-      ? { ...shipment, plannedPeriod: { ...(shipment.plannedPeriod || {}), [field]: value } }
-      : shipment)),
+    plannedPeriod: { ...(previous.plannedPeriod || {}), [field]: value },
   }));
+
+  const handleSaveShipment = async () => {
+    if (!selectedCase) return;
+    const cleaned = removeEmptyCaseValues({
+      ...shipmentDraft,
+      ivfDate: normalizeIsoDate(shipmentDraft.ivfDate),
+      receivedDate: normalizeIsoDate(shipmentDraft.receivedDate),
+      plannedPeriod: {
+        ...(shipmentDraft.plannedPeriod || {}),
+        startDate: normalizeIsoDate(shipmentDraft.plannedPeriod?.startDate),
+        endDate: normalizeIsoDate(shipmentDraft.plannedPeriod?.endDate),
+      },
+    });
+    const nextValue = Object.keys(cleaned).length ? cleaned : null;
+    try {
+      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/relations/shipment`), nextValue);
+      setCatalog(previous => ({
+        ...previous,
+        cases: previous.cases.map(item => {
+          if (String(item.id) !== String(selectedCase.id)) return item;
+          const relations = { ...(item.relations || {}) };
+          if (nextValue) relations.shipment = nextValue;
+          else delete relations.shipment;
+          return { ...item, relations };
+        }),
+      }));
+      toast.success('Shipment details saved.');
+    } catch (saveError) {
+      console.error('Unable to save the shipment details', saveError);
+      toast.error(`Could not save the shipment details: ${describeSaveError(saveError)}`);
+    }
+  };
 
   // --- The one transfer attempt + its nested hCG tests/ultrasounds ------------------------------
 
@@ -366,16 +393,6 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
       medicalIndication: draft.medicalIndication,
       geneticMaterial: draft.geneticMaterial,
       medicalTeam: draft.medicalTeam,
-      embryoShipments: arrayToMap(draft.embryoShipments.map(shipment => ({
-        ...shipment,
-        ivfDate: normalizeIsoDate(shipment.ivfDate),
-        receivedDate: normalizeIsoDate(shipment.receivedDate),
-        plannedPeriod: {
-          ...(shipment.plannedPeriod || {}),
-          startDate: normalizeIsoDate(shipment.plannedPeriod?.startDate),
-          endDate: normalizeIsoDate(shipment.plannedPeriod?.endDate),
-        },
-      }))),
       transferAttempt: {
         ...draft.transferAttempt,
         date: normalizeIsoDate(draft.transferAttempt.date),
@@ -460,77 +477,72 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
         </Field>
       </FieldGrid>
 
+      {/* One shipment only (batch 26 §5: "one case = one partner clinic = one shipment") - an edit
+          form for that one record, not a list; no add/remove, and no shipmentId for any document to
+          get out of sync with (the exact failure mode the old list model allowed). */}
       <SectionSubhead style={{ marginTop: 14 }}>Доставлення ембріонів</SectionSubhead>
-      {draft.embryoShipments.map((shipment, index) => (
-        <DocRow key={shipment.id}>
-          <DocRowHead>
-            <DocSubtitle style={{ fontWeight: 700 }}>{shipment.id || `Доставлення ${index + 1}`}</DocSubtitle>
-            <DangerButton type="button" onClick={() => removeShipment(shipment.id)} title="Remove this shipment">
-              <FaTrash />
-            </DangerButton>
-          </DocRowHead>
-          <FieldGrid>
-            <Field>
-              Клініка-відправник
-              <Select value={shipment.sourceClinicId || ''} onChange={event => updateShipmentField(shipment.id, 'sourceClinicId', event.target.value)}>
-                <option value="">— не обрано —</option>
-                {catalog.parties.partnerClinics.map(partnerClinic => (
-                  <option key={partnerClinic.id} value={String(partnerClinic.id)}>{partnerClinic.name?.uk || partnerClinic.id}</option>
-                ))}
-              </Select>
-            </Field>
-            <Field>
-              Клініка-отримувач
-              <Select
-                value={shipment.destinationClinicId || ''}
-                onChange={event => updateShipmentField(shipment.id, 'destinationClinicId', event.target.value)}
-              >
-                <option value="">— не обрано —</option>
-                {catalog.parties.clinics.map(clinic => (
-                  <option key={clinic.id} value={String(clinic.id)}>{clinic.name?.uk || clinic.medicalCenterName?.uk || clinic.id}</option>
-                ))}
-              </Select>
-            </Field>
-            <Field>
-              Дата ЗІВ
-              <FieldInput type="date" value={shipment.ivfDate || ''} onChange={event => updateShipmentField(shipment.id, 'ivfDate', event.target.value)} />
-            </Field>
-            <Field>
-              Запланований період — початок
-              <FieldInput
-                type="date"
-                value={shipment.plannedPeriod?.startDate || ''}
-                onChange={event => updateShipmentPeriodField(shipment.id, 'startDate', event.target.value)}
-              />
-            </Field>
-            <Field>
-              Запланований період — кінець
-              <FieldInput
-                type="date"
-                value={shipment.plannedPeriod?.endDate || ''}
-                onChange={event => updateShipmentPeriodField(shipment.id, 'endDate', event.target.value)}
-              />
-            </Field>
-            <Field>
-              Дата фактичного отримання
-              <FieldInput
-                type="date"
-                value={shipment.receivedDate || ''}
-                onChange={event => updateShipmentField(shipment.id, 'receivedDate', event.target.value)}
-              />
-            </Field>
-          </FieldGrid>
-          {shipment.plannedPeriod?.text?.uk || shipment.plannedPeriod?.text?.en ? (
-            <DocSubtitle style={{ marginTop: 6 }}>
-              Мігрований текстовий період: {shipment.plannedPeriod.text.uk || shipment.plannedPeriod.text.en}
-            </DocSubtitle>
-          ) : null}
-        </DocRow>
-      ))}
+      <DocRow>
+        <FieldGrid>
+          <Field>
+            Клініка-відправник
+            <Select value={shipmentDraft.sourceClinicId || ''} onChange={event => updateShipmentField('sourceClinicId', event.target.value)}>
+              <option value="">— не обрано —</option>
+              {catalog.parties.partnerClinics.map(partnerClinic => (
+                <option key={partnerClinic.id} value={String(partnerClinic.id)}>{partnerClinic.name?.uk || partnerClinic.id}</option>
+              ))}
+            </Select>
+          </Field>
+          <Field>
+            Клініка-отримувач
+            <Select
+              value={shipmentDraft.destinationClinicId || ''}
+              onChange={event => updateShipmentField('destinationClinicId', event.target.value)}
+            >
+              <option value="">— не обрано —</option>
+              {catalog.parties.clinics.map(clinic => (
+                <option key={clinic.id} value={String(clinic.id)}>{clinic.name?.uk || clinic.medicalCenterName?.uk || clinic.id}</option>
+              ))}
+            </Select>
+          </Field>
+          <Field>
+            Дата ЗІВ
+            <FieldInput type="date" value={shipmentDraft.ivfDate || ''} onChange={event => updateShipmentField('ivfDate', event.target.value)} />
+          </Field>
+          <Field>
+            Запланований період — початок
+            <FieldInput
+              type="date"
+              value={shipmentDraft.plannedPeriod?.startDate || ''}
+              onChange={event => updateShipmentPeriodField('startDate', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Запланований період — кінець
+            <FieldInput
+              type="date"
+              value={shipmentDraft.plannedPeriod?.endDate || ''}
+              onChange={event => updateShipmentPeriodField('endDate', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Дата фактичного отримання
+            <FieldInput
+              type="date"
+              value={shipmentDraft.receivedDate || ''}
+              onChange={event => updateShipmentField('receivedDate', event.target.value)}
+            />
+          </Field>
+        </FieldGrid>
+        {shipmentDraft.plannedPeriod?.text?.uk || shipmentDraft.plannedPeriod?.text?.en ? (
+          <DocSubtitle style={{ marginTop: 6 }}>
+            Мігрований текстовий період: {shipmentDraft.plannedPeriod.text.uk || shipmentDraft.plannedPeriod.text.en}
+          </DocSubtitle>
+        ) : null}
+      </DocRow>
       <RowLine style={{ marginTop: 8 }}>
-        <SmallButton type="button" onClick={addShipment}>
-          <FaPlus /> Add shipment
-        </SmallButton>
+        <PrimaryMiniButton type="button" onClick={handleSaveShipment}>
+          Save shipment
+        </PrimaryMiniButton>
       </RowLine>
 
       {/* One record only (batch 24 §2) - the successful transfer attempt's data, filled in once its
@@ -538,17 +550,6 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
       <SectionSubhead style={{ marginTop: 14 }}>Спроба переносу</SectionSubhead>
       <DocRow>
         <FieldGrid>
-          <Field>
-            Доставлення
-            <Select value={draft.transferAttempt.shipmentId || ''} onChange={event => updateTransferField('shipmentId', event.target.value)}>
-              <option value="">— не обрано —</option>
-              {draft.embryoShipments.map(shipment => (
-                <option key={shipment.id} value={shipment.id}>
-                  {formatShipmentOptionLabel(shipment, catalog.parties) || shipment.id}
-                </option>
-              ))}
-            </Select>
-          </Field>
           <Field>
             Дата переносу
             <FieldInput type="date" value={draft.transferAttempt.date || ''} onChange={event => updateTransferField('date', event.target.value)} />

--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -15,7 +15,6 @@ import {
   DOCUMENTS_CASES_PATH,
   createChildRecord,
   formatHcgTestOptionLabel,
-  formatShipmentOptionLabel,
   formatShortNameUk,
   formatUltrasoundOptionLabel,
   getMaternityHospitalDisplayName,
@@ -228,11 +227,6 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   // No notaryId field - this appendix isn't itself notarized (see TEMPLATE_DOCUMENT_CONFIG's
   // usesNotary: false for surrogacy-agreement-appendix-1).
   const [surrogacyAgreementAppendix1Draft, setSurrogacyAgreementAppendix1Draft] = useState({ date: '' });
-  // Spec §4/§14: a fresh pick always writes `shipmentId` (resolved against case.artProgram.
-  // embryoShipments); `legacyIvfDate`/`legacyShipmentPeriod` are read-only leftovers from a
-  // not-yet-migrated record, carried through unedited on save so simply opening/saving this editor
-  // (without touching the shipment dropdown) never destroys them.
-  const [embryoOwnershipDraft, setEmbryoOwnershipDraft] = useState({ shipmentId: '', legacyIvfDate: '', legacyShipmentPeriod: null });
   const [geneticAffinityCertificateDraft, setGeneticAffinityCertificateDraft] = useState({
     hcgTestId: '', ultrasoundId: '', issueDate: '', outgoingNumber: '',
   });
@@ -240,10 +234,10 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   const [medicalServicesAgreementDraft, setMedicalServicesAgreementDraft] = useState({ date: '' });
 
   // Every artProgram-referencing dropdown reads from the same source: the selected case's own
-  // shipments/transfer attempt (never converted to arrays for storage - see documentsCatalogUtils -
-  // only here, transiently, for rendering <option>s). There is only ever one transfer attempt
-  // (batch 24 §2), so its hCG tests/ultrasounds are the only thing still picked by id.
-  const artShipments = toArray(selectedCase?.artProgram?.embryoShipments);
+  // transfer attempt (never converted to arrays for storage - see documentsCatalogUtils - only
+  // here, transiently, for rendering <option>s). There is only ever one transfer attempt (batch 24
+  // §2), so its hCG tests/ultrasounds are the only thing still picked by id - the shipment itself
+  // (batch 26 §5, edited in CaseArtProgramEditor) needs no id/picker anywhere any more.
   const artTransferAttempt = selectedCase?.artProgram?.transferAttempt || null;
   const certificateHcgTests = toArray(artTransferAttempt?.hcgTests);
   const certificateUltrasounds = toArray(artTransferAttempt?.ultrasounds);
@@ -279,11 +273,6 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     });
     setSurrogacyAgreementAppendix1Draft({
       date: selectedCase?.documents?.surrogacyAgreementAppendix1?.date || '',
-    });
-    setEmbryoOwnershipDraft({
-      shipmentId: selectedCase?.documents?.embryoOwnershipStatement?.shipmentId || '',
-      legacyIvfDate: selectedCase?.documents?.embryoOwnershipStatement?.ivfDate || '',
-      legacyShipmentPeriod: selectedCase?.documents?.embryoOwnershipStatement?.shipmentPeriod || null,
     });
     setGeneticAffinityCertificateDraft({
       hcgTestId: selectedCase?.documents?.geneticAffinityCertificate?.hcgTestId || '',
@@ -488,8 +477,6 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
     }
   };
 
-  const updateEmbryoOwnershipShipmentId = shipmentId => setEmbryoOwnershipDraft(previous => ({ ...previous, shipmentId }));
-
   // A generic "save one document sub-record" helper, shared by every document below - each just
   // supplies its own storage key and cleaned payload; never writes an empty `{}` service object,
   // same rule every document editor in this file already follows.
@@ -514,20 +501,6 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       console.error(`Unable to save ${failureLabel}`, saveError);
       toast.error(`Could not save ${failureLabel}: ${describeSaveError(saveError)}`);
     }
-  };
-
-  // Spec §14: a fresh save always writes shipmentId once the admin has actually picked one from
-  // the dropdown; only a case that's still untouched (no shipmentId chosen at all) keeps whatever
-  // legacy ivfDate/shipmentPeriod it already had, so simply opening and saving this editor never
-  // destroys not-yet-migrated data.
-  const handleSaveEmbryoOwnership = () => {
-    const payload = embryoOwnershipDraft.shipmentId
-      ? { shipmentId: embryoOwnershipDraft.shipmentId }
-      : {
-        ivfDate: normalizeIsoDate(embryoOwnershipDraft.legacyIvfDate),
-        shipmentPeriod: embryoOwnershipDraft.legacyShipmentPeriod,
-      };
-    return saveCaseDocument('embryoOwnershipStatement', payload, 'Embryo ownership statement details saved.', 'the embryo ownership statement details');
   };
 
   const updateGeneticAffinityCertificateField = (field, value) => setGeneticAffinityCertificateDraft(previous => ({ ...previous, [field]: value }));
@@ -826,31 +799,9 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
         </PrimaryMiniButton>
       </RowLine>
 
-      <SectionSubhead style={{ marginTop: 14 }}>Заява про належність ембріонів</SectionSubhead>
-      <FieldGrid>
-        <Field style={{ flex: 1, minWidth: 220 }}>
-          Доставлення
-          <Select value={embryoOwnershipDraft.shipmentId || ''} onChange={event => updateEmbryoOwnershipShipmentId(event.target.value)}>
-            <option value="">— не обрано —</option>
-            {artShipments.map(shipment => (
-              <option key={shipment.id} value={shipment.id}>
-                {formatShipmentOptionLabel(shipment, catalog.parties) || shipment.id}
-              </option>
-            ))}
-          </Select>
-        </Field>
-      </FieldGrid>
-      {!embryoOwnershipDraft.shipmentId && (embryoOwnershipDraft.legacyIvfDate || embryoOwnershipDraft.legacyShipmentPeriod?.uk) ? (
-        <DocSubtitle style={{ marginTop: 6 }}>
-          Мігровані дані (зберігаються без змін, поки не обрано доставлення):
-          {' '}{embryoOwnershipDraft.legacyShipmentPeriod?.uk || ''} {embryoOwnershipDraft.legacyIvfDate || ''}
-        </DocSubtitle>
-      ) : null}
-      <RowLine style={{ marginTop: 8 }}>
-        <PrimaryMiniButton type="button" onClick={handleSaveEmbryoOwnership}>
-          Save embryo ownership statement details
-        </PrimaryMiniButton>
-      </RowLine>
+      {/* Заява про належність ембріонів no longer needs its own editor here (batch 26 §5) - it
+          resolves the case's one shipment directly (edited in CaseArtProgramEditor), with no
+          shipmentId of its own left to pick or get out of sync. */}
 
       <SectionSubhead style={{ marginTop: 14 }}>Довідка про генетичну спорідненість</SectionSubhead>
       <FieldGrid>

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -39,6 +39,7 @@ import {
   clinicLogoStorageFilePath,
   clinicLogoStorageFolder,
   DEFAULT_SIGNER_BLOCK_OFFSET_PERCENT,
+  describeDocumentSaveError,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   fillPlaceholders,
@@ -75,6 +76,7 @@ import {
   resolveCaseContext,
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,
+  stripUndefinedDeep,
   TITLE_SCOPE,
   toArray,
   toggleInlineFormat,
@@ -738,14 +740,20 @@ const PopoverCard = styled.div`
 // typing a number sets the override, clearing the field removes it - no separate reset control.
 // The draft is local so partially-typed values ("1.", "0,7") are never rewritten mid-keystroke by
 // the parsed state they commit into.
-const PlainNumberField = ({ label, initialValue, placeholder, onApply, onFieldBlur }) => {
+// `inputMode="decimal"` gets a numeric-only mobile keypad with no minus key on most Android
+// keyboards (Gboard included) - fine for always-positive values (font size, margins, ...), but it
+// silently makes a negative value untypeable on a phone even though parsePlainNumber/onApply
+// happily accept one. Fields whose value can legitimately go negative (the logo's offsetXMm/
+// offsetYMm, "+ = right"/"+ = down") opt into the full text keyboard via `negative` so the minus
+// key is actually reachable.
+const PlainNumberField = ({ label, initialValue, placeholder, onApply, onFieldBlur, negative = false }) => {
   const [draft, setDraft] = useState(initialValue);
   return (
     <Field>
       {label}
       <FieldInput
         type="text"
-        inputMode="decimal"
+        inputMode={negative ? 'text' : 'decimal'}
         value={draft}
         placeholder={placeholder}
         onChange={event => {
@@ -760,7 +768,7 @@ const PlainNumberField = ({ label, initialValue, placeholder, onApply, onFieldBl
 
 // One trigger button + its popover, sharing a boundary node so an outside-click close never
 // races the trigger's own toggle click.
-const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields }) => {
+const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields, children }) => {
   const anchorRef = useRef(null);
   useEffect(() => {
     if (!open) return undefined;
@@ -786,7 +794,7 @@ const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields }) =
       </SmallButton>
       {open ? (
         <PopoverCard>
-          {fields.map(field => (
+          {children || fields.map(field => (
             <PlainNumberField
               key={field.key}
               label={field.label}
@@ -1173,6 +1181,28 @@ const DocumentsPage = ({ isAdmin }) => {
 
   // --- Inline template editing ----------------------------------------------------------------
 
+  // Single choke point for every direct-write template save below (persistTemplate's deferred-blur
+  // flush, plus every structural insert/remove/alignment/format handler that writes immediately):
+  // sanitizes away any stray `undefined` the edit may have produced (Firebase's set() rejects the
+  // *entire* write the instant one appears anywhere in the tree, batch 26 §3 - the underlying cause
+  // behind edits being silently rejected on save, not just the message describing it), writes it,
+  // and on failure names the actual cause instead of every call site's old identical generic toast.
+  const writeTemplateToFirebase = async (docId, nextTemplate, fallbackMessage) => {
+    const sanitized = stripUndefinedDeep(nextTemplate);
+    try {
+      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), sanitized);
+      setCatalog(previous => ({
+        ...previous,
+        documents: previous.documents.map(item => (String(item.id) === String(docId) ? sanitized : item)),
+      }));
+      return true;
+    } catch (saveError) {
+      console.error('Unable to save document template', saveError);
+      toast.error(describeDocumentSaveError(saveError, fallbackMessage));
+      return false;
+    }
+  };
+
   const updateTemplate = (docId, updater) => {
     setCatalog(previous => ({
       ...previous,
@@ -1270,16 +1300,7 @@ const DocumentsPage = ({ isAdmin }) => {
     // identical.
     const currentAlign = scope === TITLE_SCOPE ? getEffectiveTitleAlign(record) : getEffectiveParagraphAlign(record);
     const nextTemplate = withTemplateScopeStyle(template, scope, { align: nextParagraphAlign(currentAlign) });
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (alignError) {
-      console.error('Unable to save the alignment change', alignError);
-      toast.error('Could not save the alignment change.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not save the alignment change.');
   };
 
   // The letterhead logo always renders before the title (spec: "лого відображай перед title") and
@@ -1313,16 +1334,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const nextTemplate = { ...template, paragraphs: buildParagraphs(template.paragraphs || []) };
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (structureError) {
-      console.error('Unable to update the document paragraph structure', structureError);
-      toast.error('Could not save the paragraph change.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not save the paragraph change.');
   };
 
   // `atIndex` may equal paragraphs.length to append a new custom paragraph after the last one.
@@ -1352,16 +1364,7 @@ const DocumentsPage = ({ isAdmin }) => {
       ...template,
       beforeTitle: [...blocks.slice(0, atIndex), { uk: '', en: '' }, ...blocks.slice(atIndex)],
     };
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (structureError) {
-      console.error('Unable to insert the before-title block', structureError);
-      toast.error('Could not save the change.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not save the change.');
   };
 
   const handleRemoveBeforeTitle = async (docId, atIndex) => {
@@ -1369,16 +1372,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const nextTemplate = { ...template, beforeTitle: (template.beforeTitle || []).filter((_, index) => index !== atIndex) };
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (structureError) {
-      console.error('Unable to remove the before-title block', structureError);
-      toast.error('Could not save the change.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not save the change.');
   };
 
   // The title is an ordinary paragraph with the standard toolbar, including delete (batch
@@ -1392,16 +1386,7 @@ const DocumentsPage = ({ isAdmin }) => {
     if (!template) return;
     const nextTemplate = { ...template };
     delete nextTemplate.title;
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (structureError) {
-      console.error('Unable to remove the title', structureError);
-      toast.error('Could not remove the title.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not remove the title.');
   };
 
   // The way back after a delete: an empty title record the admin can type into - without this a
@@ -1410,32 +1395,20 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template || template.title != null) return;
     const nextTemplate = { ...template, title: { uk: '', en: '' } };
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (structureError) {
-      console.error('Unable to add the title', structureError);
-      toast.error('Could not add the title.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not add the title.');
   };
 
   const persistTemplate = async docId => {
     if (!dirtyDocIds[docId]) return;
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), template);
+    const saved = await writeTemplateToFirebase(docId, template, 'Could not save the paragraph edits.');
+    if (saved) {
       setDirtyDocIds(previous => {
         const next = { ...previous };
         delete next[docId];
         return next;
       });
-    } catch (saveError) {
-      console.error('Unable to save document template', saveError);
-      toast.error('Could not save the paragraph edits.');
     }
   };
 
@@ -1493,16 +1466,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const nextTemplate = withTemplateScopeText(template, scope, langKey, nextRaw);
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (saveError) {
-      console.error('Unable to save the template change', saveError);
-      toast.error('Could not save the change.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not save the change.');
   };
 
   const handleApplyInlineFormat = async attr => {
@@ -1558,16 +1522,7 @@ const DocumentsPage = ({ isAdmin }) => {
       ...template,
       layoutV2: { ...template.layoutV2, blocks: buildBlocks(template.layoutV2?.blocks || []) },
     };
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (structureError) {
-      console.error('Unable to update the layoutV2 paragraph structure', structureError);
-      toast.error('Could not save the change.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not save the change.');
   };
 
   // `atIndex` may equal blocks.length to append a new paragraph after the last block.
@@ -1705,16 +1660,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const nextTemplate = { ...template };
     if (template.columns === columns) delete nextTemplate.columns;
     else nextTemplate.columns = columns;
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (columnsError) {
-      console.error('Unable to update the document column count', columnsError);
-      toast.error('Could not update the document.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not update the document.');
   };
 
   // A template carrying `layoutV2.blocks` can render two ways: the exact-layout engine
@@ -1725,16 +1671,7 @@ const DocumentsPage = ({ isAdmin }) => {
     const template = catalog.documents.find(item => String(item.id) === String(docId));
     if (!template) return;
     const nextTemplate = { ...template, rendererVersion: template.rendererVersion === 2 ? 1 : 2 };
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${docId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === String(docId) ? nextTemplate : item)),
-      }));
-    } catch (rendererError) {
-      console.error('Unable to switch the document renderer', rendererError);
-      toast.error('Could not update the document.');
-    }
+    await writeTemplateToFirebase(docId, nextTemplate, 'Could not update the document.');
   };
 
   // --- Deletes (always behind an explicit confirmation) ----------------------------------------
@@ -1951,17 +1888,10 @@ const DocumentsPage = ({ isAdmin }) => {
     const nextTemplate = { ...template };
     if (Object.keys(overrides).length) nextTemplate.format = overrides;
     else delete nextTemplate.format;
-    try {
-      await set(ref(database, `${DOCUMENTS_TEMPLATES_PATH}/${formatDocId}`), nextTemplate);
-      setCatalog(previous => ({
-        ...previous,
-        documents: previous.documents.map(item => (String(item.id) === formatDocId ? nextTemplate : item)),
-      }));
+    const saved = await writeTemplateToFirebase(formatDocId, nextTemplate, 'Could not save the format for this document.');
+    if (saved) {
       setDocFormatDraft(normalizedDraft);
       toast.success('Format saved for this document.');
-    } catch (saveError) {
-      console.error('Unable to save the per-document format override', saveError);
-      toast.error('Could not save the format for this document.');
     }
   };
 
@@ -3188,8 +3118,62 @@ const DocumentsPage = ({ isAdmin }) => {
                             to edit here at all. */}
                         {isLayoutV2Template(template) ? (
                           <>
-                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Paragraphs</DocSubtitle>
+                            {/* Task 2 (batch 26): one continuous list, in the template's own
+                                blocks order (letterhead first, same as it prints) - a block holding
+                                the clinic logo gets the exact same card/border/spacing as one
+                                holding text, never a visually special-cased section of its own. */}
+                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Blocks</DocSubtitle>
                             {template.layoutV2.blocks.map((block, blockIndex) => {
+                              if (block?.type === 'letterhead') {
+                                return (block.columns || []).map((column, columnIndex) => {
+                                  if (column?.content?.type !== 'image') return null;
+                                  const { content } = column;
+                                  const logoScope = `letterhead-${blockIndex}-${columnIndex}`;
+                                  return (
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    <ParagraphEditorBlock key={`${template.id}-lv2-logo-${blockIndex}-${columnIndex}`}>
+                                      <ParagraphControlsRow>
+                                        <RowLine style={{ gap: 6 }}>
+                                          <FormatPopoverButton
+                                            open={openFormatKey === formatPopoverKey(template.id, logoScope)}
+                                            onToggle={() => toggleFormatPopover(template.id, logoScope)}
+                                            onClose={() => closeFormatPopover(template.id)}
+                                            buttonTitle="Clinic logo - show/hide and offset (mm)"
+                                          >
+                                            <CheckLine>
+                                              <input
+                                                type="checkbox"
+                                                checked={!content.hidden}
+                                                onChange={() => handleToggleLayoutV2LogoHidden(template.id, blockIndex, columnIndex)}
+                                              />
+                                              Show logo
+                                            </CheckLine>
+                                            <PlainNumberField
+                                              label="Horizontal offset (mm, + = right)"
+                                              initialValue={content.offsetXMm !== undefined ? String(content.offsetXMm) : ''}
+                                              placeholder="0"
+                                              negative
+                                              onApply={raw => setLayoutV2LogoOffset(template.id, blockIndex, columnIndex, 'offsetXMm', raw)}
+                                              onFieldBlur={() => persistTemplate(template.id)}
+                                            />
+                                            <PlainNumberField
+                                              label="Vertical offset (mm, + = down)"
+                                              initialValue={content.offsetYMm !== undefined ? String(content.offsetYMm) : ''}
+                                              placeholder="0"
+                                              negative
+                                              onApply={raw => setLayoutV2LogoOffset(template.id, blockIndex, columnIndex, 'offsetYMm', raw)}
+                                              onFieldBlur={() => persistTemplate(template.id)}
+                                            />
+                                          </FormatPopoverButton>
+                                        </RowLine>
+                                      </ParagraphControlsRow>
+                                      <ParagraphFieldColumn>
+                                        <TextModeDisplay>Clinic logo</TextModeDisplay>
+                                      </ParagraphFieldColumn>
+                                    </ParagraphEditorBlock>
+                                  );
+                                });
+                              }
                               if (block?.type !== 'paragraph' && block?.type !== 'richParagraph') return null;
                               const scope = layoutV2Scope(blockIndex);
                               const mode = getParagraphMode(template.id, scope);
@@ -3323,54 +3307,6 @@ const DocumentsPage = ({ isAdmin }) => {
                                 <FaPlus />
                               </SmallButton>
                             </ParagraphControlsRow>
-                          </>
-                        ) : null}
-                        {/* Clinic logo (letterhead image column): a "Show logo" toggle - hides it
-                            without discarding its widthMm/heightMm/etc, so turning it back on
-                            needs no re-entering - plus horizontal/vertical offsets (mm) that move
-                            the logo image within its own fixed-width column, never the column's
-                            own widthMm. Every column (image or not) keeps its declared width
-                            regardless of the logo's offset, so the clinic contact block beside it
-                            never shifts when the logo moves (spec: "решта тексту ... не стрибала"). */}
-                        {isLayoutV2Template(template) ? (
-                          <>
-                            <DocSubtitle style={{ fontWeight: 700, marginTop: 10 }}>Clinic logo</DocSubtitle>
-                            {template.layoutV2.blocks.map((block, blockIndex) => {
-                              if (block?.type !== 'letterhead') return null;
-                              return (block.columns || []).map((column, columnIndex) => {
-                                if (column?.content?.type !== 'image') return null;
-                                const { content } = column;
-                                return (
-                                  // eslint-disable-next-line react/no-array-index-key
-                                  <ParagraphEditorBlock key={`${template.id}-lv2-logo-${blockIndex}-${columnIndex}`}>
-                                    <RowLine style={{ gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
-                                      <CheckLine>
-                                        <input
-                                          type="checkbox"
-                                          checked={!content.hidden}
-                                          onChange={() => handleToggleLayoutV2LogoHidden(template.id, blockIndex, columnIndex)}
-                                        />
-                                        Show logo
-                                      </CheckLine>
-                                      <PlainNumberField
-                                        label="Horizontal offset (mm, + = right)"
-                                        initialValue={content.offsetXMm !== undefined ? String(content.offsetXMm) : ''}
-                                        placeholder="0"
-                                        onApply={raw => setLayoutV2LogoOffset(template.id, blockIndex, columnIndex, 'offsetXMm', raw)}
-                                        onFieldBlur={() => persistTemplate(template.id)}
-                                      />
-                                      <PlainNumberField
-                                        label="Vertical offset (mm, + = down)"
-                                        initialValue={content.offsetYMm !== undefined ? String(content.offsetYMm) : ''}
-                                        placeholder="0"
-                                        onApply={raw => setLayoutV2LogoOffset(template.id, blockIndex, columnIndex, 'offsetYMm', raw)}
-                                        onFieldBlur={() => persistTemplate(template.id)}
-                                      />
-                                    </RowLine>
-                                  </ParagraphEditorBlock>
-                                );
-                              });
-                            })}
                           </>
                         ) : null}
                         {/* Task 4: the document exactly as the exported PDF - same generation

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -766,6 +766,27 @@ const PlainNumberField = ({ label, initialValue, placeholder, onApply, onFieldBl
   );
 };
 
+// Same shape/behavior as PlainNumberField, for a field whose value is arbitrary text rather than a
+// number (e.g. a block's `condition` path - batch 26 §6) - no numeric parsing/keypad hint at all.
+const PlainTextField = ({ label, initialValue, placeholder, onApply, onFieldBlur }) => {
+  const [draft, setDraft] = useState(initialValue);
+  return (
+    <Field>
+      {label}
+      <FieldInput
+        type="text"
+        value={draft}
+        placeholder={placeholder}
+        onChange={event => {
+          setDraft(event.target.value);
+          onApply(event.target.value);
+        }}
+        onBlur={onFieldBlur}
+      />
+    </Field>
+  );
+};
+
 // One trigger button + its popover, sharing a boundary node so an outside-click close never
 // races the trigger's own toggle click.
 const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields, children }) => {
@@ -794,16 +815,19 @@ const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields, chi
       </SmallButton>
       {open ? (
         <PopoverCard>
-          {children || fields.map(field => (
-            <PlainNumberField
-              key={field.key}
-              label={field.label}
-              initialValue={field.value}
-              placeholder={field.placeholder}
-              onApply={field.onApply}
-              onFieldBlur={field.onFieldBlur}
-            />
-          ))}
+          {children || fields.map(field => {
+            const FieldComponent = field.type === 'text' ? PlainTextField : PlainNumberField;
+            return (
+              <FieldComponent
+                key={field.key}
+                label={field.label}
+                initialValue={field.value}
+                placeholder={field.placeholder}
+                onApply={field.onApply}
+                onFieldBlur={field.onFieldBlur}
+              />
+            );
+          })}
         </PopoverCard>
       ) : null}
     </PopoverAnchor>
@@ -1275,6 +1299,24 @@ const DocumentsPage = ({ isAdmin }) => {
     updateTemplate(docId, template => withTemplateScopeStyle(template, scope, { [styleKey]: parsed }));
   };
 
+  // Batch 26 §6: a body paragraph's own condition (evaluateBlockCondition, documentsCatalogUtils) -
+  // a plain context path (optionally `!`-negated) that must resolve truthy against the selected
+  // case for the paragraph to print at all. Blank clears it back to "always shown". Unlike the
+  // style fields above this is a top-level paragraph field, not one more entry under `style`.
+  const setParagraphCondition = (docId, index, raw) => {
+    const trimmed = raw.trim();
+    updateTemplate(docId, template => ({
+      ...template,
+      paragraphs: toArray(template.paragraphs).map((paragraph, i) => {
+        if (i !== index) return paragraph;
+        const next = { ...paragraph };
+        if (trimmed) next.condition = trimmed;
+        else delete next.condition;
+        return next;
+      }),
+    }));
+  };
+
   // §1.3: for the before-title block the popover's "indent" field is the whole block's offset in
   // percent (notarial layout standard §3.3) - one number per document, '' restores the default.
   const setBeforeTitleOffset = (docId, raw) => {
@@ -1559,6 +1601,26 @@ const DocumentsPage = ({ isAdmin }) => {
           if (parsed === null) delete nextOverrides[styleKey];
           else nextOverrides[styleKey] = parsed;
           return { ...item, styleOverrides: nextOverrides };
+        }),
+      },
+    }));
+  };
+
+  // Batch 26 §6: same condition support as a legacy paragraph's (setParagraphCondition), for a
+  // layoutV2 paragraph/richParagraph block - a top-level `condition` field, never one more entry
+  // under styleOverrides.
+  const setLayoutV2BlockCondition = (docId, blockIndex, raw) => {
+    const trimmed = raw.trim();
+    updateTemplate(docId, template => ({
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: (template.layoutV2?.blocks || []).map((item, index) => {
+          if (index !== blockIndex) return item;
+          const next = { ...item };
+          if (trimmed) next.condition = trimmed;
+          else delete next.condition;
+          return next;
         }),
       },
     }));
@@ -3004,7 +3066,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                     open={openFormatKey === formatPopoverKey(template.id, scope)}
                                     onToggle={() => toggleFormatPopover(template.id, scope)}
                                     onClose={() => closeFormatPopover(template.id)}
-                                    buttonTitle="Paragraph formatting - font size (pt) and first-line indent (cm); empty = inherit the document value"
+                                    buttonTitle="Paragraph formatting - font size (pt), first-line indent (cm), and condition; empty = inherit/always shown"
                                     fields={[
                                       {
                                         key: 'fontSize',
@@ -3020,6 +3082,15 @@ const DocumentsPage = ({ isAdmin }) => {
                                         value: paragraphStyle.indentCm !== undefined ? String(paragraphStyle.indentCm) : '',
                                         placeholder: docFormatting.firstLineIndentCm.toFixed(1),
                                         onApply: raw => setScopeStyleField(template.id, scope, 'indentCm', raw),
+                                        onFieldBlur: () => persistTemplate(template.id),
+                                      },
+                                      {
+                                        key: 'condition',
+                                        type: 'text',
+                                        label: 'Condition (context path, ! to negate; empty = always shown)',
+                                        value: paragraph?.condition || '',
+                                        placeholder: 'e.g. geneticAffinityCertificate.oocyteSourceIsWife',
+                                        onApply: raw => setParagraphCondition(template.id, index, raw),
                                         onFieldBlur: () => persistTemplate(template.id),
                                       },
                                     ]}
@@ -3243,7 +3314,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         open={openFormatKey === formatPopoverKey(template.id, scope)}
                                         onToggle={() => toggleFormatPopover(template.id, scope)}
                                         onClose={() => closeFormatPopover(template.id)}
-                                        buttonTitle="Paragraph formatting - font size (pt); empty = inherit the template style"
+                                        buttonTitle="Paragraph formatting - font size (pt) and condition; empty = inherit/always shown"
                                         fields={[
                                           {
                                             key: 'fontSizePt',
@@ -3251,6 +3322,15 @@ const DocumentsPage = ({ isAdmin }) => {
                                             value: block.styleOverrides?.fontSizePt !== undefined ? String(block.styleOverrides.fontSizePt) : '',
                                             placeholder: '',
                                             onApply: raw => setLayoutV2StyleOverrideField(template.id, blockIndex, 'fontSizePt', raw),
+                                            onFieldBlur: () => persistTemplate(template.id),
+                                          },
+                                          {
+                                            key: 'condition',
+                                            type: 'text',
+                                            label: 'Condition (context path, ! to negate; empty = always shown)',
+                                            value: block.condition || '',
+                                            placeholder: 'e.g. geneticAffinityCertificate.oocyteSourceIsWife',
+                                            onApply: raw => setLayoutV2BlockCondition(template.id, blockIndex, raw),
                                             onFieldBlur: () => persistTemplate(template.id),
                                           },
                                         ]}

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -253,6 +253,10 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
+    // The logo's Show-logo/offset controls live behind the same "☰" settings popover every
+    // paragraph block has (batch 26 §2) - open it before the fields inside are reachable.
+    fireEvent.click(await screen.findByTitle('Clinic logo - show/hide and offset (mm)'));
+
     const logoCheckbox = await screen.findByRole('checkbox', { name: 'Show logo' });
     // eslint-disable-next-line testing-library/no-node-access
     const logoBlock = logoCheckbox.closest('.paragraph-editor-block');

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -74,7 +74,7 @@ beforeEach(() => {
   listStorageFolderFileNames.mockResolvedValue([]);
 });
 
-const PARAGRAPH_FORMAT_TITLE = 'Paragraph formatting - font size (pt) and first-line indent (cm); empty = inherit the document value';
+const PARAGRAPH_FORMAT_TITLE = 'Paragraph formatting - font size (pt), first-line indent (cm), and condition; empty = inherit/always shown';
 
 const openParagraphPopover = async paragraphText => {
   const field = await screen.findByText(paragraphText);

--- a/src/components/DocumentsPage.saveErrorMessage.test.js
+++ b/src/components/DocumentsPage.saveErrorMessage.test.js
@@ -1,0 +1,136 @@
+// Real-DOM regression test (batch 26 §3): "Could not save the paragraph edits" used to fire no
+// matter what actually went wrong - a stray `undefined` value the edit itself produced (which
+// Firebase's set() rejects outright), a permission error, a network blip, all looked identical to
+// the admin. persistTemplate/writeTemplateToFirebase (DocumentsPage.jsx) now (a) sanitizes the
+// template before every write, so a stray undefined never reaches Firebase and blocks the save at
+// all, and (b) classifies whatever *does* fail via describeDocumentSaveError instead of showing one
+// generic string regardless of cause.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  render, screen, fireEvent, waitFor, within,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('firebase/database', () => ({
+  ref: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'test-admin' } },
+  database: {},
+  deleteStorageFile: jest.fn(),
+  getStorageFileDataUrl: jest.fn(),
+  listStorageFolderFileNames: jest.fn(),
+  uploadFileToStorageFolder: jest.fn(),
+}));
+
+jest.mock('utils/accessLevel', () => ({ isInvoiceBuilderUid: () => true }));
+jest.mock('utils/pdfImageEncoding', () => ({ reencodePdfImageDataUrl: jest.fn() }));
+
+const mockToastError = jest.fn();
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { error: (...args) => mockToastError(...args), success: jest.fn() },
+}));
+
+// eslint-disable-next-line import/first
+import { ref, get, set } from 'firebase/database';
+// eslint-disable-next-line import/first
+import { listStorageFolderFileNames } from './config';
+// eslint-disable-next-line import/first
+import DocumentsPage from './DocumentsPage';
+
+beforeEach(() => {
+  mockToastError.mockClear();
+  ref.mockImplementation((_db, path) => path);
+  get.mockImplementation(async path => {
+    if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+    if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+    if (path === 'documentsBuilder/templates') {
+      return {
+        exists: () => true,
+        val: () => ({
+          'doc-1': {
+            id: 'doc-1',
+            title: { uk: 'Заява', en: 'Statement' },
+            paragraphs: [{ uk: 'Абзац.', en: 'Paragraph.' }],
+          },
+        }),
+      };
+    }
+    return { exists: () => false, val: () => null };
+  });
+  listStorageFolderFileNames.mockResolvedValue([]);
+});
+
+const PARAGRAPH_FORMAT_TITLE = 'Paragraph formatting - font size (pt) and first-line indent (cm); empty = inherit the document value';
+
+const triggerParagraphSave = async () => {
+  render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+  fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+  const field = await screen.findByText('Абзац.');
+  // eslint-disable-next-line testing-library/no-node-access
+  const block = field.closest('.paragraph-editor-block');
+  fireEvent.click(within(block).getByTitle(PARAGRAPH_FORMAT_TITLE));
+  const indentField = within(block).getByLabelText('First line indent (cm)');
+  fireEvent.change(indentField, { target: { value: '2' } });
+  fireEvent.blur(indentField);
+};
+
+describe('spec (batch 26 §3): a rejected save names its actual cause instead of one generic message', () => {
+  it('a stray-undefined-value rejection reads as an invalid-value message, not the old generic one', async () => {
+    set.mockRejectedValue(new Error("Reference.set failed: First argument contains undefined in property 'paragraphs.0.style'"));
+    await triggerParagraphSave();
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    const [message] = mockToastError.mock.calls[0];
+    expect(message).toMatch(/empty value/i);
+    expect(message).not.toBe('Could not save the paragraph edits.');
+  });
+
+  it('a permission-denied rejection reads as a permission message', async () => {
+    set.mockRejectedValue(new Error('PERMISSION_DENIED: Permission denied'));
+    await triggerParagraphSave();
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastError.mock.calls[0][0]).toMatch(/permission/i);
+  });
+
+  it('a network-failure rejection reads as a network message', async () => {
+    set.mockRejectedValue(new Error('network request failed'));
+    await triggerParagraphSave();
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastError.mock.calls[0][0]).toMatch(/network/i);
+  });
+
+  it('an unclassified rejection still falls back to this action\'s own specific message', async () => {
+    set.mockRejectedValue(new Error('something odd happened'));
+    await triggerParagraphSave();
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastError.mock.calls[0][0]).toBe('Could not save the paragraph edits.');
+  });
+
+  it('a template edit that would carry a stray undefined is sanitized before ever reaching Firebase', async () => {
+    set.mockResolvedValue(undefined);
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    const field = await screen.findByText('Абзац.');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = field.closest('.paragraph-editor-block');
+    fireEvent.click(within(block).getByTitle(PARAGRAPH_FORMAT_TITLE));
+    const indentField = within(block).getByLabelText('First line indent (cm)');
+    fireEvent.change(indentField, { target: { value: '2' } });
+    fireEvent.blur(indentField);
+
+    await waitFor(() => expect(set).toHaveBeenCalled());
+    const [, savedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
+    const traverse = value => {
+      if (Array.isArray(value)) return value.every(traverse);
+      if (value && typeof value === 'object') return Object.values(value).every(entry => entry !== undefined && traverse(entry));
+      return true;
+    };
+    expect(traverse(savedTemplate)).toBe(true);
+  });
+});

--- a/src/components/DocumentsPage.saveErrorMessage.test.js
+++ b/src/components/DocumentsPage.saveErrorMessage.test.js
@@ -67,7 +67,7 @@ beforeEach(() => {
   listStorageFolderFileNames.mockResolvedValue([]);
 });
 
-const PARAGRAPH_FORMAT_TITLE = 'Paragraph formatting - font size (pt) and first-line indent (cm); empty = inherit the document value';
+const PARAGRAPH_FORMAT_TITLE = 'Paragraph formatting - font size (pt), first-line indent (cm), and condition; empty = inherit/always shown';
 
 const triggerParagraphSave = async () => {
   render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -371,8 +371,10 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
       <DocumentTitleBlock doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} titleGap={titleGap} blankFields={blankFields} />
       {doc.paragraphs.map((paragraph, index) => {
         // Already drawn as doc.logo above - a legacy leading logo paragraph must not also render
-        // a second time in its old body position.
-        if (paragraph.type === 'logo-consumed') return null;
+        // a second time in its old body position. A conditionally-hidden paragraph (batch 26 §6)
+        // is the same kind of no-op-for-the-renderer tag, kept in the array (not spliced out) so
+        // every other paragraph's index stays stable for the editor.
+        if (paragraph.type === 'logo-consumed' || paragraph.type === 'condition-hidden') return null;
         return (
           <View key={`p-${index}`} wrap>
             {paragraph.type && paragraph.type !== 'text' ? (
@@ -845,7 +847,7 @@ const DocumentsPdfDocument = ({
     const blankFields = isOfficialFormStyle(doc);
     const headerLogoReserve = resolveHeaderLogoReserve(doc, effectiveClinicLogos, logoWidth);
     const pageStyleForDoc = headerLogoReserve ? { ...pageStyle, paddingTop: marginTop + headerLogoReserve } : pageStyle;
-    const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed');
+    const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed' && paragraph.type !== 'condition-hidden');
     const pageContentHeightPt = A4_HEIGHT_PT - marginTop - headerLogoReserve - marginBottom;
     const charsPerLine = estimateCharsPerLine({ columnWidthPt: columnContentWidth, fontSize: formatting.fontSize });
     const capacity = estimateColumnPageCapacity({

--- a/src/components/DocumentsPdfPreview.jsx
+++ b/src/components/DocumentsPdfPreview.jsx
@@ -16,6 +16,7 @@ const PreviewBlock = styled.div.attrs({ className: 'pdf-preview-block' })`
   padding: 6px 8px 8px;
   margin-top: 10px;
   background: rgba(162, 121, 63, 0.025);
+  overflow: hidden;
 `;
 
 const PreviewHead = styled.div`
@@ -70,10 +71,13 @@ const ChromeButton = styled.button`
 const PageViewport = styled.div`
   margin-top: 6px;
   touch-action: pan-y;
+  max-width: 100%;
 
   canvas {
     display: block;
     width: 100%;
+    max-width: 100%;
+    height: auto;
     border: 1px solid var(--km-border);
     border-radius: 4px;
     background: #fff;

--- a/src/components/PageNavMenu.jsx
+++ b/src/components/PageNavMenu.jsx
@@ -1,14 +1,25 @@
-// Shared "⋮" page switcher for the three UKRCOM admin pages (Documents / Invoice / Budget),
-// per the Documents-page spec §8. Rendered inside each page's header actions; relies on the
+// Shared "⋮" page switcher for the UKRCOM admin pages (Documents / Invoice / Budget / Parties /
+// Style Editor), per the Documents-page spec §8. Rendered inside each page's header actions, as
+// the first action button (batch 26 §11 - standardized placement, every page); relies on the
 // page-scoped --km-* palette variables every one of those pages defines.
+//
+// Batch 26 §10: lists every existing top-level screen, not just the five UKRCOM admin pages, so
+// this menu offers the same set of destinations everywhere it appears - addNewProfile/matching/
+// my-profile/flow used to be reachable only from ProfileDotsMenu (the profile pages' own "⋮"),
+// leaving an admin on Documents/Invoice/Budget/Parties/Style Editor with no way back to them
+// short of typing a URL.
 import React, { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const NAV_LINKS = [
-  { path: '/documents', label: 'Documents' },
-  { path: '/invoices', label: 'Invoice' },
+  { path: '/add', label: 'Add profile' },
+  { path: '/matching', label: 'Matching' },
+  { path: '/my-profile', label: 'My profile' },
+  { path: '/flow', label: 'Flow' },
   { path: '/budget', label: 'Budget' },
+  { path: '/invoices', label: 'Invoice' },
+  { path: '/documents', label: 'Documents' },
   { path: '/parties', label: 'Parties' },
   { path: '/document-styles', label: 'Style Editor' },
 ];

--- a/src/components/PageNavMenu.test.js
+++ b/src/components/PageNavMenu.test.js
@@ -1,0 +1,26 @@
+// Batch 26 §10/§11: PageNavMenu (the shared "⋮" page switcher) must list every existing top-level
+// screen - not just the five UKRCOM admin pages it originally covered - so an admin on any one of
+// them can reach addNewProfile/matching/my-profile/flow without typing a URL.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PageNavMenu from './PageNavMenu';
+
+describe('spec (batch 26 §10): PageNavMenu lists every top-level screen', () => {
+  it('opens to a dropdown containing every destination, not just the five UKRCOM admin pages', () => {
+    render(<MemoryRouter><PageNavMenu /></MemoryRouter>);
+    fireEvent.click(screen.getByTitle('Switch page'));
+
+    ['Add profile', 'Matching', 'My profile', 'Flow', 'Budget', 'Invoice', 'Documents', 'Parties', 'Style Editor']
+      .forEach(label => expect(screen.getByText(label)).toBeInTheDocument());
+  });
+
+  it('navigates to the matching route on click', () => {
+    render(<MemoryRouter><PageNavMenu /></MemoryRouter>);
+    fireEvent.click(screen.getByTitle('Switch page'));
+    fireEvent.click(screen.getByText('Matching'));
+    // The dropdown closes after a pick - the same interaction every other link already gets.
+    expect(screen.queryByText('Documents')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -1402,10 +1402,12 @@ const PartiesPage = ({ isAdmin }) => {
             <Title>Parties</Title>
           </div>
           <HeaderActions>
+            {/* Batch 26 §11: PageNavMenu first, matching every other UKRCOM admin page's header -
+                this was the one page with it last, after the Edit/Read toggle. */}
+            <PageNavMenu />
             <MiniButton type="button" onClick={handleToggleEditMode} aria-pressed={isEditMode} title={isEditMode ? 'Switch to read mode' : 'Edit parties'}>
               <FaPen /> {isEditMode ? 'Read' : 'Edit'}
             </MiniButton>
-            <PageNavMenu />
           </HeaderActions>
         </Header>
 

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -162,7 +162,10 @@ describe('spec: Parties page', () => {
     fireEvent.click(await screen.findByText('Testova Mariia & Testovyi Petro'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Clinic slot' }));
-    fireEvent.click(await screen.findByText('Клініка Мрія'));
+    // Disambiguated by role: the case's ART-program shipment editor (batch 26 §5) also always
+    // renders a "Клініка-отримувач" <option> of the same name now that it's no longer gated behind
+    // "+ Add shipment" first.
+    fireEvent.click(await screen.findByRole('button', { name: 'Клініка Мрія' }));
 
     await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/cases/case-1/relations/clinicId', 'clinic-1'));
     await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/partiesSettings/recentIds/clinics', ['clinic-1']));

--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
-import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaFileInvoiceDollar, FaFileAlt, FaAddressBook, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
+import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaFileInvoiceDollar, FaFileAlt, FaAddressBook, FaPalette, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
 import { MdPersonAddAlt1 } from 'react-icons/md';
 import { VerifyEmail } from './VerifyEmail';
 import { useAppSettings } from 'hooks/useAppSettings';
@@ -223,6 +223,9 @@ export const ProfileDotsMenu = ({
     ...(isAdmin ? [{ path: '/invoices', label: 'Invoices', description: 'Create and export client invoices', icon: <FaFileInvoiceDollar /> }] : []),
     ...(isAdmin ? [{ path: '/documents', label: 'Documents', description: 'Generate case documents from templates', icon: <FaFileAlt /> }] : []),
     ...(isAdmin ? [{ path: '/parties', label: 'Parties', description: 'Manage clinics, couples and other case parties', icon: <FaAddressBook /> }] : []),
+    // Batch 26 §10: the last of the UKRCOM admin pages PageNavMenu already lists - keeps both
+    // menus offering the same set of destinations.
+    ...(isAdmin ? [{ path: '/document-styles', label: 'Style Editor', description: 'Edit document styles and page layout', icon: <FaPalette /> }] : []),
   ];
 
   return (

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -990,6 +990,10 @@ export const ProfileForm = ({
   overlayFieldAdditions = {},
   refreshOverlayForEditor,
   deletingFieldsRef,
+  // Batch 26 §8: whether the per-field backend-navigation arrows (SearchIdBackendButton) show at
+  // all - defaults to true so a caller that hasn't wired up the toggle yet (no regression) keeps
+  // today's always-visible behavior; AddNewProfile.jsx passes its own persisted toggle state.
+  extendedMode = true,
 }) => {
   const latestProfileDraftRef = useRef(state || {});
   const profileFormVersionRef = useRef(0);
@@ -2780,7 +2784,7 @@ ${entries.join('\n')}`;
                           handleBlur(`${field.name}-${idx}`);
                         }}
                       />
-                      {canOpenSearchIdBackendShortcut(field.name, value) && (
+                      {extendedMode && canOpenSearchIdBackendShortcut(field.name, value) && (
                         <SearchIdBackendButton
                           type="button"
                           title="Відкрити запис searchId у Firebase"
@@ -3028,7 +3032,7 @@ ${entries.join('\n')}`;
                         })}
                   />
                   )}
-                  {canOpenSearchIdBackendShortcut(field.name, state[field.name]) && (
+                  {extendedMode && canOpenSearchIdBackendShortcut(field.name, state[field.name]) && (
                     <SearchIdBackendButton
                       type="button"
                       title="Відкрити запис searchId у Firebase"

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -25,7 +25,6 @@ import {
   formatGestationalAgeText,
   formatHcgTestOptionLabel,
   formatPregnancyTypeTextUk,
-  formatShipmentOptionLabel,
   formatShipmentPeriod,
   formatUltrasoundOptionLabel,
   mergeDocumentsCatalog,
@@ -67,28 +66,29 @@ const rawParties = {
 // normalizeDocumentsCatalog), never the raw id-keyed map a Firebase snapshot carries.
 const parties = normalizeDocumentsCatalog(rawParties, {}, {}).parties;
 
-// A case that uses the new startDate/endDate planned-period shape (spec: "Kikawa" scenario).
+// A case that uses the new startDate/endDate planned-period shape (spec: "Kikawa" scenario). The
+// case's one shipment (batch 26 §5: "one case = one partner clinic = one shipment") lives directly
+// on relations, never a shipmentId-addressed list - no document referencing it needs an id at all.
 const caseWithDateRangePeriod = {
   id: 'case-daterange',
-  relations: { clinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  relations: {
+    clinicId: clinic.id,
+    partnerClinicId: partnerClinic.id,
+    shipment: {
+      sourceClinicId: partnerClinic.id,
+      destinationClinicId: clinic.id,
+      ivfDate: '2021-08-17',
+      plannedPeriod: { startDate: '2026-01-01', endDate: '2026-02-01' },
+      receivedDate: '2025-08-27',
+    },
+  },
   artProgram: {
     medicalIndication: { diagnosis: { uk: 'Тестовий діагноз' } },
     geneticMaterial: { oocyteSourcePartnerRole: 'wife', spermSourcePartnerRole: 'husband' },
     medicalTeam: { physician: { name: { uk: { nominative: 'Тестова Лікарка Лікарівна' } } } },
-    embryoShipments: {
-      'shipment-1': {
-        id: 'shipment-1',
-        sourceClinicId: partnerClinic.id,
-        destinationClinicId: clinic.id,
-        ivfDate: '2021-08-17',
-        plannedPeriod: { startDate: '2026-01-01', endDate: '2026-02-01' },
-        receivedDate: '2025-08-27',
-      },
-    },
     // batch 24 §2: a single transfer attempt object, not a log of attempts - only the one
     // successful attempt's data ever matters once the program is underway.
     transferAttempt: {
-      shipmentId: 'shipment-1',
       date: '2025-09-18',
       embryoCount: 1,
       embryoStage: 'blastocyst',
@@ -104,7 +104,6 @@ const caseWithDateRangePeriod = {
     },
   },
   documents: {
-    embryoOwnershipStatement: { shipmentId: 'shipment-1' },
     geneticAffinityCertificate: {
       hcgTestId: 'hcg-1', ultrasoundId: 'ultrasound-1', issueDate: '2025-10-20', outgoingNumber: '42/1',
     },
@@ -116,6 +115,23 @@ const caseWithDateRangePeriod = {
 // A case that only ever carries the migrated freeform text period (spec: "Katsura" scenario).
 const caseWithTextPeriod = {
   id: 'case-textperiod',
+  relations: {
+    clinicId: clinic.id,
+    partnerClinicId: partnerClinic.id,
+    shipment: {
+      sourceClinicId: partnerClinic.id,
+      destinationClinicId: clinic.id,
+      ivfDate: '2021-08-17',
+      plannedPeriod: { text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } },
+    },
+  },
+};
+
+// A pre-batch-26 case: its one shipment is still stored the old, shipmentId-addressed way
+// (artProgram.embryoShipments, referenced from transferAttempt.shipmentId) - resolveShipment must
+// still find it read-only, so nothing already entered goes blank the moment this ships.
+const caseWithLegacyShipmentShape = {
+  id: 'case-legacy-shipment',
   relations: { clinicId: clinic.id, partnerClinicId: partnerClinic.id },
   artProgram: {
     embryoShipments: {
@@ -123,13 +139,10 @@ const caseWithTextPeriod = {
         id: 'shipment-1',
         sourceClinicId: partnerClinic.id,
         destinationClinicId: clinic.id,
-        ivfDate: '2021-08-17',
-        plannedPeriod: { text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } },
+        receivedDate: '2025-08-27',
       },
     },
-  },
-  documents: {
-    embryoOwnershipStatement: { shipmentId: 'shipment-1' },
+    transferAttempt: { shipmentId: 'shipment-1', date: '2025-09-18', hcgTests: {}, ultrasounds: {} },
   },
 };
 
@@ -146,20 +159,16 @@ const caseWithoutArtProgram = {
   },
 };
 
-// Every document reference points at an id that doesn't exist (spec §13/§15).
+// The transfer attempt's own hCG/ultrasound references point at ids that don't exist (spec
+// §13/§15) - the case has no shipment at all, which is an ordinary "not set" state, not a broken
+// reference (batch 26 §5 removed the shipmentId a document could dangle on in the first place).
 const caseWithBrokenReferences = {
   id: 'case-broken',
   relations: { clinicId: clinic.id },
   artProgram: {
-    embryoShipments: {
-      'shipment-1': { id: 'shipment-1', sourceClinicId: partnerClinic.id, destinationClinicId: clinic.id },
-    },
-    transferAttempt: {
-      shipmentId: 'shipment-1', date: '2025-09-18', hcgTests: {}, ultrasounds: {},
-    },
+    transferAttempt: { date: '2025-09-18', hcgTests: {}, ultrasounds: {} },
   },
   documents: {
-    embryoOwnershipStatement: { shipmentId: 'shipment-999' },
     geneticAffinityCertificate: { hcgTestId: 'hcg-999', ultrasoundId: 'ultrasound-999' },
     racssClinicLetter: { ultrasoundId: 'ultrasound-999' },
   },
@@ -174,10 +183,15 @@ const buildCatalog = (...cases) => normalizeDocumentsCatalog(
 // --- Resolvers -------------------------------------------------------------------------------
 
 describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferAttempt/resolveHcgTest/resolveUltrasound)', () => {
-  it('resolves an existing shipment by id, and the case\'s one transfer attempt (no id needed, batch 24 §2)', () => {
+  it('resolves the case\'s one shipment straight off relations, and its one transfer attempt (no id needed for either, batch 24 §2/batch 26 §5)', () => {
     const { artProgram } = caseWithDateRangePeriod;
-    expect(resolveShipment(caseWithDateRangePeriod, 'shipment-1')).toBe(artProgram.embryoShipments['shipment-1']);
+    expect(resolveShipment(caseWithDateRangePeriod)).toBe(caseWithDateRangePeriod.relations.shipment);
     expect(resolveTransferAttempt(caseWithDateRangePeriod)).toBe(artProgram.transferAttempt);
+  });
+
+  it('falls back to the pre-batch-26 shipmentId-addressed shape, read-only, when relations.shipment is unset', () => {
+    const legacyShipment = caseWithLegacyShipmentShape.artProgram.embryoShipments['shipment-1'];
+    expect(resolveShipment(caseWithLegacyShipmentShape)).toBe(legacyShipment);
   });
 
   it('resolves an existing hCG test/ultrasound from within the transfer attempt', () => {
@@ -186,12 +200,10 @@ describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferA
     expect(resolveUltrasound(transfer, 'ultrasound-1')).toBe(transfer.ultrasounds['ultrasound-1']);
   });
 
-  it('never throws and returns null for a missing/unset id, a missing artProgram, or a missing case', () => {
-    expect(resolveShipment(null, 'shipment-1')).toBeNull();
-    expect(resolveShipment(caseWithDateRangePeriod, '')).toBeNull();
-    expect(resolveShipment(caseWithDateRangePeriod, undefined)).toBeNull();
-    expect(resolveShipment(caseWithoutArtProgram, 'shipment-1')).toBeNull();
-    expect(resolveShipment(caseWithDateRangePeriod, 'shipment-999')).toBeNull();
+  it('never throws and returns null for a case with no shipment/artProgram at all, or a missing case', () => {
+    expect(resolveShipment(null)).toBeNull();
+    expect(resolveShipment(caseWithoutArtProgram)).toBeNull();
+    expect(resolveShipment(caseWithBrokenReferences)).toBeNull();
     expect(resolveTransferAttempt(caseWithoutArtProgram)).toBeNull();
     expect(resolveTransferAttempt(null)).toBeNull();
     expect(resolveHcgTest(null, 'hcg-1')).toBeNull();
@@ -206,7 +218,7 @@ describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferA
   });
 
   it('enrichShipment attaches sourceClinic (partnerClinics) and destinationClinic (clinics), null-safe', () => {
-    const shipment = resolveShipment(caseWithDateRangePeriod, 'shipment-1');
+    const shipment = resolveShipment(caseWithDateRangePeriod);
     const enriched = enrichShipment(shipment, parties);
     // enrichShipment layers a declined-name fallback onto the party record (spec batch 2026-07-25),
     // so this is no longer the exact same object reference as the fixture - just the same party.
@@ -280,7 +292,7 @@ describe('spec §6: ART formatters', () => {
 
 describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enrichHcgTestForTemplate/enrichUltrasoundForTemplate', () => {
   it('enrichShipmentForTemplate adds formatted date/period fields on top of the party-enriched shipment', () => {
-    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod, 'shipment-1'), parties);
+    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), parties);
     const enriched = enrichShipmentForTemplate(shipment);
     expect(enriched.ivfDateFormatted).toEqual({ uk: '17.08.2021', en: '17 August 2021' });
     expect(enriched.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
@@ -293,7 +305,7 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
 
   it('enrichTransferForTemplate adds dateFormatted/embryoCountText/embryoStageLabel and nests the enriched shipment', () => {
     const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
-    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod, transfer.shipmentId), parties);
+    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), parties);
     const enriched = enrichTransferForTemplate(transfer, shipment);
     expect(enriched.dateFormatted.uk).toBe('18.09.2025');
     expect(enriched.embryoCountText.uk).toBe('один ембріон');
@@ -319,29 +331,35 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
 // --- Document contexts -------------------------------------------------------------------------
 
 describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityCertificate/racssClinicLetter/medicalServicesAgreement)', () => {
-  it('embryoOwnershipStatement resolves shipment via shipmentId (startDate/endDate case)', () => {
-    const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, parties, caseWithDateRangePeriod.documents.embryoOwnershipStatement);
+  it('embryoOwnershipStatement resolves the case\'s one shipment automatically, no shipmentId of its own needed (startDate/endDate case)', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, parties, undefined);
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
     expect(context.shipment.sourceClinic.id).toBe(partnerClinic.id);
     expect(context.shipment.destinationClinic.id).toBe(clinic.id);
   });
 
-  it('embryoOwnershipStatement resolves shipment via shipmentId (migrated text case)', () => {
-    const context = buildEmbryoOwnershipStatementContext(caseWithTextPeriod, parties, caseWithTextPeriod.documents.embryoOwnershipStatement);
+  it('embryoOwnershipStatement resolves the case\'s one shipment automatically (migrated text case)', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithTextPeriod, parties, undefined);
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('квітні – травні 2026 року');
     expect(context.shipment.plannedPeriodFormatted.en).toBe('April-May 2026');
   });
 
-  it('spec §14: falls back to legacy ivfDate/shipmentPeriod fields when no shipmentId is set, never throwing', () => {
+  it('spec §14: falls back to legacy ivfDate/shipmentPeriod fields when the case has no shipment at all, never throwing', () => {
     const context = buildEmbryoOwnershipStatementContext(caseWithoutArtProgram, parties, caseWithoutArtProgram.documents.embryoOwnershipStatement);
     expect(context.shipment.ivfDateFormatted.uk).toBe('17.08.2021');
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('квітні – травні 2026 року');
     expect(context.shipment.sourceClinic).toBeNull();
   });
 
-  it('a case with neither a shipmentId nor legacy fields resolves shipment to null, never throwing', () => {
+  it('a case with neither a shipment nor legacy fields resolves shipment to null, never throwing', () => {
     const context = buildEmbryoOwnershipStatementContext({ id: 'bare-case' }, parties, undefined);
     expect(context.shipment).toBeNull();
+  });
+
+  it('falls back to the pre-batch-26 shipmentId-addressed shape, read-only, when relations.shipment is unset', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithLegacyShipmentShape, parties, undefined);
+    expect(context.shipment.sourceClinic.id).toBe(partnerClinic.id);
+    expect(context.shipment.receivedDateFormatted.uk).toBe('27.08.2025');
   });
 
   it('geneticAffinityCertificate resolves transferAttempt/hcgTest/ultrasound by id and computes the print-only fallback fields', () => {
@@ -417,7 +435,6 @@ describe('spec §13/§15: validateArtProgramReferences reports specific, actiona
   it('reports one message per broken reference, never a generic "field missing"', () => {
     const catalog = buildCatalog(caseWithBrokenReferences);
     const issues = validateArtProgramReferences(catalog, 'case-broken');
-    expect(issues).toContain('Не знайдено доставлення ембріонів shipment-999.');
     expect(issues).toContain('Не знайдено аналіз ХГЧ hcg-999.');
     expect(issues).toContain('Не знайдено УЗД ultrasound-999.');
   });
@@ -437,10 +454,7 @@ describe('spec §13/§15: validateArtProgramReferences reports specific, actiona
 // --- Dropdown option labels (spec §9) -------------------------------------------------------------
 
 describe('spec §9: human-readable dropdown labels, never a raw id', () => {
-  it('formats a shipment/hcgTest/ultrasound as the exact spec example shapes', () => {
-    const shipment = resolveShipment(caseWithDateRangePeriod, 'shipment-1');
-    expect(formatShipmentOptionLabel(shipment, parties)).toBe('Доставлення 27.08.2025 — Клініка Тестова');
-
+  it('formats an hcgTest/ultrasound as the exact spec example shapes', () => {
     const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
 
     const hcgTest = resolveHcgTest(transfer, 'hcg-1');
@@ -451,7 +465,6 @@ describe('spec §9: human-readable dropdown labels, never a raw id', () => {
   });
 
   it('every label helper is null-safe', () => {
-    expect(formatShipmentOptionLabel(null, parties)).toBe('');
     expect(formatHcgTestOptionLabel(null)).toBe('');
     expect(formatUltrasoundOptionLabel(null)).toBe('');
   });
@@ -577,20 +590,20 @@ describe('spec §11/§12: ART-derived fields are never written back to Firebase'
 
 // --- Import/export round trip stays additive (spec §12) ------------------------------------------
 
-describe('spec §12: import/merge keeps embryoShipments/hcgTests/ultrasounds as maps, transferAttempt as one object', () => {
-  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog never converts embryoShipments into arrays, and merges the one transferAttempt in place', () => {
+describe('spec §12: import/merge keeps hcgTests/ultrasounds as maps, transferAttempt/relations.shipment as one object each', () => {
+  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog merges the one transferAttempt in place, without disturbing relations.shipment', () => {
     const currentCatalog = buildCatalog(caseWithDateRangePeriod);
     const pasted = parseDocumentsTechnicalInput(JSON.stringify({
       cases: { 'case-daterange': { id: 'case-daterange', artProgram: { transferAttempt: { date: '2026-04-04' } } } },
     }));
     const { catalog: merged } = mergeDocumentsCatalog(currentCatalog, pasted);
     const mergedCase = merged.cases.find(item => item.id === 'case-daterange');
-    expect(Array.isArray(mergedCase.artProgram.embryoShipments)).toBe(false);
     // The edit landed...
     expect(mergedCase.artProgram.transferAttempt.date).toBe('2026-04-04');
-    // ...without wiping embryoCount or shipment-1, which the incoming payload never mentioned.
+    // ...without wiping embryoCount, or the case's one shipment, which the incoming payload never
+    // mentioned (batch 26 §5: relations.shipment, not a shipmentId-addressed map any more).
     expect(mergedCase.artProgram.transferAttempt.embryoCount).toBe(1);
-    expect(mergedCase.artProgram.embryoShipments['shipment-1'].id).toBe('shipment-1');
+    expect(mergedCase.relations.shipment.sourceClinicId).toBe(partnerClinic.id);
   });
 
   it('a deep merge of one hcgTest field never replaces its sibling hcgTests/ultrasounds on the transfer attempt', () => {

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -8,6 +8,7 @@ import {
   DERIVED_CONTEXT_FIELD_KEYS,
   MISSING_VALUE_PLACEHOLDER,
   buildEmbryoOwnershipStatementContext,
+  buildGeneratedDocument,
   buildGeneticAffinityCertificateContext,
   buildMedicalServicesAgreementContext,
   buildRacssClinicLetterContext,
@@ -18,6 +19,7 @@ import {
   enrichShipmentForTemplate,
   enrichTransferForTemplate,
   enrichUltrasoundForTemplate,
+  evaluateBlockCondition,
   fillPlaceholders,
   formatDateNumericUk,
   formatDateRange,
@@ -376,6 +378,18 @@ describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityC
     expect(context.outgoingNumberOrBlank).toBe('42/1');
   });
 
+  it('batch 26 §6: geneticAffinityCertificate exposes oocyteSourceIsWife, shared/cross-referenced by any other document conditioning a block on it', () => {
+    const isWife = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
+    expect(isWife.oocyteSourceIsWife).toBe(true);
+
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'donor' } } });
+    const isDonor = buildGeneticAffinityCertificateContext(donorCase, parties, {});
+    expect(isDonor.oocyteSourceIsWife).toBe(false);
+
+    // No geneticMaterial data at all (old/incomplete case) degrades to false, never throwing.
+    expect(buildGeneticAffinityCertificateContext(caseWithoutArtProgram, parties, {}).oocyteSourceIsWife).toBe(false);
+  });
+
   it('geneticAffinityCertificate falls back to print-only blanks (never persisted) when issueDate/outgoingNumber are unset', () => {
     const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
     expect(context.issueDateOrBlank.uk).toBe('__.__.____');
@@ -634,5 +648,56 @@ describe('spec §10: passport.type/countryCode are optional and never transliter
   it('a passport number is never transliterated, only formatted with a space (spec §10)', () => {
     const context = { husband: { passport: { number: 'TS0299493' } } };
     expect(fillPlaceholders('{{husband.passport.number}}', context, 'uk')).toBe('TS 0299493');
+  });
+});
+
+// --- Conditional block rendering (batch 26 §6) -----------------------------------------------
+
+describe('spec (batch 26 §6): evaluateBlockCondition - a block prints only when its condition path resolves truthy', () => {
+  it('no condition at all always renders (backward compatible)', () => {
+    expect(evaluateBlockCondition(undefined, {})).toBe(true);
+    expect(evaluateBlockCondition('', { anything: false })).toBe(true);
+  });
+
+  it('a plain path is truthy/falsy exactly like the value it points at', () => {
+    expect(evaluateBlockCondition('geneticAffinityCertificate.oocyteSourceIsWife', { geneticAffinityCertificate: { oocyteSourceIsWife: true } })).toBe(true);
+    expect(evaluateBlockCondition('geneticAffinityCertificate.oocyteSourceIsWife', { geneticAffinityCertificate: { oocyteSourceIsWife: false } })).toBe(false);
+    expect(evaluateBlockCondition('geneticAffinityCertificate.oocyteSourceIsWife', {})).toBe(false);
+  });
+
+  it('a leading "!" negates the path', () => {
+    expect(evaluateBlockCondition('!geneticAffinityCertificate.oocyteSourceIsWife', { geneticAffinityCertificate: { oocyteSourceIsWife: true } })).toBe(false);
+    expect(evaluateBlockCondition('!geneticAffinityCertificate.oocyteSourceIsWife', { geneticAffinityCertificate: { oocyteSourceIsWife: false } })).toBe(true);
+  });
+});
+
+describe('spec (batch 26 §6): buildGeneratedDocument drops a conditionally-hidden paragraph entirely, never as a blank/unresolved value', () => {
+  const buildTemplate = () => ({
+    id: 'birth-registration-surrogate-consent',
+    title: { uk: '' },
+    paragraphs: [
+      { uk: 'Ми, подружжя,', en: 'We, the spouses,' },
+      {
+        uk: "та генетичною матір'ю – Кацура Юкако, звертаємось із заявою.",
+        en: 'and the genetic mother Katsura Yukako, apply with this statement.',
+        condition: 'geneticAffinityCertificate.oocyteSourceIsWife',
+      },
+      { uk: 'Просимо зареєструвати дитину.', en: 'We ask to register the child.' },
+    ],
+  });
+
+  it('prints the conditional paragraph when the wife is the oocyte donor', () => {
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
+    const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
+    expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'text', 'text']);
+    expect(generated.paragraphs[1].uk).toContain('Кацура Юкако');
+  });
+
+  it('fully omits the paragraph (never a blank/unresolved value) when any other oocyte source is set, keeping every other paragraph\'s position stable', () => {
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'donor' } } });
+    const context = buildGeneticAffinityCertificateContext(donorCase, parties, {});
+    const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
+    expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'condition-hidden', 'text']);
+    expect(generated.paragraphs[2].uk).toBe('Просимо зареєструвати дитину.');
   });
 });

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -35,6 +35,55 @@ const COLLECTION_ID_PREFIXES = { notaries: 'notary', partnerClinics: 'partner-cl
 
 export const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
+// The Firebase RTDB client rejects `set()`/`update()` outright (a synchronous throw, before any
+// network round-trip) the instant the value tree contains a bare `undefined` anywhere - and a
+// handful of edit paths genuinely produce one (e.g. a formatting toggle that spreads
+// `{ ...block, runs: undefined }` to clear the other shape's field instead of deleting the key).
+// That single stray `undefined`, buried several levels deep in a whole-template write, used to
+// surface as the same unexplained "Could not save the paragraph edits" no matter what the admin
+// had actually just typed. Stripping it here, right before every write, means an edit that
+// otherwise produces perfectly good content is never rejected over a bookkeeping artifact the
+// admin had no way to see or work around.
+export const stripUndefinedDeep = value => {
+  if (Array.isArray(value)) return value.map(stripUndefinedDeep);
+  if (isPlainObject(value)) {
+    const next = {};
+    Object.keys(value).forEach(key => {
+      if (value[key] === undefined) return;
+      next[key] = stripUndefinedDeep(value[key]);
+    });
+    return next;
+  }
+  return value;
+};
+
+// Turns a raw save-path Error into a specific, actionable toast message instead of one generic
+// "Could not save..." string that gave no indication of what actually failed (validation? size
+// limit? network? malformed markup from a pasted link?) - named causes an admin can actually act
+// on (retry, reconnect, shorten the text) instead of a dead end. `fallback` is the call site's own
+// still-specific-to-the-action message, used only once none of these known failure shapes match,
+// so an unclassified rejection still reads as "the alignment change" or "the paragraph edits"
+// rather than being swallowed into one page-wide generic string.
+export const describeDocumentSaveError = (error, fallback) => {
+  const message = String(error?.message || error?.code || error || '');
+  if (/contains undefined in property/i.test(message)) {
+    return 'Could not save: the edit left behind an empty value the backend rejects - please retry it.';
+  }
+  if (/PERMISSION_DENIED/i.test(message)) {
+    return 'Could not save: you do not have permission to edit this document.';
+  }
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return 'Could not save: you are offline - reconnect and try again.';
+  }
+  if (/network|fetch|timed? ?out|ECONNRESET|ENOTFOUND|disconnect/i.test(message)) {
+    return 'Could not save: network error while saving - please retry.';
+  }
+  if (/too large|exceeds|maximum|max.{0,12}size|16777216|too big/i.test(message)) {
+    return 'Could not save: this content exceeds the size limit - please shorten it.';
+  }
+  return fallback || 'Could not save the edit.';
+};
+
 // Firebase RTDB silently turns a JS array into a plain `{"0": ..., "2": ...}` object once it has
 // ever been written with a gap (e.g. a record removed by key rather than re-set as a dense array),
 // so any array read back from the backend has to tolerate that shape - never assume `.val()` gives
@@ -931,23 +980,35 @@ export const TEMPLATE_DOCUMENT_CONFIG = {
 const DEFAULT_NOTARY_TEMPLATE_CONFIG = { documentKey: 'birthRegistrationConsent', usesNotary: true };
 
 // --- ART program (case.artProgram) - resolvers, formatters, document contexts ----------------
-// The medical facts of a case's fertility program (diagnosis, embryo shipments, the one successful
-// transfer attempt, its hCG tests, its ultrasounds) live once at `case.artProgram`. Embryo
-// shipments and a transfer attempt's own hCG tests/ultrasounds stay keyed by id (never converted to
-// arrays - spec §12); the transfer attempt itself is a single object, not a log of attempts (batch
-// 24 §2 - only the one successful attempt ever matters once the program is underway). Every
-// document that references one of these events (embryoOwnershipStatement,
-// geneticAffinityCertificate, racssClinicLetter) stores only the id(s) it points at
-// (shipmentId/hcgTestId/ultrasoundId); editing the underlying event once (e.g. the transfer date)
-// is instantly reflected in every document that references it, since none of them ever copy the
-// fact - they resolve it fresh every render.
+// The medical facts of a case's fertility program (diagnosis, the one embryo shipment, the one
+// successful transfer attempt, its hCG tests, its ultrasounds) live once at `case.artProgram`
+// (plus the one shipment itself, at `case.relations.shipment` - batch 26 §5). A transfer attempt's
+// own hCG tests/ultrasounds stay keyed by id (never converted to arrays - spec §12); the transfer
+// attempt itself is a single object, not a log of attempts (batch 24 §2 - only the one successful
+// attempt ever matters once the program is underway). Every document that references one of these
+// events (embryoOwnershipStatement, geneticAffinityCertificate, racssClinicLetter) resolves the
+// case's one shipment/transfer attempt directly, with only which of the transfer attempt's hCG
+// tests/ultrasounds it cites still an id choice (hcgTestId/ultrasoundId); editing the underlying
+// event once (e.g. the transfer date) is instantly reflected in every document that references it,
+// since none of them ever copy the fact - they resolve it fresh every render.
 
-// Null-safe lookups (spec §3) - a missing/unset id, or an id that no longer exists (a document
-// still pointing at a deleted event), resolves to null rather than throwing, so a template that
-// references it degrades to a visible "missing" blank instead of a white screen.
-export const resolveShipment = (caseData, shipmentId) => {
-  if (!shipmentId) return null;
-  return caseData?.artProgram?.embryoShipments?.[shipmentId] ?? null;
+// One case now carries at most one embryo shipment, stored directly on its relations (batch 26 §5:
+// "one case = one partner clinic = one shipment" - a case that ever needs a second shipment is a
+// second case, not a second entry here). This removes the old shipmentId indirection entirely - the
+// three documents that reference a shipment (embryoOwnershipStatement, and via the transfer attempt,
+// geneticAffinityCertificate/racssClinicLetter) used to each carry their own separate shipmentId
+// pointer, any one of which could be left unset/stale even after a shipment's own fields were filled
+// in, silently rendering that document's shipment.* fields blank with no indication why (the exact
+// failure this batch's partner-clinic-data-not-substituting report traced back to). A case still on
+// the pre-batch-26 shape (relations.shipment unset) falls back to whichever of those old pointers is
+// present, read-only - a fresh save always writes relations.shipment only (see
+// CaseArtProgramEditor.jsx), so every case migrates the next time its shipment is touched.
+export const resolveShipment = caseData => {
+  if (caseData?.relations?.shipment) return caseData.relations.shipment;
+  const legacyShipmentId = caseData?.artProgram?.transferAttempt?.shipmentId
+    || caseData?.documents?.embryoOwnershipStatement?.shipmentId;
+  if (!legacyShipmentId) return null;
+  return caseData?.artProgram?.embryoShipments?.[legacyShipmentId] ?? null;
 };
 
 export const resolveTransferAttempt = caseData => caseData?.artProgram?.transferAttempt ?? null;
@@ -1118,14 +1179,15 @@ export const enrichUltrasoundForTemplate = ultrasound => {
   };
 };
 
-// case.documents.embryoOwnershipStatement - spec §4. Backward compatible (spec §14): a case not
-// yet migrated off the old shape still carries `ivfDate`/`shipmentPeriod` directly on the document
-// instead of a shipmentId: those synthesize the same `.shipment.*` template fields the new shape
-// exposes, so an old template keeps rendering unchanged. A fresh save always writes shipmentId
-// (spec §14) - this fallback only ever reads what's already stored.
+// case.documents.embryoOwnershipStatement - spec §4. There is only ever the case's one shipment
+// now (batch 26 §5, resolveShipment) - no shipmentId of its own to pick. Backward compatible with
+// the even older pre-shipment shape (spec §14): a case that never had any shipment data at all
+// still carries `ivfDate`/`shipmentPeriod` directly on the document, which synthesize the same
+// `.shipment.*` template fields the resolved shape exposes, so an old template keeps rendering
+// unchanged.
 export const buildEmbryoOwnershipStatementContext = (caseData, parties, ownershipData) => {
   const data = isPlainObject(ownershipData) ? ownershipData : {};
-  const resolvedShipment = enrichShipmentForTemplate(enrichShipment(resolveShipment(caseData, data.shipmentId), parties));
+  const resolvedShipment = enrichShipmentForTemplate(enrichShipment(resolveShipment(caseData), parties));
   const legacyShipment = !resolvedShipment && (data.ivfDate || data.shipmentPeriod) ? {
     ivfDateFormatted: { uk: formatDateNumericUk(data.ivfDate), en: formatDateLongEn(data.ivfDate) },
     plannedPeriodFormatted: { uk: data.shipmentPeriod?.uk || '', en: data.shipmentPeriod?.en || '' },
@@ -1136,12 +1198,13 @@ export const buildEmbryoOwnershipStatementContext = (caseData, parties, ownershi
 };
 
 // case.documents.geneticAffinityCertificate - spec §4. There is only ever one transfer attempt
-// (batch 24 §2), so it never needs an id of its own - only which of its hCG tests/ultrasounds this
-// certificate cites is still a choice (hcgTestId/ultrasoundId).
+// (batch 24 §2) referencing the case's one shipment (batch 26 §5) - neither needs an id of its own;
+// only which of the transfer attempt's hCG tests/ultrasounds this certificate cites is still a
+// choice (hcgTestId/ultrasoundId).
 export const buildGeneticAffinityCertificateContext = (caseData, parties, certificateData) => {
   const data = isPlainObject(certificateData) ? certificateData : {};
   const transferAttempt = resolveTransferAttempt(caseData);
-  const shipment = enrichShipment(resolveShipment(caseData, transferAttempt?.shipmentId), parties);
+  const shipment = enrichShipment(resolveShipment(caseData), parties);
   return {
     ...data,
     transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
@@ -1154,11 +1217,12 @@ export const buildGeneticAffinityCertificateContext = (caseData, parties, certif
   };
 };
 
-// case.documents.racssClinicLetter - spec §4. Same single-transfer-attempt rule as above.
+// case.documents.racssClinicLetter - spec §4. Same single-transfer-attempt/single-shipment rule as
+// above.
 export const buildRacssClinicLetterContext = (caseData, parties, letterData) => {
   const data = isPlainObject(letterData) ? letterData : {};
   const transferAttempt = resolveTransferAttempt(caseData);
-  const shipment = enrichShipment(resolveShipment(caseData, transferAttempt?.shipmentId), parties);
+  const shipment = enrichShipment(resolveShipment(caseData), parties);
   return {
     ...data,
     transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
@@ -1210,11 +1274,9 @@ export const validateArtProgramReferences = (catalog, caseId) => {
   const issues = [];
   const transferAttempt = resolveTransferAttempt(caseRecord);
 
-  const ownership = documents.embryoOwnershipStatement;
-  if (ownership?.shipmentId && !resolveShipment(caseRecord, ownership.shipmentId)) {
-    issues.push(`Не знайдено доставлення ембріонів ${ownership.shipmentId}.`);
-  }
-
+  // No shipmentId to dangle any more (batch 26 §5: the case's one shipment, resolveShipment) - a
+  // case simply has one or doesn't; that's the ordinary unresolved-{{placeholder}} case, not a
+  // broken reference worth its own message here.
   const certificate = documents.geneticAffinityCertificate;
   if (certificate?.hcgTestId && !resolveHcgTest(transferAttempt, certificate.hcgTestId)) {
     issues.push(`Не знайдено аналіз ХГЧ ${certificate.hcgTestId}.`);
@@ -1238,14 +1300,6 @@ export const validateArtProgramReferences = (catalog, caseId) => {
 const joinOptionLabel = (label, dateText, details) => {
   const prefix = [label, dateText].filter(Boolean).join(' ');
   return [prefix, details].filter(Boolean).join(' — ');
-};
-
-export const formatShipmentOptionLabel = (shipment, parties) => {
-  if (!shipment) return '';
-  const enriched = enrichShipment(shipment, parties);
-  const clinicName = enriched?.sourceClinic?.name?.uk || enriched?.destinationClinic?.name?.uk || '';
-  const dateText = shipment.receivedDate ? formatDateNumericUk(shipment.receivedDate) : (shipment.ivfDate ? formatDateNumericUk(shipment.ivfDate) : '');
-  return joinOptionLabel('Доставлення', dateText, clinicName);
 };
 
 export const formatHcgTestOptionLabel = hcgTest => {
@@ -2376,12 +2430,15 @@ export const toggleLayoutV2ParagraphBold = (block, plainStart, plainEnd) => {
   const allBold = selected.length > 0 && selected.every(run => run.style === 'inlineEmphasis');
   const next = split.map(run => (within(run) ? { ...run, style: allBold ? undefined : 'inlineEmphasis' } : run));
   const mergedRuns = mergeAdjacentLayoutV2Runs(next);
+  // Firebase's `set()` rejects a value tree containing a bare `undefined` outright (batch 26 §3) -
+  // dropping the now-unused key via destructuring, rather than assigning it `undefined`, keeps
+  // this block always directly writable.
   if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
-    return {
-      ...block, type: 'paragraph', text: mergedRuns[0]?.text || '', runs: undefined,
-    };
+    const { runs: ignoredRuns, ...plainBlock } = block;
+    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
   }
-  return { ...block, type: 'richParagraph', runs: mergedRuns, text: undefined };
+  const { text: ignoredText, ...richBlock } = block;
+  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
 };
 
 // Same MS Word toggle rule as Bold, just flipping styleOverrides.fontStyle instead of the
@@ -2398,11 +2455,11 @@ export const toggleLayoutV2ParagraphItalic = (block, plainStart, plainEnd) => {
     : run));
   const mergedRuns = mergeAdjacentLayoutV2Runs(next);
   if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
-    return {
-      ...block, type: 'paragraph', text: mergedRuns[0]?.text || '', runs: undefined,
-    };
+    const { runs: ignoredRuns, ...plainBlock } = block;
+    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
   }
-  return { ...block, type: 'richParagraph', runs: mergedRuns, text: undefined };
+  const { text: ignoredText, ...richBlock } = block;
+  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
 };
 
 // --- layoutV2 paragraph full toolbar parity (mode cycle, Italic, Insert-variable) ---------------

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1214,6 +1214,11 @@ export const buildGeneticAffinityCertificateContext = (caseData, parties, certif
     // A print-only blank, never persisted (spec §4) - a fully blank pattern rather than a
     // hand-picked placeholder date, so it never silently doubles as a real value.
     issueDateOrBlank: { uk: data.issueDate ? formatDateNumericUk(data.issueDate) : '__.__.____' },
+    // Batch 26 §6: shared/cross-referenced by any other document conditioning a block on whether
+    // the wife herself was the oocyte donor (e.g. the RATS/birth-registration statement's "та
+    // генетичною матір'ю ..." clause) - the "У лікувальній програмі ДРТ використано яйцеклітини..."
+    // field this certificate itself prints from case.artProgram.geneticMaterial.
+    oocyteSourceIsWife: caseData?.artProgram?.geneticMaterial?.oocyteSourcePartnerRole === 'wife',
   };
 };
 
@@ -1510,6 +1515,26 @@ export const fillPlaceholders = (text, context, lang = 'uk') => String(text || '
   },
 );
 
+// Conditional block rendering (batch 26 §6): a paragraph/layoutV2 block can carry a `condition` -
+// a plain context path (optionally `!`-negated) that must resolve truthy for the block to render
+// at all. Unlike a placeholder inside the block's own text (which degrades to a visible "missing"
+// blank when unresolved), a block whose condition doesn't hold is dropped from the generated
+// document entirely - e.g. "та генетичною матір'ю ... Кацура Юкако," in the RATS/birth-
+// registration statement must only print when the wife herself was the oocyte donor
+// (geneticAffinityCertificate.oocyteSourceIsWife, shared/cross-referenced off the same
+// case.artProgram.geneticMaterial.oocyteSourcePartnerRole every genetic-affinity-certificate
+// resolves from - see buildGeneticAffinityCertificateContext), never shown with a blank/unresolved
+// value for any other oocyte source. No `condition` at all (the vast majority of blocks) always
+// renders, so this is fully backward compatible.
+export const evaluateBlockCondition = (condition, context) => {
+  const trimmed = String(condition || '').trim();
+  if (!trimmed) return true;
+  const negate = trimmed.startsWith('!');
+  const path = negate ? trimmed.slice(1).trim() : trimmed;
+  const value = getValueByPath(context, path);
+  return negate ? !value : Boolean(value);
+};
+
 // Text mode renders substituted placeholders, while formatting is stored against the unresolved
 // template text. Map display offsets back through those variable-sized substitutions so a range
 // after (or touching) a placeholder can never put formatting markers inside its {{token}}.
@@ -1584,6 +1609,10 @@ export const validateDocumentTemplate = (template, context) => {
     ['uk', 'en'].forEach(lang => scan(block?.[lang], lang));
   });
   toArray(template?.paragraphs).forEach(paragraph => {
+    // A conditionally-hidden paragraph (batch 26 §6) never prints, so its own unresolved
+    // placeholders (if any) are never a real problem for this export - skip it rather than
+    // nagging about a value that will never actually appear.
+    if (!evaluateBlockCondition(paragraph?.condition, context)) return;
     ['uk', 'en'].forEach(lang => scan(paragraph?.[lang], lang));
   });
   return [...missing].sort();
@@ -2252,7 +2281,11 @@ export const buildLayoutV2Document = (template, context) => {
       marginsMm: geometry.margins,
     },
     contentWidthMm: geometry.contentWidthMm,
-    blocks: template.layoutV2.blocks.map(block => normalizeLayoutV2Block(block, template, context, lang)),
+    // A conditional block (batch 26 §6, evaluateBlockCondition) that doesn't hold is dropped
+    // entirely, before normalization - never rendered with a blank/unresolved value.
+    blocks: template.layoutV2.blocks
+      .filter(block => evaluateBlockCondition(block?.condition, context))
+      .map(block => normalizeLayoutV2Block(block, template, context, lang)),
   };
 };
 
@@ -2580,10 +2613,24 @@ export const buildGeneratedDocument = (template, context) => {
       align: getParagraphStyle(template.title).align,
       fontSize: getParagraphStyle(template.title).fontSize,
     },
+    // A conditional paragraph (batch 26 §6, evaluateBlockCondition) that doesn't hold is dropped
+    // from the array entirely, never left in as a blank/unresolved entry - the `visible` flag is
+    // computed against each paragraph's own original index (so index-0 logo detection above is
+    // never thrown off by an earlier paragraph having been conditionally hidden) and stripped again
+    // once the filter has run.
     paragraphs: toArray(template.paragraphs).map((paragraph, index) => {
       const type = getParagraphType(paragraph);
       if (index === 0 && type !== 'text' && !hasDedicatedLogoField) {
         return { type: 'logo-consumed', uk: paragraph?.uk || '', en: paragraph?.en || '' };
+      }
+      // A conditionally-hidden paragraph (batch 26 §6, evaluateBlockCondition) is tagged the same
+      // no-op-for-the-renderer way an already-consumed logo paragraph is, rather than dropped from
+      // the array - dropping it would shift every later paragraph's index, which the editor UI
+      // (resolvedDoc.paragraphs[index], keyed by the *template's* paragraph index) relies on
+      // staying stable. Each renderer's own bodyParagraphs filter (see DocumentsPdfDocument.jsx/
+      // documentsDocxBuilder.js) already skips unknown/no-op types the same way.
+      if (!evaluateBlockCondition(paragraph?.condition, context)) {
+        return { type: 'condition-hidden', uk: paragraph?.uk || '', en: paragraph?.en || '' };
       }
       if (type !== 'text') {
         return { type, uk: paragraph?.uk || '', en: paragraph?.en || '' };

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -28,6 +28,7 @@ import {
   createEmptyRepresentative,
   createEmptySurrogateMother,
   deepMergeRecords,
+  describeDocumentSaveError,
   diffDocFormattingOverrides,
   emptyDocumentsCatalog,
   enrichNameWithDerivedFields,
@@ -88,6 +89,7 @@ import {
   splitParagraphsIntoColumns,
   splitParagraphsIntoPages,
   stripDerivedFields,
+  stripUndefinedDeep,
   TITLE_SCOPE,
   beforeTitleScope,
   getTemplateScopeText,
@@ -3513,5 +3515,64 @@ describe('spec: Parse & merge stays additive for new document keys on an existin
     expect(merged.documents.map(template => template.id)).toEqual([
       'legal-services-disclaimer-statement', 'surrogacy-agreement-appendix-1',
     ]);
+  });
+});
+
+describe('spec (batch 26 §3): stripUndefinedDeep - the Firebase RTDB client rejects set() outright '
+  + 'the instant a value tree contains a bare `undefined` anywhere, so a whole-template save must '
+  + 'never carry one through, no matter how deeply buried', () => {
+  it('drops a top-level undefined key, keeping every other key intact', () => {
+    expect(stripUndefinedDeep({ type: 'paragraph', text: 'Hello', runs: undefined })).toEqual({ type: 'paragraph', text: 'Hello' });
+  });
+
+  it('drops an undefined key nested arbitrarily deep inside objects and arrays alike', () => {
+    const value = {
+      layoutV2: {
+        blocks: [
+          { type: 'richParagraph', runs: [{ text: 'a', style: 'inlineEmphasis' }, { text: 'b', style: undefined }] },
+          { type: 'letterhead', columns: [{ content: { offsetXMm: -3, hidden: undefined } }] },
+        ],
+      },
+    };
+    expect(stripUndefinedDeep(value)).toEqual({
+      layoutV2: {
+        blocks: [
+          { type: 'richParagraph', runs: [{ text: 'a', style: 'inlineEmphasis' }, { text: 'b' }] },
+          { type: 'letterhead', columns: [{ content: { offsetXMm: -3 } }] },
+        ],
+      },
+    });
+  });
+
+  it('leaves null, falsy, and zero values untouched - only undefined is stripped', () => {
+    expect(stripUndefinedDeep({ a: null, b: 0, c: '', d: false })).toEqual({ a: null, b: 0, c: '', d: false });
+  });
+
+  it('passes primitives and arrays of primitives through unchanged', () => {
+    expect(stripUndefinedDeep('Hello')).toBe('Hello');
+    expect(stripUndefinedDeep(['a', 'b'])).toEqual(['a', 'b']);
+  });
+});
+
+describe('spec (batch 26 §3): describeDocumentSaveError - names the actual save failure instead of '
+  + 'one generic "Could not save..." string regardless of cause', () => {
+  it('names a stray-undefined-value rejection distinctly from every other cause', () => {
+    const error = new Error("Reference.set failed: First argument contains undefined in property 'layoutV2.blocks.0.runs'");
+    expect(describeDocumentSaveError(error, 'fallback')).toMatch(/empty value/i);
+  });
+
+  it('names a permission-denied rejection distinctly', () => {
+    const error = new Error('PERMISSION_DENIED: Permission denied');
+    expect(describeDocumentSaveError(error, 'fallback')).toMatch(/permission/i);
+  });
+
+  it('names a network-failure rejection distinctly', () => {
+    const error = new Error('network error');
+    expect(describeDocumentSaveError(error, 'fallback')).toMatch(/network/i);
+  });
+
+  it('falls back to the call site\'s own specific message for an unclassified error', () => {
+    const error = new Error('some unrelated backend hiccup');
+    expect(describeDocumentSaveError(error, 'Could not save the alignment change.')).toBe('Could not save the alignment change.');
   });
 });

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -377,7 +377,10 @@ export const buildDocumentsDocx = async ({
       }
     }
 
-    const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed');
+    // A conditionally-hidden paragraph (batch 26 §6) is the same kind of no-op-for-the-renderer tag
+    // an already-consumed logo paragraph is - excluded here, kept (not spliced out) in
+    // doc.paragraphs itself so every other paragraph's index stays stable for the editor.
+    const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed' && paragraph.type !== 'condition-hidden');
 
     if (isSingleLanguageFlow) {
       // One shared table for the whole body (not one per paragraph, unlike the bilingual/1-column

--- a/src/components/documentsPdfPreviewEngine.js
+++ b/src/components/documentsPdfPreviewEngine.js
@@ -29,7 +29,16 @@ export const loadPdfDocument = async data => {
 };
 
 // Renders one page at the container's CSS width × devicePixelRatio (spec §4.1), so the preview is
-// the exported page's own rasterization at native screen density - not an HTML approximation.
+// the exported page's own rasterization at native screen density - not an HTML approximation. Only
+// the canvas's intrinsic bitmap size (`.width`/`.height`) is set here - its *displayed* size is left
+// to CSS (`width: 100%; height: auto;`, see DocumentsPdfPreview's PageViewport), never a matching
+// inline `style.width`/`style.height` pixel pair. A fixed inline pixel width is exactly what let
+// the preview break out of its card: it only ever matched the container's width at the moment this
+// function last ran, so any later container resize (a narrower viewport, the sidebar toggling, a
+// page whose own configured width happens to differ from what `cssWidth` was computed from) left a
+// stale absolute width the container had since shrunk past. Percentage CSS instead recomputes on
+// every layout change with no extra wiring, and stays correct regardless of the PDF page's own
+// width.
 export const renderPdfPageToCanvas = async (pdfDocument, pageNumber, canvas, cssWidth, devicePixelRatio = 1) => {
   const page = await pdfDocument.getPage(pageNumber);
   const baseViewport = page.getViewport({ scale: 1 });
@@ -37,7 +46,5 @@ export const renderPdfPageToCanvas = async (pdfDocument, pageNumber, canvas, css
   const viewport = page.getViewport({ scale });
   canvas.width = Math.floor(viewport.width);
   canvas.height = Math.floor(viewport.height);
-  canvas.style.width = `${cssWidth}px`;
-  canvas.style.height = `${Math.floor(viewport.height / devicePixelRatio)}px`;
   await page.render({ canvasContext: canvas.getContext('2d'), viewport }).promise;
 };

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -1,10 +1,36 @@
 import { useEffect, useRef, useState } from 'react';
+import { FaArrowRight } from 'react-icons/fa';
 import { useAutoResize } from '../../hooks/useAutoResize';
 import { auth, fetchUserComment, saveMyCardComment } from '../config';
 
+const FALLBACK_FIREBASE_PROJECT_ID = 'webringitapp';
+const getFirebaseConsoleProjectId = () => process.env.REACT_APP_PROJECT_ID || FALLBACK_FIREBASE_PROJECT_ID;
+const getFirebaseRealtimeDatabaseName = () => {
+  const fallbackProjectId = getFirebaseConsoleProjectId();
+  const databaseUrl = process.env.REACT_APP_DATABASE_URL || '';
+  try {
+    const { hostname } = new URL(databaseUrl);
+    return hostname.split('.')[0] || `${fallbackProjectId}-default-rtdb`;
+  } catch (error) {
+    return `${fallbackProjectId}-default-rtdb`;
+  }
+};
+
+// Same backend-navigation shortcut ProfileForm's other fields already have (batch 26 §8) - jumps
+// straight to this comment's own comments/{ownerId}/{cardId} record in the Firebase console.
+const buildCommentBackendUrl = (ownerId, cardId) => {
+  if (!ownerId || !cardId) return '';
+  const projectId = getFirebaseConsoleProjectId();
+  const databaseName = getFirebaseRealtimeDatabaseName();
+  const encodedPath = ['comments', ownerId, cardId]
+    .map(segment => `~2F${encodeURIComponent(segment)}`)
+    .join('');
+  return `https://console.firebase.google.com/u/0/project/${projectId}/database/${databaseName}/data/${encodedPath}`;
+};
+
 // Персональний коментар поточного адміна до картки — зберігається в
 // comments/{ownerId}/{cardId}, а не прямо в самій картці (users/newUsers).
-export const FieldComment = ({ userData }) => {
+export const FieldComment = ({ userData, extendedMode = false }) => {
   const textareaRef = useRef(null);
   const [text, setText] = useState('');
   const autoResize = useAutoResize(textareaRef, text);
@@ -30,6 +56,8 @@ export const FieldComment = ({ userData }) => {
     if (!ownerId || !cardId) return;
     saveMyCardComment(cardId, value, ownerId);
   };
+
+  const showBackendShortcut = extendedMode && Boolean(ownerId && cardId);
 
   return (
     <div
@@ -60,10 +88,36 @@ export const FieldComment = ({ userData }) => {
           resize: 'none',
           overflowY: 'hidden',
           padding: '5px',
-          paddingRight: text ? '32px' : '5px',
+          paddingRight: showBackendShortcut ? '58px' : text ? '32px' : '5px',
           boxSizing: 'border-box',
         }}
       />
+      {showBackendShortcut && (
+        <button
+          type="button"
+          aria-label="Відкрити запис коментаря у Firebase"
+          title="Відкрити запис коментаря у Firebase"
+          onMouseDown={event => event.preventDefault()}
+          onClick={event => {
+            event.stopPropagation();
+            window.open(buildCommentBackendUrl(ownerId, cardId), '_blank', 'noopener,noreferrer');
+          }}
+          style={{
+            position: 'absolute',
+            top: '50%',
+            right: text ? '30px' : '6px',
+            transform: 'translateY(-50%)',
+            cursor: 'pointer',
+            border: 'none',
+            background: 'transparent',
+            color: '#ebe0c2',
+            padding: 0,
+            display: 'inline-flex',
+          }}
+        >
+          <FaArrowRight size={14} />
+        </button>
+      )}
       {text && (
         <button
           type="button"

--- a/src/components/smallCard/FieldComment.test.js
+++ b/src/components/smallCard/FieldComment.test.js
@@ -47,4 +47,28 @@ describe('FieldComment', () => {
 
     expect(saveMyCardComment).toHaveBeenCalledWith('user-1', '', 'admin-1');
   });
+
+  it('batch 26 §8: the backend-navigation arrow is hidden by default, shown only in extended mode', async () => {
+    const { rerender } = render(<FieldComment userData={{ userId: 'user-1' }} />);
+    await screen.findByPlaceholderText('Додайте свій коментар');
+    expect(screen.queryByLabelText('Відкрити запис коментаря у Firebase')).toBeNull();
+
+    rerender(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
+    expect(await screen.findByLabelText('Відкрити запис коментаря у Firebase')).toBeTruthy();
+  });
+
+  it('the backend-navigation arrow opens the comment\'s own comments/{ownerId}/{cardId} console URL', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
+
+    const arrow = await screen.findByLabelText('Відкрити запис коментаря у Firebase');
+    fireEvent.click(arrow);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [url] = openSpy.mock.calls[0];
+    expect(url).toContain('admin-1');
+    expect(url).toContain('user-1');
+    expect(url).toContain('comments');
+    openSpy.mockRestore();
+  });
 });

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1298,7 +1298,11 @@ export const TopBlock = ({
   additionalActions = null,
   overlayFieldAdditions = {},
   onSubmitHistorySnapshot = null,
-  stimulationScheduleToggle = null
+  stimulationScheduleToggle = null,
+  // Batch 26 §8: shows FieldComment's backend-navigation arrow (comments/{ownerId}/{cardId}) when
+  // on - off by default so a caller that hasn't wired up the toggle (no regression) keeps today's
+  // arrow-free look; AddNewProfile.jsx passes its own persisted toggle state.
+  extendedMode = false
 }) => {
   const [editableComment, setEditableComment] = React.useState('');
   const [isCommentModalOpen, setIsCommentModalOpen] = React.useState(false);
@@ -2129,7 +2133,7 @@ export const TopBlock = ({
       </div>
       <div style={commentsSectionStyle}>
         {fieldWriter({ userData: cardData, setUsers, setState, submitOptions, updateContext })}
-        <FieldComment userData={cardData} />
+        <FieldComment userData={cardData} extendedMode={extendedMode} />
         {otherAdminsComments.map(comment => (
           <div key={comment.commentId || `${comment.authorId}-${comment.text}`} style={multiCommentRowStyle}>
             <button


### PR DESCRIPTION
- Logo offset fields now accept negative values on mobile: inputMode="decimal"
  had no minus key on most touch keyboards even though the parsing already
  supported negatives.
- The Clinic logo block now renders as the first item in the same block list
  as paragraphs, in the same card style, with its Show-logo/offset controls
  moved behind the same "☰" settings popover every paragraph block uses.
- "Could not save the paragraph edits" is replaced with cause-specific
  messages (invalid value, permission, network, size limit). Root-caused and
  fixed the underlying rejection: any edit path that left a stray `undefined`
  in the template tree made Firebase's set() reject the entire write; every
  template save now sanitizes the tree first (stripUndefinedDeep) and the two
  dead-code paths that produced the undefined are fixed at the source too.
- Simplified the embryo-shipment data model to one shipment per case, stored
  directly at case.relations.shipment instead of a shipmentId-addressed list
  independently referenced by three different documents (transferAttempt,
  embryoOwnershipStatement) - any one of which could be left unlinked even
  after the shipment's own fields were filled in, which is what was causing
  partner-clinic-sourced shipment data to silently render blank. Existing
  cases on the old shape keep resolving correctly via a read-only fallback.