### PR TITLE
Fix bulk comment migration: stop transacting on the database root

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -20,7 +20,6 @@ import {
   endAt,
   endBefore,
   equalTo,
-  runTransaction,
 } from 'firebase/database';
 import { PAGE_SIZE, BATCH_SIZE, MEDICATION_SCHEDULE_CLEANUP_DAY_LIMIT } from './constants';
 import { filterOutMedicationPhotos } from '../utils/photoFilters';
@@ -1224,8 +1223,15 @@ export const migrateMyCardComment = async (cardId, text, ownerId) => {
 // multiData/comments/{ownerId}/{cardId}, під акаунт адміна, що запускає міграцію.
 // Якщо той самий cardId має різний myComment в users і newUsers, або в одному з
 // comments-root вже є коментар цього ownerId — тексти об'єднуються через '\n\n'.
-// Кожен запис змінюється транзакцією з перевіркою прочитаного значення: редагування,
-// яке сталося під час міграції, не буде перезаписане або очищене за старим snapshot.
+// НАВМИСНО не використовує runTransaction(ref2(database), ...) (транзакцію на
+// корені всієї RTDB): такий виклик вимагає `.write`-права на сам корінь `/` і
+// завантажує/блокує все дерево бази для кожного виклику — жоден реальний
+// security-ruleset такого доступу не дає, тож кожен виклик впаде з відмовою
+// доступу. Замість цього пишемо звичайним мультишляховим update() — атомарним
+// лише по перерахованих у ньому абсолютних шляхах (як і в migrateMyCardComment/
+// setUserComment вище), без потреби в правах на корінь. Атомарність — на рівні
+// чанку з 100 карток, а не окремої картки: прийнятний компроміс для одноразової
+// адмінської операції над внутрішнім полем коментаря.
 export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {}) => {
   const user = auth.currentUser;
   if (!user) throw new Error('User not authenticated');
@@ -1261,28 +1267,18 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
   const existingComments = existingSnap.val() || {};
   const legacyExistingComments = legacyExistingSnap.val() || {};
 
-  const valuesMatch = (left, right) => JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
   const mergeCommentText = (...values) =>
     [...new Set(values.flatMap(value => String(value || '').split(/\n\n+/).map(part => part.trim()).filter(Boolean)))].join('\n\n');
-  const getValueAtPath = (root, path) =>
-    path.split('/').reduce((value, key) => value?.[key], root);
-  const setValueAtPath = (root, path, value) => {
-    const keys = path.split('/');
-    const leaf = keys.pop();
-    const parent = keys.reduce((current, key) => {
-      current[key] = current[key] && typeof current[key] === 'object' ? current[key] : {};
-      return current[key];
-    }, root);
-    if (value === null) delete parent[leaf];
-    else parent[leaf] = value;
-  };
 
   const BATCH_SIZE = 100;
   const ids = Array.from(cardIds);
 
   for (let i = 0; i < ids.length; i += BATCH_SIZE) {
     const chunk = ids.slice(i, i + BATCH_SIZE);
-    for (const cardId of chunk) {
+    const updates = {};
+    const chunkCardIds = [];
+
+    chunk.forEach(cardId => {
       const usersText = String(usersData[cardId]?.myComment || '').trim();
       const newUsersText = String(newUsersData[cardId]?.myComment || '').trim();
       if (usersText && newUsersText && usersText !== newUsersText) {
@@ -1293,12 +1289,12 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
       const legacyComment = legacyExistingComments[cardId] ?? null;
       if (currentComment?.text || legacyComment?.text) report.mergedWithExisting += 1;
 
-      // When only the fallback record exists, extend it in place. Creating a
-      // current-root record would shadow a fallback edit made concurrently.
+      // Якщо запис уже є лише в легасі-корені — дописуємо туди ж, а не
+      // створюємо новий запис у поточному корені, який "затінить" паралельну
+      // легасі-правку.
       const destinationPath = currentComment || !legacyComment
         ? getCommentPath(commentsOwnerId, cardId)
         : getLegacyCommentPath(commentsOwnerId, cardId);
-      const expectedDestination = currentComment || legacyComment;
       const finalText = mergeCommentText(
         usersText,
         newUsersText,
@@ -1306,34 +1302,19 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
         currentComment?.text,
       );
 
-      try {
-        const sources = [
-          { path: `users/${cardId}/myComment`, expected: usersData[cardId]?.myComment },
-          { path: `newUsers/${cardId}/myComment`, expected: newUsersData[cardId]?.myComment },
-        ].filter(source => String(source.expected || '').trim());
+      if (usersData[cardId]?.myComment !== undefined) updates[`users/${cardId}/myComment`] = null;
+      if (newUsersData[cardId]?.myComment !== undefined) updates[`newUsers/${cardId}/myComment`] = null;
+      updates[destinationPath] = { text: finalText, updatedAt: Date.now() };
+      chunkCardIds.push(cardId);
+    });
 
-        // The destination and both legacy sources live under different RTDB
-        // branches, so transact at their common root. This validates every
-        // snapshot and applies the write/cleanup as one atomic operation.
-        // eslint-disable-next-line no-await-in-loop
-        const migrationResult = await runTransaction(ref2(database), rootValue => {
-          const nextRoot = rootValue && typeof rootValue === 'object' ? rootValue : {};
-          if (!valuesMatch(getValueAtPath(nextRoot, destinationPath), expectedDestination)) {
-            return undefined;
-          }
-          if (sources.some(source => !valuesMatch(getValueAtPath(nextRoot, source.path), source.expected))) {
-            return undefined;
-          }
-          setValueAtPath(nextRoot, destinationPath, { text: finalText, updatedAt: Date.now() });
-          sources.forEach(source => setValueAtPath(nextRoot, source.path, null));
-          return nextRoot;
-        });
-        if (!migrationResult.committed) throw new Error('Картку або коментар було змінено під час міграції');
-        report.migratedCards += 1;
-        report.migratedCardIds.push(cardId);
-      } catch (error) {
-        report.errors.push({ cardId, message: error?.message || String(error) });
-      }
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await update(ref2(database), updates);
+      report.migratedCards += chunkCardIds.length;
+      report.migratedCardIds.push(...chunkCardIds);
+    } catch (error) {
+      chunkCardIds.forEach(cardId => report.errors.push({ cardId, message: error?.message || String(error) }));
     }
     onProgress?.(Math.round(((i + chunk.length) / ids.length) * 100));
   }

--- a/src/components/config.migrateAllLegacyCardComments.test.js
+++ b/src/components/config.migrateAllLegacyCardComments.test.js
@@ -28,36 +28,42 @@ describe('bulk migration of every leftover users/newUsers myComment into multiDa
     expect(fnBody).toContain('legacyComment?.text');
   });
 
-  it('clears both sources in the same root transaction as the destination write', () => {
-    expect(fnBody).toMatch(/`users\/\$\{cardId\}\/myComment`/);
-    expect(fnBody).toMatch(/`newUsers\/\$\{cardId\}\/myComment`/);
-    expect(fnBody).toContain('runTransaction(ref2(database), rootValue');
-    expect(fnBody).toContain('sources.some(source => !valuesMatch');
-    expect(fnBody).toContain('sources.forEach(source => setValueAtPath');
+  it('never transacts on the database root: a root-anchored runTransaction needs .write on "/", which no real ruleset grants', () => {
+    expect(fnBody).not.toContain('runTransaction(');
+    expect(fnBody).not.toContain('valuesMatch');
+    expect(fnBody).not.toContain('getValueAtPath');
+    expect(fnBody).not.toContain('setValueAtPath');
+  });
+
+  it('clears both sources and writes the destination in one plain multi-path update()', () => {
+    expect(fnBody).toMatch(/`users\/\$\{cardId\}\/myComment`\]\s*=\s*null;/);
+    expect(fnBody).toMatch(/`newUsers\/\$\{cardId\}\/myComment`\]\s*=\s*null;/);
+    expect(fnBody).toContain('updates[destinationPath] = { text: finalText, updatedAt: Date.now() };');
+    expect(fnBody).toContain('await update(ref2(database), updates);');
   });
 
   it('merges conflicting/legacy/pre-existing comment text instead of dropping one side', () => {
     expect(fnBody).toContain(".join('\\n\\n')");
   });
 
-  it('chunks work and runs cards serially rather than starting unbounded transactions', () => {
+  it('chunks writes into bounded update() calls instead of one unbounded request', () => {
     expect(fnBody).toContain('const BATCH_SIZE = 100;');
     expect(fnBody).toMatch(/for \(let i = 0; i < ids\.length; i \+= BATCH_SIZE\)/);
     const writeLoopBody = fnBody.slice(fnBody.indexOf('const BATCH_SIZE = 100;'));
-    expect(writeLoopBody).toContain('for (const cardId of chunk)');
-    expect(writeLoopBody).toContain('await runTransaction(ref2(database), rootValue');
+    expect(writeLoopBody).not.toContain('Promise.all(');
+    expect(writeLoopBody).toContain('await update(ref2(database), updates);');
   });
 
   it('collects per-chunk errors instead of letting one failing chunk abort the whole run', () => {
-    expect(fnBody).toMatch(/catch \(error\) \{\s*report\.errors\.push/);
+    expect(fnBody).toMatch(/catch \(error\) \{\s*chunkCardIds\.forEach/);
     expect(fnBody).toContain('report.errors.push(');
   });
 
-  it('reports the successful card IDs only after the atomic migration commits', () => {
-    expect(fnBody.indexOf('report.migratedCards += 1;')).toBeGreaterThan(
-      fnBody.indexOf("if (!migrationResult.committed)"),
+  it('reports migrated card IDs only after the chunk update() call succeeds', () => {
+    expect(fnBody.indexOf('report.migratedCards += chunkCardIds.length;')).toBeGreaterThan(
+      fnBody.indexOf('await update(ref2(database), updates);'),
     );
-    expect(fnBody).toContain('report.migratedCardIds.push(cardId)');
+    expect(fnBody).toContain('report.migratedCardIds.push(...chunkCardIds);');
   });
 
   it('reports progress so the UI can show percent complete', () => {


### PR DESCRIPTION
## Summary
- `migrateAllLegacyCardComments` (the "Мігрувати коментарі" button on Add New Profile) was wrapping every card's write in `runTransaction(ref2(database), ...)` — a transaction anchored at the literal RTDB root. That requires `.write` permission on `/`, which no real security ruleset grants, so every call was rejected and the button reported **"Мігровано карток: 0, помилок: 10617"** in production. No data was lost — nothing committed, so comments stayed exactly where they were — but the button was completely non-functional.
- Reverted the write path to a plain multi-path `update()` per 100-card chunk, atomic only over the specific paths it touches (`users/{cardId}/myComment`, `newUsers/{cardId}/myComment`, `multiData/comments/{ownerId}/{cardId}`), the same pattern already used by `migrateMyCardComment`/`setUserComment` elsewhere in this file.
- Kept the useful parts of the interim attempts: merging against the legacy `comments/{ownerId}` root before choosing a destination, and only reporting card IDs (`report.migratedCardIds`) after their chunk's `update()` actually succeeds — this is what `AddNewProfile.jsx`'s cache/state cleanup already consumes, unchanged.
- Removed the now-unused `runTransaction` import from `config.js`.

## Test plan
- [x] `npx react-scripts test config.migrateAllLegacyCardComments config.myCommentMigration config.pruneNewUsersOnMigration config.fetchUsersByIds --watchAll=false` — all pass
- [x] `npx react-scripts test AddNewProfile FieldComment --watchAll=false` — passes except the pre-existing, unrelated `AddNewProfile.makeIndexGate` failure (confirmed present on `main` before this change too)
- [x] Full suite `npx react-scripts test --watchAll=false` — same 9 pre-existing failing suites as on `main` prior to this change, no new failures
- [x] `grep -n "runTransaction(ref2(database)" src/components/config.js` — only matches the explanatory comment, no active calls
- [ ] Manual: click "Мігрувати коментарі" on `/add` after deploy and confirm the report shows `migratedCards > 0` / `errors: 0` instead of a total failure


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJdquQmJuzMqVpajLhfQBW)_