### PR TITLE
Give layoutV2 fieldLine values the full standard paragraph toolbar

### DIFF
--- a/src/components/DocumentsPage.fieldLine.test.js
+++ b/src/components/DocumentsPage.fieldLine.test.js
@@ -3,7 +3,8 @@
 // recognized letterhead/paragraph/richParagraph, so a fieldLine's `value` (its only templated
 // content) silently never showed up in the builder even though it printed in the real PDF/DOCX (a
 // case in point: the surrogate mother's own name/birth-date line on the genetic affinity
-// certificate). This locks in the plain value/label editor added for it.
+// certificate). Its value now shares the exact same T/B/I/insert-variable/align toolbar every
+// other paragraph has - this locks that in, plus the still-plain label field alongside it.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
@@ -37,6 +38,8 @@ import { listStorageFolderFileNames } from './config';
 // eslint-disable-next-line import/first
 import DocumentsPage from './DocumentsPage';
 
+const TEXT_MODE_TITLE = "Text mode - select text and press Bold/Italic; wording isn't editable here. Tap to switch to Template mode.";
+
 beforeEach(() => {
   ref.mockImplementation((_db, path) => path);
   get.mockImplementation(async path => {
@@ -64,7 +67,7 @@ beforeEach(() => {
                 {
                   type: 'fieldLine',
                   style: 'body',
-                  value: '{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,',
+                  value: 'Кацура Юкако, донор ооцитів',
                   caption: '(прізвище, ім’я, по батькові, рік народження)',
                 },
               ],
@@ -79,28 +82,54 @@ beforeEach(() => {
   listStorageFolderFileNames.mockResolvedValue([]);
 });
 
-describe('spec: a layoutV2 fieldLine block gets a plain label/value editor', () => {
-  it('shows the current label and value, and has no label field at all for a fieldLine with none', async () => {
+// Every fieldLine row (and every other paragraph row) defaults to Text mode, which shows resolved
+// (case-substituted) wording rather than the raw {{}} markup - switching to Template mode is what
+// exposes the same editable-markup textarea a legacy paragraph's Template mode already shows.
+const fieldLineBlocks = async () => {
+  const modeButtons = await screen.findAllByTitle(TEXT_MODE_TITLE);
+  // eslint-disable-next-line testing-library/no-node-access
+  return modeButtons.map(button => button.closest('.paragraph-editor-block'));
+};
+
+describe('spec: a layoutV2 fieldLine block gets the full standard paragraph toolbar', () => {
+  it('has the same T/B/I/insert-variable/align/settings/delete buttons a paragraph block has, for both fieldLine rows', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    expect(await screen.findByDisplayValue('дружина')).toBeInTheDocument();
-    const values = await screen.findAllByDisplayValue(/р\.н\.,$/);
-    expect(values).toHaveLength(2);
-    expect(values[0]).toHaveValue('{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,');
-    expect(values[1]).toHaveValue('{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,');
+    const [wifeBlock, surrogateBlock] = await fieldLineBlocks();
+    [wifeBlock, surrogateBlock].forEach(block => {
+      expect(within(block).getByTitle(TEXT_MODE_TITLE)).toBeInTheDocument();
+      expect(within(block).getByTitle('Bold the selected text')).toBeInTheDocument();
+      expect(within(block).getByTitle('Italicize the selected text')).toBeInTheDocument();
+      expect(within(block).getByTitle('Insert a variable')).toBeInTheDocument();
+      expect(within(block).getByLabelText(/Вирівнювання/)).toBeInTheDocument();
+      expect(within(block).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown')).toBeInTheDocument();
+      expect(within(block).getByTitle('Remove this field line')).toBeInTheDocument();
+    });
 
     // Only one label field exists (the surrogate mother's fieldLine carries no `label` key at all).
-    expect(screen.getAllByPlaceholderText(/Label before the underlined value/)).toHaveLength(1);
+    expect(within(wifeBlock).getByDisplayValue('дружина')).toBeInTheDocument();
+    expect(within(surrogateBlock).queryByPlaceholderText(/Label before the underlined value/)).not.toBeInTheDocument();
   });
 
-  it('editing the value persists straight to layoutV2.blocks[index].value on blur', async () => {
+  it('switching to Template mode shows the raw {{}} markup for the value, editable like any other paragraph', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const surrogateValueField = await screen.findByDisplayValue('{{surrogateMother.name.uk.nominative}}, {{surrogateMother.birthDate}} р.н.,');
-    fireEvent.change(surrogateValueField, { target: { value: '{{surrogateMother.name.uk.nominative}}' } });
-    fireEvent.blur(surrogateValueField);
+    const [wifeBlock] = await fieldLineBlocks();
+    fireEvent.click(within(wifeBlock).getByTitle(TEXT_MODE_TITLE));
+    expect(within(wifeBlock).getByPlaceholderText('Field value')).toHaveValue('{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,');
+  });
+
+  it('editing the value in Template mode persists straight to layoutV2.blocks[index].value on blur', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [, surrogateBlock] = await fieldLineBlocks();
+    fireEvent.click(within(surrogateBlock).getByTitle(TEXT_MODE_TITLE));
+    const valueField = within(surrogateBlock).getByPlaceholderText('Field value');
+    fireEvent.change(valueField, { target: { value: '{{surrogateMother.name.uk.nominative}}' } });
+    fireEvent.blur(valueField);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
@@ -108,7 +137,40 @@ describe('spec: a layoutV2 fieldLine block gets a plain label/value editor', () 
         layoutV2: expect.objectContaining({
           blocks: [
             expect.objectContaining({ label: 'дружина' }),
-            expect.objectContaining({ value: '{{surrogateMother.name.uk.nominative}}' }),
+            expect.objectContaining({ type: 'fieldLine', value: '{{surrogateMother.name.uk.nominative}}' }),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('Bold on a selected fragment of the value produces valueRuns, still tagged fieldLine, never converted to a paragraph', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [, surrogateBlock] = await fieldLineBlocks();
+    fireEvent.click(within(surrogateBlock).getByTitle(TEXT_MODE_TITLE));
+    const valueField = within(surrogateBlock).getByPlaceholderText('Field value');
+    fireEvent.focus(valueField);
+    // "Кацура Юкако, донор ооцитів" - bold just "Кацура Юкако" (the first 12 characters).
+    valueField.setSelectionRange(0, 12);
+
+    fireEvent.click(within(surrogateBlock).getByTitle('Bold the selected text'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.anything(),
+            expect.objectContaining({
+              type: 'fieldLine',
+              value: 'Кацура Юкако, донор ооцитів',
+              valueRuns: [
+                { text: 'Кацура Юкако', style: 'inlineEmphasis' },
+                { text: ', донор ооцитів', style: undefined },
+              ],
+            }),
           ],
         }),
       }),
@@ -136,7 +198,7 @@ describe('spec: a layoutV2 fieldLine block gets a plain label/value editor', () 
     ));
   });
 
-  it('the field-line settings popover exposes a condition field, same as a paragraph block', async () => {
+  it('the field-line settings popover exposes font size (for the value) and condition, same shape as a paragraph block', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
@@ -160,5 +222,27 @@ describe('spec: a layoutV2 fieldLine block gets a plain label/value editor', () 
         }),
       }),
     ));
+  });
+
+  it('cycling Align on the value writes valueStyleOverrides.align, never the label\'s styleOverrides', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    fireEvent.click(within(wifeBlock).getByLabelText(/Вирівнювання/));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ valueStyleOverrides: expect.objectContaining({ align: expect.any(String) }) }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+    const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
+    expect(persistedTemplate.layoutV2.blocks[0].styleOverrides).toBeUndefined();
   });
 });

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -49,6 +49,7 @@ import {
   getClinicLogo,
   getEffectiveDocLayout,
   getEffectiveLayoutV2BlockAlign,
+  getEffectiveLayoutV2FieldLineValueAlign,
   getEffectiveParagraphAlign,
   getEffectiveTitleAlign,
   getLayoutLang,
@@ -1691,6 +1692,20 @@ const DocumentsPage = ({ isAdmin }) => {
     )));
   };
 
+  // A fieldLine's own `style`/`styleOverrides` govern its label (handleCycleLayoutV2Align above),
+  // never its value - the value has an entirely separate `valueStyle`/`valueStyleOverrides` pair
+  // (see getEffectiveLayoutV2FieldLineValueAlign), so its Align button needs its own cycle function
+  // writing to that pair instead.
+  const handleCycleLayoutV2FieldLineValueAlign = (docId, blockIndex) => {
+    const template = catalog.documents.find(item => String(item.id) === String(docId));
+    const block = template?.layoutV2?.blocks?.[blockIndex];
+    if (!block) return;
+    const nextAlign = nextParagraphAlign(getEffectiveLayoutV2FieldLineValueAlign(template, block));
+    applyLayoutV2BlocksChange(docId, blocks => blocks.map((item, index) => (
+      index === blockIndex ? { ...item, valueStyleOverrides: { ...item.valueStyleOverrides, align: nextAlign } } : item
+    )));
+  };
+
   const setLayoutV2StyleOverrideField = (docId, blockIndex, styleKey, raw) => {
     const parsed = parsePlainNumber(raw);
     if (parsed === undefined) return;
@@ -1704,6 +1719,27 @@ const DocumentsPage = ({ isAdmin }) => {
           if (parsed === null) delete nextOverrides[styleKey];
           else nextOverrides[styleKey] = parsed;
           return { ...item, styleOverrides: nextOverrides };
+        }),
+      },
+    }));
+  };
+
+  // Same idea as setLayoutV2StyleOverrideField, but for a fieldLine's own value style (font size)
+  // instead of the label's - the visible/underlined text is the value, so that's what the settings
+  // popover's font-size field should actually be sizing.
+  const setLayoutV2FieldLineValueStyleOverrideField = (docId, blockIndex, styleKey, raw) => {
+    const parsed = parsePlainNumber(raw);
+    if (parsed === undefined) return;
+    updateTemplate(docId, template => ({
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: (template.layoutV2?.blocks || []).map((item, index) => {
+          if (index !== blockIndex) return item;
+          const nextOverrides = { ...item.valueStyleOverrides };
+          if (parsed === null) delete nextOverrides[styleKey];
+          else nextOverrides[styleKey] = parsed;
+          return { ...item, valueStyleOverrides: nextOverrides };
         }),
       },
     }));
@@ -1775,13 +1811,10 @@ const DocumentsPage = ({ isAdmin }) => {
   // р.н.,") had no editor at all - the Blocks loop below only ever recognized
   // letterhead/paragraph/richParagraph, so a fieldLine's `value` (its only templated content, e.g.
   // the surrogate mother's own name/birth-date line) silently never showed up here even though it
-  // prints in the real document. Plain direct-value editing (no rich-run toolbar, no mode cycle) is
-  // enough - every fieldLine value in the reference templates is a flat {{}}-only string, the same
-  // shape the Logo field already edits this way (handleLogoFieldChange).
-  const setLayoutV2FieldLineValue = (docId, blockIndex, value) => applyLayoutV2BlocksChange(
-    docId,
-    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, value } : item)),
-  );
+  // prints in the real document. Its value now shares the exact same T/B/I/insert-variable/align
+  // toolbar every other paragraph has (getTemplateScopeText/withTemplateScopeText already
+  // understand a fieldLine's value/valueRuns, see layoutV2ParagraphRuns in documentsCatalogUtils),
+  // so no dedicated setter is needed here for it - only the label below is still a plain field.
 
   // The label sits to the left of the underlined value (e.g. "дружина", "та чоловік") - present on
   // some fieldLine blocks, absent on others (the surrogate mother's own line has none, see the
@@ -3397,7 +3430,31 @@ const DocumentsPage = ({ isAdmin }) => {
                                 });
                               }
                               if (block?.type === 'fieldLine') {
+                                // The exact same toolbar/mode-cycle system every other paragraph
+                                // uses (T/B/I/insert-variable/align/format/delete), just pointed at
+                                // this block's `value` instead of `text` - layoutV2ParagraphRuns/
+                                // FromMarkup and the Bold/Italic toggles (documentsCatalogUtils)
+                                // already understand a fieldLine's value/valueRuns the same way
+                                // they understand a paragraph's text/runs, so this reuses the whole
+                                // existing editor rather than a second, plainer one. Only Align and
+                                // the popover's font size differ - they read/write the value's own
+                                // valueStyle(Overrides), never the label's style(Overrides).
                                 const scope = layoutV2Scope(blockIndex);
+                                const mode = getParagraphMode(template.id, scope);
+                                const isTemplateMode = mode === 'template';
+                                const isInputMode = mode === 'input';
+                                const isTextMode = mode === 'text';
+                                const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
+                                const resolvedValue = langKey => fillPlaceholders(rawValue(langKey), getContextForTemplate(template.id), langKey);
+                                const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(resolvedValue(langKey)));
+                                const onChange = langKey => event => {
+                                  const nextRaw = isTemplateMode
+                                    ? event.target.value
+                                    : applyResolvedTextEdit(rawValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
+                                  handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
+                                };
+                                const onBlur = () => persistTemplate(template.id);
+                                const fieldKind = isTemplateMode ? 'template' : 'input-plain';
                                 return (
                                   // eslint-disable-next-line react/no-array-index-key
                                   <ParagraphEditorBlock key={`${template.id}-lv2-fieldline-${blockIndex}`}>
@@ -3410,6 +3467,42 @@ const DocumentsPage = ({ isAdmin }) => {
                                         <FaPlus />
                                       </SmallButton>
                                       <RowLine style={{ gap: 6 }}>
+                                        <SmallButton
+                                          type="button"
+                                          onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
+                                          title={PARAGRAPH_MODE_TITLE[mode]}
+                                        >
+                                          {PARAGRAPH_MODE_ICON[mode]}
+                                        </SmallButton>
+                                        <SmallButton
+                                          type="button"
+                                          disabled={isInputMode}
+                                          {...formatButtonProps('bold')}
+                                          title="Bold the selected text"
+                                        >
+                                          <FaBold />
+                                        </SmallButton>
+                                        <SmallButton
+                                          type="button"
+                                          disabled={isInputMode}
+                                          {...formatButtonProps('italic')}
+                                          title="Italicize the selected text"
+                                        >
+                                          <FaItalic />
+                                        </SmallButton>
+                                        <SmallButton
+                                          type="button"
+                                          disabled={!isTemplateMode}
+                                          onMouseDown={preventSelectionLoss}
+                                          onClick={openVariablePicker}
+                                          title="Insert a variable"
+                                        >
+                                          <FaCode />
+                                        </SmallButton>
+                                        <AlignCycleButton
+                                          align={getEffectiveLayoutV2FieldLineValueAlign(template, block)}
+                                          onCycle={() => handleCycleLayoutV2FieldLineValueAlign(template.id, blockIndex)}
+                                        />
                                         <FormatPopoverButton
                                           open={openFormatKey === formatPopoverKey(template.id, scope)}
                                           onToggle={() => toggleFormatPopover(template.id, scope)}
@@ -3419,9 +3512,9 @@ const DocumentsPage = ({ isAdmin }) => {
                                             {
                                               key: 'fontSizePt',
                                               label: 'Font size (pt)',
-                                              value: block.styleOverrides?.fontSizePt !== undefined ? String(block.styleOverrides.fontSizePt) : '',
+                                              value: block.valueStyleOverrides?.fontSizePt !== undefined ? String(block.valueStyleOverrides.fontSizePt) : '',
                                               placeholder: '',
-                                              onApply: raw => setLayoutV2StyleOverrideField(template.id, blockIndex, 'fontSizePt', raw),
+                                              onApply: raw => setLayoutV2FieldLineValueStyleOverrideField(template.id, blockIndex, 'fontSizePt', raw),
                                               onFieldBlur: () => persistTemplate(template.id),
                                             },
                                             {
@@ -3444,11 +3537,12 @@ const DocumentsPage = ({ isAdmin }) => {
                                         </DangerButton>
                                       </RowLine>
                                     </ParagraphControlsRow>
-                                    {/* Same freely-editable plain fields the Logo field already is -
-                                        a fieldLine's label (when the block carries one - some, like
-                                        the surrogate mother's own line, have none at all) and its
-                                        underlined value, both plain {{}}-only strings in every
-                                        reference template, no rich-run toolbar needed. */}
+                                    {/* The label sits to the left of the underlined value (e.g.
+                                        "дружина") - present on some fieldLine blocks, absent on
+                                        others (the surrogate mother's own line has none at all).
+                                        Always a plain {{}}-only string in every reference template
+                                        (never labelRuns), so a plain field covers it - the toolbar
+                                        above and the field below are both about the value. */}
                                     {block.label !== undefined ? (
                                       <FieldInput
                                         type="text"
@@ -3459,14 +3553,37 @@ const DocumentsPage = ({ isAdmin }) => {
                                         style={{ width: '100%', marginBottom: 6 }}
                                       />
                                     ) : null}
-                                    <FieldInput
-                                      type="text"
-                                      value={block.value || ''}
-                                      placeholder="Underlined field value - {{}} placeholders"
-                                      onChange={event => setLayoutV2FieldLineValue(template.id, blockIndex, event.target.value)}
-                                      onBlur={() => persistTemplate(template.id)}
-                                      style={{ width: '100%' }}
-                                    />
+                                    <ParagraphFieldColumn>
+                                      {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, layoutV2Lang)) ? (
+                                        <TextModeDisplay
+                                          ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                          onMouseUp={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
+                                          onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
+                                          onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind) : undefined}
+                                          title={isInputMode ? 'Click to edit the wording' : undefined}
+                                        >
+                                          <FormattedRunsPreview text={resolvedValue(layoutV2Lang)} />
+                                        </TextModeDisplay>
+                                      ) : isInputMode ? (
+                                        <RichResolvedTextField
+                                          ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                          initialText={resolvedValue(layoutV2Lang)}
+                                          placeholder="Field value"
+                                          onPlainTextChange={nextPlain => onChange(layoutV2Lang)({ target: { value: nextPlain } })}
+                                          onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
+                                          onBlur={onBlur}
+                                        />
+                                      ) : (
+                                        <AutoInlineTextarea
+                                          ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                          value={displayValue(layoutV2Lang)}
+                                          placeholder="Field value"
+                                          onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
+                                          onChange={onChange(layoutV2Lang)}
+                                          onBlur={onBlur}
+                                        />
+                                      )}
+                                    </ParagraphFieldColumn>
                                   </ParagraphEditorBlock>
                                 );
                               }

--- a/src/components/DocumentsPdfDocument.jsx
+++ b/src/components/DocumentsPdfDocument.jsx
@@ -661,7 +661,12 @@ const LayoutV2FieldLine = ({ block }) => {
         <View style={{ flex: 1, flexDirection: 'row', alignItems: 'flex-end' }}>
           {block.line?.fillBeforeValue ? <View style={[{ flex: 1, minWidth: 4 * MM_TO_PT }, lineStyle]} /> : null}
           <Text style={[layoutV2TextStyle(block.valueStyle), lineStyle, { paddingHorizontal: 1 * MM_TO_PT }]}>
-            {block.value}
+            {block.valueRuns
+              ? block.valueRuns.map((run, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <Text key={index} style={layoutV2TextStyle(run.style)}>{run.text}</Text>
+              ))
+              : block.value}
           </Text>
           {block.line?.fillAfterValue ? <View style={[{ flex: 1, minWidth: 4 * MM_TO_PT }, lineStyle]} /> : null}
         </View>

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -2648,6 +2648,10 @@ const normalizeLayoutV2Block = (block, template, context, lang) => {
         labelWidthMm: block.labelWidthMm || 0,
         labelStyle: resolveLayoutV2Style(template, block.style, block.styleOverrides),
         value: resolveLayoutV2Text(block.value, context, lang) || '',
+        // valueRuns (batch 2026-08 §: fieldLine gets the full paragraph toolbar) is the value's own
+        // bold/italic-carrying sibling, same plain-vs-runs pattern labelRuns/text-vs-runs already
+        // are - resolved the same way a richParagraph's runs are.
+        valueRuns: block.valueRuns ? resolveLayoutV2Runs(block.valueRuns, template, context, lang) : undefined,
         valueStyle: resolveLayoutV2Style(template, block.valueStyle, block.valueStyleOverrides),
         // Both formats supported (spec §4/§16): an old inline `line` object wins if present, a new
         // template names its border via `lineStyle` into the shared `lineStyles` map instead.
@@ -2812,9 +2816,22 @@ export const findUnresolvedPlaceholders = layoutV2Doc => {
 // Bold is the 'inlineEmphasis' named style; italic (added alongside the full toolbar for layoutV2
 // paragraphs) is a plain `styleOverrides.fontStyle` instead of a named style, so it works on any
 // template regardless of whether its styleSheet defines one.
-export const layoutV2ParagraphRuns = block => (block?.type === 'richParagraph'
-  ? (block.runs || []).map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }))
-  : [{ text: String(block?.text || ''), style: undefined, styleOverrides: undefined }]);
+// A fieldLine block's own templated content is its `value` (label/caption are separate, plain
+// fields - see the editor) - `valueRuns` is its bold/italic-carrying sibling, the exact same
+// plain-vs-runs pattern `text`/`runs` already is for an ordinary paragraph, so the whole toolbar
+// below (mode cycle, Bold, Italic, Insert-variable) works on a fieldLine's value identically to
+// any other paragraph's text, instead of only exposing a bare text input for it.
+export const layoutV2ParagraphRuns = block => {
+  if (block?.type === 'richParagraph') {
+    return (block.runs || []).map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }));
+  }
+  if (block?.type === 'fieldLine') {
+    return block.valueRuns
+      ? block.valueRuns.map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }))
+      : [{ text: String(block?.value || ''), style: undefined, styleOverrides: undefined }];
+  }
+  return [{ text: String(block?.text || ''), style: undefined, styleOverrides: undefined }];
+};
 
 export const layoutV2ParagraphPlainText = block => layoutV2ParagraphRuns(block).map(run => run.text).join('');
 
@@ -2870,6 +2887,29 @@ const mergeAdjacentLayoutV2Runs = runs => runs.reduce((merged, run) => {
 
 const isLayoutV2RunPlain = run => !run.style && !run.styleOverrides?.fontStyle;
 
+// Collapses a merged run list back into the block's own field shape: paragraph.text/
+// richParagraph.runs for an ordinary paragraph block, fieldLine.value/valueRuns for a fieldLine's
+// own value - collapsed to the plain single-field shape whenever nothing in the result actually
+// carries bold/italic, so an untouched/fully-unformatted block never permanently upgrades to the
+// richer shape. Shared by the Bold/Italic toggles and layoutV2ParagraphFromMarkup below, so all
+// three ways of editing a block's text agree on the same collapse rule.
+const finalizeLayoutV2ParagraphRuns = (block, mergedRuns) => {
+  if (block?.type === 'fieldLine') {
+    const plainText = mergedRuns.map(run => run.text).join('');
+    if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
+      const { valueRuns: ignoredValueRuns, ...plainBlock } = block;
+      return { ...plainBlock, value: plainText };
+    }
+    return { ...block, value: plainText, valueRuns: mergedRuns };
+  }
+  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
+    const { runs: ignoredRuns, ...plainBlock } = block;
+    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
+  }
+  const { text: ignoredText, ...richBlock } = block;
+  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
+};
+
 // MS Word toggle behavior (batch 17), same rule as toggleInlineFormat: if every run inside
 // [plainStart, plainEnd) is already 'inlineEmphasis', the whole selection loses it; otherwise the
 // whole selection gains it. Always returns a `richParagraph` (a plain `paragraph` block has no
@@ -2884,16 +2924,10 @@ export const toggleLayoutV2ParagraphBold = (block, plainStart, plainEnd) => {
   const selected = split.filter(within);
   const allBold = selected.length > 0 && selected.every(run => run.style === 'inlineEmphasis');
   const next = split.map(run => (within(run) ? { ...run, style: allBold ? undefined : 'inlineEmphasis' } : run));
-  const mergedRuns = mergeAdjacentLayoutV2Runs(next);
   // Firebase's `set()` rejects a value tree containing a bare `undefined` outright (batch 26 §3) -
   // dropping the now-unused key via destructuring, rather than assigning it `undefined`, keeps
-  // this block always directly writable.
-  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
-    const { runs: ignoredRuns, ...plainBlock } = block;
-    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
-  }
-  const { text: ignoredText, ...richBlock } = block;
-  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
+  // this block always directly writable (handled inside finalizeLayoutV2ParagraphRuns).
+  return finalizeLayoutV2ParagraphRuns(block, mergeAdjacentLayoutV2Runs(next));
 };
 
 // Same MS Word toggle rule as Bold, just flipping styleOverrides.fontStyle instead of the
@@ -2908,13 +2942,7 @@ export const toggleLayoutV2ParagraphItalic = (block, plainStart, plainEnd) => {
   const next = split.map(run => (within(run)
     ? { ...run, styleOverrides: allItalic ? undefined : { ...run.styleOverrides, fontStyle: 'italic' } }
     : run));
-  const mergedRuns = mergeAdjacentLayoutV2Runs(next);
-  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
-    const { runs: ignoredRuns, ...plainBlock } = block;
-    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
-  }
-  const { text: ignoredText, ...richBlock } = block;
-  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
+  return finalizeLayoutV2ParagraphRuns(block, mergeAdjacentLayoutV2Runs(next));
 };
 
 // --- layoutV2 paragraph full toolbar parity (mode cycle, Italic, Insert-variable) ---------------
@@ -2976,13 +3004,7 @@ export const layoutV2ParagraphFromMarkup = (existingBlock, markup) => {
     }
     nextOffset += parsedRun.text.length;
   });
-  const mergedRuns = mergeAdjacentLayoutV2Runs(runs);
-  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
-    const { runs: ignoredRuns, ...plainBlock } = existingBlock;
-    return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
-  }
-  const { text: ignoredText, ...richBlock } = existingBlock;
-  return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
+  return finalizeLayoutV2ParagraphRuns(existingBlock, mergeAdjacentLayoutV2Runs(runs));
 };
 
 // The scope key a layoutV2 paragraph/richParagraph block edits under (mirrors beforeTitleScope/
@@ -2994,6 +3016,12 @@ export const layoutV2Scope = index => `lv2:${index}`;
 // alignment override belongs on the block's own `styleOverrides` instead, never on the shared
 // named style every other block using it would also pick up.
 export const getEffectiveLayoutV2BlockAlign = (template, block) => resolveLayoutV2Style(template, block?.style, block?.styleOverrides).align || 'left';
+
+// A fieldLine's own `style`/`styleOverrides` govern its *label* (see normalizeLayoutV2Block) - its
+// value has an entirely separate `valueStyle`/`valueStyleOverrides` pair, so the Align button on a
+// fieldLine's value row (the toolbar it now shares with every other paragraph) must read/write
+// that pair instead, never the label's.
+export const getEffectiveLayoutV2FieldLineValueAlign = (template, block) => resolveLayoutV2Style(template, block?.valueStyle, block?.valueStyleOverrides).align || 'left';
 
 // One generated document, ready for the PDF/DOCX renderers: bilingual title + paragraph pairs
 // with every placeholder already substituted from the case context. Logo/logo-long paragraphs are

--- a/src/components/documentsDocxBuilder.js
+++ b/src/components/documentsDocxBuilder.js
@@ -594,7 +594,9 @@ export const buildDocumentsDocx = async ({
     const valueParagraph = new Paragraph({
       alignment: layoutV2Alignment(block.valueStyle?.align),
       spacing: { after: 0, line: lineTwipsFor(block.valueStyle), lineRule: 'auto' },
-      children: [layoutV2TextRun(block.value || '', block.valueStyle)],
+      children: block.valueRuns
+        ? block.valueRuns.map(run => layoutV2TextRun(run.text, run.style))
+        : [layoutV2TextRun(block.value || '', block.valueStyle)],
     });
     const rows = [new TableRow({
       children: [


### PR DESCRIPTION
## Summary

fieldLine blocks (label + underlined value + caption, e.g. the surrogate mother's own name/birth-date line on the genetic affinity certificate) only had a gear + trash button, unlike every other paragraph's T/B/I/insert-variable/align/settings/trash row - the mode-cycle/Bold/Italic/Insert-variable buttons simply weren't wired up for it.

- `documentsCatalogUtils.js`: `layoutV2ParagraphRuns`/`layoutV2ParagraphFromMarkup` and the Bold/Italic toggles now understand a fieldLine's `value`/new `valueRuns` field the same way they already understand a paragraph's `text`/`runs` (factored the shared "collapse back to plain vs rich shape" logic into `finalizeLayoutV2ParagraphRuns`), so a fieldLine's value reuses the exact same markup-based editor as any other paragraph. Added `getEffectiveLayoutV2FieldLineValueAlign`, since a fieldLine's Align button must act on the value's own `valueStyle`/`valueStyleOverrides`, never the label's.
- `DocumentsPdfDocument.jsx` / `documentsDocxBuilder.js`: render `block.valueRuns` (bold/italic runs) when present, falling back to the plain value string otherwise - same pattern `richParagraph`'s runs already use.
- `DocumentsPage.jsx`: the fieldLine editor row now renders the same mode-cycle/Bold/Italic/Insert-variable/Align/settings/delete toolbar every paragraph row has, wired to the value; the label (still always plain in every reference template) stays a simple text field alongside it.

## Test plan
- [x] `DocumentsPage.fieldLine.test.js` - rewritten to cover the full toolbar (buttons present, Template-mode raw markup, value edits, Bold producing `valueRuns` while staying tagged `fieldLine`, label edits, condition/font-size popover, Align cycling writing `valueStyleOverrides` not the label's `styleOverrides`)
- [x] Full `Documents*`/`CaseEditor*`/`PartiesPage*` suite (532 tests) passes
- [x] `npx eslint` on all touched files - no errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx)_