### PR TITLE
Unify the "⋮" page menu: right side, same row, never sticky

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -63,7 +63,7 @@ import InfoModal, { ModalTitle, ModalText, ModalActionRow, ModalDangerButton, Mo
 
 import { color, coloredCard, uiTokens } from './styles';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
-import { KmIconButton, KmPageMenuBar } from './styles/knowme';
+import { KmIconButton } from './styles/knowme';
 //import { formatPhoneNumber } from './inputValidations';
 import { UsersList } from './UsersList';
 import {
@@ -403,9 +403,12 @@ export const ExitButton = styled(SubmitButton)`
   }
 `;
 
+// The "⋮" menu stays on this same row as the other action buttons (never its own row), but as
+// its own flex item pushed to the far right by justify-content: space-between - so it reads as
+// separate from the button group on the left instead of sharing its cluster.
 const TopButtons = styled.div`
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
   gap: 10px;
   background: var(--km-card);
@@ -414,6 +417,14 @@ const TopButtons = styled.div`
   @media (max-width: 768px) {
     background: ${uiTokens.colors.pageBg};
   }
+`;
+
+const TopButtonsGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex-wrap: wrap;
 `;
 
 const EditActionButton = styled.button`
@@ -6635,20 +6646,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     <Container>
       <InnerContainer>
         {isLoggedIn && (
-          <KmPageMenuBar>
-            <KmIconButton
-              type="button"
-              aria-label="Відкрити меню профілю"
-              onClick={() => {
-                setShowInfoModal('dotsMenu');
-              }}
-            >
-              ⋮
-            </KmIconButton>
-          </KmPageMenuBar>
-        )}
-        {isLoggedIn && (
           <TopButtons>
+            <TopButtonsGroup>
             {state.userId && (
               <>
                 <EditActionButton
@@ -6731,6 +6730,16 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
               📦
               <DownloadSizeToastStatus>{downloadSizeToastsEnabled ? 'ON' : 'OFF'}</DownloadSizeToastStatus>
             </DownloadSizeToastToggleButton>
+            </TopButtonsGroup>
+            <KmIconButton
+              type="button"
+              aria-label="Відкрити меню профілю"
+              onClick={() => {
+                setShowInfoModal('dotsMenu');
+              }}
+            >
+              ⋮
+            </KmIconButton>
           </TopButtons>
         )}
 

--- a/src/components/AdminPageHeader.jsx
+++ b/src/components/AdminPageHeader.jsx
@@ -1,16 +1,11 @@
 // Shared page-header chrome for the UKRCOM admin pages (Documents / Invoice Builder / Parties /
-// Budget). `PageMenuBar` holds the "⋮" page-switcher (PageNavMenu) on its own row, right-aligned,
-// in normal document flow - it must never be sticky/fixed, and it must never share a row with the
-// page's other action buttons (Reload, PDF export, Edit/Read toggle, etc.), so it always lands in
-// the same top-right spot as every other "⋮" menu in the app (see styles/knowme.js's KmTopbar /
-// KmPageMenuBar, the same pattern My Profile and the User Agreement page use).
+// Budget). The "⋮" page-switcher (PageNavMenu) stays on the same row as the title and the page's
+// other action buttons - never its own row, and never sticky/fixed - but it sits inside
+// `HeaderRight` as its own flex item (with a wider gap than HeaderActions' own buttons use), so it
+// reads as separate from that button group while staying vertically centered with everything else
+// on the row. See styles/knowme.js's KmTopbar, the same pattern My Profile and the User Agreement
+// page use.
 import styled from 'styled-components';
-
-export const PageMenuBar = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 10px;
-`;
 
 export const Header = styled.header`
   display: flex;
@@ -25,15 +20,23 @@ export const Header = styled.header`
   }
 `;
 
-export const HeaderActions = styled.div`
+export const HeaderRight = styled.div`
   display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
   align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
   justify-content: flex-end;
 
   @media (max-width: 560px) {
     width: 100%;
     justify-content: flex-end;
   }
+`;
+
+export const HeaderActions = styled.div`
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
 `;

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -26,7 +26,7 @@ import {
 } from './budgetCatalogUtils';
 import { setPdfAgencyConfig } from './pdfTheme';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
 
 const INCLUDED_PREVIEW_LIMIT = 6;
 const POPULAR_PACKAGE_ID = '3';
@@ -2038,14 +2038,12 @@ const BudgetPage = ({ isAdmin = false }) => {
   return (
     <Page>
       <Shell>
-        <PageMenuBar>
-          <PageNavMenu />
-        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>{(catalog.technical?.agency?.name || UKRCOM_MARKER).toUpperCase()}</Eyebrow>
             <Title>Program Budget</Title>
           </div>
+          <HeaderRight>
           <HeaderActions>
             <MiniButton
               type="button"
@@ -2091,6 +2089,8 @@ const BudgetPage = ({ isAdmin = false }) => {
               </>
             ) : null}
           </HeaderActions>
+          <PageNavMenu />
+          </HeaderRight>
         </Header>
 
         {loading ? <StateCard>Loading budget catalog…</StateCard> : null}

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -18,7 +18,7 @@ import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFo
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
 import VariablePickerModal from './DocumentsVariablePickerModal';
 import DocumentsPdfPreview from './DocumentsPdfPreview';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -2400,14 +2400,12 @@ const DocumentsPage = ({ isAdmin }) => {
   return (
     <Page>
       <Shell>
-        <PageMenuBar>
-          <PageNavMenu />
-        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>Admin only</Eyebrow>
             <Title>Documents</Title>
           </div>
+          <HeaderRight>
           <HeaderActions>
             <MiniButton type="button" onClick={loadDocumentsData} disabled={loading} title="Reload from the backend">
               <FaSyncAlt /> Reload
@@ -2419,6 +2417,8 @@ const DocumentsPage = ({ isAdmin }) => {
               <FaFilePdf /> {isGenerating ? 'Generating…' : 'PDF'}
             </PrimaryMiniButton>
           </HeaderActions>
+          <PageNavMenu />
+          </HeaderRight>
         </Header>
 
         {loading ? <StateCard>Loading documents data…</StateCard> : null}

--- a/src/components/FlowManager.jsx
+++ b/src/components/FlowManager.jsx
@@ -41,12 +41,10 @@ const TopControls = styled.div`
   min-width: 0;
 `;
 
-// The "⋮" menu never shares a row with the page's other action buttons - it always gets its own
-// right-aligned row above them, in normal document flow (no sticky/fixed positioning), matching
-// every other "⋮" menu in the app.
-const MenuRow = styled.div`
-  display: flex;
-  justify-content: flex-end;
+// The "⋮" menu stays on this same row as the other action buttons, but a wider left margin sets
+// it apart from that button cluster instead of sharing its tight 8px gap.
+const MenuBtnWrap = styled.div`
+  margin-left: 14px;
 `;
 
 // Batch 29 §1: was four bootstrap-ish solid fills (green/blue/red/purple, one hardcoded hex per
@@ -1771,16 +1769,6 @@ export const FlowManager = ({ ownerId }) => {
 
   return (
     <Wrap>
-      <MenuRow>
-        <MenuBtn
-          type="button"
-          aria-label="Відкрити меню профілю"
-          title="Відкрити меню профілю"
-          onClick={() => setShowInfoModal('dotsMenu')}
-        >
-          ⋮
-        </MenuBtn>
-      </MenuRow>
       <TopControls>
         <TopActionBtn
           type="button"
@@ -1800,6 +1788,16 @@ export const FlowManager = ({ ownerId }) => {
           <ClipboardIcon />
         </CopyBtn>
         <DangerBtn type="button" onClick={openClearConfirm}>del</DangerBtn>
+        <MenuBtnWrap>
+          <MenuBtn
+            type="button"
+            aria-label="Відкрити меню профілю"
+            title="Відкрити меню профілю"
+            onClick={() => setShowInfoModal('dotsMenu')}
+          >
+            ⋮
+          </MenuBtn>
+        </MenuBtnWrap>
       </TopControls>
 
       <Row>

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -24,7 +24,7 @@ import { formatEuroSmart, getItemDisplayAmount, getSortedPackages, isFromPricedI
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
 import {
   addCatalogChildToPackage,
   addCustomChildToPackage,
@@ -3609,14 +3609,12 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
   return (
     <Page>
       <Shell>
-        <PageMenuBar>
-          <PageNavMenu />
-        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>Admin only</Eyebrow>
             <Title>Invoice Builder</Title>
           </div>
+          <HeaderRight>
           <HeaderActions>
             <input
               ref={fileInputRef}
@@ -3641,6 +3639,8 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
               </>
             ) : null}
           </HeaderActions>
+          <PageNavMenu />
+          </HeaderRight>
         </Header>
 
         {loading ? <StateCard>Loading invoice data…</StateCard> : null}

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -13,7 +13,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, PageMenuBar } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
 import CaseEditor from './CaseEditor';
 import {
   DOCUMENTS_CASES_PATH,
@@ -1113,19 +1113,19 @@ const PartiesPage = ({ isAdmin }) => {
   return (
     <Page>
       <Shell>
-        <PageMenuBar>
-          <PageNavMenu />
-        </PageMenuBar>
         <Header>
           <div>
             <Eyebrow>Admin only</Eyebrow>
             <Title>Parties</Title>
           </div>
+          <HeaderRight>
           <HeaderActions>
             <MiniButton type="button" onClick={handleToggleEditMode} aria-pressed={isEditMode} title={isEditMode ? 'Switch to read mode' : 'Edit parties'}>
               <FaPen /> {isEditMode ? 'Read' : 'Edit'}
             </MiniButton>
           </HeaderActions>
+          <PageNavMenu />
+          </HeaderRight>
         </Header>
 
         {loading ? (

--- a/src/components/styles/knowme.js
+++ b/src/components/styles/knowme.js
@@ -23,20 +23,6 @@ export const KmTopbar = styled.div`
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
 `;
 
-// Shared "⋮" page-menu row: right-aligned, normal document flow (never sticky/fixed - it must
-// scroll away with the rest of the content, not pin itself to the viewport), same top/right
-// spacing as KmTopbar so every page's menu trigger lands in the same spot.
-export const KmPageMenuBar = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  padding: 14px 20px 0;
-
-  @media (max-width: 560px) {
-    padding: 14px 14px 0;
-  }
-`;
-
 const BrandWrap = styled.div`
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Add New Profile's "⋮" menu moved from the left button cluster (undo/redo/EXT/OFF) to the far right of the same row, matching My Profile / User Agreement's placement, using the shared `KmIconButton` look.
- The "⋮" menu never shares a sticky header or a button-group cluster with the page's other action buttons on any page anymore: AddNewProfile's `TopButtons`, the four AdminPageHeader admin pages (Budget, Documents, Parties, Invoice Builder), FlowManager, and Matching all keep it on the same row but visually separated (space-between / extra gap), never on its own row and never mixed into another button's pill/group.
- Dropped `position: sticky` from every header that carries one of these menus (`KmTopbar`, `AdminPageHeader`'s `Header`, My Profile's header block, AddNewProfile's `TopButtons`, Matching's `HeaderContainer`) so the menu scrolls with the page instead of pinning to the viewport.
- Simplified My Profile's scroll-spy offset logic, which existed only to compensate for the removed sticky header's height, to a small constant gap.
- Restyled `PageNavMenu`'s trigger to match the shared `KmIconButton` (34×34, same border/hover/focus) for a consistent clickable area and look everywhere.

## Test plan

- [x] `npm run build` compiles successfully
- [x] Full relevant test suites pass (`PageNavMenu`, `InvoiceBuilderPage`, `BudgetPage.editMode`, `PartiesPage`, `PartiesPage.caseEditor`, `DocumentsPage.checklistScope`, `MyProfile.accountIsolation`, `MyProfile.fieldHistoryAccumulation`, `Matching.profileLayoutRegression`, `Matching.noBucketIndexing`, `Matching.loadMoreStaleGuard`, plus the AddNewProfile/DocumentsPage suites from the first commit)
- [x] Confirmed two unrelated pre-existing test failures (`AddNewProfile.makeIndexGate`, `Matching.sharedReactions`) already fail on `main` before this branch's changes

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KDEVvPDbVEPiG5rNxwbrjy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEVvPDbVEPiG5rNxwbrjy)_