### PR TITLE
Move representative POA to the case, drop empty Parties blocks, relocate Підготовка tab, separate header actions

### DIFF
--- a/src/components/AdminPageHeader.jsx
+++ b/src/components/AdminPageHeader.jsx
@@ -1,29 +1,29 @@
 // Shared page-header chrome for the UKRCOM admin pages (Documents / Invoice Builder / Parties /
-// Budget). The "⋮" page-switcher (PageNavMenu) stays on the same row as the title and the page's
-// other action buttons - never its own row, and never sticky/fixed - but it sits inside
-// `HeaderRight` as its own flex item (with a wider gap than HeaderActions' own buttons use), so it
-// reads as separate from that button group while staying vertically centered with everything else
-// on the row. See styles/knowme.js's KmTopbar, the same pattern My Profile and the User Agreement
-// page use.
+// Budget). The "⋮" page-switcher (PageNavMenu) stays on the title's own row - never its own line,
+// and never sticky/fixed - but the page's other action buttons (Export/Upload/Edit/...) render
+// separately, on their own row right below the header, right-aligned via HeaderActionsRow. This
+// keeps the title row uncluttered (title + menu only) instead of crowding a variable number of
+// buttons in next to it. See styles/knowme.js's KmTopbar, the same pattern My Profile and the User
+// Agreement page use for the title row itself.
 import styled from 'styled-components';
 
-// Always a single row, at every viewport width - never stacks the title above the actions/menu
-// on narrow screens, matching KmTopbar (My Profile / User Agreement never stack either).
+// Always a single row, at every viewport width - never stacks the title above the menu on narrow
+// screens, matching KmTopbar (My Profile / User Agreement never stack either). Only ever holds the
+// title block and PageNavMenu now - action buttons live in HeaderActionsRow below.
 export const Header = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 14px;
+  margin-bottom: 10px;
 `;
 
-export const HeaderRight = styled.div`
+// The page's own action buttons row, directly under the title/menu header - right-aligned, wraps
+// on narrow screens instead of crowding the title row.
+export const HeaderActionsRow = styled.div`
   display: flex;
-  align-items: center;
-  gap: 14px;
-  flex-wrap: nowrap;
-  min-width: 0;
   justify-content: flex-end;
+  margin-bottom: 14px;
 `;
 
 export const HeaderActions = styled.div`

--- a/src/components/BudgetPage.jsx
+++ b/src/components/BudgetPage.jsx
@@ -26,7 +26,7 @@ import {
 } from './budgetCatalogUtils';
 import { setPdfAgencyConfig } from './pdfTheme';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderActionsRow } from './AdminPageHeader';
 
 const INCLUDED_PREVIEW_LIMIT = 6;
 const POPULAR_PACKAGE_ID = '3';
@@ -2043,7 +2043,9 @@ const BudgetPage = ({ isAdmin = false }) => {
             <Eyebrow>{(catalog.technical?.agency?.name || UKRCOM_MARKER).toUpperCase()}</Eyebrow>
             <Title>Program Budget</Title>
           </div>
-          <HeaderRight>
+          <PageNavMenu />
+        </Header>
+        <HeaderActionsRow>
           <HeaderActions>
             <MiniButton
               type="button"
@@ -2051,7 +2053,7 @@ const BudgetPage = ({ isAdmin = false }) => {
               disabled={loading || Boolean(error) || isExporting}
               title="Download the client budget as a PDF"
             >
-              <FaFilePdf /> {isExporting ? 'Preparing…' : 'Export PDF'}
+              <FaFilePdf /> {isExporting ? 'Preparing…' : 'PDF'}
             </MiniButton>
             {isBudgetAdmin ? (
               <MiniButton
@@ -2083,15 +2085,13 @@ const BudgetPage = ({ isAdmin = false }) => {
                 </MiniButton>
                 {/* Temporary migration button. Remove after the budget catalog has been uploaded to the backend. */}
                 <MiniDangerButton type="button" onClick={handleUploadClick}>
-                  <FaUpload /> Upload JSON
+                  <FaUpload /> Upload
                 </MiniDangerButton>
                 <input ref={fileInputRef} type="file" accept="application/json,.json" hidden onChange={handleBudgetFileChange} />
               </>
             ) : null}
           </HeaderActions>
-          <PageNavMenu />
-          </HeaderRight>
-        </Header>
+        </HeaderActionsRow>
 
         {loading ? <StateCard>Loading budget catalog…</StateCard> : null}
         {!loading && error ? <StateCard>{error}</StateCard> : null}

--- a/src/components/CaseEditor.jsx
+++ b/src/components/CaseEditor.jsx
@@ -22,6 +22,7 @@ import {
   coupleDisplayName,
   createChildRecord,
   formatDocumentDate,
+  formatPassportNumber,
   formatShortNameUk,
   getMaternityHospitalDisplayName,
   getValueByPath,
@@ -39,14 +40,17 @@ const describeSaveError = error => `${error?.code || error?.name || 'error'}: ${
 const isFilled = value => !(value === undefined || value === null || String(value).trim() === '');
 const parseNumberOrBlank = value => (value === '' || value === undefined || value === null ? undefined : Number(value));
 
-// Batch 29 §4: several representatives can share the same full name but carry different powers of
-// attorney - this is the one line that tells them apart, in the picker and on the overview card
-// alike. Blank when neither date is filled (never an empty "Довіреність від" label).
-const representativeProxyLabel = record => {
-  const poa = record?.powerOfAttorney || {};
+// The power of attorney (signing date + apostille date) is now a static fact of the *case*
+// (relations.representativePowerOfAttorney, edited alongside the representative picker below) -
+// the same representative can act under a different POA on another case, and one POA can cover
+// several representatives at once, so a representative record no longer needs its own copy per
+// person/date pairing. Several representatives can still share the exact same full name though, so
+// this is the one line that tells them apart, in the picker and on the overview card alike - a
+// passport number and/or birth date, whichever is filled. Blank when neither is set.
+const representativeIdentityLabel = record => {
   const parts = [];
-  if (isFilled(poa.date)) parts.push(`Довіреність від ${formatDocumentDate(poa.date)}`);
-  if (isFilled(poa.apostilleDate)) parts.push(`Апостиль ${formatDocumentDate(poa.apostilleDate)}`);
+  if (isFilled(record?.passport?.number)) parts.push(`Паспорт ${formatPassportNumber(record.passport.number)}`);
+  if (isFilled(record?.birthDate)) parts.push(`${formatDocumentDate(record.birthDate)} р.н.`);
   return parts.join(' · ');
 };
 
@@ -718,6 +722,12 @@ const buildDraftFromCase = caseRecord => {
       clinicId: relations.clinicId || '',
       surrogateMotherId: relations.surrogateMotherId || '',
       representativeIds: toArray(relations.representativeIds).map(String),
+      // Static per-case power of attorney (signing date + apostille date) - see
+      // representativeIdentityLabel above for why this moved off the representative record.
+      representativePowerOfAttorney: {
+        date: relations.representativePowerOfAttorney?.date || '',
+        apostilleDate: relations.representativePowerOfAttorney?.apostilleDate || '',
+      },
     },
     childbirth: {
       maternityHospitalId: childbirth.maternityHospitalId || '',
@@ -838,7 +848,7 @@ const SECTION_DEFS = [
   // entry, each tagged with the "Підготовка"/"РАЦС" group it renders under, so the two group-level
   // collapsibles below can sum their own members' completion independently.
   {
-    key: 'surrogacyAgreement', tab: 'racs', group: 'preparation', title: 'Договір сурогатного материнства', meta: 'Номер, дата, нотаріус',
+    key: 'surrogacyAgreement', tab: 'preparation', title: 'Договір сурогатного материнства', meta: 'Номер, дата, нотаріус',
     completion: draft => {
       const d = draft.documents.surrogacyAgreement;
       const values = [d.number.uk, d.number.en, d.date, d.notaryId];
@@ -846,21 +856,21 @@ const SECTION_DEFS = [
     },
   },
   {
-    key: 'surrogacyAgreementAppendix1', tab: 'racs', group: 'preparation', title: 'Додаток №1 до договору', meta: 'Дата додатка',
+    key: 'surrogacyAgreementAppendix1', tab: 'preparation', title: 'Додаток №1 до договору', meta: 'Дата додатка',
     completion: draft => {
       const values = [draft.documents.surrogacyAgreementAppendix1.date];
       return { filled: values.filter(isFilled).length, total: values.length };
     },
   },
   {
-    key: 'medicalServicesAgreement', tab: 'racs', group: 'preparation', title: 'Договір про медичні послуги', meta: 'Дата договору',
+    key: 'medicalServicesAgreement', tab: 'preparation', title: 'Договір про медичні послуги', meta: 'Дата договору',
     completion: draft => {
       const values = [draft.documents.medicalServicesAgreement.date];
       return { filled: values.filter(isFilled).length, total: values.length };
     },
   },
   {
-    key: 'maritalStatusDeclaration', tab: 'racs', group: 'preparation', title: 'Заява СМ про відсутність шлюбу', meta: 'Дата заяви, нотаріус',
+    key: 'maritalStatusDeclaration', tab: 'preparation', title: 'Заява СМ про відсутність шлюбу', meta: 'Дата заяви, нотаріус',
     completion: draft => {
       const d = draft.documents.maritalStatusDeclaration;
       const values = [d.statementDate, d.notaryId];
@@ -868,7 +878,7 @@ const SECTION_DEFS = [
     },
   },
   {
-    key: 'legalServicesDisclaimer', tab: 'racs', group: 'preparation', title: 'Заява про ненадання юридичних послуг клінікою', meta: 'Дата заяви, нотаріус',
+    key: 'legalServicesDisclaimer', tab: 'preparation', title: 'Заява про ненадання юридичних послуг клінікою', meta: 'Дата заяви, нотаріус',
     completion: draft => {
       const d = draft.documents.legalServicesDisclaimer;
       const values = [d.statementDate, d.notaryId];
@@ -960,6 +970,13 @@ const CaseEditor = ({
   };
 
   const updateRelations = (field, value) => { setDraft(previous => ({ ...previous, relations: { ...previous.relations, [field]: value } })); markDirty(); };
+  const updateRepresentativePoa = (field, value) => {
+    setDraft(previous => ({
+      ...previous,
+      relations: { ...previous.relations, representativePowerOfAttorney: { ...previous.relations.representativePowerOfAttorney, [field]: value } },
+    }));
+    markDirty();
+  };
   const updateChildbirth = (field, value) => { setDraft(previous => ({ ...previous, childbirth: { ...previous.childbirth, [field]: value } })); markDirty(); };
   const updateChild = (childId, field, value) => {
     setDraft(previous => ({
@@ -1040,10 +1057,10 @@ const CaseEditor = ({
     maternityHospitals: maternityDisplayName,
     notaries: notaryOptionLabel,
   };
-  // Batch 29 §4: only representatives get a sublabel - several can share the exact same full name,
-  // distinguished only by which power of attorney they carry.
+  // Only representatives get a sublabel - several can share the exact same full name, distinguished
+  // by passport/birth date now that the power of attorney itself is case-level, not per-record.
   const SUB_LABEL_BY_COLLECTION = {
-    representatives: representativeProxyLabel,
+    representatives: representativeIdentityLabel,
   };
 
   const openPicker = ({ title, collection, valueId, multi = false, onApply }) => {
@@ -1223,6 +1240,7 @@ const CaseEditor = ({
             </HeaderChips>
             <Tabs role="tablist">
               <TabButton type="button" $active={activeTab === 'overview'} onClick={() => setActiveTab('overview')}>Огляд</TabButton>
+              <TabButton type="button" $active={activeTab === 'preparation'} onClick={() => setActiveTab('preparation')}>Підготовка</TabButton>
               <TabButton type="button" $active={activeTab === 'program'} onClick={() => setActiveTab('program')}>Програма ДРТ</TabButton>
               <TabButton type="button" $active={activeTab === 'racs'} onClick={() => setActiveTab('racs')}>РАЦС</TabButton>
             </Tabs>
@@ -1298,7 +1316,7 @@ const CaseEditor = ({
                       return (
                         <RepresentativeList>
                           {selected.map(record => {
-                            const sub = representativeProxyLabel(record);
+                            const sub = representativeIdentityLabel(record);
                             return (
                               <div key={record.id}>
                                 <RepresentativeName>{partyDisplayName(record)}</RepresentativeName>
@@ -1315,10 +1333,133 @@ const CaseEditor = ({
                     >
                       Змінити
                     </RelationCardButton>
+                    {/* The power of attorney itself (signing + apostille date) is static per case -
+                        one POA can cover every representative selected above, and the same
+                        representative can carry a different POA on another case, so these two
+                        dates live here rather than on the representative record. */}
+                    <FieldGrid style={{ marginTop: 10 }}>
+                      <Field>
+                        Дата довіреності
+                        <FieldInput
+                          type="date"
+                          value={draft.relations.representativePowerOfAttorney.date}
+                          onChange={event => updateRepresentativePoa('date', event.target.value)}
+                        />
+                      </Field>
+                      <Field>
+                        Дата апостилю
+                        <FieldInput
+                          type="date"
+                          value={draft.relations.representativePowerOfAttorney.apostilleDate}
+                          onChange={event => updateRepresentativePoa('apostilleDate', event.target.value)}
+                        />
+                      </Field>
+                    </FieldGrid>
                   </RelationCard>
                 </RelationGrid>
                 </SectionBody>
               </PrimarySection>
+            </div>
+          ) : null}
+
+          {activeTab === 'preparation' ? (
+            <div>
+              {/* Moved off the "РАЦС" tab (was one of its two stage-level collapsibles) - the
+                  registration itself. Same collapsible-with-counter chrome as Медичні дані/
+                  Транспортування ембріонів on the Програма ДРТ tab, just its own tab now; every
+                  field keeps its existing draft path, only the tab it renders under moved. */}
+              <CollapsibleSection
+                id="racsPreparation"
+                title="Підготовка"
+                meta="Договір сурогатного материнства, додаток №1, договір про мед. послуги, заяви СМ і клініки"
+                completion={groupCompletion(RACS_PREPARATION_KEYS, draft)}
+                open={Boolean(openSections.racsPreparation)}
+                onToggle={() => toggleSection('racsPreparation')}
+              >
+                <DocRow>
+                  <SectionSubhead style={{ margin: '0 0 6px' }}>Договір сурогатного материнства</SectionSubhead>
+                  <FieldGrid>
+                    <Field>
+                      Номер (укр)
+                      <FieldInput type="text" value={draft.documents.surrogacyAgreement.number.uk} onChange={event => updateDocumentNumberField('surrogacyAgreement', 'uk', event.target.value)} />
+                    </Field>
+                    <Field>
+                      Номер (eng)
+                      <FieldInput type="text" value={draft.documents.surrogacyAgreement.number.en} onChange={event => updateDocumentNumberField('surrogacyAgreement', 'en', event.target.value)} />
+                    </Field>
+                    <Field>
+                      Дата договору
+                      <FieldInput type="date" value={draft.documents.surrogacyAgreement.date} onChange={event => updateDocumentField('surrogacyAgreement', 'date', event.target.value)} />
+                    </Field>
+                    <Field>
+                      Нотаріус
+                      <PickerFieldButton
+                        type="button"
+                        onClick={() => openPicker({
+                          title: 'Оберіть нотаріуса', collection: 'notaries', valueId: draft.documents.surrogacyAgreement.notaryId, onApply: id => updateDocumentField('surrogacyAgreement', 'notaryId', id),
+                        })}
+                      >
+                        <PickerFieldValue $empty={!draft.documents.surrogacyAgreement.notaryId}>
+                          {(() => {
+                            const notary = catalog.parties.notaries.find(item => String(item.id) === String(draft.documents.surrogacyAgreement.notaryId));
+                            return notary ? notaryOptionLabel(notary) : '— не обрано —';
+                          })()}
+                        </PickerFieldValue>
+                        <span>›</span>
+                      </PickerFieldButton>
+                    </Field>
+                  </FieldGrid>
+                </DocRow>
+                <DocRow>
+                  <SectionSubhead style={{ margin: '0 0 6px' }}>Додаток №1 до договору</SectionSubhead>
+                  <FieldGrid>
+                    <Field>
+                      Дата додатка
+                      <FieldInput type="date" value={draft.documents.surrogacyAgreementAppendix1.date} onChange={event => updateDocumentField('surrogacyAgreementAppendix1', 'date', event.target.value)} />
+                    </Field>
+                  </FieldGrid>
+                </DocRow>
+                <DocRow>
+                  <SectionSubhead style={{ margin: '0 0 6px' }}>Договір про медичні послуги</SectionSubhead>
+                  <FieldGrid>
+                    <Field>
+                      Дата договору
+                      <FieldInput type="date" value={draft.documents.medicalServicesAgreement.date} onChange={event => updateDocumentField('medicalServicesAgreement', 'date', event.target.value)} />
+                    </Field>
+                  </FieldGrid>
+                </DocRow>
+                {[
+                  { key: 'maritalStatusDeclaration', label: 'Заява СМ про відсутність шлюбу' },
+                  { key: 'legalServicesDisclaimer', label: 'Заява про ненадання юридичних послуг клінікою' },
+                ].map(({ key, label }) => (
+                  <DocRow key={key}>
+                    <SectionSubhead style={{ margin: '0 0 6px' }}>{label}</SectionSubhead>
+                    <FieldGrid>
+                      <Field>
+                        Дата заяви
+                        <FieldInput type="date" value={draft.documents[key].statementDate} onChange={event => updateDocumentField(key, 'statementDate', event.target.value)} />
+                      </Field>
+                      <Field>
+                        Нотаріус
+                        <PickerFieldButton
+                          type="button"
+                          onClick={() => openPicker({
+                            title: 'Оберіть нотаріуса', collection: 'notaries', valueId: draft.documents[key].notaryId, onApply: id => updateDocumentField(key, 'notaryId', id),
+                          })}
+                        >
+                          <PickerFieldValue $empty={!draft.documents[key].notaryId}>
+                            {(() => {
+                              const notary = catalog.parties.notaries.find(item => String(item.id) === String(draft.documents[key].notaryId));
+                              return notary ? notaryOptionLabel(notary) : '— не обрано —';
+                            })()}
+                          </PickerFieldValue>
+                          <span>›</span>
+                        </PickerFieldButton>
+                      </Field>
+                    </FieldGrid>
+                  </DocRow>
+                ))}
+              </CollapsibleSection>
             </div>
           ) : null}
 
@@ -1480,109 +1621,12 @@ const CaseEditor = ({
 
           {activeTab === 'racs' ? (
             <div>
-              {/* Batch 29 §6: the racs tab's four flat sections (Пологи та дитина / Договір
-                  сурогатного материнства / Заяви до РАЦС / Інші документи) are regrouped into two
-                  stage-level collapsibles - "Підготовка" (everything signed/prepared before the
-                  registration itself) and "РАЦС" (the registration act and its own two
-                  attachments). Same collapsible-with-counter chrome as Медичні дані/
-                  Транспортування ембріонів on the Програма ДРТ tab, just one level up; every field
-                  keeps its existing draft path, only the section that renders it moved. §5: the
-                  purely-informational "Лист клініки до РАЦС" block (no fields of its own, no
-                  action - just a note that it's auto-generated) is dropped; the document itself
-                  still generates the same way it always did, from Documents Builder. */}
-              <CollapsibleSection
-                id="racsPreparation"
-                title="Підготовка"
-                meta="Договір сурогатного материнства, додаток №1, договір про мед. послуги, заяви СМ і клініки"
-                completion={groupCompletion(RACS_PREPARATION_KEYS, draft)}
-                open={Boolean(openSections.racsPreparation)}
-                onToggle={() => toggleSection('racsPreparation')}
-              >
-                <DocRow>
-                  <SectionSubhead style={{ margin: '0 0 6px' }}>Договір сурогатного материнства</SectionSubhead>
-                  <FieldGrid>
-                    <Field>
-                      Номер (укр)
-                      <FieldInput type="text" value={draft.documents.surrogacyAgreement.number.uk} onChange={event => updateDocumentNumberField('surrogacyAgreement', 'uk', event.target.value)} />
-                    </Field>
-                    <Field>
-                      Номер (eng)
-                      <FieldInput type="text" value={draft.documents.surrogacyAgreement.number.en} onChange={event => updateDocumentNumberField('surrogacyAgreement', 'en', event.target.value)} />
-                    </Field>
-                    <Field>
-                      Дата договору
-                      <FieldInput type="date" value={draft.documents.surrogacyAgreement.date} onChange={event => updateDocumentField('surrogacyAgreement', 'date', event.target.value)} />
-                    </Field>
-                    <Field>
-                      Нотаріус
-                      <PickerFieldButton
-                        type="button"
-                        onClick={() => openPicker({
-                          title: 'Оберіть нотаріуса', collection: 'notaries', valueId: draft.documents.surrogacyAgreement.notaryId, onApply: id => updateDocumentField('surrogacyAgreement', 'notaryId', id),
-                        })}
-                      >
-                        <PickerFieldValue $empty={!draft.documents.surrogacyAgreement.notaryId}>
-                          {(() => {
-                            const notary = catalog.parties.notaries.find(item => String(item.id) === String(draft.documents.surrogacyAgreement.notaryId));
-                            return notary ? notaryOptionLabel(notary) : '— не обрано —';
-                          })()}
-                        </PickerFieldValue>
-                        <span>›</span>
-                      </PickerFieldButton>
-                    </Field>
-                  </FieldGrid>
-                </DocRow>
-                <DocRow>
-                  <SectionSubhead style={{ margin: '0 0 6px' }}>Додаток №1 до договору</SectionSubhead>
-                  <FieldGrid>
-                    <Field>
-                      Дата додатка
-                      <FieldInput type="date" value={draft.documents.surrogacyAgreementAppendix1.date} onChange={event => updateDocumentField('surrogacyAgreementAppendix1', 'date', event.target.value)} />
-                    </Field>
-                  </FieldGrid>
-                </DocRow>
-                <DocRow>
-                  <SectionSubhead style={{ margin: '0 0 6px' }}>Договір про медичні послуги</SectionSubhead>
-                  <FieldGrid>
-                    <Field>
-                      Дата договору
-                      <FieldInput type="date" value={draft.documents.medicalServicesAgreement.date} onChange={event => updateDocumentField('medicalServicesAgreement', 'date', event.target.value)} />
-                    </Field>
-                  </FieldGrid>
-                </DocRow>
-                {[
-                  { key: 'maritalStatusDeclaration', label: 'Заява СМ про відсутність шлюбу' },
-                  { key: 'legalServicesDisclaimer', label: 'Заява про ненадання юридичних послуг клінікою' },
-                ].map(({ key, label }) => (
-                  <DocRow key={key}>
-                    <SectionSubhead style={{ margin: '0 0 6px' }}>{label}</SectionSubhead>
-                    <FieldGrid>
-                      <Field>
-                        Дата заяви
-                        <FieldInput type="date" value={draft.documents[key].statementDate} onChange={event => updateDocumentField(key, 'statementDate', event.target.value)} />
-                      </Field>
-                      <Field>
-                        Нотаріус
-                        <PickerFieldButton
-                          type="button"
-                          onClick={() => openPicker({
-                            title: 'Оберіть нотаріуса', collection: 'notaries', valueId: draft.documents[key].notaryId, onApply: id => updateDocumentField(key, 'notaryId', id),
-                          })}
-                        >
-                          <PickerFieldValue $empty={!draft.documents[key].notaryId}>
-                            {(() => {
-                              const notary = catalog.parties.notaries.find(item => String(item.id) === String(draft.documents[key].notaryId));
-                              return notary ? notaryOptionLabel(notary) : '— не обрано —';
-                            })()}
-                          </PickerFieldValue>
-                          <span>›</span>
-                        </PickerFieldButton>
-                      </Field>
-                    </FieldGrid>
-                  </DocRow>
-                ))}
-              </CollapsibleSection>
-
+              {/* §5: the purely-informational "Лист клініки до РАЦС" block (no fields of its own,
+                  no action - just a note that it's auto-generated) is dropped; the document itself
+                  still generates the same way it always did, from Documents Builder. "Підготовка"
+                  (the other half of what used to live on this tab) now renders on its own tab right
+                  after "Огляд" - see activeTab === 'preparation' below - since everything here signs
+                  off *after* it, not alongside it. */}
               <CollapsibleSection
                 id="racsRegistration"
                 title="РАЦС"

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -18,7 +18,7 @@ import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFo
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderActionsRow } from './AdminPageHeader';
 import VariablePickerModal from './DocumentsVariablePickerModal';
 import DocumentsPdfPreview from './DocumentsPdfPreview';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -2405,7 +2405,9 @@ const DocumentsPage = ({ isAdmin }) => {
             <Eyebrow>Admin only</Eyebrow>
             <Title>Documents</Title>
           </div>
-          <HeaderRight>
+          <PageNavMenu />
+        </Header>
+        <HeaderActionsRow>
           <HeaderActions>
             <MiniButton type="button" onClick={loadDocumentsData} disabled={loading} title="Reload from the backend">
               <FaSyncAlt /> Reload
@@ -2417,9 +2419,7 @@ const DocumentsPage = ({ isAdmin }) => {
               <FaFilePdf /> {isGenerating ? 'Generating…' : 'PDF'}
             </PrimaryMiniButton>
           </HeaderActions>
-          <PageNavMenu />
-          </HeaderRight>
-        </Header>
+        </HeaderActionsRow>
 
         {loading ? <StateCard>Loading documents data…</StateCard> : null}
         {!loading && error ? <StateCard>{error}</StateCard> : null}

--- a/src/components/InvoiceBuilderPage.jsx
+++ b/src/components/InvoiceBuilderPage.jsx
@@ -24,7 +24,7 @@ import { formatEuroSmart, getItemDisplayAmount, getSortedPackages, isFromPricedI
 import { useAutoResize } from '../hooks/useAutoResize';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderActionsRow } from './AdminPageHeader';
 import {
   addCatalogChildToPackage,
   addCustomChildToPackage,
@@ -3614,7 +3614,9 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
             <Eyebrow>Admin only</Eyebrow>
             <Title>Invoice Builder</Title>
           </div>
-          <HeaderRight>
+          <PageNavMenu />
+        </Header>
+        <HeaderActionsRow>
           <HeaderActions>
             <input
               ref={fileInputRef}
@@ -3626,7 +3628,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
             {activeTab === 'invoice' ? (
               <>
                 <MiniButton type="button" onClick={handleUploadClick} title="Upload an invoice JSON to the backend (an expectedExpenses array of groups is picked up too)">
-                  <FaUpload /> Upload JSON
+                  <FaUpload /> Upload
                 </MiniButton>
                 <PrimaryMiniButton
                   type="button"
@@ -3634,14 +3636,12 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                   disabled={isGenerateDisabled}
                   title="Generate and download the invoice PDF"
                 >
-                  <FaFilePdf /> {isGenerating ? 'Generating…' : 'Generate PDF'}
+                  <FaFilePdf /> {isGenerating ? 'Generating…' : 'PDF'}
                 </PrimaryMiniButton>
               </>
             ) : null}
           </HeaderActions>
-          <PageNavMenu />
-          </HeaderRight>
-        </Header>
+        </HeaderActionsRow>
 
         {loading ? <StateCard>Loading invoice data…</StateCard> : null}
         {!loading && error ? <StateCard>{error}</StateCard> : null}
@@ -4346,7 +4346,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                     onClick={handleExpectedExpensesUploadClick}
                     title="Upload an expected-expenses JSON: { packageSnapshot, milestones } or an array of groups lined up with the package's schedule"
                   >
-                    <FaUpload /> Upload JSON
+                    <FaUpload /> Upload
                   </SmallButton>
                   {expectedExpenses ? (
                     <>
@@ -4363,7 +4363,7 @@ const InvoiceBuilderPage = ({ isAdmin = false }) => {
                           ? 'Waiting for the package price formula to resolve…'
                           : 'Generate the full payment-schedule forecast PDF'}
                       >
-                        <FaFilePdf /> {isGeneratingExpectedExpenses ? 'Generating…' : 'Generate PDF'}
+                        <FaFilePdf /> {isGeneratingExpectedExpenses ? 'Generating…' : 'PDF'}
                       </PrimaryMiniButton>
                       <DangerButton type="button" onClick={deleteExpectedExpensesPlan}><FaTrash /> Delete plan</DangerButton>
                     </>

--- a/src/components/InvoiceBuilderPage.test.js
+++ b/src/components/InvoiceBuilderPage.test.js
@@ -987,7 +987,7 @@ describe('InvoiceBuilderPage', () => {
 
       const heading = Array.from(container.querySelectorAll('h2')).find(h => h.textContent === 'Expected expenses');
       const panel = heading.closest('section');
-      const uploadButton = Array.from(panel.querySelectorAll('button')).find(btn => btn.textContent.includes('Upload JSON'));
+      const uploadButton = Array.from(panel.querySelectorAll('button')).find(btn => btn.textContent.includes('Upload'));
       const fileInput = panel.querySelector('input[type="file"]');
       expect(uploadButton).toBeTruthy();
       expect(fileInput).toBeTruthy();

--- a/src/components/PartiesPage.caseEditor.test.js
+++ b/src/components/PartiesPage.caseEditor.test.js
@@ -190,9 +190,13 @@ describe('spec: case editor РАЦС tab - childbirth/child data (batch 18 §6, 
     await openCaseOne();
     await screen.findByLabelText('Пологовий будинок');
 
+    // "Підготовка" now lives on its own tab, right after "Огляд" - see the racsPreparation move.
+    fireEvent.click(screen.getByRole('button', { name: 'Підготовка' }));
+    await screen.findByLabelText('Номер (укр)');
+
     fireEvent.change(screen.getByLabelText('Номер (укр)'), { target: { value: 'Д-1' } });
     // "Дата договору" also labels medicalServicesAgreement's own date field now that both sit in
-    // the same always-open "Підготовка" group (batch 29 §6) - surrogacyAgreement's copy is first.
+    // the same always-open "Підготовка" group - surrogacyAgreement's copy is first.
     fireEvent.change(screen.getAllByLabelText('Дата договору')[0], { target: { value: '2026-05-01' } });
     // Same reasoning as above - maritalStatusDeclaration/legalServicesDisclaimer also have their
     // own "Нотаріус" picker field in the same open group; surrogacyAgreement's is first.

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -13,7 +13,7 @@ import designTokens from '../data/designTokens.json';
 import { auth, database } from './config';
 import { isInvoiceBuilderUid } from 'utils/accessLevel';
 import PageNavMenu from './PageNavMenu';
-import { Header, HeaderActions, HeaderRight } from './AdminPageHeader';
+import { Header, HeaderActions, HeaderActionsRow } from './AdminPageHeader';
 import CaseEditor from './CaseEditor';
 import {
   DOCUMENTS_CASES_PATH,
@@ -928,17 +928,18 @@ const CaseReadView = ({ catalog, selectedCaseId, onSelectCase, onCreateCase }) =
       ) : (
         <StateCard style={{ marginTop: 10 }}>No cases yet - create one above to see its data here.</StateCard>
       )}
-      {selectedCase ? groups.map(group => (
+      {/* A group with nothing resolved for this case (e.g. no genetic-affinity-certificate data
+          yet) used to still render as an empty "No data" block - dropped entirely instead, same as
+          any other case where there's simply nothing to show. */}
+      {selectedCase ? groups.filter(group => group.items.length).map(group => (
         <ReadGroupBlock key={group.label}>
           <SectionSubhead>{group.label}</SectionSubhead>
-          {group.items.length
-            ? group.items.map(item => (
-              <ReadRow key={item.path}>
-                <ReadRowLabel>{item.path}</ReadRowLabel>
-                <ReadRowValue>{item.value}</ReadRowValue>
-              </ReadRow>
-            ))
-            : <CompactValue>No data</CompactValue>}
+          {group.items.map(item => (
+            <ReadRow key={item.path}>
+              <ReadRowLabel>{item.path}</ReadRowLabel>
+              <ReadRowValue>{item.value}</ReadRowValue>
+            </ReadRow>
+          ))}
         </ReadGroupBlock>
       )) : null}
     </Panel>
@@ -1118,15 +1119,15 @@ const PartiesPage = ({ isAdmin }) => {
             <Eyebrow>Admin only</Eyebrow>
             <Title>Parties</Title>
           </div>
-          <HeaderRight>
+          <PageNavMenu />
+        </Header>
+        <HeaderActionsRow>
           <HeaderActions>
             <MiniButton type="button" onClick={handleToggleEditMode} aria-pressed={isEditMode} title={isEditMode ? 'Switch to read mode' : 'Edit parties'}>
               <FaPen /> {isEditMode ? 'Read' : 'Edit'}
             </MiniButton>
           </HeaderActions>
-          <PageNavMenu />
-          </HeaderRight>
-        </Header>
+        </HeaderActionsRow>
 
         {loading ? (
           <StateCard>Loading…</StateCard>

--- a/src/components/PartiesPage.test.js
+++ b/src/components/PartiesPage.test.js
@@ -207,7 +207,9 @@ describe('spec: Parties page read/edit modes (batch 21 §10, Budget page pattern
     // No last-selected case was ever persisted, so it falls back to the only case in the catalog.
     expect(screen.getByText('Тестова Марія')).toBeInTheDocument();
     expect(screen.getByText('Дружина')).toBeInTheDocument();
-    expect(screen.getByText('Сурогатна мати')).toBeInTheDocument();
+    // This case never set a surrogateMotherId - a group with nothing resolved for it is dropped
+    // entirely rather than rendering as an empty "No data" block.
+    expect(screen.queryByText('Сурогатна мати')).not.toBeInTheDocument();
   });
 
   it('unlocks the full party directory (all records, all groups) only once switched into Edit mode', async () => {

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -1634,10 +1634,25 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
   const partners = toArray(couple?.partners);
   const rawWife = partners.find(partner => partner?.role === 'wife') || partners[0] || null;
   const rawHusband = partners.find(partner => partner?.role === 'husband') || partners[1] || null;
+  // The power of attorney (signing date + apostille date) is a static fact of *this case*, not of
+  // the representative person - the same representative can act under a different POA in another
+  // case, and one POA can cover several representatives at once, so a separate record per
+  // date/person pairing is no longer needed. relations.representativePowerOfAttorney is
+  // authoritative when set; a representative record's own (legacy) powerOfAttorney is only a
+  // fallback for cases that pre-date this split.
+  const casePowerOfAttorney = isPlainObject(relations.representativePowerOfAttorney) ? relations.representativePowerOfAttorney : {};
   const representatives = toArray(relations.representativeIds)
     .map(id => findById(catalog.parties.representatives, id))
     .filter(Boolean)
-    .map(enrichPersonName);
+    .map(record => enrichPersonName({
+      ...record,
+      powerOfAttorney: {
+        ...record.powerOfAttorney,
+        date: casePowerOfAttorney.date || record.powerOfAttorney?.date || '',
+        apostille: casePowerOfAttorney.apostille || record.powerOfAttorney?.apostille || '',
+        apostilleDate: casePowerOfAttorney.apostilleDate || record.powerOfAttorney?.apostilleDate || '',
+      },
+    }));
 
   const childbirth = isPlainObject(caseRecord.childbirth) ? caseRecord.childbirth : {};
   const rawChildren = toArray(childbirth.children);


### PR DESCRIPTION
- relations.representativePowerOfAttorney (date/apostilleDate) is now a
  static per-case fact, resolved onto every selected representative's
  template context - the same representative can act under a different POA
  on another case, and one POA can cover several representatives, so a
  representative record no longer needs a duplicate per person/date pairing.
  Falls back to the record's own legacy powerOfAttorney for older cases.
- Parties' Read-mode view no longer renders an empty "No data" block for a
  group with nothing resolved on the selected case - it's dropped entirely.
- The case editor's "Підготовка" group now has its own tab, right after
  "Огляд", instead of living inside "РАЦС".
- Documents/Invoice Builder/Budget/Parties: the page's action buttons
  (Export/Upload/Edit/...) now render on their own row below the title/⋮
  header instead of crowding next to it; "Export PDF"/"Generate PDF" ->
  "PDF" and "Upload JSON" -> "Upload" throughout, matching Documents'
  existing "PDF" label.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01599pQ32nZVfdHvJVjR3DSq