### PR TITLE
Tag fieldLine's stacked Label/Value toolbars so they're not mistaken for duplicates

### DIFF
--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -506,6 +506,18 @@ const ParagraphControlsRow = styled.div`
   margin-bottom: 4px;
 `;
 
+// A fieldLine's label and value toolbars share the same five icons (mode/Bold/Italic/insert-var/
+// align), stacked directly on top of each other - this tiny tag is the only thing telling them
+// apart at a glance, so it's never ambiguous which row a button acts on.
+const FieldSlotTag = styled.span`
+  color: var(--km-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
+  margin-right: 2px;
+`;
+
 // Encloses one editable row's controls (Bold/Italic/Insert-variable, Insert/Remove for paragraphs)
 // together with its own text, in one visible border - so which row a button acts on is never
 // ambiguous, regardless of whether the two-column ParagraphPair below would otherwise draw its own
@@ -3488,6 +3500,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         <FaPlus />
                                       </SmallButton>
                                       <RowLine style={{ gap: 6 }}>
+                                        {hasLabel ? <FieldSlotTag>Value</FieldSlotTag> : null}
                                         <SmallButton
                                           type="button"
                                           onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
@@ -3572,6 +3585,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                       <>
                                         <ParagraphControlsRow>
                                           <RowLine style={{ gap: 6 }}>
+                                            <FieldSlotTag>Label</FieldSlotTag>
                                             <SmallButton
                                               type="button"
                                               onClick={() => setParagraphModeFor(template.id, labelScope, nextParagraphMode(labelMode))}


### PR DESCRIPTION
## Summary
- A layoutV2 fieldLine block that has a label shows two stacked toolbar rows: one for the label, one for the value. They're independently formattable fields (by design, from the previous PR), but they share the same five icon buttons (mode/Bold/Italic/insert-variable/align), so stacked directly on top of each other they look like an accidental duplicate.
- Add a small "Label"/"Value" tag to each row, shown only when a block actually has both rows, so it's unambiguous which field a row's buttons act on.

## Test plan
- [x] `npx eslint src/components/DocumentsPage.jsx` — no errors
- [x] `DocumentsPage.fieldLine.test.js` — 12/12 passing
- [x] Broader regression suite (`--testPathPattern="Documents|CaseEditor|PartiesPage"`) — 547/547 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqKLHvci9zvAhpiGC1EqBx)_