### PR TITLE
Fix stale newUsers node left behind after long-userId card migration

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2923,14 +2923,20 @@ const migrateLongUserIdCardFromNewUsers = async (userId, writtenFields) => {
       updates[`newUsers/${userId}/${field}`] = null;
     });
 
-    // userId (і будь-які клієнтські технічні ключі) ніколи не потрапляють у
-    // updates вище, тож саме вони й лишаться в newUsers після застосування
-    // цих правок. Якщо це буде єдине, що лишилось — картка вже повністю
-    // мігрована, і сам вузол newUsers/{userId} більше не потрібен.
+    // userId (і будь-які клієнтські технічні ключі, зокрема вже мігроване
+    // myComment) ніколи не потрапляють у updates вище — forEach їх свідомо
+    // пропускає, тож самі по собі вони НІКОЛИ не будуть ані перенесені, ані
+    // обнулені. Якщо саме з таких ключів (і тільки з них) і складається весь
+    // вузол — тобто leftoverKeys покриває всі ключі newUsersData без
+    // залишку — картка вже повністю мігрована й у ній не лишилось жодних
+    // значущих даних, тож сам вузол newUsers/{userId} більше не потрібен.
+    // Порівнювати з literal ['userId'] тут не можна: картка нерідко має ще й
+    // 'myComment' (чи інший транзитний ключ) поруч з userId, і тоді
+    // leftoverKeys.length буде 2+, а не 1 — але вузол все одно порожній по суті.
     const leftoverKeys = Object.keys(newUsersData).filter(
       field => field === 'userId' || transientUserDataKeys.includes(field)
     );
-    const onlyUserIdWouldRemain = leftoverKeys.length === 1 && leftoverKeys[0] === 'userId';
+    const onlyUserIdWouldRemain = leftoverKeys.length === Object.keys(newUsersData).length;
 
     if (onlyUserIdWouldRemain) {
       await update(ref2(database), { [`newUsers/${userId}`]: null });

--- a/src/components/config.pruneNewUsersOnMigration.test.js
+++ b/src/components/config.pruneNewUsersOnMigration.test.js
@@ -58,13 +58,18 @@ describe('every long-userId card save migrates the whole stale newUsers record i
     expect(migrateFnBody).toContain('transientUserDataKeys.includes(field)');
   });
 
-  it('deletes the whole newUsers/{userId} node once userId is all that would be left', () => {
+  it('deletes the whole newUsers/{userId} node once only userId/transient keys would be left, however many of them there are', () => {
     expect(migrateFnBody).toContain(
       "const leftoverKeys = Object.keys(newUsersData).filter("
     );
     expect(migrateFnBody).toContain(
-      "const onlyUserIdWouldRemain = leftoverKeys.length === 1 && leftoverKeys[0] === 'userId';"
+      "const onlyUserIdWouldRemain = leftoverKeys.length === Object.keys(newUsersData).length;"
     );
+    // Must NOT regress to comparing against a literal ['userId'] array: a card
+    // can have userId *and* a transient key like myComment side by side, and
+    // both are still fully ignorable (never migrated or nulled by the forEach
+    // above), so the whole-node delete must fire for that combination too.
+    expect(migrateFnBody).not.toContain("leftoverKeys.length === 1 && leftoverKeys[0] === 'userId'");
     expect(migrateFnBody).toContain("await update(ref2(database), { [`newUsers/${userId}`]: null });");
 
     const wholeNodeDeleteIndex = migrateFnBody.indexOf('onlyUserIdWouldRemain');


### PR DESCRIPTION
## Summary
- The bulk "Мігрувати картки" migration (merged in #2885) reported cards as un-migratable when their `newUsers/{userId}` node had `userId` sitting next to a transient key like `myComment` (e.g. `{ myComment: "", userId: "..." }`).
- Root cause: `migrateLongUserIdCardFromNewUsers` only deleted the whole stale node when the leftover keys were literally `['userId']` (length 1), but `myComment` is also skipped by the per-field sweep (it's in `transientUserDataKeys`), so a node with both keys never got cleaned up — it silently stayed in `newUsers` forever.
- Fix: delete the whole node whenever *every* remaining key is ignorable (`userId` or a transient key), regardless of how many there are, instead of requiring an exact single-key match.
- Updated `config.pruneNewUsersOnMigration.test.js` to assert the corrected condition and guard against regressing to the old literal-array comparison.

## Test plan
- [x] `react-scripts test src/components/config.pruneNewUsersOnMigration.test.js src/components/config.migrateAllLongUserIdCardsFromNewUsers.test.js src/components/config.migrateAllLegacyCardComments.test.js` — all pass
- [ ] Re-run "Мігрувати картки" on production after deploy and confirm the previously-stuck cards (userId + empty/whitespace `myComment`) are now removed from `newUsers`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZFwuF3j5jXuijMGesdNhi)_