### PR TITLE
Add search-key hint to profile creation

### DIFF
--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -8,6 +8,7 @@ import { auth, fetchUserById, searchUsersOnly } from './config';
 import { ProfileForm } from './ProfileForm';
 import SearchBar, { detectSearchParams } from './SearchBar';
 import { resolveAccess } from 'utils/accessLevel';
+import { getSearchIdIndexedFields } from 'utils/searchKeyUtils';
 import {
   acceptCreateProfileMutation,
   getEffectiveProfile,
@@ -40,6 +41,7 @@ const Status = styled.span`display:inline-block; padding:4px 9px; border-radius:
 const SearchSection = styled.section`padding:16px; margin-bottom:18px; border:1px solid var(--km-border); border-radius:16px; background:var(--km-card);`;
 const SearchResult = styled.div`display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 0; border-top:1px solid var(--km-border);`;
 const PROFILE_SEARCH_PREFILL_FIELDS = new Set(['name', 'surname', 'phone', 'email', 'telegram', 'instagram', 'facebook', 'tiktok']);
+const PROFILE_SEARCH_KEYS = ['userId', ...getSearchIdIndexedFields()];
 
 export const ProfileCreationWorkspace = () => {
   const navigate = useNavigate();
@@ -219,6 +221,13 @@ export const ProfileCreationWorkspace = () => {
       {!access.isAdmin && <SearchSection aria-label="Пошук профілю перед створенням">
         <h2>Знайти або додати картку</h2>
         <Meta>Спочатку перевірте, чи профіль уже існує. Використовується той самий пошук, що й у Matching.</Meta>
+        <Meta>
+          Пошук карток виконується за ключами: {PROFILE_SEARCH_KEYS.map((key, index) => (
+            <React.Fragment key={key}>
+              {index > 0 ? ', ' : ''}<code>{key}</code>
+            </React.Fragment>
+          ))}.
+        </Meta>
         <SearchBar
           searchFunc={searchUsersOnly}
           search={search}

--- a/src/components/ProfileCreationWorkspace.search.test.js
+++ b/src/components/ProfileCreationWorkspace.search.test.js
@@ -16,4 +16,10 @@ describe('ProfileCreationWorkspace search-before-create flow', () => {
     expect(source).toContain('const detected = detectSearchParams(search)');
     expect(source).toContain('setDraft({ userId: cardId, ...initialSearchData })');
   });
+
+  it('shows which indexed keys are used to find existing cards', () => {
+    expect(source).toContain("import { getSearchIdIndexedFields } from 'utils/searchKeyUtils'");
+    expect(source).toContain("const PROFILE_SEARCH_KEYS = ['userId', ...getSearchIdIndexedFields()]");
+    expect(source).toContain('Пошук карток виконується за ключами:');
+  });
 });


### PR DESCRIPTION
### Motivation
- Show on the Create Profile screen which indexed keys are used to find existing cards so users understand what fields the lookup covers and the hint stays aligned with the search logic.

### Description
- Import `getSearchIdIndexedFields` and add `PROFILE_SEARCH_KEYS = ['userId', ...getSearchIdIndexedFields()]`, render a short `Meta` hint listing those keys in `src/components/ProfileCreationWorkspace.jsx`, and add a regression test in `src/components/ProfileCreationWorkspace.search.test.js` that asserts the import and the presence of the hint.

### Testing
- Ran `CI=true npm test -- --runInBand src/components/ProfileCreationWorkspace.search.test.js` which passed (3 tests); and ran `npx eslint src/components/ProfileCreationWorkspace.jsx src/components/ProfileCreationWorkspace.search.test.js` with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a2554e3248326bcc4e3ca206f8f4e)