### PR TITLE
Fix profile creation indexed search coverage

### DIFF
--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -41,7 +41,9 @@ const Status = styled.span`display:inline-block; padding:4px 9px; border-radius:
 const SearchSection = styled.section`padding:16px; margin-bottom:18px; border:1px solid var(--km-border); border-radius:16px; background:var(--km-card);`;
 const SearchResult = styled.div`display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 0; border-top:1px solid var(--km-border);`;
 const PROFILE_SEARCH_PREFILL_FIELDS = new Set(['name', 'surname', 'phone', 'email', 'telegram', 'instagram', 'facebook', 'tiktok']);
-const PROFILE_SEARCH_KEYS = ['userId', ...getSearchIdIndexedFields()];
+const PROFILE_SEARCH_ID_PREFIXES = getSearchIdIndexedFields();
+const PROFILE_SEARCH_KEYS = ['userId', ...PROFILE_SEARCH_ID_PREFIXES];
+const PROFILE_SEARCH_OPTIONS = { searchIdPrefixes: PROFILE_SEARCH_ID_PREFIXES };
 
 export const ProfileCreationWorkspace = () => {
   const navigate = useNavigate();
@@ -253,6 +255,7 @@ export const ProfileCreationWorkspace = () => {
             setSearchFailed(false);
           }}
           storageKey="profileCreationSearchQuery"
+          searchOptions={PROFILE_SEARCH_OPTIONS}
           wrapperStyle={{ width: '100%' }}
           leftIcon="🔍"
         />

--- a/src/components/ProfileCreationWorkspace.search.test.js
+++ b/src/components/ProfileCreationWorkspace.search.test.js
@@ -19,7 +19,10 @@ describe('ProfileCreationWorkspace search-before-create flow', () => {
 
   it('shows which indexed keys are used to find existing cards', () => {
     expect(source).toContain("import { getSearchIdIndexedFields } from 'utils/searchKeyUtils'");
-    expect(source).toContain("const PROFILE_SEARCH_KEYS = ['userId', ...getSearchIdIndexedFields()]");
+    expect(source).toContain('const PROFILE_SEARCH_ID_PREFIXES = getSearchIdIndexedFields()');
+    expect(source).toContain("const PROFILE_SEARCH_KEYS = ['userId', ...PROFILE_SEARCH_ID_PREFIXES]");
+    expect(source).toContain('const PROFILE_SEARCH_OPTIONS = { searchIdPrefixes: PROFILE_SEARCH_ID_PREFIXES }');
+    expect(source).toContain('searchOptions={PROFILE_SEARCH_OPTIONS}');
     expect(source).toContain('Пошук карток виконується за ключами:');
   });
 });


### PR DESCRIPTION
### Motivation

- The profile-creation UI displayed a list of indexed search keys that the `SearchBar` was not actually configured to query, causing mismatches where advertised fields (e.g. `linkedin`, `youtube`, `twitter`, `line`, `otherLink`, `surname`) could be omitted from the real search path.

### Description

- Reuse the existing indexed-field helper by adding `PROFILE_SEARCH_ID_PREFIXES = getSearchIdIndexedFields()` and derive `PROFILE_SEARCH_KEYS` from that list. 
- Create `PROFILE_SEARCH_OPTIONS = { searchIdPrefixes: PROFILE_SEARCH_ID_PREFIXES }` and pass it to `SearchBar` via `searchOptions={PROFILE_SEARCH_OPTIONS}` so the bar actually queries the advertised indexed fields. 
- Update the `ProfileCreationWorkspace` displayed keys to come from the shared prefix list and update the regression test `ProfileCreationWorkspace.search.test.js` to assert the new constants and `searchOptions` usage. 

### Testing

- Ran unit tests with `CI=true npm test -- --watchAll=false --runTestsByPath src/components/ProfileCreationWorkspace.search.test.js src/components/SearchBar.partialUserId.test.js`, and both suites passed (2 suites, 30 tests passed). 
- Ran lint with `npx eslint src/components/ProfileCreationWorkspace.jsx src/components/ProfileCreationWorkspace.search.test.js`, which completed without errors. 
- Ran `git diff --check` and verified the working tree is clean after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a27bf359c83268eda1c3c87905b82)