### PR TITLE
Fix stale profile fallback reads

### DIFF
--- a/src/components/authProfilePersistence.js
+++ b/src/components/authProfilePersistence.js
@@ -3,6 +3,7 @@ import {
   updateDataInNewUsersRTDB,
   updateDataInRealtimeDB,
 } from './config';
+import { markFullProfileFallback } from '../utils/userProfileFallback';
 
 export const MY_PROFILE_DRAFT_STORAGE_KEY = 'myProfileDraft';
 export const MY_PROFILE_ROUTE = '/my-profile';
@@ -39,8 +40,10 @@ export const persistUserWithFallback = async (userId, uploadedInfo, firestoreCon
 
   await updateDataInNewUsersRTDB(
     userId,
-    shouldWriteFullProfileToNewUsers ? uploadedInfo : { lastLogin2: uploadedInfo.lastLogin2 },
-    'update'
+    shouldWriteFullProfileToNewUsers
+      ? markFullProfileFallback(uploadedInfo)
+      : { lastLogin2: uploadedInfo.lastLogin2 },
+    shouldWriteFullProfileToNewUsers ? 'update' : 'set'
   );
 };
 

--- a/src/components/authProfilePersistence.test.js
+++ b/src/components/authProfilePersistence.test.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('persistUserWithFallback freshness marker', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'authProfilePersistence.js'), 'utf8');
+
+  it('marks full fallback writes and replaces stale fallback data after canonical saves recover', () => {
+    expect(source).toContain('? markFullProfileFallback(uploadedInfo)');
+    expect(source).toContain("shouldWriteFullProfileToNewUsers ? 'update' : 'set'");
+  });
+});

--- a/src/components/config.fetchUserById.test.js
+++ b/src/components/config.fetchUserById.test.js
@@ -1,29 +1,26 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('fetchUserById preserves newUsers fallbacks for every userId format', () => {
+describe('fetchUserById fallback freshness', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
-
-  const fetchUserByIdBody = source.slice(
+  const body = source.slice(
     source.indexOf('export const fetchUserById'),
     source.indexOf('export const removeKeyFromFirebase'),
   );
 
-  it('does not return a users record before probing the fallback collection', () => {
-    const fallbackReadIndex = fetchUserByIdBody.indexOf('const newUserSnapshot = await get(userRefInNewUsers);');
-    const usersOnlyReturnIndex = fetchUserByIdBody.indexOf("__sourceCollection: 'users'");
-
-    expect(fetchUserByIdBody).not.toContain('if (isLongFormatUserId(userId))');
-    expect(fallbackReadIndex).toBeGreaterThanOrEqual(0);
-    expect(usersOnlyReturnIndex).toBeGreaterThan(fallbackReadIndex);
+  it('settles both collection reads so either readable record can be returned', () => {
+    expect(body).toContain('const [usersResult, newUsersResult] = await Promise.allSettled([');
+    expect(body).toContain("usersResult.status === 'fulfilled'");
+    expect(body).toContain("newUsersResult.status === 'fulfilled'");
   });
 
-  it('merges users/newUsers per field when both records exist', () => {
-    expect(fetchUserByIdBody).toContain(
-      '? mergeUserCollectionData(newUserSnapshot.val(), userSnapshotInUsers.val())',
-    );
-    expect(fetchUserByIdBody).toContain(
-      ': mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val())',
-    );
+  it('only makes a long-id newUsers record authoritative when marked as a full fallback', () => {
+    expect(body).toContain('isLongFormatUserId(userId) && isFullProfileFallbackData(newUsersData)');
+    expect(body).toContain("const sourceCollection = useFallback ? 'newUsers' : 'users';");
+  });
+
+  it('hydrates photos from the same collection selected as authoritative', () => {
+    expect(body).toContain('getAllUserPhotos(userId, sourceCollection)');
+    expect(body).toContain('__sourceCollection: sourceCollection');
   });
 });

--- a/src/components/config.fetchUsersByIds.longUserId.test.js
+++ b/src/components/config.fetchUsersByIds.longUserId.test.js
@@ -1,57 +1,26 @@
 import fs from 'fs';
 import path from 'path';
 
-describe('fetchUsersByIds skips newUsers for long-format userIds and trusts fresh users-cache', () => {
+describe('fetchUsersByIds long-format user fallback handling', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
-
-  const fetchUsersByIdsBody = source.slice(
+  const body = source.slice(
     source.indexOf('export const fetchUsersByIds'),
     source.indexOf('export const lazyLoadProfilePhotos'),
   );
 
-  it('checks isLongFormatUserId before falling back to the shared readSources fan-out', () => {
-    const longIdBranchIndex = fetchUsersByIdsBody.indexOf('if (!source && isLongFormatUserId(id))');
-    const readSourcesIndex = fetchUsersByIdsBody.indexOf(
-      "const readSources = source ? [source] : ['users', 'newUsers'];",
-    );
-
-    expect(longIdBranchIndex).toBeGreaterThanOrEqual(0);
-    expect(readSourcesIndex).toBeGreaterThan(longIdBranchIndex);
+  it('settles both long-id reads and only selects a marked full-profile fallback', () => {
+    expect(body).toContain('if (!source && isLongFormatUserId(id))');
+    expect(body).toContain('const [usersResult, newUsersResult] = await Promise.allSettled([');
+    expect(body).toContain('const useFallback = !hasUser || isFullProfileFallbackData(newUsersData);');
+    expect(body).toContain("__sourceCollection: useFallback ? 'newUsers' : 'users'");
   });
 
-  it('reads only users on the long-id success path, before any newUsers read', () => {
-    const longIdBranchBody = fetchUsersByIdsBody.slice(
-      fetchUsersByIdsBody.indexOf('if (!source && isLongFormatUserId(id))'),
-      fetchUsersByIdsBody.indexOf(
-        "const readSources = source ? [source] : ['users', 'newUsers'];",
-      ),
-    );
-    const usersReadIndex = longIdBranchBody.indexOf('get(ref2(database, `users/${id}`))');
-    const newUsersReadIndex = longIdBranchBody.indexOf('get(ref2(database, `newUsers/${id}`))');
-
-    expect(usersReadIndex).toBeGreaterThanOrEqual(0);
-    expect(newUsersReadIndex).toBeGreaterThan(usersReadIndex);
+  it('retains a cached card while a best-effort refresh is attempted', () => {
+    expect(body).toContain('if (cached) result[id] = cached;');
+    expect(body).toContain('return null;');
   });
 
-  it('still fans out to both collections in parallel for short-format ids (unchanged)', () => {
-    expect(fetchUsersByIdsBody).toContain(
-      "const readSources = source ? [source] : ['users', 'newUsers'];",
-    );
-  });
-
-  it('does not apply the long-id skip when an explicit collectionSource was passed', () => {
-    const longIdBranchBody = fetchUsersByIdsBody.slice(
-      fetchUsersByIdsBody.indexOf('if (!source && isLongFormatUserId(id))'),
-      fetchUsersByIdsBody.indexOf(
-        "const readSources = source ? [source] : ['users', 'newUsers'];",
-      ),
-    );
-    expect(longIdBranchBody.startsWith('if (!source && isLongFormatUserId(id))')).toBe(true);
-  });
-
-  it('trusts a users-sourced cache hit only for long-format ids', () => {
-    expect(fetchUsersByIdsBody).toContain(
-      "|| (isLongFormatUserId(id) && cached.__sourceCollection === 'users')",
-    );
+  it('still fans out to both collections for short-format ids', () => {
+    expect(body).toContain("const readSources = source ? [source] : ['users', 'newUsers'];");
   });
 });

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -67,18 +67,15 @@ describe('newUsers/users merge behaviour', () => {
     expect(addUserFromUsersBody).toContain('mergeUserCollectionData(userData, newUserData)');
   });
 
-  it('fetchUserById merges both collections and prioritizes long-id fallback writes', () => {
+  it('fetchUserById merges both collections according to the selected fresh source', () => {
     const fetchUserByIdBody = source.slice(
       source.indexOf('export const fetchUserById'),
       source.indexOf('export const removeKeyFromFirebase')
     );
 
-    expect(fetchUserByIdBody).toContain(
-      'mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val())'
-    );
-    expect(fetchUserByIdBody).toContain(
-      'mergeUserCollectionData(newUserSnapshot.val(), userSnapshotInUsers.val())'
-    );
+    expect(fetchUserByIdBody).toContain('const mergedUserData = mergeUserCollectionData(');
+    expect(fetchUserByIdBody).toContain('useFallback ? newUsersData : usersData');
+    expect(fetchUserByIdBody).toContain('useFallback ? usersData : newUsersData');
   });
 
   it('bulk merged RTDB exports merge users/newUsers per field', () => {
@@ -105,8 +102,8 @@ describe('newUsers/users merge behaviour', () => {
   });
 
   it('marks fetchUserById records with their backing collection', () => {
-    expect(source).toContain("__sourceCollection: 'newUsers'");
-    expect(source).toContain("__sourceCollection: 'users'");
+    expect(source).toContain("const sourceCollection = useFallback ? 'newUsers' : 'users';");
+    expect(source).toContain('__sourceCollection: sourceCollection');
   });
 
   it('strips client-only source markers before database writes', () => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -47,6 +47,7 @@ import { resolveEqualToSearchKeys } from '../utils/searchKeyCheckboxFilters';
 import { searchByIndexOn } from './searchByIndexOn';
 import { withAdminDownloadToast } from '../utils/backendDownloadToast';
 import { isLongFormatUserId, mergeUserCollectionData } from '../utils/mergeUserCollections';
+import { isFullProfileFallbackData } from '../utils/userProfileFallback';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -1925,44 +1926,45 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
       ) {
         result[id] = cached;
       } else {
+        if (cached) result[id] = cached;
         missingIds.push(id);
       }
     });
 
     const snaps = await Promise.all(
       missingIds.map(async id => {
-        if (!source && isLongFormatUserId(id)) {
-          const usersSnapshot = await get(ref2(database, `users/${id}`));
-          if (usersSnapshot.exists()) {
+        try {
+          if (!source && isLongFormatUserId(id)) {
+            const [usersResult, newUsersResult] = await Promise.allSettled([
+              get(ref2(database, `users/${id}`)),
+              get(ref2(database, `newUsers/${id}`)),
+            ]);
+            const usersSnapshot = usersResult.status === 'fulfilled' ? usersResult.value : null;
+            const newUsersSnapshot = newUsersResult.status === 'fulfilled' ? newUsersResult.value : null;
+            const hasUser = usersSnapshot?.exists() || false;
+            const hasNewUser = newUsersSnapshot?.exists() || false;
+            if (!hasUser && !hasNewUser) return null;
+
+            const usersData = hasUser ? usersSnapshot.val() : {};
+            const newUsersData = hasNewUser ? newUsersSnapshot.val() : {};
+            const useFallback = !hasUser || isFullProfileFallbackData(newUsersData);
             const data = {
               userId: id,
-              ...mergeUserCollectionData(usersSnapshot.val(), {}),
+              ...mergeUserCollectionData(
+                useFallback ? newUsersData : usersData,
+                useFallback ? usersData : newUsersData
+              ),
               photos: [],
               __photosHydrated: false,
-              __sourceCollection: 'users',
+              __sourceCollection: useFallback ? 'newUsers' : 'users',
             };
             return [id, updateCard(id, data)];
           }
 
-          // Fallback: інваріант ("довгі userId живуть лише в users") міг ще не
-          // встигнути виконатись для цього конкретного запису — перевіряємо
-          // newUsers про всяк випадок.
-          const newUsersSnapshot = await get(ref2(database, `newUsers/${id}`));
-          if (!newUsersSnapshot.exists()) return null;
-          const fallbackData = {
-            userId: id,
-            ...mergeUserCollectionData({}, newUsersSnapshot.val()),
-            photos: [],
-            __photosHydrated: false,
-            __sourceCollection: 'newUsers',
-          };
-          return [id, updateCard(id, fallbackData)];
-        }
-
-        const readSources = source ? [source] : ['users', 'newUsers'];
-        return Promise.all(
-          readSources.map(sourceName => get(ref2(database, `${sourceName}/${id}`)).then(snapshot => [sourceName, snapshot]))
-        ).then(entries => {
+          const readSources = source ? [source] : ['users', 'newUsers'];
+          const entries = await Promise.all(
+            readSources.map(sourceName => get(ref2(database, `${sourceName}/${id}`)).then(snapshot => [sourceName, snapshot]))
+          );
           const dataBySource = Object.fromEntries(
             entries
               .filter(([, snapshot]) => snapshot.exists())
@@ -1985,7 +1987,10 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
             __sourceCollection: hasNewUser ? 'newUsers' : 'users',
           };
           return [id, updateCard(id, data)];
-        });
+        } catch (error) {
+          console.error(`Error fetching user ${id}:`, error);
+          return null;
+        }
       })
     );
     snaps.forEach(entry => {
@@ -2982,7 +2987,9 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
     if (!skipIndexing) {
       // Перебір ключів та їх обробка
       for (const key of keysToCheck) {
-        const shouldRemoveKey = uploadedInfo[key] === '' || uploadedInfo[key] === null;
+        const shouldRemoveKey = uploadedInfo[key] === ''
+          || uploadedInfo[key] === null
+          || (condition !== 'update' && uploadedInfo[key] === undefined);
 
         if (shouldRemoveKey) {
           console.log(`${key} має пусте або null значення. Видаляємо.`);
@@ -7016,43 +7023,40 @@ export const fetchUserById = async userId => {
   const userRefInUsers = ref2(db, `users/${userId}`);
 
   try {
-    // Пошук у newUsers
-    const newUserSnapshot = await get(userRefInNewUsers);
-    if (newUserSnapshot.exists()) {
-      const userSnapshotInUsers = await get(ref2(db, `users/${userId}`));
-      const photos = await getAllUserPhotos(
-        userId,
-        userSnapshotInUsers.exists() ? null : 'newUsers'
-      );
-      if (userSnapshotInUsers.exists()) {
-        const mergedUserData = isLongFormatUserId(userId)
-          ? mergeUserCollectionData(newUserSnapshot.val(), userSnapshotInUsers.val())
-          : mergeUserCollectionData(userSnapshotInUsers.val(), newUserSnapshot.val());
+    const [usersResult, newUsersResult] = await Promise.allSettled([
+      get(userRefInUsers),
+      get(userRefInNewUsers),
+    ]);
+    const userSnapshot = usersResult.status === 'fulfilled' ? usersResult.value : null;
+    const newUserSnapshot = newUsersResult.status === 'fulfilled' ? newUsersResult.value : null;
+    const hasUser = userSnapshot?.exists() || false;
+    const hasNewUser = newUserSnapshot?.exists() || false;
+
+    if (hasUser || hasNewUser) {
+      const usersData = hasUser ? userSnapshot.val() : {};
+      const newUsersData = hasNewUser ? newUserSnapshot.val() : {};
+      const useFallback = !hasUser
+        || (isLongFormatUserId(userId) && isFullProfileFallbackData(newUsersData));
+      const sourceCollection = useFallback ? 'newUsers' : 'users';
+      const photos = await getAllUserPhotos(userId, sourceCollection);
+
+      if (hasUser && hasNewUser) {
+        const mergedUserData = mergeUserCollectionData(
+          useFallback ? newUsersData : usersData,
+          useFallback ? usersData : newUsersData
+        );
         return {
           userId,
           ...mergedUserData,
           photos,
-          __sourceCollection: 'newUsers',
+          __sourceCollection: sourceCollection,
         };
       }
       return {
         userId,
-        ...newUserSnapshot.val(),
+        ...(useFallback ? newUsersData : usersData),
         photos,
-        __sourceCollection: 'newUsers',
-      };
-    }
-
-    // Пошук у users, якщо не знайдено в newUsers
-    const userSnapshot = await get(userRefInUsers);
-    if (userSnapshot.exists()) {
-      const photos = await getAllUserPhotos(userId, 'users');
-      console.log('Знайдено користувача у users: ', userSnapshot.val());
-      return {
-        userId,
-        ...userSnapshot.val(),
-        photos,
-        __sourceCollection: 'users',
+        __sourceCollection: sourceCollection,
       };
     }
 

--- a/src/utils/userProfileFallback.js
+++ b/src/utils/userProfileFallback.js
@@ -1,0 +1,9 @@
+export const FULL_PROFILE_FALLBACK_KEY = '__fullProfileFallback';
+
+export const isFullProfileFallbackData = data =>
+  data?.[FULL_PROFILE_FALLBACK_KEY] === true;
+
+export const markFullProfileFallback = data => ({
+  ...(data || {}),
+  [FULL_PROFILE_FALLBACK_KEY]: true,
+});


### PR DESCRIPTION
### Motivation
- Long-format (auth-UID) accounts written to `newUsers` as a fallback could later be shadowed by canonical `users` saves because fallback nodes were treated as authoritative unconditionally.  This reverted newer edits.
- Independent read failures of `newUsers` or `users` could make an otherwise-readable profile disappear for long-IDs due to an unconditional fallback read ordering.
- Photos and cache source markers were not consistently aligned with the collection chosen as authoritative, causing stale photo lists and incorrect access checks.
- Batch refreshes could discard usable cached cards when a forced read for one id failed, producing blank results on transient failures.

### Description
- Add a lightweight fallback marker util `src/utils/userProfileFallback.js` that exports `markFullProfileFallback` and `isFullProfileFallbackData` to identify full-profile `newUsers` fallbacks. 
- Make `persistUserWithFallback` write a marked full-profile payload to `newUsers` when the canonical `users`/Firestore writes fail, and switch the `newUsers` write mode to `update` only for true fallbacks while using `set` otherwise (`src/components/authProfilePersistence.js`).
- Make single-profile reads robust and authoritative-selection deterministic by settling both `users` and `newUsers` reads with `Promise.allSettled`, deciding precedence using `isFullProfileFallbackData`, hydrating photos from the selected source, and returning `__sourceCollection` that corresponds to the verified authoritative collection (`src/components/config.js`).
- Improve batch `fetchUsersByIds` to preserve cached cards while attempting best-effort refreshes, isolate per-id failures with `try/catch` so a transient rejection does not collapse the whole batch, and apply the same marked-fallback selection logic for long-format ids (`src/components/config.js`).
- Ensure `updateDataInNewUsersRTDB` treats undefined vs explicit removals appropriately for non-`update` writes, removing obsolete search-index entries when fields disappear from replaced fallback nodes (`src/components/config.js`).
- Add and update regression tests to assert fallback freshness, authoritative-source selection, photo hydration from the chosen collection, cache retention during refresh, and the new persistence contract (`src/components/authProfilePersistence.test.js`, `src/components/config.fetchUserById.test.js`, `src/components/config.fetchUsersByIds.longUserId.test.js`, plus small adjustments to existing tests).

### Testing
- Ran the targeted test suites with `CI=true npm test -- --watchAll=false --runInBand src/components/config.fetchUserById.test.js src/components/config.fetchUsersByIds.longUserId.test.js src/components/config.fetchUsersByIds.test.js src/components/authProfilePersistence.test.js src/utils/mergeUserCollections.test.js` and all 5 suites (27 tests) passed.
- Ran `npx eslint` on modified files and fixed issues introduced by the change, and linting completed without errors on the updated files.
- Executed a production build with `npm run build` to verify bundling and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f8b158fec832695d63511e6f3ebde)