### PR TITLE
Introduce `buildUserRtdbLink` util and use it in TopBlock (with tests)

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -57,6 +57,7 @@ import { reencodePdfImageDataUrl } from 'utils/pdfImageEncoding';
 import { getEffectiveCycleStatus } from 'utils/cycleStatus';
 import { isAdminUid } from 'utils/accessLevel';
 import { resolveMatchingMultiDataOwnerIds } from 'utils/multiDataAccess';
+import { buildUserRtdbLink } from 'utils/firebaseUserConsoleLink';
 import { auth } from '../config';
 import toast from 'react-hot-toast';
 
@@ -619,9 +620,6 @@ const hasAgentOrIPRole = data =>
 
 const hasRoleWithoutCycle = data =>
   data.userRole === 'pp' || data.role === 'pp' || hasAgentOrIPRole(data);
-
-const buildRtdbLink = userId =>
-  `https://console.firebase.google.com/u/0/project/webringitapp/database/webringitapp-default-rtdb/data/~2FnewUsers~2F${encodeURIComponent(userId || '')}`;
 
 const resolveUserPhotoCollection = data => {
   if (data?.__sourceCollection === 'users' || data?.__sourceCollection === 'newUsers') {
@@ -2042,7 +2040,7 @@ export const TopBlock = ({
               {cardData.lastAction && cardData.userId && <span>·</span>}
               {cardData.userId && (
                 <a
-                  href={buildRtdbLink(cardData.userId)}
+                  href={buildUserRtdbLink(cardData.userId)}
                   target="_blank"
                   rel="noreferrer"
                   title="Відкрити профіль в Firebase RTDB"

--- a/src/utils/firebaseUserConsoleLink.js
+++ b/src/utils/firebaseUserConsoleLink.js
@@ -1,0 +1,9 @@
+import { isLongFormatUserId } from './mergeUserCollections';
+
+const FIREBASE_CONSOLE_DATABASE_URL =
+  'https://console.firebase.google.com/u/0/project/webringitapp/database/webringitapp-default-rtdb/data';
+
+export const buildUserRtdbLink = userId => {
+  const collection = isLongFormatUserId(userId) ? 'users' : 'newUsers';
+  return `${FIREBASE_CONSOLE_DATABASE_URL}/~2F${collection}~2F${encodeURIComponent(userId || '')}`;
+};

--- a/src/utils/firebaseUserConsoleLink.test.js
+++ b/src/utils/firebaseUserConsoleLink.test.js
@@ -1,0 +1,17 @@
+import { buildUserRtdbLink } from './firebaseUserConsoleLink';
+
+describe('buildUserRtdbLink', () => {
+  it('links long Firebase Auth user IDs to users', () => {
+    expect(buildUserRtdbLink('Oghb1LphfASVOY3b6JO1Ov4CDyD2')).toContain(
+      '/~2Fusers~2FOghb1LphfASVOY3b6JO1Ov4CDyD2'
+    );
+  });
+
+  it('keeps short legacy user IDs in newUsers', () => {
+    expect(buildUserRtdbLink('TG0016')).toContain('/~2FnewUsers~2FTG0016');
+  });
+
+  it('encodes user IDs before adding them to the Firebase path', () => {
+    expect(buildUserRtdbLink('legacy/id')).toContain('/~2FnewUsers~2Flegacy%2Fid');
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace an inline hardcoded Firebase RTDB URL builder with a reusable function that correctly chooses the collection (`users` vs `newUsers`) and encodes user IDs.

### Description
- Add `src/utils/firebaseUserConsoleLink.js` which exports `buildUserRtdbLink` and uses `isLongFormatUserId` to select the correct RTDB collection and `encodeURIComponent` to encode the ID.
- Update `src/components/smallCard/renderTopBlock.js` to import and use `buildUserRtdbLink` instead of the removed inline `buildRtdbLink` helper.
- Add unit tests in `src/utils/firebaseUserConsoleLink.test.js` covering long IDs, legacy short IDs, and encoding behavior.

### Testing
- Ran the new unit tests in `src/utils/firebaseUserConsoleLink.test.js`, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fabd0c2d883268c81cfed98e28dcb)