### PR TITLE
Unify the "⋮" page-menu across the app: right-aligned, non-sticky

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -63,6 +63,7 @@ import InfoModal, { ModalTitle, ModalText, ModalActionRow, ModalDangerButton, Mo
 
 import { color, coloredCard, uiTokens } from './styles';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
+import { KmIconButton, KmPageMenuBar } from './styles/knowme';
 //import { formatPhoneNumber } from './inputValidations';
 import { UsersList } from './UsersList';
 import {
@@ -361,34 +362,6 @@ const InnerContainer = styled.div`
   }
 `;
 
-const DotsButton = styled.button`
-  margin: 0;
-  width: 40px;
-  height: 40px;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 12px;
-  font-size: 22px;
-  line-height: 1;
-  color: var(--km-accent);
-  cursor: pointer;
-  padding: 0;
-  margin-left: auto;
-  align-items: center;
-  justify-content: center;
-  display: flex;
-  transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    color 0.2s ease;
-
-  &:hover {
-    background-color: var(--km-accent-light);
-    border-color: var(--km-accent-mid);
-    color: var(--km-accent);
-  }
-`;
-
 
 export const SubmitButton = styled.button`
   padding: 11px 14px;
@@ -435,9 +408,6 @@ const TopButtons = styled.div`
   justify-content: flex-start;
   align-items: center;
   gap: 10px;
-  position: sticky;
-  top: 0;
-  z-index: 20;
   background: var(--km-card);
   padding: 6px 0;
 
@@ -6665,17 +6635,20 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     <Container>
       <InnerContainer>
         {isLoggedIn && (
-          <TopButtons>
-            {/* Batch 26 §11: the "⋮" menu first, matching every other UKRCOM admin page's header
-                (PageNavMenu is always the first action button there). */}
-            <DotsButton
+          <KmPageMenuBar>
+            <KmIconButton
+              type="button"
               aria-label="Відкрити меню профілю"
               onClick={() => {
                 setShowInfoModal('dotsMenu');
               }}
             >
               ⋮
-            </DotsButton>
+            </KmIconButton>
+          </KmPageMenuBar>
+        )}
+        {isLoggedIn && (
+          <TopButtons>
             {state.userId && (
               <>
                 <EditActionButton

--- a/src/components/AdminPageHeader.jsx
+++ b/src/components/AdminPageHeader.jsx
@@ -1,9 +1,16 @@
-// Shared page-header chrome for the UKRCOM admin pages (Documents / Invoice Builder / Parties).
-// Mirrors my-profile's sticky top bar (MyProfile.jsx's StickyHeader + Topbar) so
-// the "⋮" page-switcher (PageNavMenu, always the first item in HeaderActions) stays pinned in the
-// same top-right corner on every page and at every viewport width, instead of each page carrying
-// its own copy of this CSS that can drift out of sync (batch 29 §1).
+// Shared page-header chrome for the UKRCOM admin pages (Documents / Invoice Builder / Parties /
+// Budget). `PageMenuBar` holds the "⋮" page-switcher (PageNavMenu) on its own row, right-aligned,
+// in normal document flow - it must never be sticky/fixed, and it must never share a row with the
+// page's other action buttons (Reload, PDF export, Edit/Read toggle, etc.), so it always lands in
+// the same top-right spot as every other "⋮" menu in the app (see styles/knowme.js's KmTopbar /
+// KmPageMenuBar, the same pattern My Profile and the User Agreement page use).
 import styled from 'styled-components';
+
+export const PageMenuBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+`;
 
 export const Header = styled.header`
   display: flex;
@@ -11,12 +18,6 @@ export const Header = styled.header`
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 14px;
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  background: var(--km-bg);
-  padding-top: 12px;
-  margin-top: -12px;
 
   @media (max-width: 560px) {
     flex-direction: column;

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -26,7 +26,7 @@ import {
 } from './budgetCatalogUtils';
 import { setPdfAgencyConfig } from './pdfTheme';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions } from './AdminPageHeader';
+import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
 
 const INCLUDED_PREVIEW_LIMIT = 6;
 const POPULAR_PACKAGE_ID = '3';
@@ -2038,13 +2038,15 @@ const BudgetPage = ({ isAdmin = false }) => {
   return (
     <Page>
       <Shell>
+        <PageMenuBar>
+          <PageNavMenu />
+        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>{(catalog.technical?.agency?.name || UKRCOM_MARKER).toUpperCase()}</Eyebrow>
             <Title>Program Budget</Title>
           </div>
           <HeaderActions>
-            <PageNavMenu />
             <MiniButton
               type="button"
               onClick={handleExportPdf}

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -18,7 +18,7 @@ import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFo
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions } from './AdminPageHeader';
+import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
 import VariablePickerModal from './DocumentsVariablePickerModal';
 import DocumentsPdfPreview from './DocumentsPdfPreview';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -2400,13 +2400,15 @@ const DocumentsPage = ({ isAdmin }) => {
   return (
     <Page>
       <Shell>
+        <PageMenuBar>
+          <PageNavMenu />
+        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>Admin only</Eyebrow>
             <Title>Documents</Title>
           </div>
           <HeaderActions>
-            <PageNavMenu />
             <MiniButton type="button" onClick={loadDocumentsData} disabled={loading} title="Reload from the backend">
               <FaSyncAlt /> Reload
             </MiniButton>

--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -41,6 +41,14 @@ const TopControls = styled.div`
   min-width: 0;
 `;
 
+// The "⋮" menu never shares a row with the page's other action buttons - it always gets its own
+// right-aligned row above them, in normal document flow (no sticky/fixed positioning), matching
+// every other "⋮" menu in the app.
+const MenuRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
 // Batch 29 §1: was four bootstrap-ish solid fills (green/blue/red/purple, one hardcoded hex per
 // action) with no relation to the rest of the app - now the same bordered/card-background/accent-
 // on-hover treatment My Profile's own "⋮" (DotsButton) uses, driven entirely by --km-* tokens.
@@ -1763,6 +1771,16 @@ export const FlowManager = ({ ownerId }) => {
 
   return (
     <Wrap>
+      <MenuRow>
+        <MenuBtn
+          type="button"
+          aria-label="Відкрити меню профілю"
+          title="Відкрити меню профілю"
+          onClick={() => setShowInfoModal('dotsMenu')}
+        >
+          ⋮
+        </MenuBtn>
+      </MenuRow>
       <TopControls>
         <TopActionBtn
           type="button"
@@ -1782,14 +1800,6 @@ export const FlowManager = ({ ownerId }) => {
           <ClipboardIcon />
         </CopyBtn>
         <DangerBtn type="button" onClick={openClearConfirm}>del</DangerBtn>
-        <MenuBtn
-          type="button"
-          aria-label="Відкрити меню профілю"
-          title="Відкрити меню профілю"
-          onClick={() => setShowInfoModal('dotsMenu')}
-        >
-          ⋮
-        </MenuBtn>
       </TopControls>
 
       <Row>

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -24,7 +24,7 @@ import { formatEuroSmart, getItemDisplayAmount, getSortedPackages, isFromPricedI
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions } from './AdminPageHeader';
+import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
 import {
   addCatalogChildToPackage,
   addCustomChildToPackage,
@@ -3609,13 +3609,15 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   return (
     <Page>
       <Shell>
+        <PageMenuBar>
+          <PageNavMenu />
+        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>Admin only</Eyebrow>
             <Title>Invoice Builder</Title>
           </div>
           <HeaderActions>
-            <PageNavMenu />
             <input
               ref={fileInputRef}
               type="file"

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5754,55 +5754,59 @@ const Matching = () => {
                   <FaHeart />
                 </ActionButton>
               </TopActionGroup>
-              <TopActionGroup aria-label="Адміністративні дії matching">
-                {showBackendTrafficToggle && (
+              {(showBackendTrafficToggle || isIndexedDebugTestUser) && (
+                <TopActionGroup aria-label="Адміністративні дії matching">
+                  {showBackendTrafficToggle && (
+                    <BackendTrafficToggleButton
+                    type="button"
+                    $active={downloadSizeToastsEnabled}
+                    aria-pressed={downloadSizeToastsEnabled}
+                    title={
+                      downloadSizeToastsEnabled
+                        ? 'Вимкнути тости щодо розміру завантаження з бекенду'
+                        : 'Увімкнути тости щодо розміру завантаження з бекенду'
+                    }
+                    aria-label={
+                      downloadSizeToastsEnabled
+                        ? 'Вимкнути тости щодо розміру завантаження з бекенду'
+                        : 'Увімкнути тости щодо розміру завантаження з бекенду'
+                    }
+                    onClick={handleDownloadSizeToastsToggle}
+                  >
+                    📦
+                    <BackendTrafficToggleStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</BackendTrafficToggleStatus>
+                  </BackendTrafficToggleButton>
+                )}
+                {isIndexedDebugTestUser && (
                   <BackendTrafficToggleButton
-                  type="button"
-                  $active={downloadSizeToastsEnabled}
-                  aria-pressed={downloadSizeToastsEnabled}
-                  title={
-                    downloadSizeToastsEnabled
-                      ? 'Вимкнути тости щодо розміру завантаження з бекенду'
-                      : 'Увімкнути тости щодо розміру завантаження з бекенду'
-                  }
-                  aria-label={
-                    downloadSizeToastsEnabled
-                      ? 'Вимкнути тости щодо розміру завантаження з бекенду'
-                      : 'Увімкнути тости щодо розміру завантаження з бекенду'
-                  }
-                  onClick={handleDownloadSizeToastsToggle}
-                >
-                  📦
-                  <BackendTrafficToggleStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</BackendTrafficToggleStatus>
-                </BackendTrafficToggleButton>
+                    type="button"
+                    $active={debugShowAllIndexedCards}
+                    aria-pressed={debugShowAllIndexedCards}
+                    title="Show filtered cards"
+                    aria-label="Show filtered cards"
+                    onClick={() => {
+                      const next = !debugShowAllIndexedCards;
+                      setDebugShowAllIndexedCards(next);
+                      localStorage.setItem(MATCHING_DEBUG_SHOW_ALL_INDEXED_CARDS_KEY, next ? 'true' : 'false');
+                      console.info('[Matching][debugShowAllIndexedCardsChanged]', { enabled: next });
+                    }}
+                  >
+                    🪲
+                    <BackendTrafficToggleStatus>{debugShowAllIndexedCards ? 'ALL' : 'NORMAL'}</BackendTrafficToggleStatus>
+                  </BackendTrafficToggleButton>
+                )}
+                </TopActionGroup>
               )}
-              {isIndexedDebugTestUser && (
-                <BackendTrafficToggleButton
-                  type="button"
-                  $active={debugShowAllIndexedCards}
-                  aria-pressed={debugShowAllIndexedCards}
-                  title="Show filtered cards"
-                  aria-label="Show filtered cards"
-                  onClick={() => {
-                    const next = !debugShowAllIndexedCards;
-                    setDebugShowAllIndexedCards(next);
-                    localStorage.setItem(MATCHING_DEBUG_SHOW_ALL_INDEXED_CARDS_KEY, next ? 'true' : 'false');
-                    console.info('[Matching][debugShowAllIndexedCardsChanged]', { enabled: next });
-                  }}
-                >
-                  🪲
-                  <BackendTrafficToggleStatus>{debugShowAllIndexedCards ? 'ALL' : 'NORMAL'}</BackendTrafficToggleStatus>
-                </BackendTrafficToggleButton>
-              )}
-                <ActionButton
-                  type="button"
-                  aria-label="Відкрити меню профілю"
-                  title="Відкрити меню профілю"
-                  onClick={() => setShowInfoModal('dotsMenu')}
-                >
-                  <FaEllipsisV />
-                </ActionButton>
-              </TopActionGroup>
+              {/* The "⋮" menu never shares a button group with the page's other action buttons -
+                  it sits on its own, right after them, not inside a TopActionGroup pill. */}
+              <ActionButton
+                type="button"
+                aria-label="Відкрити меню профілю"
+                title="Відкрити меню профілю"
+                onClick={() => setShowInfoModal('dotsMenu')}
+              >
+                <FaEllipsisV />
+              </ActionButton>
             </TopActions>
           </HeaderContainer>
           {!ownerId && (

--- a/src/components/Matching.styled.jsx
+++ b/src/components/Matching.styled.jsx
@@ -452,8 +452,7 @@ export const BackendTrafficToggleStatus = styled.span`
 `;
 
 export const HeaderContainer = styled.div`
-  position: sticky;
-  top: 0;
+  position: static;
   z-index: 12;
   display: flex;
   justify-content: flex-end;

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FiX } from 'react-icons/fi';
 import { FaEye, FaEyeSlash } from 'react-icons/fa';
@@ -50,7 +50,6 @@ const Page = styled.div`
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
-  --sticky-header-offset: 112px;
 `;
 const Topbar = styled.div`
   background: var(--card);
@@ -59,16 +58,16 @@ const Topbar = styled.div`
   display: flex;
   justify-content: space-between;
 `;
-const StickyHeader = styled.div`
-  position: sticky;
-  top: 0;
-  z-index: 30;
+// Header block (brand, "⋮" menu, progress bar, tabs) lives in normal document flow - it must
+// scroll away with the rest of the page, never pin itself to the viewport top.
+const HeaderPanel = styled.div`
   background: var(--card);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
 `;
-const FALLBACK_STICKY_HEADER_OFFSET = 112;
 const CONTENT_SECTION_TOP_GAP = 18;
-const STICKY_HEADER_EXTRA_GAP = CONTENT_SECTION_TOP_GAP;
+// How far above a section's top edge scrollToSection() stops, and how far past a section's top
+// edge the scroll-spy considers it "active" - since the header no longer overlays content when
+// scrolled, this is just a small breathing-room gap, not a header-height offset.
+const SECTION_SCROLL_GAP = CONTENT_SECTION_TOP_GAP;
 const SCROLL_ACTIVE_SECTION_GAP = 16;
 const PROGRAMMATIC_SCROLL_FALLBACK_MS = 900;
 const ProgressWrap = styled.div`padding: 16px 20px 0;`;
@@ -85,7 +84,7 @@ const Card = styled.div`
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   overflow: hidden;
-  scroll-margin-top: var(--sticky-header-offset);
+  scroll-margin-top: ${CONTENT_SECTION_TOP_GAP}px;
 `;
 const FirstContentCard = styled(Card)`margin-top: ${CONTENT_SECTION_TOP_GAP}px;`;
 const Header = styled.div`display:flex;align-items:center;gap:10px;padding:14px 18px;border-bottom:1px solid var(--border);background:var(--bg);`;
@@ -165,7 +164,7 @@ const PhotoSection = styled.div`
   border: 1.5px dashed var(--border);
   box-shadow: var(--shadow);
   min-width: 0;
-  scroll-margin-top: var(--sticky-header-offset);
+  scroll-margin-top: ${CONTENT_SECTION_TOP_GAP}px;
 `;
 const SubmitBtn = styled.button`width:100%;padding:16px;background:linear-gradient(135deg,#E8791A 0%,#F5A24B 100%);color:#fff;border:none;border-radius:var(--radius);font-size:16px;font-weight:700;`;
 const CustomOptionWrap = styled.div`margin-top:10px;`;
@@ -350,8 +349,6 @@ export const MyProfile = () => {
   const [hasAgreed, setHasAgreed] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [authHintStep, setAuthHintStep] = useState('');
-  const [stickyHeaderOffset, setStickyHeaderOffset] = useState(FALLBACK_STICKY_HEADER_OFFSET);
-  const stickyHeaderRef = useRef(null);
   const sectionRefs = useRef({});
   const tabsRef = useRef(null);
   const tabRefs = useRef({});
@@ -410,31 +407,6 @@ export const MyProfile = () => {
       window.removeEventListener('pageshow', restoreLocalDraft);
     };
   }, [restoreLocalDraft]);
-
-  useLayoutEffect(() => {
-    const updateStickyHeaderOffset = () => {
-      const headerHeight = stickyHeaderRef.current?.getBoundingClientRect().height || FALLBACK_STICKY_HEADER_OFFSET;
-      const nextOffset = Math.ceil(headerHeight + STICKY_HEADER_EXTRA_GAP);
-      setStickyHeaderOffset(prevOffset => (prevOffset === nextOffset ? prevOffset : nextOffset));
-    };
-
-    updateStickyHeaderOffset();
-
-    const resizeObserver = typeof ResizeObserver !== 'undefined' && stickyHeaderRef.current
-      ? new ResizeObserver(updateStickyHeaderOffset)
-      : null;
-
-    if (resizeObserver && stickyHeaderRef.current) {
-      resizeObserver.observe(stickyHeaderRef.current);
-    }
-
-    window.addEventListener('resize', updateStickyHeaderOffset);
-    return () => {
-      resizeObserver?.disconnect();
-      window.removeEventListener('resize', updateStickyHeaderOffset);
-    };
-  }, []);
-
 
   useEffect(() => {
     if (userId || state.userId) return;
@@ -659,14 +631,14 @@ export const MyProfile = () => {
 
   const getSectionTargetTop = useCallback((sectionEl) => {
     const sectionTop = sectionEl.getBoundingClientRect().top + window.scrollY;
-    return Math.max(0, Math.round(sectionTop - stickyHeaderOffset));
-  }, [stickyHeaderOffset]);
+    return Math.max(0, Math.round(sectionTop - SECTION_SCROLL_GAP));
+  }, []);
 
   const getActiveSectionKeyByScroll = useCallback(() => {
     const entries = getSectionEntries();
     if (entries.length === 0) return '';
 
-    const activationLine = window.scrollY + stickyHeaderOffset + SCROLL_ACTIVE_SECTION_GAP;
+    const activationLine = window.scrollY + SECTION_SCROLL_GAP + SCROLL_ACTIVE_SECTION_GAP;
     let activeKey = entries[0].key;
 
     entries.forEach(({ key, node }) => {
@@ -677,7 +649,7 @@ export const MyProfile = () => {
     });
 
     return activeKey;
-  }, [getSectionEntries, stickyHeaderOffset]);
+  }, [getSectionEntries]);
 
   const finishProgrammaticScroll = useCallback(() => {
     isManualScrollRef.current = false;
@@ -1095,8 +1067,8 @@ export const MyProfile = () => {
     </Field>;
   };
 
-  return <Page style={{ '--sticky-header-offset': `${stickyHeaderOffset}px` }}>
-    <StickyHeader ref={stickyHeaderRef}>
+  return <Page>
+    <HeaderPanel>
       <Topbar>
         <KnowMeBrand />
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
@@ -1134,7 +1106,7 @@ export const MyProfile = () => {
           </Tab>;
         })}
       </Tabs>
-    </StickyHeader>
+    </HeaderPanel>
 
     {!isProfileAccessConfirmed && <AuthCard ref={node => { sectionRefs.current.auth = node; }}>
       <Header>

--- a/src/components/PageNavMenu.jsx
+++ b/src/components/PageNavMenu.jsx
@@ -29,23 +29,33 @@ const Wrap = styled.div`
   display: inline-flex;
 `;
 
+// Matches the shared KmIconButton look (styles/knowme.js) so this trigger is visually identical
+// to every other "⋮" menu button in the app - same size, border, radius, and hover/focus states.
 const DotsButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
   border: 1px solid var(--km-border, #d9d2c2);
   background: var(--km-card, #fff);
-  color: var(--km-text, #2b2620);
-  border-radius: 6px;
-  min-height: 30px;
-  min-width: 30px;
-  padding: 4px 8px;
-  font-size: 16px;
+  color: var(--km-muted, #7a7266);
+  font-size: 18px;
   line-height: 1;
-  font-weight: 700;
   cursor: pointer;
-  transition: border-color 0.15s ease, color 0.15s ease;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 
   &:hover {
+    background: var(--km-accent-light, rgba(162, 121, 63, 0.12));
     border-color: var(--km-accent, #a2793f);
     color: var(--km-accent, #a2793f);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--km-accent, #a2793f);
+    box-shadow: 0 0 0 3px var(--km-accent-ring, rgba(162, 121, 63, 0.2));
   }
 `;
 

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -13,7 +13,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions } from './AdminPageHeader';
+import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
 import CaseEditor from './CaseEditor';
 import {
   DOCUMENTS_CASES_PATH,
@@ -1113,15 +1113,15 @@ const PartiesPage = ({ isAdmin }) => {
   return (
     <Page>
       <Shell>
+        <PageMenuBar>
+          <PageNavMenu />
+        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>Admin only</Eyebrow>
             <Title>Parties</Title>
           </div>
           <HeaderActions>
-            {/* Batch 26 §11: PageNavMenu first, matching every other UKRCOM admin page's header -
-                this was the one page with it last, after the Edit/Read toggle. */}
-            <PageNavMenu />
             <MiniButton type="button" onClick={handleToggleEditMode} aria-pressed={isEditMode} title={isEditMode ? 'Switch to read mode' : 'Edit parties'}>
               <FaPen /> {isEditMode ? 'Read' : 'Edit'}
             </MiniButton>

--- a/src/components/styles/knowme.js
+++ b/src/components/styles/knowme.js
@@ -13,9 +13,6 @@ export const KmPage = styled.div`
 `;
 
 export const KmTopbar = styled.div`
-  position: sticky;
-  top: 0;
-  z-index: 30;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -24,6 +21,20 @@ export const KmTopbar = styled.div`
   background: var(--km-card);
   border-bottom: 1px solid var(--km-border);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+`;
+
+// Shared "⋮" page-menu row: right-aligned, normal document flow (never sticky/fixed - it must
+// scroll away with the rest of the content, not pin itself to the viewport), same top/right
+// spacing as KmTopbar so every page's menu trigger lands in the same spot.
+export const KmPageMenuBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 14px 20px 0;
+
+  @media (max-width: 560px) {
+    padding: 14px 14px 0;
+  }
 `;
 
 const BrandWrap = styled.div`


### PR DESCRIPTION
Add New Profile's dots menu sat on the left, sharing a sticky row with
undo/redo/EXT/OFF. Give it its own right-aligned row above those buttons,
matching My Profile / User Agreement's placement and using the shared
KmIconButton look.

Extend the same pattern everywhere else a "⋮" menu appears: the four
UKRCOM admin pages (Budget, Documents, Parties, Invoice Builder) now
render PageNavMenu in its own row via a new AdminPageHeader PageMenuBar,
instead of as the first item in HeaderActions. FlowManager and Matching
no longer group their "⋮" trigger with other action buttons either.

Also drop position: sticky from every header that carries one of these
menus (KmTopbar, AdminPageHeader's Header, MyProfile's header block,
AddNewProfile's TopButtons, Matching's HeaderContainer) so the menu
scrolls with the page instead of pinning to the viewport. MyProfile's
scroll-spy offset logic, which existed only to compensate for that
sticky header's height, is simplified to a small constant gap now that
there's no header overlay to account for.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KDEVvPDbVEPiG5rNxwbrjy