### PR TITLE
Give layoutV2 fieldLine labels their own independent rich-text toolbar

### DIFF
--- a/src/components/DocumentsPage.fieldLine.test.js
+++ b/src/components/DocumentsPage.fieldLine.test.js
@@ -3,8 +3,11 @@
 // recognized letterhead/paragraph/richParagraph, so a fieldLine's `value` (its only templated
 // content) silently never showed up in the builder even though it printed in the real PDF/DOCX (a
 // case in point: the surrogate mother's own name/birth-date line on the genetic affinity
-// certificate). Its value now shares the exact same T/B/I/insert-variable/align toolbar every
-// other paragraph has - this locks that in, plus the still-plain label field alongside it.
+// certificate). Both its value AND its label (a fully independent field slot, e.g. bold-in-part
+// "**та**/або сперматозоїди") now share the exact same T/B/I/insert-variable/align toolbar every
+// other paragraph has - this locks that in. The label toolbar in particular fixes a real bug: it
+// used to be a bare, unformattable text input, so selecting text in it and pressing Bold always
+// failed with "Select some text first" (the toolbar only ever tracked the value field's selection).
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
@@ -82,33 +85,44 @@ beforeEach(() => {
   listStorageFolderFileNames.mockResolvedValue([]);
 });
 
-// Every fieldLine row (and every other paragraph row) defaults to Text mode, which shows resolved
-// (case-substituted) wording rather than the raw {{}} markup - switching to Template mode is what
-// exposes the same editable-markup textarea a legacy paragraph's Template mode already shows.
+// Each fieldLine row always has exactly one "Remove this field line" button, whether or not it
+// carries a label - a stable per-block anchor, unlike the mode-cycle buttons (one or two per
+// block depending on whether a label is present).
 const fieldLineBlocks = async () => {
-  const modeButtons = await screen.findAllByTitle(TEXT_MODE_TITLE);
+  const removeButtons = await screen.findAllByTitle('Remove this field line');
   // eslint-disable-next-line testing-library/no-node-access
-  return modeButtons.map(button => button.closest('.paragraph-editor-block'));
+  return removeButtons.map(button => button.closest('.paragraph-editor-block'));
 };
 
-describe('spec: a layoutV2 fieldLine block gets the full standard paragraph toolbar', () => {
-  it('has the same T/B/I/insert-variable/align/settings/delete buttons a paragraph block has, for both fieldLine rows', async () => {
+// The value's own toolbar/field always renders before the label's (see the JSX order in
+// DocumentsPage) - so among a block's Text-mode buttons, the first is always the value's, the last
+// (when a label exists at all) is the label's.
+const openValueTemplateMode = block => fireEvent.click(within(block).getAllByTitle(TEXT_MODE_TITLE)[0]);
+const openLabelTemplateMode = block => {
+  const buttons = within(block).getAllByTitle(TEXT_MODE_TITLE);
+  fireEvent.click(buttons[buttons.length - 1]);
+};
+
+describe('spec: a layoutV2 fieldLine value gets the full standard paragraph toolbar', () => {
+  it('has the same T/B/I/insert-variable/align/settings/delete buttons a paragraph block has', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock, surrogateBlock] = await fieldLineBlocks();
-    [wifeBlock, surrogateBlock].forEach(block => {
-      expect(within(block).getByTitle(TEXT_MODE_TITLE)).toBeInTheDocument();
-      expect(within(block).getByTitle('Bold the selected text')).toBeInTheDocument();
-      expect(within(block).getByTitle('Italicize the selected text')).toBeInTheDocument();
-      expect(within(block).getByTitle('Insert a variable')).toBeInTheDocument();
-      expect(within(block).getByLabelText(/Вирівнювання/)).toBeInTheDocument();
-      expect(within(block).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown')).toBeInTheDocument();
-      expect(within(block).getByTitle('Remove this field line')).toBeInTheDocument();
-    });
+    // wifeBlock has a label too, so its own toolbar's controls are duplicated (value + label) -
+    // surrogateBlock has none, so its value's toolbar is the only one.
+    expect(within(wifeBlock).getAllByTitle(TEXT_MODE_TITLE)).toHaveLength(2);
+    expect(within(wifeBlock).getAllByTitle('Bold the selected text')).toHaveLength(2);
+    expect(within(wifeBlock).getAllByTitle('Italicize the selected text')).toHaveLength(2);
+    expect(within(wifeBlock).getAllByTitle('Insert a variable')).toHaveLength(2);
+    expect(within(wifeBlock).getAllByLabelText(/Вирівнювання/)).toHaveLength(2);
+    // Only the value gets a settings popover (font size + condition) and a delete button - one
+    // each, never duplicated for the label.
+    expect(within(wifeBlock).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown')).toBeInTheDocument();
+    expect(within(wifeBlock).getByTitle('Remove this field line')).toBeInTheDocument();
 
-    // Only one label field exists (the surrogate mother's fieldLine carries no `label` key at all).
-    expect(within(wifeBlock).getByDisplayValue('дружина')).toBeInTheDocument();
+    expect(within(surrogateBlock).getAllByTitle(TEXT_MODE_TITLE)).toHaveLength(1);
+    expect(within(surrogateBlock).getAllByTitle('Bold the selected text')).toHaveLength(1);
     expect(within(surrogateBlock).queryByPlaceholderText(/Label before the underlined value/)).not.toBeInTheDocument();
   });
 
@@ -117,7 +131,7 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock] = await fieldLineBlocks();
-    fireEvent.click(within(wifeBlock).getByTitle(TEXT_MODE_TITLE));
+    openValueTemplateMode(wifeBlock);
     expect(within(wifeBlock).getByPlaceholderText('Field value')).toHaveValue('{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,');
   });
 
@@ -126,7 +140,7 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [, surrogateBlock] = await fieldLineBlocks();
-    fireEvent.click(within(surrogateBlock).getByTitle(TEXT_MODE_TITLE));
+    openValueTemplateMode(surrogateBlock);
     const valueField = within(surrogateBlock).getByPlaceholderText('Field value');
     fireEvent.change(valueField, { target: { value: '{{surrogateMother.name.uk.nominative}}' } });
     fireEvent.blur(valueField);
@@ -149,7 +163,7 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [, surrogateBlock] = await fieldLineBlocks();
-    fireEvent.click(within(surrogateBlock).getByTitle(TEXT_MODE_TITLE));
+    openValueTemplateMode(surrogateBlock);
     const valueField = within(surrogateBlock).getByPlaceholderText('Field value');
     fireEvent.focus(valueField);
     // "Кацура Юкако, донор ооцитів" - bold just "Кацура Юкако" (the first 12 characters).
@@ -177,35 +191,12 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     ));
   });
 
-  it('editing the label persists straight to layoutV2.blocks[index].label on blur', async () => {
-    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
-    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-
-    const labelField = await screen.findByDisplayValue('дружина');
-    fireEvent.change(labelField, { target: { value: 'та дружина' } });
-    fireEvent.blur(labelField);
-
-    await waitFor(() => expect(set).toHaveBeenCalledWith(
-      'documentsBuilder/templates/doc-1',
-      expect.objectContaining({
-        layoutV2: expect.objectContaining({
-          blocks: [
-            expect.objectContaining({ label: 'та дружина' }),
-            expect.anything(),
-          ],
-        }),
-      }),
-    ));
-  });
-
   it('the field-line settings popover exposes font size (for the value) and condition, same shape as a paragraph block', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const labelField = await screen.findByDisplayValue('дружина');
-    // eslint-disable-next-line testing-library/no-node-access
-    const block = labelField.closest('.paragraph-editor-block');
-    fireEvent.click(within(block).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown'));
+    const [wifeBlock] = await fieldLineBlocks();
+    fireEvent.click(within(wifeBlock).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown'));
 
     const conditionField = await screen.findByLabelText('Condition (context path, ! to negate; empty = always shown)');
     fireEvent.change(conditionField, { target: { value: 'geneticAffinityCertificate.oocyteSourceIsWife' } });
@@ -224,12 +215,13 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     ));
   });
 
-  it('cycling Align on the value writes valueStyleOverrides.align, never the label\'s styleOverrides', async () => {
+  it('cycling the value\'s Align writes valueStyleOverrides.align, never the label\'s styleOverrides', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock] = await fieldLineBlocks();
-    fireEvent.click(within(wifeBlock).getByLabelText(/Вирівнювання/));
+    // The value's Align button is the first of the two (value's toolbar renders before the label's).
+    fireEvent.click(within(wifeBlock).getAllByLabelText(/Вирівнювання/)[0]);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
@@ -244,6 +236,102 @@ describe('spec: a layoutV2 fieldLine block gets the full standard paragraph tool
     ));
     const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
     expect(persistedTemplate.layoutV2.blocks[0].styleOverrides).toBeUndefined();
+  });
+});
+
+describe('spec: a fieldLine label gets its own independent T/B/I/insert-variable/align toolbar', () => {
+  it('switching to Template mode shows the raw label markup, independent of the value', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    openLabelTemplateMode(wifeBlock);
+    expect(within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toHaveValue('дружина');
+    // The value field is untouched, still whatever mode it defaulted to (Text) - not switched
+    // along with the label.
+    expect(within(wifeBlock).queryByPlaceholderText('Field value')).not.toBeInTheDocument();
+  });
+
+  it('editing the label in Template mode persists straight to layoutV2.blocks[index].label on blur', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    openLabelTemplateMode(wifeBlock);
+    const labelField = within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
+    fireEvent.change(labelField, { target: { value: 'та дружина' } });
+    fireEvent.blur(labelField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ label: 'та дружина' }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('Bold on a selected fragment of the label actually works (the reported bug: it always failed with "Select some text first")', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    openLabelTemplateMode(wifeBlock);
+    const labelField = within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
+    fireEvent.focus(labelField);
+    // "дружина" - bold just "друж" (the first 4 characters).
+    labelField.setSelectionRange(0, 4);
+
+    // The label's own Bold button is the last of the two (value's toolbar renders first).
+    const boldButtons = within(wifeBlock).getAllByTitle('Bold the selected text');
+    fireEvent.click(boldButtons[boldButtons.length - 1]);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({
+              type: 'fieldLine',
+              label: 'дружина',
+              labelRuns: [
+                { text: 'друж', style: 'inlineEmphasis' },
+                { text: 'ина', style: undefined },
+              ],
+            }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('cycling the label\'s Align writes styleOverrides.align (the same pair an ordinary paragraph uses), never valueStyleOverrides', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    // The label's Align button is the second of the two.
+    const alignButtons = within(wifeBlock).getAllByLabelText(/Вирівнювання/);
+    fireEvent.click(alignButtons[alignButtons.length - 1]);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ styleOverrides: expect.objectContaining({ align: expect.any(String) }) }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+    const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
+    expect(persistedTemplate.layoutV2.blocks[0].valueStyleOverrides).toBeUndefined();
   });
 });
 
@@ -287,18 +375,22 @@ describe('spec: a fieldLine with labelRuns (not plain label) is still visible/ed
     });
   });
 
-  it('shows the labelRuns text (plain, concatenated) as the label field\'s value instead of leaving it blank', async () => {
+  it('shows the labelRuns text as the label field\'s value in Template mode, bold preserved via the raw **markup**', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    expect(await screen.findByDisplayValue('та/або сперматозоїди')).toBeInTheDocument();
+    const [block] = await fieldLineBlocks();
+    openLabelTemplateMode(block);
+    expect(within(block).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toHaveValue('**та**/або сперматозоїди');
   });
 
-  it('editing that label persists as plain `label`, dropping `labelRuns`', async () => {
+  it('editing that label persists as plain `label` when the edit drops the bold, clearing `labelRuns`', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const labelField = await screen.findByDisplayValue('та/або сперматозоїди');
+    const [block] = await fieldLineBlocks();
+    openLabelTemplateMode(block);
+    const labelField = within(block).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
     fireEvent.change(labelField, { target: { value: 'сперматозоїди' } });
     fireEvent.blur(labelField);
 

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -63,6 +63,7 @@ import {
   isLayoutV2Template,
   isOfficialFormStyle,
   isSingleLanguageTwoColumnLayout,
+  layoutV2LabelScope,
   layoutV2Scope,
   mapResolvedSelectionToRaw,
   legacyClinicLogoStorageFilePath,
@@ -1816,28 +1817,14 @@ const DocumentsPage = ({ isAdmin }) => {
   // understand a fieldLine's value/valueRuns, see layoutV2ParagraphRuns in documentsCatalogUtils),
   // so no dedicated setter is needed here for it - only the label below is still a plain field.
 
-  // The label sits to the left of the underlined value (e.g. "дружина", "та чоловік") - present on
-  // some fieldLine blocks, absent on others (the surrogate mother's own line has none). A block can
-  // instead carry `labelRuns` (bold-in-part label, e.g. "**та**/або сперматозоїди") - editing that
-  // one plain-text as done here drops the bold run and switches it over to the plain `label` shape,
-  // which is an acceptable trade for turning what used to be a completely blank, invisible block
-  // (label/value both unreadable) into a visible, editable one.
-  const setLayoutV2FieldLineLabel = (docId, blockIndex, value) => applyLayoutV2BlocksChange(
-    docId,
-    blocks => blocks.map((item, index) => {
-      if (index !== blockIndex) return item;
-      const { labelRuns: ignoredLabelRuns, ...rest } = item;
-      return { ...rest, label: value };
-    }),
-  );
-
-  // The label's own display text, whichever shape the block stores it in - see
-  // setLayoutV2FieldLineLabel above for why editing it always collapses to the plain `label` shape.
-  const layoutV2FieldLineLabelText = block => {
-    if (block.label !== undefined) return block.label;
-    if (block.labelRuns) return block.labelRuns.map(run => run.text).join('');
-    return undefined;
-  };
+  // The label sits to the left of the underlined value (e.g. "дружина", "та чоловік", bold-in-part
+  // "**та**/або сперматозоїди") - present on some fieldLine blocks, absent on others (the surrogate
+  // mother's own line has none at all). Whether a block has one is a plain existence check;
+  // *editing* it goes through the same generic getTemplateScopeText/handleTemplateScopeChange
+  // machinery the value row uses, addressed via its own layoutV2LabelScope - see
+  // layoutV2LabelMarkup/layoutV2LabelFromMarkup (documentsCatalogUtils) for why that gives it the
+  // exact same T/B/I/insert-variable toolbar instead of only a bare, unformattable text input.
+  const hasLayoutV2FieldLineLabel = block => block.label !== undefined || block.labelRuns !== undefined;
 
   const setLayoutV2LogoOffset = (docId, blockIndex, columnIndex, axisKey, raw) => {
     const parsed = parsePlainNumber(raw);
@@ -3469,6 +3456,26 @@ const DocumentsPage = ({ isAdmin }) => {
                                 };
                                 const onBlur = () => persistTemplate(template.id);
                                 const fieldKind = isTemplateMode ? 'template' : 'input-plain';
+                                // The label is a second, fully independent field slot on the same
+                                // block (layoutV2LabelScope) - its own mode/toolbar state, never
+                                // shared with the value's above.
+                                const hasLabel = hasLayoutV2FieldLineLabel(block);
+                                const labelScope = layoutV2LabelScope(blockIndex);
+                                const labelMode = getParagraphMode(template.id, labelScope);
+                                const isLabelTemplateMode = labelMode === 'template';
+                                const isLabelInputMode = labelMode === 'input';
+                                const isLabelTextMode = labelMode === 'text';
+                                const rawLabelValue = langKey => getTemplateScopeText(template, labelScope, langKey);
+                                const resolvedLabelValue = langKey => fillPlaceholders(rawLabelValue(langKey), getContextForTemplate(template.id), langKey);
+                                const displayLabelValue = langKey => (isLabelTemplateMode ? rawLabelValue(langKey) : plainTextOf(resolvedLabelValue(langKey)));
+                                const onLabelChange = langKey => event => {
+                                  const nextRaw = isLabelTemplateMode
+                                    ? event.target.value
+                                    : applyResolvedTextEdit(rawLabelValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
+                                  handleTemplateScopeChange(template.id, labelScope, langKey, nextRaw);
+                                };
+                                const onLabelBlur = () => persistTemplate(template.id);
+                                const labelFieldKind = isLabelTemplateMode ? 'template' : 'input-plain';
                                 return (
                                   // eslint-disable-next-line react/no-array-index-key
                                   <ParagraphEditorBlock key={`${template.id}-lv2-fieldline-${blockIndex}`}>
@@ -3552,23 +3559,89 @@ const DocumentsPage = ({ isAdmin }) => {
                                       </RowLine>
                                     </ParagraphControlsRow>
                                     {/* The label sits to the left of the underlined value (e.g.
-                                        "дружина") - present on some fieldLine blocks, absent on
-                                        others (the surrogate mother's own line has none at all). A
-                                        block can store it as plain `label` or as bold-in-part
-                                        `labelRuns` (e.g. bold "та" followed by "/або сперматозоїди") -
-                                        layoutV2FieldLineLabelText reads whichever shape is there so
-                                        this field is never silently blank/unreachable for a
-                                        labelRuns block; editing it always collapses to plain
-                                        `label` (see setLayoutV2FieldLineLabel). */}
-                                    {layoutV2FieldLineLabelText(block) !== undefined ? (
-                                      <FieldInput
-                                        type="text"
-                                        value={layoutV2FieldLineLabelText(block) || ''}
-                                        placeholder="Label before the underlined value, e.g. «дружина»"
-                                        onChange={event => setLayoutV2FieldLineLabel(template.id, blockIndex, event.target.value)}
-                                        onBlur={() => persistTemplate(template.id)}
-                                        style={{ width: '100%', marginBottom: 6 }}
-                                      />
+                                        "дружина", or bold "та" followed by "/або сперматозоїди") -
+                                        present on some fieldLine blocks, absent on others (the
+                                        surrogate mother's own line has none at all). Its own full
+                                        T/B/I/insert-variable/align toolbar, exactly like the value's
+                                        below - layoutV2LabelMarkup/FromMarkup (documentsCatalogUtils)
+                                        give it the same working Bold/Italic a bare text input never
+                                        could (the bug this fixes: bolding text here previously always
+                                        failed with "Select some text first", since the toolbar only
+                                        ever tracked the value field's selection, never this one's). */}
+                                    {hasLabel ? (
+                                      <>
+                                        <ParagraphControlsRow>
+                                          <RowLine style={{ gap: 6 }}>
+                                            <SmallButton
+                                              type="button"
+                                              onClick={() => setParagraphModeFor(template.id, labelScope, nextParagraphMode(labelMode))}
+                                              title={PARAGRAPH_MODE_TITLE[labelMode]}
+                                            >
+                                              {PARAGRAPH_MODE_ICON[labelMode]}
+                                            </SmallButton>
+                                            <SmallButton
+                                              type="button"
+                                              disabled={isLabelInputMode}
+                                              {...formatButtonProps('bold')}
+                                              title="Bold the selected text"
+                                            >
+                                              <FaBold />
+                                            </SmallButton>
+                                            <SmallButton
+                                              type="button"
+                                              disabled={isLabelInputMode}
+                                              {...formatButtonProps('italic')}
+                                              title="Italicize the selected text"
+                                            >
+                                              <FaItalic />
+                                            </SmallButton>
+                                            <SmallButton
+                                              type="button"
+                                              disabled={!isLabelTemplateMode}
+                                              onMouseDown={preventSelectionLoss}
+                                              onClick={openVariablePicker}
+                                              title="Insert a variable"
+                                            >
+                                              <FaCode />
+                                            </SmallButton>
+                                            <AlignCycleButton
+                                              align={getEffectiveLayoutV2BlockAlign(template, block)}
+                                              onCycle={() => handleCycleLayoutV2Align(template.id, blockIndex)}
+                                            />
+                                          </RowLine>
+                                        </ParagraphControlsRow>
+                                        <ParagraphFieldColumn style={{ marginBottom: 6 }}>
+                                          {isLabelTextMode || (isLabelInputMode && activeFieldKey !== fieldKey(template.id, labelScope, layoutV2Lang)) ? (
+                                            <TextModeDisplay
+                                              ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
+                                              onMouseUp={isLabelTextMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, 'text-display') : undefined}
+                                              onTouchEnd={isLabelTextMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, 'text-display') : undefined}
+                                              onMouseDown={isLabelInputMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, labelFieldKind) : undefined}
+                                              title={isLabelInputMode ? 'Click to edit the wording' : undefined}
+                                            >
+                                              <FormattedRunsPreview text={resolvedLabelValue(layoutV2Lang)} />
+                                            </TextModeDisplay>
+                                          ) : isLabelInputMode ? (
+                                            <RichResolvedTextField
+                                              ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
+                                              initialText={resolvedLabelValue(layoutV2Lang)}
+                                              placeholder="Label before the underlined value, e.g. «дружина»"
+                                              onPlainTextChange={nextPlain => onLabelChange(layoutV2Lang)({ target: { value: nextPlain } })}
+                                              onFocus={handleRichFieldFocus(template.id, labelScope, layoutV2Lang, labelFieldKind)}
+                                              onBlur={onLabelBlur}
+                                            />
+                                          ) : (
+                                            <AutoInlineTextarea
+                                              ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
+                                              value={displayLabelValue(layoutV2Lang)}
+                                              placeholder="Label before the underlined value, e.g. «дружина»"
+                                              onFocus={handleRichFieldFocus(template.id, labelScope, layoutV2Lang, labelFieldKind)}
+                                              onChange={onLabelChange(layoutV2Lang)}
+                                              onBlur={onLabelBlur}
+                                            />
+                                          )}
+                                        </ParagraphFieldColumn>
+                                      </>
                                     ) : null}
                                     <ParagraphFieldColumn>
                                       {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, layoutV2Lang)) ? (

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -2436,6 +2436,10 @@ export const paragraphScope = index => `p:${index}`;
 // `languages[0]`), so there is only ever one markup string to read/write, whichever langKey the
 // caller happens to pass.
 const layoutV2ScopeMatch = scope => /^lv2:(\d+)$/.exec(scope);
+// `lv2-label:<index>` (layoutV2LabelScope) - a fieldLine block's label, entirely independent of
+// its `lv2:<index>` value slot above. Matched separately from layoutV2ScopeMatch (never confused
+// with it - the "-label" segment makes the two patterns mutually exclusive).
+const layoutV2LabelScopeMatch = scope => /^lv2-label:(\d+)$/.exec(scope);
 
 export const getTemplateScopeText = (template, scope, langKey) => {
   if (scope === TITLE_SCOPE) return template?.title?.[langKey] || '';
@@ -2443,6 +2447,8 @@ export const getTemplateScopeText = (template, scope, langKey) => {
   if (beforeTitleMatch) return template?.beforeTitle?.[Number(beforeTitleMatch[1])]?.[langKey] || '';
   const paragraphMatch = /^p:(\d+)$/.exec(scope);
   if (paragraphMatch) return template?.paragraphs?.[Number(paragraphMatch[1])]?.[langKey] || '';
+  const layoutV2LabelMatch = layoutV2LabelScopeMatch(scope);
+  if (layoutV2LabelMatch) return layoutV2LabelMarkup(template?.layoutV2?.blocks?.[Number(layoutV2LabelMatch[1])]);
   const layoutV2Match = layoutV2ScopeMatch(scope);
   if (layoutV2Match) return layoutV2ParagraphMarkup(template?.layoutV2?.blocks?.[Number(layoutV2Match[1])]);
   return '';
@@ -2466,6 +2472,18 @@ export const withTemplateScopeText = (template, scope, langKey, value) => {
     return {
       ...template,
       paragraphs: (template.paragraphs || []).map((paragraph, i) => (i === index ? { ...paragraph, [langKey]: value } : paragraph)),
+    };
+  }
+  const layoutV2LabelMatch = layoutV2LabelScopeMatch(scope);
+  if (layoutV2LabelMatch) {
+    const index = Number(layoutV2LabelMatch[1]);
+    const blocks = template?.layoutV2?.blocks || [];
+    return {
+      ...template,
+      layoutV2: {
+        ...template.layoutV2,
+        blocks: blocks.map((block, i) => (i === index ? layoutV2LabelFromMarkup(block, value) : block)),
+      },
     };
   }
   const layoutV2Match = layoutV2ScopeMatch(scope);
@@ -2841,17 +2859,24 @@ export const findUnresolvedPlaceholders = layoutV2Doc => {
 // plain-vs-runs pattern `text`/`runs` already is for an ordinary paragraph, so the whole toolbar
 // below (mode cycle, Bold, Italic, Insert-variable) works on a fieldLine's value identically to
 // any other paragraph's text, instead of only exposing a bare text input for it.
-export const layoutV2ParagraphRuns = block => {
-  if (block?.type === 'richParagraph') {
-    return (block.runs || []).map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }));
-  }
-  if (block?.type === 'fieldLine') {
-    return block.valueRuns
-      ? block.valueRuns.map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }))
-      : [{ text: String(block?.value || ''), style: undefined, styleOverrides: undefined }];
-  }
-  return [{ text: String(block?.text || ''), style: undefined, styleOverrides: undefined }];
+// A generic "field slot" reader: any block field that can independently be either a plain string
+// or its own bold/italic-carrying `<key>Runs` sibling (text/runs, value/valueRuns, label/
+// labelRuns, ...) - factored out because a fieldLine block carries *two* such slots at once
+// (value and label), each fully independent of the other, unlike an ordinary paragraph's one.
+const layoutV2FieldSlotRuns = (block, textKey, runsKey) => {
+  const runs = block?.[runsKey];
+  if (runs) return runs.map(run => ({ text: String(run?.text || ''), style: run?.style, styleOverrides: run?.styleOverrides }));
+  return [{ text: String(block?.[textKey] || ''), style: undefined, styleOverrides: undefined }];
 };
+
+export const layoutV2ParagraphRuns = block => (block?.type === 'fieldLine'
+  ? layoutV2FieldSlotRuns(block, 'value', 'valueRuns')
+  : layoutV2FieldSlotRuns(block, 'text', 'runs'));
+
+// A fieldLine's label (e.g. "дружина", or bold-in-part "**та**/або сперматозоїди") is a second,
+// entirely independent field slot from its value - its own T/B/I/insert-variable/align toolbar row
+// (lv2-label:<index> scope, layoutV2LabelScope below) needs the same runs access the value's does.
+export const layoutV2FieldLineLabelRuns = block => layoutV2FieldSlotRuns(block, 'label', 'labelRuns');
 
 export const layoutV2ParagraphPlainText = block => layoutV2ParagraphRuns(block).map(run => run.text).join('');
 
@@ -2907,21 +2932,26 @@ const mergeAdjacentLayoutV2Runs = runs => runs.reduce((merged, run) => {
 
 const isLayoutV2RunPlain = run => !run.style && !run.styleOverrides?.fontStyle;
 
-// Collapses a merged run list back into the block's own field shape: paragraph.text/
-// richParagraph.runs for an ordinary paragraph block, fieldLine.value/valueRuns for a fieldLine's
-// own value - collapsed to the plain single-field shape whenever nothing in the result actually
-// carries bold/italic, so an untouched/fully-unformatted block never permanently upgrades to the
-// richer shape. Shared by the Bold/Italic toggles and layoutV2ParagraphFromMarkup below, so all
-// three ways of editing a block's text agree on the same collapse rule.
-const finalizeLayoutV2ParagraphRuns = (block, mergedRuns) => {
-  if (block?.type === 'fieldLine') {
-    const plainText = mergedRuns.map(run => run.text).join('');
-    if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
-      const { valueRuns: ignoredValueRuns, ...plainBlock } = block;
-      return { ...plainBlock, value: plainText };
-    }
-    return { ...block, value: plainText, valueRuns: mergedRuns };
+// Collapses a merged run list back into a generic field slot's own text/runs pair - the plain
+// single-field shape whenever nothing in the result actually carries bold/italic, so an untouched/
+// unformatted slot never permanently upgrades to the richer shape. Shared by every slot's Bold/
+// Italic toggle and its FromMarkup below, so all three ways of editing a slot's text agree on the
+// same collapse rule.
+const finalizeLayoutV2FieldSlotRuns = (block, textKey, runsKey, mergedRuns) => {
+  const plainText = mergedRuns.map(run => run.text).join('');
+  if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
+    const next = { ...block, [textKey]: plainText };
+    delete next[runsKey];
+    return next;
   }
+  return { ...block, [textKey]: plainText, [runsKey]: mergedRuns };
+};
+
+// Same collapse rule as above, but for an ordinary paragraph/richParagraph block, which additionally
+// switches its own `type` between the two shapes (a fieldLine's slots never do - `type` always stays
+// 'fieldLine' regardless of whether its value/label carry runs).
+const finalizeLayoutV2ParagraphRuns = (block, mergedRuns) => {
+  if (block?.type === 'fieldLine') return finalizeLayoutV2FieldSlotRuns(block, 'value', 'valueRuns', mergedRuns);
   if (mergedRuns.length <= 1 && mergedRuns.every(isLayoutV2RunPlain)) {
     const { runs: ignoredRuns, ...plainBlock } = block;
     return { ...plainBlock, type: 'paragraph', text: mergedRuns[0]?.text || '' };
@@ -2929,6 +2959,8 @@ const finalizeLayoutV2ParagraphRuns = (block, mergedRuns) => {
   const { text: ignoredText, ...richBlock } = block;
   return { ...richBlock, type: 'richParagraph', runs: mergedRuns };
 };
+
+const finalizeLayoutV2FieldLineLabelRuns = (block, mergedRuns) => finalizeLayoutV2FieldSlotRuns(block, 'label', 'labelRuns', mergedRuns);
 
 // MS Word toggle behavior (batch 17), same rule as toggleInlineFormat: if every run inside
 // [plainStart, plainEnd) is already 'inlineEmphasis', the whole selection loses it; otherwise the
@@ -2969,17 +3001,14 @@ export const toggleLayoutV2ParagraphItalic = (block, plainStart, plainEnd) => {
 // The legacy paragraph/beforeTitle/title editor's whole toolbar (Template/Input/Text mode cycle,
 // Bold/Italic, Insert-variable) is built on one shared **bold**/*italic* markup string per row
 // (parseFormattedRuns/serializeFormattedRuns) addressed via getTemplateScopeText/
-// withTemplateScopeText. Converting a layoutV2 paragraph/richParagraph block to and from that same
-// markup shape lets a `lv2:<index>` scope (see layoutV2Scope) reuse that entire existing editor
-// unchanged, instead of duplicating a second toolbar/mode system just for layoutV2 blocks.
-export const layoutV2ParagraphMarkup = block => serializeFormattedRuns(layoutV2ParagraphRuns(block).map(run => ({
-  text: run.text,
-  bold: run.style === 'inlineEmphasis',
-  italic: run.styleOverrides?.fontStyle === 'italic',
-})));
-
-export const layoutV2ParagraphFromMarkup = (existingBlock, markup) => {
-  const previousRuns = layoutV2ParagraphRuns(existingBlock);
+// withTemplateScopeText. Converting a layoutV2 block's field slot to and from that same markup
+// shape lets a `lv2:<index>`/`lv2-label:<index>` scope (layoutV2Scope/layoutV2LabelScope) reuse
+// that entire existing editor unchanged, instead of duplicating a second toolbar/mode system just
+// for layoutV2 blocks. Generic over which slot (getRuns/finalize) so a fieldLine's value and label
+// - two fully independent bold/italic-carrying fields on the same block - each get their own
+// working toolbar without duplicating this diff algorithm twice.
+const layoutV2MarkupFromSlot = (existingBlock, markup, getRuns, finalize) => {
+  const previousRuns = getRuns(existingBlock);
   const previousText = previousRuns.map(run => run.text).join('');
   const parsedRuns = parseFormattedRuns(markup);
   const nextText = parsedRuns.map(run => run.text).join('');
@@ -3024,12 +3053,36 @@ export const layoutV2ParagraphFromMarkup = (existingBlock, markup) => {
     }
     nextOffset += parsedRun.text.length;
   });
-  return finalizeLayoutV2ParagraphRuns(existingBlock, mergeAdjacentLayoutV2Runs(runs));
+  return finalize(existingBlock, mergeAdjacentLayoutV2Runs(runs));
 };
+
+const layoutV2RunsToMarkup = runs => serializeFormattedRuns(runs.map(run => ({
+  text: run.text,
+  bold: run.style === 'inlineEmphasis',
+  italic: run.styleOverrides?.fontStyle === 'italic',
+})));
+
+export const layoutV2ParagraphMarkup = block => layoutV2RunsToMarkup(layoutV2ParagraphRuns(block));
+
+export const layoutV2ParagraphFromMarkup = (existingBlock, markup) => layoutV2MarkupFromSlot(
+  existingBlock, markup, layoutV2ParagraphRuns, finalizeLayoutV2ParagraphRuns,
+);
+
+// A fieldLine's label - its own independent T/B/I/insert-variable/align toolbar row, the fix for a
+// block whose label was previously either a plain-only field (no bold/italic at all) or, worse,
+// fully invisible (labelRuns with no plain `label` at all - see layoutV2FieldLineLabelRuns).
+export const layoutV2LabelMarkup = block => layoutV2RunsToMarkup(layoutV2FieldLineLabelRuns(block));
+
+export const layoutV2LabelFromMarkup = (existingBlock, markup) => layoutV2MarkupFromSlot(
+  existingBlock, markup, layoutV2FieldLineLabelRuns, finalizeLayoutV2FieldLineLabelRuns,
+);
 
 // The scope key a layoutV2 paragraph/richParagraph block edits under (mirrors beforeTitleScope/
 // paragraphScope) - resolved by getTemplateScopeText/withTemplateScopeText below.
 export const layoutV2Scope = index => `lv2:${index}`;
+
+// A fieldLine block's label - its own, independent scope from layoutV2Scope's value slot above.
+export const layoutV2LabelScope = index => `lv2-label:${index}`;
 
 // The effective alignment a layoutV2 block renders with - unlike a legacy paragraph's own `style`
 // object, a layoutV2 block's `style` names a *shared* template style (resolveLayoutV2Style), so an

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -103,9 +103,14 @@ import {
   layoutV2ParagraphPlainText,
   layoutV2ParagraphMarkup,
   layoutV2ParagraphFromMarkup,
+  layoutV2FieldLineLabelRuns,
+  layoutV2LabelMarkup,
+  layoutV2LabelFromMarkup,
+  layoutV2LabelScope,
   mapResolvedSelectionToRaw,
   layoutV2Scope,
   getEffectiveLayoutV2BlockAlign,
+  getEffectiveLayoutV2FieldLineValueAlign,
   toggleLayoutV2ParagraphBold,
   toggleLayoutV2ParagraphItalic,
   upsertRecentCaseId,
@@ -1883,6 +1888,122 @@ describe('spec: layoutV2 paragraph full toolbar parity (Italic, markup round-tri
     const existing = { type: 'richParagraph', style: 'body', runs: [{ text: 'x', style: 'inlineEmphasis' }] };
     const next = layoutV2ParagraphFromMarkup(existing, 'Hello world');
     expect(next).toEqual({ type: 'paragraph', style: 'body', text: 'Hello world', runs: undefined });
+  });
+
+  // A fieldLine block's own templated content is its `value` (label/caption are a separate, second
+  // field slot - see the label tests below) - layoutV2ParagraphRuns/FromMarkup treat value/valueRuns
+  // exactly the same way they treat an ordinary paragraph's text/runs, except `type` always stays
+  // 'fieldLine' (never flips to 'paragraph'/'richParagraph' the way an ordinary block's does).
+  describe('a fieldLine block\'s value (layoutV2ParagraphRuns/Markup/FromMarkup)', () => {
+    it('reads a plain fieldLine value as one unstyled run, falls back to valueRuns when present', () => {
+      expect(layoutV2ParagraphRuns({ type: 'fieldLine', value: 'Hello' })).toEqual([{ text: 'Hello', style: undefined, styleOverrides: undefined }]);
+      const withRuns = { type: 'fieldLine', value: 'Helloworld', valueRuns: [{ text: 'Hello', style: undefined }, { text: 'world', style: 'inlineEmphasis' }] };
+      expect(layoutV2ParagraphRuns(withRuns)).toEqual([
+        { text: 'Hello', style: undefined, styleOverrides: undefined },
+        { text: 'world', style: 'inlineEmphasis', styleOverrides: undefined },
+      ]);
+    });
+
+    it('round-trips bold through the same **markup** every other paragraph uses, `type` staying \'fieldLine\' throughout', () => {
+      const block = {
+        type: 'fieldLine',
+        label: 'дружина',
+        value: 'Hello world',
+        valueRuns: [{ text: 'Hello ', style: undefined }, { text: 'world', style: 'inlineEmphasis' }],
+      };
+      const markup = layoutV2ParagraphMarkup(block);
+      expect(markup).toBe('Hello **world**');
+      const roundTripped = layoutV2ParagraphFromMarkup(block, markup);
+      expect(roundTripped.type).toBe('fieldLine');
+      expect(roundTripped.label).toBe('дружина'); // untouched - the label is a fully independent slot
+      expect(roundTripped.value).toBe('Hello world');
+      expect(roundTripped.valueRuns).toEqual(block.valueRuns);
+    });
+
+    it('collapses back to a plain value (valueRuns dropped) once the edit removes all formatting', () => {
+      const existing = { type: 'fieldLine', value: 'Helloworld', valueRuns: [{ text: 'Hello', style: 'inlineEmphasis' }, { text: 'world', style: undefined }] };
+      const next = layoutV2ParagraphFromMarkup(existing, 'Hello world');
+      expect(next).toEqual({ type: 'fieldLine', value: 'Hello world' });
+      expect('valueRuns' in next).toBe(false);
+    });
+  });
+
+  // The label is a second, entirely independent field slot from the value - its own runs/markup
+  // functions, addressed via its own lv2-label:<index> scope (layoutV2LabelScope), so a fieldLine's
+  // label gets the exact same working Bold/Italic toolbar the value does instead of a bare,
+  // unformattable text input (the bug this fixes: selecting text in the label and pressing Bold
+  // always failed with "Select some text first", since the toolbar only ever tracked the value's
+  // selection - see DocumentsPage.fieldLine.test.js for the UI-level reproduction).
+  describe('a fieldLine block\'s label (layoutV2FieldLineLabelRuns/layoutV2LabelMarkup/FromMarkup)', () => {
+    it('reads a plain label as one unstyled run, falls back to labelRuns when present, independent of the value', () => {
+      const block = { type: 'fieldLine', label: 'дружина', value: 'Hello world' };
+      expect(layoutV2FieldLineLabelRuns(block)).toEqual([{ text: 'дружина', style: undefined, styleOverrides: undefined }]);
+
+      const withLabelRuns = {
+        type: 'fieldLine',
+        labelRuns: [{ text: 'та', style: 'inlineEmphasis' }, { text: '/або сперматозоїди', style: undefined }],
+        value: '',
+      };
+      expect(layoutV2FieldLineLabelRuns(withLabelRuns)).toEqual([
+        { text: 'та', style: 'inlineEmphasis', styleOverrides: undefined },
+        { text: '/або сперматозоїди', style: undefined, styleOverrides: undefined },
+      ]);
+    });
+
+    it('layoutV2LabelMarkup/layoutV2LabelFromMarkup round-trip bold through the same **markup** the value uses, `type` staying \'fieldLine\'', () => {
+      const block = {
+        type: 'fieldLine',
+        labelRuns: [{ text: 'та', style: 'inlineEmphasis' }, { text: '/або сперматозоїди', style: undefined }],
+        value: '{{husband.name.uk.nominative}}',
+      };
+      const markup = layoutV2LabelMarkup(block);
+      expect(markup).toBe('**та**/або сперматозоїди');
+      const roundTripped = layoutV2LabelFromMarkup(block, markup);
+      expect(roundTripped.type).toBe('fieldLine');
+      expect(roundTripped.value).toBe('{{husband.name.uk.nominative}}'); // untouched - independent of the label
+      expect(roundTripped.labelRuns).toEqual(block.labelRuns);
+    });
+
+    it('collapses labelRuns to a plain label once the edit removes all formatting, never touching the value', () => {
+      const existing = {
+        type: 'fieldLine',
+        labelRuns: [{ text: 'та', style: 'inlineEmphasis' }, { text: '/або сперматозоїди', style: undefined }],
+        value: 'Кацура Наоя',
+      };
+      const next = layoutV2LabelFromMarkup(existing, 'та/або сперматозоїди');
+      expect(next).toEqual({ type: 'fieldLine', label: 'та/або сперматозоїди', value: 'Кацура Наоя' });
+      expect('labelRuns' in next).toBe(false);
+    });
+
+    it('layoutV2LabelScope never collides with layoutV2Scope, and both round-trip through getTemplateScopeText/withTemplateScopeText', () => {
+      expect(layoutV2LabelScope(2)).toBe('lv2-label:2');
+      expect(layoutV2Scope(2)).toBe('lv2:2');
+
+      const template = {
+        layoutV2: {
+          blocks: [{ type: 'paragraph', text: 'irrelevant' }, { type: 'fieldLine', label: 'дружина', value: '{{wife.name.uk.nominative}}' }],
+        },
+      };
+      expect(getTemplateScopeText(template, layoutV2Scope(1), 'uk')).toBe('{{wife.name.uk.nominative}}');
+      expect(getTemplateScopeText(template, layoutV2LabelScope(1), 'uk')).toBe('дружина');
+
+      const nextTemplate = withTemplateScopeText(template, layoutV2LabelScope(1), 'uk', '**та**/або чоловік');
+      expect(nextTemplate.layoutV2.blocks[1]).toEqual({
+        type: 'fieldLine',
+        label: 'та/або чоловік',
+        labelRuns: [{ text: 'та', style: 'inlineEmphasis' }, { text: '/або чоловік', style: undefined }],
+        value: '{{wife.name.uk.nominative}}', // untouched by the label-scoped write
+      });
+      // The other block, and the value slot on the same block, are both untouched.
+      expect(nextTemplate.layoutV2.blocks[0]).toEqual(template.layoutV2.blocks[0]);
+    });
+  });
+
+  it('getEffectiveLayoutV2FieldLineValueAlign reads valueStyle/valueStyleOverrides, independent of getEffectiveLayoutV2BlockAlign\'s style/styleOverrides', () => {
+    const template = { styleSheet: {} };
+    const block = { styleOverrides: { align: 'right' }, valueStyleOverrides: { align: 'center' } };
+    expect(getEffectiveLayoutV2BlockAlign(template, block)).toBe('right');
+    expect(getEffectiveLayoutV2FieldLineValueAlign(template, block)).toBe('center');
   });
 
   it('maps Text-mode offsets after a resolved placeholder back to unresolved offsets', () => {


### PR DESCRIPTION
## Summary
- The fieldLine **label** (e.g. "та/або сперматозоїди") was a plain-text-only field, completely disconnected from the Bold/Italic/mode-cycle/align toolbar that every other paragraph-like field in the Documents builder gets.
- Typing `**markup**` into it did nothing because it was never parsed into runs, and pressing Bold with a selection had no rich-text field to act on — this was the actual root cause of the "Select some text first" error the user hit when trying to bold part of a fieldLine label.
- Generalized the paragraph text/runs machinery in `documentsCatalogUtils.js` into a reusable "field slot" abstraction (covers `text`/`runs`, `value`/`valueRuns`, and now `label`/`labelRuns`), and gave fieldLine labels their own scope key (`lv2-label:<index>`) plus a full toolbar row in `DocumentsPage.jsx`, mirroring the value's toolbar exactly (mode cycle, Bold, Italic, insert-variable, align).

## Test plan
- [x] `npx eslint` on all touched files — no errors
- [x] `documentsCatalogUtils.test.js` — 325/325 passing (new tests cover fieldLine value/label runs, markup round-trip, scope-collision between `lv2:` and `lv2-label:`)
- [x] `DocumentsPage.fieldLine.test.js` — 12/12 passing (new describe block specifically regression-tests bolding a selected fragment of a fieldLine label)
- [x] Broader regression suite (`--testPathPattern="Documents|CaseEditor|PartiesPage"`) — 547/547 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx)_