### PR TITLE
Batch 33: keep power of attorney off the representative record, clean up Parties UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Migration backups (may contain PII - passport numbers, names)
+scripts/migration-backups
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eject": "react-scripts eject",
     "lint:js": "eslint src/**/*.{js,jsx}",
     "qa:pdf": "NODE_PATH=./src node scripts/pdfQaCheck.js",
+    "migrate:representatives": "node scripts/migrateRepresentativePowerOfAttorney.js",
     "postinstall": "patch-package"
   },
   "eslintConfig": {

--- a/scripts/migrateRepresentativePowerOfAttorney.js
+++ b/scripts/migrateRepresentativePowerOfAttorney.js
@@ -1,0 +1,234 @@
+// Batch 33 (B4): one-time cleanup for the pre-split data model, where a representative's power of
+// attorney (`powerOfAttorney.date`/`apostilleDate`) used to live inside the person record itself.
+// That meant "a new POA" meant "a new duplicate person record" (same name/passport, different
+// dates) - this script folds every such duplicate back into one person record per human, moving
+// whatever POA dates it carried onto the *case* that referenced it (relations.
+// representativePowerOfAttorney - see CaseEditor.jsx/documentsCatalogUtils.js), which is where the
+// app has stored POA data going forward since this same batch.
+//
+// Additive-first, per spec: new case-level POA data and re-pointed representativeIds are written
+// (and a backup of the untouched representatives collection is saved to disk) *before* any
+// duplicate person record is deleted. Run in report-only mode by default; nothing is written to
+// the database unless --apply is passed.
+//
+//   node scripts/migrateRepresentativePowerOfAttorney.js            # dry run, prints a report
+//   node scripts/migrateRepresentativePowerOfAttorney.js --apply    # writes the changes above
+//
+// Needs the same REACT_APP_* Firebase config the app itself uses, plus a signed-in account with
+// write access to documentsBuilder/* - set MIGRATION_EMAIL / MIGRATION_PASSWORD in the
+// environment for a service/admin account (auth is skipped if neither is set, e.g. for a database
+// whose rules don't require it).
+/* eslint-disable no-console */
+require('@babel/register')({
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+  extensions: ['.js'],
+  ignore: [/node_modules/],
+});
+
+const path = require('path');
+const fs = require('fs');
+const { initializeApp } = require('firebase/app');
+const { getAuth, signInWithEmailAndPassword } = require('firebase/auth');
+const { getDatabase, ref, get, update } = require('firebase/database');
+const {
+  DOCUMENTS_PARTIES_PATH,
+  DOCUMENTS_CASES_PATH,
+  normalizeDocumentsCatalog,
+  isPlainObject,
+  toArray,
+  partyDisplayName,
+  formatPassportNumber,
+} = require('../src/components/documentsCatalogUtils');
+
+const APPLY = process.argv.includes('--apply');
+const ROOT = path.join(__dirname, '..');
+const BACKUP_DIR = path.join(ROOT, 'scripts', 'migration-backups');
+
+const isFilled = value => !(value === undefined || value === null || String(value).trim() === '');
+
+const normalizeName = record => {
+  const nominative = record?.name?.uk?.nominative || record?.name?.en || '';
+  return String(nominative).trim().toLowerCase().replace(/\s+/g, ' ');
+};
+
+const normalizePassport = record => {
+  const number = record?.passport?.number;
+  return isFilled(number) ? formatPassportNumber(number).replace(/\s+/g, '').toUpperCase() : '';
+};
+
+// A group key needs at least one of name/passport filled in - two records that are both entirely
+// blank on both aren't safe to assume are "the same person", so each stays its own singleton group.
+const groupKeyFor = record => {
+  const name = normalizeName(record);
+  const passport = normalizePassport(record);
+  if (!name && !passport) return `__singleton__:${record.id}`;
+  return `${name}|${passport}`;
+};
+
+const REPRESENTATIVE_LEAF_PATHS = [
+  'name.uk.nominative', 'name.uk.genitive', 'name.en', 'birthDate',
+  'address.uk', 'address.en',
+  'passport.number', 'passport.issuedBy.uk', 'passport.issuedBy.en', 'passport.issueDate',
+];
+
+const filledFieldCount = record => REPRESENTATIVE_LEAF_PATHS.reduce((count, path) => {
+  const value = path.split('.').reduce((accumulator, key) => (isPlainObject(accumulator) ? accumulator[key] : undefined), record);
+  return isFilled(value) ? count + 1 : count;
+}, 0);
+
+// Legacy POA a duplicate record itself carried (pre-split records only - createEmptyRepresentative
+// no longer creates this field, but hand-pasted/older records may still have it).
+const legacyPoaOf = record => (isPlainObject(record?.powerOfAttorney) ? record.powerOfAttorney : {});
+
+const buildFirebaseApp = () => initializeApp({
+  apiKey: process.env.REACT_APP_API_KEY,
+  authDomain: process.env.REACT_APP_AUTH_DOMAIN,
+  databaseURL: process.env.REACT_APP_DATABASE_URL,
+  projectId: process.env.REACT_APP_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_APP_ID,
+});
+
+// Pure planning step, kept separate from I/O so it can be exercised with fixture data - group
+// representatives into duplicate sets, pick a canonical record per group, and work out the
+// additive case patch (re-pointed representativeIds + backfilled POA dates) needed before any
+// duplicate can be safely deleted.
+const buildMigrationPlan = catalog => {
+  const groups = new Map();
+  catalog.parties.representatives.forEach(record => {
+    const key = groupKeyFor(record);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(record);
+  });
+
+  const duplicateGroups = [...groups.values()].filter(group => group.length > 1);
+
+  // canonicalIdByDuplicateId: every duplicate's id -> the one record kept for that person.
+  const canonicalIdByDuplicateId = new Map();
+  const duplicateIdsToDelete = new Set();
+  const report = [];
+
+  duplicateGroups.forEach(group => {
+    const canonical = group.reduce((best, candidate) => (
+      filledFieldCount(candidate) > filledFieldCount(best) ? candidate : best
+    ), group[0]);
+    group.forEach(record => {
+      if (record.id === canonical.id) return;
+      canonicalIdByDuplicateId.set(String(record.id), String(canonical.id));
+      duplicateIdsToDelete.add(String(record.id));
+    });
+    report.push({
+      person: partyDisplayName(canonical) || canonical.id,
+      keptId: canonical.id,
+      removedIds: group.filter(record => record.id !== canonical.id).map(record => record.id),
+    });
+  });
+
+  // Additive step 1: re-point every case's representativeIds at the canonical id (deduped), and
+  // backfill relations.representativePowerOfAttorney from whichever duplicate the case referenced,
+  // only where the case doesn't already carry that date itself (never overwrite real case data,
+  // never invent a date that was never entered anywhere).
+  const casesPatch = {};
+  let casesTouched = 0;
+  catalog.cases.forEach(caseRecord => {
+    const relations = isPlainObject(caseRecord.relations) ? caseRecord.relations : {};
+    const originalIds = toArray(relations.representativeIds).map(String);
+    if (!originalIds.length) return;
+
+    const remappedIds = [...new Set(originalIds.map(id => canonicalIdByDuplicateId.get(id) || id))];
+    const idsChanged = remappedIds.length !== originalIds.length || remappedIds.some((id, index) => id !== originalIds[index]);
+
+    const existingPoa = isPlainObject(relations.representativePowerOfAttorney) ? relations.representativePowerOfAttorney : {};
+    let poaDate = existingPoa.date || '';
+    let poaApostilleDate = existingPoa.apostilleDate || '';
+    if (!poaDate || !poaApostilleDate) {
+      originalIds.forEach(id => {
+        if (!duplicateIdsToDelete.has(id)) return;
+        const duplicateRecord = catalog.parties.representatives.find(item => String(item.id) === id);
+        const legacyPoa = legacyPoaOf(duplicateRecord);
+        if (!poaDate && isFilled(legacyPoa.date)) poaDate = legacyPoa.date;
+        if (!poaApostilleDate && isFilled(legacyPoa.apostilleDate)) poaApostilleDate = legacyPoa.apostilleDate;
+      });
+    }
+    const poaChanged = poaDate !== (existingPoa.date || '') || poaApostilleDate !== (existingPoa.apostilleDate || '');
+
+    if (!idsChanged && !poaChanged) return;
+    casesTouched += 1;
+    casesPatch[caseRecord.id] = {
+      ...caseRecord,
+      relations: {
+        ...relations,
+        representativeIds: remappedIds,
+        representativePowerOfAttorney: { ...existingPoa, date: poaDate, apostilleDate: poaApostilleDate },
+      },
+    };
+  });
+
+  return {
+    duplicateGroups, canonicalIdByDuplicateId, duplicateIdsToDelete, report, casesPatch, casesTouched,
+  };
+};
+
+async function main() {
+  const app = buildFirebaseApp();
+  const database = getDatabase(app);
+
+  if (process.env.MIGRATION_EMAIL && process.env.MIGRATION_PASSWORD) {
+    await signInWithEmailAndPassword(getAuth(app), process.env.MIGRATION_EMAIL, process.env.MIGRATION_PASSWORD);
+  }
+
+  const [partiesSnapshot, casesSnapshot] = await Promise.all([
+    get(ref(database, DOCUMENTS_PARTIES_PATH)),
+    get(ref(database, DOCUMENTS_CASES_PATH)),
+  ]);
+  const rawParties = partiesSnapshot.val();
+  const catalog = normalizeDocumentsCatalog(rawParties, null, casesSnapshot.val());
+
+  const {
+    duplicateGroups, duplicateIdsToDelete, report, casesPatch, casesTouched,
+  } = buildMigrationPlan(catalog);
+
+  if (!duplicateGroups.length) {
+    console.log('No duplicate representative records found - nothing to migrate.');
+    return;
+  }
+
+  console.log(`Found ${duplicateGroups.length} duplicate representative group(s), ${duplicateIdsToDelete.size} record(s) to remove:`);
+  report.forEach(entry => {
+    console.log(`  - ${entry.person}: keeping ${entry.keptId}, removing [${entry.removedIds.join(', ')}]`);
+  });
+  console.log(`${casesTouched} case(s) need their relations updated (representativeIds and/or POA dates).`);
+
+  if (!APPLY) {
+    console.log('\nDry run - no changes written. Re-run with --apply to write them.');
+    return;
+  }
+
+  fs.mkdirSync(BACKUP_DIR, { recursive: true });
+  const backupPath = path.join(BACKUP_DIR, `representatives-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+  fs.writeFileSync(backupPath, JSON.stringify(rawParties?.representatives || {}, null, 2));
+  console.log(`Backed up current representatives collection to ${backupPath}`);
+
+  if (Object.keys(casesPatch).length) {
+    await update(ref(database, DOCUMENTS_CASES_PATH), casesPatch);
+    console.log(`Updated ${Object.keys(casesPatch).length} case(s).`);
+  }
+
+  // Only now, after every case has been re-pointed at the canonical record, remove the duplicates.
+  const representativesPatch = {};
+  duplicateIdsToDelete.forEach(id => { representativesPatch[id] = null; });
+  await update(ref(database, `${DOCUMENTS_PARTIES_PATH}/representatives`), representativesPatch);
+  console.log(`Removed ${duplicateIdsToDelete.size} duplicate representative record(s).`);
+}
+
+if (require.main === module) {
+  main().then(() => process.exit(0)).catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  groupKeyFor, filledFieldCount, normalizeName, normalizePassport, buildMigrationPlan,
+};

--- a/src/components/CaseEditor.jsx
+++ b/src/components/CaseEditor.jsx
@@ -111,12 +111,6 @@ const CaseHeaderTitle = styled.h2`
   letter-spacing: -0.01em;
 `;
 
-const CaseHeaderSubtitle = styled.div`
-  margin-top: 3px;
-  font-size: 12px;
-  color: var(--km-muted);
-`;
-
 const HeaderChips = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -225,12 +219,14 @@ const Chevron = styled.span`
   color: var(--km-accent);
 `;
 
+// D1 (batch 33): no border of its own - the outer Section already draws the card's one border,
+// so this only needs a background shift + padding to read as a distinct inner area, otherwise the
+// two borders stack into a doubled outline around the same block.
 const SectionBody = styled.div`
   margin-top: 8px;
   padding: 10px 12px;
-  border: 1px solid var(--km-border);
   border-radius: 8px;
-  background: var(--km-card);
+  background: var(--km-bg);
 `;
 
 const SectionSubhead = styled.h3`
@@ -1232,7 +1228,6 @@ const CaseEditor = ({
         <>
           <CaseHeaderBlock>
             <CaseHeaderTitle>{buildCaseLabel(catalog, selectedCase) || selectedCase.id}</CaseHeaderTitle>
-            <CaseHeaderSubtitle>Вся інформація згрупована за етапами - заповнені блоки можна згорнути, а незавершені видно одразу.</CaseHeaderSubtitle>
             <HeaderChips>
               <HeaderChip $complete={fieldsRollup.filled >= fieldsRollup.total}>{fieldsRollup.filled} із {fieldsRollup.total} полів</HeaderChip>
               <HeaderChip $complete={documentsRollup.filled >= documentsRollup.total}>{documentsRollup.filled} із {documentsRollup.total} полів документів</HeaderChip>
@@ -1305,49 +1300,61 @@ const CaseEditor = ({
                     <RelationCardLabel>Представники</RelationCardLabel>
                     {(() => {
                       const selected = catalog.parties.representatives.filter(item => draft.relations.representativeIds.includes(String(item.id)));
-                      if (!selected.length) return <RelationCardValue>— немає —</RelationCardValue>;
                       return (
-                        <RepresentativeList>
-                          {selected.map(record => {
-                            const sub = representativeIdentityLabel(record);
-                            return (
-                              <div key={record.id}>
-                                <RepresentativeName>{partyDisplayName(record)}</RepresentativeName>
-                                {sub ? <RepresentativeSub>{sub}</RepresentativeSub> : null}
-                              </div>
-                            );
+                        <>
+                          {selected.length ? (
+                            <RepresentativeList>
+                              {selected.map(record => {
+                                const sub = representativeIdentityLabel(record);
+                                return (
+                                  <div key={record.id}>
+                                    <RepresentativeName>{partyDisplayName(record)}</RepresentativeName>
+                                    {sub ? <RepresentativeSub>{sub}</RepresentativeSub> : null}
+                                  </div>
+                                );
+                              })}
+                            </RepresentativeList>
+                          ) : (
+                            <RelationCardValue>— немає —</RelationCardValue>
+                          )}
+                          <RelationCardButton type="button" onClick={() => openPicker({
+                            title: 'Оберіть представників', collection: 'representatives', valueId: draft.relations.representativeIds, multi: true, onApply: ids => updateRelations('representativeIds', ids),
                           })}
-                        </RepresentativeList>
+                          >
+                            Змінити
+                          </RelationCardButton>
+                          {/* Batch 33 (B3): the POA sub-block only exists once a person is chosen -
+                              first "хто", then "на підставі чого". The power of attorney itself
+                              (signing + apostille date) is static per case - one POA can cover
+                              every representative selected above, and the same representative can
+                              carry a different POA on another case, so these two dates live here
+                              rather than on the representative record. */}
+                          {selected.length ? (
+                            <>
+                              <RelationCardLabel style={{ marginTop: 10 }}>Довіреність</RelationCardLabel>
+                              <FieldGrid style={{ marginTop: 4 }}>
+                                <Field>
+                                  Дата довіреності
+                                  <FieldInput
+                                    type="date"
+                                    value={draft.relations.representativePowerOfAttorney.date}
+                                    onChange={event => updateRepresentativePoa('date', event.target.value)}
+                                  />
+                                </Field>
+                                <Field>
+                                  Дата апостилю
+                                  <FieldInput
+                                    type="date"
+                                    value={draft.relations.representativePowerOfAttorney.apostilleDate}
+                                    onChange={event => updateRepresentativePoa('apostilleDate', event.target.value)}
+                                  />
+                                </Field>
+                              </FieldGrid>
+                            </>
+                          ) : null}
+                        </>
                       );
                     })()}
-                    <RelationCardButton type="button" onClick={() => openPicker({
-                      title: 'Оберіть представників', collection: 'representatives', valueId: draft.relations.representativeIds, multi: true, onApply: ids => updateRelations('representativeIds', ids),
-                    })}
-                    >
-                      Змінити
-                    </RelationCardButton>
-                    {/* The power of attorney itself (signing + apostille date) is static per case -
-                        one POA can cover every representative selected above, and the same
-                        representative can carry a different POA on another case, so these two
-                        dates live here rather than on the representative record. */}
-                    <FieldGrid style={{ marginTop: 10 }}>
-                      <Field>
-                        Дата довіреності
-                        <FieldInput
-                          type="date"
-                          value={draft.relations.representativePowerOfAttorney.date}
-                          onChange={event => updateRepresentativePoa('date', event.target.value)}
-                        />
-                      </Field>
-                      <Field>
-                        Дата апостилю
-                        <FieldInput
-                          type="date"
-                          value={draft.relations.representativePowerOfAttorney.apostilleDate}
-                          onChange={event => updateRepresentativePoa('apostilleDate', event.target.value)}
-                        />
-                      </Field>
-                    </FieldGrid>
                   </RelationCard>
                 </RelationGrid>
                 </SectionBody>

--- a/src/components/CaseEditor.representatives.test.js
+++ b/src/components/CaseEditor.representatives.test.js
@@ -1,0 +1,108 @@
+// Real-DOM regression test for batch 33: the case editor's Огляд-tab "Представники" relation card
+// must keep power-of-attorney data off the representative record and instead read/write it at
+// relations.representativePowerOfAttorney on the case, showing the ДОВІРЕНІСТЬ date fields only
+// once a representative has actually been chosen.
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('firebase/database', () => ({
+  ref: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('./config', () => ({
+  auth: { currentUser: { uid: 'test-admin' } },
+  database: {},
+}));
+
+jest.mock('utils/accessLevel', () => ({ isInvoiceBuilderUid: () => true }));
+
+// eslint-disable-next-line import/first
+import { ref, get, set, update } from 'firebase/database';
+// eslint-disable-next-line import/first
+import PartiesPage from './PartiesPage';
+
+const buildParties = () => ({
+  couples: {},
+  surrogateMothers: {},
+  representatives: {
+    'representative-1': {
+      id: 'representative-1',
+      name: { uk: { nominative: 'Коваль Олександр Володимирович', genitive: '' }, en: '' },
+      passport: { number: 'ME680736', issuedBy: { uk: '', en: '' }, issueDate: '' },
+      birthDate: '',
+      address: { uk: '', en: '' },
+    },
+  },
+  clinics: {},
+  maternityHospitals: {},
+  notaries: {},
+});
+
+const buildCases = () => ({
+  'case-1': {
+    id: 'case-1',
+    relations: {
+      coupleId: '', clinicId: '', surrogateMotherId: '', representativeIds: [], representativePowerOfAttorney: {},
+    },
+    childbirth: { maternityHospitalId: '', children: [] },
+  },
+});
+
+beforeEach(() => {
+  ref.mockImplementation((_db, path) => path);
+  get.mockImplementation(async path => {
+    if (path === 'documentsBuilder/parties') return { exists: () => true, val: () => buildParties() };
+    if (path === 'documentsBuilder/cases') return { exists: () => true, val: () => buildCases() };
+    return { exists: () => false, val: () => null };
+  });
+  set.mockResolvedValue(undefined);
+  update.mockResolvedValue(undefined);
+  window.localStorage.clear();
+});
+
+describe('spec: case editor Огляд tab - Представники relation card (batch 33)', () => {
+  it('hides the ДОВІРЕНІСТЬ date fields until a representative is chosen, then reveals them', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
+    await screen.findByText('Огляд');
+
+    expect(await screen.findByText('— немає —')).toBeInTheDocument();
+    expect(screen.queryByText('Дата довіреності')).not.toBeInTheDocument();
+    expect(screen.queryByText('Дата апостилю')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Змінити' }).find(button => button.closest('[aria-label="Представники"]')));
+    fireEvent.click(await screen.findByRole('button', { name: /Коваль Олександр Володимирович/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Застосувати' }));
+
+    expect(await screen.findByText('Дата довіреності')).toBeInTheDocument();
+    expect(screen.getByText('Дата апостилю')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Дата довіреності'), { target: { value: '2024-07-18' } });
+    fireEvent.change(screen.getByLabelText('Дата апостилю'), { target: { value: '2024-07-20' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Зберегти все' }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith('documentsBuilder/cases', expect.objectContaining({
+      'case-1/relations': expect.objectContaining({
+        representativeIds: ['representative-1'],
+        representativePowerOfAttorney: { date: '2024-07-18', apostilleDate: '2024-07-20' },
+      }),
+    })));
+  });
+
+  it('does not offer power-of-attorney fields on the representative directory record itself', async () => {
+    render(<MemoryRouter><PartiesPage isAdmin /></MemoryRouter>);
+    fireEvent.click(await screen.findByTitle('Edit parties'));
+    fireEvent.click(await screen.findByText('Representatives'));
+    fireEvent.click(await screen.findByText('Коваль Олександр Володимирович'));
+
+    expect(await screen.findByLabelText('Name (uk, nominative)')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Power of attorney date')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Power of attorney apostille')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Power of attorney apostille date')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/PartiesPage.jsx
+++ b/src/components/PartiesPage.jsx
@@ -457,9 +457,6 @@ const REPRESENTATIVE_FIELDS = [
   { label: 'Passport issue date', path: 'passport.issueDate', type: 'date' },
   { label: 'Address (uk)', path: 'address.uk' },
   { label: 'Address (en)', path: 'address.en' },
-  { label: 'Power of attorney date', path: 'powerOfAttorney.date', type: 'date' },
-  { label: 'Power of attorney apostille', path: 'powerOfAttorney.apostille' },
-  { label: 'Power of attorney apostille date', path: 'powerOfAttorney.apostilleDate', type: 'date' },
 ];
 
 const CLINIC_FIELDS = [

--- a/src/components/documentsCatalogUtils.js
+++ b/src/components/documentsCatalogUtils.js
@@ -829,6 +829,14 @@ export const createEmptySurrogateMother = () => ({
   address: { uk: '', en: '' },
 });
 
+// Batch 33: a representative is a person, full stop - power of attorney (date + apostille date)
+// is a fact of the *case* that engages them (relations.representativePowerOfAttorney on the case,
+// edited in CaseEditor), never stored here. Without that split, a new POA meant a whole new
+// duplicate person record (same name, different dates), which is exactly what filled the picker
+// with lookalike entries. resolveCaseContext/buildDraftFromCase still read a legacy
+// `record.powerOfAttorney` off pre-migration records as a fallback - see the migration script
+// (scripts/migrateRepresentativePowerOfAttorney.js) that moves that data onto cases and dedupes
+// the person records.
 export const createEmptyRepresentative = () => ({
   id: makeRecordId('representative'),
   name: { uk: { nominative: '', genitive: '' }, en: '' },
@@ -839,12 +847,6 @@ export const createEmptyRepresentative = () => ({
   address: { uk: '', en: '' },
   passport: {
     number: '', issuedBy: { uk: '', en: '' }, issueDate: '',
-  },
-  // `apostille` (legacy, freeform) is kept for whatever already reads it; `apostilleDate` is the
-  // discrete date a signature block needs (spec batch 2026-07-24 §10) - a separate field, not a
-  // rename, so no existing template silently loses its value.
-  powerOfAttorney: {
-    date: '', apostille: '', apostilleDate: '',
   },
 });
 


### PR DESCRIPTION
- Remove the legacy powerOfAttorney fields from the Representative editor form
  and from createEmptyRepresentative - a person record is person data only.
  POA dates already lived on the case (relations.representativePowerOfAttorney,
  batch 29); the editor was still letting admins add POA back onto the person,
  which is exactly what produced duplicate person records per new POA.
- Gate the Огляд tab's ДОВІРЕНІСТЬ date fields so they only appear once a
  representative has actually been selected, under their own subheading in
  the same uppercase/bronze style used elsewhere in Parties.
- Add scripts/migrateRepresentativePowerOfAttorney.js: dry-run-by-default
  migration that groups representative records by normalized name+passport,
  keeps the most complete record per group, backfills each affected case's
  POA dates from the duplicates it referenced (never overwriting existing
  case data), backs up the representatives collection before deleting
  duplicates, and only deletes after the case relinking has been written.
- Fix the double border on Parties tab cards (Section + SectionBody both
  drew var(--km-border)) by dropping SectionBody's own border and using a
  background shift for separation instead.
- Remove the explanatory caption under the case title.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PCwjgbzSKYP2PYQJMt2DWT