### PR TITLE
Redesign Matching hidden (dislikes) tab as a compact scrollable list

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -114,7 +114,9 @@ import {
 import { getCardsByList, updateCard } from '../utils/cardsStorage';
 import { getCurrentDate } from './foramtDate';
 import InfoModal from './InfoModal';
-import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight, FaMapMarkerAlt } from 'react-icons/fa';
+import MatchingHiddenList from './MatchingHiddenList';
+import { HiddenHeaderTitle as MatchingHiddenListHeaderTitle } from './MatchingHiddenList.styled';
+import { FaFacebookF, FaFilter, FaTimes, FaHeart, FaEllipsisV, FaInstagram, FaTelegramPlane, FaViber, FaWhatsapp, FaVk, FaGlobe, FaLinkedin, FaYoutube, FaChevronLeft, FaChevronRight, FaMapMarkerAlt, FaPencilAlt } from 'react-icons/fa';
 import { FaPhoneVolume, FaXTwitter } from 'react-icons/fa6';
 import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
@@ -1362,6 +1364,7 @@ const Matching = () => {
   const ownFavoriteUsersRef = useRef(ownFavoriteUsers);
   const ownDislikeUsersRef = useRef(ownDislikeUsers);
   const [viewMode, setViewMode] = useState('default');
+  const [hiddenListEditMode, setHiddenListEditMode] = useState(false);
   const [matchingSearchStatus, setMatchingSearchStatus] = useState('');
   const matchingSearchKeyRef = useRef(null);
   const [activeProfileIndex, setActiveProfileIndex] = useState(0);
@@ -5736,6 +5739,11 @@ const Matching = () => {
         <InnerContainer>
           <HeaderContainer>
             <TopActions>
+              {viewMode === 'dislikes' && (
+                <MatchingHiddenListHeaderTitle>
+                  Приховані <span>· {Object.keys(dislikeUsers || {}).length}</span>
+                </MatchingHiddenListHeaderTitle>
+              )}
               <TopActionGroup aria-label="Фільтри matching">
                 <ActionButton
                   type="button"
@@ -5748,6 +5756,19 @@ const Matching = () => {
                   {activeFilterGroupCount > 0 && <ActionBadge>{activeFilterGroupCount}</ActionBadge>}
                 </ActionButton>
               </TopActionGroup>
+              {viewMode === 'dislikes' && (
+                <TopActionGroup aria-label="Редагування прихованих анкет">
+                  <ActionButton
+                    type="button"
+                    onClick={() => setHiddenListEditMode(v => !v)}
+                    $active={hiddenListEditMode}
+                    aria-label={hiddenListEditMode ? 'Вимкнути редагування' : 'Редагувати приховані анкети'}
+                    title={hiddenListEditMode ? 'Вимкнути редагування' : 'Редагувати приховані анкети'}
+                  >
+                    <FaPencilAlt />
+                  </ActionButton>
+                </TopActionGroup>
+              )}
               <TopActionGroup aria-label="Навігація matching">
                 <ActionButton
                   type="button"
@@ -5842,6 +5863,21 @@ const Matching = () => {
             </OwnerStatusMessage>
           )}
 
+          {viewMode === 'dislikes' ? (
+            <MatchingHiddenList
+              ownerId={ownerId}
+              users={filteredUsers}
+              hasMore={hasMore}
+              loading={loading}
+              loadMore={loadMore}
+              dislikeUsers={dislikeUsers}
+              setDislikeUsers={setDislikeUsers}
+              ownDislikeUsers={ownDislikeUsers}
+              setOwnDislikeUsers={setOwnDislikeUsers}
+              editMode={hiddenListEditMode}
+              onGoToFeed={handleDefaultModeClick}
+            />
+          ) : (
           <Grid>
             {activeProfileWithLazyPhotos ? (() => {
               const user = activeProfileWithLazyPhotos;
@@ -5948,6 +5984,7 @@ const Matching = () => {
               <OwnerStatusMessage>Немає доступних профілів</OwnerStatusMessage>
             )}
           </Grid>
+          )}
 
           {showInfoModal && (
             <InfoModal onClose={() => setShowInfoModal(false)} text="dotsMenu" Context={dotsMenu} />

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5875,6 +5875,7 @@ const Matching = () => {
               ownDislikeUsers={ownDislikeUsers}
               setOwnDislikeUsers={setOwnDislikeUsers}
               editMode={hiddenListEditMode}
+              isAdmin={isAdmin}
               onGoToFeed={handleDefaultModeClick}
             />
           ) : (

--- a/src/components/MatchingHiddenList.jsx
+++ b/src/components/MatchingHiddenList.jsx
@@ -1,0 +1,787 @@
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import toast from 'react-hot-toast';
+import { FaChevronDown, FaMapMarkerAlt, FaUndo } from 'react-icons/fa';
+import {
+  getProfileAge,
+  getProfileBio,
+  getProfileName,
+  getProfilePhotos,
+  bmiValue as computeBmiValue,
+  normalizeDisplayValue,
+} from './profileLayoutConfig';
+import { normalizeCountry, normalizeRegion } from './normalizeLocation';
+import { getContactEntries } from './contactMethods';
+import {
+  addContactViewUser,
+  addDislikeUser,
+  lazyLoadProfilePhotos,
+  removeDislikeUser,
+  updateDataInFiresoreDB,
+  updateDataInNewUsersRTDB,
+  updateDataInRealtimeDB,
+} from './config';
+import { setDislike, cacheDislikedUsers } from 'utils/dislikesStorage';
+import { removeCardFromList } from 'utils/cardsStorage';
+import * as S from './MatchingHiddenList.styled';
+
+const PAGE_SIZE = 20;
+const NOTE_TOAST_UNDO_MS = 5000;
+
+const CSECTION_KEYS = ['cSection', 'csection', 'c_section', 'cesareanSection'];
+const BIO_KEYS = ['moreInfo_main', 'comment', 'description', 'about', 'bio'];
+const UA_COUNTRY_VALUES = new Set(['україна', 'ukraine', 'ua']);
+
+const CONTACT_LABELS = {
+  phone: 'Телефон',
+  email: 'Пошта',
+  telegram: 'Telegram',
+  instagram: 'Instagram',
+  whatsapp: 'WhatsApp',
+  viber: 'Viber',
+  facebook: 'Facebook',
+  tiktok: 'TikTok',
+  linkedin: 'LinkedIn',
+  youtube: 'YouTube',
+  twitter: 'X',
+  website: 'Сайт',
+  otherLink: 'Посилання',
+  ameblo: 'Ameblo',
+};
+
+const GRID_FIELD_DEFS = [
+  { key: 'education', label: 'Освіта' },
+  { key: 'clothingSize', label: 'Одяг' },
+  { key: 'shoeSize', label: 'Взуття' },
+  { key: 'race', label: 'Раса' },
+  { key: 'eyeColor', label: 'Очі' },
+  { key: 'hair', label: 'Волосся', combined: ['hairColor', 'hairStructure'] },
+  { key: 'faceShape', label: 'Обличчя' },
+  { key: 'noseShape', label: 'Ніс' },
+  { key: 'lipsShape', label: 'Губи' },
+  { key: 'chin', label: 'Підборіддя' },
+  { key: 'bodyType', label: 'Фігура' },
+];
+
+const INITIAL_GRADIENTS = [
+  ['#E68DA2', '#C9455F'],
+  ['#D9A56B', '#B87A3F'],
+  ['#C98A6A', '#9C5B3E'],
+  ['#C0A9C6', '#8A6E96'],
+  ['#A8B49B', '#6F8266'],
+  ['#9FB4C6', '#657E93'],
+  ['#C8B79E', '#9E8563'],
+  ['#8FA9A0', '#5C7A70'],
+];
+
+const hashString = value => {
+  let hash = 0;
+  const str = String(value || '');
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+};
+
+const getGradientFor = userId => {
+  const [a, b] = INITIAL_GRADIENTS[hashString(userId) % INITIAL_GRADIENTS.length];
+  return `linear-gradient(150deg, ${a}, ${b})`;
+};
+
+const getInitials = name => {
+  const parts = String(name || '').trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+};
+
+const buildOverrideKey = (userId, field) => `${userId}::${field}`;
+
+const resolveCSectionKey = user => CSECTION_KEYS.find(key => normalizeDisplayValue(user?.[key])) || 'csection';
+const resolveBioKey = user => BIO_KEYS.find(key => normalizeDisplayValue(user?.[key])) || 'moreInfo_main';
+
+const formatShortYear = value => {
+  const match = String(value || '').trim().match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
+  if (!match) return normalizeDisplayValue(value);
+  return `${match[1]}.${match[2]}.${match[3].slice(2)}`;
+};
+
+const isValidDeliveryDate = value => /^\d{2}\.\d{2}\.\d{4}$/.test(String(value || '').trim());
+
+const abbreviateRegion = region => {
+  const normalized = normalizeRegion(region);
+  return normalized ? normalized.replace(/\s+область$/i, ' обл.') : '';
+};
+
+const getLocationLine = user => {
+  const country = normalizeCountry(normalizeDisplayValue(user?.country));
+  const city = normalizeDisplayValue(user?.city);
+  const isForeign = Boolean(country) && !UA_COUNTRY_VALUES.has(country.toLowerCase());
+  const secondary = isForeign ? country : abbreviateRegion(normalizeDisplayValue(user?.region));
+  return [city, secondary].filter(Boolean).join(', ');
+};
+
+const formatPhoneDisplay = raw => {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) return '';
+  if (/\s/.test(trimmed)) return trimmed;
+  const digits = trimmed.replace(/[^\d]/g, '');
+  if (!digits) return trimmed;
+  if (digits.length === 12 && digits.startsWith('380')) {
+    return `+${digits.slice(0, 3)} ${digits.slice(3, 5)} ${digits.slice(5, 8)} ${digits.slice(8, 10)} ${digits.slice(10, 12)}`;
+  }
+  return trimmed.startsWith('+') ? trimmed : `+${digits}`;
+};
+
+const getContactLabel = key => CONTACT_LABELS[key] || (key.charAt(0).toUpperCase() + key.slice(1));
+
+const buildGridRows = user => {
+  const rows = [];
+  GRID_FIELD_DEFS.forEach(def => {
+    if (def.combined) {
+      const [keyA, keyB] = def.combined;
+      const valA = normalizeDisplayValue(user?.[keyA]);
+      const valB = normalizeDisplayValue(user?.[keyB]);
+      if (!valA && !valB) return;
+      rows.push({
+        label: def.label,
+        parts: valA && valB
+          ? [{ field: keyA, value: valA }, { field: keyB, value: valB }]
+          : [{ field: valA ? keyA : keyB, value: valA || valB }],
+      });
+      return;
+    }
+    const value = normalizeDisplayValue(user?.[def.key]);
+    if (!value) return;
+    rows.push({ label: def.label, parts: [{ field: def.key, value }] });
+  });
+  if (rows.length % 2 === 1) {
+    rows[rows.length - 1] = { ...rows[rows.length - 1], wide: true };
+  }
+  return rows;
+};
+
+const saveProfileField = async (user, field, value) => {
+  const payload = { [field]: value };
+  if (user?.__sourceCollection === 'newUsers') {
+    await updateDataInNewUsersRTDB(user.userId, payload, 'update');
+  } else {
+    await updateDataInRealtimeDB(user.userId, payload, 'update');
+    await updateDataInFiresoreDB(user.userId, payload, 'update');
+  }
+};
+
+const EditContext = React.createContext({
+  editMode: false,
+  onSave: () => {},
+  savingFields: {},
+  fieldErrors: {},
+});
+
+const InlineField = ({ user, field, value, displayValue, placeholder, multiline, validate, validationError }) => {
+  const { editMode, onSave, savingFields, fieldErrors } = useContext(EditContext);
+  const [draft, setDraft] = useState(value || '');
+  const [localError, setLocalError] = useState('');
+
+  useEffect(() => {
+    setDraft(value || '');
+    setLocalError('');
+  }, [value]);
+
+  if (!editMode) return <>{displayValue ?? value}</>;
+
+  const key = buildOverrideKey(user.userId, field);
+  const saving = Boolean(savingFields[key]);
+  const remoteError = fieldErrors[key];
+  const error = localError || remoteError;
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === (value || '')) return;
+    if (validate && trimmed && !validate(trimmed)) {
+      setLocalError(validationError || 'Невірний формат');
+      return;
+    }
+    setLocalError('');
+    onSave(user, field, trimmed);
+  };
+
+  if (multiline) {
+    return (
+      <span>
+        <S.EditableTextarea
+          value={draft}
+          placeholder={placeholder}
+          disabled={saving}
+          onClick={e => e.stopPropagation()}
+          onTouchStart={e => e.stopPropagation()}
+          onChange={e => setDraft(e.target.value)}
+          onBlur={commit}
+        />
+        {error && <S.FieldError>{error}</S.FieldError>}
+      </span>
+    );
+  }
+
+  return (
+    <span>
+      <S.EditableInput
+        value={draft}
+        size={Math.max(2, (draft || placeholder || '').length)}
+        placeholder={placeholder}
+        disabled={saving}
+        onClick={e => e.stopPropagation()}
+        onTouchStart={e => e.stopPropagation()}
+        onChange={e => setDraft(e.target.value)}
+        onBlur={commit}
+      />
+      {error && <S.FieldError>{error}</S.FieldError>}
+    </span>
+  );
+};
+
+const renderFacts = user => {
+  const nodes = [];
+
+  const height = normalizeDisplayValue(user?.height);
+  const weight = normalizeDisplayValue(user?.weight);
+  if (height || weight) {
+    nodes.push(
+      <S.Fact key="hw">
+        <b>
+          {height && <InlineField user={user} field="height" value={height} placeholder="зріст" />}
+          {height && weight && '/'}
+          {weight && <InlineField user={user} field="weight" value={weight} placeholder="вага" />}
+        </b>
+      </S.Fact>
+    );
+  }
+
+  const bmi = computeBmiValue(user);
+  if (bmi) {
+    nodes.push(
+      <S.Fact key="bmi">
+        BMI <b><InlineField user={user} field="bmi" value={bmi} /></b>
+      </S.Fact>
+    );
+  }
+
+  const marital = normalizeDisplayValue(user?.maritalStatus);
+  if (marital) {
+    nodes.push(
+      <S.Fact key="marital"><InlineField user={user} field="maritalStatus" value={marital} /></S.Fact>
+    );
+  }
+
+  const cSectionKey = resolveCSectionKey(user);
+  const cSectionValue = normalizeDisplayValue(user?.[cSectionKey]);
+  if (cSectionValue) {
+    nodes.push(
+      <S.Fact key="cs">
+        КС <b><InlineField user={user} field={cSectionKey} value={cSectionValue} /></b>
+      </S.Fact>
+    );
+  }
+
+  const blood = normalizeDisplayValue(user?.blood);
+  if (blood) {
+    nodes.push(<S.Fact key="blood"><InlineField user={user} field="blood" value={blood} /></S.Fact>);
+  }
+
+  const ownKids = normalizeDisplayValue(user?.ownKids);
+  if (ownKids) {
+    const lastDelivery = normalizeDisplayValue(user?.lastDelivery);
+    nodes.push(
+      <S.Fact key="births">
+        пологів <b><InlineField user={user} field="ownKids" value={ownKids} /></b>
+        {lastDelivery && (
+          <>
+            , останні{' '}
+            <b>
+              <InlineField
+                user={user}
+                field="lastDelivery"
+                value={lastDelivery}
+                displayValue={formatShortYear(lastDelivery)}
+                placeholder="дд.мм.рррр"
+                validate={isValidDeliveryDate}
+                validationError="Формат дд.мм.рррр"
+              />
+            </b>
+          </>
+        )}
+      </S.Fact>
+    );
+  }
+
+  return nodes;
+};
+
+const NoteBlock = ({ user, text }) => {
+  const { editMode } = useContext(EditContext);
+  const ref = useRef(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useLayoutEffect(() => {
+    if (editMode || expanded) {
+      setOverflowing(false);
+      return;
+    }
+    const el = ref.current;
+    if (!el) return;
+    setOverflowing(el.scrollHeight - el.clientHeight > 1);
+  }, [text, editMode, expanded]);
+
+  if (!text) return null;
+
+  return (
+    <>
+      <S.Note ref={ref} $clip={!editMode && !expanded}>
+        {editMode
+          ? <InlineField user={user} field={resolveBioKey(user)} value={text} multiline />
+          : text}
+      </S.Note>
+      {!editMode && overflowing && !expanded && (
+        <S.NoteMore onClick={e => { e.stopPropagation(); setExpanded(true); }}>…</S.NoteMore>
+      )}
+    </>
+  );
+};
+
+const ContactsSection = ({ user, onOpened }) => {
+  const entries = useMemo(
+    () => getContactEntries(user).filter(entry => entry.key !== 'vk'),
+    [user]
+  );
+  const [open, setOpen] = useState(false);
+
+  if (!entries.length) return null;
+
+  return (
+    <S.ContactsBlock>
+      <S.ContactsHeader
+        type="button"
+        onClick={() => {
+          setOpen(current => {
+            const next = !current;
+            if (next) onOpened(user);
+            return next;
+          });
+        }}
+      >
+        Контакти
+        {!open && <S.ContactsStatus>показати</S.ContactsStatus>}
+      </S.ContactsHeader>
+      {open && (
+        <S.ContactsBody>
+          {entries.map(entry => (
+            <S.ContactRow
+              key={`${entry.key}-${entry.index}`}
+              href={entry.href}
+              target={entry.key === 'phone' || entry.key === 'email' ? undefined : '_blank'}
+              rel={entry.key === 'phone' || entry.key === 'email' ? undefined : 'noopener noreferrer'}
+            >
+              <span>{getContactLabel(entry.key)}</span>
+              {entry.key === 'phone' ? formatPhoneDisplay(entry.value) : entry.value}
+            </S.ContactRow>
+          ))}
+        </S.ContactsBody>
+      )}
+    </S.ContactsBlock>
+  );
+};
+
+const HiddenProfileCard = ({
+  user,
+  editMode,
+  expanded,
+  onToggleExpand,
+  onReturn,
+  onFieldSave,
+  savingFields,
+  fieldErrors,
+  onContactsOpened,
+}) => {
+  const name = getProfileName(user);
+  const age = getProfileAge(user);
+  const location = getLocationLine(user);
+  const photos = getProfilePhotos(user);
+  const photo = photos[0];
+  const bio = getProfileBio(user);
+  const gridRows = useMemo(() => buildGridRows(user), [user]);
+  const contactEntries = useMemo(
+    () => getContactEntries(user).filter(entry => entry.key !== 'vk'),
+    [user]
+  );
+  const totalCount = gridRows.length + contactEntries.length;
+
+  const editContextValue = useMemo(() => ({
+    editMode,
+    onSave: onFieldSave,
+    savingFields,
+    fieldErrors,
+  }), [editMode, onFieldSave, savingFields, fieldErrors]);
+
+  const cityValue = normalizeDisplayValue(user?.city);
+  const regionValue = normalizeDisplayValue(user?.region);
+
+  return (
+    <EditContext.Provider value={editContextValue}>
+      <S.Card
+        $editMode={editMode}
+        onClick={() => { if (!editMode) onToggleExpand(user.userId); }}
+      >
+        <S.Top>
+          <S.Photo
+            style={photo
+              ? { backgroundImage: `url(${photo})` }
+              : { backgroundImage: getGradientFor(user.userId) }}
+          >
+            {!photo && getInitials(name)}
+          </S.Photo>
+          <S.Body>
+            <S.Name>
+              <InlineField user={user} field="name" value={normalizeDisplayValue(user?.name)} />
+              {age && <>, {age}</>}
+            </S.Name>
+            {(location || (editMode && (cityValue || regionValue))) && (
+              <S.Location>
+                <FaMapMarkerAlt aria-hidden="true" />
+                <span>
+                  {editMode ? (
+                    <>
+                      <InlineField user={user} field="city" value={cityValue} />
+                      {(cityValue || regionValue) && ', '}
+                      <InlineField user={user} field="region" value={regionValue} />
+                    </>
+                  ) : location}
+                </span>
+              </S.Location>
+            )}
+            <S.FactsRow>{renderFacts(user)}</S.FactsRow>
+          </S.Body>
+          <S.Ctrl>
+            <S.ReturnButton
+              type="button"
+              title="Повернути в загальний список"
+              aria-label="Повернути в загальний список"
+              onClick={e => { e.stopPropagation(); onReturn(user); }}
+            >
+              <FaUndo size={13} />
+            </S.ReturnButton>
+            <S.ChevronButton
+              type="button"
+              $open={expanded}
+              aria-label="Показати всі дані"
+              title="Показати всі дані"
+              onClick={e => { e.stopPropagation(); onToggleExpand(user.userId); }}
+            >
+              <b>{totalCount}</b>
+              <FaChevronDown size={11} />
+            </S.ChevronButton>
+          </S.Ctrl>
+        </S.Top>
+
+        <NoteBlock user={user} text={bio} />
+
+        {expanded && (
+          <S.More onClick={e => e.stopPropagation()}>
+            {gridRows.length > 0 && (
+              <S.Grid>
+                {gridRows.map(row => (
+                  <S.GridRow key={row.label} $wide={row.wide}>
+                    {row.label}: <b>
+                      {row.parts.map((part, idx) => (
+                        <React.Fragment key={part.field}>
+                          {idx > 0 && ', '}
+                          <InlineField user={user} field={part.field} value={part.value} />
+                        </React.Fragment>
+                      ))}
+                    </b>
+                  </S.GridRow>
+                ))}
+              </S.Grid>
+            )}
+            <ContactsSection user={user} onOpened={onContactsOpened} />
+          </S.More>
+        )}
+      </S.Card>
+    </EditContext.Provider>
+  );
+};
+
+const SkeletonRows = ({ count }) => (
+  <>
+    {Array.from({ length: count }).map((_, idx) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <S.SkeletonRow key={`hidden-skeleton-${idx}`}>
+        <S.SkeletonPhoto />
+        <S.SkeletonLines>
+          <S.SkeletonLine $w="55%" $h="13px" />
+          <S.SkeletonLine $w="40%" $h="10px" />
+          <S.SkeletonLine $w="85%" $h="10px" />
+        </S.SkeletonLines>
+      </S.SkeletonRow>
+    ))}
+  </>
+);
+
+const MatchingHiddenList = ({
+  ownerId,
+  users,
+  hasMore,
+  loading,
+  loadMore,
+  dislikeUsers,
+  setDislikeUsers,
+  ownDislikeUsers,
+  setOwnDislikeUsers,
+  editMode,
+  onGoToFeed,
+}) => {
+  const [expandedIds, setExpandedIds] = useState(() => new Set());
+  const [fieldOverrides, setFieldOverrides] = useState({});
+  const [savingFields, setSavingFields] = useState({});
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [photosByUserId, setPhotosByUserId] = useState({});
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+
+  const photoRequestedRef = useRef(new Set());
+  const contactViewKeysRef = useRef(new Set());
+  const loadMoreRef = useRef(loadMore);
+  useEffect(() => { loadMoreRef.current = loadMore; }, [loadMore]);
+
+  useEffect(() => {
+    const pending = users.filter(user => (
+      user?.userId
+      && !user.__photosHydrated
+      && !photosByUserId[user.userId]
+      && !photoRequestedRef.current.has(user.userId)
+    ));
+    if (!pending.length) return;
+    pending.forEach(user => {
+      photoRequestedRef.current.add(user.userId);
+      lazyLoadProfilePhotos(user.userId, user.__sourceCollection)
+        .then(photos => {
+          setPhotosByUserId(prev => ({ ...prev, [user.userId]: Array.isArray(photos) ? photos : [] }));
+        })
+        .catch(() => {
+          setPhotosByUserId(prev => ({ ...prev, [user.userId]: [] }));
+        });
+    });
+  }, [users, photosByUserId]);
+
+  const rows = useMemo(() => users
+    .filter(user => user?.userId)
+    .map(user => {
+      const overrides = fieldOverrides[user.userId];
+      const photoOverride = photosByUserId[user.userId];
+      if (!overrides && !photoOverride) return user;
+      return {
+        ...user,
+        ...(overrides || {}),
+        photos: (photoOverride && photoOverride.length) ? photoOverride : user.photos,
+      };
+    })
+    .sort((a, b) => (Number(dislikeUsers[b.userId]) || 0) - (Number(dislikeUsers[a.userId]) || 0)),
+  [users, fieldOverrides, photosByUserId, dislikeUsers]);
+
+  const handleFieldSave = useCallback(async (user, field, value) => {
+    const userId = user.userId;
+    const key = buildOverrideKey(userId, field);
+    setFieldOverrides(prev => ({ ...prev, [userId]: { ...(prev[userId] || {}), [field]: value } }));
+    setFieldErrors(prev => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    setSavingFields(prev => ({ ...prev, [key]: true }));
+    try {
+      await saveProfileField(user, field, value);
+    } catch (error) {
+      console.error('[MatchingHiddenList] Failed to save field', field, error);
+      setFieldErrors(prev => ({ ...prev, [key]: 'Не вдалося зберегти' }));
+    } finally {
+      setSavingFields(prev => {
+        if (!(key in prev)) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
+  }, []);
+
+  const handleToggleExpand = useCallback(userId => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  }, []);
+
+  const handleContactsOpened = useCallback(user => {
+    if (!user?.userId) return;
+    const trackKey = `${ownerId || ''}:${user.userId}`;
+    if (contactViewKeysRef.current.has(trackKey)) return;
+    contactViewKeysRef.current.add(trackKey);
+    void addContactViewUser(user.userId, ownerId);
+  }, [ownerId]);
+
+  const handleUndo = useCallback((user, previousDislikedAt) => {
+    const userId = user?.userId;
+    if (!userId || !ownerId) return;
+    const timestamp = typeof previousDislikedAt === 'number' ? previousDislikedAt : Date.now();
+    setDislikeUsers(prev => ({ ...prev, [userId]: timestamp }));
+    if (setOwnDislikeUsers) {
+      setOwnDislikeUsers(prev => ({ ...(prev || {}), [userId]: timestamp }));
+    }
+    setDislike(userId, true);
+    cacheDislikedUsers({ [userId]: user });
+    addDislikeUser(userId, ownerId, timestamp).catch(error => {
+      console.error('[MatchingHiddenList] Failed to restore dislike:', error);
+    });
+  }, [ownerId, setDislikeUsers, setOwnDislikeUsers]);
+
+  const handleReturn = useCallback(user => {
+    const userId = user?.userId;
+    if (!userId || !ownerId) return;
+    const previousDislikedAt = dislikeUsers[userId];
+
+    setDislikeUsers(prev => {
+      const next = { ...prev };
+      delete next[userId];
+      return next;
+    });
+    if (setOwnDislikeUsers) {
+      setOwnDislikeUsers(prev => {
+        const next = { ...(prev || {}) };
+        delete next[userId];
+        return next;
+      });
+    }
+    setDislike(userId, false);
+    removeCardFromList(userId, 'dislike');
+    removeDislikeUser(userId, ownerId).catch(error => {
+      console.error('[MatchingHiddenList] Failed to remove dislike:', error);
+    });
+
+    toast.custom(t => (
+      <S.ToastWrap>
+        <span>Анкету повернуто</span>
+        <S.ToastUndo
+          onClick={() => {
+            handleUndo(user, previousDislikedAt);
+            toast.dismiss(t.id);
+          }}
+        >
+          Скасувати
+        </S.ToastUndo>
+      </S.ToastWrap>
+    ), { duration: NOTE_TOAST_UNDO_MS });
+  }, [dislikeUsers, handleUndo, ownerId, setDislikeUsers, setOwnDislikeUsers]);
+
+  const fetchNextPage = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return;
+    setIsLoadingMore(true);
+    setLoadError(false);
+    try {
+      await loadMoreRef.current({
+        currentVisibleCount: rows.length,
+        targetVisibleCount: rows.length + PAGE_SIZE,
+        limit: PAGE_SIZE,
+      });
+    } catch (error) {
+      console.error('[MatchingHiddenList] Failed to load more hidden profiles', error);
+      setLoadError(true);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [hasMore, isLoadingMore, rows.length]);
+
+  const sentinelRef = useRef(null);
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node || !hasMore) return undefined;
+    const observer = new IntersectionObserver(entries => {
+      if (entries.some(entry => entry.isIntersecting)) {
+        fetchNextPage();
+      }
+    }, { rootMargin: '400px' });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasMore]);
+
+  useEffect(() => {
+    if (!loading && !isLoadingMore && !loadError && hasMore && rows.length > 0 && rows.length < PAGE_SIZE) {
+      fetchNextPage();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows.length, hasMore, loading, isLoadingMore, loadError]);
+
+  const showInitialSkeleton = loading && rows.length === 0;
+  const showEmptyState = !loading && !showInitialSkeleton && rows.length === 0 && !loadError;
+
+  return (
+    <S.Wrap>
+      {editMode && (
+        <S.EditHint>Режим редагування: торкніться будь-якого значення, щоб змінити його.</S.EditHint>
+      )}
+
+      {showEmptyState ? (
+        <S.EmptyState>
+          <S.EmptyStateTitle>Тут поки порожньо</S.EmptyStateTitle>
+          <S.EmptyStateText>Тут зберігаються анкети, які ви прибрали зі стрічки.</S.EmptyStateText>
+          {onGoToFeed && (
+            <S.EmptyStateButton type="button" onClick={onGoToFeed}>До стрічки</S.EmptyStateButton>
+          )}
+        </S.EmptyState>
+      ) : (
+        <S.List>
+          {rows.map(user => (
+            <HiddenProfileCard
+              key={user.userId}
+              user={user}
+              editMode={editMode}
+              expanded={expandedIds.has(user.userId)}
+              onToggleExpand={handleToggleExpand}
+              onReturn={handleReturn}
+              onFieldSave={handleFieldSave}
+              savingFields={savingFields}
+              fieldErrors={fieldErrors}
+              onContactsOpened={handleContactsOpened}
+            />
+          ))}
+
+          {showInitialSkeleton && <SkeletonRows count={4} />}
+          {!showInitialSkeleton && isLoadingMore && <SkeletonRows count={2} />}
+
+          {loadError && (
+            <S.ErrorRow>
+              Не вдалося завантажити
+              <S.RetryButton type="button" onClick={fetchNextPage}>Спробувати ще</S.RetryButton>
+            </S.ErrorRow>
+          )}
+
+          <S.Sentinel ref={sentinelRef} />
+
+          {!hasMore && rows.length > 0 && (
+            <S.FooterNote>Приховані анкети бачите тільки ви</S.FooterNote>
+          )}
+        </S.List>
+      )}
+    </S.Wrap>
+  );
+};
+
+export default MatchingHiddenList;

--- a/src/components/MatchingHiddenList.jsx
+++ b/src/components/MatchingHiddenList.jsx
@@ -22,6 +22,7 @@ import { getContactEntries } from './contactMethods';
 import {
   addContactViewUser,
   addDislikeUser,
+  auth,
   lazyLoadProfilePhotos,
   removeDislikeUser,
   updateDataInFiresoreDB,
@@ -30,6 +31,7 @@ import {
 } from './config';
 import { setDislike, cacheDislikedUsers } from 'utils/dislikesStorage';
 import { removeCardFromList } from 'utils/cardsStorage';
+import { getOverlayForUserCard, patchOverlayField } from 'utils/multiAccountEdits';
 import * as S from './MatchingHiddenList.styled';
 
 const PAGE_SIZE = 20;
@@ -168,7 +170,11 @@ const buildGridRows = user => {
   return rows;
 };
 
-const saveProfileField = async (user, field, value) => {
+// Admin edits write straight to the canonical users/newUsers record. Non-admin
+// ("editor") edits must never touch the live record directly - they are staged
+// as a per-editor overlay (multiData/edits/{cardUserId}/{editorUserId}) that an
+// admin later accepts or rejects, same as EditProfile.jsx's remoteUpdate().
+const saveProfileFieldDirect = async (user, field, value) => {
   const payload = { [field]: value };
   if (user?.__sourceCollection === 'newUsers') {
     await updateDataInNewUsersRTDB(user.userId, payload, 'update');
@@ -178,15 +184,26 @@ const saveProfileField = async (user, field, value) => {
   }
 };
 
+const saveProfileFieldOverlay = async (user, field, value, editorUserId) => {
+  await patchOverlayField({
+    editorUserId,
+    cardUserId: user.userId,
+    fieldName: field,
+    change: { from: normalizeDisplayValue(user?.[field]) ?? '', to: value },
+  });
+};
+
 const EditContext = React.createContext({
   editMode: false,
+  isAdmin: false,
   onSave: () => {},
   savingFields: {},
   fieldErrors: {},
+  pendingFields: {},
 });
 
 const InlineField = ({ user, field, value, displayValue, placeholder, multiline, validate, validationError }) => {
-  const { editMode, onSave, savingFields, fieldErrors } = useContext(EditContext);
+  const { editMode, isAdmin, onSave, savingFields, fieldErrors, pendingFields } = useContext(EditContext);
   const [draft, setDraft] = useState(value || '');
   const [localError, setLocalError] = useState('');
 
@@ -201,6 +218,7 @@ const InlineField = ({ user, field, value, displayValue, placeholder, multiline,
   const saving = Boolean(savingFields[key]);
   const remoteError = fieldErrors[key];
   const error = localError || remoteError;
+  const pending = !isAdmin && Boolean(pendingFields[key]);
 
   const commit = () => {
     const trimmed = draft.trim();
@@ -217,6 +235,7 @@ const InlineField = ({ user, field, value, displayValue, placeholder, multiline,
     return (
       <span>
         <S.EditableTextarea
+          $pending={pending}
           value={draft}
           placeholder={placeholder}
           disabled={saving}
@@ -225,6 +244,7 @@ const InlineField = ({ user, field, value, displayValue, placeholder, multiline,
           onChange={e => setDraft(e.target.value)}
           onBlur={commit}
         />
+        {pending && !error && <S.PendingBadge title="Очікує підтвердження адміністратора">на розгляді</S.PendingBadge>}
         {error && <S.FieldError>{error}</S.FieldError>}
       </span>
     );
@@ -233,6 +253,7 @@ const InlineField = ({ user, field, value, displayValue, placeholder, multiline,
   return (
     <span>
       <S.EditableInput
+        $pending={pending}
         value={draft}
         size={Math.max(2, (draft || placeholder || '').length)}
         placeholder={placeholder}
@@ -242,6 +263,7 @@ const InlineField = ({ user, field, value, displayValue, placeholder, multiline,
         onChange={e => setDraft(e.target.value)}
         onBlur={commit}
       />
+      {pending && !error && <S.PendingBadge title="Очікує підтвердження адміністратора">•</S.PendingBadge>}
       {error && <S.FieldError>{error}</S.FieldError>}
     </span>
   );
@@ -402,12 +424,14 @@ const ContactsSection = ({ user, onOpened }) => {
 const HiddenProfileCard = ({
   user,
   editMode,
+  isAdmin,
   expanded,
   onToggleExpand,
   onReturn,
   onFieldSave,
   savingFields,
   fieldErrors,
+  pendingFields,
   onContactsOpened,
 }) => {
   const name = getProfileName(user);
@@ -425,10 +449,12 @@ const HiddenProfileCard = ({
 
   const editContextValue = useMemo(() => ({
     editMode,
+    isAdmin,
     onSave: onFieldSave,
     savingFields,
     fieldErrors,
-  }), [editMode, onFieldSave, savingFields, fieldErrors]);
+    pendingFields,
+  }), [editMode, isAdmin, onFieldSave, savingFields, fieldErrors, pendingFields]);
 
   const cityValue = normalizeDisplayValue(user?.city);
   const regionValue = normalizeDisplayValue(user?.region);
@@ -545,20 +571,61 @@ const MatchingHiddenList = ({
   ownDislikeUsers,
   setOwnDislikeUsers,
   editMode,
+  isAdmin,
   onGoToFeed,
 }) => {
   const [expandedIds, setExpandedIds] = useState(() => new Set());
   const [fieldOverrides, setFieldOverrides] = useState({});
   const [savingFields, setSavingFields] = useState({});
   const [fieldErrors, setFieldErrors] = useState({});
+  const [pendingFields, setPendingFields] = useState({});
   const [photosByUserId, setPhotosByUserId] = useState({});
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState(false);
 
   const photoRequestedRef = useRef(new Set());
+  const overlayHydratedRef = useRef(new Set());
   const contactViewKeysRef = useRef(new Set());
   const loadMoreRef = useRef(loadMore);
   useEffect(() => { loadMoreRef.current = loadMore; }, [loadMore]);
+
+  // Non-admin editors never write straight to users/newUsers - their edits are
+  // staged per-editor and only applied once an admin accepts them elsewhere
+  // (EditProfile.jsx). When they open edit mode here, hydrate any of their own
+  // still-pending overlay values so they don't lose track of an earlier draft.
+  useEffect(() => {
+    if (!editMode || isAdmin) return;
+    const editorUserId = auth.currentUser?.uid;
+    if (!editorUserId) return;
+    const candidates = users.filter(user => (
+      user?.userId && !overlayHydratedRef.current.has(user.userId)
+    ));
+    if (!candidates.length) return;
+    candidates.forEach(user => {
+      overlayHydratedRef.current.add(user.userId);
+      getOverlayForUserCard({ editorUserId, cardUserId: user.userId })
+        .then(overlay => {
+          const fields = overlay?.fields;
+          if (!fields || !Object.keys(fields).length) return;
+          const overrideValues = {};
+          const pendingKeys = {};
+          Object.entries(fields).forEach(([fieldName, change]) => {
+            if (!change || typeof change !== 'object' || !('to' in change)) return;
+            overrideValues[fieldName] = change.to ?? '';
+            pendingKeys[buildOverrideKey(user.userId, fieldName)] = true;
+          });
+          if (!Object.keys(overrideValues).length) return;
+          setFieldOverrides(prev => ({
+            ...prev,
+            [user.userId]: { ...(prev[user.userId] || {}), ...overrideValues },
+          }));
+          setPendingFields(prev => ({ ...prev, ...pendingKeys }));
+        })
+        .catch(error => {
+          console.error('[MatchingHiddenList] Failed to load pending overlay', error);
+        });
+    });
+  }, [editMode, isAdmin, users]);
 
   useEffect(() => {
     const pending = users.filter(user => (
@@ -607,7 +674,20 @@ const MatchingHiddenList = ({
     });
     setSavingFields(prev => ({ ...prev, [key]: true }));
     try {
-      await saveProfileField(user, field, value);
+      if (isAdmin) {
+        await saveProfileFieldDirect(user, field, value);
+        setPendingFields(prev => {
+          if (!(key in prev)) return prev;
+          const next = { ...prev };
+          delete next[key];
+          return next;
+        });
+      } else {
+        const editorUserId = auth.currentUser?.uid;
+        if (!editorUserId) throw new Error('Not signed in');
+        await saveProfileFieldOverlay(user, field, value, editorUserId);
+        setPendingFields(prev => ({ ...prev, [key]: true }));
+      }
     } catch (error) {
       console.error('[MatchingHiddenList] Failed to save field', field, error);
       setFieldErrors(prev => ({ ...prev, [key]: 'Не вдалося зберегти' }));
@@ -619,7 +699,7 @@ const MatchingHiddenList = ({
         return next;
       });
     }
-  }, []);
+  }, [isAdmin]);
 
   const handleToggleExpand = useCallback(userId => {
     setExpandedIds(prev => {
@@ -735,7 +815,11 @@ const MatchingHiddenList = ({
   return (
     <S.Wrap>
       {editMode && (
-        <S.EditHint>Режим редагування: торкніться будь-якого значення, щоб змінити його.</S.EditHint>
+        <S.EditHint>
+          {isAdmin
+            ? 'Режим редагування: торкніться будь-якого значення, щоб змінити його.'
+            : 'Режим редагування: зміни зберігаються як пропозиція та підуть на розгляд адміністратору.'}
+        </S.EditHint>
       )}
 
       {showEmptyState ? (
@@ -753,12 +837,14 @@ const MatchingHiddenList = ({
               key={user.userId}
               user={user}
               editMode={editMode}
+              isAdmin={isAdmin}
               expanded={expandedIds.has(user.userId)}
               onToggleExpand={handleToggleExpand}
               onReturn={handleReturn}
               onFieldSave={handleFieldSave}
               savingFields={savingFields}
               fieldErrors={fieldErrors}
+              pendingFields={pendingFields}
               onContactsOpened={handleContactsOpened}
             />
           ))}

--- a/src/components/MatchingHiddenList.styled.jsx
+++ b/src/components/MatchingHiddenList.styled.jsx
@@ -322,7 +322,9 @@ export const EditableInput = styled.input`
   letter-spacing: inherit;
   padding: 0 1px;
   min-width: 14px;
-  border-bottom: 1px dashed color-mix(in srgb, var(--matching-muted-text) 55%, transparent);
+  border-bottom: 1px dashed ${({ $pending }) => ($pending
+    ? 'var(--matching-accent)'
+    : 'color-mix(in srgb, var(--matching-muted-text) 55%, transparent)')};
 
   &:focus {
     outline: 0;
@@ -331,8 +333,20 @@ export const EditableInput = styled.input`
   }
 `;
 
+export const PendingBadge = styled.span`
+  display: inline-block;
+  margin-left: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--matching-accent);
+  vertical-align: super;
+  cursor: help;
+`;
+
 export const EditableTextarea = styled.textarea`
-  border: 1px dashed color-mix(in srgb, var(--matching-muted-text) 55%, transparent);
+  border: 1px dashed ${({ $pending }) => ($pending
+    ? 'var(--matching-accent)'
+    : 'color-mix(in srgb, var(--matching-muted-text) 55%, transparent)')};
   background: transparent;
   font: inherit;
   color: inherit;

--- a/src/components/MatchingHiddenList.styled.jsx
+++ b/src/components/MatchingHiddenList.styled.jsx
@@ -1,0 +1,499 @@
+import styled, { css, keyframes } from 'styled-components';
+
+export const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  padding: 0 10px 10px;
+  box-sizing: border-box;
+`;
+
+export const HiddenHeaderTitle = styled.div`
+  font-size: 16.5px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--matching-header-text);
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  span {
+    color: var(--matching-muted-text);
+    font-weight: 600;
+    margin-left: 2px;
+  }
+`;
+
+export const EditHint = styled.p`
+  font-size: 11.5px;
+  color: var(--matching-accent);
+  background: color-mix(in srgb, var(--matching-accent) 12%, transparent);
+  padding: 7px 14px;
+  line-height: 1.4;
+  margin: 0 0 8px;
+  border-radius: 10px;
+`;
+
+export const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 2px 0 4px;
+`;
+
+export const Card = styled.div`
+  background: var(--matching-card-bg);
+  border: 1px solid var(--matching-card-border);
+  border-radius: 20px;
+  padding: 11px;
+  cursor: ${({ $editMode }) => ($editMode ? 'default' : 'pointer')};
+  transition: opacity 200ms ease, transform 200ms ease;
+`;
+
+export const Top = styled.div`
+  display: flex;
+  gap: 11px;
+`;
+
+export const Photo = styled.div`
+  width: 58px;
+  height: 58px;
+  border-radius: 16px;
+  flex: 0 0 auto;
+  background-size: cover;
+  background-position: center;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 14px;
+  overflow: hidden;
+`;
+
+export const Body = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const Name = styled.div`
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  color: var(--matching-header-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const Location = styled.div`
+  font-size: 12px;
+  color: var(--matching-muted-text);
+  margin-top: 3px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+
+  svg {
+    flex: 0 0 auto;
+    fill: var(--matching-accent);
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
+
+export const FactsRow = styled.div`
+  font-size: 12.5px;
+  color: var(--matching-header-text);
+  opacity: 0.82;
+  margin-top: 5px;
+  line-height: 1.5;
+`;
+
+export const Fact = styled.i`
+  font-style: normal;
+  white-space: nowrap;
+  display: inline-block;
+
+  b {
+    font-weight: 650;
+  }
+
+  &::after {
+    content: '·';
+    color: var(--matching-muted-text);
+    margin: 0 5px;
+    opacity: 0.6;
+  }
+
+  &:last-child::after {
+    content: '';
+    margin: 0;
+  }
+`;
+
+export const Ctrl = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 6px;
+  flex: 0 0 auto;
+`;
+
+const ctrlButtonBase = css`
+  width: 42px;
+  height: 26px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+`;
+
+export const ReturnButton = styled.button`
+  ${ctrlButtonBase}
+  border: 1px solid color-mix(in srgb, var(--matching-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--matching-accent) 12%, transparent);
+  color: var(--matching-accent);
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+`;
+
+export const ChevronButton = styled.button`
+  ${ctrlButtonBase}
+  border: 1px solid var(--matching-card-border);
+  background: var(--matching-card-bg);
+  color: var(--matching-muted-text);
+
+  b {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--matching-muted-text);
+  }
+
+  svg {
+    transition: transform 180ms ease;
+    transform: rotate(${({ $open }) => ($open ? '180deg' : '0deg')});
+  }
+`;
+
+export const Note = styled.p`
+  font-size: 12.3px;
+  color: var(--matching-muted-text);
+  background: var(--matching-section-bg);
+  border-radius: 14px;
+  padding: 7px 10px;
+  margin: 9px 0 0;
+  line-height: 1.5;
+
+  ${({ $clip }) => $clip && css`
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  `}
+`;
+
+export const NoteMore = styled.span`
+  display: block;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 0.8;
+  color: var(--matching-accent);
+  margin: 4px 0 0 10px;
+  cursor: pointer;
+  letter-spacing: 1px;
+`;
+
+export const More = styled.div`
+  margin-top: 9px;
+`;
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 14px;
+  background: var(--matching-section-bg);
+  border-radius: 14px;
+  padding: 9px 11px;
+`;
+
+export const GridRow = styled.p`
+  margin: 0;
+  font-size: 12.3px;
+  line-height: 1.75;
+  color: var(--matching-muted-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  b {
+    color: var(--matching-header-text);
+    font-weight: 600;
+  }
+
+  ${({ $wide }) => $wide && css`grid-column: 1 / -1;`}
+`;
+
+export const ContactsBlock = styled.div`
+  margin-top: 8px;
+  border: 1px solid var(--matching-card-border);
+  border-radius: 14px;
+  overflow: hidden;
+`;
+
+export const ContactsHeader = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 11px;
+  font-size: 12.3px;
+  font-weight: 600;
+  color: var(--matching-muted-text);
+  background: var(--matching-card-bg);
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+`;
+
+export const ContactsStatus = styled.span`
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--matching-muted-text);
+`;
+
+export const ContactsBody = styled.div`
+  padding: 2px 11px 6px;
+  background: var(--matching-card-bg);
+  border-top: 1px solid var(--matching-section-bg);
+`;
+
+export const ContactRow = styled.a`
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  font-size: 12.5px;
+  color: var(--matching-accent);
+  font-weight: 500;
+  text-decoration: none;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--matching-section-bg);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  &:active {
+    opacity: 0.6;
+  }
+
+  span {
+    color: var(--matching-muted-text);
+    font-size: 11px;
+    font-weight: 400;
+    margin-right: 7px;
+    display: inline-block;
+    min-width: 64px;
+  }
+`;
+
+export const EditableInput = styled.input`
+  border: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  padding: 0 1px;
+  min-width: 14px;
+  border-bottom: 1px dashed color-mix(in srgb, var(--matching-muted-text) 55%, transparent);
+
+  &:focus {
+    outline: 0;
+    border-bottom-color: var(--matching-accent);
+    background: color-mix(in srgb, var(--matching-accent) 12%, transparent);
+  }
+`;
+
+export const EditableTextarea = styled.textarea`
+  border: 1px dashed color-mix(in srgb, var(--matching-muted-text) 55%, transparent);
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  width: 100%;
+  min-height: 44px;
+  resize: vertical;
+  border-radius: 10px;
+  padding: 6px 8px;
+
+  &:focus {
+    outline: 0;
+    border-color: var(--matching-accent);
+    background: color-mix(in srgb, var(--matching-accent) 12%, transparent);
+  }
+`;
+
+export const FieldError = styled.span`
+  display: block;
+  font-size: 10.5px;
+  color: var(--km-danger, #d64545);
+  margin-top: 2px;
+`;
+
+export const SkeletonRow = styled.div`
+  background: var(--matching-card-bg);
+  border: 1px solid var(--matching-card-border);
+  border-radius: 20px;
+  padding: 11px;
+  display: flex;
+  gap: 11px;
+`;
+
+const shimmer = keyframes`
+  0% { background-position: -120px 0; }
+  100% { background-position: 120px 0; }
+`;
+
+const shimmerBg = css`
+  background: var(--matching-section-bg);
+  background-image: linear-gradient(
+    90deg,
+    var(--matching-section-bg) 0px,
+    color-mix(in srgb, var(--matching-accent) 10%, var(--matching-section-bg)) 40px,
+    var(--matching-section-bg) 80px
+  );
+  background-size: 240px 100%;
+  animation: ${shimmer} 1.3s ease-in-out infinite;
+`;
+
+export const SkeletonPhoto = styled.div`
+  width: 58px;
+  height: 58px;
+  border-radius: 16px;
+  flex: 0 0 auto;
+  ${shimmerBg}
+`;
+
+export const SkeletonLines = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+`;
+
+export const SkeletonLine = styled.div`
+  height: ${({ $h }) => $h || '10px'};
+  width: ${({ $w }) => $w || '100%'};
+  border-radius: 6px;
+  ${shimmerBg}
+`;
+
+export const FooterNote = styled.div`
+  text-align: center;
+  padding: 14px 10px 4px;
+  font-size: 11.5px;
+  color: var(--matching-muted-text);
+`;
+
+export const ErrorRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px;
+  font-size: 13px;
+  color: var(--matching-muted-text);
+  flex-wrap: wrap;
+`;
+
+export const RetryButton = styled.button`
+  border: 1px solid var(--matching-accent);
+  color: var(--matching-accent);
+  background: transparent;
+  border-radius: 9px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+export const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 48px 20px;
+  color: var(--matching-muted-text);
+`;
+
+export const EmptyStateTitle = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--matching-header-text);
+`;
+
+export const EmptyStateText = styled.p`
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 320px;
+`;
+
+export const EmptyStateButton = styled.button`
+  border: 0;
+  background: var(--matching-accent);
+  color: #fff;
+  border-radius: 10px;
+  padding: 9px 18px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+export const Sentinel = styled.div`
+  height: 1px;
+`;
+
+export const ToastWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--matching-card-bg);
+  color: var(--matching-header-text);
+  border: 1px solid var(--matching-card-border);
+  border-radius: 14px;
+  padding: 10px 14px;
+  box-shadow: var(--matching-card-shadow);
+  font-size: 13px;
+`;
+
+export const ToastUndo = styled.button`
+  border: 0;
+  background: transparent;
+  color: var(--matching-accent);
+  font: inherit;
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+`;

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -662,11 +662,12 @@ export const removeFavoriteUser = async (userId, ownerId) => {
   }
 };
 
-export const addDislikeUser = async (userId, ownerId) => {
+export const addDislikeUser = async (userId, ownerId, dislikedAt) => {
   try {
     const owner = auth.currentUser;
     if (!owner) return;
-    await set(ref2(database, `multiData/dislikes/${ownerId || owner.uid}/${userId}`), true);
+    const timestamp = typeof dislikedAt === 'number' ? dislikedAt : Date.now();
+    await set(ref2(database, `multiData/dislikes/${ownerId || owner.uid}/${userId}`), timestamp);
   } catch (error) {
     console.error('Error adding dislike user:', error);
   }

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -132,7 +132,7 @@ const toDisplayFields = (items, user, excludeKeys = []) =>
     .map(item => ({ ...item, value: valueFor(user, item) }))
     .filter(item => shouldRenderField(item.value));
 
-const bmiValue = user => {
+export const bmiValue = user => {
   const explicit = normalizeDisplayValue(user?.bmi);
   if (explicit) return explicit;
   const weight = Number(normalizeDisplayValue(user?.weight));


### PR DESCRIPTION
Replaces the full-size single-card swiper in the dislikes tab with a
compact row-based list matching the Batch 30 mockup: collapsed rows
with a fixed non-breaking facts line, expandable field grid, collapsible
contacts with view tracking, an undo-toast return action, edit mode with
additive-only field saves, and IntersectionObserver-driven infinite
scroll on top of the existing reaction pagination (loadMore/loadReactionCards).

- New MatchingHiddenList component + styled sheet, reusing existing
  Matching field/contact/pagination infrastructure rather than
  duplicating it.
- addDislikeUser now stores a dislike timestamp (was `true`) so the list
  can sort newest-first; fully backward compatible with existing truthy
  checks and callers.
- Export bmiValue from profileLayoutConfig so the list computes BMI the
  same way the full profile card does.

Known scope limits (documented, not silently guessed): header identity
fields (name is editable, age/derived location parsing are not, since
age has no raw stored field and splitting composite location text back
into city/region reliably isn't safe) stay read-only in edit mode.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019M67PoAd6Fk3dP3T5nxGUx