### PR TITLE
Add complete card key map export

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -143,6 +143,7 @@ import { sortUsersByStimulationSchedule } from 'utils/stimulationScheduleSort';
 import { convertDriveLinkToImage } from 'utils/convertDriveLinkToImage';
 import { rebuildAllNewUsersFilterSetIndexes } from 'utils/newUsersFilterSetsIndex';
 import { mergeUserCollectionData } from 'utils/mergeUserCollections';
+import { buildFullCardKeyMap } from 'utils/cardKeyMap';
 import {
   LAST_ACTION2_FILTER,
   LAST_ACTION2_FILTER_STORAGE_KEY,
@@ -5946,40 +5947,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   }, [pendingLocalNewUsersData, pendingLocalUsersData, pendingLocalIndexTypes, runLocalSearchIndexesWithCollections]);
 
   const buildFullKeySetFromCollections = useCallback(() => {
-    if (!pendingLocalUsersData || !pendingLocalNewUsersData) {
-      toast.error('Спочатку оберіть обидва локальні файли: users.json і newUsers.json');
+    if (!pendingLocalUsersData && !pendingLocalNewUsersData) {
+      toast.error('Спочатку оберіть хоча б один файл: users.json або newUsers.json');
       return;
     }
 
-    const keySet = new Set();
-    const addKeysDeep = (value, parentKey = '') => {
-      if (Array.isArray(value)) {
-        if (parentKey) keySet.add(parentKey);
-        value.forEach(item => addKeysDeep(item, parentKey ? `${parentKey}[]` : '[]'));
-        return;
-      }
-
-      if (value && typeof value === 'object') {
-        Object.entries(value).forEach(([key, nestedValue]) => {
-          const path = parentKey ? `${parentKey}.${key}` : key;
-          keySet.add(path);
-          addKeysDeep(nestedValue, path);
-        });
-      }
-    };
-
-    [pendingLocalUsersData, pendingLocalNewUsersData].forEach(collection => {
-      Object.values(collection || {}).forEach(card => addKeysDeep(card));
-    });
-
     const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
-    const keys = Array.from(keySet).sort((a, b) => a.localeCompare(b, 'uk'));
+    const keyMap = buildFullCardKeyMap({
+      users: pendingLocalUsersData,
+      newUsers: pendingLocalNewUsersData,
+    });
     downloadJsonFile(`full-card-keys-${stamp}.json`, {
       createdAt: new Date().toISOString(),
-      totalKeys: keys.length,
-      keys,
+      ...keyMap,
     });
-    toast.success(`Згенеровано файл з повним набором ключів (${keys.length})`);
+    toast.success(`Знайдено ${keyMap.totalKeys} ключів у ${keyMap.totalCards} картках`);
   }, [downloadJsonFile, pendingLocalNewUsersData, pendingLocalUsersData]);
 
   const longPressTimerRef = useRef(null);
@@ -7441,7 +7423,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 4) Побудувати і скачати JSON індекси searchId/searchKey
               </button>
               <button type="button" onClick={buildFullKeySetFromCollections}>
-                5) Сформувати JSON з повним набором ключів карток
+                5) Перебрати всі картки й знайти повну карту ключів
               </button>
               <button type="button" onClick={() => setShowLocalIndexModal(false)}>
                 Скасувати

--- a/src/utils/cardKeyMap.js
+++ b/src/utils/cardKeyMap.js
@@ -1,0 +1,46 @@
+const isObject = value => value !== null && typeof value === 'object';
+
+const collectPaths = (value, paths, parentPath = '') => {
+  if (Array.isArray(value)) {
+    if (parentPath) paths.add(parentPath);
+    value.forEach(item => collectPaths(item, paths, parentPath ? `${parentPath}[]` : '[]'));
+    return;
+  }
+
+  if (!isObject(value)) return;
+
+  Object.entries(value).forEach(([key, nestedValue]) => {
+    const path = parentPath ? `${parentPath}.${key}` : key;
+    paths.add(path);
+    collectPaths(nestedValue, paths, path);
+  });
+};
+
+// Builds one schema catalogue from every card in the supplied collections.
+// Per-collection lists make it possible to see where a field was discovered,
+// while `keys` is the complete potential-user map across all sources.
+export const buildFullCardKeyMap = (collections = {}) => {
+  const allPaths = new Set();
+  const keysByCollection = {};
+  const cardsByCollection = {};
+
+  Object.entries(collections).forEach(([collectionName, collection]) => {
+    if (!isObject(collection)) return;
+
+    const collectionPaths = new Set();
+    const cards = Object.values(collection);
+    cards.forEach(card => collectPaths(card, collectionPaths));
+    collectionPaths.forEach(path => allPaths.add(path));
+
+    keysByCollection[collectionName] = Array.from(collectionPaths).sort((a, b) => a.localeCompare(b, 'uk'));
+    cardsByCollection[collectionName] = cards.length;
+  });
+
+  return {
+    totalCards: Object.values(cardsByCollection).reduce((total, count) => total + count, 0),
+    totalKeys: allPaths.size,
+    cardsByCollection,
+    keysByCollection,
+    keys: Array.from(allPaths).sort((a, b) => a.localeCompare(b, 'uk')),
+  };
+};

--- a/src/utils/cardKeyMap.test.js
+++ b/src/utils/cardKeyMap.test.js
@@ -1,0 +1,38 @@
+import { buildFullCardKeyMap } from './cardKeyMap';
+
+describe('buildFullCardKeyMap', () => {
+  it('collects all nested keys from every card and reports their source collections', () => {
+    const result = buildFullCardKeyMap({
+      users: {
+        one: { name: 'Anna', contacts: { phone: '1' }, children: [{ name: 'Eva' }] },
+        two: { name: 'Bob', contacts: { email: 'b@example.com' } },
+      },
+      newUsers: {
+        three: { status: 'new', children: [{ birth: { year: 2020 } }] },
+      },
+    });
+
+    expect(result.totalCards).toBe(3);
+    expect(result.cardsByCollection).toEqual({ users: 2, newUsers: 1 });
+    expect(result.keys).toEqual(expect.arrayContaining([
+      'name',
+      'contacts.phone',
+      'contacts.email',
+      'children',
+      'children[].name',
+      'children[].birth.year',
+      'status',
+    ]));
+    expect(result.keysByCollection.users).toContain('contacts.email');
+    expect(result.keysByCollection.newUsers).not.toContain('contacts.email');
+    expect(result.totalKeys).toBe(result.keys.length);
+  });
+
+  it('can build a map from only one available collection', () => {
+    const result = buildFullCardKeyMap({ users: { one: { name: 'Anna' } }, newUsers: null });
+
+    expect(result.totalCards).toBe(1);
+    expect(result.keys).toEqual(['name']);
+    expect(result.keysByCollection).toEqual({ users: ['name'] });
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a way to exhaustively discover all field paths present in user cards so operators can build a maximal map of potential user schema across collections.
- Make the key-discovery action available from the Local Index modal and allow it to work when only one collection (`users` or `newUsers`) is provided.

### Description

- Added `src/utils/cardKeyMap.js` which exports `buildFullCardKeyMap(collections)` to recursively collect nested field paths (including arrays) and produce per-collection maps and counts.
- Added unit tests in `src/utils/cardKeyMap.test.js` to cover nested objects, arrays, combined collections and single-collection scenarios.
- Integrated the utility into `src/components/AddNewProfile.jsx` by replacing the inline traversal with `buildFullCardKeyMap`, relaxing the file presence check to allow one or both collections, updating the modal button label, and including `keys`, `keysByCollection`, `cardsByCollection`, `totalCards`, and `totalKeys` in the downloaded `full-card-keys-<timestamp>.json` payload.

### Testing

- Ran unit tests with `CI=true npm test -- --watchAll=false --runInBand src/utils/cardKeyMap.test.js` and all tests passed.
- Ran linter with `npx eslint src/components/AddNewProfile.jsx src/utils/cardKeyMap.js src/utils/cardKeyMap.test.js`, which completed without errors (warnings from build tooling noted).
- Built a production bundle with `npm run build`, which completed successfully (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c4d63ce188326b72fc338212afc47)