### PR TITLE
Move profile-creation drafts under multiData and polish the create-profile UI

### DIFF
--- a/src/components/ProfileCreationWorkspace.jsx
+++ b/src/components/ProfileCreationWorkspace.jsx
@@ -3,10 +3,11 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import styled from 'styled-components';
-import { FiArrowRight, FiFolder, FiPlus, FiSearch } from 'react-icons/fi';
+import { FiArrowRight, FiChevronDown, FiFolder, FiInfo, FiPlus, FiSearch } from 'react-icons/fi';
 
 import { auth, fetchUserById, searchUsersOnly } from './config';
 import { ProfileForm } from './ProfileForm';
+import { pickerFields } from './formFields';
 import SearchBar, { detectSearchParams } from './SearchBar';
 import { resolveAccess } from 'utils/accessLevel';
 import { getSearchIdIndexedFields } from 'utils/searchKeyUtils';
@@ -54,10 +55,38 @@ const MatchingButton = styled(Button)`
   svg { color:var(--km-accent); }
   @media (max-width:380px) { grid-column:1; grid-row:auto; justify-self:start; margin-top:8px; }
 `;
+const SaveButton = styled(Button)`
+  background: linear-gradient(135deg, #E8791A 0%, #F5A24B 100%);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 10px 24px var(--km-accent-ring);
+`;
+const AcceptButton = styled(Button)`
+  background: linear-gradient(135deg, #2E9B55 0%, #57C27D 100%);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 10px 24px rgba(46, 155, 85, .25);
+`;
+const RejectButton = styled(Button)`
+  background: var(--km-danger-bg);
+  border-color: var(--km-danger-border);
+  color: var(--km-danger);
+`;
+const GhostButton = styled(Button)`
+  background: transparent;
+  border-color: transparent;
+  color: var(--km-muted);
+  box-shadow: none;
+  &:hover:not(:disabled) { background: color-mix(in srgb, var(--km-muted) 12%, transparent); border-color: var(--km-border); }
+`;
 const Card = styled.section`padding:20px; margin:12px 0; border:1px solid var(--km-border); border-radius:20px; background:var(--km-card); box-shadow:var(--km-shadow);`;
 const Actions = styled.div`display:flex; flex-wrap:wrap; gap:8px; margin-top:16px;`;
 const Meta = styled.p`margin:6px 0; color:var(--km-muted); font-size:14px; line-height:1.45; overflow-wrap:anywhere;`;
-const Status = styled.span`display:inline-block; padding:4px 9px; border-radius:999px; background:var(--km-accent-light); color:var(--km-accent); font-size:12px; font-weight:800;`;
+const Status = styled.span`
+  display:inline-block; padding:4px 9px; border-radius:999px; font-size:12px; font-weight:800;
+  background: ${({ $variant }) => ($variant === 'private' ? 'color-mix(in srgb, var(--km-muted) 16%, var(--km-card))' : 'var(--km-accent-light)')};
+  color: ${({ $variant }) => ($variant === 'private' ? 'var(--km-muted)' : 'var(--km-accent)')};
+`;
 const HeaderMeta = styled(Meta)`grid-column:1 / -1; margin:0; max-width:650px; font-size:16px;`;
 const SearchSection = styled.section`
   padding:24px; margin-bottom:30px; border:1px solid var(--km-border); border-radius:24px; background:var(--km-card);
@@ -72,6 +101,20 @@ const SearchSection = styled.section`
   @media (max-width:600px) { padding:22px 20px; ${Actions} ${Button} { width:100%; } }
 `;
 const TechnicalMeta = styled(Meta)`font-size:12px; opacity:.82; code { color:var(--km-text); }`;
+const DisclosureToggle = styled.button`
+  display:inline-flex; align-items:center; gap:6px; margin:10px 0 2px; padding:0; border:none; background:transparent;
+  color:var(--km-muted); font:700 12px/1 var(--km-font); cursor:pointer;
+  svg:last-child { transition: transform 180ms ease; }
+  &:hover { color:var(--km-accent); }
+  &:focus-visible { outline:2px solid var(--km-accent); outline-offset:3px; border-radius:4px; }
+`;
+const ProgressRow = styled.div`display:flex; justify-content:space-between; margin-bottom:8px; font-size:12px; color:var(--km-muted);`;
+const ProgressTrack = styled.div`height:5px; background:var(--km-border); border-radius:99px; overflow:hidden; margin-bottom:18px;`;
+const ProgressFill = styled.div`
+  height:100%; border-radius:99px; transition:width 250ms ease;
+  background: linear-gradient(90deg, var(--km-accent) 0%, var(--km-accent-mid) 100%);
+  width: ${({ $pct }) => $pct}%;
+`;
 const SearchResult = styled.div`display:flex; align-items:center; justify-content:space-between; gap:12px; padding:14px 0; border-top:1px solid var(--km-border); min-width:0; > span:first-child { min-width:0; overflow-wrap:anywhere; }`;
 const SectionHeader = styled.div`display:flex; align-items:center; justify-content:space-between; gap:12px; margin:0 2px 12px; color:var(--km-muted); font-size:12px; font-weight:700; letter-spacing:.1em; text-transform:uppercase;`;
 const Count = styled.span`min-width:28px; height:28px; padding:0 9px; display:inline-flex; align-items:center; justify-content:center; box-sizing:border-box; border-radius:999px; background:color-mix(in srgb, var(--km-muted) 14%, var(--km-card)); color:var(--km-text); letter-spacing:0;`;
@@ -103,6 +146,7 @@ export const ProfileCreationWorkspace = () => {
   const [searchExecuted, setSearchExecuted] = useState(false);
   const [searchNotFound, setSearchNotFound] = useState(false);
   const [searchFailed, setSearchFailed] = useState(false);
+  const [showSearchKeysDetail, setShowSearchKeysDetail] = useState(false);
 
   const refresh = useCallback(async (userId, resolvedAccess) => {
     const items = resolvedAccess.isAdmin
@@ -246,6 +290,13 @@ export const ProfileCreationWorkspace = () => {
     return next;
   });
 
+  const draftFilledPct = useMemo(() => {
+    if (!draft) return 0;
+    const fieldNames = pickerFields.map(field => field.name);
+    const filledCount = fieldNames.filter(name => String(draft[name] || '').trim() !== '').length;
+    return fieldNames.length ? Math.round((filledCount / fieldNames.length) * 100) : 0;
+  }, [draft]);
+
   const heading = useMemo(() => access?.isAdmin ? 'Нові профілі' : 'Мої нові профілі', [access]);
   if (!access) return <Page><Shell>Завантаження…</Shell></Page>;
 
@@ -256,28 +307,47 @@ export const ProfileCreationWorkspace = () => {
       <HeaderMeta>Картки зберігаються приватно до рішення адміністратора.</HeaderMeta>
     </Header>
     {draft ? <Card>
-      <Status>{activeMutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}</Status>
-      <Meta>cardId: {activeMutation.cardId} · revision: {activeMutation.revision || 0}</Meta>
+      <Status $variant={activeMutation.status === 'private' ? 'private' : 'pending'}>
+        {activeMutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}
+      </Status>
+      {access.isAdmin
+        ? <TechnicalMeta>cardId: <code>{activeMutation.cardId}</code> · revision: {activeMutation.revision || 0}</TechnicalMeta>
+        : <Meta>Чернетка{activeMutation.updatedAt ? ` · оновлено ${new Date(activeMutation.updatedAt).toLocaleString('uk-UA')}` : ''}</Meta>}
+      {!access.isAdmin && <>
+        <ProgressRow>
+          <span>Заповнено анкету</span>
+          <span style={{ color: 'var(--km-accent)', fontWeight: 700 }}>{draftFilledPct}%</span>
+        </ProgressRow>
+        <ProgressTrack><ProgressFill $pct={draftFilledPct} /></ProgressTrack>
+      </>}
       <fieldset disabled={saving} style={{ border: 0, padding: 0, margin: 0 }}>
         <ProfileForm state={draft} setState={setDraft} handleBlur={() => {}} handleSubmit={nextDraft => setDraft(nextDraft)} handleClear={clearField} handleDelKeyValue={deleteFieldValue} isAdmin={access.isAdmin} extendedMode={false} />
       </fieldset>
       <Actions>
-        <Button $primary disabled={saving} onClick={save}>{saving ? 'Збереження…' : 'Зберегти'}</Button>
-        {access.isAdmin && activeMutation.revision > 0 && <Button $primary disabled={saving} onClick={accept}>Accept</Button>}
-        {access.isAdmin && activeMutation.revision > 0 && <Button disabled={saving} onClick={reject}>Reject / Leave private</Button>}
-        <Button disabled={saving} onClick={closeEditor}>Закрити</Button>
+        <SaveButton disabled={saving} onClick={save}>{saving ? 'Збереження…' : 'Зберегти'}</SaveButton>
+        {access.isAdmin && activeMutation.revision > 0 && <AcceptButton disabled={saving} onClick={accept}>Прийняти</AcceptButton>}
+        {access.isAdmin && activeMutation.revision > 0 && <RejectButton disabled={saving} onClick={reject}>Відхилити</RejectButton>}
+        <GhostButton disabled={saving} onClick={closeEditor}>Закрити</GhostButton>
       </Actions>
     </Card> : <>
       {!access.isAdmin && <SearchSection aria-label="Пошук профілю перед створенням">
         <h2>Знайти або додати картку</h2>
         <Meta>Спочатку перевірте, чи профіль уже існує. Використовується той самий пошук, що й у Matching.</Meta>
-        <TechnicalMeta>
+        <DisclosureToggle
+          type="button"
+          aria-expanded={showSearchKeysDetail}
+          onClick={() => setShowSearchKeysDetail(previous => !previous)}
+        >
+          <FiInfo aria-hidden="true" /> Технічні деталі пошуку
+          <FiChevronDown aria-hidden="true" style={{ transform: showSearchKeysDetail ? 'rotate(180deg)' : 'none' }} />
+        </DisclosureToggle>
+        {showSearchKeysDetail && <TechnicalMeta>
           Пошук карток виконується за ключами: {PROFILE_SEARCH_KEYS.map((key, index) => (
             <React.Fragment key={key}>
               {index > 0 ? ', ' : ''}<code>{key}</code>
             </React.Fragment>
           ))}.
-        </TechnicalMeta>
+        </TechnicalMeta>}
         <SearchBar
           searchFunc={searchUsersOnly}
           search={search}
@@ -333,10 +403,15 @@ export const ProfileCreationWorkspace = () => {
       </EmptyState>}
       {mutations.map(mutation => <ProfileCard key={mutation.cardId}>
         <div>
-          <Status>{mutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}</Status>
+          <Status $variant={mutation.status === 'private' ? 'private' : 'pending'}>
+            {mutation.status === 'private' ? 'Приватний' : 'Очікує підтвердження'}
+          </Status>
           <h2>{[mutation.data?.name, mutation.data?.surname].filter(Boolean).join(' ') || 'Новий профіль'}</h2>
-          <Meta>Автор: {mutation.createdBy}</Meta>
-          <Meta>Оновлено: {mutation.updatedAt ? new Date(mutation.updatedAt).toLocaleString('uk-UA') : '—'} · revision {mutation.revision}</Meta>
+          {access.isAdmin && <Meta>Автор: {mutation.createdBy}</Meta>}
+          <Meta>
+            Оновлено: {mutation.updatedAt ? new Date(mutation.updatedAt).toLocaleString('uk-UA') : '—'}
+            {access.isAdmin ? ` · revision ${mutation.revision}` : ''}
+          </Meta>
         </div>
         <Button onClick={() => openMutation(mutation)}>Відкрити профіль</Button>
       </ProfileCard>)}

--- a/src/utils/profileMutations.js
+++ b/src/utils/profileMutations.js
@@ -5,14 +5,40 @@ import {
   SEARCH_ID_INDEXED_FIELDS,
   buildSearchIdRecordKey,
 } from './searchKeyUtils';
+import { isAdminUid } from './accessLevel';
+import { MULTI_DATA_ACCESS_FIELD } from './multiDataAccess';
 
-export const PROFILE_MUTATIONS_ROOT = 'profileMutations';
-export const PROFILE_MUTATION_HISTORY_ROOT = 'profileMutationHistory';
-export const PROFILE_IDENTITY_CLAIMS_ROOT = 'profileIdentityClaims';
+// Draft/in-review data for user-submitted cards lives under the shared
+// multiData/ namespace (same place as multiData/edits, multiData/comments)
+// instead of its own top-level root, so it rides on whatever RTDB rules
+// already govern that namespace rather than needing a brand-new root wired
+// up separately. Dedicated rules for this data can be revisited later.
+export const PROFILE_MUTATIONS_ROOT = 'multiData/profileMutations';
+export const PROFILE_MUTATION_HISTORY_ROOT = 'multiData/profileMutationHistory';
+export const PROFILE_IDENTITY_CLAIMS_ROOT = 'multiData/profileIdentityClaims';
+export const PROFILE_MUTATIONS_BY_CREATOR_ROOT = 'multiData/profileMutationsByCreator';
 
 const cleanObject = value => Object.entries(value || {}).reduce((result, [key, item]) => {
   if (key.startsWith('__') || item === undefined) return result;
   result[key] = item;
+  return result;
+}, {});
+
+// Non-admin creators only ever reach saveCreateProfileMutation through
+// ProfileForm, which already hides these fields from them - this enforces
+// the same rule again where the draft is actually written, so a forged
+// client call can't smuggle elevated access into a card that later gets
+// merged verbatim into newUsers on accept.
+const PRIVILEGED_PROFILE_FIELDS = new Set([
+  'accessLevel',
+  'canCreateProfiles',
+  'additionalAccessRules',
+  MULTI_DATA_ACCESS_FIELD,
+]);
+
+const stripPrivilegedFields = data => Object.entries(data || {}).reduce((result, [key, value]) => {
+  if (PRIVILEGED_PROFILE_FIELDS.has(key)) return result;
+  result[key] = value;
   return result;
 }, {});
 
@@ -100,11 +126,12 @@ const syncProfileSearchIdIndex = (cardId, profile) => Promise.all(
 
 export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expectedRevision }) => {
   if (!cardId || !creatorUid) throw new Error('cardId and creatorUid are required');
+  const sanitizedData = isAdminUid(creatorUid) ? (data || {}) : stripPrivilegedFields(data);
   // Write-through discovery is harmless if the later claim fails (load filters
   // missing records), while writing it first prevents a committed draft from
   // becoming undiscoverable because of a separate index failure.
-  await update(ref(database, `profileMutationsByCreator/${creatorUid}`), { [cardId]: true });
-  const identityKeys = await claimProfileIdentities({ cardId, data });
+  await update(ref(database, `${PROFILE_MUTATIONS_BY_CREATOR_ROOT}/${creatorUid}`), { [cardId]: true });
+  const identityKeys = await claimProfileIdentities({ cardId, data: sanitizedData });
   let conflict = '';
   let previousIdentityKeys = [];
   const result = await runTransaction(ref(database, `${PROFILE_MUTATIONS_ROOT}/${cardId}`), current => {
@@ -125,7 +152,7 @@ export const saveCreateProfileMutation = async ({ cardId, creatorUid, data, expe
     const mutation = {
       cardId,
       operation: 'create',
-      data: { ...cleanObject(data), userId: cardId },
+      data: { ...cleanObject(sanitizedData), userId: cardId },
       createdBy: creatorUid,
       createdAt: current?.createdAt || now,
       updatedAt: now,
@@ -155,7 +182,7 @@ export const loadProfileMutation = async cardId => {
 
 export const loadOwnProfileMutations = async creatorUid => {
   if (!creatorUid) return [];
-  const idsSnapshot = await get(ref(database, `profileMutationsByCreator/${creatorUid}`));
+  const idsSnapshot = await get(ref(database, `${PROFILE_MUTATIONS_BY_CREATOR_ROOT}/${creatorUid}`));
   const ids = idsSnapshot.exists() ? Object.keys(idsSnapshot.val() || {}) : [];
   const mutations = await Promise.all(ids.map(loadProfileMutation));
   return mutations.filter(item => item && item.createdBy === creatorUid && item.status !== 'accepted');
@@ -225,7 +252,7 @@ export const acceptCreateProfileMutation = async ({ cardId, expectedRevision, fi
     [`users/${mutation.createdBy}/createdProfileCardIds/${cardId}`]: true,
     [`${PROFILE_MUTATION_HISTORY_ROOT}/${cardId}`]: { ...mutation, status: 'accepted' },
     [`${PROFILE_MUTATIONS_ROOT}/${cardId}`]: { ...mutation, status: 'accepted' },
-    [`profileMutationsByCreator/${mutation.createdBy}/${cardId}`]: null,
+    [`${PROFILE_MUTATIONS_BY_CREATOR_ROOT}/${mutation.createdBy}/${cardId}`]: null,
   });
   releaseProfileIdentities(cardId, previousIdentityKeys.filter(key => !identityKeys.includes(key))).catch(() => {});
   return acceptedProfile;


### PR DESCRIPTION
Store profileMutations/profileMutationHistory/profileIdentityClaims/
profileMutationsByCreator under multiData/ (like multiData/edits and
multiData/comments) instead of new top-level roots, so drafts ride on
existing RTDB rules until dedicated ones are written. Non-admin creators
now have accessLevel/canCreateProfiles/additionalAccessRules/
multiDataAccessUserIds stripped server-side when a draft is saved, not
just hidden in the form.

Redesign ProfileCreationWorkspace ("Мої нові профілі"): collapse the raw
search-key list and admin-only cardId/revision debug info behind a
disclosure instead of always showing them to partners, add a fill-progress
bar reusing pickerFields, give Save/Accept/Reject/Close distinct visual
weight instead of identical buttons, localize the last English button
labels, and color-differentiate the pending/private status badges.