### PR TITLE
Make my-profile publish button reflect current state (add hide action)

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -940,6 +940,20 @@ export const MyProfile = () => {
     }
   };
 
+  const hideProfile = async () => {
+    const nextState = { ...stateRef.current, publish: false };
+    stateRef.current = nextState;
+    setState(nextState);
+
+    try {
+      await saveState(nextState, { directFields: ['publish'] });
+      toast.success('Анкету приховано');
+    } catch (error) {
+      console.error('hide profile error', error);
+      toast.error('Не вдалося приховати анкету. Спробуйте ще раз');
+    }
+  };
+
   const renderField = (name) => {
     const field = fieldsMap.get(name);
     if (!field) return null;
@@ -1248,7 +1262,9 @@ export const MyProfile = () => {
     )}
 
     <SubmitWrap>
-      <SubmitBtn type="button" onClick={publishProfile}>Опублікувати анкету</SubmitBtn>
+      <SubmitBtn type="button" onClick={state.publish ? hideProfile : publishProfile}>
+        {state.publish ? 'Приховати анкету' : 'Опублікувати анкету'}
+      </SubmitBtn>
       <p style={{ textAlign: 'center', fontSize: 11, color: 'var(--muted)', marginTop: 10 }}>Анкету можна приховати або видалити будь-коли в налаштуваннях профілю.</p>
     </SubmitWrap>
   </Page>;

--- a/src/components/MyProfile.publishToggle.test.js
+++ b/src/components/MyProfile.publishToggle.test.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('my-profile publication toggle', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'MyProfile.jsx'), 'utf8');
+
+  it('persists publish=false as a direct boolean when hiding the profile', () => {
+    const hideProfileBody = source.slice(
+      source.indexOf('const hideProfile = async () => {'),
+      source.indexOf('const renderField = (name) => {')
+    );
+
+    expect(hideProfileBody).toContain('publish: false');
+    expect(hideProfileBody).toContain("await saveState(nextState, { directFields: ['publish'] });");
+  });
+
+  it('shows the action matching the current publication state', () => {
+    expect(source).toContain('onClick={state.publish ? hideProfile : publishProfile}');
+    expect(source).toContain("{state.publish ? 'Приховати анкету' : 'Опублікувати анкету'}");
+  });
+});


### PR DESCRIPTION
### Motivation
- Кнопка на сторінці `my-profile` була незрозумілою після публікації — після натискання «Опублікувати анкету» вона лишається тією ж самою і не відображає, що анкета вже опублікована. 
- Потрібно дозволити користувачу явно приховати анкету з фронтенду, відправляючи `publish: false` у бекенд.

### Description
- Додано функцію `hideProfile` яка ставить `publish: false` у `stateRef.current`, викликає `saveState(nextState, { directFields: ['publish'] })` і показує повідомлення про успіх/помилку. 
- Змінено кнопку публікації в інтерфейсі на умовну: `onClick={state.publish ? hideProfile : publishProfile}` і текст кнопки тепер рендериться як `{state.publish ? 'Приховати анкету' : 'Опублікувати анкету'}`. 
- Додано регресійний тест `src/components/MyProfile.publishToggle.test.js`, що перевіряє наявність коду з `publish: false`, виклик `saveState(..., { directFields: ['publish'] })` і правильне відображення обробника/тексту кнопки. 

### Testing
- `CI=true npm test -- --watchAll=false --runInBand src/components/MyProfile.publishToggle.test.js src/components/MyProfile.fieldHistoryAccumulation.test.js` — тести пройшли (2 suites, 5 tests passed). 
- `npm run build` — production-збірка успішно згенерована. 
- `git diff --check` — перевірка не виявила проблем.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70f2e2ee7c8326aa995adc2452243d)