### PR TITLE
Keep local reaction metadata out of backend profile payloads

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2091,7 +2091,9 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       formatDateAndFormula(updatedState.lastDelivery)
     );
 
-    const syncedState = { ...updatedState };
+    // Cards opened from the Like/Dislike list contain local display metadata.
+    // Strip it before the state enters any save path (including user edit overlays).
+    const syncedState = sanitizeTechnicalPayload(updatedState);
 
     if (formattedLastDelivery) {
       syncedState.lastDelivery = formattedLastDelivery;

--- a/src/components/formFields.js
+++ b/src/components/formFields.js
@@ -324,6 +324,7 @@ export const newUsersRequiredFieldNames = [
 ];
 
 export const newUsersSanitizedFieldNames = [
+  '_reactionType',
   '__sourceCollection',
   '__photosHydrated',
   '__profileSnapshotVersion',

--- a/src/components/formFields.test.js
+++ b/src/components/formFields.test.js
@@ -1,0 +1,17 @@
+import { sanitizeNewUsersPayload, sanitizeTechnicalPayload } from './formFields';
+
+describe('profile payload sanitizers', () => {
+  it.each([
+    ['users', sanitizeTechnicalPayload],
+    ['newUsers', sanitizeNewUsersPayload],
+  ])('keeps reaction metadata local for %s payloads', (_collection, sanitizePayload) => {
+    expect(sanitizePayload({
+      userId: 'profile-1',
+      name: 'Profile',
+      _reactionType: 'Like/Dislike',
+    })).toEqual({
+      userId: 'profile-1',
+      name: 'Profile',
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent local UI metadata (`_reactionType`) attached to cards opened from the Like/Dislike lists from being persisted to backend collections, because these are display-only values and must remain local.

### Description
- Classify `_reactionType` as a sanitized/local technical field by adding it to `newUsersSanitizedFieldNames` in `src/components/formFields.js` so existing sanitizers drop it. 
- Sanitize the submitted profile state early in `handleSubmit` by applying `sanitizeTechnicalPayload(updatedState)` in `src/components/AddNewProfile.jsx` so local metadata is removed before any save path (admin or non-admin) runs. 
- Add a regression test `src/components/formFields.test.js` that asserts both `sanitizeTechnicalPayload` and `sanitizeNewUsersPayload` remove `_reactionType` while preserving regular profile fields.

### Testing
- ✅ Ran `CI=true npm test -- --runInBand src/components/formFields.test.js` and the test suite passed. 
- ✅ Ran `npm run lint:js -- --quiet` and lint completed without errors. 
- ✅ Verified repository diff and checks with `git diff --check` and working tree is clean after committing the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7199ec743c8326932b629316d013dc)