### PR TITLE
Add append-only JSON profile import to Add New Profile

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -113,7 +113,8 @@ import {
   sanitizeTechnicalPayload,
 } from './formFields';
 import { PAGE_SIZE, database } from './config';
-import { get as firebaseGet, ref } from 'firebase/database';
+import { get as firebaseGet, ref, update } from 'firebase/database';
+import { parseNewUsersJson } from 'utils/newUsersJsonImport';
 import {
   getBackendDownloadToastsEnabled,
   setBackendDownloadToastsEnabled,
@@ -1253,11 +1254,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   const [searchBarResetVersion, setSearchBarResetVersion] = useState(0);
   const searchListIsolationRef = useRef(Boolean((search || '').trim()));
   const [isExcelImporting, setIsExcelImporting] = useState(false);
+  const [isJsonImporting, setIsJsonImporting] = useState(false);
   const [downloadSizeToastsEnabled, setDownloadSizeToastsEnabled] = useState(() => getBackendDownloadToastsEnabled());
   const [extendedMode, setExtendedMode] = useState(() => (
     typeof localStorage !== 'undefined' && localStorage.getItem(PROFILE_FORM_EXTENDED_MODE_KEY) === 'true'
   ));
   const excelImportInputRef = useRef(null);
+  const jsonImportInputRef = useRef(null);
   const [showSearchKeyIndexPanel, setShowSearchKeyIndexPanel] = useState(false);
   const [showLocalIndexModal, setShowLocalIndexModal] = useState(false);
   const [pendingLocalIndexTypes, setPendingLocalIndexTypes] = useState([]);
@@ -1698,6 +1701,27 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     },
     [downloadJsonFile],
   );
+
+  const handleNewUsersJsonUpload = useCallback(async event => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    setIsJsonImporting(true);
+    try {
+      const cards = parseNewUsersJson(await file.text());
+
+      // update() adds these keyed cards to newUsers instead of replacing the
+      // collection, so cards that are not present in the file remain intact.
+      await update(ref(database, 'newUsers'), cards);
+      toast.success(`Завантажено карток: ${Object.keys(cards).length}`);
+    } catch (error) {
+      console.error('[AddNewProfile] JSON import failed', error);
+      toast.error(error?.message || 'Помилка при завантаженні JSON');
+    } finally {
+      setIsJsonImporting(false);
+    }
+  }, []);
   const isMountedRef = useRef(true);
   const scheduleShortcutPresenceRef = useRef({ userId: null, hasSchedule: null });
   const hasStimulationScheduleKey = state.userId
@@ -7134,6 +7158,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 onChange={handleExcelProfilesUpload}
               />
               <input
+                ref={jsonImportInputRef}
+                type="file"
+                accept="application/json,.json"
+                style={{ display: 'none' }}
+                onChange={handleNewUsersJsonUpload}
+              />
+              <input
                 ref={localExportUsersFileInputRef}
                 type="file"
                 accept="application/json,.json"
@@ -7154,6 +7185,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                 {...createLongPressHandlers('Імпортує Excel і конвертує в JSON формати')}
               >
                 {isExcelImporting ? '...' : 'XLSX'}
+              </Button>
+              <Button
+                onClick={() => jsonImportInputRef.current?.click()}
+                disabled={isJsonImporting}
+                title="Додати картки з JSON у newUsers"
+                {...createLongPressHandlers('Завантажує картки з JSON та доповнює колекцію newUsers')}
+              >
+                {isJsonImporting ? '...' : 'JSON'}
               </Button>
 
               {/* <ExcelToJson/> */}

--- a/src/utils/newUsersJsonImport.js
+++ b/src/utils/newUsersJsonImport.js
@@ -1,0 +1,39 @@
+const FIREBASE_FORBIDDEN_KEY_CHARACTERS = ['.', '#', '$', '[', ']', '/'];
+
+export const parseNewUsersJson = jsonText => {
+  let parsed;
+
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (_error) {
+    throw new Error('Файл містить некоректний JSON');
+  }
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error('JSON має бути об’єктом із картками користувачів');
+  }
+
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) {
+    throw new Error('JSON не містить карток користувачів');
+  }
+
+  return entries.reduce((cards, [key, card]) => {
+    const normalizedKey = String(key).trim();
+    if (
+      !normalizedKey ||
+      FIREBASE_FORBIDDEN_KEY_CHARACTERS.some(character => normalizedKey.includes(character))
+    ) {
+      throw new Error(`Некоректний ключ картки: ${key}`);
+    }
+    if (!card || Array.isArray(card) || typeof card !== 'object') {
+      throw new Error(`Картка ${normalizedKey} має бути об’єктом`);
+    }
+
+    cards[normalizedKey] = {
+      ...card,
+      userId: card.userId || normalizedKey,
+    };
+    return cards;
+  }, {});
+};

--- a/src/utils/newUsersJsonImport.test.js
+++ b/src/utils/newUsersJsonImport.test.js
@@ -1,0 +1,20 @@
+import { parseNewUsersJson } from './newUsersJsonImport';
+
+describe('parseNewUsersJson', () => {
+  it('keeps keyed cards and fills a missing userId from the card key', () => {
+    expect(parseNewUsersJson('{"TG0001":{"name":"Анастасія"},"TG0002":{"userId":"TG0002"}}')).toEqual({
+      TG0001: { userId: 'TG0001', name: 'Анастасія' },
+      TG0002: { userId: 'TG0002' },
+    });
+  });
+
+  it.each(['[]', 'null', '{}'])('rejects a JSON value without keyed cards: %s', value => {
+    expect(() => parseNewUsersJson(value)).toThrow();
+  });
+
+  it('rejects malformed JSON, invalid Firebase keys, and non-object cards', () => {
+    expect(() => parseNewUsersJson('{')).toThrow('некоректний JSON');
+    expect(() => parseNewUsersJson('{"TG/1":{}}')).toThrow('Некоректний ключ');
+    expect(() => parseNewUsersJson('{"TG0001":"not a card"}')).toThrow('має бути об’єктом');
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a quick way to import keyed user-card JSON into the `newUsers` collection from the Add New Profile toolbar without overwriting existing `newUsers` records.
- Validate incoming JSON to avoid corrupt keys or non-object card values and fill missing `userId` from the card key.
- Reuse existing UI and Firebase integration patterns in the Add New Profile component.

### Description

- Add `src/utils/newUsersJsonImport.js` with `parseNewUsersJson` that validates the JSON root, rejects malformed values and Firebase-forbidden key characters, and populates missing `userId` from the card key.
- Add focused unit tests in `src/utils/newUsersJsonImport.test.js` covering valid import, empty payloads, malformed JSON, invalid keys, and non-object cards.
- Extend `src/components/AddNewProfile.jsx` with a hidden JSON file input, a `JSON` toolbar `Button`, `isJsonImporting` state, and `handleNewUsersJsonUpload` which calls `update(ref(database, 'newUsers'), cards)` to append the keyed cards instead of replacing the whole collection.
- Import `update` from `firebase/database` and `parseNewUsersJson` in the Add New Profile component and show `toast` success/error feedback for the upload.

### Testing

- Ran unit tests with `CI=true npm test -- --watchAll=false src/utils/newUsersJsonImport.test.js`, and all tests passed (`5 passed`).
- Ran lint on modified files with `npx eslint src/components/AddNewProfile.jsx src/utils/newUsersJsonImport.js src/utils/newUsersJsonImport.test.js`, and there were no blocking errors reported.
- Built the app with `npm run build`; the build completed (compiled with warnings unrelated to functionality).
- Verified repository checks with `git diff --check` (no issues) and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c656e91d883269acbb957f34271d9)