### PR TITLE
Fix authoritative user collection fallback handling

### DIFF
--- a/src/components/config.fetchUserById.test.js
+++ b/src/components/config.fetchUserById.test.js
@@ -14,13 +14,15 @@ describe('fetchUserById fallback freshness', () => {
     expect(body).toContain("newUsersResult.status === 'fulfilled'");
   });
 
-  it('only makes a long-id newUsers record authoritative when marked as a full fallback', () => {
-    expect(body).toContain('isLongFormatUserId(userId) && isFullProfileFallbackData(newUsersData)');
+  it('makes short-id and valid long-id newUsers records authoritative', () => {
+    expect(body).toContain('isLegacyFullProfileFallbackData(newUsersData)');
+    expect(body).toContain('!isLongFormatUserId(userId) || longIdFallback');
     expect(body).toContain("const sourceCollection = useFallback ? 'newUsers' : 'users';");
   });
 
-  it('hydrates photos from the same collection selected as authoritative', () => {
-    expect(body).toContain('getAllUserPhotos(userId, sourceCollection)');
+  it('falls back across collections when the authoritative payload has no photos', () => {
+    expect(body).toContain('normalizePhotoValues(primaryData.photos).length > 0');
+    expect(body).toContain('getAllUserPhotos(userId, photoSource)');
     expect(body).toContain('__sourceCollection: sourceCollection');
   });
 });

--- a/src/components/config.fetchUsersByIds.longUserId.test.js
+++ b/src/components/config.fetchUsersByIds.longUserId.test.js
@@ -8,15 +8,17 @@ describe('fetchUsersByIds long-format user fallback handling', () => {
     source.indexOf('export const lazyLoadProfilePhotos'),
   );
 
-  it('settles both long-id reads and only selects a marked full-profile fallback', () => {
+  it('settles both long-id reads and accepts marked or recognizable legacy fallbacks', () => {
     expect(body).toContain('if (!source && isLongFormatUserId(id))');
     expect(body).toContain('const [usersResult, newUsersResult] = await Promise.allSettled([');
-    expect(body).toContain('const useFallback = !hasUser || isFullProfileFallbackData(newUsersData);');
+    expect(body).toContain('isFullProfileFallbackData(newUsersData)');
+    expect(body).toContain('isLegacyFullProfileFallbackData(newUsersData)');
+    expect(body).toContain('if (!hasUser && !hasUsableFallback) return null;');
     expect(body).toContain("__sourceCollection: useFallback ? 'newUsers' : 'users'");
   });
 
-  it('retains a cached card while a best-effort refresh is attempted', () => {
-    expect(body).toContain('if (cached) result[id] = cached;');
+  it('retains an unscoped cached card while keeping mismatched scoped reads clean', () => {
+    expect(body).toContain('if (cached && !source) result[id] = cached;');
     expect(body).toContain('return null;');
   });
 

--- a/src/components/config.fetchUsersByIds.test.js
+++ b/src/components/config.fetchUsersByIds.test.js
@@ -55,7 +55,8 @@ describe('newUsers/users merge behaviour', () => {
 
     expect(fetchUsersByIdsBody).toContain("const readSources = source ? [source] : ['users', 'newUsers'];");
     expect(fetchUsersByIdsBody).toContain('mergeUserCollectionData(');
-    expect(fetchUsersByIdsBody).toContain("__sourceCollection: hasNewUser ? 'newUsers' : 'users'");
+    expect(fetchUsersByIdsBody).toContain("const useNewUsers = hasNewUser && (!source || source === 'newUsers');");
+    expect(fetchUsersByIdsBody).toContain("__sourceCollection: useNewUsers ? 'newUsers' : 'users'");
   });
 
   it('addUserFromUsers merges users/newUsers per field in search results', () => {

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -47,7 +47,10 @@ import { resolveEqualToSearchKeys } from '../utils/searchKeyCheckboxFilters';
 import { searchByIndexOn } from './searchByIndexOn';
 import { withAdminDownloadToast } from '../utils/backendDownloadToast';
 import { isLongFormatUserId, mergeUserCollectionData } from '../utils/mergeUserCollections';
-import { isFullProfileFallbackData } from '../utils/userProfileFallback';
+import {
+  isFullProfileFallbackData,
+  isLegacyFullProfileFallbackData,
+} from '../utils/userProfileFallback';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -1926,7 +1929,7 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
       ) {
         result[id] = cached;
       } else {
-        if (cached) result[id] = cached;
+        if (cached && !source) result[id] = cached;
         missingIds.push(id);
       }
     });
@@ -1943,11 +1946,18 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
             const newUsersSnapshot = newUsersResult.status === 'fulfilled' ? newUsersResult.value : null;
             const hasUser = usersSnapshot?.exists() || false;
             const hasNewUser = newUsersSnapshot?.exists() || false;
+            const usersReadSucceeded = usersResult.status === 'fulfilled';
             if (!hasUser && !hasNewUser) return null;
 
             const usersData = hasUser ? usersSnapshot.val() : {};
             const newUsersData = hasNewUser ? newUsersSnapshot.val() : {};
-            const useFallback = !hasUser || isFullProfileFallbackData(newUsersData);
+            const hasUsableFallback = hasNewUser && (
+              isFullProfileFallbackData(newUsersData)
+              || isLegacyFullProfileFallbackData(newUsersData)
+              || (usersReadSucceeded && !hasUser)
+            );
+            if (!hasUser && !hasUsableFallback) return null;
+            const useFallback = hasUsableFallback;
             const data = {
               userId: id,
               ...mergeUserCollectionData(
@@ -1976,15 +1986,16 @@ export const fetchUsersByIds = async (ids, { collectionSource } = {}) => {
           const hasUser = Object.prototype.hasOwnProperty.call(dataBySource, 'users');
           const hasNewUser = Object.prototype.hasOwnProperty.call(dataBySource, 'newUsers');
           if (!hasUser && !hasNewUser) return null;
+          const useNewUsers = hasNewUser && (!source || source === 'newUsers');
           const data = {
             userId: id,
             ...mergeUserCollectionData(
-              hasUser ? dataBySource.users : {},
-              hasNewUser ? dataBySource.newUsers : {}
+              useNewUsers ? dataBySource.newUsers : dataBySource.users,
+              useNewUsers ? dataBySource.users : dataBySource.newUsers
             ),
             photos: [],
             __photosHydrated: false,
-            __sourceCollection: hasNewUser ? 'newUsers' : 'users',
+            __sourceCollection: useNewUsers ? 'newUsers' : 'users',
           };
           return [id, updateCard(id, data)];
         } catch (error) {
@@ -2956,6 +2967,14 @@ const sanitizeUploadedInfoPhones = uploadedInfo => {
   };
 };
 
+const normalizeIndexedValues = value => Array.isArray(value)
+  ? value.filter(Boolean)
+  : value && typeof value === 'object'
+    ? Object.values(value).filter(Boolean)
+    : typeof value === 'string'
+      ? [value].filter(Boolean)
+      : [];
+
 export const updateDataInRealtimeDB = async (userId, uploadedInfo, condition) => {
   try {
     const userRefRTDB = ref2(database, `users/${userId}`);
@@ -2987,14 +3006,16 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
     if (!skipIndexing) {
       // Перебір ключів та їх обробка
       for (const key of keysToCheck) {
+        const currentValues = normalizeIndexedValues(currentUserData?.[key]);
         const shouldRemoveKey = uploadedInfo[key] === ''
           || uploadedInfo[key] === null
           || (condition !== 'update' && uploadedInfo[key] === undefined);
 
         if (shouldRemoveKey) {
           console.log(`${key} має пусте або null значення. Видаляємо.`);
-          if (currentUserData[key] !== undefined && currentUserData[key] !== null) {
-            await updateSearchId(key, currentUserData[key], userId, 'remove');
+          for (const value of currentValues) {
+            const cleanedValue = key === 'phone' ? normalizePhoneForStorage(value) : value;
+            await updateSearchId(key, String(cleanedValue).toLowerCase(), userId, 'remove');
           }
           uploadedInfo[key] = null;
           continue;
@@ -3004,22 +3025,8 @@ export const updateDataInNewUsersRTDB = async (userId, uploadedInfo, condition, 
           // console.log(`${key} uploadedInfo[key] :>> `, uploadedInfo[key]);
 
           // Формуємо currentValues
-          const currentValues = Array.isArray(currentUserData?.[key])
-            ? currentUserData[key].filter(Boolean)
-            : typeof currentUserData?.[key] === 'object'
-              ? Object.values(currentUserData[key]).filter(Boolean)
-              : typeof currentUserData?.[key] === 'string'
-                ? [currentUserData[key]].filter(Boolean)
-                : [];
-
           // Формуємо newValues
-          const newValues = Array.isArray(uploadedInfo[key])
-            ? uploadedInfo[key].filter(Boolean)
-            : typeof uploadedInfo[key] === 'object'
-              ? Object.values(uploadedInfo[key]).filter(Boolean)
-              : typeof uploadedInfo[key] === 'string'
-                ? [uploadedInfo[key]].filter(Boolean)
-                : [];
+          const newValues = normalizeIndexedValues(uploadedInfo[key]);
 
           // console.log(`${key} currentValues :>> `, currentValues);
           // console.log(`${key} newValues :>> `, newValues);
@@ -7031,14 +7038,26 @@ export const fetchUserById = async userId => {
     const newUserSnapshot = newUsersResult.status === 'fulfilled' ? newUsersResult.value : null;
     const hasUser = userSnapshot?.exists() || false;
     const hasNewUser = newUserSnapshot?.exists() || false;
+    const usersReadSucceeded = usersResult.status === 'fulfilled';
 
     if (hasUser || hasNewUser) {
       const usersData = hasUser ? userSnapshot.val() : {};
       const newUsersData = hasNewUser ? newUserSnapshot.val() : {};
-      const useFallback = !hasUser
-        || (isLongFormatUserId(userId) && isFullProfileFallbackData(newUsersData));
+      const longIdFallback = isLongFormatUserId(userId) && hasNewUser && (
+        isFullProfileFallbackData(newUsersData)
+        || isLegacyFullProfileFallbackData(newUsersData)
+        || (usersReadSucceeded && !hasUser)
+      );
+      if (!hasUser && isLongFormatUserId(userId) && !longIdFallback) return null;
+      const useFallback = hasNewUser && (
+        !isLongFormatUserId(userId) || longIdFallback
+      );
       const sourceCollection = useFallback ? 'newUsers' : 'users';
-      const photos = await getAllUserPhotos(userId, sourceCollection);
+      const primaryData = useFallback ? newUsersData : usersData;
+      const photoSource = normalizePhotoValues(primaryData.photos).length > 0
+        ? sourceCollection
+        : null;
+      const photos = await getAllUserPhotos(userId, photoSource);
 
       if (hasUser && hasNewUser) {
         const mergedUserData = mergeUserCollectionData(

--- a/src/utils/userProfileFallback.js
+++ b/src/utils/userProfileFallback.js
@@ -3,6 +3,16 @@ export const FULL_PROFILE_FALLBACK_KEY = '__fullProfileFallback';
 export const isFullProfileFallbackData = data =>
   data?.[FULL_PROFILE_FALLBACK_KEY] === true;
 
+// Full-profile fallbacks written before the marker was introduced still contain
+// profile fields, whereas a successful canonical write leaves only login metadata
+// in newUsers. Keep those rollout-era profiles authoritative without mistaking a
+// session-only node for a usable profile.
+export const isLegacyFullProfileFallbackData = data => {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const metadataKeys = new Set([FULL_PROFILE_FALLBACK_KEY, 'lastLogin', 'lastLogin2']);
+  return Object.keys(data).some(key => !metadataKeys.has(key));
+};
+
 export const markFullProfileFallback = data => ({
   ...(data || {}),
   [FULL_PROFILE_FALLBACK_KEY]: true,

--- a/src/utils/userProfileFallback.test.js
+++ b/src/utils/userProfileFallback.test.js
@@ -1,0 +1,16 @@
+import {
+  isFullProfileFallbackData,
+  isLegacyFullProfileFallbackData,
+  markFullProfileFallback,
+} from './userProfileFallback';
+
+describe('user profile fallback recognition', () => {
+  it('recognizes explicitly marked fallbacks', () => {
+    expect(isFullProfileFallbackData(markFullProfileFallback({ email: 'user@example.com' }))).toBe(true);
+  });
+
+  it('recognizes rollout-era full profiles but rejects session-only metadata', () => {
+    expect(isLegacyFullProfileFallbackData({ email: 'user@example.com', lastLogin2: '2026-08-02' })).toBe(true);
+    expect(isLegacyFullProfileFallbackData({ lastLogin: '02.08.2026', lastLogin2: '2026-08-02' })).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent incorrect exposure of cached cards from the wrong collection during source-scoped reads so callers never receive data from an explicitly excluded collection.
- Ensure `newUsers` remains authoritative for short IDs while safely recognizing rollout-era full-profile fallbacks for long IDs without treating session-only metadata as a profile.
- Avoid returning or caching metadata-only `newUsers` nodes when canonical `users` reads fail, and ensure photos are hydrated from a sensible source when the selected primary payload has none.
- Ensure indexed search entries are fully cleaned when replacing fallback nodes so stale per-value `searchId` entries are removed.

### Description
- Added `isLegacyFullProfileFallbackData` to `src/utils/userProfileFallback.js` to recognize rollout-era full-profile payloads that predate the explicit `__fullProfileFallback` marker.
- In `src/components/config.js` updated `fetchUsersByIds` to: only reuse cached cards when the call is unscoped (`!source`), perform `Promise.allSettled` for long-ID reads, and treat a `newUsers` fallback as usable only when explicitly marked, recognizable as a legacy full profile, or when the `users` read succeeded and confirmed absence; otherwise reject metadata-only nodes.
- Adjusted the per-id merge path to respect an explicit `collectionSource` by computing `useNewUsers` and setting `__sourceCollection` accordingly so source-scoped reads return correctly-scoped records.
- Hardened `fetchUserById` similarly: refuse long-ID unmarked metadata fallbacks when canonical `users` is unreadable, and compute `photoSource` (falling back to the secondary collection) when the authoritative payload has no `photos` field so photo hydration inherits canonical photos when appropriate.
- Introduced `normalizeIndexedValues` in `src/components/config.js` and used it in `updateDataInNewUsersRTDB` so removal of indexed keys iterates normalized current values (arrays, sparse RTDB objects, or strings) and calls `updateSearchId` per-item, preventing leftover searchable entries.
- Updated several focused tests and added `src/utils/userProfileFallback.test.js` to cover explicit markers, legacy fallback recognition, and the new selection logic and behaviors.

### Testing
- Ran `CI=true npm test -- --runInBand src/components/config.fetchUsersByIds.longUserId.test.js src/components/config.fetchUserById.test.js src/components/config.fetchUsersByIds.test.js src/utils/userProfileFallback.test.js`, and all matching suites passed (4 suites, 22 tests passed).
- Ran `npx eslint` on the modified files (`src/components/config.js`, `src/utils/userProfileFallback.js`, and updated tests`) with no reported issues.
- Ran `git diff --check` (style checks) with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f8f5b5a9883269f912041a3226686)