### PR TITLE
Prevent stale comparison actions and saves

### DIFF
--- a/src/components/smallCard/btnCompare.js
+++ b/src/components/smallCard/btnCompare.js
@@ -7,13 +7,16 @@ import { handleSubmitAll } from './actions';
 let latestCompareRequest = 0;
 const pendingCardSaves = new Map();
 
-const queueCardSave = user => {
-  const userId = user?.userId;
+const queueCardSave = (userId, getUser) => {
   if (!userId) return;
   const previousSave = pendingCardSaves.get(userId) || Promise.resolve();
   const nextSave = previousSave
     .catch(() => undefined)
-    .then(() => handleSubmitAll(user, 'overwrite'))
+    .then(() => {
+      const latestUser = getUser();
+      if (!latestUser) return undefined;
+      return handleSubmitAll(latestUser, 'overwrite');
+    })
     .finally(() => {
       if (pendingCardSaves.get(userId) === nextSave) pendingCardSaves.delete(userId);
     });
@@ -106,12 +109,13 @@ export const btnCompare = (
     updatedUsers[targetUserId] = updatedTargetUser;
     if (usersRef) usersRef.current = updatedUsers;
     setUsers(updatedUsers);
-    queueCardSave(updatedTargetUser);
+    queueCardSave(targetUserId, () => (usersRef?.current || users)[targetUserId]);
   };
 
   const handleCompareClick = async e => {
     e.stopPropagation();
     const requestId = ++latestCompareRequest;
+    setCompare(null);
     setShowInfoModal('compareCards');
     const entries = Object.entries(users);
     const currentUserRaw = entries[index]?.[1] || {};


### PR DESCRIPTION
### Motivation
- Prevent the compare modal from exposing the previous comparison while fresh comment data is being fetched so users cannot interact with stale table cells.
- Avoid queued full-card saves replaying stale snapshots and overwriting newer edits made after a queued save was scheduled.

### Description
- Clear any existing comparison content before opening the modal by calling `setCompare(null)` prior to `setShowInfoModal('compareCards')` so the UI shows a neutral/loading state while comments load.
- Refactor `queueCardSave` to accept `(userId, getUser)` and resolve `getUser()` at execution time so each queued save calls `handleSubmitAll` with the latest card state instead of a captured snapshot.
- Change the callers to enqueue saves as `queueCardSave(targetUserId, () => (usersRef?.current || users)[targetUserId])` and preserve per-card serialization using the existing `pendingCardSaves` Map and cleanup in `finally`.

### Testing
- Ran `git diff --check` which reported no problems.
- Ran `npx eslint src/components/smallCard/btnCompare.js` which completed without lint errors for the modified file.
- Ran full test suite with `CI=true npm test -- --watchAll=false --runInBand`; the run completed but showed unrelated failures in 9 existing suites while 88 suites (1,104 tests) passed, so the change did not introduce new visible test regressions in the modified area.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f8d607504832691cd557f93c41f72)