### PR TITLE
Add styled confirmation before logout

### DIFF
--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
 import { FaRegUser, FaUserEdit, FaUsers, FaSignOutAlt, FaTrashAlt, FaEye, FaProjectDiagram, FaEuroSign, FaFileInvoiceDollar, FaFileAlt, FaAddressBook, FaMoon, FaSun, FaGlobe } from 'react-icons/fa';
 import { MdPersonAddAlt1 } from 'react-icons/md';
 import { VerifyEmail } from './VerifyEmail';
 import { useAppSettings } from 'hooks/useAppSettings';
+import {
+  ModalActionRow,
+  ModalDangerButton,
+  ModalGhostButton,
+  ModalText,
+  ModalTitle,
+} from './InfoModal';
 
 const MenuShell = styled.nav`
   width: 100%;
@@ -128,6 +135,24 @@ const VerifyWrap = styled.div`
   margin-top: 8px;
 `;
 
+const LogoutConfirmation = styled.div`
+  padding: 10px 6px 6px;
+  text-align: center;
+`;
+
+const LogoutIcon = styled.div`
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 14px;
+  border-radius: 16px;
+  background: var(--km-danger-bg);
+  color: var(--km-danger);
+  font-size: 20px;
+`;
+
 const SettingRow = styled.div`
   display: grid;
   grid-template-columns: 34px 1fr auto;
@@ -195,6 +220,9 @@ export const ProfileDotsMenu = ({
 }) => {
   const location = useLocation();
   const { themeMode, setThemeMode, language, setLanguage } = useAppSettings();
+  const [isLogoutConfirmationOpen, setIsLogoutConfirmationOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const cancelLogoutRef = useRef(null);
   const resolvedAccess = normalizeAccess(access);
   const canSeePrivilegedNav = isAdmin || resolvedAccess.canAccessAdd || resolvedAccess.canAccessMatching;
 
@@ -208,6 +236,59 @@ export const ProfileDotsMenu = ({
     onSelect?.();
     action?.();
   };
+
+  useEffect(() => {
+    if (!isLogoutConfirmationOpen) return undefined;
+
+    cancelLogoutRef.current?.focus();
+    const handleKeyDown = event => {
+      if (event.key === 'Escape' && !isLoggingOut) {
+        setIsLogoutConfirmationOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isLogoutConfirmationOpen, isLoggingOut]);
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await onExit?.();
+      onSelect?.();
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  if (isLogoutConfirmationOpen) {
+    return (
+      <LogoutConfirmation
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="logout-confirmation-title"
+        aria-describedby="logout-confirmation-description"
+      >
+        <LogoutIcon aria-hidden="true"><FaSignOutAlt /></LogoutIcon>
+        <ModalTitle id="logout-confirmation-title">Вийти з акаунта?</ModalTitle>
+        <ModalText id="logout-confirmation-description">
+          Ви точно хочете завершити поточну сесію?
+        </ModalText>
+        <ModalActionRow>
+          <ModalGhostButton
+            ref={cancelLogoutRef}
+            type="button"
+            disabled={isLoggingOut}
+            onClick={() => setIsLogoutConfirmationOpen(false)}
+          >
+            Ні, залишитися
+          </ModalGhostButton>
+          <ModalDangerButton type="button" disabled={isLoggingOut} onClick={handleLogout}>
+            {isLoggingOut ? 'Виходимо…' : 'Так, вийти'}
+          </ModalDangerButton>
+        </ModalActionRow>
+      </LogoutConfirmation>
+    );
+  }
 
   const navItems = [
     { path: '/my-profile', label: 'Мій профіль', icon: <FaRegUser /> },
@@ -342,7 +423,7 @@ export const ProfileDotsMenu = ({
             </VerifyWrap>
           )}
           {isSessionActive && onExit && (
-            <MenuItem type="button" role="menuitem" $danger onClick={() => handleAction(onExit)}>
+            <MenuItem type="button" role="menuitem" $danger onClick={() => setIsLogoutConfirmationOpen(true)}>
               <ItemIcon $danger><FaSignOutAlt /></ItemIcon>
               <span>
                 <ItemLabel>Вийти</ItemLabel>

--- a/src/components/ProfileDotsMenu.test.jsx
+++ b/src/components/ProfileDotsMenu.test.jsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProfileDotsMenu } from './ProfileDotsMenu';
+
+jest.mock('./VerifyEmail', () => ({ VerifyEmail: () => null }));
+
+const renderMenu = props => render(
+  <MemoryRouter>
+    <ProfileDotsMenu
+      navigate={jest.fn()}
+      onExit={jest.fn()}
+      onSelect={jest.fn()}
+      {...props}
+    />
+  </MemoryRouter>,
+);
+
+describe('ProfileDotsMenu logout confirmation', () => {
+  it('does not end the session until logout is confirmed', async () => {
+    const onExit = jest.fn().mockResolvedValue(undefined);
+    const onSelect = jest.fn();
+    renderMenu({ onExit, onSelect });
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Вийти/ }));
+
+    expect(screen.getByRole('dialog', { name: 'Вийти з акаунта?' })).not.toBeNull();
+    expect(onExit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ні, залишитися' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Вийти з акаунта?' })).toBeNull();
+    expect(onExit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Вийти/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Так, вийти' }));
+
+    await waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the confirmation with Escape', () => {
+    renderMenu();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Вийти/ }));
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Вийти з акаунта?' })).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent accidental sign-outs by adding an explicit confirmation step before performing the logout action, while keeping the UI visually consistent with existing modals.

### Description
- Add a confirmation dialog to `ProfileDotsMenu.jsx` that opens when the user clicks the logout menu item and asks "Вийти з акаунта?" with actions "Ні, залишитися" and "Так, вийти".
- Reuse existing modal styles and components from `InfoModal` (`ModalTitle`, `ModalText`, `ModalActionRow`, `ModalDangerButton`, `ModalGhostButton`) and add small local styled components `LogoutConfirmation` and `LogoutIcon` for layout.
- Implement state management and keyboard accessibility: `isLogoutConfirmationOpen`, `isLoggingOut`, focus placement on the cancel button, `Escape` to dismiss, and in-progress state that disables buttons and shows `Виходимо…` while `onExit` resolves.
- Add `src/components/ProfileDotsMenu.test.jsx` with tests that mock `VerifyEmail` to avoid Firebase initialization and cover cancel, confirm, and `Escape` dismissal flows.

### Testing
- Ran `CI=true npm test -- --watchAll=false --runInBand src/components/ProfileDotsMenu.test.jsx` and the suite passed (2 tests passed).
- Built the app with `npm run build` and the production build completed successfully.
- Ran `git diff --check` to verify no whitespace/diff issues and found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f8f429dfc8326ad34138cc0cb8a3d)