### PR TITLE
Migrate per-admin card comments to `multiData/comments`, add path constant and improve comment UI/error handling

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -755,7 +755,7 @@ const EditProfile = () => {
   }, [state, userId]);
 
   // myComment no longer lives on the card itself — it's a per-admin note
-  // in comments/{ownerId}/{cardId} (setUserComment/fetchUserComment). Once the card is
+  // in multiData/comments/{ownerId}/{cardId} (setUserComment/fetchUserComment). Once the card is
   // loaded, overlay the current admin's own comment onto state.myComment so
   // the existing ProfileForm textarea keeps working exactly as before, and
   // mirror it into lastSyncedSnapshotRef so remoteUpdate's change-detection

--- a/src/components/EditProfile.myCommentPersonalization.test.js
+++ b/src/components/EditProfile.myCommentPersonalization.test.js
@@ -9,7 +9,7 @@ describe('EditProfile treats myComment as the current admin\'s personal note', (
     expect(source).toContain('saveMyCardComment,');
   });
 
-  it('seeds state.myComment from the current admin\'s own comments/{ownerId}/{cardId} entry on load', () => {
+  it('seeds state.myComment from the current admin\'s own multiData/comments/{ownerId}/{cardId} entry on load', () => {
     const seedEffectBody = source.slice(
       source.indexOf("if (!userId || !currentUid || !isAdmin || !dataSource) return;"),
       source.indexOf('}, [userId, currentUid, isAdmin, dataSource]);')

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -82,6 +82,7 @@ import {
   searchUsersOnly,
   fetchUserComments,
   saveMyCardComment,
+  COMMENTS_ROOT_PATH,
   fetchUsersByIds,
   database,
   auth,
@@ -2033,7 +2034,7 @@ const Matching = () => {
               paths: accessOwnerIds.map(sharedOwnerId => ({
                 favorites: `multiData/favorites/${sharedOwnerId}`,
                 dislikes: `multiData/dislikes/${sharedOwnerId}`,
-                comments: `comments/${sharedOwnerId}`,
+                comments: `${COMMENTS_ROOT_PATH}/${sharedOwnerId}`,
               })),
             });
             setMultiDataOwnerIds(resolvedOwnerIds);

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1070,7 +1070,11 @@ export const fetchCycleUsersData = async (
   }
 };
 
-// Особистий коментар адміна до картки — comments/{ownerId}/{cardId} = { text, updatedAt }.
+export const COMMENTS_ROOT_PATH = 'multiData/comments';
+const getCommentPath = (ownerId, cardId) =>
+  [COMMENTS_ROOT_PATH, ownerId, cardId].filter(Boolean).join('/');
+
+// Особистий коментар адміна до картки — multiData/comments/{ownerId}/{cardId} = { text, updatedAt }.
 // Рівно один запис на пару ownerId+cardId: повторне збереження оновлює його
 // (set), а не створює новий запис із випадковим ключем (push() не використовується).
 export const setUserComment = async (cardId, text, ownerId) => {
@@ -1084,11 +1088,14 @@ export const setUserComment = async (cardId, text, ownerId) => {
     }
     const commentsOwnerId = ownerId || user.uid;
     const updatedAt = Date.now();
-    await set(ref2(database, `comments/${commentsOwnerId}/${cardId}`), { text, updatedAt });
+    await set(ref2(database, getCommentPath(commentsOwnerId, cardId)), { text, updatedAt });
     return { lastAction: updatedAt };
   } catch (error) {
     console.error('Error setting comment:', error);
-    return null;
+    // A comment is saved outside the card payload, so callers cannot infer a
+    // failed write from the regular profile save. Keep the Firebase error
+    // intact (notably `PERMISSION_DENIED`) so the comment field can surface it.
+    throw error;
   }
 };
 
@@ -1102,7 +1109,7 @@ export const updateCommentByOwner = async ({ ownerId, cardId, text }) => {
       throw new Error('ownerId, cardId і text обовʼязкові');
     }
     const updatedAt = Date.now();
-    await set(ref2(database, `comments/${ownerId}/${cardId}`), { text, updatedAt });
+    await set(ref2(database, getCommentPath(ownerId, cardId)), { text, updatedAt });
     return { lastAction: updatedAt, ownerId };
   } catch (error) {
     console.error('Error updating comment by owner:', error);
@@ -1119,7 +1126,7 @@ export const deleteCommentByOwner = async ({ ownerId, cardId }) => {
     if (!ownerId || !cardId) {
       throw new Error('ownerId і cardId обовʼязкові');
     }
-    await remove(ref2(database, `comments/${ownerId}/${cardId}`));
+    await remove(ref2(database, getCommentPath(ownerId, cardId)));
     return true;
   } catch (error) {
     console.error('Error deleting comment by owner:', error);
@@ -1130,7 +1137,7 @@ export const deleteCommentByOwner = async ({ ownerId, cardId }) => {
 export const fetchUserComment = async (ownerId, cardId) => {
   try {
     if (!ownerId || !cardId) return null;
-    const snap = await get(ref2(database, `comments/${ownerId}/${cardId}`));
+    const snap = await get(ref2(database, getCommentPath(ownerId, cardId)));
     if (!snap.exists()) return null;
     const value = snap.val();
     return {
@@ -1144,13 +1151,16 @@ export const fetchUserComment = async (ownerId, cardId) => {
 };
 
 // Зберігає (або, для порожнього тексту, видаляє) особистий коментар поточного
-// адміна до картки в comments/{ownerId}/{cardId} — замінює старий підхід "писати прямо
+// адміна до картки в multiData/comments/{ownerId}/{cardId} — замінює старий підхід "писати прямо
 // в поле myComment на картці".
 export const saveMyCardComment = async (cardId, text, ownerId) => {
   const trimmed = (text || '').trim();
   if (!trimmed) {
     const commentsOwnerId = ownerId || auth.currentUser?.uid;
-    await deleteCommentByOwner({ ownerId: commentsOwnerId, cardId });
+    const deleted = await deleteCommentByOwner({ ownerId: commentsOwnerId, cardId });
+    if (!deleted) {
+      throw new Error('Не вдалося видалити коментар');
+    }
     return null;
   }
   return setUserComment(cardId, text, ownerId);
@@ -1160,7 +1170,7 @@ export const fetchUserComments = async (ownerId, cardIds = []) => {
   try {
     incrementMatchingLoadStat('commentsReads', Array.isArray(cardIds) ? cardIds.length : 0);
     if (!ownerId || !Array.isArray(cardIds) || !cardIds.length) return {};
-    const snap = await get(ref2(database, `comments/${ownerId}`));
+    const snap = await get(ref2(database, getCommentPath(ownerId)));
     if (!snap.exists()) return {};
     const ownerComments = snap.val() || {};
     const result = {};
@@ -1182,7 +1192,7 @@ export const fetchUserComments = async (ownerId, cardIds = []) => {
 export const fetchAllCommentsByCardId = async cardId => {
   try {
     if (!cardId) return [];
-    const snap = await get(ref2(database, 'comments'));
+    const snap = await get(ref2(database, COMMENTS_ROOT_PATH));
     if (!snap.exists()) return [];
 
     const result = [];
@@ -2681,7 +2691,7 @@ const removeUndefined = obj => {
 
 // Ключі, які ніколи не мають лишатись записаними на самій картці users/newUsers:
 // клієнтські кеш-мітки (транзитні за природою) та 'myComment', яке мігрувало в
-// окреме сховище comments/{ownerId}/{cardId} (per-адмін коментарі, config.js: setUserComment
+// окреме сховище multiData/comments/{ownerId}/{cardId} (per-адмін коментарі, config.js: setUserComment
 // / fetchUserComment). Останнє тут не тому, що воно транзитне, а тому, що для
 // нього тепер є власне джерело правди — картка більше не повинна його дублювати.
 const transientUserDataKeys = [

--- a/src/components/config.myCommentMigration.test.js
+++ b/src/components/config.myCommentMigration.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('myComment moves off the card into comments/{ownerId}/{cardId} (per-admin)', () => {
+describe('myComment moves off the card into multiData/comments/{ownerId}/{cardId} (per-admin)', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
 
   it('strips myComment from every users/newUsers write and actively deletes it on updates', () => {
@@ -12,12 +12,13 @@ describe('myComment moves off the card into comments/{ownerId}/{cardId} (per-adm
     expect(transientKeysBody).toContain("'myComment',");
   });
 
-  it('writes comments directly to comments/{ownerId}/{cardId} without push() or a commentId', () => {
+  it('writes comments directly to multiData/comments/{ownerId}/{cardId} without push() or a commentId', () => {
     const fnBody = source.slice(
       source.indexOf('export const setUserComment'),
       source.indexOf('export const updateCommentByOwner')
     );
-    expect(fnBody).toContain('comments/${commentsOwnerId}/${cardId}');
+    expect(source).toContain("export const COMMENTS_ROOT_PATH = 'multiData/comments';");
+    expect(fnBody).toContain('getCommentPath(commentsOwnerId, cardId)');
     expect(fnBody).not.toContain('push(');
     expect(fnBody).not.toContain('orderByChild');
     expect(fnBody).not.toContain('authorId');
@@ -32,12 +33,12 @@ describe('myComment moves off the card into comments/{ownerId}/{cardId} (per-adm
     expect(fnBody).toContain('return setUserComment(cardId, text, ownerId);');
   });
 
-  it('reads a single comment straight from comments/{ownerId}/{cardId}, without orderByChild/equalTo', () => {
+  it('reads a single comment straight from multiData/comments/{ownerId}/{cardId}, without orderByChild/equalTo', () => {
     const fnBody = source.slice(
       source.indexOf('export const fetchUserComment '),
       source.indexOf('export const saveMyCardComment')
     );
-    expect(fnBody).toContain('comments/${ownerId}/${cardId}');
+    expect(fnBody).toContain('getCommentPath(ownerId, cardId)');
     expect(fnBody).not.toContain('orderByChild');
     expect(fnBody).not.toContain('equalTo');
   });

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { FaArrowRight } from 'react-icons/fa';
 import { useAutoResize } from '../../hooks/useAutoResize';
-import { auth, fetchUserComment, saveMyCardComment } from '../config';
+import { COMMENTS_ROOT_PATH, auth, fetchUserComment, saveMyCardComment } from '../config';
+import toast from 'react-hot-toast';
 
 const FALLBACK_FIREBASE_PROJECT_ID = 'webringitapp';
 const getFirebaseConsoleProjectId = () => process.env.REACT_APP_PROJECT_ID || FALLBACK_FIREBASE_PROJECT_ID;
@@ -17,19 +18,19 @@ const getFirebaseRealtimeDatabaseName = () => {
 };
 
 // Same backend-navigation shortcut ProfileForm's other fields already have (batch 26 §8) - jumps
-// straight to this comment's own comments/{ownerId}/{cardId} record in the Firebase console.
+// straight to this comment's own multiData/comments/{ownerId}/{cardId} record in Firebase.
 const buildCommentBackendUrl = (ownerId, cardId) => {
   if (!ownerId || !cardId) return '';
   const projectId = getFirebaseConsoleProjectId();
   const databaseName = getFirebaseRealtimeDatabaseName();
-  const encodedPath = ['comments', ownerId, cardId]
+  const encodedPath = [...COMMENTS_ROOT_PATH.split('/'), ownerId, cardId]
     .map(segment => `~2F${encodeURIComponent(segment)}`)
     .join('');
   return `https://console.firebase.google.com/u/0/project/${projectId}/database/${databaseName}/data/${encodedPath}`;
 };
 
 // Персональний коментар поточного адміна до картки — зберігається в
-// comments/{ownerId}/{cardId}, а не прямо в самій картці (users/newUsers).
+// multiData/comments/{ownerId}/{cardId}, а не прямо в самій картці (users/newUsers).
 export const FieldComment = ({ userData, extendedMode = false }) => {
   const textareaRef = useRef(null);
   const [text, setText] = useState('');
@@ -52,9 +53,20 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
     };
   }, [ownerId, cardId]);
 
-  const persist = value => {
-    if (!ownerId || !cardId) return;
-    saveMyCardComment(cardId, value, ownerId);
+  const persist = async value => {
+    if (!ownerId || !cardId) {
+      toast.error('Не вдалося зберегти коментар: користувач або картка не визначені');
+      return false;
+    }
+
+    try {
+      await saveMyCardComment(cardId, value, ownerId);
+      return true;
+    } catch (error) {
+      const details = error?.message || String(error);
+      toast.error(`Не вдалося зберегти коментар: ${details}`);
+      return false;
+    }
   };
 
   const showBackendShortcut = extendedMode && Boolean(ownerId && cardId);
@@ -79,7 +91,7 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
           autoResize(e.target);
         }}
         onBlur={() => {
-          persist(textareaRef.current?.value ?? '');
+          void persist(textareaRef.current?.value ?? '');
         }}
         style={{
           // marginLeft: '10px',
@@ -98,8 +110,10 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
           aria-label="Відкрити запис коментаря у Firebase"
           title="Відкрити запис коментаря у Firebase"
           onMouseDown={event => event.preventDefault()}
-          onClick={event => {
+          onClick={async event => {
             event.stopPropagation();
+            const saved = await persist(textareaRef.current?.value ?? '');
+            if (!saved) return;
             window.open(buildCommentBackendUrl(ownerId, cardId), '_blank', 'noopener,noreferrer');
           }}
           style={{
@@ -122,10 +136,10 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
         <button
           type="button"
           aria-label="Очистити коментар"
-          onClick={event => {
+          onClick={async event => {
             event.stopPropagation();
             setText('');
-            persist('');
+            await persist('');
           }}
           style={{
             position: 'absolute',

--- a/src/components/smallCard/FieldComment.test.js
+++ b/src/components/smallCard/FieldComment.test.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn(),
+}));
+
 jest.mock('../config', () => ({
+  COMMENTS_ROOT_PATH: 'multiData/comments',
   auth: { currentUser: { uid: 'admin-1' } },
   fetchUserComment: jest.fn(),
   saveMyCardComment: jest.fn(),
 }));
 
 const { fetchUserComment, saveMyCardComment } = require('../config');
+const toast = require('react-hot-toast');
 const { FieldComment } = require('./FieldComment');
 
 describe('FieldComment', () => {
@@ -15,6 +21,8 @@ describe('FieldComment', () => {
     fetchUserComment.mockReset();
     saveMyCardComment.mockReset();
     fetchUserComment.mockResolvedValue(null);
+    saveMyCardComment.mockResolvedValue({ lastAction: 123 });
+    toast.error.mockReset();
   });
 
   it("loads the current admin's own comment for this card, not a card field", async () => {
@@ -57,18 +65,39 @@ describe('FieldComment', () => {
     expect(await screen.findByLabelText('Відкрити запис коментаря у Firebase')).toBeTruthy();
   });
 
-  it('the backend-navigation arrow opens the comment\'s own comments/{ownerId}/{cardId} console URL', async () => {
+  it('saves the current draft before opening the comment backend URL', async () => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
     render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
 
     const arrow = await screen.findByLabelText('Відкрити запис коментаря у Firebase');
+    const textarea = screen.getByPlaceholderText('Додайте свій коментар');
+    fireEvent.change(textarea, { target: { value: 'unsaved draft' } });
     fireEvent.click(arrow);
 
-    expect(openSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(openSpy).toHaveBeenCalledTimes(1));
+    expect(saveMyCardComment).toHaveBeenCalledWith('user-1', 'unsaved draft', 'admin-1');
     const [url] = openSpy.mock.calls[0];
     expect(url).toContain('admin-1');
     expect(url).toContain('user-1');
+    expect(url).toContain('multiData');
     expect(url).toContain('comments');
+    openSpy.mockRestore();
+  });
+
+  it('shows a toast and does not open the backend URL when saving fails', async () => {
+    const error = new Error('PERMISSION_DENIED');
+    saveMyCardComment.mockRejectedValue(error);
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
+
+    fireEvent.click(await screen.findByLabelText('Відкрити запис коментаря у Firebase'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Не вдалося зберегти коментар: PERMISSION_DENIED'
+      );
+    });
+    expect(openSpy).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
 });

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -1299,7 +1299,8 @@ export const TopBlock = ({
   overlayFieldAdditions = {},
   onSubmitHistorySnapshot = null,
   stimulationScheduleToggle = null,
-  // Batch 26 §8: shows FieldComment's backend-navigation arrow (comments/{ownerId}/{cardId}) when
+  // Batch 26 §8: shows FieldComment's backend-navigation arrow
+  // (multiData/comments/{ownerId}/{cardId}) when
   // on - off by default so a caller that hasn't wired up the toggle (no regression) keeps today's
   // arrow-free look; AddNewProfile.jsx passes its own persisted toggle state.
   extendedMode = false


### PR DESCRIPTION
### Motivation
- Consolidate per-admin card comments under a stable root path `multiData/comments` instead of the old `comments` path. 
- Ensure the comment storage is a single source of truth outside of the card payload (`myComment` removed from card writes). 
- Improve UX and reliability when saving comments from the UI by surfacing errors and guaranteeing drafts are saved before opening the backend URL. 

### Description
- Introduces `COMMENTS_ROOT_PATH = 'multiData/comments'` and a `getCommentPath(ownerId, cardId)` helper, and updates all comment helpers to use this path. 
- Updates comment APIs (`setUserComment`, `updateCommentByOwner`, `deleteCommentByOwner`, `fetchUserComment`, `fetchUserComments`, `fetchAllCommentsByCardId`, `saveMyCardComment`) to read/write under `multiData/comments` and to surface write errors (throw on failures where appropriate). 
- Enhances the comment UI (`FieldComment`) to import `COMMENTS_ROOT_PATH`, build backend console URLs using the new path, make `persist` async with toast-based error reporting, and ensure drafts are saved before opening the backend URL; clearing and backend actions await the persisted result. 
- Adjusts references and messages in `EditProfile`, `Matching`, `renderTopBlock` and updates multiple tests to reflect the path and behavior changes. 

### Testing
- Ran unit tests for the changed areas including `config.myCommentMigration.test.js`, `EditProfile.myCommentPersonalization.test.js`, and `smallCard/FieldComment.test.js`, and they passed. 
- Executed the full test suite with `npm test` and observed no regressions in the test run. 
- Verified the new toast-based error path in tests by mocking `saveMyCardComment` to reject and asserting no backend URL was opened and `toast.error` was called.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c74f954188326b62011433c3c11ab)