### PR TITLE
Merge a layoutV2 fieldLine's label/value into one row with one toolbar

### DIFF
--- a/src/components/DocumentsPage.fieldLine.test.js
+++ b/src/components/DocumentsPage.fieldLine.test.js
@@ -1,13 +1,14 @@
 // Real-DOM regression test: a layoutV2 `fieldLine` block (label + underlined value + caption, e.g.
-// "дружина ___ КАЦУРА ЮКАКО, ... р.н.,") used to have no editor at all - the Blocks loop only ever
-// recognized letterhead/paragraph/richParagraph, so a fieldLine's `value` (its only templated
-// content) silently never showed up in the builder even though it printed in the real PDF/DOCX (a
-// case in point: the surrogate mother's own name/birth-date line on the genetic affinity
-// certificate). Both its value AND its label (a fully independent field slot, e.g. bold-in-part
-// "**та**/або сперматозоїди") now share the exact same T/B/I/insert-variable/align toolbar every
-// other paragraph has - this locks that in. The label toolbar in particular fixes a real bug: it
-// used to be a bare, unformattable text input, so selecting text in it and pressing Bold always
-// failed with "Select some text first" (the toolbar only ever tracked the value field's selection).
+// "дружина ___ КАЦУРА ЮКАКО, ... р.н.,") shares ONE T/B/I/insert-variable toolbar and mode toggle
+// across both its label and its value (previously two fully independent toolbars, stacked on top of
+// each other, one per field) - a reported source of confusion: the "У лікувальній програмі ДРТ
+// використано яйцеклітини" label and its {{oocyteSourceDisplay}} value looked like two disconnected
+// blocks with two different sets of controls, even though they render as one line in the actual
+// certificate. Bold/Italic/insert-variable already acted on whichever field held the browser
+// selection (activeFieldRef) regardless of which copy of the button was pressed, so merging them
+// into one shared button changes nothing about what they can do - only Align keeps two buttons,
+// since a label's alignment and its value's alignment really do resolve to two different style
+// overrides (styleOverrides.align vs valueStyleOverrides.align).
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
@@ -86,53 +87,82 @@ beforeEach(() => {
 });
 
 // Each fieldLine row always has exactly one "Remove this field line" button, whether or not it
-// carries a label - a stable per-block anchor, unlike the mode-cycle buttons (one or two per
-// block depending on whether a label is present).
+// carries a label - a stable per-block anchor.
 const fieldLineBlocks = async () => {
   const removeButtons = await screen.findAllByTitle('Remove this field line');
   // eslint-disable-next-line testing-library/no-node-access
   return removeButtons.map(button => button.closest('.paragraph-editor-block'));
 };
 
-// The value's own toolbar/field always renders before the label's (see the JSX order in
-// DocumentsPage) - so among a block's Text-mode buttons, the first is always the value's, the last
-// (when a label exists at all) is the label's.
-const openValueTemplateMode = block => fireEvent.click(within(block).getAllByTitle(TEXT_MODE_TITLE)[0]);
-const openLabelTemplateMode = block => {
-  const buttons = within(block).getAllByTitle(TEXT_MODE_TITLE);
-  fireEvent.click(buttons[buttons.length - 1]);
-};
+// One shared mode toggle now drives both the label and the value at once.
+const openFieldLineTemplateMode = block => fireEvent.click(within(block).getByTitle(TEXT_MODE_TITLE));
 
-describe('spec: a layoutV2 fieldLine value gets the full standard paragraph toolbar', () => {
-  it('has the same T/B/I/insert-variable/align/settings/delete buttons a paragraph block has', async () => {
+describe('spec: a layoutV2 fieldLine shares one toolbar across its label and its value', () => {
+  it('has exactly one T/B/I/insert-variable button whether or not the block carries a label', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock, surrogateBlock] = await fieldLineBlocks();
-    // wifeBlock has a label too, so its own toolbar's controls are duplicated (value + label) -
-    // surrogateBlock has none, so its value's toolbar is the only one.
-    expect(within(wifeBlock).getAllByTitle(TEXT_MODE_TITLE)).toHaveLength(2);
-    expect(within(wifeBlock).getAllByTitle('Bold the selected text')).toHaveLength(2);
-    expect(within(wifeBlock).getAllByTitle('Italicize the selected text')).toHaveLength(2);
-    expect(within(wifeBlock).getAllByTitle('Insert a variable')).toHaveLength(2);
+    expect(within(wifeBlock).getByTitle(TEXT_MODE_TITLE)).toBeInTheDocument();
+    expect(within(wifeBlock).getByTitle('Bold the selected text')).toBeInTheDocument();
+    expect(within(wifeBlock).getByTitle('Italicize the selected text')).toBeInTheDocument();
+    expect(within(wifeBlock).getByTitle('Insert a variable')).toBeInTheDocument();
+    // The label's own alignment and the value's own alignment stay two distinct controls (they
+    // write two different style overrides) - the only pair that isn't merged into one.
     expect(within(wifeBlock).getAllByLabelText(/Вирівнювання/)).toHaveLength(2);
-    // Only the value gets a settings popover (font size + condition) and a delete button - one
-    // each, never duplicated for the label.
     expect(within(wifeBlock).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown')).toBeInTheDocument();
     expect(within(wifeBlock).getByTitle('Remove this field line')).toBeInTheDocument();
 
-    expect(within(surrogateBlock).getAllByTitle(TEXT_MODE_TITLE)).toHaveLength(1);
-    expect(within(surrogateBlock).getAllByTitle('Bold the selected text')).toHaveLength(1);
+    expect(within(surrogateBlock).getByTitle(TEXT_MODE_TITLE)).toBeInTheDocument();
+    expect(within(surrogateBlock).getByTitle('Bold the selected text')).toBeInTheDocument();
+    // No label on this block, so only the value's Align button shows up.
+    expect(within(surrogateBlock).getAllByLabelText(/Вирівнювання/)).toHaveLength(1);
     expect(within(surrogateBlock).queryByPlaceholderText(/Label before the underlined value/)).not.toBeInTheDocument();
   });
 
-  it('switching to Template mode shows the raw {{}} markup for the value, editable like any other paragraph', async () => {
+  it('the label and value fields render side by side inside one shared row, not stacked as separate blocks', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock] = await fieldLineBlocks();
-    openValueTemplateMode(wifeBlock);
+    // eslint-disable-next-line testing-library/no-node-access
+    const contentRow = wifeBlock.querySelector('.field-line-content-row');
+    expect(contentRow).toBeInTheDocument();
+    openFieldLineTemplateMode(wifeBlock);
+    expect(within(contentRow).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toBeInTheDocument();
+    expect(within(contentRow).getByPlaceholderText('Field value')).toBeInTheDocument();
+  });
+
+  it('the "+" button inserts a new paragraph after this whole line, never a slot between the label and its value', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    expect(within(wifeBlock).getByTitle('Insert a new paragraph after this one')).toBeInTheDocument();
+    fireEvent.click(within(wifeBlock).getByTitle('Insert a new paragraph after this one'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ label: 'дружина' }),
+            expect.objectContaining({ type: 'paragraph', text: '' }),
+            expect.objectContaining({ type: 'fieldLine', value: 'Кацура Юкако, донор ооцитів' }),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('switching the shared mode to Template shows the raw {{}} markup for both the value and the label', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    openFieldLineTemplateMode(wifeBlock);
     expect(within(wifeBlock).getByPlaceholderText('Field value')).toHaveValue('{{wife.name.uk.nominative}}, {{wife.birthDate}} р.н.,');
+    expect(within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toHaveValue('дружина');
   });
 
   it('editing the value in Template mode persists straight to layoutV2.blocks[index].value on blur', async () => {
@@ -140,7 +170,7 @@ describe('spec: a layoutV2 fieldLine value gets the full standard paragraph tool
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [, surrogateBlock] = await fieldLineBlocks();
-    openValueTemplateMode(surrogateBlock);
+    openFieldLineTemplateMode(surrogateBlock);
     const valueField = within(surrogateBlock).getByPlaceholderText('Field value');
     fireEvent.change(valueField, { target: { value: '{{surrogateMother.name.uk.nominative}}' } });
     fireEvent.blur(valueField);
@@ -158,12 +188,35 @@ describe('spec: a layoutV2 fieldLine value gets the full standard paragraph tool
     ));
   });
 
-  it('Bold on a selected fragment of the value produces valueRuns, still tagged fieldLine, never converted to a paragraph', async () => {
+  it('editing the label in Template mode persists straight to layoutV2.blocks[index].label on blur', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    openFieldLineTemplateMode(wifeBlock);
+    const labelField = within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
+    fireEvent.change(labelField, { target: { value: 'та дружина' } });
+    fireEvent.blur(labelField);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ label: 'та дружина' }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('Bold on a selected fragment of the value produces valueRuns via the one shared Bold button, still tagged fieldLine', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [, surrogateBlock] = await fieldLineBlocks();
-    openValueTemplateMode(surrogateBlock);
+    openFieldLineTemplateMode(surrogateBlock);
     const valueField = within(surrogateBlock).getByPlaceholderText('Field value');
     fireEvent.focus(valueField);
     // "Кацура Юкако, донор ооцитів" - bold just "Кацура Юкако" (the first 12 characters).
@@ -185,6 +238,39 @@ describe('spec: a layoutV2 fieldLine value gets the full standard paragraph tool
                 { text: ', донор ооцитів', style: undefined },
               ],
             }),
+          ],
+        }),
+      }),
+    ));
+  });
+
+  it('Bold on a selected fragment of the label actually works via the same shared Bold button (the reported bug: it always failed with "Select some text first")', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    openFieldLineTemplateMode(wifeBlock);
+    const labelField = within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
+    fireEvent.focus(labelField);
+    // "дружина" - bold just "друж" (the first 4 characters).
+    labelField.setSelectionRange(0, 4);
+
+    fireEvent.click(within(wifeBlock).getByTitle('Bold the selected text'));
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({
+              type: 'fieldLine',
+              label: 'дружина',
+              labelRuns: [
+                { text: 'друж', style: 'inlineEmphasis' },
+                { text: 'ина', style: undefined },
+              ],
+            }),
+            expect.anything(),
           ],
         }),
       }),
@@ -215,13 +301,36 @@ describe('spec: a layoutV2 fieldLine value gets the full standard paragraph tool
     ));
   });
 
-  it('cycling the value\'s Align writes valueStyleOverrides.align, never the label\'s styleOverrides', async () => {
+  it('cycling the label\'s Align (the first of the two buttons) writes styleOverrides.align, never valueStyleOverrides', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock] = await fieldLineBlocks();
-    // The value's Align button is the first of the two (value's toolbar renders before the label's).
-    fireEvent.click(within(wifeBlock).getAllByLabelText(/Вирівнювання/)[0]);
+    const alignButtons = within(wifeBlock).getAllByLabelText(/Вирівнювання/);
+    fireEvent.click(alignButtons[0]);
+
+    await waitFor(() => expect(set).toHaveBeenCalledWith(
+      'documentsBuilder/templates/doc-1',
+      expect.objectContaining({
+        layoutV2: expect.objectContaining({
+          blocks: [
+            expect.objectContaining({ styleOverrides: expect.objectContaining({ align: expect.any(String) }) }),
+            expect.anything(),
+          ],
+        }),
+      }),
+    ));
+    const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
+    expect(persistedTemplate.layoutV2.blocks[0].valueStyleOverrides).toBeUndefined();
+  });
+
+  it('cycling the value\'s Align (the second of the two buttons) writes valueStyleOverrides.align, never styleOverrides', async () => {
+    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
+
+    const [wifeBlock] = await fieldLineBlocks();
+    const alignButtons = within(wifeBlock).getAllByLabelText(/Вирівнювання/);
+    fireEvent.click(alignButtons[alignButtons.length - 1]);
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
@@ -239,107 +348,10 @@ describe('spec: a layoutV2 fieldLine value gets the full standard paragraph tool
   });
 });
 
-describe('spec: a fieldLine label gets its own independent T/B/I/insert-variable/align toolbar', () => {
-  it('switching to Template mode shows the raw label markup, independent of the value', async () => {
-    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
-    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-
-    const [wifeBlock] = await fieldLineBlocks();
-    openLabelTemplateMode(wifeBlock);
-    expect(within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toHaveValue('дружина');
-    // The value field is untouched, still whatever mode it defaulted to (Text) - not switched
-    // along with the label.
-    expect(within(wifeBlock).queryByPlaceholderText('Field value')).not.toBeInTheDocument();
-  });
-
-  it('editing the label in Template mode persists straight to layoutV2.blocks[index].label on blur', async () => {
-    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
-    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-
-    const [wifeBlock] = await fieldLineBlocks();
-    openLabelTemplateMode(wifeBlock);
-    const labelField = within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
-    fireEvent.change(labelField, { target: { value: 'та дружина' } });
-    fireEvent.blur(labelField);
-
-    await waitFor(() => expect(set).toHaveBeenCalledWith(
-      'documentsBuilder/templates/doc-1',
-      expect.objectContaining({
-        layoutV2: expect.objectContaining({
-          blocks: [
-            expect.objectContaining({ label: 'та дружина' }),
-            expect.anything(),
-          ],
-        }),
-      }),
-    ));
-  });
-
-  it('Bold on a selected fragment of the label actually works (the reported bug: it always failed with "Select some text first")', async () => {
-    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
-    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-
-    const [wifeBlock] = await fieldLineBlocks();
-    openLabelTemplateMode(wifeBlock);
-    const labelField = within(wifeBlock).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
-    fireEvent.focus(labelField);
-    // "дружина" - bold just "друж" (the first 4 characters).
-    labelField.setSelectionRange(0, 4);
-
-    // The label's own Bold button is the last of the two (value's toolbar renders first).
-    const boldButtons = within(wifeBlock).getAllByTitle('Bold the selected text');
-    fireEvent.click(boldButtons[boldButtons.length - 1]);
-
-    await waitFor(() => expect(set).toHaveBeenCalledWith(
-      'documentsBuilder/templates/doc-1',
-      expect.objectContaining({
-        layoutV2: expect.objectContaining({
-          blocks: [
-            expect.objectContaining({
-              type: 'fieldLine',
-              label: 'дружина',
-              labelRuns: [
-                { text: 'друж', style: 'inlineEmphasis' },
-                { text: 'ина', style: undefined },
-              ],
-            }),
-            expect.anything(),
-          ],
-        }),
-      }),
-    ));
-  });
-
-  it('cycling the label\'s Align writes styleOverrides.align (the same pair an ordinary paragraph uses), never valueStyleOverrides', async () => {
-    render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
-    fireEvent.click(await screen.findByTitle('Edit paragraphs'));
-
-    const [wifeBlock] = await fieldLineBlocks();
-    // The label's Align button is the second of the two.
-    const alignButtons = within(wifeBlock).getAllByLabelText(/Вирівнювання/);
-    fireEvent.click(alignButtons[alignButtons.length - 1]);
-
-    await waitFor(() => expect(set).toHaveBeenCalledWith(
-      'documentsBuilder/templates/doc-1',
-      expect.objectContaining({
-        layoutV2: expect.objectContaining({
-          blocks: [
-            expect.objectContaining({ styleOverrides: expect.objectContaining({ align: expect.any(String) }) }),
-            expect.anything(),
-          ],
-        }),
-      }),
-    ));
-    const [, persistedTemplate] = set.mock.calls.find(call => call[0] === 'documentsBuilder/templates/doc-1');
-    expect(persistedTemplate.layoutV2.blocks[0].valueStyleOverrides).toBeUndefined();
-  });
-});
-
 // A fieldLine block can carry a bold-in-part `labelRuns` (e.g. bold "та" + "/або сперматозоїди")
-// instead of a plain `label` string - before this fix, that meant `block.label !== undefined` was
-// false, so the label field never rendered at all, and with an unset/blank `value` too the whole
-// row looked like a totally empty, unreachable block in the builder (exactly what a user reported
-// seeing between the "яйцеклітини" fieldLine and "Перенесення ембріона...").
+// instead of a plain `label` string - before an earlier fix, that meant `block.label !== undefined`
+// was false, so the label field never rendered at all, and with an unset/blank `value` too the whole
+// row looked like a totally empty, unreachable block in the builder.
 describe('spec: a fieldLine with labelRuns (not plain label) is still visible/editable, never a blank block', () => {
   beforeEach(() => {
     get.mockImplementation(async path => {
@@ -380,7 +392,7 @@ describe('spec: a fieldLine with labelRuns (not plain label) is still visible/ed
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [block] = await fieldLineBlocks();
-    openLabelTemplateMode(block);
+    openFieldLineTemplateMode(block);
     expect(within(block).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toHaveValue('**та**/або сперматозоїди');
   });
 
@@ -389,7 +401,7 @@ describe('spec: a fieldLine with labelRuns (not plain label) is still visible/ed
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [block] = await fieldLineBlocks();
-    openLabelTemplateMode(block);
+    openFieldLineTemplateMode(block);
     const labelField = within(block).getByPlaceholderText('Label before the underlined value, e.g. «дружина»');
     fireEvent.change(labelField, { target: { value: 'сперматозоїди' } });
     fireEvent.blur(labelField);

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -506,18 +506,6 @@ const ParagraphControlsRow = styled.div`
   margin-bottom: 4px;
 `;
 
-// A fieldLine's label and value toolbars share the same five icons (mode/Bold/Italic/insert-var/
-// align), stacked directly on top of each other - this tiny tag is the only thing telling them
-// apart at a glance, so it's never ambiguous which row a button acts on.
-const FieldSlotTag = styled.span`
-  color: var(--km-muted);
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  white-space: nowrap;
-  margin-right: 2px;
-`;
-
 // Encloses one editable row's controls (Bold/Italic/Insert-variable, Insert/Remove for paragraphs)
 // together with its own text, in one visible border - so which row a button acts on is never
 // ambiguous, regardless of whether the two-column ParagraphPair below would otherwise draw its own
@@ -540,6 +528,17 @@ const ParagraphFieldColumn = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2px;
+`;
+
+// A fieldLine's label and its value now sit side by side on one visual line (e.g. "У лікувальній
+// програмі ДРТ використано яйцеклітини" immediately followed by the underlined value) instead of
+// stacked on separate rows with a gap between them, which used to read as two disconnected
+// paragraphs. Wraps on narrow screens rather than overflowing.
+const FieldLineContentRow = styled.div.attrs({ className: 'field-line-content-row' })`
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
 `;
 
 // Text mode's live display (spec batch 21 §2/§9): renders the resolved text with bold/italic
@@ -986,14 +985,18 @@ const ALIGN_ICONS = {
   left: FaAlignLeft, center: FaAlignCenter, right: FaAlignRight, justify: FaAlignJustify,
 };
 
-const AlignCycleButton = ({ align, onCycle }) => {
+// `label` optionally distinguishes two Align buttons sitting in the same toolbar (a fieldLine's
+// label vs its value each keep their own alignment) - omitted everywhere else, unchanged from
+// before.
+const AlignCycleButton = ({ align, onCycle, label }) => {
   const Icon = ALIGN_ICONS[align] || FaAlignLeft;
+  const suffix = label ? ` (${label})` : '';
   return (
     <SmallButton
       type="button"
       onClick={onCycle}
-      aria-label={`Вирівнювання: ${align}`}
-      title={`Alignment: ${align}. Tap to cycle Left → Center → Right → Justify.`}
+      aria-label={`Вирівнювання${suffix}: ${align}`}
+      title={`Alignment${suffix}: ${align}. Tap to cycle Left → Center → Right → Justify.`}
     >
       <Icon />
     </SmallButton>
@@ -3443,20 +3446,34 @@ const DocumentsPage = ({ isAdmin }) => {
                                 });
                               }
                               if (block?.type === 'fieldLine') {
-                                // The exact same toolbar/mode-cycle system every other paragraph
-                                // uses (T/B/I/insert-variable/align/format/delete), just pointed at
-                                // this block's `value` instead of `text` - layoutV2ParagraphRuns/
-                                // FromMarkup and the Bold/Italic toggles (documentsCatalogUtils)
-                                // already understand a fieldLine's value/valueRuns the same way
-                                // they understand a paragraph's text/runs, so this reuses the whole
-                                // existing editor rather than a second, plainer one. Only Align and
-                                // the popover's font size differ - they read/write the value's own
-                                // valueStyle(Overrides), never the label's style(Overrides).
+                                // The label and value used to each carry their own independent
+                                // T/B/I/insert-variable/align toolbar, stacked as two separate rows
+                                // above two separate stacked fields - correct, but it read as two
+                                // disconnected paragraphs with two different sets of controls
+                                // (reported: "У лікувальній програмі ДРТ використано яйцеклітини" and
+                                // its {{oocyteSourceDisplay}} value looked like unrelated blocks).
+                                // Bold/Italic/insert-variable already act on whichever field currently
+                                // holds the selection (activeFieldRef, see formatButtonProps/
+                                // openVariablePicker above) regardless of which copy of the button was
+                                // pressed, so duplicating them per field never bought any extra
+                                // capability - only one shared mode/Bold/Italic/insert-variable now
+                                // drives both fields at once. Align stays two buttons (label vs value
+                                // genuinely resolve to different style overrides,
+                                // styleOverrides.align vs valueStyleOverrides.align - see
+                                // handleCycleLayoutV2Align/handleCycleLayoutV2FieldLineValueAlign),
+                                // just placed in the one shared row instead of two.
                                 const scope = layoutV2Scope(blockIndex);
+                                const hasLabel = hasLayoutV2FieldLineLabel(block);
+                                const labelScope = layoutV2LabelScope(blockIndex);
                                 const mode = getParagraphMode(template.id, scope);
                                 const isTemplateMode = mode === 'template';
                                 const isInputMode = mode === 'input';
                                 const isTextMode = mode === 'text';
+                                const setSharedMode = nextMode => {
+                                  setParagraphModeFor(template.id, scope, nextMode);
+                                  if (hasLabel) setParagraphModeFor(template.id, labelScope, nextMode);
+                                };
+                                const fieldKind = isTemplateMode ? 'template' : 'input-plain';
                                 const rawValue = langKey => getTemplateScopeText(template, scope, langKey);
                                 const resolvedValue = langKey => fillPlaceholders(rawValue(langKey), getContextForTemplate(template.id), langKey);
                                 const displayValue = langKey => (isTemplateMode ? rawValue(langKey) : plainTextOf(resolvedValue(langKey)));
@@ -3467,43 +3484,34 @@ const DocumentsPage = ({ isAdmin }) => {
                                   handleTemplateScopeChange(template.id, scope, langKey, nextRaw);
                                 };
                                 const onBlur = () => persistTemplate(template.id);
-                                const fieldKind = isTemplateMode ? 'template' : 'input-plain';
-                                // The label is a second, fully independent field slot on the same
-                                // block (layoutV2LabelScope) - its own mode/toolbar state, never
-                                // shared with the value's above.
-                                const hasLabel = hasLayoutV2FieldLineLabel(block);
-                                const labelScope = layoutV2LabelScope(blockIndex);
-                                const labelMode = getParagraphMode(template.id, labelScope);
-                                const isLabelTemplateMode = labelMode === 'template';
-                                const isLabelInputMode = labelMode === 'input';
-                                const isLabelTextMode = labelMode === 'text';
                                 const rawLabelValue = langKey => getTemplateScopeText(template, labelScope, langKey);
                                 const resolvedLabelValue = langKey => fillPlaceholders(rawLabelValue(langKey), getContextForTemplate(template.id), langKey);
-                                const displayLabelValue = langKey => (isLabelTemplateMode ? rawLabelValue(langKey) : plainTextOf(resolvedLabelValue(langKey)));
+                                const displayLabelValue = langKey => (isTemplateMode ? rawLabelValue(langKey) : plainTextOf(resolvedLabelValue(langKey)));
                                 const onLabelChange = langKey => event => {
-                                  const nextRaw = isLabelTemplateMode
+                                  const nextRaw = isTemplateMode
                                     ? event.target.value
                                     : applyResolvedTextEdit(rawLabelValue(langKey), getContextForTemplate(template.id), langKey, event.target.value);
                                   handleTemplateScopeChange(template.id, labelScope, langKey, nextRaw);
                                 };
                                 const onLabelBlur = () => persistTemplate(template.id);
-                                const labelFieldKind = isLabelTemplateMode ? 'template' : 'input-plain';
                                 return (
                                   // eslint-disable-next-line react/no-array-index-key
                                   <ParagraphEditorBlock key={`${template.id}-lv2-fieldline-${blockIndex}`}>
                                     <ParagraphControlsRow>
+                                      {/* Adds the next paragraph below this whole label+value line -
+                                          never a separate insertion point between the label and its
+                                          own value, since together they're one line, not two. */}
                                       <SmallButton
                                         type="button"
-                                        onClick={() => handleInsertLayoutV2Paragraph(template.id, blockIndex)}
-                                        title="Insert a new paragraph above this one"
+                                        onClick={() => handleInsertLayoutV2Paragraph(template.id, blockIndex + 1)}
+                                        title="Insert a new paragraph after this one"
                                       >
                                         <FaPlus />
                                       </SmallButton>
                                       <RowLine style={{ gap: 6 }}>
-                                        {hasLabel ? <FieldSlotTag>Value</FieldSlotTag> : null}
                                         <SmallButton
                                           type="button"
-                                          onClick={() => setParagraphModeFor(template.id, scope, nextParagraphMode(mode))}
+                                          onClick={() => setSharedMode(nextParagraphMode(mode))}
                                           title={PARAGRAPH_MODE_TITLE[mode]}
                                         >
                                           {PARAGRAPH_MODE_ICON[mode]}
@@ -3533,9 +3541,17 @@ const DocumentsPage = ({ isAdmin }) => {
                                         >
                                           <FaCode />
                                         </SmallButton>
+                                        {hasLabel ? (
+                                          <AlignCycleButton
+                                            align={getEffectiveLayoutV2BlockAlign(template, block)}
+                                            onCycle={() => handleCycleLayoutV2Align(template.id, blockIndex)}
+                                            label="label"
+                                          />
+                                        ) : null}
                                         <AlignCycleButton
                                           align={getEffectiveLayoutV2FieldLineValueAlign(template, block)}
                                           onCycle={() => handleCycleLayoutV2FieldLineValueAlign(template.id, blockIndex)}
+                                          label={hasLabel ? 'value' : undefined}
                                         />
                                         <FormatPopoverButton
                                           open={openFormatKey === formatPopoverKey(template.id, scope)}
@@ -3571,77 +3587,30 @@ const DocumentsPage = ({ isAdmin }) => {
                                         </DangerButton>
                                       </RowLine>
                                     </ParagraphControlsRow>
-                                    {/* The label sits to the left of the underlined value (e.g.
-                                        "дружина", or bold "та" followed by "/або сперматозоїди") -
-                                        present on some fieldLine blocks, absent on others (the
-                                        surrogate mother's own line has none at all). Its own full
-                                        T/B/I/insert-variable/align toolbar, exactly like the value's
-                                        below - layoutV2LabelMarkup/FromMarkup (documentsCatalogUtils)
-                                        give it the same working Bold/Italic a bare text input never
-                                        could (the bug this fixes: bolding text here previously always
-                                        failed with "Select some text first", since the toolbar only
-                                        ever tracked the value field's selection, never this one's). */}
-                                    {hasLabel ? (
-                                      <>
-                                        <ParagraphControlsRow>
-                                          <RowLine style={{ gap: 6 }}>
-                                            <FieldSlotTag>Label</FieldSlotTag>
-                                            <SmallButton
-                                              type="button"
-                                              onClick={() => setParagraphModeFor(template.id, labelScope, nextParagraphMode(labelMode))}
-                                              title={PARAGRAPH_MODE_TITLE[labelMode]}
-                                            >
-                                              {PARAGRAPH_MODE_ICON[labelMode]}
-                                            </SmallButton>
-                                            <SmallButton
-                                              type="button"
-                                              disabled={isLabelInputMode}
-                                              {...formatButtonProps('bold')}
-                                              title="Bold the selected text"
-                                            >
-                                              <FaBold />
-                                            </SmallButton>
-                                            <SmallButton
-                                              type="button"
-                                              disabled={isLabelInputMode}
-                                              {...formatButtonProps('italic')}
-                                              title="Italicize the selected text"
-                                            >
-                                              <FaItalic />
-                                            </SmallButton>
-                                            <SmallButton
-                                              type="button"
-                                              disabled={!isLabelTemplateMode}
-                                              onMouseDown={preventSelectionLoss}
-                                              onClick={openVariablePicker}
-                                              title="Insert a variable"
-                                            >
-                                              <FaCode />
-                                            </SmallButton>
-                                            <AlignCycleButton
-                                              align={getEffectiveLayoutV2BlockAlign(template, block)}
-                                              onCycle={() => handleCycleLayoutV2Align(template.id, blockIndex)}
-                                            />
-                                          </RowLine>
-                                        </ParagraphControlsRow>
-                                        <ParagraphFieldColumn style={{ marginBottom: 6 }}>
-                                          {isLabelTextMode || (isLabelInputMode && activeFieldKey !== fieldKey(template.id, labelScope, layoutV2Lang)) ? (
+                                    {/* The label sits to the left of the underlined value on the same
+                                        line (e.g. "дружина", or bold "та" followed by "/або
+                                        сперматозоїди") - present on some fieldLine blocks, absent on
+                                        others (the surrogate mother's own line has none at all). */}
+                                    <FieldLineContentRow>
+                                      {hasLabel ? (
+                                        <ParagraphFieldColumn style={{ flex: '1 1 45%', minWidth: 110 }}>
+                                          {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, labelScope, layoutV2Lang)) ? (
                                             <TextModeDisplay
                                               ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
-                                              onMouseUp={isLabelTextMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, 'text-display') : undefined}
-                                              onTouchEnd={isLabelTextMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, 'text-display') : undefined}
-                                              onMouseDown={isLabelInputMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, labelFieldKind) : undefined}
-                                              title={isLabelInputMode ? 'Click to edit the wording' : undefined}
+                                              onMouseUp={isTextMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, 'text-display') : undefined}
+                                              onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, 'text-display') : undefined}
+                                              onMouseDown={isInputMode ? handleRichFieldFocus(template.id, labelScope, layoutV2Lang, fieldKind) : undefined}
+                                              title={isInputMode ? 'Click to edit the wording' : undefined}
                                             >
                                               <FormattedRunsPreview text={resolvedLabelValue(layoutV2Lang)} />
                                             </TextModeDisplay>
-                                          ) : isLabelInputMode ? (
+                                          ) : isInputMode ? (
                                             <RichResolvedTextField
                                               ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
                                               initialText={resolvedLabelValue(layoutV2Lang)}
                                               placeholder="Label before the underlined value, e.g. «дружина»"
                                               onPlainTextChange={nextPlain => onLabelChange(layoutV2Lang)({ target: { value: nextPlain } })}
-                                              onFocus={handleRichFieldFocus(template.id, labelScope, layoutV2Lang, labelFieldKind)}
+                                              onFocus={handleRichFieldFocus(template.id, labelScope, layoutV2Lang, fieldKind)}
                                               onBlur={onLabelBlur}
                                             />
                                           ) : (
@@ -3649,45 +3618,45 @@ const DocumentsPage = ({ isAdmin }) => {
                                               ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
                                               value={displayLabelValue(layoutV2Lang)}
                                               placeholder="Label before the underlined value, e.g. «дружина»"
-                                              onFocus={handleRichFieldFocus(template.id, labelScope, layoutV2Lang, labelFieldKind)}
+                                              onFocus={handleRichFieldFocus(template.id, labelScope, layoutV2Lang, fieldKind)}
                                               onChange={onLabelChange(layoutV2Lang)}
                                               onBlur={onLabelBlur}
                                             />
                                           )}
                                         </ParagraphFieldColumn>
-                                      </>
-                                    ) : null}
-                                    <ParagraphFieldColumn>
-                                      {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, layoutV2Lang)) ? (
-                                        <TextModeDisplay
-                                          ref={registerFieldNode(template.id, scope, layoutV2Lang)}
-                                          onMouseUp={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
-                                          onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
-                                          onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind) : undefined}
-                                          title={isInputMode ? 'Click to edit the wording' : undefined}
-                                        >
-                                          <FormattedRunsPreview text={resolvedValue(layoutV2Lang)} />
-                                        </TextModeDisplay>
-                                      ) : isInputMode ? (
-                                        <RichResolvedTextField
-                                          ref={registerFieldNode(template.id, scope, layoutV2Lang)}
-                                          initialText={resolvedValue(layoutV2Lang)}
-                                          placeholder="Field value"
-                                          onPlainTextChange={nextPlain => onChange(layoutV2Lang)({ target: { value: nextPlain } })}
-                                          onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
-                                          onBlur={onBlur}
-                                        />
-                                      ) : (
-                                        <AutoInlineTextarea
-                                          ref={registerFieldNode(template.id, scope, layoutV2Lang)}
-                                          value={displayValue(layoutV2Lang)}
-                                          placeholder="Field value"
-                                          onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
-                                          onChange={onChange(layoutV2Lang)}
-                                          onBlur={onBlur}
-                                        />
-                                      )}
-                                    </ParagraphFieldColumn>
+                                      ) : null}
+                                      <ParagraphFieldColumn style={{ flex: '1 1 45%', minWidth: 110 }}>
+                                        {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, layoutV2Lang)) ? (
+                                          <TextModeDisplay
+                                            ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                            onMouseUp={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
+                                            onTouchEnd={isTextMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, 'text-display') : undefined}
+                                            onMouseDown={isInputMode ? handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind) : undefined}
+                                            title={isInputMode ? 'Click to edit the wording' : undefined}
+                                          >
+                                            <FormattedRunsPreview text={resolvedValue(layoutV2Lang)} />
+                                          </TextModeDisplay>
+                                        ) : isInputMode ? (
+                                          <RichResolvedTextField
+                                            ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                            initialText={resolvedValue(layoutV2Lang)}
+                                            placeholder="Field value"
+                                            onPlainTextChange={nextPlain => onChange(layoutV2Lang)({ target: { value: nextPlain } })}
+                                            onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
+                                            onBlur={onBlur}
+                                          />
+                                        ) : (
+                                          <AutoInlineTextarea
+                                            ref={registerFieldNode(template.id, scope, layoutV2Lang)}
+                                            value={displayValue(layoutV2Lang)}
+                                            placeholder="Field value"
+                                            onFocus={handleRichFieldFocus(template.id, scope, layoutV2Lang, fieldKind)}
+                                            onChange={onChange(layoutV2Lang)}
+                                            onBlur={onBlur}
+                                          />
+                                        )}
+                                      </ParagraphFieldColumn>
+                                    </FieldLineContentRow>
                                   </ParagraphEditorBlock>
                                 );
                               }


### PR DESCRIPTION
The genetic-affinity certificate's "У лікувальній програмі ДРТ
використано яйцеклітини" label and its oocyte/sperm source value used
to render as two stacked fields, each with its own full T/B/I/insert-
variable/align toolbar - visually two disconnected blocks even though
they print as a single line. Bold/Italic/insert-variable already acted
on whichever field held the current selection regardless of which
toolbar copy triggered them, so merging those (plus the mode toggle)
into one shared control set changes nothing about what they can do.
Align keeps two buttons, since a label's alignment and its value's
alignment write two different style overrides.

The "+" now inserts the next paragraph after the whole label+value
line instead of above it, and there's no separate insertion point
between a label and its own value.