### PR TITLE
Persist create-profile search queries

### DIFF
--- a/src/components/AddNewProfile.jsx
+++ b/src/components/AddNewProfile.jsx
@@ -41,6 +41,7 @@ import {
   fetchUsersByIds,
   lazyLoadProfilePhotos,
   migrateAllLegacyCardComments,
+  addMatchingSearchQuery,
 } from './config';
 import { fetchUsersBySearchKeyGitNewPaged } from './gitNewLoad';
 import {
@@ -2650,6 +2651,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
       setLastSearchBarQuery('');
       return;
     }
+    addMatchingSearchQuery(normalized, ownerId);
     searchListIsolationRef.current = true;
     setSearchLoading(true);
     setHasSearched(true);
@@ -2666,6 +2668,7 @@ export const AddNewProfile = ({ isLoggedIn, setIsLoggedIn }) => {
     setHasMore,
     setSearchBarQueryActive,
     setLastSearchBarQuery,
+    ownerId,
   ]);
 
   const handleFilterChange = useCallback(nextFilters => {

--- a/src/components/AddNewProfile.searchQueries.test.js
+++ b/src/components/AddNewProfile.searchQueries.test.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('AddNewProfile search query persistence', () => {
+  it('stores executed searches through the shared matching backend helper', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'AddNewProfile.jsx'), 'utf8');
+
+    expect(source).toContain('addMatchingSearchQuery(normalized, ownerId);');
+    expect(source).toMatch(/migrateAllLegacyCardComments,\s+addMatchingSearchQuery,/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Create Profile executed searches updated local UI state but did not persist executed `searchQuery` values to the same per-owner backend path that Matching uses, so searches from Create Profile were not recorded server-side.

### Description
- Reused the existing backend helper by importing `addMatchingSearchQuery` into `src/components/AddNewProfile.jsx` and invoking `addMatchingSearchQuery(normalized, ownerId)` from `handleSearchExecuted` for non-empty searches while adding `ownerId` to the hook dependency array.
- Added a small regression test `src/components/AddNewProfile.searchQueries.test.js` that asserts the helper is wired into `AddNewProfile`.

### Testing
- Ran `npx eslint src/components/AddNewProfile.jsx src/components/AddNewProfile.searchQueries.test.js` which passed.
- Ran `CI=true npm test -- --runInBand src/components/AddNewProfile.searchQueries.test.js` which passed.
- Observed unrelated pre-existing failures in `src/components/Matching.sharedReactions.test.js` when running that suite, which are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a25e29ad08326bc5e41bc373be91d)