### PR TITLE
Preserve legacy photo in local profile saves

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -2015,7 +2015,14 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
   // submission order, regardless of how fast each call's own fetch/merge
   // happens to resolve - the actual fix for the deletion-order race.
   const enqueueProfileSync = params => {
-    const { syncedState, saveRequestId, localSaveVersion, removeKeys, deletedKeys } = params;
+    const {
+      syncedState,
+      localCardState = syncedState,
+      saveRequestId,
+      localSaveVersion,
+      removeKeys,
+      deletedKeys,
+    } = params;
 
     const runSync = async () => {
       try {
@@ -2048,7 +2055,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
 
         deletedKeys.forEach(key => pendingDeletedKeysRef.current.delete(key));
 
-        const savedCachedCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
+        const savedCachedCard = updateCachedUser(localCardState, { removeKeys }) || localCardState;
         cacheFetchedUsers({ [syncedState.userId]: savedCachedCard }, cacheLoad2Users, filters);
         liveFieldsRef.current = savedCachedCard;
         setState(savedCachedCard, {
@@ -2094,11 +2101,21 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     // Cards opened from the Like/Dislike list contain local display metadata.
     // Strip it before the state enters any save path (including user edit overlays).
     const syncedState = sanitizeTechnicalPayload(updatedState);
+    const localCardState = { ...syncedState };
+
+    // The singular `photo` field is legacy backend data, but TopBlock still
+    // displays it. Keep it local so optimistic and save-confirmed state do not
+    // blank legacy-only profiles after the backend payload is sanitized.
+    if (hasOwn(updatedState, 'photo')) {
+      localCardState.photo = updatedState.photo;
+    }
 
     if (formattedLastDelivery) {
       syncedState.lastDelivery = formattedLastDelivery;
+      localCardState.lastDelivery = formattedLastDelivery;
     } else {
       delete syncedState.lastDelivery;
+      delete localCardState.lastDelivery;
     }
 
     registerHistorySnapshot(syncedState);
@@ -2111,7 +2128,8 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
         overwrite,
         delCondition,
         deletedKeys: [],
-        optimisticCard: syncedState,
+        optimisticCard: localCardState,
+        localCardState,
         removeKeys: [],
         hasNewState,
         formattedLastDelivery,
@@ -2128,7 +2146,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     removeKeys.forEach(key => pendingDeletedKeysRef.current.add(key));
     const deletedKeys = normalizeDeletedKeys(pendingDeletedKeysRef.current, removeKeys);
 
-    const optimisticCard = updateCachedUser(syncedState, { removeKeys }) || syncedState;
+    const optimisticCard = updateCachedUser(localCardState, { removeKeys }) || localCardState;
     const localSaveVersion = profileSnapshotVersionRef.current + 1;
     liveFieldsRef.current = optimisticCard;
     setState(optimisticCard, {
@@ -2156,6 +2174,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       delCondition,
       deletedKeys,
       optimisticCard,
+      localCardState,
       removeKeys,
       saveRequestId,
       localSaveVersion,


### PR DESCRIPTION
### Motivation
- Fix a UI regression where profiles that only had the legacy singular `photo` field lost their visible image after edits because `sanitizeTechnicalPayload` removed display-only fields before optimistic/local cache updates. 

### Description
- Create a `localCardState` (clone of the sanitized `syncedState`) inside `handleSubmit` and reattach the legacy `photo` field from the original `updatedState` when present so display logic (`TopBlock`) still sees the image. 
- Preserve `lastDelivery` in both `syncedState` and `localCardState` so display/optimistic state and backend payload remain consistent. 
- Thread `localCardState` through the optimistic UI/cache update path: pass it into `updateCachedUser` and use it for optimistic `setState`/cache updates while continuing to send the sanitized `syncedState` to remote save paths. 
- Extend `enqueueProfileSync` parameter list with an optional `localCardState` (defaulting to `syncedState`) and use it when applying save-confirmed updates to the local cache, leaving remote behavior unchanged. All edits are in `src/components/AddNewProfile.jsx` and follow existing helpers (`sanitizeTechnicalPayload`, `updateCachedUser`, `enqueueProfileSync`, `handleSubmit`).

### Testing
- Ran unit tests for payload sanitizers with `CI=true npm test -- --watchAll=false src/components/formFields.test.js`, and the tests passed (`2 passed`).
- Linted the modified file with `npx eslint src/components/AddNewProfile.jsx`, which completed without errors (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7246c0243c832698c8d42648ea2605)