### PR TITLE
Fix user fallback reads and resilient photo loading

### DIFF
--- a/src/components/config.fetchUserById.test.js
+++ b/src/components/config.fetchUserById.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('fetchUserById skips newUsers for long-format userIds', () => {
+describe('fetchUserById preserves newUsers fallbacks for every userId format', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
 
   const fetchUserByIdBody = source.slice(
@@ -9,30 +9,21 @@ describe('fetchUserById skips newUsers for long-format userIds', () => {
     source.indexOf('export const removeKeyFromFirebase'),
   );
 
-  it('checks isLongFormatUserId before the unconditional newUsers probe', () => {
-    const longIdBranchIndex = fetchUserByIdBody.indexOf('if (isLongFormatUserId(userId))');
-    const usersReadIndex = fetchUserByIdBody.indexOf('get(userRefInUsers)');
-    const unconditionalNewUsersReadIndex = fetchUserByIdBody.indexOf(
-      'const newUserSnapshot = await get(userRefInNewUsers);',
-    );
+  it('does not return a users record before probing the fallback collection', () => {
+    const fallbackReadIndex = fetchUserByIdBody.indexOf('const newUserSnapshot = await get(userRefInNewUsers);');
+    const usersOnlyReturnIndex = fetchUserByIdBody.indexOf("__sourceCollection: 'users'");
 
-    expect(longIdBranchIndex).toBeGreaterThanOrEqual(0);
-    expect(usersReadIndex).toBeGreaterThan(longIdBranchIndex);
-    expect(usersReadIndex).toBeLessThan(unconditionalNewUsersReadIndex);
+    expect(fetchUserByIdBody).not.toContain('if (isLongFormatUserId(userId))');
+    expect(fallbackReadIndex).toBeGreaterThanOrEqual(0);
+    expect(usersOnlyReturnIndex).toBeGreaterThan(fallbackReadIndex);
   });
 
-  it('returns a users-sourced record with photos when the long-id branch hits', () => {
-    const longIdBranchBody = fetchUserByIdBody.slice(
-      fetchUserByIdBody.indexOf('if (isLongFormatUserId(userId))'),
-      fetchUserByIdBody.indexOf('const newUserSnapshot = await get(userRefInNewUsers);'),
-    );
-    expect(longIdBranchBody).toContain("getAllUserPhotos(userId, 'users')");
-    expect(longIdBranchBody).toContain("__sourceCollection: 'users'");
-  });
-
-  it('still merges users/newUsers per field for the short-id path (unchanged)', () => {
+  it('merges users/newUsers per field when both records exist', () => {
     expect(fetchUserByIdBody).toContain(
-      'mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val())',
+      '? mergeUserCollectionData(newUserSnapshot.val(), userSnapshotInUsers.val())',
+    );
+    expect(fetchUserByIdBody).toContain(
+      ': mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val())',
     );
   });
 });

--- a/src/components/config.fetchUsersByIds.longUserId.test.js
+++ b/src/components/config.fetchUsersByIds.longUserId.test.js
@@ -49,9 +49,9 @@ describe('fetchUsersByIds skips newUsers for long-format userIds and trusts fres
     expect(longIdBranchBody.startsWith('if (!source && isLongFormatUserId(id))')).toBe(true);
   });
 
-  it('trusts a fresh users-sourced cache hit the same way it already trusts newUsers', () => {
+  it('trusts a users-sourced cache hit only for long-format ids', () => {
     expect(fetchUsersByIdsBody).toContain(
-      "(cached.__sourceCollection === 'newUsers' || cached.__sourceCollection === 'users')",
+      "|| (isLongFormatUserId(id) && cached.__sourceCollection === 'users')",
     );
   });
 });

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -67,7 +67,7 @@ describe('newUsers/users merge behaviour', () => {
     expect(addUserFromUsersBody).toContain('mergeUserCollectionData(userData, newUserData)');
   });
 
-  it('fetchUserById merges users/newUsers per field so stale newUsers data cannot shadow fresh users data', () => {
+  it('fetchUserById merges both collections and prioritizes long-id fallback writes', () => {
     const fetchUserByIdBody = source.slice(
       source.indexOf('export const fetchUserById'),
       source.indexOf('export const removeKeyFromFirebase')
@@ -75,6 +75,9 @@ describe('newUsers/users merge behaviour', () => {
 
     expect(fetchUserByIdBody).toContain(
       'mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val())'
+    );
+    expect(fetchUserByIdBody).toContain(
+      'mergeUserCollectionData(newUserSnapshot.val(), userSnapshotInUsers.val())'
     );
   });
 

--- a/src/components/config.getAllUserPhotos.test.js
+++ b/src/components/config.getAllUserPhotos.test.js
@@ -25,6 +25,17 @@ describe('getAllUserPhotos skips newUsers for long-format userIds on the cold-lo
     expect(newUsersReadIndex).toBeGreaterThan(usersReadIndex);
   });
 
+  it('keeps long-id database reads best-effort when either collection rejects', () => {
+    const longIdBranchBody = getAllUserPhotosBody.slice(
+      getAllUserPhotosBody.indexOf('if (!collectionSource && isLongFormatUserId(userId))'),
+      getAllUserPhotosBody.indexOf('const sourceCollections = getPhotoSourceCollections(collectionSource);'),
+    );
+
+    expect(longIdBranchBody.match(/Promise\.allSettled/g)).toHaveLength(2);
+    expect(longIdBranchBody).toContain("console.error('Error loading user photos from users:'");
+    expect(longIdBranchBody).toContain("console.error('Error loading user photos from newUsers:'");
+  });
+
   it('leaves the explicit-collectionSource path (getPhotoSourceCollections) untouched', () => {
     expect(getAllUserPhotosBody).toContain(
       'const sourceCollections = getPhotoSourceCollections(collectionSource);',

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -1918,7 +1918,10 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
         result[id] = cached;
       } else if (
         cached && !source
-        && (cached.__sourceCollection === 'newUsers' || cached.__sourceCollection === 'users')
+        && (
+          cached.__sourceCollection === 'newUsers'
+          || (isLongFormatUserId(id) && cached.__sourceCollection === 'users')
+        )
       ) {
         result[id] = cached;
       } else {
@@ -3268,14 +3271,27 @@ export const getAllUserPhotos = async (userId, collectionSource = null, { includ
 
   let databaseUrls;
   if (!collectionSource && isLongFormatUserId(userId)) {
-    const usersSnapshot = await get(ref2(database, `users/${userId}`));
-    if (usersSnapshot.exists()) {
-      databaseUrls = normalizePhotoValues(usersSnapshot.val()?.photos);
+    const [usersResult] = await Promise.allSettled([
+      get(ref2(database, `users/${userId}`)),
+    ]);
+    if (usersResult.status === 'rejected') {
+      console.error('Error loading user photos from users:', usersResult.reason);
+      databaseUrls = [];
+    } else if (usersResult.value.exists()) {
+      databaseUrls = normalizePhotoValues(usersResult.value.val()?.photos);
     } else {
       // Fallback: інваріант ("довгі userId живуть лише в users") міг ще не
       // встигнути виконатись для цього конкретного запису.
-      const newUsersSnapshot = await get(ref2(database, `newUsers/${userId}`));
-      databaseUrls = newUsersSnapshot.exists() ? normalizePhotoValues(newUsersSnapshot.val()?.photos) : [];
+      const [newUsersResult] = await Promise.allSettled([
+        get(ref2(database, `newUsers/${userId}`)),
+      ]);
+      if (newUsersResult.status === 'rejected') {
+        console.error('Error loading user photos from newUsers:', newUsersResult.reason);
+        databaseUrls = [];
+      } else {
+        const newUsersSnapshot = newUsersResult.value;
+        databaseUrls = newUsersSnapshot.exists() ? normalizePhotoValues(newUsersSnapshot.val()?.photos) : [];
+      }
     }
   } else {
     const sourceCollections = getPhotoSourceCollections(collectionSource);
@@ -7000,22 +7016,6 @@ export const fetchUserById = async userId => {
   const userRefInUsers = ref2(db, `users/${userId}`);
 
   try {
-    if (isLongFormatUserId(userId)) {
-      const usersOnlySnapshot = await get(userRefInUsers);
-      if (usersOnlySnapshot.exists()) {
-        const photos = await getAllUserPhotos(userId, 'users');
-        return {
-          userId,
-          ...usersOnlySnapshot.val(),
-          photos,
-          __sourceCollection: 'users',
-        };
-      }
-      // Fallback: інваріант ("довгі userId живуть лише в users") міг ще не
-      // встигнути виконатись для цього конкретного запису — перевіряємо
-      // newUsers про всяк випадок, як і раніше для коротких id нижче.
-    }
-
     // Пошук у newUsers
     const newUserSnapshot = await get(userRefInNewUsers);
     if (newUserSnapshot.exists()) {
@@ -7025,9 +7025,12 @@ export const fetchUserById = async userId => {
         userSnapshotInUsers.exists() ? null : 'newUsers'
       );
       if (userSnapshotInUsers.exists()) {
+        const mergedUserData = isLongFormatUserId(userId)
+          ? mergeUserCollectionData(newUserSnapshot.val(), userSnapshotInUsers.val())
+          : mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val());
         return {
           userId,
-          ...mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val()),
+          ...mergedUserData,
           photos,
           __sourceCollection: 'newUsers',
         };


### PR DESCRIPTION
### Motivation
- Prevent short-format IDs from incorrectly short-circuiting the `users`/`newUsers` merge by restricting `users`-cache-trust to long-format IDs only.
- Preserve best-effort photo results when RTDB reads for a long-format ID fail so Storage photos are not discarded on a single DB error.
- Ensure `fetchUserById` does not treat a stale `users/$uid` node as authoritative when a successful `newUsers` fallback exists, so profile edits saved via fallback remain visible.

### Description
- Updated `fetchUsersByIds` to accept a cached `__sourceCollection === 'users'` entry only when `isLongFormatUserId(id)` is true, while leaving `newUsers` cache hits unchanged.
- Reworked the cold `getAllUserPhotos` long-ID path to use settled reads (`Promise.allSettled`) for `users` and `newUsers`, log individual failures, and keep previously loaded Storage URLs instead of aborting on a single rejection.
- Changed `fetchUserById` to probe `newUsers` first and merge collections with the correct precedence, and to prefer the full `newUsers` fallback for long-id fallback writes when both records exist. The merge order is chosen based on `isLongFormatUserId(userId)` to preserve the intended ownership semantics.
- Added/updated focused regression tests to cover long-ID cache behavior, photo-read resilience, and profile fallback merging (tests under `src/components/*` were adjusted accordingly).

### Testing
- Ran the focused test set with `CI=true npm test -- --watchAll=false --runTestsByPath src/components/config.fetchUsersByIds.longUserId.test.js src/components/config.getAllUserPhotos.test.js src/components/config.fetchUserById.test.js src/components/config.fetchUsersByIds.test.js`, and all 4 suites (26 tests) passed. 
- Built a production bundle with `npm run build`, which completed successfully. 
- Ran `git diff --check` to validate no obvious diff issues prior to finalizing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f86c1e92483269a63fed13c3de1ce)