### PR TITLE
Show which request drove a grouped backend-traffic toast

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2740,9 +2740,10 @@ export const fetchNewUsersCollectionInRTDB = async (searchedValue, options = {})
     }
 
     // Broad date search intentionally checks several date fields. Do not run it for
-    // explicit EqualTo/searchKey requests: selected checkboxes must limit backend
-    // queries to only those selected keys.
-    const shouldRunBroadDateSearch = searchKey !== 'searchId' && !forceSearchKeyBucket && !forceEqualToAllCards;
+    // explicit EqualTo/searchKey/partialUserId requests: selected checkboxes must limit
+    // backend queries to only those selected keys.
+    const shouldRunBroadDateSearch =
+      searchKey !== 'searchId' && !forceSearchKeyBucket && !forceEqualToAllCards && !forcePartialUserIdSearch;
     const isDateSearch = shouldRunBroadDateSearch
       ? await searchByDate(searchValue, uniqueUserIds, users)
       : false;

--- a/src/utils/__tests__/backendDownloadToast.test.js
+++ b/src/utils/__tests__/backendDownloadToast.test.js
@@ -71,6 +71,27 @@ describe('backendDownloadToast admin traffic tracker', () => {
     expect(toast.success).toHaveBeenCalled();
   });
 
+  it('names the heaviest request in a grouped toast so a big payload is not a mystery', () => {
+    const { tracker, toast } = loadTracker();
+    window.__getBackendDownloadToastUid = () => ADMIN_UID;
+
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ id: 1 }) },
+      { operation: 'get', source: 'config', path: 'newUsers/TG0009' },
+    );
+    tracker.recordAdminBackendTraffic(
+      { exists: () => true, val: () => ({ bio: 'x'.repeat(5000) }) },
+      { operation: 'get', source: 'config', path: 'users/TG0009' },
+    );
+    jest.advanceTimersByTime(1000);
+
+    expect(toast.success).toHaveBeenCalledTimes(1);
+    const [message] = toast.success.mock.calls[0];
+    expect(message).toContain('2 tracked');
+    expect(message).toContain('users/TG0009');
+    expect(message).toContain('%');
+  });
+
   it('collects stats while silent mode suppresses toast output', () => {
     const { tracker, toast } = loadTracker();
     window.__getBackendDownloadToastUid = () => ADMIN_UID;

--- a/src/utils/backendDownloadToast.js
+++ b/src/utils/backendDownloadToast.js
@@ -447,15 +447,31 @@ const shouldEstimateAndToast = (runtime, request) => {
 
 const isSilentMode = () => !getBackendDownloadToastsEnabled();
 
+const HEAVY_CONTRIBUTOR_SHARE = 0.6;
+
+const describeHeaviestContributor = batch => {
+  const heaviest = batch.maxRequest;
+  if (!heaviest || heaviest.bytes <= 0) return '';
+
+  const share = batch.bytes > 0 ? heaviest.bytes / batch.bytes : 0;
+  const shareLabel = share >= HEAVY_CONTRIBUTOR_SHARE
+    ? ` (${Math.round(share * 100)}% пакету)`
+    : '';
+  return ` · найважчий: ${heaviest.operation} ${heaviest.path} — ${formatBytes(heaviest.bytes)}${shareLabel}`;
+};
+
 const scheduleToast = request => {
   if (isSilentMode()) return;
   const runtime = getRuntime();
-  runtime.pendingToast = runtime.pendingToast || { bytes: 0, requests: 0, sources: new Set(), operations: new Set(), lastRequest: null, maxSeverity: 'normal' };
+  runtime.pendingToast = runtime.pendingToast || { bytes: 0, requests: 0, sources: new Set(), operations: new Set(), lastRequest: null, maxRequest: null, maxSeverity: 'normal' };
   runtime.pendingToast.bytes += request.bytes;
   runtime.pendingToast.requests += 1;
   if (request.source) runtime.pendingToast.sources.add(request.source);
   runtime.pendingToast.operations.add(request.operation);
   runtime.pendingToast.lastRequest = request;
+  if (!runtime.pendingToast.maxRequest || request.bytes > runtime.pendingToast.maxRequest.bytes) {
+    runtime.pendingToast.maxRequest = request;
+  }
   const severity = getSeverity(request.bytes);
   if (severity === 'critical' || (severity === 'warning' && runtime.pendingToast.maxSeverity === 'normal')) {
     runtime.pendingToast.maxSeverity = severity;
@@ -475,7 +491,7 @@ const scheduleToast = request => {
       .join(' ');
     const message = isSingleRequest
       ? makeMessage(batch.lastRequest)
-      : `Backend traffic${groupedContext ? ` ${groupedContext}` : ''}: ${formatBytes(batch.bytes)} (${batch.requests} tracked / sampled requests)`;
+      : `Backend traffic${groupedContext ? ` ${groupedContext}` : ''}: ${formatBytes(batch.bytes)} (${batch.requests} tracked / sampled requests)${describeHeaviestContributor(batch)}`;
     const toastFn = batch.maxSeverity === 'critical' ? toast.error : batch.maxSeverity === 'warning' ? toast : toast.success;
     toastFn(message, { duration: TOAST_DURATION_MS, icon: batch.maxSeverity === 'normal' ? '📦' : '⚠️' });
   }, TOAST_GROUP_DELAY_MS);


### PR DESCRIPTION
## Summary
- Grouped "Backend traffic" toasts (multiple Firebase reads batched within 750ms) only showed a combined byte total and a list of operation names, with no way to tell whether a large number came from one genuinely big record or a fan-out across many small ones. The toast now names the heaviest single request in the batch (operation, path, size, and its share of the total), so a report like "350 KB, 6 requests" is actionable instead of a mystery.
- Closes a real checkbox-bypass gap found while investigating the 350KB reports: the broad date-field search in `fetchNewUsersCollectionInRTDB` (`config.js`) ran regardless of the `userId (частковий збіг)` checkbox whenever the query text happened to look like a date, contrary to its own comment that selected checkboxes must limit backend queries. It's now skipped for forced partial-userId searches, the same way it was already skipped for searchId/searchKey/equalTo.

## Test plan
- [x] `npx react-scripts test --watchAll=false src/utils/__tests__/backendDownloadToast.test.js` — new test asserts the grouped toast message names the heaviest request and its share of the batch
- [x] Full test suite (`npx react-scripts test --watchAll=false`) — same pre-existing unrelated failures as on `main`, no new regressions
- [x] `npx eslint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017z1Nj8Eha41eHqHLRVFCCM

---
_Generated by [Claude Code](https://claude.ai/code/session_017z1Nj8Eha41eHqHLRVFCCM)_