### PR TITLE
Skip broad prefix-scan fallback when card is already found via index

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -1312,6 +1312,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         { key: 'equalToAllCards', label: 'equalTo по всіх карточках (за поточним ключем)' },
         { key: 'searchKey', label: 'searchKey bucket/date' },
         { key: 'partialUserId', label: 'userId (частковий збіг)' },
+        { key: 'broadTextSearch', label: 'широкий пошук (contains, усі поля users/newUsers)' },
       ],
     },
     {
@@ -1352,15 +1353,17 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     'equalToAllCards',
     'searchKey',
     'partialUserId',
+    'broadTextSearch',
     ...SEARCH_KEY_OPTIONS.map(option => option.key),
   ];
   const CONTACT_SEARCH_KEYS = ['phone', 'telegram', 'instagram', 'ameblo', 'facebook', 'email', 'vk', 'tiktok', 'linkedin', 'youtube', 'twitter', 'line', 'otherLink', 'other'];
 
   const defaultEnabledSearchKeys = SEARCH_SCOPE_BLOCKS.flatMap(block => block.options).reduce(
     (acc, option) => {
-      // equalTo-пошук має вмикатись тільки явним чекбоксом користувача.
-      // Раніше через дефолт `true` для всіх ключів цей режим запускався неочікувано.
-      acc[option.key] = option.key !== 'equalToAllCards' && option.key !== 'searchKey';
+      // equalTo-пошук і широкий (contains по всіх полях) пошук мають вмикатись тільки
+      // явним чекбоксом користувача. Раніше через дефолт `true` для всіх ключів
+      // ці режими запускались неочікувано і ганяли зайві запити до Firebase.
+      acc[option.key] = option.key !== 'equalToAllCards' && option.key !== 'searchKey' && option.key !== 'broadTextSearch';
       return acc;
     },
     {},

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2125,7 +2125,8 @@ export const searchUserByPartialUserIdUsers = async (userId, users) => {
 };
 
 export const searchUsersOnly = async (searchedValue, options = {}) => {
-  const { searchIdPrefixes, allowTelegramPrefixMatches = false } = options;
+  const { searchIdPrefixes, allowTelegramPrefixMatches = false, enabledSearchKeys } = options;
+  const isBroadTextSearchEnabled = Boolean(enabledSearchKeys?.broadTextSearch);
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
   const searchIdOptions = shouldSkipBroadFallback
@@ -2162,11 +2163,10 @@ export const searchUsersOnly = async (searchedValue, options = {}) => {
       return users;
     }
 
-    // Індексований пошук вище (searchBySearchIdUsers/userId) вже покриває переважну
-    // більшість запитів. Широкий fallback (до ~32 запитів по всіх 16 полях × users/newUsers)
-    // потрібен лише коли індекс нічого не знайшов — інакше він щоразу тягне зайвий трафік
-    // навіть для вже знайденої картки.
-    if (Object.keys(users).length === 0) {
+    // Широкий fallback (до ~32 запитів по всіх 16 полях × users/newUsers) дорого коштує
+    // по трафіку, тому виконується лише коли користувач сам явно увімкнув чекбокс
+    // "широкий пошук" (enabledSearchKeys.broadTextSearch), а не автоматично щоразу.
+    if (isBroadTextSearchEnabled) {
       await searchByPrefixesUsers(searchValue, uniqueUserIds, users);
       await searchUserByPartialUserId(searchValue, users);
     }
@@ -2707,7 +2707,9 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     searchKeyFields,
     forcePartialUserIdSearch = false,
     allowTelegramPrefixMatches = false,
+    enabledSearchKeys,
   } = options;
+  const isBroadTextSearchEnabled = Boolean(enabledSearchKeys?.broadTextSearch);
   if (isDev) console.log('fetchNewUsersCollectionInRTDB → searchedValue:', searchedValue);
   const { searchKey, searchValue, modifiedSearchValue } = makeSearchKeyValue(searchedValue, { searchIdPrefixes });
   const shouldSkipBroadFallback = shouldSkipBroadFallbackForExactSearchId(searchKey, options);
@@ -2766,10 +2768,11 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
           searchIdOptions,
         );
 
-        // Так само як у searchUsersOnly: широкий fallback (searchByPrefixes ганяє до
-        // 16 полів × 2 регістри × users/newUsers, searchByIndexOn — ще додатково) потрібен
-        // лише коли швидкий індексований пошук вище нічого не знайшов.
-        if (!shouldSkipBroadFallback && Object.keys(users).length === 0) {
+        // searchByPrefixes ганяє до 16 полів × 2 регістри × users/newUsers, searchByIndexOn —
+        // ще додатково. Це дорого по трафіку, тому виконується лише коли користувач сам
+        // явно увімкнув чекбокс "широкий пошук" (enabledSearchKeys.broadTextSearch),
+        // а не автоматично для кожного пошуку картки.
+        if (!shouldSkipBroadFallback && isBroadTextSearchEnabled) {
           await searchByPrefixes(searchValue, uniqueUserIds, users);
           await searchByIndexOn({
             searchValue,

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2162,8 +2162,14 @@ export const searchUsersOnly = async (searchedValue, options = {}) => {
       return users;
     }
 
-    await searchByPrefixesUsers(searchValue, uniqueUserIds, users);
-    await searchUserByPartialUserId(searchValue, users);
+    // Індексований пошук вище (searchBySearchIdUsers/userId) вже покриває переважну
+    // більшість запитів. Широкий fallback (до ~32 запитів по всіх 16 полях × users/newUsers)
+    // потрібен лише коли індекс нічого не знайшов — інакше він щоразу тягне зайвий трафік
+    // навіть для вже знайденої картки.
+    if (Object.keys(users).length === 0) {
+      await searchByPrefixesUsers(searchValue, uniqueUserIds, users);
+      await searchUserByPartialUserId(searchValue, users);
+    }
 
     if (Object.keys(users).length === 1) {
       const id = Object.keys(users)[0];
@@ -2760,7 +2766,10 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
           searchIdOptions,
         );
 
-        if (!shouldSkipBroadFallback) {
+        // Так само як у searchUsersOnly: широкий fallback (searchByPrefixes ганяє до
+        // 16 полів × 2 регістри × users/newUsers, searchByIndexOn — ще додатково) потрібен
+        // лише коли швидкий індексований пошук вище нічого не знайшов.
+        if (!shouldSkipBroadFallback && Object.keys(users).length === 0) {
           await searchByPrefixes(searchValue, uniqueUserIds, users);
           await searchByIndexOn({
             searchValue,


### PR DESCRIPTION
searchUsersOnly and fetchNewUsersCollectionInRTDB always ran an expensive
fallback (searchByPrefixesUsers/searchByPrefixes + searchByIndexOn or
searchUserByPartialUserId) after the fast indexed searchId lookup, even
when that lookup already found the card. The fallback scans up to 16
contact/name fields x 2 case variants x users/newUsers collections, which
is what produced the large "Backend traffic" toasts seen when searching
for a card. Now it only runs when the indexed search found nothing.