### PR TITLE
Auto-fill genetic-affinity donor/spouse fields, fix invisible labelRuns block

### DIFF
--- a/src/components/DocumentsPage.fieldLine.test.js
+++ b/src/components/DocumentsPage.fieldLine.test.js
@@ -246,3 +246,71 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     expect(persistedTemplate.layoutV2.blocks[0].styleOverrides).toBeUndefined();
   });
 });
+
+// A fieldLine block can carry a bold-in-part `labelRuns` (e.g. bold "та" + "/або сперматозоїди")
+// instead of a plain `label` string - before this fix, that meant `block.label !== undefined` was
+// false, so the label field never rendered at all, and with an unset/blank `value` too the whole
+// row looked like a totally empty, unreachable block in the builder (exactly what a user reported
+// seeing between the "яйцеклітини" fieldLine and "Перенесення ембріона...").
+describe('spec: a fieldLine with labelRuns (not plain label) is still visible/editable, never a blank block', () => {
+  beforeEach(() => {
+    get.mockImplementation(async path => {
+      if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => ({}) };
+      if (path === 'documentsBuilder/cases') return { exists: () => false, val: () => null };
+      if (path === 'documentsBuilder/templates') {
+        return {
+          exists: () => true,
+          val: () => ({
+            'doc-1': {
+              id: 'doc-1',
+              catalogName: 'Genetic affinity certificate',
+              rendererVersion: 2,
+              languages: ['uk'],
+              layoutV2: {
+                contentWidthMm: 180,
+                blocks: [{
+                  type: 'fieldLine',
+                  style: 'body',
+                  labelRuns: [
+                    { text: 'та', style: 'inlineEmphasis' },
+                    { text: '/або сперматозоїди' },
+                  ],
+                  value: '',
+                  caption: '(прізвище, ініціали / код донора)',
+                }],
+              },
+            },
+          }),
+        };
+      }
+      return { exists: () => false, val: () => null };
+    });
+  });
+
+  it('shows the labelRuns text (plain, concatenated) as the label field\'s value instead of leaving it blank', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    expect(await screen.findByDisplayValue('та/або сперматозоїди')).toBeInTheDocument();
+  });
+
+  it('editing that label persists as plain `label`, dropping `labelRuns`', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const labelField = await screen.findByDisplayValue('та/або сперматозоїди');
+    fireEvent.change(labelField, { target: { value: 'сперматозоїди' } });
+    fireEvent.blur(labelField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [expect.objectContaining({ type: 'fieldLine', label: 'сперматозоїди' })],
+        }),
+      }),
+    ));
+    const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
+    expect(persistedTemplate.layoutV2.blocks[0].labelRuns).toBeUndefined();
+  });
+});

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -1817,13 +1817,27 @@ const DocumentsPage = ({ isAdmin }) => {
   // so no dedicated setter is needed here for it - only the label below is still a plain field.
 
   // The label sits to the left of the underlined value (e.g. "дружина", "та чоловік") - present on
-  // some fieldLine blocks, absent on others (the surrogate mother's own line has none, see the
-  // fixture template). Only ever a plain string in every reference template (never `labelRuns`,
-  // the richer alternative), so a plain field covers it the same way.
+  // some fieldLine blocks, absent on others (the surrogate mother's own line has none). A block can
+  // instead carry `labelRuns` (bold-in-part label, e.g. "**та**/або сперматозоїди") - editing that
+  // one plain-text as done here drops the bold run and switches it over to the plain `label` shape,
+  // which is an acceptable trade for turning what used to be a completely blank, invisible block
+  // (label/value both unreadable) into a visible, editable one.
   const setLayoutV2FieldLineLabel = (docId, blockIndex, value) => applyLayoutV2BlocksChange(
     docId,
-    blocks => blocks.map((item, index) => (index === blockIndex ? { ...item, label: value } : item)),
+    blocks => blocks.map((item, index) => {
+      if (index !== blockIndex) return item;
+      const { labelRuns: ignoredLabelRuns, ...rest } = item;
+      return { ...rest, label: value };
+    }),
   );
+
+  // The label's own display text, whichever shape the block stores it in - see
+  // setLayoutV2FieldLineLabel above for why editing it always collapses to the plain `label` shape.
+  const layoutV2FieldLineLabelText = block => {
+    if (block.label !== undefined) return block.label;
+    if (block.labelRuns) return block.labelRuns.map(run => run.text).join('');
+    return undefined;
+  };
 
   const setLayoutV2LogoOffset = (docId, blockIndex, columnIndex, axisKey, raw) => {
     const parsed = parsePlainNumber(raw);
@@ -3539,14 +3553,17 @@ const DocumentsPage = ({ isAdmin }) => {
                                     </ParagraphControlsRow>
                                     {/* The label sits to the left of the underlined value (e.g.
                                         "дружина") - present on some fieldLine blocks, absent on
-                                        others (the surrogate mother's own line has none at all).
-                                        Always a plain {{}}-only string in every reference template
-                                        (never labelRuns), so a plain field covers it - the toolbar
-                                        above and the field below are both about the value. */}
-                                    {block.label !== undefined ? (
+                                        others (the surrogate mother's own line has none at all). A
+                                        block can store it as plain `label` or as bold-in-part
+                                        `labelRuns` (e.g. bold "та" followed by "/або сперматозоїди") -
+                                        layoutV2FieldLineLabelText reads whichever shape is there so
+                                        this field is never silently blank/unreachable for a
+                                        labelRuns block; editing it always collapses to plain
+                                        `label` (see setLayoutV2FieldLineLabel). */}
+                                    {layoutV2FieldLineLabelText(block) !== undefined ? (
                                       <FieldInput
                                         type="text"
-                                        value={block.label || ''}
+                                        value={layoutV2FieldLineLabelText(block) || ''}
                                         placeholder="Label before the underlined value, e.g. «дружина»"
                                         onChange={event => setLayoutV2FieldLineLabel(template.id, blockIndex, event.target.value)}
                                         onBlur={() => persistTemplate(template.id)}

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -358,6 +358,29 @@ describe('spec §1.8/§4: document contexts (embryoOwnershipStatement/geneticAff
     expect(buildGeneticAffinityCertificateContext(caseWithoutArtProgram, resolvedClinics, {}).oocyteSourceIsWife).toBe(false);
   });
 
+  it('geneticAffinityCertificate resolves oocyteSourceDisplay/spermSourceDisplay to the spouse\'s own name when they were the source, the raw donor code otherwise', () => {
+    const wife = { name: { uk: { nominative: 'Кацура Юкако' }, en: 'Katsura Yukako' } };
+    const husband = { name: { uk: { nominative: 'Кацура Кеіго' }, en: 'Katsura Keigo' } };
+
+    // caseWithDateRangePeriod: geneticMaterial: { oocyte: 'wife', sperm: 'husband' } - both spouses
+    // provided their own material, so both fields resolve to the spouses' own names.
+    const spousesContext = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {}, { wife, husband });
+    expect(spousesContext.oocyteSourceDisplay).toEqual({ uk: 'Кацура Юкако', en: 'Katsura Yukako' });
+    expect(spousesContext.spermSourceDisplay).toEqual({ uk: 'Кацура Кеіго', en: 'Katsura Keigo' });
+
+    // A donor code (anything other than 'wife'/'husband', spec §1.7/§6/GENETIC_SOURCE_ROLE_VALUES)
+    // is displayed as itself, never resolved to a spouse's name.
+    const donorCase = deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyte: 'ED-123', sperm: 'SD-456' } } });
+    const donorContext = buildGeneticAffinityCertificateContext(donorCase, resolvedClinics, {}, { wife, husband });
+    expect(donorContext.oocyteSourceDisplay).toEqual({ uk: 'ED-123', en: 'ED-123' });
+    expect(donorContext.spermSourceDisplay).toEqual({ uk: 'SD-456', en: 'SD-456' });
+
+    // No source recorded at all, or no wife/husband passed in (an older call site that doesn't
+    // know about this yet) - blank, never a throw or a leaked "undefined".
+    expect(buildGeneticAffinityCertificateContext(caseWithoutArtProgram, resolvedClinics, {}, { wife, husband }).oocyteSourceDisplay).toEqual({ uk: '', en: '' });
+    expect(buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {}).oocyteSourceDisplay).toEqual({ uk: '', en: '' });
+  });
+
   it('geneticAffinityCertificate falls back to print-only blanks (never persisted) when issueDate/outgoingNumber are unset', () => {
     const context = buildGeneticAffinityCertificateContext(caseWithDateRangePeriod, resolvedClinics, {});
     expect(context.issueDateOrBlank.uk).toBe('__.__.____');
@@ -426,6 +449,19 @@ describe('integration: resolveCaseContext wires every ART document context in, n
     expect(fillPlaceholders('{{racssClinicLetter.transferAttempt.shipment.receivedDateFormatted.uk}}', context, 'uk')).toBe('27.08.2025');
     expect(fillPlaceholders('{{medicalServicesAgreement.dateFormatted.uk}}', context, 'uk')).toBe('12.09.2025');
     expect(fillPlaceholders('{{case.artProgram.medicalIndications.uk}}', context, 'uk')).toBe('Тестовий діагноз');
+  });
+
+  it('wires oocyteSourceDisplay/spermSourceDisplay through resolveCaseContext using the case\'s own couple, no per-case typing needed', () => {
+    const catalog = buildCatalog(caseWithDateRangePeriod);
+    const context = resolveCaseContext(catalog, 'case-daterange');
+    // caseWithDateRangePeriod: geneticMaterial: { oocyte: 'wife', sperm: 'husband' }, couple-fixture
+    // partners are Кацура Юкако (wife) / Кацура Кеіго (husband).
+    expect(fillPlaceholders('{{geneticAffinityCertificate.oocyteSourceDisplay.uk}}', context, 'uk')).toBe('Кацура Юкако');
+    expect(fillPlaceholders('{{geneticAffinityCertificate.spermSourceDisplay.uk}}', context, 'uk')).toBe('Кацура Кеіго');
+
+    const donorCatalog = buildCatalog(deepMergeRecords(caseWithDateRangePeriod, { artProgram: { geneticMaterial: { oocyte: 'ED-123' } } }));
+    const donorContext = resolveCaseContext(donorCatalog, 'case-daterange');
+    expect(fillPlaceholders('{{geneticAffinityCertificate.oocyteSourceDisplay.uk}}', donorContext, 'uk')).toBe('ED-123');
   });
 
   it('spec §5.1: exposes the same singleton shipment/transfer/hcgTest/ultrasound/ivf as top-level canonical context aliases, alongside the document-scoped ones', () => {
@@ -504,7 +540,8 @@ describe('integration: resolveCaseContext wires every ART document context in, n
 describe('spec §1.9: ART-derived fields are never written back to Firebase', () => {
   it('DERIVED_CONTEXT_FIELD_KEYS lists every runtime-only ART field named in the spec', () => {
     ['plannedPeriodFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
-      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank']
+      'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
+      'oocyteSourceDisplay', 'spermSourceDisplay']
       .forEach(key => expect(DERIVED_CONTEXT_FIELD_KEYS).toContain(key));
   });
 

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -395,6 +395,7 @@ export const DERIVED_CONTEXT_FIELD_KEYS = [
   // resolveCaseContext call, never written back to Firebase.
   'plannedPeriodFormatted', 'receivedDateFormatted', 'certificateDateFormatted',
   'embryoCountText', 'embryoStageLabel', 'gestationalAgeText', 'pregnancyTypeText', 'issueDateOrBlank', 'outgoingNumberOrBlank',
+  'oocyteSourceDisplay', 'spermSourceDisplay',
 ];
 
 // Recursively strips every DERIVED_CONTEXT_FIELD_KEYS key out of a value before it's serialized
@@ -1556,10 +1557,23 @@ export const buildEmbryoOwnershipStatementContext = (caseData, clinics, ownershi
 // attempt referencing the case's one shipment - none of them need an id of their own, and neither
 // does the transfer attempt's hCG test/ultrasound (spec §1.5: existence alone means positive/
 // confirmed) - nothing left to select by id.
-export const buildGeneticAffinityCertificateContext = (caseData, clinics, certificateData) => {
+// Which name/code actually belongs on a "У лікувальній програмі ДРТ використано яйцеклітини/
+// сперматозоїди ..." line - case.artProgram.geneticMaterial.oocyte (or .sperm) already records
+// exactly who provided the material ('wife'/'husband', or any other non-empty value is a donor
+// code, spec §1.7/§6/GENETIC_SOURCE_ROLE_VALUES), so the certificate can resolve this itself
+// instead of leaving it for the admin to type in and keep in sync by hand.
+const geneticSourceDisplayName = (sourceValue, role, ownerPerson) => {
+  if (sourceValue === role) return ownerPerson ? { uk: ownerPerson.name?.uk?.nominative || '', en: ownerPerson.name?.en || '' } : { uk: '', en: '' };
+  if (isGeneticSourceDonorCode(sourceValue)) return { uk: sourceValue, en: sourceValue };
+  return { uk: '', en: '' };
+};
+
+export const buildGeneticAffinityCertificateContext = (caseData, clinics, certificateData, relatedPersons = {}) => {
   const data = isPlainObject(certificateData) ? certificateData : {};
   const transferAttempt = resolveTransferAttempt(caseData);
   const shipment = enrichShipment(resolveShipment(caseData), clinics);
+  const oocyteSource = caseData?.artProgram?.geneticMaterial?.oocyte;
+  const spermSource = caseData?.artProgram?.geneticMaterial?.sperm;
   return {
     ...data,
     transferAttempt: enrichTransferForTemplate(transferAttempt, shipment),
@@ -1574,7 +1588,13 @@ export const buildGeneticAffinityCertificateContext = (caseData, clinics, certif
     // матір'ю ..." clause) - the "У лікувальній програмі ДРТ використано яйцеклітини..." field this
     // certificate itself prints from the case's scalar case.artProgram.geneticMaterial.oocyte
     // (spec §1.7/§6).
-    oocyteSourceIsWife: caseData?.artProgram?.geneticMaterial?.oocyte === 'wife',
+    oocyteSourceIsWife: oocyteSource === 'wife',
+    // The certificate's own fieldLine values for "яйцеклітини"/"сперматозоїди": the spouse's own
+    // name when they were the source, the raw donor code otherwise - {{geneticAffinityCertificate.
+    // oocyteSourceDisplay.uk}}/{{...spermSourceDisplay.uk}} in the template, no manual per-case
+    // typing needed.
+    oocyteSourceDisplay: geneticSourceDisplayName(oocyteSource, 'wife', relatedPersons.wife),
+    spermSourceDisplay: geneticSourceDisplayName(spermSource, 'husband', relatedPersons.husband),
   };
 };
 
@@ -1720,7 +1740,7 @@ export const resolveCaseContext = (catalog, caseId, { childId, templateId } = {}
   // editing an event once (e.g. the transfer date) is reflected in every document that references
   // it.
   const embryoOwnershipStatement = buildEmbryoOwnershipStatementContext(caseRecord, resolvedClinics, documents.embryoOwnershipStatement);
-  const geneticAffinityCertificate = buildGeneticAffinityCertificateContext(caseRecord, resolvedClinics, documents.geneticAffinityCertificate);
+  const geneticAffinityCertificate = buildGeneticAffinityCertificateContext(caseRecord, resolvedClinics, documents.geneticAffinityCertificate, { wife, husband });
   const racssClinicLetter = buildRacssClinicLetterContext(caseRecord, resolvedClinics, documents.racssClinicLetter);
   const medicalServicesAgreement = buildMedicalServicesAgreementContext(documents.medicalServicesAgreement);
 


### PR DESCRIPTION
## Summary

- `documentsCatalogUtils.js`: `buildGeneticAffinityCertificateContext` now computes `oocyteSourceDisplay`/`spermSourceDisplay` - the spouse's own name when `case.artProgram.geneticMaterial.oocyte`/`sperm` names them as the source (`'wife'`/`'husband'`), the raw donor code otherwise, blank when unset. This was previously left for manual per-case typing even though the source (spouse vs. donor code) was already recorded on the case - the "У лікувальній програмі ДРТ використано яйцеклітини"/"та/або сперматозоїди" fieldLine values can now just reference `{{geneticAffinityCertificate.oocyteSourceDisplay.uk}}`/`{{...spermSourceDisplay.uk}}` instead of being typed by hand each time. Added both to `DERIVED_CONTEXT_FIELD_KEYS` (never written back to Firebase) and wired `wife`/`husband` into the `resolveCaseContext` call site.
- `DocumentsPage.jsx`: a fieldLine block whose label is stored as `labelRuns` (bold-in-part, e.g. bold "та" + "/або сперматозоїди") never rendered anything in the editor - `block.label !== undefined` was false, so the label field silently never appeared, and with an empty value too the whole row looked like a completely blank, unreachable block (reported as "donor data disappeared" - it hadn't, the row editing it was invisible). `layoutV2FieldLineLabelText` now reads either shape so the field is always visible; editing it collapses to the plain `label` shape (dropping the bold run - an acceptable trade for making a previously-invisible block editable at all).

## Test plan
- [x] `documentsCatalogUtils.artProgram.test.js` - new tests for `oocyteSourceDisplay`/`spermSourceDisplay` (spouse name, donor code, unset, `resolveCaseContext` integration, `DERIVED_CONTEXT_FIELD_KEYS`) - full suite (76 tests) passes
- [x] `DocumentsPage.fieldLine.test.js` - new tests for the `labelRuns` visibility/edit fix - full suite (9 tests) passes
- [x] Full `Documents*`/`CaseEditor*`/`PartiesPage*` suite (536 tests) passes
- [x] `npx eslint` on all touched files - no errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx)_