### PR TITLE
Harden profile creation review workflow

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -4541,7 +4541,9 @@ const Matching = () => {
   }, [collectionSource, loadReactionCards, reloadDefault]);
 
   const visibleUsers = useMemo(() => mergeMatchingCandidateUsers({
-    users: [...users, ...personalCreateProfiles],
+    users: collectionSource === 'newUsers' || viewMode === 'favorites' || viewMode === 'dislikes'
+      ? [...users, ...personalCreateProfiles]
+      : users,
     additionalNewUsers,
     sharedReactionCandidateUsers,
     isAdmin,

--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -54,6 +54,7 @@ export const ProfileCreationWorkspace = () => {
   const [searchResults, setSearchResults] = useState([]);
   const [searchExecuted, setSearchExecuted] = useState(false);
   const [searchNotFound, setSearchNotFound] = useState(false);
+  const [searchFailed, setSearchFailed] = useState(false);
 
   const refresh = useCallback(async (userId, resolvedAccess) => {
     const items = resolvedAccess.isAdmin
@@ -87,11 +88,11 @@ export const ProfileCreationWorkspace = () => {
     const requestedCardId = searchParams.get('cardId');
     if (!requestedCardId || !mutations.length) return;
     const mutation = mutations.find(item => item.cardId === requestedCardId);
-    if (mutation) {
+    if (mutation && activeMutation?.cardId !== mutation.cardId) {
       setActiveMutation(mutation);
       setDraft(getEffectiveProfile({ mutation }));
     }
-  }, [mutations, searchParams]);
+  }, [activeMutation?.cardId, mutations, searchParams]);
 
   const startNew = () => {
     const cardId = reserveProfileCardId();
@@ -120,6 +121,7 @@ export const ProfileCreationWorkspace = () => {
     setSearchResults([]);
     setSearchExecuted(false);
     setSearchNotFound(false);
+    setSearchFailed(false);
   };
 
   const openMutation = mutation => {
@@ -147,7 +149,9 @@ export const ProfileCreationWorkspace = () => {
       setActiveMutation(saved);
       await refresh(uid, access);
     } catch (error) {
-      toast.error(error?.message === 'REVISION_CONFLICT' ? 'Профіль уже змінено. Оновіть сторінку.' : 'Не вдалося зберегти профіль');
+      toast.error(error?.message === 'REVISION_CONFLICT'
+        ? 'Профіль уже змінено. Оновіть сторінку.'
+        : error?.message === 'DUPLICATE_PROFILE' ? 'Профіль з такими контактами вже існує або очікує перевірки.' : 'Не вдалося зберегти профіль');
     } finally {
       setSaving(false);
     }
@@ -202,7 +206,9 @@ export const ProfileCreationWorkspace = () => {
     {draft ? <Card>
       <Status>{activeMutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}</Status>
       <Meta>cardId: {activeMutation.cardId} · revision: {activeMutation.revision || 0}</Meta>
-      <ProfileForm state={draft} setState={setDraft} handleBlur={() => {}} handleSubmit={nextDraft => setDraft(nextDraft)} handleClear={clearField} handleDelKeyValue={deleteFieldValue} isAdmin={access.isAdmin} extendedMode={false} />
+      <fieldset disabled={saving} style={{ border: 0, padding: 0, margin: 0 }}>
+        <ProfileForm state={draft} setState={setDraft} handleBlur={() => {}} handleSubmit={nextDraft => setDraft(nextDraft)} handleClear={clearField} handleDelKeyValue={deleteFieldValue} isAdmin={access.isAdmin} extendedMode={false} />
+      </fieldset>
       <Actions>
         <Button $primary disabled={saving} onClick={save}>{saving ? 'Збереження…' : 'Зберегти'}</Button>
         {access.isAdmin && activeMutation.revision > 0 && <Button $primary disabled={saving} onClick={accept}>Accept</Button>}
@@ -214,7 +220,11 @@ export const ProfileCreationWorkspace = () => {
         <h2>Знайти або додати картку</h2>
         <Meta>Спочатку перевірте, чи профіль уже існує. Використовується той самий пошук, що й у Matching.</Meta>
         <SearchBar
-          searchFunc={searchUsersOnly}
+          searchFunc={async (...args) => {
+            const result = await searchUsersOnly(...args);
+            setSearchFailed(result === null);
+            return result === null ? {} : result;
+          }}
           search={search}
           setSearch={updateSearch}
           setUsers={applySearchUsers}
@@ -228,6 +238,7 @@ export const ProfileCreationWorkspace = () => {
             setSearchResults([]);
             setSearchNotFound(false);
             setSearchExecuted(false);
+            setSearchFailed(false);
           }}
           storageKey="profileCreationSearchQuery"
           wrapperStyle={{ width: '100%' }}
@@ -238,10 +249,11 @@ export const ProfileCreationWorkspace = () => {
           <Status>Вже існує</Status>
         </SearchResult>)}
         {searchExecuted && searchNotFound && <Meta>Профіль не знайдено. Можна створити нову приватну картку.</Meta>}
+        {searchExecuted && searchFailed && <Meta>Не вдалося виконати пошук. Спробуйте ще раз.</Meta>}
         <Actions>
           <Button
             $primary
-            disabled={!search.trim() || !searchExecuted || !searchNotFound || searchResults.length > 0}
+            disabled={!search.trim() || !searchExecuted || !searchNotFound || searchFailed || searchResults.length > 0}
             onClick={startNew}
           >
             + Додати профіль

--- a/src/components/ProfileCreationWorkspace.search.test.js
+++ b/src/components/ProfileCreationWorkspace.search.test.js
@@ -7,8 +7,8 @@ describe('ProfileCreationWorkspace search-before-create flow', () => {
   it('reuses Matching search primitives and blocks creation until a completed not-found search', () => {
     expect(source).toContain("import { auth, fetchUserById, searchUsersOnly } from './config'");
     expect(source).toContain("import SearchBar, { detectSearchParams } from './SearchBar'");
-    expect(source).toContain('searchFunc={searchUsersOnly}');
-    expect(source).toContain('!searchExecuted || !searchNotFound || searchResults.length > 0');
+    expect(source).toContain('const result = await searchUsersOnly(...args)');
+    expect(source).toContain('!searchExecuted || !searchNotFound || searchFailed || searchResults.length > 0');
   });
 
   it('prefills the new private card from the detected search field', () => {

--- a/src/utils/profileMutations.js
+++ b/src/utils/profileMutations.js
@@ -1,9 +1,14 @@
-import { get, push, ref, update } from 'firebase/database';
+import { get, push, ref, runTransaction, update } from 'firebase/database';
 
-import { database } from 'components/config';
+import { database, syncUserSearchKeyIndex } from 'components/config';
+import {
+  SEARCH_ID_INDEXED_FIELDS,
+  buildSearchIdRecordKey,
+} from './searchKeyUtils';
 
 export const PROFILE_MUTATIONS_ROOT = 'profileMutations';
 export const PROFILE_MUTATION_HISTORY_ROOT = 'profileMutationHistory';
+export const PROFILE_IDENTITY_CLAIMS_ROOT = 'profileIdentityClaims';
 
 const cleanObject = value => Object.entries(value || {}).reduce((result, [key, item]) => {
   if (key.startsWith('__') || item === undefined) return result;
@@ -24,33 +29,100 @@ export const getEffectiveProfile = ({ baseProfile, mutation } = {}) => {
 
 export const reserveProfileCardId = () => push(ref(database, PROFILE_MUTATIONS_ROOT)).key;
 
+const getSearchIdKeys = (data, { contactsOnly = false } = {}) => Object.entries(cleanObject(data))
+  .filter(([field]) => SEARCH_ID_INDEXED_FIELDS.has(field) && (!contactsOnly || (field !== 'name' && field !== 'surname')))
+  .flatMap(([field, rawValue]) => (Array.isArray(rawValue) ? rawValue : [rawValue])
+    .map(value => buildSearchIdRecordKey({ [field]: value }))
+    .filter(Boolean))
+  .filter((value, index, values) => values.indexOf(value) === index);
+
+const claimProfileIdentities = async ({ cardId, data }) => {
+  const claims = getSearchIdKeys(data, { contactsOnly: true });
+  const acquired = [];
+  try {
+    for (const claim of claims) {
+      // Existing canonical profiles predate the reservation table, so consult the
+      // established exact-search index before attempting the atomic claim.
+      // eslint-disable-next-line no-await-in-loop
+      const indexed = await get(ref(database, `searchId/${claim}`));
+      if (indexed.exists()) {
+        const indexedIds = Array.isArray(indexed.val()) ? indexed.val() : [indexed.val()];
+        if (indexedIds.some(id => id && id !== cardId)) throw new Error('DUPLICATE_PROFILE');
+      }
+      let alreadyOwned = false;
+      // A claim is a durable reservation: accepted cards continue to block duplicates.
+      // eslint-disable-next-line no-await-in-loop
+      const result = await runTransaction(ref(database, `${PROFILE_IDENTITY_CLAIMS_ROOT}/${claim}`), current => {
+        alreadyOwned = current === cardId;
+        return current == null || alreadyOwned ? cardId : undefined;
+      }, { applyLocally: false });
+      if (!result.committed) throw new Error('DUPLICATE_PROFILE');
+      if (!alreadyOwned) acquired.push(claim);
+    }
+  } catch (error) {
+    await Promise.all(acquired.map(claim => runTransaction(
+      ref(database, `${PROFILE_IDENTITY_CLAIMS_ROOT}/${claim}`),
+      current => current === cardId ? null : current,
+      { applyLocally: false },
+    )));
+    throw error;
+  }
+  return { claims, acquired };
+};
+
+const releaseProfileIdentities = (cardId, claims) => Promise.all(claims.map(claim => runTransaction(
+  ref(database, `${PROFILE_IDENTITY_CLAIMS_ROOT}/${claim}`),
+  current => current === cardId ? null : current,
+  { applyLocally: false },
+)));
+
+const syncProfileSearchIdIndex = (cardId, profile) => Promise.all(getSearchIdKeys(profile).map(key => runTransaction(
+  ref(database, `searchId/${key}`),
+  current => {
+    const ids = (Array.isArray(current) ? current : [current]).filter(Boolean);
+    if (ids.includes(cardId)) return current;
+    const next = [...ids, cardId];
+    return next.length === 1 ? next[0] : next;
+  },
+  { applyLocally: false },
+)));
+
 export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expectedRevision }) => {
   if (!cardId || !creatorUid) throw new Error('cardId and creatorUid are required');
   const mutationRef = ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`);
-  const snapshot = await get(mutationRef);
-  const current = snapshot.exists() ? snapshot.val() : null;
-
-  if (current && current.createdBy !== creatorUid) throw new Error('Profile mutation belongs to another user');
-  if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
-    throw new Error('REVISION_CONFLICT');
+  const { acquired } = await claimProfileIdentities({ cardId, data });
+  let conflict = '';
+  const result = await runTransaction(mutationRef, current => {
+    if (current && current.createdBy !== creatorUid) {
+      conflict = 'Profile mutation belongs to another user';
+      return undefined;
+    }
+    if (current && current.status !== 'pendingReview' && current.status !== 'private') {
+      conflict = 'REVISION_CONFLICT';
+      return undefined;
+    }
+    if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
+      conflict = 'REVISION_CONFLICT';
+      return undefined;
+    }
+    const now = Date.now();
+    return {
+      cardId,
+      operation: 'create',
+      data: { ...cleanObject(data), userId: cardId },
+      createdBy: creatorUid,
+      createdAt: current?.createdAt || now,
+      updatedAt: now,
+      revision: Number(current?.revision || 0) + 1,
+      status: 'pendingReview',
+    };
+  }, { applyLocally: false });
+  if (!result.committed) {
+    await releaseProfileIdentities(cardId, acquired);
+    throw new Error(conflict || 'REVISION_CONFLICT');
   }
-
-  const now = Date.now();
-  const mutation = {
-    cardId,
-    operation: 'create',
-    data: { ...cleanObject(data), userId: cardId },
-    createdBy: creatorUid,
-    createdAt: current?.createdAt || now,
-    updatedAt: now,
-    revision: Number(current?.revision || 0) + 1,
-    status: 'pendingReview',
-  };
-  await update(ref(database), {
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: mutation,
-    [`profileMutationsByCreator/${creatorUid}/${cardId}`]: true,
-  });
-  return mutation;
+  await update(ref(database, `profileMutationsByCreator/${creatorUid}`), { [cardId]: true });
+  return result.snapshot.val();
 };
 
 export const loadProfileMutation = async cardId => {
@@ -80,31 +152,61 @@ export const loadGrantedCreatedProfiles = async creatorUid => {
 export const loadAllCreateProfileMutations = async () => {
   const snapshot = await get(ref(database, PROFILE_MUTATIONS_ROOT));
   if (!snapshot.exists()) return [];
-  return Object.values(snapshot.val() || {}).filter(item => item?.operation === 'create');
+  return Object.values(snapshot.val() || {}).filter(item => (
+    item?.operation === 'create' && item.status !== 'accepted' && item.status !== 'accepting'
+  ));
 };
 
 export const acceptCreateProfileMutation = async ({ cardId, expectedRevision, finalData }) => {
-  const mutation = await loadProfileMutation(cardId);
-  if (!mutation || mutation.operation !== 'create') throw new Error('Profile mutation not found');
-  if (Number(mutation.revision) !== Number(expectedRevision)) throw new Error('REVISION_CONFLICT');
-
   const acceptedAt = Date.now();
+  let conflict = 'Profile mutation not found';
+  const result = await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), mutation => {
+    if (!mutation || mutation.operation !== 'create') return undefined;
+    if (mutation.status !== 'pendingReview' && mutation.status !== 'private') return undefined;
+    if (Number(mutation.revision) !== Number(expectedRevision)) {
+      conflict = 'REVISION_CONFLICT';
+      return undefined;
+    }
+    return { ...mutation, status: 'accepting', acceptedAt };
+  }, { applyLocally: false });
+  if (!result.committed) throw new Error(conflict);
+  const mutation = result.snapshot.val();
   const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
+  try {
+    await claimProfileIdentities({ cardId, data: profile });
+  } catch (error) {
+    await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), current => (
+      current?.status === 'accepting' && current?.acceptedAt === acceptedAt
+        ? { ...current, status: 'pendingReview', acceptedAt: null }
+        : current
+    ), { applyLocally: false });
+    throw error;
+  }
   await update(ref(database), {
     [`newUsers/${cardId}`]: profile,
     [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
     [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: null,
+    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
     [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
   });
+  await Promise.all([
+    syncProfileSearchIdIndex(cardId, profile),
+    syncUserSearchKeyIndex(cardId, {}, profile),
+  ]);
   return profile;
 };
 
 export const rejectCreateProfileMutation = async ({ cardId, expectedRevision }) => {
-  const mutation = await loadProfileMutation(cardId);
-  if (!mutation) throw new Error('Profile mutation not found');
-  if (Number(mutation.revision) !== Number(expectedRevision)) throw new Error('REVISION_CONFLICT');
-  const rejected = { ...mutation, status: 'private', updatedAt: Date.now() };
-  await update(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), rejected);
-  return rejected;
+  let conflict = 'Profile mutation not found';
+  const result = await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), mutation => {
+    if (!mutation) return undefined;
+    if (mutation.status !== 'pendingReview') return undefined;
+    if (Number(mutation.revision) !== Number(expectedRevision)) {
+      conflict = 'REVISION_CONFLICT';
+      return undefined;
+    }
+    return { ...mutation, status: 'private', updatedAt: Date.now() };
+  }, { applyLocally: false });
+  if (!result.committed) throw new Error(conflict);
+  return result.snapshot.val();
 };


### PR DESCRIPTION
### Motivation
- Prevent duplicate profiles by reserving identity keys for pending and accepted cards and consulting existing exact-search indexes before allowing creation.
- Make revision/version checks atomic so concurrent saves/accepts cannot silently overwrite each other or accept stale data.
- Ensure accepted profiles are indexed for later duplicate detection and search loads so approvals become visible to matching and duplicate checks.
- Improve UX around search and saving by surfacing search failures, disabling creation on failed searches, and preserving in-flight edits while saving.

### Description
- Reworked `src/utils/profileMutations.js` to use Firebase transactions (`runTransaction`) for `saveCreateProfileMutation`, `acceptCreateProfileMutation`, and `rejectCreateProfileMutation`, performing server-side compare-and-swap checks for revisions and status transitions.
- Added an identity reservation layer under `profileIdentityClaims` that atomically claims searchable identity keys (built via `buildSearchIdRecordKey`) during creation and acceptance to block duplicates, with safe rollback on failures (`claimProfileIdentities`, `releaseProfileIdentities`).
- When a profile is accepted the change now writes the canonical profile into `newUsers` and updates both `searchId` and the existing search-key indexes (`syncProfileSearchIdIndex` and `syncUserSearchKeyIndex`) so the record participates in later searches and dedupe logic.
- Kept accepted mutation records in place (marked `accepted`) instead of unconditionally nulling them so stale clients cannot recreate cards; excluded `accepted`/`accepting` items from admin review lists (`loadAllCreateProfileMutations` filter).
- Updated `src/components/ProfileCreationWorkspace.jsx` to: disable the editor while saving (wrap `ProfileForm` in a disabled `fieldset`), avoid blindly rehydrating the draft if the same active card is already open, wrap `searchUsersOnly` with a failure-aware wrapper and surface a retry message, and prevent starting creation when the search failed or didn’t complete.
- Updated `src/components/Matching.jsx` merge logic so `personalCreateProfiles` are only injected into the deck when the collection source is `newUsers` (or in certain reaction modes), preventing personal pending/accepted `newUsers` cards from leaking into the normal `users` deck.
- Adjusted and updated the search-before-create test to expect the new failure-aware search wrapper and added small test-source assertions accordingly.

### Testing
- Ran unit tests: `npm test -- --watchAll=false src/utils/profileMutations.test.js src/components/ProfileCreationWorkspace.search.test.js src/components/ProfileDotsMenu.test.jsx`, all suites passed (3 suites, 10 tests) with a non-failing worker teardown warning reported by Jest.
- Ran lint check: `npx eslint src/utils/profileMutations.js src/components/ProfileCreationWorkspace.jsx src/components/Matching.jsx` and there were no blocking lint failures (only environment warnings from toolchain dependencies).
- Built production bundle: `npm run build` completed successfully and produced an optimized build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a13d29600832688015fa7717fc3c7)