### PR TITLE
Preserve newUsers data during card migration

### DIFF
--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2908,7 +2908,21 @@ const migrateLongUserIdCardFromNewUsers = async (userId, writtenFields) => {
 
     const updates = {};
     Object.keys(newUsersData).forEach(field => {
-      if (!field || field === 'userId' || transientUserDataKeys.includes(field)) return;
+      if (!field) return;
+
+      // A non-empty legacy comment is still the only source of truth until the
+      // independently run comment migration copies it to multiData/comments.
+      // Keep it visible to that migration instead of treating it as disposable
+      // client metadata.
+      if (field === 'myComment' && String(newUsersData[field] || '').trim()) return;
+
+      if (field === 'userId' || transientUserDataKeys.includes(field)) {
+        // Delete only children present in the snapshot. Deleting the parent
+        // node would also erase profile fields concurrently written after the
+        // reads above (for example by persistUserWithFallback).
+        updates[`newUsers/${userId}/${field}`] = null;
+        return;
+      }
 
       const confirmedInUsers = Object.prototype.hasOwnProperty.call(usersData, field);
       const explicitlyDeletedNow = Object.prototype.hasOwnProperty.call(fieldValues, field)
@@ -2923,20 +2937,9 @@ const migrateLongUserIdCardFromNewUsers = async (userId, writtenFields) => {
       updates[`newUsers/${userId}/${field}`] = null;
     });
 
-    // userId (і будь-які клієнтські технічні ключі) ніколи не потрапляють у
-    // updates вище, тож саме вони й лишаться в newUsers після застосування
-    // цих правок. Якщо це буде єдине, що лишилось — картка вже повністю
-    // мігрована, і сам вузол newUsers/{userId} більше не потрібен.
-    const leftoverKeys = Object.keys(newUsersData).filter(
-      field => field === 'userId' || transientUserDataKeys.includes(field)
-    );
-    const onlyUserIdWouldRemain = leftoverKeys.length === 1 && leftoverKeys[0] === 'userId';
-
-    if (onlyUserIdWouldRemain) {
-      await update(ref2(database), { [`newUsers/${userId}`]: null });
-      return;
-    }
-
+    // The same atomic update removes every observed child after meaningful
+    // fields have been copied. RTDB removes the parent automatically when no
+    // children remain, while an unmigrated comment or a concurrent write stays.
     if (Object.keys(updates).length > 0) {
       await update(ref2(database), updates);
     }

--- a/src/components/config.pruneNewUsersOnMigration.test.js
+++ b/src/components/config.pruneNewUsersOnMigration.test.js
@@ -53,23 +53,21 @@ describe('every long-userId card save migrates the whole stale newUsers record i
     expect(migrateFnBody).not.toMatch(/catch \(error\) \{\s*console\.error\([^)]*\);\s*throw error;/);
   });
 
-  it('excludes userId and transient client-only keys from the migration sweep', () => {
+  it('removes observed userId and transient client-only keys as child updates', () => {
     expect(migrateFnBody).toContain("field === 'userId'");
     expect(migrateFnBody).toContain('transientUserDataKeys.includes(field)');
+    expect(migrateFnBody).toContain('updates[`newUsers/${userId}/${field}`] = null;');
   });
 
-  it('deletes the whole newUsers/{userId} node once userId is all that would be left', () => {
-    expect(migrateFnBody).toContain(
-      "const leftoverKeys = Object.keys(newUsersData).filter("
-    );
-    expect(migrateFnBody).toContain(
-      "const onlyUserIdWouldRemain = leftoverKeys.length === 1 && leftoverKeys[0] === 'userId';"
-    );
-    expect(migrateFnBody).toContain("await update(ref2(database), { [`newUsers/${userId}`]: null });");
+  it('never deletes the whole node, so fields written after the snapshot survive', () => {
+    expect(migrateFnBody).not.toContain("updates[`newUsers/${userId}`] = null");
+    expect(migrateFnBody).not.toContain("{ [`newUsers/${userId}`]: null }");
+    expect(migrateFnBody).toContain('await update(ref2(database), updates);');
+  });
 
-    const wholeNodeDeleteIndex = migrateFnBody.indexOf('onlyUserIdWouldRemain');
-    const perFieldUpdateIndex = migrateFnBody.indexOf('if (Object.keys(updates).length > 0)');
-    expect(wholeNodeDeleteIndex).toBeGreaterThan(-1);
-    expect(perFieldUpdateIndex).toBeGreaterThan(wholeNodeDeleteIndex);
+  it('preserves a non-empty legacy comment for the independent comment migration', () => {
+    expect(migrateFnBody).toContain(
+      "if (field === 'myComment' && String(newUsersData[field] || '').trim()) return;"
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Avoid losing an unmigrated per-admin `myComment` when admins run the generic card migration before the dedicated comment migration. 
- Prevent erasing profile fields written concurrently after the migration read by the admin sweep. 
- Ensure the migration reports and one-pass sweep behavior remain correct by removing only observed children rather than aggressively deleting parent nodes.

### Description
- In `migrateLongUserIdCardFromNewUsers` the per-field loop now skips non-empty `myComment` so legacy comments remain available for the independent comment migration. 
- Replace whole-node deletion logic with explicit child deletions: `userId` and other transient keys are removed as `updates['newUsers/${userId}/${field}'] = null` and meaningful fields are copied to `users/${userId}/${field}` when needed. 
- Remove the `leftoverKeys` / `onlyUserIdWouldRemain` whole-node deletion branch and rely on the same atomic multi-path `update(ref2(database), updates)` so RTDB prunes empty parents while preserving concurrent writes. 
- Updated regression tests in `src/components/config.pruneNewUsersOnMigration.test.js` to assert child-level removals, to prohibit whole-node deletion, and to ensure `myComment` preservation for migration.

### Testing
- Ran the targeted test suites with `CI=true npm test -- --watchAll=false src/components/config.pruneNewUsersOnMigration.test.js src/components/config.migrateAllLongUserIdCardsFromNewUsers.test.js src/components/config.myCommentMigration.test.js` and all 3 suites (25 tests) passed. 
- Linted with `npx eslint src/components/config.js src/components/config.pruneNewUsersOnMigration.test.js` which completed with warnings but no errors. 
- Verified `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f3e2bd41c8326b735263c0e5042ce)