### PR TITLE
Add bulk migration of long-userId cards from newUsers into users

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -41,6 +41,7 @@ import {
   fetchUsersByIds,
   lazyLoadProfilePhotos,
   migrateAllLegacyCardComments,
+  migrateAllLongUserIdCardsFromNewUsers,
 } from './config';
 import { fetchUsersBySearchKeyGitNewPaged } from './gitNewLoad';
 import {
@@ -6158,6 +6159,41 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     }
   };
 
+  const handleMigrateAllLongUserIdCardsFromNewUsers = async () => {
+    if (!isAdmin) return;
+    if (
+      !window.confirm(
+        'Це перенесе всі картки з довгим userId (реальні акаунти) з newUsers у users, ' +
+          'доповнивши дані там, де їх ще бракує, і повністю прибере ці картки з newUsers. ' +
+          'Дію неможливо скасувати вручну. Продовжити?',
+      )
+    ) {
+      return;
+    }
+
+    const toastId = 'migrate-long-userid-cards-progress';
+    toast.loading('Міграція карток...', { id: toastId });
+    try {
+      const report = await migrateAllLongUserIdCardsFromNewUsers({
+        onProgress: percent => toast.loading(`Міграція карток... ${percent}%`, { id: toastId }),
+      });
+      if (report.migratedCards) {
+        clearAllCardsCache();
+      }
+      toast.success(
+        `Мігровано карток: ${report.migratedCards}` +
+          (report.errors.length ? `, не вдалося перенести: ${report.errors.length}` : ''),
+        { id: toastId },
+      );
+      if (report.errors.length) {
+        console.error('[AddNewProfile] Cards left in newUsers after migration', report.errors);
+      }
+    } catch (error) {
+      console.error('[AddNewProfile] Long-userId card migration failed', error);
+      toast.error(`Помилка міграції карток: ${error?.message || 'невідома помилка'}`, { id: toastId });
+    }
+  };
+
   useEffect(() => {
     if (!searchIdAndSearchKeyOnlyMode) {
       setShowSearchKeyIndexPanel(false);
@@ -7168,6 +7204,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
                   title="Перенести всі старі коментарі карток у multiData/comments"
                 >
                   Мігрувати коментарі
+                </Button>
+              )}
+              {isAdmin && (
+                <Button
+                  onClick={handleMigrateAllLongUserIdCardsFromNewUsers}
+                  title="Перенести всі картки з довгим userId з newUsers у users"
+                >
+                  Мігрувати картки
                 </Button>
               )}
               {<Button onClick={searchDuplicates} {...createLongPressHandlers('Шукає дублікати карток')}>DPL</Button>}

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2945,6 +2945,59 @@ const migrateLongUserIdCardFromNewUsers = async (userId, writtenFields) => {
   }
 };
 
+// Одноразова адмінська операція-аналог migrateAllLegacyCardComments вище, але
+// для самих карток: наздоганяє всі картки з довгим userId (реальний Firebase
+// Auth акаунт), які досі мають "хвіст" у newUsers, але довго не редагувались —
+// а тому жодного разу не пройшли через лінивий per-save sweep
+// (migrateLongUserIdCardFromNewUsers, застосовується автоматично лише під час
+// збереження картки в updateDataInRealtimeDB). Переносить (не перезаписуючи
+// вже підтверджені в users значення) кожне поле, що лишилось тільки в
+// newUsers, і прибирає застарілий дублікат картки з newUsers — так само, як і
+// при звичайному редагуванні. В кінці перевіряє, що жодної картки з довгим
+// userId не лишилось у newUsers ("сміття"), і повертає їх список в errors,
+// якщо щось не вдалося перенести.
+export const migrateAllLongUserIdCardsFromNewUsers = async ({ onProgress } = {}) => {
+  const user = auth.currentUser;
+  if (!user) throw new Error('User not authenticated');
+
+  const newUsersSnap = await get(ref2(database, 'newUsers'));
+  const newUsersData = newUsersSnap.val() || {};
+  const longUserIds = Object.keys(newUsersData).filter(id => String(id || '').length > 20);
+
+  const report = {
+    scannedNewUsers: Object.keys(newUsersData).length,
+    longUserIdCandidates: longUserIds.length,
+    migratedCards: 0,
+    migratedCardIds: [],
+    errors: [],
+  };
+  if (!longUserIds.length) return report;
+
+  for (let i = 0; i < longUserIds.length; i += 1) {
+    const userId = longUserIds[i];
+    // eslint-disable-next-line no-await-in-loop
+    await migrateLongUserIdCardFromNewUsers(userId, {});
+    report.migratedCards += 1;
+    report.migratedCardIds.push(userId);
+    onProgress?.(Math.round(((i + 1) / longUserIds.length) * 100));
+  }
+
+  // migrateLongUserIdCardFromNewUsers навмисно ковтає власні помилки (щоб
+  // цей sweep ніколи не валив збереження картки під час звичайного
+  // редагування), тож перевіряємо результат окремим фінальним читанням: якщо
+  // після проходу картка з довгим userId досі лежить у newUsers — щось не
+  // перенеслось, і про це має дізнатись адмін, а не мовчки лишити сміття.
+  const verifySnap = await get(ref2(database, 'newUsers'));
+  const verifyData = verifySnap.val() || {};
+  Object.keys(verifyData)
+    .filter(id => String(id || '').length > 20)
+    .forEach(cardId => {
+      report.errors.push({ cardId, message: 'Картка досі лишається в newUsers після міграції' });
+    });
+
+  return report;
+};
+
 export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) => {
   try {
     const userRefRTDB = ref2(database, `users/${userId}`);

--- a/src/components/config.migrateAllLongUserIdCardsFromNewUsers.test.js
+++ b/src/components/config.migrateAllLongUserIdCardsFromNewUsers.test.js
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('bulk migration of every long-userId card from newUsers into users', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+
+  const fnBody = source.slice(
+    source.indexOf('export const migrateAllLongUserIdCardsFromNewUsers'),
+    source.indexOf('export const updateDataInRealtimeDB')
+  );
+
+  it('exists and reads the newUsers root wholesale, without querying helpers', () => {
+    expect(fnBody).toBeTruthy();
+    expect(fnBody).toContain("get(ref2(database, 'newUsers'))");
+    expect(fnBody).not.toContain('orderByChild');
+    expect(fnBody).not.toContain('equalTo');
+  });
+
+  it('only targets cards whose newUsers key (userId) is long, i.e. backed by a real account', () => {
+    expect(fnBody).toContain("String(id || '').length > 20");
+  });
+
+  it('reuses the same per-card merge/cleanup logic as the per-save sweep instead of duplicating it', () => {
+    expect(fnBody).toContain('await migrateLongUserIdCardFromNewUsers(userId, {});');
+  });
+
+  it('never transacts on the database root', () => {
+    expect(fnBody).not.toContain('runTransaction(');
+  });
+
+  it('reports progress so the UI can show percent complete', () => {
+    expect(fnBody).toContain('onProgress?.(');
+  });
+
+  it('verifies afterwards that no long-userId card is left behind in newUsers', () => {
+    const verifyBody = fnBody.slice(fnBody.indexOf('const verifySnap'));
+    expect(verifyBody).toContain("get(ref2(database, 'newUsers'))");
+    expect(verifyBody).toContain("String(id || '').length > 20");
+    expect(verifyBody).toContain('report.errors.push(');
+  });
+
+  it('collects migrated card ids and counts', () => {
+    expect(fnBody).toContain('report.migratedCards += 1;');
+    expect(fnBody).toContain('report.migratedCardIds.push(userId);');
+  });
+});


### PR DESCRIPTION
Extends the existing comment-migration pattern (migrateAllLegacyCardComments)
with an admin-triggered one-off sweep, migrateAllLongUserIdCardsFromNewUsers,
that catches every newUsers card whose key length is >20 chars (a real
Firebase Auth account) regardless of whether it's ever been edited again.

It reuses the exact per-card merge/cleanup logic already used by the per-save
migrateLongUserIdCardFromNewUsers trigger: any field missing in users gets
backfilled from newUsers, existing users data always wins, and the stale
newUsers record is removed once fully migrated. A final verification read
reports any long-userId card still left in newUsers so nothing is silently
lost or left behind.

Wired to an admin-only "Мігрувати картки" button in AddNewProfile.jsx next to
the existing comment migration button.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YZFwuF3j5jXuijMGesdNhi