### PR TITLE
Fix legacy comment migration consistency

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -136,6 +136,7 @@ import {
   getCacheKey,
 } from 'utils/cache';
 import { updateCard, saveCard } from 'utils/cardsStorage';
+import { clearCachedComments } from 'utils/commentsStorage';
 import {
   formatDateAndFormula,
   formatDateToDisplay,
@@ -6120,11 +6121,13 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       });
       if (report.migratedCards) {
         clearAllCardsCache();
+        clearCachedComments(auth.currentUser?.uid, report.migratedCardIds);
+        const migratedCardIds = new Set(report.migratedCardIds);
         setUsers(currentUsers =>
           Object.fromEntries(
             Object.entries(currentUsers).map(([cardId, card]) => {
               const cardWithoutLegacyComment = { ...(card || {}) };
-              delete cardWithoutLegacyComment.myComment;
+              if (migratedCardIds.has(cardId)) delete cardWithoutLegacyComment.myComment;
               return [cardId, cardWithoutLegacyComment];
             }),
           ),

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1247,6 +1247,7 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
     scannedUsers: Object.keys(usersData).length,
     scannedNewUsers: Object.keys(newUsersData).length,
     migratedCards: 0,
+    migratedCardIds: [],
     fromBothCollections: 0,
     mergedWithExisting: 0,
     errors: [],
@@ -1262,7 +1263,19 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
 
   const valuesMatch = (left, right) => JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
   const mergeCommentText = (...values) =>
-    [...new Set(values.map(value => String(value || '').trim()).filter(Boolean))].join('\n\n');
+    [...new Set(values.flatMap(value => String(value || '').split(/\n\n+/).map(part => part.trim()).filter(Boolean)))].join('\n\n');
+  const getValueAtPath = (root, path) =>
+    path.split('/').reduce((value, key) => value?.[key], root);
+  const setValueAtPath = (root, path, value) => {
+    const keys = path.split('/');
+    const leaf = keys.pop();
+    const parent = keys.reduce((current, key) => {
+      current[key] = current[key] && typeof current[key] === 'object' ? current[key] : {};
+      return current[key];
+    }, root);
+    if (value === null) delete parent[leaf];
+    else parent[leaf] = value;
+  };
 
   const BATCH_SIZE = 100;
   const ids = Array.from(cardIds);
@@ -1294,27 +1307,30 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
       );
 
       try {
-        // eslint-disable-next-line no-await-in-loop
-        const destinationResult = await runTransaction(ref2(database, destinationPath), value => {
-          if (!valuesMatch(value, expectedDestination)) return undefined;
-          return { text: finalText, updatedAt: Date.now() };
-        });
-        if (!destinationResult.committed) throw new Error('Коментар було змінено під час міграції');
-
         const sources = [
           { path: `users/${cardId}/myComment`, expected: usersData[cardId]?.myComment },
           { path: `newUsers/${cardId}/myComment`, expected: newUsersData[cardId]?.myComment },
         ].filter(source => String(source.expected || '').trim());
+
+        // The destination and both legacy sources live under different RTDB
+        // branches, so transact at their common root. This validates every
+        // snapshot and applies the write/cleanup as one atomic operation.
         // eslint-disable-next-line no-await-in-loop
-        const sourceResults = await Promise.all(sources.map(source =>
-          runTransaction(ref2(database, source.path), value =>
-            valuesMatch(value, source.expected) ? null : undefined,
-          )
-        ));
-        if (sourceResults.some(result => !result.committed)) {
-          throw new Error('Картку було змінено під час міграції');
-        }
+        const migrationResult = await runTransaction(ref2(database), rootValue => {
+          const nextRoot = rootValue && typeof rootValue === 'object' ? rootValue : {};
+          if (!valuesMatch(getValueAtPath(nextRoot, destinationPath), expectedDestination)) {
+            return undefined;
+          }
+          if (sources.some(source => !valuesMatch(getValueAtPath(nextRoot, source.path), source.expected))) {
+            return undefined;
+          }
+          setValueAtPath(nextRoot, destinationPath, { text: finalText, updatedAt: Date.now() });
+          sources.forEach(source => setValueAtPath(nextRoot, source.path, null));
+          return nextRoot;
+        });
+        if (!migrationResult.committed) throw new Error('Картку або коментар було змінено під час міграції');
         report.migratedCards += 1;
+        report.migratedCardIds.push(cardId);
       } catch (error) {
         report.errors.push({ cardId, message: error?.message || String(error) });
       }

--- a/src/components/config.migrateAllLegacyCardComments.test.js
+++ b/src/components/config.migrateAllLegacyCardComments.test.js
@@ -28,10 +28,12 @@ describe('bulk migration of every leftover users/newUsers myComment into multiDa
     expect(fnBody).toContain('legacyComment?.text');
   });
 
-  it('clears myComment on both card collections with compare-and-set transactions', () => {
+  it('clears both sources in the same root transaction as the destination write', () => {
     expect(fnBody).toMatch(/`users\/\$\{cardId\}\/myComment`/);
     expect(fnBody).toMatch(/`newUsers\/\$\{cardId\}\/myComment`/);
-    expect(fnBody).toContain('runTransaction(ref2(database, source.path)');
+    expect(fnBody).toContain('runTransaction(ref2(database), rootValue');
+    expect(fnBody).toContain('sources.some(source => !valuesMatch');
+    expect(fnBody).toContain('sources.forEach(source => setValueAtPath');
   });
 
   it('merges conflicting/legacy/pre-existing comment text instead of dropping one side', () => {
@@ -43,7 +45,7 @@ describe('bulk migration of every leftover users/newUsers myComment into multiDa
     expect(fnBody).toMatch(/for \(let i = 0; i < ids\.length; i \+= BATCH_SIZE\)/);
     const writeLoopBody = fnBody.slice(fnBody.indexOf('const BATCH_SIZE = 100;'));
     expect(writeLoopBody).toContain('for (const cardId of chunk)');
-    expect(writeLoopBody).toContain('await runTransaction(ref2(database, destinationPath)');
+    expect(writeLoopBody).toContain('await runTransaction(ref2(database), rootValue');
   });
 
   it('collects per-chunk errors instead of letting one failing chunk abort the whole run', () => {
@@ -51,10 +53,11 @@ describe('bulk migration of every leftover users/newUsers myComment into multiDa
     expect(fnBody).toContain('report.errors.push(');
   });
 
-  it('counts a card only after destination and source transactions commit', () => {
+  it('reports the successful card IDs only after the atomic migration commits', () => {
     expect(fnBody.indexOf('report.migratedCards += 1;')).toBeGreaterThan(
-      fnBody.indexOf("sourceResults.some(result => !result.committed)"),
+      fnBody.indexOf("if (!migrationResult.committed)"),
     );
+    expect(fnBody).toContain('report.migratedCardIds.push(cardId)');
   });
 
   it('reports progress so the UI can show percent complete', () => {

--- a/src/utils/__tests__/commentsStorage.test.js
+++ b/src/utils/__tests__/commentsStorage.test.js
@@ -1,5 +1,6 @@
 import {
   COMMENTS_TTL_MS,
+  clearCachedComments,
   getCachedComment,
   loadComments,
   saveComments,
@@ -44,6 +45,18 @@ describe('commentsStorage owner-scoped cache', () => {
 
     expect(loadComments()['owner-a']).toHaveProperty('card-1');
     expect(loadComments()['owner-a']).not.toHaveProperty('card-2');
+  });
+
+  it('clears only migrated cards for the selected owner', () => {
+    setLocalComment('owner-a', 'card-1', 'migrated', 100);
+    setLocalComment('owner-a', 'card-2', 'unchanged', 200);
+    setLocalComment('owner-b', 'card-1', 'other owner', 300);
+
+    clearCachedComments('owner-a', ['card-1']);
+
+    expect(getCachedComment('owner-a', 'card-1')).toBeNull();
+    expect(getCachedComment('owner-a', 'card-2').text).toBe('unchanged');
+    expect(getCachedComment('owner-b', 'card-1').text).toBe('other owner');
   });
 });
 

--- a/src/utils/commentsStorage.js
+++ b/src/utils/commentsStorage.js
@@ -69,6 +69,15 @@ export const saveComments = comments => {
   }
 };
 
+export const clearCachedComments = (ownerId, cardIds = []) => {
+  if (!ownerId || !Array.isArray(cardIds) || !cardIds.length) return;
+  const comments = loadComments();
+  if (!comments[ownerId]) return;
+  cardIds.forEach(cardId => delete comments[ownerId][cardId]);
+  if (!Object.keys(comments[ownerId]).length) delete comments[ownerId];
+  saveComments(comments);
+};
+
 export const getOwnerComments = ownerId => loadComments()[ownerId] || {};
 
 export const getCachedComment = (ownerId, cardId) => {


### PR DESCRIPTION
### Motivation
- Prevent partial migration side-effects that remove `myComment` from cards whose source/cleanup transactions failed. 
- Avoid inflating merged comments on retries by deduplicating constituent comment parts. 
- Ensure destination commits validate source snapshots atomically so concurrent edits are not shadowed. 
- Invalidate only affected owner-scoped comment cache entries so migrated cards do not continue showing stale/empty comments.

### Description
- Make the migration atomic by transacting at the RTDB common root and validating both the chosen destination snapshot and all legacy source snapshots in `migrateAllLegacyCardComments` (`src/components/config.js`).
- Change `mergeCommentText` to deduplicate individual comment parts (split on `\n\n`) so retries do not duplicate sections, and add `migratedCardIds` to the migration `report` so callers know exactly which cards succeeded (`src/components/config.js`).
- Add `getValueAtPath` / `setValueAtPath` helpers used by the root transaction to read/write nested RTDB paths in a single atomic update (`src/components/config.js`).
- Preserve `myComment` only for cards that failed migration and remove it from cards that succeeded by using `report.migratedCardIds` in the UI cleanup path (`src/components/AddNewProfile.jsx`).
- Add targeted cache invalidation `clearCachedComments(ownerId, cardIds)` to the owner-scoped comments cache and call it after successful migrations so only affected owner/card entries are removed (`src/utils/commentsStorage.js`).
- Update unit tests to reflect atomic source cleanup, migrated-card reporting, and cache invalidation behavior (`src/components/config.migrateAllLegacyCardComments.test.js`, `src/utils/__tests__/commentsStorage.test.js`).

### Testing
- Ran the focused Jest suites with `CI=true npm test -- --watchAll=false --runInBand src/components/config.migrateAllLegacyCardComments.test.js src/utils/__tests__/commentsStorage.test.js`, and both suites passed (all tests green).
- Ran `npx eslint` on the modified files and `git diff --check` with no problems reported.
- Verified the UI code path now calls `clearCachedComments` and only removes `myComment` from successfully migrated card IDs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dea7f0ab08326bd4c99c6c4f11dfa)