### PR TITLE
Harden profile mutation publishing and search error handling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3816,6 +3816,10 @@ const Matching = () => {
     }
   }, [buildMatchingSearchStatusText]);
 
+  const handleMatchingSearchError = React.useCallback(() => {
+    setMatchingSearchStatus('Пошук тимчасово недоступний. Спробуйте ще раз.');
+  }, []);
+
   const searchUsers = async (params, options = {}) => {
     const [key, value] = Object.entries(params)[0] || [];
     const term = key && value ? `${key}=${value}` : undefined;
@@ -5712,6 +5716,7 @@ const Matching = () => {
                 storageKey={SEARCH_KEY}
                 onSearchKey={handleMatchingSearchKey}
                 onSearchExecuted={handleMatchingSearchExecuted}
+                onSearchError={handleMatchingSearchError}
                 onClear={() => {
                   setMatchingSearchStatus('');
                   matchingSearchKeyRef.current = null;

--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -54,6 +54,7 @@ export const ProfileCreationWorkspace = () => {
   const [searchResults, setSearchResults] = useState([]);
   const [searchExecuted, setSearchExecuted] = useState(false);
   const [searchNotFound, setSearchNotFound] = useState(false);
+  const [searchError, setSearchError] = useState(false);
 
   const refresh = useCallback(async (userId, resolvedAccess) => {
     const items = resolvedAccess.isAdmin
@@ -120,6 +121,7 @@ export const ProfileCreationWorkspace = () => {
     setSearchResults([]);
     setSearchExecuted(false);
     setSearchNotFound(false);
+    setSearchError(false);
   };
 
   const openMutation = mutation => {
@@ -223,11 +225,19 @@ export const ProfileCreationWorkspace = () => {
             setSearchNotFound(Boolean(value));
             if (value) setSearchResults([]);
           }}
-          onSearchExecuted={() => setSearchExecuted(true)}
+          onSearchExecuted={() => {
+            setSearchExecuted(true);
+            setSearchError(false);
+          }}
+          onSearchError={() => {
+            setSearchError(true);
+            setSearchNotFound(false);
+          }}
           onClear={() => {
             setSearchResults([]);
             setSearchNotFound(false);
             setSearchExecuted(false);
+            setSearchError(false);
           }}
           storageKey="profileCreationSearchQuery"
           wrapperStyle={{ width: '100%' }}
@@ -238,10 +248,11 @@ export const ProfileCreationWorkspace = () => {
           <Status>Вже існує</Status>
         </SearchResult>)}
         {searchExecuted && searchNotFound && <Meta>Профіль не знайдено. Можна створити нову приватну картку.</Meta>}
+        {searchError && <Meta role="alert">Пошук тимчасово недоступний. Спробуйте ще раз.</Meta>}
         <Actions>
           <Button
             $primary
-            disabled={!search.trim() || !searchExecuted || !searchNotFound || searchResults.length > 0}
+            disabled={!search.trim() || !searchExecuted || !searchNotFound || searchResults.length > 0 || searchError}
             onClick={startNew}
           >
             + Додати профіль

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1088,6 +1088,7 @@ const SearchBar = ({
   setSearch: externalSetSearch,
   onClear,
   onSearchExecuted,
+  onSearchError,
   wrapperStyle = {},
   leftIcon = SearchIcon,
   storageKey = 'searchQuery',
@@ -1254,7 +1255,7 @@ const SearchBar = ({
       const { key, value } = detectSearchParams(search);
       loadCachedResult(key, value);
       if (!suppressInitialSearchExecution) {
-        writeData(search);
+        executeSearch(search);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -2125,6 +2126,20 @@ const SearchBar = ({
     }
   };
 
+  const executeSearch = async (query = search, options = {}) => {
+    const requestId = options.requestId ?? activeSearchRequestRef.current + 1;
+    activeSearchRequestRef.current = requestId;
+    try {
+      await writeData(query, { ...options, requestId });
+    } catch (error) {
+      if (activeSearchRequestRef.current !== requestId) return;
+      applyUserNotFound(false, requestId);
+      applyState({}, requestId);
+      applyUsers({}, requestId);
+      onSearchError && onSearchError(error);
+    }
+  };
+
   return (
     <InputDiv style={wrapperStyle}>
       {leftIcon && <span style={{ marginRight: '5px' }}>{leftIcon}</span>}
@@ -2137,13 +2152,13 @@ const SearchBar = ({
           onKeyDown={e => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault();
-              writeData(search);
+              executeSearch(search);
             }
           }}
           onFocus={() => setShowHistory(true)}
           onBlur={() => {
             setTimeout(() => setShowHistory(false), 100);
-            writeData();
+            executeSearch();
           }}
         />
         {search && (
@@ -2167,7 +2182,7 @@ const SearchBar = ({
               onClick={() => {
                 if (!item.startsWith('!')) setSearch(item);
                 setShowHistory(false);
-                writeData(item);
+                executeSearch(item);
               }}
             >
               <span>{item}</span>

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2189,7 +2189,7 @@ export const searchUsersOnly = async (searchedValue, options = {}) => {
     return {};
   } catch (error) {
     console.error('Error searching users only:', error);
-    return null;
+    throw error;
   }
 };
 

--- a/src/utils/profileMutations.js
+++ b/src/utils/profileMutations.js
@@ -1,9 +1,14 @@
-import { get, push, ref, update } from 'firebase/database';
+import { get, push, ref, runTransaction, update } from 'firebase/database';
 
 import { database } from 'components/config';
+import { buildSearchIndexCandidates, encodeKey } from './searchIndexCandidates';
+import { getSearchIdIndexedFields, normalizeSearchIdInput } from './searchKeyUtils';
 
 export const PROFILE_MUTATIONS_ROOT = 'profileMutations';
 export const PROFILE_MUTATION_HISTORY_ROOT = 'profileMutationHistory';
+export const PROFILE_IDENTITY_RESERVATIONS_ROOT = 'profileIdentityReservations';
+
+const NON_UNIQUE_INDEX_FIELDS = new Set(['name', 'surname']);
 
 const cleanObject = value => Object.entries(value || {}).reduce((result, [key, item]) => {
   if (key.startsWith('__') || item === undefined) return result;
@@ -11,14 +16,111 @@ const cleanObject = value => Object.entries(value || {}).reduce((result, [key, i
   return result;
 }, {});
 
+const extractValues = value => {
+  if (value === undefined || value === null) return [];
+  if (typeof value === 'string' || typeof value === 'number') return [value];
+  if (Array.isArray(value)) return value.flatMap(extractValues);
+  if (typeof value === 'object') return Object.values(value).flatMap(extractValues);
+  return [];
+};
+
+export const buildProfileSearchIndexKeys = profile => getSearchIdIndexedFields().reduce((result, field) => {
+  extractValues(profile?.[field]).forEach(value => {
+    buildSearchIndexCandidates(field, normalizeSearchIdInput(field, value)).forEach(candidate => {
+      if (candidate) result.add(`${field}_${encodeKey(String(candidate).toLowerCase())}`);
+    });
+  });
+  return result;
+}, new Set());
+
+const getUniqueIdentityKeys = profile => [...buildProfileSearchIndexKeys(profile)]
+  .filter(key => !NON_UNIQUE_INDEX_FIELDS.has(key.split('_', 1)[0]));
+
+const reservationCardId = reservation => (
+  reservation && typeof reservation === 'object' ? reservation.cardId : reservation
+);
+
+const canonicalContainsOtherCard = (owners, cardId) => {
+  if (!owners) return false;
+  if (Array.isArray(owners)) return owners.some(owner => owner !== cardId);
+  return owners !== cardId;
+};
+
+const reserveIdentityKeys = async (cardId, keys) => {
+  const token = push(ref(database, PROFILE_IDENTITY_RESERVATIONS_ROOT)).key;
+  const acquired = [];
+  try {
+    for (const key of keys) {
+      // Legacy profiles predate reservations, so validate their canonical entry before claiming.
+      // New drafts retain their claim through acceptance, closing the accept/reserve race.
+      // eslint-disable-next-line no-await-in-loop
+      const canonical = await get(ref(database, `searchId/${key}`));
+      if (canonical.exists() && canonicalContainsOtherCard(canonical.val(), cardId)) {
+        throw new Error('DUPLICATE_PROFILE');
+      }
+      // A token makes concurrent saves of the same card independently releasable.
+      // eslint-disable-next-line no-await-in-loop
+      const result = await runTransaction(
+        ref(database, `${PROFILE_IDENTITY_RESERVATIONS_ROOT}/${key}`),
+        current => {
+          const owner = reservationCardId(current);
+          if (owner && owner !== cardId) return undefined;
+          const tokens = current && typeof current === 'object' ? current.tokens || {} : {};
+          return { cardId, tokens: { ...tokens, [token]: true } };
+        },
+        { applyLocally: false },
+      );
+      if (!result.committed) throw new Error('DUPLICATE_PROFILE');
+      acquired.push(key);
+    }
+    return { keys: acquired, token };
+  } catch (error) {
+    await releaseIdentityKeys(cardId, acquired, token);
+    throw error;
+  }
+};
+
+const releaseIdentityKeys = async (cardId, keys, token) => {
+  await Promise.all((keys || []).map(key => runTransaction(
+    ref(database, `${PROFILE_IDENTITY_RESERVATIONS_ROOT}/${key}`),
+    current => {
+      if (reservationCardId(current) !== cardId) return current;
+      if (!current || typeof current !== 'object' || !token) return null;
+      const tokens = { ...(current.tokens || {}) };
+      delete tokens[token];
+      if (Object.keys(tokens).length) return { ...current, tokens };
+      return current.durable || current.accepted ? { ...current, tokens: null } : null;
+    },
+    { applyLocally: false },
+  )));
+};
+
+const retainAcceptedIdentityKeys = async (cardId, keys) => Promise.all(keys.map(key => runTransaction(
+  ref(database, `${PROFILE_IDENTITY_RESERVATIONS_ROOT}/${key}`),
+  current => reservationCardId(current) === cardId ? { cardId, accepted: true } : undefined,
+  { applyLocally: false },
+)));
+
+const retainSavedIdentityKeys = async (cardId, keys) => Promise.all(keys.map(key => runTransaction(
+  ref(database, `${PROFILE_IDENTITY_RESERVATIONS_ROOT}/${key}`),
+  current => reservationCardId(current) === cardId ? { ...current, cardId, durable: true } : undefined,
+  { applyLocally: false },
+)));
+
+const mergeNonUniqueSearchIndexes = async (cardId, keys) => Promise.all(keys.map(key => runTransaction(
+  ref(database, `searchId/${key}`),
+  current => {
+    const owners = Array.isArray(current) ? current : current ? [current] : [];
+    if (!owners.includes(cardId)) owners.push(cardId);
+    return owners.length === 1 ? owners[0] : owners;
+  },
+  { applyLocally: false },
+)));
+
 export const getEffectiveProfile = ({ baseProfile, mutation } = {}) => {
   if (mutation?.status === 'accepted' || mutation?.status === 'archived') return baseProfile || null;
-  if (mutation?.operation === 'create' && !baseProfile) {
-    return { ...cleanObject(mutation.data), userId: mutation.cardId };
-  }
-  if (mutation?.operation === 'update' && baseProfile) {
-    return { ...baseProfile, ...cleanObject(mutation.data) };
-  }
+  if (mutation?.operation === 'create' && !baseProfile) return { ...cleanObject(mutation.data), userId: mutation.cardId };
+  if (mutation?.operation === 'update' && baseProfile) return { ...baseProfile, ...cleanObject(mutation.data) };
   return baseProfile || null;
 };
 
@@ -26,31 +128,57 @@ export const reserveProfileCardId = () => push(ref(database, PROFILE_MUTATIONS_R
 
 export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expectedRevision }) => {
   if (!cardId || !creatorUid) throw new Error('cardId and creatorUid are required');
+  const identityKeys = getUniqueIdentityKeys(data);
+  const reservation = await reserveIdentityKeys(cardId, identityKeys);
   const mutationRef = ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`);
-  const snapshot = await get(mutationRef);
-  const current = snapshot.exists() ? snapshot.val() : null;
+  let creatorIndexWritten = false;
+  let conflict = false;
+  let ownerConflict = false;
+  let previousIdentityKeys = [];
 
-  if (current && current.createdBy !== creatorUid) throw new Error('Profile mutation belongs to another user');
-  if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
-    throw new Error('REVISION_CONFLICT');
+  try {
+    // Write the discoverability pointer first. A dangling pointer is harmless (the loader
+    // filters it), and can always be retried; the inverse ordering could orphan a draft.
+    await update(ref(database), { [`profileMutationsByCreator/${creatorUid}/${cardId}`]: true });
+    creatorIndexWritten = true;
+    const now = Date.now();
+    const result = await runTransaction(mutationRef, current => {
+      if (current && current.createdBy !== creatorUid) { ownerConflict = true; return undefined; }
+      if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
+        conflict = true;
+        return undefined;
+      }
+      previousIdentityKeys = current?.identityKeys || [];
+      return {
+        cardId,
+        operation: 'create',
+        data: { ...cleanObject(data), userId: cardId },
+        createdBy: creatorUid,
+        createdAt: current?.createdAt || now,
+        updatedAt: now,
+        revision: Number(current?.revision || 0) + 1,
+        status: 'pendingReview',
+        identityKeys,
+      };
+    }, { applyLocally: false });
+    if (!result.committed) {
+      if (ownerConflict) throw new Error('Profile mutation belongs to another user');
+      if (conflict) throw new Error('REVISION_CONFLICT');
+      throw new Error('PROFILE_MUTATION_SAVE_FAILED');
+    }
+    const saved = result.snapshot.val();
+    await retainSavedIdentityKeys(cardId, identityKeys);
+    await releaseIdentityKeys(cardId, reservation.keys, reservation.token);
+    const removedKeys = previousIdentityKeys.filter(key => !identityKeys.includes(key));
+    await releaseIdentityKeys(cardId, removedKeys);
+    return saved;
+  } catch (error) {
+    await releaseIdentityKeys(cardId, reservation.keys, reservation.token);
+    if (creatorIndexWritten && (ownerConflict || conflict)) {
+      await update(ref(database), { [`profileMutationsByCreator/${creatorUid}/${cardId}`]: null });
+    }
+    throw error;
   }
-
-  const now = Date.now();
-  const mutation = {
-    cardId,
-    operation: 'create',
-    data: { ...cleanObject(data), userId: cardId },
-    createdBy: creatorUid,
-    createdAt: current?.createdAt || now,
-    updatedAt: now,
-    revision: Number(current?.revision || 0) + 1,
-    status: 'pendingReview',
-  };
-  await update(ref(database), {
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: mutation,
-    [`profileMutationsByCreator/${creatorUid}/${cardId}`]: true,
-  });
-  return mutation;
 };
 
 export const loadProfileMutation = async cardId => {
@@ -84,20 +212,53 @@ export const loadAllCreateProfileMutations = async () => {
 };
 
 export const acceptCreateProfileMutation = async ({ cardId, expectedRevision, finalData }) => {
-  const mutation = await loadProfileMutation(cardId);
-  if (!mutation || mutation.operation !== 'create') throw new Error('Profile mutation not found');
-  if (Number(mutation.revision) !== Number(expectedRevision)) throw new Error('REVISION_CONFLICT');
+  let invalid = false;
+  let conflict = false;
+  const transition = await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), current => {
+    if (!current || current.operation !== 'create') { invalid = true; return undefined; }
+    if (current.status !== 'pendingReview' || Number(current.revision) !== Number(expectedRevision)) {
+      conflict = true;
+      return undefined;
+    }
+    return { ...current, status: 'accepting', updatedAt: Date.now() };
+  }, { applyLocally: false });
+  if (!transition.committed) {
+    if (invalid) throw new Error('Profile mutation not found');
+    if (conflict) throw new Error('REVISION_CONFLICT');
+    throw new Error('PROFILE_MUTATION_ACCEPT_FAILED');
+  }
+  const mutation = transition.snapshot.val();
 
-  const acceptedAt = Date.now();
   const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
-  await update(ref(database), {
-    [`newUsers/${cardId}`]: profile,
-    [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
-    [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: null,
-    [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
-  });
-  return profile;
+  const identityKeys = getUniqueIdentityKeys(profile);
+  let reservation;
+  const acceptedAt = Date.now();
+  const allIndexKeys = [...buildProfileSearchIndexKeys(profile)];
+  const nonUniqueKeys = allIndexKeys.filter(key => NON_UNIQUE_INDEX_FIELDS.has(key.split('_', 1)[0]));
+  const uniqueUpdates = identityKeys.reduce((updates, key) => ({ ...updates, [`searchId/${key}`]: cardId }), {});
+
+  try {
+    reservation = await reserveIdentityKeys(cardId, identityKeys);
+    await update(ref(database), {
+      [`newUsers/${cardId}`]: profile,
+      ...uniqueUpdates,
+      [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
+      [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, data: profile, identityKeys, status: 'accepted', acceptedAt },
+      [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: null,
+      [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
+    });
+    await mergeNonUniqueSearchIndexes(cardId, nonUniqueKeys);
+    await retainAcceptedIdentityKeys(cardId, identityKeys);
+    return profile;
+  } catch (error) {
+    if (reservation) await releaseIdentityKeys(cardId, reservation.keys, reservation.token);
+    await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), current => (
+      current?.status === 'accepting' && Number(current.revision) === Number(expectedRevision)
+        ? { ...current, status: 'pendingReview', updatedAt: Date.now() }
+        : current
+    ), { applyLocally: false });
+    throw error;
+  }
 };
 
 export const rejectCreateProfileMutation = async ({ cardId, expectedRevision }) => {

--- a/src/utils/profileMutations.test.js
+++ b/src/utils/profileMutations.test.js
@@ -1,4 +1,4 @@
-import { getEffectiveProfile } from './profileMutations';
+import { buildProfileSearchIndexKeys, getEffectiveProfile } from './profileMutations';
 
 jest.mock('components/config', () => ({ database: {} }));
 
@@ -13,5 +13,18 @@ describe('profile mutations', () => {
       .toEqual({ userId: '1', name: 'B' });
     expect(getEffectiveProfile({ baseProfile: { userId: '1', name: 'A' }, mutation: { status: 'accepted', operation: 'create', data: { name: 'B' } } }))
       .toEqual({ userId: '1', name: 'A' });
+  });
+
+  it('builds normalized search index candidates for accepted profile data', () => {
+    expect([...buildProfileSearchIndexKeys({
+      name: 'Anna Maria',
+      email: 'ANNA@example.com',
+      phone: '050 123 45 67',
+    })]).toEqual(expect.arrayContaining([
+      'name_anna_space_maria',
+      'name_annamaria',
+      'email_anna_at_example_dot_com',
+      'phone_380501234567',
+    ]));
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent accepted profile publishes from overwriting existing `searchId` entries when multiple profiles share non-unique keys like `name`/`surname` by merging rather than replacing values.
- Make profile-draft save/accept flows robust to races and partial failures so reservations and creator indexes are not left orphaned and accept operations remain retryable.
- Stop stale search errors from clearing newer results and provide a way for callers to present backend outages distinctly from valid no-results responses.

### Description
- Introduced a reservation layer for identity keys under `PROFILE_IDENTITY_RESERVATIONS_ROOT` with per-save tokens and transactional `reserveIdentityKeys`/`releaseIdentityKeys` helpers, and durable markers for saved/accepted drafts in `src/utils/profileMutations.js`.
- Generate normalized index keys via `buildProfileSearchIndexKeys` and only publish per-key canonical `searchId` values for identity keys while merging non-unique fields (`name`/`surname`) into arrays with `mergeNonUniqueSearchIndexes` to avoid destructive overwrites.
- Made `saveCreateProfileMutation` create the `profileMutationsByCreator` pointer first, claim identity keys, write the mutation inside a `runTransaction`, and retain/release reservations reliably on success/failure to avoid orphaned reservations and REVISION_CONFLICT paths.
- Hardened `acceptCreateProfileMutation` to transition mutations to an `accepting` state with `runTransaction`, reserve identity keys from the final accepted data, atomically publish `newUsers` + unique `searchId` updates, merge non-unique indexes, and roll the mutation back to `pendingReview` on publication failure.
- Added request-aware search error handling in `SearchBar` by introducing `executeSearch` with request ids and an `onSearchError` callback, and wired outage UI handling into `ProfileCreationWorkspace` and `Matching` to prevent creating a profile while the backend is unavailable; also changed `searchUsersOnly` to rethrow backend errors so consumers can distinguish outages from empty results.

### Testing
- Unit tests: ran `npm test` for `src/utils/profileMutations.test.js`, `src/components/ProfileCreationWorkspace.search.test.js`, and `src/components/SearchBar.partialUserId.test.js`, and all test suites passed (`3 suites, 32 tests` succeeded).
- Lint: ran `eslint` on modified files (`src/utils/profileMutations.js`, related tests and components) and there were no lint failures on the checked files.
- Added a unit assertion for `buildProfileSearchIndexKeys` to validate normalized index candidates and it passes as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a158d4da48326a0b7390201ef18fa)