### PR TITLE
Migrate legacy per-card comments to admin multiData and update FieldComment UI

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1166,6 +1166,34 @@ export const saveMyCardComment = async (cardId, text, ownerId) => {
   return setUserComment(cardId, text, ownerId);
 };
 
+// Atomically moves an edited legacy card comment to the current admin's
+// personal multiData record. Removing both possible card locations is safe:
+// a card has a single canonical source, while old imports can leave a stale
+// duplicate behind in the other collection.
+export const migrateMyCardComment = async (cardId, text, ownerId) => {
+  const user = auth.currentUser;
+  if (!user) throw new Error('User not authenticated');
+  if (!cardId) throw new Error('cardId обовʼязковий');
+
+  const commentsOwnerId = ownerId || user.uid;
+  const trimmed = String(text || '').trim();
+  const updates = {
+    [`users/${cardId}/myComment`]: null,
+    [`newUsers/${cardId}/myComment`]: null,
+  };
+
+  if (trimmed) {
+    const updatedAt = Date.now();
+    updates[getCommentPath(commentsOwnerId, cardId)] = { text, updatedAt };
+    await update(ref2(database), updates);
+    return { lastAction: updatedAt };
+  }
+
+  updates[getCommentPath(commentsOwnerId, cardId)] = null;
+  await update(ref2(database), updates);
+  return null;
+};
+
 export const fetchUserComments = async (ownerId, cardIds = []) => {
   try {
     incrementMatchingLoadStat('commentsReads', Array.isArray(cardIds) ? cardIds.length : 0);

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -1,7 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { FaArrowRight } from 'react-icons/fa';
 import { useAutoResize } from '../../hooks/useAutoResize';
-import { COMMENTS_ROOT_PATH, auth, fetchUserComment, saveMyCardComment } from '../config';
+import {
+  COMMENTS_ROOT_PATH,
+  auth,
+  fetchUserComment,
+  migrateMyCardComment,
+  saveMyCardComment,
+} from '../config';
 import toast from 'react-hot-toast';
 
 const FALLBACK_FIREBASE_PROJECT_ID = 'webringitapp';
@@ -31,36 +37,53 @@ const buildCommentBackendUrl = (ownerId, cardId) => {
 
 // Персональний коментар поточного адміна до картки — зберігається в
 // multiData/comments/{ownerId}/{cardId}, а не прямо в самій картці (users/newUsers).
-export const FieldComment = ({ userData, extendedMode = false }) => {
+export const FieldComment = ({ userData, extendedMode = false, onLegacyCommentMigrated }) => {
   const textareaRef = useRef(null);
   const [text, setText] = useState('');
   const autoResize = useAutoResize(textareaRef, text);
   const ownerId = auth.currentUser?.uid;
   const cardId = userData.userId;
+  const legacyComment = String(userData.myComment || '').trim();
+  const initialTextRef = useRef('');
+  const hasLegacyCommentRef = useRef(Boolean(legacyComment));
 
   useEffect(() => {
     let cancelled = false;
-    setText('');
+    setText(legacyComment);
+    initialTextRef.current = legacyComment;
+    hasLegacyCommentRef.current = Boolean(legacyComment);
     if (!ownerId || !cardId) return undefined;
 
     fetchUserComment(ownerId, cardId).then(existing => {
       if (cancelled) return;
-      setText(existing?.text || '');
+      const ownComment = String(existing?.text || '').trim();
+      const combined = [legacyComment, ownComment].filter(Boolean).join('\n\n');
+      setText(combined);
+      initialTextRef.current = combined;
     });
 
     return () => {
       cancelled = true;
     };
-  }, [ownerId, cardId]);
+  }, [ownerId, cardId, legacyComment]);
 
-  const persist = async value => {
+  const persist = async (value, force = false) => {
     if (!ownerId || !cardId) {
       toast.error('Не вдалося зберегти коментар: користувач або картка не визначені');
       return false;
     }
 
+    if (!force && value === initialTextRef.current) return true;
+
     try {
-      await saveMyCardComment(cardId, value, ownerId);
+      if (hasLegacyCommentRef.current) {
+        await migrateMyCardComment(cardId, value, ownerId);
+        hasLegacyCommentRef.current = false;
+        onLegacyCommentMigrated?.();
+      } else {
+        await saveMyCardComment(cardId, value, ownerId);
+      }
+      initialTextRef.current = value;
       return true;
     } catch (error) {
       const details = error?.message || String(error);
@@ -112,7 +135,7 @@ export const FieldComment = ({ userData, extendedMode = false }) => {
           onMouseDown={event => event.preventDefault()}
           onClick={async event => {
             event.stopPropagation();
-            const saved = await persist(textareaRef.current?.value ?? '');
+            const saved = await persist(textareaRef.current?.value ?? '', true);
             if (!saved) return;
             window.open(buildCommentBackendUrl(ownerId, cardId), '_blank', 'noopener,noreferrer');
           }}

--- a/src/components/smallCard/FieldComment.test.js
+++ b/src/components/smallCard/FieldComment.test.js
@@ -9,10 +9,11 @@ jest.mock('../config', () => ({
   COMMENTS_ROOT_PATH: 'multiData/comments',
   auth: { currentUser: { uid: 'admin-1' } },
   fetchUserComment: jest.fn(),
+  migrateMyCardComment: jest.fn(),
   saveMyCardComment: jest.fn(),
 }));
 
-const { fetchUserComment, saveMyCardComment } = require('../config');
+const { fetchUserComment, migrateMyCardComment, saveMyCardComment } = require('../config');
 const toast = require('react-hot-toast');
 const { FieldComment } = require('./FieldComment');
 
@@ -20,20 +21,42 @@ describe('FieldComment', () => {
   beforeEach(() => {
     fetchUserComment.mockReset();
     saveMyCardComment.mockReset();
+    migrateMyCardComment.mockReset();
     fetchUserComment.mockResolvedValue(null);
     saveMyCardComment.mockResolvedValue({ lastAction: 123 });
+    migrateMyCardComment.mockResolvedValue({ lastAction: 123 });
     toast.error.mockReset();
   });
 
-  it("loads the current admin's own comment for this card, not a card field", async () => {
+  it("combines the legacy card comment and current admin's multiData comment", async () => {
     fetchUserComment.mockResolvedValue({ text: 'my private note', updatedAt: 123 });
 
     render(<FieldComment userData={{ userId: 'user-1', myComment: 'legacy card value' }} />);
 
     expect(fetchUserComment).toHaveBeenCalledWith('admin-1', 'user-1');
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('Додайте свій коментар').value).toBe('my private note');
+      expect(screen.getByPlaceholderText('Додайте свій коментар').value).toBe('legacy card value\n\nmy private note');
     });
+  });
+
+  it('migrates an edited legacy comment and notifies the card state', async () => {
+    const onMigrated = jest.fn();
+    render(
+      <FieldComment
+        userData={{ userId: 'user-1', myComment: 'legacy' }}
+        onLegacyCommentMigrated={onMigrated}
+      />
+    );
+
+    const textarea = await screen.findByPlaceholderText('Додайте свій коментар');
+    fireEvent.change(textarea, { target: { value: 'legacy edited' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(migrateMyCardComment).toHaveBeenCalledWith('user-1', 'legacy edited', 'admin-1');
+    });
+    expect(saveMyCardComment).not.toHaveBeenCalled();
+    expect(onMigrated).toHaveBeenCalledTimes(1);
   });
 
   it('saves via saveMyCardComment on blur, keyed by the admin uid, not the card object', async () => {

--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -2134,7 +2134,24 @@ export const TopBlock = ({
       </div>
       <div style={commentsSectionStyle}>
         {fieldWriter({ userData: cardData, setUsers, setState, submitOptions, updateContext })}
-        <FieldComment userData={cardData} extendedMode={extendedMode} />
+        <FieldComment
+          userData={cardData}
+          extendedMode={extendedMode}
+          onLegacyCommentMigrated={() => {
+            const removeLegacyComment = user => {
+              if (!user) return user;
+              const nextUser = { ...user };
+              delete nextUser.myComment;
+              return nextUser;
+            };
+            if (typeof setUsers === 'function') {
+              setUsers(prev => updateUserInState(prev, cardData.userId, removeLegacyComment));
+            }
+            if (typeof setState === 'function' && !isFromListOfUsers) {
+              setState(prev => removeLegacyComment(prev));
+            }
+          }}
+        />
         {otherAdminsComments.map(comment => (
           <div key={comment.commentId || `${comment.authorId}-${comment.text}`} style={multiCommentRowStyle}>
             <button


### PR DESCRIPTION
### Motivation
- Legacy per-card comment field (`myComment` on `users/newUsers`) should be moved to the admin-scoped multiData location (`multiData/comments/{ownerId}/{cardId}`) to keep a single canonical source and avoid stale duplicates.
- The UI should surface both the legacy card comment and the current admin's personal comment, and migrate legacy content on first edit to avoid data loss.

### Description
- Added `migrateMyCardComment` in `src/components/config.js` which atomically moves/removes legacy comment locations (`users/{cardId}/myComment` and `newUsers/{cardId}/myComment`) and writes to `multiData/comments/{ownerId}/{cardId}` when non-empty using a single `update` call; returns `{ lastAction }` or `null`.
- Updated `FieldComment` (`src/components/smallCard/FieldComment.js`) to combine the legacy `userData.myComment` and the admin's existing multiData comment into the textarea initial value, and to track whether a legacy comment exists using refs.
- Changed `persist` logic to call `migrateMyCardComment` on first edit when a legacy comment is present and to call `saveMyCardComment` otherwise, and added a `force` flag to bypass no-op checks for backend-navigation button saves via `persist(..., true)`.
- Added an `onLegacyCommentMigrated` prop to `FieldComment` and wired it from `renderTopBlock.js` to remove the `myComment` field from in-memory card/state when migration completes, using `setUsers` / `setState` helpers.
- Updated tests in `src/components/smallCard/FieldComment.test.js` to mock and exercise `migrateMyCardComment`, to assert combined initial text, and to assert migration behavior and the `onLegacyCommentMigrated` callback.

### Testing
- Ran unit tests for `FieldComment` via the Jest test suite, including the new migration test `migrates an edited legacy comment and notifies the card state`, and all tests in `src/components/smallCard/FieldComment.test.js` passed.
- Existing tests that assert saving and clearing behavior still passed after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d16d146c48326afb6e12a7a41a0ef)