### PR TITLE
Fix stale comparison and comment updates

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -1381,6 +1381,9 @@ const Matching = () => {
   const defaultListKey = `default:${collectionSource}`;
   const [filterResetToken, setFilterResetToken] = useState(0);
   const [comments, setComments] = useState({});
+  const commentsRef = useRef(comments);
+  commentsRef.current = comments;
+  const dispatchedCommentSaveRef = useRef(null);
   const [sharedComments, setSharedComments] = useState({});
   const [showFilters, setShowFilters] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
@@ -1388,9 +1391,16 @@ const Matching = () => {
   useEffect(() => {
     const syncCopiedComment = event => {
       if (event.detail?.ownerId !== ownerId || !event.detail?.cardId) return;
+      const eventText = String(event.detail.text || '');
+      const dispatchedSave = dispatchedCommentSaveRef.current;
+      if (
+        dispatchedSave?.cardId === event.detail.cardId
+        && dispatchedSave.text === eventText
+        && commentsRef.current[event.detail.cardId] !== eventText
+      ) return;
       setComments(previous => ({
         ...previous,
-        [event.detail.cardId]: String(event.detail.text || ''),
+        [event.detail.cardId]: eventText,
       }));
     };
     window.addEventListener(COMMENTS_UPDATED_EVENT, syncCopiedComment);
@@ -5881,6 +5891,7 @@ const Matching = () => {
                       commentValue={comments[user.userId] || ''}
                       sharedCommentTexts={sharedComments[user.userId] || []}
                       onCommentChange={val => {
+                        commentsRef.current = { ...commentsRef.current, [user.userId]: val };
                         setComments(prev => ({ ...prev, [user.userId]: val }));
                       }}
                       onCommentBlur={async () => {
@@ -5888,8 +5899,11 @@ const Matching = () => {
                           const text = comments[user.userId] || '';
                           try {
                             const res = await saveMyCardComment(user.userId, text, ownerId);
+                            dispatchedCommentSaveRef.current = { cardId: user.userId, text };
                             setLocalComment(ownerId, user.userId, text, res?.lastAction);
+                            dispatchedCommentSaveRef.current = null;
                           } catch (error) {
+                            dispatchedCommentSaveRef.current = null;
                             const details = error?.message || String(error);
                             toast.error(`Не вдалося зберегти коментар: ${details}`);
                           }

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -149,6 +149,8 @@ const UsersList = ({
   isDateInRange,
   onOpenMoreActions,
 }) => {
+  const usersRef = React.useRef(users);
+  usersRef.current = users;
   const entries = Object.entries(users);
 
   const handleCreate = async item => {
@@ -226,6 +228,7 @@ const UsersList = ({
                     setUsers,
                     setShowInfoModal,
                     setCompare,
+                    usersRef,
                     { ...cardActionButtonStyle, backgroundColor: 'purple' },
                   )}
                   {btnMore(

--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -5,6 +5,20 @@ import { setLocalComment } from '../../utils/commentsStorage';
 import { handleSubmitAll } from './actions';
 
 let latestCompareRequest = 0;
+const pendingCardSaves = new Map();
+
+const queueCardSave = user => {
+  const userId = user?.userId;
+  if (!userId) return;
+  const previousSave = pendingCardSaves.get(userId) || Promise.resolve();
+  const nextSave = previousSave
+    .catch(() => undefined)
+    .then(() => handleSubmitAll(user, 'overwrite'))
+    .finally(() => {
+      if (pendingCardSaves.get(userId) === nextSave) pendingCardSaves.delete(userId);
+    });
+  pendingCardSaves.set(userId, nextSave);
+};
 
 const compareIcon = (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -43,6 +57,7 @@ export const btnCompare = (
   setUsers,
   setShowInfoModal,
   setCompare,
+  usersRef,
   style = {},
   content = compareIcon,
 ) => {
@@ -71,12 +86,13 @@ export const btnCompare = (
       return;
     }
 
-    if (!users[targetUserId]) {
+    const latestUsers = usersRef?.current || users;
+    if (!latestUsers[targetUserId]) {
       console.error(`User with ID ${targetUserId} not found`);
       return;
     }
 
-    const updatedUsers = { ...users };
+    const updatedUsers = { ...latestUsers };
     const updatedTargetUser = { ...updatedUsers[targetUserId] };
     if (key === 'getInTouch' || key === 'lastCycle') {
       updatedTargetUser[key] = sourceValue;
@@ -88,13 +104,15 @@ export const btnCompare = (
     }
     delete updatedTargetUser.duplicate;
     updatedUsers[targetUserId] = updatedTargetUser;
+    if (usersRef) usersRef.current = updatedUsers;
     setUsers(updatedUsers);
-    handleSubmitAll(updatedTargetUser, 'overwrite');
+    queueCardSave(updatedTargetUser);
   };
 
   const handleCompareClick = async e => {
     e.stopPropagation();
     const requestId = ++latestCompareRequest;
+    setShowInfoModal('compareCards');
     const entries = Object.entries(users);
     const currentUserRaw = entries[index]?.[1] || {};
     const nextUserRaw = entries[index + 1]?.[1] || {};
@@ -127,19 +145,21 @@ export const btnCompare = (
       const uniqueCurrent = [...currentSet].filter(value => !nextSet.has(value));
       const uniqueNext = [...nextSet].filter(value => !currentSet.has(value));
       const isUserId = key === 'userId';
+      const canCopyCurrent = !isUserId && currentSet.size > 0;
+      const canCopyNext = !isUserId && nextSet.size > 0;
       const cellStyle = { width: '40%', whiteSpace: 'normal', wordBreak: 'break-word' };
       return (
         <tr key={key}>
           <td style={{ width: '20%', whiteSpace: 'normal', wordBreak: 'break-word' }}>{key}</td>
           <td
-            style={{ ...cellStyle, cursor: isUserId ? 'default' : 'pointer' }}
-            onClick={isUserId ? undefined : () => copyValue(key, currentUser[key], nextUser.userId)}
+            style={{ ...cellStyle, cursor: canCopyCurrent ? 'pointer' : 'default' }}
+            onClick={canCopyCurrent ? () => copyValue(key, currentUser[key], nextUser.userId) : undefined}
           >
             {uniqueCurrent.join(', ')}
           </td>
           <td
-            style={{ ...cellStyle, cursor: isUserId ? 'default' : 'pointer' }}
-            onClick={isUserId ? undefined : () => copyValue(key, nextUser[key], currentUser.userId)}
+            style={{ ...cellStyle, cursor: canCopyNext ? 'pointer' : 'default' }}
+            onClick={canCopyNext ? () => copyValue(key, nextUser[key], currentUser.userId) : undefined}
           >
             {uniqueNext.join(', ')}
           </td>
@@ -147,7 +167,6 @@ export const btnCompare = (
       );
     }).filter(Boolean);
 
-    setShowInfoModal('compareCards');
     setCompare(
       <div style={{ fontSize: '10px', fontFamily: 'Arial, sans-serif' }}>
         <table border="1" cellSpacing="0" cellPadding="5" style={{ borderCollapse: 'collapse', width: '100%' }}>


### PR DESCRIPTION
### Motivation
- Prevent comparison copy actions and backend saves from using a stale snapshot of the users map captured when the modal opened.
- Avoid copying empty cell values that can accidentally clear destination fields or comments.
- Ensure opening a comparison does not get overwritten by an earlier asynchronous read when the user opens another modal.
- Stop completed background comment saves or copy events from overwriting newer in-editor drafts.

### Description
- Read and update the live users map by adding a `usersRef` and passing it from `UsersList` into `btnCompare`, and use `usersRef.current` for copy operations instead of the original snapshot (`src/components/UsersList.jsx`, `src/components/smallCard/btnCompare.js`).
- Serialize full-card saves per user using a `pendingCardSaves` map and `queueCardSave` to chain `handleSubmitAll` calls so concurrent copies do not clobber newer card state (`src/components/smallCard/btnCompare.js`).
- Disable click handlers and pointer cursor for empty comparison cells by checking source-set size before attaching `onClick`, preventing blank-side clicks from deleting data (`src/components/smallCard/btnCompare.js`).
- Claim the comparison modal earlier by calling `setShowInfoModal('compareCards')` before awaiting comment fetches so later modal actions are not replaced by an older comparison completion (`src/components/smallCard/btnCompare.js`).
- Preserve newer comment drafts by tracking in-memory comment state with `commentsRef`, and by recording a dispatched save token in `dispatchedCommentSaveRef` to ignore self-generated stale `COMMENTS_UPDATED_EVENT` updates that would otherwise overwrite newer editor text (`src/components/Matching.jsx`).

### Testing
- Ran `git diff --check` with no reported whitespace errors, which succeeded.
- Ran `npx eslint src/components/smallCard/btnCompare.js src/components/UsersList.jsx src/components/Matching.jsx` which completed without blocking errors.
- Ran `npm run build`, and the production build completed successfully and produced a deployable `build/` output (bundle sizes reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f89161ae48326a3607d31f95da820)