### PR TITLE
Documents Builder: v5 ART-program migration + party name/country schema fixes

### DIFF
--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -546,14 +546,16 @@ const REPRESENTATIVE_FIELDS = [
 
 const CLINIC_FIELDS = [
   { label: 'Kind', path: 'kind', type: 'select', options: CLINIC_KINDS },
-  { label: 'Name (uk)', path: 'name.uk' },
+  // Every template reads these grammatical forms straight off name.uk (e.g.
+  // {{clinic.name.uk.nominative}}, {{clinic.name.uk.accusative}} "у клініку «Вікторія»") - genitive/
+  // accusative are optional, blank until an admin fills them in.
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
+  { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
+  { label: 'Name (uk, accusative "у ...")', path: 'name.uk.accusative' },
   { label: 'Name (en)', path: 'name.en' },
-  // Locative Ukrainian form ("у клініці «Вікторія»") - optional, falls back to the plain
-  // nominative Name above when blank (see enrichShipment/withDeclinedNameFallback).
-  { label: 'Name (uk, locative "у ...")', path: 'nameLocative.uk' },
-  { label: 'Legal name (uk)', path: 'legalName.uk' },
+  { label: 'Legal name (uk, nominative)', path: 'legalName.uk.nominative' },
   { label: 'Legal name (en)', path: 'legalName.en' },
-  { label: 'Medical center name (uk)', path: 'medicalCenterName.uk' },
+  { label: 'Medical center name (uk, nominative)', path: 'medicalCenterName.uk.nominative' },
   { label: 'Medical center name (en)', path: 'medicalCenterName.en' },
   { label: 'Address (uk)', path: 'address.uk' },
   { label: 'Address (en)', path: 'address.en' },
@@ -586,12 +588,14 @@ const CLINIC_FIELDS = [
 // EDRPOU/license/director/bank/logo fields, which don't apply to a clinic that never signs
 // anything itself.
 const PARTNER_CLINIC_FIELDS = [
-  { label: 'Name (uk)', path: 'name.uk' },
+  // Every template reads these grammatical forms straight off name.uk/country.uk (e.g.
+  // {{partnerClinic.name.uk.genitive}}, {{partnerClinic.country.uk.genitive}} "з клініки «Оті Юме»,
+  // Японії") - genitive is optional, blank until an admin fills it in.
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
+  { label: 'Name (uk, genitive "з ...")', path: 'name.uk.genitive' },
   { label: 'Name (en)', path: 'name.en' },
-  // Genitive Ukrainian form ("з клініки «Оті Юме»") - optional, falls back to the plain nominative
-  // Name above when blank (see enrichShipment/withDeclinedNameFallback).
-  { label: 'Name (uk, genitive "з ...")', path: 'nameGenitive.uk' },
-  { label: 'Country (uk)', path: 'country.uk' },
+  { label: 'Country (uk, nominative)', path: 'country.uk.nominative' },
+  { label: 'Country (uk, genitive "з ...")', path: 'country.uk.genitive' },
   { label: 'Country (en)', path: 'country.en' },
   { label: 'Address (uk)', path: 'address.uk' },
   { label: 'Address (en)', path: 'address.en' },
@@ -601,7 +605,7 @@ const PARTNER_CLINIC_FIELDS = [
 // full bilingual `name`, read via getMaternityHospitalDisplayName (see maternityDisplayName
 // below), never a hand-typed abbreviation.
 const MATERNITY_HOSPITAL_FIELDS = [
-  { label: 'Name (uk)', path: 'name.uk' },
+  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
   { label: 'Name (en)', path: 'name.en' },
   { label: 'EDRPOU', path: 'edrpou' },
   { label: 'Address (uk)', path: 'address.uk' },

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -40,7 +40,7 @@ const buildParties = () => ({
   },
   representatives: {},
   clinics: {
-    'clinic-1': { id: 'clinic-1', name: { uk: 'Клініка Мрія' } },
+    'clinic-1': { id: 'clinic-1', name: { uk: { nominative: 'Клініка Мрія' } } },
   },
   maternityHospitals: {},
   notaries: {},
@@ -92,10 +92,10 @@ describe('spec: Parties page', () => {
 
     fireEvent.click(screen.getByText('Clinics'));
     const clinicRow = await screen.findByText('Клініка Мрія');
-    expect(screen.queryByLabelText('Name (uk)')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Name (uk, nominative)')).not.toBeInTheDocument();
 
     fireEvent.click(clinicRow);
-    expect(await screen.findByLabelText('Name (uk)')).toHaveValue('Клініка Мрія');
+    expect(await screen.findByLabelText('Name (uk, nominative)')).toHaveValue('Клініка Мрія');
   });
 
   it('editing a field on blur persists it additively to the record path', async () => {

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -714,10 +714,19 @@ const enrichPersonName = person => {
 // The maternity hospital's display name used to read a stored `shortName` field (spec §6: no
 // longer created or persisted) - this is the safe replacement: the full bilingual name, uk
 // preferred, falling back to en, never an automatic legal-name abbreviation (that algorithm is
-// for personal names, not organizations).
-export const getMaternityHospitalDisplayName = maternityHospital => (
-  maternityHospital?.name?.uk || maternityHospital?.name?.en || ''
-);
+// for personal names, not organizations). `name.uk`/`name.en` can be stored either as a plain
+// string (createEmptyMaternityHospital's shape) or as a `{nominative, genitive, ...}` object (the
+// same grammatical-forms shape every other party's name uses) - never assume one over the other,
+// or a real record on the shape this function doesn't expect renders a raw object as a React
+// child (a hard crash, not just a blank field) wherever this string is displayed.
+export const getMaternityHospitalDisplayName = maternityHospital => {
+  const { uk, en } = maternityHospital?.name || {};
+  if (typeof uk === 'string' && uk) return uk;
+  if (isPlainObject(uk) && (uk.nominative || uk.short)) return uk.nominative || uk.short;
+  if (typeof en === 'string' && en) return en;
+  if (isPlainObject(en) && (en.full || en.short)) return en.full || en.short;
+  return '';
+};
 
 // --- Party record shapes (Parties page, batch 19 §1) --------------------------------------------
 // Canonical "blank record" for each party collection - the shape a freshly-added record starts
@@ -793,14 +802,14 @@ export const CLINIC_KINDS = ['foreign', 'ukrainian'];
 export const createEmptyClinic = () => ({
   id: makeRecordId('clinic'),
   kind: 'ukrainian',
-  name: { uk: '', en: '' },
-  // The Ukrainian locative form of `name.uk` ("у клініці «Вікторія»", as opposed to the nominative
-  // "клініка «Вікторія»") - a document that names this clinic after "у" reads nameLocative.uk when
-  // filled in, falling back to the plain nominative name otherwise (see enrichShipment). Optional,
-  // never required by any template that only ever reads `name.uk`.
-  nameLocative: { uk: '', en: '' },
-  legalName: { uk: '', en: '' },
-  medicalCenterName: { uk: '', en: '' },
+  // `name.uk`/`legalName.uk`/`medicalCenterName.uk` carry their grammatical forms directly as
+  // siblings of `nominative` (`{{clinic.name.uk.accusative}}`, `{{clinic.name.uk.nominative}}` -
+  // real templates read these paths straight off the clinic, never through a separate
+  // nameLocative-style field) - genitive/accusative are optional, blank until an admin fills them
+  // in, never required by a template that only ever reads `.nominative`.
+  name: { uk: { nominative: '', genitive: '', accusative: '' }, en: '' },
+  legalName: { uk: { nominative: '' }, en: '' },
+  medicalCenterName: { uk: { nominative: '' }, en: '' },
   address: { uk: '', en: '' },
   phone: '',
   email: '',
@@ -825,23 +834,22 @@ export const createEmptyClinic = () => ({
 // just the name and address a static document needs to reference it by.
 export const createEmptyPartnerClinic = () => ({
   id: makeRecordId('partner-clinic'),
-  name: { uk: '', en: '' },
-  // The Ukrainian genitive form of `name.uk` ("з клініки «Оті Юме»", as opposed to the nominative
-  // "клініка «Оті Юме»") - a document that names this clinic after "з" reads nameGenitive.uk when
-  // filled in, falling back to the plain nominative name otherwise (see enrichShipment).
-  nameGenitive: { uk: '', en: '' },
-  // Country a shipment "from" this clinic is described as coming from (geneticAffinityCertificate's
-  // "з ..., Японія" - spec batch 2026-07-25). Optional, never required by any template that doesn't
-  // reference it.
-  country: { uk: '', en: '' },
+  // `name.uk`/`country.uk` carry their grammatical forms directly as siblings of `nominative`
+  // ({{partnerClinic.name.uk.genitive}}, {{partnerClinic.country.uk.genitive}} - real templates
+  // read these paths straight off the partner clinic) - genitive is optional, blank until an admin
+  // fills it in, never required by a template that only ever reads `.nominative`/plain `.en`.
+  name: { uk: { nominative: '', genitive: '' }, en: '' },
+  country: { uk: { nominative: '', genitive: '' }, en: '' },
   address: { uk: '', en: '' },
 });
 
 // `shortName` is never stored (spec §6) - use getMaternityHospitalDisplayName wherever the UI
-// used to read `maternityHospital.shortName.uk`.
+// used to read `maternityHospital.shortName.uk`. `name.uk` carries its nominative form as an
+// object sibling (`{{maternityHospital.name.uk}}` resolves it via the generic nominative fallback
+// in fillPlaceholders), same shape every other party's name uses - never a plain string.
 export const createEmptyMaternityHospital = () => ({
   id: makeRecordId('maternity-hospital'),
-  name: { uk: '', en: '' },
+  name: { uk: { nominative: '' }, en: '' },
   edrpou: '',
   address: { uk: '', en: '' },
 });
@@ -1252,20 +1260,20 @@ export const resolveGeneticSourceLabel = (source, { wife, husband } = {}) => {
   return { uk: source, en: source };
 };
 
-// A declined-form name field (nameGenitive on a partner clinic, nameLocative on a clinic) falls
-// back to the plain nominative `name` when the admin hasn't filled the grammatical variant in yet -
-// a document referencing "{{...sourceClinic.nameGenitive.uk}}" never renders blank just because
-// only the nominative name was ever entered (spec batch 2026-07-25: Ukrainian grammar after
-// "у"/"з" needs the clinic's name declined, not its bare nominative form).
-const withDeclinedNameFallback = (record, field) => {
+// A name's declined grammatical form (genitive "з клініки «Оті Юме»", accusative "у клініку
+// «Вікторія»") lives directly on `name.uk` as a sibling of `nominative` (spec: the same
+// {nominative, genitive, accusative} shape every party's name uses) - falls back to the plain
+// nominative form when the admin hasn't filled the declined variant in yet, and to '' (never a
+// leaked object) when `name.uk` is still a plain, not-yet-migrated string.
+const withDeclinedNameFallback = (record, grammaticalCase) => {
   if (!record) return record;
-  const declined = record[field] || {};
+  const nameUk = record?.name?.uk;
+  const nameEn = record?.name?.en;
+  const declinedUk = isPlainObject(nameUk) ? (nameUk[grammaticalCase] || nameUk.nominative || '') : (nameUk || '');
+  const declinedEn = isPlainObject(nameEn) ? (nameEn.full || nameEn.short || '') : (nameEn || '');
   return {
     ...record,
-    [field]: {
-      uk: declined.uk || record.name?.uk || '',
-      en: declined.en || record.name?.en || '',
-    },
+    [grammaticalCase]: { uk: declinedUk, en: declinedEn },
   };
 };
 
@@ -1273,12 +1281,15 @@ const withDeclinedNameFallback = (record, field) => {
 // clinic and Ukrainian destination clinic are the case's own relations
 // (relations.partnerClinicId/ukrainianClinicId), already resolved once in resolveCaseContext and
 // passed in here - never mutates the stored shipment, just layers the resolved party records on top.
+// The real templates read `{{partnerClinic.name.uk.genitive}}`/`{{clinic.name.uk.accusative}}`
+// directly (never through this shipment-nested alias) - `sourceClinic`/`destinationClinic` are kept
+// as a convenience alias for any template that does reference them through the shipment.
 export const enrichShipment = (shipment, { partnerClinic, clinic } = {}) => {
   if (!shipment) return null;
   return {
     ...shipment,
-    sourceClinic: withDeclinedNameFallback(partnerClinic, 'nameGenitive'),
-    destinationClinic: withDeclinedNameFallback(clinic, 'nameLocative'),
+    sourceClinic: withDeclinedNameFallback(partnerClinic, 'genitive'),
+    destinationClinic: withDeclinedNameFallback(clinic, 'accusative'),
   };
 };
 

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -2936,14 +2936,15 @@ describe('spec: Parties page record shapes', () => {
 
     // A partner clinic is a deliberately simplified party type (spec §5) - just name/address (plus
     // the genitive name form and shipment-origin country, spec batch 2026-07-25), no EDRPOU/
-    // license/director/bank/logo the Ukrainian clinic record carries.
+    // license/director/bank/logo the Ukrainian clinic record carries. name.uk/country.uk carry
+    // their grammatical forms directly (spec v5: the same {nominative, genitive, ...} shape every
+    // party's name uses), not a separate nameGenitive field.
     const partnerClinic = createEmptyPartnerClinic();
     expect(partnerClinic.id).toMatch(/^partner-clinic-/);
     expect(partnerClinic).toEqual({
       id: partnerClinic.id,
-      name: { uk: '', en: '' },
-      nameGenitive: { uk: '', en: '' },
-      country: { uk: '', en: '' },
+      name: { uk: { nominative: '', genitive: '' }, en: '' },
+      country: { uk: { nominative: '', genitive: '' }, en: '' },
       address: { uk: '', en: '' },
     });
 


### PR DESCRIPTION
## Summary
- Migrates `case.artProgram` to the v5 singleton shape (`embryoShipment`, `transferAttempt.hcgTest`/`.ultrasound`, scalar `oocyteSource`/`spermSource`, `medicalIndications`, `relations.ukrainianClinicId`), with one idempotent migration boundary (`migrateCaseToV5`/`migrateCasesToV5`) that reports missing/ambiguous/unmigratable legacy data instead of guessing.
- Adds canonical top-level ART-program context aliases and a template-variable audit utility (`auditTemplateVariables`/`classifyTemplateVariablePath`).
- Rewrites `CaseArtProgramEditor`/`CaseChildbirthTransactionEditor` for the new singleton/scalar model (removes the old hCG/ultrasound dropdown selectors and the preselection bug they caused).
- Fixes a crash when editing a case in Parties (`getMaternityHospitalDisplayName` rendered a raw object as a React child for real maternity-hospital records).
- Fixes partner-clinic genitive/country data never resolving in the genetic-affinity certificate — `PARTNER_CLINIC_FIELDS`/`CLINIC_FIELDS` now expose the actual grammatical-form paths (`name.uk.genitive`, `country.uk.genitive`, etc.) real templates and real data use, instead of an unused separate field.

## Test plan
- [x] `documentsCatalogUtils.test.js` / `documentsCatalogUtils.artProgram.test.js` — full rewrite/extension for the v5 shapes, migration boundary, and template audit (all passing)
- [x] `PartiesPage.test.js` / `PartiesPage.caseEditor.test.js` — updated fixtures/assertions (all passing)
- [x] Reproduced both Parties bugs against the real reference JSON data via scratch RTL tests before fixing, confirmed fixed, removed scratch tests
- [x] Full `src/components` suite: 877 passing (same handful of pre-existing unrelated failures as on `main`, verified via `git stash`)
- [x] Production build (`react-scripts build`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiAWCuo3gq5Tw9J4HqPc4V)_