### PR TITLE
Add profile creation workspace, permission flag `canCreateProfiles`, and supporting mutations

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -14,6 +14,7 @@ import BudgetPage from './BudgetPage';
 import InvoiceBuilderPage from './InvoiceBuilderPage';
 import DocumentsPage from './DocumentsPage';
 import PartiesPage from './PartiesPage';
+import ProfileCreationWorkspace from './ProfileCreationWorkspace';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth, fetchUserById } from './config';
 import { resolveAccess } from 'utils/accessLevel';
@@ -26,6 +27,7 @@ export const App = () => {
   const [canAccessAdd, setCanAccessAdd] = useState(false);
   const [canAccessMatching, setCanAccessMatching] = useState(false);
   const [canAccessInvoices, setCanAccessInvoices] = useState(false);
+  const [canCreateProfiles, setCanCreateProfiles] = useState(false);
   const [isAccessResolved, setIsAccessResolved] = useState(false);
   // console.log('isLoggedIn :>> ', isLoggedIn);
 
@@ -48,11 +50,12 @@ export const App = () => {
     const isRootRoute = location.pathname === '/';
     const isUnauthorizedAddRoute = location.pathname === '/add' && !canAccessAdd;
     const isUnauthorizedMatchingRoute = location.pathname === '/matching' && !canAccessMatching;
+    const isUnauthorizedCreateRoute = location.pathname === '/matching/create-profile' && !canCreateProfiles;
 
-    if (isRootRoute || isUnauthorizedAddRoute || isUnauthorizedMatchingRoute) {
+    if (isRootRoute || isUnauthorizedAddRoute || isUnauthorizedMatchingRoute || isUnauthorizedCreateRoute) {
       navigate('/my-profile');
     }
-  }, [isLoggedIn, isAccessResolved, navigate, isAdmin, location.pathname, canAccessAdd, canAccessMatching]);
+  }, [isLoggedIn, isAccessResolved, navigate, isAdmin, location.pathname, canAccessAdd, canAccessMatching, canCreateProfiles]);
 
   // Special page for admin
   useEffect(() => {
@@ -61,19 +64,22 @@ export const App = () => {
         localStorage.setItem('ownerId', user.uid);
         let accessLevel = '';
         let userRole = '';
+        let canCreateProfilesForUser = false;
         try {
           const profile = await fetchUserById(user.uid);
           accessLevel = profile?.accessLevel || '';
           userRole = profile?.userRole || profile?.role || '';
+          canCreateProfilesForUser = profile?.canCreateProfiles === true;
         } catch (error) {
           console.error('Failed to load access profile for routes', error);
         }
 
-        const access = resolveAccess({ uid: user.uid, accessLevel, userRole });
+        const access = resolveAccess({ uid: user.uid, accessLevel, userRole, canCreateProfiles: canCreateProfilesForUser });
         setIsAdmin(access.isAdmin);
         setCanAccessAdd(access.canAccessAdd);
         setCanAccessMatching(access.canAccessMatching);
         setCanAccessInvoices(access.canAccessInvoices);
+        setCanCreateProfiles(access.canCreateProfiles);
         localStorage.setItem('accessLevel', accessLevel);
         localStorage.setItem('userRole', userRole);
         setIsAccessResolved(true);
@@ -85,6 +91,7 @@ export const App = () => {
         setCanAccessAdd(false);
         setCanAccessMatching(false);
         setCanAccessInvoices(false);
+        setCanCreateProfiles(false);
         setIsAccessResolved(true);
       }
     });
@@ -101,6 +108,7 @@ export const App = () => {
       {isAdmin && <Route path="/my-profile-old" element={<MyProfileOld isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       {canAccessAdd && <Route path="/add" element={<AddNewProfile isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />}
       {canAccessMatching && <Route path="/matching" element={<Matching />} />}
+      {canCreateProfiles && <Route path="/matching/create-profile" element={<ProfileCreationWorkspace />} />}
       {isAdmin && <Route path="/edit/:userId" element={<EditProfile />} />}
       {isAdmin && <Route path="/medications/:userId" element={<MedicationsPage />} />}
       {isAdmin && <Route path="/flow" element={<FlowManager ownerId={auth.currentUser?.uid} />} />}

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -122,6 +122,7 @@ import { MdEmail } from 'react-icons/md';
 import { SiTiktok } from 'react-icons/si';
 import { getContactEntries, CONTACT_LINK_BUILDERS } from './contactMethods';
 import { ProfileDotsMenu } from './ProfileDotsMenu';
+import { getEffectiveProfile, loadGrantedCreatedProfiles, loadOwnProfileMutations } from 'utils/profileMutations';
 import { useAppSettings } from 'hooks/useAppSettings';
 import { handleEmptyFetch } from './loadMoreUtils';
 import { collectMatchingIndexedLoadMorePage } from 'utils/matchingIndexedLoadMore';
@@ -1390,6 +1391,7 @@ const Matching = () => {
   const [showFilters, setShowFilters] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [ownerId, setOwnerId] = useState(null);
+  const [personalCreateProfiles, setPersonalCreateProfiles] = useState([]);
   useEffect(() => {
     const syncCopiedComment = event => {
       if (event.detail?.ownerId !== ownerId || !event.detail?.cardId) return;
@@ -1412,6 +1414,7 @@ const Matching = () => {
   const [multiDataOwnerIds, setMultiDataOwnerIds] = useState([]);
   const [currentAccessLevel, setCurrentAccessLevel] = useState(() => localStorage.getItem('accessLevel') || '');
   const [currentUserRole, setCurrentUserRole] = useState(() => localStorage.getItem('userRole') || '');
+  const [currentCanCreateProfiles, setCurrentCanCreateProfiles] = useState(() => localStorage.getItem('canCreateProfiles') === 'true');
   const [currentAdditionalAccessRules, setCurrentAdditionalAccessRules] = useState(
     () => localStorage.getItem('additionalAccessRules') || ''
   );
@@ -1427,7 +1430,38 @@ const Matching = () => {
     uid: auth.currentUser?.uid,
     accessLevel: currentAccessLevel,
     userRole: currentUserRole,
+    canCreateProfiles: currentCanCreateProfiles,
   });
+  const isAdmin = access.isAdmin;
+
+  useEffect(() => {
+    let active = true;
+    if (!ownerId || isAdmin) {
+      setPersonalCreateProfiles([]);
+      return () => { active = false; };
+    }
+    Promise.all([loadOwnProfileMutations(ownerId), loadGrantedCreatedProfiles(ownerId)])
+      .then(([items, grantedProfiles]) => {
+        if (!active) return;
+        const pendingProfiles = items.map(mutation => ({
+          ...getEffectiveProfile({ mutation }),
+          publish: true,
+          __sourceCollection: 'newUsers',
+          __matchingAccessAllowed: true,
+          __profileMutationOperation: 'create',
+          __profileMutationStatus: mutation.status,
+        }));
+        const acceptedProfiles = grantedProfiles.map(profile => ({
+          ...profile,
+          publish: profile.publish ?? true,
+          __sourceCollection: 'newUsers',
+          __matchingAccessAllowed: true,
+        }));
+        setPersonalCreateProfiles([...acceptedProfiles, ...pendingProfiles]);
+      })
+      .catch(error => console.error('Failed to load personal create profiles', error));
+    return () => { active = false; };
+  }, [isAdmin, ownerId]);
   const matchingDefaultFilters = useMemo(
     () => getDefaultFilters({ mode: 'matching', nonAdminAllActive: !access.isAdmin }),
     [access.isAdmin],
@@ -1439,7 +1473,6 @@ const Matching = () => {
   const filterDrawerSubtitle = activeFilterGroupCount > 0
     ? `Активно змінено груп: ${activeFilterGroupCount}`
     : 'Всі профілі показані за поточними правилами доступу';
-  const isAdmin = access.isAdmin;
   const isIndexedDebugTestUser = String(auth.currentUser?.uid || ownerId || '').trim() === MATCHING_LOG_MODE_TEST_USER_ID;
   const parsedAdditionalAccessRules = useMemo(
     () => parseAdditionalAccessRuleGroups(currentAdditionalAccessRules),
@@ -2040,6 +2073,7 @@ const Matching = () => {
             const profile = await fetchUserById(user.uid);
             const accessLevel = profile?.accessLevel || '';
             const userRole = profile?.userRole || profile?.role || '';
+            const canCreateProfiles = profile?.canCreateProfiles === true;
             const additionalAccessRules = profile?.additionalAccessRules || '';
             const searchKeySetKeys = await resolveAdditionalSearchKeySetKeysForMatching(profile, user.uid);
 
@@ -2047,10 +2081,12 @@ const Matching = () => {
 
             setCurrentAccessLevel(accessLevel);
             setCurrentUserRole(userRole);
+            setCurrentCanCreateProfiles(canCreateProfiles);
             setCurrentAdditionalAccessRules(additionalAccessRules);
             setCurrentSearchKeySetKeys(searchKeySetKeys);
             localStorage.setItem('accessLevel', accessLevel);
             localStorage.setItem('userRole', userRole);
+            localStorage.setItem('canCreateProfiles', canCreateProfiles ? 'true' : 'false');
             localStorage.setItem('additionalAccessRules', additionalAccessRules);
             localStorage.setItem('additionalSearchKeySetKeys', searchKeySetKeys.join(','));
             const rawMultiDataAccessUserIds = profile?.[MULTI_DATA_ACCESS_FIELD];
@@ -4505,7 +4541,7 @@ const Matching = () => {
   }, [collectionSource, loadReactionCards, reloadDefault]);
 
   const visibleUsers = useMemo(() => mergeMatchingCandidateUsers({
-    users,
+    users: [...users, ...personalCreateProfiles],
     additionalNewUsers,
     sharedReactionCandidateUsers,
     isAdmin,
@@ -4526,6 +4562,7 @@ const Matching = () => {
     parsedAdditionalAccessRules,
     sharedReactionCandidateUsers,
     users,
+    personalCreateProfiles,
     viewMode,
     collectionSource,
   ]);

--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import styled from 'styled-components';
+
+import { auth, fetchUserById } from './config';
+import { ProfileForm } from './ProfileForm';
+import { resolveAccess } from 'utils/accessLevel';
+import {
+  acceptCreateProfileMutation,
+  getEffectiveProfile,
+  loadAllCreateProfileMutations,
+  loadOwnProfileMutations,
+  rejectCreateProfileMutation,
+  reserveProfileCardId,
+  saveCreateProfileMutation,
+} from 'utils/profileMutations';
+
+const Page = styled.main`
+  min-height: 100vh;
+  padding: 24px 12px 64px;
+  background: var(--km-bg);
+  color: var(--km-text);
+`;
+const Shell = styled.div`max-width: 920px; margin: 0 auto;`;
+const Header = styled.header`display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:20px;`;
+const Title = styled.h1`margin:0; font-size:24px;`;
+const Button = styled.button`
+  border: 1px solid var(--km-border); border-radius: 12px; padding: 10px 16px;
+  background: ${({ $primary }) => ($primary ? 'var(--km-accent)' : 'var(--km-card)')};
+  color: ${({ $primary }) => ($primary ? '#fff' : 'var(--km-text)')}; cursor:pointer; font-weight:700;
+  &:disabled { opacity:.55; cursor:not-allowed; }
+`;
+const Card = styled.section`padding:18px; margin:12px 0; border:1px solid var(--km-border); border-radius:16px; background:var(--km-card);`;
+const Actions = styled.div`display:flex; flex-wrap:wrap; gap:8px; margin-top:16px;`;
+const Meta = styled.p`margin:6px 0; color:var(--km-muted); font-size:13px;`;
+const Status = styled.span`display:inline-block; padding:4px 9px; border-radius:999px; background:var(--km-accent-light); color:var(--km-accent); font-size:12px; font-weight:800;`;
+
+export const ProfileCreationWorkspace = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [uid, setUid] = useState('');
+  const [access, setAccess] = useState(null);
+  const [mutations, setMutations] = useState([]);
+  const [draft, setDraft] = useState(null);
+  const [activeMutation, setActiveMutation] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(async (userId, resolvedAccess) => {
+    const items = resolvedAccess.isAdmin
+      ? await loadAllCreateProfileMutations()
+      : await loadOwnProfileMutations(userId);
+    setMutations(items.sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0)));
+  }, []);
+
+  useEffect(() => onAuthStateChanged(auth, async user => {
+    if (!user) {
+      navigate('/login', { replace: true });
+      return;
+    }
+    const profile = await fetchUserById(user.uid);
+    const resolved = resolveAccess({
+      uid: user.uid,
+      accessLevel: profile?.accessLevel,
+      userRole: profile?.userRole || profile?.role,
+      canCreateProfiles: profile?.canCreateProfiles,
+    });
+    if (!resolved.canCreateProfiles) {
+      navigate('/matching', { replace: true });
+      return;
+    }
+    setUid(user.uid);
+    setAccess(resolved);
+    await refresh(user.uid, resolved);
+  }), [navigate, refresh]);
+
+  useEffect(() => {
+    const requestedCardId = searchParams.get('cardId');
+    if (!requestedCardId || !mutations.length) return;
+    const mutation = mutations.find(item => item.cardId === requestedCardId);
+    if (mutation) {
+      setActiveMutation(mutation);
+      setDraft(getEffectiveProfile({ mutation }));
+    }
+  }, [mutations, searchParams]);
+
+  const startNew = () => {
+    const cardId = reserveProfileCardId();
+    setActiveMutation({ cardId, revision: 0, status: 'pendingReview', createdBy: uid });
+    setDraft({ userId: cardId });
+    setSearchParams({ cardId });
+  };
+
+  const openMutation = mutation => {
+    setActiveMutation(mutation);
+    setDraft(getEffectiveProfile({ mutation }));
+    setSearchParams({ cardId: mutation.cardId });
+  };
+
+  const closeEditor = () => {
+    setDraft(null);
+    setActiveMutation(null);
+    setSearchParams({});
+  };
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const saved = await saveCreateProfileMutation({
+        cardId: activeMutation.cardId,
+        creatorUid: activeMutation.createdBy || uid,
+        data: draft,
+        expectedRevision: activeMutation.revision,
+      });
+      toast.success('Профіль збережено й надіслано на перевірку');
+      setActiveMutation(saved);
+      await refresh(uid, access);
+    } catch (error) {
+      toast.error(error?.message === 'REVISION_CONFLICT' ? 'Профіль уже змінено. Оновіть сторінку.' : 'Не вдалося зберегти профіль');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const accept = async () => {
+    setSaving(true);
+    try {
+      await acceptCreateProfileMutation({ cardId: activeMutation.cardId, expectedRevision: activeMutation.revision, finalData: draft });
+      toast.success('Профіль прийнято');
+      closeEditor();
+      await refresh(uid, access);
+    } catch (error) {
+      toast.error(error?.message === 'REVISION_CONFLICT' ? 'Автор уже оновив профіль. Перевірте нову версію.' : 'Не вдалося прийняти профіль');
+    } finally { setSaving(false); }
+  };
+
+  const reject = async () => {
+    setSaving(true);
+    try {
+      await rejectCreateProfileMutation({ cardId: activeMutation.cardId, expectedRevision: activeMutation.revision });
+      toast.success('Профіль залишено приватним');
+      closeEditor();
+      await refresh(uid, access);
+    } finally { setSaving(false); }
+  };
+
+  const clearField = (fieldName, index) => setDraft(previous => {
+    const next = { ...(previous || {}) };
+    if (Number.isInteger(index) && Array.isArray(next[fieldName])) {
+      const values = [...next[fieldName]];
+      values.splice(index, 1);
+      if (values.length) next[fieldName] = values;
+      else delete next[fieldName];
+      return next;
+    }
+    delete next[fieldName];
+    return next;
+  });
+
+  const deleteFieldValue = fieldName => setDraft(previous => {
+    const next = { ...(previous || {}) };
+    delete next[fieldName];
+    return next;
+  });
+
+  const heading = useMemo(() => access?.isAdmin ? 'Нові профілі' : 'Мої нові профілі', [access]);
+  if (!access) return <Page><Shell>Завантаження…</Shell></Page>;
+
+  return <Page><Shell>
+    <Header><div><Title>{heading}</Title><Meta>Картки зберігаються приватно до рішення адміністратора.</Meta></div><Button onClick={() => navigate('/matching')}>Matching</Button></Header>
+    {draft ? <Card>
+      <Status>{activeMutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}</Status>
+      <Meta>cardId: {activeMutation.cardId} · revision: {activeMutation.revision || 0}</Meta>
+      <ProfileForm state={draft} setState={setDraft} handleBlur={() => {}} handleSubmit={nextDraft => setDraft(nextDraft)} handleClear={clearField} handleDelKeyValue={deleteFieldValue} isAdmin={access.isAdmin} extendedMode={false} />
+      <Actions>
+        <Button $primary disabled={saving} onClick={save}>{saving ? 'Збереження…' : 'Зберегти'}</Button>
+        {access.isAdmin && activeMutation.revision > 0 && <Button $primary disabled={saving} onClick={accept}>Accept</Button>}
+        {access.isAdmin && activeMutation.revision > 0 && <Button disabled={saving} onClick={reject}>Reject / Leave private</Button>}
+        <Button disabled={saving} onClick={closeEditor}>Закрити</Button>
+      </Actions>
+    </Card> : <>
+      <Actions>{!access.isAdmin && <Button $primary onClick={startNew}>+ Додати профіль</Button>}</Actions>
+      {mutations.length === 0 && <Card>Нових профілів поки немає.</Card>}
+      {mutations.map(mutation => <Card key={mutation.cardId}>
+        <Status>{mutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}</Status>
+        <h2>{[mutation.data?.name, mutation.data?.surname].filter(Boolean).join(' ') || 'Новий профіль'}</h2>
+        <Meta>Автор: {mutation.createdBy}</Meta><Meta>Оновлено: {mutation.updatedAt ? new Date(mutation.updatedAt).toLocaleString('uk-UA') : '—'} · revision {mutation.revision}</Meta>
+        <Button onClick={() => openMutation(mutation)}>Відкрити профіль</Button>
+      </Card>)}
+    </>}
+  </Shell></Page>;
+};
+
+export default ProfileCreationWorkspace;

--- a/src/components/ProfileDotsMenu.jsx
+++ b/src/components/ProfileDotsMenu.jsx
@@ -203,6 +203,7 @@ const SegmentedOption = styled.button`
 const normalizeAccess = access => ({
   canAccessAdd: Boolean(access?.canAccessAdd),
   canAccessMatching: Boolean(access?.canAccessMatching),
+  canCreateProfiles: Boolean(access?.canCreateProfiles),
 });
 
 export const ProfileDotsMenu = ({
@@ -298,6 +299,9 @@ export const ProfileDotsMenu = ({
       : []),
     ...(canSeePrivilegedNav && (isAdmin || resolvedAccess.canAccessMatching)
       ? [{ path: '/matching', label: 'Matching', description: 'Пошук і порівняння анкет', icon: <FaUsers /> }]
+      : []),
+    ...((isAdmin || resolvedAccess.canCreateProfiles)
+      ? [{ path: '/matching/create-profile', label: isAdmin ? 'Нові профілі' : 'Додати профіль', description: isAdmin ? 'Перевірка нових карток' : 'Створити приватну картку', icon: <MdPersonAddAlt1 /> }]
       : []),
     ...(isAdmin ? [{ path: '/flow', label: 'Flow', icon: <FaProjectDiagram /> }] : []),
     ...(isAdmin ? [{ path: '/budget', label: 'Budget', description: 'Program budget and other expenses', icon: <FaEuroSign /> }] : []),

--- a/src/components/ProfileDotsMenu.test.jsx
+++ b/src/components/ProfileDotsMenu.test.jsx
@@ -16,6 +16,12 @@ const renderMenu = props => render(
 );
 
 describe('ProfileDotsMenu logout confirmation', () => {
+  it('shows profile creation only with the dedicated permission', () => {
+    const { rerender } = renderMenu({ access: { canAccessMatching: true } });
+    expect(screen.queryByRole('menuitem', { name: /Додати профіль/ })).toBeNull();
+    rerender(<MemoryRouter><ProfileDotsMenu navigate={jest.fn()} access={{ canCreateProfiles: true }} /></MemoryRouter>);
+    expect(screen.getByRole('menuitem', { name: /Додати профіль/ })).not.toBeNull();
+  });
   it('does not end the session until logout is confirmed', async () => {
     const onExit = jest.fn().mockResolvedValue(undefined);
     const onSelect = jest.fn();

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -98,6 +98,12 @@ export const getFieldsToRender = state => {
 };
 
 const PROFILE_FORM_FIELDS_TO_HIDE = new Set(['getInTouch']);
+const PROFILE_FORM_TECHNICAL_FIELDS = new Set([
+  'accessLevel',
+  'canCreateProfiles',
+  'additionalAccessRules',
+  MULTI_DATA_ACCESS_FIELD,
+]);
 
 const PROFILE_FORM_LABELS = {
   lastLogin: 'Останній логін',
@@ -1952,9 +1958,6 @@ export const ProfileForm = ({
     'ownKids',
     'lastDelivery',
     'role',
-    'accessLevel',
-    ADDITIONAL_ACCESS_FIELD,
-    MULTI_DATA_ACCESS_FIELD,
   ];
 
   const accessLevelOptions = [
@@ -1974,6 +1977,17 @@ export const ProfileForm = ({
 
     if (canManageAccessLevel && !next.some(field => field.name === 'accessLevel')) {
       next = [...next, { name: 'accessLevel', placeholder: 'рівень доступу', ukrainian: 'рівень доступу', ukrainianHint: 'рівень доступу' }];
+    }
+
+    if (canManageAccessLevel && !next.some(field => field.name === 'canCreateProfiles')) {
+      next = [
+        ...next,
+        {
+          name: 'canCreateProfiles',
+          placeholder: 'дозвіл на створення карток',
+          ukrainianHint: 'дозволити користувачу створювати нові картки',
+        },
+      ];
     }
 
     if (canManageAccessLevel && !next.some(field => field.name === ADDITIONAL_ACCESS_FIELD)) {
@@ -2472,7 +2486,10 @@ ${entries.join('\n')}`;
     ...priorityOrder
       .map(key => normalizedFieldsToRender.find(field => field.name === key))
       .filter(Boolean),
-    ...normalizedFieldsToRender.filter(field => !priorityOrder.includes(field.name)),
+    ...normalizedFieldsToRender.filter(
+      field => !priorityOrder.includes(field.name) && !PROFILE_FORM_TECHNICAL_FIELDS.has(field.name)
+    ),
+    ...normalizedFieldsToRender.filter(field => PROFILE_FORM_TECHNICAL_FIELDS.has(field.name)),
   ];
 
   const roleTokens = Array.isArray(state?.role || state?.userRole)
@@ -2696,7 +2713,7 @@ ${entries.join('\n')}`;
                   autoResizePpTechnicalInput(e.target);
                 }}
                 onBlur={handlePpTechnicalInputSubmit}
-                placeholder="Технічний інпут для PP"
+                placeholder="Вставте контакт або технічні дані — парсер розподілить їх по полях"
               />
             </InputFieldContainer>
           </InputDiv>
@@ -2704,7 +2721,7 @@ ${entries.join('\n')}`;
       </PickerContainer>
       {sortedFieldsToRender
         .filter(field => !['myComment', 'writer'].includes(field.name))
-        .filter(field => (isAdmin ? true : field.name !== ADDITIONAL_ACCESS_FIELD))
+        .filter(field => (isAdmin ? true : !PROFILE_FORM_TECHNICAL_FIELDS.has(field.name)))
         .filter(field => {
           if (!shouldHideFieldsForClPp) return true;
           return !HIDDEN_FOR_CL_PP_FIELDS.has(field.name);
@@ -2722,6 +2739,12 @@ ${entries.join('\n')}`;
               : state[field.name] || '';
           return (
             <React.Fragment key={index}>
+            {isAdmin && PROFILE_FORM_TECHNICAL_FIELDS.has(field.name) &&
+              !sortedFieldsToRender.slice(0, index).some(item => PROFILE_FORM_TECHNICAL_FIELDS.has(item.name)) && (
+                <TechnicalFieldsSection>
+                  <TechnicalFieldsTitle>Технічні налаштування</TechnicalFieldsTitle>
+                </TechnicalFieldsSection>
+              )}
             <PickerContainer
               style={hasOverlaySuggestions ? { flexDirection: 'column', alignItems: 'stretch' } : undefined}
             >
@@ -2878,6 +2901,21 @@ ${entries.join('\n')}`;
                           {option.label}
                         </option>
                       ))}
+                    </AccessLevelSelect>
+                  ) : field.name === 'canCreateProfiles' ? (
+                    <AccessLevelSelect
+                      name={field.name}
+                      aria-label="Дозволити створення карток"
+                      value={state[field.name] === true ? 'true' : 'false'}
+                      onFocus={() => handleFieldFocus && handleFieldFocus(field.name)}
+                      onChange={e => {
+                        const value = e.target.value === 'true';
+                        setState(prevState => ({ ...prevState, [field.name]: value }));
+                      }}
+                      onBlur={() => handleBlur(field.name)}
+                    >
+                      <option value="false">Створення карток заборонено</option>
+                      <option value="true">Дозволити створення карток</option>
                     </AccessLevelSelect>
                   ) : field.name === ADDITIONAL_ACCESS_FIELD ? (
                     <>
@@ -3469,6 +3507,22 @@ const FormCard = styled.div`
     padding: 12px;
     border-radius: ${uiTokens.radius.lg};
   }
+`;
+
+const TechnicalFieldsSection = styled.section`
+  width: 100%;
+  margin-top: 28px;
+  padding-top: 18px;
+  border-top: 1px solid var(--km-border);
+`;
+
+const TechnicalFieldsTitle = styled.h3`
+  margin: 0 0 12px;
+  color: var(--km-muted);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 `;
 
 

--- a/src/components/ProfileForm.technicalFields.test.js
+++ b/src/components/ProfileForm.technicalFields.test.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('ProfileForm technical settings', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'ProfileForm.jsx'), 'utf8');
+
+  it('provides an admin boolean control for profile creation access', () => {
+    expect(source).toContain("name: 'canCreateProfiles'");
+    expect(source).toContain('aria-label="Дозволити створення карток"');
+    expect(source).toContain("const value = e.target.value === 'true'");
+  });
+
+  it('keeps technical fields admin-only and renders them after regular fields', () => {
+    expect(source).toContain("!PROFILE_FORM_TECHNICAL_FIELDS.has(field.name)");
+    expect(source).toContain('...normalizedFieldsToRender.filter(field => PROFILE_FORM_TECHNICAL_FIELDS.has(field.name))');
+    expect(source).toContain('<TechnicalFieldsSection>');
+    expect(source).toContain('border-top: 1px solid var(--km-border)');
+  });
+
+  it('keeps the PP parser as the first visible input', () => {
+    const parserPosition = source.indexOf('fieldName="ppTechnicalInput"');
+    const fieldsLoopPosition = source.indexOf('{sortedFieldsToRender');
+    expect(parserPosition).toBeGreaterThan(-1);
+    expect(parserPosition).toBeLessThan(fieldsLoopPosition);
+  });
+});

--- a/src/utils/accessLevel.js
+++ b/src/utils/accessLevel.js
@@ -45,16 +45,18 @@ export const canAccessAddByLevel = accessLevel => {
   return hasAdd;
 };
 
-export const resolveAccess = ({ uid, accessLevel, role, userRole } = {}) => {
+export const resolveAccess = ({ uid, accessLevel, role, userRole, canCreateProfiles = false } = {}) => {
   const isAdmin = isAdminUid(uid);
   const canAccessMatching = isAdmin || canAccessMatchingByLevel(accessLevel) || canAccessMatchingByRole({ role, userRole });
   const canAccessAdd = isAdmin || canAccessAddByLevel(accessLevel);
   const canAccessInvoices = isInvoiceBuilderUid(uid);
+  const canCreateProfilesResolved = isAdmin || canCreateProfiles === true;
 
   return {
     isAdmin,
     canAccessMatching,
     canAccessAdd,
     canAccessInvoices,
+    canCreateProfiles: canCreateProfilesResolved,
   };
 };

--- a/src/utils/accessLevel.test.js
+++ b/src/utils/accessLevel.test.js
@@ -29,6 +29,7 @@ describe('accessLevel', () => {
       canAccessMatching: true,
       canAccessAdd: true,
       canAccessInvoices: true,
+      canCreateProfiles: true,
     });
   });
 
@@ -38,6 +39,7 @@ describe('accessLevel', () => {
       canAccessMatching: true,
       canAccessAdd: false,
       canAccessInvoices: false,
+      canCreateProfiles: false,
     });
   });
 
@@ -46,5 +48,10 @@ describe('accessLevel', () => {
     expect(access.canAccessInvoices).toBe(true);
     expect(access.isAdmin).toBe(false);
     expect(access.canAccessAdd).toBe(false);
+  });
+
+  it('grants profile creation only through its explicit permission', () => {
+    expect(resolveAccess({ uid: 'viewer', canCreateProfiles: true }).canCreateProfiles).toBe(true);
+    expect(resolveAccess({ uid: 'viewer', accessLevel: 'matching add' }).canCreateProfiles).toBe(false);
   });
 });

--- a/src/utils/profileMutations.js
+++ b/src/utils/profileMutations.js
@@ -1,0 +1,110 @@
+import { get, push, ref, update } from 'firebase/database';
+
+import { database } from 'components/config';
+
+export const PROFILE_MUTATIONS_ROOT = 'profileMutations';
+export const PROFILE_MUTATION_HISTORY_ROOT = 'profileMutationHistory';
+
+const cleanObject = value => Object.entries(value || {}).reduce((result, [key, item]) => {
+  if (key.startsWith('__') || item === undefined) return result;
+  result[key] = item;
+  return result;
+}, {});
+
+export const getEffectiveProfile = ({ baseProfile, mutation } = {}) => {
+  if (mutation?.status === 'accepted' || mutation?.status === 'archived') return baseProfile || null;
+  if (mutation?.operation === 'create' && !baseProfile) {
+    return { ...cleanObject(mutation.data), userId: mutation.cardId };
+  }
+  if (mutation?.operation === 'update' && baseProfile) {
+    return { ...baseProfile, ...cleanObject(mutation.data) };
+  }
+  return baseProfile || null;
+};
+
+export const reserveProfileCardId = () => push(ref(database, PROFILE_MUTATIONS_ROOT)).key;
+
+export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expectedRevision }) => {
+  if (!cardId || !creatorUid) throw new Error('cardId and creatorUid are required');
+  const mutationRef = ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`);
+  const snapshot = await get(mutationRef);
+  const current = snapshot.exists() ? snapshot.val() : null;
+
+  if (current && current.createdBy !== creatorUid) throw new Error('Profile mutation belongs to another user');
+  if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
+    throw new Error('REVISION_CONFLICT');
+  }
+
+  const now = Date.now();
+  const mutation = {
+    cardId,
+    operation: 'create',
+    data: { ...cleanObject(data), userId: cardId },
+    createdBy: creatorUid,
+    createdAt: current?.createdAt || now,
+    updatedAt: now,
+    revision: Number(current?.revision || 0) + 1,
+    status: 'pendingReview',
+  };
+  await update(ref(database), {
+    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: mutation,
+    [`profileMutationsByCreator/${creatorUid}/${cardId}`]: true,
+  });
+  return mutation;
+};
+
+export const loadProfileMutation = async cardId => {
+  const snapshot = await get(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`));
+  return snapshot.exists() ? snapshot.val() : null;
+};
+
+export const loadOwnProfileMutations = async creatorUid => {
+  if (!creatorUid) return [];
+  const idsSnapshot = await get(ref(database, `profileMutationsByCreator/${creatorUid}`));
+  const ids = idsSnapshot.exists() ? Object.keys(idsSnapshot.val() || {}) : [];
+  const mutations = await Promise.all(ids.map(loadProfileMutation));
+  return mutations.filter(item => item && item.createdBy === creatorUid && item.status !== 'accepted');
+};
+
+export const loadGrantedCreatedProfiles = async creatorUid => {
+  if (!creatorUid) return [];
+  const snapshot = await get(ref(database, `users/${creatorUid}/createdProfileCardIds`));
+  const ids = snapshot.exists() ? Object.keys(snapshot.val() || {}) : [];
+  const profiles = await Promise.all(ids.map(async cardId => {
+    const profileSnapshot = await get(ref(database, `newUsers/${cardId}`));
+    return profileSnapshot.exists() ? { userId: cardId, ...profileSnapshot.val() } : null;
+  }));
+  return profiles.filter(Boolean);
+};
+
+export const loadAllCreateProfileMutations = async () => {
+  const snapshot = await get(ref(database, PROFILE_MUTATIONS_ROOT));
+  if (!snapshot.exists()) return [];
+  return Object.values(snapshot.val() || {}).filter(item => item?.operation === 'create');
+};
+
+export const acceptCreateProfileMutation = async ({ cardId, expectedRevision, finalData }) => {
+  const mutation = await loadProfileMutation(cardId);
+  if (!mutation || mutation.operation !== 'create') throw new Error('Profile mutation not found');
+  if (Number(mutation.revision) !== Number(expectedRevision)) throw new Error('REVISION_CONFLICT');
+
+  const acceptedAt = Date.now();
+  const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
+  await update(ref(database), {
+    [`newUsers/${cardId}`]: profile,
+    [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
+    [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
+    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: null,
+    [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
+  });
+  return profile;
+};
+
+export const rejectCreateProfileMutation = async ({ cardId, expectedRevision }) => {
+  const mutation = await loadProfileMutation(cardId);
+  if (!mutation) throw new Error('Profile mutation not found');
+  if (Number(mutation.revision) !== Number(expectedRevision)) throw new Error('REVISION_CONFLICT');
+  const rejected = { ...mutation, status: 'private', updatedAt: Date.now() };
+  await update(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), rejected);
+  return rejected;
+};

--- a/src/utils/profileMutations.test.js
+++ b/src/utils/profileMutations.test.js
@@ -1,0 +1,17 @@
+import { getEffectiveProfile } from './profileMutations';
+
+jest.mock('components/config', () => ({ database: {} }));
+
+describe('profile mutations', () => {
+  it('renders a create mutation without a base profile', () => {
+    expect(getEffectiveProfile({ mutation: { operation: 'create', cardId: 'card-1', data: { name: 'Anna' } } }))
+      .toEqual({ userId: 'card-1', name: 'Anna' });
+  });
+
+  it('merges update data and ignores accepted mutations', () => {
+    expect(getEffectiveProfile({ baseProfile: { userId: '1', name: 'A' }, mutation: { operation: 'update', data: { name: 'B' } } }))
+      .toEqual({ userId: '1', name: 'B' });
+    expect(getEffectiveProfile({ baseProfile: { userId: '1', name: 'A' }, mutation: { status: 'accepted', operation: 'create', data: { name: 'B' } } }))
+      .toEqual({ userId: '1', name: 'A' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce a controlled workflow that lets users create private profiles and lets admins review/accept them by adding an explicit `canCreateProfiles` permission and a dedicated workspace.

### Description
- Add `canCreateProfiles` propagation: extend `resolveAccess` to accept `canCreateProfiles`, persist it in `App` and `Matching`, and gate routing to `/matching/create-profile` in `App.jsx`.
- New UI and flow: add `ProfileCreationWorkspace` component with editor/listing, reservation, save, accept and reject actions using a new backend helper API surface in `utils/profileMutations.js`.
- Matching integration: load and merge personal created/created-by-author profiles into the matching deck via `loadOwnProfileMutations`, `loadGrantedCreatedProfiles`, and `getEffectiveProfile` so created cards appear with other candidates.
- Profile admin UX: expose `canCreateProfiles` as a technical admin field in `ProfileForm` and group technical fields under a new `TechnicalFieldsSection`, and add a nav entry in `ProfileDotsMenu` guarded by the new permission.

### Testing
- Ran automated tests with `npm test` which include `accessLevel.test.js`, `profileMutations.test.js`, `ProfileForm.technicalFields.test.js`, and updated `ProfileDotsMenu.test.jsx`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79e79882f08326a9b4b8fd64112530)