### PR TITLE
Preserve concurrent edits during legacy comment migration

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1298,7 +1298,6 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
       const destinationPath = currentComment || !legacyComment
         ? getCommentPath(commentsOwnerId, cardId)
         : getLegacyCommentPath(commentsOwnerId, cardId);
-      const expectedDestination = currentComment || legacyComment;
       const finalText = mergeCommentText(
         usersText,
         newUsersText,
@@ -1311,14 +1310,19 @@ export const migrateAllLegacyCardComments = async (ownerId, { onProgress } = {})
           { path: `users/${cardId}/myComment`, expected: usersData[cardId]?.myComment },
           { path: `newUsers/${cardId}/myComment`, expected: newUsersData[cardId]?.myComment },
         ].filter(source => String(source.expected || '').trim());
+        const comments = [
+          { path: getCommentPath(commentsOwnerId, cardId), expected: currentComment },
+          { path: getLegacyCommentPath(commentsOwnerId, cardId), expected: legacyComment },
+        ];
 
-        // The destination and both legacy sources live under different RTDB
-        // branches, so transact at their common root. This validates every
-        // snapshot and applies the write/cleanup as one atomic operation.
+        // Both comment roots and both legacy sources live under different RTDB
+        // branches, so transact at their common root. Validate both comment
+        // locations even though only one is the destination: a concurrent edit
+        // to the fallback would otherwise be shadowed by the migrated record.
         // eslint-disable-next-line no-await-in-loop
         const migrationResult = await runTransaction(ref2(database), rootValue => {
           const nextRoot = rootValue && typeof rootValue === 'object' ? rootValue : {};
-          if (!valuesMatch(getValueAtPath(nextRoot, destinationPath), expectedDestination)) {
+          if (comments.some(comment => !valuesMatch(getValueAtPath(nextRoot, comment.path), comment.expected))) {
             return undefined;
           }
           if (sources.some(source => !valuesMatch(getValueAtPath(nextRoot, source.path), source.expected))) {

--- a/src/components/config.migrateAllLegacyCardComments.test.js
+++ b/src/components/config.migrateAllLegacyCardComments.test.js
@@ -28,10 +28,13 @@ describe('bulk migration of every leftover users/newUsers myComment into multiDa
     expect(fnBody).toContain('legacyComment?.text');
   });
 
-  it('clears both sources in the same root transaction as the destination write', () => {
+  it('validates both comment roots and clears both sources in the same root transaction', () => {
     expect(fnBody).toMatch(/`users\/\$\{cardId\}\/myComment`/);
     expect(fnBody).toMatch(/`newUsers\/\$\{cardId\}\/myComment`/);
     expect(fnBody).toContain('runTransaction(ref2(database), rootValue');
+    expect(fnBody).toContain('{ path: getCommentPath(commentsOwnerId, cardId), expected: currentComment }');
+    expect(fnBody).toContain('{ path: getLegacyCommentPath(commentsOwnerId, cardId), expected: legacyComment }');
+    expect(fnBody).toContain('comments.some(comment => !valuesMatch');
     expect(fnBody).toContain('sources.some(source => !valuesMatch');
     expect(fnBody).toContain('sources.forEach(source => setValueAtPath');
   });


### PR DESCRIPTION
### Motivation
- Prevent silent overwrites during the bulk migration of legacy per-card comments by ensuring a card is not migrated if either comment location changed after the initial snapshot.
- Keep the migration atomic and correct when many cards are processed while other sessions may concurrently edit comment records.

### Description
- Validate both comment roots (`getCommentPath` and `getLegacyCommentPath`) inside a single `runTransaction(ref2(database), ...)` at the common RTDB root and abort the card migration when either comment differs from its snapshot. 
- Continue to validate and clear legacy sources (`users/${cardId}/myComment` and `newUsers/${cardId}/myComment`) inside the same atomic transaction and write the merged `multiData/comments` entry only when all checks pass.
- Add a local `comments` array to represent both comment paths and use `getValueAtPath`/`setValueAtPath` helpers to read/modify the combined transaction payload.
- Extend the regression test `src/components/config.migrateAllLegacyCardComments.test.js` to assert that both comment roots are validated and included in the conditional root transaction.

### Testing
- Ran the migration unit test: `CI=true npm test -- --watchAll=false --runTestsByPath src/components/config.migrateAllLegacyCardComments.test.js`, and all tests passed (9 passed).
- Linted the modified files with `npx eslint src/components/config.js src/components/config.migrateAllLegacyCardComments.test.js` with no new failures.
- Checked code health with `git diff --check` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e06414aac8326a630c7d1a13de911)