### PR TITLE
Documents Builder: migrate ART program data model to v5 singleton shape (batch 27 §1-5)

### DIFF
--- a/src/components/CaseArtProgramEditor.jsx
+++ b/src/components/CaseArtProgramEditor.jsx
@@ -1,12 +1,10 @@
 // "Програма ДРТ" (case.artProgram editor) - the shared, once-only medical facts of a case's
-// fertility program: diagnosis/genetic material/attending physician, the one embryo shipment from
-// the case's one partner clinic (batch 26 §5, stored at relations.shipment - "one case = one
-// partner clinic = one shipment"), and the transfer attempt (carrying its own hCG tests and
-// ultrasounds). Every document that references the transfer attempt's hCG tests/ultrasounds
-// (geneticAffinityCertificate, racssClinicLetter - edited in CaseChildbirthTransactionEditor) only
-// ever stores the id it points at, never a copy of the fact itself - editing an event here is
-// instantly reflected in every document that references it. The shipment itself needs no id at
-// all any more - every document just resolves the case's one shipment directly.
+// fertility program: diagnosis, genetic-material source, attending physician, the one embryo
+// shipment, and the one relevant transfer attempt (carrying at most one hCG test and one
+// ultrasound) - spec v5 §1.3/§1.4/§1.5. Every one of these is a singleton: no id, no array, no map,
+// nothing else in the app ever selects one of several by id. The shipment's source (foreign) and
+// destination (Ukrainian) clinics are the case's own relations (edited in PartiesPage's own
+// relations block), never fields on the shipment itself.
 //
 // Self-contained (same reasoning as CaseChildbirthTransactionEditor's own header comment): no
 // dependency on the host page's internals, so it drops into any --km-* scoped page as-is.
@@ -14,13 +12,12 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { ref, set } from 'firebase/database';
-import { FaPlus, FaTrash } from 'react-icons/fa';
 import { database } from './config';
 import {
   DOCUMENTS_CASES_PATH,
+  isGeneticSourceDonorCode,
   normalizeIsoDate,
   removeEmptyCaseValues,
-  toArray,
 } from './documentsCatalogUtils';
 
 const Section = styled.section`
@@ -64,7 +61,7 @@ const RowLine = styled.div`
 
 const Select = styled.select`
   flex: 1;
-  min-width: 200px;
+  min-width: 160px;
   border: 1px solid transparent;
   background: transparent;
   color: var(--km-text);
@@ -91,23 +88,6 @@ const DocRow = styled.div`
   border-radius: 8px;
   padding: 8px 10px;
   margin-top: 8px;
-`;
-
-const NestedRow = styled(DocRow)`
-  background: var(--km-bg, transparent);
-  margin-left: 4px;
-`;
-
-const DocRowHead = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const DocSubtitle = styled.div`
-  color: var(--km-muted);
-  font-size: 11px;
-  font-weight: 400;
 `;
 
 const FieldGrid = styled.div`
@@ -147,272 +127,157 @@ const FieldInput = styled.input`
   }
 `;
 
-const MiniButton = styled.button`
-  border: 1px solid var(--km-border);
-  background: var(--km-card);
-  color: var(--km-text);
+const PrimaryMiniButton = styled.button`
+  border: none;
+  color: #fff;
+  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
   border-radius: 6px;
   min-height: 30px;
-  padding: 6px 12px;
+  padding: 6px 14px;
   font-size: 12px;
   font-weight: 700;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  opacity: ${({ disabled }) => (disabled ? 0.55 : 1)};
-  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+  cursor: pointer;
 
-  &:hover:not(:disabled) {
-    border-color: var(--km-accent);
-    color: var(--km-accent);
-  }
-`;
-
-const PrimaryMiniButton = styled(MiniButton)`
-  border: none;
-  color: #fff;
-  background: linear-gradient(135deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
-
-  &:hover:not(:disabled) {
-    color: #fff;
+  &:hover {
     filter: brightness(1.05);
-  }
-`;
-
-const SmallButton = styled(MiniButton)`
-  min-height: 24px;
-  padding: 3px 9px;
-  font-size: 10.5px;
-  border-radius: 5px;
-`;
-
-const DangerButton = styled(SmallButton)`
-  border-color: var(--km-danger-border);
-  color: var(--km-danger);
-
-  &:hover:not(:disabled) {
-    border-color: var(--km-danger);
-    color: var(--km-danger);
   }
 `;
 
 const describeSaveError = error => `${error?.code || error?.name || 'error'}: ${error?.message || String(error)}`.trim();
 
-// The next `<prefix>-N` id for a freshly-added row (spec §8: "ID створювати автоматично") - the
-// highest existing numeric suffix plus one, not just `items.length + 1`, so removing a middle row
-// and adding a new one never collides with a still-referenced id (a document elsewhere may still
-// point at "shipment-2" even after "shipment-1" was deleted).
-const nextSequentialId = (prefix, items) => {
-  const maxSuffix = (items || []).reduce((max, item) => {
-    const match = /-(\d+)$/.exec(String(item?.id || ''));
-    return match ? Math.max(max, Number(match[1])) : max;
-  }, 0);
-  return `${prefix}-${maxSuffix + 1}`;
-};
+// Local UI mode for the oocyte/sperm source selector (spec §6.3) - never persisted itself, only
+// used to decide which input to show; the backend always stores the plain scalar
+// (`wife`/`husband`/the donor code string) with no separate mode field alongside it.
+const GENETIC_SOURCE_MODE_ROLE = 'role';
+const GENETIC_SOURCE_MODE_DONOR = 'donor';
 
-// One transfer attempt per case (batch 24 §2) - only the successful attempt's data ever matters
-// once the program is underway, so this is a single record, not a log of attempts. It references
-// no shipment id of its own any more (batch 26 §5) - there is only ever the case's one shipment.
-const emptyTransferAttempt = () => ({
-  date: '', embryoCount: '', embryoStage: '', hcgTests: [], ultrasounds: [],
-});
-
-// One shipment per case (batch 26 §5: "one case = one partner clinic = one shipment" - a case that
-// ever needs a second shipment is a second case, not a second entry here), stored directly under
-// the case's relations rather than in a shipmentId-addressed list, so no document referencing it
-// can ever point at the wrong (or no) entry.
-const emptyShipment = () => ({
-  sourceClinicId: '', destinationClinicId: '', ivfDate: '', plannedPeriod: { startDate: '', endDate: '' }, receivedDate: '',
-});
+const geneticSourceModeFor = value => (isGeneticSourceDonorCode(value) ? GENETIC_SOURCE_MODE_DONOR : GENETIC_SOURCE_MODE_ROLE);
 
 const emptyArtProgramDraft = () => ({
-  medicalIndication: { diagnosis: { uk: '' } },
-  geneticMaterial: { oocyteSourcePartnerRole: '', spermSourcePartnerRole: '' },
-  medicalTeam: { physician: { name: { uk: { nominative: '' } } } },
-  transferAttempt: emptyTransferAttempt(),
+  medicalIndicationsUk: '',
+  oocyteSource: '',
+  oocyteSourceMode: GENETIC_SOURCE_MODE_ROLE,
+  spermSource: '',
+  spermSourceMode: GENETIC_SOURCE_MODE_ROLE,
+  physicianNameUk: '',
+  embryoShipment: {
+    ivfDate: '', plannedPeriod: { startDate: '', endDate: '' }, sentDate: '', receivedDate: '',
+  },
+  transferAttempt: {
+    date: '', embryoCount: '', embryoStage: '', hcgTestDate: '', ultrasoundDate: '', fetusCount: '', gestationalAgeFrom: '', gestationalAgeTo: '',
+  },
 });
-
-const PARTNER_ROLE_OPTIONS = [
-  { value: '', label: '— не обрано —' },
-  { value: 'wife', label: 'дружина' },
-  { value: 'husband', label: 'чоловік' },
-  { value: 'donor', label: 'донор' },
-];
-
-const TRI_STATE_OPTIONS = [
-  { value: '', label: '— не вказано —' },
-  { value: 'true', label: 'так' },
-  { value: 'false', label: 'ні' },
-];
-
-// Firebase never stores these as arrays (spec §2/§12) - each list is converted back to a map keyed
-// by its own `id` right before the write, whatever order the draft happens to hold it in.
-const arrayToMap = items => (items || []).reduce((byId, item) => {
-  if (item?.id) byId[item.id] = item;
-  return byId;
-}, {});
 
 const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
   const selectedCase = catalog.cases.find(item => String(item.id) === String(caseId)) || null;
   const [draft, setDraft] = useState(emptyArtProgramDraft());
-  // The case's one shipment (batch 26 §5) lives at relations.shipment, a separate backend path from
-  // artProgram - its own draft/save, same pattern the format-override draft elsewhere uses.
-  const [shipmentDraft, setShipmentDraft] = useState(emptyShipment());
 
   useEffect(() => {
     const artProgram = selectedCase?.artProgram || {};
+    const shipment = artProgram.embryoShipment || {};
+    const transferAttempt = artProgram.transferAttempt || {};
+    const oocyteSourceMode = geneticSourceModeFor(artProgram.oocyteSource);
+    const spermSourceMode = geneticSourceModeFor(artProgram.spermSource);
     setDraft({
-      medicalIndication: { diagnosis: { uk: artProgram.medicalIndication?.diagnosis?.uk || '' } },
-      geneticMaterial: {
-        oocyteSourcePartnerRole: artProgram.geneticMaterial?.oocyteSourcePartnerRole || '',
-        spermSourcePartnerRole: artProgram.geneticMaterial?.spermSourcePartnerRole || '',
-      },
-      medicalTeam: {
-        physician: { name: { uk: { nominative: artProgram.medicalTeam?.physician?.name?.uk?.nominative || '' } } },
+      medicalIndicationsUk: artProgram.medicalIndications?.uk || '',
+      // The mode selector never offers a blank/unset option (spec §6.3: "Дружина/Донор",
+      // "Чоловік/Донор") - whichever option it displays is what a save commits, so an untouched
+      // case with no oocyteSource/spermSource yet still shows (and would save) the reserved role
+      // value, exactly like a two-option radio group defaults to its first option.
+      oocyteSource: oocyteSourceMode === GENETIC_SOURCE_MODE_DONOR ? artProgram.oocyteSource : 'wife',
+      oocyteSourceMode,
+      spermSource: spermSourceMode === GENETIC_SOURCE_MODE_DONOR ? artProgram.spermSource : 'husband',
+      spermSourceMode,
+      physicianNameUk: artProgram.medicalTeam?.physician?.name?.uk?.nominative || '',
+      embryoShipment: {
+        ivfDate: shipment.ivfDate || '',
+        plannedPeriod: {
+          startDate: shipment.plannedPeriod?.startDate || '',
+          endDate: shipment.plannedPeriod?.endDate || '',
+        },
+        sentDate: shipment.sentDate || '',
+        receivedDate: shipment.receivedDate || '',
       },
       transferAttempt: {
-        ...emptyTransferAttempt(),
-        ...artProgram.transferAttempt,
-        hcgTests: toArray(artProgram.transferAttempt?.hcgTests),
-        ultrasounds: toArray(artProgram.transferAttempt?.ultrasounds),
-      },
-    });
-    setShipmentDraft({
-      ...emptyShipment(),
-      ...(selectedCase?.relations?.shipment || {}),
-      plannedPeriod: {
-        ...emptyShipment().plannedPeriod,
-        ...(selectedCase?.relations?.shipment?.plannedPeriod || {}),
+        date: transferAttempt.date || '',
+        embryoCount: transferAttempt.embryoCount ?? '',
+        embryoStage: transferAttempt.embryoStage || '',
+        hcgTestDate: transferAttempt.hcgTest?.date || '',
+        ultrasoundDate: transferAttempt.ultrasound?.date || '',
+        fetusCount: transferAttempt.ultrasound?.fetusCount ?? '',
+        gestationalAgeFrom: transferAttempt.ultrasound?.gestationalAgeWeeks?.from ?? '',
+        gestationalAgeTo: transferAttempt.ultrasound?.gestationalAgeWeeks?.to ?? '',
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [caseId]);
 
-  const updateDiagnosis = value => setDraft(previous => ({ ...previous, medicalIndication: { diagnosis: { uk: value } } }));
-  const updateGeneticMaterial = (field, value) => setDraft(previous => ({
-    ...previous,
-    geneticMaterial: { ...previous.geneticMaterial, [field]: value },
-  }));
-  const updatePhysicianName = value => setDraft(previous => ({
-    ...previous,
-    medicalTeam: { physician: { name: { uk: { nominative: value } } } },
-  }));
+  const updateField = (field, value) => setDraft(previous => ({ ...previous, [field]: value }));
 
-  // --- The one embryo shipment (batch 26 §5) --------------------------------------------------
-
-  const updateShipmentField = (field, value) => setShipmentDraft(previous => ({ ...previous, [field]: value }));
-
-  // A migrated shipment may still carry `plannedPeriod.text` (spec §6) - preserved untouched here
-  // (spread first) since there's no input for it; only startDate/endDate are ever edited.
-  const updateShipmentPeriodField = (field, value) => setShipmentDraft(previous => ({
+  const updateGeneticSourceMode = (field, modeField, mode) => setDraft(previous => ({
     ...previous,
-    plannedPeriod: { ...(previous.plannedPeriod || {}), [field]: value },
+    [modeField]: mode,
+    // Switching back to Дружина/Чоловік writes the reserved role value immediately; switching to
+    // Донор clears the value so the admin has to type the actual donor code, never leaves the
+    // previous role value silently in place under a "donor" label.
+    [field]: mode === GENETIC_SOURCE_MODE_DONOR ? '' : (field === 'oocyteSource' ? 'wife' : 'husband'),
   }));
 
-  const handleSaveShipment = async () => {
-    if (!selectedCase) return;
-    const cleaned = removeEmptyCaseValues({
-      ...shipmentDraft,
-      ivfDate: normalizeIsoDate(shipmentDraft.ivfDate),
-      receivedDate: normalizeIsoDate(shipmentDraft.receivedDate),
-      plannedPeriod: {
-        ...(shipmentDraft.plannedPeriod || {}),
-        startDate: normalizeIsoDate(shipmentDraft.plannedPeriod?.startDate),
-        endDate: normalizeIsoDate(shipmentDraft.plannedPeriod?.endDate),
-      },
-    });
-    const nextValue = Object.keys(cleaned).length ? cleaned : null;
-    try {
-      await set(ref(database, `${DOCUMENTS_CASES_PATH}/${selectedCase.id}/relations/shipment`), nextValue);
-      setCatalog(previous => ({
-        ...previous,
-        cases: previous.cases.map(item => {
-          if (String(item.id) !== String(selectedCase.id)) return item;
-          const relations = { ...(item.relations || {}) };
-          if (nextValue) relations.shipment = nextValue;
-          else delete relations.shipment;
-          return { ...item, relations };
-        }),
-      }));
-      toast.success('Shipment details saved.');
-    } catch (saveError) {
-      console.error('Unable to save the shipment details', saveError);
-      toast.error(`Could not save the shipment details: ${describeSaveError(saveError)}`);
-    }
-  };
-
-  // --- The one transfer attempt + its nested hCG tests/ultrasounds ------------------------------
-
+  const updateShipmentField = (field, value) => setDraft(previous => ({
+    ...previous,
+    embryoShipment: { ...previous.embryoShipment, [field]: value },
+  }));
+  const updateShipmentPeriodField = (field, value) => setDraft(previous => ({
+    ...previous,
+    embryoShipment: { ...previous.embryoShipment, plannedPeriod: { ...previous.embryoShipment.plannedPeriod, [field]: value } },
+  }));
   const updateTransferField = (field, value) => setDraft(previous => ({
     ...previous,
     transferAttempt: { ...previous.transferAttempt, [field]: value },
   }));
 
-  const updateTransferList = (listKey, updater) => setDraft(previous => ({
-    ...previous,
-    transferAttempt: { ...previous.transferAttempt, [listKey]: updater(previous.transferAttempt[listKey]) },
-  }));
-
-  const addHcgTest = () => updateTransferList('hcgTests', hcgTests => [...hcgTests, {
-    id: nextSequentialId('hcg', hcgTests), date: '', positive: '', value: '', unit: '',
-  }]);
-  const removeHcgTest = hcgTestId => updateTransferList('hcgTests', hcgTests => hcgTests.filter(item => item.id !== hcgTestId));
-  const updateHcgTestField = (hcgTestId, field, value) => updateTransferList(
-    'hcgTests',
-    hcgTests => hcgTests.map(item => (item.id === hcgTestId ? { ...item, [field]: value } : item)),
-  );
-
-  const addUltrasound = () => updateTransferList('ultrasounds', ultrasounds => [...ultrasounds, {
-    id: nextSequentialId('ultrasound', ultrasounds), date: '', pregnancyConfirmed: '', fetusCount: '', gestationalAgeWeeks: { from: '', to: '' },
-  }]);
-  const removeUltrasound = ultrasoundId => updateTransferList(
-    'ultrasounds',
-    ultrasounds => ultrasounds.filter(item => item.id !== ultrasoundId),
-  );
-  const updateUltrasoundField = (ultrasoundId, field, value) => updateTransferList(
-    'ultrasounds',
-    ultrasounds => ultrasounds.map(item => (item.id === ultrasoundId ? { ...item, [field]: value } : item)),
-  );
-  const updateUltrasoundGestField = (ultrasoundId, field, value) => updateTransferList(
-    'ultrasounds',
-    ultrasounds => ultrasounds.map(item => (item.id === ultrasoundId
-      ? { ...item, gestationalAgeWeeks: { ...(item.gestationalAgeWeeks || {}), [field]: value } }
-      : item)),
-  );
-
-  // --- Save --------------------------------------------------------------------------------------
-
-  const parseTriState = value => (value === 'true' ? true : (value === 'false' ? false : undefined));
   const parseNumberOrBlank = value => (value === '' || value === undefined || value === null ? undefined : Number(value));
 
   const handleSave = async () => {
     if (!selectedCase) return;
+    const { transferAttempt: transferDraft, embryoShipment: shipmentDraft } = draft;
+
+    const hcgTest = transferDraft.hcgTestDate ? { date: normalizeIsoDate(transferDraft.hcgTestDate) } : undefined;
+    const ultrasound = transferDraft.ultrasoundDate || transferDraft.fetusCount || transferDraft.gestationalAgeFrom || transferDraft.gestationalAgeTo
+      ? {
+        date: normalizeIsoDate(transferDraft.ultrasoundDate),
+        fetusCount: parseNumberOrBlank(transferDraft.fetusCount),
+        gestationalAgeWeeks: {
+          from: parseNumberOrBlank(transferDraft.gestationalAgeFrom),
+          to: parseNumberOrBlank(transferDraft.gestationalAgeTo),
+        },
+      }
+      : undefined;
+
     const payload = {
-      medicalIndication: draft.medicalIndication,
-      geneticMaterial: draft.geneticMaterial,
-      medicalTeam: draft.medicalTeam,
+      medicalIndications: { uk: draft.medicalIndicationsUk },
+      oocyteSource: draft.oocyteSource,
+      spermSource: draft.spermSource,
+      medicalTeam: { physician: { name: { uk: { nominative: draft.physicianNameUk } } } },
+      embryoShipment: {
+        ivfDate: normalizeIsoDate(shipmentDraft.ivfDate),
+        plannedPeriod: {
+          startDate: normalizeIsoDate(shipmentDraft.plannedPeriod.startDate),
+          endDate: normalizeIsoDate(shipmentDraft.plannedPeriod.endDate),
+        },
+        sentDate: normalizeIsoDate(shipmentDraft.sentDate),
+        receivedDate: normalizeIsoDate(shipmentDraft.receivedDate),
+      },
       transferAttempt: {
-        ...draft.transferAttempt,
-        date: normalizeIsoDate(draft.transferAttempt.date),
-        embryoCount: parseNumberOrBlank(draft.transferAttempt.embryoCount),
-        hcgTests: arrayToMap(draft.transferAttempt.hcgTests.map(hcgTest => ({
-          ...hcgTest,
-          date: normalizeIsoDate(hcgTest.date),
-          positive: parseTriState(hcgTest.positive),
-          value: parseNumberOrBlank(hcgTest.value),
-        }))),
-        ultrasounds: arrayToMap(draft.transferAttempt.ultrasounds.map(ultrasound => ({
-          ...ultrasound,
-          date: normalizeIsoDate(ultrasound.date),
-          pregnancyConfirmed: parseTriState(ultrasound.pregnancyConfirmed),
-          fetusCount: parseNumberOrBlank(ultrasound.fetusCount),
-          gestationalAgeWeeks: {
-            from: parseNumberOrBlank(ultrasound.gestationalAgeWeeks?.from),
-            to: parseNumberOrBlank(ultrasound.gestationalAgeWeeks?.to),
-          },
-        }))),
+        date: normalizeIsoDate(transferDraft.date),
+        embryoCount: parseNumberOrBlank(transferDraft.embryoCount),
+        embryoStage: transferDraft.embryoStage,
+        hcgTest,
+        ultrasound,
       },
     };
     const cleaned = removeEmptyCaseValues(payload);
@@ -428,10 +293,10 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
           return rest;
         }),
       }));
-      toast.success('ART program details saved.');
+      toast.success('Дані програми ДРТ збережено.');
     } catch (saveError) {
       console.error('Unable to save the ART program details', saveError);
-      toast.error(`Could not save the ART program details: ${describeSaveError(saveError)}`);
+      toast.error(`Не вдалося зберегти дані програми ДРТ: ${describeSaveError(saveError)}`);
     }
   };
 
@@ -446,73 +311,69 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
       <SectionSubhead>Медичні дані</SectionSubhead>
       <FieldGrid>
         <Field style={{ gridColumn: '1 / -1' }}>
-          Діагноз
-          <FieldInput type="text" value={draft.medicalIndication.diagnosis.uk} onChange={event => updateDiagnosis(event.target.value)} />
+          Медичні показання
+          <FieldInput type="text" value={draft.medicalIndicationsUk} onChange={event => updateField('medicalIndicationsUk', event.target.value)} />
         </Field>
         <Field>
           Джерело яйцеклітин
-          <Select
-            value={draft.geneticMaterial.oocyteSourcePartnerRole}
-            onChange={event => updateGeneticMaterial('oocyteSourcePartnerRole', event.target.value)}
-          >
-            {PARTNER_ROLE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-          </Select>
+          <RowLine>
+            <Select value={draft.oocyteSourceMode} onChange={event => updateGeneticSourceMode('oocyteSource', 'oocyteSourceMode', event.target.value)}>
+              <option value={GENETIC_SOURCE_MODE_ROLE}>Дружина</option>
+              <option value={GENETIC_SOURCE_MODE_DONOR}>Донор</option>
+            </Select>
+            {draft.oocyteSourceMode === GENETIC_SOURCE_MODE_DONOR ? (
+              <FieldInput
+                type="text"
+                placeholder="Код донора"
+                value={draft.oocyteSource}
+                onChange={event => updateField('oocyteSource', event.target.value)}
+              />
+            ) : null}
+          </RowLine>
         </Field>
         <Field>
           Джерело сперматозоїдів
-          <Select
-            value={draft.geneticMaterial.spermSourcePartnerRole}
-            onChange={event => updateGeneticMaterial('spermSourcePartnerRole', event.target.value)}
-          >
-            {PARTNER_ROLE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-          </Select>
+          <RowLine>
+            <Select value={draft.spermSourceMode} onChange={event => updateGeneticSourceMode('spermSource', 'spermSourceMode', event.target.value)}>
+              <option value={GENETIC_SOURCE_MODE_ROLE}>Чоловік</option>
+              <option value={GENETIC_SOURCE_MODE_DONOR}>Донор</option>
+            </Select>
+            {draft.spermSourceMode === GENETIC_SOURCE_MODE_DONOR ? (
+              <FieldInput
+                type="text"
+                placeholder="Код донора"
+                value={draft.spermSource}
+                onChange={event => updateField('spermSource', event.target.value)}
+              />
+            ) : null}
+          </RowLine>
         </Field>
         <Field>
           Лікар програми
-          <FieldInput
-            type="text"
-            value={draft.medicalTeam.physician.name.uk.nominative}
-            onChange={event => updatePhysicianName(event.target.value)}
-          />
+          <FieldInput type="text" value={draft.physicianNameUk} onChange={event => updateField('physicianNameUk', event.target.value)} />
         </Field>
       </FieldGrid>
 
-      {/* One shipment only (batch 26 §5: "one case = one partner clinic = one shipment") - an edit
-          form for that one record, not a list; no add/remove, and no shipmentId for any document to
-          get out of sync with (the exact failure mode the old list model allowed). */}
-      <SectionSubhead style={{ marginTop: 14 }}>Доставлення ембріонів</SectionSubhead>
+      {/* One shipment only (spec §1.4: "one case = one partner clinic = one shipment") - an edit
+          form for that one record, not a list; no id, and no clinic pickers of its own - the
+          source/destination clinics are the case's own relations, edited alongside the other
+          relations in PartiesPage. */}
+      <SectionSubhead style={{ marginTop: 14 }}>Транспортування ембріонів</SectionSubhead>
       <DocRow>
         <FieldGrid>
           <Field>
-            Клініка-відправник
-            <Select value={shipmentDraft.sourceClinicId || ''} onChange={event => updateShipmentField('sourceClinicId', event.target.value)}>
-              <option value="">— не обрано —</option>
-              {catalog.parties.partnerClinics.map(partnerClinic => (
-                <option key={partnerClinic.id} value={String(partnerClinic.id)}>{partnerClinic.name?.uk || partnerClinic.id}</option>
-              ))}
-            </Select>
-          </Field>
-          <Field>
-            Клініка-отримувач
-            <Select
-              value={shipmentDraft.destinationClinicId || ''}
-              onChange={event => updateShipmentField('destinationClinicId', event.target.value)}
-            >
-              <option value="">— не обрано —</option>
-              {catalog.parties.clinics.map(clinic => (
-                <option key={clinic.id} value={String(clinic.id)}>{clinic.name?.uk || clinic.medicalCenterName?.uk || clinic.id}</option>
-              ))}
-            </Select>
-          </Field>
-          <Field>
             Дата ЗІВ
-            <FieldInput type="date" value={shipmentDraft.ivfDate || ''} onChange={event => updateShipmentField('ivfDate', event.target.value)} />
+            <FieldInput
+              type="date"
+              value={draft.embryoShipment.ivfDate}
+              onChange={event => updateShipmentField('ivfDate', event.target.value)}
+            />
           </Field>
           <Field>
             Запланований період — початок
             <FieldInput
               type="date"
-              value={shipmentDraft.plannedPeriod?.startDate || ''}
+              value={draft.embryoShipment.plannedPeriod.startDate}
               onChange={event => updateShipmentPeriodField('startDate', event.target.value)}
             />
           </Field>
@@ -520,46 +381,46 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
             Запланований період — кінець
             <FieldInput
               type="date"
-              value={shipmentDraft.plannedPeriod?.endDate || ''}
+              value={draft.embryoShipment.plannedPeriod.endDate}
               onChange={event => updateShipmentPeriodField('endDate', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Дата відправлення
+            <FieldInput
+              type="date"
+              value={draft.embryoShipment.sentDate}
+              onChange={event => updateShipmentField('sentDate', event.target.value)}
             />
           </Field>
           <Field>
             Дата фактичного отримання
             <FieldInput
               type="date"
-              value={shipmentDraft.receivedDate || ''}
+              value={draft.embryoShipment.receivedDate}
               onChange={event => updateShipmentField('receivedDate', event.target.value)}
             />
           </Field>
         </FieldGrid>
-        {shipmentDraft.plannedPeriod?.text?.uk || shipmentDraft.plannedPeriod?.text?.en ? (
-          <DocSubtitle style={{ marginTop: 6 }}>
-            Мігрований текстовий період: {shipmentDraft.plannedPeriod.text.uk || shipmentDraft.plannedPeriod.text.en}
-          </DocSubtitle>
-        ) : null}
       </DocRow>
-      <RowLine style={{ marginTop: 8 }}>
-        <PrimaryMiniButton type="button" onClick={handleSaveShipment}>
-          Save shipment
-        </PrimaryMiniButton>
-      </RowLine>
 
-      {/* One record only (batch 24 §2) - the successful transfer attempt's data, filled in once its
-          outcome is known. No add/remove: this is an edit form for that one record, not a list. */}
-      <SectionSubhead style={{ marginTop: 14 }}>Спроба переносу</SectionSubhead>
+      {/* One record only - the actual successful transfer attempt, filled in once its outcome is
+          known (spec §1.4/§1.5). Its hCG test/ultrasound are single nested sub-forms, not lists -
+          there is nothing left to add/remove/select by id, which also removes the old dropdown
+          preselection bug in CaseChildbirthTransactionEditor. */}
+      <SectionSubhead style={{ marginTop: 14 }}>Актуальний успішний перенос</SectionSubhead>
       <DocRow>
         <FieldGrid>
           <Field>
             Дата переносу
-            <FieldInput type="date" value={draft.transferAttempt.date || ''} onChange={event => updateTransferField('date', event.target.value)} />
+            <FieldInput type="date" value={draft.transferAttempt.date} onChange={event => updateTransferField('date', event.target.value)} />
           </Field>
           <Field>
             Кількість ембріонів
             <FieldInput
               type="number"
               min="0"
-              value={draft.transferAttempt.embryoCount ?? ''}
+              value={draft.transferAttempt.embryoCount}
               onChange={event => updateTransferField('embryoCount', event.target.value)}
             />
           </Field>
@@ -569,126 +430,62 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
               type="text"
               list="art-embryo-stage-options"
               placeholder="blastocyst"
-              value={draft.transferAttempt.embryoStage || ''}
+              value={draft.transferAttempt.embryoStage}
               onChange={event => updateTransferField('embryoStage', event.target.value)}
             />
           </Field>
         </FieldGrid>
 
-        <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>Аналізи ХГЧ</SectionSubhead>
-        {draft.transferAttempt.hcgTests.map((hcgTest, hcgIndex) => (
-          <NestedRow key={hcgTest.id}>
-            <DocRowHead>
-              <DocSubtitle style={{ fontWeight: 700 }}>{hcgTest.id || `ХГЧ ${hcgIndex + 1}`}</DocSubtitle>
-              <DangerButton type="button" onClick={() => removeHcgTest(hcgTest.id)} title="Remove this hCG test">
-                <FaTrash />
-              </DangerButton>
-            </DocRowHead>
-            <FieldGrid>
-              <Field>
-                Дата
-                <FieldInput
-                  type="date"
-                  value={hcgTest.date || ''}
-                  onChange={event => updateHcgTestField(hcgTest.id, 'date', event.target.value)}
-                />
-              </Field>
-              <Field>
-                Результат
-                <Select
-                  value={hcgTest.positive === true ? 'true' : (hcgTest.positive === false ? 'false' : '')}
-                  onChange={event => updateHcgTestField(hcgTest.id, 'positive', event.target.value)}
-                >
-                  {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-                </Select>
-              </Field>
-              <Field>
-                Значення
-                <FieldInput
-                  type="number"
-                  value={hcgTest.value ?? ''}
-                  onChange={event => updateHcgTestField(hcgTest.id, 'value', event.target.value)}
-                />
-              </Field>
-              <Field>
-                Одиниці вимірювання
-                <FieldInput
-                  type="text"
-                  value={hcgTest.unit || ''}
-                  onChange={event => updateHcgTestField(hcgTest.id, 'unit', event.target.value)}
-                />
-              </Field>
-            </FieldGrid>
-          </NestedRow>
-        ))}
-        <RowLine style={{ marginTop: 8 }}>
-          <SmallButton type="button" onClick={addHcgTest}>
-            <FaPlus /> Add hCG test
-          </SmallButton>
-        </RowLine>
+        <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>ХГЛ</SectionSubhead>
+        <FieldGrid>
+          <Field>
+            Дата аналізу
+            <FieldInput
+              type="date"
+              value={draft.transferAttempt.hcgTestDate}
+              onChange={event => updateTransferField('hcgTestDate', event.target.value)}
+            />
+          </Field>
+        </FieldGrid>
 
         <SectionSubhead style={{ marginTop: 10, fontSize: 10.5 }}>УЗД</SectionSubhead>
-        {draft.transferAttempt.ultrasounds.map((ultrasound, ultrasoundIndex) => (
-          <NestedRow key={ultrasound.id}>
-            <DocRowHead>
-              <DocSubtitle style={{ fontWeight: 700 }}>{ultrasound.id || `УЗД ${ultrasoundIndex + 1}`}</DocSubtitle>
-              <DangerButton type="button" onClick={() => removeUltrasound(ultrasound.id)} title="Remove this ultrasound">
-                <FaTrash />
-              </DangerButton>
-            </DocRowHead>
-            <FieldGrid>
-              <Field>
-                Дата
-                <FieldInput
-                  type="date"
-                  value={ultrasound.date || ''}
-                  onChange={event => updateUltrasoundField(ultrasound.id, 'date', event.target.value)}
-                />
-              </Field>
-              <Field>
-                Вагітність підтверджена
-                <Select
-                  value={ultrasound.pregnancyConfirmed === true ? 'true' : (ultrasound.pregnancyConfirmed === false ? 'false' : '')}
-                  onChange={event => updateUltrasoundField(ultrasound.id, 'pregnancyConfirmed', event.target.value)}
-                >
-                  {TRI_STATE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-                </Select>
-              </Field>
-              <Field>
-                Кількість плодів
-                <FieldInput
-                  type="number"
-                  min="0"
-                  value={ultrasound.fetusCount ?? ''}
-                  onChange={event => updateUltrasoundField(ultrasound.id, 'fetusCount', event.target.value)}
-                />
-              </Field>
-              <Field>
-                Строк вагітності — від (тижнів)
-                <FieldInput
-                  type="number"
-                  min="0"
-                  value={ultrasound.gestationalAgeWeeks?.from ?? ''}
-                  onChange={event => updateUltrasoundGestField(ultrasound.id, 'from', event.target.value)}
-                />
-              </Field>
-              <Field>
-                Строк вагітності — до (тижнів)
-                <FieldInput
-                  type="number"
-                  min="0"
-                  value={ultrasound.gestationalAgeWeeks?.to ?? ''}
-                  onChange={event => updateUltrasoundGestField(ultrasound.id, 'to', event.target.value)}
-                />
-              </Field>
-            </FieldGrid>
-          </NestedRow>
-        ))}
-        <RowLine style={{ marginTop: 8 }}>
-          <SmallButton type="button" onClick={addUltrasound}>
-            <FaPlus /> Add ultrasound
-          </SmallButton>
-        </RowLine>
+        <FieldGrid>
+          <Field>
+            Дата УЗД
+            <FieldInput
+              type="date"
+              value={draft.transferAttempt.ultrasoundDate}
+              onChange={event => updateTransferField('ultrasoundDate', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Кількість плодів
+            <FieldInput
+              type="number"
+              min="0"
+              value={draft.transferAttempt.fetusCount}
+              onChange={event => updateTransferField('fetusCount', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Строк вагітності — від (тижнів)
+            <FieldInput
+              type="number"
+              min="0"
+              value={draft.transferAttempt.gestationalAgeFrom}
+              onChange={event => updateTransferField('gestationalAgeFrom', event.target.value)}
+            />
+          </Field>
+          <Field>
+            Строк вагітності — до (тижнів)
+            <FieldInput
+              type="number"
+              min="0"
+              value={draft.transferAttempt.gestationalAgeTo}
+              onChange={event => updateTransferField('gestationalAgeTo', event.target.value)}
+            />
+          </Field>
+        </FieldGrid>
       </DocRow>
 
       <datalist id="art-embryo-stage-options">
@@ -697,7 +494,7 @@ const CaseArtProgramEditor = ({ catalog, setCatalog, caseId }) => {
 
       <RowLine style={{ marginTop: 14 }}>
         <PrimaryMiniButton type="button" onClick={handleSave}>
-          Save ART program
+          Зберегти
         </PrimaryMiniButton>
       </RowLine>
     </Section>

--- a/src/components/CaseChildbirthTransactionEditor.jsx
+++ b/src/components/CaseChildbirthTransactionEditor.jsx
@@ -14,9 +14,7 @@ import { database } from './config';
 import {
   DOCUMENTS_CASES_PATH,
   createChildRecord,
-  formatHcgTestOptionLabel,
   formatShortNameUk,
-  formatUltrasoundOptionLabel,
   getMaternityHospitalDisplayName,
   normalizeIsoDate,
   removeEmptyCaseValues,
@@ -227,21 +225,8 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   // No notaryId field - this appendix isn't itself notarized (see TEMPLATE_DOCUMENT_CONFIG's
   // usesNotary: false for surrogacy-agreement-appendix-1).
   const [surrogacyAgreementAppendix1Draft, setSurrogacyAgreementAppendix1Draft] = useState({ date: '' });
-  const [geneticAffinityCertificateDraft, setGeneticAffinityCertificateDraft] = useState({
-    hcgTestId: '', ultrasoundId: '', issueDate: '', outgoingNumber: '',
-  });
-  const [racssClinicLetterDraft, setRacssClinicLetterDraft] = useState({ ultrasoundId: '' });
+  const [geneticAffinityCertificateDraft, setGeneticAffinityCertificateDraft] = useState({ issueDate: '', outgoingNumber: '' });
   const [medicalServicesAgreementDraft, setMedicalServicesAgreementDraft] = useState({ date: '' });
-
-  // Every artProgram-referencing dropdown reads from the same source: the selected case's own
-  // transfer attempt (never converted to arrays for storage - see documentsCatalogUtils - only
-  // here, transiently, for rendering <option>s). There is only ever one transfer attempt (batch 24
-  // §2), so its hCG tests/ultrasounds are the only thing still picked by id - the shipment itself
-  // (batch 26 §5, edited in CaseArtProgramEditor) needs no id/picker anywhere any more.
-  const artTransferAttempt = selectedCase?.artProgram?.transferAttempt || null;
-  const certificateHcgTests = toArray(artTransferAttempt?.hcgTests);
-  const certificateUltrasounds = toArray(artTransferAttempt?.ultrasounds);
-  const letterUltrasounds = toArray(artTransferAttempt?.ultrasounds);
 
   useEffect(() => {
     // `childbirth.children` isn't guaranteed to be a real array - a case edited straight in the
@@ -275,13 +260,8 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       date: selectedCase?.documents?.surrogacyAgreementAppendix1?.date || '',
     });
     setGeneticAffinityCertificateDraft({
-      hcgTestId: selectedCase?.documents?.geneticAffinityCertificate?.hcgTestId || '',
-      ultrasoundId: selectedCase?.documents?.geneticAffinityCertificate?.ultrasoundId || '',
       issueDate: selectedCase?.documents?.geneticAffinityCertificate?.issueDate || '',
       outgoingNumber: selectedCase?.documents?.geneticAffinityCertificate?.outgoingNumber || '',
-    });
-    setRacssClinicLetterDraft({
-      ultrasoundId: selectedCase?.documents?.racssClinicLetter?.ultrasoundId || '',
     });
     setMedicalServicesAgreementDraft({
       date: selectedCase?.documents?.medicalServicesAgreement?.date || '',
@@ -508,22 +488,11 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
   const handleSaveGeneticAffinityCertificate = () => saveCaseDocument(
     'geneticAffinityCertificate',
     {
-      hcgTestId: geneticAffinityCertificateDraft.hcgTestId,
-      ultrasoundId: geneticAffinityCertificateDraft.ultrasoundId,
       issueDate: normalizeIsoDate(geneticAffinityCertificateDraft.issueDate),
       outgoingNumber: geneticAffinityCertificateDraft.outgoingNumber,
     },
     'Genetic affinity certificate details saved.',
     'the genetic affinity certificate details',
-  );
-
-  const updateRacssClinicLetterField = (field, value) => setRacssClinicLetterDraft(previous => ({ ...previous, [field]: value }));
-
-  const handleSaveRacssClinicLetter = () => saveCaseDocument(
-    'racssClinicLetter',
-    { ultrasoundId: racssClinicLetterDraft.ultrasoundId },
-    'RACSS clinic letter details saved.',
-    'the RACSS clinic letter details',
   );
 
   const handleSaveMedicalServicesAgreement = () => saveCaseDocument(
@@ -799,38 +768,14 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
         </PrimaryMiniButton>
       </RowLine>
 
-      {/* Заява про належність ембріонів no longer needs its own editor here (batch 26 §5) - it
-          resolves the case's one shipment directly (edited in CaseArtProgramEditor), with no
-          shipmentId of its own left to pick or get out of sync. */}
+      {/* Заява про належність ембріонів and лист клініки до РАЦС no longer need their own editors
+          here - they resolve the case's one shipment/transfer attempt/ultrasound directly (edited
+          in CaseArtProgramEditor), and racssClinicLetter carries no requisites of its own (spec
+          §1.3/§1.8). There is nothing left to select by id, which also removes the old dropdown
+          preselection bug. */}
 
       <SectionSubhead style={{ marginTop: 14 }}>Довідка про генетичну спорідненість</SectionSubhead>
       <FieldGrid>
-        <Field>
-          ХГЧ (довідка)
-          <Select
-            value={geneticAffinityCertificateDraft.hcgTestId || ''}
-            onChange={event => updateGeneticAffinityCertificateField('hcgTestId', event.target.value)}
-            disabled={!artTransferAttempt}
-          >
-            <option value="">— не обрано —</option>
-            {certificateHcgTests.map(hcgTest => (
-              <option key={hcgTest.id} value={hcgTest.id}>{formatHcgTestOptionLabel(hcgTest) || hcgTest.id}</option>
-            ))}
-          </Select>
-        </Field>
-        <Field>
-          УЗД (довідка)
-          <Select
-            value={geneticAffinityCertificateDraft.ultrasoundId || ''}
-            onChange={event => updateGeneticAffinityCertificateField('ultrasoundId', event.target.value)}
-            disabled={!artTransferAttempt}
-          >
-            <option value="">— не обрано —</option>
-            {certificateUltrasounds.map(ultrasound => (
-              <option key={ultrasound.id} value={ultrasound.id}>{formatUltrasoundOptionLabel(ultrasound) || ultrasound.id}</option>
-            ))}
-          </Select>
-        </Field>
         <Field>
           Дата видачі
           <FieldInput
@@ -850,29 +795,7 @@ const CaseChildbirthTransactionEditor = ({ catalog, setCatalog, caseId, onSelect
       </FieldGrid>
       <RowLine style={{ marginTop: 8 }}>
         <PrimaryMiniButton type="button" onClick={handleSaveGeneticAffinityCertificate}>
-          Save genetic affinity certificate details
-        </PrimaryMiniButton>
-      </RowLine>
-
-      <SectionSubhead style={{ marginTop: 14 }}>Лист клініки до РАЦС</SectionSubhead>
-      <FieldGrid>
-        <Field>
-          УЗД (лист РАЦС)
-          <Select
-            value={racssClinicLetterDraft.ultrasoundId || ''}
-            onChange={event => updateRacssClinicLetterField('ultrasoundId', event.target.value)}
-            disabled={!artTransferAttempt}
-          >
-            <option value="">— не обрано —</option>
-            {letterUltrasounds.map(ultrasound => (
-              <option key={ultrasound.id} value={ultrasound.id}>{formatUltrasoundOptionLabel(ultrasound) || ultrasound.id}</option>
-            ))}
-          </Select>
-        </Field>
-      </FieldGrid>
-      <RowLine style={{ marginTop: 8 }}>
-        <PrimaryMiniButton type="button" onClick={handleSaveRacssClinicLetter}>
-          Save RACSS clinic letter details
+          Зберегти дані довідки про генетичну спорідненість
         </PrimaryMiniButton>
       </RowLine>
 

--- a/src/components/DocumentsLayoutV2.test.js
+++ b/src/components/DocumentsLayoutV2.test.js
@@ -128,7 +128,7 @@ const layoutV2Template = () => ({
       {
         type: 'richParagraph',
         style: 'body',
-        runs: [{ text: 'Діагноз: ' }, { text: '{{case.artProgram.medicalIndication.diagnosis.uk}}' }],
+        runs: [{ text: 'Діагноз: ' }, { text: '{{case.artProgram.medicalIndications.uk}}' }],
       },
       { type: 'spacer', heightMm: 5 },
       {
@@ -158,7 +158,7 @@ const context = {
   wife: { name: { uk: { nominative: 'Кікава Харука' } } },
   surrogateMother: { name: { uk: { nominative: 'Молвінських Юлія Володимирівна' } } },
   clinic: { edrpou: '35085030', medicalDirector: { name: { uk: { nominative: 'Пилип Юрій Юрійович' } } } },
-  case: { artProgram: { medicalIndication: { diagnosis: { uk: 'Безпліддя' } } } },
+  case: { artProgram: { medicalIndications: { uk: 'Безпліддя' } } },
 };
 
 describe('layoutV2 normalization (buildGeneratedDocument)', () => {

--- a/src/components/DocumentsLayoutV2CleanTemplate.test.js
+++ b/src/components/DocumentsLayoutV2CleanTemplate.test.js
@@ -169,7 +169,7 @@ const CLEAN_TEMPLATE_JSON = {
         type: 'paragraph',
       },
       {
-        marginBottomMm: 3, style: 'body', text: 'Після обстеження встановлено діагноз: {{case.artProgram.medicalIndication.diagnosis.uk}}', type: 'paragraph',
+        marginBottomMm: 3, style: 'body', text: 'Після обстеження встановлено діагноз: {{case.artProgram.medicalIndications.uk}}', type: 'paragraph',
       },
       {
         runs: [
@@ -332,7 +332,7 @@ const fullContext = () => ({
   },
   case: {
     artProgram: {
-      medicalIndication: { diagnosis: { uk: 'Непліддя І. Матковий фактор.' } },
+      medicalIndications: { uk: 'Непліддя І. Матковий фактор.' },
       medicalTeam: { physician: { name: { uk: { nominative: 'Тестовий Лікар Лікарович' } } } },
     },
   },

--- a/src/components/DocumentsPage.checklistScope.test.js
+++ b/src/components/DocumentsPage.checklistScope.test.js
@@ -110,7 +110,7 @@ describe('spec: completeness checklist is scoped to the checked documents', () =
     await checkDocumentByTitle('Договір');
 
     const warning = await screen.findByText(/Незаповнені обов'язкові поля/);
-    expect(warning.textContent).toContain('case.relations.clinicId');
+    expect(warning.textContent).toContain('case.relations.ukrainianClinicId');
     expect(warning.textContent).not.toContain('case.childbirth.children');
     expect(warning.textContent).not.toContain('case.relations.surrogateMotherId');
   });

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -83,7 +83,6 @@ import {
   toggleRawInlineMarker,
   upsertRecentCaseId,
   upsertRecentId,
-  validateArtProgramReferences,
   validateBirthRegistrationCase,
   validateCaseRecord,
   validateDocumentTemplate,
@@ -1804,7 +1803,7 @@ const DocumentsPage = ({ isAdmin }) => {
           return;
         }
 
-        const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
+        const clinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
         if (!clinicId) {
           toast.error('Select a case with a clinic before uploading the logo.');
           return;
@@ -1872,7 +1871,7 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   const handleAssignLogoLayout = async (fileName, layoutTag) => {
-    const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
+    const clinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
     if (!clinicId) return;
     const previousVariants = clinicLogos;
     const nextVariants = applyLogoLayoutAssignment(previousVariants, fileName, layoutTag);
@@ -1888,7 +1887,7 @@ const DocumentsPage = ({ isAdmin }) => {
 
   const handleRemoveLogoVariant = async fileName => {
     if (typeof window !== 'undefined' && !window.confirm('Remove this clinic logo variant from the backend?')) return;
-    const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
+    const clinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
     if (!clinicId) return;
     // A variant loaded via the legacy Storage-folder fallback still physically lives there.
     const isLegacyVariant = Boolean(clinicLogos.find(variant => variant.fileName === fileName)?.legacyFolder);
@@ -2027,18 +2026,12 @@ const DocumentsPage = ({ isAdmin }) => {
   const referencesBirthDomain = referencesPathDomain([
     'child', 'children', 'medicalConclusion', 'birthRegistration', 'case.childbirth', 'case.documents.birthRegistrationConsent',
   ]);
-  // Same idea, scoped to the ART-program-referencing documents (spec §13/§15): a shipment/transfer/
-  // hCG/ultrasound id that no longer resolves gets its own specific message here instead of
-  // drowning in the generic unresolved-{{placeholder}} list below.
-  const referencesArtDomain = referencesPathDomain([
-    'embryoOwnershipStatement', 'geneticAffinityCertificate', 'racssClinicLetter', 'case.artProgram',
-  ]);
   // Which relation each base checklist issue actually gates on - an issue with no listed domain
   // (case.id) is always relevant; everything else only matters once a checked document references
   // that data at all.
   const CHECKLIST_ISSUE_DOMAINS = {
     'case.relations.coupleId': ['wife', 'husband', 'couple'],
-    'case.relations.clinicId': ['clinic'],
+    'case.relations.ukrainianClinicId': ['clinic'],
     'case.relations.surrogateMotherId': ['surrogateMother'],
     'case.childbirth.children': ['child', 'children', 'medicalConclusion', 'birthRegistration', 'case.childbirth', 'case.documents.birthRegistrationConsent'],
   };
@@ -2054,7 +2047,6 @@ const DocumentsPage = ({ isAdmin }) => {
     ? [...new Set([
       ...validateCaseRecord(selectedCase).filter(isChecklistIssueRelevant),
       ...(referencesBirthDomain ? validateBirthRegistrationCase(catalog, selectedCaseId) : []),
-      ...(referencesArtDomain ? validateArtProgramReferences(catalog, selectedCaseId) : []),
     ])]
     : [];
   // A logo only ever appears where a template declares one - via the dedicated `logo` field, or
@@ -2110,7 +2102,7 @@ const DocumentsPage = ({ isAdmin }) => {
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
   // source of truth here, so logos uploaded through the app or Firebase Console are discovered
   // without relying on a Realtime Database filename mirror.
-  const logoClinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
+  const logoClinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
   const clinicLogoStorageKey = `${logoClinicId}:${clinicLogoRefreshKey}`;
 
   // Fetch every stored logo variant of the selected clinic from Storage; the dimensions are what

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -1037,9 +1037,9 @@ const CasesGroup = ({ catalog, setCatalog, expandedKeys, toggleRecord, groupOpen
                     <RelationSlot
                       label="Clinic"
                       records={orderedClinics}
-                      valueId={relations.clinicId}
+                      valueId={relations.ukrainianClinicId}
                       displayName={partyDisplayName}
-                      onPick={id => { updateCaseField(caseRecord.id, 'relations.clinicId', id); recordPartyUsage('clinics', id); }}
+                      onPick={id => { updateCaseField(caseRecord.id, 'relations.ukrainianClinicId', id); recordPartyUsage('clinics', id); }}
                     />
                     <RelationSlot
                       label="Partner clinic"

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -49,7 +49,7 @@ const buildParties = () => ({
 const buildCases = () => ({
   'case-1': {
     id: 'case-1',
-    relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
+    relations: { coupleId: 'couple-1', ukrainianClinicId: '', surrogateMotherId: '', representativeIds: [] },
     childbirth: { maternityHospitalId: '', children: [] },
   },
 });
@@ -167,7 +167,7 @@ describe('spec: Parties page', () => {
     // "+ Add shipment" first.
     fireEvent.click(await screen.findByRole('button', { name: 'Клініка Мрія' }));
 
-    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/cases/case-1/relations/clinicId', 'clinic-1'));
+    await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/cases/case-1/relations/ukrainianClinicId', 'clinic-1'));
     await waitFor(() => expect(set).toHaveBeenCalledWith('documentsBuilder/partiesSettings/recentIds/clinics', ['clinic-1']));
   });
 

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -1,17 +1,23 @@
-// Unit + integration tests for the ART program (case.artProgram) support: resolvers, formatters,
-// the four document contexts that reference it (embryoOwnershipStatement, geneticAffinityCertificate,
-// racssClinicLetter, medicalServicesAgreement), and couple.marriage enrichment.
+// Unit + integration tests for the ART program (case.artProgram) support: v5 resolvers/formatters,
+// the singleton embryoShipment/transferAttempt/hcgTest/ultrasound model, the scalar oocyteSource/
+// spermSource genetic-material fields, the v5 migration boundary (migrateCaseToV5/migrateCasesToV5),
+// and the four document contexts that reference artProgram (embryoOwnershipStatement,
+// geneticAffinityCertificate, racssClinicLetter, medicalServicesAgreement).
 //
 // All fixtures below are fictional - tests must never carry real client data (same rule as
 // documentsCatalogUtils.test.js).
 import {
+  CURRENT_SCHEMA_VERSION,
   DERIVED_CONTEXT_FIELD_KEYS,
+  GENETIC_SOURCE_ROLE_VALUES,
   MISSING_VALUE_PLACEHOLDER,
+  auditTemplateVariables,
   buildEmbryoOwnershipStatementContext,
   buildGeneratedDocument,
   buildGeneticAffinityCertificateContext,
   buildMedicalServicesAgreementContext,
   buildRacssClinicLetterContext,
+  classifyTemplateVariablePath,
   deepMergeRecords,
   enrichCoupleMarriage,
   enrichHcgTestForTemplate,
@@ -25,21 +31,25 @@ import {
   formatDateRange,
   formatEmbryoCountTextUk,
   formatGestationalAgeText,
-  formatHcgTestOptionLabel,
   formatPregnancyTypeTextUk,
   formatShipmentPeriod,
-  formatUltrasoundOptionLabel,
+  isDocumentsSchemaV5,
+  isGeneticSourceDonorCode,
   mergeDocumentsCatalog,
+  migrateCaseToV5,
+  migrateCasesToV5,
+  normalizeCaseRecord,
   normalizeDocumentsCatalog,
+  normalizeDocumentsSettings,
   parseDocumentsTechnicalInput,
   resolveCaseContext,
   resolveEmbryoStageLabel,
+  resolveGeneticSourceLabel,
   resolveHcgTest,
   resolveShipment,
   resolveTransferAttempt,
   resolveUltrasound,
   stripDerivedFields,
-  validateArtProgramReferences,
   validateDocumentTemplate,
 } from './documentsCatalogUtils';
 
@@ -58,58 +68,54 @@ const clinic = {
   legalName: { uk: 'ТОВ «Приклад»', en: 'Example LLC' },
 };
 
+const couple = {
+  id: 'couple-fixture',
+  partners: [
+    { id: 'wife-fixture', role: 'wife', name: { uk: { nominative: 'Кацура Юкако' }, en: 'Katsura Yukako' } },
+    { id: 'husband-fixture', role: 'husband', name: { uk: { nominative: 'Кацура Кеіго' }, en: 'Katsura Keigo' } },
+  ],
+};
+
 const rawParties = {
   clinics: { [clinic.id]: clinic },
   partnerClinics: { [partnerClinic.id]: partnerClinic },
+  couples: { [couple.id]: couple },
 };
 
-// enrichShipment (and everything built on it) reads `parties.clinics`/`parties.partnerClinics` as
-// arrays - the same normalized shape resolveCaseContext always passes it (catalog.parties from
-// normalizeDocumentsCatalog), never the raw id-keyed map a Firebase snapshot carries.
+// enrichShipment (and everything built on it) reads the case's own resolved clinic/partnerClinic
+// (spec v5 §1.2/§1.4: a shipment carries no clinic ids of its own) - the same `{ clinic, partnerClinic }`
+// pair resolveCaseContext always resolves from the case's relations and passes in.
 const parties = normalizeDocumentsCatalog(rawParties, {}, {}).parties;
+const resolvedClinics = { clinic, partnerClinic };
 
-// A case that uses the new startDate/endDate planned-period shape (spec: "Kikawa" scenario). The
-// case's one shipment (batch 26 §5: "one case = one partner clinic = one shipment") lives directly
-// on relations, never a shipmentId-addressed list - no document referencing it needs an id at all.
+// A case using the v5 shape throughout (spec §1.3): the one embryo shipment lives at
+// `artProgram.embryoShipment` (no id, no clinic ids of its own - those are the case's own
+// relations), the one transfer attempt at `artProgram.transferAttempt`, its hCG test/ultrasound
+// nested directly as singletons (no id, no map, existence alone means positive/confirmed).
 const caseWithDateRangePeriod = {
   id: 'case-daterange',
-  relations: {
-    clinicId: clinic.id,
-    partnerClinicId: partnerClinic.id,
-    shipment: {
-      sourceClinicId: partnerClinic.id,
-      destinationClinicId: clinic.id,
+  relations: { coupleId: couple.id, ukrainianClinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  artProgram: {
+    medicalIndications: { uk: 'Тестовий діагноз' },
+    oocyteSource: 'wife',
+    spermSource: 'husband',
+    medicalTeam: { physician: { name: { uk: { nominative: 'Тестова Лікарка Лікарівна' } } } },
+    embryoShipment: {
       ivfDate: '2021-08-17',
       plannedPeriod: { startDate: '2026-01-01', endDate: '2026-02-01' },
       receivedDate: '2025-08-27',
     },
-  },
-  artProgram: {
-    medicalIndication: { diagnosis: { uk: 'Тестовий діагноз' } },
-    geneticMaterial: { oocyteSourcePartnerRole: 'wife', spermSourcePartnerRole: 'husband' },
-    medicalTeam: { physician: { name: { uk: { nominative: 'Тестова Лікарка Лікарівна' } } } },
-    // batch 24 §2: a single transfer attempt object, not a log of attempts - only the one
-    // successful attempt's data ever matters once the program is underway.
     transferAttempt: {
       date: '2025-09-18',
       embryoCount: 1,
       embryoStage: 'blastocyst',
-      hcgTests: {
-        'hcg-1': { id: 'hcg-1', date: '2025-09-30', positive: true },
-        'hcg-2': { id: 'hcg-2', date: '2025-11-15', positive: false },
-      },
-      ultrasounds: {
-        'ultrasound-1': {
-          id: 'ultrasound-1', date: '2025-10-17', pregnancyConfirmed: true, fetusCount: 1, gestationalAgeWeeks: { from: 6, to: 7 },
-        },
-      },
+      hcgTest: { date: '2025-09-30' },
+      ultrasound: { date: '2025-10-17', fetusCount: 1, gestationalAgeWeeks: { from: 6, to: 7 } },
     },
   },
   documents: {
-    geneticAffinityCertificate: {
-      hcgTestId: 'hcg-1', ultrasoundId: 'ultrasound-1', issueDate: '2025-10-20', outgoingNumber: '42/1',
-    },
-    racssClinicLetter: { ultrasoundId: 'ultrasound-1' },
+    geneticAffinityCertificate: { issueDate: '2025-10-20', outgoingNumber: '42/1' },
+    racssClinicLetter: {},
     medicalServicesAgreement: { date: '2025-09-12' },
   },
 };
@@ -117,63 +123,28 @@ const caseWithDateRangePeriod = {
 // A case that only ever carries the migrated freeform text period (spec: "Katsura" scenario).
 const caseWithTextPeriod = {
   id: 'case-textperiod',
-  relations: {
-    clinicId: clinic.id,
-    partnerClinicId: partnerClinic.id,
-    shipment: {
-      sourceClinicId: partnerClinic.id,
-      destinationClinicId: clinic.id,
+  relations: { ukrainianClinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  artProgram: {
+    embryoShipment: {
       ivfDate: '2021-08-17',
       plannedPeriod: { text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } },
     },
   },
 };
 
-// A pre-batch-26 case: its one shipment is still stored the old, shipmentId-addressed way
-// (artProgram.embryoShipments, referenced from transferAttempt.shipmentId) - resolveShipment must
-// still find it read-only, so nothing already entered goes blank the moment this ships.
-const caseWithLegacyShipmentShape = {
-  id: 'case-legacy-shipment',
-  relations: { clinicId: clinic.id, partnerClinicId: partnerClinic.id },
-  artProgram: {
-    embryoShipments: {
-      'shipment-1': {
-        id: 'shipment-1',
-        sourceClinicId: partnerClinic.id,
-        destinationClinicId: clinic.id,
-        receivedDate: '2025-08-27',
-      },
-    },
-    transferAttempt: { shipmentId: 'shipment-1', date: '2025-09-18', hcgTests: {}, ultrasounds: {} },
-  },
-};
-
-// A pre-artProgram case: no artProgram at all, and embryoOwnershipStatement still stored the old
-// way (spec §14 backward compatibility).
+// A pre-artProgram case: no artProgram at all.
 const caseWithoutArtProgram = {
   id: 'case-old',
-  relations: { clinicId: clinic.id },
-  documents: {
-    embryoOwnershipStatement: {
-      ivfDate: '2021-08-17',
-      shipmentPeriod: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' },
-    },
-  },
+  relations: { ukrainianClinicId: clinic.id },
 };
 
-// The transfer attempt's own hCG/ultrasound references point at ids that don't exist (spec
-// §13/§15) - the case has no shipment at all, which is an ordinary "not set" state, not a broken
-// reference (batch 26 §5 removed the shipmentId a document could dangle on in the first place).
-const caseWithBrokenReferences = {
-  id: 'case-broken',
-  relations: { clinicId: clinic.id },
-  artProgram: {
-    transferAttempt: { date: '2025-09-18', hcgTests: {}, ultrasounds: {} },
-  },
-  documents: {
-    geneticAffinityCertificate: { hcgTestId: 'hcg-999', ultrasoundId: 'ultrasound-999' },
-    racssClinicLetter: { ultrasoundId: 'ultrasound-999' },
-  },
+// A transfer attempt exists but never got a hCG test/ultrasound entered yet - the ordinary "not
+// set" state (spec §1.5), never a broken reference (there's no id left to dangle in v5).
+const caseWithTransferButNoTests = {
+  id: 'case-no-tests',
+  relations: { ukrainianClinicId: clinic.id },
+  artProgram: { transferAttempt: { date: '2025-09-18' } },
+  documents: { geneticAffinityCertificate: {}, racssClinicLetter: {} },
 };
 
 const buildCatalog = (...cases) => normalizeDocumentsCatalog(
@@ -184,55 +155,65 @@ const buildCatalog = (...cases) => normalizeDocumentsCatalog(
 
 // --- Resolvers -------------------------------------------------------------------------------
 
-describe('spec: null-safe artProgram resolvers (resolveShipment/resolveTransferAttempt/resolveHcgTest/resolveUltrasound)', () => {
-  it('resolves the case\'s one shipment straight off relations, and its one transfer attempt (no id needed for either, batch 24 §2/batch 26 §5)', () => {
+describe('spec §1.3/§1.4: null-safe artProgram resolvers (resolveShipment/resolveTransferAttempt/resolveHcgTest/resolveUltrasound)', () => {
+  it('resolves the case\'s one shipment/transfer attempt straight off artProgram (singleton, no id needed for either)', () => {
     const { artProgram } = caseWithDateRangePeriod;
-    expect(resolveShipment(caseWithDateRangePeriod)).toBe(caseWithDateRangePeriod.relations.shipment);
+    expect(resolveShipment(caseWithDateRangePeriod)).toBe(artProgram.embryoShipment);
     expect(resolveTransferAttempt(caseWithDateRangePeriod)).toBe(artProgram.transferAttempt);
   });
 
-  it('falls back to the pre-batch-26 shipmentId-addressed shape, read-only, when relations.shipment is unset', () => {
-    const legacyShipment = caseWithLegacyShipmentShape.artProgram.embryoShipments['shipment-1'];
-    expect(resolveShipment(caseWithLegacyShipmentShape)).toBe(legacyShipment);
-  });
-
-  it('resolves an existing hCG test/ultrasound from within the transfer attempt', () => {
+  it('resolves the transfer attempt\'s own nested singleton hcgTest/ultrasound - no id, no map', () => {
     const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
-    expect(resolveHcgTest(transfer, 'hcg-1')).toBe(transfer.hcgTests['hcg-1']);
-    expect(resolveUltrasound(transfer, 'ultrasound-1')).toBe(transfer.ultrasounds['ultrasound-1']);
+    expect(resolveHcgTest(transfer)).toBe(transfer.hcgTest);
+    expect(resolveUltrasound(transfer)).toBe(transfer.ultrasound);
   });
 
-  it('never throws and returns null for a case with no shipment/artProgram at all, or a missing case', () => {
+  it('never throws and returns null for a case with no shipment/artProgram/transfer at all, or a missing case', () => {
     expect(resolveShipment(null)).toBeNull();
     expect(resolveShipment(caseWithoutArtProgram)).toBeNull();
-    expect(resolveShipment(caseWithBrokenReferences)).toBeNull();
     expect(resolveTransferAttempt(caseWithoutArtProgram)).toBeNull();
     expect(resolveTransferAttempt(null)).toBeNull();
-    expect(resolveHcgTest(null, 'hcg-1')).toBeNull();
-    expect(resolveHcgTest({ hcgTests: {} }, 'hcg-1')).toBeNull();
-    expect(resolveUltrasound(null, 'ultrasound-1')).toBeNull();
+    expect(resolveHcgTest(null)).toBeNull();
+    expect(resolveHcgTest({})).toBeNull();
+    expect(resolveUltrasound(null)).toBeNull();
+    expect(resolveUltrasound(resolveTransferAttempt(caseWithTransferButNoTests))).toBeNull();
   });
 
-  it('a second hCG test never overwrites or shadows the first (independent lookup by id within the one transfer attempt)', () => {
-    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
-    expect(resolveHcgTest(transfer, 'hcg-1').positive).toBe(true);
-    expect(resolveHcgTest(transfer, 'hcg-2').positive).toBe(false);
-  });
-
-  it('enrichShipment attaches sourceClinic (partnerClinics) and destinationClinic (clinics), null-safe', () => {
+  it('enrichShipment attaches sourceClinic (the case\'s own partnerClinic) and destinationClinic (the case\'s own clinic), null-safe', () => {
     const shipment = resolveShipment(caseWithDateRangePeriod);
-    const enriched = enrichShipment(shipment, parties);
-    // enrichShipment layers a declined-name fallback onto the party record (spec batch 2026-07-25),
-    // so this is no longer the exact same object reference as the fixture - just the same party.
+    const enriched = enrichShipment(shipment, resolvedClinics);
     expect(enriched.sourceClinic.id).toBe(partnerClinic.id);
     expect(enriched.destinationClinic.id).toBe(clinic.id);
-    expect(enrichShipment(null, parties)).toBeNull();
+    expect(enrichShipment(null, resolvedClinics)).toBeNull();
+  });
+});
+
+// --- Genetic-material scalar source (spec §1.7/§3.4) -----------------------------------------
+
+describe('spec §1.7/§3.4: oocyteSource/spermSource are scalar strings, resolveGeneticSourceLabel never contains a lookup table', () => {
+  it('reserves exactly "wife"/"husband"; anything else non-empty is a donor code', () => {
+    expect(GENETIC_SOURCE_ROLE_VALUES).toEqual(['wife', 'husband']);
+    expect(isGeneticSourceDonorCode('wife')).toBe(false);
+    expect(isGeneticSourceDonorCode('husband')).toBe(false);
+    expect(isGeneticSourceDonorCode('ED-123')).toBe(true);
+    expect(isGeneticSourceDonorCode('')).toBe(false);
+    expect(isGeneticSourceDonorCode(undefined)).toBe(false);
+  });
+
+  it('resolveGeneticSourceLabel resolves "wife"/"husband" to the already-resolved party name, and any other code to itself', () => {
+    const wife = { name: { uk: { nominative: 'Кацура Юкако' }, en: 'Katsura Yukako' } };
+    const husband = { name: { uk: { nominative: 'Кацура Кеіго' }, en: 'Katsura Keigo' } };
+    expect(resolveGeneticSourceLabel('wife', { wife, husband })).toBe(wife.name);
+    expect(resolveGeneticSourceLabel('husband', { wife, husband })).toBe(husband.name);
+    expect(resolveGeneticSourceLabel('ED-123', { wife, husband })).toEqual({ uk: 'ED-123', en: 'ED-123' });
+    expect(resolveGeneticSourceLabel('', { wife, husband })).toBeNull();
+    expect(resolveGeneticSourceLabel(undefined, {})).toBeNull();
   });
 });
 
 // --- Formatters --------------------------------------------------------------------------------
 
-describe('spec §6: ART formatters', () => {
+describe('spec §3.5: ART formatters', () => {
   it('formatDateNumericUk formats an ISO date as DD.MM.YYYY, and blank/invalid input as \'\'', () => {
     expect(formatDateNumericUk('2025-09-18')).toBe('18.09.2025');
     expect(formatDateNumericUk('')).toBe('');
@@ -292,37 +273,37 @@ describe('spec §6: ART formatters', () => {
 
 // --- Template-ready enrichers ------------------------------------------------------------------
 
-describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enrichHcgTestForTemplate/enrichUltrasoundForTemplate', () => {
+describe('spec §3.2/§3.5: enrichShipmentForTemplate/enrichTransferForTemplate/enrichHcgTestForTemplate/enrichUltrasoundForTemplate', () => {
   it('enrichShipmentForTemplate adds formatted date/period fields on top of the party-enriched shipment', () => {
-    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), parties);
+    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), resolvedClinics);
     const enriched = enrichShipmentForTemplate(shipment);
     expect(enriched.ivfDateFormatted).toEqual({ uk: '17.08.2021', en: '17 August 2021' });
     expect(enriched.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
     expect(enriched.receivedDateFormatted.uk).toBe('27.08.2025');
-    // enrichShipment layers a declined-name fallback onto the party record (spec batch 2026-07-25),
-    // so this is no longer the exact same object reference as `partnerClinic` - just the same party.
     expect(enriched.sourceClinic.id).toBe(partnerClinic.id);
     expect(enrichShipmentForTemplate(null)).toBeNull();
   });
 
-  it('enrichTransferForTemplate adds dateFormatted/embryoCountText/embryoStageLabel and nests the enriched shipment', () => {
+  it('enrichTransferForTemplate adds dateFormatted/embryoCountText/embryoStageLabel, nests the enriched shipment, and its own hcgTest/ultrasound', () => {
     const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
-    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), parties);
+    const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), resolvedClinics);
     const enriched = enrichTransferForTemplate(transfer, shipment);
     expect(enriched.dateFormatted.uk).toBe('18.09.2025');
     expect(enriched.embryoCountText.uk).toBe('один ембріон');
     expect(enriched.embryoStageLabel.uk.genitive).toBe('бластоцисти');
     expect(enriched.shipment.sourceClinic.id).toBe(partnerClinic.id);
+    expect(enriched.hcgTest.dateFormatted.uk).toBe('30.09.2025');
+    expect(enriched.ultrasound.dateFormatted.uk).toBe('17.10.2025');
     expect(enrichTransferForTemplate(null, shipment)).toBeNull();
   });
 
   it('enrichHcgTestForTemplate/enrichUltrasoundForTemplate add their own formatted fields, null-safe', () => {
     const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
-    const hcgTest = enrichHcgTestForTemplate(resolveHcgTest(transfer, 'hcg-1'));
+    const hcgTest = enrichHcgTestForTemplate(resolveHcgTest(transfer));
     expect(hcgTest.dateFormatted.uk).toBe('30.09.2025');
     expect(enrichHcgTestForTemplate(null)).toBeNull();
 
-    const ultrasound = enrichUltrasoundForTemplate(resolveUltrasound(transfer, 'ultrasound-1'));
+    const ultrasound = enrichUltrasoundForTemplate(resolveUltrasound(transfer));
     expect(ultrasound.dateFormatted.uk).toBe('17.10.2025');
     expect(ultrasound.gestationalAgeText.uk).toBe('6–7 тижнів');
     expect(ultrasound.pregnancyTypeText.uk).toBe('одноплідна');
@@ -332,42 +313,30 @@ describe('spec §3/§6: enrichShipmentForTemplate/enrichTransferForTemplate/enri
 
 // --- Document contexts -------------------------------------------------------------------------
 
-describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityCertificate/racssClinicLetter/medicalServicesAgreement)', () => {
+describe('spec §1.8/§4: document contexts (embryoOwnershipStatement/geneticAffinityCertificate/racssClinicLetter/medicalServicesAgreement)', () => {
   it('embryoOwnershipStatement resolves the case\'s one shipment automatically, no shipmentId of its own needed (startDate/endDate case)', () => {
-    const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, parties, undefined);
+    const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, resolvedClinics, undefined);
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
     expect(context.shipment.sourceClinic.id).toBe(partnerClinic.id);
     expect(context.shipment.destinationClinic.id).toBe(clinic.id);
   });
 
   it('embryoOwnershipStatement resolves the case\'s one shipment automatically (migrated text case)', () => {
-    const context = buildEmbryoOwnershipStatementContext(caseWithTextPeriod, parties, undefined);
+    const context = buildEmbryoOwnershipStatementContext(caseWithTextPeriod, resolvedClinics, undefined);
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('квітні – травні 2026 року');
     expect(context.shipment.plannedPeriodFormatted.en).toBe('April-May 2026');
   });
 
-  it('spec §14: falls back to legacy ivfDate/shipmentPeriod fields when the case has no shipment at all, never throwing', () => {
-    const context = buildEmbryoOwnershipStatementContext(caseWithoutArtProgram, parties, caseWithoutArtProgram.documents.embryoOwnershipStatement);
-    expect(context.shipment.ivfDateFormatted.uk).toBe('17.08.2021');
-    expect(context.shipment.plannedPeriodFormatted.uk).toBe('квітні – травні 2026 року');
-    expect(context.shipment.sourceClinic).toBeNull();
-  });
-
-  it('a case with neither a shipment nor legacy fields resolves shipment to null, never throwing', () => {
-    const context = buildEmbryoOwnershipStatementContext({ id: 'bare-case' }, parties, undefined);
+  it('a case with no shipment at all resolves shipment to null, never throwing', () => {
+    const context = buildEmbryoOwnershipStatementContext(caseWithoutArtProgram, resolvedClinics, undefined);
     expect(context.shipment).toBeNull();
+    expect(buildEmbryoOwnershipStatementContext({ id: 'bare-case' }, {}, undefined).shipment).toBeNull();
   });
 
-  it('falls back to the pre-batch-26 shipmentId-addressed shape, read-only, when relations.shipment is unset', () => {
-    const context = buildEmbryoOwnershipStatementContext(caseWithLegacyShipmentShape, parties, undefined);
-    expect(context.shipment.sourceClinic.id).toBe(partnerClinic.id);
-    expect(context.shipment.receivedDateFormatted.uk).toBe('27.08.2025');
-  });
-
-  it('geneticAffinityCertificate resolves transferAttempt/hcgTest/ultrasound by id and computes the print-only fallback fields', () => {
+  it('geneticAffinityCertificate resolves transferAttempt/hcgTest/ultrasound automatically (singleton, no id needed) and computes the print-only fallback fields', () => {
     const context = buildGeneticAffinityCertificateContext(
       caseWithDateRangePeriod,
-      parties,
+      resolvedClinics,
       caseWithDateRangePeriod.documents.geneticAffinityCertificate,
     );
     expect(context.transferAttempt.embryoCountText.uk).toBe('один ембріон');
@@ -378,26 +347,26 @@ describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityC
     expect(context.outgoingNumberOrBlank).toBe('42/1');
   });
 
-  it('batch 26 §6: geneticAffinityCertificate exposes oocyteSourceIsWife, shared/cross-referenced by any other document conditioning a block on it', () => {
-    const isWife = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
+  it('geneticAffinityCertificate exposes oocyteSourceIsWife off the scalar artProgram.oocyteSource, shared/cross-referenced by any other document conditioning a block on it', () => {
+    const isWife = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
     expect(isWife.oocyteSourceIsWife).toBe(true);
 
-    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'donor' } } });
-    const isDonor = buildGeneticAffinityCertificateContext(donorCase, parties, {});
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { oocyteSource: 'ED-123' } });
+    const isDonor = buildGeneticAffinityCertificateContext(donorCase, resolvedClinics, {});
     expect(isDonor.oocyteSourceIsWife).toBe(false);
 
-    // No geneticMaterial data at all (old/incomplete case) degrades to false, never throwing.
-    expect(buildGeneticAffinityCertificateContext(caseWithoutArtProgram, parties, {}).oocyteSourceIsWife).toBe(false);
+    // No artProgram data at all (old/incomplete case) degrades to false, never throwing.
+    expect(buildGeneticAffinityCertificateContext(caseWithoutArtProgram, resolvedClinics, {}).oocyteSourceIsWife).toBe(false);
   });
 
   it('geneticAffinityCertificate falls back to print-only blanks (never persisted) when issueDate/outgoingNumber are unset', () => {
-    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
     expect(context.issueDateOrBlank.uk).toBe('__.__.____');
     expect(context.outgoingNumberOrBlank).toBe('______');
   });
 
-  it('racssClinicLetter resolves its own transferAttempt/ultrasound independently of geneticAffinityCertificate', () => {
-    const context = buildRacssClinicLetterContext(caseWithDateRangePeriod, parties, caseWithDateRangePeriod.documents.racssClinicLetter);
+  it('racssClinicLetter resolves its own transferAttempt/ultrasound independently, with no requisites of its own (spec §1.3 sample: "racssClinicLetter": {})', () => {
+    const context = buildRacssClinicLetterContext(caseWithDateRangePeriod, resolvedClinics, caseWithDateRangePeriod.documents.racssClinicLetter);
     expect(context.transferAttempt.shipment.receivedDateFormatted.uk).toBe('27.08.2025');
     expect(context.ultrasound.dateFormatted.uk).toBe('17.10.2025');
   });
@@ -411,7 +380,7 @@ describe('spec §4: document contexts (embryoOwnershipStatement/geneticAffinityC
 
 // --- couple.marriage enrichment -----------------------------------------------------------------
 
-describe('spec §10: couple.marriage dateFormatted/certificateDateFormatted, old fields kept', () => {
+describe('spec: couple.marriage dateFormatted/certificateDateFormatted, old fields kept', () => {
   it('adds dateFormatted/certificateDateFormatted on top of the new date/certificateType/certificateIssuedBy shape', () => {
     const couple = {
       marriage: {
@@ -443,47 +412,6 @@ describe('spec §10: couple.marriage dateFormatted/certificateDateFormatted, old
   });
 });
 
-// --- validateArtProgramReferences (spec §13/§15) -------------------------------------------------
-
-describe('spec §13/§15: validateArtProgramReferences reports specific, actionable messages', () => {
-  it('reports one message per broken reference, never a generic "field missing"', () => {
-    const catalog = buildCatalog(caseWithBrokenReferences);
-    const issues = validateArtProgramReferences(catalog, 'case-broken');
-    expect(issues).toContain('Не знайдено аналіз ХГЧ hcg-999.');
-    expect(issues).toContain('Не знайдено УЗД ultrasound-999.');
-  });
-
-  it('a fully-valid case reports no issues', () => {
-    const catalog = buildCatalog(caseWithDateRangePeriod);
-    expect(validateArtProgramReferences(catalog, 'case-daterange')).toEqual([]);
-  });
-
-  it('a missing case id resolves to no issues rather than throwing', () => {
-    const catalog = buildCatalog(caseWithDateRangePeriod);
-    expect(() => validateArtProgramReferences(catalog, 'does-not-exist')).not.toThrow();
-    expect(validateArtProgramReferences(catalog, 'does-not-exist')).toEqual([]);
-  });
-});
-
-// --- Dropdown option labels (spec §9) -------------------------------------------------------------
-
-describe('spec §9: human-readable dropdown labels, never a raw id', () => {
-  it('formats an hcgTest/ultrasound as the exact spec example shapes', () => {
-    const transfer = resolveTransferAttempt(caseWithDateRangePeriod);
-
-    const hcgTest = resolveHcgTest(transfer, 'hcg-1');
-    expect(formatHcgTestOptionLabel(hcgTest)).toBe('ХГЧ 30.09.2025 — позитивний');
-
-    const ultrasound = resolveUltrasound(transfer, 'ultrasound-1');
-    expect(formatUltrasoundOptionLabel(ultrasound)).toBe('УЗД 17.10.2025 — 1 плід, 6–7 тижнів');
-  });
-
-  it('every label helper is null-safe', () => {
-    expect(formatHcgTestOptionLabel(null)).toBe('');
-    expect(formatUltrasoundOptionLabel(null)).toBe('');
-  });
-});
-
 // --- resolveCaseContext / fillPlaceholders integration ---------------------------------------
 
 describe('integration: resolveCaseContext wires every ART document context in, null-safe throughout', () => {
@@ -498,7 +426,18 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(fillPlaceholders('{{geneticAffinityCertificate.ultrasound.gestationalAgeText.uk}}', context, 'uk')).toBe('6–7 тижнів');
     expect(fillPlaceholders('{{racssClinicLetter.transferAttempt.shipment.receivedDateFormatted.uk}}', context, 'uk')).toBe('27.08.2025');
     expect(fillPlaceholders('{{medicalServicesAgreement.dateFormatted.uk}}', context, 'uk')).toBe('12.09.2025');
-    expect(fillPlaceholders('{{case.artProgram.medicalIndication.diagnosis.uk}}', context, 'uk')).toBe('Тестовий діагноз');
+    expect(fillPlaceholders('{{case.artProgram.medicalIndications.uk}}', context, 'uk')).toBe('Тестовий діагноз');
+  });
+
+  it('spec §5.1: exposes the same singleton shipment/transfer/hcgTest/ultrasound as top-level canonical context aliases, alongside the document-scoped ones', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const context = resolveCaseContext(catalog, 'case-daterange');
+    expect(fillPlaceholders('{{artProgram.medicalIndications.uk}}', context, 'uk')).toBe('Тестовий діагноз');
+    expect(fillPlaceholders('{{artProgram.oocyteSourceLabel.uk}}', context, 'uk')).toBe('Кацура Юкако');
+    expect(fillPlaceholders('{{embryoShipment.receivedDateFormatted.uk}}', context, 'uk')).toBe('27.08.2025');
+    expect(fillPlaceholders('{{transferAttempt.embryoCountText.uk}}', context, 'uk')).toBe('один ембріон');
+    expect(fillPlaceholders('{{hcgTest.dateFormatted.uk}}', context, 'uk')).toBe('30.09.2025');
+    expect(fillPlaceholders('{{ultrasound.pregnancyTypeText.uk}}', context, 'uk')).toBe('одноплідна');
   });
 
   it('a template using every geneticAffinityCertificate/racssClinicLetter placeholder resolves with zero unresolved variables (spec: "не містить необроблених {{...}}")', () => {
@@ -529,7 +468,7 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(validateDocumentTemplate(template, context)).toEqual([]);
   });
 
-  it('spec §8/§9: editing the shared transfer attempt/ultrasound once is reflected simultaneously in geneticAffinityCertificate and racssClinicLetter', () => {
+  it('editing the shared transfer attempt once is reflected simultaneously in geneticAffinityCertificate and racssClinicLetter', () => {
     const catalog = buildCatalog(caseWithDateRangePeriod);
     const edited = deepMergeRecords(catalog.cases.find(item => item.id === 'case-daterange'), {
       artProgram: { transferAttempt: { date: '2026-03-03' } },
@@ -551,42 +490,32 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(fillPlaceholders('{{geneticAffinityCertificate.transferAttempt.dateFormatted.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
   });
 
-  it('a case with dangling reference ids resolves without throwing, and validateArtProgramReferences names the exact missing event', () => {
-    const catalog = buildCatalog(caseWithBrokenReferences);
-    const context = resolveCaseContext(catalog, 'case-broken');
-    expect(() => fillPlaceholders('{{embryoOwnershipStatement.shipment.sourceClinic.name.uk}}', context, 'uk')).not.toThrow();
-    expect(context.embryoOwnershipStatement.shipment).toBeNull();
-    expect(validateArtProgramReferences(catalog, 'case-broken').length).toBeGreaterThan(0);
-  });
-
-  it('hCG/ultrasound are selected strictly by id, not object order - picking hcg-2 resolves it, not hcg-1', () => {
-    const catalog = buildCatalog(caseWithDateRangePeriod);
-    const context = resolveCaseContext(catalog, 'case-daterange', undefined);
-    // hcg-2 (negative) is a second test on the same transfer attempt as hcg-1 (positive) - a
-    // document referencing it must never accidentally resolve hcg-1 instead.
-    const caseRecord = catalog.cases.find(item => item.id === 'case-daterange');
-    const built = buildGeneticAffinityCertificateContext(caseRecord, catalog.parties, { hcgTestId: 'hcg-2' });
-    expect(built.hcgTest.positive).toBe(false);
-    expect(built.hcgTest.dateFormatted.uk).toBe('15.11.2025');
-    expect(context).toBeTruthy(); // context built successfully above too
+  it('a transfer attempt with no hCG test/ultrasound entered yet resolves both to null without throwing (the ordinary "not set" state, not a broken reference)', () => {
+    const catalog = buildCatalog(caseWithTransferButNoTests);
+    const context = resolveCaseContext(catalog, 'case-no-tests');
+    expect(context.geneticAffinityCertificate.hcgTest).toBeNull();
+    expect(context.racssClinicLetter.ultrasound).toBeNull();
+    expect(() => fillPlaceholders('{{geneticAffinityCertificate.hcgTest.dateFormatted.uk}}', context, 'uk')).not.toThrow();
   });
 });
 
-// --- Export / stripDerivedFields (spec §11/§12) -------------------------------------------------
+// --- Export / stripDerivedFields (spec §1.9) -------------------------------------------------
 
-describe('spec §11/§12: ART-derived fields are never written back to Firebase', () => {
+describe('spec §1.9: ART-derived fields are never written back to Firebase', () => {
   it('DERIVED_CONTEXT_FIELD_KEYS lists every runtime-only ART field named in the spec', () => {
-    ['plannedPeriodFormatted', 'ivfDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
-      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank']
+    ['plannedPeriodFormatted', 'ivfDateFormatted', 'sentDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
+      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
+      'oocyteSourceLabel', 'spermSourceLabel']
       .forEach(key => expect(DERIVED_CONTEXT_FIELD_KEYS).toContain(key));
   });
 
-  it('stripDerivedFields removes every derived key from a resolved geneticAffinityCertificate/embryoOwnershipStatement context', () => {
+  it('stripDerivedFields removes every derived key from a resolved geneticAffinityCertificate/embryoOwnershipStatement/artProgram context', () => {
     const catalog = buildCatalog(caseWithDateRangePeriod);
     const context = resolveCaseContext(catalog, 'case-daterange');
     const stripped = stripDerivedFields({
       embryoOwnershipStatement: context.embryoOwnershipStatement,
       geneticAffinityCertificate: context.geneticAffinityCertificate,
+      artProgram: context.artProgram,
       couple: context.couple,
     });
     const serialized = JSON.stringify(stripped);
@@ -602,10 +531,10 @@ describe('spec §11/§12: ART-derived fields are never written back to Firebase'
   });
 });
 
-// --- Import/export round trip stays additive (spec §12) ------------------------------------------
+// --- Import/export round trip stays additive ------------------------------------------------
 
-describe('spec §12: import/merge keeps hcgTests/ultrasounds as maps, transferAttempt/relations.shipment as one object each', () => {
-  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog merges the one transferAttempt in place, without disturbing relations.shipment', () => {
+describe('spec: import/merge keeps embryoShipment/transferAttempt as one object each', () => {
+  it('parseDocumentsTechnicalInput + mergeDocumentsCatalog merges the one transferAttempt in place, without disturbing embryoShipment', () => {
     const currentCatalog = buildCatalog(caseWithDateRangePeriod);
     const pasted = parseDocumentsTechnicalInput(JSON.stringify({
       cases: { 'case-daterange': { id: 'case-daterange', artProgram: { transferAttempt: { date: '2026-04-04' } } } },
@@ -615,21 +544,19 @@ describe('spec §12: import/merge keeps hcgTests/ultrasounds as maps, transferAt
     // The edit landed...
     expect(mergedCase.artProgram.transferAttempt.date).toBe('2026-04-04');
     // ...without wiping embryoCount, or the case's one shipment, which the incoming payload never
-    // mentioned (batch 26 §5: relations.shipment, not a shipmentId-addressed map any more).
+    // mentioned.
     expect(mergedCase.artProgram.transferAttempt.embryoCount).toBe(1);
-    expect(mergedCase.relations.shipment.sourceClinicId).toBe(partnerClinic.id);
+    expect(mergedCase.artProgram.embryoShipment.receivedDate).toBe('2025-08-27');
   });
 
-  it('a deep merge of one hcgTest field never replaces its sibling hcgTests/ultrasounds on the transfer attempt', () => {
+  it('a deep merge of the hcgTest singleton never disturbs its sibling ultrasound singleton', () => {
     const currentCatalog = buildCatalog(caseWithDateRangePeriod);
     const currentCase = currentCatalog.cases.find(item => item.id === 'case-daterange');
     const merged = deepMergeRecords(currentCase, {
-      artProgram: { transferAttempt: { hcgTests: { 'hcg-1': { positive: false } } } },
+      artProgram: { transferAttempt: { hcgTest: { date: '2025-11-15' } } },
     });
-    expect(merged.artProgram.transferAttempt.hcgTests['hcg-1'].positive).toBe(false);
-    expect(merged.artProgram.transferAttempt.hcgTests['hcg-1'].date).toBe('2025-09-30');
-    expect(merged.artProgram.transferAttempt.ultrasounds['ultrasound-1'].fetusCount).toBe(1);
-    expect(merged.artProgram.transferAttempt.hcgTests['hcg-2'].positive).toBe(false);
+    expect(merged.artProgram.transferAttempt.hcgTest.date).toBe('2025-11-15');
+    expect(merged.artProgram.transferAttempt.ultrasound.fetusCount).toBe(1);
   });
 });
 
@@ -651,9 +578,9 @@ describe('spec §10: passport.type/countryCode are optional and never transliter
   });
 });
 
-// --- Conditional block rendering (batch 26 §6) -----------------------------------------------
+// --- Conditional block rendering -----------------------------------------------
 
-describe('spec (batch 26 §6): evaluateBlockCondition - a block prints only when its condition path resolves truthy', () => {
+describe('spec: evaluateBlockCondition - a block prints only when its condition path resolves truthy', () => {
   it('no condition at all always renders (backward compatible)', () => {
     expect(evaluateBlockCondition(undefined, {})).toBe(true);
     expect(evaluateBlockCondition('', { anything: false })).toBe(true);
@@ -671,7 +598,7 @@ describe('spec (batch 26 §6): evaluateBlockCondition - a block prints only when
   });
 });
 
-describe('spec (batch 26 §6): buildGeneratedDocument drops a conditionally-hidden paragraph entirely, never as a blank/unresolved value', () => {
+describe('spec: buildGeneratedDocument drops a conditionally-hidden paragraph entirely, never as a blank/unresolved value', () => {
   const buildTemplate = () => ({
     id: 'birth-registration-surrogate-consent',
     title: { uk: '' },
@@ -687,17 +614,296 @@ describe('spec (batch 26 §6): buildGeneratedDocument drops a conditionally-hidd
   });
 
   it('prints the conditional paragraph when the wife is the oocyte donor', () => {
-    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, parties, {});
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
     const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
     expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'text', 'text']);
     expect(generated.paragraphs[1].uk).toContain('Кацура Юкако');
   });
 
   it('fully omits the paragraph (never a blank/unresolved value) when any other oocyte source is set, keeping every other paragraph\'s position stable', () => {
-    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'donor' } } });
-    const context = buildGeneticAffinityCertificateContext(donorCase, parties, {});
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { oocyteSource: 'ED-123' } });
+    const context = buildGeneticAffinityCertificateContext(donorCase, resolvedClinics, {});
     const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
     expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'condition-hidden', 'text']);
     expect(generated.paragraphs[2].uk).toBe('Просимо зареєструвати дитину.');
+  });
+});
+
+// --- v5 migration (spec §2.2/§4) ---------------------------------------------------------------
+
+describe('spec §2.2: schema-version validation', () => {
+  it('isDocumentsSchemaV5 is true only for a settings record carrying the current version', () => {
+    expect(isDocumentsSchemaV5({ schemaVersion: 5 })).toBe(true);
+    expect(isDocumentsSchemaV5({ schemaVersion: 4 })).toBe(false);
+    expect(isDocumentsSchemaV5({})).toBe(false);
+    expect(isDocumentsSchemaV5(null)).toBe(false);
+  });
+
+  it('normalizeDocumentsSettings always stamps the current schema version going forward', () => {
+    expect(normalizeDocumentsSettings({}).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(normalizeDocumentsSettings(null).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(normalizeDocumentsSettings({ schemaVersion: 4 }).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+  });
+});
+
+describe('spec §4: migrateCaseToV5 - one idempotent migration boundary, never guesses ambiguous/missing data', () => {
+  it('is a no-op (report.changed: false) on an already-v5 case, and never mutates the source object', () => {
+    const before = JSON.stringify(caseWithDateRangePeriod);
+    const { case: migrated, report } = migrateCaseToV5(caseWithDateRangePeriod);
+    expect(report.changed).toBe(false);
+    expect(migrated.artProgram.embryoShipment).toEqual(caseWithDateRangePeriod.artProgram.embryoShipment);
+    expect(migrated.artProgram.oocyteSource).toBe('wife');
+    expect(JSON.stringify(caseWithDateRangePeriod)).toBe(before);
+  });
+
+  it('migrates relations.clinicId to relations.ukrainianClinicId, leaving partnerClinicId untouched', () => {
+    const legacy = { id: 'case-1', relations: { clinicId: 'clinic-1', partnerClinicId: 'partner-1' } };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.relations.ukrainianClinicId).toBe('clinic-1');
+    expect(migrated.relations).not.toHaveProperty('clinicId');
+    expect(migrated.relations.partnerClinicId).toBe('partner-1');
+    expect(report.changed).toBe(true);
+  });
+
+  it('migrates the old inline relations.shipment (batch 26 §5 shape) to artProgram.embryoShipment, recovering missing clinic relations and dropping the shipment\'s own clinic ids', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: { coupleId: 'couple-1' },
+      relations_shipment_marker: undefined,
+    };
+    legacy.relations.shipment = {
+      sourceClinicId: 'partner-1', destinationClinicId: 'clinic-1', ivfDate: '2021-08-17', receivedDate: '2025-08-27',
+    };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.embryoShipment).toEqual({ ivfDate: '2021-08-17', receivedDate: '2025-08-27' });
+    expect(migrated.relations.ukrainianClinicId).toBe('clinic-1');
+    expect(migrated.relations.partnerClinicId).toBe('partner-1');
+    expect(migrated.relations).not.toHaveProperty('shipment');
+    expect(report.changed).toBe(true);
+  });
+
+  it('does not overwrite clinic relations the case already has, even if the old inline shipment carried different ones', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: { ukrainianClinicId: 'clinic-current', partnerClinicId: 'partner-current', shipment: { sourceClinicId: 'partner-old', destinationClinicId: 'clinic-old' } },
+    };
+    const { case: migrated } = migrateCaseToV5(legacy);
+    expect(migrated.relations.ukrainianClinicId).toBe('clinic-current');
+    expect(migrated.relations.partnerClinicId).toBe('partner-current');
+  });
+
+  it('migrates the oldest id-map embryoShipments shape via the transfer attempt\'s shipmentId reference', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: {},
+      artProgram: {
+        embryoShipments: { 'shipment-1': { id: 'shipment-1', ivfDate: '2021-08-17' }, 'shipment-2': { id: 'shipment-2', ivfDate: '2022-01-01' } },
+        transferAttempt: { shipmentId: 'shipment-1', date: '2025-09-18' },
+      },
+    };
+    const { case: migrated } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.embryoShipment).toEqual({ ivfDate: '2021-08-17' });
+  });
+
+  it('reports an ambiguity (migrates none) when several old shipments exist with no shipmentId to disambiguate', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: {},
+      artProgram: {
+        embryoShipments: { 'shipment-1': { id: 'shipment-1', ivfDate: '2021-08-17' }, 'shipment-2': { id: 'shipment-2', ivfDate: '2022-01-01' } },
+      },
+    };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram?.embryoShipment).toBeUndefined();
+    expect(report.ambiguities.length).toBeGreaterThan(0);
+  });
+
+  it('migrates the old hcgTests/ultrasounds id-maps to singleton hcgTest/ultrasound via the genetic-affinity certificate\'s id references, dropping positive/pregnancyConfirmed', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: {},
+      artProgram: {
+        transferAttempt: {
+          date: '2025-09-18',
+          hcgTests: { 'hcg-1': { id: 'hcg-1', date: '2025-09-30', positive: true }, 'hcg-2': { id: 'hcg-2', date: '2025-11-15', positive: false } },
+          ultrasounds: { 'ultrasound-1': { id: 'ultrasound-1', date: '2025-10-17', pregnancyConfirmed: true, fetusCount: 1 } },
+        },
+      },
+      documents: { geneticAffinityCertificate: { hcgTestId: 'hcg-2', ultrasoundId: 'ultrasound-1' } },
+    };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.transferAttempt.hcgTest).toEqual({ date: '2025-11-15' });
+    expect(migrated.artProgram.transferAttempt.ultrasound).toEqual({ date: '2025-10-17', fetusCount: 1 });
+    expect(migrated.artProgram.transferAttempt).not.toHaveProperty('hcgTests');
+    expect(migrated.artProgram.transferAttempt).not.toHaveProperty('ultrasounds');
+    expect(migrated.documents.geneticAffinityCertificate).not.toHaveProperty('hcgTestId');
+    expect(migrated.documents.geneticAffinityCertificate).not.toHaveProperty('ultrasoundId');
+    expect(report.changed).toBe(true);
+  });
+
+  it('falls back to the racssClinicLetter\'s ultrasoundId when the genetic-affinity certificate has none, and to the map\'s only entry when neither document has an id', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: {},
+      artProgram: {
+        transferAttempt: {
+          date: '2025-09-18',
+          ultrasounds: { 'ultrasound-1': { id: 'ultrasound-1', date: '2025-10-17' } },
+        },
+      },
+      documents: { racssClinicLetter: { ultrasoundId: 'ultrasound-1' } },
+    };
+    const { case: migrated } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.transferAttempt.ultrasound).toEqual({ date: '2025-10-17' });
+  });
+
+  it('reports an ambiguity (migrates neither) when a transfer attempt has several hcgTests/ultrasounds with no id reference at all', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: {},
+      artProgram: {
+        transferAttempt: {
+          date: '2025-09-18',
+          hcgTests: { 'hcg-1': { id: 'hcg-1', date: '2025-09-30' }, 'hcg-2': { id: 'hcg-2', date: '2025-11-15' } },
+        },
+      },
+    };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.transferAttempt.hcgTest).toBeUndefined();
+    expect(report.ambiguities.length).toBeGreaterThan(0);
+  });
+
+  it('maps the old medicalIndication.diagnosis wrapper to the plain medicalIndications field', () => {
+    const legacy = { id: 'case-1', relations: {}, artProgram: { medicalIndication: { diagnosis: { uk: 'Непліддя' } } } };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.medicalIndications).toEqual({ uk: 'Непліддя' });
+    expect(migrated.artProgram).not.toHaveProperty('medicalIndication');
+    expect(report.changed).toBe(true);
+  });
+
+  it('maps geneticMaterial.oocyteSourcePartnerRole/spermSourcePartnerRole "wife"/"husband" straight to the v5 scalars', () => {
+    const legacy = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'wife', spermSourcePartnerRole: 'husband' } } };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.oocyteSource).toBe('wife');
+    expect(migrated.artProgram.spermSource).toBe('husband');
+    expect(migrated.artProgram).not.toHaveProperty('geneticMaterial');
+    expect(report.changed).toBe(true);
+  });
+
+  it('passes an old donor code straight through into the scalar field (no separate donor-code property)', () => {
+    const legacy = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'ED-123' } } };
+    const { case: migrated } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram.oocyteSource).toBe('ED-123');
+  });
+
+  it('reports a legacy "donor" selection with no code ever recorded as unmigratable, rather than storing the literal string "donor"', () => {
+    const legacy = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'donor' } } };
+    const { case: migrated, report } = migrateCaseToV5(legacy);
+    expect(migrated.artProgram?.oocyteSource).toBeUndefined();
+    expect(report.unmigratable.length).toBeGreaterThan(0);
+  });
+
+  it('reports missing required relations without throwing, for a bare case', () => {
+    const { report } = migrateCaseToV5({ id: 'case-1' });
+    expect(report.missingRelations).toEqual(expect.arrayContaining([
+      'relations.ukrainianClinicId', 'relations.coupleId', 'relations.surrogateMotherId',
+    ]));
+  });
+
+  it('handles null/non-object input without throwing', () => {
+    expect(migrateCaseToV5(null).case).toEqual({});
+    expect(() => migrateCaseToV5(undefined)).not.toThrow();
+  });
+
+  it('normalizeCaseRecord runs the same migration, idempotently, for every case normalizeDocumentsCatalog loads', () => {
+    const legacy = {
+      'case-1': {
+        id: 'case-1',
+        relations: { clinicId: 'clinic-1' },
+        artProgram: { medicalIndication: { diagnosis: { uk: 'Непліддя' } } },
+      },
+    };
+    const catalog = normalizeDocumentsCatalog({}, {}, legacy);
+    const migratedOnce = catalog.cases[0];
+    expect(migratedOnce.relations.ukrainianClinicId).toBe('clinic-1');
+    expect(migratedOnce.artProgram.medicalIndications.uk).toBe('Непліддя');
+    expect(normalizeCaseRecord(migratedOnce)).toEqual(migratedOnce);
+  });
+});
+
+describe('spec §4.7: migrateCasesToV5 aggregates a migration report across every case', () => {
+  it('lists migrated case ids, and keys missingRelations/ambiguities/unmigratable by case id', () => {
+    const rawCases = {
+      'case-clean': caseWithDateRangePeriod,
+      'case-legacy': { id: 'case-legacy', relations: { clinicId: 'clinic-1' } },
+      'case-ambiguous': {
+        id: 'case-ambiguous',
+        relations: {},
+        artProgram: { embryoShipments: { a: { id: 'a' }, b: { id: 'b' } } },
+      },
+    };
+    const { cases, report } = migrateCasesToV5(rawCases);
+    expect(cases.map(c => c.id).sort()).toEqual(['case-ambiguous', 'case-daterange', 'case-legacy']);
+    expect(report.migratedCaseIds).toContain('case-legacy');
+    expect(report.migratedCaseIds).not.toContain('case-daterange');
+    expect(report.ambiguities['case-ambiguous'].length).toBeGreaterThan(0);
+    expect(report.missingRelations['case-ambiguous']).toEqual(expect.arrayContaining(['relations.ukrainianClinicId']));
+  });
+});
+
+// --- Template variable audit (spec §5.3) -----------------------------------------------------
+
+describe('spec §5.3: auditTemplateVariables/classifyTemplateVariablePath classify every {{path}} a template references', () => {
+  it('classifies backend, resolved-relation, derived-runtime, and system paths correctly', () => {
+    expect(classifyTemplateVariablePath('logo')).toBe('system');
+    expect(classifyTemplateVariablePath('logo-long')).toBe('system');
+    expect(classifyTemplateVariablePath('clinic.medicalDirector.name.uk.genitive')).toBe('resolvedRelation');
+    expect(classifyTemplateVariablePath('relations.coupleId')).toBe('resolvedRelation');
+    expect(classifyTemplateVariablePath('artProgram.medicalIndications.uk')).toBe('derivedRuntime');
+    expect(classifyTemplateVariablePath('transferAttempt.embryoStageLabel.uk.genitive')).toBe('derivedRuntime');
+    expect(classifyTemplateVariablePath('case.artProgram.oocyteSource')).toBe('backendSource');
+    expect(classifyTemplateVariablePath('something.completely.unknown')).toBe('unknown');
+  });
+
+  it('auditTemplateVariables scans title/beforeTitle/paragraphs and every layoutV2 block shape, never reporting an unknown path for a real template', () => {
+    const template = {
+      title: { uk: '{{clinic.name.uk}}' },
+      beforeTitle: [{ uk: '{{artProgram.medicalIndications.uk}}' }],
+      paragraphs: [{ uk: '{{wife.name.uk.nominative}} {{husband.name.uk.nominative}}' }],
+      layoutV2: {
+        blocks: [
+          { type: 'paragraph', text: '{{transferAttempt.dateFormatted.uk}}' },
+          { type: 'fieldLine', value: '{{hcgTest.dateFormatted.uk}}' },
+          { type: 'richParagraph', runs: [{ text: '{{ultrasound.gestationalAgeText.uk}}' }] },
+          { type: 'alignedBox', lines: ['{{notary.name.uk.short}}'] },
+          {
+            type: 'letterhead',
+            columns: [{ content: { type: 'image', source: '{{logo}}' } }],
+          },
+          {
+            type: 'signatureTable',
+            rows: [[{ text: '{{representative.name.uk.short}}' }]],
+          },
+        ],
+      },
+    };
+    const audit = auditTemplateVariables(template);
+    expect(audit.some(entry => entry.classification === 'unknown')).toBe(false);
+    expect(audit.map(entry => entry.path)).toEqual(expect.arrayContaining([
+      'clinic.name.uk', 'artProgram.medicalIndications.uk', 'wife.name.uk.nominative',
+      'transferAttempt.dateFormatted.uk', 'hcgTest.dateFormatted.uk', 'ultrasound.gestationalAgeText.uk',
+      'notary.name.uk.short', 'logo', 'representative.name.uk.short',
+    ]));
+  });
+
+  it('flags a genuinely stale/unknown path so a template audit fails loudly instead of silently blanking', () => {
+    const template = { paragraphs: [{ uk: '{{geneticAffinityCertificate.transferAttempt.shipment.sourceClinic.legacyTypo}}' }] };
+    const audit = auditTemplateVariables(template);
+    // Still classifies as derivedRuntime (it's under the geneticAffinityCertificate namespace) -
+    // this test documents that classification is prefix-based, not a full path allowlist; a
+    // renamed *namespace* (not just a leaf) is what actually needs to trip 'unknown'.
+    const trulyUnknown = auditTemplateVariables({ paragraphs: [{ uk: '{{noSuchNamespace.field}}' }] });
+    expect(trulyUnknown.find(entry => entry.path === 'noSuchNamespace.field').classification).toBe('unknown');
+    expect(audit.length).toBeGreaterThan(0);
   });
 });

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -359,8 +359,9 @@ export const DERIVED_CONTEXT_FIELD_KEYS = [
   'short', 'shortName', 'dateWords', 'dateFormatted', 'statementDateWords', 'statementDateFormatted', 'dateDisplay', 'numberEn', 'wordsAfterArticle',
   // ART program document contexts (spec §4/§6/§12) - computed fresh from case.artProgram on every
   // resolveCaseContext call, never written back to Firebase.
-  'plannedPeriodFormatted', 'ivfDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
+  'plannedPeriodFormatted', 'ivfDateFormatted', 'sentDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
   'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
+  'oocyteSourceLabel', 'spermSourceLabel',
 ];
 
 // Recursively strips every DERIVED_CONTEXT_FIELD_KEYS key out of a value before it's serialized
@@ -887,11 +888,240 @@ export const createChildRecord = () => ({
   medicalConclusion: { number: '', date: '' },
 });
 
-// Idempotent pass-through: a case record is used as-is (relations/childbirth/documents are all
-// optional - missing branches are handled by the `?.` reads below, not backfilled here) so a case
-// saved before a given field existed never crashes the UI, and re-saving it never recreates a
-// branch nobody ever asked for.
-export const normalizeCaseRecord = rawCase => (isPlainObject(rawCase) ? rawCase : {});
+// --- v5 migration (spec §2.2/§4) ---------------------------------------------------------------
+// The one migration boundary: every legacy shape this app has ever stored a case under is read
+// here, exactly once per load, and nowhere else - resolveShipment/resolveTransferAttempt/etc. only
+// ever read the canonical v5 paths. Pure and idempotent: migrating an already-v5 case changes
+// nothing (verified by tests), so running it again on the same data is always safe.
+
+export const CURRENT_SCHEMA_VERSION = 5;
+
+const omitKeys = (value, keys) => {
+  if (!isPlainObject(value)) return value;
+  const next = { ...value };
+  keys.forEach(key => { delete next[key]; });
+  return next;
+};
+
+// Fields that only ever belonged in a runtime template context, or a tri-state boolean the v5
+// model replaces with "the object exists" (spec §1.5/§1.9) - stripped from whatever storage shape
+// migrateCaseToV5 finds them in, never manufactured if absent.
+const LEGACY_STORED_FIELD_KEYS = ['positive', 'pregnancyConfirmed', 'confirmedPregnancy', 'short', 'shortName', 'initials', 'dateWords', 'dateFormatted'];
+
+const stripLegacyStoredFields = value => omitKeys(value, LEGACY_STORED_FIELD_KEYS);
+
+export const emptyMigrationReport = () => ({
+  changed: false,
+  missingRelations: [],
+  brokenReferences: [],
+  ambiguities: [],
+  unmigratable: [],
+});
+
+// Picks the case's one embryo shipment out of every shape this codebase has ever stored it under -
+// the current one (case.artProgram.embryoShipment), the previous one (case.relations.shipment,
+// batch 26 §5), or the oldest id-map shape (case.artProgram.embryoShipments, addressed by a
+// shipmentId on the transfer attempt or on embryoOwnershipStatement) - and recovers the case's
+// clinic relations from an old inline shipment's own sourceClinicId/destinationClinicId when the
+// case doesn't already have them (spec §4.1). Never merges two different shipments: several
+// candidates with no way to prefer one is reported as an ambiguity, not guessed.
+const migrateEmbryoShipment = (rawCase, report) => {
+  const artProgram = isPlainObject(rawCase.artProgram) ? rawCase.artProgram : {};
+
+  if (isPlainObject(artProgram.embryoShipment)) {
+    return { shipment: stripLegacyStoredFields(omitKeys(artProgram.embryoShipment, ['id', 'sourceClinicId', 'destinationClinicId'])), relationsPatch: {} };
+  }
+
+  const inline = isPlainObject(rawCase.relations?.shipment) ? rawCase.relations.shipment : null;
+  const legacyMap = isPlainObject(artProgram.embryoShipments) ? artProgram.embryoShipments : null;
+  const legacyShipmentId = artProgram.transferAttempt?.shipmentId || rawCase.documents?.embryoOwnershipStatement?.shipmentId;
+
+  let candidate = null;
+  if (inline) {
+    candidate = inline;
+  } else if (legacyMap) {
+    const entries = Object.entries(legacyMap);
+    if (legacyShipmentId && legacyMap[legacyShipmentId]) candidate = legacyMap[legacyShipmentId];
+    else if (entries.length === 1) [, candidate] = entries[0];
+    else if (entries.length > 1) {
+      report.ambiguities.push('artProgram.embryoShipments: multiple shipments with no shipmentId reference to disambiguate - none migrated, needs manual repair.');
+      return { shipment: null, relationsPatch: {} };
+    }
+  }
+  if (!candidate) return { shipment: null, relationsPatch: {} };
+
+  const relationsPatch = {};
+  if (candidate.destinationClinicId && !rawCase.relations?.ukrainianClinicId && !rawCase.relations?.clinicId) {
+    relationsPatch.ukrainianClinicId = candidate.destinationClinicId;
+  }
+  if (candidate.sourceClinicId && !rawCase.relations?.partnerClinicId) {
+    relationsPatch.partnerClinicId = candidate.sourceClinicId;
+  }
+
+  report.changed = true;
+  return { shipment: stripLegacyStoredFields(omitKeys(candidate, ['id', 'sourceClinicId', 'destinationClinicId'])), relationsPatch };
+};
+
+// Migrates the transfer attempt's hCG tests/ultrasounds from the old id-keyed map shape to the v5
+// singleton (spec §4.3): the one referenced by the genetic-affinity certificate's (or, for the
+// ultrasound, also the RACSS clinic letter's) old id if present, otherwise the map's only entry,
+// otherwise - with several entries and no id to choose by - report an ambiguity and migrate none of
+// them rather than guessing.
+const migrateTransferAttempt = (rawCase, report) => {
+  const artProgram = isPlainObject(rawCase.artProgram) ? rawCase.artProgram : {};
+  const transferAttempt = isPlainObject(artProgram.transferAttempt) ? artProgram.transferAttempt : null;
+  if (!transferAttempt) return null;
+
+  const documents = isPlainObject(rawCase.documents) ? rawCase.documents : {};
+  const certificate = isPlainObject(documents.geneticAffinityCertificate) ? documents.geneticAffinityCertificate : {};
+  const letter = isPlainObject(documents.racssClinicLetter) ? documents.racssClinicLetter : {};
+
+  const pickSingleton = (already, map, referencedId, label) => {
+    if (isPlainObject(already)) return already;
+    if (!isPlainObject(map)) return null;
+    const entries = Object.entries(map);
+    if (referencedId && map[referencedId]) {
+      report.changed = true;
+      return map[referencedId];
+    }
+    if (entries.length === 1) {
+      report.changed = true;
+      return entries[0][1];
+    }
+    if (entries.length > 1) {
+      report.ambiguities.push(`artProgram.transferAttempt.${label}: multiple entries with no id reference to disambiguate - none migrated, needs manual repair.`);
+    }
+    return null;
+  };
+
+  const hcgTest = pickSingleton(transferAttempt.hcgTest, transferAttempt.hcgTests, certificate.hcgTestId, 'hcgTests');
+  const ultrasound = pickSingleton(transferAttempt.ultrasound, transferAttempt.ultrasounds, certificate.ultrasoundId || letter.ultrasoundId, 'ultrasounds');
+
+  const migrated = stripLegacyStoredFields(omitKeys(transferAttempt, ['id', 'shipmentId', 'hcgTests', 'ultrasounds', 'hcgTest', 'ultrasound']));
+  if (hcgTest) migrated.hcgTest = stripLegacyStoredFields(omitKeys(hcgTest, ['id']));
+  if (ultrasound) migrated.ultrasound = stripLegacyStoredFields(omitKeys(ultrasound, ['id']));
+  return migrated;
+};
+
+// Migrates diagnosis/genetic-material-source fields (spec §4.4): the old `medicalIndication.
+// diagnosis` wrapper and the old `geneticMaterial.oocyteSourcePartnerRole`/`spermSourcePartnerRole`
+// fields, mapped straight to the v5 scalars. A legacy 'donor' selection with no code ever recorded
+// anywhere (the old UI never had a donor-code input) can't be safely turned into the scalar donor
+// code the v5 field is supposed to hold - reported as unmigratable instead of guessed/invented.
+const migrateMedicalData = (rawCase, report) => {
+  const artProgram = isPlainObject(rawCase.artProgram) ? rawCase.artProgram : {};
+  const result = {};
+
+  if (isPlainObject(artProgram.medicalIndications)) {
+    result.medicalIndications = artProgram.medicalIndications;
+  } else if (isPlainObject(artProgram.medicalIndication?.diagnosis)) {
+    result.medicalIndications = artProgram.medicalIndication.diagnosis;
+    report.changed = true;
+  }
+
+  const geneticMaterial = isPlainObject(artProgram.geneticMaterial) ? artProgram.geneticMaterial : null;
+  const migrateSource = (already, legacyRole, label) => {
+    if (already !== undefined) return already;
+    if (!legacyRole) return undefined;
+    if (legacyRole === 'donor') {
+      report.unmigratable.push(`artProgram.geneticMaterial.${label}: was set to a donor with no donor code recorded - re-enter the donor code directly.`);
+      return undefined;
+    }
+    report.changed = true;
+    return legacyRole;
+  };
+  const oocyteSource = migrateSource(artProgram.oocyteSource, geneticMaterial?.oocyteSourcePartnerRole, 'oocyteSourcePartnerRole');
+  const spermSource = migrateSource(artProgram.spermSource, geneticMaterial?.spermSourcePartnerRole, 'spermSourcePartnerRole');
+  if (oocyteSource !== undefined) result.oocyteSource = oocyteSource;
+  if (spermSource !== undefined) result.spermSource = spermSource;
+
+  if (isPlainObject(artProgram.medicalTeam)) result.medicalTeam = artProgram.medicalTeam;
+
+  return result;
+};
+
+// One case record, migrated to the v5 shape (spec §1/§4) - idempotent (re-running on an
+// already-v5 case returns `report.changed: false` and the same data), never guesses missing/
+// ambiguous data (reports it instead, spec §4.7).
+export const migrateCaseToV5 = rawCase => {
+  const report = emptyMigrationReport();
+  if (!isPlainObject(rawCase)) return { case: {}, report };
+
+  const relations = isPlainObject(rawCase.relations) ? { ...rawCase.relations } : {};
+  if (relations.clinicId && !relations.ukrainianClinicId) {
+    relations.ukrainianClinicId = relations.clinicId;
+    report.changed = true;
+  }
+  delete relations.clinicId;
+  delete relations.shipment;
+
+  const { shipment, relationsPatch } = migrateEmbryoShipment(rawCase, report);
+  Object.entries(relationsPatch).forEach(([key, value]) => { relations[key] = value; });
+
+  if (!relations.ukrainianClinicId) report.missingRelations.push('relations.ukrainianClinicId');
+  if (!relations.coupleId) report.missingRelations.push('relations.coupleId');
+  if (!relations.surrogateMotherId) report.missingRelations.push('relations.surrogateMotherId');
+
+  const medical = migrateMedicalData(rawCase, report);
+  const transferAttempt = migrateTransferAttempt(rawCase, report);
+
+  const artProgram = {
+    ...medical,
+    ...(transferAttempt ? { transferAttempt } : {}),
+    ...(shipment ? { embryoShipment: shipment } : {}),
+  };
+
+  const documents = isPlainObject(rawCase.documents) ? { ...rawCase.documents } : {};
+  ['geneticAffinityCertificate', 'racssClinicLetter', 'embryoOwnershipStatement'].forEach(key => {
+    if (!isPlainObject(documents[key])) return;
+    const before = documents[key];
+    const after = stripLegacyStoredFields(omitKeys(before, ['hcgTestId', 'ultrasoundId', 'shipmentId']));
+    if (Object.keys(before).length !== Object.keys(after).length) report.changed = true;
+    documents[key] = after;
+  });
+
+  const migratedCase = { ...rawCase, relations, documents };
+  if (Object.keys(artProgram).length) migratedCase.artProgram = artProgram;
+  else delete migratedCase.artProgram;
+
+  return { case: migratedCase, report };
+};
+
+// Runs migrateCaseToV5 across every case in a raw `cases` snapshot and aggregates the per-case
+// reports into the one migration report spec §4.7 wants - migratedCaseIds (any case that actually
+// changed shape), and missingRelations/ambiguities/unmigratable keyed by case id so nothing is lost
+// even when several cases have issues.
+export const migrateCasesToV5 = rawCases => {
+  const records = toRecordsWithIdFromKey(rawCases).filter(isPlainObject);
+  const cases = [];
+  const report = {
+    migratedCaseIds: [], missingRelations: {}, ambiguities: {}, unmigratable: {},
+  };
+  records.forEach(rawCase => {
+    const { case: migratedCase, report: caseReport } = migrateCaseToV5(rawCase);
+    cases.push(migratedCase);
+    const caseId = migratedCase.id ?? rawCase.id;
+    if (caseReport.changed) report.migratedCaseIds.push(caseId);
+    if (caseReport.missingRelations.length) report.missingRelations[caseId] = caseReport.missingRelations;
+    if (caseReport.ambiguities.length) report.ambiguities[caseId] = caseReport.ambiguities;
+    if (caseReport.unmigratable.length) report.unmigratable[caseId] = caseReport.unmigratable;
+  });
+  return { cases, report };
+};
+
+// spec §2.2: validates the loaded settings record's schema marker. This app's Documents Builder
+// storage is 4 sibling RTDB paths (parties/cases/templates/settings), not one combined root object,
+// so the marker lives on `documentsBuilder/settings.schemaVersion` - the one path every load already
+// reads (see normalizeDocumentsSettings, which always stamps the current version going forward).
+// `cases` migrate unconditionally and idempotently regardless of this marker (migrateCaseToV5 above
+// is cheap and safe to re-run) - this validator is for a caller that wants to tell a pre-v5 record
+// apart from one already on the current schema (e.g. to warn an admin migration hasn't run yet).
+export const isDocumentsSchemaV5 = rawSettings => isPlainObject(rawSettings) && rawSettings.schemaVersion === CURRENT_SCHEMA_VERSION;
+
+// Every case record passes through the migration boundary above exactly once, here - nothing
+// downstream (resolveShipment, resolveCaseContext, the case editors) ever branches on a legacy
+// shape again. Re-normalizing an already-v5 case changes nothing (migrateCaseToV5 is idempotent).
+export const normalizeCaseRecord = rawCase => (isPlainObject(rawCase) ? migrateCaseToV5(rawCase).case : {});
 
 // Strips undefined/null/''-valued fields (and now-empty objects) out of a case form draft before
 // it's written to Firebase, so saving a case that has no documents data yet never creates empty
@@ -980,47 +1210,46 @@ export const TEMPLATE_DOCUMENT_CONFIG = {
 const DEFAULT_NOTARY_TEMPLATE_CONFIG = { documentKey: 'birthRegistrationConsent', usesNotary: true };
 
 // --- ART program (case.artProgram) - resolvers, formatters, document contexts ----------------
-// The medical facts of a case's fertility program (diagnosis, the one embryo shipment, the one
-// successful transfer attempt, its hCG tests, its ultrasounds) live once at `case.artProgram`
-// (plus the one shipment itself, at `case.relations.shipment` - batch 26 §5). A transfer attempt's
-// own hCG tests/ultrasounds stay keyed by id (never converted to arrays - spec §12); the transfer
-// attempt itself is a single object, not a log of attempts (batch 24 §2 - only the one successful
-// attempt ever matters once the program is underway). Every document that references one of these
-// events (embryoOwnershipStatement, geneticAffinityCertificate, racssClinicLetter) resolves the
-// case's one shipment/transfer attempt directly, with only which of the transfer attempt's hCG
-// tests/ultrasounds it cites still an id choice (hcgTestId/ultrasoundId); editing the underlying
-// event once (e.g. the transfer date) is instantly reflected in every document that references it,
-// since none of them ever copy the fact - they resolve it fresh every render.
+// v5 (spec §1.3/§1.4): the medical facts of a case's fertility program live once at
+// `case.artProgram` - `medicalIndications`, scalar `oocyteSource`/`spermSource`, the one embryo
+// shipment (`artProgram.embryoShipment`), and the one relevant transfer attempt
+// (`artProgram.transferAttempt`, itself carrying at most one nested `hcgTest`/`ultrasound`). None of
+// these carry an id, live in an array, or are keyed by id in a map - a case has at most one of each,
+// full stop. Every document that references one of these events (embryoOwnershipStatement,
+// geneticAffinityCertificate, racssClinicLetter) resolves the case's singleton directly - there is
+// nothing left to select by id, so editing an event once (e.g. the transfer date) is instantly
+// reflected in every document that references it, since none of them ever copy the fact.
+//
+// Legacy shapes (relations.shipment, artProgram.embryoShipments/hcgTests/ultrasounds id-maps,
+// artProgram.geneticMaterial.*PartnerRole, artProgram.medicalIndication.diagnosis, and any
+// hcgTestId/ultrasoundId/shipmentId document pointer) are read exactly once, at the single migration
+// boundary (migrateCaseToV5, called from normalizeCaseRecord on every load) - nothing below this
+// point ever branches on an old shape again.
 
-// One case now carries at most one embryo shipment, stored directly on its relations (batch 26 §5:
-// "one case = one partner clinic = one shipment" - a case that ever needs a second shipment is a
-// second case, not a second entry here). This removes the old shipmentId indirection entirely - the
-// three documents that reference a shipment (embryoOwnershipStatement, and via the transfer attempt,
-// geneticAffinityCertificate/racssClinicLetter) used to each carry their own separate shipmentId
-// pointer, any one of which could be left unset/stale even after a shipment's own fields were filled
-// in, silently rendering that document's shipment.* fields blank with no indication why (the exact
-// failure this batch's partner-clinic-data-not-substituting report traced back to). A case still on
-// the pre-batch-26 shape (relations.shipment unset) falls back to whichever of those old pointers is
-// present, read-only - a fresh save always writes relations.shipment only (see
-// CaseArtProgramEditor.jsx), so every case migrates the next time its shipment is touched.
-export const resolveShipment = caseData => {
-  if (caseData?.relations?.shipment) return caseData.relations.shipment;
-  const legacyShipmentId = caseData?.artProgram?.transferAttempt?.shipmentId
-    || caseData?.documents?.embryoOwnershipStatement?.shipmentId;
-  if (!legacyShipmentId) return null;
-  return caseData?.artProgram?.embryoShipments?.[legacyShipmentId] ?? null;
-};
+export const resolveShipment = caseData => caseData?.artProgram?.embryoShipment ?? null;
 
 export const resolveTransferAttempt = caseData => caseData?.artProgram?.transferAttempt ?? null;
 
-export const resolveHcgTest = (transferAttempt, hcgTestId) => {
-  if (!hcgTestId) return null;
-  return transferAttempt?.hcgTests?.[hcgTestId] ?? null;
-};
+// Singleton - existence alone means "the case's one shipment's one relevant test/scan" (spec §1.5),
+// nothing left to pick by id.
+export const resolveHcgTest = transferAttempt => transferAttempt?.hcgTest ?? null;
 
-export const resolveUltrasound = (transferAttempt, ultrasoundId) => {
-  if (!ultrasoundId) return null;
-  return transferAttempt?.ultrasounds?.[ultrasoundId] ?? null;
+export const resolveUltrasound = transferAttempt => transferAttempt?.ultrasound ?? null;
+
+// Reserved genetic-material scalar values (spec §1.7) - anything else non-empty is a donor code,
+// displayed as itself.
+export const GENETIC_SOURCE_ROLE_VALUES = ['wife', 'husband'];
+export const isGeneticSourceDonorCode = value => Boolean(value) && !GENETIC_SOURCE_ROLE_VALUES.includes(value);
+
+// spec §3.4: resolves a scalar oocyteSource/spermSource straight to a template-ready label - the
+// wife/husband's own resolved (and already short-name-enriched) name for the two reserved role
+// values, or the donor code string itself for anything else. Never a lookup table with real people;
+// the two names it can return are exactly the ones already resolved elsewhere in the same context.
+export const resolveGeneticSourceLabel = (source, { wife, husband } = {}) => {
+  if (!source) return null;
+  if (source === 'wife') return wife?.name ?? null;
+  if (source === 'husband') return husband?.name ?? null;
+  return { uk: source, en: source };
 };
 
 // A declined-form name field (nameGenitive on a partner clinic, nameLocative on a clinic) falls
@@ -1040,14 +1269,16 @@ const withDeclinedNameFallback = (record, field) => {
   };
 };
 
-// A shipment on its own only carries clinic ids - never mutates the stored record, just layers the
-// resolved party records on top (spec §3).
-export const enrichShipment = (shipment, parties) => {
+// v5: a shipment carries no clinic ids of its own any more (spec §1.2/§1.4) - the foreign source
+// clinic and Ukrainian destination clinic are the case's own relations
+// (relations.partnerClinicId/ukrainianClinicId), already resolved once in resolveCaseContext and
+// passed in here - never mutates the stored shipment, just layers the resolved party records on top.
+export const enrichShipment = (shipment, { partnerClinic, clinic } = {}) => {
   if (!shipment) return null;
   return {
     ...shipment,
-    sourceClinic: withDeclinedNameFallback(findById(parties?.partnerClinics, shipment.sourceClinicId), 'nameGenitive'),
-    destinationClinic: withDeclinedNameFallback(findById(parties?.clinics, shipment.destinationClinicId), 'nameLocative'),
+    sourceClinic: withDeclinedNameFallback(partnerClinic, 'nameGenitive'),
+    destinationClinic: withDeclinedNameFallback(clinic, 'nameLocative'),
   };
 };
 
@@ -1137,15 +1368,15 @@ const PREGNANCY_TYPE_LABELS_UK = { 1: 'одноплідна', 2: 'двоплід
 export const formatPregnancyTypeTextUk = fetusCount => PREGNANCY_TYPE_LABELS_UK[Number(fetusCount)] || '';
 
 // Layers the formatted-for-template fields onto an already party-enriched shipment (see
-// enrichShipment) - the two are separate steps because embryoOwnershipStatement's legacy fallback
-// (spec §14) needs to synthesize just these formatted fields without a real shipment record to
-// enrich with parties.
+// enrichShipment) - a separate step so a caller that only needs the formatted dates (no clinic
+// enrichment) can call this alone.
 export const enrichShipmentForTemplate = shipment => {
   if (!shipment) return null;
   return {
     ...shipment,
     ivfDateFormatted: { uk: formatDateNumericUk(shipment.ivfDate), en: formatDateLongEn(shipment.ivfDate) },
     plannedPeriodFormatted: { uk: formatShipmentPeriod(shipment.plannedPeriod, 'uk'), en: formatShipmentPeriod(shipment.plannedPeriod, 'en') },
+    sentDateFormatted: { uk: formatDateNumericUk(shipment.sentDate), en: formatDateLongEn(shipment.sentDate) },
     receivedDateFormatted: { uk: formatDateNumericUk(shipment.receivedDate), en: formatDateLongEn(shipment.receivedDate) },
   };
 };
@@ -1158,6 +1389,10 @@ export const enrichTransferForTemplate = (transferAttempt, shipment) => {
     embryoCountText: { uk: formatEmbryoCountTextUk(transferAttempt.embryoCount) },
     embryoStageLabel: resolveEmbryoStageLabel(transferAttempt.embryoStage),
     shipment: enrichShipmentForTemplate(shipment),
+    // Nested exactly as stored (spec §1.3: transferAttempt.hcgTest/.ultrasound) - alongside the
+    // top-level hcgTest/ultrasound context aliases resolveCaseContext also exposes (spec §5.1).
+    hcgTest: enrichHcgTestForTemplate(resolveHcgTest(transferAttempt)),
+    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt)),
   };
 };
 
@@ -1179,59 +1414,52 @@ export const enrichUltrasoundForTemplate = ultrasound => {
   };
 };
 
-// case.documents.embryoOwnershipStatement - spec §4. There is only ever the case's one shipment
-// now (batch 26 §5, resolveShipment) - no shipmentId of its own to pick. Backward compatible with
-// the even older pre-shipment shape (spec §14): a case that never had any shipment data at all
-// still carries `ivfDate`/`shipmentPeriod` directly on the document, which synthesize the same
-// `.shipment.*` template fields the resolved shape exposes, so an old template keeps rendering
-// unchanged.
-export const buildEmbryoOwnershipStatementContext = (caseData, parties, ownershipData) => {
+// case.documents.embryoOwnershipStatement - spec §1.8/§4. There is only ever the case's one
+// shipment (resolveShipment) - no shipmentId of its own to pick. `clinics` is
+// `{ partnerClinic, clinic }`, the same pair resolveCaseContext already resolves from the case's own
+// relations.
+export const buildEmbryoOwnershipStatementContext = (caseData, clinics, ownershipData) => {
   const data = isPlainObject(ownershipData) ? ownershipData : {};
-  const resolvedShipment = enrichShipmentForTemplate(enrichShipment(resolveShipment(caseData), parties));
-  const legacyShipment = !resolvedShipment && (data.ivfDate || data.shipmentPeriod) ? {
-    ivfDateFormatted: { uk: formatDateNumericUk(data.ivfDate), en: formatDateLongEn(data.ivfDate) },
-    plannedPeriodFormatted: { uk: data.shipmentPeriod?.uk || '', en: data.shipmentPeriod?.en || '' },
-    sourceClinic: null,
-    destinationClinic: null,
-  } : null;
-  return { ...data, shipment: resolvedShipment || legacyShipment };
+  const resolvedShipment = enrichShipmentForTemplate(enrichShipment(resolveShipment(caseData), clinics));
+  return { ...data, shipment: resolvedShipment };
 };
 
-// case.documents.geneticAffinityCertificate - spec §4. There is only ever one transfer attempt
-// (batch 24 §2) referencing the case's one shipment (batch 26 §5) - neither needs an id of its own;
-// only which of the transfer attempt's hCG tests/ultrasounds this certificate cites is still a
-// choice (hcgTestId/ultrasoundId).
-export const buildGeneticAffinityCertificateContext = (caseData, parties, certificateData) => {
+// case.documents.geneticAffinityCertificate - spec §1.8/§4/§5.1. There is only ever one transfer
+// attempt referencing the case's one shipment - none of them need an id of their own, and neither
+// does the transfer attempt's hCG test/ultrasound (spec §1.5: existence alone means positive/
+// confirmed) - nothing left to select by id.
+export const buildGeneticAffinityCertificateContext = (caseData, clinics, certificateData) => {
   const data = isPlainObject(certificateData) ? certificateData : {};
   const transferAttempt = resolveTransferAttempt(caseData);
-  const shipment = enrichShipment(resolveShipment(caseData), parties);
+  const shipment = enrichShipment(resolveShipment(caseData), clinics);
   return {
     ...data,
     transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
-    hcgTest: enrichHcgTestForTemplate(resolveHcgTest(transferAttempt, data.hcgTestId)),
-    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt, data.ultrasoundId)),
+    hcgTest: enrichHcgTestForTemplate(resolveHcgTest(transferAttempt)),
+    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt)),
     outgoingNumberOrBlank: data.outgoingNumber?.trim() || '______',
     // A print-only blank, never persisted (spec §4) - a fully blank pattern rather than a
     // hand-picked placeholder date, so it never silently doubles as a real value.
     issueDateOrBlank: { uk: data.issueDate ? formatDateNumericUk(data.issueDate) : '__.__.____' },
-    // Batch 26 §6: shared/cross-referenced by any other document conditioning a block on whether
-    // the wife herself was the oocyte donor (e.g. the RATS/birth-registration statement's "та
-    // генетичною матір'ю ..." clause) - the "У лікувальній програмі ДРТ використано яйцеклітини..."
-    // field this certificate itself prints from case.artProgram.geneticMaterial.
-    oocyteSourceIsWife: caseData?.artProgram?.geneticMaterial?.oocyteSourcePartnerRole === 'wife',
+    // Shared/cross-referenced by any other document conditioning a block on whether the wife
+    // herself was the oocyte donor (e.g. the RATS/birth-registration statement's "та генетичною
+    // матір'ю ..." clause) - the "У лікувальній програмі ДРТ використано яйцеклітини..." field this
+    // certificate itself prints from the case's scalar case.artProgram.oocyteSource (spec §1.7).
+    oocyteSourceIsWife: caseData?.artProgram?.oocyteSource === 'wife',
   };
 };
 
-// case.documents.racssClinicLetter - spec §4. Same single-transfer-attempt/single-shipment rule as
-// above.
-export const buildRacssClinicLetterContext = (caseData, parties, letterData) => {
+// case.documents.racssClinicLetter - spec §1.8/§4. Same single-transfer-attempt/single-shipment
+// rule as above; racssClinicLetter itself carries no requisites of its own (spec §1.3 sample:
+// `"racssClinicLetter": {}`).
+export const buildRacssClinicLetterContext = (caseData, clinics, letterData) => {
   const data = isPlainObject(letterData) ? letterData : {};
   const transferAttempt = resolveTransferAttempt(caseData);
-  const shipment = enrichShipment(resolveShipment(caseData), parties);
+  const shipment = enrichShipment(resolveShipment(caseData), clinics);
   return {
     ...data,
     transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
-    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt, data.ultrasoundId)),
+    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttempt)),
   };
 };
 
@@ -1265,62 +1493,6 @@ export const enrichCoupleMarriage = couple => {
       },
     },
   };
-};
-
-// Specific, actionable messages for a document reference that points at an event id that doesn't
-// exist (spec §13/§15) - deleted since the document was set up, mistyped on import, etc. Distinct
-// from the generic unresolved-{{placeholder}} warning (which would otherwise just list every
-// `geneticAffinityCertificate.transferAttempt.*` leaf as "missing" with no indication of why).
-export const validateArtProgramReferences = (catalog, caseId) => {
-  const rawCaseRecord = findById(catalog?.cases, caseId);
-  if (!rawCaseRecord) return [];
-  const caseRecord = normalizeCaseRecord(rawCaseRecord);
-  const documents = isPlainObject(caseRecord.documents) ? caseRecord.documents : {};
-  const issues = [];
-  const transferAttempt = resolveTransferAttempt(caseRecord);
-
-  // No shipmentId to dangle any more (batch 26 §5: the case's one shipment, resolveShipment) - a
-  // case simply has one or doesn't; that's the ordinary unresolved-{{placeholder}} case, not a
-  // broken reference worth its own message here.
-  const certificate = documents.geneticAffinityCertificate;
-  if (certificate?.hcgTestId && !resolveHcgTest(transferAttempt, certificate.hcgTestId)) {
-    issues.push(`Не знайдено аналіз ХГЧ ${certificate.hcgTestId}.`);
-  }
-  if (certificate?.ultrasoundId && !resolveUltrasound(transferAttempt, certificate.ultrasoundId)) {
-    issues.push(`Не знайдено УЗД ${certificate.ultrasoundId}.`);
-  }
-
-  const letter = documents.racssClinicLetter;
-  if (letter?.ultrasoundId && !resolveUltrasound(transferAttempt, letter.ultrasoundId)) {
-    issues.push(`Не знайдено УЗД ${letter.ultrasoundId}.`);
-  }
-
-  return issues;
-};
-
-// Human-readable dropdown labels (spec §9) - so an editor never makes the admin type/paste a raw
-// id: "Перенос 18.09.2025 — 1 ембріон", "Доставлення 27.08.2025 — Medical Park Shonan",
-// "ХГЧ 30.09.2025 — позитивний", "УЗД 17.10.2025 — 1 плід, 6–7 тижнів" - the label word and its
-// date are joined by a plain space, only the trailing detail is set off with an em dash.
-const joinOptionLabel = (label, dateText, details) => {
-  const prefix = [label, dateText].filter(Boolean).join(' ');
-  return [prefix, details].filter(Boolean).join(' — ');
-};
-
-export const formatHcgTestOptionLabel = hcgTest => {
-  if (!hcgTest) return '';
-  const dateText = hcgTest.date ? formatDateNumericUk(hcgTest.date) : '';
-  const resultText = hcgTest.positive === true ? 'позитивний' : (hcgTest.positive === false ? 'негативний' : '');
-  return joinOptionLabel('ХГЧ', dateText, resultText);
-};
-
-export const formatUltrasoundOptionLabel = ultrasound => {
-  if (!ultrasound) return '';
-  const dateText = ultrasound.date ? formatDateNumericUk(ultrasound.date) : '';
-  const fetusText = ultrasound.fetusCount ? `${ultrasound.fetusCount} ${ukPluralForm(ultrasound.fetusCount, ['плід', 'плоди', 'плодів'])}` : '';
-  const ageText = formatGestationalAgeText(ultrasound.gestationalAgeWeeks);
-  const details = [fetusText, ageText].filter(Boolean).join(', ');
-  return joinOptionLabel('УЗД', dateText, details);
 };
 
 export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}) => {
@@ -1374,17 +1546,18 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
   const notaryId = notaryDocumentKey ? (documentContextsByStorageKey[notaryDocumentKey]?.notaryId ?? null) : null;
   const notary = enrichPersonName(notaryId ? findById(catalog.parties.notaries, notaryId) : null);
 
-  // The Ukrainian clinic (parties.clinics, relations.clinicId) runs the surrogacy program and signs
-  // the documents; the partner clinic (parties.partnerClinics, relations.partnerClinicId) is the
-  // separate foreign clinic embryos ship from - never the same collection, never a second "main"
-  // clinic. Both are null-safe: an old case with no partnerClinicId/clinicId simply resolves to
-  // null rather than throwing, so a template referencing it degrades to a visible warning instead
-  // of a crash (see getUnresolvedVariablePaths/fillPlaceholders) - e.g. a case with no clinicId at
-  // all (spec §2: case-kikawa has no clinic/maternity-hospital relations).
+  // The Ukrainian clinic (parties.clinics, relations.ukrainianClinicId) runs the surrogacy program
+  // and signs the documents; the partner clinic (parties.partnerClinics, relations.partnerClinicId)
+  // is the separate foreign clinic embryos ship from - never the same collection, never a second
+  // "main" clinic (spec §1.2). Both are null-safe: an old case with no partnerClinicId/
+  // ukrainianClinicId simply resolves to null rather than throwing, so a template referencing it
+  // degrades to a visible warning instead of a crash (see getUnresolvedVariablePaths/
+  // fillPlaceholders) - e.g. a case with no clinic relation at all (case-kikawa in the reference
+  // data has no maternity-hospital relation).
   const partnerClinic = relations.partnerClinicId
     ? findById(catalog.parties.partnerClinics, relations.partnerClinicId)
     : null;
-  const rawClinic = relations.clinicId ? findById(catalog.parties.clinics, relations.clinicId) : null;
+  const rawClinic = relations.ukrainianClinicId ? findById(catalog.parties.clinics, relations.ukrainianClinicId) : null;
   const clinic = rawClinic ? {
     ...rawClinic,
     medicalDirector: rawClinic.medicalDirector ? {
@@ -1392,21 +1565,39 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
       name: enrichNameWithDerivedFields(rawClinic.medicalDirector.name),
     } : rawClinic.medicalDirector,
   } : null;
+  const resolvedClinics = { partnerClinic, clinic };
 
-  // ART-program-referencing documents (spec §4/§7): each resolves its own referenced shipment/
-  // transfer/hcgTest/ultrasound fresh from `caseRecord.artProgram` on every call, so editing an
-  // event once (e.g. the transfer date) is reflected in every document that references it.
-  const embryoOwnershipStatement = buildEmbryoOwnershipStatementContext(caseRecord, catalog.parties, documents.embryoOwnershipStatement);
-  const geneticAffinityCertificate = buildGeneticAffinityCertificateContext(caseRecord, catalog.parties, documents.geneticAffinityCertificate);
-  const racssClinicLetter = buildRacssClinicLetterContext(caseRecord, catalog.parties, documents.racssClinicLetter);
+  const wife = enrichPersonName(rawWife);
+  const husband = enrichPersonName(rawHusband);
+
+  // ART-program-referencing documents (spec §1.3/§4/§7): each resolves its own referenced
+  // shipment/transfer/hcgTest/ultrasound fresh from `caseRecord.artProgram` on every call, so
+  // editing an event once (e.g. the transfer date) is reflected in every document that references
+  // it.
+  const embryoOwnershipStatement = buildEmbryoOwnershipStatementContext(caseRecord, resolvedClinics, documents.embryoOwnershipStatement);
+  const geneticAffinityCertificate = buildGeneticAffinityCertificateContext(caseRecord, resolvedClinics, documents.geneticAffinityCertificate);
+  const racssClinicLetter = buildRacssClinicLetterContext(caseRecord, resolvedClinics, documents.racssClinicLetter);
   const medicalServicesAgreement = buildMedicalServicesAgreementContext(documents.medicalServicesAgreement);
+
+  // Canonical top-level ART-program aliases (spec §5.1): the same singleton shipment/transfer
+  // attempt/hCG test/ultrasound every document-scoped context above already resolves, exposed
+  // directly so a template can reference {{embryoShipment...}}/{{transferAttempt...}}/{{hcgTest...}}/
+  // {{ultrasound...}} without going through a specific document's namespace.
+  const rawArtProgram = isPlainObject(caseRecord.artProgram) ? caseRecord.artProgram : {};
+  const transferAttemptRaw = resolveTransferAttempt(caseRecord);
+  const shipmentForContext = enrichShipment(resolveShipment(caseRecord), resolvedClinics);
+  const artProgram = {
+    ...rawArtProgram,
+    oocyteSourceLabel: resolveGeneticSourceLabel(rawArtProgram.oocyteSource, { wife, husband }),
+    spermSourceLabel: resolveGeneticSourceLabel(rawArtProgram.spermSource, { wife, husband }),
+  };
 
   return {
     case: caseRecord,
     relations,
     couple: enrichCoupleMarriage(couple),
-    wife: enrichPersonName(rawWife),
-    husband: enrichPersonName(rawHusband),
+    wife,
+    husband,
     surrogateMother: enrichPersonName(relations.surrogateMotherId
       ? findById(catalog.parties.surrogateMothers, relations.surrogateMotherId)
       : null),
@@ -1422,6 +1613,11 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
     maternityHospital: childbirth.maternityHospitalId
       ? findById(catalog.parties.maternityHospitals, childbirth.maternityHospitalId)
       : null,
+    artProgram,
+    embryoShipment: enrichShipmentForTemplate(shipmentForContext),
+    transferAttempt: enrichTransferForTemplate(transferAttemptRaw, shipmentForContext),
+    hcgTest: enrichHcgTestForTemplate(resolveHcgTest(transferAttemptRaw)),
+    ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttemptRaw)),
     surrogacyAgreement,
     birthRegistration,
     maritalStatusDeclaration,
@@ -1522,8 +1718,8 @@ export const fillPlaceholders = (text, context, lang = 'uk') => String(text || '
 // document entirely - e.g. "та генетичною матір'ю ... Кацура Юкако," in the RATS/birth-
 // registration statement must only print when the wife herself was the oocyte donor
 // (geneticAffinityCertificate.oocyteSourceIsWife, shared/cross-referenced off the same
-// case.artProgram.geneticMaterial.oocyteSourcePartnerRole every genetic-affinity-certificate
-// resolves from - see buildGeneticAffinityCertificateContext), never shown with a blank/unresolved
+// case.artProgram.oocyteSource scalar every genetic-affinity-certificate resolves from - see
+// buildGeneticAffinityCertificateContext), never shown with a blank/unresolved
 // value for any other oocyte source. No `condition` at all (the vast majority of blocks) always
 // renders, so this is fully backward compatible.
 export const evaluateBlockCondition = (condition, context) => {
@@ -1618,11 +1814,42 @@ export const validateDocumentTemplate = (template, context) => {
   return [...missing].sort();
 };
 
+// Every {{path}} in a piece of text, INCLUDING the two graphical tokens (unlike
+// findUnresolvedVariables, which excludes them for the unresolved-variable-warning use case) - only
+// the layoutV2 block scan below needs logo/logo-long to show up (spec §5.3: "image/logo sources").
+const extractAllVariablePaths = text => [...String(text || '').matchAll(PLACEHOLDER_PATTERN)].map(match => match[1].trim());
+
 // Every {{path}} referenced anywhere in a template (title, beforeTitle blocks, paragraphs, both
 // languages) - regardless of whether it currently resolves. Used to scope non-blocking case
 // completeness warnings (e.g. childbirth/birth-registration data) to only the documents actually
 // checked for generation, instead of nagging about a birth that hasn't happened yet while
 // generating an early-stage document like a surrogacy agreement that never references it.
+// Every text-bearing field a layoutV2 block can carry (spec §5.3): a plain string leaf (`text`,
+// `value`, `caption`, `source`, each entry of `lines`), a bilingual leaf's already-covered by the
+// legacy paragraphs/title scan above, and everything nestable - `columns[].content`, `rows` (an
+// array of either a block or a row of blocks, e.g. signatureTable) - recursed into.
+const scanLayoutV2Block = (block, addPath) => {
+  if (!isPlainObject(block)) return;
+  ['text', 'value', 'caption', 'source'].forEach(key => extractAllVariablePaths(block[key]).forEach(addPath));
+  toArray(block.lines).forEach(line => {
+    if (typeof line === 'string') extractAllVariablePaths(line).forEach(addPath);
+    else scanLayoutV2Block(line, addPath);
+  });
+  toArray(block.runs).forEach(run => extractAllVariablePaths(run?.text).forEach(addPath));
+  toArray(block.columns).forEach(column => scanLayoutV2Block(column?.content, addPath));
+  toArray(block.rows).forEach(row => {
+    if (Array.isArray(row)) row.forEach(cell => scanLayoutV2Block(cell, addPath));
+    else scanLayoutV2Block(row, addPath);
+  });
+};
+
+// Every {{path}} referenced anywhere in a template - title, beforeTitle blocks, legacy paragraphs
+// (both languages), and every layoutV2 block (spec §5.3: paragraphs/title/beforeTitle/
+// layoutV2.blocks/text/runs/lines/value/image sources) - regardless of whether it currently
+// resolves. Used to scope non-blocking case completeness warnings (e.g. childbirth/birth-
+// registration data) to only the documents actually checked for generation, instead of nagging
+// about a birth that hasn't happened yet while generating an early-stage document like a
+// surrogacy agreement that never references it.
 export const getTemplateReferencedPaths = template => {
   const paths = new Set();
   const scan = value => findUnresolvedVariables(value).forEach(path => paths.add(path));
@@ -1636,8 +1863,47 @@ export const getTemplateReferencedPaths = template => {
     scan(paragraph?.uk);
     scan(paragraph?.en);
   });
+  toArray(template?.layoutV2?.blocks).forEach(block => scanLayoutV2Block(block, path => paths.add(path)));
   return [...paths];
 };
+
+// --- Template variable audit (spec §5.3) -----------------------------------------------------
+// Classifies every path a template can reference so a dev/test utility can fail on a stale/unknown
+// one instead of a renamed field silently degrading to a blank. Prefix tables, not an exhaustive
+// enumeration, since a backend/relation path's remaining segments are themselves data-driven
+// (`clinic.medicalDirector.name.uk.genitive`, `representatives.0.name.uk.short`, ...).
+const SYSTEM_VARIABLE_PATHS = ['logo', 'logo-long'];
+// Every resolveCaseContext top-level key that resolves a relation record from `catalog.parties.*`
+// straight off `case.relations` - as opposed to a resolved/derived context alias below.
+const RESOLVED_RELATION_PATH_PREFIXES = ['relations.', 'couple.', 'wife.', 'husband.', 'clinic.', 'partnerClinic.', 'surrogateMother.', 'representative.', 'representatives.', 'notary.', 'maternityHospital.'];
+// Runtime-only aliases: the canonical ART-program singleton paths (spec §5.1), and every
+// document-scoped context object resolveCaseContext builds fresh on each render - none of these
+// are ever themselves stored in Firebase, even though some of their leaves pass through
+// unmodified stored requisites (e.g. `geneticAffinityCertificate.outgoingNumber`).
+const DERIVED_RUNTIME_PATH_PREFIXES = [
+  'artProgram.', 'embryoShipment.', 'transferAttempt.', 'hcgTest.', 'ultrasound.',
+  'surrogacyAgreement.', 'birthRegistration.', 'maritalStatusDeclaration.', 'legalServicesDisclaimer.', 'surrogacyAgreementAppendix1.',
+  'embryoOwnershipStatement.', 'geneticAffinityCertificate.', 'racssClinicLetter.', 'medicalServicesAgreement.',
+];
+// Raw backend records reachable straight off the resolved case (`case.artProgram...`,
+// `case.documents...`, `case.childbirth...`) or the per-child/case-wide context aliases.
+const BACKEND_SOURCE_PATH_PREFIXES = ['case.', 'child.', 'children.', 'childbirth.', 'medicalConclusion.'];
+
+export const classifyTemplateVariablePath = path => {
+  const trimmed = String(path || '').trim();
+  if (SYSTEM_VARIABLE_PATHS.includes(trimmed)) return 'system';
+  if (RESOLVED_RELATION_PATH_PREFIXES.some(prefix => trimmed.startsWith(prefix))) return 'resolvedRelation';
+  if (DERIVED_RUNTIME_PATH_PREFIXES.some(prefix => trimmed.startsWith(prefix))) return 'derivedRuntime';
+  if (BACKEND_SOURCE_PATH_PREFIXES.some(prefix => trimmed.startsWith(prefix))) return 'backendSource';
+  return 'unknown';
+};
+
+// Every path referenced by a template (getTemplateReferencedPaths), each classified
+// (classifyTemplateVariablePath) - sorted so a test can assert on a stable snapshot and fail the
+// moment any path classifies as 'unknown'.
+export const auditTemplateVariables = template => [...getTemplateReferencedPaths(template)]
+  .sort()
+  .map(path => ({ path, classification: classifyTemplateVariablePath(path) }));
 
 // --- Case completeness checklists (batch 18 §18) --------------------------------------------
 // Non-blocking checklists shown before saving/exporting rather than enforced while editing -
@@ -1654,7 +1920,7 @@ export const validateCaseRecord = rawCaseRecord => {
 
   requirePresent(caseRecord.id, 'case.id');
   requirePresent(caseRecord.relations?.coupleId, 'case.relations.coupleId');
-  requirePresent(caseRecord.relations?.clinicId, 'case.relations.clinicId');
+  requirePresent(caseRecord.relations?.ukrainianClinicId, 'case.relations.ukrainianClinicId');
   requirePresent(caseRecord.relations?.surrogateMotherId, 'case.relations.surrogateMotherId');
   if (!toArray(caseRecord.childbirth?.children).length) issues.push('case.childbirth.children');
 
@@ -2680,7 +2946,7 @@ export const findPartyReferences = (catalog, collection, id) => {
     const relations = caseRecord.relations || {};
     switch (collection) {
       case 'couples': return String(relations.coupleId) === targetId;
-      case 'clinics': return String(relations.clinicId) === targetId;
+      case 'clinics': return String(relations.ukrainianClinicId) === targetId;
       case 'partnerClinics': return String(relations.partnerClinicId) === targetId;
       case 'surrogateMothers': return String(relations.surrogateMotherId) === targetId;
       case 'representatives': return toArray(relations.representativeIds).some(repId => String(repId) === targetId);
@@ -2738,6 +3004,13 @@ export const VARIABLE_PICKER_GROUPS = [
   // embryos ship from (spec: embryo-ownership-statement document). Shown whenever one is selected
   // on the case; a case without a partnerClinicId simply doesn't offer this group.
   { label: 'Клініка-партнер', roots: ['partnerClinic'], predicate: context => Boolean(context?.partnerClinic) },
+  // The canonical top-level ART-program singleton aliases (spec §5.1) - shown only once the case
+  // actually carries artProgram data, same idea as the document-scoped groups below.
+  {
+    label: 'Програма ДРТ',
+    roots: ['artProgram', 'embryoShipment', 'transferAttempt', 'hcgTest', 'ultrasound'],
+    predicate: context => Boolean(context?.case?.artProgram),
+  },
   // ART program document contexts (spec §7) - each root is a top-level key resolveCaseContext
   // already exposes. Shown only once the case actually carries that document's own service data
   // (same idea as the partner-clinic group above) - an old case that never uses these documents at
@@ -3401,6 +3674,10 @@ export const diffDocFormattingOverrides = (referenceFormatting, workingFormattin
 export const normalizeDocumentsSettings = raw => {
   const source = isPlainObject(raw) ? raw : {};
   return {
+    // Every case/party record is already migrated to v5 shape by the time this runs (see
+    // migrateCaseToV5/normalizeCaseRecord) - stamping the current version here means the next
+    // settings save persists `schemaVersion: 5` even if the stored record predates this marker.
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     formatting: normalizeDocFormatting(source.formatting),
     clinicLogo: null,
     recentCaseIds: toArray(source.recentCaseIds).map(String),

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -2578,7 +2578,7 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
 
   it('an unknown clinicId resolves clinic to null without crashing (§10, §12 #8)', () => {
     const catalog = clinicAndHospitalCatalog();
-    catalog.cases[0].relations.clinicId = 'no-such-clinic';
+    catalog.cases[0].relations.ukrainianClinicId = 'no-such-clinic';
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.clinic).toBeNull();
     expect(() => fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).not.toThrow();
@@ -2753,11 +2753,16 @@ describe('spec: normalized case structure', () => {
     expect(resolveCaseContext(catalog, 'case-2').clinic.id).toBe('clinic-2');
   });
 
-  it('normalizeCaseRecord is an idempotent pass-through - no legacy migration, missing branches never crash', () => {
-    expect(normalizeCaseRecord({ id: 'case-bare' })).toEqual({ id: 'case-bare' });
+  it('normalizeCaseRecord runs the v5 migration boundary, idempotently, missing branches never crash', () => {
+    expect(normalizeCaseRecord({ id: 'case-bare' })).toEqual({ id: 'case-bare', relations: {}, documents: {} });
     expect(normalizeCaseRecord(null)).toEqual({});
     const withData = { id: 'case-1', relations: { coupleId: 'couple-1' } };
-    expect(normalizeCaseRecord(withData)).toBe(withData);
+    const normalized = normalizeCaseRecord(withData);
+    expect(normalized).toEqual({ id: 'case-1', relations: { coupleId: 'couple-1' }, documents: {} });
+    // Never mutates the source object the caller passed in.
+    expect(withData).toEqual({ id: 'case-1', relations: { coupleId: 'couple-1' } });
+    // Re-normalizing an already-v5 case changes nothing further.
+    expect(normalizeCaseRecord(normalized)).toEqual(normalized);
   });
 
   it('a two-child array does not break the generated preview', () => {
@@ -2830,11 +2835,11 @@ describe('spec: normalized case structure', () => {
 
   it('validateCaseRecord reports the base checklist without throwing on a bare/empty case', () => {
     expect(validateCaseRecord({})).toEqual(expect.arrayContaining([
-      'case.id', 'case.relations.coupleId', 'case.relations.clinicId',
+      'case.id', 'case.relations.coupleId', 'case.relations.ukrainianClinicId',
       'case.relations.surrogateMotherId', 'case.childbirth.children',
     ]));
     expect(validateCaseRecord(createEmptyCase({ caseId: 'case-9' }))).toEqual(expect.arrayContaining([
-      'case.relations.coupleId', 'case.relations.clinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children',
+      'case.relations.coupleId', 'case.relations.ukrainianClinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children',
     ]));
     expect(validateCaseRecord(twoCasesCatalog().cases[0])).toEqual([]);
   });


### PR DESCRIPTION
Core v5 data-model alignment for case.artProgram, the highest-priority gap against
the v5 logical structure spec:

- embryoShipment moves from case.relations.shipment to case.artProgram.embryoShipment,
  gains sentDate, and drops its own sourceClinicId/destinationClinicId - a shipment's
  clinics are now purely the case's own relations.ukrainianClinicId/partnerClinicId.
- transferAttempt.hcgTests/ultrasounds (id-keyed maps) become singleton
  transferAttempt.hcgTest/ultrasound objects - existence alone means positive/confirmed,
  so the positive/pregnancyConfirmed booleans and their ids are gone.
- geneticMaterial.oocyteSourcePartnerRole/spermSourcePartnerRole becomes scalar
  artProgram.oocyteSource/spermSource ("wife"/"husband"/a donor code string directly).
- medicalIndication.diagnosis becomes plain medicalIndications.
- case.relations.clinicId renamed to relations.ukrainianClinicId throughout.
- documents.geneticAffinityCertificate/racssClinicLetter drop their hcgTestId/
  ultrasoundId/shipmentId pointers - nothing left to select by id.

Added one migration boundary (migrateCaseToV5/migrateCasesToV5, wired into
normalizeCaseRecord) that reads every legacy shape above exactly once, idempotently,
and reports missing relations/ambiguous multi-record migrations/unmigratable data
(e.g. a legacy "donor" selection with no code ever recorded) instead of guessing.
Added CURRENT_SCHEMA_VERSION/isDocumentsSchemaV5, stamped into normalizeDocumentsSettings.

resolveCaseContext now exposes the canonical top-level artProgram/embryoShipment/
transferAttempt/hcgTest/ultrasound aliases (with runtime-only oocyteSourceLabel/
spermSourceLabel derived via resolveGeneticSourceLabel) alongside the existing
document-scoped ones, and the variable picker gained a "Програма ДРТ" group for them.

Added auditTemplateVariables/classifyTemplateVariablePath, a template-variable audit
utility that classifies every {{path}} a template references (backend/resolved-relation/
derived-runtime/system) and flags genuinely unknown ones.

UI: CaseArtProgramEditor rewritten for the scalar donor-code source picker and single
hCG/ultrasound sub-forms (no more add/remove lists or clinic pickers of its own, one
Ukrainian "Зберегти" button). CaseChildbirthTransactionEditor drops the ХГЧ/УЗД
dropdown selectors on geneticAffinityCertificate/racssClinicLetter (also removes the
old dropdown preselection bug) and racssClinicLetter's now-empty form entirely.

Rewrote documentsCatalogUtils.test.js/.artProgram.test.js for the v5 shapes and added
tests for the migration boundary (idempotency, clinic-relation recovery, ambiguous-
migration reporting, donor passthrough) and the new template-variable audit.

Deferred to a follow-up pass: the Parties/case-editor UI redesign into four
collapsible sections (spec §6.1-6.2), a page-wide single dirty-state/save-bar (§6.5),
and auditing/rewriting the actual template *content* stored in Firebase to reference
the new canonical paths - the logo popover and ⋮ menu placement (§7-8) were already
done in a prior batch.