### PR TITLE
Surface comment save failures, require successful save before opening backend URL, and add UI toast + tests

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1088,7 +1088,10 @@ export const setUserComment = async (cardId, text, ownerId) => {
     return { lastAction: updatedAt };
   } catch (error) {
     console.error('Error setting comment:', error);
-    return null;
+    // A comment is saved outside the card payload, so callers cannot infer a
+    // failed write from the regular profile save. Keep the Firebase error
+    // intact (notably `PERMISSION_DENIED`) so the comment field can surface it.
+    throw error;
   }
 };
 
@@ -1150,7 +1153,10 @@ export const saveMyCardComment = async (cardId, text, ownerId) => {
   const trimmed = (text || '').trim();
   if (!trimmed) {
     const commentsOwnerId = ownerId || auth.currentUser?.uid;
-    await deleteCommentByOwner({ ownerId: commentsOwnerId, cardId });
+    const deleted = await deleteCommentByOwner({ ownerId: commentsOwnerId, cardId });
+    if (!deleted) {
+      throw new Error('Не вдалося видалити коментар');
+    }
     return null;
   }
   return setUserComment(cardId, text, ownerId);

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { FaArrowRight } from 'react-icons/fa';
 import { useAutoResize } from '../../hooks/useAutoResize';
 import { auth, fetchUserComment, saveMyCardComment } from '../config';
+import toast from 'react-hot-toast';
 
 const FALLBACK_FIREBASE_PROJECT_ID = 'webringitapp';
 const getFirebaseConsoleProjectId = () => process.env.REACT_APP_PROJECT_ID || FALLBACK_FIREBASE_PROJECT_ID;
@@ -52,9 +53,20 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
     };
   }, [ownerId, cardId]);
 
-  const persist = value => {
-    if (!ownerId || !cardId) return;
-    saveMyCardComment(cardId, value, ownerId);
+  const persist = async value => {
+    if (!ownerId || !cardId) {
+      toast.error('Не вдалося зберегти коментар: користувач або картка не визначені');
+      return false;
+    }
+
+    try {
+      await saveMyCardComment(cardId, value, ownerId);
+      return true;
+    } catch (error) {
+      const details = error?.message || String(error);
+      toast.error(`Не вдалося зберегти коментар: ${details}`);
+      return false;
+    }
   };
 
   const showBackendShortcut = extendedMode && Boolean(ownerId && cardId);
@@ -79,7 +91,7 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
           autoResize(e.target);
         }}
         onBlur={() => {
-          persist(textareaRef.current?.value ?? '');
+          void persist(textareaRef.current?.value ?? '');
         }}
         style={{
           // marginLeft: '10px',
@@ -98,8 +110,10 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
           aria-label="Відкрити запис коментаря у Firebase"
           title="Відкрити запис коментаря у Firebase"
           onMouseDown={event => event.preventDefault()}
-          onClick={event => {
+          onClick={async event => {
             event.stopPropagation();
+            const saved = await persist(textareaRef.current?.value ?? '');
+            if (!saved) return;
             window.open(buildCommentBackendUrl(ownerId, cardId), '_blank', 'noopener,noreferrer');
           }}
           style={{
@@ -122,10 +136,10 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
         <button
           type="button"
           aria-label="Очистити коментар"
-          onClick={event => {
+          onClick={async event => {
             event.stopPropagation();
             setText('');
-            persist('');
+            await persist('');
           }}
           style={{
             position: 'absolute',

--- a/src/components/smallCard/FieldComment.test.js
+++ b/src/components/smallCard/FieldComment.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn(),
+}));
+
 jest.mock('../config', () => ({
   auth: { currentUser: { uid: 'admin-1' } },
   fetchUserComment: jest.fn(),
@@ -8,6 +12,7 @@ jest.mock('../config', () => ({
 }));
 
 const { fetchUserComment, saveMyCardComment } = require('../config');
+const toast = require('react-hot-toast');
 const { FieldComment } = require('./FieldComment');
 
 describe('FieldComment', () => {
@@ -15,6 +20,8 @@ describe('FieldComment', () => {
     fetchUserComment.mockReset();
     saveMyCardComment.mockReset();
     fetchUserComment.mockResolvedValue(null);
+    saveMyCardComment.mockResolvedValue({ lastAction: 123 });
+    toast.error.mockReset();
   });
 
   it("loads the current admin's own comment for this card, not a card field", async () => {
@@ -57,18 +64,38 @@ describe('FieldComment', () => {
     expect(await screen.findByLabelText('Відкрити запис коментаря у Firebase')).toBeTruthy();
   });
 
-  it('the backend-navigation arrow opens the comment\'s own comments/{ownerId}/{cardId} console URL', async () => {
+  it('saves the current draft before opening the comment backend URL', async () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
     render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
 
     const arrow = await screen.findByLabelText('Відкрити запис коментаря у Firebase');
+    const textarea = screen.getByPlaceholderText('Додайте свій коментар');
+    fireEvent.change(textarea, { target: { value: 'unsaved draft' } });
     fireEvent.click(arrow);
 
-    expect(openSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(openSpy).toHaveBeenCalledTimes(1));
+    expect(saveMyCardComment).toHaveBeenCalledWith('user-1', 'unsaved draft', 'admin-1');
     const [url] = openSpy.mock.calls[0];
     expect(url).toContain('admin-1');
     expect(url).toContain('user-1');
     expect(url).toContain('comments');
+    openSpy.mockRestore();
+  });
+
+  it('shows a toast and does not open the backend URL when saving fails', async () => {
+    const error = new Error('PERMISSION_DENIED');
+    saveMyCardComment.mockRejectedValue(error);
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
+
+    fireEvent.click(await screen.findByLabelText('Відкрити запис коментаря у Firebase'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Не вдалося зберегти коментар: PERMISSION_DENIED'
+      );
+    });
+    expect(openSpy).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Motivation

- Ensure callers can detect and surface Firebase write errors when saving personal comments so permission errors are not swallowed. 
- Prevent opening the Firebase console to a comment record unless the latest draft was successfully persisted. 
- Provide user-visible feedback on save failures and add tests to cover the new behavior.

### Description

- Change `setUserComment` to rethrow Firebase errors instead of returning `null`, preserving original error details (e.g. `PERMISSION_DENIED`).
- Make `saveMyCardComment` verify that `deleteCommentByOwner` succeeded when clearing a comment and throw on failure. 
- Update `FieldComment` to use `react-hot-toast` for error feedback, make the local `persist` function async and return success/failure, and `await` saves on blur/clear and before opening the backend console URL. 
- Add a backend-console shortcut save step: the arrow button now saves the current draft first and only opens the Firebase console if the save succeeds. 
- Update and extend `FieldComment.test.js` with a `react-hot-toast` mock and new tests that verify saving-before-open and that failures trigger a toast and prevent navigation.

### Testing

- Ran the updated unit tests for `FieldComment` (Jest + React Testing Library) which include the new tests for save-before-open and save-failure toast behavior, and they passed. 
- Existing `FieldComment` tests for loading, blur-save, clear-save, and backend shortcut visibility were kept and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c74f954188326b62011433c3c11ab)