### PR TITLE
Fix case editor draft safety and completion tracking

### DIFF
--- a/src/components/CaseEditor.jsx
+++ b/src/components/CaseEditor.jsx
@@ -658,7 +658,11 @@ const SaveStateLabel = styled.strong`
 
 const GENETIC_SOURCE_MODE_ROLE = 'role';
 const GENETIC_SOURCE_MODE_DONOR = 'donor';
-const geneticSourceModeFor = value => (isGeneticSourceDonorCode(value) ? GENETIC_SOURCE_MODE_DONOR : GENETIC_SOURCE_MODE_ROLE);
+const GENETIC_SOURCE_MODE_UNSET = '';
+const geneticSourceModeFor = value => {
+  if (!isFilled(value)) return GENETIC_SOURCE_MODE_UNSET;
+  return isGeneticSourceDonorCode(value) ? GENETIC_SOURCE_MODE_DONOR : GENETIC_SOURCE_MODE_ROLE;
+};
 
 const notaryOptionLabel = notary => {
   const nominative = notary?.name?.uk?.nominative || '';
@@ -903,7 +907,6 @@ const CaseEditor = ({
     setDirty(false);
     setActiveTab('overview');
     setSavedAtLabel('');
-    draftRevision.current = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCaseId]);
 
@@ -964,7 +967,7 @@ const CaseEditor = ({
       artProgram: {
         ...previous.artProgram,
         [modeField]: mode,
-        [field]: mode === GENETIC_SOURCE_MODE_DONOR ? '' : (field === 'oocyteSource' ? 'wife' : 'husband'),
+        [field]: mode === GENETIC_SOURCE_MODE_ROLE ? (field === 'oocyteSource' ? 'wife' : 'husband') : '',
       },
     }));
     markDirty();
@@ -1074,8 +1077,8 @@ const CaseEditor = ({
       })).length > 0;
       const shouldIncludeGeneticSource = hasOtherArtProgramContent
         || Boolean(selectedCase.artProgram)
-        || draft.artProgram.oocyteSourceMode === GENETIC_SOURCE_MODE_DONOR
-        || draft.artProgram.spermSourceMode === GENETIC_SOURCE_MODE_DONOR;
+        || isFilled(draft.artProgram.oocyteSourceMode)
+        || isFilled(draft.artProgram.spermSourceMode);
       if (shouldIncludeGeneticSource) {
         artProgramPayload.oocyteSource = draft.artProgram.oocyteSource;
         artProgramPayload.spermSource = draft.artProgram.spermSource;
@@ -1338,6 +1341,7 @@ const CaseEditor = ({
                         value={draft.artProgram.oocyteSourceMode}
                         onChange={event => updateGeneticSourceMode('oocyteSource', 'oocyteSourceMode', event.target.value)}
                       >
+                        <option value={GENETIC_SOURCE_MODE_UNSET}>Оберіть джерело</option>
                         <option value={GENETIC_SOURCE_MODE_ROLE}>Дружина</option>
                         <option value={GENETIC_SOURCE_MODE_DONOR}>Донор</option>
                       </Select>
@@ -1354,6 +1358,7 @@ const CaseEditor = ({
                         value={draft.artProgram.spermSourceMode}
                         onChange={event => updateGeneticSourceMode('spermSource', 'spermSourceMode', event.target.value)}
                       >
+                        <option value={GENETIC_SOURCE_MODE_UNSET}>Оберіть джерело</option>
                         <option value={GENETIC_SOURCE_MODE_ROLE}>Чоловік</option>
                         <option value={GENETIC_SOURCE_MODE_DONOR}>Донор</option>
                       </Select>

--- a/src/components/CaseEditor.jsx
+++ b/src/components/CaseEditor.jsx
@@ -10,7 +10,7 @@
 // CaseArtProgramEditor/CaseChildbirthTransactionEditor components: every field those used to own a
 // separate Save button for now lives in one unified per-case draft, committed by the single sticky
 // "Зберегти все" bar (spec §4) - a real behavior change, not just a visual one.
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { ref, set, update } from 'firebase/database';
@@ -695,9 +695,9 @@ const buildDraftFromCase = caseRecord => {
     },
     artProgram: {
       medicalIndicationsUk: artProgram.medicalIndications?.uk || '',
-      oocyteSource: oocyteSourceMode === GENETIC_SOURCE_MODE_DONOR ? artProgram.oocyteSource : 'wife',
+      oocyteSource: artProgram.oocyteSource || '',
       oocyteSourceMode,
-      spermSource: spermSourceMode === GENETIC_SOURCE_MODE_DONOR ? artProgram.spermSource : 'husband',
+      spermSource: artProgram.spermSource || '',
       spermSourceMode,
       physicianNameUk: artProgram.medicalTeam?.physician?.name?.uk?.nominative || '',
       embryoShipment: {
@@ -786,16 +786,14 @@ const SECTION_DEFS = [
     key: 'childbirth', tab: 'racs', title: 'Пологи та дитина', meta: 'Дані для реєстрації народження',
     completion: draft => {
       const c = draft.childbirth;
-      const child = c.children[0] || {};
-      const values = [
-        c.maternityHospitalId,
-        c.children.length ? 'x' : '',
+      const values = [c.maternityHospitalId, c.children.length ? 'x' : ''];
+      c.children.forEach(child => values.push(
         child.sex,
         child.birthDate,
         child.birthPlace?.uk,
         child.medicalConclusion?.number,
         child.medicalConclusion?.date,
-      ];
+      ));
       return { filled: values.filter(isFilled).length, total: values.length };
     },
   },
@@ -835,7 +833,13 @@ const sectionCompletion = (key, draft) => SECTION_DEFS.find(section => section.k
 // against the embryo-shipment timeline, then falls back to the first section (in a fixed, logical
 // order) that isn't fully filled yet. --------------------------------------------------------------
 
-const todayIso = () => new Date().toISOString().slice(0, 10);
+const todayIso = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
 
 const buildNextMilestone = draft => {
   const shipment = draft.artProgram.embryoShipment;
@@ -892,12 +896,14 @@ const CaseEditor = ({
   const [saving, setSaving] = useState(false);
   const [savedAtLabel, setSavedAtLabel] = useState('');
   const [picker, setPicker] = useState(null);
+  const draftRevision = useRef(0);
 
   useEffect(() => {
     setDraft(buildDraftFromCase(selectedCase));
     setDirty(false);
     setActiveTab('overview');
     setSavedAtLabel('');
+    draftRevision.current = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCaseId]);
 
@@ -913,7 +919,15 @@ const CaseEditor = ({
     bumpRecentCase(id);
   };
 
-  const markDirty = () => setDirty(true);
+  const handleCreateCase = () => {
+    if (dirty && typeof window !== 'undefined' && !window.confirm('Є незбережені зміни. Створити нову справу без збереження?')) return;
+    onCreateCase();
+  };
+
+  const markDirty = () => {
+    draftRevision.current += 1;
+    setDirty(true);
+  };
 
   const updateRelations = (field, value) => { setDraft(previous => ({ ...previous, relations: { ...previous.relations, [field]: value } })); markDirty(); };
   const updateChildbirth = (field, value) => { setDraft(previous => ({ ...previous, childbirth: { ...previous.childbirth, [field]: value } })); markDirty(); };
@@ -1019,6 +1033,7 @@ const CaseEditor = ({
 
   const handleSaveAll = async () => {
     if (!selectedCase) return;
+    const submittedRevision = draftRevision.current;
     setSaving(true);
     try {
       const cleanedRelations = removeEmptyCaseValues({ ...draft.relations });
@@ -1081,13 +1096,18 @@ const CaseEditor = ({
         medicalServicesAgreement: { date: normalizeIsoDate(draft.documents.medicalServicesAgreement.date) },
       };
       const cleanedDocuments = removeEmptyCaseValues(documentsPayload);
-      const nextDocuments = Object.keys(cleanedDocuments).length ? cleanedDocuments : null;
+      const nextDocuments = { ...(selectedCase.documents || {}) };
+      Object.keys(documentsPayload).forEach(key => {
+        if (cleanedDocuments[key]) nextDocuments[key] = cleanedDocuments[key];
+        else delete nextDocuments[key];
+      });
+      const persistedDocuments = Object.keys(nextDocuments).length ? nextDocuments : null;
 
       const patch = {
         [`${selectedCase.id}/relations`]: cleanedRelations,
         [`${selectedCase.id}/childbirth`]: cleanedChildbirth,
         [`${selectedCase.id}/artProgram`]: nextArtProgram,
-        [`${selectedCase.id}/documents`]: nextDocuments,
+        [`${selectedCase.id}/documents`]: persistedDocuments,
       };
       await update(ref(database, DOCUMENTS_CASES_PATH), patch);
 
@@ -1097,11 +1117,11 @@ const CaseEditor = ({
           if (String(item.id) !== String(selectedCase.id)) return item;
           const next = { ...item, relations: cleanedRelations, childbirth: cleanedChildbirth };
           if (nextArtProgram) next.artProgram = nextArtProgram; else delete next.artProgram;
-          if (nextDocuments) next.documents = nextDocuments; else delete next.documents;
+          if (persistedDocuments) next.documents = persistedDocuments; else delete next.documents;
           return next;
         }),
       }));
-      setDirty(false);
+      if (draftRevision.current === submittedRevision) setDirty(false);
       setSavedAtLabel(new Date().toLocaleTimeString('uk-UA', { hour: '2-digit', minute: '2-digit' }));
       toast.success('Усі зміни збережено.');
     } catch (saveError) {
@@ -1157,7 +1177,7 @@ const CaseEditor = ({
             {buildCaseLabel(catalog, caseRecord) || caseRecord.id}
           </CasePill>
         ))}
-        <NewCasePill type="button" onClick={onCreateCase}>+ Нова справа</NewCasePill>
+        <NewCasePill type="button" onClick={handleCreateCase}>+ Нова справа</NewCasePill>
       </SwitcherRow>
 
       {selectedCase ? (

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -121,6 +121,7 @@ describe('spec: case editor РАЦС tab - childbirth/child data (batch 18 §6, 
     fireEvent.click(screen.getByRole('button', { name: /додати дитину/i }));
 
     expect(screen.getAllByText('Дитина 2').length).toBeGreaterThan(0);
+    expect(screen.getByText('7/12')).toBeInTheDocument();
   });
 
   it('removing a child drops its card', async () => {
@@ -156,6 +157,15 @@ describe('spec: case editor РАЦС tab - childbirth/child data (batch 18 §6, 
   });
 
   it('editing the surrogacy agreement and picking a notary persists them alongside the childbirth data in the same save', async () => {
+    const cases = buildCases();
+    cases['case-1'].documents = {
+      embryoOwnershipStatement: { statementDate: '2026-04-30', notaryId: 'legacy-notary' },
+    };
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => buildParties() };
+      if (path === 'documentsBuilder/cases') return { exists: () => true, val: () => cases };
+      return { exists: () => false, val: () => null };
+    });
     await openCaseOne();
     await screen.findByLabelText('Пологовий будинок');
 
@@ -170,6 +180,7 @@ describe('spec: case editor РАЦС tab - childbirth/child data (batch 18 §6, 
     await waitFor(() => expect(update).toHaveBeenCalledWith('documentsBuilder/cases', expect.objectContaining({
       'case-1/documents': expect.objectContaining({
         surrogacyAgreement: { number: { uk: 'Д-1' }, date: '2026-05-01', notaryId: 'notary-1' },
+        embryoOwnershipStatement: { statementDate: '2026-04-30', notaryId: 'legacy-notary' },
       }),
     })));
   });

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -96,6 +96,24 @@ describe('spec: case editor РАЦС tab - childbirth/child data (batch 18 §6, 
     expect(screen.getByLabelText('Стать')).toHaveValue('female');
   });
 
+  it('requires missing genetic sources to be explicitly selected', async () => {
+    await openCaseOne();
+    fireEvent.click(screen.getByRole('button', { name: 'Програма ДРТ' }));
+
+    const oocyteSource = screen.getByLabelText('Джерело яйцеклітин');
+    const spermSource = screen.getByLabelText('Джерело сперматозоїдів');
+    expect(oocyteSource).toHaveValue('');
+    expect(spermSource).toHaveValue('');
+
+    fireEvent.change(oocyteSource, { target: { value: 'role' } });
+    fireEvent.change(spermSource, { target: { value: 'role' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти все' }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith('documentsBuilder/cases', expect.objectContaining({
+      'case-1/artProgram': expect.objectContaining({ oocyteSource: 'wife', spermSource: 'husband' }),
+    })));
+  });
+
   it('picking a different maternity hospital via the bottom sheet updates the field', async () => {
     const parties = buildParties();
     parties.maternityHospitals['hospital-2'] = { id: 'hospital-2', name: { uk: 'Пологовий будинок №2', en: '' } };


### PR DESCRIPTION
### Motivation
- Prevent accidental data loss when saving a unified per-case draft by preserving existing document records that the draft does not model. 
- Ensure admins cannot silently discard unsaved edits when creating a new case or when edits occur while a save is in flight. 
- Make completion badges and next-milestone logic reflect local calendar dates and all visible child records instead of misleading defaults or UTC-derived days.

### Description
- Merge edited document keys into the existing `selectedCase.documents` before patching Firebase, and write a leaf-level `/documents` patch that preserves unmodeled documents. (`src/components/CaseEditor.jsx`) 
- Route the New Case button through an unsaved-change guard (`handleCreateCase`) so creating a new case prompts when the draft is dirty. (`src/components/CaseEditor.jsx`) 
- Add a `draftRevision` `useRef` counter and only clear `dirty` if the save completed for the same draft revision, so edits made during an in-flight save remain dirty. (`src/components/CaseEditor.jsx`) 
- Compute `todayIso` from local date components, aggregate childbirth completion across every child instead of inspecting only `children[0]`, and stop fabricating genetic-source defaults for completion counts. (`src/components/CaseEditor.jsx`) 
- Add and adjust regression assertions to `src/components/PartiesPage.caseEditor.test.js` to cover multi-child completion totals and preservation of legacy/unmodeled document records.

### Testing
- Ran linting with `npx eslint src/components/CaseEditor.jsx src/components/PartiesPage.caseEditor.test.js`, which passed. 
- Ran the focused test suite with `CI=true npm test -- --watchAll=false --runInBand src/components/PartiesPage.caseEditor.test.js`, which passed (7 tests green). 
- Verified there were no diff/format issues with `git diff --check` prior to committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b17e753788326a0e8ad818c142d90)