### PR TITLE
Keep admin page title and "⋮" menu row level on mobile

### DIFF
--- a/src/components/AdminPageHeader.jsx
+++ b/src/components/AdminPageHeader.jsx
@@ -7,17 +7,14 @@
 // page use.
 import styled from 'styled-components';
 
+// Always a single row, at every viewport width - never stacks the title above the actions/menu
+// on narrow screens, matching KmTopbar (My Profile / User Agreement never stack either).
 export const Header = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 14px;
-
-  @media (max-width: 560px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
 `;
 
 export const HeaderRight = styled.div`
@@ -26,11 +23,6 @@ export const HeaderRight = styled.div`
   gap: 14px;
   flex-wrap: wrap;
   justify-content: flex-end;
-
-  @media (max-width: 560px) {
-    width: 100%;
-    justify-content: flex-end;
-  }
 `;
 
 export const HeaderActions = styled.div`


### PR DESCRIPTION
## Summary

- `AdminPageHeader`'s `Header` switched to `flex-direction: column` under 560px, stacking the page title above the Read/Edit/⋮ buttons row instead of keeping them on the same level - visible on Parties, Documents, Budget and Invoice Builder on phone-width screens.
- `KmTopbar` (used by My Profile / User Agreement, the reference pages for this menu) never stacks at any viewport width, so this drops the same override here to match.

## Test plan

- [x] `npm run build` compiles successfully
- [x] `PartiesPage`, `PartiesPage.caseEditor`, `InvoiceBuilderPage`, `BudgetPage.editMode`, `DocumentsPage.checklistScope` test suites pass
- [x] Verified the resulting single-row layout with a static CSS mockup of each page's actual header styles at a 390px viewport

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KDEVvPDbVEPiG5rNxwbrjy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEVvPDbVEPiG5rNxwbrjy)_