### PR TITLE
Batch 29: unify page-header ⋮ positioning, restore clinic-logo variant control, simplify Parties Overview

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -432,6 +432,15 @@ const TopButtons = styled.div`
   justify-content: flex-start;
   align-items: center;
   gap: 10px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--km-card);
+  padding: 6px 0;
+
+  @media (max-width: 768px) {
+    background: ${uiTokens.colors.pageBg};
+  }
 `;
 
 const EditActionButton = styled.button`

--- a/src/components/AdminPageHeader.jsx
+++ b/src/components/AdminPageHeader.jsx
@@ -1,0 +1,38 @@
+// Shared page-header chrome for the UKRCOM admin pages (Documents / Invoice Builder / Parties /
+// Style Editor). Mirrors my-profile's sticky top bar (MyProfile.jsx's StickyHeader + Topbar) so
+// the "⋮" page-switcher (PageNavMenu, always the first item in HeaderActions) stays pinned in the
+// same top-right corner on every page and at every viewport width, instead of each page carrying
+// its own copy of this CSS that can drift out of sync (batch 29 §1).
+import styled from 'styled-components';
+
+export const Header = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--km-bg);
+  padding-top: 12px;
+  margin-top: -12px;
+
+  @media (max-width: 560px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;
+
+export const HeaderActions = styled.div`
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+
+  @media (max-width: 560px) {
+    width: 100%;
+    justify-content: flex-end;
+  }
+`;

--- a/src/components/CaseEditor.jsx
+++ b/src/components/CaseEditor.jsx
@@ -230,6 +230,19 @@ const SectionSubhead = styled.h3`
   }
 `;
 
+// Batch 29 §4: the Overview tab's one always-expanded section (relations) - same look as
+// CollapsibleSection's Section/SectionHead, but never clickable/collapsible, since it's the tab's
+// whole purpose now rather than one accordion item among several.
+const PrimarySection = styled(Section)`
+  border-color: var(--km-accent);
+`;
+
+const PrimarySectionHead = styled(SectionHead)`
+  cursor: default;
+  background: var(--km-accent-light);
+  border-color: var(--km-accent);
+`;
+
 const CollapsibleSection = ({ id, title, meta, completion, open, onToggle, children }) => {
   const badge = completion ? (
     <Badge $complete={completion.filled >= completion.total}>{completion.filled}/{completion.total}</Badge>
@@ -465,39 +478,6 @@ const PrimaryButton = styled.button`
   &:hover:not(:disabled) {
     filter: brightness(1.05);
   }
-`;
-
-// --- Next-milestone reminder card (spec §6) --------------------------------------------------------
-
-const MilestoneCard = styled.div`
-  margin-top: 10px;
-  border: 1px solid var(--km-danger-border);
-  background: var(--km-danger-bg, rgba(179, 82, 63, 0.08));
-  border-radius: 10px;
-  padding: 12px 14px;
-`;
-
-const MilestoneAllDone = styled.div`
-  margin-top: 10px;
-  border: 1px solid var(--km-border);
-  background: var(--km-bg);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 12.5px;
-  color: var(--km-muted);
-`;
-
-const MilestoneTitle = styled.div`
-  font-size: 12.5px;
-  font-weight: 800;
-  color: var(--km-danger);
-`;
-
-const MilestoneMessage = styled.div`
-  margin-top: 4px;
-  font-size: 12px;
-  color: var(--km-text);
-  line-height: 1.4;
 `;
 
 // --- Bottom-sheet picker modal (spec §5) - reused for every "pick from list" interaction on the
@@ -749,8 +729,8 @@ const buildDraftFromCase = caseRecord => {
   };
 };
 
-// --- Per-section required-field configs (spec §2/§7): the single source of truth for both the
-// completion badges and the next-milestone card below, so the two can never disagree. -------------
+// --- Per-section required-field configs (spec §2/§7): the single source of truth for every
+// section's completion badge. -----------------------------------------------------------------
 
 const SECTION_DEFS = [
   {
@@ -833,42 +813,6 @@ const SECTION_DEFS = [
 
 const sectionCompletion = (key, draft) => SECTION_DEFS.find(section => section.key === key)?.completion(draft) || { filled: 0, total: 0 };
 
-// --- Next-milestone reminder logic (spec §6): a real, if small, feature - compares today's date
-// against the embryo-shipment timeline, then falls back to the first section (in a fixed, logical
-// order) that isn't fully filled yet. --------------------------------------------------------------
-
-const todayIso = () => {
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = String(today.getMonth() + 1).padStart(2, '0');
-  const day = String(today.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
-const buildNextMilestone = draft => {
-  const shipment = draft.artProgram.embryoShipment;
-  if (shipment.plannedPeriod.endDate && todayIso() > shipment.plannedPeriod.endDate && !isFilled(shipment.sentDate)) {
-    return {
-      meta: 'Транспортування ембріонів',
-      message: 'Запланований період минув, але дата відправлення не вказана. Заповніть її, щоб справа не виглядала незавершеною.',
-      tab: 'program',
-      sectionKey: 'embryoShipment',
-    };
-  }
-  for (const section of SECTION_DEFS) {
-    const { filled, total } = section.completion(draft);
-    if (filled < total) {
-      return {
-        meta: section.title,
-        message: `У розділі «${section.title}» заповнено ${filled} із ${total} обов'язкових полів.`,
-        tab: section.tab,
-        sectionKey: section.key,
-      };
-    }
-  }
-  return null;
-};
-
 // --- Component ----------------------------------------------------------------------------------
 
 const CaseEditor = ({
@@ -880,12 +824,10 @@ const CaseEditor = ({
 
   const [activeTab, setActiveTab] = useState('overview');
   // Actionable/working sections start open, purely reference-y ones start collapsed (same idea the
-  // reviewed mockup used) - documentsRollup/ratsStatements/otherDocuments/racssClinicLetter are the
-  // ones an admin visits far less often than the working set below.
+  // reviewed mockup used) - ratsStatements/otherDocuments/racssClinicLetter are the ones an admin
+  // visits far less often than the working set below. Overview's own relations section is no
+  // longer part of this - it's always expanded now (batch 29 §4), never collapsible.
   const [openSections, setOpenSections] = useState({
-    relations: true,
-    milestone: true,
-    documentsRollup: false,
     medicalData: true,
     embryoShipment: true,
     transferAttempt: true,
@@ -911,10 +853,6 @@ const CaseEditor = ({
   }, [selectedCaseId]);
 
   const toggleSection = key => setOpenSections(previous => ({ ...previous, [key]: !previous[key] }));
-  const jumpTo = (tab, sectionKey) => {
-    setActiveTab(tab);
-    if (sectionKey) setOpenSections(previous => ({ ...previous, [sectionKey]: true }));
-  };
 
   const handleSelectCase = id => {
     if (dirty && typeof window !== 'undefined' && !window.confirm('Є незбережені зміни. Перейти до іншої справи без збереження?')) return;
@@ -1159,7 +1097,6 @@ const CaseEditor = ({
     );
   }
 
-  const milestone = selectedCase ? buildNextMilestone(draft) : null;
   const documentsRollup = ['surrogacyAgreement', 'ratsStatements', 'otherDocuments']
     .map(key => sectionCompletion(key, draft))
     .reduce((acc, item) => ({ filled: acc.filled + item.filled, total: acc.total + item.total }), { filled: 0, total: 0 });
@@ -1201,14 +1138,23 @@ const CaseEditor = ({
 
           {activeTab === 'overview' ? (
             <div>
-              <CollapsibleSection
-                id="relations"
-                title="Учасники та зв'язки"
-                meta="Пара, клініки, сурогатна мати, представники"
-                completion={sectionCompletion('relations', draft)}
-                open={Boolean(openSections.relations)}
-                onToggle={() => toggleSection('relations')}
-              >
+              {/* Batch 29 §3/§4: the milestone reminder and the documents/RACS rollup cards were
+                  dropped for being low-value - relations is now the tab's whole purpose, so it's
+                  shown directly (no header row a click could hide, no collapse state to track). */}
+              <PrimarySection>
+                <PrimarySectionHead>
+                  <SectionHeadInfo>
+                    <SectionTitle>Учасники та зв'язки</SectionTitle>
+                    <SectionMeta>Пара, клініки, сурогатна мати, представники</SectionMeta>
+                  </SectionHeadInfo>
+                  <HeadRight>
+                    {(() => {
+                      const completion = sectionCompletion('relations', draft);
+                      return <Badge $complete={completion.filled >= completion.total}>{completion.filled}/{completion.total}</Badge>;
+                    })()}
+                  </HeadRight>
+                </PrimarySectionHead>
+                <SectionBody>
                 <RelationGrid>
                   <RelationCard role="group" aria-label="Пара">
                     <RelationCardLabel>Пара</RelationCardLabel>
@@ -1281,40 +1227,8 @@ const CaseEditor = ({
                     </RelationCardButton>
                   </RelationCard>
                 </RelationGrid>
-              </CollapsibleSection>
-
-              <CollapsibleSection
-                id="milestone"
-                title="Найближчий етап"
-                meta={milestone ? milestone.meta : 'Усе актуальне'}
-                open={Boolean(openSections.milestone)}
-                onToggle={() => toggleSection('milestone')}
-              >
-                {milestone ? (
-                  <MilestoneCard>
-                    <MilestoneTitle>Потрібна увага</MilestoneTitle>
-                    <MilestoneMessage>{milestone.message}</MilestoneMessage>
-                    <RowLine style={{ marginTop: 10 }}>
-                      <MiniButton type="button" onClick={() => jumpTo(milestone.tab, milestone.sectionKey)}>Доповнити дані</MiniButton>
-                    </RowLine>
-                  </MilestoneCard>
-                ) : (
-                  <MilestoneAllDone>Усі найближчі кроки виконано.</MilestoneAllDone>
-                )}
-              </CollapsibleSection>
-
-              <CollapsibleSection
-                id="documentsRollup"
-                title="Документи та реєстрація"
-                meta="Договори, заяви, довідки"
-                completion={documentsRollup}
-                open={Boolean(openSections.documentsRollup)}
-                onToggle={() => toggleSection('documentsRollup')}
-              >
-                <RowLine>
-                  <MiniButton type="button" onClick={() => jumpTo('racs')}>Перейти до РАЦС</MiniButton>
-                </RowLine>
-              </CollapsibleSection>
+                </SectionBody>
+              </PrimarySection>
             </div>
           ) : null}
 

--- a/src/components/CaseEditor.jsx
+++ b/src/components/CaseEditor.jsx
@@ -653,17 +653,17 @@ const buildDraftFromCase = caseRecord => {
   const relations = caseRecord?.relations || {};
   const childbirth = caseRecord?.childbirth || {};
   const artProgram = caseRecord?.artProgram || {};
+  const geneticMaterial = artProgram.geneticMaterial || {};
   const shipment = artProgram.embryoShipment || {};
   const transferAttempt = artProgram.transferAttempt || {};
   const documents = caseRecord?.documents || {};
-  const oocyteSourceMode = geneticSourceModeFor(artProgram.oocyteSource);
-  const spermSourceMode = geneticSourceModeFor(artProgram.spermSource);
+  const oocyteSourceMode = geneticSourceModeFor(geneticMaterial.oocyte);
+  const spermSourceMode = geneticSourceModeFor(geneticMaterial.sperm);
 
   return {
     relations: {
       coupleId: relations.coupleId || '',
-      ukrainianClinicId: relations.ukrainianClinicId || '',
-      partnerClinicId: relations.partnerClinicId || '',
+      clinicId: relations.clinicId || '',
       surrogateMotherId: relations.surrogateMotherId || '',
       representativeIds: toArray(relations.representativeIds).map(String),
     },
@@ -679,16 +679,16 @@ const buildDraftFromCase = caseRecord => {
     },
     artProgram: {
       medicalIndicationsUk: artProgram.medicalIndications?.uk || '',
-      oocyteSource: artProgram.oocyteSource || '',
+      oocyteSource: geneticMaterial.oocyte || '',
       oocyteSourceMode,
-      spermSource: artProgram.spermSource || '',
+      spermSource: geneticMaterial.sperm || '',
       spermSourceMode,
       physicianNameUk: artProgram.medicalTeam?.physician?.name?.uk?.nominative || '',
+      ivfDate: artProgram.ivf?.date || '',
       embryoShipment: {
-        ivfDate: shipment.ivfDate || '',
-        plannedPeriod: { startDate: shipment.plannedPeriod?.startDate || '', endDate: shipment.plannedPeriod?.endDate || '' },
-        sentDate: shipment.sentDate || '',
+        plannedPeriod: { start: shipment.plannedPeriod?.start || '', end: shipment.plannedPeriod?.end || '' },
         receivedDate: shipment.receivedDate || '',
+        sourceClinicId: shipment.sourceClinicId || '',
       },
       transferAttempt: {
         date: transferAttempt.date || '',
@@ -734,9 +734,9 @@ const buildDraftFromCase = caseRecord => {
 
 const SECTION_DEFS = [
   {
-    key: 'relations', tab: 'overview', title: 'Учасники та зв’язки', meta: 'Пара, клініки, сурогатна мати, представники',
+    key: 'relations', tab: 'overview', title: 'Учасники та зв’язки', meta: 'Пара, клініка, сурогатна мати, представники',
     completion: draft => {
-      const core = ['coupleId', 'ukrainianClinicId', 'surrogateMotherId'].filter(path => isFilled(getValueByPath(draft.relations, path))).length;
+      const core = ['coupleId', 'clinicId', 'surrogateMotherId'].filter(path => isFilled(getValueByPath(draft.relations, path))).length;
       const rep = draft.relations.representativeIds.length > 0 ? 1 : 0;
       return { filled: core + rep, total: 4 };
     },
@@ -753,7 +753,7 @@ const SECTION_DEFS = [
     key: 'embryoShipment', tab: 'program', title: 'Транспортування ембріонів', meta: 'Ключові дати логістики',
     completion: draft => {
       const s = draft.artProgram.embryoShipment;
-      const values = [s.ivfDate, s.plannedPeriod.startDate, s.plannedPeriod.endDate, s.sentDate, s.receivedDate];
+      const values = [draft.artProgram.ivfDate, s.plannedPeriod.start, s.plannedPeriod.end, s.receivedDate, s.sourceClinicId];
       return { filled: values.filter(isFilled).length, total: values.length };
     },
   },
@@ -946,7 +946,6 @@ const CaseEditor = ({
   const DISPLAY_NAME_BY_COLLECTION = {
     couples: coupleDisplayName,
     clinics: partyDisplayName,
-    partnerClinics: partyDisplayName,
     surrogateMothers: partyDisplayName,
     representatives: partyDisplayName,
     maternityHospitals: maternityDisplayName,
@@ -994,22 +993,23 @@ const CaseEditor = ({
       const artProgramPayload = {
         medicalIndications: { uk: draft.artProgram.medicalIndicationsUk },
         medicalTeam: { physician: { name: { uk: { nominative: draft.artProgram.physicianNameUk } } } },
+        ivf: { date: normalizeIsoDate(draft.artProgram.ivfDate) },
         embryoShipment: {
-          ivfDate: normalizeIsoDate(shipmentDraft.ivfDate),
-          plannedPeriod: { startDate: normalizeIsoDate(shipmentDraft.plannedPeriod.startDate), endDate: normalizeIsoDate(shipmentDraft.plannedPeriod.endDate) },
-          sentDate: normalizeIsoDate(shipmentDraft.sentDate),
+          plannedPeriod: { start: normalizeIsoDate(shipmentDraft.plannedPeriod.start), end: normalizeIsoDate(shipmentDraft.plannedPeriod.end) },
           receivedDate: normalizeIsoDate(shipmentDraft.receivedDate),
+          sourceClinicId: shipmentDraft.sourceClinicId,
         },
         transferAttempt: { date: normalizeIsoDate(transferDraft.date), embryoCount: parseNumberOrBlank(transferDraft.embryoCount), embryoStage: transferDraft.embryoStage, hcgTest, ultrasound },
       };
       // The genetic-source mode selector never offers a blank option (it always displays
       // Дружина/Чоловік or Донор) - saving it unconditionally would fabricate
-      // oocyteSource/spermSource on every single-save, even for a case whose ART Program tab was
-      // never touched. Only include it once there's other real ART-program content, the case
+      // geneticMaterial.oocyte/sperm on every single-save, even for a case whose ART Program tab
+      // was never touched. Only include it once there's other real ART-program content, the case
       // already had one, or the admin actively chose the donor option.
       const hasOtherArtProgramContent = Object.keys(removeEmptyCaseValues({
         medicalIndications: artProgramPayload.medicalIndications,
         medicalTeam: artProgramPayload.medicalTeam,
+        ivf: artProgramPayload.ivf,
         embryoShipment: artProgramPayload.embryoShipment,
         transferAttempt: artProgramPayload.transferAttempt,
       })).length > 0;
@@ -1018,8 +1018,7 @@ const CaseEditor = ({
         || isFilled(draft.artProgram.oocyteSourceMode)
         || isFilled(draft.artProgram.spermSourceMode);
       if (shouldIncludeGeneticSource) {
-        artProgramPayload.oocyteSource = draft.artProgram.oocyteSource;
-        artProgramPayload.spermSource = draft.artProgram.spermSource;
+        artProgramPayload.geneticMaterial = { oocyte: draft.artProgram.oocyteSource, sperm: draft.artProgram.spermSource };
       }
       const cleanedArtProgram = removeEmptyCaseValues(artProgramPayload);
       const nextArtProgram = Object.keys(cleanedArtProgram).length ? cleanedArtProgram : null;
@@ -1173,26 +1172,12 @@ const CaseEditor = ({
                   <RelationCard role="group" aria-label="Клініка">
                     <RelationCardLabel>Клініка</RelationCardLabel>
                     <RelationCardValue>{(() => {
-                      const clinic = catalog.parties.clinics.find(item => String(item.id) === String(draft.relations.ukrainianClinicId));
+                      const clinic = catalog.parties.clinics.find(item => String(item.id) === String(draft.relations.clinicId));
                       return clinic ? partyDisplayName(clinic) : '— не обрано —';
                     })()}
                     </RelationCardValue>
                     <RelationCardButton type="button" onClick={() => openPicker({
-                      title: 'Оберіть клініку', collection: 'clinics', valueId: draft.relations.ukrainianClinicId, onApply: id => updateRelations('ukrainianClinicId', id),
-                    })}
-                    >
-                      Змінити
-                    </RelationCardButton>
-                  </RelationCard>
-                  <RelationCard role="group" aria-label="Партнерська клініка">
-                    <RelationCardLabel>Партнерська клініка</RelationCardLabel>
-                    <RelationCardValue>{(() => {
-                      const partnerClinic = catalog.parties.partnerClinics.find(item => String(item.id) === String(draft.relations.partnerClinicId));
-                      return partnerClinic ? partyDisplayName(partnerClinic) : '— не обрано —';
-                    })()}
-                    </RelationCardValue>
-                    <RelationCardButton type="button" onClick={() => openPicker({
-                      title: 'Оберіть партнерську клініку', collection: 'partnerClinics', valueId: draft.relations.partnerClinicId, onApply: id => updateRelations('partnerClinicId', id),
+                      title: 'Оберіть клініку', collection: 'clinics', valueId: draft.relations.clinicId, onApply: id => updateRelations('clinicId', id),
                     })}
                     >
                       Змінити
@@ -1299,23 +1284,36 @@ const CaseEditor = ({
                 <FieldGrid>
                   <Field>
                     Дата ЗІВ
-                    <FieldInput type="date" value={draft.artProgram.embryoShipment.ivfDate} onChange={event => updateShipmentField('ivfDate', event.target.value)} />
+                    <FieldInput type="date" value={draft.artProgram.ivfDate} onChange={event => updateArtField('ivfDate', event.target.value)} />
                   </Field>
                   <Field>
                     Запланований період — початок
-                    <FieldInput type="date" value={draft.artProgram.embryoShipment.plannedPeriod.startDate} onChange={event => updateShipmentPeriodField('startDate', event.target.value)} />
+                    <FieldInput type="date" value={draft.artProgram.embryoShipment.plannedPeriod.start} onChange={event => updateShipmentPeriodField('start', event.target.value)} />
                   </Field>
                   <Field>
                     Запланований період — кінець
-                    <FieldInput type="date" value={draft.artProgram.embryoShipment.plannedPeriod.endDate} onChange={event => updateShipmentPeriodField('endDate', event.target.value)} />
-                  </Field>
-                  <Field>
-                    Дата відправлення
-                    <FieldInput type="date" value={draft.artProgram.embryoShipment.sentDate} onChange={event => updateShipmentField('sentDate', event.target.value)} />
+                    <FieldInput type="date" value={draft.artProgram.embryoShipment.plannedPeriod.end} onChange={event => updateShipmentPeriodField('end', event.target.value)} />
                   </Field>
                   <Field>
                     Дата фактичного отримання
                     <FieldInput type="date" value={draft.artProgram.embryoShipment.receivedDate} onChange={event => updateShipmentField('receivedDate', event.target.value)} />
+                  </Field>
+                  <Field>
+                    Клініка-відправник
+                    <PickerFieldButton
+                      type="button"
+                      onClick={() => openPicker({
+                        title: 'Оберіть клініку-відправника', collection: 'clinics', valueId: draft.artProgram.embryoShipment.sourceClinicId, onApply: id => updateShipmentField('sourceClinicId', id),
+                      })}
+                    >
+                      <PickerFieldValue $empty={!draft.artProgram.embryoShipment.sourceClinicId}>
+                        {(() => {
+                          const sourceClinic = catalog.parties.clinics.find(item => String(item.id) === String(draft.artProgram.embryoShipment.sourceClinicId));
+                          return sourceClinic ? partyDisplayName(sourceClinic) : '— не обрано —';
+                        })()}
+                      </PickerFieldValue>
+                      <span>›</span>
+                    </PickerFieldButton>
                   </Field>
                 </FieldGrid>
               </CollapsibleSection>

--- a/src/components/DocumentStyleEditorPage.jsx
+++ b/src/components/DocumentStyleEditorPage.jsx
@@ -22,6 +22,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
+import { Header, HeaderActions } from './AdminPageHeader';
 import DocumentsPdfPreview from './DocumentsPdfPreview';
 import {
   DEFAULT_DOC_FORMATTING,
@@ -71,19 +72,6 @@ const Shell = styled.div`
   margin: 0 auto;
 `;
 
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-
-  @media (max-width: 560px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
 const Eyebrow = styled.div`
   color: var(--km-accent);
   font-size: 10.5px;
@@ -101,18 +89,6 @@ const Title = styled.h1`
   letter-spacing: -0.02em;
 `;
 
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-
-  @media (max-width: 560px) {
-    width: 100%;
-    justify-content: flex-start;
-  }
-`;
 
 const StateCard = styled.div`
   padding: 20px;

--- a/src/components/DocumentsPage.checklistScope.test.js
+++ b/src/components/DocumentsPage.checklistScope.test.js
@@ -110,7 +110,7 @@ describe('spec: completeness checklist is scoped to the checked documents', () =
     await checkDocumentByTitle('Договір');
 
     const warning = await screen.findByText(/Незаповнені обов'язкові поля/);
-    expect(warning.textContent).toContain('case.relations.ukrainianClinicId');
+    expect(warning.textContent).toContain('case.relations.clinicId');
     expect(warning.textContent).not.toContain('case.childbirth.children');
     expect(warning.textContent).not.toContain('case.relations.surrogateMotherId');
   });

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1862,7 +1862,7 @@ const DocumentsPage = ({ isAdmin }) => {
           return;
         }
 
-        const clinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
+        const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
         if (!clinicId) {
           toast.error('Select a case with a clinic before uploading the logo.');
           return;
@@ -1930,7 +1930,7 @@ const DocumentsPage = ({ isAdmin }) => {
   };
 
   const handleAssignLogoLayout = async (fileName, layoutTag) => {
-    const clinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
+    const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
     if (!clinicId) return;
     const previousVariants = clinicLogos;
     const nextVariants = applyLogoLayoutAssignment(previousVariants, fileName, layoutTag);
@@ -1946,7 +1946,7 @@ const DocumentsPage = ({ isAdmin }) => {
 
   const handleRemoveLogoVariant = async fileName => {
     if (typeof window !== 'undefined' && !window.confirm('Remove this clinic logo variant from the backend?')) return;
-    const clinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
+    const clinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
     if (!clinicId) return;
     // A variant loaded via the legacy Storage-folder fallback still physically lives there.
     const isLegacyVariant = Boolean(clinicLogos.find(variant => variant.fileName === fileName)?.legacyFolder);
@@ -2090,7 +2090,7 @@ const DocumentsPage = ({ isAdmin }) => {
   // that data at all.
   const CHECKLIST_ISSUE_DOMAINS = {
     'case.relations.coupleId': ['wife', 'husband', 'couple'],
-    'case.relations.ukrainianClinicId': ['clinic'],
+    'case.relations.clinicId': ['clinic'],
     'case.relations.surrogateMotherId': ['surrogateMother'],
     'case.childbirth.children': ['child', 'children', 'medicalConclusion', 'birthRegistration', 'case.childbirth', 'case.documents.birthRegistrationConsent'],
   };
@@ -2136,14 +2136,14 @@ const DocumentsPage = ({ isAdmin }) => {
   const unresolvedVariables = [...new Set(selectedTemplateContexts.flatMap(({ template, context }) => (
     context ? validateDocumentTemplate(template, context) : []
   )))].sort();
-  // A case with no partnerClinicId set (old cases, or one just cleared - spec §3) resolves
-  // caseContext.partnerClinic to null, so every {{partnerClinic.*}} token in a selected template
-  // shows up in unresolvedVariables like any other missing field - technically correct (never a
-  // leaked {{token}}, never a crash) but "partnerClinic.name.uk, partnerClinic.address.uk, ..." is
-  // not a useful message on its own. Surface the actual cause instead, once, and drop the
+  // A case with no shipment sourceClinicId set (old cases, or one just cleared - spec §3/§4)
+  // resolves caseContext.sourceClinic to null, so every {{sourceClinic.*}} token in a selected
+  // template shows up in unresolvedVariables like any other missing field - technically correct
+  // (never a leaked {{token}}, never a crash) but "sourceClinic.name.uk, sourceClinic.address.uk,
+  // ..." is not a useful message on its own. Surface the actual cause instead, once, and drop the
   // redundant per-field paths from the generic list.
-  const missingPartnerClinic = Boolean(caseContext) && !caseContext.partnerClinic
-    && unresolvedVariables.some(path => path.startsWith('partnerClinic.'));
+  const missingSourceClinic = Boolean(caseContext) && !caseContext.sourceClinic
+    && unresolvedVariables.some(path => path.startsWith('sourceClinic.'));
   // Same idea for the notary (spec §8): a document that references {{notary...}} but whose own
   // notaryId isn't set (or points at a deleted notary) never crashes - it just surfaces one clear
   // message instead of a wall of unresolved notary.* paths.
@@ -2152,7 +2152,7 @@ const DocumentsPage = ({ isAdmin }) => {
     && getTemplateReferencedPaths(template).some(path => path === 'notary' || path.startsWith('notary.'))
   ));
   const visibleUnresolvedVariables = unresolvedVariables.filter(path => {
-    if (missingPartnerClinic && path.startsWith('partnerClinic.')) return false;
+    if (missingSourceClinic && path.startsWith('sourceClinic.')) return false;
     if (missingNotary && (path === 'notary' || path.startsWith('notary.'))) return false;
     return true;
   });
@@ -2161,7 +2161,7 @@ const DocumentsPage = ({ isAdmin }) => {
   // The selected case's clinicId maps directly to the Storage logo folder. Storage is the
   // source of truth here, so logos uploaded through the app or Firebase Console are discovered
   // without relying on a Realtime Database filename mirror.
-  const logoClinicId = selectedCase?.relations?.ukrainianClinicId ? String(selectedCase.relations.ukrainianClinicId) : '';
+  const logoClinicId = selectedCase?.relations?.clinicId ? String(selectedCase.relations.clinicId) : '';
   const clinicLogoStorageKey = `${logoClinicId}:${clinicLogoRefreshKey}`;
 
   // Fetch every stored logo variant of the selected clinic from Storage; the dimensions are what
@@ -2284,8 +2284,8 @@ const DocumentsPage = ({ isAdmin }) => {
   const confirmUnresolvedVariables = () => {
     if (typeof window === 'undefined') return true;
     const sections = [];
-    if (missingPartnerClinic) {
-      sections.push('Для цього документа не вибрана клініка-партнер.');
+    if (missingSourceClinic) {
+      sections.push('Для цього документа не вибрана клініка-відправник.');
     }
     if (missingNotary) {
       sections.push('Для цього документа не вибрано нотаріуса.');
@@ -2503,9 +2503,9 @@ const DocumentsPage = ({ isAdmin }) => {
                   />
                 </DocLogoPreviewRow>
               ) : null}
-              {missingPartnerClinic ? (
+              {missingSourceClinic ? (
                 <DocSubtitle style={{ marginTop: 8, color: 'var(--km-danger)' }}>
-                  Для цього документа не вибрана клініка-партнер.
+                  Для цього документа не вибрана клініка-відправник.
                 </DocSubtitle>
               ) : null}
               {missingNotary ? (

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -18,6 +18,7 @@ import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFo
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
+import { Header, HeaderActions } from './AdminPageHeader';
 import VariablePickerModal from './DocumentsVariablePickerModal';
 import DocumentsPdfPreview from './DocumentsPdfPreview';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -108,6 +109,14 @@ const LOGO_LAYOUT_OPTIONS = [
   { tag: '2col', label: '{{logo-long}}', title: 'Use this variant for the {{logo-long}} token - one shared full-width logo' },
 ];
 
+// Which token a letterhead block's own image column draws (batch 29 §2) - distinct from
+// LOGO_LAYOUT_OPTIONS above, which assigns an uploaded logo *file* to a layout tag, not which
+// token a specific document's block uses.
+const LOGO_VARIANT_TOKENS = [
+  { token: 'logo', label: '{{logo}}' },
+  { token: 'logo-long', label: '{{logo-long}}' },
+];
+
 // Mobile admins can't easily reach the browser devtools console, so every Storage failure below
 // is folded into the on-screen message with the real Firebase/network error code - "see the
 // browser console" alone leaves them stuck with no way to report what actually went wrong.
@@ -143,19 +152,6 @@ const Shell = styled.div`
   margin: 0 auto;
 `;
 
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-
-  @media (max-width: 560px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
 const Eyebrow = styled.div`
   color: var(--km-accent);
   font-size: 10.5px;
@@ -171,19 +167,6 @@ const Title = styled.h1`
   font-size: clamp(20px, 4vw, 27px);
   line-height: 1.05;
   letter-spacing: -0.02em;
-`;
-
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-
-  @media (max-width: 560px) {
-    width: 100%;
-    justify-content: flex-start;
-  }
 `;
 
 const MiniButton = styled.button`
@@ -1714,6 +1697,14 @@ const DocumentsPage = ({ isAdmin }) => {
 
   const handleToggleLayoutV2LogoHidden = (docId, blockIndex, columnIndex) => applyLayoutV2ImageContentChange(
     docId, blockIndex, columnIndex, content => ({ ...content, hidden: !content.hidden }),
+  );
+
+  // Which clinic-logo token this column draws (batch 29 §2: the settings popover only exposed
+  // show/hide + offsets, with no way to switch {{logo}} <-> {{logo-long}} short of pasting raw
+  // JSON) - source stays the token itself (never a resolved data URL), same convention as
+  // normalizeLayoutV2Content/LOGO_TOKEN_PATTERN.
+  const setLayoutV2LogoVariant = (docId, blockIndex, columnIndex, token) => applyLayoutV2ImageContentChange(
+    docId, blockIndex, columnIndex, content => ({ ...content, source: `{{${token}}}` }),
   );
 
   const setLayoutV2LogoOffset = (docId, blockIndex, columnIndex, axisKey, raw) => {
@@ -3279,6 +3270,22 @@ const DocumentsPage = ({ isAdmin }) => {
                                               />
                                               Show logo
                                             </CheckLine>
+                                            <Field>
+                                              Variant
+                                              <ToggleGroup>
+                                                {LOGO_VARIANT_TOKENS.map(({ token, label }) => (
+                                                  <ToggleOption
+                                                    key={token}
+                                                    type="button"
+                                                    $active={String(content.source || '').trim() === `{{${token}}}`}
+                                                    onClick={() => setLayoutV2LogoVariant(template.id, blockIndex, columnIndex, token)}
+                                                    title={`Use the ${label} token for this logo`}
+                                                  >
+                                                    {label}
+                                                  </ToggleOption>
+                                                ))}
+                                              </ToggleGroup>
+                                            </Field>
                                             <PlainNumberField
                                               label="Horizontal offset (mm, + = right)"
                                               initialValue={content.offsetXMm !== undefined ? String(content.offsetXMm) : ''}

--- a/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
+++ b/src/components/DocumentsPage.layoutV2ParagraphBold.test.js
@@ -296,6 +296,57 @@ describe('spec: layoutV2 paragraph blocks get the full paragraph toolbar', () =>
     ));
   });
 
+  it('switches the letterhead logo between the {{logo}} and {{logo-long}} tokens from the same settings popover', async () => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'doc-1': {
+              id: 'doc-1',
+              catalogName: 'Genetic affinity certificate',
+              rendererVersion: 2,
+              languages: ['uk'],
+              layoutV2: {
+                blocks: [{
+                  type: 'letterhead',
+                  columnGapMm: 5,
+                  columns: [
+                    { widthMm: 64.4, content: { type: 'image', source: '{{logo}}', widthMm: 64.4, heightMm: 17 } },
+                    { widthMm: 110.6, content: { type: 'stack', lines: ['contact'] } },
+                  ],
+                }],
+              },
+            },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+    fireEvent.click(await screen.findByTitle('Clinic logo - show/hide and offset (mm)'));
+
+    fireEvent.click(await screen.findByTitle('Use the {{logo-long}} token for this logo'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [expect.objectContaining({
+            columns: [
+              expect.objectContaining({ widthMm: 64.4, content: expect.objectContaining({ source: '{{logo-long}}' }) }),
+              expect.objectContaining({ widthMm: 110.6 }),
+            ],
+          })],
+        }),
+      }),
+    ));
+  });
+
   it('does not show the layoutV2 paragraph section for a legacy (non-layoutV2) template', async () => {
     get.mockImplementation(async path => {
       if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -24,6 +24,7 @@ import { formatEuroSmart, getItemDisplayAmount, getSortedPackages, isFromPricedI
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
+import { Header, HeaderActions } from './AdminPageHeader';
 import {
   addCatalogChildToPackage,
   addCustomChildToPackage,
@@ -156,19 +157,6 @@ const Shell = styled.div`
   margin: 0 auto;
 `;
 
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-
-  @media (max-width: 560px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
 const Eyebrow = styled.div`
   color: var(--km-accent);
   font-size: 10.5px;
@@ -186,18 +174,6 @@ const Title = styled.h1`
   letter-spacing: -0.02em;
 `;
 
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-
-  @media (max-width: 560px) {
-    width: 100%;
-    justify-content: flex-start;
-  }
-`;
 
 const MiniButton = styled.button`
   border: 1px solid var(--km-border);

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -110,7 +110,7 @@ describe('spec: case editor РАЦС tab - childbirth/child data (batch 18 §6, 
     fireEvent.click(screen.getByRole('button', { name: 'Зберегти все' }));
 
     await waitFor(() => expect(update).toHaveBeenCalledWith('documentsBuilder/cases', expect.objectContaining({
-      'case-1/artProgram': expect.objectContaining({ oocyteSource: 'wife', spermSource: 'husband' }),
+      'case-1/artProgram': expect.objectContaining({ geneticMaterial: { oocyte: 'wife', sperm: 'husband' } }),
     })));
   });
 

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -26,7 +26,6 @@ import {
   coupleDisplayName,
   createEmptyCase,
   createEmptyClinic,
-  createEmptyPartnerClinic,
   createEmptyCouple,
   createEmptyMaternityHospital,
   createEmptyNotary,
@@ -471,6 +470,14 @@ const CLINIC_FIELDS = [
   { label: 'Name (uk, genitive)', path: 'name.uk.genitive' },
   { label: 'Name (uk, accusative "у ...")', path: 'name.uk.accusative' },
   { label: 'Name (en)', path: 'name.en' },
+  // v6 (spec §1): every clinic - Ukrainian or foreign - lives in this one collection now, so a
+  // foreign clinic (e.g. an embryo shipment's own source clinic) needs its country here too - blank
+  // and unused by a Ukrainian clinic, same as legalName/edrpou/bank/license/medicalDirector below
+  // are blank and unused by a foreign one.
+  { label: 'Country code', path: 'country.code' },
+  { label: 'Country (uk, nominative)', path: 'country.uk.nominative' },
+  { label: 'Country (uk, genitive "з ...")', path: 'country.uk.genitive' },
+  { label: 'Country (en)', path: 'country.en' },
   { label: 'Legal name (uk, nominative)', path: 'legalName.uk.nominative' },
   { label: 'Legal name (en)', path: 'legalName.en' },
   { label: 'Medical center name (uk, nominative)', path: 'medicalCenterName.uk.nominative' },
@@ -499,24 +506,6 @@ const CLINIC_FIELDS = [
   { label: 'Director authority type (en)', path: 'medicalDirector.authority.type.en' },
   { label: 'Director authority number', path: 'medicalDirector.authority.number' },
   { label: 'Director authority date', path: 'medicalDirector.authority.date', type: 'date' },
-];
-
-// A partner clinic is deliberately a simplified party type (spec §5): just the two bilingual
-// fields a static document needs to name and address it by - never the Ukrainian clinic's
-// EDRPOU/license/director/bank/logo fields, which don't apply to a clinic that never signs
-// anything itself.
-const PARTNER_CLINIC_FIELDS = [
-  // Every template reads these grammatical forms straight off name.uk/country.uk (e.g.
-  // {{partnerClinic.name.uk.genitive}}, {{partnerClinic.country.uk.genitive}} "з клініки «Оті Юме»,
-  // Японії") - genitive is optional, blank until an admin fills it in.
-  { label: 'Name (uk, nominative)', path: 'name.uk.nominative' },
-  { label: 'Name (uk, genitive "з ...")', path: 'name.uk.genitive' },
-  { label: 'Name (en)', path: 'name.en' },
-  { label: 'Country (uk, nominative)', path: 'country.uk.nominative' },
-  { label: 'Country (uk, genitive "з ...")', path: 'country.uk.genitive' },
-  { label: 'Country (en)', path: 'country.en' },
-  { label: 'Address (uk)', path: 'address.uk' },
-  { label: 'Address (en)', path: 'address.en' },
 ];
 
 // `shortName` is never stored (spec §6) - the maternity hospital's display name is always its
@@ -934,7 +923,7 @@ const CaseReadView = ({ catalog, selectedCaseId, onSelectCase, onCreateCase }) =
 // --- Page ---------------------------------------------------------------------------------------
 
 const EMPTY_RECENT_IDS = {
-  couples: [], clinics: [], partnerClinics: [], surrogateMothers: [], representatives: [], notaries: [], maternityHospitals: [],
+  couples: [], clinics: [], surrogateMothers: [], representatives: [], notaries: [], maternityHospitals: [],
 };
 
 // Same view/edit pattern as the Budget page (spec batch 21 §10): read mode is the default, an
@@ -991,7 +980,6 @@ const PartiesPage = ({ isAdmin }) => {
       setRecentIds({
         couples: toArray(rawRecentIds?.couples),
         clinics: toArray(rawRecentIds?.clinics),
-        partnerClinics: toArray(rawRecentIds?.partnerClinics),
         surrogateMothers: toArray(rawRecentIds?.surrogateMothers),
         representatives: toArray(rawRecentIds?.representatives),
         notaries: toArray(rawRecentIds?.notaries),
@@ -1183,20 +1171,6 @@ const PartiesPage = ({ isAdmin }) => {
               toggleRecord={toggleRecord}
               groupOpen={Boolean(openGroups.clinics)}
               onToggleGroup={() => toggleGroup('clinics')}
-            />
-            <SimplePartyGroup
-              title="Partner clinics"
-              collection="partnerClinics"
-              records={catalog.parties.partnerClinics}
-              fieldDefs={PARTNER_CLINIC_FIELDS}
-              displayName={partyDisplayName}
-              createEmpty={createEmptyPartnerClinic}
-              catalog={catalog}
-              setCatalog={setCatalog}
-              expandedKeys={expandedKeys}
-              toggleRecord={toggleRecord}
-              groupOpen={Boolean(openGroups.partnerClinics)}
-              onToggleGroup={() => toggleGroup('partnerClinics')}
             />
             <SimplePartyGroup
               title="Maternity hospitals"

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -13,6 +13,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
+import { Header, HeaderActions } from './AdminPageHeader';
 import CaseEditor from './CaseEditor';
 import {
   DOCUMENTS_CASES_PATH,
@@ -81,19 +82,6 @@ const Shell = styled.div`
   margin: 0 auto;
 `;
 
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-
-  @media (max-width: 560px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
 const Eyebrow = styled.div`
   color: var(--km-accent);
   font-size: 10.5px;
@@ -111,18 +99,6 @@ const Title = styled.h1`
   letter-spacing: -0.02em;
 `;
 
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-
-  @media (max-width: 560px) {
-    width: 100%;
-    justify-content: flex-start;
-  }
-`;
 
 const MiniButton = styled.button`
   border: 1px solid var(--km-border);

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -52,7 +52,7 @@ const buildParties = () => ({
 const buildCases = () => ({
   'case-1': {
     id: 'case-1',
-    relations: { coupleId: 'couple-1', ukrainianClinicId: '', surrogateMotherId: '', representativeIds: [] },
+    relations: { coupleId: 'couple-1', clinicId: '', surrogateMotherId: '', representativeIds: [] },
     childbirth: { maternityHospitalId: '', children: [] },
   },
 });
@@ -180,7 +180,7 @@ describe('spec: Parties page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Зберегти все' }));
 
     await waitFor(() => expect(update).toHaveBeenCalledWith('documentsBuilder/cases', expect.objectContaining({
-      'case-1/relations': expect.objectContaining({ ukrainianClinicId: 'clinic-1' }),
+      'case-1/relations': expect.objectContaining({ clinicId: 'clinic-1' }),
     })));
   });
 

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -1,8 +1,9 @@
-// Unit + integration tests for the ART program (case.artProgram) support: v5 resolvers/formatters,
-// the singleton embryoShipment/transferAttempt/hcgTest/ultrasound model, the scalar oocyteSource/
-// spermSource genetic-material fields, the v5 migration boundary (migrateCaseToV5/migrateCasesToV5),
-// and the four document contexts that reference artProgram (embryoOwnershipStatement,
-// geneticAffinityCertificate, racssClinicLetter, medicalServicesAgreement).
+// Unit + integration tests for the ART program (case.artProgram) support: v6 resolvers/formatters,
+// the singleton embryoShipment/transferAttempt/hcgTest/ultrasound/ivf model, the flat
+// geneticMaterial.oocyte/sperm genetic-material fields, the v6 migration boundary
+// (migrateCaseToV6/migrateCasesToV6), and the four document contexts that reference artProgram
+// (embryoOwnershipStatement, geneticAffinityCertificate, racssClinicLetter,
+// medicalServicesAgreement).
 //
 // All fixtures below are fictional - tests must never carry real client data (same rule as
 // documentsCatalogUtils.test.js).
@@ -21,6 +22,7 @@ import {
   deepMergeRecords,
   enrichCoupleMarriage,
   enrichHcgTestForTemplate,
+  enrichIvfForTemplate,
   enrichShipment,
   enrichShipmentForTemplate,
   enrichTransferForTemplate,
@@ -33,18 +35,17 @@ import {
   formatGestationalAgeText,
   formatPregnancyTypeTextUk,
   formatShipmentPeriod,
-  isDocumentsSchemaV5,
+  isDocumentsSchemaV6,
   isGeneticSourceDonorCode,
   mergeDocumentsCatalog,
-  migrateCaseToV5,
-  migrateCasesToV5,
+  migrateCaseToV6,
+  migrateCasesToV6,
   normalizeCaseRecord,
   normalizeDocumentsCatalog,
   normalizeDocumentsSettings,
   parseDocumentsTechnicalInput,
   resolveCaseContext,
   resolveEmbryoStageLabel,
-  resolveGeneticSourceLabel,
   resolveHcgTest,
   resolveShipment,
   resolveTransferAttempt,
@@ -55,8 +56,10 @@ import {
 
 // --- Fixtures ------------------------------------------------------------------------------
 
-const partnerClinic = {
-  id: 'partner-clinic-fixture',
+// The clinic embryos ship from - v6 (spec §1): lives in the same unified `parties.clinics`
+// collection as every other clinic, never a separate `partnerClinics` one.
+const sourceClinic = {
+  id: 'source-clinic-fixture',
   name: { uk: 'Клініка Тестова', en: 'Test Clinic' },
   country: { uk: 'Японія', en: 'Japan' },
   address: { uk: 'Адреса', en: 'Address' },
@@ -77,32 +80,32 @@ const couple = {
 };
 
 const rawParties = {
-  clinics: { [clinic.id]: clinic },
-  partnerClinics: { [partnerClinic.id]: partnerClinic },
+  clinics: { [clinic.id]: clinic, [sourceClinic.id]: sourceClinic },
   couples: { [couple.id]: couple },
 };
 
-// enrichShipment (and everything built on it) reads the case's own resolved clinic/partnerClinic
-// (spec v5 §1.2/§1.4: a shipment carries no clinic ids of its own) - the same `{ clinic, partnerClinic }`
-// pair resolveCaseContext always resolves from the case's relations and passes in.
+// enrichShipment (and everything built on it) reads the case's own resolved clinic/sourceClinic
+// (spec v6 §3/§4: the shipment carries its own sourceClinicId, resolved from the unified
+// parties.clinics - the destination clinic is always the case's own relations.clinicId) - the
+// same `{ clinic, sourceClinic }` pair resolveCaseContext always resolves and passes in.
 const parties = normalizeDocumentsCatalog(rawParties, {}, {}).parties;
-const resolvedClinics = { clinic, partnerClinic };
+const resolvedClinics = { clinic, sourceClinic };
 
-// A case using the v5 shape throughout (spec §1.3): the one embryo shipment lives at
-// `artProgram.embryoShipment` (no id, no clinic ids of its own - those are the case's own
-// relations), the one transfer attempt at `artProgram.transferAttempt`, its hCG test/ultrasound
+// A case using the v6 shape throughout (spec §1-§7): the one embryo shipment lives at
+// `artProgram.embryoShipment` (no id, but its own sourceClinicId), the standalone `artProgram.ivf`
+// singleton, the one transfer attempt at `artProgram.transferAttempt`, its hCG test/ultrasound
 // nested directly as singletons (no id, no map, existence alone means positive/confirmed).
 const caseWithDateRangePeriod = {
   id: 'case-daterange',
-  relations: { coupleId: couple.id, ukrainianClinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  relations: { coupleId: couple.id, clinicId: clinic.id },
   artProgram: {
     medicalIndications: { uk: 'Тестовий діагноз' },
-    oocyteSource: 'wife',
-    spermSource: 'husband',
+    geneticMaterial: { oocyte: 'wife', sperm: 'husband' },
     medicalTeam: { physician: { name: { uk: { nominative: 'Тестова Лікарка Лікарівна' } } } },
+    ivf: { date: '2021-08-17' },
     embryoShipment: {
-      ivfDate: '2021-08-17',
-      plannedPeriod: { startDate: '2026-01-01', endDate: '2026-02-01' },
+      sourceClinicId: sourceClinic.id,
+      plannedPeriod: { start: '2026-01-01', end: '2026-02-01' },
       receivedDate: '2025-08-27',
     },
     transferAttempt: {
@@ -123,10 +126,11 @@ const caseWithDateRangePeriod = {
 // A case that only ever carries the migrated freeform text period (spec: "Katsura" scenario).
 const caseWithTextPeriod = {
   id: 'case-textperiod',
-  relations: { ukrainianClinicId: clinic.id, partnerClinicId: partnerClinic.id },
+  relations: { clinicId: clinic.id },
   artProgram: {
+    ivf: { date: '2021-08-17' },
     embryoShipment: {
-      ivfDate: '2021-08-17',
+      sourceClinicId: sourceClinic.id,
       plannedPeriod: { text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } },
     },
   },
@@ -135,14 +139,14 @@ const caseWithTextPeriod = {
 // A pre-artProgram case: no artProgram at all.
 const caseWithoutArtProgram = {
   id: 'case-old',
-  relations: { ukrainianClinicId: clinic.id },
+  relations: { clinicId: clinic.id },
 };
 
 // A transfer attempt exists but never got a hCG test/ultrasound entered yet - the ordinary "not
-// set" state (spec §1.5), never a broken reference (there's no id left to dangle in v5).
+// set" state (spec §1.5), never a broken reference (there's no id left to dangle in v6).
 const caseWithTransferButNoTests = {
   id: 'case-no-tests',
-  relations: { ukrainianClinicId: clinic.id },
+  relations: { clinicId: clinic.id },
   artProgram: { transferAttempt: { date: '2025-09-18' } },
   documents: { geneticAffinityCertificate: {}, racssClinicLetter: {} },
 };
@@ -179,18 +183,18 @@ describe('spec §1.3/§1.4: null-safe artProgram resolvers (resolveShipment/reso
     expect(resolveUltrasound(resolveTransferAttempt(caseWithTransferButNoTests))).toBeNull();
   });
 
-  it('enrichShipment attaches sourceClinic (the case\'s own partnerClinic) and destinationClinic (the case\'s own clinic), null-safe', () => {
+  it('enrichShipment attaches sourceClinic (the shipment\'s own sourceClinicId) and destinationClinic (the case\'s own clinic), null-safe', () => {
     const shipment = resolveShipment(caseWithDateRangePeriod);
     const enriched = enrichShipment(shipment, resolvedClinics);
-    expect(enriched.sourceClinic.id).toBe(partnerClinic.id);
+    expect(enriched.sourceClinic.id).toBe(sourceClinic.id);
     expect(enriched.destinationClinic.id).toBe(clinic.id);
     expect(enrichShipment(null, resolvedClinics)).toBeNull();
   });
 });
 
-// --- Genetic-material scalar source (spec §1.7/§3.4) -----------------------------------------
+// --- Genetic-material scalar source (spec §1.7/§6) -----------------------------------------
 
-describe('spec §1.7/§3.4: oocyteSource/spermSource are scalar strings, resolveGeneticSourceLabel never contains a lookup table', () => {
+describe('spec §1.7/§6: geneticMaterial.oocyte/sperm are plain scalar strings, never auto-resolved to a label', () => {
   it('reserves exactly "wife"/"husband"; anything else non-empty is a donor code', () => {
     expect(GENETIC_SOURCE_ROLE_VALUES).toEqual(['wife', 'husband']);
     expect(isGeneticSourceDonorCode('wife')).toBe(false);
@@ -198,16 +202,6 @@ describe('spec §1.7/§3.4: oocyteSource/spermSource are scalar strings, resolve
     expect(isGeneticSourceDonorCode('ED-123')).toBe(true);
     expect(isGeneticSourceDonorCode('')).toBe(false);
     expect(isGeneticSourceDonorCode(undefined)).toBe(false);
-  });
-
-  it('resolveGeneticSourceLabel resolves "wife"/"husband" to the already-resolved party name, and any other code to itself', () => {
-    const wife = { name: { uk: { nominative: 'Кацура Юкако' }, en: 'Katsura Yukako' } };
-    const husband = { name: { uk: { nominative: 'Кацура Кеіго' }, en: 'Katsura Keigo' } };
-    expect(resolveGeneticSourceLabel('wife', { wife, husband })).toBe(wife.name);
-    expect(resolveGeneticSourceLabel('husband', { wife, husband })).toBe(husband.name);
-    expect(resolveGeneticSourceLabel('ED-123', { wife, husband })).toEqual({ uk: 'ED-123', en: 'ED-123' });
-    expect(resolveGeneticSourceLabel('', { wife, husband })).toBeNull();
-    expect(resolveGeneticSourceLabel(undefined, {})).toBeNull();
   });
 });
 
@@ -226,8 +220,8 @@ describe('spec §3.5: ART formatters', () => {
     expect(formatDateRange('2026-01-01', '2026-02-01', 'en')).toBe('01 January 2026 - 01 February 2026');
   });
 
-  it('formatShipmentPeriod prefers startDate/endDate when present, falls back to the migrated text', () => {
-    expect(formatShipmentPeriod({ startDate: '2026-01-01', endDate: '2026-02-01' }, 'uk')).toBe('01.01.2026 – 01.02.2026');
+  it('formatShipmentPeriod prefers start/end when present, falls back to the migrated text', () => {
+    expect(formatShipmentPeriod({ start: '2026-01-01', end: '2026-02-01' }, 'uk')).toBe('01.01.2026 – 01.02.2026');
     expect(formatShipmentPeriod({ text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } }, 'uk')).toBe('квітні – травні 2026 року');
     expect(formatShipmentPeriod({ text: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' } }, 'en')).toBe('April-May 2026');
     expect(formatShipmentPeriod(null, 'uk')).toBe('');
@@ -273,15 +267,19 @@ describe('spec §3.5: ART formatters', () => {
 
 // --- Template-ready enrichers ------------------------------------------------------------------
 
-describe('spec §3.2/§3.5: enrichShipmentForTemplate/enrichTransferForTemplate/enrichHcgTestForTemplate/enrichUltrasoundForTemplate', () => {
+describe('spec §3.2/§3.5: enrichShipmentForTemplate/enrichTransferForTemplate/enrichHcgTestForTemplate/enrichUltrasoundForTemplate/enrichIvfForTemplate', () => {
   it('enrichShipmentForTemplate adds formatted date/period fields on top of the party-enriched shipment', () => {
     const shipment = enrichShipment(resolveShipment(caseWithDateRangePeriod), resolvedClinics);
     const enriched = enrichShipmentForTemplate(shipment);
-    expect(enriched.ivfDateFormatted).toEqual({ uk: '17.08.2021', en: '17 August 2021' });
     expect(enriched.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
     expect(enriched.receivedDateFormatted.uk).toBe('27.08.2025');
-    expect(enriched.sourceClinic.id).toBe(partnerClinic.id);
+    expect(enriched.sourceClinic.id).toBe(sourceClinic.id);
     expect(enrichShipmentForTemplate(null)).toBeNull();
+  });
+
+  it('enrichIvfForTemplate adds dateFormatted independently of the shipment (spec §5/§7)', () => {
+    expect(enrichIvfForTemplate({ date: '2021-08-17' }).dateFormatted).toEqual({ uk: '17.08.2021', en: '17 August 2021' });
+    expect(enrichIvfForTemplate(null)).toBeNull();
   });
 
   it('enrichTransferForTemplate adds dateFormatted/embryoCountText/embryoStageLabel, nests the enriched shipment, and its own hcgTest/ultrasound', () => {
@@ -291,7 +289,7 @@ describe('spec §3.2/§3.5: enrichShipmentForTemplate/enrichTransferForTemplate/
     expect(enriched.dateFormatted.uk).toBe('18.09.2025');
     expect(enriched.embryoCountText.uk).toBe('один ембріон');
     expect(enriched.embryoStageLabel.uk.genitive).toBe('бластоцисти');
-    expect(enriched.shipment.sourceClinic.id).toBe(partnerClinic.id);
+    expect(enriched.shipment.sourceClinic.id).toBe(sourceClinic.id);
     expect(enriched.hcgTest.dateFormatted.uk).toBe('30.09.2025');
     expect(enriched.ultrasound.dateFormatted.uk).toBe('17.10.2025');
     expect(enrichTransferForTemplate(null, shipment)).toBeNull();
@@ -314,10 +312,10 @@ describe('spec §3.2/§3.5: enrichShipmentForTemplate/enrichTransferForTemplate/
 // --- Document contexts -------------------------------------------------------------------------
 
 describe('spec §1.8/§4: document contexts (embryoOwnershipStatement/geneticAffinityCertificate/racssClinicLetter/medicalServicesAgreement)', () => {
-  it('embryoOwnershipStatement resolves the case\'s one shipment automatically, no shipmentId of its own needed (startDate/endDate case)', () => {
+  it('embryoOwnershipStatement resolves the case\'s one shipment automatically, no shipmentId of its own needed (start/end period case)', () => {
     const context = buildEmbryoOwnershipStatementContext(caseWithDateRangePeriod, resolvedClinics, undefined);
     expect(context.shipment.plannedPeriodFormatted.uk).toBe('01.01.2026 – 01.02.2026');
-    expect(context.shipment.sourceClinic.id).toBe(partnerClinic.id);
+    expect(context.shipment.sourceClinic.id).toBe(sourceClinic.id);
     expect(context.shipment.destinationClinic.id).toBe(clinic.id);
   });
 
@@ -340,18 +338,18 @@ describe('spec §1.8/§4: document contexts (embryoOwnershipStatement/geneticAff
       caseWithDateRangePeriod.documents.geneticAffinityCertificate,
     );
     expect(context.transferAttempt.embryoCountText.uk).toBe('один ембріон');
-    expect(context.transferAttempt.shipment.sourceClinic.id).toBe(partnerClinic.id);
+    expect(context.transferAttempt.shipment.sourceClinic.id).toBe(sourceClinic.id);
     expect(context.hcgTest.dateFormatted.uk).toBe('30.09.2025');
     expect(context.ultrasound.gestationalAgeText.uk).toBe('6–7 тижнів');
     expect(context.issueDateOrBlank.uk).toBe('20.10.2025');
     expect(context.outgoingNumberOrBlank).toBe('42/1');
   });
 
-  it('geneticAffinityCertificate exposes oocyteSourceIsWife off the scalar artProgram.oocyteSource, shared/cross-referenced by any other document conditioning a block on it', () => {
+  it('geneticAffinityCertificate exposes oocyteSourceIsWife off the scalar artProgram.geneticMaterial.oocyte, shared/cross-referenced by any other document conditioning a block on it', () => {
     const isWife = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
     expect(isWife.oocyteSourceIsWife).toBe(true);
 
-    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { oocyteSource: 'ED-123' } });
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyte: 'ED-123' } } });
     const isDonor = buildGeneticAffinityCertificateContext(donorCase, resolvedClinics, {});
     expect(isDonor.oocyteSourceIsWife).toBe(false);
 
@@ -429,11 +427,12 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(fillPlaceholders('{{case.artProgram.medicalIndications.uk}}', context, 'uk')).toBe('Тестовий діагноз');
   });
 
-  it('spec §5.1: exposes the same singleton shipment/transfer/hcgTest/ultrasound as top-level canonical context aliases, alongside the document-scoped ones', () => {
+  it('spec §5.1: exposes the same singleton shipment/transfer/hcgTest/ultrasound/ivf as top-level canonical context aliases, alongside the document-scoped ones', () => {
     const catalog = buildCatalog(caseWithDateRangePeriod);
     const context = resolveCaseContext(catalog, 'case-daterange');
     expect(fillPlaceholders('{{artProgram.medicalIndications.uk}}', context, 'uk')).toBe('Тестовий діагноз');
-    expect(fillPlaceholders('{{artProgram.oocyteSourceLabel.uk}}', context, 'uk')).toBe('Кацура Юкако');
+    expect(fillPlaceholders('{{artProgram.geneticMaterial.oocyte}}', context, 'uk')).toBe('wife');
+    expect(fillPlaceholders('{{ivf.dateFormatted.uk}}', context, 'uk')).toBe('17.08.2021');
     expect(fillPlaceholders('{{embryoShipment.receivedDateFormatted.uk}}', context, 'uk')).toBe('27.08.2025');
     expect(fillPlaceholders('{{transferAttempt.embryoCountText.uk}}', context, 'uk')).toBe('один ембріон');
     expect(fillPlaceholders('{{hcgTest.dateFormatted.uk}}', context, 'uk')).toBe('30.09.2025');
@@ -503,9 +502,8 @@ describe('integration: resolveCaseContext wires every ART document context in, n
 
 describe('spec §1.9: ART-derived fields are never written back to Firebase', () => {
   it('DERIVED_CONTEXT_FIELD_KEYS lists every runtime-only ART field named in the spec', () => {
-    ['plannedPeriodFormatted', 'ivfDateFormatted', 'sentDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
-      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
-      'oocyteSourceLabel', 'spermSourceLabel']
+    ['plannedPeriodFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
+      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank']
       .forEach(key => expect(DERIVED_CONTEXT_FIELD_KEYS).toContain(key));
   });
 
@@ -621,7 +619,7 @@ describe('spec: buildGeneratedDocument drops a conditionally-hidden paragraph en
   });
 
   it('fully omits the paragraph (never a blank/unresolved value) when any other oocyte source is set, keeping every other paragraph\'s position stable', () => {
-    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { oocyteSource: 'ED-123' } });
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyte: 'ED-123' } } });
     const context = buildGeneticAffinityCertificateContext(donorCase, resolvedClinics, {});
     const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
     expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'condition-hidden', 'text']);
@@ -632,77 +630,109 @@ describe('spec: buildGeneratedDocument drops a conditionally-hidden paragraph en
 // --- v5 migration (spec §2.2/§4) ---------------------------------------------------------------
 
 describe('spec §2.2: schema-version validation', () => {
-  it('isDocumentsSchemaV5 is true only for a settings record carrying the current version', () => {
-    expect(isDocumentsSchemaV5({ schemaVersion: 5 })).toBe(true);
-    expect(isDocumentsSchemaV5({ schemaVersion: 4 })).toBe(false);
-    expect(isDocumentsSchemaV5({})).toBe(false);
-    expect(isDocumentsSchemaV5(null)).toBe(false);
+  it('isDocumentsSchemaV6 is true only for a settings record carrying the current version', () => {
+    expect(isDocumentsSchemaV6({ schemaVersion: 6 })).toBe(true);
+    expect(isDocumentsSchemaV6({ schemaVersion: 5 })).toBe(false);
+    expect(isDocumentsSchemaV6({})).toBe(false);
+    expect(isDocumentsSchemaV6(null)).toBe(false);
   });
 
   it('normalizeDocumentsSettings always stamps the current schema version going forward', () => {
     expect(normalizeDocumentsSettings({}).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(normalizeDocumentsSettings(null).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
-    expect(normalizeDocumentsSettings({ schemaVersion: 4 }).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(normalizeDocumentsSettings({ schemaVersion: 5 }).schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 });
 
-describe('spec §4: migrateCaseToV5 - one idempotent migration boundary, never guesses ambiguous/missing data', () => {
-  it('is a no-op (report.changed: false) on an already-v5 case, and never mutates the source object', () => {
+describe('spec §4/§9: migrateCaseToV6 - one idempotent migration boundary, never guesses ambiguous/missing data', () => {
+  it('is a no-op (report.changed: false) on an already-v6 case, and never mutates the source object', () => {
     const before = JSON.stringify(caseWithDateRangePeriod);
-    const { case: migrated, report } = migrateCaseToV5(caseWithDateRangePeriod);
+    const { case: migrated, report } = migrateCaseToV6(caseWithDateRangePeriod);
     expect(report.changed).toBe(false);
     expect(migrated.artProgram.embryoShipment).toEqual(caseWithDateRangePeriod.artProgram.embryoShipment);
-    expect(migrated.artProgram.oocyteSource).toBe('wife');
+    expect(migrated.artProgram.geneticMaterial.oocyte).toBe('wife');
     expect(JSON.stringify(caseWithDateRangePeriod)).toBe(before);
   });
 
-  it('migrates relations.clinicId to relations.ukrainianClinicId, leaving partnerClinicId untouched', () => {
-    const legacy = { id: 'case-1', relations: { clinicId: 'clinic-1', partnerClinicId: 'partner-1' } };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
-    expect(migrated.relations.ukrainianClinicId).toBe('clinic-1');
-    expect(migrated.relations).not.toHaveProperty('clinicId');
-    expect(migrated.relations.partnerClinicId).toBe('partner-1');
+  it('leaves the ancient pre-v5 relations.clinicId untouched - it already means what v6 wants again', () => {
+    const legacy = { id: 'case-1', relations: { clinicId: 'clinic-1' } };
+    const { case: migrated, report } = migrateCaseToV6(legacy);
+    expect(migrated.relations.clinicId).toBe('clinic-1');
+    expect(report.changed).toBe(false);
+  });
+
+  it('migrates the v5 relations.ukrainianClinicId to relations.clinicId, and drops the retired relations.partnerClinicId (spec §9)', () => {
+    const legacy = { id: 'case-1', relations: { ukrainianClinicId: 'clinic-1', partnerClinicId: 'partner-1' } };
+    const { case: migrated, report } = migrateCaseToV6(legacy);
+    expect(migrated.relations.clinicId).toBe('clinic-1');
+    expect(migrated.relations).not.toHaveProperty('ukrainianClinicId');
+    expect(migrated.relations).not.toHaveProperty('partnerClinicId');
     expect(report.changed).toBe(true);
   });
 
-  it('migrates the old inline relations.shipment (batch 26 §5 shape) to artProgram.embryoShipment, recovering missing clinic relations and dropping the shipment\'s own clinic ids', () => {
+  it('migrates the old inline relations.shipment (batch 26 §5 shape) to artProgram.embryoShipment, recovering the destination clinic relation and keeping the shipment\'s own source clinic id in place', () => {
     const legacy = {
       id: 'case-1',
       relations: { coupleId: 'couple-1' },
-      relations_shipment_marker: undefined,
     };
     legacy.relations.shipment = {
       sourceClinicId: 'partner-1', destinationClinicId: 'clinic-1', ivfDate: '2021-08-17', receivedDate: '2025-08-27',
     };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
-    expect(migrated.artProgram.embryoShipment).toEqual({ ivfDate: '2021-08-17', receivedDate: '2025-08-27' });
-    expect(migrated.relations.ukrainianClinicId).toBe('clinic-1');
-    expect(migrated.relations.partnerClinicId).toBe('partner-1');
+    const { case: migrated, report } = migrateCaseToV6(legacy);
+    expect(migrated.artProgram.embryoShipment).toEqual({ sourceClinicId: 'partner-1', receivedDate: '2025-08-27' });
+    expect(migrated.artProgram.ivf).toEqual({ date: '2021-08-17' });
+    expect(migrated.relations.clinicId).toBe('clinic-1');
     expect(migrated.relations).not.toHaveProperty('shipment');
     expect(report.changed).toBe(true);
   });
 
-  it('does not overwrite clinic relations the case already has, even if the old inline shipment carried different ones', () => {
+  it('does not overwrite the case\'s own clinicId, even if the old inline shipment carried a different destinationClinicId', () => {
     const legacy = {
       id: 'case-1',
-      relations: { ukrainianClinicId: 'clinic-current', partnerClinicId: 'partner-current', shipment: { sourceClinicId: 'partner-old', destinationClinicId: 'clinic-old' } },
+      relations: { clinicId: 'clinic-current', shipment: { sourceClinicId: 'partner-old', destinationClinicId: 'clinic-old' } },
     };
-    const { case: migrated } = migrateCaseToV5(legacy);
-    expect(migrated.relations.ukrainianClinicId).toBe('clinic-current');
-    expect(migrated.relations.partnerClinicId).toBe('partner-current');
+    const { case: migrated } = migrateCaseToV6(legacy);
+    expect(migrated.relations.clinicId).toBe('clinic-current');
+    expect(migrated.artProgram.embryoShipment.sourceClinicId).toBe('partner-old');
   });
 
-  it('migrates the oldest id-map embryoShipments shape via the transfer attempt\'s shipmentId reference', () => {
+  it('recovers a v5 case\'s relations.partnerClinicId onto the shipment\'s own sourceClinicId, when the shipment has none of its own', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: { clinicId: 'clinic-1', partnerClinicId: 'partner-1' },
+      artProgram: { embryoShipment: { receivedDate: '2025-08-27' } },
+    };
+    const { case: migrated, report } = migrateCaseToV6(legacy);
+    expect(migrated.artProgram.embryoShipment.sourceClinicId).toBe('partner-1');
+    expect(migrated.relations).not.toHaveProperty('partnerClinicId');
+    expect(report.changed).toBe(true);
+  });
+
+  it('migrates the oldest id-map embryoShipments shape via the transfer attempt\'s shipmentId reference, splitting ivfDate out to artProgram.ivf', () => {
     const legacy = {
       id: 'case-1',
       relations: {},
       artProgram: {
-        embryoShipments: { 'shipment-1': { id: 'shipment-1', ivfDate: '2021-08-17' }, 'shipment-2': { id: 'shipment-2', ivfDate: '2022-01-01' } },
+        embryoShipments: { 'shipment-1': { id: 'shipment-1', ivfDate: '2021-08-17', receivedDate: '2025-08-27' }, 'shipment-2': { id: 'shipment-2', ivfDate: '2022-01-01' } },
         transferAttempt: { shipmentId: 'shipment-1', date: '2025-09-18' },
       },
     };
-    const { case: migrated } = migrateCaseToV5(legacy);
-    expect(migrated.artProgram.embryoShipment).toEqual({ ivfDate: '2021-08-17' });
+    const { case: migrated } = migrateCaseToV6(legacy);
+    expect(migrated.artProgram.embryoShipment).toEqual({ receivedDate: '2025-08-27' });
+    expect(migrated.artProgram.ivf).toEqual({ date: '2021-08-17' });
+  });
+
+  it('drops an old shipment whose only content was ivfDate - never persists an empty embryoShipment: {}', () => {
+    const legacy = {
+      id: 'case-1',
+      relations: {},
+      artProgram: {
+        embryoShipments: { 'shipment-1': { id: 'shipment-1', ivfDate: '2021-08-17' } },
+      },
+    };
+    const { case: migrated } = migrateCaseToV6(legacy);
+    expect(migrated.artProgram.embryoShipment).toBeUndefined();
+    expect(migrated.artProgram.ivf).toEqual({ date: '2021-08-17' });
   });
 
   it('reports an ambiguity (migrates none) when several old shipments exist with no shipmentId to disambiguate', () => {
@@ -713,7 +743,7 @@ describe('spec §4: migrateCaseToV5 - one idempotent migration boundary, never g
         embryoShipments: { 'shipment-1': { id: 'shipment-1', ivfDate: '2021-08-17' }, 'shipment-2': { id: 'shipment-2', ivfDate: '2022-01-01' } },
       },
     };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
+    const { case: migrated, report } = migrateCaseToV6(legacy);
     expect(migrated.artProgram?.embryoShipment).toBeUndefined();
     expect(report.ambiguities.length).toBeGreaterThan(0);
   });
@@ -731,7 +761,7 @@ describe('spec §4: migrateCaseToV5 - one idempotent migration boundary, never g
       },
       documents: { geneticAffinityCertificate: { hcgTestId: 'hcg-2', ultrasoundId: 'ultrasound-1' } },
     };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
+    const { case: migrated, report } = migrateCaseToV6(legacy);
     expect(migrated.artProgram.transferAttempt.hcgTest).toEqual({ date: '2025-11-15' });
     expect(migrated.artProgram.transferAttempt.ultrasound).toEqual({ date: '2025-10-17', fetusCount: 1 });
     expect(migrated.artProgram.transferAttempt).not.toHaveProperty('hcgTests');
@@ -753,7 +783,7 @@ describe('spec §4: migrateCaseToV5 - one idempotent migration boundary, never g
       },
       documents: { racssClinicLetter: { ultrasoundId: 'ultrasound-1' } },
     };
-    const { case: migrated } = migrateCaseToV5(legacy);
+    const { case: migrated } = migrateCaseToV6(legacy);
     expect(migrated.artProgram.transferAttempt.ultrasound).toEqual({ date: '2025-10-17' });
   });
 
@@ -768,86 +798,91 @@ describe('spec §4: migrateCaseToV5 - one idempotent migration boundary, never g
         },
       },
     };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
+    const { case: migrated, report } = migrateCaseToV6(legacy);
     expect(migrated.artProgram.transferAttempt.hcgTest).toBeUndefined();
     expect(report.ambiguities.length).toBeGreaterThan(0);
   });
 
   it('maps the old medicalIndication.diagnosis wrapper to the plain medicalIndications field', () => {
     const legacy = { id: 'case-1', relations: {}, artProgram: { medicalIndication: { diagnosis: { uk: 'Непліддя' } } } };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
+    const { case: migrated, report } = migrateCaseToV6(legacy);
     expect(migrated.artProgram.medicalIndications).toEqual({ uk: 'Непліддя' });
     expect(migrated.artProgram).not.toHaveProperty('medicalIndication');
     expect(report.changed).toBe(true);
   });
 
-  it('maps geneticMaterial.oocyteSourcePartnerRole/spermSourcePartnerRole "wife"/"husband" straight to the v5 scalars', () => {
-    const legacy = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'wife', spermSourcePartnerRole: 'husband' } } };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
-    expect(migrated.artProgram.oocyteSource).toBe('wife');
-    expect(migrated.artProgram.spermSource).toBe('husband');
-    expect(migrated.artProgram).not.toHaveProperty('geneticMaterial');
-    expect(report.changed).toBe(true);
+  it('maps the ancient geneticMaterial.oocyteSourcePartnerRole/spermSourcePartnerRole and the v5 scalar oocyteSource/spermSource straight to the flat v6 geneticMaterial.oocyte/sperm', () => {
+    const ancient = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'wife', spermSourcePartnerRole: 'husband' } } };
+    const { case: migratedAncient, report: ancientReport } = migrateCaseToV6(ancient);
+    expect(migratedAncient.artProgram.geneticMaterial).toEqual({ oocyte: 'wife', sperm: 'husband' });
+    expect(ancientReport.changed).toBe(true);
+
+    const v5Shaped = { id: 'case-2', relations: {}, artProgram: { oocyteSource: 'wife', spermSource: 'husband' } };
+    const { case: migratedV5, report: v5Report } = migrateCaseToV6(v5Shaped);
+    expect(migratedV5.artProgram.geneticMaterial).toEqual({ oocyte: 'wife', sperm: 'husband' });
+    expect(migratedV5.artProgram).not.toHaveProperty('oocyteSource');
+    expect(migratedV5.artProgram).not.toHaveProperty('spermSource');
+    expect(v5Report.changed).toBe(true);
   });
 
-  it('passes an old donor code straight through into the scalar field (no separate donor-code property)', () => {
+  it('passes an old donor code straight through into the flat scalar field (no separate donor-code property)', () => {
     const legacy = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'ED-123' } } };
-    const { case: migrated } = migrateCaseToV5(legacy);
-    expect(migrated.artProgram.oocyteSource).toBe('ED-123');
+    const { case: migrated } = migrateCaseToV6(legacy);
+    expect(migrated.artProgram.geneticMaterial.oocyte).toBe('ED-123');
   });
 
   it('reports a legacy "donor" selection with no code ever recorded as unmigratable, rather than storing the literal string "donor"', () => {
     const legacy = { id: 'case-1', relations: {}, artProgram: { geneticMaterial: { oocyteSourcePartnerRole: 'donor' } } };
-    const { case: migrated, report } = migrateCaseToV5(legacy);
-    expect(migrated.artProgram?.oocyteSource).toBeUndefined();
+    const { case: migrated, report } = migrateCaseToV6(legacy);
+    expect(migrated.artProgram?.geneticMaterial?.oocyte).toBeUndefined();
     expect(report.unmigratable.length).toBeGreaterThan(0);
   });
 
   it('reports missing required relations without throwing, for a bare case', () => {
-    const { report } = migrateCaseToV5({ id: 'case-1' });
+    const { report } = migrateCaseToV6({ id: 'case-1' });
     expect(report.missingRelations).toEqual(expect.arrayContaining([
-      'relations.ukrainianClinicId', 'relations.coupleId', 'relations.surrogateMotherId',
+      'relations.clinicId', 'relations.coupleId', 'relations.surrogateMotherId',
     ]));
   });
 
   it('handles null/non-object input without throwing', () => {
-    expect(migrateCaseToV5(null).case).toEqual({});
-    expect(() => migrateCaseToV5(undefined)).not.toThrow();
+    expect(migrateCaseToV6(null).case).toEqual({});
+    expect(() => migrateCaseToV6(undefined)).not.toThrow();
   });
 
   it('normalizeCaseRecord runs the same migration, idempotently, for every case normalizeDocumentsCatalog loads', () => {
     const legacy = {
       'case-1': {
         id: 'case-1',
-        relations: { clinicId: 'clinic-1' },
+        relations: { ukrainianClinicId: 'clinic-1' },
         artProgram: { medicalIndication: { diagnosis: { uk: 'Непліддя' } } },
       },
     };
     const catalog = normalizeDocumentsCatalog({}, {}, legacy);
     const migratedOnce = catalog.cases[0];
-    expect(migratedOnce.relations.ukrainianClinicId).toBe('clinic-1');
+    expect(migratedOnce.relations.clinicId).toBe('clinic-1');
     expect(migratedOnce.artProgram.medicalIndications.uk).toBe('Непліддя');
     expect(normalizeCaseRecord(migratedOnce)).toEqual(migratedOnce);
   });
 });
 
-describe('spec §4.7: migrateCasesToV5 aggregates a migration report across every case', () => {
+describe('spec §4.7: migrateCasesToV6 aggregates a migration report across every case', () => {
   it('lists migrated case ids, and keys missingRelations/ambiguities/unmigratable by case id', () => {
     const rawCases = {
       'case-clean': caseWithDateRangePeriod,
-      'case-legacy': { id: 'case-legacy', relations: { clinicId: 'clinic-1' } },
+      'case-legacy': { id: 'case-legacy', relations: { ukrainianClinicId: 'clinic-1' } },
       'case-ambiguous': {
         id: 'case-ambiguous',
         relations: {},
         artProgram: { embryoShipments: { a: { id: 'a' }, b: { id: 'b' } } },
       },
     };
-    const { cases, report } = migrateCasesToV5(rawCases);
+    const { cases, report } = migrateCasesToV6(rawCases);
     expect(cases.map(c => c.id).sort()).toEqual(['case-ambiguous', 'case-daterange', 'case-legacy']);
     expect(report.migratedCaseIds).toContain('case-legacy');
     expect(report.migratedCaseIds).not.toContain('case-daterange');
     expect(report.ambiguities['case-ambiguous'].length).toBeGreaterThan(0);
-    expect(report.missingRelations['case-ambiguous']).toEqual(expect.arrayContaining(['relations.ukrainianClinicId']));
+    expect(report.missingRelations['case-ambiguous']).toEqual(expect.arrayContaining(['relations.clinicId']));
   });
 });
 
@@ -861,7 +896,7 @@ describe('spec §5.3: auditTemplateVariables/classifyTemplateVariablePath classi
     expect(classifyTemplateVariablePath('relations.coupleId')).toBe('resolvedRelation');
     expect(classifyTemplateVariablePath('artProgram.medicalIndications.uk')).toBe('derivedRuntime');
     expect(classifyTemplateVariablePath('transferAttempt.embryoStageLabel.uk.genitive')).toBe('derivedRuntime');
-    expect(classifyTemplateVariablePath('case.artProgram.oocyteSource')).toBe('backendSource');
+    expect(classifyTemplateVariablePath('case.artProgram.geneticMaterial.oocyte')).toBe('backendSource');
     expect(classifyTemplateVariablePath('something.completely.unknown')).toBe('unknown');
   });
 

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -26,12 +26,12 @@ export const clinicLogoStorageFilePath = (clinicId, fileName) => `${clinicLogoSt
 export const legacyClinicLogoStorageFolder = clinicId => `${DOCUMENTS_PARTIES_PATH}/cases/clinics/${clinicId}/logo`;
 export const legacyClinicLogoStorageFilePath = (clinicId, fileName) => `${legacyClinicLogoStorageFolder(clinicId)}/${fileName}`;
 
-export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'partnerClinics', 'maternityHospitals', 'notaries'];
+export const PARTY_COLLECTIONS = ['couples', 'surrogateMothers', 'representatives', 'clinics', 'maternityHospitals', 'notaries'];
 
 // mergeCollection derives an id prefix for un-identified incoming records by stripping a trailing
 // 's' off the collection name; 'notaries' isn't a simple plural ('notarys' would be wrong), so it
 // needs the explicit override.
-const COLLECTION_ID_PREFIXES = { notaries: 'notary', partnerClinics: 'partner-clinic' };
+const COLLECTION_ID_PREFIXES = { notaries: 'notary' };
 
 export const isPlainObject = value => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
@@ -160,7 +160,7 @@ export const clinicLogoEntriesToBackend = variants => (variants || [])
 export const emptyDocumentsCatalog = () => ({
   cases: [],
   parties: {
-    couples: [], surrogateMothers: [], representatives: [], clinics: [], partnerClinics: [], maternityHospitals: [], notaries: [],
+    couples: [], surrogateMothers: [], representatives: [], clinics: [], maternityHospitals: [], notaries: [],
   },
   documents: [],
   clinicLogos: {},
@@ -359,9 +359,8 @@ export const DERIVED_CONTEXT_FIELD_KEYS = [
   'short', 'shortName', 'dateWords', 'dateFormatted', 'statementDateWords', 'statementDateFormatted', 'dateDisplay', 'numberEn', 'wordsAfterArticle',
   // ART program document contexts (spec §4/§6/§12) - computed fresh from case.artProgram on every
   // resolveCaseContext call, never written back to Firebase.
-  'plannedPeriodFormatted', 'ivfDateFormatted', 'sentDateFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
+  'plannedPeriodFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
   'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
-  'oocyteSourceLabel', 'spermSourceLabel',
 ];
 
 // Recursively strips every DERIVED_CONTEXT_FIELD_KEYS key out of a value before it's serialized
@@ -829,6 +828,12 @@ export const createEmptyClinic = () => ({
   // nameLocative-style field) - genitive/accusative are optional, blank until an admin fills them
   // in, never required by a template that only ever reads `.nominative`.
   name: { uk: { nominative: '', genitive: '', accusative: '' }, en: '' },
+  // v6 (spec §1): every clinic - Ukrainian or foreign - lives in this one collection now, so
+  // `country` (blank/optional, like every other field here) is part of the shared shape rather
+  // than a separate simplified partner-clinic record. A foreign clinic (e.g. the shipment's own
+  // sourceClinic) typically only ever fills in name/country/address - never required to also carry
+  // legalName/edrpou/bank/license/medicalDirector below.
+  country: { code: '', uk: { nominative: '', genitive: '' }, en: '' },
   legalName: { uk: { nominative: '' }, en: '' },
   medicalCenterName: { uk: { nominative: '' }, en: '' },
   address: { uk: '', en: '' },
@@ -847,21 +852,6 @@ export const createEmptyClinic = () => ({
     name: { uk: { nominative: '', genitive: '' }, en: { full: '' } },
     authority: { type: { uk: '', en: '' }, number: '', date: '' },
   },
-});
-
-// A partner clinic is the foreign clinic embryos ship from - a distinct, deliberately simplified
-// party type from the Ukrainian `clinics` collection (which performs the surrogacy program itself
-// and carries a full legal/banking profile): no EDRPOU, license, director, bank details, or logo,
-// just the name and address a static document needs to reference it by.
-export const createEmptyPartnerClinic = () => ({
-  id: makeRecordId('partner-clinic'),
-  // `name.uk`/`country.uk` carry their grammatical forms directly as siblings of `nominative`
-  // ({{partnerClinic.name.uk.genitive}}, {{partnerClinic.country.uk.genitive}} - real templates
-  // read these paths straight off the partner clinic) - genitive is optional, blank until an admin
-  // fills it in, never required by a template that only ever reads `.nominative`/plain `.en`.
-  name: { uk: { nominative: '', genitive: '' }, en: '' },
-  country: { uk: { nominative: '', genitive: '' }, en: '' },
-  address: { uk: '', en: '' },
 });
 
 // `shortName` is never stored (spec §6) - use getMaternityHospitalDisplayName wherever the UI
@@ -917,13 +907,14 @@ export const createChildRecord = () => ({
   medicalConclusion: { number: '', date: '' },
 });
 
-// --- v5 migration (spec §2.2/§4) ---------------------------------------------------------------
+// --- v6 migration (spec §1-§9: unified `parties.clinics`, single relations.clinicId/
+// embryoShipment.sourceClinicId, artProgram.ivf.date, flat geneticMaterial.oocyte/sperm) ---------
 // The one migration boundary: every legacy shape this app has ever stored a case under is read
 // here, exactly once per load, and nowhere else - resolveShipment/resolveTransferAttempt/etc. only
-// ever read the canonical v5 paths. Pure and idempotent: migrating an already-v5 case changes
+// ever read the canonical v6 paths. Pure and idempotent: migrating an already-v6 case changes
 // nothing (verified by tests), so running it again on the same data is always safe.
 
-export const CURRENT_SCHEMA_VERSION = 5;
+export const CURRENT_SCHEMA_VERSION = 6;
 
 const omitKeys = (value, keys) => {
   if (!isPlainObject(value)) return value;
@@ -932,9 +923,9 @@ const omitKeys = (value, keys) => {
   return next;
 };
 
-// Fields that only ever belonged in a runtime template context, or a tri-state boolean the v5
+// Fields that only ever belonged in a runtime template context, or a tri-state boolean the v5+
 // model replaces with "the object exists" (spec §1.5/§1.9) - stripped from whatever storage shape
-// migrateCaseToV5 finds them in, never manufactured if absent.
+// migrateCaseToV6 finds them in, never manufactured if absent.
 const LEGACY_STORED_FIELD_KEYS = ['positive', 'pregnancyConfirmed', 'confirmedPregnancy', 'short', 'shortName', 'initials', 'dateWords', 'dateFormatted'];
 
 const stripLegacyStoredFields = value => omitKeys(value, LEGACY_STORED_FIELD_KEYS);
@@ -947,18 +938,60 @@ export const emptyMigrationReport = () => ({
   unmigratable: [],
 });
 
+// A shipment's plannedPeriod carries either the v6 start/end pair or the old startDate/endDate
+// pair (never both) - the migrated text-only shape (spec §6 fallback) passes through unchanged.
+const migratePlannedPeriod = period => {
+  if (!isPlainObject(period)) return { period: undefined, changed: false };
+  if (period.start !== undefined || period.end !== undefined) {
+    return { period: omitKeys(period, ['startDate', 'endDate']), changed: false };
+  }
+  if (period.startDate !== undefined || period.endDate !== undefined) {
+    return { period: { ...omitKeys(period, ['startDate', 'endDate']), start: period.startDate, end: period.endDate }, changed: true };
+  }
+  return { period, changed: false };
+};
+
+// A shipment's own clinic-of-origin (spec §3/§4): v6 keeps `sourceClinicId` directly on the
+// shipment (never resolved from a `relations.partnerClinicId`/separate `parties.partnerClinics`
+// collection any more) - `ivfDate` (spec §5) and `sentDate` (spec §7, dropped entirely) never
+// belong here either. `legacySourceClinicId` is the case's own now-retired
+// `relations.partnerClinicId`, read once by the caller and passed in only as a fallback for a
+// shipment that doesn't already carry its own sourceClinicId.
+const migrateShipmentToV6 = (shipment, legacySourceClinicId, report) => {
+  const next = stripLegacyStoredFields(omitKeys(shipment, ['id', 'destinationClinicId', 'ivfDate', 'sentDate', 'plannedPeriod']));
+  if (shipment.destinationClinicId !== undefined || shipment.sentDate !== undefined) report.changed = true;
+
+  const { period, changed: periodChanged } = migratePlannedPeriod(shipment.plannedPeriod);
+  if (period !== undefined) next.plannedPeriod = period;
+  if (periodChanged) report.changed = true;
+
+  if (!next.sourceClinicId && legacySourceClinicId) {
+    next.sourceClinicId = legacySourceClinicId;
+    report.changed = true;
+  }
+
+  return next;
+};
+
 // Picks the case's one embryo shipment out of every shape this codebase has ever stored it under -
 // the current one (case.artProgram.embryoShipment), the previous one (case.relations.shipment,
 // batch 26 §5), or the oldest id-map shape (case.artProgram.embryoShipments, addressed by a
 // shipmentId on the transfer attempt or on embryoOwnershipStatement) - and recovers the case's
-// clinic relations from an old inline shipment's own sourceClinicId/destinationClinicId when the
-// case doesn't already have them (spec §4.1). Never merges two different shipments: several
-// candidates with no way to prefer one is reported as an ambiguity, not guessed.
+// clinic relations from an old inline shipment's own destinationClinicId, or the case's own
+// (now-retired) relations.partnerClinicId, when the shipment doesn't already carry its own
+// sourceClinicId (spec §4.1). Never merges two different shipments: several candidates with no
+// way to prefer one is reported as an ambiguity, not guessed.
 const migrateEmbryoShipment = (rawCase, report) => {
   const artProgram = isPlainObject(rawCase.artProgram) ? rawCase.artProgram : {};
+  const legacySourceClinicId = rawCase.relations?.partnerClinicId;
 
   if (isPlainObject(artProgram.embryoShipment)) {
-    return { shipment: stripLegacyStoredFields(omitKeys(artProgram.embryoShipment, ['id', 'sourceClinicId', 'destinationClinicId'])), relationsPatch: {} };
+    const shipment = artProgram.embryoShipment;
+    return {
+      shipment: migrateShipmentToV6(shipment, legacySourceClinicId, report),
+      ivfDate: shipment.ivfDate,
+      relationsPatch: {},
+    };
   }
 
   const inline = isPlainObject(rawCase.relations?.shipment) ? rawCase.relations.shipment : null;
@@ -974,21 +1007,22 @@ const migrateEmbryoShipment = (rawCase, report) => {
     else if (entries.length === 1) [, candidate] = entries[0];
     else if (entries.length > 1) {
       report.ambiguities.push('artProgram.embryoShipments: multiple shipments with no shipmentId reference to disambiguate - none migrated, needs manual repair.');
-      return { shipment: null, relationsPatch: {} };
+      return { shipment: null, ivfDate: undefined, relationsPatch: {} };
     }
   }
-  if (!candidate) return { shipment: null, relationsPatch: {} };
+  if (!candidate) return { shipment: null, ivfDate: undefined, relationsPatch: {} };
 
   const relationsPatch = {};
-  if (candidate.destinationClinicId && !rawCase.relations?.ukrainianClinicId && !rawCase.relations?.clinicId) {
-    relationsPatch.ukrainianClinicId = candidate.destinationClinicId;
-  }
-  if (candidate.sourceClinicId && !rawCase.relations?.partnerClinicId) {
-    relationsPatch.partnerClinicId = candidate.sourceClinicId;
+  if (candidate.destinationClinicId && !rawCase.relations?.clinicId && !rawCase.relations?.ukrainianClinicId) {
+    relationsPatch.clinicId = candidate.destinationClinicId;
   }
 
   report.changed = true;
-  return { shipment: stripLegacyStoredFields(omitKeys(candidate, ['id', 'sourceClinicId', 'destinationClinicId'])), relationsPatch };
+  return {
+    shipment: migrateShipmentToV6(candidate, candidate.sourceClinicId || legacySourceClinicId, report),
+    ivfDate: candidate.ivfDate,
+    relationsPatch,
+  };
 };
 
 // Migrates the transfer attempt's hCG tests/ultrasounds from the old id-keyed map shape to the v5
@@ -1032,11 +1066,14 @@ const migrateTransferAttempt = (rawCase, report) => {
   return migrated;
 };
 
-// Migrates diagnosis/genetic-material-source fields (spec §4.4): the old `medicalIndication.
-// diagnosis` wrapper and the old `geneticMaterial.oocyteSourcePartnerRole`/`spermSourcePartnerRole`
-// fields, mapped straight to the v5 scalars. A legacy 'donor' selection with no code ever recorded
-// anywhere (the old UI never had a donor-code input) can't be safely turned into the scalar donor
-// code the v5 field is supposed to hold - reported as unmigratable instead of guessed/invented.
+// Migrates diagnosis/genetic-material-source fields (spec §4.4/§6): the old `medicalIndication.
+// diagnosis` wrapper, and every genetic-material-source shape this app has stored - the ancient
+// `geneticMaterial.oocyteSourcePartnerRole`/`spermSourcePartnerRole`, and the v5 scalar
+// `artProgram.oocyteSource`/`spermSource` - both mapped straight to the flat v6
+// `geneticMaterial.oocyte`/`geneticMaterial.sperm` scalars (never a nested `{ source }` wrapper).
+// A legacy 'donor' selection with no code ever recorded anywhere (the old UI never had a
+// donor-code input) can't be safely turned into the scalar donor code the field is supposed to
+// hold - reported as unmigratable instead of guessed/invented.
 const migrateMedicalData = (rawCase, report) => {
   const artProgram = isPlainObject(rawCase.artProgram) ? rawCase.artProgram : {};
   const result = {};
@@ -1048,9 +1085,13 @@ const migrateMedicalData = (rawCase, report) => {
     report.changed = true;
   }
 
-  const geneticMaterial = isPlainObject(artProgram.geneticMaterial) ? artProgram.geneticMaterial : null;
-  const migrateSource = (already, legacyRole, label) => {
+  const legacyGeneticMaterial = isPlainObject(artProgram.geneticMaterial) ? artProgram.geneticMaterial : null;
+  const migrateSource = (already, legacyValue, legacyRole, label) => {
     if (already !== undefined) return already;
+    if (legacyValue !== undefined) {
+      report.changed = true;
+      return legacyValue;
+    }
     if (!legacyRole) return undefined;
     if (legacyRole === 'donor') {
       report.unmigratable.push(`artProgram.geneticMaterial.${label}: was set to a donor with no donor code recorded - re-enter the donor code directly.`);
@@ -1059,45 +1100,64 @@ const migrateMedicalData = (rawCase, report) => {
     report.changed = true;
     return legacyRole;
   };
-  const oocyteSource = migrateSource(artProgram.oocyteSource, geneticMaterial?.oocyteSourcePartnerRole, 'oocyteSourcePartnerRole');
-  const spermSource = migrateSource(artProgram.spermSource, geneticMaterial?.spermSourcePartnerRole, 'spermSourcePartnerRole');
-  if (oocyteSource !== undefined) result.oocyteSource = oocyteSource;
-  if (spermSource !== undefined) result.spermSource = spermSource;
+  const oocyte = migrateSource(legacyGeneticMaterial?.oocyte, artProgram.oocyteSource, legacyGeneticMaterial?.oocyteSourcePartnerRole, 'oocyteSourcePartnerRole');
+  const sperm = migrateSource(legacyGeneticMaterial?.sperm, artProgram.spermSource, legacyGeneticMaterial?.spermSourcePartnerRole, 'spermSourcePartnerRole');
+  if (oocyte !== undefined || sperm !== undefined) {
+    result.geneticMaterial = {};
+    if (oocyte !== undefined) result.geneticMaterial.oocyte = oocyte;
+    if (sperm !== undefined) result.geneticMaterial.sperm = sperm;
+  }
 
   if (isPlainObject(artProgram.medicalTeam)) result.medicalTeam = artProgram.medicalTeam;
 
   return result;
 };
 
-// One case record, migrated to the v5 shape (spec §1/§4) - idempotent (re-running on an
-// already-v5 case returns `report.changed: false` and the same data), never guesses missing/
-// ambiguous data (reports it instead, spec §4.7).
-export const migrateCaseToV5 = rawCase => {
+// One case record, migrated to the v6 shape (spec §1-§9) - idempotent (re-running on an
+// already-v6 case returns `report.changed: false` and the same data), never guesses missing/
+// ambiguous data (reports it instead, spec §4.7). The ancient pre-v5 `relations.clinicId` already
+// meant exactly what v6's `relations.clinicId` means again (v5 was the one detour that renamed it
+// to `ukrainianClinicId` to make room for a separate `partnerClinicId`) - so it's left untouched
+// here, and only the v5 name gets renamed back.
+export const migrateCaseToV6 = rawCase => {
   const report = emptyMigrationReport();
   if (!isPlainObject(rawCase)) return { case: {}, report };
 
   const relations = isPlainObject(rawCase.relations) ? { ...rawCase.relations } : {};
-  if (relations.clinicId && !relations.ukrainianClinicId) {
-    relations.ukrainianClinicId = relations.clinicId;
+  if (relations.ukrainianClinicId && !relations.clinicId) {
+    relations.clinicId = relations.ukrainianClinicId;
     report.changed = true;
   }
-  delete relations.clinicId;
+  if (relations.ukrainianClinicId !== undefined) { delete relations.ukrainianClinicId; report.changed = true; }
+  if (relations.partnerClinicId !== undefined) { delete relations.partnerClinicId; report.changed = true; }
   delete relations.shipment;
 
-  const { shipment, relationsPatch } = migrateEmbryoShipment(rawCase, report);
+  const { shipment, ivfDate, relationsPatch } = migrateEmbryoShipment(rawCase, report);
   Object.entries(relationsPatch).forEach(([key, value]) => { relations[key] = value; });
 
-  if (!relations.ukrainianClinicId) report.missingRelations.push('relations.ukrainianClinicId');
+  if (!relations.clinicId) report.missingRelations.push('relations.clinicId');
   if (!relations.coupleId) report.missingRelations.push('relations.coupleId');
   if (!relations.surrogateMotherId) report.missingRelations.push('relations.surrogateMotherId');
 
   const medical = migrateMedicalData(rawCase, report);
   const transferAttempt = migrateTransferAttempt(rawCase, report);
 
+  const rawArtProgram = isPlainObject(rawCase.artProgram) ? rawCase.artProgram : {};
+  let ivf;
+  if (isPlainObject(rawArtProgram.ivf) && rawArtProgram.ivf.date !== undefined) {
+    ivf = rawArtProgram.ivf;
+  } else if (ivfDate !== undefined) {
+    ivf = { date: ivfDate };
+    report.changed = true;
+  }
+
   const artProgram = {
     ...medical,
     ...(transferAttempt ? { transferAttempt } : {}),
-    ...(shipment ? { embryoShipment: shipment } : {}),
+    // A shipment whose only stored content was ivfDate (now split out to artProgram.ivf above)
+    // migrates to an empty object - never persisted as `embryoShipment: {}`.
+    ...(shipment && Object.keys(shipment).length ? { embryoShipment: shipment } : {}),
+    ...(ivf ? { ivf } : {}),
   };
 
   const documents = isPlainObject(rawCase.documents) ? { ...rawCase.documents } : {};
@@ -1116,18 +1176,18 @@ export const migrateCaseToV5 = rawCase => {
   return { case: migratedCase, report };
 };
 
-// Runs migrateCaseToV5 across every case in a raw `cases` snapshot and aggregates the per-case
+// Runs migrateCaseToV6 across every case in a raw `cases` snapshot and aggregates the per-case
 // reports into the one migration report spec §4.7 wants - migratedCaseIds (any case that actually
 // changed shape), and missingRelations/ambiguities/unmigratable keyed by case id so nothing is lost
 // even when several cases have issues.
-export const migrateCasesToV5 = rawCases => {
+export const migrateCasesToV6 = rawCases => {
   const records = toRecordsWithIdFromKey(rawCases).filter(isPlainObject);
   const cases = [];
   const report = {
     migratedCaseIds: [], missingRelations: {}, ambiguities: {}, unmigratable: {},
   };
   records.forEach(rawCase => {
-    const { case: migratedCase, report: caseReport } = migrateCaseToV5(rawCase);
+    const { case: migratedCase, report: caseReport } = migrateCaseToV6(rawCase);
     cases.push(migratedCase);
     const caseId = migratedCase.id ?? rawCase.id;
     if (caseReport.changed) report.migratedCaseIds.push(caseId);
@@ -1142,15 +1202,15 @@ export const migrateCasesToV5 = rawCases => {
 // storage is 4 sibling RTDB paths (parties/cases/templates/settings), not one combined root object,
 // so the marker lives on `documentsBuilder/settings.schemaVersion` - the one path every load already
 // reads (see normalizeDocumentsSettings, which always stamps the current version going forward).
-// `cases` migrate unconditionally and idempotently regardless of this marker (migrateCaseToV5 above
-// is cheap and safe to re-run) - this validator is for a caller that wants to tell a pre-v5 record
+// `cases` migrate unconditionally and idempotently regardless of this marker (migrateCaseToV6 above
+// is cheap and safe to re-run) - this validator is for a caller that wants to tell a pre-v6 record
 // apart from one already on the current schema (e.g. to warn an admin migration hasn't run yet).
-export const isDocumentsSchemaV5 = rawSettings => isPlainObject(rawSettings) && rawSettings.schemaVersion === CURRENT_SCHEMA_VERSION;
+export const isDocumentsSchemaV6 = rawSettings => isPlainObject(rawSettings) && rawSettings.schemaVersion === CURRENT_SCHEMA_VERSION;
 
 // Every case record passes through the migration boundary above exactly once, here - nothing
 // downstream (resolveShipment, resolveCaseContext, the case editors) ever branches on a legacy
-// shape again. Re-normalizing an already-v5 case changes nothing (migrateCaseToV5 is idempotent).
-export const normalizeCaseRecord = rawCase => (isPlainObject(rawCase) ? migrateCaseToV5(rawCase).case : {});
+// shape again. Re-normalizing an already-v6 case changes nothing (migrateCaseToV6 is idempotent).
+export const normalizeCaseRecord = rawCase => (isPlainObject(rawCase) ? migrateCaseToV6(rawCase).case : {});
 
 // Strips undefined/null/''-valued fields (and now-empty objects) out of a case form draft before
 // it's written to Firebase, so saving a case that has no documents data yet never creates empty
@@ -1239,21 +1299,23 @@ export const TEMPLATE_DOCUMENT_CONFIG = {
 const DEFAULT_NOTARY_TEMPLATE_CONFIG = { documentKey: 'birthRegistrationConsent', usesNotary: true };
 
 // --- ART program (case.artProgram) - resolvers, formatters, document contexts ----------------
-// v5 (spec §1.3/§1.4): the medical facts of a case's fertility program live once at
-// `case.artProgram` - `medicalIndications`, scalar `oocyteSource`/`spermSource`, the one embryo
-// shipment (`artProgram.embryoShipment`), and the one relevant transfer attempt
-// (`artProgram.transferAttempt`, itself carrying at most one nested `hcgTest`/`ultrasound`). None of
-// these carry an id, live in an array, or are keyed by id in a map - a case has at most one of each,
-// full stop. Every document that references one of these events (embryoOwnershipStatement,
-// geneticAffinityCertificate, racssClinicLetter) resolves the case's singleton directly - there is
-// nothing left to select by id, so editing an event once (e.g. the transfer date) is instantly
-// reflected in every document that references it, since none of them ever copy the fact.
+// v6 (spec §1-§7): the medical facts of a case's fertility program live once at `case.artProgram`
+// - `medicalIndications`, flat `geneticMaterial.oocyte`/`geneticMaterial.sperm`, the standalone
+// `ivf.date`, the one embryo shipment (`artProgram.embryoShipment`, carrying its own
+// `sourceClinicId`), and the one relevant transfer attempt (`artProgram.transferAttempt`, itself
+// carrying at most one nested `hcgTest`/`ultrasound`). None of these carry an id, live in an
+// array, or are keyed by id in a map - a case has at most one of each, full stop. Every document
+// that references one of these events (embryoOwnershipStatement, geneticAffinityCertificate,
+// racssClinicLetter) resolves the case's singleton directly - there is nothing left to select by
+// id, so editing an event once (e.g. the transfer date) is instantly reflected in every document
+// that references it, since none of them ever copy the fact.
 //
 // Legacy shapes (relations.shipment, artProgram.embryoShipments/hcgTests/ultrasounds id-maps,
-// artProgram.geneticMaterial.*PartnerRole, artProgram.medicalIndication.diagnosis, and any
-// hcgTestId/ultrasoundId/shipmentId document pointer) are read exactly once, at the single migration
-// boundary (migrateCaseToV5, called from normalizeCaseRecord on every load) - nothing below this
-// point ever branches on an old shape again.
+// artProgram.geneticMaterial.*PartnerRole, artProgram.medicalIndication.diagnosis, the v5 scalar
+// oocyteSource/spermSource, relations.ukrainianClinicId/partnerClinicId, and any
+// hcgTestId/ultrasoundId/shipmentId document pointer) are read exactly once, at the single
+// migration boundary (migrateCaseToV6, called from normalizeCaseRecord on every load) - nothing
+// below this point ever branches on an old shape again.
 
 export const resolveShipment = caseData => caseData?.artProgram?.embryoShipment ?? null;
 
@@ -1265,21 +1327,12 @@ export const resolveHcgTest = transferAttempt => transferAttempt?.hcgTest ?? nul
 
 export const resolveUltrasound = transferAttempt => transferAttempt?.ultrasound ?? null;
 
-// Reserved genetic-material scalar values (spec §1.7) - anything else non-empty is a donor code,
-// displayed as itself.
+// Reserved genetic-material scalar values (spec §1.7/§6) - anything else non-empty is a donor
+// code, displayed as itself. `geneticMaterial.oocyte`/`geneticMaterial.sperm` are read as plain
+// raw values (spec §6) - never auto-resolved to a name/label here; the genetic-affinity
+// certificate leaves those fields blank for manual entry.
 export const GENETIC_SOURCE_ROLE_VALUES = ['wife', 'husband'];
 export const isGeneticSourceDonorCode = value => Boolean(value) && !GENETIC_SOURCE_ROLE_VALUES.includes(value);
-
-// spec §3.4: resolves a scalar oocyteSource/spermSource straight to a template-ready label - the
-// wife/husband's own resolved (and already short-name-enriched) name for the two reserved role
-// values, or the donor code string itself for anything else. Never a lookup table with real people;
-// the two names it can return are exactly the ones already resolved elsewhere in the same context.
-export const resolveGeneticSourceLabel = (source, { wife, husband } = {}) => {
-  if (!source) return null;
-  if (source === 'wife') return wife?.name ?? null;
-  if (source === 'husband') return husband?.name ?? null;
-  return { uk: source, en: source };
-};
 
 // A name's declined grammatical form (genitive "з клініки «Оті Юме»", accusative "у клініку
 // «Вікторія»") lives directly on `name.uk` as a sibling of `nominative` (spec: the same
@@ -1298,18 +1351,19 @@ const withDeclinedNameFallback = (record, grammaticalCase) => {
   };
 };
 
-// v5: a shipment carries no clinic ids of its own any more (spec §1.2/§1.4) - the foreign source
-// clinic and Ukrainian destination clinic are the case's own relations
-// (relations.partnerClinicId/ukrainianClinicId), already resolved once in resolveCaseContext and
-// passed in here - never mutates the stored shipment, just layers the resolved party records on top.
-// The real templates read `{{partnerClinic.name.uk.genitive}}`/`{{clinic.name.uk.accusative}}`
-// directly (never through this shipment-nested alias) - `sourceClinic`/`destinationClinic` are kept
-// as a convenience alias for any template that does reference them through the shipment.
-export const enrichShipment = (shipment, { partnerClinic, clinic } = {}) => {
+// v6 (spec §3/§4): a shipment carries its own sourceClinicId (resolved to `sourceClinic`,
+// looked up straight off the unified `parties.clinics` - never a separate `partnerClinics`
+// collection); the destination clinic is always the case's own `clinic` (relations.clinicId), the
+// same one every other document already resolves - never mutates the stored shipment, just layers
+// the resolved party records on top. The real templates read `{{sourceClinic.name.uk.genitive}}`/
+// `{{clinic.name.uk.accusative}}` directly (never through this shipment-nested alias) -
+// `sourceClinic`/`destinationClinic` are kept as a convenience alias for any template that does
+// reference them through the shipment.
+export const enrichShipment = (shipment, { sourceClinic, clinic } = {}) => {
   if (!shipment) return null;
   return {
     ...shipment,
-    sourceClinic: withDeclinedNameFallback(partnerClinic, 'genitive'),
+    sourceClinic: withDeclinedNameFallback(sourceClinic, 'genitive'),
     destinationClinic: withDeclinedNameFallback(clinic, 'accusative'),
   };
 };
@@ -1325,18 +1379,17 @@ export const formatDateNumericUk = value => (isIsoDate(value) ? formatDocumentDa
 
 // A date range, spelled out long-form in English and numeric in Ukrainian - "01.01.2026 – 01.02.2026"
 // / "01 January 2026 - 01 February 2026". Used only when a shipment's plannedPeriod carries real
-// startDate/endDate values (the new shape) rather than a migrated freeform text (see
-// formatShipmentPeriod).
-export const formatDateRange = (startDate, endDate, locale) => {
-  if (locale === 'en') return `${formatDateLongEn(startDate)} - ${formatDateLongEn(endDate)}`;
-  return `${formatDateNumericUk(startDate)} – ${formatDateNumericUk(endDate)}`;
+// start/end values rather than a migrated freeform text (see formatShipmentPeriod).
+export const formatDateRange = (start, end, locale) => {
+  if (locale === 'en') return `${formatDateLongEn(start)} - ${formatDateLongEn(end)}`;
+  return `${formatDateNumericUk(start)} – ${formatDateNumericUk(end)}`;
 };
 
-// Supports both plannedPeriod shapes (spec §6): the new startDate/endDate pair, or a migrated
-// freeform text kept verbatim per locale - never both computed and stored, this only ever reads
-// whichever shape is actually present.
+// Supports both plannedPeriod shapes (spec §6/§7): the v6 start/end pair, or a migrated freeform
+// text kept verbatim per locale - never both computed and stored, this only ever reads whichever
+// shape is actually present.
 export const formatShipmentPeriod = (period, locale = 'uk') => {
-  if (period?.startDate && period?.endDate) return formatDateRange(period.startDate, period.endDate, locale);
+  if (period?.start && period?.end) return formatDateRange(period.start, period.end, locale);
   return period?.text?.[locale] ?? '';
 };
 
@@ -1401,15 +1454,24 @@ export const formatPregnancyTypeTextUk = fetusCount => PREGNANCY_TYPE_LABELS_UK[
 
 // Layers the formatted-for-template fields onto an already party-enriched shipment (see
 // enrichShipment) - a separate step so a caller that only needs the formatted dates (no clinic
-// enrichment) can call this alone.
+// enrichment) can call this alone. `ivfDate`/`sentDate` no longer belong to the shipment at all
+// (spec §5/§7) - see enrichIvfForTemplate for the former, the latter is dropped entirely.
 export const enrichShipmentForTemplate = shipment => {
   if (!shipment) return null;
   return {
     ...shipment,
-    ivfDateFormatted: { uk: formatDateNumericUk(shipment.ivfDate), en: formatDateLongEn(shipment.ivfDate) },
     plannedPeriodFormatted: { uk: formatShipmentPeriod(shipment.plannedPeriod, 'uk'), en: formatShipmentPeriod(shipment.plannedPeriod, 'en') },
-    sentDateFormatted: { uk: formatDateNumericUk(shipment.sentDate), en: formatDateLongEn(shipment.sentDate) },
     receivedDateFormatted: { uk: formatDateNumericUk(shipment.receivedDate), en: formatDateLongEn(shipment.receivedDate) },
+  };
+};
+
+// case.artProgram.ivf (spec §5/§7) - a standalone singleton, distinct from the shipment, so
+// {{ivf.dateFormatted.uk}}/{{ivf.dateFormatted.en}} resolve independently of it.
+export const enrichIvfForTemplate = ivf => {
+  if (!ivf) return null;
+  return {
+    ...ivf,
+    dateFormatted: { uk: formatDateNumericUk(ivf.date), en: formatDateLongEn(ivf.date) },
   };
 };
 
@@ -1448,8 +1510,8 @@ export const enrichUltrasoundForTemplate = ultrasound => {
 
 // case.documents.embryoOwnershipStatement - spec §1.8/§4. There is only ever the case's one
 // shipment (resolveShipment) - no shipmentId of its own to pick. `clinics` is
-// `{ partnerClinic, clinic }`, the same pair resolveCaseContext already resolves from the case's own
-// relations.
+// `{ sourceClinic, clinic }`, the same pair resolveCaseContext already resolves from the case's own
+// relations/shipment.
 export const buildEmbryoOwnershipStatementContext = (caseData, clinics, ownershipData) => {
   const data = isPlainObject(ownershipData) ? ownershipData : {};
   const resolvedShipment = enrichShipmentForTemplate(enrichShipment(resolveShipment(caseData), clinics));
@@ -1476,8 +1538,9 @@ export const buildGeneticAffinityCertificateContext = (caseData, clinics, certif
     // Shared/cross-referenced by any other document conditioning a block on whether the wife
     // herself was the oocyte donor (e.g. the RATS/birth-registration statement's "та генетичною
     // матір'ю ..." clause) - the "У лікувальній програмі ДРТ використано яйцеклітини..." field this
-    // certificate itself prints from the case's scalar case.artProgram.oocyteSource (spec §1.7).
-    oocyteSourceIsWife: caseData?.artProgram?.oocyteSource === 'wife',
+    // certificate itself prints from the case's scalar case.artProgram.geneticMaterial.oocyte
+    // (spec §1.7/§6).
+    oocyteSourceIsWife: caseData?.artProgram?.geneticMaterial?.oocyte === 'wife',
   };
 };
 
@@ -1578,26 +1641,27 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
   const notaryId = notaryDocumentKey ? (documentContextsByStorageKey[notaryDocumentKey]?.notaryId ?? null) : null;
   const notary = enrichPersonName(notaryId ? findById(catalog.parties.notaries, notaryId) : null);
 
-  // The Ukrainian clinic (parties.clinics, relations.ukrainianClinicId) runs the surrogacy program
-  // and signs the documents; the partner clinic (parties.partnerClinics, relations.partnerClinicId)
-  // is the separate foreign clinic embryos ship from - never the same collection, never a second
-  // "main" clinic (spec §1.2). Both are null-safe: an old case with no partnerClinicId/
-  // ukrainianClinicId simply resolves to null rather than throwing, so a template referencing it
-  // degrades to a visible warning instead of a crash (see getUnresolvedVariablePaths/
-  // fillPlaceholders) - e.g. a case with no clinic relation at all (case-kikawa in the reference
-  // data has no maternity-hospital relation).
-  const partnerClinic = relations.partnerClinicId
-    ? findById(catalog.parties.partnerClinics, relations.partnerClinicId)
-    : null;
-  const rawClinic = relations.ukrainianClinicId ? findById(catalog.parties.clinics, relations.ukrainianClinicId) : null;
-  const clinic = rawClinic ? {
+  // The case's own clinic (parties.clinics, relations.clinicId) both runs the surrogacy program in
+  // Ukraine and receives the embryos - it signs the documents and is the destination every shipment
+  // resolves against; the shipment's own sourceClinicId (spec §3/§4) resolves the separate foreign
+  // clinic embryos ship from, from that same unified `parties.clinics` collection - never a second
+  // "main" clinic, never a distinct `partnerClinics` collection any more (spec §1). Both are
+  // null-safe: a case with no clinicId/sourceClinicId simply resolves to null rather than throwing,
+  // so a template referencing it degrades to a visible warning instead of a crash (see
+  // getUnresolvedVariablePaths/fillPlaceholders) - e.g. a case with no clinic relation at all
+  // (case-kikawa in the reference data has no maternity-hospital relation).
+  const enrichClinic = rawClinic => (rawClinic ? {
     ...rawClinic,
     medicalDirector: rawClinic.medicalDirector ? {
       ...rawClinic.medicalDirector,
       name: enrichNameWithDerivedFields(rawClinic.medicalDirector.name),
     } : rawClinic.medicalDirector,
-  } : null;
-  const resolvedClinics = { partnerClinic, clinic };
+  } : null);
+  const clinic = enrichClinic(relations.clinicId ? findById(catalog.parties.clinics, relations.clinicId) : null);
+  const rawArtProgram = isPlainObject(caseRecord.artProgram) ? caseRecord.artProgram : {};
+  const rawShipment = resolveShipment(caseRecord);
+  const sourceClinic = enrichClinic(rawShipment?.sourceClinicId ? findById(catalog.parties.clinics, rawShipment.sourceClinicId) : null);
+  const resolvedClinics = { sourceClinic, clinic };
 
   const wife = enrichPersonName(rawWife);
   const husband = enrichPersonName(rawHusband);
@@ -1612,17 +1676,12 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
   const medicalServicesAgreement = buildMedicalServicesAgreementContext(documents.medicalServicesAgreement);
 
   // Canonical top-level ART-program aliases (spec §5.1): the same singleton shipment/transfer
-  // attempt/hCG test/ultrasound every document-scoped context above already resolves, exposed
+  // attempt/hCG test/ultrasound/ivf every document-scoped context above already resolves, exposed
   // directly so a template can reference {{embryoShipment...}}/{{transferAttempt...}}/{{hcgTest...}}/
-  // {{ultrasound...}} without going through a specific document's namespace.
-  const rawArtProgram = isPlainObject(caseRecord.artProgram) ? caseRecord.artProgram : {};
+  // {{ultrasound...}}/{{ivf...}} without going through a specific document's namespace.
   const transferAttemptRaw = resolveTransferAttempt(caseRecord);
-  const shipmentForContext = enrichShipment(resolveShipment(caseRecord), resolvedClinics);
-  const artProgram = {
-    ...rawArtProgram,
-    oocyteSourceLabel: resolveGeneticSourceLabel(rawArtProgram.oocyteSource, { wife, husband }),
-    spermSourceLabel: resolveGeneticSourceLabel(rawArtProgram.spermSource, { wife, husband }),
-  };
+  const shipmentForContext = enrichShipment(rawShipment, resolvedClinics);
+  const artProgram = rawArtProgram;
 
   return {
     case: caseRecord,
@@ -1634,7 +1693,7 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
       ? findById(catalog.parties.surrogateMothers, relations.surrogateMotherId)
       : null),
     clinic,
-    partnerClinic,
+    sourceClinic,
     representative: representatives[0] || null,
     representatives,
     childbirth,
@@ -1650,6 +1709,7 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
     transferAttempt: enrichTransferForTemplate(transferAttemptRaw, shipmentForContext),
     hcgTest: enrichHcgTestForTemplate(resolveHcgTest(transferAttemptRaw)),
     ultrasound: enrichUltrasoundForTemplate(resolveUltrasound(transferAttemptRaw)),
+    ivf: enrichIvfForTemplate(rawArtProgram.ivf),
     surrogacyAgreement,
     birthRegistration,
     maritalStatusDeclaration,
@@ -1750,7 +1810,7 @@ export const fillPlaceholders = (text, context, lang = 'uk') => String(text || '
 // document entirely - e.g. "та генетичною матір'ю ... Кацура Юкако," in the RATS/birth-
 // registration statement must only print when the wife herself was the oocyte donor
 // (geneticAffinityCertificate.oocyteSourceIsWife, shared/cross-referenced off the same
-// case.artProgram.oocyteSource scalar every genetic-affinity-certificate resolves from - see
+// case.artProgram.geneticMaterial.oocyte scalar every genetic-affinity-certificate resolves from - see
 // buildGeneticAffinityCertificateContext), never shown with a blank/unresolved
 // value for any other oocyte source. No `condition` at all (the vast majority of blocks) always
 // renders, so this is fully backward compatible.
@@ -1907,13 +1967,13 @@ export const getTemplateReferencedPaths = template => {
 const SYSTEM_VARIABLE_PATHS = ['logo', 'logo-long'];
 // Every resolveCaseContext top-level key that resolves a relation record from `catalog.parties.*`
 // straight off `case.relations` - as opposed to a resolved/derived context alias below.
-const RESOLVED_RELATION_PATH_PREFIXES = ['relations.', 'couple.', 'wife.', 'husband.', 'clinic.', 'partnerClinic.', 'surrogateMother.', 'representative.', 'representatives.', 'notary.', 'maternityHospital.'];
+const RESOLVED_RELATION_PATH_PREFIXES = ['relations.', 'couple.', 'wife.', 'husband.', 'clinic.', 'sourceClinic.', 'surrogateMother.', 'representative.', 'representatives.', 'notary.', 'maternityHospital.'];
 // Runtime-only aliases: the canonical ART-program singleton paths (spec §5.1), and every
 // document-scoped context object resolveCaseContext builds fresh on each render - none of these
 // are ever themselves stored in Firebase, even though some of their leaves pass through
 // unmodified stored requisites (e.g. `geneticAffinityCertificate.outgoingNumber`).
 const DERIVED_RUNTIME_PATH_PREFIXES = [
-  'artProgram.', 'embryoShipment.', 'transferAttempt.', 'hcgTest.', 'ultrasound.',
+  'artProgram.', 'embryoShipment.', 'transferAttempt.', 'hcgTest.', 'ultrasound.', 'ivf.',
   'surrogacyAgreement.', 'birthRegistration.', 'maritalStatusDeclaration.', 'legalServicesDisclaimer.', 'surrogacyAgreementAppendix1.',
   'embryoOwnershipStatement.', 'geneticAffinityCertificate.', 'racssClinicLetter.', 'medicalServicesAgreement.',
 ];
@@ -1952,7 +2012,7 @@ export const validateCaseRecord = rawCaseRecord => {
 
   requirePresent(caseRecord.id, 'case.id');
   requirePresent(caseRecord.relations?.coupleId, 'case.relations.coupleId');
-  requirePresent(caseRecord.relations?.ukrainianClinicId, 'case.relations.ukrainianClinicId');
+  requirePresent(caseRecord.relations?.clinicId, 'case.relations.clinicId');
   requirePresent(caseRecord.relations?.surrogateMotherId, 'case.relations.surrogateMotherId');
   if (!toArray(caseRecord.childbirth?.children).length) issues.push('case.childbirth.children');
 
@@ -2990,8 +3050,11 @@ export const findPartyReferences = (catalog, collection, id) => {
     const relations = caseRecord.relations || {};
     switch (collection) {
       case 'couples': return String(relations.coupleId) === targetId;
-      case 'clinics': return String(relations.ukrainianClinicId) === targetId;
-      case 'partnerClinics': return String(relations.partnerClinicId) === targetId;
+      // A clinic can be referenced two ways now (spec §1/§4): as the case's own destination clinic
+      // (relations.clinicId), or as a shipment's source clinic (artProgram.embryoShipment.
+      // sourceClinicId) - either one counts as a reference.
+      case 'clinics': return String(relations.clinicId) === targetId
+        || String(caseRecord.artProgram?.embryoShipment?.sourceClinicId) === targetId;
       case 'surrogateMothers': return String(relations.surrogateMotherId) === targetId;
       case 'representatives': return toArray(relations.representativeIds).some(repId => String(repId) === targetId);
       case 'maternityHospitals': return String(caseRecord.childbirth?.maternityHospitalId) === targetId;
@@ -3043,16 +3106,18 @@ export const VARIABLE_PICKER_GROUPS = [
   { label: 'Довірена особа', roots: ['representative'] },
   { label: 'Клініка — іноземна', roots: ['clinic'], predicate: context => context?.clinic?.kind === 'foreign' },
   { label: 'Клініка — українська', roots: ['clinic'], predicate: context => context?.clinic?.kind !== 'foreign' },
-  // Distinct from the `clinic` groups above: the partner clinic (parties.partnerClinics) is never
-  // the case's own `clinic` record under a different kind - it's the separate foreign clinic
-  // embryos ship from (spec: embryo-ownership-statement document). Shown whenever one is selected
-  // on the case; a case without a partnerClinicId simply doesn't offer this group.
-  { label: 'Клініка-партнер', roots: ['partnerClinic'], predicate: context => Boolean(context?.partnerClinic) },
+  // Distinct from the `clinic` groups above: the source clinic (spec §3/§4, resolved from the
+  // shipment's own sourceClinicId - still looked up in the same unified `parties.clinics`, never a
+  // separate collection) is never the case's own `clinic` record under a different kind - it's the
+  // separate clinic embryos ship from (spec: embryo-ownership-statement document). Shown whenever
+  // one is selected on the case; a case without a shipment sourceClinicId simply doesn't offer
+  // this group.
+  { label: 'Клініка-відправник', roots: ['sourceClinic'], predicate: context => Boolean(context?.sourceClinic) },
   // The canonical top-level ART-program singleton aliases (spec §5.1) - shown only once the case
   // actually carries artProgram data, same idea as the document-scoped groups below.
   {
     label: 'Програма ДРТ',
-    roots: ['artProgram', 'embryoShipment', 'transferAttempt', 'hcgTest', 'ultrasound'],
+    roots: ['artProgram', 'embryoShipment', 'transferAttempt', 'hcgTest', 'ultrasound', 'ivf'],
     predicate: context => Boolean(context?.case?.artProgram),
   },
   // ART program document contexts (spec §7) - each root is a top-level key resolveCaseContext
@@ -3718,9 +3783,9 @@ export const diffDocFormattingOverrides = (referenceFormatting, workingFormattin
 export const normalizeDocumentsSettings = raw => {
   const source = isPlainObject(raw) ? raw : {};
   return {
-    // Every case/party record is already migrated to v5 shape by the time this runs (see
-    // migrateCaseToV5/normalizeCaseRecord) - stamping the current version here means the next
-    // settings save persists `schemaVersion: 5` even if the stored record predates this marker.
+    // Every case/party record is already migrated to v6 shape by the time this runs (see
+    // migrateCaseToV6/normalizeCaseRecord) - stamping the current version here means the next
+    // settings save persists `schemaVersion: 6` even if the stored record predates this marker.
     schemaVersion: CURRENT_SCHEMA_VERSION,
     formatting: normalizeDocFormatting(source.formatting),
     clinicLogo: null,

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -24,7 +24,6 @@ import {
   createEmptyMaternityHospital,
   createEmptyNotary,
   createEmptyPartner,
-  createEmptyPartnerClinic,
   createEmptyRepresentative,
   createEmptySurrogateMother,
   deepMergeRecords,
@@ -369,20 +368,20 @@ describe('mergeDocumentsCatalog', () => {
     expect(templatePatchRecord.title.en).toBe('No id');
   });
 
-  // Spec (batch 2026-07-24) §11: importing `{"cases":{"case-1":{"relations":{"partnerClinicId":...}}}}`
-  // must never wipe clinicId/coupleId/surrogateMotherId/representativeIds already on that case -
-  // the merge into `relations` (and `documents`) has to be a deep, additive, field-by-field merge,
-  // exactly like every other nested case branch.
-  it('adding partnerClinicId via Parse & merge never wipes the case\'s existing relations (spec §11)', () => {
+  // Spec (batch 2026-07-24) §11: importing `{"cases":{"case-1":{"relations":{"clinicId":...}}}}`
+  // must never wipe coupleId/surrogateMotherId/representativeIds already on that case - the merge
+  // into `relations` (and `documents`) has to be a deep, additive, field-by-field merge, exactly
+  // like every other nested case branch.
+  it('adding clinicId via Parse & merge never wipes the case\'s existing relations (spec §11)', () => {
     const current = { ...emptyDocumentsCatalog() };
     current.cases = [{
       id: 'case-1',
       relations: {
-        clinicId: 'clinic-1', coupleId: 'couple-2', surrogateMotherId: 'surrogate-mother-2', representativeIds: ['representative-1'],
+        coupleId: 'couple-2', surrogateMotherId: 'surrogate-mother-2', representativeIds: ['representative-1'],
       },
     }];
     const incoming = parseDocumentsTechnicalInput(JSON.stringify({
-      cases: { 'case-1': { relations: { partnerClinicId: 'partner-clinic-1' } } },
+      cases: { 'case-1': { relations: { clinicId: 'clinic-1' } } },
     }));
     const { catalog } = mergeDocumentsCatalog(current, incoming);
     const mergedCase = catalog.cases[0];
@@ -391,24 +390,28 @@ describe('mergeDocumentsCatalog', () => {
       coupleId: 'couple-2',
       surrogateMotherId: 'surrogate-mother-2',
       representativeIds: ['representative-1'],
-      partnerClinicId: 'partner-clinic-1',
     });
   });
 
-  it('merges parties.partnerClinics, cases.*.documents.embryoOwnershipStatement and templates.embryo-ownership-statement additively (spec §11)', () => {
+  // v6 (spec §1): the shipment's source clinic lives in the same unified `parties.clinics`
+  // collection as every other clinic - never a separate `partnerClinics` one.
+  it('merges parties.clinics, cases.*.documents.embryoOwnershipStatement and templates.embryo-ownership-statement additively (spec §11)', () => {
     const current = sampleCatalog();
     const incoming = parseDocumentsTechnicalInput(JSON.stringify({
       parties: {
-        partnerClinics: {
-          'partner-clinic-1': {
-            id: 'partner-clinic-1',
+        clinics: {
+          'clinic-2': {
+            id: 'clinic-2',
             name: { uk: 'Клініка Оті Юме у м. Нагоя', en: 'Ochi Yume Clinic Nagoya' },
             address: { uk: 'Нагоя', en: 'Nagoya' },
           },
         },
       },
       cases: {
-        'case-1': { relations: { partnerClinicId: 'partner-clinic-1' }, documents: { embryoOwnershipStatement: { ivfDate: '2021-08-17' } } },
+        'case-1': {
+          artProgram: { embryoShipment: { sourceClinicId: 'clinic-2' } },
+          documents: { embryoOwnershipStatement: { ivfDate: '2021-08-17' } },
+        },
       },
       templates: {
         'embryo-ownership-statement': { id: 'embryo-ownership-statement', title: { uk: 'Щодо приналежності ембріонів', en: 'Regarding ownership of embryos' } },
@@ -416,14 +419,13 @@ describe('mergeDocumentsCatalog', () => {
     }));
     const { catalog } = mergeDocumentsCatalog(current, incoming);
 
-    expect(catalog.parties.partnerClinics.map(record => record.id)).toEqual(['partner-clinic-1']);
+    expect(catalog.parties.clinics.map(record => record.id).sort()).toEqual(['clinic-1', 'clinic-2']);
     // Every party collection that wasn't touched by this import stays exactly as it was.
-    expect(catalog.parties.clinics.map(record => record.id)).toEqual(['clinic-1']);
     expect(catalog.parties.couples.map(record => record.id)).toEqual(['couple-1']);
 
     const mergedCase = catalog.cases.find(record => record.id === 'case-1');
     expect(mergedCase.relations.coupleId).toBe('couple-1');
-    expect(mergedCase.relations.partnerClinicId).toBe('partner-clinic-1');
+    expect(mergedCase.artProgram.embryoShipment.sourceClinicId).toBe('clinic-2');
     expect(mergedCase.documents.embryoOwnershipStatement.ivfDate).toBe('2021-08-17');
 
     expect(catalog.documents.some(record => record.id === 'embryo-ownership-statement')).toBe(true);
@@ -787,23 +789,24 @@ describe('spec: universal placeholder resolver', () => {
   });
 });
 
-// --- spec (batch 2026-07-24): partner clinic + embryo ownership statement document -------------
-// The Ukrainian clinic (parties.clinics, case.relations.clinicId) runs the surrogacy program; the
-// partner clinic (parties.partnerClinics, case.relations.partnerClinicId) is a distinct, foreign,
-// deliberately simplified party - the clinic embryos ship from. Both must resolve independently on
-// the same case, and a case without a partnerClinicId must degrade gracefully, never crash.
-const partnerClinicCatalog = ({ withPartnerClinic = true, ivfDate = '2021-08-17' } = {}) => normalizeDocumentsCatalog(
+// --- spec v6 §1/§3/§4: source clinic + embryo ownership statement document ---------------------
+// The destination clinic (parties.clinics, case.relations.clinicId) runs the surrogacy program;
+// the source clinic (parties.clinics, case.artProgram.embryoShipment.sourceClinicId - the same
+// unified collection, never a separate `partnerClinics` one) is the clinic embryos ship from.
+// Both must resolve independently on the same case, and a case whose shipment has no
+// sourceClinicId must degrade gracefully, never crash.
+const clinicWithSourceCatalog = ({ withSourceClinic = true, ivfDate = '2021-08-17' } = {}) => normalizeDocumentsCatalog(
   {
+    // v6 (spec §1): the shipment's source clinic lives in the same unified `clinics` collection
+    // as the destination clinic - never a separate `partnerClinics` one.
     clinics: {
       'clinic-1': {
         id: 'clinic-1',
         medicalCenterName: { uk: 'МЦ «Надія»', en: 'MC "Nadiya"' },
         legalName: { uk: 'ТОВ «Надія»', en: 'Nadiya LLC' },
       },
-    },
-    partnerClinics: {
-      'partner-clinic-1': {
-        id: 'partner-clinic-1',
+      'clinic-2': {
+        id: 'clinic-2',
         name: { uk: 'Клініка Оті Юме у м. Нагоя', en: 'Ochi Yume Clinic Nagoya' },
         address: {
           uk: 'Хісая Парксайд Будівля 8F, 3-19-12 Маруноуті, округ Нака, місто Нагоя, префектура Айті',
@@ -826,9 +829,9 @@ const partnerClinicCatalog = ({ withPartnerClinic = true, ivfDate = '2021-08-17'
       id: 'case-1',
       relations: {
         clinicId: 'clinic-1',
-        ...(withPartnerClinic ? { partnerClinicId: 'partner-clinic-1' } : {}),
         representativeIds: ['representative-1'],
       },
+      artProgram: withSourceClinic ? { embryoShipment: { sourceClinicId: 'clinic-2' } } : undefined,
       documents: {
         embryoOwnershipStatement: {
           shipmentPeriod: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' },
@@ -839,33 +842,33 @@ const partnerClinicCatalog = ({ withPartnerClinic = true, ivfDate = '2021-08-17'
   },
 );
 
-describe('spec: partner clinic is a distinct party type from the Ukrainian clinic', () => {
-  it('resolves context.partnerClinic from parties.partnerClinics via relations.partnerClinicId, independent of context.clinic', () => {
-    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+describe('spec v6 §3/§4: the source clinic is resolved from the same unified clinics collection, independent of the destination clinic', () => {
+  it('resolves context.sourceClinic from parties.clinics via embryoShipment.sourceClinicId, independent of context.clinic', () => {
+    const context = resolveCaseContext(clinicWithSourceCatalog(), 'case-1');
     expect(context.clinic.id).toBe('clinic-1');
-    expect(context.partnerClinic.id).toBe('partner-clinic-1');
-    expect(fillPlaceholders('{{partnerClinic.name.uk}}', context, 'uk')).toBe('Клініка Оті Юме у м. Нагоя');
-    expect(fillPlaceholders('{{partnerClinic.name.en}}', context, 'en')).toBe('Ochi Yume Clinic Nagoya');
-    expect(fillPlaceholders('{{partnerClinic.address.uk}}', context, 'uk')).toContain('Нагоя');
+    expect(context.sourceClinic.id).toBe('clinic-2');
+    expect(fillPlaceholders('{{sourceClinic.name.uk}}', context, 'uk')).toBe('Клініка Оті Юме у м. Нагоя');
+    expect(fillPlaceholders('{{sourceClinic.name.en}}', context, 'en')).toBe('Ochi Yume Clinic Nagoya');
+    expect(fillPlaceholders('{{sourceClinic.address.uk}}', context, 'uk')).toContain('Нагоя');
   });
 
-  it('resolves context.partnerClinic to null (not undefined, not a throw) when the case has no partnerClinicId (old cases)', () => {
-    const context = resolveCaseContext(partnerClinicCatalog({ withPartnerClinic: false }), 'case-1');
-    expect(context.partnerClinic).toBeNull();
-    expect(() => fillPlaceholders('{{partnerClinic.name.uk}}', context, 'uk')).not.toThrow();
-    expect(fillPlaceholders('{{partnerClinic.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
+  it('resolves context.sourceClinic to null (not undefined, not a throw) when the shipment has no sourceClinicId (old cases)', () => {
+    const context = resolveCaseContext(clinicWithSourceCatalog({ withSourceClinic: false }), 'case-1');
+    expect(context.sourceClinic).toBeNull();
+    expect(() => fillPlaceholders('{{sourceClinic.name.uk}}', context, 'uk')).not.toThrow();
+    expect(fillPlaceholders('{{sourceClinic.name.uk}}', context, 'uk')).toBe(MISSING_VALUE_PLACEHOLDER);
   });
 
-  it('flags {{partnerClinic.*}} as unresolved only when no partner clinic is selected, never when one is', () => {
-    const template = { title: { uk: '', en: '' }, paragraphs: [{ uk: '{{partnerClinic.name.uk}}', en: '{{partnerClinic.name.en}}' }] };
-    const withClinic = resolveCaseContext(partnerClinicCatalog({ withPartnerClinic: true }), 'case-1');
-    const withoutClinic = resolveCaseContext(partnerClinicCatalog({ withPartnerClinic: false }), 'case-1');
+  it('flags {{sourceClinic.*}} as unresolved only when no source clinic is selected, never when one is', () => {
+    const template = { title: { uk: '', en: '' }, paragraphs: [{ uk: '{{sourceClinic.name.uk}}', en: '{{sourceClinic.name.en}}' }] };
+    const withClinic = resolveCaseContext(clinicWithSourceCatalog({ withSourceClinic: true }), 'case-1');
+    const withoutClinic = resolveCaseContext(clinicWithSourceCatalog({ withSourceClinic: false }), 'case-1');
     expect(validateDocumentTemplate(template, withClinic)).toEqual([]);
-    expect(validateDocumentTemplate(template, withoutClinic)).toEqual(['partnerClinic.name.en', 'partnerClinic.name.uk']);
+    expect(validateDocumentTemplate(template, withoutClinic)).toEqual(['sourceClinic.name.en', 'sourceClinic.name.uk']);
   });
 
-  it('deleting/never-setting partnerClinicId never disturbs clinicId/coupleId/etc on the same case (null-safe, additive)', () => {
-    const catalog = partnerClinicCatalog({ withPartnerClinic: false });
+  it('deleting/never-setting the shipment\'s sourceClinicId never disturbs clinicId/coupleId/etc on the same case (null-safe, additive)', () => {
+    const catalog = clinicWithSourceCatalog({ withSourceClinic: false });
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.clinic.id).toBe('clinic-1');
     expect(context.representatives).toHaveLength(1);
@@ -874,18 +877,18 @@ describe('spec: partner clinic is a distinct party type from the Ukrainian clini
 
 describe('spec: case.documents.embryoOwnershipStatement resolves through the existing `case` root', () => {
   it('resolves shipmentPeriod.uk/en directly, no derived context field needed', () => {
-    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog(), 'case-1');
     expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.shipmentPeriod.uk}}', context, 'uk')).toBe('квітні – травні 2026 року');
     expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.shipmentPeriod.en}}', context, 'en')).toBe('April-May 2026');
   });
 
   it('formats an ISO-stored ivfDate as DD.MM.YYYY, same as every other document date', () => {
-    const context = resolveCaseContext(partnerClinicCatalog({ ivfDate: '2021-08-17' }), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog({ ivfDate: '2021-08-17' }), 'case-1');
     expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.ivfDate}}', context, 'uk')).toBe('17.08.2021');
   });
 
   it('still renders a legacy DD.MM.YYYY-stored ivfDate correctly (read-time compatibility, spec §6)', () => {
-    const context = resolveCaseContext(partnerClinicCatalog({ ivfDate: '17.08.2021' }), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog({ ivfDate: '17.08.2021' }), 'case-1');
     expect(fillPlaceholders('{{case.documents.embryoOwnershipStatement.ivfDate}}', context, 'uk')).toBe('17.08.2021');
   });
 
@@ -899,14 +902,14 @@ describe('spec: case.documents.embryoOwnershipStatement resolves through the exi
 
 describe('spec: clinic name for the new document is medicalCenterName, not clinic.name', () => {
   it('resolves clinic.medicalCenterName.uk/en for a clinic record that never set clinic.name', () => {
-    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog(), 'case-1');
     expect(context.clinic.name).toBeUndefined();
     expect(fillPlaceholders('{{clinic.medicalCenterName.uk}}', context, 'uk')).toBe('МЦ «Надія»');
     expect(fillPlaceholders('{{clinic.medicalCenterName.en}}', context, 'en')).toBe('MC "Nadiya"');
   });
 
   it('flags {{clinic.name.uk}} as unresolved when the real clinic record never populated `name` (spec §12)', () => {
-    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog(), 'case-1');
     const template = { title: { uk: '', en: '' }, paragraphs: [{ uk: '{{clinic.name.uk}}', en: '' }] };
     expect(validateDocumentTemplate(template, context)).toEqual(['clinic.name.uk']);
   });
@@ -914,7 +917,7 @@ describe('spec: clinic name for the new document is medicalCenterName, not clini
 
 describe('spec: representative passport/power-of-attorney fields + centralized passport-number formatting (§10)', () => {
   it('resolves the extended representative.passport.issuedBy/issueDate and powerOfAttorney.apostilleDate fields', () => {
-    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog(), 'case-1');
     expect(fillPlaceholders('{{representative.passport.issuedBy.uk}}', context, 'uk')).toBe('ДМС України');
     expect(fillPlaceholders('{{representative.passport.issuedBy.en}}', context, 'en')).toBe('SMS of Ukraine');
     expect(fillPlaceholders('{{representative.passport.issueDate}}', context, 'uk')).toBe('06.05.2019');
@@ -929,7 +932,7 @@ describe('spec: representative passport/power-of-attorney fields + centralized p
   });
 
   it('fillPlaceholders formats representative.passport.number through the centralized formatter automatically', () => {
-    const context = resolveCaseContext(partnerClinicCatalog(), 'case-1');
+    const context = resolveCaseContext(clinicWithSourceCatalog(), 'case-1');
     expect(fillPlaceholders('{{representative.passport.number}}', context, 'uk')).toBe('ME 680736');
   });
 });
@@ -955,10 +958,10 @@ const EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE = {
     },
     {
       uk: 'У результаті проведення програми запліднення in vitro (ЗІВ) від {{case.documents.embryoOwnershipStatement.ivfDate}} '
-        + 'у клініці {{partnerClinic.name.uk}} (адреса: {{partnerClinic.address.uk}}), нами як генетичними батьками отримано '
+        + 'у клініці {{sourceClinic.name.uk}} (адреса: {{sourceClinic.address.uk}}), нами як генетичними батьками отримано '
         + 'ембріони, що належать виключно нам.',
       en: 'As a result of the in vitro fertilization (IVF) program dated {{case.documents.embryoOwnershipStatement.ivfDate}} '
-        + 'at {{partnerClinic.name.en}} (address: {{partnerClinic.address.en}}), embryos were obtained that belong '
+        + 'at {{sourceClinic.name.en}} (address: {{sourceClinic.address.en}}), embryos were obtained that belong '
         + 'exclusively to us as the genetic parents.',
     },
     {
@@ -1019,10 +1022,10 @@ const katsuraStyleCatalog = () => normalizeDocumentsCatalog(
         medicalCenterName: { uk: 'МЦ «Надія»', en: 'MC "Nadiya"' },
         legalName: { uk: 'ТОВ «Надія»', en: 'Nadiya LLC' },
       },
-    },
-    partnerClinics: {
-      'partner-clinic-1': {
-        id: 'partner-clinic-1',
+      // v6 (spec §1): the source clinic lives in this same unified collection, never a separate
+      // `partnerClinics` one.
+      'clinic-2': {
+        id: 'clinic-2',
         name: { uk: 'Клініка Оті Юме у м. Нагоя', en: 'Ochi Yume Clinic Nagoya' },
         address: {
           uk: 'Хісая Парксайд Будівля 8F, 3-19-12 Маруноуті, округ Нака, місто Нагоя, префектура Айті',
@@ -1037,11 +1040,11 @@ const katsuraStyleCatalog = () => normalizeDocumentsCatalog(
       id: 'case-mrry82h1-bws4eb',
       relations: {
         clinicId: 'clinic-1',
-        partnerClinicId: 'partner-clinic-1',
         coupleId: 'couple-2',
         surrogateMotherId: 'surrogate-mother-2',
         representativeIds: ['representative-1'],
       },
+      artProgram: { embryoShipment: { sourceClinicId: 'clinic-2' } },
       documents: {
         embryoOwnershipStatement: {
           shipmentPeriod: { uk: 'квітні – травні 2026 року', en: 'April-May 2026' },
@@ -1090,7 +1093,7 @@ describe('spec: embryo-ownership-statement template (batch 2026-07-24 §7-13)', 
     expect(shipmentParagraph.en).toContain('MC "Nadiya"');
   });
 
-  it('resolves the Japanese partner clinic name/address independently of the Ukrainian clinic (spec §4)', () => {
+  it('resolves the Japanese source clinic name/address independently of the destination clinic (spec §4)', () => {
     const catalog = katsuraStyleCatalog();
     const context = resolveCaseContext(catalog, 'case-mrry82h1-bws4eb');
     const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
@@ -1100,23 +1103,26 @@ describe('spec: embryo-ownership-statement template (batch 2026-07-24 §7-13)', 
     expect(ivfParagraph.en).toContain('Ochi Yume Clinic Nagoya');
   });
 
-  it('degrades to a clear warning, never a leaked {{partnerClinic...}} token, when the case has no partner clinic selected (spec §3, §14 checklist #10)', () => {
+  it('degrades to a clear warning, never a leaked {{sourceClinic...}} token, when the case has no source clinic selected (spec §3, §14 checklist #10)', () => {
     const catalog = katsuraStyleCatalog();
-    const caseWithoutPartnerClinic = {
+    const caseWithoutSourceClinic = {
       ...catalog.cases[0],
-      relations: { ...catalog.cases[0].relations, partnerClinicId: undefined },
+      artProgram: {
+        ...catalog.cases[0].artProgram,
+        embryoShipment: { ...catalog.cases[0].artProgram.embryoShipment },
+      },
     };
-    delete caseWithoutPartnerClinic.relations.partnerClinicId;
-    const catalogWithoutPartnerClinic = { ...catalog, cases: [caseWithoutPartnerClinic] };
-    const context = resolveCaseContext(catalogWithoutPartnerClinic, 'case-mrry82h1-bws4eb');
-    expect(context.partnerClinic).toBeNull();
+    delete caseWithoutSourceClinic.artProgram.embryoShipment.sourceClinicId;
+    const catalogWithoutSourceClinic = { ...catalog, cases: [caseWithoutSourceClinic] };
+    const context = resolveCaseContext(catalogWithoutSourceClinic, 'case-mrry82h1-bws4eb');
+    expect(context.sourceClinic).toBeNull();
     const generated = buildGeneratedDocument(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context);
     generated.paragraphs.forEach(paragraph => {
       expect(paragraph.uk).not.toMatch(/\{\{|}}/);
       expect(paragraph.en).not.toMatch(/\{\{|}}/);
     });
     expect(validateDocumentTemplate(EMBRYO_OWNERSHIP_STATEMENT_TEMPLATE, context)).toEqual(
-      expect.arrayContaining(['partnerClinic.address.uk', 'partnerClinic.name.uk']),
+      expect.arrayContaining(['sourceClinic.address.uk', 'sourceClinic.name.uk']),
     );
   });
 });
@@ -2578,7 +2584,7 @@ describe('spec: normalized clinic + maternityHospital structure (batch 17)', () 
 
   it('an unknown clinicId resolves clinic to null without crashing (§10, §12 #8)', () => {
     const catalog = clinicAndHospitalCatalog();
-    catalog.cases[0].relations.ukrainianClinicId = 'no-such-clinic';
+    catalog.cases[0].relations.clinicId = 'no-such-clinic';
     const context = resolveCaseContext(catalog, 'case-1');
     expect(context.clinic).toBeNull();
     expect(() => fillPlaceholders('{{clinic.name.uk}}', context, 'uk')).not.toThrow();
@@ -2835,11 +2841,11 @@ describe('spec: normalized case structure', () => {
 
   it('validateCaseRecord reports the base checklist without throwing on a bare/empty case', () => {
     expect(validateCaseRecord({})).toEqual(expect.arrayContaining([
-      'case.id', 'case.relations.coupleId', 'case.relations.ukrainianClinicId',
+      'case.id', 'case.relations.coupleId', 'case.relations.clinicId',
       'case.relations.surrogateMotherId', 'case.childbirth.children',
     ]));
     expect(validateCaseRecord(createEmptyCase({ caseId: 'case-9' }))).toEqual(expect.arrayContaining([
-      'case.relations.coupleId', 'case.relations.ukrainianClinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children',
+      'case.relations.coupleId', 'case.relations.clinicId', 'case.relations.surrogateMotherId', 'case.childbirth.children',
     ]));
     expect(validateCaseRecord(twoCasesCatalog().cases[0])).toEqual([]);
   });
@@ -2930,23 +2936,16 @@ describe('spec: Parties page record shapes', () => {
     // Needed by the surrogacy-agreement template ({{representative.birthDate}},
     // {{representative.address.uk}}) - previously missing from the blank record shape.
     expect(createEmptyRepresentative()).toEqual(expect.objectContaining({ birthDate: '', address: { uk: '', en: '' } }));
-    expect(createEmptyClinic().id).toMatch(/^clinic-/);
     expect(createEmptyMaternityHospital().id).toMatch(/^maternity-hospital-/);
     expect(createEmptyNotary().id).toMatch(/^notary-/);
 
-    // A partner clinic is a deliberately simplified party type (spec §5) - just name/address (plus
-    // the genitive name form and shipment-origin country, spec batch 2026-07-25), no EDRPOU/
-    // license/director/bank/logo the Ukrainian clinic record carries. name.uk/country.uk carry
-    // their grammatical forms directly (spec v5: the same {nominative, genitive, ...} shape every
-    // party's name uses), not a separate nameGenitive field.
-    const partnerClinic = createEmptyPartnerClinic();
-    expect(partnerClinic.id).toMatch(/^partner-clinic-/);
-    expect(partnerClinic).toEqual({
-      id: partnerClinic.id,
-      name: { uk: { nominative: '', genitive: '' }, en: '' },
-      country: { uk: { nominative: '', genitive: '' }, en: '' },
-      address: { uk: '', en: '' },
-    });
+    // v6 (spec §1): every clinic - Ukrainian or foreign - is the same record shape in the same
+    // unified `clinics` collection, so the blank record carries `country` too (blank/optional,
+    // filled in only for a foreign clinic) alongside the Ukrainian-only legalName/edrpou/license/
+    // bank/medicalDirector fields - never a second, simplified "partner clinic" record shape.
+    const clinic = createEmptyClinic();
+    expect(clinic.id).toMatch(/^clinic-/);
+    expect(clinic.country).toEqual({ code: '', uk: { nominative: '', genitive: '' }, en: '' });
 
     // Two calls never collide, same guarantee makeRecordId already gives createChildRecord.
     expect(createEmptyCouple().id).not.toBe(couple.id);
@@ -3287,13 +3286,13 @@ const noClinicCaseCatalog = (overrides = {}) => normalizeDocumentsCatalog(
 );
 
 describe('spec §2/§3: null-safe context for a case with no clinic/maternity-hospital relations at all', () => {
-  it('never throws, and resolves clinic/maternityHospital/partnerClinic to null', () => {
+  it('never throws, and resolves clinic/maternityHospital/sourceClinic to null', () => {
     const catalog = noClinicCaseCatalog();
     expect(() => resolveCaseContext(catalog, 'case-no-clinic')).not.toThrow();
     const context = resolveCaseContext(catalog, 'case-no-clinic');
     expect(context.clinic).toBeNull();
     expect(context.maternityHospital).toBeNull();
-    expect(context.partnerClinic).toBeNull();
+    expect(context.sourceClinic).toBeNull();
     expect(context.wife.name.uk.nominative).toBe('Приклад Марія Іванівна');
   });
 


### PR DESCRIPTION
- Extract the Documents/Invoice Builder/Parties/Style Editor page header into a shared
  AdminPageHeader (sticky, always right-aligned incl. mobile) instead of four duplicated
  Header/HeaderActions definitions that drifted (mobile flipped the "⋮" menu to the left).
- Make AddNewProfile's dots-menu row sticky too, so it stays reachable while scrolling,
  matching my-profile's pinned top bar.
- Add a logo-variant toggle ({{logo}} / {{logo-long}}) to the Clinic logo block's settings
  popover in Documents Builder - show/hide and offsets already worked, but there was no way
  to switch which token a letterhead logo column uses without pasting raw JSON.
- Parties Overview tab: drop the "Найближчий етап" milestone card and the "Документи та
  реєстрація"/"Перейти до РАЦС" card (batch 28 retraction), and make "Учасники та зв'язки"
  the tab's always-expanded primary content instead of one collapsible section among several.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgthQoLxjPiKgLUazrJxBW