### PR TITLE
Documents Builder: fix off-screen logo popover, support {{logo}} in plain paragraphs

### DIFF
--- a/src/components/DocumentsLayoutV2.test.js
+++ b/src/components/DocumentsLayoutV2.test.js
@@ -205,6 +205,102 @@ describe('layoutV2 normalization (buildGeneratedDocument)', () => {
   });
 });
 
+// spec: an admin should be able to place the clinic logo by typing {{logo}}/{{logo-long}} into an
+// ordinary paragraph or richParagraph block (the full T/B/I/align/condition toolbar every other
+// block has), not only through the dedicated letterhead/image block - same convention the legacy
+// (non-layoutV2) renderer already applies to a leading paragraph.
+describe('layoutV2: {{logo}}/{{logo-long}} typed as a plain paragraph/richParagraph block', () => {
+  const templateWithLogoParagraph = () => ({
+    ...layoutV2Template(),
+    layoutV2: {
+      ...layoutV2Template().layoutV2,
+      blocks: [
+        { type: 'paragraph', style: 'body', text: '{{logo}}' },
+        { type: 'richParagraph', style: 'body', runs: [{ text: '{{logo-long}}' }] },
+        { type: 'paragraph', style: 'titleMain', text: 'ДОВІДКА' },
+      ],
+    },
+  });
+
+  it('tags the block with logoToken instead of leaving literal {{logo}} text, and carries no other paragraph fields', () => {
+    const resolved = buildGeneratedDocument(templateWithLogoParagraph(), context);
+    const [logoBlock, logoLongBlock, titleBlock] = resolved.layoutV2.blocks;
+    expect(logoBlock.logoToken).toBe('logo');
+    expect(logoBlock.text).toBeUndefined();
+    expect(logoLongBlock.logoToken).toBe('logo-long');
+    expect(logoLongBlock.runs).toBeUndefined();
+    expect(titleBlock.text).toBe('ДОВІДКА');
+    const serialized = JSON.stringify(resolved.layoutV2);
+    expect(serialized).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+
+  it('a plain paragraph/richParagraph whose text is NOT exactly {{logo}} keeps rendering as ordinary text', () => {
+    const template = {
+      ...templateWithLogoParagraph(),
+      layoutV2: {
+        ...templateWithLogoParagraph().layoutV2,
+        blocks: [
+          { type: 'paragraph', style: 'body', text: '{{logo}} in the middle of a sentence' },
+          { type: 'richParagraph', style: 'body', runs: [{ text: '{{logo}}' }, { text: ' plus another run' }] },
+        ],
+      },
+    };
+    const resolved = buildGeneratedDocument(template, context);
+    expect(resolved.layoutV2.blocks[0].logoToken).toBeUndefined();
+    expect(resolved.layoutV2.blocks[0].text).toContain('in the middle of a sentence');
+    expect(resolved.layoutV2.blocks[1].logoToken).toBeUndefined();
+    expect(resolved.layoutV2.blocks[1].runs.map(run => run.text).join('')).toContain('plus another run');
+  });
+
+  it('renders a real PDF that embeds the logo image from a plain paragraph typed as {{logo}}', async () => {
+    const { pdf, Font } = await import('@react-pdf/renderer');
+    const documentsModule = await import('./DocumentsPdfDocument');
+    Font.register({
+      family: 'Tinos',
+      fonts: [{ src: toDataUri('Tinos-Regular.ttf'), fontWeight: 400 }],
+    });
+    Font.registerHyphenationCallback(word => [word]);
+    const DocumentsPdfDocument = documentsModule.default;
+    const collect = async streamPromise => {
+      const stream = await streamPromise;
+      const chunks = [];
+      await new Promise((resolve, reject) => {
+        stream.on('data', chunk => chunks.push(chunk));
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      return Buffer.concat(chunks);
+    };
+
+    const resolved = buildGeneratedDocument(templateWithLogoParagraph(), context);
+    const withLogoElement = React.createElement(DocumentsPdfDocument, { documents: [resolved], layout: 'two-column', clinicLogos });
+    const withLogo = await collect(pdf(withLogoElement).toBuffer());
+
+    const withoutLogoResolved = buildGeneratedDocument({
+      ...templateWithLogoParagraph(),
+      layoutV2: { ...templateWithLogoParagraph().layoutV2, blocks: [{ type: 'paragraph', style: 'titleMain', text: 'ДОВІДКА' }] },
+    }, context);
+    const withoutLogoElement = React.createElement(DocumentsPdfDocument, { documents: [withoutLogoResolved], layout: 'two-column', clinicLogos });
+    const withoutLogo = await collect(pdf(withoutLogoElement).toBuffer());
+
+    // Embedding the (tiny, base64) logo image twice (once per {{logo}}/{{logo-long}} block) makes
+    // the PDF meaningfully bigger than the same document with no logo blocks at all.
+    expect(withLogo.length).toBeGreaterThan(withoutLogo.length);
+  }, 20000);
+
+  it('builds a real DOCX that embeds the logo image from a plain paragraph typed as {{logo}}', async () => {
+    const { buildDocumentsDocx } = await import('./documentsDocxBuilder');
+    const resolved = buildGeneratedDocument(templateWithLogoParagraph(), context);
+    const withLogoBlob = await buildDocumentsDocx({ documents: [resolved], layout: 'two-column', clinicLogos });
+    const withoutLogoResolved = buildGeneratedDocument({
+      ...templateWithLogoParagraph(),
+      layoutV2: { ...templateWithLogoParagraph().layoutV2, blocks: [{ type: 'paragraph', style: 'titleMain', text: 'ДОВІДКА' }] },
+    }, context);
+    const withoutLogoBlob = await buildDocumentsDocx({ documents: [withoutLogoResolved], layout: 'two-column', clinicLogos });
+    expect(withLogoBlob.size).toBeGreaterThan(withoutLogoBlob.size);
+  }, 20000);
+});
+
 describe('layoutV2 PDF renderer (real @react-pdf render)', () => {
   it('renders a layoutV2 document without throwing', async () => {
     const { pdf, Font } = await import('@react-pdf/renderer');

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -5,8 +5,9 @@
 // parties + cases, paragraph templates, and a settings record (favourite formatting values +
 // recently used cases). Clinic logo files live directly in Firebase Storage by clinic id.
 import React, {
-  useCallback, useEffect, useMemo, useRef, useState,
+  useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
@@ -714,17 +715,67 @@ const CheckLine = styled.label`
 // the per-paragraph overrides, and the before-title block offset - every slider is gone (§1.4).
 // Values apply live as typed; the popover closes on outside click or Esc, no OK/Apply buttons.
 
-const PopoverAnchor = styled.span`
-  position: relative;
-  display: inline-flex;
-`;
+// A popover anchored inside a long scrolling document (spec: "test near the top, middle, and
+// bottom of a long template") used to be `position: absolute` inside a `position: relative`
+// inline anchor - correct only for a trigger with enough room to its bottom-right, which a block
+// near the top of the page (the logo/letterhead settings button included) never has, so the card
+// rendered partly or fully off-screen instead of clipping/scrolling into view. Rendered through a
+// portal to document.body instead, positioned in viewport (not document) coordinates from the
+// trigger's own bounding rect, flipped above the trigger when there's no room below and shifted
+// horizontally to stay clear of both viewport edges - the same fix applies to every popover using
+// it, not just the logo one.
+const VIEWPORT_POPOVER_PADDING = 12;
+
+const useFloatingPopoverPosition = (open, anchorRef, cardRef) => {
+  const [position, setPosition] = useState(null);
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return undefined;
+    }
+    const recalculate = () => {
+      const anchor = anchorRef.current;
+      const card = cardRef.current;
+      if (!anchor || !card) return;
+      const anchorRect = anchor.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+
+      let top = anchorRect.bottom + 6;
+      if (top + cardRect.height > viewportHeight - VIEWPORT_POPOVER_PADDING) {
+        const above = anchorRect.top - 6 - cardRect.height;
+        top = above >= VIEWPORT_POPOVER_PADDING ? above : Math.max(VIEWPORT_POPOVER_PADDING, viewportHeight - VIEWPORT_POPOVER_PADDING - cardRect.height);
+      }
+
+      // Right-aligned to the trigger by default (matches the old anchor's `right: 0`), shifted
+      // left/right only as far as needed to clear the viewport edge on either side.
+      let left = anchorRect.right - cardRect.width;
+      if (left < VIEWPORT_POPOVER_PADDING) left = VIEWPORT_POPOVER_PADDING;
+      if (left + cardRect.width > viewportWidth - VIEWPORT_POPOVER_PADDING) left = viewportWidth - VIEWPORT_POPOVER_PADDING - cardRect.width;
+
+      setPosition({ top, left });
+    };
+    recalculate();
+    window.addEventListener('resize', recalculate);
+    // `true` (capture) so this also fires for scrolling inside any nested scroll container, not
+    // just the window itself.
+    window.addEventListener('scroll', recalculate, true);
+    return () => {
+      window.removeEventListener('resize', recalculate);
+      window.removeEventListener('scroll', recalculate, true);
+    };
+  }, [open, anchorRef, cardRef]);
+  return position;
+};
 
 const PopoverCard = styled.div`
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 40;
+  position: fixed;
+  z-index: 1000;
   min-width: 180px;
+  max-width: calc(100vw - ${VIEWPORT_POPOVER_PADDING * 2}px);
+  max-height: calc(100vh - ${VIEWPORT_POPOVER_PADDING * 2}px);
+  overflow-y: auto;
   background: var(--km-card);
   border: 1px solid var(--km-border);
   border-radius: 8px;
@@ -786,17 +837,25 @@ const PlainTextField = ({ label, initialValue, placeholder, onApply, onFieldBlur
   );
 };
 
-// One trigger button + its popover, sharing a boundary node so an outside-click close never
-// races the trigger's own toggle click.
+// One trigger button + its popover (rendered through a portal, see useFloatingPopoverPosition
+// above) - anchorRef/cardRef together form the outside-click boundary now that they're no longer
+// DOM siblings.
 const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields, children }) => {
   const anchorRef = useRef(null);
+  const cardRef = useRef(null);
+  const position = useFloatingPopoverPosition(open, anchorRef, cardRef);
   useEffect(() => {
     if (!open) return undefined;
     const handlePointerDown = event => {
-      if (anchorRef.current && !anchorRef.current.contains(event.target)) onClose();
+      if (anchorRef.current?.contains(event.target)) return;
+      if (cardRef.current?.contains(event.target)) return;
+      onClose();
     };
     const handleKeyDown = event => {
-      if (event.key === 'Escape') onClose();
+      if (event.key === 'Escape') {
+        onClose();
+        anchorRef.current?.focus();
+      }
     };
     document.addEventListener('mousedown', handlePointerDown);
     document.addEventListener('touchstart', handlePointerDown);
@@ -807,29 +866,30 @@ const FormatPopoverButton = ({ open, onToggle, onClose, buttonTitle, fields, chi
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [open, onClose]);
+  const popoverContent = (
+    <PopoverCard ref={cardRef} style={position ? { top: position.top, left: position.left } : { top: -9999, left: -9999, visibility: 'hidden' }}>
+      {children || fields.map(field => {
+        const FieldComponent = field.type === 'text' ? PlainTextField : PlainNumberField;
+        return (
+          <FieldComponent
+            key={field.key}
+            label={field.label}
+            initialValue={field.value}
+            placeholder={field.placeholder}
+            onApply={field.onApply}
+            onFieldBlur={field.onFieldBlur}
+          />
+        );
+      })}
+    </PopoverCard>
+  );
   return (
-    <PopoverAnchor ref={anchorRef}>
-      <SmallButton type="button" onClick={onToggle} title={buttonTitle}>
+    <>
+      <SmallButton ref={anchorRef} type="button" onClick={onToggle} title={buttonTitle}>
         <FaSlidersH />
       </SmallButton>
-      {open ? (
-        <PopoverCard>
-          {children || fields.map(field => {
-            const FieldComponent = field.type === 'text' ? PlainTextField : PlainNumberField;
-            return (
-              <FieldComponent
-                key={field.key}
-                label={field.label}
-                initialValue={field.value}
-                placeholder={field.placeholder}
-                onApply={field.onApply}
-                onFieldBlur={field.onFieldBlur}
-              />
-            );
-          })}
-        </PopoverCard>
-      ) : null}
-    </PopoverAnchor>
+      {open && typeof document !== 'undefined' ? createPortal(popoverContent, document.body) : null}
+    </>
   );
 };
 
@@ -840,13 +900,20 @@ const DocLayoutSettingsPopoverButton = ({
   open, onToggle, onClose, columnOptions, activeColumns, onSetColumns, hasLayoutV2, layoutV2Active, onToggleLayoutV2,
 }) => {
   const anchorRef = useRef(null);
+  const cardRef = useRef(null);
+  const position = useFloatingPopoverPosition(open, anchorRef, cardRef);
   useEffect(() => {
     if (!open) return undefined;
     const handlePointerDown = event => {
-      if (anchorRef.current && !anchorRef.current.contains(event.target)) onClose();
+      if (anchorRef.current?.contains(event.target)) return;
+      if (cardRef.current?.contains(event.target)) return;
+      onClose();
     };
     const handleKeyDown = event => {
-      if (event.key === 'Escape') onClose();
+      if (event.key === 'Escape') {
+        onClose();
+        anchorRef.current?.focus();
+      }
     };
     document.addEventListener('mousedown', handlePointerDown);
     document.addEventListener('touchstart', handlePointerDown);
@@ -857,38 +924,39 @@ const DocLayoutSettingsPopoverButton = ({
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [open, onClose]);
+  const popoverContent = (
+    <PopoverCard ref={cardRef} style={position ? { top: position.top, left: position.left } : { top: -9999, left: -9999, visibility: 'hidden' }}>
+      <Field>
+        Columns
+        <ToggleGroup>
+          {columnOptions.map(columnsOption => (
+            <ToggleOption
+              key={columnsOption}
+              type="button"
+              $active={activeColumns === columnsOption}
+              onClick={() => onSetColumns(columnsOption)}
+              title={`Render this document with ${columnsOption} column${columnsOption > 1 ? 's' : ''}, regardless of the page's selector above. Tap again to clear the override.`}
+            >
+              {columnsOption} col
+            </ToggleOption>
+          ))}
+        </ToggleGroup>
+      </Field>
+      {hasLayoutV2 ? (
+        <CheckLine>
+          <input type="checkbox" checked={layoutV2Active} onChange={onToggleLayoutV2} />
+          <FaMagic /> Exact layout {layoutV2Active ? 'on' : 'off'}
+        </CheckLine>
+      ) : null}
+    </PopoverCard>
+  );
   return (
-    <PopoverAnchor ref={anchorRef}>
-      <SmallButton type="button" onClick={onToggle} title="Document layout settings - column count, renderer">
+    <>
+      <SmallButton ref={anchorRef} type="button" onClick={onToggle} title="Document layout settings - column count, renderer">
         <FaCog />
       </SmallButton>
-      {open ? (
-        <PopoverCard>
-          <Field>
-            Columns
-            <ToggleGroup>
-              {columnOptions.map(columnsOption => (
-                <ToggleOption
-                  key={columnsOption}
-                  type="button"
-                  $active={activeColumns === columnsOption}
-                  onClick={() => onSetColumns(columnsOption)}
-                  title={`Render this document with ${columnsOption} column${columnsOption > 1 ? 's' : ''}, regardless of the page's selector above. Tap again to clear the override.`}
-                >
-                  {columnsOption} col
-                </ToggleOption>
-              ))}
-            </ToggleGroup>
-          </Field>
-          {hasLayoutV2 ? (
-            <CheckLine>
-              <input type="checkbox" checked={layoutV2Active} onChange={onToggleLayoutV2} />
-              <FaMagic /> Exact layout {layoutV2Active ? 'on' : 'off'}
-            </CheckLine>
-          ) : null}
-        </PopoverCard>
-      ) : null}
-    </PopoverAnchor>
+      {open && typeof document !== 'undefined' ? createPortal(popoverContent, document.body) : null}
+    </>
   );
 };
 

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -258,8 +258,6 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     fireEvent.click(await screen.findByTitle('Clinic logo - show/hide and offset (mm)'));
 
     const logoCheckbox = await screen.findByRole('checkbox', { name: 'Show logo' });
-    // eslint-disable-next-line testing-library/no-node-access
-    const logoBlock = logoCheckbox.closest('.paragraph-editor-block');
     fireEvent.click(logoCheckbox);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
@@ -276,10 +274,10 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
       }),
     ));
 
-    const xField = within(logoBlock).getByLabelText('Horizontal offset (mm, + = right)');
+    const xField = screen.getByLabelText('Horizontal offset (mm, + = right)');
     fireEvent.change(xField, { target: { value: '3' } });
     fireEvent.blur(xField);
-    const yField = within(logoBlock).getByLabelText('Vertical offset (mm, + = down)');
+    const yField = screen.getByLabelText('Vertical offset (mm, + = down)');
     fireEvent.change(yField, { target: { value: '-2' } });
     fireEvent.blur(yField);
 

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -97,12 +97,12 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const indentedBlock = await openParagraphPopover('Абзац з відступом.');
-    const indentField = within(indentedBlock).getByLabelText('First line indent (cm)');
+    const indentField = screen.getByLabelText('First line indent (cm)');
     expect(indentField).toHaveValue('1');
 
     fireEvent.click(within(indentedBlock).getByTitle(PARAGRAPH_FORMAT_TITLE)); // close the first popover
     const plainBlock = await openParagraphPopover('Абзац без відступу.');
-    const inheritedField = within(plainBlock).getByLabelText('First line indent (cm)');
+    const inheritedField = screen.getByLabelText('First line indent (cm)');
     expect(inheritedField).toHaveValue('');
     expect(inheritedField).toHaveAttribute('placeholder', '1.5'); // notarial standard §3.1 default
   });
@@ -112,7 +112,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const plainBlock = await openParagraphPopover('Абзац без відступу.');
-    const indentField = within(plainBlock).getByLabelText('First line indent (cm)');
+    const indentField = screen.getByLabelText('First line indent (cm)');
     fireEvent.change(indentField, { target: { value: '2.5' } });
     fireEvent.blur(indentField);
 
@@ -136,7 +136,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const indentedBlock = await openParagraphPopover('Абзац з відступом.');
-    const indentField = within(indentedBlock).getByLabelText('First line indent (cm)');
+    const indentField = screen.getByLabelText('First line indent (cm)');
     fireEvent.change(indentField, { target: { value: '' } });
     fireEvent.blur(indentField);
 
@@ -159,7 +159,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const indentedBlock = await openParagraphPopover('Абзац з відступом.');
-    const sizeField = within(indentedBlock).getByLabelText('Font size (pt)');
+    const sizeField = screen.getByLabelText('Font size (pt)');
     expect(sizeField).toHaveValue('');
     expect(sizeField).toHaveAttribute('placeholder', '12');
     fireEvent.change(sizeField, { target: { value: '10' } });

--- a/src/components/DocumentsPage.saveErrorMessage.test.js
+++ b/src/components/DocumentsPage.saveErrorMessage.test.js
@@ -76,7 +76,7 @@ const triggerParagraphSave = async () => {
   // eslint-disable-next-line testing-library/no-node-access
   const block = field.closest('.paragraph-editor-block');
   fireEvent.click(within(block).getByTitle(PARAGRAPH_FORMAT_TITLE));
-  const indentField = within(block).getByLabelText('First line indent (cm)');
+  const indentField = screen.getByLabelText('First line indent (cm)');
   fireEvent.change(indentField, { target: { value: '2' } });
   fireEvent.blur(indentField);
 };
@@ -120,7 +120,7 @@ describe('spec (batch 26 §3): a rejected save names its actual cause instead of
     // eslint-disable-next-line testing-library/no-node-access
     const block = field.closest('.paragraph-editor-block');
     fireEvent.click(within(block).getByTitle(PARAGRAPH_FORMAT_TITLE));
-    const indentField = within(block).getByLabelText('First line indent (cm)');
+    const indentField = screen.getByLabelText('First line indent (cm)');
     fireEvent.change(indentField, { target: { value: '2' } });
     fireEvent.blur(indentField);
 

--- a/src/components/DocumentsPage.templateBoldItalic.test.js
+++ b/src/components/DocumentsPage.templateBoldItalic.test.js
@@ -294,7 +294,7 @@ describe('spec: beforeTitle rows drop the align/bold pickers, unified with parag
     expect(screen.queryAllByRole('slider')).toHaveLength(0);
 
     fireEvent.click(within(block).getByTitle("Block formatting - font size (pt) and the signer block's offset (%)"));
-    const offsetField = within(block).getByLabelText('Offset (%)');
+    const offsetField = screen.getByLabelText('Offset (%)');
     expect(offsetField).toHaveValue('');
     expect(offsetField).toHaveAttribute('placeholder', '47.2'); // 8.5 cm of the 18 cm text width
 

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -590,6 +590,28 @@ const LayoutV2AlignedBox = ({ block, contentWidthMm }) => (
   </View>
 );
 
+// A plain paragraph/richParagraph block typed as just {{logo}}/{{logo-long}} (spec: same
+// convention the legacy renderer already applies to a leading paragraph) - draws the actual
+// clinic logo image instead of literal text, centered, sized from the page's configured logo
+// width (the same default the letterhead/image block's own author-chosen widthMm otherwise
+// covers). Renders nothing (not even its own margins) when no logo variant is uploaded yet -
+// consistent with the legacy LogoBlock, which never leaves an empty placeholder box behind.
+const LayoutV2LogoParagraph = ({ block, clinicLogos, logoWidthPt }) => {
+  const variant = getClinicLogo(clinicLogos, block.logoToken);
+  if (!variant?.dataUrl) return null;
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        marginTop: (block.marginTopMm || 0) * MM_TO_PT,
+        marginBottom: (block.marginBottomMm || 0) * MM_TO_PT,
+      }}
+    >
+      <Image src={variant.dataUrl} style={{ width: logoWidthPt || 156 }} />
+    </View>
+  );
+};
+
 const LayoutV2Paragraph = ({ block }) => (
   <Text
     style={[
@@ -698,7 +720,10 @@ const LayoutV2SignatureTable = ({ block }) => (
   </View>
 );
 
-const LayoutV2Block = ({ block, clinicLogos, contentWidthMm }) => {
+const LayoutV2Block = ({
+  block, clinicLogos, contentWidthMm, logoWidthPt,
+}) => {
+  if (block.logoToken) return <LayoutV2LogoParagraph block={block} clinicLogos={clinicLogos} logoWidthPt={logoWidthPt} />;
   switch (block.type) {
     case 'letterhead': return <LayoutV2Letterhead block={block} clinicLogos={clinicLogos} />;
     case 'alignedBox': return <LayoutV2AlignedBox block={block} contentWidthMm={contentWidthMm} />;
@@ -711,7 +736,7 @@ const LayoutV2Block = ({ block, clinicLogos, contentWidthMm }) => {
   }
 };
 
-const renderLayoutV2DocumentPage = (doc, clinicLogos) => {
+const renderLayoutV2DocumentPage = (doc, clinicLogos, logoWidthPt) => {
   const page = doc.layoutV2.page || {};
   const margins = page.marginsMm || {
     top: 5, right: 15, bottom: 10, left: 15,
@@ -736,7 +761,7 @@ const renderLayoutV2DocumentPage = (doc, clinicLogos) => {
       {doc.layoutV2.blocks.map((block, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <View key={index} wrap>
-          <LayoutV2Block block={block} clinicLogos={clinicLogos} contentWidthMm={contentWidthMm} />
+          <LayoutV2Block block={block} clinicLogos={clinicLogos} contentWidthMm={contentWidthMm} logoWidthPt={logoWidthPt} />
         </View>
       ))}
     </Page>
@@ -925,7 +950,7 @@ const DocumentsPdfDocument = ({
       {documents.flatMap(doc => {
         // A layoutV2 document is fully self-describing (its own page/margins/styles) and never
         // follows the page-wide bilingual/column layout selector - see buildLayoutV2Document.
-        if (doc.layoutV2) return [renderLayoutV2DocumentPage(doc, effectiveClinicLogos)];
+        if (doc.layoutV2) return [renderLayoutV2DocumentPage(doc, effectiveClinicLogos, configuredLogoWidth)];
         const effectiveLayout = getEffectiveDocLayout(doc, layout);
         return isSingleLanguageTwoColumnLayout(effectiveLayout)
           ? renderSingleLanguagePages(doc, effectiveLayout)

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -2483,18 +2483,30 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
         style: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         lines: (block.lines || []).map(line => resolveLayoutV2Text(line, context, lang)),
       };
-    case 'paragraph':
+    // A plain paragraph/richParagraph whose whole (unresolved) text is exactly {{logo}}/
+    // {{logo-long}} - same convention the legacy (non-layoutV2) renderer already uses
+    // (getTemplateLogoType) - draws an actual clinic logo image instead of literal text, so an
+    // admin can place the logo anywhere by just typing the token into an ordinary paragraph (full
+    // T/B/I/align/condition toolbar), not only through the dedicated letterhead/image block.
+    case 'paragraph': {
+      const logoMatch = LOGO_TOKEN_PATTERN.exec(String(block.text || '').trim());
+      if (logoMatch) return { ...base, logoToken: logoMatch[1] };
       return {
         ...base,
         style: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         text: resolveLayoutV2Text(block.text, context, lang) || '',
       };
-    case 'richParagraph':
+    }
+    case 'richParagraph': {
+      const runs = block.runs || [];
+      const logoMatch = runs.length === 1 ? LOGO_TOKEN_PATTERN.exec(String(runs[0]?.text || '').trim()) : null;
+      if (logoMatch) return { ...base, logoToken: logoMatch[1] };
       return {
         ...base,
         style: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         runs: resolveLayoutV2Runs(block.runs, template, context, lang),
       };
+    }
     case 'fieldLine':
       return {
         ...base,

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -537,6 +537,22 @@ export const buildDocumentsDocx = async ({
     }));
   };
 
+  // A plain paragraph/richParagraph block typed as just {{logo}}/{{logo-long}} (spec: same
+  // convention the legacy renderer already applies to a leading paragraph) - reuses the same
+  // centered, non-floating logoParagraph the legacy renderer draws its own {{logo}} paragraph
+  // with, sized from the page's configured logo width, so an admin can place the logo anywhere by
+  // just typing the token into an ordinary paragraph instead of only through the dedicated
+  // letterhead/image block. Renders nothing when no logo variant is uploaded yet.
+  const layoutV2LogoParagraph = (block, clinicLogos) => {
+    const variant = getClinicLogo(clinicLogos, block.logoToken);
+    if (!variant?.dataUrl) return [];
+    const decoded = decodeLogoDataUrl(variant.dataUrl);
+    if (!decoded) return [];
+    const ratio = variant.width && variant.height ? variant.height / variant.width : 0.25;
+    const widthPx = Math.round(formatting.logoWidthMm * MM_TO_PX);
+    return [logoParagraph(decoded, widthPx, ratio)];
+  };
+
   const layoutV2Paragraph = block => new Paragraph({
     alignment: layoutV2Alignment(block.style?.align),
     spacing: {
@@ -642,6 +658,7 @@ export const buildDocumentsDocx = async ({
   };
 
   const layoutV2BlockChildren = (block, contentWidthTwips, clinicLogos) => {
+    if (block.logoToken) return layoutV2LogoParagraph(block, clinicLogos);
     switch (block.type) {
       case 'letterhead': return [layoutV2Letterhead(block, clinicLogos)];
       case 'alignedBox': return layoutV2AlignedBox(block, contentWidthTwips);


### PR DESCRIPTION
## Summary
- Fixes the block-settings popover ("☰"/"⚙", used by every paragraph, the letterhead logo block, and the document-layout button) rendering off-screen — reproduced against the reported screenshot. Now rendered through a portal to `document.body`, viewport-aware (flip/shift/padding/max-height+scroll), recomputed on resize/scroll.
- Adds support for typing `{{logo}}`/`{{logo-long}}` as the whole text of an ordinary `paragraph`/`richParagraph` block in a layoutV2 template — renders as the actual clinic logo image in both PDF and DOCX, same convention the legacy (non-layoutV2) renderer already uses. Lets an admin place the logo with the full standard toolbar instead of only through the dedicated letterhead/image block.
- Investigated the "not all paragraphs render" report: reproduced the CaseArtProgramEditor save → reload → render round trip and confirmed it resolves correctly end-to-end once the transfer/hCG/ultrasound data is actually entered — this was missing case data, not a rendering bug.

## Test plan
- [x] New `DocumentsLayoutV2.test.js` suite: `{{logo}}` detection in paragraph/richParagraph blocks, non-matching text still renders as text, real PDF render embeds the logo, real DOCX build embeds the logo
- [x] Updated 4 `DocumentsPage.*.test.js` files whose popover-field queries were scoped to `within(block)` (now portaled outside that DOM subtree) to query the document directly
- [x] Full `src/components` suite: 881 passing (same handful of pre-existing unrelated failures as before, verified via `git stash`)
- [x] Production build (`react-scripts build`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiAWCuo3gq5Tw9J4HqPc4V)_