### PR TITLE
Stop searchId falling back to all fields when checkboxes are unchecked

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -499,6 +499,10 @@ const hasExplicitEmptySearchKeyList = (searchOptions = {}, optionKey) =>
   Array.isArray(searchOptions?.[optionKey]) && searchOptions[optionKey].length === 0;
 
 const resolveSearchIdPrefixStrategy = (input, searchOptions = {}) => {
+  if (hasExplicitEmptySearchKeyList(searchOptions, 'searchIdPrefixes')) {
+    return { primaryPrefixes: [], fallbackPrefixes: [], shouldRetryWithFallbackPrefixes: false };
+  }
+
   const configuredPrefixes = resolveSelectedSearchKeys(
     searchOptions,
     'searchIdPrefixes',

--- a/src/components/SearchBar.partialUserId.test.js
+++ b/src/components/SearchBar.partialUserId.test.js
@@ -472,6 +472,64 @@ describe('SearchBar cache-first search', () => {
     document.body.removeChild(container);
   });
 
+  it('does not fan out to every searchId prefix when searchIdPrefixes is explicitly empty', async () => {
+    const searchFunc = jest.fn().mockResolvedValue({});
+    const setUsers = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.render(React.createElement(SearchBar, {
+        searchFunc,
+        search: 'УК СМ Марія Бекер 02.06.2026',
+        setSearch: jest.fn(),
+        setUsers,
+        setState: jest.fn(),
+        setUserNotFound: jest.fn(),
+        enabledSearchKeys: {
+          telegram: true,
+          searchId: true,
+          partialUserId: false,
+          searchKey: false,
+          equalToAllCards: true,
+        },
+        searchOptions: {
+          enabledSearchKeys: {
+            telegram: true,
+            searchId: true,
+            partialUserId: false,
+            searchKey: false,
+            equalToAllCards: true,
+          },
+          equalToKeys: ['telegram'],
+          searchIdPrefixes: [],
+        },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(searchFunc).toHaveBeenCalledWith(
+      { telegram: 'УК СМ Марія Бекер 02.06.2026' },
+      expect.objectContaining({
+        forceEqualToAllCards: true,
+        equalToKeys: ['telegram'],
+      }),
+    );
+    expect(searchFunc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ searchId: expect.anything() }),
+      expect.anything(),
+    );
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
   it('renders UK-trigger telegram prefix matches as a list even when one match is returned', async () => {
     const searchFunc = jest.fn().mockResolvedValue({
       userId: 'oksana',

--- a/src/utils/searchKeyCheckboxFilters.js
+++ b/src/utils/searchKeyCheckboxFilters.js
@@ -1,6 +1,3 @@
-import { getSearchIdIndexedFields } from './searchKeyUtils';
-const SEARCH_ID_CHECKBOX_KEYS = getSearchIdIndexedFields();
-
 const EQUAL_TO_INDEX_KEYS = [
   'instagram',
   'ameblo',
@@ -28,22 +25,6 @@ const EQUAL_TO_INDEX_KEYS = [
   'lastCycle',
   'lastLogin',
 ];
-
-export const getSearchIdPrefixes = searchIdPrefixes => {
-  if (!Array.isArray(searchIdPrefixes) || searchIdPrefixes.length === 0) {
-    return SEARCH_ID_CHECKBOX_KEYS;
-  }
-
-  const normalizedPrefixes = searchIdPrefixes
-    .map(prefix => (typeof prefix === 'string' ? prefix.trim() : ''))
-    .filter(Boolean);
-
-  const allowedPrefixes = SEARCH_ID_CHECKBOX_KEYS.filter(prefix =>
-    normalizedPrefixes.includes(prefix)
-  );
-
-  return allowedPrefixes.length > 0 ? allowedPrefixes : SEARCH_ID_CHECKBOX_KEYS;
-};
 
 export const resolveEqualToSearchKeys = equalToKeys => {
   if (!Array.isArray(equalToKeys)) {

--- a/src/utils/searchKeyUtils.js
+++ b/src/utils/searchKeyUtils.js
@@ -28,16 +28,18 @@ export const isSearchIdIndexedField = field => SEARCH_ID_INDEXED_FIELDS.has(fiel
 
 export const getSearchIdPrefixes = searchIdPrefixes => {
   const fallback = getSearchIdIndexedFields();
-  if (!Array.isArray(searchIdPrefixes) || searchIdPrefixes.length === 0) {
+  if (!Array.isArray(searchIdPrefixes)) {
     return fallback;
+  }
+  if (searchIdPrefixes.length === 0) {
+    return [];
   }
 
   const normalizedPrefixes = searchIdPrefixes
     .map(prefix => (typeof prefix === 'string' ? prefix.trim() : ''))
     .filter(Boolean);
 
-  const allowedPrefixes = fallback.filter(prefix => normalizedPrefixes.includes(prefix));
-  return allowedPrefixes.length > 0 ? allowedPrefixes : fallback;
+  return fallback.filter(prefix => normalizedPrefixes.includes(prefix));
 };
 
 const SOCIAL_SEARCH_KEYS = new Set([

--- a/src/utils/searchKeyUtils.test.js
+++ b/src/utils/searchKeyUtils.test.js
@@ -2,6 +2,7 @@ import {
   buildSearchIdRecordKey,
   normalizeSearchIdInput,
   buildSearchIdCandidateKeys,
+  getSearchIdPrefixes,
 } from './searchKeyUtils';
 
 const youtubeChannelId = 'UC4LwxzuzRqwSpa1A64eziDQ';
@@ -37,5 +38,21 @@ describe('searchKeyUtils exact searchId behavior', () => {
       includeVariants: false,
       includePrefixMatches: false,
     })).toEqual(['telegram_ук см alia 09.10.2025']);
+  });
+});
+
+describe('getSearchIdPrefixes', () => {
+  it('keeps searchId prefix search scoped to explicitly selected keys', () => {
+    expect(getSearchIdPrefixes(['telegram'])).toEqual(['telegram']);
+    expect(getSearchIdPrefixes(['telegram', 'phone'])).toEqual(['phone', 'telegram']);
+  });
+
+  it('does not fall back to every searchId prefix for an explicit empty selection', () => {
+    expect(getSearchIdPrefixes([])).toEqual([]);
+    expect(getSearchIdPrefixes(['unknownKey'])).toEqual([]);
+  });
+
+  it('keeps the legacy all-prefixes fallback only when no explicit key list is provided', () => {
+    expect(getSearchIdPrefixes()).toEqual(expect.arrayContaining(['phone', 'telegram', 'instagram']));
   });
 });


### PR DESCRIPTION
runEqualToAllCardsSearch and runSearchKeyBucketSearch already short-circuit
to zero backend calls when their field-list option is an explicit empty
array (all checkboxes off), but resolveSearchIdPrefixStrategy had no
equivalent guard and silently expanded an explicit empty searchIdPrefixes
selection to all 16 indexed fields, firing unintended Firebase reads for
fields the user never enabled. Also aligns getSearchIdPrefixes in
searchKeyUtils.js with the equivalent (already-fixed) equalTo resolver, and
removes an unused duplicate copy of the same fallback logic.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017z1Nj8Eha41eHqHLRVFCCM