### PR TITLE
Harden profile mutation publish flow and search error handling

### DIFF
--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -3816,6 +3816,10 @@ const Matching = () => {
     }
   }, [buildMatchingSearchStatusText]);
 
+  const handleMatchingSearchError = React.useCallback(() => {
+    setMatchingSearchStatus('Не вдалося виконати пошук. Спробуйте ще раз.');
+  }, []);
+
   const searchUsers = async (params, options = {}) => {
     const [key, value] = Object.entries(params)[0] || [];
     const term = key && value ? `${key}=${value}` : undefined;
@@ -5714,6 +5718,7 @@ const Matching = () => {
                 storageKey={SEARCH_KEY}
                 onSearchKey={handleMatchingSearchKey}
                 onSearchExecuted={handleMatchingSearchExecuted}
+                onSearchError={handleMatchingSearchError}
                 onClear={() => {
                   setMatchingSearchStatus('');
                   matchingSearchKeyRef.current = null;

--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -220,11 +220,7 @@ export const ProfileCreationWorkspace = () => {
         <h2>Знайти або додати картку</h2>
         <Meta>Спочатку перевірте, чи профіль уже існує. Використовується той самий пошук, що й у Matching.</Meta>
         <SearchBar
-          searchFunc={async (...args) => {
-            const result = await searchUsersOnly(...args);
-            setSearchFailed(result === null);
-            return result === null ? {} : result;
-          }}
+          searchFunc={searchUsersOnly}
           search={search}
           setSearch={updateSearch}
           setUsers={applySearchUsers}
@@ -233,7 +229,14 @@ export const ProfileCreationWorkspace = () => {
             setSearchNotFound(Boolean(value));
             if (value) setSearchResults([]);
           }}
-          onSearchExecuted={() => setSearchExecuted(true)}
+          onSearchExecuted={() => {
+            setSearchExecuted(true);
+            setSearchFailed(false);
+          }}
+          onSearchError={() => {
+            setSearchFailed(true);
+            setSearchNotFound(false);
+          }}
           onClear={() => {
             setSearchResults([]);
             setSearchNotFound(false);

--- a/src/components/ProfileCreationWorkspace.search.test.js
+++ b/src/components/ProfileCreationWorkspace.search.test.js
@@ -7,7 +7,8 @@ describe('ProfileCreationWorkspace search-before-create flow', () => {
   it('reuses Matching search primitives and blocks creation until a completed not-found search', () => {
     expect(source).toContain("import { auth, fetchUserById, searchUsersOnly } from './config'");
     expect(source).toContain("import SearchBar, { detectSearchParams } from './SearchBar'");
-    expect(source).toContain('const result = await searchUsersOnly(...args)');
+    expect(source).toContain('searchFunc={searchUsersOnly}');
+    expect(source).toContain('onSearchError={() => {');
     expect(source).toContain('!searchExecuted || !searchNotFound || searchFailed || searchResults.length > 0');
   });
 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1088,6 +1088,7 @@ const SearchBar = ({
   setSearch: externalSetSearch,
   onClear,
   onSearchExecuted,
+  onSearchError,
   wrapperStyle = {},
   leftIcon = SearchIcon,
   storageKey = 'searchQuery',
@@ -1875,7 +1876,7 @@ const SearchBar = ({
     return false;
   };
 
-  const writeData = async (query = search, options = {}) => {
+  const executeWriteData = async (query = search, options = {}) => {
     const {
       requestId: inheritedRequestId = null,
       suppressHistory = false,
@@ -1980,7 +1981,7 @@ const SearchBar = ({
           collector.lastUsers = undefined;
           collector.lastUserNotFound = false;
 
-          await writeData(value, {
+          await executeWriteData(value, {
             requestId,
             suppressHistory: true,
             suppressSearchExecuted: true,
@@ -2122,6 +2123,20 @@ const SearchBar = ({
       } else {
         applyUsers(res, requestId);
       }
+    }
+  };
+
+  const writeData = async (query = search, options = {}) => {
+    const requestId = options.requestId ?? ++activeSearchRequestRef.current;
+    try {
+      return await executeWriteData(query, { ...options, requestId });
+    } catch (error) {
+      if (activeSearchRequestRef.current !== requestId) return undefined;
+      applyUserNotFound(false, requestId);
+      applyState({}, requestId);
+      applyUsers({}, requestId);
+      onSearchError && onSearchError(error);
+      return undefined;
     }
   };
 

--- a/src/utils/profileMutations.js
+++ b/src/utils/profileMutations.js
@@ -1,4 +1,4 @@
-import { get, push, ref, runTransaction, update } from 'firebase/database';
+import { get, push, ref, runTransaction } from 'firebase/database';
 
 import { database, syncUserSearchKeyIndex } from 'components/config';
 import {
@@ -36,63 +36,23 @@ const getSearchIdKeys = (data, { contactsOnly = false } = {}) => Object.entries(
     .filter(Boolean))
   .filter((value, index, values) => values.indexOf(value) === index);
 
-const claimProfileIdentities = async ({ cardId, data }) => {
-  const claims = getSearchIdKeys(data, { contactsOnly: true });
-  const acquired = [];
-  try {
-    for (const claim of claims) {
-      // Existing canonical profiles predate the reservation table, so consult the
-      // established exact-search index before attempting the atomic claim.
-      // eslint-disable-next-line no-await-in-loop
-      const indexed = await get(ref(database, `searchId/${claim}`));
-      if (indexed.exists()) {
-        const indexedIds = Array.isArray(indexed.val()) ? indexed.val() : [indexed.val()];
-        if (indexedIds.some(id => id && id !== cardId)) throw new Error('DUPLICATE_PROFILE');
-      }
-      let alreadyOwned = false;
-      // A claim is a durable reservation: accepted cards continue to block duplicates.
-      // eslint-disable-next-line no-await-in-loop
-      const result = await runTransaction(ref(database, `${PROFILE_IDENTITY_CLAIMS_ROOT}/${claim}`), current => {
-        alreadyOwned = current === cardId;
-        return current == null || alreadyOwned ? cardId : undefined;
-      }, { applyLocally: false });
-      if (!result.committed) throw new Error('DUPLICATE_PROFILE');
-      if (!alreadyOwned) acquired.push(claim);
-    }
-  } catch (error) {
-    await Promise.all(acquired.map(claim => runTransaction(
-      ref(database, `${PROFILE_IDENTITY_CLAIMS_ROOT}/${claim}`),
-      current => current === cardId ? null : current,
-      { applyLocally: false },
-    )));
-    throw error;
-  }
-  return { claims, acquired };
+const asIds = value => (Array.isArray(value) ? value : [value]).filter(Boolean);
+
+const hasOtherOwner = (value, cardId) => asIds(value).some(id => id !== cardId);
+
+const appendIndexId = (value, cardId) => {
+  const ids = asIds(value);
+  if (!ids.includes(cardId)) ids.push(cardId);
+  return ids.length === 1 ? ids[0] : ids;
 };
-
-const releaseProfileIdentities = (cardId, claims) => Promise.all(claims.map(claim => runTransaction(
-  ref(database, `${PROFILE_IDENTITY_CLAIMS_ROOT}/${claim}`),
-  current => current === cardId ? null : current,
-  { applyLocally: false },
-)));
-
-const syncProfileSearchIdIndex = (cardId, profile) => Promise.all(getSearchIdKeys(profile).map(key => runTransaction(
-  ref(database, `searchId/${key}`),
-  current => {
-    const ids = (Array.isArray(current) ? current : [current]).filter(Boolean);
-    if (ids.includes(cardId)) return current;
-    const next = [...ids, cardId];
-    return next.length === 1 ? next[0] : next;
-  },
-  { applyLocally: false },
-)));
 
 export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expectedRevision }) => {
   if (!cardId || !creatorUid) throw new Error('cardId and creatorUid are required');
-  const mutationRef = ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`);
-  const { acquired } = await claimProfileIdentities({ cardId, data });
+  const identityKeys = getSearchIdKeys(data, { contactsOnly: true });
   let conflict = '';
-  const result = await runTransaction(mutationRef, current => {
+  const result = await runTransaction(ref(database), currentRoot => {
+    const root = currentRoot || {};
+    const current = root[PROFILE_MUTATIONS_ROOT]?.[cardId];
     if (current && current.createdBy !== creatorUid) {
       conflict = 'Profile mutation belongs to another user';
       return undefined;
@@ -105,8 +65,14 @@ export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expe
       conflict = 'REVISION_CONFLICT';
       return undefined;
     }
+    const searchId = root.searchId || {};
+    const claims = root[PROFILE_IDENTITY_CLAIMS_ROOT] || {};
+    if (identityKeys.some(key => hasOtherOwner(searchId[key], cardId) || (claims[key] && claims[key] !== cardId))) {
+      conflict = 'DUPLICATE_PROFILE';
+      return undefined;
+    }
     const now = Date.now();
-    return {
+    const mutation = {
       cardId,
       operation: 'create',
       data: { ...cleanObject(data), userId: cardId },
@@ -115,14 +81,27 @@ export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expe
       updatedAt: now,
       revision: Number(current?.revision || 0) + 1,
       status: 'pendingReview',
+      identityKeys,
+    };
+    const nextClaims = { ...claims };
+    (current?.identityKeys || []).forEach(key => {
+      if (!identityKeys.includes(key) && nextClaims[key] === cardId) delete nextClaims[key];
+    });
+    identityKeys.forEach(key => { nextClaims[key] = cardId; });
+    return {
+      ...root,
+      [PROFILE_MUTATIONS_ROOT]: { ...(root[PROFILE_MUTATIONS_ROOT] || {}), [cardId]: mutation },
+      [PROFILE_IDENTITY_CLAIMS_ROOT]: nextClaims,
+      profileMutationsByCreator: {
+        ...(root.profileMutationsByCreator || {}),
+        [creatorUid]: { ...(root.profileMutationsByCreator?.[creatorUid] || {}), [cardId]: true },
+      },
     };
   }, { applyLocally: false });
   if (!result.committed) {
-    await releaseProfileIdentities(cardId, acquired);
     throw new Error(conflict || 'REVISION_CONFLICT');
   }
-  await update(ref(database, `profileMutationsByCreator/${creatorUid}`), { [cardId]: true });
-  return result.snapshot.val();
+  return result.snapshot.val()?.[PROFILE_MUTATIONS_ROOT]?.[cardId];
 };
 
 export const loadProfileMutation = async cardId => {
@@ -160,40 +139,63 @@ export const loadAllCreateProfileMutations = async () => {
 export const acceptCreateProfileMutation = async ({ cardId, expectedRevision, finalData }) => {
   const acceptedAt = Date.now();
   let conflict = 'Profile mutation not found';
-  const result = await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), mutation => {
+  let acceptedProfile = null;
+  const result = await runTransaction(ref(database), currentRoot => {
+    const root = currentRoot || {};
+    const mutation = root[PROFILE_MUTATIONS_ROOT]?.[cardId];
     if (!mutation || mutation.operation !== 'create') return undefined;
     if (mutation.status !== 'pendingReview' && mutation.status !== 'private') return undefined;
     if (Number(mutation.revision) !== Number(expectedRevision)) {
       conflict = 'REVISION_CONFLICT';
       return undefined;
     }
-    return { ...mutation, status: 'accepting', acceptedAt };
+    const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
+    const identityKeys = getSearchIdKeys(profile, { contactsOnly: true });
+    const searchKeys = getSearchIdKeys(profile);
+    const searchId = root.searchId || {};
+    const claims = root[PROFILE_IDENTITY_CLAIMS_ROOT] || {};
+    if (identityKeys.some(key => hasOtherOwner(searchId[key], cardId) || (claims[key] && claims[key] !== cardId))) {
+      conflict = 'DUPLICATE_PROFILE';
+      return undefined;
+    }
+
+    const nextClaims = { ...claims };
+    (mutation.identityKeys || []).forEach(key => {
+      if (!identityKeys.includes(key) && nextClaims[key] === cardId) delete nextClaims[key];
+    });
+    identityKeys.forEach(key => { nextClaims[key] = cardId; });
+    const nextSearchId = { ...searchId };
+    searchKeys.forEach(key => { nextSearchId[key] = appendIndexId(nextSearchId[key], cardId); });
+    const acceptedMutation = { ...mutation, data: profile, identityKeys, status: 'accepted', acceptedAt };
+    const creatorIndex = { ...(root.profileMutationsByCreator?.[mutation.createdBy] || {}) };
+    delete creatorIndex[cardId];
+    acceptedProfile = profile;
+    return {
+      ...root,
+      newUsers: { ...(root.newUsers || {}), [cardId]: profile },
+      users: {
+        ...(root.users || {}),
+        [mutation.createdBy]: {
+          ...(root.users?.[mutation.createdBy] || {}),
+          createdProfileCardIds: {
+            ...(root.users?.[mutation.createdBy]?.createdProfileCardIds || {}),
+            [cardId]: true,
+          },
+        },
+      },
+      [PROFILE_MUTATION_HISTORY_ROOT]: { ...(root[PROFILE_MUTATION_HISTORY_ROOT] || {}), [cardId]: acceptedMutation },
+      [PROFILE_MUTATIONS_ROOT]: { ...(root[PROFILE_MUTATIONS_ROOT] || {}), [cardId]: acceptedMutation },
+      [PROFILE_IDENTITY_CLAIMS_ROOT]: nextClaims,
+      searchId: nextSearchId,
+      profileMutationsByCreator: {
+        ...(root.profileMutationsByCreator || {}),
+        [mutation.createdBy]: creatorIndex,
+      },
+    };
   }, { applyLocally: false });
   if (!result.committed) throw new Error(conflict);
-  const mutation = result.snapshot.val();
-  const profile = { ...cleanObject(finalData || mutation.data), userId: cardId };
-  try {
-    await claimProfileIdentities({ cardId, data: profile });
-  } catch (error) {
-    await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), current => (
-      current?.status === 'accepting' && current?.acceptedAt === acceptedAt
-        ? { ...current, status: 'pendingReview', acceptedAt: null }
-        : current
-    ), { applyLocally: false });
-    throw error;
-  }
-  await update(ref(database), {
-    [`newUsers/${cardId}`]: profile,
-    [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
-    [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
-    [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: { ...mutation, data: profile, status: 'accepted', acceptedAt },
-    [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
-  });
-  await Promise.all([
-    syncProfileSearchIdIndex(cardId, profile),
-    syncUserSearchKeyIndex(cardId, {}, profile),
-  ]);
-  return profile;
+  await syncUserSearchKeyIndex(cardId, {}, acceptedProfile);
+  return acceptedProfile;
 };
 
 export const rejectCreateProfileMutation = async ({ cardId, expectedRevision }) => {


### PR DESCRIPTION
### Motivation

- Prevent data loss and races when creating or accepting profile mutations by making identity claims, creator indexing, and publication changes atomic and by revalidating identity keys from the accepted payload. 
- Preserve existing search index entries for non-unique `searchId` keys by merging IDs instead of overwriting scalar values. 
- Stop stale search failures from clearing newer results or turning a transient backend error into a persistent “not found” state in the UI.

### Description

- Make `saveCreateProfileMutation` perform a root-level transaction that validates revision/owner, checks `searchId` canonical ownership, records `identityKeys`, updates durable `profileIdentityClaims`, and atomically updates `profileMutations` + `profileMutationsByCreator` in the same transaction (changes in `src/utils/profileMutations.js`).
- Make `acceptCreateProfileMutation` an atomic root-level transaction that revalidates identity keys derived from the accepted `finalData`, updates durable claims, publishes `newUsers`/history, merges the `cardId` into existing `searchId` entries (preserving arrays/scalars), and removes the creator index in the same transaction (changes in `src/utils/profileMutations.js`).
- Add helper logic to treat `searchId` index leaves as scalar-or-array and append `cardId` (using `appendIndexId`/`asIds`/`hasOtherOwner`) to avoid overwriting non-unique entries (changes in `src/utils/profileMutations.js`).
- Avoid stale-search fallout by separating `executeWriteData` from a `writeData` wrapper in `SearchBar`, and add an `onSearchError` callback so errors from older requests do not clear newer results (changes in `src/components/SearchBar.jsx`).
- In the profile-creation UI (`ProfileCreationWorkspace.jsx`) use `searchFunc={searchUsersOnly}` directly and add `onSearchError`/`onSearchExecuted` handling to keep outage state distinct from not-found results and to clear error when retrying.
- Provide a dedicated outage message in Matching by wiring `onSearchError` to a `handleMatchingSearchError` status string (changes in `src/components/Matching.jsx`).
- Update the test that asserts the profile-creation search integration to expect the new `searchFunc` usage and explicit error handler (changes in `src/components/ProfileCreationWorkspace.search.test.js`).

### Testing

- Ran lint: `npx eslint src/utils/profileMutations.js src/components/SearchBar.jsx src/components/ProfileCreationWorkspace.jsx src/components/Matching.jsx src/components/ProfileCreationWorkspace.search.test.js` and no blocking errors were reported. 
- Ran unit tests: `CI=true npm test -- --watch=false src/utils/profileMutations.test.js src/components/ProfileCreationWorkspace.search.test.js src/components/SearchBar.partialUserId.test.js`, and all test suites passed (3 suites, 31 tests passed). 
- Verified repository diff/format checks (`git diff --check`) and that the modified files containing the new logic are `src/utils/profileMutations.js`, `src/components/SearchBar.jsx`, `src/components/ProfileCreationWorkspace.jsx`, `src/components/Matching.jsx`, and the adjusted test `src/components/ProfileCreationWorkspace.search.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a1aceb9088326a2f0a235a0bb72ac)