### PR TITLE
Fix Parties/Documents builder issues: POA fields, layout controls, conditional clauses, fieldLine editor

### DIFF
--- a/src/components/DocumentsPage.fieldLine.test.js
+++ b/src/components/DocumentsPage.fieldLine.test.js
@@ -1,0 +1,164 @@
+// Real-DOM regression test: a layoutV2 `fieldLine` block (label + underlined value + caption, e.g.
+// "дружина ___ КАЦУРА ЮКАКО, ... р.н.,") used to have no editor at all - the Blocks loop only ever
+// recognized letterhead/paragraph/richParagraph, so a fieldLine's `value` (its only templated
+// content) silently never showed up in the builder even though it printed in the real PDF/DOCX (a
+// case in point: the surrogate mother's own name/birth-date line on the genetic affinity
+// certificate). This locks in the plain value/label editor added for it.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  render, screen, fireEvent, waitFor, within,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('firebase/database', () => ({
+  ref: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'test-admin' } },
+  database: {},
+  deleteStorageFile: jest.fn(),
+  getStorageFileDataUrl: jest.fn(),
+  listStorageFolderFileNames: jest.fn(),
+  uploadFileToStorageFolder: jest.fn(),
+}));
+
+jest.mock('utils/accessLevel', () => ({ isInvoiceBuilderUid: () => true }));
+jest.mock('utils/pdfImageEncoding', () => ({ reencodePdfImageDataUrl: jest.fn() }));
+
+// eslint-disable-next-line import/first
+import { ref, get, set } from 'firebase/database';
+// eslint-disable-next-line import/first
+import { listStorageFolderFileNames } from './config';
+// eslint-disable-next-line import/first
+import DocumentsPage from './DocumentsPage';
+
+beforeEach(() => {
+  ref.mockImplementation((_db, path) => path);
+  get.mockImplementation(async path => {
+    if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+    if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+    if (path === 'documentsBuilder/templates') {
+      return {
+        exists: () => true,
+        val: () => ({
+          'doc-1': {
+            id: 'doc-1',
+            catalogName: 'Genetic affinity certificate',
+            rendererVersion: 2,
+            languages: ['uk'],
+            layoutV2: {
+              contentWidthMm: 180,
+              blocks: [
+                {
+                  type: 'fieldLine',
+                  style: 'body',
+                  label: 'дружина',
+                  value: '{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,',
+                  caption: '(прізвище, ім’я, по батькові, рік народження)',
+                },
+                {
+                  type: 'fieldLine',
+                  style: 'body',
+                  value: '{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,',
+                  caption: '(прізвище, ім’я, по батькові, рік народження)',
+                },
+              ],
+            },
+          },
+        }),
+      };
+    }
+    return { exists: () => false, val: () => null };
+  });
+  set.mockResolvedValue(undefined);
+  listStorageFolderFileNames.mockResolvedValue([]);
+});
+
+describe('spec: a layoutV2 fieldLine block gets a plain label/value editor', () => {
+  it('shows the current label and value, and has no label field at all for a fieldLine with none', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    expect(await screen.findByDisplayValue('дружина')).toBeInTheDocument();
+    const values = await screen.findAllByDisplayValue(/р\.н\.,$/);
+    expect(values).toHaveLength(2);
+    expect(values[0]).toHaveValue('{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,');
+    expect(values[1]).toHaveValue('{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,');
+
+    // Only one label field exists (the surrogate mother's fieldLine carries no `label` key at all).
+    expect(screen.getAllByPlaceholderText(/Label before the underlined value/)).toHaveLength(1);
+  });
+
+  it('editing the value persists straight to layoutV2.blocks[index].value on blur', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const surrogateValueField = await screen.findByDisplayValue('{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,');
+    fireEvent.change(surrogateValueField, { target: { value: '{{surrogateMother.name.uk.nominative}}' } });
+    fireEvent.blur(surrogateValueField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ label: 'дружина' }),
+            expect.objectContaining({ value: '{{surrogateMother.name.uk.nominative}}' }),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('editing the label persists straight to layoutV2.blocks[index].label on blur', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const labelField = await screen.findByDisplayValue('дружина');
+    fireEvent.change(labelField, { target: { value: 'та дружина' } });
+    fireEvent.blur(labelField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ label: 'та дружина' }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('the field-line settings popover exposes a condition field, same as a paragraph block', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const labelField = await screen.findByDisplayValue('дружина');
+    // eslint-disable-next-line testing-library/no-node-access
+    const block = labelField.closest('.paragraph-editor-block');
+    fireEvent.click(within(block).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown'));
+
+    const conditionField = await screen.findByLabelText('Condition (context path, ! to negate; empty = always shown)');
+    fireEvent.change(conditionField, { target: { value: 'geneticAffinityCertificate.oocyteSourceIsWife' } });
+    fireEvent.blur(conditionField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ condition: 'geneticAffinityCertificate.oocyteSourceIsWife' }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+  });
+});

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -11,7 +11,7 @@ import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
 import { get, ref, set, update } from 'firebase/database';
-import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaCog, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaMagic, FaPlus, FaSearch, FaSlidersH, FaSyncAlt, FaTrash, FaUpload } from 'react-icons/fa';
+import { FaAlignCenter, FaAlignJustify, FaAlignLeft, FaAlignRight, FaBold, FaChevronDown, FaChevronUp, FaCode, FaCog, FaFilePdf, FaFileWord, FaHeart, FaItalic, FaLink, FaMagic, FaPlus, FaSearch, FaSlidersH, FaSyncAlt, FaTrash, FaUnlink, FaUpload } from 'react-icons/fa';
 import { saveAs } from 'file-saver';
 import designTokens from '../data/designTokens.json';
 import { auth, database, deleteStorageFile, getStorageFileDataUrl, listStorageFolderFileNames, uploadFileToStorageFolder } from './config';
@@ -1483,6 +1483,19 @@ const DocumentsPage = ({ isAdmin }) => {
     );
   };
 
+  // A paragraph tagged `joinWithPrevious` prints as a straight continuation of whatever paragraph
+  // precedes it - no line break, no first-line indent, no forced capital first letter
+  // (buildGeneratedDocument/groupJoinedParagraphs, documentsCatalogUtils) - instead of always
+  // starting a new indented paragraph. Lets a paragraph whose only reason to be its own array entry
+  // is a `condition` (a mid-sentence clause, e.g. "та генетичною матір'ю ...") still read as one
+  // continuous sentence whether or not that clause itself is shown.
+  const handleToggleParagraphJoinPrevious = (docId, atIndex) => applyParagraphStructureChange(
+    docId,
+    paragraphs => paragraphs.map((paragraph, index) => (
+      index === atIndex ? { ...paragraph, joinWithPrevious: !paragraph.joinWithPrevious } : paragraph
+    )),
+  );
+
   // beforeTitle blocks have no per-case override to reindex (see getTemplateScopeText) - insert/
   // remove is a direct template write, persisted immediately like the paragraph structure edits
   // above, just without applyParagraphStructureChange's override-shifting.
@@ -1756,6 +1769,27 @@ const DocumentsPage = ({ isAdmin }) => {
   // nothing for a blank/unmatched source).
   const setLayoutV2LogoSource = (docId, blockIndex, columnIndex, value) => applyLayoutV2ImageContentChange(
     docId, blockIndex, columnIndex, content => ({ ...content, source: value }),
+  );
+
+  // A fieldLine block (label + underlined value + caption, e.g. "дружина ___ КАЦУРА ЮКАКО, ...
+  // р.н.,") had no editor at all - the Blocks loop below only ever recognized
+  // letterhead/paragraph/richParagraph, so a fieldLine's `value` (its only templated content, e.g.
+  // the surrogate mother's own name/birth-date line) silently never showed up here even though it
+  // prints in the real document. Plain direct-value editing (no rich-run toolbar, no mode cycle) is
+  // enough - every fieldLine value in the reference templates is a flat {{}}-only string, the same
+  // shape the Logo field already edits this way (handleLogoFieldChange).
+  const setLayoutV2FieldLineValue = (docId, blockIndex, value) => applyLayoutV2BlocksChange(
+    docId,
+    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, value } : item)),
+  );
+
+  // The label sits to the left of the underlined value (e.g. "дружина", "та чоловік") - present on
+  // some fieldLine blocks, absent on others (the surrogate mother's own line has none, see the
+  // fixture template). Only ever a plain string in every reference template (never `labelRuns`,
+  // the richer alternative), so a plain field covers it the same way.
+  const setLayoutV2FieldLineLabel = (docId, blockIndex, value) => applyLayoutV2BlocksChange(
+    docId,
+    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, label: value } : item)),
   );
 
   const setLayoutV2LogoOffset = (docId, blockIndex, columnIndex, axisKey, raw) => {
@@ -3143,6 +3177,16 @@ const DocumentsPage = ({ isAdmin }) => {
                                     align={getEffectiveParagraphAlign(paragraph)}
                                     onCycle={() => handleCycleAlign(template.id, scope)}
                                   />
+                                  <SmallButton
+                                    type="button"
+                                    disabled={index === 0}
+                                    onClick={() => handleToggleParagraphJoinPrevious(template.id, index)}
+                                    title={paragraph?.joinWithPrevious
+                                      ? 'Continues the previous paragraph, no line break/indent. Tap to split into its own paragraph again.'
+                                      : 'Continue the previous paragraph instead of starting a new one (no line break/indent) - for a conditional clause mid-sentence.'}
+                                  >
+                                    {paragraph?.joinWithPrevious ? <FaLink /> : <FaUnlink />}
+                                  </SmallButton>
                                   <FormatPopoverButton
                                     open={openFormatKey === formatPopoverKey(template.id, scope)}
                                     onToggle={() => toggleFormatPopover(template.id, scope)}
@@ -3351,6 +3395,80 @@ const DocumentsPage = ({ isAdmin }) => {
                                     </ParagraphEditorBlock>
                                   );
                                 });
+                              }
+                              if (block?.type === 'fieldLine') {
+                                const scope = layoutV2Scope(blockIndex);
+                                return (
+                                  // eslint-disable-next-line react/no-array-index-key
+                                  <ParagraphEditorBlock key={`${template.id}-lv2-fieldline-${blockIndex}`}>
+                                    <ParagraphControlsRow>
+                                      <SmallButton
+                                        type="button"
+                                        onClick={() => handleInsertLayoutV2Paragraph(template.id, blockIndex)}
+                                        title="Insert a new paragraph above this one"
+                                      >
+                                        <FaPlus />
+                                      </SmallButton>
+                                      <RowLine style={{ gap: 6 }}>
+                                        <FormatPopoverButton
+                                          open={openFormatKey === formatPopoverKey(template.id, scope)}
+                                          onToggle={() => toggleFormatPopover(template.id, scope)}
+                                          onClose={() => closeFormatPopover(template.id)}
+                                          buttonTitle="Field line formatting - font size (pt) and condition; empty = inherit/always shown"
+                                          fields={[
+                                            {
+                                              key: 'fontSizePt',
+                                              label: 'Font size (pt)',
+                                              value: block.styleOverrides?.fontSizePt !== undefined ? String(block.styleOverrides.fontSizePt) : '',
+                                              placeholder: '',
+                                              onApply: raw => setLayoutV2StyleOverrideField(template.id, blockIndex, 'fontSizePt', raw),
+                                              onFieldBlur: () => persistTemplate(template.id),
+                                            },
+                                            {
+                                              key: 'condition',
+                                              type: 'text',
+                                              label: 'Condition (context path, ! to negate; empty = always shown)',
+                                              value: block.condition || '',
+                                              placeholder: 'e.g. geneticAffinityCertificate.oocyteSourceIsWife',
+                                              onApply: raw => setLayoutV2BlockCondition(template.id, blockIndex, raw),
+                                              onFieldBlur: () => persistTemplate(template.id),
+                                            },
+                                          ]}
+                                        />
+                                        <DangerButton
+                                          type="button"
+                                          onClick={() => handleRemoveLayoutV2Block(template.id, blockIndex)}
+                                          title="Remove this field line"
+                                        >
+                                          <FaTrash />
+                                        </DangerButton>
+                                      </RowLine>
+                                    </ParagraphControlsRow>
+                                    {/* Same freely-editable plain fields the Logo field already is -
+                                        a fieldLine's label (when the block carries one - some, like
+                                        the surrogate mother's own line, have none at all) and its
+                                        underlined value, both plain {{}}-only strings in every
+                                        reference template, no rich-run toolbar needed. */}
+                                    {block.label !== undefined ? (
+                                      <FieldInput
+                                        type="text"
+                                        value={block.label || ''}
+                                        placeholder="Label before the underlined value, e.g. «дружина»"
+                                        onChange={event => setLayoutV2FieldLineLabel(template.id, blockIndex, event.target.value)}
+                                        onBlur={() => persistTemplate(template.id)}
+                                        style={{ width: '100%', marginBottom: 6 }}
+                                      />
+                                    ) : null}
+                                    <FieldInput
+                                      type="text"
+                                      value={block.value || ''}
+                                      placeholder="Underlined field value - {{}} placeholders"
+                                      onChange={event => setLayoutV2FieldLineValue(template.id, blockIndex, event.target.value)}
+                                      onBlur={() => persistTemplate(template.id)}
+                                      style={{ width: '100%' }}
+                                    />
+                                  </ParagraphEditorBlock>
+                                );
                               }
                               if (block?.type !== 'paragraph' && block?.type !== 'richParagraph') return null;
                               const scope = layoutV2Scope(blockIndex);

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -21,6 +21,7 @@ import {
   getClinicLogo,
   getEffectiveDocLayout,
   getLayoutLang,
+  groupJoinedParagraphs,
   isBilingualLayout,
   isOfficialFormStyle,
   isParagraphBold,
@@ -369,29 +370,22 @@ const DocumentBlock = ({ doc, layout, cellStyles, titleGap, logoWidth, longLogoW
       {showBodyLogo ? <LogoBlock type={doc.logo} {...logoBlockProps} /> : null}
       <BeforeTitleBlocks doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} blankFields={blankFields} />
       <DocumentTitleBlock doc={doc} isBilingual={isBilingual} lang={lang} cellStyles={cellStyles} titleGap={titleGap} blankFields={blankFields} />
-      {doc.paragraphs.map((paragraph, index) => {
-        // Already drawn as doc.logo above - a legacy leading logo paragraph must not also render
-        // a second time in its old body position. A conditionally-hidden paragraph (batch 26 §6)
-        // is the same kind of no-op-for-the-renderer tag, kept in the array (not spliced out) so
-        // every other paragraph's index stays stable for the editor.
-        if (paragraph.type === 'logo-consumed' || paragraph.type === 'condition-hidden') return null;
-        return (
-          <View key={`p-${index}`} wrap>
-            {paragraph.type && paragraph.type !== 'text' ? (
-              <LogoBlock type={paragraph.type} {...logoBlockProps} />
-            ) : (
-              <TextParagraph
-                paragraph={paragraph}
-                isBilingual={isBilingual}
-                lang={lang}
-                cellStyles={cellStyles}
-                allowPageBreaks={doc.allowPageBreaks}
-                blankFields={blankFields}
-              />
-            )}
-          </View>
-        );
-      })}
+      {groupJoinedParagraphs(doc.paragraphs).map((paragraph, index) => (
+        <View key={`p-${index}`} wrap>
+          {paragraph.type && paragraph.type !== 'text' ? (
+            <LogoBlock type={paragraph.type} {...logoBlockProps} />
+          ) : (
+            <TextParagraph
+              paragraph={paragraph}
+              isBilingual={isBilingual}
+              lang={lang}
+              cellStyles={cellStyles}
+              allowPageBreaks={doc.allowPageBreaks}
+              blankFields={blankFields}
+            />
+          )}
+        </View>
+      ))}
     </View>
   );
 };
@@ -872,7 +866,7 @@ const DocumentsPdfDocument = ({
     const blankFields = isOfficialFormStyle(doc);
     const headerLogoReserve = resolveHeaderLogoReserve(doc, effectiveClinicLogos, logoWidth);
     const pageStyleForDoc = headerLogoReserve ? { ...pageStyle, paddingTop: marginTop + headerLogoReserve } : pageStyle;
-    const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed' && paragraph.type !== 'condition-hidden');
+    const bodyParagraphs = groupJoinedParagraphs(doc.paragraphs);
     const pageContentHeightPt = A4_HEIGHT_PT - marginTop - headerLogoReserve - marginBottom;
     const charsPerLine = estimateCharsPerLine({ columnWidthPt: columnContentWidth, fontSize: formatting.fontSize });
     const capacity = estimateColumnPageCapacity({

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -35,6 +35,7 @@ import {
   formatGestationalAgeText,
   formatPregnancyTypeTextUk,
   formatShipmentPeriod,
+  groupJoinedParagraphs,
   isDocumentsSchemaV6,
   isGeneticSourceDonorCode,
   mergeDocumentsCatalog,
@@ -624,6 +625,66 @@ describe('spec: buildGeneratedDocument drops a conditionally-hidden paragraph en
     const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
     expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'condition-hidden', 'text']);
     expect(generated.paragraphs[2].uk).toBe('Просимо зареєструвати дитину.');
+  });
+});
+
+describe('spec: joinWithPrevious keeps a conditional clause reading as one continuous sentence', () => {
+  // A middle clause conditioned on oocyteSourceIsWife (same idea as the describe block above),
+  // but this time both the clause and the paragraph after it are tagged joinWithPrevious - the
+  // author's intent is one flowing sentence across all three template paragraphs, shown or not.
+  const buildTemplate = () => ({
+    id: 'birth-registration-surrogate-consent',
+    title: { uk: '' },
+    paragraphs: [
+      { uk: 'з генетичним батьком – Кацура Наоя,', en: 'with the genetic father Katsura Naoya,' },
+      {
+        uk: " та генетичною матір'ю – Кацура Юкако,",
+        en: ' and the genetic mother Katsura Yukako,',
+        condition: 'geneticAffinityCertificate.oocyteSourceIsWife',
+        joinWithPrevious: true,
+      },
+      {
+        uk: ' були записані батьками.', en: ' were registered as the parents.', joinWithPrevious: true,
+      },
+    ],
+  });
+
+  it('buildGeneratedDocument never force-capitalizes a joinWithPrevious paragraph (it is not a new sentence)', () => {
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
+    const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
+    expect(generated.paragraphs[0].uk).toBe('З генетичним батьком – Кацура Наоя,');
+    expect(generated.paragraphs[1].uk).toBe(" та генетичною матір'ю – Кацура Юкако,");
+    expect(generated.paragraphs[2].uk).toBe(' були записані батьками.');
+  });
+
+  it('groupJoinedParagraphs merges the whole chain into one paragraph when the clause is shown', () => {
+    const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
+    const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
+    const grouped = groupJoinedParagraphs(generated.paragraphs);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].uk).toBe("З генетичним батьком – Кацура Наоя, та генетичною матір'ю – Кацура Юкако, були записані батьками.");
+  });
+
+  it('groupJoinedParagraphs still joins across a hidden clause - the chain never breaks just because its middle link is invisible', () => {
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyte: 'ED-123' } } });
+    const context = buildGeneticAffinityCertificateContext(donorCase, resolvedClinics, {});
+    const generated = buildGeneratedDocument(buildTemplate(), { geneticAffinityCertificate: context });
+    expect(generated.paragraphs.map(p => p.type)).toEqual(['text', 'condition-hidden', 'text']);
+    const grouped = groupJoinedParagraphs(generated.paragraphs);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].uk).toBe('З генетичним батьком – Кацура Наоя, були записані батьками.');
+  });
+
+  it('a paragraph immediately after a hidden non-joining paragraph is unaffected (no accidental merge)', () => {
+    const paragraphs = [
+      { type: 'text', uk: 'Перше речення.', en: 'First sentence.' },
+      { type: 'condition-hidden', uk: 'приховано', en: 'hidden' },
+      { type: 'text', uk: 'Друге речення.', en: 'Second sentence.' },
+    ];
+    expect(groupJoinedParagraphs(paragraphs)).toEqual([
+      { type: 'text', uk: 'Перше речення.', en: 'First sentence.' },
+      { type: 'text', uk: 'Друге речення.', en: 'Second sentence.' },
+    ]);
   });
 });
 

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -3062,17 +3062,52 @@ export const buildGeneratedDocument = (template, context) => {
       // renderers. An absent key means "inherit the document's own formatting" (fontSize /
       // firstLineIndentCm / default alignment).
       const style = getParagraphStyle(paragraph);
+      // joinWithPrevious (groupJoinedParagraphs below) - a paragraph that continues the previous
+      // one mid-sentence must never get the usual forced capital first letter (it isn't starting a
+      // new sentence), only the paragraph that actually opens the group should.
+      const resolveText = langKey => {
+        const filled = fillPlaceholders(localizedText(paragraph, langKey), context, langKey);
+        return paragraph.joinWithPrevious ? filled : capitalizeFirstLetter(filled);
+      };
       return {
         type,
         bold: style.bold,
         align: style.align,
         indentCm: style.indentCm,
         fontSize: style.fontSize,
-        uk: capitalizeFirstLetter(fillPlaceholders(localizedText(paragraph, 'uk'), context, 'uk')),
-        en: capitalizeFirstLetter(fillPlaceholders(localizedText(paragraph, 'en'), context, 'en')),
+        joinWithPrevious: Boolean(paragraph.joinWithPrevious),
+        uk: resolveText('uk'),
+        en: resolveText('en'),
       };
     }),
   };
+};
+
+// A generated document's `paragraphs` array keeps one entry per *template* paragraph (never
+// merged, never dropped - see the comment above) so the editor can still show/edit each block on
+// its own. Rendering is different: a paragraph tagged `joinWithPrevious` (the paragraph-row toolbar
+// toggle) is meant to print as a straight continuation of whatever paragraph immediately precedes
+// it - no line break, no first-line indent of its own - most commonly a conditional clause
+// (evaluateBlockCondition) sitting mid-sentence, which must read as one continuous paragraph
+// whether or not the clause itself is shown. This is the renderer-only step that actually merges
+// those runs together, called once by each renderer (DocumentsPdfDocument.jsx,
+// documentsDocxBuilder.js) in place of their old plain condition-hidden/logo-consumed filter.
+// condition-hidden/logo-consumed entries are dropped here (they never had anything to print) but
+// never break the chain - a paragraph after one still joins whatever visible paragraph precedes it,
+// exactly as if the hidden one had never been in the array at all.
+export const groupJoinedParagraphs = paragraphs => {
+  const groups = [];
+  toArray(paragraphs).forEach(paragraph => {
+    if (paragraph?.type === 'condition-hidden' || paragraph?.type === 'logo-consumed') return;
+    const previousGroup = groups[groups.length - 1];
+    if (paragraph?.joinWithPrevious && previousGroup?.type === 'text' && paragraph?.type === 'text') {
+      previousGroup.uk = `${previousGroup.uk || ''}${paragraph.uk || ''}`;
+      previousGroup.en = `${previousGroup.en || ''}${paragraph.en || ''}`;
+      return;
+    }
+    groups.push({ ...paragraph });
+  });
+  return groups;
 };
 
 // --- Case selector --------------------------------------------------------------------------

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -13,6 +13,7 @@ import {
   getClinicLogo,
   getEffectiveDocLayout,
   getLayoutLang,
+  groupJoinedParagraphs,
   isBilingualLayout,
   isOfficialFormStyle,
   isParagraphBold,
@@ -378,9 +379,12 @@ export const buildDocumentsDocx = async ({
     }
 
     // A conditionally-hidden paragraph (batch 26 §6) is the same kind of no-op-for-the-renderer tag
-    // an already-consumed logo paragraph is - excluded here, kept (not spliced out) in
+    // an already-consumed logo paragraph is - dropped here, kept (not spliced out) in
     // doc.paragraphs itself so every other paragraph's index stays stable for the editor.
-    const bodyParagraphs = doc.paragraphs.filter(paragraph => paragraph.type !== 'logo-consumed' && paragraph.type !== 'condition-hidden');
+    // groupJoinedParagraphs also merges a `joinWithPrevious` paragraph into whichever visible
+    // paragraph precedes it, so a conditional mid-sentence clause prints as one continuous
+    // paragraph instead of its own indented block.
+    const bodyParagraphs = groupJoinedParagraphs(doc.paragraphs);
 
     if (isSingleLanguageFlow) {
       // One shared table for the whole body (not one per paragraph, unlike the bilingual/1-column


### PR DESCRIPTION
## Summary

**Parties page (CaseEditor.jsx)**
- Representative power-of-attorney date/apostille date now fall back to the representative's own legacy `powerOfAttorney` fields when the case-level ones are unset - previously showed blank inputs in edit mode despite the data existing (and being shown in read/document mode).
- Dropped the now-empty "4/4" header strip above the Пара/Клініка/... cards on the Огляд tab.

**Documents builder (DocumentsPage.jsx / documentsCatalogUtils.js / DocumentsPdfDocument.jsx / documentsDocxBuilder.js)**
- Moved the page-wide language+column selector into each document's own gear popover, so a document that pins its own languages is no longer silently exempt from a selector that visibly did nothing for it. Merged the adjacent sliders-icon formatting button (font size / first-line indent) into the same gear popover - one settings button + trash per row. The builder's own uk/en column preview now reflects each document's effective layout instead of only the shared fallback.
- A layoutV2 document's clinic-logo block now has a plain, freely-editable/clearable text field for its `{{logo}}`/`{{logo-long}}` token, matching a legacy document's own Logo field instead of only exposing show/hide + variant buttons.
- Added a `joinWithPrevious` paragraph toggle (toolbar button) so a paragraph can print as a straight continuation of the one before it - no line break, no first-line indent, no forced capital first letter - instead of always starting a new indented paragraph. Lets a mid-sentence conditional clause (`condition`, e.g. the genetic-mother clause in "Заява СМ в РАЦС") read as one continuous sentence whether or not it's shown; the chain still joins correctly across a hidden paragraph in the middle.
- Added an editor for layoutV2 `fieldLine` blocks (label + underlined value + caption) - previously these had zero editor UI even though they render in the PDF (e.g. the surrogate mother's own name/birth-date line on the Довідка про генетичну спорідненість).

## Test plan
- [x] `documentsCatalogUtils.artProgram.test.js`, `documentsCatalogUtils.test.js` - full suite passes
- [x] `DocumentsPage.*.test.js` (paragraphIndent, layoutV2ParagraphBold, checklistScope, childSelector, saveErrorMessage, templateBoldItalic, richFormatting, variablePicker, fieldLine) - full suite passes
- [x] `DocumentsPageNumbering.smoke.test.js`, `DocumentsLayoutV2*.test.js`, `DocumentsRenderers.smoke.test.js`, `__pdfSmoke.test.js` - full suite passes
- [x] `PartiesPage.caseEditor.test.js`, `PartiesPage.test.js` - full suite passes
- [x] `npx eslint` on all touched files - no errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx)_