### PR TITLE
Refine field-line sizing and editor controls

### DIFF
--- a/src/components/DocumentsPage.fieldLine.test.js
+++ b/src/components/DocumentsPage.fieldLine.test.js
@@ -110,6 +110,8 @@ describe('spec: a layoutV2 fieldLine shares one toolbar across its label and its
     // The label's own alignment and the value's own alignment stay two distinct controls (they
     // write two different style overrides) - the only pair that isn't merged into one.
     expect(within(wifeBlock).getAllByLabelText(/Вирівнювання/)).toHaveLength(2);
+    expect(within(wifeBlock).getByText('Label')).toBeVisible();
+    expect(within(wifeBlock).getByText('Value')).toBeVisible();
     expect(within(wifeBlock).getByTitle('Field line formatting - font size (pt) and condition; empty = inherit/always shown')).toBeInTheDocument();
     expect(within(wifeBlock).getByTitle('Remove this field line')).toBeInTheDocument();
 
@@ -131,23 +133,28 @@ describe('spec: a layoutV2 fieldLine shares one toolbar across its label and its
     openFieldLineTemplateMode(wifeBlock);
     expect(within(contentRow).getByPlaceholderText('Label before the underlined value, e.g. «дружина»')).toBeInTheDocument();
     expect(within(contentRow).getByPlaceholderText('Field value')).toBeInTheDocument();
+    // The short label consumes only its intrinsic width; the value takes the remaining room.
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(contentRow.firstChild).toHaveStyle({ flex: '0 1 auto', maxWidth: '45%' });
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(contentRow.lastChild).toHaveStyle({ flex: '1 1 0' });
   });
 
-  it('the "+" button inserts a new paragraph after this whole line, never a slot between the label and its value', async () => {
+  it('the "+" button inserts a new paragraph before the whole line, never between its label and value', async () => {
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
     const [wifeBlock] = await fieldLineBlocks();
-    expect(within(wifeBlock).getByTitle('Insert a new paragraph after this one')).toBeInTheDocument();
-    fireEvent.click(within(wifeBlock).getByTitle('Insert a new paragraph after this one'));
+    expect(within(wifeBlock).getByTitle('Insert a new paragraph above this one')).toBeInTheDocument();
+    fireEvent.click(within(wifeBlock).getByTitle('Insert a new paragraph above this one'));
 
     await waitFor(() => expect(set).toHaveBeenCalledWith(
       'documentsBuilder/templates/doc-1',
       expect.objectContaining({
         layoutV2: expect.objectContaining({
           blocks: [
-            expect.objectContaining({ label: 'дружина' }),
             expect.objectContaining({ type: 'paragraph', text: '' }),
+            expect.objectContaining({ label: 'дружина' }),
             expect.objectContaining({ type: 'fieldLine', value: 'Кацура Юкако, донор ооцитів' }),
           ],
         }),

--- a/src/components/DocumentsPage.jsx
+++ b/src/components/DocumentsPage.jsx
@@ -999,6 +999,7 @@ const AlignCycleButton = ({ align, onCycle, label }) => {
       title={`Alignment${suffix}: ${align}. Tap to cycle Left → Center → Right → Justify.`}
     >
       <Icon />
+      {label ? <span>{label}</span> : null}
     </SmallButton>
   );
 };
@@ -3498,13 +3499,12 @@ const DocumentsPage = ({ isAdmin }) => {
                                   // eslint-disable-next-line react/no-array-index-key
                                   <ParagraphEditorBlock key={`${template.id}-lv2-fieldline-${blockIndex}`}>
                                     <ParagraphControlsRow>
-                                      {/* Adds the next paragraph below this whole label+value line -
-                                          never a separate insertion point between the label and its
-                                          own value, since together they're one line, not two. */}
+                                      {/* Insert before the whole field line. The label and value are
+                                          fields inside the same block, so this cannot split them. */}
                                       <SmallButton
                                         type="button"
-                                        onClick={() => handleInsertLayoutV2Paragraph(template.id, blockIndex + 1)}
-                                        title="Insert a new paragraph after this one"
+                                        onClick={() => handleInsertLayoutV2Paragraph(template.id, blockIndex)}
+                                        title="Insert a new paragraph above this one"
                                       >
                                         <FaPlus />
                                       </SmallButton>
@@ -3545,13 +3545,13 @@ const DocumentsPage = ({ isAdmin }) => {
                                           <AlignCycleButton
                                             align={getEffectiveLayoutV2BlockAlign(template, block)}
                                             onCycle={() => handleCycleLayoutV2Align(template.id, blockIndex)}
-                                            label="label"
+                                            label="Label"
                                           />
                                         ) : null}
                                         <AlignCycleButton
                                           align={getEffectiveLayoutV2FieldLineValueAlign(template, block)}
                                           onCycle={() => handleCycleLayoutV2FieldLineValueAlign(template.id, blockIndex)}
-                                          label={hasLabel ? 'value' : undefined}
+                                          label={hasLabel ? 'Value' : undefined}
                                         />
                                         <FormatPopoverButton
                                           open={openFormatKey === formatPopoverKey(template.id, scope)}
@@ -3593,7 +3593,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                         others (the surrogate mother's own line has none at all). */}
                                     <FieldLineContentRow>
                                       {hasLabel ? (
-                                        <ParagraphFieldColumn style={{ flex: '1 1 45%', minWidth: 110 }}>
+                                        <ParagraphFieldColumn style={{ flex: '0 1 auto', minWidth: 0, maxWidth: '45%' }}>
                                           {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, labelScope, layoutV2Lang)) ? (
                                             <TextModeDisplay
                                               ref={registerFieldNode(template.id, labelScope, layoutV2Lang)}
@@ -3625,7 +3625,7 @@ const DocumentsPage = ({ isAdmin }) => {
                                           )}
                                         </ParagraphFieldColumn>
                                       ) : null}
-                                      <ParagraphFieldColumn style={{ flex: '1 1 45%', minWidth: 110 }}>
+                                      <ParagraphFieldColumn style={{ flex: '1 1 0', minWidth: 110 }}>
                                         {isTextMode || (isInputMode && activeFieldKey !== fieldKey(template.id, scope, layoutV2Lang)) ? (
                                           <TextModeDisplay
                                             ref={registerFieldNode(template.id, scope, layoutV2Lang)}


### PR DESCRIPTION
### Motivation
- Make short field-line labels size to their intrinsic content so the value field uses remaining editor width for better visual flow.
- Make the two alignment controls visually identifiable so sighted users know which aligns the label vs the value.
- Restore the paragraph insertion behavior that inserts a paragraph before a field-line block (without splitting its label and value).
- Expand regression coverage to lock these behaviors in tests.

### Description
- Render the alignment control label text inside `AlignCycleButton` so the icon-only buttons show `Label` / `Value` visually in addition to `aria-label` and `title` (in `src/components/DocumentsPage.jsx`).
- Change the paragraph-insert button on field-line blocks to call `handleInsertLayoutV2Paragraph(template.id, blockIndex)` and update its `title` to "Insert a new paragraph above this one" to restore insertion before the block (in `src/components/DocumentsPage.jsx`).
- Adjust field-line column sizing: label column now uses `style={{ flex: '0 1 auto', minWidth: 0, maxWidth: '45%' }}` and value column uses `style={{ flex: '1 1 0', minWidth: 110 }}` so short labels do not take ~50% of the editor width (in `src/components/DocumentsPage.jsx`).
- Update the alignment `label` strings from lowercase to `"Label"` / `"Value"` where passed (in `src/components/DocumentsPage.jsx`).
- Update tests in `src/components/DocumentsPage.fieldLine.test.js` to assert visible `Label` and `Value` text, the new flex styles for columns, and the restored insertion-before ordering.

### Testing
- Ran the field-line unit tests with `CI=true npm test -- --runInBand src/components/DocumentsPage.fieldLine.test.js`, and the suite passed: 13 tests, 13 passed.
- Ran lint with `npm run lint:js -- --quiet`, which produced no errors.
- Ran `git diff --check` and `git diff --stat` to verify no whitespace/format issues; no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d41022b08326a79a0f8210e0eeea)