### PR TITLE
Fix card-compare tool: restore comment diff/copy after myComment moved to multiData

### DIFF
--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import toast from 'react-hot-toast';
 import { handleSubmitAll } from './actions';
+import { auth, fetchUserComment, saveMyCardComment } from '../config';
 
 const compareIcon = (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -85,19 +87,33 @@ export const btnCompare = (
   
   
 
-  window.handleClick = (key, nextVal, currentVal, userIdCur, userIdNext) => {
+  window.handleClick = async (key, nextVal, currentVal, userIdCur, userIdNext) => {
     if (key === 'myComment') {
-      nextVal = decodeURIComponent(nextVal);
-      currentVal = decodeURIComponent(currentVal);
+      // Коментар більше не поле картки — живе окремо в
+      // multiData/comments/{ownerId}/{cardId} (config.js: setUserComment/
+      // fetchUserComment), тому копіюємо його туди напряму, а не через
+      // updatedTargetUser + handleSubmitAll, як інші поля картки.
+      const decodedNext = decodeURIComponent(nextVal);
+      const decodedCurrent = decodeURIComponent(currentVal);
+      const targetUserId = decodedCurrent ? userIdNext : userIdCur;
+      const commentOwnerId = auth.currentUser?.uid;
+      if (!commentOwnerId || !targetUserId) return;
+      try {
+        await saveMyCardComment(targetUserId, decodedCurrent || decodedNext, commentOwnerId);
+        toast.success('Коментар скопійовано в іншу картку');
+      } catch (error) {
+        toast.error(`Не вдалося скопіювати коментар: ${error?.message || 'невідома помилка'}`);
+      }
+      return;
     }
     const targetUserId = currentVal ? userIdNext : userIdCur;
     console.log('Target User ID:', targetUserId);
-  
+
     if (users[targetUserId]) {
       const updatedUsers = { ...users };
       const updatedTargetUser = { ...updatedUsers[targetUserId] };
-  
-      if (key === 'getInTouch' || key === 'lastCycle' || key === 'myComment') {
+
+      if (key === 'getInTouch' || key === 'lastCycle') {
         updatedTargetUser[key] = currentVal || nextVal;
       } else {
         const mergedValue = mergeValues(key, currentVal, nextVal);
@@ -128,11 +144,22 @@ export const btnCompare = (
   
   
 
-const handleCompareClick = (e, index, users, delKeys, setShowInfoModal, setCompare) => {
+const handleCompareClick = async (e, index, users, delKeys, setShowInfoModal, setCompare) => {
   e.stopPropagation();
   const entries = Object.entries(users);
-  const currentUser = entries[index][1] || {};
-  const nextUser = entries[index + 1]?.[1] || {};
+  const currentUserRaw = entries[index][1] || {};
+  const nextUserRaw = entries[index + 1]?.[1] || {};
+
+  // myComment більше не поле картки (config.js: transientUserDataKeys), а живе в
+  // multiData/comments/{ownerId}/{cardId} — довантажуємо його тут окремо, щоб
+  // порівняння й копіювання коментарів між картками й далі працювало.
+  const ownerId = auth.currentUser?.uid;
+  const [currentCommentResult, nextCommentResult] = await Promise.all([
+    ownerId && currentUserRaw.userId ? fetchUserComment(ownerId, currentUserRaw.userId) : Promise.resolve(null),
+    ownerId && nextUserRaw.userId ? fetchUserComment(ownerId, nextUserRaw.userId) : Promise.resolve(null),
+  ]);
+  const currentUser = { ...currentUserRaw, myComment: currentCommentResult?.text || '' };
+  const nextUser = { ...nextUserRaw, myComment: nextCommentResult?.text || '' };
 
   const filteredKeys = new Set([
     ...Object.keys(currentUser).filter(key => !delKeys.includes(key) && key !== 'duplicate'),

--- a/src/components/smallCard/btnCompare.test.js
+++ b/src/components/smallCard/btnCompare.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('./actions', () => ({
+  handleSubmitAll: jest.fn(),
+}));
+
+jest.mock('../config', () => ({
+  auth: { currentUser: { uid: 'admin-1' } },
+  fetchUserComment: jest.fn(),
+  saveMyCardComment: jest.fn(),
+}));
+
+const toast = require('react-hot-toast');
+const { handleSubmitAll } = require('./actions');
+const { fetchUserComment, saveMyCardComment } = require('../config');
+const { btnCompare } = require('./btnCompare');
+
+describe('btnCompare: myComment lives in multiData/comments, not on the card', () => {
+  beforeEach(() => {
+    fetchUserComment.mockReset();
+    saveMyCardComment.mockReset();
+    handleSubmitAll.mockReset();
+    toast.success.mockReset();
+    toast.error.mockReset();
+  });
+
+  const users = {
+    'user-1': { userId: 'user-1', name: 'A' },
+    'user-2': { userId: 'user-2', name: 'B' },
+  };
+
+  it('fetches each card\'s multiData comment (not userData.myComment) and shows a diff row when they differ', async () => {
+    fetchUserComment.mockImplementation(async (ownerId, cardId) => {
+      if (cardId === 'user-1') return { text: 'comment from card 1', lastAction: 1 };
+      if (cardId === 'user-2') return { text: 'comment from card 2', lastAction: 2 };
+      return null;
+    });
+
+    const setUsers = jest.fn();
+    const setShowInfoModal = jest.fn();
+    const setCompare = jest.fn();
+
+    render(
+      <div>{btnCompare(0, users, setUsers, setShowInfoModal, setCompare)}</div>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Порівняти' }));
+
+    await waitFor(() => expect(setCompare).toHaveBeenCalled());
+    expect(fetchUserComment).toHaveBeenCalledWith('admin-1', 'user-1');
+    expect(fetchUserComment).toHaveBeenCalledWith('admin-1', 'user-2');
+    const html = setCompare.mock.calls[0][0];
+    expect(html).toContain('myComment');
+    expect(html).toContain('comment from card 1');
+    expect(html).toContain('comment from card 2');
+    expect(setShowInfoModal).toHaveBeenCalledWith('compareCards');
+  });
+
+  it('does not show a myComment row when both cards have the same comment (or none)', async () => {
+    fetchUserComment.mockResolvedValue(null);
+    const setCompare = jest.fn();
+
+    render(
+      <div>{btnCompare(0, users, jest.fn(), jest.fn(), setCompare)}</div>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Порівняти' }));
+
+    await waitFor(() => expect(setCompare).toHaveBeenCalled());
+    expect(setCompare.mock.calls[0][0]).not.toContain('myComment');
+  });
+
+  it('copies a comment via saveMyCardComment (multiData), never through handleSubmitAll/updated card state', async () => {
+    fetchUserComment.mockResolvedValue(null);
+    render(<div>{btnCompare(0, users, jest.fn(), jest.fn(), jest.fn())}</div>);
+
+    window.handleClick('myComment', encodeURIComponent(''), encodeURIComponent('the comment'), 'user-1', 'user-2');
+    await waitFor(() => expect(saveMyCardComment).toHaveBeenCalledWith('user-2', 'the comment', 'admin-1'));
+    expect(handleSubmitAll).not.toHaveBeenCalled();
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('shows an error toast when saving the copied comment fails', async () => {
+    fetchUserComment.mockResolvedValue(null);
+    saveMyCardComment.mockRejectedValueOnce(new Error('PERMISSION_DENIED'));
+    render(<div>{btnCompare(0, users, jest.fn(), jest.fn(), jest.fn())}</div>);
+
+    window.handleClick('myComment', encodeURIComponent(''), encodeURIComponent('the comment'), 'user-1', 'user-2');
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(
+      'Не вдалося скопіювати коментар: PERMISSION_DENIED'
+    ));
+  });
+});


### PR DESCRIPTION
## Summary
- The "Порівняти" (compare cards) tool in `src/components/smallCard/btnCompare.js` built its diff table directly from the two card objects' own fields. Since `myComment` no longer lives on the card, it silently disappeared from every comparison, and click-to-copy stopped working.

## Closing without merging
While rebasing this branch onto the latest `main`, commit [`ba6fe0f` "Fix comment copying in card comparison"](https://github.com/KnowMe-app/main/commit/ba6fe0f105af252b0b9348c85c19743123b5bd5c) landed directly on `main` fixing this exact same bug, more thoroughly: proper JSX rows instead of `window.handleClick` + `dangerouslySetInnerHTML`, a stale-request guard (`latestCompareRequest`) for rapid clicks, and keeping the local comment cache (`setLocalComment`) in sync after copying — plus related fixes in `AddNewProfile.jsx`, `Matching.jsx`, and `FieldComment.js` that this PR didn't touch.

Merging this PR now would revert that better fix. Closing as superseded; no further action needed here.
