### PR TITLE
Migrate personal comments to multiData/comments with legacy fallback and save error handling

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -510,6 +510,7 @@ const EditProfile = () => {
   async function remoteUpdate({ updatedState, overwrite, delCondition, deletedKeys = [] }) {
     const editorUserId = auth.currentUser?.uid;
     const canWriteMain = isAdminUid(editorUserId);
+    let commentSaveFailed = false;
 
     if (!canWriteMain) {
       const canonical =
@@ -531,7 +532,15 @@ const EditProfile = () => {
       const previousComment = lastSyncedSnapshotRef.current?.myComment ?? '';
       const nextComment = updatedState.myComment ?? '';
       if (nextComment !== previousComment) {
-        await saveMyCardComment(updatedState.userId, nextComment, editorUserId);
+        try {
+          await saveMyCardComment(updatedState.userId, nextComment, editorUserId);
+        } catch (error) {
+          // Keep the previous baseline so the same draft is retried on the
+          // next profile sync instead of being marked as successfully saved.
+          commentSaveFailed = true;
+          const details = error?.message || String(error);
+          toast.error(`Не вдалося зберегти коментар: ${details}`);
+        }
       }
     }
 
@@ -635,7 +644,10 @@ const EditProfile = () => {
       }
     }
 
-    return prepareSyncedSnapshot(updatedState, deletedKeys);
+    const syncedState = commentSaveFailed
+      ? { ...updatedState, myComment: lastSyncedSnapshotRef.current?.myComment ?? '' }
+      : updatedState;
+    return prepareSyncedSnapshot(syncedState, deletedKeys);
   }
 
 

--- a/src/components/EditProfile.myCommentPersonalization.test.js
+++ b/src/components/EditProfile.myCommentPersonalization.test.js
@@ -28,5 +28,7 @@ describe('EditProfile treats myComment as the current admin\'s personal note', (
     );
     expect(remoteUpdateBody).toContain('if (nextComment !== previousComment)');
     expect(remoteUpdateBody).toContain('await saveMyCardComment(updatedState.userId, nextComment, editorUserId);');
+    expect(remoteUpdateBody).toContain('commentSaveFailed = true;');
+    expect(remoteUpdateBody).toContain("myComment: lastSyncedSnapshotRef.current?.myComment ?? ''");
   });
 });

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5865,8 +5865,13 @@ const Matching = () => {
                       onCommentBlur={async () => {
                         if (auth.currentUser) {
                           const text = comments[user.userId] || '';
-                          const res = await saveMyCardComment(user.userId, text, ownerId);
-                          setLocalComment(ownerId, user.userId, text, res?.lastAction);
+                          try {
+                            const res = await saveMyCardComment(user.userId, text, ownerId);
+                            setLocalComment(ownerId, user.userId, text, res?.lastAction);
+                          } catch (error) {
+                            const details = error?.message || String(error);
+                            toast.error(`Не вдалося зберегти коментар: ${details}`);
+                          }
                         }
                       }}
                       onAdminEdit={() => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1071,8 +1071,15 @@ export const fetchCycleUsersData = async (
 };
 
 export const COMMENTS_ROOT_PATH = 'multiData/comments';
+export const LEGACY_COMMENTS_ROOT_PATH = 'comments';
 const getCommentPath = (ownerId, cardId) =>
   [COMMENTS_ROOT_PATH, ownerId, cardId].filter(Boolean).join('/');
+const getLegacyCommentPath = (ownerId, cardId) =>
+  [LEGACY_COMMENTS_ROOT_PATH, ownerId, cardId].filter(Boolean).join('/');
+const normalizeComment = value => ({
+  text: typeof value?.text === 'string' ? value.text : '',
+  lastAction: typeof value?.updatedAt === 'number' ? value.updatedAt : 0,
+});
 
 // Особистий коментар адміна до картки — multiData/comments/{ownerId}/{cardId} = { text, updatedAt }.
 // Рівно один запис на пару ownerId+cardId: повторне збереження оновлює його
@@ -1088,7 +1095,10 @@ export const setUserComment = async (cardId, text, ownerId) => {
     }
     const commentsOwnerId = ownerId || user.uid;
     const updatedAt = Date.now();
-    await set(ref2(database, getCommentPath(commentsOwnerId, cardId)), { text, updatedAt });
+    await update(ref2(database), {
+      [getCommentPath(commentsOwnerId, cardId)]: { text, updatedAt },
+      [getLegacyCommentPath(commentsOwnerId, cardId)]: null,
+    });
     return { lastAction: updatedAt };
   } catch (error) {
     console.error('Error setting comment:', error);
@@ -1109,7 +1119,10 @@ export const updateCommentByOwner = async ({ ownerId, cardId, text }) => {
       throw new Error('ownerId, cardId і text обовʼязкові');
     }
     const updatedAt = Date.now();
-    await set(ref2(database, getCommentPath(ownerId, cardId)), { text, updatedAt });
+    await update(ref2(database), {
+      [getCommentPath(ownerId, cardId)]: { text, updatedAt },
+      [getLegacyCommentPath(ownerId, cardId)]: null,
+    });
     return { lastAction: updatedAt, ownerId };
   } catch (error) {
     console.error('Error updating comment by owner:', error);
@@ -1126,7 +1139,10 @@ export const deleteCommentByOwner = async ({ ownerId, cardId }) => {
     if (!ownerId || !cardId) {
       throw new Error('ownerId і cardId обовʼязкові');
     }
-    await remove(ref2(database, getCommentPath(ownerId, cardId)));
+    await update(ref2(database), {
+      [getCommentPath(ownerId, cardId)]: null,
+      [getLegacyCommentPath(ownerId, cardId)]: null,
+    });
     return true;
   } catch (error) {
     console.error('Error deleting comment by owner:', error);
@@ -1138,12 +1154,20 @@ export const fetchUserComment = async (ownerId, cardId) => {
   try {
     if (!ownerId || !cardId) return null;
     const snap = await get(ref2(database, getCommentPath(ownerId, cardId)));
-    if (!snap.exists()) return null;
-    const value = snap.val();
-    return {
-      text: typeof value?.text === 'string' ? value.text : '',
-      lastAction: typeof value?.updatedAt === 'number' ? value.updatedAt : 0,
-    };
+    if (snap.exists()) return normalizeComment(snap.val());
+
+    // Keep this as a read-only compatibility fallback. A client-side copy can
+    // overwrite a save (or resurrect a deletion) made after the legacy read.
+    // Normal writes atomically move the entry and clear its legacy copy.
+    let legacySnap;
+    try {
+      legacySnap = await get(ref2(database, getLegacyCommentPath(ownerId, cardId)));
+    } catch (error) {
+      console.error('Error fetching legacy comment:', error);
+      return null;
+    }
+    if (!legacySnap.exists()) return null;
+    return normalizeComment(legacySnap.val());
   } catch (error) {
     console.error('Error fetching comment:', error);
     return null;
@@ -1180,6 +1204,7 @@ export const migrateMyCardComment = async (cardId, text, ownerId) => {
   const updates = {
     [`users/${cardId}/myComment`]: null,
     [`newUsers/${cardId}/myComment`]: null,
+    [getLegacyCommentPath(commentsOwnerId, cardId)]: null,
   };
 
   if (trimmed) {
@@ -1199,16 +1224,20 @@ export const fetchUserComments = async (ownerId, cardIds = []) => {
     incrementMatchingLoadStat('commentsReads', Array.isArray(cardIds) ? cardIds.length : 0);
     if (!ownerId || !Array.isArray(cardIds) || !cardIds.length) return {};
     const snap = await get(ref2(database, getCommentPath(ownerId)));
-    if (!snap.exists()) return {};
+    let legacyComments = {};
+    try {
+      const legacySnap = await get(ref2(database, getLegacyCommentPath(ownerId)));
+      legacyComments = legacySnap.val() || {};
+    } catch (error) {
+      // Legacy compatibility must never hide successfully loaded current data.
+      console.error('Error fetching legacy comments:', error);
+    }
     const ownerComments = snap.val() || {};
     const result = {};
     cardIds.forEach(cardId => {
-      const value = ownerComments[cardId];
+      const value = ownerComments[cardId] || legacyComments[cardId];
       if (!value || typeof value !== 'object') return;
-      result[cardId] = {
-        text: typeof value.text === 'string' ? value.text : '',
-        lastAction: typeof value.updatedAt === 'number' ? value.updatedAt : 0,
-      };
+      result[cardId] = normalizeComment(value);
     });
     return result;
   } catch (error) {
@@ -1221,13 +1250,24 @@ export const fetchAllCommentsByCardId = async cardId => {
   try {
     if (!cardId) return [];
     const snap = await get(ref2(database, COMMENTS_ROOT_PATH));
-    if (!snap.exists()) return [];
+    let legacyCommentsByOwner = {};
+    try {
+      const legacySnap = await get(ref2(database, LEGACY_COMMENTS_ROOT_PATH));
+      legacyCommentsByOwner = legacySnap.val() || {};
+    } catch (error) {
+      // Shared current comments remain usable when the optional fallback fails.
+      console.error('Error fetching all legacy comments by cardId:', error);
+    }
 
     const result = [];
+    const commentsByOwner = snap.val() || {};
+    const ownerIds = new Set([
+      ...Object.keys(commentsByOwner),
+      ...Object.keys(legacyCommentsByOwner),
+    ]);
 
-    Object.entries(snap.val() || {}).forEach(([ownerId, ownerComments]) => {
-      if (!ownerComments || typeof ownerComments !== 'object') return;
-      const value = ownerComments[cardId];
+    ownerIds.forEach(ownerId => {
+      const value = commentsByOwner[ownerId]?.[cardId] || legacyCommentsByOwner[ownerId]?.[cardId];
       if (!value || typeof value !== 'object') return;
       const text = String(value.text || '').trim();
       if (!text) return;

--- a/src/components/config.myCommentMigration.test.js
+++ b/src/components/config.myCommentMigration.test.js
@@ -42,4 +42,23 @@ describe('myComment moves off the card into multiData/comments/{ownerId}/{cardId
     expect(fnBody).not.toContain('orderByChild');
     expect(fnBody).not.toContain('equalTo');
   });
+
+  it('uses a read-only legacy fallback without risking concurrent comment overwrites', () => {
+    const singleReadBody = source.slice(
+      source.indexOf('export const fetchUserComment '),
+      source.indexOf('export const saveMyCardComment')
+    );
+    const bulkReadBody = source.slice(
+      source.indexOf('export const fetchUserComments'),
+      source.indexOf('const buildFlowRef')
+    );
+
+    expect(source).toContain("export const LEGACY_COMMENTS_ROOT_PATH = 'comments';");
+    expect(singleReadBody).toContain('getLegacyCommentPath(ownerId, cardId)');
+    expect(singleReadBody).not.toContain('[getCommentPath(ownerId, cardId)]: value');
+    expect(bulkReadBody).toContain('getLegacyCommentPath(ownerId)');
+    expect(bulkReadBody).toContain('LEGACY_COMMENTS_ROOT_PATH');
+    expect(bulkReadBody).not.toContain('await update(ref2(database), migrations)');
+    expect(bulkReadBody).not.toContain('Promise.all([');
+  });
 });

--- a/src/components/smallCard/FieldComment.js
+++ b/src/components/smallCard/FieldComment.js
@@ -135,9 +135,16 @@ export const FieldComment = ({ userData, extendedMode = false, onLegacyCommentMi
           onMouseDown={event => event.preventDefault()}
           onClick={async event => {
             event.stopPropagation();
+            // Reserve the tab while this trusted click still has transient
+            // user activation; Firebase writes may outlive the popup window.
+            const backendWindow = window.open('about:blank', '_blank');
+            if (backendWindow) backendWindow.opener = null;
             const saved = await persist(textareaRef.current?.value ?? '', true);
-            if (!saved) return;
-            window.open(buildCommentBackendUrl(ownerId, cardId), '_blank', 'noopener,noreferrer');
+            if (!saved) {
+              backendWindow?.close();
+              return;
+            }
+            if (backendWindow) backendWindow.location.href = buildCommentBackendUrl(ownerId, cardId);
           }}
           style={{
             position: 'absolute',

--- a/src/components/smallCard/FieldComment.test.js
+++ b/src/components/smallCard/FieldComment.test.js
@@ -89,7 +89,8 @@ describe('FieldComment', () => {
   });
 
   it('saves the current draft before opening the comment backend URL', async () => {
-    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    const backendWindow = { location: { href: '' }, close: jest.fn(), opener: window };
+    const openSpy = jest.spyOn(window, 'open').mockReturnValue(backendWindow);
     render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
 
     const arrow = await screen.findByLabelText('Відкрити запис коментаря у Firebase');
@@ -98,19 +99,23 @@ describe('FieldComment', () => {
     fireEvent.click(arrow);
 
     await waitFor(() => expect(openSpy).toHaveBeenCalledTimes(1));
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
     expect(saveMyCardComment).toHaveBeenCalledWith('user-1', 'unsaved draft', 'admin-1');
-    const [url] = openSpy.mock.calls[0];
+    const url = backendWindow.location.href;
     expect(url).toContain('admin-1');
     expect(url).toContain('user-1');
     expect(url).toContain('multiData');
     expect(url).toContain('comments');
+    expect(backendWindow.opener).toBeNull();
+    expect(backendWindow.close).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
 
   it('shows a toast and does not open the backend URL when saving fails', async () => {
     const error = new Error('PERMISSION_DENIED');
     saveMyCardComment.mockRejectedValue(error);
-    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    const backendWindow = { location: { href: '' }, close: jest.fn(), opener: window };
+    const openSpy = jest.spyOn(window, 'open').mockReturnValue(backendWindow);
     render(<FieldComment userData={{ userId: 'user-1' }} extendedMode />);
 
     fireEvent.click(await screen.findByLabelText('Відкрити запис коментаря у Firebase'));
@@ -120,7 +125,9 @@ describe('FieldComment', () => {
         'Не вдалося зберегти коментар: PERMISSION_DENIED'
       );
     });
-    expect(openSpy).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+    expect(backendWindow.location.href).toBe('');
+    expect(backendWindow.close).toHaveBeenCalledTimes(1);
     openSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Motivation
- Move admin personal comments off the card into the new `multiData/comments` location while preserving read compatibility with the legacy `comments` path and avoiding concurrent overwrite/resurrection issues.
- Improve robustness of comment saves so UI actions handle backend write failures without corrupting in-memory draft state or opening stale backend links.

### Description
- Introduced `LEGACY_COMMENTS_ROOT_PATH`, `getLegacyCommentPath`, and `normalizeComment` and updated comment helpers to write atomically to the new path while clearing the legacy entry using `update(ref2(database), ...)` in `config.js`.
- Added a read-only legacy fallback in `fetchUserComment`, merged legacy entries in `fetchUserComments`, and included legacy owners when enumerating comments in `fetchAllCommentsByCardId` to preserve backward compatibility without risking overwrites.
- Ensured migrations (`migrateMyCardComment`) also clear the legacy path, and adjusted `updateCommentByOwner` / `deleteCommentByOwner` to operate via atomic `update` calls that clear legacy copies.
- Made comment saves resilient in `EditProfile.jsx` by wrapping `saveMyCardComment` in a `try/catch`, setting a `commentSaveFailed` flag, and ensuring the returned synced snapshot retains the previous `myComment` baseline when the save fails so drafts are retried later.
- Hardened the matching UI and small-card backend navigation by catching save errors and showing a toast instead of throwing, and by opening a temporary `about:blank` window with `opener` nulled while the save is performed so the popup is only navigated on success and closed on failure (changes in `Matching.jsx` and `smallCard/FieldComment.js`).
- Updated tests to assert the new behaviors and compatibility hooks in `EditProfile.myCommentPersonalization.test.js`, `config.myCommentMigration.test.js`, and `smallCard/FieldComment.test.js`.

### Testing
- Ran unit tests (`npm test`) including updated tests for `EditProfile.myCommentPersonalization.test.js`, `config.myCommentMigration.test.js`, and `smallCard/FieldComment.test.js`, and all tests passed.
- Verified comment save failure paths trigger `toast.error` in UI tests and that backend-window behavior is exercised and behaves as expected in the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d1eca9aa8832686df53e99d855d35)