### PR TITLE
Update deploy workflow to Node 24 and fix test lint warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '16'
+          node-version: '24'
 
       - name: Create .env file
         run: |

--- a/src/components/CaseEditor.representatives.test.js
+++ b/src/components/CaseEditor.representatives.test.js
@@ -4,7 +4,7 @@
 // once a representative has actually been chosen.
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('firebase/database', () => ({
@@ -75,7 +75,7 @@ describe('spec: case editor Огляд tab - Представники relation c
     expect(screen.queryByText('Дата довіреності')).not.toBeInTheDocument();
     expect(screen.queryByText('Дата апостилю')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Змінити' }).find(button => button.closest('[aria-label="Представники"]')));
+    fireEvent.click(within(screen.getByLabelText('Представники')).getByRole('button', { name: 'Змінити' }));
     fireEvent.click(await screen.findByRole('button', { name: /Коваль Олександр Володимирович/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Застосувати' }));
 

--- a/src/components/DocumentsPage.paragraphIndent.test.js
+++ b/src/components/DocumentsPage.paragraphIndent.test.js
@@ -101,7 +101,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     expect(indentField).toHaveValue('1');
 
     fireEvent.click(within(indentedBlock).getByTitle(PARAGRAPH_FORMAT_TITLE)); // close the first popover
-    const plainBlock = await openParagraphPopover('Абзац без відступу.');
+    await openParagraphPopover('Абзац без відступу.');
     const inheritedField = screen.getByLabelText('First line indent (cm)');
     expect(inheritedField).toHaveValue('');
     expect(inheritedField).toHaveAttribute('placeholder', '1.5'); // notarial standard §3.1 default
@@ -111,7 +111,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const plainBlock = await openParagraphPopover('Абзац без відступу.');
+    await openParagraphPopover('Абзац без відступу.');
     const indentField = screen.getByLabelText('First line indent (cm)');
     fireEvent.change(indentField, { target: { value: '2.5' } });
     fireEvent.blur(indentField);
@@ -135,7 +135,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const indentedBlock = await openParagraphPopover('Абзац з відступом.');
+    await openParagraphPopover('Абзац з відступом.');
     const indentField = screen.getByLabelText('First line indent (cm)');
     fireEvent.change(indentField, { target: { value: '' } });
     fireEvent.blur(indentField);
@@ -158,7 +158,7 @@ describe('spec: per-paragraph formatting popover (no sliders anywhere, §1.4)', 
     render(<MemoryRouter><DocumentsPage isAdmin /></MemoryRouter>);
     fireEvent.click(await screen.findByTitle('Edit paragraphs'));
 
-    const indentedBlock = await openParagraphPopover('Абзац з відступом.');
+    await openParagraphPopover('Абзац з відступом.');
     const sizeField = screen.getByLabelText('Font size (pt)');
     expect(sizeField).toHaveValue('');
     expect(sizeField).toHaveAttribute('placeholder', '12');

--- a/src/components/config.addUserToResults.test.js
+++ b/src/components/config.addUserToResults.test.js
@@ -3,6 +3,7 @@ import path from 'path';
 
 describe('addUserToResults / addUserFromUsers skip newUsers for long-format userIds', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+  const userIdTemplate = `${String.fromCharCode(36)}{userId}`;
 
   const addUserToResultsBody = source.slice(
     source.indexOf('const addUserToResults'),
@@ -23,9 +24,9 @@ describe('addUserToResults / addUserFromUsers skip newUsers for long-format user
     // the unconditional short-id fallback (newUsers-then-users) must come after it,
     // i.e. only reachable once the long-id branch has already returned.
     const longIdBranchIndex = addUserToResultsBody.indexOf('if (isLongFormatUserId(userId))');
-    const usersReadIndex = addUserToResultsBody.indexOf('get(ref2(database, `users/${userId}`))');
+    const usersReadIndex = addUserToResultsBody.indexOf(`get(ref2(database, \`users/${userIdTemplate}\`))`);
     const unconditionalNewUsersReadIndex = addUserToResultsBody.indexOf(
-      'const userSnapshotInNewUsers = await get(ref2(database, `newUsers/${userId}`));',
+      `const userSnapshotInNewUsers = await get(ref2(database, \`newUsers/${userIdTemplate}\`));`,
     );
     expect(longIdBranchIndex).toBeGreaterThanOrEqual(0);
     expect(usersReadIndex).toBeGreaterThan(longIdBranchIndex);

--- a/src/components/config.getAllUserPhotos.test.js
+++ b/src/components/config.getAllUserPhotos.test.js
@@ -3,6 +3,7 @@ import path from 'path';
 
 describe('getAllUserPhotos skips newUsers for long-format userIds on the cold-lookup path', () => {
   const source = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+  const userIdTemplate = `${String.fromCharCode(36)}{userId}`;
 
   const getAllUserPhotosBody = source.slice(
     source.indexOf('export const getAllUserPhotos'),
@@ -18,8 +19,8 @@ describe('getAllUserPhotos skips newUsers for long-format userIds on the cold-lo
       getAllUserPhotosBody.indexOf('if (!collectionSource && isLongFormatUserId(userId))'),
       getAllUserPhotosBody.indexOf('const sourceCollections = getPhotoSourceCollections(collectionSource);'),
     );
-    const usersReadIndex = longIdBranchBody.indexOf('get(ref2(database, `users/${userId}`))');
-    const newUsersReadIndex = longIdBranchBody.indexOf('get(ref2(database, `newUsers/${userId}`))');
+    const usersReadIndex = longIdBranchBody.indexOf(`get(ref2(database, \`users/${userIdTemplate}\`))`);
+    const newUsersReadIndex = longIdBranchBody.indexOf(`get(ref2(database, \`newUsers/${userIdTemplate}\`))`);
 
     expect(usersReadIndex).toBeGreaterThanOrEqual(0);
     expect(newUsersReadIndex).toBeGreaterThan(usersReadIndex);

--- a/src/components/documentsCatalogUtils.artProgram.test.js
+++ b/src/components/documentsCatalogUtils.artProgram.test.js
@@ -89,7 +89,6 @@ const rawParties = {
 // (spec v6 §3/§4: the shipment carries its own sourceClinicId, resolved from the unified
 // parties.clinics - the destination clinic is always the case's own relations.clinicId) - the
 // same `{ clinic, sourceClinic }` pair resolveCaseContext always resolves and passes in.
-const parties = normalizeDocumentsCatalog(rawParties, {}, {}).parties;
 const resolvedClinics = { clinic, sourceClinic };
 
 // A case using the v6 shape throughout (spec §1-§7): the one embryo shipment lives at

--- a/src/components/documentsCatalogUtils.test.js
+++ b/src/components/documentsCatalogUtils.test.js
@@ -80,7 +80,6 @@ import {
   parseFormattedRuns,
   pickLogoVariantForLayout,
   plainTextOf,
-  removeEmptyCaseValues,
   resolveCaseContext,
   resolveEffectiveDocFormatting,
   resolveMergedRecordsForPersistence,


### PR DESCRIPTION
### Motivation
- Upgrade the GitHub Actions job to supported Node.js runtime and action releases to avoid deprecated Node 16/20 usage during deploy. 
- Replace fragile direct DOM traversal in tests with Testing Library scoped queries to follow best practices and avoid eslint warnings. 
- Remove unused imports/fixtures and avoid template-string inspection lint warnings to keep tests clean and maintainable.

### Description
- Updated `.github/workflows/deploy.yml` to use `actions/checkout@v7`, `actions/setup-node@v7`, and `node-version: '24'`.
- Replaced a direct DOM traversal in `src/components/CaseEditor.representatives.test.js` with Testing Library's `within(screen.getByLabelText('Представники')).getByRole(...)` and added `within` to the import list.
- Simplified `src/components/DocumentsPage.paragraphIndent.test.js` by awaiting `openParagraphPopover(...)` where the returned block was unused to remove unused-variable warnings.
- Fixed literal template-string inspection in `src/components/config.getAllUserPhotos.test.js` and `src/components/config.addUserToResults.test.js` by constructing a `userIdTemplate` helper and using it in `indexOf` searches, and removed the unused `removeEmptyCaseValues` import and an unused `parties` fixture in documentsCatalog utils tests.

### Testing
- Ran `npm run lint:js` which completed (no lint errors introduced; only the unrelated dependency warning from `babel-preset-react-app` remained). 
- Ran unit tests with `CI= npm test -- --watchAll=false src/components/CaseEditor.representatives.test.js src/components/config.getAllUserPhotos.test.js src/components/config.addUserToResults.test.js src/components/DocumentsPage.paragraphIndent.test.js --runInBand` and all test suites passed (`4` suites, `21` tests total, all passing). 
- Ran `npm run build` which completed successfully and produced a deployable `build` folder.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72b6a0e0948326b999270e03cacb99)