### PR TITLE
Add admin button to bulk-migrate legacy card comments into multiData

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -40,6 +40,7 @@ import {
   fetchUsersBySearchKeyBloodPaged,
   fetchUsersByIds,
   lazyLoadProfilePhotos,
+  migrateAllLegacyCardComments,
 } from './config';
 import { fetchUsersBySearchKeyGitNewPaged } from './gitNewLoad';
 import {
@@ -6130,6 +6131,34 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
+  const handleMigrateAllLegacyCardComments = async () => {
+    if (!isAdmin) return;
+    if (
+      !window.confirm(
+        'Це перенесе всі старі коментарі з users/newUsers у multiData/comments під ваш акаунт ' +
+          'і видалить їх з карток. Дію неможливо скасувати вручну. Продовжити?',
+      )
+    ) {
+      return;
+    }
+
+    const toastId = 'migrate-legacy-card-comments-progress';
+    toast.loading('Міграція коментарів...', { id: toastId });
+    try {
+      const report = await migrateAllLegacyCardComments(auth.currentUser?.uid, {
+        onProgress: percent => toast.loading(`Міграція коментарів... ${percent}%`, { id: toastId }),
+      });
+      toast.success(
+        `Мігровано карток: ${report.migratedCards}` +
+          (report.errors.length ? `, помилок: ${report.errors.length}` : ''),
+        { id: toastId },
+      );
+    } catch (error) {
+      console.error('[AddNewProfile] Comment migration failed', error);
+      toast.error(`Помилка міграції коментарів: ${error?.message || 'невідома помилка'}`, { id: toastId });
+    }
+  };
+
   useEffect(() => {
     if (!searchIdAndSearchKeyOnlyMode) {
       setShowSearchKeyIndexPanel(false);
@@ -7132,6 +7161,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                     Індекси
                   </Button>
                 </>
+              )}
+              {isAdmin && (
+                <Button
+                  onClick={handleMigrateAllLegacyCardComments}
+                  title="Перенести всі старі коментарі карток у multiData/comments"
+                >
+                  Мігрувати коментарі
+                </Button>
               )}
               {<Button onClick={searchDuplicates} {...createLongPressHandlers('Шукає дублікати карток')}>DPL</Button>}
               <Button

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1219,6 +1219,90 @@ export const migrateMyCardComment = async (cardId, text, ownerId) => {
   return null;
 };
 
+// Масово переносить залишкові myComment з УСІХ карток users/newUsers у
+// multiData/comments/{ownerId}/{cardId}, під акаунт адміна, що запускає міграцію.
+// НЕ чіпає LEGACY_COMMENTS_ROOT_PATH ('comments/{ownerId}/{cardId}'): ця структура
+// фактично не використовується, а update() з кількома шляхами атомарний — permission
+// denied на нерелевантному legacy-шляху зірвав би весь чанк, включно з головними
+// записами. Якщо той самий cardId має різний myComment в users і newUsers, або в
+// multiData вже є коментар цього ownerId — тексти об'єднуються через '\n\n', а не
+// перезаписуються, щоб жоден коментар не загубився.
+export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {}) => {
+  const user = auth.currentUser;
+  if (!user) throw new Error('User not authenticated');
+  const commentsOwnerId = ownerId || user.uid;
+
+  const [usersSnap, newUsersSnap] = await Promise.all([
+    get(ref2(database, 'users')),
+    get(ref2(database, 'newUsers')),
+  ]);
+  const usersData = usersSnap.val() || {};
+  const newUsersData = newUsersSnap.val() || {};
+
+  const cardIds = new Set([
+    ...Object.keys(usersData).filter(id => String(usersData[id]?.myComment || '').trim()),
+    ...Object.keys(newUsersData).filter(id => String(newUsersData[id]?.myComment || '').trim()),
+  ]);
+
+  const report = {
+    scannedUsers: Object.keys(usersData).length,
+    scannedNewUsers: Object.keys(newUsersData).length,
+    migratedCards: 0,
+    fromBothCollections: 0,
+    mergedWithExisting: 0,
+    errors: [],
+  };
+  if (!cardIds.size) return report;
+
+  const existingSnap = await get(ref2(database, getCommentPath(commentsOwnerId)));
+  const existingComments = existingSnap.val() || {};
+
+  const BATCH_SIZE = 100;
+  const ids = Array.from(cardIds);
+
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const chunk = ids.slice(i, i + BATCH_SIZE);
+    const updates = {};
+
+    chunk.forEach(cardId => {
+      const usersText = String(usersData[cardId]?.myComment || '').trim();
+      const newUsersText = String(newUsersData[cardId]?.myComment || '').trim();
+      const legacyParts = [...new Set([usersText, newUsersText].filter(Boolean))];
+      if (usersText && newUsersText && usersText !== newUsersText) {
+        report.fromBothCollections += 1;
+      }
+
+      const existingText = String(existingComments[cardId]?.text || '').trim();
+      const finalParts = existingText
+        ? [...legacyParts, existingText].filter((value, index, arr) => arr.indexOf(value) === index)
+        : legacyParts;
+      if (existingText) report.mergedWithExisting += 1;
+
+      const finalText = finalParts.join('\n\n');
+
+      // Примітка: LEGACY_COMMENTS_ROOT_PATH тут свідомо не обнуляється (див. коментар над функцією).
+      updates[`users/${cardId}/myComment`] = null;
+      updates[`newUsers/${cardId}/myComment`] = null;
+      updates[getCommentPath(commentsOwnerId, cardId)] = { text: finalText, updatedAt: Date.now() };
+      report.migratedCards += 1;
+    });
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await update(ref2(database), updates);
+      // Кожен чанк — один атомарний update(): або весь застосувався (і myComment
+      // очищено, і коментар вже в multiData), або жоден запис із чанку не пройшов.
+      // Тому переривання процесу ніколи не губить коментар — лише лишає
+      // немігровану частину карток на наступний запуск.
+    } catch (error) {
+      chunk.forEach(cardId => report.errors.push({ cardId, message: error?.message || String(error) }));
+    }
+    onProgress?.(Math.round(((i + chunk.length) / ids.length) * 100));
+  }
+
+  return report;
+};
+
 export const fetchUserComments = async (ownerId, cardIds = []) => {
   try {
     incrementMatchingLoadStat('commentsReads', Array.isArray(cardIds) ? cardIds.length : 0);

--- a/src/components/config.migrateAllLegacyCardComments.test.js
+++ b/src/components/config.migrateAllLegacyCardComments.test.js
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('bulk migration of every leftover users/newUsers myComment into multiData/comments', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+
+  const fnBody = source.slice(
+    source.indexOf('export const migrateAllLegacyCardComments'),
+    source.indexOf('export const fetchUserComments')
+  );
+
+  it('exists and reads both users and newUsers roots wholesale', () => {
+    expect(fnBody).toBeTruthy();
+    expect(fnBody).toContain("get(ref2(database, 'users'))");
+    expect(fnBody).toContain("get(ref2(database, 'newUsers'))");
+  });
+
+  it('writes comments via getCommentPath, without push() or querying helpers', () => {
+    expect(fnBody).toContain('getCommentPath(commentsOwnerId, cardId)');
+    expect(fnBody).not.toMatch(/push\(ref2\(/);
+    expect(fnBody).not.toContain('orderByChild');
+    expect(fnBody).not.toContain('equalTo');
+  });
+
+  it('never touches the unused legacy comments root, so a permission-denied there cannot abort a chunk', () => {
+    expect(fnBody).not.toMatch(/getLegacyCommentPath\(/);
+    expect(fnBody).not.toMatch(/updates\[.*LEGACY_COMMENTS_ROOT_PATH/);
+  });
+
+  it('clears myComment on both card collections', () => {
+    expect(fnBody).toContain('updates[`users/${cardId}/myComment`] = null;');
+    expect(fnBody).toContain('updates[`newUsers/${cardId}/myComment`] = null;');
+  });
+
+  it('merges conflicting/legacy/pre-existing comment text instead of dropping one side', () => {
+    expect(fnBody).toContain("finalParts.join('\\n\\n')");
+  });
+
+  it('chunks writes into bounded update() calls instead of one unbounded request', () => {
+    expect(fnBody).toContain('const BATCH_SIZE = 100;');
+    expect(fnBody).toMatch(/for \(let i = 0; i < ids\.length; i \+= BATCH_SIZE\)/);
+    const writeLoopBody = fnBody.slice(fnBody.indexOf('const BATCH_SIZE = 100;'));
+    expect(writeLoopBody).not.toContain('Promise.all(');
+    expect(writeLoopBody).toContain('await update(ref2(database), updates);');
+  });
+
+  it('collects per-chunk errors instead of letting one failing chunk abort the whole run', () => {
+    expect(fnBody).toMatch(/catch \(error\) \{\s*chunk\.forEach/);
+    expect(fnBody).toContain('report.errors.push(');
+  });
+
+  it('reports progress so the UI can show percent complete', () => {
+    expect(fnBody).toContain('onProgress?.(');
+  });
+});


### PR DESCRIPTION
Historical myComment fields on users/newUsers cards were only migrated
into multiData/comments/{ownerId}/{cardId} lazily, one card at a time,
whenever an admin happened to open it in FieldComment. Add a bulk
admin action on Add New Profile that migrates every remaining card in
one pass, merging any conflicting/pre-existing text instead of
overwriting it, so no comment is lost and the users/newUsers
collections shrink for everyone else.