### PR TITLE
Make profile publication and search handling race-safe

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3816,6 +3816,11 @@ const Matching = () => {
     }
   }, [buildMatchingSearchStatusText]);
 
+  const handleMatchingSearchError = React.useCallback(() => {
+    matchingSearchKeyRef.current = null;
+    setMatchingSearchStatus('Пошук тимчасово недоступний');
+  }, []);
+
   const searchUsers = async (params, options = {}) => {
     const [key, value] = Object.entries(params)[0] || [];
     const term = key && value ? `${key}=${value}` : undefined;
@@ -5707,6 +5712,7 @@ const Matching = () => {
                 setUsers={handleMatchingSearchResultStatus}
                 setState={handleMatchingSearchStateStatus}
                 setUserNotFound={handleMatchingSearchNotFound}
+                onSearchError={handleMatchingSearchError}
                 wrapperStyle={{ width: '100%', marginBottom: 0 }}
                 leftIcon="🔍"
                 storageKey={SEARCH_KEY}

--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -54,6 +54,7 @@ export const ProfileCreationWorkspace = () => {
   const [searchResults, setSearchResults] = useState([]);
   const [searchExecuted, setSearchExecuted] = useState(false);
   const [searchNotFound, setSearchNotFound] = useState(false);
+  const [searchError, setSearchError] = useState(false);
 
   const refresh = useCallback(async (userId, resolvedAccess) => {
     const items = resolvedAccess.isAdmin
@@ -120,6 +121,7 @@ export const ProfileCreationWorkspace = () => {
     setSearchResults([]);
     setSearchExecuted(false);
     setSearchNotFound(false);
+    setSearchError(false);
   };
 
   const openMutation = mutation => {
@@ -223,16 +225,26 @@ export const ProfileCreationWorkspace = () => {
             setSearchNotFound(Boolean(value));
             if (value) setSearchResults([]);
           }}
-          onSearchExecuted={() => setSearchExecuted(true)}
+          onSearchExecuted={() => {
+            setSearchExecuted(true);
+            setSearchError(false);
+          }}
+          onSearchSuccess={() => setSearchError(false)}
+          onSearchError={() => {
+            setSearchError(true);
+            setSearchNotFound(false);
+          }}
           onClear={() => {
             setSearchResults([]);
             setSearchNotFound(false);
             setSearchExecuted(false);
+            setSearchError(false);
           }}
           storageKey="profileCreationSearchQuery"
           wrapperStyle={{ width: '100%' }}
           leftIcon="🔍"
         />
+        {searchError && <Meta>Пошук тимчасово недоступний. Спробуйте ще раз.</Meta>}
         {searchResults.map(profile => <SearchResult key={profile.userId}>
           <span><strong>{[profile.name, profile.surname].filter(Boolean).join(' ') || 'Профіль знайдено'}</strong><Meta>{profile.userId}</Meta></span>
           <Status>Вже існує</Status>

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1088,6 +1088,8 @@ const SearchBar = ({
   setSearch: externalSetSearch,
   onClear,
   onSearchExecuted,
+  onSearchError,
+  onSearchSuccess,
   wrapperStyle = {},
   leftIcon = SearchIcon,
   storageKey = 'searchQuery',
@@ -1875,7 +1877,7 @@ const SearchBar = ({
     return false;
   };
 
-  const writeData = async (query = search, options = {}) => {
+  const executeSearch = async (query = search, options = {}) => {
     const {
       requestId: inheritedRequestId = null,
       suppressHistory = false,
@@ -2122,6 +2124,20 @@ const SearchBar = ({
       } else {
         applyUsers(res, requestId);
       }
+    }
+  };
+
+  const writeData = async (query = search, options = {}) => {
+    const requestId = options.requestId ?? ++activeSearchRequestRef.current;
+    try {
+      await executeSearch(query, { ...options, requestId });
+      if (activeSearchRequestRef.current === requestId) onSearchSuccess && onSearchSuccess();
+    } catch (error) {
+      if (activeSearchRequestRef.current !== requestId) return;
+      applyUserNotFound(false, requestId);
+      applyState({}, requestId);
+      applyUsers({}, requestId);
+      onSearchError && onSearchError(error);
     }
   };
 

--- a/src/components/config.js
+++ b/src/components/config.js
@@ -2189,7 +2189,7 @@ export const searchUsersOnly = async (searchedValue, options = {}) => {
     return {};
   } catch (error) {
     console.error('Error searching users only:', error);
-    return null;
+    throw error;
   }
 };
 

--- a/src/utils/profileMutations.js
+++ b/src/utils/profileMutations.js
@@ -1,9 +1,14 @@
-import { get, push, ref, update } from 'firebase/database';
+import { get, push, ref, runTransaction, update } from 'firebase/database';
 
 import { database } from 'components/config';
+import { buildSearchIndexCandidates, encodeKey } from './searchIndexCandidates';
+import { SEARCH_ID_INDEXED_FIELDS, normalizeSearchIdInput } from './searchKeyUtils';
 
 export const PROFILE_MUTATIONS_ROOT = 'profileMutations';
 export const PROFILE_MUTATION_HISTORY_ROOT = 'profileMutationHistory';
+export const PROFILE_IDENTITY_RESERVATIONS_ROOT = 'profileIdentityReservations';
+
+const NON_UNIQUE_IDENTITY_FIELDS = new Set(['name', 'surname']);
 
 const cleanObject = value => Object.entries(value || {}).reduce((result, [key, item]) => {
   if (key.startsWith('__') || item === undefined) return result;
@@ -11,14 +16,40 @@ const cleanObject = value => Object.entries(value || {}).reduce((result, [key, i
   return result;
 }, {});
 
+const fieldValues = value => (Array.isArray(value) ? value : [value])
+  .filter(item => item !== undefined && item !== null && String(item).trim());
+
+export const buildProfileIdentityKeys = profile => [...SEARCH_ID_INDEXED_FIELDS]
+  .filter(field => !NON_UNIQUE_IDENTITY_FIELDS.has(field))
+  .flatMap(field => fieldValues(profile?.[field]).flatMap(value => {
+    const normalized = normalizeSearchIdInput(field, value);
+    return normalized ? buildSearchIndexCandidates(field, normalized)
+      .map(candidate => `${field}_${encodeKey(candidate)}`) : [];
+  }))
+  .filter((key, index, keys) => keys.indexOf(key) === index);
+
+export const buildProfileSearchIndexKeys = profile => [...SEARCH_ID_INDEXED_FIELDS]
+  .flatMap(field => fieldValues(profile?.[field]).flatMap(value => {
+    const normalized = normalizeSearchIdInput(field, value);
+    return normalized ? buildSearchIndexCandidates(field, normalized)
+      .map(candidate => ({ field, key: `${field}_${encodeKey(candidate)}` })) : [];
+  }))
+  .filter((entry, index, entries) => entries.findIndex(item => item.key === entry.key) === index);
+
+const ownersIncludeAnotherCard = (owners, cardId) => owners != null &&
+  (Array.isArray(owners) ? owners.some(owner => owner !== cardId) : owners !== cardId);
+
+const addSearchOwner = (owners, cardId, allowMultiple) => {
+  if (!owners) return cardId;
+  if (!allowMultiple || owners === cardId) return cardId;
+  const values = Array.isArray(owners) ? owners : [owners];
+  return values.includes(cardId) ? values : [...values, cardId];
+};
+
 export const getEffectiveProfile = ({ baseProfile, mutation } = {}) => {
   if (mutation?.status === 'accepted' || mutation?.status === 'archived') return baseProfile || null;
-  if (mutation?.operation === 'create' && !baseProfile) {
-    return { ...cleanObject(mutation.data), userId: mutation.cardId };
-  }
-  if (mutation?.operation === 'update' && baseProfile) {
-    return { ...baseProfile, ...cleanObject(mutation.data) };
-  }
+  if (mutation?.operation === 'create' && !baseProfile) return { ...cleanObject(mutation.data), userId: mutation.cardId };
+  if (mutation?.operation === 'update' && baseProfile) return { ...baseProfile, ...cleanObject(mutation.data) };
   return baseProfile || null;
 };
 
@@ -26,31 +57,55 @@ export const reserveProfileCardId = () => push(ref(database, PROFILE_MUTATIONS_R
 
 export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expectedRevision }) => {
   if (!cardId || !creatorUid) throw new Error('cardId and creatorUid are required');
-  const mutationRef = ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`);
-  const snapshot = await get(mutationRef);
-  const current = snapshot.exists() ? snapshot.val() : null;
-
-  if (current && current.createdBy !== creatorUid) throw new Error('Profile mutation belongs to another user');
-  if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
-    throw new Error('REVISION_CONFLICT');
-  }
-
   const now = Date.now();
-  const mutation = {
-    cardId,
-    operation: 'create',
-    data: { ...cleanObject(data), userId: cardId },
-    createdBy: creatorUid,
-    createdAt: current?.createdAt || now,
-    updatedAt: now,
-    revision: Number(current?.revision || 0) + 1,
-    status: 'pendingReview',
-  };
-  await update(ref(database), {
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: mutation,
-    [`profileMutationsByCreator/${creatorUid}/${cardId}`]: true,
-  });
-  return mutation;
+  const profile = { ...cleanObject(data), userId: cardId };
+  const identityKeys = buildProfileIdentityKeys(profile);
+  let failure = 'PROFILE_MUTATION_SAVE_FAILED';
+  let savedMutation;
+
+  const result = await runTransaction(ref(database), currentRoot => {
+    const root = currentRoot || {};
+    const mutations = { ...(root[PROFILE_MUTATIONS_ROOT] || {}) };
+    const current = mutations[cardId];
+    if (current && current.createdBy !== creatorUid) {
+      failure = 'Profile mutation belongs to another user';
+      return undefined;
+    }
+    if (current && expectedRevision != null && Number(current.revision) !== Number(expectedRevision)) {
+      failure = 'REVISION_CONFLICT';
+      return undefined;
+    }
+
+    const searchId = root.searchId || {};
+    const reservations = { ...(root[PROFILE_IDENTITY_RESERVATIONS_ROOT] || {}) };
+    if (identityKeys.some(key => ownersIncludeAnotherCard(searchId[key], cardId) ||
+      (reservations[key] && reservations[key] !== cardId))) {
+      failure = 'DUPLICATE_PROFILE';
+      return undefined;
+    }
+    (current?.identityKeys || []).filter(key => !identityKeys.includes(key)).forEach(key => {
+      if (reservations[key] === cardId) delete reservations[key];
+    });
+    identityKeys.forEach(key => { reservations[key] = cardId; });
+
+    savedMutation = {
+      cardId, operation: 'create', data: profile, createdBy: creatorUid,
+      createdAt: current?.createdAt || now, updatedAt: now,
+      revision: Number(current?.revision || 0) + 1, status: 'pendingReview', identityKeys,
+    };
+    mutations[cardId] = savedMutation;
+    return {
+      ...root,
+      [PROFILE_MUTATIONS_ROOT]: mutations,
+      [PROFILE_IDENTITY_RESERVATIONS_ROOT]: reservations,
+      profileMutationsByCreator: {
+        ...(root.profileMutationsByCreator || {}),
+        [creatorUid]: { ...(root.profileMutationsByCreator?.[creatorUid] || {}), [cardId]: true },
+      },
+    };
+  }, { applyLocally: false });
+  if (!result.committed) throw new Error(failure);
+  return savedMutation;
 };
 
 export const loadProfileMutation = async cardId => {
@@ -84,20 +139,54 @@ export const loadAllCreateProfileMutations = async () => {
 };
 
 export const acceptCreateProfileMutation = async ({ cardId, expectedRevision, finalData }) => {
-  const mutation = await loadProfileMutation(cardId);
-  if (!mutation || mutation.operation !== 'create') throw new Error('Profile mutation not found');
-  if (Number(mutation.revision) !== Number(expectedRevision)) throw new Error('REVISION_CONFLICT');
-
   const acceptedAt = Date.now();
-  const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
-  await update(ref(database), {
-    [`newUsers/${cardId}`]: profile,
-    [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
-    [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: null,
-    [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
-  });
-  return profile;
+  let failure = 'Profile mutation not found';
+  let acceptedProfile;
+  const result = await runTransaction(ref(database), currentRoot => {
+    const root = currentRoot || {};
+    const mutation = root[PROFILE_MUTATIONS_ROOT]?.[cardId];
+    if (!mutation || mutation.operation !== 'create') return undefined;
+    if (mutation.status !== 'pendingReview' || Number(mutation.revision) !== Number(expectedRevision)) {
+      failure = 'REVISION_CONFLICT';
+      return undefined;
+    }
+    const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
+    const identityKeys = buildProfileIdentityKeys(profile);
+    const searchEntries = buildProfileSearchIndexKeys(profile);
+    const searchId = { ...(root.searchId || {}) };
+    const reservations = { ...(root[PROFILE_IDENTITY_RESERVATIONS_ROOT] || {}) };
+    if (identityKeys.some(key => ownersIncludeAnotherCard(searchId[key], cardId) ||
+      (reservations[key] && reservations[key] !== cardId))) {
+      failure = 'DUPLICATE_PROFILE';
+      return undefined;
+    }
+    searchEntries.forEach(({ field, key }) => {
+      searchId[key] = addSearchOwner(searchId[key], cardId, NON_UNIQUE_IDENTITY_FIELDS.has(field));
+    });
+    (mutation.identityKeys || []).forEach(key => { if (reservations[key] === cardId) delete reservations[key]; });
+    identityKeys.forEach(key => { if (reservations[key] === cardId) delete reservations[key]; });
+
+    const mutations = { ...(root[PROFILE_MUTATIONS_ROOT] || {}) };
+    delete mutations[cardId];
+    const creatorIndex = { ...(root.profileMutationsByCreator?.[mutation.createdBy] || {}) };
+    delete creatorIndex[cardId];
+    acceptedProfile = profile;
+    return {
+      ...root, searchId, newUsers: { ...(root.newUsers || {}), [cardId]: profile },
+      users: { ...(root.users || {}), [mutation.createdBy]: {
+        ...(root.users?.[mutation.createdBy] || {}), createdProfileCardIds: {
+          ...(root.users?.[mutation.createdBy]?.createdProfileCardIds || {}), [cardId]: true,
+        },
+      } },
+      [PROFILE_MUTATION_HISTORY_ROOT]: { ...(root[PROFILE_MUTATION_HISTORY_ROOT] || {}),
+        [cardId]: { ...mutation, data: profile, status: 'accepted', acceptedAt } },
+      [PROFILE_MUTATIONS_ROOT]: mutations,
+      [PROFILE_IDENTITY_RESERVATIONS_ROOT]: reservations,
+      profileMutationsByCreator: { ...(root.profileMutationsByCreator || {}), [mutation.createdBy]: creatorIndex },
+    };
+  }, { applyLocally: false });
+  if (!result.committed) throw new Error(failure);
+  return acceptedProfile;
 };
 
 export const rejectCreateProfileMutation = async ({ cardId, expectedRevision }) => {


### PR DESCRIPTION
### Motivation

- Prevent acceptance and save races that overwrite or orphan profile records and search indexes when identity keys collide or administrator edits differ from saved drafts.
- Preserve multi-owner search index entries for non-unique fields (e.g. `name`/`surname`) so accepting a common name does not drop other IDs from the index.
- Ensure identity reservations, canonical index ownership, and creator-index updates are consistent and atomic to avoid stuck `accepting` states and lost creator indexes.
- Stop stale search request failures from clearing newer results and surface backend outages separately from legitimate no-results responses.

### Description

- Reworked `src/utils/profileMutations.js` to perform create/save and accept flows inside a single `runTransaction` over a common root, adding `PROFILE_IDENTITY_RESERVATIONS_ROOT` and reservation logic, and making publication/history/creator-index writes atomic. 
- Added `buildProfileIdentityKeys` and `buildProfileSearchIndexKeys` (using existing `buildSearchIndexCandidates`/`normalizeSearchIdInput`) and logic to merge IDs into `searchId` entries for non-unique fields instead of replacing scalar values. 
- Hardened duplicate checks to consult canonical `searchId` and reservation state inside the same transaction to close the reservation/acceptance race and to release reservations when appropriate. 
- Made search error handling request-aware by adding `onSearchError`/`onSearchSuccess` and isolating stale failures in `src/components/SearchBar.jsx`, updated `ProfileCreationWorkspace.jsx` to track and show `searchError`, and added a matching search error handler in `src/components/Matching.jsx`. 
- Changed `searchUsersOnly` in `src/components/config.js` to rethrow backend errors so consumers can distinguish outages from empty results.

### Testing

- Ran unit tests with `npm test -- --runInBand src/utils/profileMutations.test.js src/components/ProfileCreationWorkspace.search.test.js src/components/SearchBar.partialUserId.test.js` and all test suites passed (3 suites, 31 tests). 
- Ran `npx eslint` on modified files (`src/utils/profileMutations.js`, `src/components/SearchBar.jsx`, `src/components/ProfileCreationWorkspace.jsx`, `src/components/Matching.jsx`, `src/components/config.js`) with no fatal lint failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a15f0c8bc83269b8f5d0d04bada00)