### PR TITLE
Honor profile source in Firebase console links

### DIFF
--- a/src/components/smallCard/renderTopBlock.js
+++ b/src/components/smallCard/renderTopBlock.js
@@ -2040,7 +2040,7 @@ export const TopBlock = ({
               {cardData.lastAction && cardData.userId && <span>·</span>}
               {cardData.userId && (
                 <a
-                  href={buildUserRtdbLink(cardData.userId)}
+                  href={buildUserRtdbLink(cardData.userId, cardData.__sourceCollection)}
                   target="_blank"
                   rel="noreferrer"
                   title="Відкрити профіль в Firebase RTDB"

--- a/src/utils/firebaseUserConsoleLink.js
+++ b/src/utils/firebaseUserConsoleLink.js
@@ -3,7 +3,7 @@ import { isLongFormatUserId } from './mergeUserCollections';
 const FIREBASE_CONSOLE_DATABASE_URL =
   'https://console.firebase.google.com/u/0/project/webringitapp/database/webringitapp-default-rtdb/data';
 
-export const buildUserRtdbLink = userId => {
-  const collection = isLongFormatUserId(userId) ? 'users' : 'newUsers';
+export const buildUserRtdbLink = (userId, sourceCollection) => {
+  const collection = sourceCollection || (isLongFormatUserId(userId) ? 'users' : 'newUsers');
   return `${FIREBASE_CONSOLE_DATABASE_URL}/~2F${collection}~2F${encodeURIComponent(userId || '')}`;
 };

--- a/src/utils/firebaseUserConsoleLink.test.js
+++ b/src/utils/firebaseUserConsoleLink.test.js
@@ -11,6 +11,12 @@ describe('buildUserRtdbLink', () => {
     expect(buildUserRtdbLink('TG0016')).toContain('/~2FnewUsers~2FTG0016');
   });
 
+  it('honors an explicit source collection for a long user ID', () => {
+    expect(buildUserRtdbLink('Oghb1LphfASVOY3b6JO1Ov4CDyD2', 'newUsers')).toContain(
+      '/~2FnewUsers~2FOghb1LphfASVOY3b6JO1Ov4CDyD2'
+    );
+  });
+
   it('encodes user IDs before adding them to the Firebase path', () => {
     expect(buildUserRtdbLink('legacy/id')).toContain('/~2FnewUsers~2Flegacy%2Fid');
   });


### PR DESCRIPTION
### Motivation
- Long-format Firebase Auth user IDs may have their full profile stored in `newUsers`, but the existing helper always computed the collection from the ID format which can link to a nonexistent `users/<id>` record.
- Ensure the Firebase RTDB link opens the exact record being displayed by honoring an explicit `__sourceCollection` when available.

### Description
- Change `buildUserRtdbLink` to accept an optional `sourceCollection` parameter and fall back to `isLongFormatUserId` classification when it is absent (`src/utils/firebaseUserConsoleLink.js`).
- Pass the displayed card's `__sourceCollection` into `buildUserRtdbLink` from `TopBlock` so long-ID profiles fetched from `newUsers` resolve correctly (`src/components/smallCard/renderTopBlock.js`).
- Add a unit test that verifies an explicit `sourceCollection` is honored for long-format IDs while keeping existing fallback and encoding tests (`src/utils/firebaseUserConsoleLink.test.js`).

### Testing
- Ran `CI=true npm test -- --runInBand src/utils/firebaseUserConsoleLink.test.js`, and the test suite passed (4 tests, 4 passed).
- Ran `npx eslint src/utils/firebaseUserConsoleLink.js src/utils/firebaseUserConsoleLink.test.js src/components/smallCard/renderTopBlock.js`, and linting reported no errors.
- Ran `git diff --check` and `git status` to validate the working tree, with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb61064f88326960e31ada41bba12)