### PR TITLE
Reflect profile publication state in status badge

### DIFF
--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -204,8 +204,8 @@ const StatusBadge = styled.button`
   font-weight: 600;
   padding: 5px 12px;
   border-radius: 99px;
-  background: #FEE9E9;
-  color: #D44;
+  background: ${({ $published }) => ($published ? '#EBF8EF' : '#FEE9E9')};
+  color: ${({ $published }) => ($published ? '#2E9B55' : '#D44')};
   cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
 `;
 const HighlightableLabel = styled(Label)`
@@ -1086,8 +1086,15 @@ export const MyProfile = () => {
       <Topbar>
         <KnowMeBrand />
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <StatusBadge type="button" $clickable={!isProfileAccessConfirmed} onClick={handleAuthBadgeClick}>
-            ● {isProfileAccessConfirmed ? 'Прихована' : 'Логін не відбувся'}
+          <StatusBadge
+            type="button"
+            $clickable={!isProfileAccessConfirmed}
+            $published={state.publish === true}
+            onClick={handleAuthBadgeClick}
+          >
+            ● {isProfileAccessConfirmed
+              ? (state.publish === true ? 'Опублікована' : 'Прихована')
+              : 'Логін не відбувся'}
           </StatusBadge>
           <DotsButton type='button' aria-label='Відкрити меню профілю' onClick={() => setShowInfoModal('dotsMenu')}>⋮</DotsButton>
         </div>

--- a/src/components/MyProfile.publishToggle.test.js
+++ b/src/components/MyProfile.publishToggle.test.js
@@ -18,4 +18,13 @@ describe('my-profile publication toggle', () => {
     expect(source).toContain('onClick={state.publish ? hideProfile : publishProfile}');
     expect(source).toContain("{state.publish ? 'Приховати анкету' : 'Опублікувати анкету'}");
   });
+
+  it('uses the current publish state for the profile status marker', () => {
+    expect(source).toContain('$published={state.publish === true}');
+    expect(source).toContain("state.publish === true ? 'Опублікована' : 'Прихована'");
+  });
+
+  it('keeps the failed login status for profiles without confirmed access', () => {
+    expect(source).toContain(": 'Логін не відбувся'");
+  });
 });


### PR DESCRIPTION
### Motivation

- Derive the confirmed-profile status label from the strict `state.publish` boolean so the header marker reflects the actual publication state.
- Keep the existing red styling and the special "Логін не відбувся" state for unconfirmed access while reusing current color tokens for published success state. 
- Minimise changes by reusing the existing `StatusBadge` component and only adding a prop to control appearance and label.

### Description

- Extended the `StatusBadge` styled-component to accept a `$published` prop and use a green background/text when `$published` is `true`, otherwise retain the existing red palette (`src/components/MyProfile.jsx`).
- Updated the `StatusBadge` usage to pass `$published={state.publish === true}` and render the label as `Опублікована` when confirmed and published, `Прихована` when confirmed but not published, and `Логін не відбувся` when access is not confirmed (`src/components/MyProfile.jsx`).
- Added tests in `src/components/MyProfile.publishToggle.test.js` to assert the component uses `$published`, shows `Опублікована` / `Прихована` based on `state.publish`, and preserves the `Логін не відбувся` text for unconfirmed access.

### Testing

- Ran `CI=true npm test -- --runInBand --watchAll=false src/components/MyProfile.publishToggle.test.js` and the suite passed (`4 passed, 4 total`).
- Ran `npx eslint src/components/MyProfile.jsx src/components/MyProfile.publishToggle.test.js` with no lint errors reported.
- Ran `git diff --check` to validate whitespace/merge issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70fa8831d48326ac4879ab042f2a27)