### PR TITLE
Fix Matching hidden list defects and normalize blood group formatting

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -5741,7 +5741,7 @@ const Matching = () => {
             <TopActions>
               {viewMode === 'dislikes' && (
                 <MatchingHiddenListHeaderTitle>
-                  Приховані <span>· {Object.keys(dislikeUsers || {}).length}</span>
+                  Приховані
                 </MatchingHiddenListHeaderTitle>
               )}
               <TopActionGroup aria-label="Фільтри matching">
@@ -5779,6 +5779,9 @@ const Matching = () => {
                   title={viewMode === 'dislikes' ? 'Повернутись до загального списку' : 'Показати дизлайки'}
                 >
                   <FaTimes />
+                  {Object.keys(dislikeUsers || {}).length > 0 && (
+                    <ActionBadge>{Object.keys(dislikeUsers || {}).length}</ActionBadge>
+                  )}
                 </ActionButton>
                 <ActionButton
                   type="button"

--- a/src/components/MatchingHiddenList.jsx
+++ b/src/components/MatchingHiddenList.jsx
@@ -16,6 +16,8 @@ import {
   getProfilePhotos,
   bmiValue as computeBmiValue,
   normalizeDisplayValue,
+  maritalStatusLabel,
+  getBloodGroupDisplay,
 } from './profileLayoutConfig';
 import { normalizeCountry, normalizeRegion } from './normalizeLocation';
 import { getContactEntries } from './contactMethods';
@@ -23,6 +25,7 @@ import {
   addContactViewUser,
   addDislikeUser,
   auth,
+  fetchUserComments,
   lazyLoadProfilePhotos,
   removeDislikeUser,
   updateDataInFiresoreDB,
@@ -30,6 +33,7 @@ import {
   updateDataInRealtimeDB,
 } from './config';
 import { setDislike, cacheDislikedUsers } from 'utils/dislikesStorage';
+import { loadComments, saveComments } from 'utils/commentsStorage';
 import { removeCardFromList } from 'utils/cardsStorage';
 import { getOverlayForUserCard, patchOverlayField } from 'utils/multiAccountEdits';
 import * as S from './MatchingHiddenList.styled';
@@ -295,10 +299,13 @@ const renderFacts = user => {
     );
   }
 
-  const marital = normalizeDisplayValue(user?.maritalStatus);
-  if (marital) {
+  const maritalRaw = normalizeDisplayValue(user?.maritalStatus);
+  const maritalDisplay = maritalStatusLabel(maritalRaw);
+  if (maritalDisplay) {
     nodes.push(
-      <S.Fact key="marital"><InlineField user={user} field="maritalStatus" value={marital} /></S.Fact>
+      <S.Fact key="marital">
+        <InlineField user={user} field="maritalStatus" value={maritalRaw} displayValue={maritalDisplay} />
+      </S.Fact>
     );
   }
 
@@ -312,9 +319,14 @@ const renderFacts = user => {
     );
   }
 
-  const blood = normalizeDisplayValue(user?.blood);
-  if (blood) {
-    nodes.push(<S.Fact key="blood"><InlineField user={user} field="blood" value={blood} /></S.Fact>);
+  const bloodRaw = normalizeDisplayValue(user?.blood);
+  const bloodDisplay = getBloodGroupDisplay(user);
+  if (bloodDisplay) {
+    nodes.push(
+      <S.Fact key="blood">
+        <InlineField user={user} field="blood" value={bloodRaw} displayValue={bloodDisplay} />
+      </S.Fact>
+    );
   }
 
   const ownKids = normalizeDisplayValue(user?.ownKids);
@@ -346,32 +358,40 @@ const renderFacts = user => {
   return nodes;
 };
 
-const NoteBlock = ({ user, text }) => {
+// variant "comment" renders the client's own multiData/comments note (why the
+// card was hidden) in a plain-font block with a background; variant "bio"
+// renders the candidate's self-written description in italics without one.
+// Only "bio" is editable here - the comment is edited on the full profile
+// card's dedicated Comment box, not inline in this list.
+const NoteBlock = ({ user, text, variant = 'bio', editable = false }) => {
   const { editMode } = useContext(EditContext);
   const ref = useRef(null);
   const [expanded, setExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
+  const showEditor = editable && editMode;
 
   useLayoutEffect(() => {
-    if (editMode || expanded) {
+    if (showEditor || expanded) {
       setOverflowing(false);
       return;
     }
     const el = ref.current;
     if (!el) return;
     setOverflowing(el.scrollHeight - el.clientHeight > 1);
-  }, [text, editMode, expanded]);
+  }, [text, showEditor, expanded]);
 
   if (!text) return null;
 
+  const Wrapper = variant === 'comment' ? S.Note : S.SelfDescription;
+
   return (
     <>
-      <S.Note ref={ref} $clip={!editMode && !expanded}>
-        {editMode
+      <Wrapper ref={ref} $clip={!showEditor && !expanded}>
+        {showEditor
           ? <InlineField user={user} field={resolveBioKey(user)} value={text} multiline />
           : text}
-      </S.Note>
-      {!editMode && overflowing && !expanded && (
+      </Wrapper>
+      {!showEditor && overflowing && !expanded && (
         <S.NoteMore onClick={e => { e.stopPropagation(); setExpanded(true); }}>…</S.NoteMore>
       )}
     </>
@@ -433,6 +453,7 @@ const HiddenProfileCard = ({
   fieldErrors,
   pendingFields,
   onContactsOpened,
+  clientComment,
 }) => {
   const name = getProfileName(user);
   const age = getProfileAge(user);
@@ -440,6 +461,7 @@ const HiddenProfileCard = ({
   const photos = getProfilePhotos(user);
   const photo = photos[0];
   const bio = getProfileBio(user);
+  const facts = useMemo(() => renderFacts(user), [user]);
   const gridRows = useMemo(() => buildGridRows(user), [user]);
   const contactEntries = useMemo(
     () => getContactEntries(user).filter(entry => entry.key !== 'vk'),
@@ -458,6 +480,8 @@ const HiddenProfileCard = ({
 
   const cityValue = normalizeDisplayValue(user?.city);
   const regionValue = normalizeDisplayValue(user?.region);
+  const hasLocation = Boolean(location || (editMode && (cityValue || regionValue)));
+  const isUnfilled = facts.length === 0 && !hasLocation;
 
   return (
     <EditContext.Provider value={editContextValue}>
@@ -478,7 +502,7 @@ const HiddenProfileCard = ({
               <InlineField user={user} field="name" value={normalizeDisplayValue(user?.name)} />
               {age && <>, {age}</>}
             </S.Name>
-            {(location || (editMode && (cityValue || regionValue))) && (
+            {hasLocation && (
               <S.Location>
                 <FaMapMarkerAlt aria-hidden="true" />
                 <span>
@@ -492,7 +516,11 @@ const HiddenProfileCard = ({
                 </span>
               </S.Location>
             )}
-            <S.FactsRow>{renderFacts(user)}</S.FactsRow>
+            {facts.length > 0 ? (
+              <S.FactsRow>{facts}</S.FactsRow>
+            ) : isUnfilled && (
+              <S.EmptyNote>Анкета не заповнена</S.EmptyNote>
+            )}
           </S.Body>
           <S.Ctrl>
             <S.ReturnButton
@@ -516,7 +544,7 @@ const HiddenProfileCard = ({
           </S.Ctrl>
         </S.Top>
 
-        <NoteBlock user={user} text={bio} />
+        <NoteBlock user={user} text={clientComment} variant="comment" />
 
         {expanded && (
           <S.More onClick={e => e.stopPropagation()}>
@@ -536,6 +564,7 @@ const HiddenProfileCard = ({
                 ))}
               </S.Grid>
             )}
+            <NoteBlock user={user} text={bio} variant="bio" editable />
             <ContactsSection user={user} onOpened={onContactsOpened} />
           </S.More>
         )}
@@ -580,10 +609,12 @@ const MatchingHiddenList = ({
   const [fieldErrors, setFieldErrors] = useState({});
   const [pendingFields, setPendingFields] = useState({});
   const [photosByUserId, setPhotosByUserId] = useState({});
+  const [commentsByUserId, setCommentsByUserId] = useState({});
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState(false);
 
   const photoRequestedRef = useRef(new Set());
+  const commentRequestedRef = useRef(new Set());
   const overlayHydratedRef = useRef(new Set());
   const contactViewKeysRef = useRef(new Set());
   const loadMoreRef = useRef(loadMore);
@@ -646,6 +677,48 @@ const MatchingHiddenList = ({
         });
     });
   }, [users, photosByUserId]);
+
+  // The client's personal note about why a card was hidden lives in
+  // multiData/comments/{ownerId}/{cardId} (see config.js's fetchUserComments/
+  // saveMyCardComment), not on the profile record itself - same store the
+  // full profile card's "Comment" box reads from in Matching.jsx.
+  useEffect(() => {
+    if (!ownerId) return;
+    const pendingIds = users
+      .map(user => user?.userId)
+      .filter(Boolean)
+      .filter(userId => !(userId in commentsByUserId) && !commentRequestedRef.current.has(userId));
+    if (!pendingIds.length) return;
+
+    const cachedForOwner = loadComments()[ownerId] || {};
+    const fromCache = {};
+    const toFetch = [];
+    pendingIds.forEach(userId => {
+      commentRequestedRef.current.add(userId);
+      if (cachedForOwner[userId]) fromCache[userId] = cachedForOwner[userId].text || '';
+      else toFetch.push(userId);
+    });
+    if (Object.keys(fromCache).length) {
+      setCommentsByUserId(prev => ({ ...prev, ...fromCache }));
+    }
+    if (!toFetch.length) return;
+
+    fetchUserComments(ownerId, toFetch)
+      .then(result => {
+        const textByUserId = {};
+        toFetch.forEach(userId => { textByUserId[userId] = result[userId]?.text || ''; });
+        setCommentsByUserId(prev => ({ ...prev, ...textByUserId }));
+        const allComments = loadComments();
+        allComments[ownerId] = { ...(allComments[ownerId] || {}), ...result };
+        saveComments(allComments);
+      })
+      .catch(error => {
+        console.error('[MatchingHiddenList] Failed to load comments', error);
+        const fallback = {};
+        toFetch.forEach(userId => { fallback[userId] = ''; });
+        setCommentsByUserId(prev => ({ ...prev, ...fallback }));
+      });
+  }, [users, ownerId, commentsByUserId]);
 
   const rows = useMemo(() => users
     .filter(user => user?.userId)
@@ -846,6 +919,7 @@ const MatchingHiddenList = ({
               fieldErrors={fieldErrors}
               pendingFields={pendingFields}
               onContactsOpened={handleContactsOpened}
+              clientComment={commentsByUserId[user.userId] || ''}
             />
           ))}
 

--- a/src/components/MatchingHiddenList.styled.jsx
+++ b/src/components/MatchingHiddenList.styled.jsx
@@ -118,6 +118,13 @@ export const FactsRow = styled.div`
   line-height: 1.5;
 `;
 
+export const EmptyNote = styled.div`
+  font-size: 12px;
+  color: var(--matching-muted-text);
+  margin-top: 5px;
+  line-height: 1.5;
+`;
+
 export const Fact = styled.i`
   font-style: normal;
   white-space: nowrap;
@@ -127,14 +134,14 @@ export const Fact = styled.i`
     font-weight: 650;
   }
 
-  &::after {
+  &::before {
     content: '·';
     color: var(--matching-muted-text);
     margin: 0 5px;
     opacity: 0.6;
   }
 
-  &:last-child::after {
+  &:first-child::before {
     content: '';
     margin: 0;
   }
@@ -193,12 +200,30 @@ export const ChevronButton = styled.button`
 
 export const Note = styled.p`
   font-size: 12.3px;
-  color: var(--matching-muted-text);
+  color: var(--matching-header-text);
   background: var(--matching-section-bg);
   border-radius: 14px;
   padding: 7px 10px;
   margin: 9px 0 0;
   line-height: 1.5;
+  max-height: none;
+
+  ${({ $clip }) => $clip && css`
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  `}
+`;
+
+export const SelfDescription = styled.p`
+  font-size: 12.3px;
+  font-style: italic;
+  color: var(--matching-muted-text);
+  padding: 0;
+  margin: 9px 0 0;
+  line-height: 1.5;
+  max-height: none;
 
   ${({ $clip }) => $clip && css`
     display: -webkit-box;
@@ -257,18 +282,20 @@ export const ContactsBlock = styled.div`
 `;
 
 export const ContactsHeader = styled.button`
+  font: inherit;
   display: flex;
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 9px 11px;
+  height: 34px;
+  padding: 8px 11px;
+  box-sizing: border-box;
   font-size: 12.3px;
   font-weight: 600;
   color: var(--matching-muted-text);
   background: var(--matching-card-bg);
   border: 0;
   cursor: pointer;
-  font: inherit;
   text-align: left;
 `;
 
@@ -280,7 +307,7 @@ export const ContactsStatus = styled.span`
 `;
 
 export const ContactsBody = styled.div`
-  padding: 2px 11px 6px;
+  padding: 0 11px;
   background: var(--matching-card-bg);
   border-top: 1px solid var(--matching-section-bg);
 `;
@@ -288,12 +315,13 @@ export const ContactsBody = styled.div`
 export const ContactRow = styled.a`
   display: flex;
   align-items: center;
-  min-height: 32px;
+  height: 34px;
+  box-sizing: border-box;
   font-size: 12.5px;
   color: var(--matching-accent);
   font-weight: 500;
   text-decoration: none;
-  padding: 7px 0;
+  padding: 8px 0;
   border-bottom: 1px solid var(--matching-section-bg);
 
   &:last-child {

--- a/src/components/profileLayoutConfig.js
+++ b/src/components/profileLayoutConfig.js
@@ -29,6 +29,73 @@ export const normalizeDisplayValue = value => {
 
 export const shouldRenderField = value => Boolean(normalizeDisplayValue(value));
 
+const YES_TOKENS = new Set(['yes', 'true']);
+const NO_TOKENS = new Set(['no', 'false']);
+
+const yesNoLabel = (rawValue, yesText, noText) => {
+  const normalized = normalizeDisplayValue(rawValue).toLowerCase();
+  if (!normalized) return '';
+  if (YES_TOKENS.has(normalized)) return yesText;
+  if (NO_TOKENS.has(normalized)) return noText;
+  return normalizeDisplayValue(rawValue);
+};
+
+export const maritalStatusLabel = value => yesNoLabel(value, 'заміжня', 'не заміжня');
+export const glassesLabel = value => yesNoLabel(value, 'так', 'ні');
+const ownKidsBooleanLabel = value => yesNoLabel(value, 'є', 'немає');
+
+// blood is stored as one combined field ("3+", "2", "+", "AB-", roman numerals,
+// Ukrainian "І" instead of Latin "I", verbose Rh words, etc). Parse it into an
+// ABO letter and a Rh sign so the two missing-half cases (bare sign, bare
+// group) can be rendered with context instead of as a lone character.
+const CYRILLIC_I_RE = /[Іі]/g;
+const toLatinRoman = value => value.replace(CYRILLIC_I_RE, ch => (ch === 'І' ? 'I' : 'i'));
+
+const ABO_LETTER_BY_TOKEN = {
+  '1': 'O', i: 'O', o: 'O',
+  '2': 'A', ii: 'A', a: 'A',
+  '3': 'B', iii: 'B', b: 'B',
+  '4': 'AB', iv: 'AB', ab: 'AB',
+};
+const ABO_TOKEN_RE = /^(iv|iii|ii|ab|i|a|b|o|[1-4])/i;
+const RH_POSITIVE_RE = /^(rh)?\s*(\+|pos(itive)?)$/i;
+const RH_NEGATIVE_RE = /^(rh)?\s*(-|neg(ative)?)$/i;
+
+export const parseBloodValue = rawValue => {
+  const trimmed = toLatinRoman(String(rawValue ?? '').trim());
+  if (!trimmed) return { abo: '', rh: '' };
+
+  let rest = trimmed;
+  let abo = '';
+  const aboMatch = rest.match(ABO_TOKEN_RE);
+  if (aboMatch) {
+    abo = ABO_LETTER_BY_TOKEN[aboMatch[1].toLowerCase()] || '';
+    rest = rest.slice(aboMatch[0].length).trim();
+  }
+
+  let rh = '';
+  const rhCandidate = rest.replace(/−/g, '-').trim();
+  if (rhCandidate) {
+    if (RH_POSITIVE_RE.test(rhCandidate)) rh = '+';
+    else if (RH_NEGATIVE_RE.test(rhCandidate)) rh = '-';
+  }
+
+  return { abo, rh };
+};
+
+export const formatBloodGroup = (abo, rh) => {
+  const sign = rh === '+' ? '+' : rh === '-' ? '−' : '';
+  if (abo && sign) return `${abo}${sign}`;
+  if (abo) return abo;
+  if (sign) return `Rh${sign}`;
+  return null;
+};
+
+export const getBloodGroupDisplay = user => {
+  const { abo, rh } = parseBloodValue(normalizeDisplayValue(user?.blood));
+  return formatBloodGroup(abo, rh);
+};
+
 export const getProfileRole = user => {
   const role = normalizeDisplayValue(user?.role || user?.userRole).toLowerCase();
   if (['ed', 'egg donor', 'egg_donor'].includes(role)) return 'ed';
@@ -115,13 +182,24 @@ export const getProfilePhotos = user => {
   return [...new Set(rawPhotos.map(normalizeDisplayValue).filter(Boolean).map(convertDriveLinkToImage))];
 };
 
-const field = (key, label, valueGetter, sourceKeys) => ({
+// `resolved: true` marks getters that already return final human-readable text
+// (e.g. "немає"), which must not be re-run through normalizeDisplayValue's
+// EMPTY_VALUES sentinel stripping - that set exists to drop raw DB placeholders
+// like "-"/"n/a", but it also happens to contain the word "немає" itself, which
+// would otherwise wrongly delete an intentionally rendered "немає" answer.
+const field = (key, label, valueGetter, sourceKeys, { resolved = false } = {}) => ({
   key,
   label,
   valueGetter,
   sourceKeys: sourceKeys || [key],
+  resolved,
 });
-const valueFor = (user, item) => normalizeDisplayValue(item.valueGetter ? item.valueGetter(user) : user?.[item.key]);
+const valueFor = (user, item) => {
+  if (!item.valueGetter) return normalizeDisplayValue(user?.[item.key]);
+  const result = item.valueGetter(user);
+  if (item.resolved) return typeof result === 'string' ? result.trim() : normalizeDisplayValue(result);
+  return normalizeDisplayValue(result);
+};
 const isExcluded = (item, excludeKeys = []) => {
   const excluded = new Set(excludeKeys || []);
   return [item.key, ...(item.sourceKeys || [])].some(key => excluded.has(key));
@@ -130,7 +208,7 @@ const toDisplayFields = (items, user, excludeKeys = []) =>
   items
     .filter(item => !isExcluded(item, excludeKeys))
     .map(item => ({ ...item, value: valueFor(user, item) }))
-    .filter(item => shouldRenderField(item.value));
+    .filter(item => (item.resolved ? Boolean(item.value) : shouldRenderField(item.value)));
 
 export const bmiValue = user => {
   const explicit = normalizeDisplayValue(user?.bmi);
@@ -150,7 +228,9 @@ const ownKidsValue = user => {
   return raw;
 };
 
-
+const ownKidsDisplayValue = user => ownKidsBooleanLabel(ownKidsValue(user));
+const maritalStatusDisplayValue = user => maritalStatusLabel(user?.maritalStatus);
+const glassesDisplayValue = user => glassesLabel(user?.glasses);
 
 const donorExperienceValue = user => {
   const exp = normalizeDisplayValue(user?.experience || user?.donationExperience || user?.previousDonation);
@@ -164,13 +244,13 @@ const heroFields = {
     field('height', 'Height'),
     field('weight', 'Weight'),
     field('bmi', 'BMI', bmiValue, ['bmi']),
-    field('blood', 'Blood/Rh'),
+    field('blood', 'Blood/Rh', getBloodGroupDisplay, ['blood'], { resolved: true }),
     field('experience', 'Exp', donorExperienceValue, ['experience', 'donationExperience', 'previousDonation', 'donationCount', 'donationsCount']),
   ],
   ip: [
     field('country', 'Country'),
     field('city', 'City'),
-    field('maritalStatus', 'Family'),
+    field('maritalStatus', 'Family', maritalStatusDisplayValue, ['maritalStatus'], { resolved: true }),
     field('programInterest', 'Program'),
     field('lookingFor', 'Looking for'),
   ],
@@ -196,12 +276,11 @@ const heroFields = {
 const quickFacts = {
   ed: [
     ...heroFields.ed,
-    field('rh', 'RH'),
   ],
   ip: [
     field('country', 'Country'),
     field('city', 'City'),
-    field('maritalStatus', 'Family status'),
+    field('maritalStatus', 'Family status', maritalStatusDisplayValue, ['maritalStatus'], { resolved: true }),
     field('programInterest', 'Program interest'),
     field('budget', 'Budget'),
   ],
@@ -229,14 +308,14 @@ const quickFacts = {
 const sectionConfig = {
   ed: [
     { title: 'Main information', fields: [
-      field('education', 'Education'), field('profession', 'Profession'), field('maritalStatus', 'Marital status'),
-      field('ownKids', 'Own kids', ownKidsValue), field('clothingSize', 'Clothing'), field('shoeSize', 'Shoe'),
+      field('education', 'Education'), field('profession', 'Profession'), field('maritalStatus', 'Marital status', maritalStatusDisplayValue, ['maritalStatus'], { resolved: true }),
+      field('ownKids', 'Own kids', ownKidsDisplayValue, ['ownKids'], { resolved: true }), field('clothingSize', 'Clothing'), field('shoeSize', 'Shoe'),
     ] },
     { title: 'Appearance', variant: 'chips', fields: [
       field('eyeColor', 'Eyes'), field('hairColor', 'Hair color'), field('hairStructure', 'Hair structure'),
       field('faceShape', 'Face shape'), field('noseShape', 'Nose'), field('lipsShape', 'Lips'),
       field('chin', 'Chin'), field('bodyType', 'Body type'), field('breastSize', 'Breast size'),
-      field('race', 'Race'), field('glasses', 'Glasses'),
+      field('race', 'Race'), field('glasses', 'Glasses', glassesDisplayValue, ['glasses'], { resolved: true }),
     ] },
     { title: 'Donation experience', fields: [
       field('experience', 'Previous donation'), field('donationCount', 'Donation count'), field('donationsCount', 'Donations'),
@@ -245,7 +324,7 @@ const sectionConfig = {
   ],
   ip: [
     { title: 'Main information', fields: [
-      field('country', 'Country'), field('city', 'City'), field('region', 'Region'), field('maritalStatus', 'Family status'),
+      field('country', 'Country'), field('city', 'City'), field('region', 'Region'), field('maritalStatus', 'Family status', maritalStatusDisplayValue, ['maritalStatus'], { resolved: true }),
       field('programInterest', 'Program interest'), field('lookingFor', 'Looking for'), field('budget', 'Budget'),
     ] },
   ],


### PR DESCRIPTION
Batch 31: fixes raw Yes/No leaking into marital status/own kids/glasses
display (hidden list facts row and the full profile card), adds a shared
formatBloodGroup(abo, rh) utility to render blood type as O+/AB-/A/Rh+
everywhere in Matching instead of bare partial fragments, moves the
"·" fact divider to ::before so it no longer dangles at wrapped line ends,
fixes the note line-clamp, collapses unfilled hidden cards to a compact
"Анкета не заповнена" state, tightens the contacts block to 34px rows
(the collapsed row was inflated by a misordered `font: inherit`), splits
the client's personal comment (multiData/comments) from the candidate's
self-description into two distinct blocks, and shortens the "Приховані"
header so it stops truncating.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012MWwQfJ7ozbtznktborCR2