### PR TITLE
Keep admin header menu on the same flex line

### DIFF
--- a/src/components/AdminPageHeader.jsx
+++ b/src/components/AdminPageHeader.jsx
@@ -21,12 +21,14 @@ export const HeaderRight = styled.div`
   display: flex;
   align-items: center;
   gap: 14px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  min-width: 0;
   justify-content: flex-end;
 `;
 
 export const HeaderActions = styled.div`
   display: flex;
+  min-width: 0;
   gap: 6px;
   flex-wrap: wrap;
   align-items: center;


### PR DESCRIPTION
### Motivation
- On narrow viewports the right-side wrapper could wrap the page navigation menu onto a second internal flex line, causing the ⋮ menu to sit below the title/actions instead of remaining row-level.
- The intent is to keep the header as a single row while letting the action group shrink and wrap its own buttons internally.

### Description
- Set `HeaderRight` to `flex-wrap: nowrap` and add `min-width: 0` so the right-side wrapper does not force the page nav onto a new line.
- Add `min-width: 0` to `HeaderActions` so action buttons can shrink and wrap internally instead of pushing the menu out of the row.
- Modified file: `src/components/AdminPageHeader.jsx`.

### Testing
- Ran `npx eslint src/components/AdminPageHeader.jsx` and it passed.
- Built the production bundle with `CI=true npm run build` and the build completed successfully.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e35026014832693f1e550560be38f)