### PR TITLE
Protect bulk comment migration from concurrent edits

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -6148,6 +6148,18 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       const report = await migrateAllLegacyCardComments(auth.currentUser?.uid, {
         onProgress: percent => toast.loading(`Міграція коментарів... ${percent}%`, { id: toastId }),
       });
+      if (report.migratedCards) {
+        clearAllCardsCache();
+        setUsers(currentUsers =>
+          Object.fromEntries(
+            Object.entries(currentUsers).map(([cardId, card]) => {
+              const cardWithoutLegacyComment = { ...(card || {}) };
+              delete cardWithoutLegacyComment.myComment;
+              return [cardId, cardWithoutLegacyComment];
+            }),
+          ),
+        );
+      }
       toast.success(
         `Мігровано карток: ${report.migratedCards}` +
           (report.errors.length ? `, помилок: ${report.errors.length}` : ''),

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -20,6 +20,7 @@ import {
   endAt,
   endBefore,
   equalTo,
+  runTransaction,
 } from 'firebase/database';
 import { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 import { filterOutMedicationPhotos } from '../utils/photoFilters';
@@ -1221,12 +1222,10 @@ export const migrateMyCardComment = async (cardId, text, ownerId) => {
 
 // Масово переносить залишкові myComment з УСІХ карток users/newUsers у
 // multiData/comments/{ownerId}/{cardId}, під акаунт адміна, що запускає міграцію.
-// НЕ чіпає LEGACY_COMMENTS_ROOT_PATH ('comments/{ownerId}/{cardId}'): ця структура
-// фактично не використовується, а update() з кількома шляхами атомарний — permission
-// denied на нерелевантному legacy-шляху зірвав би весь чанк, включно з головними
-// записами. Якщо той самий cardId має різний myComment в users і newUsers, або в
-// multiData вже є коментар цього ownerId — тексти об'єднуються через '\n\n', а не
-// перезаписуються, щоб жоден коментар не загубився.
+// Якщо той самий cardId має різний myComment в users і newUsers, або в одному з
+// comments-root вже є коментар цього ownerId — тексти об'єднуються через '\n\n'.
+// Кожен запис змінюється транзакцією з перевіркою прочитаного значення: редагування,
+// яке сталося під час міграції, не буде перезаписане або очищене за старим snapshot.
 export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {}) => {
   const user = auth.currentUser;
   if (!user) throw new Error('User not authenticated');
@@ -1254,48 +1253,71 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
   };
   if (!cardIds.size) return report;
 
-  const existingSnap = await get(ref2(database, getCommentPath(commentsOwnerId)));
+  const [existingSnap, legacyExistingSnap] = await Promise.all([
+    get(ref2(database, getCommentPath(commentsOwnerId))),
+    get(ref2(database, getLegacyCommentPath(commentsOwnerId))),
+  ]);
   const existingComments = existingSnap.val() || {};
+  const legacyExistingComments = legacyExistingSnap.val() || {};
+
+  const valuesMatch = (left, right) => JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+  const mergeCommentText = (...values) =>
+    [...new Set(values.map(value => String(value || '').trim()).filter(Boolean))].join('\n\n');
 
   const BATCH_SIZE = 100;
   const ids = Array.from(cardIds);
 
   for (let i = 0; i < ids.length; i += BATCH_SIZE) {
     const chunk = ids.slice(i, i + BATCH_SIZE);
-    const updates = {};
-
-    chunk.forEach(cardId => {
+    for (const cardId of chunk) {
       const usersText = String(usersData[cardId]?.myComment || '').trim();
       const newUsersText = String(newUsersData[cardId]?.myComment || '').trim();
-      const legacyParts = [...new Set([usersText, newUsersText].filter(Boolean))];
       if (usersText && newUsersText && usersText !== newUsersText) {
         report.fromBothCollections += 1;
       }
 
-      const existingText = String(existingComments[cardId]?.text || '').trim();
-      const finalParts = existingText
-        ? [...legacyParts, existingText].filter((value, index, arr) => arr.indexOf(value) === index)
-        : legacyParts;
-      if (existingText) report.mergedWithExisting += 1;
+      const currentComment = existingComments[cardId] ?? null;
+      const legacyComment = legacyExistingComments[cardId] ?? null;
+      if (currentComment?.text || legacyComment?.text) report.mergedWithExisting += 1;
 
-      const finalText = finalParts.join('\n\n');
+      // When only the fallback record exists, extend it in place. Creating a
+      // current-root record would shadow a fallback edit made concurrently.
+      const destinationPath = currentComment || !legacyComment
+        ? getCommentPath(commentsOwnerId, cardId)
+        : getLegacyCommentPath(commentsOwnerId, cardId);
+      const expectedDestination = currentComment || legacyComment;
+      const finalText = mergeCommentText(
+        usersText,
+        newUsersText,
+        legacyComment?.text,
+        currentComment?.text,
+      );
 
-      // Примітка: LEGACY_COMMENTS_ROOT_PATH тут свідомо не обнуляється (див. коментар над функцією).
-      updates[`users/${cardId}/myComment`] = null;
-      updates[`newUsers/${cardId}/myComment`] = null;
-      updates[getCommentPath(commentsOwnerId, cardId)] = { text: finalText, updatedAt: Date.now() };
-      report.migratedCards += 1;
-    });
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const destinationResult = await runTransaction(ref2(database, destinationPath), value => {
+          if (!valuesMatch(value, expectedDestination)) return undefined;
+          return { text: finalText, updatedAt: Date.now() };
+        });
+        if (!destinationResult.committed) throw new Error('Коментар було змінено під час міграції');
 
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      await update(ref2(database), updates);
-      // Кожен чанк — один атомарний update(): або весь застосувався (і myComment
-      // очищено, і коментар вже в multiData), або жоден запис із чанку не пройшов.
-      // Тому переривання процесу ніколи не губить коментар — лише лишає
-      // немігровану частину карток на наступний запуск.
-    } catch (error) {
-      chunk.forEach(cardId => report.errors.push({ cardId, message: error?.message || String(error) }));
+        const sources = [
+          { path: `users/${cardId}/myComment`, expected: usersData[cardId]?.myComment },
+          { path: `newUsers/${cardId}/myComment`, expected: newUsersData[cardId]?.myComment },
+        ].filter(source => String(source.expected || '').trim());
+        // eslint-disable-next-line no-await-in-loop
+        const sourceResults = await Promise.all(sources.map(source =>
+          runTransaction(ref2(database, source.path), value =>
+            valuesMatch(value, source.expected) ? null : undefined,
+          )
+        ));
+        if (sourceResults.some(result => !result.committed)) {
+          throw new Error('Картку було змінено під час міграції');
+        }
+        report.migratedCards += 1;
+      } catch (error) {
+        report.errors.push({ cardId, message: error?.message || String(error) });
+      }
     }
     onProgress?.(Math.round(((i + chunk.length) / ids.length) * 100));
   }

--- a/src/components/config.migrateAllLegacyCardComments.test.js
+++ b/src/components/config.migrateAllLegacyCardComments.test.js
@@ -22,31 +22,39 @@ describe('bulk migration of every leftover users/newUsers myComment into multiDa
     expect(fnBody).not.toContain('equalTo');
   });
 
-  it('never touches the unused legacy comments root, so a permission-denied there cannot abort a chunk', () => {
-    expect(fnBody).not.toMatch(/getLegacyCommentPath\(/);
-    expect(fnBody).not.toMatch(/updates\[.*LEGACY_COMMENTS_ROOT_PATH/);
+  it('merges the supported legacy comments fallback before choosing a destination', () => {
+    expect(fnBody).toContain('getLegacyCommentPath(commentsOwnerId)');
+    expect(fnBody).toContain('legacyExistingComments');
+    expect(fnBody).toContain('legacyComment?.text');
   });
 
-  it('clears myComment on both card collections', () => {
-    expect(fnBody).toContain('updates[`users/${cardId}/myComment`] = null;');
-    expect(fnBody).toContain('updates[`newUsers/${cardId}/myComment`] = null;');
+  it('clears myComment on both card collections with compare-and-set transactions', () => {
+    expect(fnBody).toMatch(/`users\/\$\{cardId\}\/myComment`/);
+    expect(fnBody).toMatch(/`newUsers\/\$\{cardId\}\/myComment`/);
+    expect(fnBody).toContain('runTransaction(ref2(database, source.path)');
   });
 
   it('merges conflicting/legacy/pre-existing comment text instead of dropping one side', () => {
-    expect(fnBody).toContain("finalParts.join('\\n\\n')");
+    expect(fnBody).toContain(".join('\\n\\n')");
   });
 
-  it('chunks writes into bounded update() calls instead of one unbounded request', () => {
+  it('chunks work and runs cards serially rather than starting unbounded transactions', () => {
     expect(fnBody).toContain('const BATCH_SIZE = 100;');
     expect(fnBody).toMatch(/for \(let i = 0; i < ids\.length; i \+= BATCH_SIZE\)/);
     const writeLoopBody = fnBody.slice(fnBody.indexOf('const BATCH_SIZE = 100;'));
-    expect(writeLoopBody).not.toContain('Promise.all(');
-    expect(writeLoopBody).toContain('await update(ref2(database), updates);');
+    expect(writeLoopBody).toContain('for (const cardId of chunk)');
+    expect(writeLoopBody).toContain('await runTransaction(ref2(database, destinationPath)');
   });
 
   it('collects per-chunk errors instead of letting one failing chunk abort the whole run', () => {
-    expect(fnBody).toMatch(/catch \(error\) \{\s*chunk\.forEach/);
+    expect(fnBody).toMatch(/catch \(error\) \{\s*report\.errors\.push/);
     expect(fnBody).toContain('report.errors.push(');
+  });
+
+  it('counts a card only after destination and source transactions commit', () => {
+    expect(fnBody.indexOf('report.migratedCards += 1;')).toBeGreaterThan(
+      fnBody.indexOf("sourceResults.some(result => !result.committed)"),
+    );
   });
 
   it('reports progress so the UI can show percent complete', () => {


### PR DESCRIPTION
### Motivation
- Prevent concurrent edits or deletions from being overwritten or resurrected during the bulk migration of per-admin `myComment` fields into the canonical `multiData/comments` root. 
- Ensure legacy-fallback comments (`comments/{ownerId}/{cardId}`) are merged and not accidentally shadowed by creating a current-root record when a fallback-only comment exists.
- Count a card as migrated only after all required writes/cleanups succeed to avoid overstating success when batches partially fail.
- Invalidate in-memory and persistent card caches after a successful migration so UI components do not display stale `myComment` values.

### Description
- Use Firebase compare-and-set transactions by importing and calling `runTransaction` to perform destination writes and to null out the transient `myComment` values only when the current value still matches the snapshot read by the migration. 
- Read both the current comments root (`multiData/comments/{ownerId}`) and the legacy fallback (`comments/{ownerId}`) up-front, merge unique non-empty comment parts with `\n\n` and prefer updating the existing fallback record in place when appropriate, avoiding shadowing a fallback-only comment. 
- Process cards in bounded batches (keeps `BATCH_SIZE = 100`) but run per-card transactions serially inside the chunk; increment `report.migratedCards` only after both the destination transaction and the source cleanup transactions commit. 
- On successful migration (when `report.migratedCards > 0`), call `clearAllCardsCache()` and remove `myComment` from the in-memory `users` state via `setUsers(...)` to prevent stale legacy fields from being treated as comments by the UI. 
- Update migration tests (`config.migrateAllLegacyCardComments.test.js`) to assert that the code merges the legacy fallback, uses compare-and-set semantics for source cleanup, runs per-card transactions, and only counts cards after transactions commit.

### Testing
- Ran the migration-related unit tests with `CI=true npm test -- --runInBand src/components/config.migrateAllLegacyCardComments.test.js src/components/config.myCommentMigration.test.js`, and both suites passed (14 tests total). 
- Ran `npx eslint` against the modified files and fixed issues so linting completes without errors (only minor warnings were surfaced and addressed during the changes).
- Verified the modified test expectations now cover fallback merging, transactional cleanup, bounded processing, and post-commit success accounting and they pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dcc8aff58832688c52d2d4eab9e10)